### PR TITLE
fix(vpn): use unbuffered channel in speaker

### DIFF
--- a/vpn/speaker.go
+++ b/vpn/speaker.go
@@ -225,7 +225,7 @@ func (s *speaker[_, R, _]) newRPC() (uint64, chan R) {
 	defer s.mu.Unlock()
 	msgID := s.nextMsgID
 	s.nextMsgID++
-	c := make(chan R, 1)
+	c := make(chan R)
 	s.responseChans[msgID] = c
 	return msgID, c
 }


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/253.

The Tunnel closing mechanism encounters a race if the passed `io.ReadWriteCloser` is shared between the Tunnel and the Manager, specifically if the closing of the Conn by one causes a read fail on the other.

The sequence of events during the flakey tests is as follows:

1. Tunnel sends stop response
2. Tunnel closes` sendch`
3. `net.Pipe` gets closed by Tunnel's `sendLoop` ending
4. Manager's `serdes` reads the response successfully and passes it to the speaker via the `recvCh`. 
5. The speaker tries to deliver the response via the message's `respCh`. The `respCh` is buffered so this is non-blocking.
6. The `recvLoopDone` channel is closed by the `recvCh` getting closed (by failing to read from the closed conn)
7. `unaryRPC` is finally scheduled to run, where both of these conditions in a select block are ready, and so whether or not the response is returned is random.
```
[...]
	case <-s.recvLoopDone:
		logger.Debug(s.ctx, "recvLoopDone while waiting for response")
		return resp, io.ErrUnexpectedEOF
	case resp = <-respCh:
		logger.Debug(s.ctx, "got response", slog.F("resp", resp))
		return resp, nil
```

The solution is to therefore make the `respCh` unbuffered. That way, it's not possible for the `recvLoopDone` channel to be closed until the `respCh` is read from.