### PR TITLE
fix: increase node max heap allocation during e2e builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -666,6 +666,8 @@ jobs:
         name: make gen
 
       - run: pnpm build
+        env:
+          NODE_OPTIONS: ${{ github.repository_owner == 'coder' && '--max_old_space_size=8192' || '' }}
         working-directory: site
 
       - run: pnpm playwright:install


### PR DESCRIPTION
We're already using a 16GB runner, so this should fix flakes like:
https://github.com/coder/coder/actions/runs/12172097355/job/33950290293
https://github.com/coder/coder/actions/runs/11653425091/job/32445787079

This is the same `NODE_OPTION` we already set in the dogfood dockerfile.