### PR TITLE
fix(site): wait until port is available in e2e

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -1,8 +1,8 @@
 import { type ChildProcess, exec, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import net from "node:net";
 import path from "node:path";
 import { Duplex } from "node:stream";
-import net from "node:net";
 import { type BrowserContext, type Page, expect, test } from "@playwright/test";
 import { API } from "api/api";
 import type {
@@ -711,7 +711,7 @@ async function waitForPort(port: number, host = "0.0.0.0", timeout = 5000): Prom
 function isPortAvailable(port: number, host = "0.0.0.0"): Promise<boolean> {
 	return new Promise((resolve) => {
 		const probe = net.createServer()
-			.once('error', (err: any) => {
+			.once('error', (err: NodeJS.ErrnoException) => {
 				if (err.code === 'EADDRINUSE') {
 					resolve(false); // port is in use
 				} else {

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -699,7 +699,7 @@ export const createServer = async (
 async function waitForPort(
 	port: number,
 	host = "0.0.0.0",
-	timeout = 5000,
+	timeout = 30000,
 ): Promise<void> {
 	const start = Date.now();
 	while (Date.now() - start < timeout) {
@@ -707,7 +707,8 @@ async function waitForPort(
 		if (available) {
 			return;
 		}
-		await new Promise((resolve) => setTimeout(resolve, 100)); // Wait 1 second before retrying
+		console.warn(`${host}:${port} is in use, checking again in 1s`)
+		await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second before retrying
 	}
 	throw new Error(
 		`Timeout: port ${port} is still in use after ${timeout / 1000} seconds.`,

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -707,7 +707,7 @@ async function waitForPort(
 		if (available) {
 			return;
 		}
-		console.warn(`${host}:${port} is in use, checking again in 1s`)
+		console.warn(`${host}:${port} is in use, checking again in 1s`);
 		await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second before retrying
 	}
 	throw new Error(

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -696,7 +696,11 @@ export const createServer = async (
 	return e;
 };
 
-async function waitForPort(port: number, host = "0.0.0.0", timeout = 5000): Promise<void> {
+async function waitForPort(
+	port: number,
+	host = "0.0.0.0",
+	timeout = 5000,
+): Promise<void> {
 	const start = Date.now();
 	while (Date.now() - start < timeout) {
 		const available = await isPortAvailable(port, host);
@@ -705,20 +709,23 @@ async function waitForPort(port: number, host = "0.0.0.0", timeout = 5000): Prom
 		}
 		await new Promise((resolve) => setTimeout(resolve, 100)); // Wait 1 second before retrying
 	}
-	throw new Error(`Timeout: port ${port} is still in use after ${timeout / 1000} seconds.`);
+	throw new Error(
+		`Timeout: port ${port} is still in use after ${timeout / 1000} seconds.`,
+	);
 }
 
 function isPortAvailable(port: number, host = "0.0.0.0"): Promise<boolean> {
 	return new Promise((resolve) => {
-		const probe = net.createServer()
-			.once('error', (err: NodeJS.ErrnoException) => {
-				if (err.code === 'EADDRINUSE') {
+		const probe = net
+			.createServer()
+			.once("error", (err: NodeJS.ErrnoException) => {
+				if (err.code === "EADDRINUSE") {
 					resolve(false); // port is in use
 				} else {
 					resolve(false); // some other error occurred
 				}
 			})
-			.once('listening', () => {
+			.once("listening", () => {
 				probe.close();
 				resolve(true); // port is available
 			})


### PR DESCRIPTION
Related: https://github.com/coder/internal/issues/212

This PR modifies the logic responsible for creating a server in E2E tests to check if the port is free. Alternatively, we could refactor the framework to dynamically create server instances, but this solution might be a cheaper quick win.

Note:

I'll leave it as is now, it might be worth asking somebody with a frontend skillset to double-check this contribution.