### PR TITLE
chore(go.mod): remove replace directive for dlclark/regexp2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,9 +34,6 @@ replace github.com/fatedier/kcp-go => github.com/coder/kcp-go v2.0.4-0.202204091
 // https://github.com/tcnksm/go-httpstat/pull/29
 replace github.com/tcnksm/go-httpstat => github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322
 
-// See https://github.com/dlclark/regexp2/issues/63
-replace github.com/dlclark/regexp2 => github.com/dlclark/regexp2 v1.7.0
-
 // There are a few minor changes we make to Tailscale that we're slowly upstreaming. Compare here:
 // https://github.com/tailscale/tailscale/compare/main...coder:tailscale:main
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20241218201526-b53d914d625f

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/disintegration/gift v1.2.1 h1:Y005a1X4Z7Uc+0gLpSAsKhWi4qLtsdEcMIbbdvd
 github.com/disintegration/gift v1.2.1/go.mod h1:Jh2i7f7Q2BM7Ezno3PhfezbR1xpUg9dUg3/RlKGr4HI=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
-github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/cli v27.1.1+incompatible h1:goaZxOqs4QKxznZjjBWKONQci/MywhtRv2oNn0GkeZE=
 github.com/docker/cli v27.1.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v27.2.0+incompatible h1:Rk9nIVdfH3+Vz4cyI/uhbINhEZ/oLmc+CBXmH6fbNk4=


### PR DESCRIPTION
Right now, it looks like we only utilise dlclark/regexp2 as a transitive dependency of charmbracelet/glamour:

```
$ go mod why github.com/dlclark/regexp2
# github.com/dlclark/regexp2
github.com/coder/coder/v2/coderd/render
github.com/charmbracelet/glamour/ansi
github.com/alecthomas/chroma/v2
github.com/dlclark/regexp2
```

The reason for this replacement was to avoid a goroutine leak in unit tests.
However, I'm currently unable to replace the goroutine leak as we do not perform any leak detection tests in `coderd/render`.

If required, we can use the workaround detailed in regexp2's README.md:

https://github.com/dlclark/regexp2/blob/v1.11.4/README.md#goroutine-leak-error