### PR TITLE
fix(site): remove hard-coded activity bump label

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.test.tsx
@@ -203,42 +203,42 @@ describe("ttlShutdownAt", () => {
 		[
 			"One hour --> helper text shows shutdown after 1 hour",
 			1,
-			"Your workspace will shut down 1 hour after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 1 hour after its next start.",
 		],
 		[
 			"Two hours --> helper text shows shutdown after 2 hours",
 			2,
-			"Your workspace will shut down 2 hours after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 2 hours after its next start.",
 		],
 		[
 			"24 hours --> helper text shows shutdown after 1 day",
 			24,
-			"Your workspace will shut down 1 day after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 1 day after its next start.",
 		],
 		[
 			"48 hours --> helper text shows shutdown after 2 days",
 			48,
-			"Your workspace will shut down 2 days after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 2 days after its next start.",
 		],
 		[
 			"1.2 hours --> helper text shows shutdown after 1 hour and 12 minutes",
 			1.2,
-			"Your workspace will shut down 1 hour and 12 minutes after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 1 hour and 12 minutes after its next start.",
 		],
 		[
 			"24.2 hours --> helper text shows shutdown after 1 day and 12 minutes",
 			24.2,
-			"Your workspace will shut down 1 day and 12 minutes after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 1 day and 12 minutes after its next start.",
 		],
 		[
 			"0.2 hours --> helper text shows shutdown after 12 minutes",
 			0.2,
-			"Your workspace will shut down 12 minutes after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 12 minutes after its next start.",
 		],
 		[
 			"48.258 hours --> helper text shows shutdown after 2 days and 15 minutes and 28 seconds",
 			48.258,
-			"Your workspace will shut down 2 days and 15 minutes and 28 seconds after its next start. We delay shutdown by 1 hour whenever we detect activity.",
+			"Your workspace will shut down 2 days and 15 minutes and 28 seconds after its next start.",
 		],
 	])("%p", (_, ttlHours, expected) => {
 		expect(ttlShutdownAt(ttlHours)).toEqual(expected);

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -464,7 +464,7 @@ export const ttlShutdownAt = (formTTL: number): string => {
 		return `Your workspace will shut down ${formatDuration(
 			intervalToDuration({ start: 0, end: formTTL * 60 * 60 * 1000 }),
 			{ delimiter: " and " },
-		)} after its next start. We delay shutdown by 1 hour whenever we detect activity.`;
+		)} after its next start.`;
 	} catch (e) {
 		if (e instanceof RangeError) {
 			return Language.errorTtlMax;


### PR DESCRIPTION
Closes #15536.

The setting description is already dynamically set correctly, and I don't believe it warrants repeating.

![image](https://github.com/user-attachments/assets/467b2ef3-468a-4634-819f-98f36c86b5ab)
