### PR TITLE
ci: pin weekly-docs runner ubuntu version to 22.04

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -15,7 +15,8 @@ permissions:
 
 jobs:
   check-docs:
-    runs-on: ubuntu-latest
+    # later versions of Ubuntu have disabled unprivileged user namespaces, which are required by the action
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # required to post PR review comments by the action
     steps:


### PR DESCRIPTION
The action is currently failing due to the runner using `ubuntu-latest`, which is now `24.04`,

See [the Ubuntu blog](https://ubuntu.com/blog/whats-new-in-security-for-ubuntu-24-04-lts#:~:text=22.04%20LTS.-,Unprivileged%20user%20namespace%20restrictions,-Unprivileged%20user%20namespaces) for more.