### PR TITLE
chore: run macOS, windows, and race tests with Postgres in CI

### DIFF
--- a/.github/actions/setup-imdisk/action.yaml
+++ b/.github/actions/setup-imdisk/action.yaml
@@ -15,13 +15,13 @@ runs:
         curl -L -o files.cab https://github.com/coder/imdisk-artifacts/raw/92a17839ebc0ee3e69be019f66b3e9b5d2de4482/files.cab
         curl -L -o install.bat https://github.com/coder/imdisk-artifacts/raw/92a17839ebc0ee3e69be019f66b3e9b5d2de4482/install.bat
         cd ..
-    
+
     - name: Install ImDisk
       shell: cmd
       run: |
         cd imdisk
         install.bat /silent
-        
+
     - name: Create RAM Disk
       shell: cmd
       run: |

--- a/.github/actions/setup-imdisk/action.yaml
+++ b/.github/actions/setup-imdisk/action.yaml
@@ -1,0 +1,28 @@
+name: "Setup ImDisk"
+if: runner.os == 'Windows'
+description: |
+  Sets up the ImDisk toolkit for Windows and creates a RAM disk on drive R:.
+inputs:
+runs:
+  using: "composite"
+  steps:
+    - name: Download ImDisk
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        mkdir imdisk
+        cd imdisk
+        curl -L -o files.cab https://github.com/coder/imdisk-artifacts/raw/92a17839ebc0ee3e69be019f66b3e9b5d2de4482/files.cab
+        curl -L -o install.bat https://github.com/coder/imdisk-artifacts/raw/92a17839ebc0ee3e69be019f66b3e9b5d2de4482/install.bat
+        cd ..
+    
+    - name: Install ImDisk
+      shell: cmd
+      run: |
+        cd imdisk
+        install.bat /silent
+        
+    - name: Create RAM Disk
+      shell: cmd
+      run: |
+        imdisk -a -s 4096M -m R: -p "/fs:ntfs /q /y"

--- a/.github/actions/setup-imdisk/action.yaml
+++ b/.github/actions/setup-imdisk/action.yaml
@@ -2,7 +2,6 @@ name: "Setup ImDisk"
 if: runner.os == 'Windows'
 description: |
   Sets up the ImDisk toolkit for Windows and creates a RAM disk on drive R:.
-inputs:
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -370,7 +370,7 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   test-go-pg:
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'windows-latest-16-cores' || matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge'}}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
@@ -383,7 +383,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-2022
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
@@ -430,20 +429,56 @@ jobs:
             go run scripts/embedded-pg/main.go
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
           fi
-      # This is used by the `required` job to determine if the test-go-pg job
-      # failed or not on the given OS. Matrix jobs don't support `outputs`
-      # well - the last job to run overwrites them. Instead, we write to
-      # artifacts.
-      - if: always()
-        run: echo "0" > "test-go-pg_result_${{ matrix.os }}"
-      - if: failure()
-        run: echo "1" > "test-go-pg_result_${{ matrix.os }}"
-      - name: Upload result artifact
-        if: always()
-        uses: actions/upload-artifact@v4
+
+      - name: Upload test stats to Datadog
+        timeout-minutes: 1
+        continue-on-error: true
+        uses: ./.github/actions/upload-datadog
+        if: success() || failure()
         with:
-          name: "test-go-pg_result_${{ matrix.os }}"
-          path: "test-go-pg_result_${{ matrix.os }}"
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+
+  # NOTE: this could instead be defined as a matrix strategy, but we want to
+  # temporarily allow windows tests to fail. Using a matrix strategy here makes
+  # the check in the `required` job rather complicated.
+  test-go-pg-windows:
+    runs-on: ${{ github.repository_owner == 'coder' && 'windows-latest-16-cores' }}
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    # This timeout must be greater than the timeout set by `go test` in
+    # `make test-postgres` to ensure we receive a trace of running
+    # goroutines. Setting this to the timeout +5m should work quite well
+    # even if some of the preceding steps are slow.
+    timeout-minutes: 25
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
+
+      - name: Test with PostgreSQL Database
+        env:
+          POSTGRES_VERSION: "13"
+          TS_DEBUG_DISCO: "true"
+        shell: bash
+        run: |
+          # By default Go will use the number of logical CPUs, which
+          # is a fine default.
+          PARALLEL_FLAG=""
+
+          go run scripts/embedded-pg/main.go
+          DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
 
       - name: Upload test stats to Datadog
         timeout-minutes: 1
@@ -867,54 +902,29 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
-      - name: Download test-go-pg Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: test-go-pg_result
-          pattern: test-go-pg_result_*
-          merge-multiple: true
+
       - name: Ensure required checks
-        shell: python
         run: |
-          import json
-          import sys
-          import os
-          from pathlib import Path
+          echo "Checking required checks"
+          echo "- fmt: ${{ needs.fmt.result }}"
+          echo "- lint: ${{ needs.lint.result }}"
+          echo "- gen: ${{ needs.gen.result }}"
+          echo "- test-go: ${{ needs.test-go.result }}"
+          echo "- test-go-pg: ${{ needs.test-go-pg.result }}"
+          echo "- test-go-race: ${{ needs.test-go-race.result }}"
+          echo "- test-go-race-pg: ${{ needs.test-go-race-pg.result }}"
+          echo "- test-js: ${{ needs.test-js.result }}"
+          echo "- test-e2e: ${{ needs.test-e2e.result }}"
+          echo "- offlinedocs: ${{ needs.offlinedocs.result }}"
+          echo
 
-          print("Checking required checks")
+          # We allow skipped jobs to pass, but not failed or cancelled jobs.
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One of the required checks has failed or has been cancelled"
+            exit 1
+          fi
 
-          jobs = json.loads(os.environ["NEEDS"])
-          job_names = sorted(jobs.keys())
-          for job_name in job_names:
-              result = jobs[job_name]["result"]
-              print(f"- {job_name}: {result}")
-          print()
-
-          failed = False
-          for job_name in job_names:
-              result = jobs[job_name]["result"]
-
-              # Skip test-go-pg failures on windows
-              if job_name == "test-go-pg" and result == "failure":
-                  result_artifacts = list(Path("test-go-pg_result").glob("test-go-pg_result_*"))
-                  results = {f.name: int(f.read_text()) for f in result_artifacts}
-                  del results["test-go-pg_result_windows-2022"]
-                  # We should have received 3 result artifacts: linux, macos, and windows
-                  if len(result_artifacts) == 3 and sum(results.values()) == 0:
-                      print("test-go-pg on windows-2022 failed, but we are temporarily skipping it until it's fixed")
-                      continue
-
-              if result in ["failure", "cancelled"]:
-                  failed = True
-                  break
-
-          if failed:
-              print("One of the required checks has failed or has been cancelled")
-              sys.exit(1)
-
-          print("Required checks have passed")
-        env:
-          NEEDS: ${{ toJSON(needs) }}
+          echo "Required checks have passed"
 
   # Builds the dylibs and upload it as an artifact so it can be embedded in the main build
   build-dylib:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -905,10 +905,6 @@ jobs:
                       print("test-go-pg on windows-2022 failed, but we are temporarily skipping it until it's fixed")
                       continue
 
-              if job_name == "test-go-race-pg" and result == "failure":
-                  print("test-go-race-pg failed, but we are temporarily skipping it until it's fixed")
-                  continue
-
               if result in ["failure", "cancelled"]:
                   failed = True
                   break

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -431,7 +431,6 @@ jobs:
             go run scripts/embedded-pg/main.go
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
           fi
-
       # This is used by the `required` job to determine if the test-go-pg job
       # failed or not on the given OS. Matrix jobs don't support `outputs`
       # well - the last job to run overwrites them. Instead, we write to

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -379,7 +379,6 @@ jobs:
     # even if some of the preceding steps are slow.
     timeout-minutes: 25
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -370,15 +370,17 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   test-go-pg:
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
-    needs:
-      - changes
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'windows-latest-16-cores' || matrix.os }}
+    needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
-    # This timeout must be greater than the timeout set by `go test` in
-    # `make test-postgres` to ensure we receive a trace of running
-    # goroutines. Setting this to the timeout +5m should work quite well
-    # even if some of the preceding steps are slow.
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-2022
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
@@ -400,8 +402,31 @@ jobs:
         env:
           POSTGRES_VERSION: "13"
           TS_DEBUG_DISCO: "true"
+        shell: bash
         run: |
-          make test-postgres
+          # if macOS, install google-chrome for scaletests
+          # As another concern, should we really have this kind of external dependency
+          # requirement on standard CI?
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            brew install google-chrome
+          fi
+
+          # By default Go will use the number of logical CPUs, which
+          # is a fine default.
+          PARALLEL_FLAG=""
+
+          # macOS will output "The default interactive shell is now zsh"
+          # intermittently in CI...
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
+          fi
+
+          if [ "${{ runner.os }}" == "Linux" ]; then
+            make test-postgres
+          else
+            go run scripts/embedded-pg/main.go
+            DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
+          fi
 
       - name: Upload test stats to Datadog
         timeout-minutes: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -538,6 +538,47 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
+  test-go-race-pg:
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    timeout-minutes: 25
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
+
+      # We run race tests with reduced parallelism because they use more CPU and we were finding
+      # instances where tests appear to hang for multiple seconds, resulting in flaky tests when
+      # short timeouts are used.
+      # c.f. discussion on https://github.com/coder/coder/pull/15106
+      - name: Run Tests
+        env:
+          POSTGRES_VERSION: "16"
+        run: |
+          make test-postgres-docker
+          DB=ci gotestsum --junitfile="gotests.xml" -- -race -parallel 4 -p 4 ./...
+
+      - name: Upload test stats to Datadog
+        timeout-minutes: 1
+        continue-on-error: true
+        uses: ./.github/actions/upload-datadog
+        if: always()
+        with:
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+
   # Tailnet integration tests only run when the `tailnet` directory or `go.sum`
   # and `go.mod` are changed. These tests are to ensure we don't add regressions
   # to tailnet, either due to our code or due to updating dependencies.
@@ -815,6 +856,7 @@ jobs:
       - test-go
       - test-go-pg
       - test-go-race
+      - test-go-race-pg
       - test-js
       - test-e2e
       - offlinedocs
@@ -862,7 +904,11 @@ jobs:
                   if sum(results.values()) == 0:
                       print("test-go-pg on windows-2022 failed, but we are temporarily skipping it until it's fixed")
                       continue
-              
+
+              if job_name == "test-go-race-pg" and result == "failure":
+                  print("test-go-race-pg failed, but we are temporarily skipping it until it's fixed")
+                  continue
+
               if result in ["failure", "cancelled"]:
                   failed = True
                   break

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -370,7 +370,7 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   test-go-pg:
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge'}}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge' || matrix.os }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
@@ -442,7 +442,7 @@ jobs:
   # temporarily allow windows tests to fail. Using a matrix strategy here makes
   # the check in the `required` job rather complicated.
   test-go-pg-windows:
-    runs-on: ${{ github.repository_owner == 'coder' && 'windows-latest-16-cores' }}
+    runs-on: ${{ github.repository_owner == 'coder' && 'windows-latest-16-cores' || 'windows-latest' }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -899,7 +899,8 @@ jobs:
                   result_artifacts = list(Path("test-go-pg_result").glob("test-go-pg_result_*"))
                   results = {f.name: int(f.read_text()) for f in result_artifacts}
                   del results["test-go-pg_result_windows-2022"]
-                  if sum(results.values()) == 0:
+                  # We should have received 3 result artifacts: linux, macos, and windows
+                  if len(result_artifacts) == 3 and sum(results.values()) == 0:
                       print("test-go-pg on windows-2022 failed, but we are temporarily skipping it until it's fixed")
                       continue
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -373,6 +373,10 @@ jobs:
     runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'windows-latest-16-cores' || matrix.os }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    # This timeout must be greater than the timeout set by `go test` in
+    # `make test-postgres` to ensure we receive a trace of running
+    # goroutines. Setting this to the timeout +5m should work quite well
+    # even if some of the preceding steps are slow.
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -427,6 +431,21 @@ jobs:
             go run scripts/embedded-pg/main.go
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
           fi
+
+      # This is used by the `required` job to determine if the test-go-pg job
+      # failed or not on the given OS. Matrix jobs don't support `outputs`
+      # well - the last job to run overwrites them. Instead, we write to
+      # artifacts.
+      - if: always()
+        run: echo "0" > "test-go-pg_result_${{ matrix.os }}"
+      - if: failure()
+        run: echo "1" > "test-go-pg_result_${{ matrix.os }}"
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "test-go-pg_result_${{ matrix.os }}"
+          path: "test-go-pg_result_${{ matrix.os }}"
 
       - name: Upload test stats to Datadog
         timeout-minutes: 1
@@ -808,28 +827,53 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
-
+      - name: Download test-go-pg Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: test-go-pg_result
+          pattern: test-go-pg_result_*
+          merge-multiple: true
       - name: Ensure required checks
+        shell: python
         run: |
-          echo "Checking required checks"
-          echo "- fmt: ${{ needs.fmt.result }}"
-          echo "- lint: ${{ needs.lint.result }}"
-          echo "- gen: ${{ needs.gen.result }}"
-          echo "- test-go: ${{ needs.test-go.result }}"
-          echo "- test-go-pg: ${{ needs.test-go-pg.result }}"
-          echo "- test-go-race: ${{ needs.test-go-race.result }}"
-          echo "- test-js: ${{ needs.test-js.result }}"
-          echo "- test-e2e: ${{ needs.test-e2e.result }}"
-          echo "- offlinedocs: ${{ needs.offlinedocs.result }}"
-          echo
+          import json
+          import sys
+          import os
+          from pathlib import Path
 
-          # We allow skipped jobs to pass, but not failed or cancelled jobs.
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "One of the required checks has failed or has been cancelled"
-            exit 1
-          fi
+          print("Checking required checks")
 
-          echo "Required checks have passed"
+          jobs = json.loads(os.environ["NEEDS"])
+          job_names = sorted(jobs.keys())
+          for job_name in job_names:
+              result = jobs[job_name]["result"]
+              print(f"- {job_name}: {result}")
+          print()
+
+          failed = False
+          for job_name in job_names:
+              result = jobs[job_name]["result"]
+
+              # Skip test-go-pg failures on windows
+              if job_name == "test-go-pg" and result == "failure":
+                  result_artifacts = list(Path("test-go-pg_result").glob("test-go-pg_result_*"))
+                  results = {f.name: int(f.read_text()) for f in result_artifacts}
+                  del results["test-go-pg_result_windows-2022"]
+                  if sum(results.values()) == 0:
+                      print("test-go-pg on windows-2022 failed, but we are temporarily skipping it until it's fixed")
+                      continue
+              
+              if result in ["failure", "cancelled"]:
+                  failed = True
+                  break
+
+          if failed:
+              print("One of the required checks has failed or has been cancelled")
+              sys.exit(1)
+
+          print("Required checks have passed")
+        env:
+          NEEDS: ${{ toJSON(needs) }}
 
   # Builds the dylibs and upload it as an artifact so it can be embedded in the main build
   build-dylib:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -370,7 +370,7 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   test-go-pg:
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge' || matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'macos-latest-xlarge' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'windows-latest-16-cores' || matrix.os }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
@@ -383,6 +383,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-2022
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
@@ -429,56 +430,6 @@ jobs:
             go run scripts/embedded-pg/main.go
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
           fi
-
-      - name: Upload test stats to Datadog
-        timeout-minutes: 1
-        continue-on-error: true
-        uses: ./.github/actions/upload-datadog
-        if: success() || failure()
-        with:
-          api-key: ${{ secrets.DATADOG_API_KEY }}
-
-  # NOTE: this could instead be defined as a matrix strategy, but we want to
-  # temporarily allow windows tests to fail. Using a matrix strategy here makes
-  # the check in the `required` job rather complicated.
-  test-go-pg-windows:
-    runs-on: ${{ github.repository_owner == 'coder' && 'windows-latest-16-cores' || 'windows-latest' }}
-    needs: changes
-    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
-    # This timeout must be greater than the timeout set by `go test` in
-    # `make test-postgres` to ensure we receive a trace of running
-    # goroutines. Setting this to the timeout +5m should work quite well
-    # even if some of the preceding steps are slow.
-    timeout-minutes: 25
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-        with:
-          fetch-depth: 1
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Setup Terraform
-        uses: ./.github/actions/setup-tf
-
-      - name: Test with PostgreSQL Database
-        env:
-          POSTGRES_VERSION: "13"
-          TS_DEBUG_DISCO: "true"
-        shell: bash
-        run: |
-          # By default Go will use the number of logical CPUs, which
-          # is a fine default.
-          PARALLEL_FLAG=""
-
-          go run scripts/embedded-pg/main.go
-          DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
 
       - name: Upload test stats to Datadog
         timeout-minutes: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,76 +150,35 @@ jobs:
   #       run: git diff --exit-code
 
   lint:
-    needs: changes
-    if: needs.changes.outputs.offlinedocs-only == 'false' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    runs-on: windows-latest-16-cores
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-        with:
-          fetch-depth: 1
-
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Get golangci-lint cache dir
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Download and Install ImDisk
+        shell: powershell
         run: |
-          linter_ver=$(egrep -o 'GOLANGCI_LINT_VERSION=\S+' dogfood/contents/Dockerfile | cut -d '=' -f 2)
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$linter_ver
-          dir=$(golangci-lint cache status | awk '/Dir/ { print $2 }')
-          echo "LINT_CACHE_DIR=$dir" >> $GITHUB_ENV
-
-      - name: golangci-lint cache
-        uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
-        with:
-          path: |
-            ${{ env.LINT_CACHE_DIR }}
-          key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/*.go') }}
-          restore-keys: |
-            golangci-lint-${{ runner.os }}-
-
-      # Check for any typos
-      - name: Check for typos
-        uses: crate-ci/typos@b74202f74b4346efdbce7801d187ec57b266bac8 # v1.27.3
-        with:
-          config: .github/workflows/typos.toml
-
-      - name: Fix the typos
-        if: ${{ failure() }}
+          $url = "https://sourceforge.net/projects/imdisk-toolkit/files/20190130/ImDiskTk.exe"
+          Invoke-WebRequest -Uri $url -OutFile "ImDiskTk.exe"
+          Start-Process -FilePath "ImDiskTk.exe" -ArgumentList "/fullsilent" -Wait
+          
+      - name: Create RAM Disk
+        shell: cmd
         run: |
-          echo "::notice:: you can automatically fix typos from your CLI:
-          cargo install typos-cli
-          typos -c .github/workflows/typos.toml -w"
-
-      # Needed for helm chart linting
-      - name: Install helm
-        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
-        with:
-          version: v3.9.2
-
-      - name: make lint
+          imdisk -a -s 512M -m R: -p "/fs:ntfs /q /y"
+          
+      - name: Test RAM Disk
+        shell: cmd
         run: |
-          make --output-sync=line -j lint
-
-      - name: Check workflow files
+          dir R:
+          echo "Testing write to RAM disk" > R:\test.txt
+          type R:\test.txt
+          
+      - name: Cleanup RAM Disk
+        if: always()
+        shell: cmd
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.4
-          ./actionlint -color -shellcheck= -ignore "set-output"
-        shell: bash
-
-      - name: Check for unstaged files
-        run: |
-          rm -f ./actionlint ./typos
-          ./scripts/check_unstaged.sh
-        shell: bash
+          imdisk -D -m R:
 
   gen:
     timeout-minutes: 8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,7 +221,6 @@ jobs:
           ./scripts/check_unstaged.sh
         shell: bash
 
-
   gen:
     timeout-minutes: 8
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,43 +150,77 @@ jobs:
   #       run: git diff --exit-code
 
   lint:
-    runs-on: windows-latest-16-cores
+    needs: changes
+    if: needs.changes.outputs.offlinedocs-only == 'false' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
 
-      - name: Download ImDisk
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Get golangci-lint cache dir
+        run: |
+          linter_ver=$(egrep -o 'GOLANGCI_LINT_VERSION=\S+' dogfood/contents/Dockerfile | cut -d '=' -f 2)
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$linter_ver
+          dir=$(golangci-lint cache status | awk '/Dir/ { print $2 }')
+          echo "LINT_CACHE_DIR=$dir" >> $GITHUB_ENV
+
+      - name: golangci-lint cache
+        uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
+        with:
+          path: |
+            ${{ env.LINT_CACHE_DIR }}
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-
+
+      # Check for any typos
+      - name: Check for typos
+        uses: crate-ci/typos@b74202f74b4346efdbce7801d187ec57b266bac8 # v1.27.3
+        with:
+          config: .github/workflows/typos.toml
+
+      - name: Fix the typos
+        if: ${{ failure() }}
+        run: |
+          echo "::notice:: you can automatically fix typos from your CLI:
+          cargo install typos-cli
+          typos -c .github/workflows/typos.toml -w"
+
+      # Needed for helm chart linting
+      - name: Install helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.9.2
+
+      - name: make lint
+        run: |
+          make --output-sync=line -j lint
+
+      - name: Check workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.4
+          ./actionlint -color -shellcheck= -ignore "set-output"
         shell: bash
+
+      - name: Check for unstaged files
         run: |
-          mkdir imdisk
-          cd imdisk
-          curl -L -o files.cab https://imdisk-ci-files.pages.dev/ImDiskTk20241123/files.cab
-          curl -L -o install.bat https://imdisk-ci-files.pages.dev/ImDiskTk20241123/install.bat
-          cd ..
-      
-      - name: Install ImDisk
-        shell: cmd
-        run: |
-          cd imdisk
-          install.bat /silent
-          
-      - name: Create RAM Disk
-        shell: cmd
-        run: |
-          imdisk -a -s 512M -m R: -p "/fs:ntfs /q /y"
-          
-      - name: Test RAM Disk
-        shell: cmd
-        run: |
-          dir R:
-          echo "Testing write to RAM disk" > R:\test.txt
-          type R:\test.txt
-          
-      - name: Cleanup RAM Disk
-        if: always()
-        shell: cmd
-        run: |
-          imdisk -D -m R:
+          rm -f ./actionlint ./typos
+          ./scripts/check_unstaged.sh
+        shell: bash
+
 
   gen:
     timeout-minutes: 8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,13 +154,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
-      - name: Download and Install ImDisk
+
+      - name: Download ImDisk
         shell: powershell
         run: |
-          $url = "https://sourceforge.net/projects/imdisk-toolkit/files/20190130/ImDiskTk.exe"
-          Invoke-WebRequest -Uri $url -OutFile "ImDiskTk.exe"
-          Start-Process -FilePath "ImDiskTk.exe" -ArgumentList "/fullsilent" -Wait -Verb RunAs
+          $url = "https://sourceforge.net/projects/imdisk-toolkit/files/20241123/ImDiskTk-x64.zip/download"
+          Invoke-WebRequest -Uri $url -OutFile "ImDiskTk.zip"
+          Expand-Archive -Path "ImDiskTk.zip" -DestinationPath "ImDiskTk"
+      
+      - name: Install ImDisk
+        shell: cmd
+        run: |
+          cd ImDiskTk
+          install.bat /silent
           
       - name: Create RAM Disk
         shell: cmd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,6 +368,29 @@ jobs:
       - name: Setup Terraform
         uses: ./.github/actions/setup-tf
 
+      - name: Download ImDisk
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir imdisk
+          cd imdisk
+          curl -L -o files.cab https://imdisk-ci-files.pages.dev/ImDiskTk20241123/files.cab
+          curl -L -o install.bat https://imdisk-ci-files.pages.dev/ImDiskTk20241123/install.bat
+          cd ..
+      
+      - name: Install ImDisk
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          cd imdisk
+          install.bat /silent
+          
+      - name: Create RAM Disk
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          imdisk -a -s 4096M -m R: -p "/fs:ntfs /q /y"
+
       - name: Test with PostgreSQL Database
         env:
           POSTGRES_VERSION: "13"
@@ -394,10 +417,10 @@ jobs:
           if [ "${{ runner.os }}" == "Linux" ]; then
             make test-postgres
           elif [ "${{ runner.os }}" == "Windows" ]; then
-            # Create temp dir on D: drive for Windows. The default C: drive is extremely
-            # slow: https://github.com/actions/runner-images/issues/8755
-            mkdir -p "D:/temp/embedded-pg"
-            go run scripts/embedded-pg/main.go -path "D:/temp/embedded-pg"
+            # Create temp dir on the R: ramdisk drive for Windows. The default
+            # C: drive is extremely slow: https://github.com/actions/runner-images/issues/8755
+            mkdir -p "R:/temp/embedded-pg"
+            go run scripts/embedded-pg/main.go -path "R:/temp/embedded-pg"
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
           else
             go run scripts/embedded-pg/main.go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,7 @@ jobs:
         run: |
           $url = "https://sourceforge.net/projects/imdisk-toolkit/files/20190130/ImDiskTk.exe"
           Invoke-WebRequest -Uri $url -OutFile "ImDiskTk.exe"
-          Start-Process -FilePath "ImDiskTk.exe" -ArgumentList "/fullsilent" -Wait
+          Start-Process -FilePath "ImDiskTk.exe" -ArgumentList "/fullsilent" -Wait -Verb RunAs
           
       - name: Create RAM Disk
         shell: cmd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,28 +368,9 @@ jobs:
       - name: Setup Terraform
         uses: ./.github/actions/setup-tf
 
-      - name: Download ImDisk
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          mkdir imdisk
-          cd imdisk
-          curl -L -o files.cab https://imdisk-ci-files.pages.dev/ImDiskTk20241123/files.cab
-          curl -L -o install.bat https://imdisk-ci-files.pages.dev/ImDiskTk20241123/install.bat
-          cd ..
-      
-      - name: Install ImDisk
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          cd imdisk
-          install.bat /silent
-          
-      - name: Create RAM Disk
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          imdisk -a -s 4096M -m R: -p "/fs:ntfs /q /y"
+      # Sets up the ImDisk toolkit for Windows and creates a RAM disk on drive R:.
+      - name: Setup ImDisk
+        uses: ./.github/actions/setup-imdisk
 
       - name: Test with PostgreSQL Database
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,16 +156,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download ImDisk
-        shell: powershell
+        shell: bash
         run: |
-          $url = "https://sourceforge.net/projects/imdisk-toolkit/files/20241123/ImDiskTk-x64.zip/download"
-          Invoke-WebRequest -Uri $url -OutFile "ImDiskTk.zip"
-          Expand-Archive -Path "ImDiskTk.zip" -DestinationPath "ImDiskTk"
+          mkdir imdisk
+          cd imdisk
+          curl -L -o files.cab https://imdisk-ci-files.pages.dev/ImDiskTk20241123/files.cab
+          curl -L -o install.bat https://imdisk-ci-files.pages.dev/ImDiskTk20241123/install.bat
+          cd ..
       
       - name: Install ImDisk
         shell: cmd
         run: |
-          cd ImDiskTk
+          cd imdisk
           install.bat /silent
           
       - name: Create RAM Disk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -404,6 +404,7 @@ jobs:
 
       # Sets up the ImDisk toolkit for Windows and creates a RAM disk on drive R:.
       - name: Setup ImDisk
+        if: runner.os == 'Windows'
         uses: ./.github/actions/setup-imdisk
 
       - name: Test with PostgreSQL Database
@@ -432,7 +433,7 @@ jobs:
           if [ "${{ runner.os }}" == "Linux" ]; then
             make test-postgres
           elif [ "${{ runner.os }}" == "Windows" ]; then
-            # Create temp dir on the R: ramdisk drive for Windows. The default
+            # Create a temp dir on the R: ramdisk drive for Windows. The default
             # C: drive is extremely slow: https://github.com/actions/runner-images/issues/8755
             mkdir -p "R:/temp/embedded-pg"
             go run scripts/embedded-pg/main.go -path "R:/temp/embedded-pg"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -426,6 +426,12 @@ jobs:
 
           if [ "${{ runner.os }}" == "Linux" ]; then
             make test-postgres
+          elif [ "${{ runner.os }}" == "Windows" ]; then
+            # Create temp dir on D: drive for Windows. The default C: drive is extremely
+            # slow: https://github.com/actions/runner-images/issues/8755
+            mkdir -p "D:/temp/embedded-pg"
+            go run scripts/embedded-pg/main.go -path "D:/temp/embedded-pg"
+            DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
           else
             go run scripts/embedded-pg/main.go
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -1,0 +1,63 @@
+// Start an embedded postgres database on port 5432. Used in CI on macOS and Windows.
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+)
+
+func main() {
+	postgresPath := filepath.Join(os.TempDir(), "coder-test-postgres")
+	ep := embeddedpostgres.NewDatabase(
+		embeddedpostgres.DefaultConfig().
+			Version(embeddedpostgres.V16).
+			BinariesPath(filepath.Join(postgresPath, "bin")).
+			DataPath(filepath.Join(postgresPath, "data")).
+			RuntimePath(filepath.Join(postgresPath, "runtime")).
+			CachePath(filepath.Join(postgresPath, "cache")).
+			Username("postgres").
+			Password("postgres").
+			Database("postgres").
+			Port(uint32(5432)).
+			Logger(os.Stdout),
+	)
+	err := ep.Start()
+	if err != nil {
+		panic(err)
+	}
+	// We execute these queries instead of using the embeddedpostgres
+	// StartParams because it doesn't work on Windows. The library
+	// seems to have a bug where it sends malformed parameters to
+	// pg_ctl. It encloses each parameter in single quotes, which
+	// Windows can't handle.
+	paramQueries := []string{
+		`ALTER SYSTEM SET effective_cache_size = '1GB';`,
+		`ALTER SYSTEM SET fsync = 'off';`,
+		`ALTER SYSTEM SET full_page_writes = 'off';`,
+		`ALTER SYSTEM SET max_connections = '1000';`,
+		`ALTER SYSTEM SET shared_buffers = '1GB';`,
+		`ALTER SYSTEM SET synchronous_commit = 'off';`,
+	}
+	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
+	if err != nil {
+		panic(err)
+	}
+	for _, query := range paramQueries {
+		if _, err := db.Exec(query); err != nil {
+			panic(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		panic(err)
+	}
+	// We restart the database to apply all the parameters.
+	if err := ep.Stop(); err != nil {
+		panic(err)
+	}
+	if err := ep.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -21,6 +21,7 @@ func main() {
 			Username("postgres").
 			Password("postgres").
 			Database("postgres").
+			Encoding("UTF8").
 			Port(uint32(5432)).
 			Logger(os.Stdout),
 	)
@@ -40,6 +41,7 @@ func main() {
 		`ALTER SYSTEM SET max_connections = '1000';`,
 		`ALTER SYSTEM SET shared_buffers = '1GB';`,
 		`ALTER SYSTEM SET synchronous_commit = 'off';`,
+		`ALTER SYSTEM SET client_encoding = 'UTF8';`,
 	}
 	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -43,6 +43,8 @@ func main() {
 	// seems to have a bug where it sends malformed parameters to
 	// pg_ctl. It encloses each parameter in single quotes, which
 	// Windows can't handle.
+	// Related issue:
+	// https://github.com/fergusstrange/embedded-postgres/issues/145
 	paramQueries := []string{
 		`ALTER SYSTEM SET effective_cache_size = '1GB';`,
 		`ALTER SYSTEM SET fsync = 'off';`,

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"database/sql"
+	"flag"
 	"os"
 	"path/filepath"
 
@@ -10,7 +11,15 @@ import (
 )
 
 func main() {
+	var customPath string
+	flag.StringVar(&customPath, "path", "", "Optional custom path for postgres data directory")
+	flag.Parse()
+
 	postgresPath := filepath.Join(os.TempDir(), "coder-test-postgres")
+	if customPath != "" {
+		postgresPath = customPath
+	}
+
 	ep := embeddedpostgres.NewDatabase(
 		embeddedpostgres.DefaultConfig().
 			Version(embeddedpostgres.V16).


### PR DESCRIPTION
This PR is the second in a series aimed at closing https://github.com/coder/coder/issues/15109.

## Changes

- adds `scripts/embedded-pg/main.go`, which can start a native Postgres database. This is used to set up PG on Windows and macOS, as these platforms don't support Docker in Github Actions.
- runs the `test-go-pg` job on macOS and Windows too
- adds the `test-go-race-go` job, which runs race tests with Postgres on Linux