### PR TITLE
fix(site): do not error on closed build logs stream

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -280,7 +280,7 @@ export const watchBuildLogsByBuildId = (
 	);
 
 	socket.addEventListener("error", () => {
-		if (socket.readyState == socket.CLOSED) {
+		if (socket.readyState === socket.CLOSED) {
 			return;
 		}
 		onError?.(new Error("Connection for logs failed."));

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -280,6 +280,9 @@ export const watchBuildLogsByBuildId = (
 	);
 
 	socket.addEventListener("error", () => {
+		if (socket.readyState == socket.CLOSED) {
+			return;
+		}
 		onError?.(new Error("Connection for logs failed."));
 		socket.close();
 	});


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/15937

Sometimes logs can't be read rapidly before even establishing the connection with the WebSocket. Unfortunately, we can't abort the connecting process, but we can't prevent the error box from popping up.