### PR TITLE
fix: improve shell compatibility of netstat check in test

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1219,8 +1219,10 @@ func TestSSH(t *testing.T) {
 		// started and accepting input on stdin.
 		_ = pty.Peek(ctx, 1)
 
-		pty.WriteLine(fmt.Sprintf("netstat -an | grep -q %s; echo \"returned $?\"", remoteSock))
-		pty.ExpectMatchContext(ctx, "returned 0")
+		// This needs to support most shells on Linux or macOS
+		// We can't include exactly what's expected in the input, as that will always be matched
+		pty.WriteLine(fmt.Sprintf(`echo "results: $(netstat -an | grep %s | wc -l | tr -d ' ')"`, remoteSock))
+		pty.ExpectMatchContext(ctx, "results: 1")
 
 		// And we're done.
 		pty.WriteLine("exit")


### PR DESCRIPTION
When I wrote the original just the other day, I used `$?`, which is fine on CI and in most cases. It's not fine when the person running the test has their system shell set to Fish. In the interest of letting this test pass locally, we'll instead just grab the line count of the grep output. However, `wc` is padded on macos with spaces, so we need to get rid of those too.