### PR TITLE
fix: fix parsing of IPv6 addresses in coder port-forward

### DIFF
--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -92,6 +92,16 @@ func TestPortForward(t *testing.T) {
 			},
 			localAddress: []string{"10.10.10.99:9999", "10.10.10.10:1010"},
 		},
+		{
+			name:    "TCP-IPv6",
+			network: "tcp", flag: []string{"--tcp=[fe80::99]:9999:%v", "--tcp=[fe80::10]:1010:%v"},
+			setupRemote: func(t *testing.T) net.Listener {
+				l, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err, "create TCP listener")
+				return l
+			},
+			localAddress: []string{"[fe80::99]:9999", "[fe80::10]:1010"},
+		},
 	}
 
 	// Setup agent once to be shared between test-cases (avoid expensive


### PR DESCRIPTION
fixes: #15561

Fixes parsing of IPv6 local addresses on `coder port-forward`