### PR TITLE
chore: predicate slack notification job on other jobs

### DIFF
--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -74,8 +74,11 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   notify-slack-on-failure:
+    needs:
+      - go-race
+      - go-timing
     runs-on: ubuntu-latest
-    if: always() && failure()
+    if: failure()
 
     steps:
       - name: Send Slack notification


### PR DESCRIPTION
`always()` does not seem to work

Extending https://github.com/coder/coder/pull/16105