### PR TITLE
fix(scripts/coder-dev.sh): silence output if stdout is not a TTY

### DIFF
--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -39,7 +39,13 @@ case $BINARY_TYPE in
 coder-slim)
 	# Ensure the coder slim binary is always up-to-date with local
 	# changes, this simplifies usage of this script for development.
-	make -j "${RELATIVE_BINARY_PATH}"
+	# NOTE: we send all output of `make` to /dev/null so that we do not break
+	# scripts that read the output of this command.
+	if [[ -t 1 ]]; then
+		make -j "${RELATIVE_BINARY_PATH}"
+	else
+		make -j "${RELATIVE_BINARY_PATH}" >/dev/null 2>&1
+	fi
 	;;
 coder)
 	if [[ ! -x "${CODER_DEV_BIN}" ]]; then


### PR DESCRIPTION
The `make -j` output was sometimes emitting non-JSON output from `go generate`, resulting in errors like the below:

```
++ /home/coder/src/coder/coder/scripts/coder-dev.sh organizations show me -o json
++ jq -r '.[] | select(.is_default) | .name'
parse error: Invalid numeric literal at line 1, column 3
```

This PR modifies `coder-dev.sh` to silence the output of `make` if the output is not a TTY.