### PR TITLE
fix(site): only show provisioner warnings for pending workspaces

### DIFF
--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -111,12 +111,13 @@ export const Workspace: FC<WorkspaceProps> = ({
 	);
 
 	const workspaceRunning = workspace.latest_build.status === "running";
+	const workspacePending = workspace.latest_build.status === "pending";
 	const haveBuildLogs = (buildLogs ?? []).length > 0;
+	const shouldShowBuildLogs = haveBuildLogs && !workspaceRunning;
 	const provisionersHealthy =
-		(workspace.latest_build.matched_provisioners?.available ?? 0) > 0;
-	const shouldDisplayBuildLogs = haveBuildLogs && !workspaceRunning;
+		(workspace.latest_build.matched_provisioners?.available ?? 1) > 0;
 	const shouldShowProvisionerAlert =
-		!workspaceRunning && !haveBuildLogs && !provisionersHealthy;
+		workspacePending && !haveBuildLogs && !provisionersHealthy && !isRestarting;
 
 	return (
 		<div
@@ -244,7 +245,7 @@ export const Workspace: FC<WorkspaceProps> = ({
 						/>
 					)}
 
-					{shouldDisplayBuildLogs && (
+					{shouldShowBuildLogs && (
 						<WorkspaceBuildLogsSection logs={buildLogs} />
 					)}
 


### PR DESCRIPTION
When creating, starting, stopping or otherwise mutating a workspace, we used to erroneously and briefly display a provisioner health warning alert. This PR updates the component to only display this warning if the build is pending, not "starting" or any other state that means a provisioner has already acquired the job.