### PR TITLE
feat(examples/templates/digitalocean-linux): add code-server and jetbrains gateway modules

### DIFF
--- a/examples/templates/digitalocean-linux/main.tf
+++ b/examples/templates/digitalocean-linux/main.tf
@@ -264,6 +264,38 @@ resource "coder_agent" "main" {
   }
 }
 
+# See https://registry.coder.com/modules/code-server
+module "code-server" {
+  count  = data.coder_workspace.me.start_count
+  source = "registry.coder.com/modules/code-server/coder"
+
+  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = ">= 1.0.0"
+
+  agent_id = coder_agent.main.id
+  order    = 1
+}
+
+# See https://registry.coder.com/modules/jetbrains-gateway
+module "jetbrains_gateway" {
+  count  = data.coder_workspace.me.start_count
+  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+
+  # JetBrains IDEs to make available for the user to select
+  jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
+  default        = "IU"
+
+  # Default folder to open when starting a JetBrains IDE
+  folder = "/home/coder"
+
+  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = ">= 1.0.0"
+
+  agent_id   = coder_agent.main.id
+  agent_name = "main"
+  order      = 2
+}
+
 resource "digitalocean_volume" "home_volume" {
   region                   = data.coder_parameter.region.value
   name                     = "coder-${data.coder_workspace.me.id}-home"


### PR DESCRIPTION
This PR adds the code-server and JetBrains Gateway modules.

- Testing
  - [x] Workspace gets provisioned
  - [x] code-server works as intended
  - [x] JetBrains gateway works as intended
