### PR TITLE
docs: add a link to the quickstart guide in the install Coder document

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -6,8 +6,8 @@ We support two release channels: mainline and stable - read the
 [Releases](./releases.md) page to learn more about which best suits your team.
 
 There are several ways to install Coder. Follow the steps on this page for a
-minimal installation of Coder, or for a step-by-step guide on how
-to install and configure your first Coder deployment, follow the
+minimal installation of Coder, or for a step-by-step guide on how to install and
+configure your first Coder deployment, follow the
 [quickstart guide](../tutorials/quickstart.md).
 
 For production deployments with 50+ users, we recommend

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -5,9 +5,14 @@ A single CLI (`coder`) is used for both the Coder server and the client.
 We support two release channels: mainline and stable - read the
 [Releases](./releases.md) page to learn more about which best suits your team.
 
-There are several ways to install Coder. For production deployments with 50+
-users, we recommend [installing on Kubernetes](./kubernetes.md). Otherwise, you
-can install Coder on your local machine or on a VM:
+There are several ways to install Coder. Follow the steps on this page for a
+minimal installation of Coder or follow the
+[quickstart guide](../tutorials/quickstart.md) for a step-by-step guide on how
+to install and configure your first Coder deployment.
+
+For production deployments with 50+ users, we recommend
+[installing on Kubernetes](./kubernetes.md). Otherwise, you can install Coder on
+your local machine or on a VM:
 
 <div class="tabs">
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -6,9 +6,9 @@ We support two release channels: mainline and stable - read the
 [Releases](./releases.md) page to learn more about which best suits your team.
 
 There are several ways to install Coder. Follow the steps on this page for a
-minimal installation of Coder or follow the
-[quickstart guide](../tutorials/quickstart.md) for a step-by-step guide on how
-to install and configure your first Coder deployment.
+minimal installation of Coder, or for a step-by-step guide on how
+to install and configure your first Coder deployment, follow the
+[quickstart guide](../tutorials/quickstart.md).
 
 For production deployments with 50+ users, we recommend
 [installing on Kubernetes](./kubernetes.md). Otherwise, you can install Coder on


### PR DESCRIPTION
[preview](https://coder.com/docs/@install-link-quickstart/install)