### PR TITLE
fix: add error that provisionerkeys require the externalprovisioners feature

### DIFF
--- a/enterprise/cli/provisionerkeys_test.go
+++ b/enterprise/cli/provisionerkeys_test.go
@@ -26,7 +26,7 @@ func TestProvisionerKeys(t *testing.T) {
 		client, owner := coderdenttest.New(t, &coderdenttest.Options{
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{
-					codersdk.FeatureMultipleOrganizations: 1,
+					codersdk.FeatureExternalProvisionerDaemons: 1,
 				},
 			},
 		})

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -343,7 +343,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Use(
 				apiKeyMiddleware,
 				httpmw.ExtractOrganizationParam(api.Database),
-				api.RequireFeatureMW(codersdk.FeatureMultipleOrganizations),
+				api.RequireFeatureMW(codersdk.FeatureExternalProvisionerDaemons),
 			)
 			r.Get("/", api.provisionerKeys)
 			r.Post("/", api.postProvisionerKey)

--- a/enterprise/coderd/provisionerkeys_test.go
+++ b/enterprise/coderd/provisionerkeys_test.go
@@ -27,6 +27,7 @@ func TestProvisionerKeys(t *testing.T) {
 		LicenseOptions: &coderdenttest.LicenseOptions{
 			Features: license.Features{
 				codersdk.FeatureExternalProvisionerDaemons: 1,
+				codersdk.FeatureMultipleOrganizations:      1,
 			},
 		},
 	})

--- a/enterprise/coderd/provisionerkeys_test.go
+++ b/enterprise/coderd/provisionerkeys_test.go
@@ -26,7 +26,7 @@ func TestProvisionerKeys(t *testing.T) {
 		},
 		LicenseOptions: &coderdenttest.LicenseOptions{
 			Features: license.Features{
-				codersdk.FeatureMultipleOrganizations: 1,
+				codersdk.FeatureExternalProvisionerDaemons: 1,
 			},
 		},
 	})


### PR DESCRIPTION
it currently requires the multiple organizations feature, which doesn't make for a good error message. it's a bit misleading and confusing, and would be better gated by the external provisioners feature.

I'm not actually _adding_ an error, I'm changing an existing one, but our title bot refuses to let me name the pr accurately 🙃