### PR TITLE
chore: include merged claims into the database

### DIFF
--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -214,6 +214,9 @@ func (p AgentIDNamePair) Value() (driver.Value, error) {
 type UserLinkClaims struct {
 	IDTokenClaims  map[string]interface{} `json:"id_token_claims"`
 	UserInfoClaims map[string]interface{} `json:"user_info_claims"`
+	// MergeClaims are computed in Golang. It is the result of merging
+	// the IDTokenClaims and UserInfoClaims. UserInfoClaims take precedence.
+	MergedClaims map[string]interface{} `json:"merged_claims"`
 }
 
 func (a *UserLinkClaims) Scan(src interface{}) error {

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1326,6 +1326,7 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		UserClaims: database.UserLinkClaims{
 			IDTokenClaims:  idtokenClaims,
 			UserInfoClaims: userInfoClaims,
+			MergedClaims:   mergedClaims,
 		},
 	}).SetInitAuditRequest(func(params *audit.RequestParams) (*audit.Request[database.User], func()) {
 		return audit.InitRequest[database.User](rw, params)

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -64,6 +64,16 @@ func TestUserLinks(t *testing.T) {
 					"number": float64(2),
 				},
 			},
+			MergedClaims: map[string]interface{}{
+				"sub": "123",
+				"groups": []interface{}{
+					"foo", "bar",
+				},
+				"number": float64(2),
+				"struct": map[string]interface{}{
+					"number": float64(2),
+				},
+			},
 		}
 
 		updated, err := crypt.UpdateUserLink(ctx, database.UpdateUserLinkParams{


### PR DESCRIPTION
Merging happens before IDP sync. Storing this will make some SQL queries much simplier.

Currently the SQL queries look like this:
https://github.com/coder/coder/blob/664e7344bf90fc632ce4412cb5c41e83d0f3972f/coderd/database/queries/user_links.sql#L65-L97

Query is duplicated over both fields with a union. This query is also incorrect, as merged claims do not properly merge arrays of duplicated fields.