### PR TITLE
fix(examples): add keep_locally to docker_image resources

### DIFF
--- a/examples/jfrog/docker/main.tf
+++ b/examples/jfrog/docker/main.tf
@@ -144,6 +144,7 @@ resource "docker_image" "main" {
   triggers = {
     dir_sha1 = sha1(join("", [for f in fileset(path.module, "build/*") : filesha1("${path.module}/${f}")]))
   }
+  keep_locally = true
 }
 
 resource "docker_container" "workspace" {

--- a/examples/parameters/main.tf
+++ b/examples/parameters/main.tf
@@ -92,6 +92,7 @@ resource "docker_image" "main" {
   triggers = {
     dir_sha1 = sha1(join("", [for f in fileset(path.module, "build/*") : filesha1(f)]))
   }
+  keep_locally = true
 }
 
 resource "docker_container" "workspace" {

--- a/examples/templates/docker-devcontainer/main.tf
+++ b/examples/templates/docker-devcontainer/main.tf
@@ -154,7 +154,8 @@ data "local_sensitive_file" "cache_repo_dockerconfigjson" {
 }
 
 resource "docker_image" "devcontainer_builder_image" {
-  name = local.devcontainer_builder_image
+  name         = local.devcontainer_builder_image
+  keep_locally = true
 }
 
 resource "docker_volume" "workspaces" {


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/15972

Adds `keep_locally = true` to other templates that use the `docker_image` resource to prevent the docker provider from attempting to remove the image upon workspace deletion.

We had set this in some other places (such as the `dogfood` template) but had not set this consistently in other templates.