### PR TITLE
chore: ensure coder is logged before querying orgs

### DIFF
--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -162,8 +162,10 @@ fatal() {
 	# Check if credentials are already set up to avoid setting up again.
 	"${CODER_DEV_SHIM}" list >/dev/null 2>&1 && touch "${PROJECT_ROOT}/.coderv2/developsh-did-first-setup"
 
-	if [ ! -f "${PROJECT_ROOT}/.coderv2/developsh-did-first-setup" ]; then
+	if ! "${CODER_DEV_SHIM}" whoami >/dev/null 2>&1; then
 		# Try to create the initial admin user.
+		echo "Login required; use admin@coder.com and password '${password}'" >&2
+
 		if "${CODER_DEV_SHIM}" login http://127.0.0.1:3000 --first-user-username=admin --first-user-email=admin@coder.com --first-user-password="${password}" --first-user-full-name="Admin User" --first-user-trial=false; then
 			# Only create this file if an admin user was successfully
 			# created, otherwise we won't retry on a later attempt.


### PR DESCRIPTION
https://github.com/coder/coder/pull/15603 and https://github.com/coder/coder/pull/13923 introduced steps into `develop.sh` which use the `coder` CLI to execute queries (both for organizations, at it turns out).

However, these commands assume there's a value API token issued and used by the CLI. If not, `develop.sh` fails to start up with the following error:

```
/home/coder/coder/build/coder_2.17.2-devel+78f9f43c9_linux_amd64
== CMD: /home/coder/coder/scripts/coder-dev.sh server --http-address 0.0.0.0:3000 --swagger-enable --dangerous-allow-cors-requests=true --enable-terraform-debug-mode
== Waiting for Coder to become ready
[API] Started HTTP listener at http://0.0.0.0:3000/
[API] Using built-in PostgreSQL (/home/coder/coder/.coderv2/postgres)
[API] Opening tunnel so workspaces can connect to your deployment. For production scenarios, specify an external access URL
[API] ╔═══════════════════════════════════════════════╗
[API] ║               View the Web UI:                ║
[API] ║   https://4be2pat11602q.pit-1.try.coder.app/   ║
[API] ╚═══════════════════════════════════════════════╝
...
Encountered an error running "coder organizations show", see "coder organizations show --help" for more information
error: You are signed out or your session has expired. Please sign in again to continue.
Suggestion: Try logging in using 'coder login'.
== FAIL: Script encountered an error
[API] Interrupt caught, gracefully exiting. Use ctrl+\ to force quit
[API] Shutting down API server...
[API] 
[API] Gracefully shut down API server
...
```

We have `"${PROJECT_ROOT}/.coderv2/developsh-did-first-setup"` is used as a state file to indicate that the first user has been setup. This change forces this branch to always be followed if auth fails. If the first user already exists, it'll fail gracefully.

A future improvement to this would be to avoid trying to recreate the first (and regular) user.