### PR TITLE
chore(testutil): add testutil.GoleakOptions

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -58,7 +58,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 // NOTE: These tests only work when your default shell is bash for some reason.

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestExecuteBasic(t *testing.T) {

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestNewServer_ServeClient(t *testing.T) {

--- a/cli/clitest/clitest_test.go
+++ b/cli/clitest/clitest_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestCli(t *testing.T) {

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 )
@@ -29,15 +30,7 @@ func TestMain(m *testing.M) {
 		// See: https://github.com/coder/coder/issues/8954
 		os.Exit(m.Run())
 	}
-	goleak.VerifyTestMain(m,
-		// The lumberjack library is used by by agent and seems to leave
-		// goroutines after Close(), fails TestGitSSH tests.
-		// https://github.com/natefinch/lumberjack/pull/100
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1"),
-		// The pq library appears to leave around a goroutine after Close().
-		goleak.IgnoreTopFunction("github.com/lib/pq.NewDialListener"),
-	)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func Test_formatExamples(t *testing.T) {

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -1256,5 +1256,5 @@ func mustWorkspaceParameters(t *testing.T, client *codersdk.Client, workspaceID 
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }

--- a/coderd/autobuild/notify/notifier_test.go
+++ b/coderd/autobuild/notify/notifier_test.go
@@ -122,5 +122,5 @@ func durations(ds ...time.Duration) []time.Duration {
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -39,7 +39,7 @@ import (
 var updateGoldenFiles = flag.Bool("update", false, "Update golden files")
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestBuildInfo(t *testing.T) {

--- a/coderd/coderdtest/coderdtest_test.go
+++ b/coderd/coderdtest/coderdtest_test.go
@@ -6,10 +6,11 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestNew(t *testing.T) {

--- a/coderd/cryptokeys/cache_test.go
+++ b/coderd/cryptokeys/cache_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestCryptoKeyCache(t *testing.T) {

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 // Ensures no goroutines leak.

--- a/coderd/database/dbrollup/dbrollup_test.go
+++ b/coderd/database/dbrollup/dbrollup_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestRollup_Close(t *testing.T) {

--- a/coderd/database/dbtestutil/postgres_test.go
+++ b/coderd/database/dbtestutil/postgres_test.go
@@ -12,10 +12,11 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/migrations"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestOpen(t *testing.T) {

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestMigrate(t *testing.T) {

--- a/coderd/notifications/dispatch/smtp_test.go
+++ b/coderd/notifications/dispatch/smtp_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestSMTP(t *testing.T) {

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -56,7 +56,7 @@ import (
 var updateGoldenFiles = flag.Bool("update", false, "Update golden files")
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 // TestBasicNotificationRoundtrip enqueues a message to the store, waits for it to be acquired by a notifier,

--- a/coderd/provisionerdserver/acquirer_test.go
+++ b/coderd/provisionerdserver/acquirer_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 // TestAcquirer_Store tests that a database.Store is accepted as a provisionerdserver.AcquirerStore

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestTelemetry(t *testing.T) {

--- a/coderd/unhanger/detector_test.go
+++ b/coderd/unhanger/detector_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestDetectorNoJobs(t *testing.T) {

--- a/coderd/updatecheck/updatecheck_test.go
+++ b/coderd/updatecheck/updatecheck_test.go
@@ -154,5 +154,5 @@ func TestChecker_Latest(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }

--- a/coderd/workspacestats/tracker_test.go
+++ b/coderd/workspacestats/tracker_test.go
@@ -219,5 +219,5 @@ func TestTracker_MultipleInstances(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -55,7 +55,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestEntitlements(t *testing.T) {

--- a/enterprise/derpmesh/derpmesh_test.go
+++ b/enterprise/derpmesh/derpmesh_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestDERPMesh(t *testing.T) {

--- a/enterprise/provisionerd/remoteprovisioners_test.go
+++ b/enterprise/provisionerd/remoteprovisioners_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestRemoteConnector_Mainline(t *testing.T) {

--- a/enterprise/replicasync/replicasync_test.go
+++ b/enterprise/replicasync/replicasync_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestReplica(t *testing.T) {

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestPGCoordinatorSingle_ClientWithoutAgent(t *testing.T) {

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func closedWithin(c chan struct{}, d time.Duration) func() bool {

--- a/provisionersdk/serve_test.go
+++ b/provisionersdk/serve_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestProvisionerSDK(t *testing.T) {

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -15,10 +15,11 @@ import (
 
 	"github.com/coder/coder/v2/pty"
 	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestStart(t *testing.T) {

--- a/pty/start_windows_test.go
+++ b/pty/start_windows_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/coder/v2/pty"
 	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestStart(t *testing.T) {

--- a/support/support_test.go
+++ b/support/support_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestRun(t *testing.T) {

--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestTailnet(t *testing.T) {

--- a/tailnet/tailnettest/tailnettest_test.go
+++ b/tailnet/tailnettest/tailnettest_test.go
@@ -6,10 +6,11 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/coder/coder/v2/tailnet/tailnettest"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestRunDERPAndSTUN(t *testing.T) {

--- a/testutil/eventually_test.go
+++ b/testutil/eventually_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 func TestEventually(t *testing.T) {

--- a/testutil/goleak.go
+++ b/testutil/goleak.go
@@ -1,0 +1,18 @@
+package testutil
+
+import "go.uber.org/goleak"
+
+// GoleakOptions is a common list of options to pass to goleak. This is useful if there is a known
+// leaky function we want to exclude from goleak.
+var GoleakOptions []goleak.Option = []goleak.Option{
+	// seelog (indirect dependency of dd-trace-go) has a known goroutine leak (https://github.com/cihub/seelog/issues/182)
+	// When https://github.com/DataDog/dd-trace-go/issues/2987 is resolved, this can be removed.
+	goleak.IgnoreAnyFunction("github.com/cihub/seelog.(*asyncLoopLogger).processQueue"),
+	// The lumberjack library is used by by agent and seems to leave
+	// goroutines after Close(), fails TestGitSSH tests.
+	// https://github.com/natefinch/lumberjack/pull/100
+	goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1"),
+	// The pq library appears to leave around a goroutine after Close().
+	goleak.IgnoreTopFunction("github.com/lib/pq.NewDialListener"),
+}

--- a/vpn/speaker_internal_test.go
+++ b/vpn/speaker_internal_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, testutil.GoleakOptions...)
 }
 
 // TestSpeaker_RawPeer tests the speaker with a peer that we simulate by directly making reads and


### PR DESCRIPTION
- Adds `testutil.GoleakOptions` and consolidates existing options to this location
- Pre-emptively adds required ignore for this Dependabot PR to pass CI  https://github.com/coder/coder/pull/16066 