### PR TITLE
chore: improve error when db migration fails

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2157,6 +2157,10 @@ func ConnectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 
 	err = migrations.Up(sqlDB)
 	if err != nil {
+		// Checks for database schema version mismatch
+		if errors.Is(err, os.ErrNotExist) && strings.Contains(err.Error(), "no migration found for version") {
+			return nil, xerrors.New("Current database schema requires a newer version of Coder!")
+		}
 		return nil, xerrors.Errorf("migrate up: %w", err)
 	}
 	// The default is 0 but the request will fail with a 500 if the DB


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/14248

When older coder executables encounter database schemas from newer builds that have newer migrations, they produce a somewhat inscrutable error that doesn't provide the user a meaningful call to action.

Current:
```
2024-08-12 17:51:10.327 [erro]  connect to postgres failed ...
    error= migrate up:
               github.com/coder/coder/v2/cli.ConnectToPostgres
                   /home/runner/work/coder/coder/cli/server.go:2157
             - up:
               github.com/coder/coder/v2/coderd/database/migrations.UpWithFS
                   /home/runner/work/coder/coder/coderd/database/migrations/migrate.go:82
             - no migration found for version 237: read down for version 237 .: file does not exist
 ```
Proposal:

```
2024-08-12 17:51:10.327 [erro]  connect to postgres failed ...
    error= Current database requires Coder version 2.14.0 or greater
```
@angrycub  @johnstcn 

I did see a script [here](https://github.com/coder/coder/blob/main/scripts/releasemigrations/main.go#L1) mapping releases and migrations. 

But I'm not sure how to have the version to upgrade to be specified in the error message.  So I have changed the error message to `Current database schema requires a newer version of Coder!`. Please do let me know if I'm missing anything.
