### PR TITLE
chore: only notify about CI failure on `main` if `required` job fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1280,10 +1280,6 @@ jobs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*Failed Job:*\n${{ github.job }}"
-                  },
-                  {
-                    "type": "mrkdwn",
                     "text": "*Committer:*\n${{ github.actor }}"
                   },
                   {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1252,8 +1252,10 @@ jobs:
           make sqlc-vet
 
   notify-slack-on-failure:
+    needs:
+      - required
     runs-on: ubuntu-latest
-    if: always() && failure() && github.ref == 'refs/heads/main'
+    if: failure() && github.ref == 'refs/heads/main'
 
     steps:
       - name: Send Slack notification

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -103,10 +103,6 @@ jobs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*Failed Job:*\n${{ github.job }}"
-                  },
-                  {
-                    "type": "mrkdwn",
                     "text": "*Committer:*\n${{ github.actor }}"
                   },
                   {


### PR DESCRIPTION
This should be the last PR to get this working

Looks like the `nightly-gauntlet` is working as expected, and this is a clone of that.

@ethanndickson @matifali sorry fellas, last review from me I'm hoping