### PR TITLE
chore(scripts/develop.sh): auto determine first org name and run terraform init

### DIFF
--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -203,7 +203,7 @@ fatal() {
 	# If we have docker available and the "docker" template doesn't already
 	# exist, then let's try to create a template!
 	template_name="docker"
-	# Determine the name of the default org with some jq hax!
+	# Determine the name of the default org with some jq hacks!
 	first_org_name=$("${CODER_DEV_SHIM}" organizations show me -o json | jq -r '.[] | select(.is_default) | .name')
 	if docker info >/dev/null 2>&1 && ! "${CODER_DEV_SHIM}" templates versions list "${template_name}" >/dev/null 2>&1; then
 		# sometimes terraform isn't installed yet when we go to create the

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -19,6 +19,7 @@ DEFAULT_PASSWORD="SomeSecurePassword!"
 password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"
 use_proxy=0
 multi_org=0
+first_org="coder"
 
 args="$(getopt -o "" -l access-url:,use-proxy,agpl,debug,password:,multi-organization -- "$@")"
 eval set -- "$args"
@@ -216,8 +217,8 @@ fatal() {
 		DOCKER_HOST="$(docker context inspect --format '{{ .Endpoints.docker.Host }}')"
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" >"${temp_template_dir}/params.yaml"
 		(
-			echo "Pushing docker template to 'first-organization'..."
-			"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org first-organization
+			echo "Pushing docker template to '${first_org}'..."
+			"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org "${first_org}"
 			if [ "${multi_org}" -gt "0" ]; then
 				echo "Pushing docker template to '${another_org}'..."
 				"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org "${another_org}"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -19,7 +19,6 @@ DEFAULT_PASSWORD="SomeSecurePassword!"
 password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"
 use_proxy=0
 multi_org=0
-first_org="coder"
 
 args="$(getopt -o "" -l access-url:,use-proxy,agpl,debug,password:,multi-organization -- "$@")"
 eval set -- "$args"
@@ -204,6 +203,8 @@ fatal() {
 	# If we have docker available and the "docker" template doesn't already
 	# exist, then let's try to create a template!
 	template_name="docker"
+	# Determine the name of the default org with some jq hax!
+	first_org_name=$("${CODER_DEV_SHIM}" organizations show me -o json | jq -r '.[] | select(.is_default) | .name')
 	if docker info >/dev/null 2>&1 && ! "${CODER_DEV_SHIM}" templates versions list "${template_name}" >/dev/null 2>&1; then
 		# sometimes terraform isn't installed yet when we go to create the
 		# template
@@ -217,8 +218,8 @@ fatal() {
 		DOCKER_HOST="$(docker context inspect --format '{{ .Endpoints.docker.Host }}')"
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" >"${temp_template_dir}/params.yaml"
 		(
-			echo "Pushing docker template to '${first_org}'..."
-			"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org "${first_org}"
+			echo "Pushing docker template to '${first_org_name}'..."
+			"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org "${first_org_name}"
 			if [ "${multi_org}" -gt "0" ]; then
 				echo "Pushing docker template to '${another_org}'..."
 				"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org "${another_org}"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -214,6 +214,8 @@ fatal() {
 		echo "Initializing docker template..."
 		temp_template_dir="$(mktemp -d)"
 		"${CODER_DEV_SHIM}" templates init --id "${template_name}" "${temp_template_dir}"
+		# Run terraform init so we get a terraform.lock.hcl
+		pushd "${temp_template_dir}" && terraform init && popd
 
 		DOCKER_HOST="$(docker context inspect --format '{{ .Endpoints.docker.Host }}')"
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" >"${temp_template_dir}/params.yaml"


### PR DESCRIPTION
Updates `develop.sh` to automatically determine the name of the 'first org' when pushing the initial template.

Also runs `terraform init` before running `coder templates push` (pet peeve).

