### PR TITLE
fix(provisioner/terraform/tfparse): skip evaluation of unrelated parameters (#16023)

### DIFF
--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1201,6 +1201,11 @@ func TestWorkspaceTagsTerraform(t *testing.T) {
 		provider "coder" {}
 		data "coder_workspace" "me" {}
 		data "coder_workspace_owner" "me" {}
+		data "coder_parameter" "unrelated" {
+			name    = "unrelated"
+			type    = "list(string)"
+			default = jsonencode(["a", "b"])
+		}
 		%s
 	`
 

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -26,7 +26,7 @@ func (s *server) Parse(sess *provisionersdk.Session, _ *proto.ParseRequest, _ <-
 		return provisionersdk.ParseErrorf("load module: %s", formatDiagnostics(sess.WorkDirectory, diags))
 	}
 
-	workspaceTags, err := parser.WorkspaceTags(ctx)
+	workspaceTags, _, err := parser.WorkspaceTags(ctx)
 	if err != nil {
 		return provisionersdk.ParseErrorf("can't load workspace tags: %v", err)
 	}

--- a/provisioner/terraform/tfparse/tfparse_test.go
+++ b/provisioner/terraform/tfparse/tfparse_test.go
@@ -34,7 +34,7 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 			name: "single text file",
 			files: map[string]string{
 				"file.txt": `
-		hello world`,
+					hello world`,
 			},
 			expectTags:  map[string]string{},
 			expectError: "",
@@ -49,8 +49,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -71,8 +73,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -94,8 +98,13 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					variable "unrelated" {
+						type = bool
+					}
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 					  name = "az"
@@ -128,8 +137,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "${""}${"a"}"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -158,8 +169,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						type    = string
@@ -195,8 +208,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "eu"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 					  name = "az"
@@ -235,8 +250,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -263,8 +280,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -300,8 +319,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 					variable "notregion" {
 						type = string
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -332,8 +353,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -368,8 +391,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -402,8 +427,10 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						type    = string
 						default = "region.us"
 					}
-					data "base" "ours" {
-						all = true
+					data "coder_parameter" "unrelated" {
+						name    = "unrelated"
+						type    = "list(string)"
+						default = jsonencode(["a", "b"])
 					}
 					data "coder_parameter" "az" {
 						name = "az"
@@ -421,6 +448,103 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 			},
 			expectTags:  nil,
 			expectError: `Function calls not allowed; Functions may not be called here.`,
+		},
+		{
+			name: "supported types",
+			files: map[string]string{
+				"main.tf": `
+					variable "stringvar" {
+						type    = string
+						default = "a"
+					}
+					variable "numvar" {
+						type    = number
+						default = 1
+					}
+					variable "boolvar" {
+						type    = bool
+						default = true
+					}
+					variable "listvar" {
+						type    = list(string)
+						default = ["a"]
+					}
+					variable "mapvar" {
+						type    = map(string)
+						default = {"a": "b"}
+					}
+					data "coder_parameter" "stringparam" {
+						name    = "stringparam"
+						type    = "string"
+						default = "a"
+					}
+					data "coder_parameter" "numparam" {
+						name    = "numparam"
+						type    = "number"
+						default = 1
+					}
+					data "coder_parameter" "boolparam" {
+						name    = "boolparam"
+						type    = "bool"
+						default = true
+					}
+					data "coder_parameter" "listparam" {
+						name    = "listparam"
+						type    = "list(string)"
+						default = "[\"a\", \"b\"]"
+					}
+					data "coder_workspace_tags" "tags" {
+						tags = {
+							"stringvar"   = var.stringvar
+							"numvar"      = var.numvar
+							"boolvar"     = var.boolvar
+							"listvar"     = var.listvar
+							"mapvar"      = var.mapvar
+							"stringparam" = data.coder_parameter.stringparam.value
+							"numparam"    = data.coder_parameter.numparam.value
+							"boolparam"   = data.coder_parameter.boolparam.value
+							"listparam"   = data.coder_parameter.listparam.value
+						}
+					}`,
+			},
+			expectTags: map[string]string{
+				"stringvar":   "a",
+				"numvar":      "1",
+				"boolvar":     "true",
+				"listvar":     `["a"]`,
+				"mapvar":      `{"a":"b"}`,
+				"stringparam": "a",
+				"numparam":    "1",
+				"boolparam":   "true",
+				"listparam":   `["a", "b"]`,
+			},
+			expectError: ``,
+		},
+		{
+			name: "overlapping var name",
+			files: map[string]string{
+				`main.tf`: `
+				variable "a" {
+					type = string
+					default = "1"
+				}
+				variable "unused" {
+					type = map(string)
+					default = {"a" : "b"}
+				}
+				variable "ab" {
+					description = "This is a variable of type string"
+					type        = string
+					default     = "ab"
+				}
+				data "coder_workspace_tags" "tags" {
+					tags = {
+						"foo": "bar",
+						"a": var.a,
+					}
+				}`,
+			},
+			expectTags: map[string]string{"foo": "bar", "a": "1"},
 		},
 	} {
 		tc := tc
@@ -505,7 +629,7 @@ func BenchmarkWorkspaceTagDefaultsFromFile(b *testing.B) {
 			tfparse.WriteArchive(tarFile, "application/x-tar", tmpDir)
 			parser, diags := tfparse.New(tmpDir, tfparse.WithLogger(logger))
 			require.NoError(b, diags.Err())
-			_, err := parser.WorkspaceTags(ctx)
+			_, _, err := parser.WorkspaceTags(ctx)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -519,7 +643,7 @@ func BenchmarkWorkspaceTagDefaultsFromFile(b *testing.B) {
 			tfparse.WriteArchive(zipFile, "application/zip", tmpDir)
 			parser, diags := tfparse.New(tmpDir, tfparse.WithLogger(logger))
 			require.NoError(b, diags.Err())
-			_, err := parser.WorkspaceTags(ctx)
+			_, _, err := parser.WorkspaceTags(ctx)
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
* Improves tfparse test coverage to include more parameter types and values
* Adds tests with unrelated parameters that should be ignored by tfparse
* Modifies tfparse to only attempt evaluation of parameters referenced by coder_workspace_tags

(cherry picked from commit 1ab10cf80c86e6fd11ee18547e5ae18112e006d3)