### PR TITLE
chore: add parent PID to coder ssh log file name

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -124,18 +124,26 @@ func (r *RootCmd) ssh() *serpent.Command {
 				if err != nil {
 					return xerrors.Errorf("generate nonce: %w", err)
 				}
-				logFilePath := filepath.Join(
-					logDirPath,
-					fmt.Sprintf(
-						"coder-ssh-%s-%s.log",
-						// The time portion makes it easier to find the right
-						// log file.
-						time.Now().Format("20060102-150405"),
-						// The nonce prevents collisions, as SSH invocations
-						// frequently happen in parallel.
-						nonce,
-					),
+				logFileBaseName := fmt.Sprintf(
+					"coder-ssh-%s-%s",
+					// The time portion makes it easier to find the right
+					// log file.
+					time.Now().Format("20060102-150405"),
+					// The nonce prevents collisions, as SSH invocations
+					// frequently happen in parallel.
+					nonce,
 				)
+				if stdio {
+					// The VS Code extension obtains the PID of the SSH process to
+					// find the log file associated with a SSH session.
+					//
+					// We get the parent PID because it's assumed `ssh` is calling this
+					// command via the ProxyCommand SSH option.
+					logFileBaseName += fmt.Sprintf("-%d", os.Getppid())
+				}
+				logFileBaseName += ".log"
+
+				logFilePath := filepath.Join(logDirPath, logFileBaseName)
 				logFile, err := os.OpenFile(
 					logFilePath,
 					os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_EXCL,


### PR DESCRIPTION
Part of bringing `coder ssh` to parity with `coder vscodessh` is associating the log files with a particular parent process (in this case, the ssh process that spawned the coder CLI via `ProxyCommand`). `coder vscodessh` named log files using the parent PID, but coder ssh is missing this. Add the parent PID to the log file name when used in stdio mode so that the VS Code extension will be able to identify the correct log file.

See also #16078.