### PR TITLE
feat: allow entering non-default values in multi-select

### DIFF
--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -195,7 +195,7 @@ func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor > 0 {
 				m.cursor--
 			} else {
-				m.cursor = len(options) - 1
+				m.cursor = len(options)
 			}
 
 		case tea.KeyDown:
@@ -300,9 +300,10 @@ func (m selectModel) filteredOptions() []string {
 }
 
 type MultiSelectOptions struct {
-	Message  string
-	Options  []string
-	Defaults []string
+	Message           string
+	Options           []string
+	Defaults          []string
+	EnableCustomInput bool
 }
 
 func MultiSelect(inv *serpent.Invocation, opts MultiSelectOptions) ([]string, error) {
@@ -328,9 +329,10 @@ func MultiSelect(inv *serpent.Invocation, opts MultiSelectOptions) ([]string, er
 	}
 
 	initialModel := multiSelectModel{
-		search:  textinput.New(),
-		options: options,
-		message: opts.Message,
+		search:            textinput.New(),
+		options:           options,
+		message:           opts.Message,
+		enableCustomInput: opts.EnableCustomInput,
 	}
 
 	initialModel.search.Prompt = ""
@@ -370,12 +372,15 @@ type multiSelectOption struct {
 }
 
 type multiSelectModel struct {
-	search   textinput.Model
-	options  []*multiSelectOption
-	cursor   int
-	message  string
-	canceled bool
-	selected bool
+	search            textinput.Model
+	options           []*multiSelectOption
+	cursor            int
+	message           string
+	canceled          bool
+	selected          bool
+	isInputMode       bool   // New field to track if we're adding a custom option
+	customInput       string // New field to store custom input
+	enableCustomInput bool   // New field to control whether custom input is allowed
 }
 
 func (multiSelectModel) Init() tea.Cmd {
@@ -385,6 +390,10 @@ func (multiSelectModel) Init() tea.Cmd {
 //nolint:revive // For same reason as previous Update definition
 func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
+
+	if m.isInputMode {
+		return m.handleCustomInputMode(msg)
+	}
 
 	switch msg := msg.(type) {
 	case terminateMsg:
@@ -398,6 +407,11 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case tea.KeyEnter:
+			// Switch to custom input mode if we're on the "+ Add custom value:" option
+			if m.enableCustomInput && m.cursor == len(m.filteredOptions()) {
+				m.isInputMode = true
+				return m, nil
+			}
 			if len(m.options) != 0 {
 				m.selected = true
 				return m, tea.Quit
@@ -414,15 +428,17 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case tea.KeyUp:
 			options := m.filteredOptions()
+			maxIndex := len(options)
 			if m.cursor > 0 {
 				m.cursor--
 			} else {
-				m.cursor = len(options) - 1
+				m.cursor = maxIndex
 			}
 
 		case tea.KeyDown:
 			options := m.filteredOptions()
-			if m.cursor < len(options)-1 {
+			maxIndex := len(options)
+			if m.cursor < maxIndex {
 				m.cursor++
 			} else {
 				m.cursor = 0
@@ -457,6 +473,52 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// handleCustomInputMode manages keyboard interactions when in custom input mode
+func (m *multiSelectModel) handleCustomInputMode(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.Type {
+	case tea.KeyEnter:
+		return m.handleCustomInputSubmission()
+
+	case tea.KeyCtrlC:
+		m.canceled = true
+		return m, tea.Quit
+
+	case tea.KeyBackspace:
+		return m.handleCustomInputBackspace()
+
+	default:
+		m.customInput += keyMsg.String()
+		return m, nil
+	}
+}
+
+// handleCustomInputSubmission processes the submission of custom input
+func (m *multiSelectModel) handleCustomInputSubmission() (tea.Model, tea.Cmd) {
+	if m.customInput != "" {
+		m.options = append(m.options, &multiSelectOption{
+			option: m.customInput,
+			chosen: true,
+		})
+	}
+	// Reset input state regardless of whether input was empty
+	m.customInput = ""
+	m.isInputMode = false
+	return m, nil
+}
+
+// handleCustomInputBackspace handles backspace in custom input mode
+func (m *multiSelectModel) handleCustomInputBackspace() (tea.Model, tea.Cmd) {
+	if len(m.customInput) > 0 {
+		m.customInput = m.customInput[:len(m.customInput)-1]
+	}
+	return m, nil
+}
+
 func (m multiSelectModel) View() string {
 	var s strings.Builder
 
@@ -469,13 +531,19 @@ func (m multiSelectModel) View() string {
 		return s.String()
 	}
 
+	if m.isInputMode {
+		_, _ = s.WriteString(fmt.Sprintf("%s\nEnter custom value: %s\n", msg, m.customInput))
+		return s.String()
+	}
+
 	_, _ = s.WriteString(fmt.Sprintf(
 		"%s %s[Use arrows to move, space to select, <right> to all, <left> to none, type to filter]\n",
 		msg,
 		m.search.View(),
 	))
 
-	for i, option := range m.filteredOptions() {
+	options := m.filteredOptions()
+	for i, option := range options {
 		cursor := "  "
 		chosen := "[ ]"
 		o := option.option
@@ -498,6 +566,16 @@ func (m multiSelectModel) View() string {
 		))
 	}
 
+	if m.enableCustomInput {
+		// Add the "+ Add custom value" option at the bottom
+		cursor := "  "
+		text := " + Add custom value"
+		if m.cursor == len(options) {
+			cursor = pretty.Sprint(DefaultStyles.Keyword, "> ")
+			text = pretty.Sprint(DefaultStyles.Keyword, text)
+		}
+		_, _ = s.WriteString(fmt.Sprintf("%s%s\n", cursor, text))
+	}
 	return s.String()
 }
 

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -195,7 +195,7 @@ func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor > 0 {
 				m.cursor--
 			} else {
-				m.cursor = len(options)
+				m.cursor = len(options) - 1
 			}
 
 		case tea.KeyDown:
@@ -378,9 +378,9 @@ type multiSelectModel struct {
 	message           string
 	canceled          bool
 	selected          bool
-	isCustomInputMode bool   // New field to track if we're adding a custom option
-	customInput       string // New field to store custom input
-	enableCustomInput bool   // New field to control whether custom input is allowed
+	isCustomInputMode bool   // track if we're adding a custom option
+	customInput       string // store custom input
+	enableCustomInput bool   // control whether custom input is allowed
 }
 
 func (multiSelectModel) Init() tea.Cmd {

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -517,7 +517,7 @@ func (m *multiSelectModel) handleCustomInputSubmission() (tea.Model, tea.Cmd) {
 
 	// Check for duplicates
 	for i, opt := range m.options {
-		if strings.EqualFold(opt.option, m.customInput) {
+		if opt.option == m.customInput {
 			// If the option exists but isn't chosen, select it
 			if !opt.chosen {
 				opt.chosen = true

--- a/cli/prompts.go
+++ b/cli/prompts.go
@@ -156,9 +156,10 @@ func (RootCmd) promptExample() *serpent.Command {
 					multiSelectValues, multiSelectError = cliui.MultiSelect(inv, cliui.MultiSelectOptions{
 						Message: "Select some things:",
 						Options: []string{
-							"Code", "Chair", "Whale", "Diamond", "Carrot",
+							"Code", "Chairs", "Whale", "Diamond", "Carrot",
 						},
-						Defaults: []string{"Code"},
+						Defaults:          []string{"Code"},
+						EnableCustomInput: true,
 					})
 				}
 				_, _ = fmt.Fprintf(inv.Stdout, "%q are nice choices.\n", strings.Join(multiSelectValues, ", "))

--- a/cli/prompts.go
+++ b/cli/prompts.go
@@ -41,6 +41,15 @@ func (RootCmd) promptExample() *serpent.Command {
 			Default:     "",
 			Value:       serpent.StringArrayOf(&multiSelectValues),
 		}
+
+		enableCustomInput       bool
+		enableCustomInputOption = serpent.Option{
+			Name:        "enable-custom-input",
+			Description: "Enable custom input option in multi-select.",
+			Required:    false,
+			Flag:        "enable-custom-input",
+			Value:       serpent.BoolOf(&enableCustomInput),
+		}
 	)
 	cmd := &serpent.Command{
 		Use:   "prompt-example",
@@ -159,12 +168,12 @@ func (RootCmd) promptExample() *serpent.Command {
 							"Code", "Chairs", "Whale", "Diamond", "Carrot",
 						},
 						Defaults:          []string{"Code"},
-						EnableCustomInput: true,
+						EnableCustomInput: enableCustomInput,
 					})
 				}
 				_, _ = fmt.Fprintf(inv.Stdout, "%q are nice choices.\n", strings.Join(multiSelectValues, ", "))
 				return multiSelectError
-			}, useThingsOption),
+			}, useThingsOption, enableCustomInputOption),
 			promptCmd("rich-parameter", func(inv *serpent.Invocation) error {
 				value, err := cliui.RichSelect(inv, cliui.RichSelectOptions{
 					Options: []codersdk.TemplateVersionParameterOption{


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/15488

cliui.Multiselect currently does not allow users to input custom options if zero choices are provided.


### Proposed Solution

cliui.MultiSelect should always allow users to specify another option.

For example, when running coder exp prompt-example multi-select: 

PS: I have modified the text a bit from the original issue

```
? Select some things:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [x] Code
  [ ] Chair
  [ ] Whale
  [ ] Diamond
  [ ] Carrot
  ... Other
+ Add custom value


? Select some things:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
? Enter custom value: potato⏎


? Select some things:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
  [x] Code
  [ ] Chair
  [ ] Whale
  [ ] Diamond
  [ ] Carrot
  [x] potato
>  ... Other
+ Add custom value

```

Attaching a recording for the same

https://github.com/user-attachments/assets/ce02cfab-4549-4431-b0d7-c7c2d69ae7ca




