### PR TITLE
ci: try building images on GitHub-hosted runner again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -976,7 +976,7 @@ jobs:
       - changes
       - build-dylib
     if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    runs-on: "ubuntu-22.04"
     permissions:
       packages: write # Needed to push images to ghcr.io
     env:


### PR DESCRIPTION
Try to work around following issue:
```
--- Creating multi-arch Docker image (ghcr.io/coder/coder-preview:main-2.18.0-devel-36c2cf8a4)
ghcr.io/coder/coder-preview:main-v2.18.0-devel-36c2cf8a4-amd64 is a manifest list
Error: Process completed with exit code 1.
```