### PR TITLE
chore: reduce parallelism for test-go-pg on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -453,7 +453,8 @@ jobs:
             DB=ci gotestsum --format standard-quiet -- -v -short -count=1 -parallel 4 -p 4 ./...
           else
             go run scripts/embedded-pg/main.go
-            DB=ci gotestsum --format standard-quiet -- -v -short -count=1 ./...
+            # Reduce test parallelism, like for Windows above.
+            DB=ci gotestsum --format standard-quiet -- -v -short -count=1 -parallel 4 -p 4 ./...
           fi
 
       - name: Upload test stats to Datadog


### PR DESCRIPTION
We're seeing test-go-pg flakes on macOS in CI. We've had the same problem on Windows, and reducing test parallelism in https://github.com/coder/coder/pull/16090 seemed to help. This PR makes the same change on macOS.