### PR TITLE
fix: make announcement editor multiline

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
@@ -55,6 +55,7 @@ export const AnnouncementBannerDialog: FC<AnnouncementBannerDialogProps> = ({
 								helperText: "Markdown bold, italics, and links are supported.",
 							})}
 							fullWidth
+							multiline
 							inputProps={{
 								"aria-label": "Message",
 								placeholder: "Enter a message for the banner",


### PR DESCRIPTION
Closes #15171

<img width="1406" alt="Screenshot 2025-01-15 at 2 28 39 PM" src="https://github.com/user-attachments/assets/e9c02b66-4027-406b-b010-bb8801af33d7" />
