### PR TITLE
fix: correct link to premium plan

### DIFF
--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -58,7 +58,7 @@ export const Paywall: FC<PaywallProps> = ({
 				</ul>
 				<div css={styles.learnButton}>
 					<Button
-						href={docs("/licensing")}
+						href="https://coder.com/pricing#compare-plans"
 						target="_blank"
 						rel="noreferrer"
 						startIcon={<span css={{ fontSize: 22 }}>&rarr;</span>}

--- a/site/src/components/Paywall/PopoverPaywall.tsx
+++ b/site/src/components/Paywall/PopoverPaywall.tsx
@@ -62,7 +62,7 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 				</ul>
 				<div css={styles.learnButton}>
 					<Button
-						href={docs("/licensing")}
+						href="https://coder.com/pricing#compare-plans"
 						target="_blank"
 						rel="noreferrer"
 						startIcon={<span css={{ fontSize: 22 }}>&rarr;</span>}


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15911

The link target `/licensing` does not exist, so we need to link to _Pricing Plans_ instead.