### PR TITLE
chore: prevent db migrations from running on all cli commands

### DIFF
--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -46,7 +46,7 @@ func (*RootCmd) resetPassword() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := ConnectToPostgres(inv.Context(), logger, false, sqlDriver, postgresURL)
+			sqlDB, err := ConnectToPostgres(inv.Context(), logger, sqlDriver, postgresURL, nil)
 			if err != nil {
 				return xerrors.Errorf("dial postgres: %w", err)
 			}

--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -3,22 +3,27 @@
 package cli
 
 import (
-	"database/sql"
 	"fmt"
 
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+	"github.com/coder/coder/v2/coderd/database/awsiamrds"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/migrations"
 	"github.com/coder/coder/v2/coderd/userpassword"
 )
 
 func (*RootCmd) resetPassword() *serpent.Command {
-	var postgresURL string
+	var (
+		postgresURL  string
+		postgresAuth string
+	)
 
 	root := &serpent.Command{
 		Use:        "reset-password <username>",
@@ -27,20 +32,25 @@ func (*RootCmd) resetPassword() *serpent.Command {
 		Handler: func(inv *serpent.Invocation) error {
 			username := inv.Args[0]
 
-			sqlDB, err := sql.Open("postgres", postgresURL)
+			logger := slog.Make(sloghuman.Sink(inv.Stdout))
+			if ok, _ := inv.ParsedFlags().GetBool("verbose"); ok {
+				logger = logger.Leveled(slog.LevelDebug)
+			}
+
+			sqlDriver := "postgres"
+			if codersdk.PostgresAuth(postgresAuth) == codersdk.PostgresAuthAWSIAMRDS {
+				var err error
+				sqlDriver, err = awsiamrds.Register(inv.Context(), sqlDriver)
+				if err != nil {
+					return xerrors.Errorf("register aws rds iam auth: %w", err)
+				}
+			}
+
+			sqlDB, err := ConnectToPostgres(inv.Context(), logger, false, sqlDriver, postgresURL)
 			if err != nil {
 				return xerrors.Errorf("dial postgres: %w", err)
 			}
-			defer sqlDB.Close()
-			err = sqlDB.Ping()
-			if err != nil {
-				return xerrors.Errorf("ping postgres: %w", err)
-			}
 
-			err = migrations.EnsureClean(sqlDB)
-			if err != nil {
-				return xerrors.Errorf("database needs migration: %w", err)
-			}
 			db := database.New(sqlDB)
 
 			user, err := db.GetUserByEmailOrUsername(inv.Context(), database.GetUserByEmailOrUsernameParams{
@@ -96,6 +106,14 @@ func (*RootCmd) resetPassword() *serpent.Command {
 			Description: "URL of a PostgreSQL database to connect to.",
 			Env:         "CODER_PG_CONNECTION_URL",
 			Value:       serpent.StringOf(&postgresURL),
+		},
+		serpent.Option{
+			Name:        "Postgres Connection Auth",
+			Description: "Type of auth to use when connecting to postgres.",
+			Flag:        "postgres-connection-auth",
+			Env:         "CODER_PG_CONNECTION_AUTH",
+			Default:     "password",
+			Value:       serpent.EnumOf(&postgresAuth, codersdk.PostgresAuthDrivers...),
 		},
 	}
 

--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -50,6 +50,7 @@ func (*RootCmd) resetPassword() *serpent.Command {
 			if err != nil {
 				return xerrors.Errorf("dial postgres: %w", err)
 			}
+			defer sqlDB.Close()
 
 			db := database.New(sqlDB)
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -2095,6 +2095,7 @@ func IsLocalhost(host string) bool {
 // If set to false, no database changes will be applied, however the migration version
 // will be checked. If the database is not fully up to date with its migrations, then
 // an error will be returned.
+// nolint:revive // 'migrate' is a control flag.
 func ConnectToPostgres(ctx context.Context, logger slog.Logger, migrate bool, driver string, dbURL string) (sqlDB *sql.DB, err error) {
 	logger.Debug(ctx, "connecting to postgresql")
 

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -72,7 +72,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := ConnectToPostgres(ctx, logger, sqlDriver, newUserDBURL)
+			sqlDB, err := ConnectToPostgres(ctx, logger, false, sqlDriver, newUserDBURL)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -72,7 +72,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := ConnectToPostgres(ctx, logger, false, sqlDriver, newUserDBURL)
+			sqlDB, err := ConnectToPostgres(ctx, logger, sqlDriver, newUserDBURL, nil)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1832,6 +1832,8 @@ func TestConnectToPostgres(t *testing.T) {
 	}
 
 	t.Run("Migrate", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		t.Cleanup(cancel)
 
@@ -1849,6 +1851,8 @@ func TestConnectToPostgres(t *testing.T) {
 	})
 
 	t.Run("NoMigrate", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		t.Cleanup(cancel)
 

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -38,11 +38,13 @@ import (
 	"tailscale.com/derp/derphttp"
 	"tailscale.com/types/key"
 
+	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/migrations"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/codersdk"
@@ -1828,20 +1830,48 @@ func TestConnectToPostgres(t *testing.T) {
 	if !dbtestutil.WillUsePostgres() {
 		t.Skip("this test does not make sense without postgres")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
-	t.Cleanup(cancel)
 
-	log := testutil.Logger(t)
+	t.Run("Migrate", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		t.Cleanup(cancel)
 
-	dbURL, err := dbtestutil.Open(t)
-	require.NoError(t, err)
+		log := testutil.Logger(t)
 
-	sqlDB, err := cli.ConnectToPostgres(ctx, log, true, "postgres", dbURL)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = sqlDB.Close()
+		dbURL, err := dbtestutil.Open(t)
+		require.NoError(t, err)
+
+		sqlDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL, migrations.Up)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = sqlDB.Close()
+		})
+		require.NoError(t, sqlDB.PingContext(ctx))
 	})
-	require.NoError(t, sqlDB.PingContext(ctx))
+
+	t.Run("NoMigrate", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		t.Cleanup(cancel)
+
+		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+		dbURL, err := dbtestutil.Open(t)
+		require.NoError(t, err)
+
+		okDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL, nil)
+		require.NoError(t, err)
+		defer okDB.Close()
+
+		// Set the migration number forward
+		_, err = okDB.Exec(`UPDATE schema_migrations SET version = version + 1`)
+		require.NoError(t, err)
+
+		_, err = cli.ConnectToPostgres(ctx, log, "postgres", dbURL, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "database needs migration")
+
+		require.NoError(t, okDB.PingContext(ctx))
+	})
+
 }
 
 func TestServer_InvalidDERP(t *testing.T) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1875,7 +1875,6 @@ func TestConnectToPostgres(t *testing.T) {
 
 		require.NoError(t, okDB.PingContext(ctx))
 	})
-
 }
 
 func TestServer_InvalidDERP(t *testing.T) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1836,7 +1836,7 @@ func TestConnectToPostgres(t *testing.T) {
 	dbURL, err := dbtestutil.Open(t)
 	require.NoError(t, err)
 
-	sqlDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL)
+	sqlDB, err := cli.ConnectToPostgres(ctx, log, true, "postgres", dbURL)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = sqlDB.Close()

--- a/cli/testdata/coder_reset-password_--help.golden
+++ b/cli/testdata/coder_reset-password_--help.golden
@@ -6,6 +6,9 @@ USAGE:
   Directly connect to the database to reset a user's password
 
 OPTIONS:
+      --postgres-connection-auth password|awsiamrds, $CODER_PG_CONNECTION_AUTH (default: password)
+          Type of auth to use when connecting to postgres.
+
       --postgres-url string, $CODER_PG_CONNECTION_URL
           URL of a PostgreSQL database to connect to.
 

--- a/coderd/database/awsiamrds/awsiamrds_test.go
+++ b/coderd/database/awsiamrds/awsiamrds_test.go
@@ -32,7 +32,7 @@ func TestDriver(t *testing.T) {
 	sqlDriver, err := awsiamrds.Register(ctx, "postgres")
 	require.NoError(t, err)
 
-	db, err := cli.ConnectToPostgres(ctx, testutil.Logger(t), sqlDriver, url)
+	db, err := cli.ConnectToPostgres(ctx, testutil.Logger(t), true, sqlDriver, url)
 	require.NoError(t, err)
 	defer func() {
 		_ = db.Close()

--- a/coderd/database/awsiamrds/awsiamrds_test.go
+++ b/coderd/database/awsiamrds/awsiamrds_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/coderd/database/awsiamrds"
+	"github.com/coder/coder/v2/coderd/database/migrations"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -32,7 +33,7 @@ func TestDriver(t *testing.T) {
 	sqlDriver, err := awsiamrds.Register(ctx, "postgres")
 	require.NoError(t, err)
 
-	db, err := cli.ConnectToPostgres(ctx, testutil.Logger(t), true, sqlDriver, url)
+	db, err := cli.ConnectToPostgres(ctx, testutil.Logger(t), sqlDriver, url, migrations.Up)
 	require.NoError(t, err)
 	defer func() {
 		_ = db.Close()

--- a/docs/reference/cli/reset-password.md
+++ b/docs/reference/cli/reset-password.md
@@ -19,3 +19,13 @@ coder reset-password [flags] <username>
 | Environment | <code>$CODER_PG_CONNECTION_URL</code> |
 
 URL of a PostgreSQL database to connect to.
+
+### --postgres-connection-auth
+
+|             |                                        |
+| ----------- | -------------------------------------- |
+| Type        | <code>password\|awsiamrds</code>       |
+| Environment | <code>$CODER_PG_CONNECTION_AUTH</code> |
+| Default     | <code>password</code>                  |
+
+Type of auth to use when connecting to postgres.

--- a/docs/reference/cli/reset-password.md
+++ b/docs/reference/cli/reset-password.md
@@ -23,7 +23,7 @@ URL of a PostgreSQL database to connect to.
 ### --postgres-connection-auth
 
 |             |                                        |
-| ----------- | -------------------------------------- |
+|-------------|----------------------------------------|
 | Type        | <code>password\|awsiamrds</code>       |
 | Environment | <code>$CODER_PG_CONNECTION_AUTH</code> |
 | Default     | <code>password</code>                  |

--- a/enterprise/cli/server_dbcrypt.go
+++ b/enterprise/cli/server_dbcrypt.go
@@ -98,7 +98,7 @@ func (*RootCmd) dbcryptRotateCmd() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, false, sqlDriver, flags.PostgresURL)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}
@@ -163,7 +163,7 @@ func (*RootCmd) dbcryptDecryptCmd() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, false, sqlDriver, flags.PostgresURL)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}
@@ -219,7 +219,7 @@ Are you sure you want to continue?`
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, false, sqlDriver, flags.PostgresURL)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}

--- a/enterprise/cli/server_dbcrypt.go
+++ b/enterprise/cli/server_dbcrypt.go
@@ -98,7 +98,7 @@ func (*RootCmd) dbcryptRotateCmd() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, false, sqlDriver, flags.PostgresURL)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}
@@ -163,7 +163,7 @@ func (*RootCmd) dbcryptDecryptCmd() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, false, sqlDriver, flags.PostgresURL)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}
@@ -219,7 +219,7 @@ Are you sure you want to continue?`
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, false, sqlDriver, flags.PostgresURL)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}


### PR DESCRIPTION
Error when running future version of date coder cli to the coderd version
```
 $ coder server create-admin-user --postgres-url="postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
2024-12-30 21:25:24.436 [erro]  connect to postgres failed ...
    error= migrate up:
               github.com/coder/coder/v2/cli.ConnectToPostgres
                   /home/steven/go/src/github.com/coder/coder/cli/server.go:2169
             - database needs migration:
               github.com/coder/coder/v2/coderd/database/migrations.EnsureClean
                   /home/steven/go/src/github.com/coder/coder/coderd/database/migrations/migrate.go:185
             - current version is 272, but later version 273 exists:
               github.com/coder/coder/v2/coderd/database/migrations.CheckLatestVersion
                   /home/steven/go/src/github.com/coder/coder/coderd/database/migrations/migrate.go:200
Encountered an error running "coder server create-admin-user", see "coder server create-admin-user --help" for more information
error: connect to postgres: migrate up: database needs migration: current version is 272, but later version 273 exists
```

# Note

It is unfortunate we have to add these options manually on each command that uses a database.

```
	root.Options = serpent.OptionSet{
		{
			Flag:        "postgres-url",
			Description: "URL of a PostgreSQL database to connect to.",
			Env:         "CODER_PG_CONNECTION_URL",
			Value:       serpent.StringOf(&postgresURL),
		},
		serpent.Option{
			Name:        "Postgres Connection Auth",
			Description: "Type of auth to use when connecting to postgres.",
			Flag:        "postgres-connection-auth",
			Env:         "CODER_PG_CONNECTION_AUTH",
			Default:     "password",
			Value:       serpent.EnumOf(&postgresAuth, codersdk.PostgresAuthDrivers...),
		},
	}

```

I would rather see this all implemented in some standard way for the cli. From the flags to the opening of the database, to the migrations.

Closes https://github.com/coder/coder/issues/15976