### PR TITLE
feat(site): show license utilization in general settings

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.stories.tsx
@@ -42,6 +42,7 @@ const meta: Meta<typeof GeneralSettingsPageView> = {
 		deploymentDAUs: MockDeploymentDAUResponse,
 		invalidExperiments: [],
 		safeExperiments: [],
+		entitlements: undefined,
 	},
 };
 
@@ -134,5 +135,59 @@ export const invalidExperimentsEnabled: Story = {
 		],
 		safeExperiments: ["shared-ports"],
 		invalidExperiments: ["invalid"],
+	},
+};
+
+export const WithLicenseUtilization: Story = {
+	args: {
+		entitlements: {
+			...MockEntitlementsWithUserLimit,
+			features: {
+				...MockEntitlementsWithUserLimit.features,
+				user_limit: {
+					...MockEntitlementsWithUserLimit.features.user_limit,
+					enabled: true,
+					actual: 75,
+					limit: 100,
+					entitlement: "entitled",
+				},
+			},
+		},
+	},
+};
+
+export const HighLicenseUtilization: Story = {
+	args: {
+		entitlements: {
+			...MockEntitlementsWithUserLimit,
+			features: {
+				...MockEntitlementsWithUserLimit.features,
+				user_limit: {
+					...MockEntitlementsWithUserLimit.features.user_limit,
+					enabled: true,
+					actual: 95,
+					limit: 100,
+					entitlement: "entitled",
+				},
+			},
+		},
+	},
+};
+
+export const NoLicenseLimit: Story = {
+	args: {
+		entitlements: {
+			...MockEntitlementsWithUserLimit,
+			features: {
+				...MockEntitlementsWithUserLimit.features,
+				user_limit: {
+					...MockEntitlementsWithUserLimit.features.user_limit,
+					enabled: false,
+					actual: 0,
+					limit: 0,
+					entitlement: "entitled",
+				},
+			},
+		},
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.stories.tsx
@@ -174,6 +174,23 @@ export const HighLicenseUtilization: Story = {
 	},
 };
 
+export const ExceedsLicenseUtilization: Story = {
+	args: {
+		entitlements: {
+			...MockEntitlementsWithUserLimit,
+			features: {
+				...MockEntitlementsWithUserLimit.features,
+				user_limit: {
+					...MockEntitlementsWithUserLimit.features.user_limit,
+					enabled: true,
+					actual: 100,
+					limit: 95,
+					entitlement: "entitled",
+				},
+			},
+		},
+	},
+};
 export const NoLicenseLimit: Story = {
 	args: {
 		entitlements: {

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -70,8 +70,8 @@ export const GeneralSettingsPageView: FC<GeneralSettingsPageViewProps> = ({
 								licenseUtilizationPercentage < 0.9
 									? "primary"
 									: licenseUtilizationPercentage < 1
-									? "warning"
-									: "error"
+										? "warning"
+										: "error"
 							}
 							css={{
 								height: 24,

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -1,4 +1,5 @@
 import AlertTitle from "@mui/material/AlertTitle";
+import LinearProgress from "@mui/material/LinearProgress";
 import type {
 	DAUsResponse,
 	Entitlements,
@@ -10,7 +11,6 @@ import {
 	ActiveUsersTitle,
 } from "components/ActiveUserChart/ActiveUserChart";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
-import { Gauge } from "components/Gauge/Gauge";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
 import type { FC } from "react";
@@ -64,9 +64,14 @@ export const GeneralSettingsPageView: FC<GeneralSettingsPageViewProps> = ({
 				{licenseUtilizationPercentage && (
 					<div css={{ marginBottom: 24, height: 200 }}>
 						<ChartSection title="License Utilization">
-							<Gauge
+							<LinearProgress
+								variant="determinate"
 								value={licenseUtilizationPercentage * 100}
-								label="License Usage"
+								css={{
+									height: 24,
+									borderRadius: 4,
+									marginBottom: 8,
+								}}
 							/>
 							<span
 								css={{

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -65,7 +65,7 @@ export const GeneralSettingsPageView: FC<GeneralSettingsPageViewProps> = ({
 					<ChartSection title="License Utilization">
 						<LinearProgress
 							variant="determinate"
-							value={(licenseUtilizationPercentage % 1) * 100}
+							value={Math.min(licenseUtilizationPercentage * 100, 100)}
 							color={
 								licenseUtilizationPercentage < 0.9
 									? "primary"

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -62,30 +62,35 @@ export const GeneralSettingsPageView: FC<GeneralSettingsPageViewProps> = ({
 					</div>
 				)}
 				{licenseUtilizationPercentage && (
-					<div css={{ marginBottom: 24, height: 200 }}>
-						<ChartSection title="License Utilization">
-							<LinearProgress
-								variant="determinate"
-								value={licenseUtilizationPercentage * 100}
-								css={{
-									height: 24,
-									borderRadius: 4,
-									marginBottom: 8,
-								}}
-							/>
-							<span
-								css={{
-									fontSize: "0.75rem",
-									display: "block",
-									textAlign: "right",
-								}}
-							>
-								{Math.round(licenseUtilizationPercentage * 100)}% used (
-								{entitlements!.features.user_limit.actual}/
-								{entitlements!.features.user_limit.limit} users)
-							</span>
-						</ChartSection>
-					</div>
+					<ChartSection title="License Utilization">
+						<LinearProgress
+							variant="determinate"
+							value={(licenseUtilizationPercentage % 1) * 100}
+							color={
+								licenseUtilizationPercentage < 0.9
+									? "primary"
+									: licenseUtilizationPercentage < 1
+									? "warning"
+									: "error"
+							}
+							css={{
+								height: 24,
+								borderRadius: 4,
+								marginBottom: 8,
+							}}
+						/>
+						<span
+							css={{
+								fontSize: "0.75rem",
+								display: "block",
+								textAlign: "right",
+							}}
+						>
+							{Math.round(licenseUtilizationPercentage * 100)}% used (
+							{entitlements!.features.user_limit.actual}/
+							{entitlements!.features.user_limit.limit} users)
+						</span>
+					</ChartSection>
 				)}
 				{invalidExperiments.length > 0 && (
 					<Alert severity="warning">

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -10,6 +10,7 @@ import {
 	ActiveUsersTitle,
 } from "components/ActiveUserChart/ActiveUserChart";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { Gauge } from "components/Gauge/Gauge";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
 import type { FC } from "react";
@@ -36,6 +37,12 @@ export const GeneralSettingsPageView: FC<GeneralSettingsPageViewProps> = ({
 	safeExperiments,
 	invalidExperiments,
 }) => {
+	const licenseUtilizationPercentage =
+		entitlements?.features?.user_limit?.actual &&
+		entitlements?.features?.user_limit?.limit
+			? entitlements.features.user_limit.actual /
+				entitlements.features.user_limit.limit
+			: undefined;
 	return (
 		<>
 			<SettingsHeader
@@ -51,6 +58,27 @@ export const GeneralSettingsPageView: FC<GeneralSettingsPageViewProps> = ({
 					<div css={{ marginBottom: 24, height: 200 }}>
 						<ChartSection title={<ActiveUsersTitle interval="day" />}>
 							<ActiveUserChart data={deploymentDAUs.entries} interval="day" />
+						</ChartSection>
+					</div>
+				)}
+				{licenseUtilizationPercentage && (
+					<div css={{ marginBottom: 24, height: 200 }}>
+						<ChartSection title="License Utilization">
+							<Gauge
+								value={licenseUtilizationPercentage * 100}
+								label="License Usage"
+							/>
+							<span
+								css={{
+									fontSize: "0.75rem",
+									display: "block",
+									textAlign: "right",
+								}}
+							>
+								{Math.round(licenseUtilizationPercentage * 100)}% used (
+								{entitlements!.features.user_limit.actual}/
+								{entitlements!.features.user_limit.limit} users)
+							</span>
 						</ChartSection>
 					</div>
 				)}


### PR DESCRIPTION
This PR is the first iteration towards #15297

We cannot yet show license utilization over time, so we show current license utilization.
This is because we don't track user states over time. We only track the current user state. A graph over time filtering by active users would therefore not account for day to day changes in user state and be inaccurate.
DB schema migrations and related updates will follow that allow us to show license utilization over time.

![image](https://github.com/user-attachments/assets/91bd6e8c-e74c-4ef5-aa6b-271fd245da37)
