### PR TITLE
chore: make scim auth header case insensitive for 'bearer'

### DIFF
--- a/enterprise/coderd/scim/scimtypes.go
+++ b/enterprise/coderd/scim/scimtypes.go
@@ -1,6 +1,11 @@
 package scim
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/imulab/go-scim/pkg/v2/spec"
+)
 
 type ServiceProviderConfig struct {
 	Schemas        []string               `json:"schemas"`
@@ -43,4 +48,38 @@ type AuthenticationScheme struct {
 	Description string `json:"description"`
 	SpecURI     string `json:"specUri"`
 	DocURI      string `json:"documentationUri"`
+}
+
+// HTTPError wraps a *spec.Error for correct usage with
+// 'handlerutil.WriteError'. This error type is cursed to be
+// absolutely strange and specific to the SCIM library we use.
+//
+// The library expects *spec.Error to be returned on unwrap, and the
+// internal error description to be returned by a json.Marshal of the
+// top level error.
+type HTTPError struct {
+	scim     *spec.Error
+	internal error
+}
+
+func NewHTTPError(status int, eType string, err error) *HTTPError {
+	return &HTTPError{
+		scim: &spec.Error{
+			Status: status,
+			Type:   eType,
+		},
+		internal: err,
+	}
+}
+
+func (e HTTPError) Error() string {
+	return e.internal.Error()
+}
+
+func (e HTTPError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.internal)
+}
+
+func (e HTTPError) Unwrap() error {
+	return e.scim
 }

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -597,10 +597,14 @@ func TestScimError(t *testing.T) {
 	// Demonstrates that we cannot use the standard errors
 	rw := httptest.NewRecorder()
 	_ = handlerutil.WriteError(rw, spec.ErrNotFound)
-	require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+	resp := rw.Result()
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 	// Our error wrapper works
 	rw = httptest.NewRecorder()
 	_ = handlerutil.WriteError(rw, scim.NewHTTPError(http.StatusNotFound, spec.ErrNotFound.Type, fmt.Errorf("not found")))
-	require.Equal(t, http.StatusNotFound, rw.Result().StatusCode)
+	resp = rw.Result()
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/imulab/go-scim/pkg/v2/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -603,7 +604,7 @@ func TestScimError(t *testing.T) {
 
 	// Our error wrapper works
 	rw = httptest.NewRecorder()
-	_ = handlerutil.WriteError(rw, scim.NewHTTPError(http.StatusNotFound, spec.ErrNotFound.Type, fmt.Errorf("not found")))
+	_ = handlerutil.WriteError(rw, scim.NewHTTPError(http.StatusNotFound, spec.ErrNotFound.Type, xerrors.New("not found")))
 	resp = rw.Result()
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)


### PR DESCRIPTION
Fixes status codes to return more than 500. The way we were using the package, it always returned a status code 500