### PR TITLE
fix(cli): properly handle build log streaming during `coder ping`

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -103,11 +103,6 @@ func (r *RootCmd) ping() *serpent.Command {
 			ctx, cancel := context.WithCancel(inv.Context())
 			defer cancel()
 
-			spin := spinner.New(spinner.CharSets[5], 100*time.Millisecond)
-			spin.Writer = inv.Stderr
-			spin.Suffix = pretty.Sprint(cliui.DefaultStyles.Keyword, " Collecting diagnostics...")
-			spin.Start()
-
 			notifyCtx, notifyCancel := inv.SignalNotifyContext(ctx, StopSignals...)
 			defer notifyCancel()
 
@@ -118,9 +113,14 @@ func (r *RootCmd) ping() *serpent.Command {
 				workspaceName,
 			)
 			if err != nil {
-				spin.Stop()
 				return err
 			}
+
+			// Start spinner after any build logs have finished streaming
+			spin := spinner.New(spinner.CharSets[5], 100*time.Millisecond)
+			spin.Writer = inv.Stderr
+			spin.Suffix = pretty.Sprint(cliui.DefaultStyles.Keyword, " Collecting diagnostics...")
+			spin.Start()
 
 			opts := &workspacesdk.DialAgentOptions{}
 

--- a/codersdk/healthsdk/interfaces.go
+++ b/codersdk/healthsdk/interfaces.go
@@ -68,11 +68,14 @@ func generateInterfacesReport(st *interfaces.State) (report InterfacesReport) {
 			continue
 		}
 		report.Interfaces = append(report.Interfaces, healthIface)
-		if iface.MTU < safeMTU {
+		// Some loopback interfaces on Windows have a negative MTU, which we can
+		// safely ignore in diagnostics.
+		if iface.MTU > 0 && iface.MTU < safeMTU {
 			report.Severity = health.SeverityWarning
 			report.Warnings = append(report.Warnings,
 				health.Messagef(health.CodeInterfaceSmallMTU,
-					"Network interface %s has MTU %d (less than %d), which may degrade the quality of direct connections", iface.Name, iface.MTU, safeMTU),
+					"Network interface %s has MTU %d (less than %d), which may degrade the quality of direct "+
+						"connections or render them unusable.", iface.Name, iface.MTU, safeMTU),
 			)
 		}
 	}


### PR DESCRIPTION
Closes #15584.

- The `Collecting Diagnostics` spinner now starts after the workspace build logs (if any) have finished streaming.
- Removes network interfaces with negative MTUs from `healthsdk` diagnostics.
- Improves the wording on diagnostics for MTUs below the 'safe' value to indicate that direct connections may be degraded, or rendered unusable (i.e. if every packet is dropped).