### PR TITLE
chore: update guts to first tagged release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/chromedp/chromedp v0.11.0
 	github.com/cli/safeexec v1.0.1
 	github.com/coder/flog v1.1.0
-	github.com/coder/guts v0.0.0-20241217141209-abb2d09b4aa5
+	github.com/coder/guts v1.0.0
 	github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0
 	github.com/coder/quartz v0.1.2
 	github.com/coder/retry v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVp
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322/go.mod h1:rOLFDDVKVFiDqZFXoteXc97YXx7kFi9kYqR+2ETPkLQ=
 github.com/coder/go-scim/pkg/v2 v2.0.0-20230221055123-1d63c1222136 h1:0RgB61LcNs24WOxc3PBvygSNTQurm0PYPujJjLLOzs0=
 github.com/coder/go-scim/pkg/v2 v2.0.0-20230221055123-1d63c1222136/go.mod h1:VkD1P761nykiq75dz+4iFqIQIZka189tx1BQLOp0Skc=
-github.com/coder/guts v0.0.0-20241217141209-abb2d09b4aa5 h1:IFKvGmAZ0ziutzyhtkQ7kK+y7CEKobq5hNPacC9aHJs=
-github.com/coder/guts v0.0.0-20241217141209-abb2d09b4aa5/go.mod h1:SfmxjDaSfPjzKJ9mGU4sA/1OHU+u66uRfhFF+y4BARQ=
+github.com/coder/guts v1.0.0 h1:Ba6TBOeED+96Dv8IdISjbGhCzHKicqSc4SEYVV+4zeE=
+github.com/coder/guts v1.0.0/go.mod h1:SfmxjDaSfPjzKJ9mGU4sA/1OHU+u66uRfhFF+y4BARQ=
 github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048 h1:3jzYUlGH7ZELIH4XggXhnTnP05FCYiAFeQpoN+gNR5I=
 github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=


### PR DESCRIPTION
Changes error about name collision in generation to a warning. The name collision still exists, just moved it to a warning rather than an error in the logs.

Changes to the log are in the `guts` pkg

```
$ make -B site/src/api/typesGenerated.ts
2024/12/30 09:04:10 WARN enum list Entitlements cannot be added, an existing declaration with that name exists. To generate this enum list, the name collision must be resolved.  existing=Interface:Entitlements
2024/12/30 09:04:10 WARN enum list Experiments cannot be added, an existing declaration with that name exists. To generate this enum list, the name collision must be resolved.  existing=Alias:Experiments
```