### PR TITLE
chore: ensure go file is valid during generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -659,8 +659,10 @@ examples/examples.gen.json: scripts/examplegen/main.go examples/examples.go $(sh
 	go run ./scripts/examplegen/main.go > examples/examples.gen.json
 
 coderd/rbac/object_gen.go: scripts/typegen/rbacobject.gotmpl scripts/typegen/main.go coderd/rbac/object.go coderd/rbac/policy/policy.go
-	go run scripts/typegen/main.go rbac object > /tmp/object_gen.go
-	mv /tmp/object_gen.go coderd/rbac/object_gen.go
+	tempdir=$(shell mktemp -d /tmp/typegen_rbac_object.XXXXXX)
+	go run ./scripts/typegen/main.go rbac object > "$$tempdir/object_gen.go"
+	mv -v "$$tempdir/object_gen.go" coderd/rbac/object_gen.go
+	rmdir -v "$$tempdir"
 
 codersdk/rbacresources_gen.go: scripts/typegen/codersdk.gotmpl scripts/typegen/main.go coderd/rbac/object.go coderd/rbac/policy/policy.go
 	# Do no overwrite codersdk/rbacresources_gen.go directly, as it would make the file empty, breaking

--- a/Makefile
+++ b/Makefile
@@ -659,7 +659,8 @@ examples/examples.gen.json: scripts/examplegen/main.go examples/examples.go $(sh
 	go run ./scripts/examplegen/main.go > examples/examples.gen.json
 
 coderd/rbac/object_gen.go: scripts/typegen/rbacobject.gotmpl scripts/typegen/main.go coderd/rbac/object.go coderd/rbac/policy/policy.go
-	go run scripts/typegen/main.go rbac object > coderd/rbac/object_gen.go
+	go run scripts/typegen/main.go rbac object > /tmp/object_gen.go
+	mv /tmp/object_gen.go coderd/rbac/object_gen.go
 
 codersdk/rbacresources_gen.go: scripts/typegen/codersdk.gotmpl scripts/typegen/main.go coderd/rbac/object.go coderd/rbac/policy/policy.go
 	# Do no overwrite codersdk/rbacresources_gen.go directly, as it would make the file empty, breaking


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/258

I think we have this problem for other generated files too. We might want to have some general solution we can use, maybe some small shell script? Unsure