### PR TITLE
chore(docs): mention skipped january mainline release in calendar

### DIFF
--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -71,8 +71,11 @@ pages.
 > used to test under-development features and bug fixes that have not yet been
 > released to [`mainline`](#mainline-releases) or [`stable`](#stable-releases).
 >
-> > **Important**: The `preview` image is not intended for production use.
+> The `preview` image is not intended for production use.
 
-> **Note**: v2.18 was promoted to stable on January 7th, 2025. We'll be skipping
-> the January release each year as most of our engineering team is out for the
-> holiday period. We'll return to our regular release cadence on February 4th.
+### A note about January releases
+
+v2.18 was promoted to stable on January 7th, 2025.
+
+Effective starting January, 2025 we will skip the January release each year because most of our engineering team is out for the December holiday period.
+We'll return to our regular release cadence on February 4th.

--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -61,8 +61,8 @@ pages.
 | 2.14.x       | August 06, 2024    | Not Supported    |
 | 2.15.x       | September 03, 2024 | Not Supported    |
 | 2.16.x       | October 01, 2024   | Security Support |
-| 2.17.x       | November 05, 2024  | Stable           |
-| 2.18.x       | December 03, 2024  | Mainline         |
+| 2.17.x       | November 05, 2024  | Security Support |
+| 2.18.x       | December 03, 2024  | Stable           |
 | 2.19.x       | February 04, 2024  | Not Released     |
 
 > **Tip**: We publish a
@@ -72,3 +72,7 @@ pages.
 > released to [`mainline`](#mainline-releases) or [`stable`](#stable-releases).
 >
 > > **Important**: The `preview` image is not intended for production use.
+
+> **Note**: v2.18 was promoted to stable on January 7th, 2025. We'll be skipping
+> the January release each year as most of our engineering team is out for the
+> holiday period. We'll return to our regular release cadence on February 4th.


### PR DESCRIPTION
We've skipped the January release as most of our engineering team was on holiday. We'll continue this practice annually. 