### PR TITLE
fix: fix listening flake on TestTailnet_ForcesWebSockets

### DIFF
--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -131,23 +131,28 @@ func TestTailnet(t *testing.T) {
 		stitch(t, w2, w1)
 		stitch(t, w1, w2)
 		require.True(t, w2.AwaitReachable(ctx, w1IP))
-		conn := make(chan struct{}, 1)
+		done := make(chan struct{})
+		listening := make(chan struct{})
 		go func() {
+			defer close(done)
 			listener, err := w1.Listen("tcp", ":35565")
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 			defer listener.Close()
+			close(listening)
 			nc, err := listener.Accept()
 			if !assert.NoError(t, err) {
 				return
 			}
 			_ = nc.Close()
-			conn <- struct{}{}
 		}()
 
+		testutil.RequireRecvCtx(ctx, t, listening)
 		nc, err := w2.DialContextTCP(ctx, netip.AddrPortFrom(w1IP, 35565))
 		require.NoError(t, err)
 		_ = nc.Close()
-		<-conn
+		testutil.RequireRecvCtx(ctx, t, done)
 
 		nodes := make(chan *tailnet.Node, 1)
 		w2.SetNodeCallback(func(node *tailnet.Node) {


### PR DESCRIPTION
Fixes a test flake on TestTailnet_ForcesWebsockets like:

```
    t.go:106: 2024-11-18 07:44:25.939 [debu]  w2: dial tcp  addr_port="[fd7a:115c:a1e0:46cc:bd8e:400d:1bc6:f6ac]:35565"
    t.go:106: 2024-11-18 07:44:25.943 [debu]  w1.net.netstack: netstack: could not connect to local server at 127.0.0.1:35565 (or [::1]:35565)%!(EXTRA *net.OpError=dial tcp [::1]:35565: connect: connection refused)
    conn_test.go:146:
        	Error Trace:	/Users/spike/repos/coder/tailnet/conn_test.go:146
        	Error:      	Received unexpected error:
        	            	connect tcp [fd7a:115c:a1e0:46cc:bd8e:400d:1bc6:f6ac]:35565: connection was refused
        	Test:       	TestTailnet/ForcesWebSockets
    t.go:106: 2024-11-18 07:44:25.945 [info]  w1: closing tailnet Conn
    t.go:106: 2024-11-18 07:44:25.945 [debu]  w1: closing configMaps configLoop
    t.go:106: 2024-11-18 07:44:25.945 [debu]  w1: closing nodeUpdater updateLoop
    t.go:106: 2024-11-18 07:44:25.945 [debu]  w1: closed netstack
    conn_test.go:135:
        	Error Trace:	/Users/spike/repos/coder/tailnet/conn_test.go:135
        	            				/Users/spike/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.darwin-arm64/src/runtime/asm_arm64.s:1222
        	Error:      	Received unexpected error:
        	            	connection closed:
        	            	    github.com/coder/coder/v2/tailnet.init
        	            	        <autogenerated>:1
        	Test:       	TestTailnet/ForcesWebSockets
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1039771dc]

goroutine 2224 [running]:
github.com/coder/coder/v2/tailnet_test.TestTailnet.func3.2()
	/Users/spike/repos/coder/tailnet/conn_test.go:136 +0x7c
created by github.com/coder/coder/v2/tailnet_test.TestTailnet.func3 in goroutine 109
	/Users/spike/repos/coder/tailnet/conn_test.go:133 +0x7dc
```

Test didn't synchronize listening on the port before dialing it. 

It also has a nil pointer deference when the test fails, which causes a bunch of unrelated output. Also fixed.