### PR TITLE
chore: add the --ephemeral server flag

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -393,10 +393,10 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 
 			if vals.EphemeralDeployment.Value() {
 				r.globalConfig = filepath.Join(os.TempDir(), fmt.Sprintf("coder_ephemeral_%d", time.Now().UnixMilli()))
-				cliui.Infof(inv.Stdout, "Using an ephemeral deployment (%s)", r.globalConfig)
 				if err := os.MkdirAll(r.globalConfig, 0o700); err != nil {
 					return xerrors.Errorf("create ephemeral deployment directory: %w", err)
 				}
+				cliui.Infof(inv.Stdout, "Using an ephemeral deployment (%s)", r.globalConfig)
 				defer func() {
 					cliui.Infof(inv.Stdout, "Removing ephemeral deployment directory...")
 					if err := os.RemoveAll(r.globalConfig); err != nil {

--- a/cli/server.go
+++ b/cli/server.go
@@ -396,7 +396,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				if err := os.MkdirAll(r.globalConfig, 0o700); err != nil {
 					return xerrors.Errorf("create ephemeral deployment directory: %w", err)
 				}
-				cliui.Infof(inv.Stdout, "Using an ephemeral deployment (%s)", r.globalConfig)
+				cliui.Infof(inv.Stdout, "Using an ephemeral deployment directory (%s)", r.globalConfig)
 				defer func() {
 					cliui.Infof(inv.Stdout, "Removing ephemeral deployment directory...")
 					if err := os.RemoveAll(r.globalConfig); err != nil {

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -54,7 +54,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 
 			if newUserDBURL == "" {
 				cliui.Infof(inv.Stdout, "Using built-in PostgreSQL (%s)", cfg.PostgresPath())
-				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger)
+				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "")
 				if err != nil {
 					return err
 				}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -191,6 +191,7 @@ func TestServer(t *testing.T) {
 		)
 		pty := ptytest.New(t).Attach(inv)
 
+		// Embedded postgres takes a while to fire up.
 		const superDuperLong = testutil.WaitSuperLong * 3
 		ctx, cancelFunc := context.WithCancel(testutil.Context(t, superDuperLong))
 		errCh := make(chan error, 1)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -212,7 +212,6 @@ func TestServer(t *testing.T) {
 		<-errCh
 
 		require.NoDirExists(t, rootDir)
-
 	})
 	t.Run("BuiltinPostgresURL", func(t *testing.T) {
 		t.Parallel()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -177,6 +177,43 @@ func TestServer(t *testing.T) {
 			return err == nil && rawURL != ""
 		}, superDuperLong, testutil.IntervalFast, "failed to get access URL")
 	})
+	t.Run("EphemeralDeployment", func(t *testing.T) {
+		t.Parallel()
+		if testing.Short() {
+			t.SkipNow()
+		}
+
+		inv, _ := clitest.New(t,
+			"server",
+			"--http-address", ":0",
+			"--access-url", "http://example.com",
+			"--ephemeral",
+		)
+		pty := ptytest.New(t).Attach(inv)
+
+		const superDuperLong = testutil.WaitSuperLong * 3
+		ctx, cancelFunc := context.WithCancel(testutil.Context(t, superDuperLong))
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- inv.WithContext(ctx).Run()
+		}()
+		pty.ExpectMatch("Using an ephemeral deployment")
+		rootDirLine := pty.ReadLine(ctx)
+		rootDir := strings.TrimPrefix(rootDirLine, "Using an ephemeral deployment")
+		rootDir = strings.TrimSpace(rootDir)
+		rootDir = strings.TrimPrefix(rootDir, "(")
+		rootDir = strings.TrimSuffix(rootDir, ")")
+		require.NotEmpty(t, rootDir)
+		require.DirExists(t, rootDir)
+
+		pty.ExpectMatch("View the Web UI")
+
+		cancelFunc()
+		<-errCh
+
+		require.NoDirExists(t, rootDir)
+
+	})
 	t.Run("BuiltinPostgresURL", func(t *testing.T) {
 		t.Parallel()
 		root, _ := clitest.New(t, "server", "postgres-builtin-url")

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -206,7 +206,7 @@ func TestServer(t *testing.T) {
 		require.NotEmpty(t, rootDir)
 		require.DirExists(t, rootDir)
 
-		pty.ExpectMatch("View the Web UI")
+		pty.ExpectMatchContext(ctx, "View the Web UI")
 
 		cancelFunc()
 		<-errCh

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -198,9 +198,9 @@ func TestServer(t *testing.T) {
 		go func() {
 			errCh <- inv.WithContext(ctx).Run()
 		}()
-		pty.ExpectMatch("Using an ephemeral deployment")
+		pty.ExpectMatch("Using an ephemeral deployment directory")
 		rootDirLine := pty.ReadLine(ctx)
-		rootDir := strings.TrimPrefix(rootDirLine, "Using an ephemeral deployment")
+		rootDir := strings.TrimPrefix(rootDirLine, "Using an ephemeral deployment directory")
 		rootDir = strings.TrimSpace(rootDir)
 		rootDir = strings.TrimPrefix(rootDir, "(")
 		rootDir = strings.TrimSuffix(rootDir, ")")

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -446,6 +446,10 @@ cacheDir: [cache dir]
 # Controls whether data will be stored in an in-memory database.
 # (default: <unset>, type: bool)
 inMemoryDatabase: false
+# Controls whether Coder data, including built-in Postgres, will be stored in a
+# temporary directory and deleted when the server is stopped.
+# (default: <unset>, type: bool)
+ephemeralDeployment: false
 # Type of auth to use when connecting to postgres. For AWS RDS, using IAM
 # authentication (awsiamrds) is recommended.
 # (default: password, type: enum[password\|awsiamrds])

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10875,6 +10875,9 @@ const docTemplate = `{
                 "enable_terraform_debug_mode": {
                     "type": "boolean"
                 },
+                "ephemeral_deployment": {
+                    "type": "boolean"
+                },
                 "experiments": {
                     "type": "array",
                     "items": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9718,6 +9718,9 @@
 				"enable_terraform_debug_mode": {
 					"type": "boolean"
 				},
+				"ephemeral_deployment": {
+					"type": "boolean"
+				},
 				"experiments": {
 					"type": "array",
 					"items": {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -350,6 +350,7 @@ type DeploymentValues struct {
 	ProxyTrustedOrigins             serpent.StringArray                  `json:"proxy_trusted_origins,omitempty" typescript:",notnull"`
 	CacheDir                        serpent.String                       `json:"cache_directory,omitempty" typescript:",notnull"`
 	InMemoryDatabase                serpent.Bool                         `json:"in_memory_database,omitempty" typescript:",notnull"`
+	EphemeralDeployment             serpent.Bool                         `json:"ephemeral_deployment,omitempty" typescript:",notnull"`
 	PostgresURL                     serpent.String                       `json:"pg_connection_url,omitempty" typescript:",notnull"`
 	PostgresAuth                    string                               `json:"pg_auth,omitempty" typescript:",notnull"`
 	OAuth2                          OAuth2Config                         `json:"oauth2,omitempty" typescript:",notnull"`
@@ -2281,6 +2282,15 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Hidden:      true,
 			Value:       &c.InMemoryDatabase,
 			YAML:        "inMemoryDatabase",
+		},
+		{
+			Name:        "Ephemeral Deployment",
+			Description: "Controls whether Coder data, including built-in Postgres, will be stored in a temporary directory and deleted when the server is stopped.",
+			Flag:        "ephemeral",
+			Env:         "CODER_EPHEMERAL",
+			Hidden:      true,
+			Value:       &c.EphemeralDeployment,
+			YAML:        "ephemeralDeployment",
 		},
 		{
 			Name:        "Postgres Connection URL",

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -224,6 +224,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "user": {}
     },
     "enable_terraform_debug_mode": true,
+    "ephemeral_deployment": true,
     "experiments": [
       "string"
     ],

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1867,6 +1867,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "user": {}
     },
     "enable_terraform_debug_mode": true,
+    "ephemeral_deployment": true,
     "experiments": [
       "string"
     ],
@@ -2336,6 +2337,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "user": {}
   },
   "enable_terraform_debug_mode": true,
+  "ephemeral_deployment": true,
   "experiments": [
     "string"
   ],
@@ -2646,6 +2648,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `disable_path_apps`                  | boolean                                                                                              | false    |              |                                                                    |
 | `docs_url`                           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
 | `enable_terraform_debug_mode`        | boolean                                                                                              | false    |              |                                                                    |
+| `ephemeral_deployment`               | boolean                                                                                              | false    |              |                                                                    |
 | `experiments`                        | array of string                                                                                      | false    |              |                                                                    |
 | `external_auth`                      | [serpent.Struct-array_codersdk_ExternalAuthConfig](#serpentstruct-array_codersdk_externalauthconfig) | false    |              |                                                                    |
 | `external_token_encryption_keys`     | array of string                                                                                      | false    |              |                                                                    |

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -623,6 +623,7 @@ export interface DeploymentValues {
 	readonly proxy_trusted_origins?: string;
 	readonly cache_directory?: string;
 	readonly in_memory_database?: boolean;
+	readonly ephemeral_deployment?: boolean;
 	readonly pg_connection_url?: string;
 	readonly pg_auth?: string;
 	readonly oauth2?: OAuth2Config;


### PR DESCRIPTION
Another PR to address https://github.com/coder/coder/issues/15109.

Changes:
- Introduces the `--ephemeral` flag, which changes the Coder config directory to a temporary location. The config directory is where the built-in PostgreSQL stores its data, so using a new one results in a deployment with a fresh state.

The `--ephemeral` flag is set to replace the `--in-memory` flag once the in-memory database is removed.