### PR TITLE
docs: fix workspacebuilds logs api docs

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7696,13 +7696,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Before Unix timestamp",
+                        "description": "Before log id",
                         "name": "before",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "After Unix timestamp",
+                        "description": "After log id",
                         "name": "after",
                         "in": "query"
                     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6798,13 +6798,13 @@
 					},
 					{
 						"type": "integer",
-						"description": "Before Unix timestamp",
+						"description": "Before log id",
 						"name": "before",
 						"in": "query"
 					},
 					{
 						"type": "integer",
-						"description": "After Unix timestamp",
+						"description": "After log id",
 						"name": "after",
 						"in": "query"
 					},

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -655,8 +655,8 @@ func (api *API) workspaceBuildParameters(rw http.ResponseWriter, r *http.Request
 // @Produce json
 // @Tags Builds
 // @Param workspacebuild path string true "Workspace build ID"
-// @Param before query int false "Before Unix timestamp"
-// @Param after query int false "After Unix timestamp"
+// @Param before query int false "Before log id"
+// @Param after query int false "After log id"
 // @Param follow query bool false "Follow log stream"
 // @Success 200 {array} codersdk.ProvisionerJobLog
 // @Router /workspacebuilds/{workspacebuild}/logs [get]

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -451,12 +451,12 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/log
 
 ### Parameters
 
-| Name             | In    | Type    | Required | Description           |
-|------------------|-------|---------|----------|-----------------------|
-| `workspacebuild` | path  | string  | true     | Workspace build ID    |
-| `before`         | query | integer | false    | Before Unix timestamp |
-| `after`          | query | integer | false    | After Unix timestamp  |
-| `follow`         | query | boolean | false    | Follow log stream     |
+| Name             | In    | Type    | Required | Description        |
+|------------------|-------|---------|----------|--------------------|
+| `workspacebuild` | path  | string  | true     | Workspace build ID |
+| `before`         | query | integer | false    | Before log id      |
+| `after`          | query | integer | false    | After log id       |
+| `follow`         | query | boolean | false    | Follow log stream  |
 
 ### Example responses
 


### PR DESCRIPTION
Merges @coryb 's PR #16051 

> The before/after params were documented at Unix timestamps, but they are the log line ids.
