### PR TITLE
fix(coderd/database): aggregate user engagement statistics by interval

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1713,7 +1713,6 @@ func (s *MethodTestSuite) TestUser() {
 			StartTime: time.Now().Add(-time.Hour * 24 * 30),
 			EndTime:   time.Now(),
 			Interval:  int32((time.Hour * 24).Seconds()),
-			TzOffset:  0,
 		}).Asserts(rbac.ResourceUser, policy.ActionRead)
 	}))
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1712,6 +1712,8 @@ func (s *MethodTestSuite) TestUser() {
 		check.Args(database.GetUserStatusCountsParams{
 			StartTime: time.Now().Add(-time.Hour * 24 * 30),
 			EndTime:   time.Now(),
+			Interval:  int32((time.Hour * 24).Seconds()),
+			TzOffset:  0,
 		}).Asserts(rbac.ResourceUser, policy.ActionRead)
 	}))
 }

--- a/coderd/database/dbtime/dbtime.go
+++ b/coderd/database/dbtime/dbtime.go
@@ -16,3 +16,9 @@ func Now() time.Time {
 func Time(t time.Time) time.Time {
 	return t.Round(time.Microsecond)
 }
+
+// StartOfDay returns the first timestamp of the day of the input timestamp in its location.
+func StartOfDay(t time.Time) time.Time {
+	year, month, day := t.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, t.Location())
+}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3099,12 +3099,11 @@ WITH
 	-- dates_of_interest defines all points in time that are relevant to the query.
 	-- It includes the start_time, all status changes, all deletions, and the end_time.
 dates_of_interest AS (
-	SELECT
-		(generate_series(
-			$1::timestamptz,
-			$2::timestamptz,
-			($3::int || ' seconds')::interval
-		) + ($4::int || ' seconds')::interval)::timestamptz AS date
+	SELECT date FROM generate_series(
+		$1::timestamptz,
+		$2::timestamptz,
+		(CASE WHEN $3::int <= 0 THEN 3600 * 24 ELSE $3::int END || ' seconds')::interval
+	) AS date
 ),
 	-- latest_status_before_range defines the status of each user before the start_time.
 	-- We do not include users who were deleted before the start_time. We use this to ensure that
@@ -3180,7 +3179,7 @@ ranked_status_change_per_user_per_date AS (
 	LEFT JOIN relevant_status_changes rsc1 ON rsc1.changed_at <= d.date
 )
 SELECT
-	rscpupd.date,
+	rscpupd.date::timestamptz AS date,
 	statuses.new_status AS status,
 	COUNT(rscpupd.user_id) FILTER (
 		WHERE rscpupd.rn = 1
@@ -3205,7 +3204,6 @@ type GetUserStatusCountsParams struct {
 	StartTime time.Time `db:"start_time" json:"start_time"`
 	EndTime   time.Time `db:"end_time" json:"end_time"`
 	Interval  int32     `db:"interval" json:"interval"`
-	TzOffset  int32     `db:"tz_offset" json:"tz_offset"`
 }
 
 type GetUserStatusCountsRow struct {
@@ -3227,12 +3225,7 @@ type GetUserStatusCountsRow struct {
 // We do not start counting from 0 at the start_time. We check the last status change before the start_time for each user. As such,
 // the result shows the total number of users in each status on any particular day.
 func (q *sqlQuerier) GetUserStatusCounts(ctx context.Context, arg GetUserStatusCountsParams) ([]GetUserStatusCountsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getUserStatusCounts,
-		arg.StartTime,
-		arg.EndTime,
-		arg.Interval,
-		arg.TzOffset,
-	)
+	rows, err := q.db.QueryContext(ctx, getUserStatusCounts, arg.StartTime, arg.EndTime, arg.Interval)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -777,100 +777,99 @@ GROUP BY utp.num, utp.template_ids, utp.name, utp.type, utp.display_name, utp.de
 -- The time range is inclusively defined by the start_time and end_time parameters.
 --
 -- Bucketing:
--- Between the start_time and end_time, we generate buckets based on the interval parameter
--- (defaulting to daily if interval <= 0). The timestamps are adjusted by the tz_offset
--- parameter to align with the desired timezone.
+-- Between the start_time and end_time, we include each timestamp where a user's status changed or they were deleted.
+-- We do not bucket these results by day or some other time unit. This is because such bucketing would hide potentially
+-- important patterns. If a user was active for 23 hours and 59 minutes, and then suspended, a daily bucket would hide this.
+-- A daily bucket would also have required us to carefully manage the timezone of the bucket based on the timezone of the user.
 --
 -- Accumulation:
--- We do not start counting from 0 at the start_time. We check the last status change
--- before the start_time for each user. As such, the result shows the total number of
--- users in each status at each interval.
+-- We do not start counting from 0 at the start_time. We check the last status change before the start_time for each user. As such,
+-- the result shows the total number of users in each status on any particular day.
 WITH
 	-- dates_of_interest defines all points in time that are relevant to the query.
-	-- It generates regular intervals between start_time and end_time based on the interval
-	-- parameter, adjusted by the timezone offset.
-	dates_of_interest AS (
-		SELECT
-			(generate_series(
-				@start_time::timestamptz + (@tz_offset::int || ' seconds')::interval,
-				@end_time::timestamptz + (@tz_offset::int || ' seconds')::interval,
-				(CASE WHEN @interval::int <= 0 THEN 3600 * 24 ELSE @interval::int END|| ' seconds')::interval
-			))::timestamptz AS date
-	),
-	-- latest_status_before_range finds each user's last status before start_time.
-	-- Users who were deleted before start_time are excluded. This ensures accurate
-	-- initial counts at the start of the time range.
-	latest_status_before_range AS (
-		SELECT
-			DISTINCT usc.user_id,
-			usc.new_status,
-			usc.changed_at,
-			ud.deleted
-		FROM user_status_changes usc
-		LEFT JOIN LATERAL (
-			SELECT COUNT(*) > 0 AS deleted
-			FROM user_deleted ud
-			WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < @start_time)
-		) AS ud ON true
-		WHERE usc.changed_at < @start_time::timestamptz
-		ORDER BY usc.user_id, usc.changed_at DESC
-	),
-	-- status_changes_during_range captures all status changes between start_time and end_time.
-	-- Changes after a user's deletion date are excluded, as deleted users should not have
-	-- status changes.
-	status_changes_during_range AS (
-		SELECT
-			usc.user_id,
-			usc.new_status,
-			usc.changed_at,
-			ud.deleted
-		FROM user_status_changes usc
-		LEFT JOIN LATERAL (
-			SELECT COUNT(*) > 0 AS deleted
-			FROM user_deleted ud
-			WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
-		) AS ud ON true
-		WHERE usc.changed_at >= @start_time::timestamptz
-			AND usc.changed_at <= @end_time::timestamptz
-	),
-	-- relevant_status_changes combines user statuses from before and during the time range.
-	-- Only includes non-deleted users to ensure accurate counting.
-	relevant_status_changes AS (
-		SELECT
-			user_id,
-			new_status,
-			changed_at
-		FROM latest_status_before_range
-		WHERE NOT deleted
+	-- It includes the start_time, all status changes, all deletions, and the end_time.
+dates_of_interest AS (
+	SELECT date FROM generate_series(
+		@start_time::timestamptz,
+		@end_time::timestamptz,
+		(CASE WHEN @interval::int <= 0 THEN 3600 * 24 ELSE @interval::int END || ' seconds')::interval
+	) AS date
+),
+	-- latest_status_before_range defines the status of each user before the start_time.
+	-- We do not include users who were deleted before the start_time. We use this to ensure that
+	-- we correctly count users prior to the start_time for a complete graph.
+latest_status_before_range AS (
+    SELECT
+        DISTINCT usc.user_id,
+        usc.new_status,
+        usc.changed_at,
+        ud.deleted
+    FROM user_status_changes usc
+	LEFT JOIN LATERAL (
+		SELECT COUNT(*) > 0 AS deleted
+		FROM user_deleted ud
+		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < @start_time)
+	) AS ud ON true
+    WHERE usc.changed_at < @start_time::timestamptz
+    ORDER BY usc.user_id, usc.changed_at DESC
+),
+	-- status_changes_during_range defines the status of each user during the start_time and end_time.
+	-- If a user is deleted during the time range, we count status changes between the start_time and the deletion date.
+	-- Theoretically, it should probably not be possible to update the status of a deleted user, but we
+	-- need to ensure that this is enforced, so that a change in business logic later does not break this graph.
+status_changes_during_range AS (
+    SELECT
+        usc.user_id,
+        usc.new_status,
+        usc.changed_at,
+        ud.deleted
+    FROM user_status_changes usc
+	LEFT JOIN LATERAL (
+		SELECT COUNT(*) > 0 AS deleted
+		FROM user_deleted ud
+		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
+	) AS ud ON true
+    WHERE usc.changed_at >= @start_time::timestamptz
+        AND usc.changed_at <= @end_time::timestamptz
+),
+	-- relevant_status_changes defines the status of each user at any point in time.
+	-- It includes the status of each user before the start_time, and the status of each user during the start_time and end_time.
+relevant_status_changes AS (
+    SELECT
+        user_id,
+        new_status,
+        changed_at
+    FROM latest_status_before_range
+    WHERE NOT deleted
 
-		UNION ALL
+    UNION ALL
 
-		SELECT
-			user_id,
-			new_status,
-			changed_at
-		FROM status_changes_during_range
-		WHERE NOT deleted
-	),
-	-- statuses collects all distinct status values that appeared in the time range
-	-- or just before it, ensuring we have a complete set of statuses to count.
-	statuses AS (
-		SELECT DISTINCT new_status FROM relevant_status_changes
-	),
-	-- ranked_status_change_per_user_per_date finds the latest status for each user
-	-- at each interval date. The row_number helps us select only the most recent
-	-- status change when multiple changes occur before an interval.
-	ranked_status_change_per_user_per_date AS (
-		SELECT
-		d.date,
-		rsc1.user_id,
-		ROW_NUMBER() OVER (PARTITION BY d.date, rsc1.user_id ORDER BY rsc1.changed_at DESC) AS rn,
-		rsc1.new_status
-		FROM dates_of_interest d
-		LEFT JOIN relevant_status_changes rsc1 ON rsc1.changed_at <= d.date
-	)
+    SELECT
+        user_id,
+        new_status,
+        changed_at
+    FROM status_changes_during_range
+    WHERE NOT deleted
+),
+	-- statuses defines all the distinct statuses that were present just before and during the time range.
+	-- This is used to ensure that we have a series for every relevant status.
+statuses AS (
+	SELECT DISTINCT new_status FROM relevant_status_changes
+),
+	-- We only want to count the latest status change for each user on each date and then filter them by the relevant status.
+	-- We use the row_number function to ensure that we only count the latest status change for each user on each date.
+	-- We then filter the status changes by the relevant status in the final select statement below.
+ranked_status_change_per_user_per_date AS (
+	SELECT
+	d.date,
+	rsc1.user_id,
+	ROW_NUMBER() OVER (PARTITION BY d.date, rsc1.user_id ORDER BY rsc1.changed_at DESC) AS rn,
+	rsc1.new_status
+	FROM dates_of_interest d
+	LEFT JOIN relevant_status_changes rsc1 ON rsc1.changed_at <= d.date
+)
 SELECT
-	rscpupd.date,
+	rscpupd.date::timestamptz AS date,
 	statuses.new_status AS status,
 	COUNT(rscpupd.user_id) FILTER (
 		WHERE rscpupd.rn = 1

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -777,98 +777,98 @@ GROUP BY utp.num, utp.template_ids, utp.name, utp.type, utp.display_name, utp.de
 -- The time range is inclusively defined by the start_time and end_time parameters.
 --
 -- Bucketing:
--- Between the start_time and end_time, we include each timestamp where a user's status changed or they were deleted.
--- We do not bucket these results by day or some other time unit. This is because such bucketing would hide potentially
--- important patterns. If a user was active for 23 hours and 59 minutes, and then suspended, a daily bucket would hide this.
--- A daily bucket would also have required us to carefully manage the timezone of the bucket based on the timezone of the user.
+-- Between the start_time and end_time, we generate buckets based on the interval parameter
+-- (defaulting to daily if interval <= 0). The timestamps are adjusted by the tz_offset
+-- parameter to align with the desired timezone.
 --
 -- Accumulation:
--- We do not start counting from 0 at the start_time. We check the last status change before the start_time for each user. As such,
--- the result shows the total number of users in each status on any particular day.
+-- We do not start counting from 0 at the start_time. We check the last status change
+-- before the start_time for each user. As such, the result shows the total number of
+-- users in each status at each interval.
 WITH
 	-- dates_of_interest defines all points in time that are relevant to the query.
-	-- It includes the start_time, all status changes, all deletions, and the end_time.
-dates_of_interest AS (
-	SELECT
-		(generate_series(
-			@start_time::timestamptz,
-			@end_time::timestamptz,
-			(@interval::int || ' seconds')::interval
-		) + (@tz_offset::int || ' seconds')::interval)::timestamptz AS date
-),
-	-- latest_status_before_range defines the status of each user before the start_time.
-	-- We do not include users who were deleted before the start_time. We use this to ensure that
-	-- we correctly count users prior to the start_time for a complete graph.
-latest_status_before_range AS (
-    SELECT
-        DISTINCT usc.user_id,
-        usc.new_status,
-        usc.changed_at,
-        ud.deleted
-    FROM user_status_changes usc
-	LEFT JOIN LATERAL (
-		SELECT COUNT(*) > 0 AS deleted
-		FROM user_deleted ud
-		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < @start_time)
-	) AS ud ON true
-    WHERE usc.changed_at < @start_time::timestamptz
-    ORDER BY usc.user_id, usc.changed_at DESC
-),
-	-- status_changes_during_range defines the status of each user during the start_time and end_time.
-	-- If a user is deleted during the time range, we count status changes between the start_time and the deletion date.
-	-- Theoretically, it should probably not be possible to update the status of a deleted user, but we
-	-- need to ensure that this is enforced, so that a change in business logic later does not break this graph.
-status_changes_during_range AS (
-    SELECT
-        usc.user_id,
-        usc.new_status,
-        usc.changed_at,
-        ud.deleted
-    FROM user_status_changes usc
-	LEFT JOIN LATERAL (
-		SELECT COUNT(*) > 0 AS deleted
-		FROM user_deleted ud
-		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
-	) AS ud ON true
-    WHERE usc.changed_at >= @start_time::timestamptz
-        AND usc.changed_at <= @end_time::timestamptz
-),
-	-- relevant_status_changes defines the status of each user at any point in time.
-	-- It includes the status of each user before the start_time, and the status of each user during the start_time and end_time.
-relevant_status_changes AS (
-    SELECT
-        user_id,
-        new_status,
-        changed_at
-    FROM latest_status_before_range
-    WHERE NOT deleted
+	-- It generates regular intervals between start_time and end_time based on the interval
+	-- parameter, adjusted by the timezone offset.
+	dates_of_interest AS (
+		SELECT
+			(generate_series(
+				@start_time::timestamptz + (@tz_offset::int || ' seconds')::interval,
+				@end_time::timestamptz + (@tz_offset::int || ' seconds')::interval,
+				(CASE WHEN @interval::int <= 0 THEN 3600 * 24 ELSE @interval::int END|| ' seconds')::interval
+			))::timestamptz AS date
+	),
+	-- latest_status_before_range finds each user's last status before start_time.
+	-- Users who were deleted before start_time are excluded. This ensures accurate
+	-- initial counts at the start of the time range.
+	latest_status_before_range AS (
+		SELECT
+			DISTINCT usc.user_id,
+			usc.new_status,
+			usc.changed_at,
+			ud.deleted
+		FROM user_status_changes usc
+		LEFT JOIN LATERAL (
+			SELECT COUNT(*) > 0 AS deleted
+			FROM user_deleted ud
+			WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < @start_time)
+		) AS ud ON true
+		WHERE usc.changed_at < @start_time::timestamptz
+		ORDER BY usc.user_id, usc.changed_at DESC
+	),
+	-- status_changes_during_range captures all status changes between start_time and end_time.
+	-- Changes after a user's deletion date are excluded, as deleted users should not have
+	-- status changes.
+	status_changes_during_range AS (
+		SELECT
+			usc.user_id,
+			usc.new_status,
+			usc.changed_at,
+			ud.deleted
+		FROM user_status_changes usc
+		LEFT JOIN LATERAL (
+			SELECT COUNT(*) > 0 AS deleted
+			FROM user_deleted ud
+			WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
+		) AS ud ON true
+		WHERE usc.changed_at >= @start_time::timestamptz
+			AND usc.changed_at <= @end_time::timestamptz
+	),
+	-- relevant_status_changes combines user statuses from before and during the time range.
+	-- Only includes non-deleted users to ensure accurate counting.
+	relevant_status_changes AS (
+		SELECT
+			user_id,
+			new_status,
+			changed_at
+		FROM latest_status_before_range
+		WHERE NOT deleted
 
-    UNION ALL
+		UNION ALL
 
-    SELECT
-        user_id,
-        new_status,
-        changed_at
-    FROM status_changes_during_range
-    WHERE NOT deleted
-),
-	-- statuses defines all the distinct statuses that were present just before and during the time range.
-	-- This is used to ensure that we have a series for every relevant status.
-statuses AS (
-	SELECT DISTINCT new_status FROM relevant_status_changes
-),
-	-- We only want to count the latest status change for each user on each date and then filter them by the relevant status.
-	-- We use the row_number function to ensure that we only count the latest status change for each user on each date.
-	-- We then filter the status changes by the relevant status in the final select statement below.
-ranked_status_change_per_user_per_date AS (
-	SELECT
-	d.date,
-	rsc1.user_id,
-	ROW_NUMBER() OVER (PARTITION BY d.date, rsc1.user_id ORDER BY rsc1.changed_at DESC) AS rn,
-	rsc1.new_status
-	FROM dates_of_interest d
-	LEFT JOIN relevant_status_changes rsc1 ON rsc1.changed_at <= d.date
-)
+		SELECT
+			user_id,
+			new_status,
+			changed_at
+		FROM status_changes_during_range
+		WHERE NOT deleted
+	),
+	-- statuses collects all distinct status values that appeared in the time range
+	-- or just before it, ensuring we have a complete set of statuses to count.
+	statuses AS (
+		SELECT DISTINCT new_status FROM relevant_status_changes
+	),
+	-- ranked_status_change_per_user_per_date finds the latest status for each user
+	-- at each interval date. The row_number helps us select only the most recent
+	-- status change when multiple changes occur before an interval.
+	ranked_status_change_per_user_per_date AS (
+		SELECT
+		d.date,
+		rsc1.user_id,
+		ROW_NUMBER() OVER (PARTITION BY d.date, rsc1.user_id ORDER BY rsc1.changed_at DESC) AS rn,
+		rsc1.new_status
+		FROM dates_of_interest d
+		LEFT JOIN relevant_status_changes rsc1 ON rsc1.changed_at <= d.date
+	)
 SELECT
 	rscpupd.date,
 	statuses.new_status AS status,

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -306,6 +306,7 @@ func (api *API) insightsUserStatusCounts(rw http.ResponseWriter, r *http.Request
 	p := httpapi.NewQueryParamParser()
 	vals := r.URL.Query()
 	tzOffset := p.Int(vals, 0, "tz_offset")
+	interval := p.Int(vals, int((24 * time.Hour).Seconds()), "interval")
 	p.ErrorExcessParams(vals)
 
 	if len(p.Errors) > 0 {
@@ -327,6 +328,8 @@ func (api *API) insightsUserStatusCounts(rw http.ResponseWriter, r *http.Request
 	rows, err := api.Database.GetUserStatusCounts(ctx, database.GetUserStatusCountsParams{
 		StartTime: sixtyDaysAgo,
 		EndTime:   nextHourInLoc,
+		Interval:  int32(interval),
+		TzOffset:  int32(tzOffset),
 	})
 	if err != nil {
 		if httpapi.IsUnauthorizedError(err) {

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 
 	"github.com/google/uuid"
 	"golang.org/x/exp/slices"


### PR DESCRIPTION
This PR addresses the TODO comment here:
https://github.com/coder/coder/pull/16134/files#diff-1844f895bb005f036da11d800fe2a76b54bfddd481c5d8cb15f210c64679caa5R47

The backend now backfills entries for dates with no status changes.