### PR TITLE
chore(Makefile): add convenience gen/db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,6 +543,9 @@ GEN_FILES := \
 gen: $(GEN_FILES)
 .PHONY: gen
 
+gen/db: $(DB_GEN_FILES)
+.PHONY: gen/db
+
 # Mark all generated files as fresh so make thinks they're up-to-date. This is
 # used during releases so we don't run generation scripts.
 gen/mark-fresh:


### PR DESCRIPTION
When making changes to DB files I didn't want to wait for all of our code-gen to complete, so I added `make gen/db` for convenience. Meant to be run manually when needed, not explicitly part of the build process.
