### PR TITLE
chore(docs): tweak replica verbiage on reference architectures

### DIFF
--- a/docs/admin/infrastructure/validated-architectures/1k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/1k-users.md
@@ -12,9 +12,9 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 ### Coderd nodes
 
-| Users       | Node capacity       | Replicas            | GCP             | AWS        | Azure             |
-|-------------|---------------------|---------------------|-----------------|------------|-------------------|
-| Up to 1,000 | 2 vCPU, 8 GB memory | 1-2 / 1 coderd each | `n1-standard-2` | `t3.large` | `Standard_D2s_v3` |
+| Users       | Node capacity       | Replicas                 | GCP             | AWS        | Azure             |
+|-------------|---------------------|--------------------------|-----------------|------------|-------------------|
+| Up to 1,000 | 2 vCPU, 8 GB memory | 1-2 nodes, 1 coderd each | `n1-standard-2` | `t3.large` | `Standard_D2s_v3` |
 
 **Footnotes**:
 
@@ -23,9 +23,9 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 ### Provisioner nodes
 
-| Users       | Node capacity        | Replicas                       | GCP              | AWS          | Azure             |
-|-------------|----------------------|--------------------------------|------------------|--------------|-------------------|
-| Up to 1,000 | 8 vCPU, 32 GB memory | 2 nodes / 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
+|-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
+| Up to 1,000 | 8 vCPU, 32 GB memory | 2 nodes, 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -33,9 +33,9 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 ### Workspace nodes
 
-| Users       | Node capacity        | Replicas                | GCP              | AWS          | Azure             |
-|-------------|----------------------|-------------------------|------------------|--------------|-------------------|
-| Up to 1,000 | 8 vCPU, 32 GB memory | 64 / 16 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Users       | Node capacity        | Replicas                     | GCP              | AWS          | Azure             |
+|-------------|----------------------|------------------------------|------------------|--------------|-------------------|
+| Up to 1,000 | 8 vCPU, 32 GB memory | 64 nodes, 16 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -48,4 +48,4 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 | Users       | Node capacity       | Replicas | Storage | GCP                | AWS           | Azure             |
 |-------------|---------------------|----------|---------|--------------------|---------------|-------------------|
-| Up to 1,000 | 2 vCPU, 8 GB memory | 1        | 512 GB  | `db-custom-2-7680` | `db.t3.large` | `Standard_D2s_v3` |
+| Up to 1,000 | 2 vCPU, 8 GB memory | 1 node   | 512 GB  | `db-custom-2-7680` | `db.t3.large` | `Standard_D2s_v3` |

--- a/docs/admin/infrastructure/validated-architectures/2k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/2k-users.md
@@ -17,15 +17,15 @@ deployment reliability under load.
 
 ### Coderd nodes
 
-| Users       | Node capacity        | Replicas                | GCP             | AWS         | Azure             |
-|-------------|----------------------|-------------------------|-----------------|-------------|-------------------|
-| Up to 2,000 | 4 vCPU, 16 GB memory | 2 nodes / 1 coderd each | `n1-standard-4` | `t3.xlarge` | `Standard_D4s_v3` |
+| Users       | Node capacity        | Replicas               | GCP             | AWS         | Azure             |
+|-------------|----------------------|------------------------|-----------------|-------------|-------------------|
+| Up to 2,000 | 4 vCPU, 16 GB memory | 2 nodes, 1 coderd each | `n1-standard-4` | `t3.xlarge` | `Standard_D4s_v3` |
 
 ### Provisioner nodes
 
-| Users       | Node capacity        | Replicas                       | GCP              | AWS          | Azure             |
-|-------------|----------------------|--------------------------------|------------------|--------------|-------------------|
-| Up to 2,000 | 8 vCPU, 32 GB memory | 4 nodes / 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
+|-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
+| Up to 2,000 | 8 vCPU, 32 GB memory | 4 nodes, 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -36,9 +36,9 @@ deployment reliability under load.
 
 ### Workspace nodes
 
-| Users       | Node capacity        | Replicas                 | GCP              | AWS          | Azure             |
-|-------------|----------------------|--------------------------|------------------|--------------|-------------------|
-| Up to 2,000 | 8 vCPU, 32 GB memory | 128 / 16 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
+|-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
+| Up to 2,000 | 8 vCPU, 32 GB memory | 128 nodes, 16 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -51,7 +51,7 @@ deployment reliability under load.
 
 | Users       | Node capacity        | Replicas | Storage | GCP                 | AWS            | Azure             |
 |-------------|----------------------|----------|---------|---------------------|----------------|-------------------|
-| Up to 2,000 | 4 vCPU, 16 GB memory | 1        | 1 TB    | `db-custom-4-15360` | `db.t3.xlarge` | `Standard_D4s_v3` |
+| Up to 2,000 | 4 vCPU, 16 GB memory | 1 node   | 1 TB    | `db-custom-4-15360` | `db.t3.xlarge` | `Standard_D4s_v3` |
 
 **Footnotes**:
 

--- a/docs/admin/infrastructure/validated-architectures/3k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/3k-users.md
@@ -18,15 +18,15 @@ continuously improve the reliability and performance of the platform.
 
 ### Coderd nodes
 
-| Users       | Node capacity        | Replicas          | GCP             | AWS         | Azure             |
-|-------------|----------------------|-------------------|-----------------|-------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 4 / 1 coderd each | `n1-standard-4` | `t3.xlarge` | `Standard_D4s_v3` |
+| Users       | Node capacity        | Replicas              | GCP             | AWS         | Azure             |
+|-------------|----------------------|-----------------------|-----------------|-------------|-------------------|
+| Up to 3,000 | 8 vCPU, 32 GB memory | 4 node, 1 coderd each | `n1-standard-4` | `t3.xlarge` | `Standard_D4s_v3` |
 
 ### Provisioner nodes
 
-| Users       | Node capacity        | Replicas                 | GCP              | AWS          | Azure             |
-|-------------|----------------------|--------------------------|------------------|--------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 8 / 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
+|-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
+| Up to 3,000 | 8 vCPU, 32 GB memory | 8 nodes, 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -38,9 +38,9 @@ continuously improve the reliability and performance of the platform.
 
 ### Workspace nodes
 
-| Users       | Node capacity        | Replicas                       | GCP              | AWS          | Azure             |
-|-------------|----------------------|--------------------------------|------------------|--------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 256 nodes / 12 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
+|-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
+| Up to 3,000 | 8 vCPU, 32 GB memory | 256 nodes, 12 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -54,7 +54,7 @@ continuously improve the reliability and performance of the platform.
 
 | Users       | Node capacity        | Replicas | Storage | GCP                 | AWS             | Azure             |
 |-------------|----------------------|----------|---------|---------------------|-----------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 2        | 1.5 TB  | `db-custom-8-30720` | `db.t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 3,000 | 8 vCPU, 32 GB memory | 2 nodes  | 1.5 TB  | `db-custom-8-30720` | `db.t3.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 


### PR DESCRIPTION
A seller noted that the `/` operator made the node count hard to interpret. 