### PR TITLE
docs: add crypto_keys to list of dbcrypt fields

### DIFF
--- a/docs/admin/security/database-encryption.md
+++ b/docs/admin/security/database-encryption.md
@@ -22,6 +22,7 @@ The following database fields are currently encrypted:
 - `user_links.oauth_refresh_token`
 - `external_auth_links.oauth_access_token`
 - `external_auth_links.oauth_refresh_token`
+- `crypto_keys.secret`
 
 Additional database fields may be encrypted in the future.
 


### PR DESCRIPTION
closes: https://github.com/coder/internal/issues/220

Updates docs that talk about what db fields we encrypt.  We've recently added `crypto_keys.secret` to the list, but didn't add it to the docs.