### PR TITLE
chore: acquire lock for individual workspace transition

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -183,7 +183,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 						return xerrors.Errorf("try acquire lifecycle executor lock: %w", err)
 					}
 					if !ok {
-						e.log.Debug(e.ctx, "unable to acquire lock for workspace, skipping", slog.F("workspace_id", wsID))
+						log.Debug(e.ctx, "unable to acquire lock for workspace, skipping")
 						return nil
 					}
 

--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -399,7 +399,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 				}
 				return nil
 			}()
-			if err != nil {
+			if err != nil && !xerrors.Is(err, context.Canceled) {
 				log.Error(e.ctx, "failed to transition workspace", slog.Error(err))
 				statsMu.Lock()
 				stats.Errors[wsID] = err

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -111,11 +111,16 @@ func TestMultipleLifecycleExecutors(t *testing.T) {
 	// Get both clients to perform a lifecycle execution tick
 	next := sched.Next(workspace.LatestBuild.CreatedAt)
 
+	startCh := make(chan struct{})
 	go func() {
+		<-startCh
 		tickCh <- next
-		tickCh <- next
-		close(tickCh)
 	}()
+	go func() {
+		<-startCh
+		tickCh <- next
+	}()
+	close(startCh)
 
 	// Now we want to check the stats for both clients
 	statsA := <-statsChA

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/schedule"
@@ -70,6 +71,74 @@ func TestExecutorAutostartOK(t *testing.T) {
 	template, err := client.Template(ctx, workspace.TemplateID)
 	require.NoError(t, err)
 	require.Equal(t, template.AutostartRequirement.DaysOfWeek, []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"})
+}
+
+func TestMultipleLifecycleExecutors(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+
+	var (
+		sched = mustSchedule(t, "CRON_TZ=UTC 0 * * * *")
+		// Create our first client
+		tickChA  = make(chan time.Time)
+		statsChA = make(chan autobuild.Stats)
+		clientA  = coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			AutobuildTicker:          tickChA,
+			AutobuildStats:           statsChA,
+			Database:                 db,
+			Pubsub:                   ps,
+		})
+		// ... And then our second client
+		tickChB  = make(chan time.Time)
+		statsChB = make(chan autobuild.Stats)
+		_        = coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			AutobuildTicker:          tickChB,
+			AutobuildStats:           statsChB,
+			Database:                 db,
+			Pubsub:                   ps,
+		})
+		// Now create a workspace (we can use either client, it doesn't matter)
+		workspace = mustProvisionWorkspace(t, clientA, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.AutostartSchedule = ptr.Ref(sched.String())
+		})
+	)
+
+	// Have the workspace stopped so we can perform an autostart
+	workspace = coderdtest.MustTransitionWorkspace(t, clientA, workspace.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+
+	// Get both clients to perform a lifecycle execution tick
+	next := sched.Next(workspace.LatestBuild.CreatedAt)
+	go func() {
+		tickChA <- next
+		close(tickChA)
+	}()
+	go func() {
+		tickChB <- next
+		close(tickChB)
+	}()
+
+	// Now we want to check the stats for both clients
+	statsA := <-statsChA
+	statsB := <-statsChB
+
+	// We expect there to be no errors
+	assert.Len(t, statsA.Errors, 0)
+	assert.Len(t, statsB.Errors, 0)
+
+	// We also expect there to have been only one transition
+	require.Equal(t, 1, len(statsA.Transitions)+len(statsB.Transitions))
+
+	stats := statsA
+	if len(statsB.Transitions) == 1 {
+		stats = statsB
+	}
+
+	// And we expect this transition to have been a start transition
+	assert.Contains(t, stats.Transitions, workspace.ID)
+	assert.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[workspace.ID])
 }
 
 func TestExecutorAutostartTemplateUpdated(t *testing.T) {


### PR DESCRIPTION
When Coder is ran in High Availability mode, each Coder instance has a lifecycle executor. These lifecycle executors are all trying to do the same work, and whilst transactions saves us from this causing an issue, we are still doing extra work that could be prevented.

This PR adds a `TryAcquireLock` call for each attempted workspace transition, meaning two Coder instances shouldn't duplicate effort. 

This approach does still allow _some_ duplicated effort to occur though. This is because we aren't locking the entire `runOnce` function, meaning the follow scenario could still occur:

1. Instance `X` **calls** `GetWorkspacesEligibleForTransition`, returning Workspace `W`
2. Instance `X` **acquires lock** to transition workspace `W`
3. Instance `X` **starts** transitioning Workspace `W`
4. Instance `Y` **calls** `GetWorkspacesEligibleForTransition`, returning Workspace `W`
5. Instance `X` **finishes** transitioning Workspace `W`
6. Instance `X` **releases lock** to transition workspace `W`
7. Instance `Y` **acquires lock** to transition workspace `W`
8. Instance `Y` **starts** transitioning Workspace `W`
9. Instance `Y` **fails** to transition Workspace `W`
10. Instance `Y` **releases lock** to transition workspace `W`

I decided against locking `runOnce` for now as we run each workspace transition in their own transaction. Using nested transactions here will require extra design work and consideration.