### PR TITLE
feat(coderd/database): order user engagement statistics by date

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3211,6 +3211,7 @@ SELECT
 FROM ranked_status_change_per_user_per_date rscpupd
 CROSS JOIN statuses
 GROUP BY rscpupd.date, statuses.new_status
+ORDER BY rscpupd.date
 `
 
 type GetUserStatusCountsParams struct {

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -900,5 +900,5 @@ SELECT
 	) AS count
 FROM ranked_status_change_per_user_per_date rscpupd
 CROSS JOIN statuses
-GROUP BY rscpupd.date, statuses.new_status;
-
+GROUP BY rscpupd.date, statuses.new_status
+ORDER BY rscpupd.date;


### PR DESCRIPTION
This PR orders user engagement statistics by date as mentioned [here](https://github.com/coder/coder/pull/16134/files#diff-1844f895bb005f036da11d800fe2a76b54bfddd481c5d8cb15f210c64679caa5R47)