### PR TITLE
chore: record and raise problematic http protocols for each proxy

### DIFF
--- a/site/src/contexts/useProxyLatency.ts
+++ b/site/src/contexts/useProxyLatency.ts
@@ -15,8 +15,10 @@ export interface ProxyLatencyReport {
 	latencyMS: number;
 	// at is when the latency was recorded.
 	at: Date;
-	// nextHopProtocol can determine if HTTP/2 is being used.
-	// https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol
+	/**
+	 * nextHopProtocol can determine if HTTP/2 is being used.
+	 * https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol
+	 */
 	nextHopProtocol?: string;
 }
 

--- a/site/src/contexts/useProxyLatency.ts
+++ b/site/src/contexts/useProxyLatency.ts
@@ -16,6 +16,7 @@ export interface ProxyLatencyReport {
 	// at is when the latency was recorded.
 	at: Date;
 	// nextHopProtocol can determine if HTTP/2 is being used.
+	// https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol
 	nextHopProtocol?: string;
 }
 

--- a/site/src/contexts/useProxyLatency.ts
+++ b/site/src/contexts/useProxyLatency.ts
@@ -15,6 +15,8 @@ export interface ProxyLatencyReport {
 	latencyMS: number;
 	// at is when the latency was recorded.
 	at: Date;
+	// nextHopProtocol can determine if HTTP/2 is being used.
+	nextHopProtocol?: string;
 }
 
 interface ProxyLatencyAction {
@@ -151,6 +153,7 @@ export const useProxyLatency = (
 			// https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Resource_timing
 			let latencyMS = 0;
 			let accurate = false;
+			let nextHopProtocol: string | undefined = undefined;
 			if (
 				"requestStart" in entry &&
 				(entry as PerformanceResourceTiming).requestStart !== 0
@@ -159,6 +162,7 @@ export const useProxyLatency = (
 				const timingEntry = entry as PerformanceResourceTiming;
 				latencyMS = timingEntry.responseStart - timingEntry.requestStart;
 				accurate = true;
+				nextHopProtocol = timingEntry.nextHopProtocol;
 			} else {
 				// This is the total duration of the request and will be off by a good margin.
 				// This is a fallback if the better timing is not available.
@@ -175,7 +179,8 @@ export const useProxyLatency = (
 					latencyMS,
 					accurate,
 					at: new Date(),
-				},
+					nextHopProtocol: nextHopProtocol,
+				} as ProxyLatencyReport,
 			};
 			dispatchProxyLatencies(update);
 			// Also save to local storage to persist the latency across page refreshes.

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -34,10 +34,10 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.1":
 				extraWarnings.push(
 					`Requests to the proxy are using ${latency.nextHopProtocol}, ` +
-						"the server might not support HTTP/2. " +
-						"For usability reasons, HTTP/2 or above is recommended. " +
-						"Pages may fail to load if the web browser's concurrent " +
-						"connection limit is reached.",
+					"the server might not support HTTP/2. " +
+					"For usability reasons, HTTP/2 or above is recommended. " +
+					"Pages may fail to load if the web browser's concurrent " +
+					"connection limit is reached.",
 				);
 		}
 	}

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -33,9 +33,11 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.0":
 			case "http/1.1":
 				extraWarnings.push(
-					`Requests to the proxy are using ${latency.nextHopProtocol}, the server might not support HTTP/2. ` +
+					`Requests to the proxy are using ${latency.nextHopProtocol}, ` +
+						`the server might not support HTTP/2. ` +
 						`For usability reasons, HTTP/2 or above is recommended. ` +
-						`Pages may fail to load if the web browser's concurrent connection limit is reached.`,
+						`Pages may fail to load if the web browser's concurrent ` +
+						`connection limit is reached.`,
 				);
 		}
 	}

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -34,11 +34,11 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.1":
 				extraWarnings.push(
 					// biome-ignore lint/style/useTemplate: easier to read short lines
-					`Requests to the proxy are using ${latency.nextHopProtocol}, ` +
-						"the server might not support HTTP/2. " +
+					`Requests to the proxy from current browser are using "${latency.nextHopProtocol}". ` +
+						"The proxy server might not support HTTP/2. " +
 						"For usability reasons, HTTP/2 or above is recommended. " +
 						"Pages may fail to load if the web browser's concurrent " +
-						"connection limit is reached.",
+						"connection limit per host is reached.",
 				);
 		}
 	}
@@ -134,7 +134,7 @@ const ProxyMessagesRow: FC<ProxyMessagesRowProps> = ({
 				title={
 					<span css={{ color: theme.palette.warning.light }}>Warnings</span>
 				}
-				messages={proxy.status?.report?.warnings.concat(extraWarnings)}
+				messages={[...(proxy.status?.report?.warnings ?? []), ...extraWarnings]}
 			/>
 		</>
 	);

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -33,7 +33,7 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.0":
 			case "http/1.1":
 				extraWarnings.push(
-					`Requests to the proxy are using ${latency.nextHopProtocol}, and the server does not support HTTP/2. ` +
+					`Requests to the proxy are using ${latency.nextHopProtocol}, the server might not support HTTP/2. ` +
 						`For usability reasons, HTTP/2 or above is recommended. ` +
 						`Pages may fail to load if the web browser's concurrent connection limit is reached.`,
 				);

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -34,10 +34,10 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.1":
 				extraWarnings.push(
 					`Requests to the proxy are using ${latency.nextHopProtocol}, ` +
-						`the server might not support HTTP/2. ` +
-						`For usability reasons, HTTP/2 or above is recommended. ` +
-						`Pages may fail to load if the web browser's concurrent ` +
-						`connection limit is reached.`,
+						"the server might not support HTTP/2. " +
+						"For usability reasons, HTTP/2 or above is recommended. " +
+						"Pages may fail to load if the web browser's concurrent " +
+						"connection limit is reached.",
 				);
 		}
 	}

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -26,7 +26,7 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 	// All users can see healthy/unhealthy, some can see more.
 	let statusBadge = <ProxyStatus proxy={proxy} />;
 	let shouldShowMessages = false;
-	let extraWarnings: string[] = [];
+	const extraWarnings: string[] = [];
 	if (latency?.nextHopProtocol) {
 		switch (latency.nextHopProtocol) {
 			case "http/0.9":
@@ -34,8 +34,8 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.1":
 				extraWarnings.push(
 					`Requests to the proxy are using ${latency.nextHopProtocol}, and the server does not support HTTP/2. ` +
-					`For usability reasons, HTTP/2 or above is recommended. ` +
-					`Pages may fail to load if the web browser's concurrent connection limit is reached.`,
+						`For usability reasons, HTTP/2 or above is recommended. ` +
+						`Pages may fail to load if the web browser's concurrent connection limit is reached.`,
 				);
 		}
 	}

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -33,11 +33,12 @@ export const ProxyRow: FC<ProxyRowProps> = ({ proxy, latency }) => {
 			case "http/1.0":
 			case "http/1.1":
 				extraWarnings.push(
+					// biome-ignore lint/style/useTemplate: easier to read short lines
 					`Requests to the proxy are using ${latency.nextHopProtocol}, ` +
-					"the server might not support HTTP/2. " +
-					"For usability reasons, HTTP/2 or above is recommended. " +
-					"Pages may fail to load if the web browser's concurrent " +
-					"connection limit is reached.",
+						"the server might not support HTTP/2. " +
+						"For usability reasons, HTTP/2 or above is recommended. " +
+						"Pages may fail to load if the web browser's concurrent " +
+						"connection limit is reached.",
 				);
 		}
 	}

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -206,6 +206,7 @@ export const MockProxyLatencies: Record<string, ProxyLatencyReport> = {
 						100) %
 					250,
 				at: new Date(),
+				nextHopProtocol: proxy.id === "8444931c-0247-4171-842a-569d9f9cbadb" ? "http/1.1" : "h2",
 			};
 			return acc;
 		},

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -206,7 +206,10 @@ export const MockProxyLatencies: Record<string, ProxyLatencyReport> = {
 						100) %
 					250,
 				at: new Date(),
-				nextHopProtocol: proxy.id === "8444931c-0247-4171-842a-569d9f9cbadb" ? "http/1.1" : "h2",
+				nextHopProtocol:
+					proxy.id === "8444931c-0247-4171-842a-569d9f9cbadb"
+						? "http/1.1"
+						: "h2",
 			};
 			return acc;
 		},


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/15887

Adds warnings to the proxy and proxy health pages on HTTP 1.1, 1.0, 0.9 protocols. 


![Screenshot From 2024-12-18 08-52-38](https://github.com/user-attachments/assets/64940d48-ec3f-4af2-924b-461f33121184)


# Implementation notes

Only the performance API can return the HTTP protocol type. We already use the performance API for latency timings, and each proxy could have this issue. So it made the most sense to put the warnings here.

Imo we should raise this error to admins more seriously and obviously, but that can wait.
