### PR TITLE
chore: exclude otlp trace provider from slim builds

### DIFF
--- a/coderd/tracing/exporter.go
+++ b/coderd/tracing/exporter.go
@@ -1,3 +1,5 @@
+//go:build !slim
+
 package tracing
 
 import (


### PR DESCRIPTION
This adds a build flag to `exporter.go` in `coderd/tracing` that skips compiling the file in slim builds. This file brings in some relatively hefty dependencies that were growing the size of the slim binary a few megabytes. All files that import `exporter.go` also aren't included in slim builds, so this is safe.

We end up saving 5.4MB on the Linux slim binary.

<details>
<summary>Binary size diff: </summary>
<br>

```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Diff between coder-slim_2.18.2-devel+53806906e_linux_amd64 and coder-slim_2.18.2-devel+6ae349276_linux_amd │
│ 64                                                                                                         │
├──────────┬─────────────────────────────────────────────────────────────────┬──────────┬──────────┬─────────┤
│ PERCENT  │ NAME                                                            │ OLD SIZE │ NEW SIZE │ DIFF    │
├──────────┼─────────────────────────────────────────────────────────────────┼──────────┼──────────┼─────────┤
│ +0.40%   │ internal/profile                                                │ 140 kB   │ 140 kB   │ +555 B  │
│ +0.02%   │ github.com/coder/coder/v2                                       │ 3.2 MB   │ 3.2 MB   │ +535 B  │
│ +0.01%   │ tailscale.com                                                   │ 3.7 MB   │ 3.7 MB   │ +257 B  │
│ +0.10%   │ cloud.google.com/go/logging                                     │ 207 kB   │ 207 kB   │ +217 B  │
│ +0.02%   │ github.com/miekg/dns                                            │ 555 kB   │ 555 kB   │ +84 B   │
│ +0.02%   │ github.com/godbus/dbus/v5                                       │ 330 kB   │ 330 kB   │ +79 B   │
│ +0.08%   │ github.com/mdlayher/socket                                      │ 80 kB    │ 80 kB    │ +66 B   │
│ +0.04%   │ database/sql                                                    │ 154 kB   │ 154 kB   │ +60 B   │
│ +0.03%   │ github.com/prometheus/client_golang                             │ 172 kB   │ 172 kB   │ +43 B   │
│ +0.02%   │ github.com/fxamacker/cbor/v2                                    │ 175 kB   │ 175 kB   │ +43 B   │
│ +0.01%   │ github.com/zclconf/go-cty                                       │ 779 kB   │ 779 kB   │ +39 B   │
│ +0.04%   │ github.com/tailscale/goupnp                                     │ 76 kB    │ 76 kB    │ +34 B   │
│ +0.11%   │ gopkg.in/natefinch/lumberjack.v2                                │ 30 kB    │ 30 kB    │ +33 B   │
│ +0.00%   │ golang.org/x/crypto                                             │ 646 kB   │ 646 kB   │ +29 B   │
│ +0.22%   │ github.com/pion/udp                                             │ 13 kB    │ 13 kB    │ +29 B   │
│ +0.04%   │ github.com/go-chi/chi/v5                                        │ 53 kB    │ 53 kB    │ +23 B   │
│ +0.04%   │ github.com/google/nftables                                      │ 62 kB    │ 62 kB    │ +23 B   │
│ +0.01%   │ github.com/hashicorp/go-cty                                     │ 270 kB   │ 270 kB   │ +21 B   │
│ +1.96%   │ github.com/mitchellh/copystructure                              │ 1.1 kB   │ 1.1 kB   │ +21 B   │
│ +2.09%   │ github.com/hashicorp/terraform-plugin-sdk/v2                    │ 957 B    │ 977 B    │ +20 B   │
│ +0.17%   │ github.com/hashicorp/go-version                                 │ 11 kB    │ 11 kB    │ +18 B   │
│ +0.10%   │ github.com/pkg/diff                                             │ 19 kB    │ 19 kB    │ +18 B   │
│ +0.04%   │ github.com/google/btree                                         │ 43 kB    │ 43 kB    │ +17 B   │
│ +0.11%   │ github.com/adrg/xdg                                             │ 14 kB    │ 14 kB    │ +15 B   │
│ +0.08%   │ cloud.google.com/go/longrunning                                 │ 20 kB    │ 20 kB    │ +15 B   │
│ +0.04%   │ github.com/prometheus/client_model                              │ 36 kB    │ 36 kB    │ +15 B   │
│ +6.73%   │ github.com/josharian/native                                     │ 223 B    │ 238 B    │ +15 B   │
│ +0.00%   │ github.com/klauspost/compress                                   │ 251 kB   │ 251 kB   │ +12 B   │
│ +0.01%   │ sync                                                            │ 91 kB    │ 91 kB    │ +12 B   │
│ +0.02%   │ mime                                                            │ 72 kB    │ 72 kB    │ +12 B   │
│ +0.00%   │ github.com/tailscale/golang-x-crypto                            │ 228 kB   │ 228 kB   │ +11 B   │
│ +0.01%   │ github.com/tidwall/gjson                                        │ 90 kB    │ 90 kB    │ +10 B   │
│ +0.01%   │ cdr.dev/slog                                                    │ 65 kB    │ 65 kB    │ +9 B    │
│ +0.07%   │ text/tabwriter                                                  │ 12 kB    │ 12 kB    │ +9 B    │
│ +0.08%   │ github.com/coder/pretty                                         │ 12 kB    │ 12 kB    │ +9 B    │
│ +0.00%   │ github.com/vmihailenco/msgpack                                  │ 294 kB   │ 294 kB   │ +9 B    │
│ +1.61%   │ github.com/hashicorp/terraform-plugin-log                       │ 496 B    │ 504 B    │ +8 B    │
│ +0.01%   │ github.com/mdlayher/netlink                                     │ 54 kB    │ 54 kB    │ +8 B    │
│ +0.06%   │ encoding/csv                                                    │ 12 kB    │ 12 kB    │ +7 B    │
│ +0.13%   │ encoding/base32                                                 │ 5.6 kB   │ 5.6 kB   │ +7 B    │
│ +0.01%   │ storj.io/drpc                                                   │ 84 kB    │ 84 kB    │ +7 B    │
│ +0.04%   │ github.com/tidwall/pretty                                       │ 16 kB    │ 16 kB    │ +7 B    │
│ +0.01%   │ internal/poll                                                   │ 89 kB    │ 89 kB    │ +6 B    │
│ +0.08%   │ github.com/gofrs/flock                                          │ 7.3 kB   │ 7.3 kB   │ +6 B    │
│ +0.20%   │ github.com/google/go-cmp                                        │ 2.5 kB   │ 2.5 kB   │ +5 B    │
│ +0.07%   │ golang.org/x/mod                                                │ 7.1 kB   │ 7.1 kB   │ +5 B    │
│ +0.00%   │ time                                                            │ 154 kB   │ 154 kB   │ +5 B    │
│ +0.02%   │ github.com/briandowns/spinner                                   │ 28 kB    │ 28 kB    │ +5 B    │
│ +0.07%   │ github.com/cenkalti/backoff/v4                                  │ 7.3 kB   │ 7.3 kB   │ +5 B    │
│ +0.00%   │ github.com/prometheus/procfs                                    │ 345 kB   │ 345 kB   │ +5 B    │
│ +0.02%   │ github.com/google/uuid                                          │ 22 kB    │ 22 kB    │ +5 B    │
│ +0.04%   │ expvar                                                          │ 10 kB    │ 10 kB    │ +4 B    │
│ +0.01%   │ strings                                                         │ 58 kB    │ 58 kB    │ +4 B    │
│ +0.04%   │ github.com/hashicorp/go-multierror                              │ 10 kB    │ 10 kB    │ +4 B    │
│ +0.16%   │ github.com/tidwall/match                                        │ 2.6 kB   │ 2.6 kB   │ +4 B    │
│ +0.17%   │ github.com/hashicorp/go-reap                                    │ 1.8 kB   │ 1.8 kB   │ +3 B    │
│ +0.09%   │ inet.af/peercred                                                │ 2.3 kB   │ 2.3 kB   │ +2 B    │
│ +0.70%   │ github.com/coreos/go-iptables                                   │ 287 B    │ 289 B    │ +2 B    │
│ +0.01%   │ github.com/pion/transport/v2                                    │ 16 kB    │ 16 kB    │ +2 B    │
│ +0.03%   │ github.com/fatih/color                                          │ 6.6 kB   │ 6.6 kB   │ +2 B    │
│ +0.06%   │ github.com/gen2brain/beeep                                      │ 3.3 kB   │ 3.3 kB   │ +2 B    │
│ +0.00%   │ github.com/gliderlabs/ssh                                       │ 99 kB    │ 99 kB    │ +2 B    │
│ +0.00%   │ github.com/charmbracelet/lipgloss                               │ 257 kB   │ 257 kB   │ +2 B    │
│ +0.01%   │ github.com/cakturk/go-netstat                                   │ 7.9 kB   │ 7.9 kB   │ +1 B    │
│ +0.00%   │ strconv                                                         │ 59 kB    │ 59 kB    │ +1 B    │
│ -100%    │ github.com/ryanuber/go-glob                                     │          │          │ +0 B    │
│ -100%    │ go.opentelemetry.io/collector/semconv                           │          │          │ +0 B    │
│ -100%    │ github.com/hashicorp/go-secure-stdlib/strutil                   │          │          │ +0 B    │
│ -100%    │ go.opentelemetry.io/collector/config/configtelemetry            │          │          │ +0 B    │
│ -0.00%   │ filippo.io/edwards25519                                         │ 40 kB    │ 40 kB    │ -1 B    │
│ -0.00%   │ text/template                                                   │ 242 kB   │ 242 kB   │ -1 B    │
│ -0.00%   │ github.com/leodido/go-urn                                       │ 56 kB    │ 56 kB    │ -1 B    │
│ -0.02%   │ github.com/go-jose/go-jose/v4                                   │ 5.2 kB   │ 5.2 kB   │ -1 B    │
│ -0.01%   │ github.com/prometheus/common                                    │ 17 kB    │ 17 kB    │ -1 B    │
│ -0.00%   │ encoding/asn1                                                   │ 69 kB    │ 69 kB    │ -2 B    │
│ -0.06%   │ github.com/armon/circbuf                                        │ 3.1 kB   │ 3.1 kB   │ -2 B    │
│ -0.28%   │ github.com/pkg/browser                                          │ 1.4 kB   │ 1.4 kB   │ -4 B    │
│ -0.00%   │ gopkg.in/yaml.v3                                                │ 299 kB   │ 299 kB   │ -4 B    │
│ -0.47%   │ github.com/coder/retry                                          │ 1.1 kB   │ 1.1 kB   │ -5 B    │
│ -0.00%   │ github.com/gabriel-vasile/mimetype                              │ 214 kB   │ 214 kB   │ -5 B    │
│ -0.14%   │ github.com/mitchellh/go-ps                                      │ 3.6 kB   │ 3.6 kB   │ -5 B    │
│ -0.07%   │ github.com/wagslane/go-password-validator                       │ 8.6 kB   │ 8.6 kB   │ -6 B    │
│ -0.02%   │ bytes                                                           │ 39 kB    │ 39 kB    │ -6 B    │
│ -0.01%   │ github.com/robfig/cron/v3                                       │ 48 kB    │ 48 kB    │ -6 B    │
│ -0.02%   │ cloud.google.com/go/compute/metadata                            │ 31 kB    │ 31 kB    │ -7 B    │
│ -0.29%   │ github.com/cespare/xxhash/v2                                    │ 2.4 kB   │ 2.4 kB   │ -7 B    │
│ -0.01%   │ github.com/charmbracelet/bubbles                                │ 61 kB    │ 61 kB    │ -7 B    │
│ -0.13%   │ github.com/bgentry/speakeasy                                    │ 6.4 kB   │ 6.3 kB   │ -8 B    │
│ -0.01%   │ html                                                            │ 119 kB   │ 119 kB   │ -8 B    │
│ -0.01%   │ golang.org/x/text                                               │ 158 kB   │ 158 kB   │ -9 B    │
│ -0.01%   │ encoding/xml                                                    │ 120 kB   │ 120 kB   │ -10 B   │
│ -0.04%   │ github.com/spf13/afero                                          │ 24 kB    │ 24 kB    │ -10 B   │
│ -0.01%   │ github.com/tailscale/netlink                                    │ 120 kB   │ 120 kB   │ -10 B   │
│ -2.29%   │ hash/adler32                                                    │ 436 B    │ 426 B    │ -10 B   │
│ -0.01%   │ github.com/coder/quartz                                         │ 79 kB    │ 79 kB    │ -11 B   │
│ -0.00%   │ encoding/gob                                                    │ 225 kB   │ 225 kB   │ -11 B   │
│ -0.02%   │ github.com/jsimonetti/rtnetlink                                 │ 75 kB    │ 75 kB    │ -14 B   │
│ -0.02%   │ golang.org/x/exp                                                │ 97 kB    │ 97 kB    │ -19 B   │
│ -0.13%   │ golang.org/x/time                                               │ 16 kB    │ 16 kB    │ -21 B   │
│ -0.03%   │ github.com/hashicorp/yamux                                      │ 66 kB    │ 66 kB    │ -23 B   │
│ -0.23%   │ go.uber.org/atomic                                              │ 10 kB    │ 10 kB    │ -24 B   │
│ -0.17%   │ github.com/pkg/errors                                           │ 15 kB    │ 15 kB    │ -26 B   │
│ -0.00%   │ gvisor.dev/gvisor                                               │ 2.7 MB   │ 2.7 MB   │ -29 B   │
│ -0.02%   │ github.com/coder/serpent                                        │ 179 kB   │ 179 kB   │ -39 B   │
│ -0.02%   │ github.com/spf13/pflag                                          │ 203 kB   │ 202 kB   │ -44 B   │
│ -8.08%   │ github.com/x448/float16                                         │ 804 B    │ 739 B    │ -65 B   │
│ -0.05%   │ github.com/pkg/sftp                                             │ 133 kB   │ 133 kB   │ -72 B   │
│ -0.02%   │ github.com/hashicorp/hcl/v2                                     │ 492 kB   │ 491 kB   │ -74 B   │
│ -0.07%   │ github.com/elastic/go-sysinfo                                   │ 163 kB   │ 163 kB   │ -121 B  │
│ -0.04%   │ github.com/go-playground/validator/v10                          │ 305 kB   │ 305 kB   │ -123 B  │
│ -0.15%   │ github.com/coder/websocket                                      │ 107 kB   │ 107 kB   │ -164 B  │
│ -0.21%   │ archive/tar                                                     │ 80 kB    │ 79 kB    │ -171 B  │
│ -100%    │ github.com/DataDog/go-sqllexer                                  │ 246 B    │          │ -246 B  │
│ -100%    │ github.com/golang/protobuf                                      │ 252 B    │          │ -252 B  │
│ -0.17%   │ encoding/json                                                   │ 159 kB   │ 159 kB   │ -263 B  │
│ -0.53%   │ io                                                              │ 54 kB    │ 53 kB    │ -283 B  │
│ -0.18%   │ os                                                              │ 199 kB   │ 199 kB   │ -367 B  │
│ -0.14%   │ math                                                            │ 272 kB   │ 272 kB   │ -376 B  │
│ -0.04%   │ golang.org/x/net                                                │ 1.1 MB   │ 1.1 MB   │ -406 B  │
│ -100%    │ github.com/DataDog/go-runtime-metrics-internal                  │ 432 B    │          │ -432 B  │
│ -100%    │ github.com/DataDog/datadog-agent/pkg/remoteconfig/state         │ 559 B    │          │ -559 B  │
│ -0.37%   │ github.com/jedib0t/go-pretty/v6                                 │ 169 kB   │ 168 kB   │ -622 B  │
│ -0.21%   │ reflect                                                         │ 296 kB   │ 295 kB   │ -629 B  │
│ -100%    │ github.com/DataDog/datadog-go/v5                                │ 676 B    │          │ -676 B  │
│ -100%    │ github.com/DataDog/datadog-agent/pkg/obfuscate                  │ 954 B    │          │ -954 B  │
│ -100%    │ github.com/outcaste-io/ristretto                                │ 1.1 kB   │          │ -1.1 kB │
│ -100%    │ github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes │ 1.1 kB   │          │ -1.1 kB │
│ -2.49%   │ golang.org/x/sys                                                │ 60 kB    │ 59 kB    │ -1.5 kB │
│ -100%    │ go.opentelemetry.io/collector/component                         │ 1.5 kB   │          │ -1.5 kB │
│ -0.14%   │ crypto                                                          │ 1.2 MB   │ 1.2 MB   │ -1.7 kB │
│ -100%    │ github.com/hashicorp/go-secure-stdlib/parseutil                 │ 2.1 kB   │          │ -2.1 kB │
│ -0.23%   │ runtime                                                         │ 982 kB   │ 980 kB   │ -2.3 kB │
│ -100%    │ github.com/DataDog/datadog-agent/pkg/trace                      │ 2.9 kB   │          │ -2.9 kB │
│ -8.68%   │ context                                                         │ 37 kB    │ 34 kB    │ -3.2 kB │
│ -100%    │ github.com/tklauser/numcpus                                     │ 3.3 kB   │          │ -3.3 kB │
│ -100%    │ github.com/DataDog/go-libddwaf/v3                               │ 3.6 kB   │          │ -3.6 kB │
│ -100%    │ gopkg.in/yaml.v2                                                │ 4.2 kB   │          │ -4.2 kB │
│ -100%    │ github.com/DataDog/appsec-internal-go                           │ 5.5 kB   │          │ -5.5 kB │
│ -100%    │ github.com/modern-go/concurrent                                 │ 5.6 kB   │          │ -5.6 kB │
│ -100%    │ github.com/dustin/go-humanize                                   │ 5.8 kB   │          │ -5.8 kB │
│ -100%    │ go.uber.org/multierr                                            │ 6.4 kB   │          │ -6.4 kB │
│ -100%    │ github.com/DataDog/datadog-agent/pkg/util/log                   │ 6.4 kB   │          │ -6.4 kB │
│ -100%    │ github.com/DataDog/gostackparse                                 │ 6.9 kB   │          │ -6.9 kB │
│ -100%    │ github.com/philhofer/fwd                                        │ 7.3 kB   │          │ -7.3 kB │
│ -100%    │ github.com/secure-systems-lab/go-securesystemslib               │ 7.5 kB   │          │ -7.5 kB │
│ -100%    │ github.com/shirou/gopsutil/v3                                   │ 8.3 kB   │          │ -8.3 kB │
│ -9.36%   │ slices                                                          │ 89 kB    │ 81 kB    │ -8.3 kB │
│ -100%    │ github.com/tklauser/go-sysconf                                  │ 8.5 kB   │          │ -8.5 kB │
│ -100%    │ github.com/spaolacci/murmur3                                    │ 8.8 kB   │          │ -8.8 kB │
│ -100%    │ github.com/grpc-ecosystem/grpc-gateway/v2                       │ 11 kB    │          │ -11 kB  │
│ -4.67%   │ go.opentelemetry.io/otel                                        │ 246 kB   │ 235 kB   │ -12 kB  │
│ -100%    │ github.com/eapache/queue/v2                                     │ 12 kB    │          │ -12 kB  │
│ -0.95%   │ google.golang.org/protobuf                                      │ 1.8 MB   │ 1.8 MB   │ -17 kB  │
│ -100%    │ github.com/DataDog/datadog-agent/pkg/util/scrubber              │ 19 kB    │          │ -19 kB  │
│ -2.36%   │ google.golang.org/grpc                                          │ 964 kB   │ 941 kB   │ -23 kB  │
│ -1.92%   │ net                                                             │ 1.6 MB   │ 1.6 MB   │ -31 kB  │
│ -100%    │ gopkg.in/ini.v1                                                 │ 33 kB    │          │ -33 kB  │
│ -100%    │ github.com/richardartoul/molecule                               │ 33 kB    │          │ -33 kB  │
│ -15.56%  │ google.golang.org/genproto                                      │ 228 kB   │ 192 kB   │ -36 kB  │
│ -47.48%  │ archive/zip                                                     │ 89 kB    │ 47 kB    │ -42 kB  │
│ -100%    │ github.com/DataDog/sketches-go                                  │ 47 kB    │          │ -47 kB  │
│ -100%    │ github.com/DataDog/go-tuf                                       │ 48 kB    │          │ -48 kB  │
│ -8.91%   │ <autogenerated>                                                 │ 670 kB   │ 611 kB   │ -60 kB  │
│ -100%    │ go.opentelemetry.io/proto/otlp                                  │ 63 kB    │          │ -63 kB  │
│ -100.00% │ github.com/mitchellh/mapstructure                               │ 73 kB    │          │ -73 kB  │
│ -100%    │ github.com/hashicorp/go-sockaddr                                │ 111 kB   │          │ -111 kB │
│ -100%    │ github.com/google/pprof                                         │ 143 kB   │          │ -143 kB │
│ -100%    │ github.com/tinylib/msgp                                         │ 150 kB   │          │ -150 kB │
│ -100%    │ go.uber.org/zap                                                 │ 199 kB   │          │ -199 kB │
│ -100%    │ gopkg.in/DataDog/dd-trace-go.v1                                 │ 244 kB   │          │ -244 kB │
│ -100%    │ github.com/cihub/seelog                                         │ 290 kB   │          │ -290 kB │
│ -100%    │ github.com/DataDog/datadog-agent/pkg/proto                      │ 303 kB   │          │ -303 kB │
│ -100%    │ github.com/json-iterator/go                                     │ 426 kB   │          │ -426 kB │
│ -100%    │ github.com/modern-go/reflect2                                   │ 485 kB   │          │ -485 kB │
│ -100%    │ go.opentelemetry.io/collector/pdata                             │ 746 kB   │          │ -746 kB │
│ -100%    │ github.com/gogo/protobuf                                        │ 1.1 MB   │          │ -1.1 MB │
├──────────┼─────────────────────────────────────────────────────────────────┼──────────┼──────────┼─────────┤
│ -16.68%  │ .itablink                                                       │ 25 kB    │ 21 kB    │ -4.2 kB │
│ -23.31%  │ .go.buildinfo                                                   │ 22 kB    │ 16 kB    │ -5.0 kB │
│ -10.31%  │ .typelink                                                       │ 66 kB    │ 59 kB    │ -6.8 kB │
│ -9.12%   │ .data                                                           │ 266 kB   │ 242 kB   │ -24 kB  │
│ -5.06%   │ .noptrdata                                                      │ 713 kB   │ 677 kB   │ -36 kB  │
│ -8.62%   │ .rodata                                                         │ 9.5 MB   │ 8.7 MB   │ -821 kB │
├──────────┼─────────────────────────────────────────────────────────────────┼──────────┼──────────┼─────────┤
│ -12.04%  │ coder-slim_2.18.2-devel+53806906e_linux_amd64                   │ 45 MB    │ 39 MB    │ -5.4 MB │
│          │ coder-slim_2.18.2-devel+6ae349276_linux_amd64                   │          │          │         │
└──────────┴─────────────────────────────────────────────────────────────────┴──────────┴──────────┴─────────┘
```
</details>

