### PR TITLE
fix: persist the devtunnel file in a docker volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,10 @@ services:
     #  - "998" # docker group on host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # Use "docker volume rm coder_coder_home" to reset the dev tunnel url (https://abc.xyz.try.coder.app)
+      # This volume is not required in a production environment - you may safely remove it.
+      # Coder can recreate all the files it needs on restart.
+      - coder_home:/home/coder
     depends_on:
       database:
         condition: service_healthy
@@ -47,3 +51,4 @@ services:
       retries: 5
 volumes:
   coder_data:
+  coder_home:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     #  - "998" # docker group on host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      # Use "docker volume rm coder_coder_home" to reset the dev tunnel url (https://abc.xyz.try.coder.app)
+      # Run "docker volume rm coder_coder_home" to reset the dev tunnel url (https://abc.xyz.try.coder.app).
       # This volume is not required in a production environment - you may safely remove it.
       # Coder can recreate all the files it needs on restart.
       - coder_home:/home/coder


### PR DESCRIPTION
Addresses https://github.com/coder/coder/issues/15663.

This PR saves the entire coder home directory in a Docker volume to make the dev tunnel URL persistent across container restarts.

I initially wanted to persist only the config directory, but Docker Compose cannot set permissions on a named volume unless the directory it’s mounted on already exists within the container. The `/home/coder/.config` directory, however, is not created by default in the Dockerfile. When I attempt to mount it, [Docker creates it with root permissions](https://github.com/moby/moby/issues/2259#issue-21132999), and Coder cannot write to it. I encounter the following error:

```
coder-1     | Started HTTP listener at http://0.0.0.0:7080
coder-1     | Opening tunnel so workspaces can connect to your deployment. For production scenarios, specify an external access URL
coder-1     | Encountered an error running "coder server", see "coder server --help" for more information
coder-1     | error: create tunnel: read or generate config: get config path: mkdirall config dir "/home/coder/.config/coderv2": mkdir /home/coder/.config/coderv2: permission denied
```

Creating the directory in the Dockerfile would resolve the issue for new images but would break `docker-compose.yml` for all existing Coder images. Mounting the entire home directory avoids this problem, but it makes it less clear to admins which files need to be persisted. It’s a trade-off - I believe keeping Docker Compose backwards-compatible is more important, and I hope the added comment clarifies the purpose of the volume for new users.