### PR TITLE
chore(site): use `.gitignore` in `biome.jsonc`

### DIFF
--- a/site/biome.jsonc
+++ b/site/biome.jsonc
@@ -1,14 +1,13 @@
 {
+	"vcs": {
+		"enabled": true,
+		"useIgnoreFile": true,
+		"clientKind": "git",
+		"root": ".."
+	},
 	"files": {
-		"ignore": [
-			"build/",
-			"node_modules/",
-			"out/",
-			"test-results/",
-			"e2e/**/*Generated.ts",
-			"pnpm-lock.yaml",
-			"storybook-static/"
-		]
+		"ignore": ["e2e/**/*Generated.ts", "pnpm-lock.yaml"],
+		"ignoreUnknown": true
 	},
 	"linter": {
 		"rules": {


### PR DESCRIPTION
Following up on a comment in #15831, we can use the ignore file from VCS in biome.