### PR TITLE
fix: add missing idp-org-sync sidebar item

### DIFF
--- a/site/src/modules/management/DeploymentSidebarView.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.tsx
@@ -101,6 +101,11 @@ const DeploymentSettingsNavigation: FC<DeploymentSettingsNavigationProps> = ({
 						</div>
 					</SidebarNavItem>
 				)}
+				{permissions.viewOrganizationIDPSyncSettings && (
+					<SidebarNavItem href="idp-org-sync">
+						IdP Organization Sync
+					</SidebarNavItem>
+				)}
 				{!isPremium && <SidebarNavItem href="premium">Premium</SidebarNavItem>}
 			</div>
 		</div>


### PR DESCRIPTION
During the work to split the deployment and organizations sidebars, the sidebar item for idp organization sync was accidentally removed. 