### PR TITLE
chore: remove usage of wsconn in favor of websocket

### DIFF
--- a/tailnet/derp.go
+++ b/tailnet/derp.go
@@ -10,7 +10,6 @@ import (
 
 	"nhooyr.io/websocket"
 	"tailscale.com/derp"
-	"tailscale.com/net/wsconn"
 )
 
 // WithWebsocketSupport returns an http.Handler that upgrades
@@ -60,7 +59,7 @@ func WithWebsocketSupport(s *derp.Server, base http.Handler) (http.Handler, func
 				c.Close(websocket.StatusPolicyViolation, "client must speak the derp subprotocol")
 				return
 			}
-			wc := wsconn.NetConn(ctx, c, websocket.MessageBinary)
+			wc := websocket.NetConn(ctx, c, websocket.MessageBinary)
 			brw := bufio.NewReadWriter(bufio.NewReader(wc), bufio.NewWriter(wc))
 			s.Accept(ctx, wc, brw, r.RemoteAddr)
 		}), func() {


### PR DESCRIPTION
Mirrors this change in coder/tailscale: https://github.com/coder/tailscale/commit/49a2c1225cce5e7fcf182a725270c60cc039b7ee#diff-c39ff5f79c0226eb014e7df056129cbc551290695965212810a617dbdecc6d37R53

We still need to move to coder/websocket