### PR TITLE
fix: docs reference in create headless user flow

### DIFF
--- a/site/src/pages/CreateUserPage/CreateUserForm.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.tsx
@@ -51,7 +51,7 @@ export const authMethodLanguage = {
 				<Link
 					target="_blank"
 					rel="noopener"
-					href="https://coder.com/docs/admin/auth#disable-built-in-authentication"
+					href="https://coder.com/docs/admin/users/headless-auth"
 				>
 					documentation
 				</Link>{" "}


### PR DESCRIPTION
when creating a headless user, the linked documentation sent users to the `Disable password auth` page, instead of the headless user documentation. this PR corrects the typescript.