### PR TITLE
fix: fix tailnet resume using incorrect DB reference

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -61,7 +61,6 @@ import (
 	"github.com/coder/serpent"
 	"github.com/coder/wgtunnel/tunnelsdk"
 
-	"github.com/coder/coder/v2/coderd/cryptokeys"
 	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/notifications/reports"
 	"github.com/coder/coder/v2/coderd/runtimeconfig"
@@ -753,25 +752,6 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			if err != nil {
 				return xerrors.Errorf("set deployment id: %w", err)
 			}
-
-			fetcher := &cryptokeys.DBFetcher{
-				DB: options.Database,
-			}
-
-			resumeKeycache, err := cryptokeys.NewSigningCache(ctx,
-				logger,
-				fetcher,
-				codersdk.CryptoKeyFeatureTailnetResume,
-			)
-			if err != nil {
-				logger.Critical(ctx, "failed to properly instantiate tailnet resume signing cache", slog.Error(err))
-			}
-
-			options.CoordinatorResumeTokenProvider = tailnet.NewResumeTokenKeyProvider(
-				resumeKeycache,
-				quartz.NewReal(),
-				tailnet.DefaultResumeTokenExpiry,
-			)
 
 			options.RuntimeConfig = runtimeconfig.NewManager()
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -467,7 +467,7 @@ func New(options *Options) *API {
 			codersdk.CryptoKeyFeatureOIDCConvert,
 		)
 		if err != nil {
-			options.Logger.Critical(ctx, "failed to properly instantiate oidc convert signing cache", slog.Error(err))
+			options.Logger.Fatal(ctx, "failed to properly instantiate oidc convert signing cache", slog.Error(err))
 		}
 	}
 
@@ -478,7 +478,7 @@ func New(options *Options) *API {
 			codersdk.CryptoKeyFeatureWorkspaceAppsToken,
 		)
 		if err != nil {
-			options.Logger.Critical(ctx, "failed to properly instantiate app signing key cache", slog.Error(err))
+			options.Logger.Fatal(ctx, "failed to properly instantiate app signing key cache", slog.Error(err))
 		}
 	}
 
@@ -489,8 +489,28 @@ func New(options *Options) *API {
 			codersdk.CryptoKeyFeatureWorkspaceAppsAPIKey,
 		)
 		if err != nil {
-			options.Logger.Critical(ctx, "failed to properly instantiate app encryption key cache", slog.Error(err))
+			options.Logger.Fatal(ctx, "failed to properly instantiate app encryption key cache", slog.Error(err))
 		}
+	}
+
+	if options.CoordinatorResumeTokenProvider == nil {
+		fetcher := &cryptokeys.DBFetcher{
+			DB: options.Database,
+		}
+
+		resumeKeycache, err := cryptokeys.NewSigningCache(ctx,
+			options.Logger,
+			fetcher,
+			codersdk.CryptoKeyFeatureTailnetResume,
+		)
+		if err != nil {
+			options.Logger.Fatal(ctx, "failed to properly instantiate tailnet resume signing cache", slog.Error(err))
+		}
+		options.CoordinatorResumeTokenProvider = tailnet.NewResumeTokenKeyProvider(
+			resumeKeycache,
+			options.Clock,
+			tailnet.DefaultResumeTokenExpiry,
+		)
 	}
 
 	updatesProvider := NewUpdatesProvider(options.Logger.Named("workspace_updates"), options.Pubsub, options.Database, options.Authorizer)


### PR DESCRIPTION
- We were instantiating a cryptokey cache with a vanilla reference to the database instead of one wrapped by dbcrypt.
- Fixes an issue where failing to instantiate unrelated keycaches does not fatally error out.