### PR TITLE
fix: fix goroutine leak in log streaming over websocket

### DIFF
--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/codersdk/drpc"
+	"github.com/coder/coder/v2/codersdk/wsjson"
 	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionerd/runner"
 )
@@ -162,36 +163,8 @@ func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after
 		}
 		return nil, nil, ReadBodyAsError(res)
 	}
-	logs := make(chan ProvisionerJobLog)
-	closed := make(chan struct{})
-	go func() {
-		defer close(closed)
-		defer close(logs)
-		defer conn.Close(websocket.StatusGoingAway, "")
-		var log ProvisionerJobLog
-		for {
-			msgType, msg, err := conn.Read(ctx)
-			if err != nil {
-				return
-			}
-			if msgType != websocket.MessageText {
-				return
-			}
-			err = json.Unmarshal(msg, &log)
-			if err != nil {
-				return
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case logs <- log:
-			}
-		}
-	}()
-	return logs, closeFunc(func() error {
-		<-closed
-		return nil
-	}), nil
+	d := wsjson.NewDecoder[ProvisionerJobLog](conn, websocket.MessageText, c.logger)
+	return d.Chan(), d, nil
 }
 
 // ServeProvisionerDaemonRequest are the parameters to call ServeProvisionerDaemon with

--- a/codersdk/wsjson/decoder.go
+++ b/codersdk/wsjson/decoder.go
@@ -1,0 +1,75 @@
+package wsjson
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+
+	"nhooyr.io/websocket"
+
+	"cdr.dev/slog"
+)
+
+type Decoder[T any] struct {
+	conn       *websocket.Conn
+	typ        websocket.MessageType
+	ctx        context.Context
+	cancel     context.CancelFunc
+	chanCalled atomic.Bool
+	logger     slog.Logger
+}
+
+// Chan starts the decoder reading from the websocket and returns a channel for reading the
+// resulting values. The chan T is closed if the underlying websocket is closed, or we encounter an
+// error. We also close the underlying websocket if we encounter an error reading or decoding.
+func (d *Decoder[T]) Chan() <-chan T {
+	if !d.chanCalled.CompareAndSwap(false, true) {
+		panic("chan called more than once")
+	}
+	values := make(chan T, 1)
+	go func() {
+		defer close(values)
+		defer d.conn.Close(websocket.StatusGoingAway, "")
+		for {
+			// we don't use d.ctx here because it only gets canceled after closing the connection
+			// and a "connection closed" type error is more clear than context canceled.
+			typ, b, err := d.conn.Read(context.Background())
+			if err != nil {
+				// might be benign like EOF, so just log at debug
+				d.logger.Debug(d.ctx, "error reading from websocket", slog.Error(err))
+				return
+			}
+			if typ != d.typ {
+				d.logger.Error(d.ctx, "websocket type mismatch while decoding")
+				return
+			}
+			var value T
+			err = json.Unmarshal(b, &value)
+			if err != nil {
+				d.logger.Error(d.ctx, "error unmarshalling", slog.Error(err))
+				return
+			}
+			select {
+			case values <- value:
+				// OK
+			case <-d.ctx.Done():
+				return
+			}
+		}
+	}()
+	return values
+}
+
+// nolint: revive // complains that Encoder has the same function name
+func (d *Decoder[T]) Close() error {
+	err := d.conn.Close(websocket.StatusNormalClosure, "")
+	d.cancel()
+	return err
+}
+
+// NewDecoder creates a JSON-over-websocket decoder for type T, which must be deserializable from
+// JSON.
+func NewDecoder[T any](conn *websocket.Conn, typ websocket.MessageType, logger slog.Logger) *Decoder[T] {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Decoder[T]{conn: conn, ctx: ctx, cancel: cancel, typ: typ, logger: logger}
+}

--- a/codersdk/wsjson/encoder.go
+++ b/codersdk/wsjson/encoder.go
@@ -1,0 +1,42 @@
+package wsjson
+
+import (
+	"context"
+	"encoding/json"
+
+	"golang.org/x/xerrors"
+	"nhooyr.io/websocket"
+)
+
+type Encoder[T any] struct {
+	conn *websocket.Conn
+	typ  websocket.MessageType
+}
+
+func (e *Encoder[T]) Encode(v T) error {
+	w, err := e.conn.Writer(context.Background(), e.typ)
+	if err != nil {
+		return xerrors.Errorf("get websocket writer: %w", err)
+	}
+	defer w.Close()
+	j := json.NewEncoder(w)
+	err = j.Encode(v)
+	if err != nil {
+		return xerrors.Errorf("encode json: %w", err)
+	}
+	return nil
+}
+
+func (e *Encoder[T]) Close(c websocket.StatusCode) error {
+	return e.conn.Close(c, "")
+}
+
+// NewEncoder creates a JSON-over websocket encoder for the type T, which must be JSON-serializable.
+// You may then call Encode() to send objects over the websocket. Creating an Encoder closes the
+// websocket for reading, turning it into a unidirectional write stream of JSON-encoded objects.
+func NewEncoder[T any](conn *websocket.Conn, typ websocket.MessageType) *Encoder[T] {
+	// Here we close the websocket for reading, so that the websocket library will handle pings and
+	// close frames.
+	_ = conn.CloseRead(context.Background())
+	return &Encoder[T]{conn: conn, typ: typ}
+}


### PR DESCRIPTION
fixes #14881

Our handlers for streaming logs don't read from the websocket. We don't allow the client to send us any data, but the websocket library we use requires reading from the websocket to properly handle pings and closing. Not doing so can [can cause the websocket to hang on write](https://github.com/coder/websocket/issues/405), leaking go routines which were noticed in #14881.

This fixes the issue, and in process refactors our log streaming to a encoder/decoder package which provides generic types for sending JSON over websocket.

I'd also like for us to upgrade to the latest https://github.com/coder/websocket but we should also upgrade our tailscale fork before doing so to avoid including two copies of the websocket library.