### PR TITLE
feat!: extract provisioner tags from coder_workspace_tags data source

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -426,7 +426,7 @@ func createValidTemplateVersion(inv *serpent.Invocation, args createValidTemplat
 		cliui.Warnf(inv.Stderr, `No provisioners are available to handle the job!
 Please contact your deployment administrator for assistance.
 Details:
-	Provisioner Job ID : %s
+	Provisioner job ID : %s
 	Requested tags     : %s
 `, version.Job.ID, tagsJSON.String())
 	} else if version.MatchedProvisioners.Available == 0 {
@@ -434,9 +434,9 @@ Details:
 Your build will proceed once they become available.
 If this persists, please contact your deployment administrator for assistance.
 Details:
-	Provisioner Job ID : %s
+	Provisioner job ID : %s
 	Requested tags     : %s
-	Most Recently Seen : %s
+	Most recently seen : %s
 `, version.Job.ID, strings.TrimSpace(tagsJSON.String()), version.MatchedProvisioners.MostRecentlySeen.Time)
 	}
 

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -488,6 +488,8 @@ data "coder_workspace_tags" "tags" {
 
 			cancel()
 			<-done
+
+			require.Contains(t, stderr.String(), "No provisioners are available to handle the job!")
 		})
 
 		t.Run("ChangeTags", func(t *testing.T) {

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -442,10 +442,11 @@ func TestTemplatePush(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run `coder templates push`
-			// TODO: assert warning about no available provisioners in output.
-			// This is returned from the API.
 			templateName := strings.ReplaceAll(testutil.GetRandomName(t), "_", "-")
+			var stdout, stderr strings.Builder
 			inv, root := clitest.New(t, "templates", "push", templateName, "-d", tempDir, "--yes")
+			inv.Stdout = &stdout
+			inv.Stderr = &stderr
 			clitest.SetupConfig(t, templateAdmin, root)
 
 			// Don't forget to clean up!
@@ -471,6 +472,8 @@ func TestTemplatePush(t *testing.T) {
 
 			cancel()
 			<-done
+
+			require.Contains(t, stderr.String(), "No provisioners are available to handle the job!")
 		})
 
 		t.Run("ChangeTags", func(t *testing.T) {

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -16,9 +17,12 @@ import (
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisioner/terraform/tfparse"
+	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -405,6 +409,69 @@ func TestTemplatePush(t *testing.T) {
 
 	t.Run("ProvisionerTags", func(t *testing.T) {
 		t.Parallel()
+
+		t.Run("WorkspaceTagsTerraform", func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
+
+			// Start an instance **without** a built-in provisioner.
+			// We're not actually testing that the Terraform applies.
+			// What we test is that a provisioner job is created with the expected
+			// tags based on the __content__ of the Terraform.
+			store, ps := dbtestutil.NewDB(t)
+			client := coderdtest.New(t, &coderdtest.Options{
+				Database: store,
+				Pubsub:   ps,
+			})
+
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+			// Create a tar file with some pre-defined content
+			tarFile := testutil.CreateTar(t, map[string]string{
+				"main.tf": `data "coder_workspace_tags" "tags" {
+						tags = {
+						"foo": "bar"
+						}
+					}`,
+			})
+
+			// Write the tar file to disk.
+			tempDir := t.TempDir()
+			err := tfparse.WriteArchive(tarFile, "application/x-tar", tempDir)
+			require.NoError(t, err)
+
+			// Run `coder templates push`
+			// TODO: assert warning about no available provisioners in output.
+			// This is returned from the API.
+			templateName := strings.ReplaceAll(testutil.GetRandomName(t), "_", "-")
+			inv, root := clitest.New(t, "templates", "push", templateName, "-d", tempDir, "--yes")
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			// Don't forget to clean up!
+			cancelCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			done := make(chan error)
+			go func() {
+				done <- inv.WithContext(cancelCtx).Run()
+			}()
+
+			// Assert that a provisioner job was created with the desired tags.
+			wantTags := database.StringMap(provisionersdk.MutateTags(uuid.Nil, map[string]string{"foo": "bar"}))
+			require.Eventually(t, func() bool {
+				jobs, err := store.GetProvisionerJobsCreatedAfter(ctx, time.Time{})
+				if !assert.NoError(t, err) {
+					return false
+				}
+				if len(jobs) == 0 {
+					return false
+				}
+				return assert.EqualValues(t, wantTags, jobs[0].Tags)
+			}, testutil.WaitShort, testutil.IntervalSlow)
+
+			cancel()
+			<-done
+		})
 
 		t.Run("ChangeTags", func(t *testing.T) {
 			t.Parallel()

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13725,10 +13725,12 @@ const docTemplate = `{
         "codersdk.TemplateVersionWarning": {
             "type": "string",
             "enum": [
-                "UNSUPPORTED_WORKSPACES"
+                "UNSUPPORTED_WORKSPACES",
+                "NO_MATCHING_PROVISIONERS"
             ],
             "x-enum-varnames": [
-                "TemplateVersionWarningUnsupportedWorkspaces"
+                "TemplateVersionWarningUnsupportedWorkspaces",
+                "TemplateVersionWarningNoMatchingProvisioners"
             ]
         },
         "codersdk.TimingStage": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13721,12 +13721,10 @@ const docTemplate = `{
         "codersdk.TemplateVersionWarning": {
             "type": "string",
             "enum": [
-                "UNSUPPORTED_WORKSPACES",
-                "NO_MATCHING_PROVISIONERS"
+                "UNSUPPORTED_WORKSPACES"
             ],
             "x-enum-varnames": [
-                "TemplateVersionWarningUnsupportedWorkspaces",
-                "TemplateVersionWarningNoMatchingProvisioners"
+                "TemplateVersionWarningUnsupportedWorkspaces"
             ]
         },
         "codersdk.TimingStage": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11349,6 +11349,24 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.MatchedProvisioners": {
+            "type": "object",
+            "properties": {
+                "available": {
+                    "description": "Available is the number of provisioner daemons that are available to\ntake jobs. This may be less than the count if some provisioners are\nbusy or have been stopped.",
+                    "type": "integer"
+                },
+                "count": {
+                    "description": "Count is the number of provisioner daemons that matched the given\ntags. If the count is 0, it means no provisioner daemons matched the\nrequested tags.",
+                    "type": "integer"
+                },
+                "most_recently_seen": {
+                    "description": "MostRecentlySeen is the most recently seen time of the set of matched\nprovisioners. If no provisioners matched, this field will be null.",
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
         "codersdk.MinimalOrganization": {
             "type": "object",
             "required": [
@@ -13541,6 +13559,9 @@ const docTemplate = `{
                 },
                 "job": {
                     "$ref": "#/definitions/codersdk.ProvisionerJob"
+                },
+                "matched_provisioners": {
+                    "$ref": "#/definitions/codersdk.MatchedProvisioners"
                 },
                 "message": {
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12455,8 +12455,11 @@
 		},
 		"codersdk.TemplateVersionWarning": {
 			"type": "string",
-			"enum": ["UNSUPPORTED_WORKSPACES"],
-			"x-enum-varnames": ["TemplateVersionWarningUnsupportedWorkspaces"]
+			"enum": ["UNSUPPORTED_WORKSPACES", "NO_MATCHING_PROVISIONERS"],
+			"x-enum-varnames": [
+				"TemplateVersionWarningUnsupportedWorkspaces",
+				"TemplateVersionWarningNoMatchingProvisioners"
+			]
 		},
 		"codersdk.TimingStage": {
 			"type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12451,11 +12451,8 @@
 		},
 		"codersdk.TemplateVersionWarning": {
 			"type": "string",
-			"enum": ["UNSUPPORTED_WORKSPACES", "NO_MATCHING_PROVISIONERS"],
-			"x-enum-varnames": [
-				"TemplateVersionWarningUnsupportedWorkspaces",
-				"TemplateVersionWarningNoMatchingProvisioners"
-			]
+			"enum": ["UNSUPPORTED_WORKSPACES"],
+			"x-enum-varnames": ["TemplateVersionWarningUnsupportedWorkspaces"]
 		},
 		"codersdk.TimingStage": {
 			"type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10171,6 +10171,24 @@
 				}
 			}
 		},
+		"codersdk.MatchedProvisioners": {
+			"type": "object",
+			"properties": {
+				"available": {
+					"description": "Available is the number of provisioner daemons that are available to\ntake jobs. This may be less than the count if some provisioners are\nbusy or have been stopped.",
+					"type": "integer"
+				},
+				"count": {
+					"description": "Count is the number of provisioner daemons that matched the given\ntags. If the count is 0, it means no provisioner daemons matched the\nrequested tags.",
+					"type": "integer"
+				},
+				"most_recently_seen": {
+					"description": "MostRecentlySeen is the most recently seen time of the set of matched\nprovisioners. If no provisioners matched, this field will be null.",
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
 		"codersdk.MinimalOrganization": {
 			"type": "object",
 			"required": ["id"],
@@ -12286,6 +12304,9 @@
 				},
 				"job": {
 					"$ref": "#/definitions/codersdk.ProvisionerJob"
+				},
+				"matched_provisioners": {
+					"$ref": "#/definitions/codersdk.MatchedProvisioners"
 				},
 				"message": {
 					"type": "string"

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1343,9 +1343,6 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		}
 	}
 
-	// Ensures the "owner" is properly applied.
-	// tags := provisionersdk.MutateTags(apiKey.UserID, req.ProvisionerTags)
-
 	if req.ExampleID != "" && req.FileID != uuid.Nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "You cannot specify both an example_id and a file_id.",
@@ -1480,6 +1477,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		return
 	}
 
+	// Ensure the "owner" tag is properly applied in addition to request tags and coder_workspace_tags.
 	// Tag order precedence:
 	// 1) User-specified tags in the request
 	// 2) Tags parsed from coder_workspace_tags data source in template file

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1519,10 +1519,9 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 			WantTags:       tags,
 		}); err != nil {
 			api.Logger.Error(ctx, "failed to check eligible provisioner daemons for job", slog.Error(err))
-		}
-
-		// If there are no eligible provisioners at the time of insertion, add a warning.
-		if len(eligibleProvisioners) == 0 {
+		} else if len(eligibleProvisioners) == 0 {
+			// If there are no eligible provisioners at the time of insertion, add a warning.
+			// TODO(Cian): check provisioner last_seen?
 			api.Logger.Warn(ctx, "no matching provisioners found for job",
 				slog.F("user_id", apiKey.UserID),
 				slog.F("job_id", jobID),

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1483,9 +1483,6 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 	// Tag order precedence:
 	// 1) User-specified tags in the request
 	// 2) Tags sniffed automatically from template file
-	// OLD
-	// tags := provisionersdk.MutateTags(apiKey.UserID, req.ProvisionerTags)
-	// NEW
 	tags := provisionersdk.MutateTags(apiKey.UserID, req.ProvisionerTags, sniffedTags)
 
 	var templateVersion database.TemplateVersion

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1439,7 +1439,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		}
 	}
 
-	// Try to sniff template tags from the given file.
+	// Try to parse template tags from the given file.
 	tempDir, err := os.MkdirTemp("", "tfparse-*")
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -1471,7 +1471,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		return
 	}
 
-	sniffedTags, err := parser.WorkspaceTagDefaults(ctx)
+	parsedTags, err := parser.WorkspaceTagDefaults(ctx)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error checking workspace tags",
@@ -1482,8 +1482,9 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 
 	// Tag order precedence:
 	// 1) User-specified tags in the request
-	// 2) Tags sniffed automatically from template file
-	tags := provisionersdk.MutateTags(apiKey.UserID, req.ProvisionerTags, sniffedTags)
+	// 2) Tags parsed from coder_workspace_tags data source in template file
+	// 2 may clobber 1.
+	tags := provisionersdk.MutateTags(apiKey.UserID, req.ProvisionerTags, parsedTags)
 
 	var templateVersion database.TemplateVersion
 	var provisionerJob database.ProvisionerJob

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1522,6 +1522,12 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 
 		// If there are no eligible provisioners at the time of insertion, add a warning.
 		if len(eligibleProvisioners) == 0 {
+			api.Logger.Warn(ctx, "no matching provisioners found for job",
+				slog.F("user_id", apiKey.UserID),
+				slog.F("job_id", jobID),
+				slog.F("job_type", database.ProvisionerJobTypeTemplateVersionImport),
+				slog.F("tags", tags),
+			)
 			warnings = append(warnings, codersdk.TemplateVersionWarningNoMatchingProvisioners)
 		}
 

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1438,7 +1438,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 	}
 
 	// Try to parse template tags from the given file.
-	tempDir, err := os.MkdirTemp("", "tfparse-*")
+	tempDir, err := os.MkdirTemp(api.Options.CacheDir, "tfparse-*")
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error checking workspace tags",

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -254,15 +254,15 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 				name: "main.tf with no tags",
 				files: map[string]string{
 					`main.tf`: `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {}`,
+						variable "a" {
+							type = string
+							default = "1"
+						}
+						data "coder_parameter" "b" {
+							type = string
+							default = "2"
+						}
+						resource "null_resource" "test" {}`,
 				},
 				wantTags: map[string]string{"owner": "", "scope": "organization"},
 			},
@@ -270,18 +270,18 @@ resource "null_resource" "test" {}`,
 				name: "main.tf with empty workspace tags",
 				files: map[string]string{
 					`main.tf`: `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {}
-}`,
+					variable "a" {
+						type = string
+						default = "1"
+					}
+					data "coder_parameter" "b" {
+						type = string
+						default = "2"
+					}
+					resource "null_resource" "test" {}
+					data "coder_workspace_tags" "tags" {
+						tags = {}
+					}`,
 				},
 				wantTags: map[string]string{"owner": "", "scope": "organization"},
 			},
@@ -289,22 +289,22 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with workspace tags",
 				files: map[string]string{
 					`main.tf`: `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"foo": "bar",
-		"a": var.a,
-		"b": data.coder_parameter.b.value,
-	}
-}`,
+						variable "a" {
+							type = string
+							default = "1"
+						}
+						data "coder_parameter" "b" {
+							type = string
+							default = "2"
+						}
+						resource "null_resource" "test" {}
+						data "coder_workspace_tags" "tags" {
+							tags = {
+								"foo": "bar",
+								"a": var.a,
+								"b": data.coder_parameter.b.value,
+							}
+						}`,
 				},
 				wantTags: map[string]string{"owner": "", "scope": "organization", "foo": "bar", "a": "1", "b": "2"},
 			},
@@ -312,22 +312,22 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with workspace tags and request tags",
 				files: map[string]string{
 					`main.tf`: `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"foo": "bar",
-		"a": var.a,
-		"b": data.coder_parameter.b.value,
-	}
-}`,
+					variable "a" {
+						type = string
+						default = "1"
+					}
+					data "coder_parameter" "b" {
+						type = string
+						default = "2"
+					}
+					resource "null_resource" "test" {}
+					data "coder_workspace_tags" "tags" {
+						tags = {
+							"foo": "bar",
+							"a": var.a,
+							"b": data.coder_parameter.b.value,
+						}
+					}`,
 				},
 				reqTags:  map[string]string{"baz": "zap", "foo": "noclobber"},
 				wantTags: map[string]string{"owner": "", "scope": "organization", "foo": "bar", "baz": "zap", "a": "1", "b": "2"},
@@ -336,25 +336,25 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with disallowed workspace tag value",
 				files: map[string]string{
 					`main.tf`: `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {
-	name = "foo"
-}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"foo": "bar",
-		"a": var.a,
-		"b": data.coder_parameter.b.value,
-		"test": null_resource.test.name,
-	}
-}`,
+						variable "a" {
+							type = string
+							default = "1"
+						}
+						data "coder_parameter" "b" {
+							type = string
+							default = "2"
+						}
+						resource "null_resource" "test" {
+							name = "foo"
+						}
+						data "coder_workspace_tags" "tags" {
+							tags = {
+								"foo": "bar",
+								"a": var.a,
+								"b": data.coder_parameter.b.value,
+								"test": null_resource.test.name,
+							}
+						}`,
 				},
 				expectError: `Unknown variable; There is no variable named "null_resource".`,
 			},
@@ -362,25 +362,25 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with disallowed function in tag value",
 				files: map[string]string{
 					`main.tf`: `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {
-	name = "foo"
-}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"foo": "bar",
-		"a": var.a,
-		"b": data.coder_parameter.b.value,
-		"test": try(null_resource.test.name, "whatever"),
-	}
-}`,
+						variable "a" {
+							type = string
+							default = "1"
+						}
+						data "coder_parameter" "b" {
+							type = string
+							default = "2"
+						}
+						resource "null_resource" "test" {
+							name = "foo"
+						}
+						data "coder_workspace_tags" "tags" {
+							tags = {
+								"foo": "bar",
+								"a": var.a,
+								"b": data.coder_parameter.b.value,
+								"test": try(null_resource.test.name, "whatever"),
+							}
+						}`,
 				},
 				expectError: `Function calls not allowed; Functions may not be called here.`,
 			},
@@ -392,13 +392,13 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with workspace tags that attempts to set user scope",
 				files: map[string]string{
 					`main.tf`: `
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"scope": "user",
-		"owner": "12345678-1234-1234-1234-1234567890ab",
-	}
-}`,
+						resource "null_resource" "test" {}
+						data "coder_workspace_tags" "tags" {
+							tags = {
+								"scope": "user",
+								"owner": "12345678-1234-1234-1234-1234567890ab",
+							}
+						}`,
 				},
 				wantTags: map[string]string{"owner": templateAdminUser.ID.String(), "scope": "user"},
 			},
@@ -406,13 +406,13 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with workspace tags that attempt to clobber org ID",
 				files: map[string]string{
 					`main.tf`: `
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"scope": "organization",
-		"owner": "12345678-1234-1234-1234-1234567890ab",
-	}
-}`,
+						resource "null_resource" "test" {}
+						data "coder_workspace_tags" "tags" {
+							tags = {
+								"scope": "organization",
+								"owner": "12345678-1234-1234-1234-1234567890ab",
+							}
+						}`,
 				},
 				wantTags: map[string]string{"owner": "", "scope": "organization"},
 			},
@@ -420,12 +420,12 @@ data "coder_workspace_tags" "tags" {
 				name: "main.tf with workspace tags that set scope=user",
 				files: map[string]string{
 					`main.tf`: `
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"scope": "user",
-	}
-}`,
+						resource "null_resource" "test" {}
+						data "coder_workspace_tags" "tags" {
+							tags = {
+								"scope": "user",
+							}
+						}`,
 				},
 				wantTags: map[string]string{"owner": templateAdminUser.ID.String(), "scope": "user"},
 			},

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -226,7 +226,7 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 	t.Run("WorkspaceTags", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testutil.Context(t, testutil.WaitShort)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		store, ps := dbtestutil.NewDB(t)
 		client := coderdtest.New(t, &coderdtest.Options{
 			Database: store,

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -461,6 +461,11 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 				} else {
 					require.ErrorContains(t, err, tt.expectError)
 				}
+
+				// Also assert that we get the expected information back from the API endpoint
+				require.Zero(t, tv.MatchedProvisioners.Count)
+				require.Zero(t, tv.MatchedProvisioners.Available)
+				require.Zero(t, tv.MatchedProvisioners.MostRecentlySeen.Time)
 			})
 		}
 	})

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -231,7 +231,6 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 		// TODO(Cian): I'd also like to assert that the correct raw tag values are stored in the database,
 		//             but in order to do this, we need to actually run the job! This isn't straightforward right now.
 
-		ctx := testutil.Context(t, testutil.WaitLong)
 		store, ps := dbtestutil.NewDB(t)
 		client := coderdtest.New(t, &coderdtest.Options{
 			Database: store,
@@ -434,6 +433,8 @@ data "coder_workspace_tags" "tags" {
 			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitShort)
+
 				// Create an archive from the files provided in the test case.
 				tarFile := testutil.CreateTar(t, tt.files)
 
@@ -453,7 +454,6 @@ data "coder_workspace_tags" "tags" {
 
 				if tt.expectError == "" {
 					require.NoError(t, err)
-
 					// Assert the expected provisioner job is created from the template version import
 					pj, err := store.GetProvisionerJobByID(ctx, tv.Job.ID)
 					require.NoError(t, err)
@@ -461,7 +461,6 @@ data "coder_workspace_tags" "tags" {
 				} else {
 					require.ErrorContains(t, err, tt.expectError)
 				}
-
 			})
 		}
 	})

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -51,6 +51,22 @@ type ProvisionerDaemon struct {
 	Tags           map[string]string `json:"tags"`
 }
 
+// MatchedProvisioners represents the number of provisioner daemons
+// available to take a job at a specific point in time.
+type MatchedProvisioners struct {
+	// Count is the number of provisioner daemons that matched the given
+	// tags. If the count is 0, it means no provisioner daemons matched the
+	// requested tags.
+	Count int `json:"count"`
+	// Available is the number of provisioner daemons that are available to
+	// take jobs. This may be less than the count if some provisioners are
+	// busy or have been stopped.
+	Available int `json:"available"`
+	// MostRecentlySeen is the most recently seen time of the set of matched
+	// provisioners. If no provisioners matched, this field will be null.
+	MostRecentlySeen NullTime `json:"most_recently_seen,omitempty" format:"date-time"`
+}
+
 // ProvisionerJobStatus represents the at-time state of a job.
 type ProvisionerJobStatus string
 

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -31,7 +31,8 @@ type TemplateVersion struct {
 	CreatedBy      MinimalUser    `json:"created_by"`
 	Archived       bool           `json:"archived"`
 
-	Warnings []TemplateVersionWarning `json:"warnings,omitempty" enums:"DEPRECATED_PARAMETERS"`
+	Warnings            []TemplateVersionWarning `json:"warnings,omitempty" enums:"DEPRECATED_PARAMETERS"`
+	MatchedProvisioners MatchedProvisioners      `json:"matched_provisioners,omitempty"`
 }
 
 type TemplateVersionExternalAuth struct {

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -14,7 +14,8 @@ import (
 type TemplateVersionWarning string
 
 const (
-	TemplateVersionWarningUnsupportedWorkspaces TemplateVersionWarning = "UNSUPPORTED_WORKSPACES"
+	TemplateVersionWarningUnsupportedWorkspaces  TemplateVersionWarning = "UNSUPPORTED_WORKSPACES"
+	TemplateVersionWarningNoMatchingProvisioners TemplateVersionWarning = "NO_MATCHING_PROVISIONERS"
 )
 
 // TemplateVersion represents a single version of a template.

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -14,8 +14,7 @@ import (
 type TemplateVersionWarning string
 
 const (
-	TemplateVersionWarningUnsupportedWorkspaces  TemplateVersionWarning = "UNSUPPORTED_WORKSPACES"
-	TemplateVersionWarningNoMatchingProvisioners TemplateVersionWarning = "NO_MATCHING_PROVISIONERS"
+	TemplateVersionWarningUnsupportedWorkspaces TemplateVersionWarning = "UNSUPPORTED_WORKSPACES"
 )
 
 // TemplateVersion represents a single version of a template.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5749,10 +5749,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value                      |
-| -------------------------- |
-| `UNSUPPORTED_WORKSPACES`   |
-| `NO_MATCHING_PROVISIONERS` |
+| Value                    |
+| ------------------------ |
+| `UNSUPPORTED_WORKSPACES` |
 
 ## codersdk.TimingStage
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5761,9 +5761,10 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value                    |
-| ------------------------ |
-| `UNSUPPORTED_WORKSPACES` |
+| Value                      |
+| -------------------------- |
+| `UNSUPPORTED_WORKSPACES`   |
+| `NO_MATCHING_PROVISIONERS` |
 
 ## codersdk.TimingStage
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3296,6 +3296,24 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | --------------- | ------ | -------- | ------------ | ----------- |
 | `session_token` | string | true     |              |             |
 
+## codersdk.MatchedProvisioners
+
+```json
+{
+	"available": 0,
+	"count": 0,
+	"most_recently_seen": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name                 | Type    | Required | Restrictions | Description                                                                                                                                                         |
+| -------------------- | ------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `available`          | integer | false    |              | Available is the number of provisioner daemons that are available to take jobs. This may be less than the count if some provisioners are busy or have been stopped. |
+| `count`              | integer | false    |              | Count is the number of provisioner daemons that matched the given tags. If the count is 0, it means no provisioner daemons matched the requested tags.              |
+| `most_recently_seen` | string  | false    |              | Most recently seen is the most recently seen time of the set of matched provisioners. If no provisioners matched, this field will be null.                          |
+
 ## codersdk.MinimalOrganization
 
 ```json
@@ -5570,6 +5588,11 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 		},
 		"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
 	},
+	"matched_provisioners": {
+		"available": 0,
+		"count": 0,
+		"most_recently_seen": "2019-08-24T14:15:22Z"
+	},
 	"message": "string",
 	"name": "string",
 	"organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
@@ -5582,20 +5605,21 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ### Properties
 
-| Name              | Type                                                                        | Required | Restrictions | Description |
-| ----------------- | --------------------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `archived`        | boolean                                                                     | false    |              |             |
-| `created_at`      | string                                                                      | false    |              |             |
-| `created_by`      | [codersdk.MinimalUser](#codersdkminimaluser)                                | false    |              |             |
-| `id`              | string                                                                      | false    |              |             |
-| `job`             | [codersdk.ProvisionerJob](#codersdkprovisionerjob)                          | false    |              |             |
-| `message`         | string                                                                      | false    |              |             |
-| `name`            | string                                                                      | false    |              |             |
-| `organization_id` | string                                                                      | false    |              |             |
-| `readme`          | string                                                                      | false    |              |             |
-| `template_id`     | string                                                                      | false    |              |             |
-| `updated_at`      | string                                                                      | false    |              |             |
-| `warnings`        | array of [codersdk.TemplateVersionWarning](#codersdktemplateversionwarning) | false    |              |             |
+| Name                   | Type                                                                        | Required | Restrictions | Description |
+| ---------------------- | --------------------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `archived`             | boolean                                                                     | false    |              |             |
+| `created_at`           | string                                                                      | false    |              |             |
+| `created_by`           | [codersdk.MinimalUser](#codersdkminimaluser)                                | false    |              |             |
+| `id`                   | string                                                                      | false    |              |             |
+| `job`                  | [codersdk.ProvisionerJob](#codersdkprovisionerjob)                          | false    |              |             |
+| `matched_provisioners` | [codersdk.MatchedProvisioners](#codersdkmatchedprovisioners)                | false    |              |             |
+| `message`              | string                                                                      | false    |              |             |
+| `name`                 | string                                                                      | false    |              |             |
+| `organization_id`      | string                                                                      | false    |              |             |
+| `readme`               | string                                                                      | false    |              |             |
+| `template_id`          | string                                                                      | false    |              |             |
+| `updated_at`           | string                                                                      | false    |              |             |
+| `warnings`             | array of [codersdk.TemplateVersionWarning](#codersdktemplateversionwarning) | false    |              |             |
 
 ## codersdk.TemplateVersionExternalAuth
 

--- a/docs/reference/api/templates.md
+++ b/docs/reference/api/templates.md
@@ -446,6 +446,11 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
 		},
 		"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
 	},
+	"matched_provisioners": {
+		"available": 0,
+		"count": 0,
+		"most_recently_seen": "2019-08-24T14:15:22Z"
+	},
 	"message": "string",
 	"name": "string",
 	"organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
@@ -516,6 +521,11 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
 			"property2": "string"
 		},
 		"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
+	},
+	"matched_provisioners": {
+		"available": 0,
+		"count": 0,
+		"most_recently_seen": "2019-08-24T14:15:22Z"
 	},
 	"message": "string",
 	"name": "string",
@@ -611,6 +621,11 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/templa
 			"property2": "string"
 		},
 		"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
+	},
+	"matched_provisioners": {
+		"available": 0,
+		"count": 0,
+		"most_recently_seen": "2019-08-24T14:15:22Z"
 	},
 	"message": "string",
 	"name": "string",
@@ -1121,6 +1136,11 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions \
 			},
 			"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
 		},
+		"matched_provisioners": {
+			"available": 0,
+			"count": 0,
+			"most_recently_seen": "2019-08-24T14:15:22Z"
+		},
 		"message": "string",
 		"name": "string",
 		"organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
@@ -1142,38 +1162,42 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions \
 
 Status Code **200**
 
-| Name                 | Type                                                                     | Required | Restrictions | Description |
-| -------------------- | ------------------------------------------------------------------------ | -------- | ------------ | ----------- |
-| `[array item]`       | array                                                                    | false    |              |             |
-| `» archived`         | boolean                                                                  | false    |              |             |
-| `» created_at`       | string(date-time)                                                        | false    |              |             |
-| `» created_by`       | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |             |
-| `»» avatar_url`      | string(uri)                                                              | false    |              |             |
-| `»» id`              | string(uuid)                                                             | true     |              |             |
-| `»» username`        | string                                                                   | true     |              |             |
-| `» id`               | string(uuid)                                                             | false    |              |             |
-| `» job`              | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |             |
-| `»» canceled_at`     | string(date-time)                                                        | false    |              |             |
-| `»» completed_at`    | string(date-time)                                                        | false    |              |             |
-| `»» created_at`      | string(date-time)                                                        | false    |              |             |
-| `»» error`           | string                                                                   | false    |              |             |
-| `»» error_code`      | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |             |
-| `»» file_id`         | string(uuid)                                                             | false    |              |             |
-| `»» id`              | string(uuid)                                                             | false    |              |             |
-| `»» queue_position`  | integer                                                                  | false    |              |             |
-| `»» queue_size`      | integer                                                                  | false    |              |             |
-| `»» started_at`      | string(date-time)                                                        | false    |              |             |
-| `»» status`          | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |             |
-| `»» tags`            | object                                                                   | false    |              |             |
-| `»»» [any property]` | string                                                                   | false    |              |             |
-| `»» worker_id`       | string(uuid)                                                             | false    |              |             |
-| `» message`          | string                                                                   | false    |              |             |
-| `» name`             | string                                                                   | false    |              |             |
-| `» organization_id`  | string(uuid)                                                             | false    |              |             |
-| `» readme`           | string                                                                   | false    |              |             |
-| `» template_id`      | string(uuid)                                                             | false    |              |             |
-| `» updated_at`       | string(date-time)                                                        | false    |              |             |
-| `» warnings`         | array                                                                    | false    |              |             |
+| Name                     | Type                                                                     | Required | Restrictions | Description                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------ | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `[array item]`           | array                                                                    | false    |              |                                                                                                                                                                     |
+| `» archived`             | boolean                                                                  | false    |              |                                                                                                                                                                     |
+| `» created_at`           | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `» created_by`           | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |                                                                                                                                                                     |
+| `»» avatar_url`          | string(uri)                                                              | false    |              |                                                                                                                                                                     |
+| `»» id`                  | string(uuid)                                                             | true     |              |                                                                                                                                                                     |
+| `»» username`            | string                                                                   | true     |              |                                                                                                                                                                     |
+| `» id`                   | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» job`                  | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |                                                                                                                                                                     |
+| `»» canceled_at`         | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» completed_at`        | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» created_at`          | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» error`               | string                                                                   | false    |              |                                                                                                                                                                     |
+| `»» error_code`          | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |                                                                                                                                                                     |
+| `»» file_id`             | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `»» id`                  | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `»» queue_position`      | integer                                                                  | false    |              |                                                                                                                                                                     |
+| `»» queue_size`          | integer                                                                  | false    |              |                                                                                                                                                                     |
+| `»» started_at`          | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» status`              | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |                                                                                                                                                                     |
+| `»» tags`                | object                                                                   | false    |              |                                                                                                                                                                     |
+| `»»» [any property]`     | string                                                                   | false    |              |                                                                                                                                                                     |
+| `»» worker_id`           | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» matched_provisioners` | [codersdk.MatchedProvisioners](schemas.md#codersdkmatchedprovisioners)   | false    |              |                                                                                                                                                                     |
+| `»» available`           | integer                                                                  | false    |              | Available is the number of provisioner daemons that are available to take jobs. This may be less than the count if some provisioners are busy or have been stopped. |
+| `»» count`               | integer                                                                  | false    |              | Count is the number of provisioner daemons that matched the given tags. If the count is 0, it means no provisioner daemons matched the requested tags.              |
+| `»» most_recently_seen`  | string(date-time)                                                        | false    |              | Most recently seen is the most recently seen time of the set of matched provisioners. If no provisioners matched, this field will be null.                          |
+| `» message`              | string                                                                   | false    |              |                                                                                                                                                                     |
+| `» name`                 | string                                                                   | false    |              |                                                                                                                                                                     |
+| `» organization_id`      | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» readme`               | string                                                                   | false    |              |                                                                                                                                                                     |
+| `» template_id`          | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» updated_at`           | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `» warnings`             | array                                                                    | false    |              |                                                                                                                                                                     |
 
 #### Enumerated Values
 
@@ -1350,6 +1374,11 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions/{templ
 			},
 			"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
 		},
+		"matched_provisioners": {
+			"available": 0,
+			"count": 0,
+			"most_recently_seen": "2019-08-24T14:15:22Z"
+		},
 		"message": "string",
 		"name": "string",
 		"organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
@@ -1371,38 +1400,42 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions/{templ
 
 Status Code **200**
 
-| Name                 | Type                                                                     | Required | Restrictions | Description |
-| -------------------- | ------------------------------------------------------------------------ | -------- | ------------ | ----------- |
-| `[array item]`       | array                                                                    | false    |              |             |
-| `» archived`         | boolean                                                                  | false    |              |             |
-| `» created_at`       | string(date-time)                                                        | false    |              |             |
-| `» created_by`       | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |             |
-| `»» avatar_url`      | string(uri)                                                              | false    |              |             |
-| `»» id`              | string(uuid)                                                             | true     |              |             |
-| `»» username`        | string                                                                   | true     |              |             |
-| `» id`               | string(uuid)                                                             | false    |              |             |
-| `» job`              | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |             |
-| `»» canceled_at`     | string(date-time)                                                        | false    |              |             |
-| `»» completed_at`    | string(date-time)                                                        | false    |              |             |
-| `»» created_at`      | string(date-time)                                                        | false    |              |             |
-| `»» error`           | string                                                                   | false    |              |             |
-| `»» error_code`      | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |             |
-| `»» file_id`         | string(uuid)                                                             | false    |              |             |
-| `»» id`              | string(uuid)                                                             | false    |              |             |
-| `»» queue_position`  | integer                                                                  | false    |              |             |
-| `»» queue_size`      | integer                                                                  | false    |              |             |
-| `»» started_at`      | string(date-time)                                                        | false    |              |             |
-| `»» status`          | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |             |
-| `»» tags`            | object                                                                   | false    |              |             |
-| `»»» [any property]` | string                                                                   | false    |              |             |
-| `»» worker_id`       | string(uuid)                                                             | false    |              |             |
-| `» message`          | string                                                                   | false    |              |             |
-| `» name`             | string                                                                   | false    |              |             |
-| `» organization_id`  | string(uuid)                                                             | false    |              |             |
-| `» readme`           | string                                                                   | false    |              |             |
-| `» template_id`      | string(uuid)                                                             | false    |              |             |
-| `» updated_at`       | string(date-time)                                                        | false    |              |             |
-| `» warnings`         | array                                                                    | false    |              |             |
+| Name                     | Type                                                                     | Required | Restrictions | Description                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------ | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `[array item]`           | array                                                                    | false    |              |                                                                                                                                                                     |
+| `» archived`             | boolean                                                                  | false    |              |                                                                                                                                                                     |
+| `» created_at`           | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `» created_by`           | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |                                                                                                                                                                     |
+| `»» avatar_url`          | string(uri)                                                              | false    |              |                                                                                                                                                                     |
+| `»» id`                  | string(uuid)                                                             | true     |              |                                                                                                                                                                     |
+| `»» username`            | string                                                                   | true     |              |                                                                                                                                                                     |
+| `» id`                   | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» job`                  | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |                                                                                                                                                                     |
+| `»» canceled_at`         | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» completed_at`        | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» created_at`          | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» error`               | string                                                                   | false    |              |                                                                                                                                                                     |
+| `»» error_code`          | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |                                                                                                                                                                     |
+| `»» file_id`             | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `»» id`                  | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `»» queue_position`      | integer                                                                  | false    |              |                                                                                                                                                                     |
+| `»» queue_size`          | integer                                                                  | false    |              |                                                                                                                                                                     |
+| `»» started_at`          | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `»» status`              | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |                                                                                                                                                                     |
+| `»» tags`                | object                                                                   | false    |              |                                                                                                                                                                     |
+| `»»» [any property]`     | string                                                                   | false    |              |                                                                                                                                                                     |
+| `»» worker_id`           | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» matched_provisioners` | [codersdk.MatchedProvisioners](schemas.md#codersdkmatchedprovisioners)   | false    |              |                                                                                                                                                                     |
+| `»» available`           | integer                                                                  | false    |              | Available is the number of provisioner daemons that are available to take jobs. This may be less than the count if some provisioners are busy or have been stopped. |
+| `»» count`               | integer                                                                  | false    |              | Count is the number of provisioner daemons that matched the given tags. If the count is 0, it means no provisioner daemons matched the requested tags.              |
+| `»» most_recently_seen`  | string(date-time)                                                        | false    |              | Most recently seen is the most recently seen time of the set of matched provisioners. If no provisioners matched, this field will be null.                          |
+| `» message`              | string                                                                   | false    |              |                                                                                                                                                                     |
+| `» name`                 | string                                                                   | false    |              |                                                                                                                                                                     |
+| `» organization_id`      | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» readme`               | string                                                                   | false    |              |                                                                                                                                                                     |
+| `» template_id`          | string(uuid)                                                             | false    |              |                                                                                                                                                                     |
+| `» updated_at`           | string(date-time)                                                        | false    |              |                                                                                                                                                                     |
+| `» warnings`             | array                                                                    | false    |              |                                                                                                                                                                     |
 
 #### Enumerated Values
 
@@ -1468,6 +1501,11 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion} \
 			"property2": "string"
 		},
 		"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
+	},
+	"matched_provisioners": {
+		"available": 0,
+		"count": 0,
+		"most_recently_seen": "2019-08-24T14:15:22Z"
 	},
 	"message": "string",
 	"name": "string",
@@ -1548,6 +1586,11 @@ curl -X PATCH http://coder-server:8080/api/v2/templateversions/{templateversion}
 			"property2": "string"
 		},
 		"worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b"
+	},
+	"matched_provisioners": {
+		"available": 0,
+		"count": 0,
+		"most_recently_seen": "2019-08-24T14:15:22Z"
 	},
 	"message": "string",
 	"name": "string",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -758,6 +758,13 @@ export interface LoginWithPasswordResponse {
 	readonly session_token: string;
 }
 
+// From codersdk/provisionerdaemons.go
+export interface MatchedProvisioners {
+	readonly count: number;
+	readonly available: number;
+	readonly most_recently_seen?: string;
+}
+
 // From codersdk/organizations.go
 export interface MinimalOrganization {
 	readonly id: string;
@@ -1463,6 +1470,7 @@ export interface TemplateVersion {
 	readonly created_by: MinimalUser;
 	readonly archived: boolean;
 	readonly warnings?: Readonly<Array<TemplateVersionWarning>>;
+	readonly matched_provisioners?: MatchedProvisioners;
 }
 
 // From codersdk/templateversions.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2253,8 +2253,8 @@ export type TemplateRole = "" | "admin" | "use"
 export const TemplateRoles: TemplateRole[] = ["", "admin", "use"]
 
 // From codersdk/templateversions.go
-export type TemplateVersionWarning = "NO_MATCHING_PROVISIONERS" | "UNSUPPORTED_WORKSPACES"
-export const TemplateVersionWarnings: TemplateVersionWarning[] = ["NO_MATCHING_PROVISIONERS", "UNSUPPORTED_WORKSPACES"]
+export type TemplateVersionWarning = "UNSUPPORTED_WORKSPACES"
+export const TemplateVersionWarnings: TemplateVersionWarning[] = ["UNSUPPORTED_WORKSPACES"]
 
 // From codersdk/workspacebuilds.go
 export type TimingStage = "apply" | "connect" | "cron" | "graph" | "init" | "plan" | "start" | "stop"

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2253,8 +2253,8 @@ export type TemplateRole = "" | "admin" | "use"
 export const TemplateRoles: TemplateRole[] = ["", "admin", "use"]
 
 // From codersdk/templateversions.go
-export type TemplateVersionWarning = "UNSUPPORTED_WORKSPACES"
-export const TemplateVersionWarnings: TemplateVersionWarning[] = ["UNSUPPORTED_WORKSPACES"]
+export type TemplateVersionWarning = "NO_MATCHING_PROVISIONERS" | "UNSUPPORTED_WORKSPACES"
+export const TemplateVersionWarnings: TemplateVersionWarning[] = ["NO_MATCHING_PROVISIONERS", "UNSUPPORTED_WORKSPACES"]
 
 // From codersdk/workspacebuilds.go
 export type TimingStage = "apply" | "connect" | "cron" | "graph" | "init" | "plan" | "start" | "stop"


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/15087 and https://github.com/coder/coder/issues/15427

- Extracts provisioner job tags from `coder_workspace_tags` on template version creation using `provisioner/terraform/tfparse` added in https://github.com/coder/coder/pull/15236
- Drops a WARN log in coderd if no matching provisioners found.
- Also drops a warning message in the CLI if no provisioners are found.
- To support both CLI and UI warnings, added a `codersdk.MatchedProvisioners` struct to the `TemplateVersion` response containing details of how many provisioners were around at the time of the insert.

NOTE: As this effectively blocks template creation if `coder_workspace_tags` is malformed or references anything other than a Terraform variable or `coder_parameter`, I am marking this as a breaking change.

Testing notes:
- I elected to forego standing up a Terraform provisioner in `coderdtest` in favour of just creating the template version and asserting that a provisioner job was created with the expected tags.

Checklist:

- [x] API updates: extract tags from uploaded file_id, apply tags to provisioner job
- [x] CLI updates: show warning if no provisioners available upon template version creation

Manual testing performed:
- `./develop.sh -- --provisioner-daemons=0` with a separate `./scripts/coder-dev.sh --key=foobar` where foobar.keys = `{"foo": "bar"}`
- Edited sample docker template with following:
```
data coder_parameter "foo" {
  name = "foo"
  type = "string"
  default = "bar"
}
data coder_workspace_tags "tags" {
  tags = {
    "foo": data.coder_parameter.foo.value
  }
}
```
- Ran `coder template push` and observed the job get picked up
- Checked in local database and observed the correct row in `template_version_workspace_tags`:
```
coder=# select * from template_version_workspace_tags where template_version_id = 'e2406123-a492-4bc3-a41a-811aba7536c2';
         template_version_id          | key |             value              
--------------------------------------+-----+--------------------------------
 e2406123-a492-4bc3-a41a-811aba7536c2 | foo | data.coder_parameter.foo.value
```
- Ran `coder create` and observed the job getting picked up correctly.

- Failure case: `coder templates push <template>` with no workspace tags available:
```
> Upload "examples/templates/docker"? (yes/no) yes
WARN: No provisioners are available to handle the job!
Please contact your deployment administrator for assistance.
Details:
        Provisioner Job ID : e0808861-62e0-40e9-b45b-817d8fede28e
        Requested tags     : {"foo":"baz","owner":"","scope":"organization"}


==> ⧗ Queued (next)
```

- Failure case: create template but provisioners have not been around for a while:
```
WARN: All available provisioner daemons have been silent for a while.
Your build will proceed once they become available.
If this persists, please contact your deployment administrator for assistance.
Details:
        Provisioner Job ID : e8b5abee-b325-40b5-8571-3f6c486445f7
        Requested tags     : {"foo":"bar","owner":"","scope":"organization"}
        Most Recently Seen : 2024-11-22 17:29:00.862597 +0000 UTC
```

Remaining work:
- [ ] Currently the interactive template editor UI does not handle any case where POST `/api/v2/organizations/:org/templateversions` returns an error. This will need to be addressed in a follow-up PR.
- [ ] Update documentation -- will be addressed in a separate PR.
- [ ] UI updates: show warning if no provisioners available upon template version creation (should be handled by https://github.com/coder/coder/issues/15048)
