### PR TITLE
fix(codersdk): fix typo in telemetry option description

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -624,9 +624,9 @@ updating, and deleting workspace resources.
           in queued state for a long time, consider increasing this.
 
 TELEMETRY OPTIONS: 
-Telemetry is critical to our ability to improve Coder. We strip all
-personalinformation before sending data to our servers. Please only disable
-telemetrywhen required by your organization's security policy.
+Telemetry is critical to our ability to improve Coder. We strip all personal
+information before sending data to our servers. Please only disable telemetry
+when required by your organization's security policy.
 
       --telemetry bool, $CODER_TELEMETRY_ENABLE (default: false)
           Whether telemetry is enabled or not. Coder collects anonymized usage

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -390,8 +390,8 @@ oidc:
   # (default: <unset>, type: bool)
   dangerousSkipIssuerChecks: false
 # Telemetry is critical to our ability to improve Coder. We strip all personal
-# information before sending data to our servers. Please only disable telemetry
-# when required by your organization's security policy.
+#  information before sending data to our servers. Please only disable telemetry
+#  when required by your organization's security policy.
 telemetry:
   # Whether telemetry is enabled or not. Coder collects anonymized usage data to
   # help improve our product.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -904,8 +904,8 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Name: "Telemetry",
 			YAML: "telemetry",
 			Description: `Telemetry is critical to our ability to improve Coder. We strip all personal
-information before sending data to our servers. Please only disable telemetry
-when required by your organization's security policy.`,
+ information before sending data to our servers. Please only disable telemetry
+ when required by your organization's security policy.`,
 		}
 		deploymentGroupProvisioning = serpent.Group{
 			Name:        "Provisioning",

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -625,9 +625,9 @@ updating, and deleting workspace resources.
           in queued state for a long time, consider increasing this.
 
 TELEMETRY OPTIONS: 
-Telemetry is critical to our ability to improve Coder. We strip all
-personalinformation before sending data to our servers. Please only disable
-telemetrywhen required by your organization's security policy.
+Telemetry is critical to our ability to improve Coder. We strip all personal
+information before sending data to our servers. Please only disable telemetry
+when required by your organization's security policy.
 
       --telemetry bool, $CODER_TELEMETRY_ENABLE (default: false)
           Whether telemetry is enabled or not. Coder collects anonymized usage


### PR DESCRIPTION
Fixed typos in telemetry help text by adding spaces between "personal information" and "telemetry when"

Change-Id: I897c5918c6661f9c16fdcb503c1c50e74c8f343a
Signed-off-by: Thomas Kosiewski <tk@coder.com>
