### PR TITLE
fix: use `netstat` over `ss` when testing unix socket

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1146,9 +1146,8 @@ func TestSSH(t *testing.T) {
 		// started and accepting input on stdin.
 		_ = pty.Peek(ctx, 1)
 
-		// Download the test page
-		pty.WriteLine(fmt.Sprintf("ss -xl state listening src %s | wc -l", remoteSock))
-		pty.ExpectMatch("2")
+		pty.WriteLine(fmt.Sprintf("netstat -an | grep -q %s; echo \"returned $?\"", remoteSock))
+		pty.ExpectMatchContext(ctx, "returned 0")
 
 		// And we're done.
 		pty.WriteLine("exit")


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/274.

`TestSSH/RemoteForwardUnixSocket` previously used `ss` for confirming if a socket was listening. `ss` isn't available on macOS, causing the test to flake. 

The test previously passed on macOS as a 2 could always be read on the SSH connection, presumably reading it as part of some escape sequence? I confirmed the test passed on Linux if you comment out the `ss` command, the pty would always read a sequence ending in `[?2`.