### PR TITLE
feat: allow old GitHub names

### DIFF
--- a/codersdk/name.go
+++ b/codersdk/name.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	UsernameValidRegex = regexp.MustCompile("^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$")
+	UsernameValidRegex = regexp.MustCompile("^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*-?$")
 	usernameReplace    = regexp.MustCompile("[^a-zA-Z0-9-]*")
 
 	templateVersionName = regexp.MustCompile(`^[a-zA-Z0-9]+(?:[_.-]{1}[a-zA-Z0-9]+)*$`)

--- a/codersdk/name_test.go
+++ b/codersdk/name_test.go
@@ -34,6 +34,7 @@ func TestUsernameValid(t *testing.T) {
 		{"abcdefghijklmnopqrst", true},
 		{"abcdefghijklmnopqrstu", true},
 		{"wow-test", true},
+		{"github-legacy-name-", true},
 
 		{"", false},
 		{" ", false},

--- a/site/src/utils/formUtils.test.ts
+++ b/site/src/utils/formUtils.test.ts
@@ -193,5 +193,10 @@ describe("form util functions", () => {
 			const validate = () => nameSchema.validateSync("test 3");
 			expect(validate).toThrow();
 		});
+
+		it("allows '3-test-' to be used as a name", () => {
+			const validate = () => nameSchema.validateSync("3-test-");
+			expect(validate).not.toThrow();
+		});
 	});
 });

--- a/site/src/utils/formUtils.ts
+++ b/site/src/utils/formUtils.ts
@@ -112,7 +112,7 @@ export const onChangeTrimmed =
 // REMARK: Keep these consts in sync with coderd/httpapi/httpapi.go
 const maxLenName = 32;
 const displayNameMaxLength = 64;
-const usernameRE = /^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/;
+const usernameRE = /^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*-?$/;
 const displayNameRE = /^[^\s](.*[^\s])?$/;
 
 // REMARK: see #1756 for name/username semantics


### PR DESCRIPTION
Some people have old names that could include a trailing hyphen, like mine: `Chagui-`

This PR allows them to use coder, instead of getting this error on login:
`'in tx: execute transaction: create user: invalid username "Chagui-": must be alphanumeric with hyphens'`

The error already doesn't say anything about no trailing hyphens, so no change is needed there.