### PR TITLE
refactor: set min width as 80px for buttons

### DIFF
--- a/site/src/components/Button/Button.tsx
+++ b/site/src/components/Button/Button.tsx
@@ -9,7 +9,7 @@ import { cn } from "utils/cn";
 
 export const buttonVariants = cva(
 	`inline-flex items-center justify-center gap-1 whitespace-nowrap
-	border-solid rounded-md transition-colors
+	border-solid rounded-md transition-colors min-w-20
 	text-sm font-semibold font-medium  cursor-pointer no-underline
 	focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
 	disabled:pointer-events-none disabled:text-content-disabled


### PR DESCRIPTION
During a [design discussion](https://www.figma.com/design/OR75XeUI0Z3ksqt1mHsNQw?node-id=1849-2788#1091281774), I realized that buttons should have a minimum width of 80px.

<img width="304" alt="attachment" src="https://github.com/user-attachments/assets/55bc444e-b156-442f-9ccd-1dc84bbce7e5" />
