### PR TITLE
fix(cli): handle version mismatch re MatchedProvisioners response

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -492,7 +492,7 @@ Details:
 Details:
 	Provisioner job ID : %s
 	Requested tags     : %s
-	Last response      : %s
+	Most recently seen : %s
 `
 )
 

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -416,7 +416,7 @@ func createValidTemplateVersion(inv *serpent.Invocation, args createValidTemplat
 	if err != nil {
 		return nil, err
 	}
-
+	WarnMatchedProvisioners(inv, version)
 	err = cliui.ProvisionerJob(inv.Context(), inv.Stdout, cliui.ProvisionerJobOptions{
 		Fetch: func() (codersdk.ProvisionerJob, error) {
 			version, err := client.TemplateVersion(inv.Context(), version.ID)

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -432,13 +432,25 @@ func TestTemplatePush(t *testing.T) {
 				{
 					name: "provisioner stale",
 					setupDaemon: func(ctx context.Context, store database.Store, owner codersdk.CreateFirstUserResponse, tags database.StringMap) error {
-						_, err := store.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
+						pk, err := store.InsertProvisionerKey(ctx, database.InsertProvisionerKeyParams{
+							ID:             uuid.New(),
+							CreatedAt:      now,
+							OrganizationID: owner.OrganizationID,
+							Name:           "test",
+							Tags:           tags,
+							HashedSecret:   []byte("secret"),
+						})
+						if err != nil {
+							return err
+						}
+						_, err = store.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
 							Provisioners:   []database.ProvisionerType{database.ProvisionerTypeTerraform},
 							LastSeenAt:     sql.NullTime{Time: oneHourAgo, Valid: true},
 							CreatedAt:      oneHourAgo,
 							Name:           "test",
 							Tags:           tags,
 							OrganizationID: owner.OrganizationID,
+							KeyID:          pk.ID,
 						})
 						return err
 					},
@@ -447,13 +459,25 @@ func TestTemplatePush(t *testing.T) {
 				{
 					name: "active provisioner",
 					setupDaemon: func(ctx context.Context, store database.Store, owner codersdk.CreateFirstUserResponse, tags database.StringMap) error {
-						_, err := store.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
+						pk, err := store.InsertProvisionerKey(ctx, database.InsertProvisionerKeyParams{
+							ID:             uuid.New(),
+							CreatedAt:      now,
+							OrganizationID: owner.OrganizationID,
+							Name:           "test",
+							Tags:           tags,
+							HashedSecret:   []byte("secret"),
+						})
+						if err != nil {
+							return err
+						}
+						_, err = store.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
 							Provisioners:   []database.ProvisionerType{database.ProvisionerTypeTerraform},
 							LastSeenAt:     sql.NullTime{Time: now, Valid: true},
 							CreatedAt:      now,
 							Name:           "test-active",
 							Tags:           tags,
 							OrganizationID: owner.OrganizationID,
+							KeyID:          pk.ID,
 						})
 						return err
 					},

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/echo"
@@ -412,84 +414,133 @@ func TestTemplatePush(t *testing.T) {
 
 		t.Run("WorkspaceTagsTerraform", func(t *testing.T) {
 			t.Parallel()
-			ctx := testutil.Context(t, testutil.WaitShort)
+			now := dbtime.Now()
+			oneHourAgo := now.Add(-time.Hour)
 
-			// Start an instance **without** a built-in provisioner.
-			// We're not actually testing that the Terraform applies.
-			// What we test is that a provisioner job is created with the expected
-			// tags based on the __content__ of the Terraform.
-			store, ps := dbtestutil.NewDB(t)
-			client := coderdtest.New(t, &coderdtest.Options{
-				Database: store,
-				Pubsub:   ps,
-			})
+			tests := []struct {
+				name         string
+				setupDaemon  func(ctx context.Context, store database.Store, owner codersdk.CreateFirstUserResponse, tags database.StringMap) error
+				expectOutput string
+			}{
+				{
+					name: "no provisioners available",
+					setupDaemon: func(_ context.Context, _ database.Store, _ codersdk.CreateFirstUserResponse, _ database.StringMap) error {
+						return nil
+					},
+					expectOutput: "there are no provisioners that accept the required tags",
+				},
+				{
+					name: "provisioner stale",
+					setupDaemon: func(ctx context.Context, store database.Store, owner codersdk.CreateFirstUserResponse, tags database.StringMap) error {
+						_, err := store.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
+							Provisioners:   []database.ProvisionerType{database.ProvisionerTypeTerraform},
+							LastSeenAt:     sql.NullTime{Time: oneHourAgo, Valid: true},
+							CreatedAt:      oneHourAgo,
+							Name:           "test",
+							Tags:           tags,
+							OrganizationID: owner.OrganizationID,
+						})
+						return err
+					},
+					expectOutput: "Provisioners that accept the required tags have not responded for longer than expected",
+				},
+				{
+					name: "active provisioner",
+					setupDaemon: func(ctx context.Context, store database.Store, owner codersdk.CreateFirstUserResponse, tags database.StringMap) error {
+						_, err := store.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
+							Provisioners:   []database.ProvisionerType{database.ProvisionerTypeTerraform},
+							LastSeenAt:     sql.NullTime{Time: now, Valid: true},
+							CreatedAt:      now,
+							Name:           "test-active",
+							Tags:           tags,
+							OrganizationID: owner.OrganizationID,
+						})
+						return err
+					},
+					expectOutput: "",
+				},
+			}
 
-			owner := coderdtest.CreateFirstUser(t, client)
-			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+			for _, tt := range tests {
+				tt := tt
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 
-			// Create a tar file with some pre-defined content
-			tarFile := testutil.CreateTar(t, map[string]string{
-				"main.tf": `
-variable "a" {
-	type = string
-	default = "1"
-}
-data "coder_parameter" "b" {
-	type = string
-	default = "2"
-}
-resource "null_resource" "test" {}
-data "coder_workspace_tags" "tags" {
-	tags = {
-		"foo": "bar",
-		"a": var.a,
-		"b": data.coder_parameter.b.value,
-	}
-}`,
-			})
+					// Start an instance **without** a built-in provisioner.
+					// We're not actually testing that the Terraform applies.
+					// What we test is that a provisioner job is created with the expected
+					// tags based on the __content__ of the Terraform.
+					store, ps := dbtestutil.NewDB(t)
+					client := coderdtest.New(t, &coderdtest.Options{
+						Database: store,
+						Pubsub:   ps,
+					})
 
-			// Write the tar file to disk.
-			tempDir := t.TempDir()
-			err := tfparse.WriteArchive(tarFile, "application/x-tar", tempDir)
-			require.NoError(t, err)
+					owner := coderdtest.CreateFirstUser(t, client)
+					templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
 
-			// Run `coder templates push`
-			templateName := strings.ReplaceAll(testutil.GetRandomName(t), "_", "-")
-			var stdout, stderr strings.Builder
-			inv, root := clitest.New(t, "templates", "push", templateName, "-d", tempDir, "--yes")
-			inv.Stdout = &stdout
-			inv.Stderr = &stderr
-			clitest.SetupConfig(t, templateAdmin, root)
+					// Create a tar file with some pre-defined content
+					tarFile := testutil.CreateTar(t, map[string]string{
+						"main.tf": `
+							variable "a" {
+								type = string
+								default = "1"
+							}
+							data "coder_parameter" "b" {
+								type = string
+								default = "2"
+							}
+							resource "null_resource" "test" {}
+							data "coder_workspace_tags" "tags" {
+								tags = {
+									"a": var.a,
+									"b": data.coder_parameter.b.value,
+									"test_name": "` + tt.name + `"
+								}
+							}`,
+					})
 
-			// Don't forget to clean up!
-			cancelCtx, cancel := context.WithCancel(ctx)
-			t.Cleanup(cancel)
-			done := make(chan error)
-			go func() {
-				done <- inv.WithContext(cancelCtx).Run()
-			}()
+					// Write the tar file to disk.
+					tempDir := t.TempDir()
+					err := tfparse.WriteArchive(tarFile, "application/x-tar", tempDir)
+					require.NoError(t, err)
 
-			// Assert that a provisioner job was created with the desired tags.
-			wantTags := database.StringMap(provisionersdk.MutateTags(uuid.Nil, map[string]string{
-				"foo": "bar",
-				"a":   "1",
-				"b":   "2",
-			}))
-			require.Eventually(t, func() bool {
-				jobs, err := store.GetProvisionerJobsCreatedAfter(ctx, time.Time{})
-				if !assert.NoError(t, err) {
-					return false
-				}
-				if len(jobs) == 0 {
-					return false
-				}
-				return assert.EqualValues(t, wantTags, jobs[0].Tags)
-			}, testutil.WaitShort, testutil.IntervalSlow)
+					wantTags := database.StringMap(provisionersdk.MutateTags(uuid.Nil, map[string]string{
+						"a":         "1",
+						"b":         "2",
+						"test_name": tt.name,
+					}))
 
-			cancel()
-			<-done
+					templateName := strings.ReplaceAll(testutil.GetRandomName(t), "_", "-")
 
-			require.Contains(t, stderr.String(), "No provisioners are available to handle the job!")
+					var output strings.Builder
+					inv, root := clitest.New(t, "templates", "push", templateName, "-d", tempDir, "--yes")
+					inv.Stdout = &output
+					inv.Stderr = &output
+					clitest.SetupConfig(t, templateAdmin, root)
+
+					ctx := testutil.Context(t, testutil.WaitShort)
+					require.NoError(t, tt.setupDaemon(ctx, store, owner, wantTags))
+
+					cancelCtx, cancel := context.WithCancel(ctx)
+					t.Cleanup(cancel)
+					done := make(chan error)
+					go func() {
+						done <- inv.WithContext(cancelCtx).Run()
+					}()
+
+					require.Eventually(t, func() bool {
+						jobs, err := store.GetProvisionerJobsCreatedAfter(ctx, time.Time{})
+						return assert.NoError(t, err) && len(jobs) == 1 && assert.EqualValues(t, wantTags, jobs[0].Tags)
+					}, testutil.WaitShort, testutil.IntervalFast)
+					cancel()
+					<-done
+
+					if tt.expectOutput != "" {
+						require.Contains(t, output.String(), tt.expectOutput)
+					}
+				})
+			}
 		})
 
 		t.Run("ChangeTags", func(t *testing.T) {

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -555,7 +555,13 @@ func TestTemplatePush(t *testing.T) {
 
 					require.Eventually(t, func() bool {
 						jobs, err := store.GetProvisionerJobsCreatedAfter(ctx, time.Time{})
-						return assert.NoError(t, err) && len(jobs) == 1 && assert.EqualValues(t, wantTags, jobs[0].Tags)
+						if !assert.NoError(t, err) {
+							return false
+						}
+						if len(jobs) == 0 {
+							return false
+						}
+						return assert.EqualValues(t, wantTags, jobs[0].Tags)
 					}, testutil.WaitShort, testutil.IntervalFast)
 					cancel()
 					<-done

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -536,11 +536,9 @@ func TestTemplatePush(t *testing.T) {
 
 					templateName := strings.ReplaceAll(testutil.GetRandomName(t), "_", "-")
 
-					var output strings.Builder
 					inv, root := clitest.New(t, "templates", "push", templateName, "-d", tempDir, "--yes")
-					inv.Stdout = &output
-					inv.Stderr = &output
 					clitest.SetupConfig(t, templateAdmin, root)
+					pty := ptytest.New(t).Attach(inv)
 
 					ctx := testutil.Context(t, testutil.WaitShort)
 					now := dbtime.Now()
@@ -563,12 +561,13 @@ func TestTemplatePush(t *testing.T) {
 						}
 						return assert.EqualValues(t, wantTags, jobs[0].Tags)
 					}, testutil.WaitShort, testutil.IntervalFast)
-					cancel()
-					<-done
 
 					if tt.expectOutput != "" {
-						require.Contains(t, output.String(), tt.expectOutput)
+						pty.ExpectMatch(tt.expectOutput)
 					}
+
+					cancel()
+					<-done
 				})
 			}
 		})

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1719,7 +1719,7 @@ func convertTemplateVersion(version database.TemplateVersion, job codersdk.Provi
 		},
 		Archived:            version.Archived,
 		Warnings:            warnings,
-		MatchedProvisioners: matchedProvisioners,
+		MatchedProvisioners: &matchedProvisioners,
 	}
 }
 

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -77,7 +77,7 @@ func (api *API) templateVersion(rw http.ResponseWriter, r *http.Request) {
 		warnings = append(warnings, codersdk.TemplateVersionWarningUnsupportedWorkspaces)
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(jobs[0]), codersdk.MatchedProvisioners{}, warnings))
+	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(jobs[0]), nil, warnings))
 }
 
 // @Summary Patch template version by ID
@@ -173,7 +173,7 @@ func (api *API) patchTemplateVersion(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(updatedTemplateVersion, convertProvisionerJob(jobs[0]), codersdk.MatchedProvisioners{}, nil))
+	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(updatedTemplateVersion, convertProvisionerJob(jobs[0]), nil, nil))
 }
 
 // @Summary Cancel template version by ID
@@ -814,7 +814,7 @@ func (api *API) templateVersionsByTemplate(rw http.ResponseWriter, r *http.Reque
 				return err
 			}
 
-			apiVersions = append(apiVersions, convertTemplateVersion(version, convertProvisionerJob(job), codersdk.MatchedProvisioners{}, nil))
+			apiVersions = append(apiVersions, convertTemplateVersion(version, convertProvisionerJob(job), nil, nil))
 		}
 
 		return nil
@@ -869,7 +869,7 @@ func (api *API) templateVersionByName(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(jobs[0]), codersdk.MatchedProvisioners{}, nil))
+	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(jobs[0]), nil, nil))
 }
 
 // @Summary Get template version by organization, template, and name
@@ -934,7 +934,7 @@ func (api *API) templateVersionByOrganizationTemplateAndName(rw http.ResponseWri
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(jobs[0]), codersdk.MatchedProvisioners{}, nil))
+	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(jobs[0]), nil, nil))
 }
 
 // @Summary Get previous template version by organization, template, and name
@@ -1020,7 +1020,7 @@ func (api *API) previousTemplateVersionByOrganizationTemplateAndName(rw http.Res
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(previousTemplateVersion, convertProvisionerJob(jobs[0]), codersdk.MatchedProvisioners{}, nil))
+	httpapi.Write(ctx, rw, http.StatusOK, convertTemplateVersion(previousTemplateVersion, convertProvisionerJob(jobs[0]), nil, nil))
 }
 
 // @Summary Archive template unused versions by template id
@@ -1633,7 +1633,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 			ProvisionerJob: provisionerJob,
 			QueuePosition:  0,
 		}),
-		matchedProvisioners,
+		&matchedProvisioners,
 		warnings))
 }
 
@@ -1701,7 +1701,7 @@ func (api *API) templateVersionLogs(rw http.ResponseWriter, r *http.Request) {
 	api.provisionerJobLogs(rw, r, job)
 }
 
-func convertTemplateVersion(version database.TemplateVersion, job codersdk.ProvisionerJob, matchedProvisioners codersdk.MatchedProvisioners, warnings []codersdk.TemplateVersionWarning) codersdk.TemplateVersion {
+func convertTemplateVersion(version database.TemplateVersion, job codersdk.ProvisionerJob, matchedProvisioners *codersdk.MatchedProvisioners, warnings []codersdk.TemplateVersionWarning) codersdk.TemplateVersion {
 	return codersdk.TemplateVersion{
 		ID:             version.ID,
 		TemplateID:     &version.TemplateID.UUID,
@@ -1719,7 +1719,7 @@ func convertTemplateVersion(version database.TemplateVersion, job codersdk.Provi
 		},
 		Archived:            version.Archived,
 		Warnings:            warnings,
-		MatchedProvisioners: &matchedProvisioners,
+		MatchedProvisioners: matchedProvisioners,
 	}
 }
 

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -471,14 +471,13 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 					pj, err := store.GetProvisionerJobByID(ctx, tv.Job.ID)
 					require.NoError(t, err)
 					require.EqualValues(t, tt.wantTags, pj.Tags)
+					// Also assert that we get the expected information back from the API endpoint
+					require.Zero(t, tv.MatchedProvisioners.Count)
+					require.Zero(t, tv.MatchedProvisioners.Available)
+					require.Zero(t, tv.MatchedProvisioners.MostRecentlySeen.Time)
 				} else {
 					require.ErrorContains(t, err, tt.expectError)
 				}
-
-				// Also assert that we get the expected information back from the API endpoint
-				require.Zero(t, tv.MatchedProvisioners.Count)
-				require.Zero(t, tv.MatchedProvisioners.Available)
-				require.Zero(t, tv.MatchedProvisioners.MostRecentlySeen.Time)
 			})
 		}
 	})

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -53,6 +53,7 @@ type ProvisionerDaemon struct {
 
 // MatchedProvisioners represents the number of provisioner daemons
 // available to take a job at a specific point in time.
+// Introduced in Coder version 2.18.0.
 type MatchedProvisioners struct {
 	// Count is the number of provisioner daemons that matched the given
 	// tags. If the count is 0, it means no provisioner daemons matched the

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -32,7 +32,7 @@ type TemplateVersion struct {
 	Archived       bool           `json:"archived"`
 
 	Warnings            []TemplateVersionWarning `json:"warnings,omitempty" enums:"DEPRECATED_PARAMETERS"`
-	MatchedProvisioners MatchedProvisioners      `json:"matched_provisioners,omitempty"`
+	MatchedProvisioners *MatchedProvisioners     `json:"matched_provisioners,omitempty"`
 }
 
 type TemplateVersionExternalAuth struct {


### PR DESCRIPTION
* Modifies `MatchedProvisioners` response of `codersdk.TemplateVersion` to be a pointer
* CLI now checks for absence of `*MatchedProvisioners` before showing warning regarding provisioners
* Extracts logic for warning about provisioners to a function
* Improves test coverage for CLI template push with `coder_workspace_tags`.