### PR TITLE
docs: add a glossary page to the documentation

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1487,7 +1487,7 @@
 				{
 					"title": "Glossary",
 					"description": "A list of common terms",
-					"path": "./reference/glossary.mdx",
+					"path": "./reference/glossary.md",
 					"icon_path": "./images/icons/notes.svg"
 				}
 			]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1483,6 +1483,12 @@
 							"path": "./reference/agent-api/schemas.md"
 						}
 					]
+				},
+				{
+					"title": "Glossary",
+					"description": "A list of common terms",
+					"path": "./reference/glossary.mdx",
+					"icon_path": "./images/icons/notes.svg"
 				}
 			]
 		}

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,7 +1,6 @@
 ---
 title: Glossary
 description: A list of common terms.
-date: December 20, 2024
 ---
 
 ## A
@@ -14,9 +13,11 @@ date: December 20, 2024
 
 ### Access URL
 
-An IP address or URL for the Coder deployment. You can set the access URL to `https://coder.example.com` or anything else that works for your deployment.
+An IP address or URL for the Coder deployment. You can set the access URL to
+`https://coder.example.com` or anything else that works for your deployment.
 
-If an access URL is not specified, Coder will create a publicly accessible URL to reverse proxy your deployment for simple setup.
+If an access URL is not specified, Coder will create a publicly accessible URL
+to reverse proxy your deployment for simple setup.
 
 **Link:** [Setup - Access URL](../admin/setup/index.md#access-url)
 
@@ -30,13 +31,7 @@ If an access URL is not specified, Coder will create a publicly accessible URL t
 
 **Link:**
 
-## D
-
-## E
-
-## F
-
-## G
+## D E F G
 
 ## H
 
@@ -54,17 +49,7 @@ If an access URL is not specified, Coder will create a publicly accessible URL t
 
 **Link:**
 
-## J
-
-## K
-
-## L
-
-## M
-
-## N
-
-## O
+## J K L M N O
 
 ## P
 
@@ -112,8 +97,4 @@ If an access URL is not specified, Coder will create a publicly accessible URL t
 
 **Link:**
 
-## X
-
-## Y
-
-## Z
+## X Y Z

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -1,0 +1,119 @@
+---
+title: Glossary
+description: A list of common terms.
+date: December 20, 2024
+---
+
+## A
+
+### Abstraction
+
+(definition)
+
+**Link:**
+
+### Access URL
+
+An IP address or URL for the Coder deployment. You can set the access URL to `https://coder.example.com` or anything else that works for your deployment.
+
+If an access URL is not specified, Coder will create a publicly accessible URL to reverse proxy your deployment for simple setup.
+
+**Link:** [Setup - Access URL](../admin/setup/index.md#access-url)
+
+## B
+
+## C
+
+### code-server
+
+(definition)
+
+**Link:**
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+### Health check / healthz
+
+(definition)
+
+**Link:**
+
+## I
+
+### Image
+
+(definition)
+
+**Link:**
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+### Provisioner
+
+(definition)
+
+**Link:**
+
+## Q
+
+## R
+
+### RBAC
+
+(definition)
+
+**Link:**
+
+## S
+
+## T
+
+### Template
+
+(definition)
+
+**Link:**
+
+## U
+
+## V
+
+### Validated Architecture
+
+(definition)
+
+**Link:**
+
+## W
+
+### Workspace
+
+(definition)
+
+**Link:**
+
+## X
+
+## Y
+
+## Z


### PR DESCRIPTION
[preview](https://coder.com/docs/@glossary/reference/glossary)

- I tested it as `.mdx`, but it got rendered with the extension? making it a `.md` instead
- I don't really like the way the empty letter headings looks, so I ~might~ am going to combine the empty ones as placeholders ( `## D E F G`)