### PR TITLE
refactor: update border-radius to match the new designs

### DIFF
--- a/site/src/components/Avatar/Avatar.tsx
+++ b/site/src/components/Avatar/Avatar.tsx
@@ -18,13 +18,13 @@ import { getExternalImageStylesFromUrl } from "theme/externalImages";
 import { cn } from "utils/cn";
 
 const avatarVariants = cva(
-	"relative flex shrink-0 overflow-hidden rounded border border-solid bg-surface-secondary text-content-secondary",
+	"relative flex shrink-0 overflow-hidden border border-solid bg-surface-secondary text-content-secondary",
 	{
 		variants: {
 			size: {
-				lg: "h-[--avatar-lg] w-[--avatar-lg] rounded-[6px] text-sm font-medium",
-				md: "h-[--avatar-default] w-[--avatar-default] text-2xs",
-				sm: "h-[--avatar-sm] w-[--avatar-sm] text-[8px]",
+				lg: "h-[--avatar-lg] w-[--avatar-lg] text-sm font-medium rounded-sm",
+				md: "h-[--avatar-default] w-[--avatar-default] text-2xs rounded-xs",
+				sm: "h-[--avatar-sm] w-[--avatar-sm] text-[8px] rounded-xs",
 			},
 			variant: {
 				default: null,

--- a/site/src/components/Button/Button.tsx
+++ b/site/src/components/Button/Button.tsx
@@ -9,7 +9,7 @@ import { cn } from "utils/cn";
 
 export const buttonVariants = cva(
 	`inline-flex items-center justify-center gap-1 whitespace-nowrap
-	border-solid rounded-md transition-colors min-w-20
+	border-solid rounded-sm transition-colors min-w-20
 	text-sm font-semibold font-medium  cursor-pointer no-underline
 	focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
 	disabled:pointer-events-none disabled:text-content-disabled

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -27,7 +27,6 @@
 		--border-default: 240 6% 90%;
 		--border-success: 142 76% 36%;
 		--border-destructive: 0 84% 60%;
-		--radius: 0.5rem;
 		--chart-1: 12 76% 61%;
 		--chart-2: 173 58% 39%;
 		--chart-3: 197 37% 24%;

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -19,9 +19,15 @@ module.exports = {
 				"3xl": ["2rem", "2.5rem"],
 			},
 			borderRadius: {
-				lg: "var(--radius)",
-				md: "calc(var(--radius) - 2px)",
-				sm: "calc(var(--radius) - 4px)",
+				// In Tailwind's border radius configuration, the default value differs
+				// from the `md` size. In our setup, the default value should align with
+				// `md`.
+				DEFAULT: "0.5rem",
+				lg: "0.75rem",
+				md: "0.5rem",
+				sm: "0.375rem",
+				xs: "0.25rem",
+				xxs: "0.125rem",
 			},
 			colors: {
 				content: {


### PR DESCRIPTION
Updated the border radius values to align with our design specifications. Additionally, I converted the values to `rem` to maintain consistency with the pattern used for other values.

<img width="410" alt="Screenshot 2025-01-15 at 10 37 55" src="https://github.com/user-attachments/assets/6ce09bd0-add4-4b68-ad05-dfffa33e0d7e" />
