### PR TITLE
fix(site): avoid constructing invalid apps url

### DIFF
--- a/site/src/utils/apps.ts
+++ b/site/src/utils/apps.ts
@@ -29,9 +29,8 @@ export const createAppLinkHref = (
 	}
 
 	if (appsHost && app.subdomain && app.subdomain_name) {
-		const baseUrl = `${protocol}//${appsHost}`;
+		const baseUrl = `${protocol}//${appsHost.replace("*", app.subdomain_name)}`;
 		const url = new URL(baseUrl);
-		url.hostname = appsHost.replace("*", app.subdomain_name);
 		url.pathname = "/";
 
 		href = url.toString();

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -13,9 +13,8 @@ export const portForwardURL = (
 
 	const subdomain = `${port}${suffix}--${agentName}--${workspaceName}--${username}`;
 
-	const baseUrl = `${location.protocol}//${host}`;
+	const baseUrl = `${location.protocol}//${host.replace("*", subdomain)}`;
 	const url = new URL(baseUrl);
-	url.hostname = host.replace("*", subdomain);
 
 	return url.toString();
 };


### PR DESCRIPTION
In Firefox, parsing a URL containing a `*` returns an error:
```
new URL("https://*--apps.sydney.fly.dev.coder.com") 
```
```
Uncaught TypeError: URL constructor: https://*--apps.sydney.fly.dev.coder.com is not a valid URL.
    <anonymous> debugger eval code:1
```

In Chrome and Node, this same URL does not produce an error.

This causes a workspace dashboard with apps to fail to load on Firefox.
![image](https://github.com/user-attachments/assets/eeea4fe5-3759-432b-b7ce-22dfad5f8218)


