### PR TITLE
chore: improve e2e organization test

### DIFF
--- a/site/e2e/tests/organizations.spec.ts
+++ b/site/e2e/tests/organizations.spec.ts
@@ -17,20 +17,27 @@ test("create and delete organization", async ({ page }) => {
 		waitUntil: "domcontentloaded",
 	});
 
-	await page.getByLabel("Slug", { exact: true }).fill("floop");
+	await page.getByLabel("Slug").fill("floop");
 	await page.getByLabel("Display name").fill("Floop");
 	await page.getByLabel("Description").fill("Org description floop");
 	await page.getByLabel("Icon", { exact: true }).fill("/emojis/1f957.png");
-
 	await page.getByRole("button", { name: "Submit" }).click();
 
 	// Expect to be redirected to the new organization
 	await expectUrl(page).toHavePathName("/organizations/floop");
 	await expect(page.getByText("Organization created.")).toBeVisible();
 
+	await page.getByLabel("Slug").fill("wibble");
+	await page.getByLabel("Description").fill("Org description wibble");
+	await page.getByRole("button", { name: "Submit" }).click();
+
+	// Expect to be redirected when renaming the organization
+	await expectUrl(page).toHavePathName("/organizations/wibble");
+	await expect(page.getByText("Organization settings updated.")).toBeVisible();
+
 	await page.getByRole("button", { name: "Delete this organization" }).click();
 	const dialog = page.getByTestId("dialog");
-	await dialog.getByLabel("Name").fill("floop");
+	await dialog.getByLabel("Name").fill("wibble");
 	await dialog.getByRole("button", { name: "Delete" }).click();
 	await expect(page.getByText("Organization deleted.")).toBeVisible();
 });


### PR DESCRIPTION
Closes coder/internal#164

Check that the organization update form works properly, and that you get redirected when changing the "slug"