### PR TITLE
feat(dogfood/contents): set coder_workspace_tags in dogfood template

### DIFF
--- a/docs/admin/provisioners.md
+++ b/docs/admin/provisioners.md
@@ -302,7 +302,7 @@ will use in concert with the Helm chart for deploying the Coder server.
 1. Store the key in a kubernetes secret:
 
    ```sh
-   kubectl create secret generic coder-provisioner-psk --from-literal=my-cool-key=`<key omitted>`
+   kubectl create secret generic coder-provisioner-keys --from-literal=my-cool-key=`<key omitted>`
    ```
 
 1. Create a `provisioner-values.yaml` file for the provisioner daemons Helm

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -102,6 +102,12 @@ data "coder_external_auth" "github" {
 
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
+data "coder_workspace_tags" "tags" {
+  tags = {
+    "cluster" : "dogfood-v2"
+    "env" : "gke"
+  }
+}
 
 module "slackme" {
   source           = "registry.coder.com/modules/slackme/coder"


### PR DESCRIPTION
Relates to: https://github.com/coder/dogfood/issues/77 https://github.com/coder/coder/issues/15428
Depends on: https://github.com/coder/coder/issues/15048

Sets `coder_workspace_tags` on our dogfood template.

When this is merged, we also need to update the provisioners to use a provisioner key.