### PR TITLE
feat: change port-forward to opportunistically listen on IPv6

### DIFF
--- a/cli/portforward_internal_test.go
+++ b/cli/portforward_internal_test.go
@@ -29,15 +29,15 @@ func Test_parsePortForwards(t *testing.T) {
 				},
 			},
 			want: []portForwardSpec{
-				{"tcp", "127.0.0.1:8000", "tcp", "127.0.0.1:8000"},
-				{"tcp", "127.0.0.1:8080", "tcp", "127.0.0.1:8081"},
-				{"tcp", "127.0.0.1:9000", "tcp", "127.0.0.1:9000"},
-				{"tcp", "127.0.0.1:9001", "tcp", "127.0.0.1:9001"},
-				{"tcp", "127.0.0.1:9002", "tcp", "127.0.0.1:9002"},
-				{"tcp", "127.0.0.1:9003", "tcp", "127.0.0.1:9005"},
-				{"tcp", "127.0.0.1:9004", "tcp", "127.0.0.1:9006"},
-				{"tcp", "127.0.0.1:10000", "tcp", "127.0.0.1:10000"},
-				{"tcp", "127.0.0.1:4444", "tcp", "127.0.0.1:4444"},
+				{"tcp", noAddr, 8000, 8000},
+				{"tcp", noAddr, 8080, 8081},
+				{"tcp", noAddr, 9000, 9000},
+				{"tcp", noAddr, 9001, 9001},
+				{"tcp", noAddr, 9002, 9002},
+				{"tcp", noAddr, 9003, 9005},
+				{"tcp", noAddr, 9004, 9006},
+				{"tcp", noAddr, 10000, 10000},
+				{"tcp", noAddr, 4444, 4444},
 			},
 		},
 		{
@@ -46,7 +46,7 @@ func Test_parsePortForwards(t *testing.T) {
 				tcpSpecs: []string{"127.0.0.1:8080:8081"},
 			},
 			want: []portForwardSpec{
-				{"tcp", "127.0.0.1:8080", "tcp", "127.0.0.1:8081"},
+				{"tcp", ipv4Loopback, 8080, 8081},
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func Test_parsePortForwards(t *testing.T) {
 				tcpSpecs: []string{"[::1]:8080:8081"},
 			},
 			want: []portForwardSpec{
-				{"tcp", "[::1]:8080", "tcp", "127.0.0.1:8081"},
+				{"tcp", ipv6Loopback, 8080, 8081},
 			},
 		},
 		{
@@ -64,9 +64,9 @@ func Test_parsePortForwards(t *testing.T) {
 				udpSpecs: []string{"8000,8080-8081"},
 			},
 			want: []portForwardSpec{
-				{"udp", "127.0.0.1:8000", "udp", "127.0.0.1:8000"},
-				{"udp", "127.0.0.1:8080", "udp", "127.0.0.1:8080"},
-				{"udp", "127.0.0.1:8081", "udp", "127.0.0.1:8081"},
+				{"udp", noAddr, 8000, 8000},
+				{"udp", noAddr, 8080, 8080},
+				{"udp", noAddr, 8081, 8081},
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func Test_parsePortForwards(t *testing.T) {
 				udpSpecs: []string{"127.0.0.1:8080:8081"},
 			},
 			want: []portForwardSpec{
-				{"udp", "127.0.0.1:8080", "udp", "127.0.0.1:8081"},
+				{"udp", ipv4Loopback, 8080, 8081},
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func Test_parsePortForwards(t *testing.T) {
 				udpSpecs: []string{"[::1]:8080:8081"},
 			},
 			want: []portForwardSpec{
-				{"udp", "[::1]:8080", "udp", "127.0.0.1:8081"},
+				{"udp", ipv6Loopback, 8080, 8081},
 			},
 		},
 		{

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -68,6 +68,17 @@ func TestPortForward(t *testing.T) {
 			localAddress: []string{"127.0.0.1:5555", "127.0.0.1:6666"},
 		},
 		{
+			name:    "TCP-opportunistic-ipv6",
+			network: "tcp",
+			flag:    []string{"--tcp=5566:%v", "--tcp=6655:%v"},
+			setupRemote: func(t *testing.T) net.Listener {
+				l, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err, "create TCP listener")
+				return l
+			},
+			localAddress: []string{"[::1]:5566", "[::1]:6655"},
+		},
+		{
 			name:    "UDP",
 			network: "udp",
 			flag:    []string{"--udp=7777:%v", "--udp=8888:%v"},
@@ -81,6 +92,21 @@ func TestPortForward(t *testing.T) {
 				return l
 			},
 			localAddress: []string{"127.0.0.1:7777", "127.0.0.1:8888"},
+		},
+		{
+			name:    "UDP-opportunistic-ipv6",
+			network: "udp",
+			flag:    []string{"--udp=7788:%v", "--udp=8877:%v"},
+			setupRemote: func(t *testing.T) net.Listener {
+				addr := net.UDPAddr{
+					IP:   net.ParseIP("127.0.0.1"),
+					Port: 0,
+				}
+				l, err := udp.Listen("udp", &addr)
+				require.NoError(t, err, "create UDP listener")
+				return l
+			},
+			localAddress: []string{"[::1]:7788", "[::1]:8877"},
 		},
 		{
 			name:    "TCPWithAddress",
@@ -286,6 +312,63 @@ func TestPortForward(t *testing.T) {
 
 		cancel()
 		err := <-errC
+		require.ErrorIs(t, err, context.Canceled)
+
+		flushCtx := testutil.Context(t, testutil.WaitShort)
+		testutil.RequireSendCtx(flushCtx, t, wuTick, dbtime.Now())
+		_ = testutil.RequireRecvCtx(flushCtx, t, wuFlush)
+		updated, err := client.Workspace(context.Background(), workspace.ID)
+		require.NoError(t, err)
+		require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)
+	})
+
+	t.Run("IPv6Busy", func(t *testing.T) {
+		t.Parallel()
+
+		remoteLis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err, "create TCP listener")
+		p1 := setupTestListener(t, remoteLis)
+
+		// Create a flag that forwards from local 5555 to remote listener port.
+		flag := fmt.Sprintf("--tcp=5555:%v", p1)
+
+		// Launch port-forward in a goroutine so we can start dialing
+		// the "local" listener.
+		inv, root := clitest.New(t, "-v", "port-forward", workspace.Name, flag)
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t)
+		inv.Stdin = pty.Input()
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+
+		iNet := newInProcNet()
+		inv.Net = iNet
+
+		// listen on port 5555 on IPv6 so it's busy when we try to port forward
+		busyLis, err := iNet.Listen("tcp", "[::1]:5555")
+		require.NoError(t, err)
+		defer busyLis.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+		errC := make(chan error)
+		go func() {
+			err := inv.WithContext(ctx).Run()
+			t.Logf("command complete; err=%s", err.Error())
+			errC <- err
+		}()
+		pty.ExpectMatchContext(ctx, "Ready!")
+
+		// Test IPv4 still works
+		dialCtx, dialCtxCancel := context.WithTimeout(ctx, testutil.WaitShort)
+		defer dialCtxCancel()
+		c1, err := iNet.dial(dialCtx, addr{"tcp", "127.0.0.1:5555"})
+		require.NoError(t, err, "open connection 1 to 'local' listener")
+		defer c1.Close()
+		testDial(t, c1)
+
+		cancel()
+		err = <-errC
 		require.ErrorIs(t, err, context.Canceled)
 
 		flushCtx := testutil.Context(t, testutil.WaitShort)


### PR DESCRIPTION
If the local IP address is not explicitly set, previously we assumed 127.0.0.1 (that is, IPv4 only localhost). This PR adds support to opportunistically _also_ listen on IPv6 ::1.