### PR TITLE
fix: remove backtick from valid password characters

### DIFF
--- a/examples/templates/azure-windows/main.tf
+++ b/examples/templates/azure-windows/main.tf
@@ -65,9 +65,9 @@ resource "random_password" "admin_password" {
   length  = 16
   special = true
   # https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements#reference
-  # we remove characters that require special handling in XML, as this is how we pass it to the VM
-  # namely: <>&'"
-  override_special = "~!@#$%^*_-+=`|\\(){}[]:;,.?/"
+  # we remove characters that require special handling in XML, as this is how we pass it to the VM; we also remove the powershell escape character
+  # namely: <>&'`"
+  override_special = "~!@#$%^*_-+=|\\(){}[]:;,.?/"
 }
 
 locals {


### PR DESCRIPTION
Since backticks are the PowerShell escape character, they are silently consumed. To actually use backticks, they would need to be doubled when used.

This change increases the safety of generated passwords for other terraform modules that might use this value unawares.