### PR TITLE
chore(enterprise): do not fail test on unexpected request

### DIFF
--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -6,10 +6,13 @@ import (
 	"regexp"
 	"testing"
 
+	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/serpent"
 
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -26,7 +29,6 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
-	"github.com/coder/serpent"
 )
 
 // nolint:bodyclose
@@ -1147,7 +1149,7 @@ func setupOIDCTest(t *testing.T, settings oidcTestConfig) *oidcTestRunner {
 	fake := oidctest.NewFakeIDP(t,
 		append([]oidctest.FakeIDPOpt{
 			oidctest.WithStaticUserInfo(settings.Userinfo),
-			oidctest.WithLogging(t, nil),
+			oidctest.WithLogging(t, &slogtest.Options{IgnoreErrors: true}),
 			// Run fake IDP on a real webserver
 			oidctest.WithServing(),
 		}, settings.FakeOpts...)...,

--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -6,11 +6,12 @@ import (
 	"regexp"
 	"testing"
 
-	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/sloggers/slogtest"
 
 	"github.com/coder/serpent"
 


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/280

Likely similar to https://github.com/coder/coder/blob/cd890aa3a0fac2db6d0abcda8b303217d435192a/coderd/workspaceapps/proxy.go#L377-L381

Alternatively (or additionally) we could have the `FakeIDP.httpHandler` handle the `/derp` path, but in general we probably shouldn't be failing these tests on a logged error?