### PR TITLE
fix: update `/builds` transition example

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10240,7 +10240,6 @@ const docTemplate = `{
                 },
                 "transition": {
                     "enum": [
-                        "create",
                         "start",
                         "stop",
                         "delete"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9114,7 +9114,7 @@
 					"format": "uuid"
 				},
 				"transition": {
-					"enum": ["create", "start", "stop", "delete"],
+					"enum": ["start", "stop", "delete"],
 					"allOf": [
 						{
 							"$ref": "#/definitions/codersdk.WorkspaceTransition"

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -93,7 +93,7 @@ const (
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.
 type CreateWorkspaceBuildRequest struct {
 	TemplateVersionID uuid.UUID           `json:"template_version_id,omitempty" format:"uuid"`
-	Transition        WorkspaceTransition `json:"transition" validate:"oneof=create start stop delete,required"`
+	Transition        WorkspaceTransition `json:"transition" validate:"oneof=start stop delete,required"`
 	DryRun            bool                `json:"dry_run,omitempty"`
 	ProvisionerState  []byte              `json:"state,omitempty"`
 	// Orphan may be set for the Destroy transition.

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -1458,7 +1458,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 	],
 	"state": [0],
 	"template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
-	"transition": "create"
+	"transition": "start"
 }
 ```
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1400,7 +1400,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 	],
 	"state": [0],
 	"template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
-	"transition": "create"
+	"transition": "start"
 }
 ```
 
@@ -1421,7 +1421,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Property     | Value    |
 | ------------ | -------- |
 | `log_level`  | `debug`  |
-| `transition` | `create` |
 | `transition` | `start`  |
 | `transition` | `stop`   |
 | `transition` | `delete` |


### PR DESCRIPTION
fixes the `POST /builds` `transition` value in the example payload. the correct value is `start | stop` instead of `create`