### PR TITLE
chore(docs/admin/infrastructure): call out and link to awsiamrds auth for aws rds

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -51,13 +51,15 @@ OPTIONS:
           all available experiments.
 
       --postgres-auth password|awsiamrds, $CODER_PG_AUTH (default: password)
-          Type of auth to use when connecting to postgres.
+          Type of auth to use when connecting to postgres. For AWS RDS, using
+          IAM authentication (awsiamrds) is recommended.
 
       --postgres-url string, $CODER_PG_CONNECTION_URL
           URL of a PostgreSQL database. If empty, PostgreSQL binaries will be
           downloaded from Maven (https://repo1.maven.org/maven2) and store all
           data in the config root. Access the built-in database with "coder
-          server postgres-builtin-url".
+          server postgres-builtin-url". Note that any special characters in the
+          URL must be URL-encoded.
 
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -446,7 +446,8 @@ cacheDir: [cache dir]
 # Controls whether data will be stored in an in-memory database.
 # (default: <unset>, type: bool)
 inMemoryDatabase: false
-# Type of auth to use when connecting to postgres.
+# Type of auth to use when connecting to postgres. For AWS RDS, using IAM
+# authentication (awsiamrds) is recommended.
 # (default: password, type: enum[password\|awsiamrds])
 pgAuth: password
 # A URL to an external Terms of Service that must be accepted by users when

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2284,7 +2284,7 @@ when required by your organization's security policy.`,
 		},
 		{
 			Name:        "Postgres Connection URL",
-			Description: "URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with \"coder server postgres-builtin-url\".",
+			Description: "URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with \"coder server postgres-builtin-url\". Note that any special characters in the URL must be URL-encoded.",
 			Flag:        "postgres-url",
 			Env:         "CODER_PG_CONNECTION_URL",
 			Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2292,7 +2292,7 @@ when required by your organization's security policy.`,
 		},
 		{
 			Name:        "Postgres Auth",
-			Description: "Type of auth to use when connecting to postgres.",
+			Description: "Type of auth to use when connecting to postgres. For AWS RDS, using IAM authentication (awsiamrds) is recommended.",
 			Flag:        "postgres-auth",
 			Env:         "CODER_PG_AUTH",
 			Default:     "password",

--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -94,7 +94,7 @@ external PostgreSQL 13+ database for production deployments.
 
 A managed PostgreSQL database, with daily backups, is recommended:
 
-- For AWS: Amazon RDS for PostgreSQL using [RDS IAM authentication](../../reference/cli/server.md#--postgres-auth).
+- For AWS: Amazon RDS for PostgreSQL (preferably using [RDS IAM authentication](../../reference/cli/server.md#--postgres-auth)).
 - For Azure: Azure Database for PostgreSQL
 - Flexible Server For GCP: Cloud SQL for PostgreSQL
 

--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -94,7 +94,8 @@ external PostgreSQL 13+ database for production deployments.
 
 A managed PostgreSQL database, with daily backups, is recommended:
 
-- For AWS: Amazon RDS for PostgreSQL (preferably using [RDS IAM authentication](../../reference/cli/server.md#--postgres-auth)).
+- For AWS: Amazon RDS for PostgreSQL (preferably using
+  [RDS IAM authentication](../../reference/cli/server.md#--postgres-auth)).
 - For Azure: Azure Database for PostgreSQL
 - Flexible Server For GCP: Cloud SQL for PostgreSQL
 

--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -94,7 +94,7 @@ external PostgreSQL 13+ database for production deployments.
 
 A managed PostgreSQL database, with daily backups, is recommended:
 
-- For AWS: Amazon RDS for PostgreSQL
+- For AWS: Amazon RDS for PostgreSQL using [RDS IAM authentication](../../reference/cli/server.md#--postgres-auth).
 - For Azure: Azure Database for PostgreSQL
 - Flexible Server For GCP: Cloud SQL for PostgreSQL
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -948,7 +948,7 @@ The directory to cache temporary files. If unspecified and $CACHE_DIRECTORY is s
 | Type        | <code>string</code>                   |
 | Environment | <code>$CODER_PG_CONNECTION_URL</code> |
 
-URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with "coder server postgres-builtin-url".
+URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with "coder server postgres-builtin-url". Note that any special characters in the URL must be URL-encoded.
 
 ### --postgres-auth
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -959,7 +959,7 @@ URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded f
 | YAML        | <code>pgAuth</code>              |
 | Default     | <code>password</code>            |
 
-Type of auth to use when connecting to postgres.
+Type of auth to use when connecting to postgres. For AWS RDS, using IAM authentication (awsiamrds) is recommended.
 
 ### --secure-auth-cookie
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -52,13 +52,15 @@ OPTIONS:
           all available experiments.
 
       --postgres-auth password|awsiamrds, $CODER_PG_AUTH (default: password)
-          Type of auth to use when connecting to postgres.
+          Type of auth to use when connecting to postgres. For AWS RDS, using
+          IAM authentication (awsiamrds) is recommended.
 
       --postgres-url string, $CODER_PG_CONNECTION_URL
           URL of a PostgreSQL database. If empty, PostgreSQL binaries will be
           downloaded from Maven (https://repo1.maven.org/maven2) and store all
           data in the config root. Access the built-in database with "coder
-          server postgres-builtin-url".
+          server postgres-builtin-url". Note that any special characters in the
+          URL must be URL-encoded.
 
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/15954

It took me way too long to find out exactly how to specify AWS IAM DB auth, so making it a bit more accessible.
I've also seen a few cases where folks get tripped up by special characters in their DB URLs, so calling this out explicitly.