### PR TITLE
fix(agent): start rpty lifecycle after all reads/writes

### DIFF
--- a/agent/reconnectingpty/screen.go
+++ b/agent/reconnectingpty/screen.go
@@ -78,8 +78,6 @@ func newScreen(ctx context.Context, cmd *pty.Cmd, options *Options, logger slog.
 	}
 	rpty.id = hex.EncodeToString(buf)
 
-	go rpty.lifecycle(ctx, logger)
-
 	settings := []string{
 		// Disable the startup message that appears for five seconds.
 		"startup_message off",
@@ -123,6 +121,8 @@ func newScreen(ctx context.Context, cmd *pty.Cmd, options *Options, logger slog.
 		rpty.state.setState(StateDone, xerrors.Errorf("create config file: %w", err))
 		return rpty
 	}
+
+	go rpty.lifecycle(ctx, logger)
 
 	return rpty
 }


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/214

#15475 missed that we also write to `rpty` after starting `rpty.lifecycle()`.
This PR moves the function call right at the end. Hopefully this should address the data races before we go resorting to mutexes. 