### PR TITLE
docs: update external auth to better explain process

### DIFF
--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -11,9 +11,8 @@ application. The following providers are supported:
 
 The next step is to configure the Coder server to use the OAuth application by
 setting the following environment variables:
-<div class="tabs">
 
-## Environment Variables
+## Configuration
 
 ```env
 CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>"
@@ -29,43 +28,10 @@ The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
 reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
 GitHub provider).
 
-## Docker Compose
-
-```yaml
-services:
-	coder:
-		environment:
-			CODER_EXTERNAL_AUTH_0_ID: <USER_DEFINED_ID>
-			CODER_EXTERNAL_AUTH_0_TYPE: <github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>
-			CODER_EXTERNAL_AUTH_0_CLIENT_ID: <OAuth app client ID>
-			CODER_EXTERNAL_AUTH_0_CLIENT_SECRET: <OAuth app client secret>
-```
 
 The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
 reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
 GitHub provider).
-
-## Docker CLI
-
-```sh
-export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
-docker run --rm -it \
-	-e CODER_ACCESS_URL="https://coder.example.com" \
-	-e CODER_PG_CONECTION_URL="postgresql://username:password@database/coder" \
-	-e CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>" \
-	-e CODER_EXTERNAL_AUTH_0_TYPE="<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>" \
-	-e CODER_EXTERNAL_AUTH_0_CLIENT_ID="<OAuth app client ID>" \
-	-e CODER_EXTERNAL_AUTH_0_CLIENT_SECRET="<OAuth app client secret>" \
-	-v /var/run/docker.sock:/var/run/docker.sock \
-	--group-add $DOCKER_GROUP \
-	ghcr.io/coder/coder:latest
-```
-
-The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
-reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
-GitHub provider).
-
-</div>
 
 You can now add the following code to any template. This will add a button to the workspace setup page which will allow you to authenticate with your provider.
 

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -11,21 +11,71 @@ application. The following providers are supported:
 
 The next step is to configure the Coder server to use the OAuth application by
 setting the following environment variables:
+<div class="tabs">
+
+## Environment Variables
 
 ```env
 CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>"
 CODER_EXTERNAL_AUTH_0_TYPE=<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>
-CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
-CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
+CODER_EXTERNAL_AUTH_0_CLIENT_ID=<OAuth app client ID>
+CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=<OAuth app client secret>
 
 # Optionally, configure a custom display name and icon
 CODER_EXTERNAL_AUTH_0_DISPLAY_NAME="Google Calendar"
 CODER_EXTERNAL_AUTH_0_DISPLAY_ICON="https://mycustomicon.com/google.svg"
 ```
+The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
+reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
+GitHub provider).
+
+## Docker Compose
+
+```yaml
+services:
+	coder:
+		environment:
+			CODER_EXTERNAL_AUTH_0_ID: <USER_DEFINED_ID>
+			CODER_EXTERNAL_AUTH_0_TYPE: <github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>
+			CODER_EXTERNAL_AUTH_0_CLIENT_ID: <OAuth app client ID>
+			CODER_EXTERNAL_AUTH_0_CLIENT_SECRET: <OAuth app client secret>
+```
 
 The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
 reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
 GitHub provider).
+
+## Docker CLI
+
+```sh
+export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
+docker run --rm -it \
+	-e CODER_ACCESS_URL="https://coder.example.com" \
+	-e CODER_PG_CONECTION_URL="postgresql://username:password@database/coder" \
+	-e CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>" \
+	-e CODER_EXTERNAL_AUTH_0_TYPE="<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>" \
+	-e CODER_EXTERNAL_AUTH_0_CLIENT_ID="<OAuth app client ID>" \
+	-e CODER_EXTERNAL_AUTH_0_CLIENT_SECRET="<OAuth app client secret>" \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	--group-add $DOCKER_GROUP \
+	ghcr.io/coder/coder:latest
+```
+
+The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
+reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
+GitHub provider).
+
+</div>
+
+You can now add the following code to any template. This will add a button to the workspace setup page which will allow you to authenticate with your provider.
+
+```tf
+data "coder_external_auth" "<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>" {
+	id = "<USER_DEFINED_ID>"
+}
+```
+
+Inside your terraform code, you now have access to authentication variables. Reference the documentation for your chosen provider for more information on how to supply it with a token.
 
 ## GitHub
 

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -73,6 +73,13 @@ You can now add the following code to any template. This will add a button to th
 data "coder_external_auth" "<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>" {
 	id = "<USER_DEFINED_ID>"
 }
+
+# Github Example (CODER_EXTERNAL_AUTH_0_ID="github-auth")
+# makes a github authentication token available at data.coder_external_auth.github.access_token
+data "coder_external_auth" "github" {
+   id = "github-auth"
+}
+
 ```
 
 Inside your terraform code, you now have access to authentication variables. Reference the documentation for your chosen provider for more information on how to supply it with a token.

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -28,11 +28,6 @@ The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
 reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
 GitHub provider).
 
-
-The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
-reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
-GitHub provider).
-
 You can now add the following code to any template. This will add a button to the workspace setup page which will allow you to authenticate with your provider.
 
 ```tf
@@ -49,6 +44,14 @@ data "coder_external_auth" "github" {
 ```
 
 Inside your terraform code, you now have access to authentication variables. Reference the documentation for your chosen provider for more information on how to supply it with a token.
+
+### Workspace CLI
+An access token can be accessed within the workspace by using
+
+```
+coder external-auth <USER_DEFINED_ID> access-token
+```
+
 
 ## GitHub
 


### PR DESCRIPTION
Reference #15968 

Adds more information on how to add external auth, including docker-compose and docker CLI examples and terraform code for template integration.