### PR TITLE
chore(cli): skip scaletest tests when race detector enabled

### DIFF
--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -18,6 +18,10 @@ import (
 func TestScaleTestCreateWorkspaces(t *testing.T) {
 	t.Parallel()
 
+	if testutil.RaceEnabled() {
+		t.Skip("Skipping due to race detector")
+	}
+
 	// This test only validates that the CLI command accepts known arguments.
 	// More thorough testing is done in scaletest/createworkspaces/run_test.go.
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -65,6 +69,10 @@ func TestScaleTestCreateWorkspaces(t *testing.T) {
 func TestScaleTestWorkspaceTraffic(t *testing.T) {
 	t.Parallel()
 
+	if testutil.RaceEnabled() {
+		t.Skip("Skipping due to race detector")
+	}
+
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
@@ -95,6 +103,10 @@ func TestScaleTestWorkspaceTraffic(t *testing.T) {
 func TestScaleTestWorkspaceTraffic_Template(t *testing.T) {
 	t.Parallel()
 
+	if testutil.RaceEnabled() {
+		t.Skip("Skipping due to race detector")
+	}
+
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
@@ -119,6 +131,10 @@ func TestScaleTestWorkspaceTraffic_Template(t *testing.T) {
 // This test just validates that the CLI command accepts its known arguments.
 func TestScaleTestWorkspaceTraffic_TargetWorkspaces(t *testing.T) {
 	t.Parallel()
+
+	if testutil.RaceEnabled() {
+		t.Skip("Skipping due to race detector")
+	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
@@ -145,6 +161,10 @@ func TestScaleTestWorkspaceTraffic_TargetWorkspaces(t *testing.T) {
 func TestScaleTestCleanup_Template(t *testing.T) {
 	t.Parallel()
 
+	if testutil.RaceEnabled() {
+		t.Skip("Skipping due to race detector")
+	}
+
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
@@ -169,6 +189,10 @@ func TestScaleTestCleanup_Template(t *testing.T) {
 // This test just validates that the CLI command accepts its known arguments.
 func TestScaleTestDashboard(t *testing.T) {
 	t.Parallel()
+	if testutil.RaceEnabled() {
+		t.Skip("Skipping due to race detector")
+	}
+
 	t.Run("MinWait", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitShort)


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/265

This isn't an ideal solution but the race detector tends to make these flake out.