### PR TITLE
chore(docs): skip january release in calendar

### DIFF
--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -63,7 +63,7 @@ pages.
 | 2.16.x       | October 01, 2024   | Security Support |
 | 2.17.x       | November 05, 2024  | Stable           |
 | 2.18.x       | December 03, 2024  | Mainline         |
-| 2.19.x       | January 07, 2024   | Not Released     |
+| 2.19.x       | February 04, 2024   | Not Released     |
 
 > **Tip**: We publish a
 > [`preview`](https://github.com/coder/coder/pkgs/container/coder-preview) image

--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -63,7 +63,7 @@ pages.
 | 2.16.x       | October 01, 2024   | Security Support |
 | 2.17.x       | November 05, 2024  | Stable           |
 | 2.18.x       | December 03, 2024  | Mainline         |
-| 2.19.x       | February 04, 2024   | Not Released     |
+| 2.19.x       | February 04, 2024  | Not Released     |
 
 > **Tip**: We publish a
 > [`preview`](https://github.com/coder/coder/pkgs/container/coder-preview) image


### PR DESCRIPTION
We're skipping the January release as our teams have been out during the holidays. Our next minor version increment will be on February 4th.