### PR TITLE
fix: give cla workflow pull request write permissions

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -41,6 +41,8 @@ jobs:
 
   cla:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2


### PR DESCRIPTION
When https://github.com/coder/coder/pull/15349 was added, it implicitly set all the other permissions to none.

From https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
> If you specify the access for any of these permissions, all of those that are not specified are set to none.
