### PR TITLE
fix: ignore cancellation error in test

### DIFF
--- a/provisionersdk/agent_test.go
+++ b/provisionersdk/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -119,7 +120,9 @@ func TestAgentScript(t *testing.T) {
 
 		// Kill the command, wait for the command to yield.
 		err := cmd.Cancel()
-		if err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			t.Log("script has already finished execution")
+		} else if err != nil {
 			t.Fatalf("unable to cancel the command: %v, see logs:\n%s", err, output.String())
 		}
 		wg.Wait()


### PR DESCRIPTION
Fixes: https://github.com/coder/internal/issues/211

It seems that the script process can finish before the test runner tries to cancel it. We can ignore this fact as the test aims to check versions.