### PR TITLE
docs: fix typo in prometheus.md

### DIFF
--- a/docs/admin/integrations/prometheus.md
+++ b/docs/admin/integrations/prometheus.md
@@ -59,7 +59,7 @@ spec:
 ### Prometheus configuration
 
 To allow Prometheus to scrape the Coder metrics, you will need to create a
-`scape_config` in your `prometheus.yml` file, or in the Prometheus Helm chart
+`scrape_config` in your `prometheus.yml` file, or in the Prometheus Helm chart
 values. The following is an example `scrape_config`.
 
 ```yaml


### PR DESCRIPTION
Fixes small `scrape_config` typo in `prometheus.md`