### PR TITLE
chore: remove Tokyo server from dogfood

### DIFF
--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -20,7 +20,6 @@ locals {
     "ap-sydney"     = "tcp://wolfgang-syd-cdr-dev.tailscale.svc.cluster.local:2375"
     "sa-saopaulo"   = "tcp://oberstein-sao-cdr-dev.tailscale.svc.cluster.local:2375"
     "za-cpt"        = "tcp://schonkopf-cpt-cdr-dev.tailscale.svc.cluster.local:2375"
-    "ja-tokyo"      = "tcp://reuenthal-tokyo-cdr-dev.tailscale.svc.cluster.local:2375"
   }
 
   repo_base_dir  = data.coder_parameter.repo_base_dir.value == "~" ? "/home/coder" : replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
@@ -82,11 +81,6 @@ data "coder_parameter" "region" {
     icon  = "/emojis/1f1ff-1f1e6.png"
     name  = "Cape Town"
     value = "za-cpt"
-  }
-  option {
-    icon  = "/emojis/1f1ef-1f1f5.png"
-    name  = "Tokyo"
-    value = "ja-tokyo"
   }
 }
 


### PR DESCRIPTION
All workspaces in Tokyo have been deleted.