### PR TITLE
fix(provisioner/terraform/tfparse): skip evaluation of unrelated parameters

### DIFF
--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1412,6 +1412,11 @@ func TestWorkspaceTagsTerraform(t *testing.T) {
 		provider "coder" {}
 		data "coder_workspace" "me" {}
 		data "coder_workspace_owner" "me" {}
+		data "coder_parameter" "unrelated" {
+			name    = "unrelated"
+			type    = "list(string)"
+			default = jsonencode(["a", "b"])
+		}
 		%s
 	`
 

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -26,7 +26,7 @@ func (s *server) Parse(sess *provisionersdk.Session, _ *proto.ParseRequest, _ <-
 		return provisionersdk.ParseErrorf("load module: %s", formatDiagnostics(sess.WorkDirectory, diags))
 	}
 
-	workspaceTags, err := parser.WorkspaceTags(ctx)
+	workspaceTags, _, err := parser.WorkspaceTags(ctx)
 	if err != nil {
 		return provisionersdk.ParseErrorf("can't load workspace tags: %v", err)
 	}

--- a/provisioner/terraform/tfparse/tfparse.go
+++ b/provisioner/terraform/tfparse/tfparse.go
@@ -598,7 +598,11 @@ func interfaceToString(i interface{}) (string, error) {
 		return strconv.FormatFloat(v, 'f', -1, 64), nil
 	case bool:
 		return strconv.FormatBool(v), nil
-	default:
-		return "", xerrors.Errorf("unsupported type %T", v)
+	default: // just try to JSON-encode it.
+		var sb strings.Builder
+		if err := json.NewEncoder(&sb).Encode(i); err != nil {
+			return "", xerrors.Errorf("convert %T: %w", v, err)
+		}
+		return strings.TrimSpace(sb.String()), nil
 	}
 }

--- a/provisioner/terraform/tfparse/tfparse_test.go
+++ b/provisioner/terraform/tfparse/tfparse_test.go
@@ -462,6 +462,14 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = bool
 						default = true
 					}
+					variable "listvar" {
+						type    = list(string)
+						default = ["a"]
+					}
+					variable "mapvar" {
+						type    = map(string)
+						default = {"a": "b"}
+					}
 					data "coder_parameter" "stringparam" {
 						name    = "stringparam"
 						type    = "string"
@@ -487,6 +495,8 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 							"stringvar"   = var.stringvar
 							"numvar"      = var.numvar
 							"boolvar"     = var.boolvar
+							"listvar"     = var.listvar
+							"mapvar"      = var.mapvar
 							"stringparam" = data.coder_parameter.stringparam.value
 							"numparam"    = data.coder_parameter.numparam.value
 							"boolparam"   = data.coder_parameter.boolparam.value
@@ -498,6 +508,8 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 				"stringvar":   "a",
 				"numvar":      "1",
 				"boolvar":     "true",
+				"listvar":     `["a"]`,
+				"mapvar":      `{"a":"b"}`,
 				"stringparam": "a",
 				"numparam":    "1",
 				"boolparam":   "true",
@@ -506,46 +518,16 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 			expectError: ``,
 		},
 		{
-			name: "unsupported list variable",
-			files: map[string]string{
-				"main.tf": `
-					variable "listvar" {
-						type    = list(string)
-						default = ["a"]
-					}
-					data "coder_workspace_tags" "tags" {
-						tags = {
-							listvar = var.listvar
-						}
-					}`,
-			},
-			expectTags:  nil,
-			expectError: `can't convert variable default value to string: unsupported type []interface {}`,
-		},
-		{
-			name: "unsupported map variable",
-			files: map[string]string{
-				"main.tf": `
-					variable "mapvar" {
-						type    = map(string)
-						default = {"a": "b"}
-					}
-					data "coder_workspace_tags" "tags" {
-						tags = {
-							mapvar = var.mapvar
-						}
-					}`,
-			},
-			expectTags:  nil,
-			expectError: `can't convert variable default value to string: unsupported type map[string]interface {}`,
-		},
-		{
 			name: "overlapping var name",
 			files: map[string]string{
 				`main.tf`: `
 				variable "a" {
 					type = string
 					default = "1"
+				}
+				variable "unused" {
+					type = map(string)
+					default = {"a" : "b"}
 				}
 				variable "ab" {
 					description = "This is a variable of type string"

--- a/provisioner/terraform/tfparse/tfparse_test.go
+++ b/provisioner/terraform/tfparse/tfparse_test.go
@@ -49,8 +49,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -71,8 +73,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -94,8 +98,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 					  name = "az"
@@ -128,8 +134,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "${""}${"a"}"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -158,8 +166,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						type    = string
@@ -195,8 +205,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "eu"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 					  name = "az"
@@ -235,8 +247,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -263,8 +277,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -300,8 +316,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 					variable "notregion" {
 						type = string
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -332,8 +350,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -368,8 +388,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -402,8 +424,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "region.us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -421,6 +445,99 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 			},
 			expectTags:  nil,
 			expectError: `Function calls not allowed; Functions may not be called here.`,
+		},
+		{
+			name: "supported types",
+			files: map[string]string{
+				"main.tf": `
+					variable "stringvar" {
+						type    = string
+						default = "a"
+					}
+					variable "numvar" {
+						type    = number
+						default = 1
+					}
+					variable "boolvar" {
+						type    = bool
+						default = true
+					}
+					data "coder_parameter" "stringparam" {
+						name    = "stringparam"
+						type    = "string"
+						default = "a"
+					}
+					data "coder_parameter" "numparam" {
+						name    = "numparam"
+						type    = "number"
+						default = 1
+					}
+					data "coder_parameter" "boolparam" {
+						name    = "boolparam"
+						type    = "bool"
+						default = true
+					}
+					data "coder_parameter" "listparam" {
+						name    = "listparam"
+						type    = "list(string)"
+						default = "[\"a\", \"b\"]"
+					}
+					data "coder_workspace_tags" "tags" {
+						tags = {
+							"stringvar"   = var.stringvar
+							"numvar"      = var.numvar
+							"boolvar"     = var.boolvar
+							"stringparam" = data.coder_parameter.stringparam.value
+							"numparam"    = data.coder_parameter.numparam.value
+							"boolparam"   = data.coder_parameter.boolparam.value
+							"listparam"   = data.coder_parameter.listparam.value
+						}
+					}`,
+			},
+			expectTags: map[string]string{
+				"stringvar":   "a",
+				"numvar":      "1",
+				"boolvar":     "true",
+				"stringparam": "a",
+				"numparam":    "1",
+				"boolparam":   "true",
+				"listparam":   `["a", "b"]`,
+			},
+			expectError: ``,
+		},
+		{
+			name: "unsupported list variable",
+			files: map[string]string{
+				"main.tf": `
+					variable "listvar" {
+						type    = list(string)
+						default = ["a"]
+					}
+					data "coder_workspace_tags" "tags" {
+						tags = {
+							listvar = var.listvar
+						}
+					}`,
+			},
+			expectTags:  nil,
+			expectError: `can't convert variable default value to string: unsupported type []interface {}`,
+		},
+		{
+			name: "unsupported map variable",
+			files: map[string]string{
+				"main.tf": `
+					variable "mapvar" {
+						type    = map(string)
+						default = {"a": "b"}
+					}
+					data "coder_workspace_tags" "tags" {
+						tags = {
+							mapvar = var.mapvar
+						}
+					}`,
+			},
+			expectTags:  nil,
+			expectError: `can't convert variable default value to string: unsupported type map[string]interface {}`,
 		},
 	} {
 		tc := tc

--- a/provisioner/terraform/tfparse/tfparse_test.go
+++ b/provisioner/terraform/tfparse/tfparse_test.go
@@ -98,6 +98,9 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
+					variable "unrelated" {
+						type = bool
+					}
 					data "coder_parameter" "unrelated" {
 						name    = "unrelated"
 						type    = "list(string)"


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/16021

`tfparse` had been enforcing the "no functions, no locals" rule for _all_ `coder_parameter` default values, where we only want to enforce this for ones referenced by `coder_workspace_tags`.

* Improves tfparse test coverage to include more parameter types and values
* Adds tests with unrelated parameters that should be ignored by tfparse
* Modifies tfparse to only attempt evaluation of variables/parameters referenced by coder_workspace_tags