### PR TITLE
chore: embed `Info.plist` in dylib

### DIFF
--- a/scripts/sign_darwin.sh
+++ b/scripts/sign_darwin.sh
@@ -9,7 +9,7 @@
 # certificate.
 #
 # For the Coder CLI, the binary_identifier should be "com.coder.cli".
-# For the CoderVPN `.dylib`, the binary_identifier should be "com.coder.vpn".
+# For the CoderVPN `.dylib`, the binary_identifier should be "com.coder.Coder-Desktop.VPN.dylib".
 #
 # You can check if a binary is signed by running the following command on a Mac:
 #   codesign -dvv path/to/binary

--- a/vpn/dylib/info.plist.tmpl
+++ b/vpn/dylib/info.plist.tmpl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>CoderVPN</string>
+    <key>CFBundleIdentifier</key>
+    <string>${BUNDLE_IDENTIFIER}</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION_STRING}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${SHORT_VERSION_STRING}</string>
+</dict>
+</plist>


### PR DESCRIPTION
Relates to https://github.com/coder/coder-desktop-macos/issues/2

This embeds:
- "CoderVPN" as `CFBundleName`
- The build version, e.g. `2.18.1-devel+1317c3043` as `CFBundleVersion`
- The semantic version, e.g. `2.18.1` as `CFBundleShortVersionString`
- The bundle identifier, `com.coder.Coder-Desktop.VPN.dylib` as `CFBundleIdentifier`.

into the `__TEXT __info_plist` section of the Coder VPN `.dylib`. This allows the Desktop app to read the version of the dylib after it's been downloaded.

There exists a Swift API for reading this section: https://developer.apple.com/documentation/corefoundation/1537134-cfbundlecopyinfodictionaryforurl
> ... This function will attempt to read an information dictionary from the (__TEXT, __info_plist) section of the file


```
$ codesign -dvvvv ./coder-vpn_2.18.1-devel+a8155f75a_darwin_arm64.dylib
Identifier=com.coder.Coder-Desktop.VPN.dylib
[...]
Info.plist entries=4
```

```
$ codesign -dvvvv ./coder-vpn_2.18.1-devel+a8155f75a_darwin_amd64.dylib
Identifier=com.coder.Coder-Desktop.VPN.dylib
[...]
Info.plist entries=4
```

```
$ otool -X -s __TEXT __info_plist ./coder-vpn_2.18.1-devel+a8155f75a_darwin_amd64.dylib | xxd -r
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>CFBundleName</key>
    <string>CoderVPN</string>
    <key>CFBundleIdentifier</key>
    <string>com.coder.Coder-Desktop.VPN.dylib</string>
    <key>CFBundleVersion</key>
    <string>2.18.1-devel+a8155f75a</string>
    <key>CFBundleShortVersionString</key>
    <string>2.18.1</string>
</dict>
</plist>
```


Note:
I initially tried to see if `Info.plist` could be embedded *within* the signature using `rcodesign`. It lets you supply an `Info.plist` but it would appear to only add the hash of the file to the signature, see [example](https://github.com/indygreg/apple-platform-rs/blob/main/apple-codesign/tests/cmd/sign-macho-info-plist.trycmd). 
Inspecting the signature with `codesign` would return `Info.plist=not bound`.