### PR TITLE
fix: remove `disablePortal` from `Popover`

### DIFF
--- a/site/src/components/Popover/Popover.tsx
+++ b/site/src/components/Popover/Popover.tsx
@@ -171,7 +171,6 @@ export const PopoverContent: FC<PopoverContentProps> = ({
 
 	return (
 		<MuiPopover
-			disablePortal
 			css={{
 				// When it is on hover mode, and the mode is moving from the trigger to
 				// the popover, if there is any space, the popover will be closed. I


### PR DESCRIPTION
There's a reason that using a portal is the default behavior, and I have no idea why we're setting this. It's a fix in an edge case, not a prop to set all the time. 😅