### PR TITLE
fix: unify `coder create` and `coder delete` help message (#15668)

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -39,7 +39,7 @@ func (r *RootCmd) create() *serpent.Command {
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
 		Annotations: workspaceCommand,
-		Use:         "create [name]",
+		Use:         "create [workspace]",
 		Short:       "Create a workspace",
 		Long: FormatExamples(
 			Example{

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -21,6 +21,12 @@ func (r *RootCmd) deleteWorkspace() *serpent.Command {
 		Annotations: workspaceCommand,
 		Use:         "delete <workspace>",
 		Short:       "Delete a workspace",
+		Long: FormatExamples(
+			Example{
+				Description: "Delete a workspace for another user (if you have permission)",
+				Command:     "coder delete <username>/<workspace_name>",
+			},
+		),
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(1),
 			r.InitClient(client),

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -1,7 +1,7 @@
 coder v0.0.0-devel
 
 USAGE:
-  coder create [flags] [name]
+  coder create [flags] [workspace]
 
   Create a workspace
 

--- a/cli/testdata/coder_delete_--help.golden
+++ b/cli/testdata/coder_delete_--help.golden
@@ -7,6 +7,10 @@ USAGE:
 
   Aliases: rm
 
+    - Delete a workspace for another user (if you have permission):
+  
+       $ coder delete <username>/<workspace_name>
+
 OPTIONS:
       --orphan bool
           Delete a workspace without deleting its resources. This can delete a

--- a/docs/reference/cli/create.md
+++ b/docs/reference/cli/create.md
@@ -7,7 +7,7 @@ Create a workspace
 ## Usage
 
 ```console
-coder create [flags] [name]
+coder create [flags] [workspace]
 ```
 
 ## Description

--- a/docs/reference/cli/delete.md
+++ b/docs/reference/cli/delete.md
@@ -14,6 +14,14 @@ Aliases:
 coder delete [flags] <workspace>
 ```
 
+## Description
+
+```console
+  - Delete a workspace for another user (if you have permission):
+
+     $ coder delete <username>/<workspace_name>
+```
+
 ## Options
 
 ### --orphan


### PR DESCRIPTION
Closes #15668