### PR TITLE
feat: make username in Initialize.ps1 dynamic

### DIFF
--- a/examples/templates/azure-windows/Initialize.ps1.tftpl
+++ b/examples/templates/azure-windows/Initialize.ps1.tftpl
@@ -64,7 +64,7 @@ $task = @{
 	Action = (New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-sta -ExecutionPolicy Unrestricted -Command "C:\AzureData\CoderAgent.ps1 *>>  C:\AzureData\CoderAgent.log"')
 	Trigger = (New-ScheduledTaskTrigger -AtStartup), (New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(15))
 	Settings = (New-ScheduledTaskSettingsSet -DontStopOnIdleEnd -ExecutionTimeLimit ([TimeSpan]::FromDays(3650)) -Compatibility Win8)
-	Principal = (New-ScheduledTaskPrincipal -UserId 'vm\coder' -RunLevel Highest -LogonType S4U)
+	Principal = (New-ScheduledTaskPrincipal -UserId "$env:COMPUTERNAME\$env:USERNAME" -RunLevel Highest -LogonType S4U)
 }
 Register-ScheduledTask @task -Force
 


### PR DESCRIPTION
This PR switches the `UserId` from a constant to a generated values based on the script environment. This enables users to rename their machine and default user name without having to edit this element as well.
