### PR TITLE
chore: implement generic function for codersdk request methods

### DIFF
--- a/codersdk/authorization.go
+++ b/codersdk/authorization.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 )
 
@@ -62,14 +61,10 @@ type AuthorizationObject struct {
 // AuthCheck allows the authenticated user to check if they have the given permissions
 // to a set of resources.
 func (c *Client) AuthCheck(ctx context.Context, req AuthorizationRequest) (AuthorizationResponse, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/v2/authcheck", req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return AuthorizationResponse{}, ReadBodyAsError(res)
-	}
-	var resp AuthorizationResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return makeSDKRequest[AuthorizationResponse](ctx, c, sdkRequestArgs{
+		Method:     http.MethodPost,
+		URL:        "/api/v2/authcheck",
+		Body:       req,
+		ExpectCode: http.StatusOK,
+	})
 }

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -265,22 +264,12 @@ func (c *Client) DeleteOrganization(ctx context.Context, orgID string) error {
 
 // ProvisionerDaemons returns provisioner daemons available.
 func (c *Client) ProvisionerDaemons(ctx context.Context) ([]ProvisionerDaemon, error) {
-	res, err := c.Request(ctx, http.MethodGet,
+	return makeSDKRequest[[]ProvisionerDaemon](ctx, c, sdkRequestArgs{
+		Method: http.MethodGet,
 		// TODO: the organization path parameter is currently ignored.
-		"/api/v2/organizations/default/provisionerdaemons",
-		nil,
-	)
-	if err != nil {
-		return nil, xerrors.Errorf("execute request: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, ReadBodyAsError(res)
-	}
-
-	var daemons []ProvisionerDaemon
-	return daemons, json.NewDecoder(res.Body).Decode(&daemons)
+		URL:        "/api/v2/organizations/default/provisionerdaemons",
+		ExpectCode: http.StatusOK,
+	})
 }
 
 func (c *Client) OrganizationProvisionerDaemons(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerDaemon, error) {

--- a/codersdk/request.go
+++ b/codersdk/request.go
@@ -1,0 +1,38 @@
+package codersdk
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type sdkRequestArgs struct {
+	Method     string
+	URL        string
+	Body       any
+	ReqOpts    []RequestOption
+	ExpectCode int
+}
+
+type noResponse struct{}
+
+func makeSDKRequest[T any](ctx context.Context, cli *Client, req sdkRequestArgs) (T, error) {
+	var empty T
+	res, err := cli.Request(ctx, req.Method, req.URL, req.Body, req.ReqOpts...)
+	if err != nil {
+		return empty, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != req.ExpectCode {
+		return empty, ReadBodyAsError(res)
+	}
+
+	switch (any)(empty).(type) {
+	case noResponse:
+		// noResponse means the caller does not care about the response body
+		return empty, nil
+	default:
+	}
+	var result T
+	return result, json.NewDecoder(res.Body).Decode(&result)
+}

--- a/codersdk/request.go
+++ b/codersdk/request.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 )
 
+// @typescript-ignore sdkRequestArgs
 type sdkRequestArgs struct {
 	Method     string
 	URL        string
@@ -13,6 +14,7 @@ type sdkRequestArgs struct {
 	ExpectCode int
 }
 
+// @typescript-ignore noResponse
 type noResponse struct{}
 
 func makeSDKRequest[T any](ctx context.Context, cli *Client, req sdkRequestArgs) (T, error) {


### PR DESCRIPTION
Currently we copy + paste and tweak. Makes sense to DRY and reuse a standard request function.

I will fix the rest over time if this is approved.