### PR TITLE
fix: ensure active Organizations Page nav links are highlighted

### DIFF
--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -67,7 +67,7 @@ export const SettingsSidebarNavItem: FC<SettingsSidebarNavItemProps> = ({
 		<NavLink
 			end={end}
 			to={href}
-			className={({ isActive }) =>
+			className={() =>
 				cn(
 					"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
 					{

--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import type { CSSObject, Interpolation, Theme } from "@emotion/react";
 import { Stack } from "components/Stack/Stack";
 import { type ClassName, useClassName } from "hooks/useClassName";
 import type { ElementType, FC, ReactNode } from "react";
-import { Link, NavLink, useLocation } from "react-router-dom";
+import { Link, NavLink, useMatch } from "react-router-dom";
 import { cn } from "utils/cn";
 
 interface SidebarProps {
@@ -61,18 +61,8 @@ export const SettingsSidebarNavItem: FC<SettingsSidebarNavItemProps> = ({
 	href,
 	end,
 }) => {
+	const matchResult = useMatch(href);
 
-	const location = useLocation();
-	if (end) {
-		console.log('Current Path:', location.pathname);
-		console.log('NavLink href:', href);
-	}
-
-	const normalizePath = (path: string) =>
-		path.endsWith('/') ? path.slice(0, -1) : path;
-
-	const isInitiallyActive =
-		normalizePath(location.pathname) === normalizePath(href);
 	return (
 		<NavLink
 			end={end}
@@ -81,7 +71,7 @@ export const SettingsSidebarNavItem: FC<SettingsSidebarNavItemProps> = ({
 				cn(
 					"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
 					{
-						"font-semibold text-content-primary": isActive || isInitiallyActive,
+						"font-semibold text-content-primary": matchResult !== null,
 					},
 				)
 			}

--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -61,20 +61,19 @@ export const SettingsSidebarNavItem: FC<SettingsSidebarNavItemProps> = ({
 	href,
 	end,
 }) => {
+	// useMatch is necessary to verify if the current path matches the href on the initial render of the route
 	const matchResult = useMatch(href);
 
 	return (
 		<NavLink
 			end={end}
 			to={href}
-			className={() =>
-				cn(
-					"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
-					{
-						"font-semibold text-content-primary": matchResult !== null,
-					},
-				)
-			}
+			className={cn(
+				"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
+				{
+					"font-semibold text-content-primary": matchResult !== null,
+				},
+			)}
 		>
 			{children}
 		</NavLink>

--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import type { CSSObject, Interpolation, Theme } from "@emotion/react";
 import { Stack } from "components/Stack/Stack";
 import { type ClassName, useClassName } from "hooks/useClassName";
 import type { ElementType, FC, ReactNode } from "react";
-import { Link, NavLink } from "react-router-dom";
+import { Link, NavLink, useLocation } from "react-router-dom";
 import { cn } from "utils/cn";
 
 interface SidebarProps {
@@ -61,6 +61,18 @@ export const SettingsSidebarNavItem: FC<SettingsSidebarNavItemProps> = ({
 	href,
 	end,
 }) => {
+
+	const location = useLocation();
+	if (end) {
+		console.log('Current Path:', location.pathname);
+		console.log('NavLink href:', href);
+	}
+
+	const normalizePath = (path: string) =>
+		path.endsWith('/') ? path.slice(0, -1) : path;
+
+	const isInitiallyActive =
+		normalizePath(location.pathname) === normalizePath(href);
 	return (
 		<NavLink
 			end={end}
@@ -69,7 +81,7 @@ export const SettingsSidebarNavItem: FC<SettingsSidebarNavItemProps> = ({
 				cn(
 					"relative text-sm text-content-secondary no-underline font-medium py-2 px-3 hover:bg-surface-secondary rounded-md transition ease-in-out duration-150",
 					{
-						"font-semibold text-content-primary": isActive,
+						"font-semibold text-content-primary": isActive || isInitiallyActive,
 					},
 				)
 			}


### PR DESCRIPTION
Normally the react router Navlink should normalize the url path and match with or without a / on the end of the path. 

This is a fix to use useMatch() to explicitly see if the current path is a match to an href to determine whether to apply active styling to the navlink