### PR TITLE
ci: fetch annotated tags during release/build-dylib

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # If the event that triggered the build was an annotated tag (which our
+      # tags are supposed to be), actions/checkout has a bug where the tag in
+      # question is only a lightweight tag and not a full annotated tag. This
+      # command seems to fix it.
+      # https://github.com/actions/checkout/issues/290
+      - name: Fetch git tags
+        run: git fetch --tags --force
+
       - name: Setup build tools
         run: |
           brew install bash gnu-getopt make


### PR DESCRIPTION
The release action [ran into an issue](https://github.com/coder/coder/actions/runs/12147281426) building the dylib today, as the version script that's run during the build job was unable to find an annotated tag. This is a step it skips during dry-runs.

```
ERROR: version.sh: the current commit is not tagged with an annotated tag
```

This was almost certainly caused by omitting the `git fetch --tags --force` that's present on each other release action job, as the workflow passes on a release dry-run when run against a regular branch, that's not an annotated tag.

From an existing comment:
>   If the event that triggered the build was an annotated tag (which our
     tags are supposed to be), actions/checkout has a bug where the tag in
      question is only a lightweight tag and not a full annotated tag.