### PR TITLE
fix: loosen timing checks for heartbeats

### DIFF
--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -410,7 +410,7 @@ func TestPGCoordinatorSingle_SendsHeartbeats(t *testing.T) {
 		}
 		require.Greater(t, heartbeats[0].Sub(start), time.Duration(0))
 		require.Greater(t, heartbeats[1].Sub(start), time.Duration(0))
-		return assert.Greater(t, heartbeats[1].Sub(heartbeats[0]), tailnet.HeartbeatPeriod*9/10)
+		return assert.Greater(t, heartbeats[1].Sub(heartbeats[0]), tailnet.HeartbeatPeriod*3/4)
 	}, testutil.WaitMedium, testutil.IntervalMedium)
 }
 


### PR DESCRIPTION
Fixes #15782.

I believe that Windows doesn't always have high-resolution timers available, so this PR loosens the check for PG Coordinator heartbeats, to avoid flakes like:

https://github.com/coder/coder/actions/runs/12397381823/job/34607639048