### PR TITLE
ci: integrate cherry-pick-bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: false


### PR DESCRIPTION
Integrates [`cherry-pick-bot`](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot) to automate cheery picks to release branches. 

This works by commenting 

```
/cherry-pick release/2.XX
```
On any **Merged** or **Open** PR and this will automatically open the cheery-pick PR.

- [x] [Install](https://github.com/apps/gcp-cherry-pick-bot) the bot to `coder/coder` repo.

cc: @kylecarbs , @ammario and @sreya for installing the bot.


Some popular repos making use of this:

1. https://github.com/zed-industries/zed
2. https://github.com/flutter/flutter
3. https://github.com/argoproj/argo-cd
4. https://github.com/runatlantis/atlantis
5. https://github.com/flutter/engine
