### PR TITLE
fix: filter unique script timings per build

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -105,20 +105,6 @@ export const NavigateToStartStage: Story = {
 	},
 };
 
-// Test case for https://github.com/coder/coder/issues/15413
-export const DuplicatedScriptTiming: Story = {
-	args: {
-		agentScriptTimings: [
-			WorkspaceTimingsResponse.agent_script_timings[0],
-			{
-				...WorkspaceTimingsResponse.agent_script_timings[0],
-				started_at: "2021-09-01T00:00:00Z",
-				ended_at: "2021-09-01T00:00:00Z",
-			},
-		],
-	},
-};
-
 // Loading when agent script timings are empty
 // Test case for https://github.com/coder/coder/issues/15273
 export const LoadingWhenAgentScriptTimingsAreEmpty: Story = {

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -9,8 +9,6 @@ import type {
 	AgentScriptTiming,
 	ProvisionerTiming,
 } from "api/typesGenerated";
-import sortBy from "lodash/sortBy";
-import uniqBy from "lodash/uniqBy";
 import { type FC, useState } from "react";
 import { type TimeRange, calcDuration, mergeTimeRanges } from "./Chart/utils";
 import { ResourcesChart, isCoderResource } from "./ResourcesChart";
@@ -44,16 +42,9 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 	defaultIsOpen = false,
 }) => {
 	const [view, setView] = useState<TimingView>({ name: "default" });
-	// This is a workaround to deal with the BE returning multiple timings for a
-	// single agent script when it should return only one. Reference:
-	// https://github.com/coder/coder/issues/15413#issuecomment-2493663571
-	const uniqScriptTimings = uniqBy(
-		sortBy(agentScriptTimings, (t) => new Date(t.started_at).getTime() * -1),
-		(t) => t.display_name,
-	);
 	const timings = [
 		...provisionerTimings,
-		...uniqScriptTimings,
+		...agentScriptTimings,
 		...agentConnectionTimings,
 	].sort((a, b) => {
 		return new Date(a.started_at).getTime() - new Date(b.started_at).getTime();

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -26,6 +26,8 @@ import { useAuthenticated } from "contexts/auth/RequireAuth";
 import dayjs from "dayjs";
 import { useEmbeddedMetadata } from "hooks/useEmbeddedMetadata";
 import { useWorkspaceBuildLogs } from "hooks/useWorkspaceBuildLogs";
+import sortBy from "lodash/sortBy";
+import uniqBy from "lodash/uniqBy";
 import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
 import { type FC, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
@@ -37,8 +39,6 @@ import { UpdateBuildParametersDialog } from "./UpdateBuildParametersDialog";
 import { Workspace } from "./Workspace";
 import { WorkspaceDeleteDialog } from "./WorkspaceDeleteDialog";
 import type { WorkspacePermissions } from "./permissions";
-import sortBy from "lodash/sortBy";
-import uniqBy from "lodash/uniqBy";
 
 interface WorkspaceReadyPageProps {
 	template: TypesGen.Template;

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -172,10 +172,11 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 			return {
 				...data,
 				agent_script_timings: uniqBy(
-					sortBy(data.agent_script_timings, (t) =>
-						new Date(t.started_at).getTime(),
-					),
-					(t) => t.display_name,
+					sortBy(data.agent_script_timings, [
+						"display_name",
+						"started_at",
+					]).reverse(),
+					"display_name",
 				),
 			};
 		},

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -205,8 +205,6 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 		},
 	});
 
-	console.log(timingsQuery.data?.agent_connection_timings);
-
 	const runLastBuild = (
 		buildParameters: TypesGen.WorkspaceBuildParameter[] | undefined,
 		debug: boolean,


### PR DESCRIPTION
The timings endpoint is incorrectly returning multiple script timings instead of a single one. This commit implements a workaround to address the issue on the FE side.

Partially addresses https://github.com/coder/coder/issues/15921 by identifying that the provisioner timings contain outdated dates, resulting in an excessively long time window. This causes the chart to attempt rendering thousands of ticks, consuming significant memory.