### PR TITLE
feat(helm/provisioner): support deploying multiple provisioners in same namespace

### DIFF
--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -113,7 +113,7 @@ coder:
     annotations: {}
     # coder.serviceAccount.name -- The service account name
     name: coder
-    # coder.serviceAccount.name -- Whether to create the service account or use existing service account
+    # coder.serviceAccount.disableCreate -- Whether to create the service account or use existing service account.
     disableCreate: false
 
   # coder.securityContext -- Fields related to the container's security

--- a/helm/provisioner/README.md
+++ b/helm/provisioner/README.md
@@ -32,5 +32,114 @@ coder:
       value: "0.0.0.0:2112"
   replicaCount: 10
 provisionerDaemon:
-  pskSecretName: "coder-provisioner-psk"
+  keySecretName: "coder-provisionerd-key"
+  keySecretKey: "provisionerd-key"
 ```
+
+## Specific Examples
+
+Below are some common specific use-cases when deploying a Coder provisioner.
+
+### Set Labels and Annotations
+
+If you need to set deployment- or pod-level labels and annotations, set `coder.{annotations,labels}` or `coder.{podAnnotations,podLabels}`.
+
+Example:
+```yaml
+coder:
+  # ...
+  annotations:
+    com.coder/annotation/foo: bar
+    com.coder/annotation/baz: qux
+  labels:
+    com.coder/label/foo: bar
+    com.coder/label/baz: qux
+  podAnnotations:
+    com.coder/podAnnotation/foo: bar
+    com.coder/podAnnotation/baz: qux
+  podLabels:
+    com.coder/podLabel/foo: bar
+    com.coder/podLabel/baz: qux
+```
+
+### Additional Templates
+
+You can include extra Kubernetes manifests in `extraTemplates`.
+
+The below example will also create a `ConfigMap` along with the Helm release:
+
+```yaml
+coder:
+  # ...
+provisionerDaemon:
+  # ...
+extraTemplates:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: some-config
+      namespace: {{ .Release.Namespace }}
+    data:
+      key: some-value
+```
+
+### Disable Service Account Creation
+
+### Deploying multiple provisioners in the same namespace
+
+To deploy multiple provisioners in the same namespace, set the following values explicitly to avoid conflicts:
+- `nameOverride`: controls the name of the provisioner deployment
+- `serviceAccount.name`: controls the name of the service account.
+
+Note that `nameOverride` does not apply to `extraTemplates`, as illustrated below:
+
+```yaml
+coder:
+  # ...
+  serviceAccount:
+    name: other-coder-provisioner
+provisionerDaemon:
+  # ...
+nameOverride: "other-coder-provisioner"
+extraTemplates:
+	- |
+		apiVersion: v1
+		kind: ConfigMap
+		metadata:
+		  name: some-other-config
+		  namespace: {{ .Release.Namespace }}
+		data:
+		  key: some-other-value
+```
+
+If you wish to deploy a second provisioner that references an existing service account, you can do so as follows:
+
+- Set `coder.serviceAccount.disableCreate=true` to disable service account creation,
+- Set `coder.serviceAccount.workspacePerms=false` to disable creation of a role and role binding,
+- Set `coder.serviceAccount.nameOverride` to the name of an existing service account.
+
+See below for a concrete example:
+```yaml
+coder:
+  # ...
+  serviceAccount:
+    name: preexisting-service-account
+    disableCreate: true
+    workspacePerms: false
+provisionerDaemon:
+  # ...
+nameOverride: "other-coder-provisioner"
+```
+
+# Testing
+
+The test suite for this chart lives in `./tests/chart_test.go`.
+
+Each test case runs `helm template` against the corresponding `test_case.yaml`, and compares the output with that of the corresponding `test_case.golden` in `./tests/testdata`.
+If `expectedError` is not empty for that specific test case, no corresponding `.golden` file is required.
+
+To add a new test case:
+- Create an appropriately named `.yaml` file in `testdata/` along with a corresponding `.golden` file, if required.
+- Add the test case to the array in `chart_test.go`, setting `name` to the name of the files you added previously (without the extension). If appropriate, set `expectedError`.
+- Run the tests and ensure that no regressions in existing test cases occur: `go test ./tests`.

--- a/helm/provisioner/README.md
+++ b/helm/provisioner/README.md
@@ -45,6 +45,7 @@ Below are some common specific use-cases when deploying a Coder provisioner.
 If you need to set deployment- or pod-level labels and annotations, set `coder.{annotations,labels}` or `coder.{podAnnotations,podLabels}`.
 
 Example:
+
 ```yaml
 coder:
   # ...
@@ -89,6 +90,7 @@ extraTemplates:
 ### Deploying multiple provisioners in the same namespace
 
 To deploy multiple provisioners in the same namespace, set the following values explicitly to avoid conflicts:
+
 - `nameOverride`: controls the name of the provisioner deployment
 - `serviceAccount.name`: controls the name of the service account.
 
@@ -120,6 +122,7 @@ If you wish to deploy a second provisioner that references an existing service a
 - Set `coder.serviceAccount.nameOverride` to the name of an existing service account.
 
 See below for a concrete example:
+
 ```yaml
 coder:
   # ...
@@ -140,6 +143,7 @@ Each test case runs `helm template` against the corresponding `test_case.yaml`, 
 If `expectedError` is not empty for that specific test case, no corresponding `.golden` file is required.
 
 To add a new test case:
+
 - Create an appropriately named `.yaml` file in `testdata/` along with a corresponding `.golden` file, if required.
 - Add the test case to the array in `chart_test.go`, setting `name` to the name of the files you added previously (without the extension). If appropriate, set `expectedError`.
 - Run the tests and ensure that no regressions in existing test cases occur: `go test ./tests`.

--- a/helm/provisioner/templates/coder.yaml
+++ b/helm/provisioner/templates/coder.yaml
@@ -1,5 +1,7 @@
 ---
+{{- if not .Values.coder.serviceAccount.disableCreate }}
 {{ include "libcoder.serviceaccount" (list . "coder.serviceaccount") }}
+{{- end }}
 
 ---
 {{ include "libcoder.deployment" (list . "coder.deployment") }}

--- a/helm/provisioner/tests/chart_test.go
+++ b/helm/provisioner/tests/chart_test.go
@@ -78,6 +78,10 @@ var testCases = []testCase{
 		name:          "extra_templates",
 		expectedError: "",
 	},
+	{
+		name:          "sa_disabled",
+		expectedError: "",
+	},
 }
 
 type testCase struct {

--- a/helm/provisioner/tests/chart_test.go
+++ b/helm/provisioner/tests/chart_test.go
@@ -82,6 +82,14 @@ var testCases = []testCase{
 		name:          "sa_disabled",
 		expectedError: "",
 	},
+	{
+		name:          "name_override",
+		expectedError: "",
+	},
+	{
+		name:          "name_override_existing_sa",
+		expectedError: "",
+	},
 }
 
 type testCase struct {

--- a/helm/provisioner/tests/testdata/name_override.golden
+++ b/helm/provisioner/tests/testdata/name_override.golden
@@ -1,0 +1,144 @@
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: other-coder-provisioner
+    app.kubernetes.io/part-of: other-coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: other-coder-provisioner
+---
+# Source: coder-provisioner/templates/extra-templates.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: some-config
+  namespace: default
+data:
+  key: some-value
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: other-coder-provisioner-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "other-coder-provisioner"
+subjects:
+  - kind: ServiceAccount
+    name: "other-coder-provisioner"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: other-coder-provisioner-workspace-perms
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: other-coder-provisioner
+    app.kubernetes.io/part-of: other-coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: other-coder-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: other-coder-provisioner
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: other-coder-provisioner
+        app.kubernetes.io/part-of: other-coder-provisioner
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-provisioner-0.1.0
+    spec:
+      containers:
+      - args:
+        - provisionerd
+        - start
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_PROVISIONER_DAEMON_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: coder-provisioner-psk
+        - name: CODER_URL
+          value: http://coder.default.svc.cluster.local
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        name: coder
+        ports: null
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: other-coder-provisioner
+      terminationGracePeriodSeconds: 600
+      volumes: []

--- a/helm/provisioner/tests/testdata/name_override.yaml
+++ b/helm/provisioner/tests/testdata/name_override.yaml
@@ -1,0 +1,16 @@
+coder:
+  image:
+    tag: latest
+  serviceAccount:
+    name: other-coder-provisioner
+nameOverride: "other-coder-provisioner"
+# Note that extraTemplates does not respect nameOverride.
+extraTemplates:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: some-config
+      namespace: {{ .Release.Namespace }}
+    data:
+      key: some-value

--- a/helm/provisioner/tests/testdata/name_override_existing_sa.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa.golden
@@ -1,0 +1,67 @@
+---
+# Source: coder-provisioner/templates/coder.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: other-coder-provisioner
+    app.kubernetes.io/part-of: other-coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: other-coder-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: other-coder-provisioner
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: other-coder-provisioner
+        app.kubernetes.io/part-of: other-coder-provisioner
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-provisioner-0.1.0
+    spec:
+      containers:
+      - args:
+        - provisionerd
+        - start
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_PROVISIONER_DAEMON_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: coder-provisioner-psk
+        - name: CODER_URL
+          value: http://coder.default.svc.cluster.local
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        name: coder
+        ports: null
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: existing-coder-provisioner-serviceaccount
+      terminationGracePeriodSeconds: 600
+      volumes: []

--- a/helm/provisioner/tests/testdata/name_override_existing_sa.yaml
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa.yaml
@@ -1,0 +1,8 @@
+coder:
+  image:
+    tag: latest
+  serviceAccount:
+    name: "existing-coder-provisioner-serviceaccount"
+    disableCreate: true
+    workspacePerms: false
+nameOverride: "other-coder-provisioner"

--- a/helm/provisioner/tests/testdata/sa_disabled.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled.golden
@@ -1,0 +1,67 @@
+---
+# Source: coder-provisioner/templates/coder.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: coder-provisioner
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: coder-provisioner
+        app.kubernetes.io/part-of: coder-provisioner
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-provisioner-0.1.0
+    spec:
+      containers:
+      - args:
+        - provisionerd
+        - start
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_PROVISIONER_DAEMON_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: coder-provisioner-psk
+        - name: CODER_URL
+          value: http://coder.default.svc.cluster.local
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        name: coder
+        ports: null
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: coder-provisioner
+      terminationGracePeriodSeconds: 600
+      volumes: []

--- a/helm/provisioner/tests/testdata/sa_disabled.yaml
+++ b/helm/provisioner/tests/testdata/sa_disabled.yaml
@@ -1,0 +1,6 @@
+coder:
+  image:
+    tag: latest
+  serviceAccount:
+    workspacePerms: false
+    disableCreate: true

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -74,6 +74,8 @@ coder:
     annotations: {}
     # coder.serviceAccount.name -- The service account name
     name: coder-provisioner
+    # coder.serviceAccount.disableCreate -- Whether to create the service account or use existing service account.
+    disableCreate: false
 
   # coder.securityContext -- Fields related to the container's security
   # context (as opposed to the pod). Some fields are also present in the pod


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/15437

- Adds support for `coder.serviceAccount.disableCreate` (originally added to `helm/coder` in https://github.com/coder/coder/pull/14817).
- Adds documentation and examples in `helm/provisioner/README.md` on deploying multiple provisioners in the same namespace leveraging `nameOverride`.

This allows us to support the following use-cases:

1) Deploying multiple provisioner daemons with separate service accounts and roles: set `nameOverride` and `coder.serviceAccount.Name`
2) Deploying a provisioner daemon that references an existing service account without creating a separate sa/role/rolebinding: set `coder.serviceAccount.disableCreate=true`, `coder.serviceAccount.workspacePerms=false` and `coder.serviceAccount.name=<name of existing sa>`.


Validated `nameOverride` using kustomize:

```
# Staged changes
--- a/kustomize/mycluster/coder/provisioner/kustomization.yaml
+++ b/kustomize/mycluster/coder/provisioner/kustomization.yaml
@@ -7,6 +7,12 @@ helmCharts:
     version: "2.17.2"
     namespace: coder
     valuesFile: provisioner-values.yaml
+  - name: coder-provisioner
+    releaseName: other-coder-provisioner
+    repo: https://helm.coder.com/v2
+    version: "2.17.2"
+    namespace: coder
+    valuesFile: other-provisioner-values.yaml

--- /dev/null
+++ b/kustomize/mycluster/coder/provisioner/other-provisioner-values.yaml
@@ -0,0 +1,7 @@
+coder:
+  serviceAccount:
+    name: "other-coder-provisioner"
+provisionerDaemon:
+  keySecretName: other-coder-provisioner-keys
+  keySecretKey: other-coder-onprem-1
+nameOverride: "other-coder-provisioner"

# Resulting new files (no modifications):

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	clusters/mycluster/coder/generated/deployment-other-coder-provisioner.yaml
	clusters/mycluster/coder/generated/role-other-coder-provisioner-workspace-perms.yaml
	clusters/mycluster/coder/generated/rolebinding-other-coder-provisioner.yaml
	clusters/mycluster/coder/generated/serviceaccount-other-coder-provisioner.yaml
```

