### PR TITLE
test(coderd/database/dbauthz): compare outputs with cmp

### DIFF
--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/stretchr/testify/require"
@@ -198,11 +199,9 @@ func (s *MethodTestSuite) Subtest(testCaseF func(db database.Store, check *expec
 				s.Equal(len(testCase.outputs), len(outputs), "method %q returned unexpected number of outputs", methodName)
 				for i := range outputs {
 					a, b := testCase.outputs[i].Interface(), outputs[i].Interface()
-					if reflect.TypeOf(a).Kind() == reflect.Slice || reflect.TypeOf(a).Kind() == reflect.Array {
-						// Order does not matter
-						s.ElementsMatch(a, b, "method %q returned unexpected output %d", methodName, i)
-					} else {
-						s.Equal(a, b, "method %q returned unexpected output %d", methodName, i)
+					// Use cmp.Diff to get a nice diff of the two values.
+					if diff := cmp.Diff(a, b); diff != "" {
+						s.Failf("compare outputs failed", "method %q returned unexpected output %d (-want +got):\n%s", methodName, i, diff)
 					}
 				}
 			}

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/stretchr/testify/require"
@@ -200,7 +201,7 @@ func (s *MethodTestSuite) Subtest(testCaseF func(db database.Store, check *expec
 				for i := range outputs {
 					a, b := testCase.outputs[i].Interface(), outputs[i].Interface()
 					// Use cmp.Diff to get a nice diff of the two values.
-					if diff := cmp.Diff(a, b); diff != "" {
+					if diff := cmp.Diff(a, b, cmpopts.EquateEmpty()); diff != "" {
 						s.Failf("compare outputs failed", "method %q returned unexpected output %d (-want +got):\n%s", methodName, i, diff)
 					}
 				}


### PR DESCRIPTION
This produces a more readable diff than that of the assert library.

After:

```
--- FAIL: TestMethodTestSuite (0.01s)
    setup_test.go:80: Skipping method "AcquireLock": Not relevant
    setup_test.go:80: Skipping method "InTx": Not relevant
    setup_test.go:80: Skipping method "PGLocks": Not relevant
    setup_test.go:80: Skipping method "Ping": Not relevant
    setup_test.go:80: Skipping method "TryAcquireLock": Not relevant
    setup_test.go:80: Skipping method "Wrappers": Not relevant
    --- FAIL: TestMethodTestSuite/TestExtraMethods (0.00s)
        --- FAIL: TestMethodTestSuite/TestExtraMethods/GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner (0.00s)
            --- FAIL: TestMethodTestSuite/TestExtraMethods/GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner/Success (0.00s)
                setup_test.go:205:
                    	Error Trace:	/home/coder/coder/coderd/database/dbauthz/setup_test.go:205
                    	            				/home/coder/.local/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:115
                    	Error:      	compare outputs failed
                    	Test:       	TestMethodTestSuite/TestExtraMethods/GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner/Success
                    	Messages:   	method "GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner" returned unexpected output 0 (-want +got):
                    	            	  []database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow{
                    	            	  	{
                    	            	  		ProvisionerJob: database.ProvisionerJob{
                    	            	  			... // 5 identical fields
                    	            	  			CompletedAt: {},
                    	            	  			Error:       {},
                    	            	  			OrganizationID: uuid.UUID{
                    	            	- 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                    	            	+ 				0x3c, 0x73, 0x64, 0xe4, 0x17, 0x3b, 0x49, 0x2c, 0x80, 0x96, 0x0f, 0x1e, 0x3d, 0x02, 0x26, 0x37,
                    	            	  			},
                    	            	  			InitiatorID: {0x48, 0x1f, 0x5f, 0xaf, ...},
                    	            	  			Provisioner: "echo",
                    	            	  			... // 9 identical fields
                    	            	  		},
                    	            	  		QueuePosition:    2,
                    	            	  		QueueSize:        2,
                    	            	  		AvailableWorkers: nil,
                    	            	  	},
                    	            	+ 	{
                    	            	+ 		ProvisionerJob: database.ProvisionerJob{
                    	            	+ 			ID:             s"f494b47c-c149-409e-b5e2-a4f35ed4934a",
                    	            	+ 			CreatedAt:      s"2025-01-16 13:48:11.140543 +0000 UTC",
                    	            	+ 			UpdatedAt:      s"2025-01-16 13:48:11.140543 +0000 UTC",
                    	            	+ 			OrganizationID: s"3c7364e4-173b-492c-8096-0f1e3d022637",
                    	            	+ 			InitiatorID:    s"1e31c809-5d01-4aee-82f9-b851039e7201",
                    	            	+ 			Provisioner:    "echo",
                    	            	+ 			StorageMethod:  "file",
                    	            	+ 			Type:           "template_version_import",
                    	            	+ 			...
                    	            	+ 		},
                    	            	+ 		QueuePosition: 1,
                    	            	+ 		QueueSize:     2,
                    	            	+ 	},
                    	            	  }
FAIL
FAIL	github.com/coder/coder/v2/coderd/database/dbauthz	0.046s
FAIL
```

Before (hard to parse):

```
--- FAIL: TestMethodTestSuite (0.01s)
    setup_test.go:79: Skipping method "AcquireLock": Not relevant
    setup_test.go:79: Skipping method "InTx": Not relevant
    setup_test.go:79: Skipping method "PGLocks": Not relevant
    setup_test.go:79: Skipping method "Ping": Not relevant
    setup_test.go:79: Skipping method "TryAcquireLock": Not relevant
    setup_test.go:79: Skipping method "Wrappers": Not relevant
    --- FAIL: TestMethodTestSuite/TestExtraMethods (0.00s)
        --- FAIL: TestMethodTestSuite/TestExtraMethods/GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner (0.00s)
            --- FAIL: TestMethodTestSuite/TestExtraMethods/GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner/Success (0.00s)
                setup_test.go:207:
                    	Error Trace:	/home/coder/coder/coderd/database/dbauthz/setup_test.go:207
                    	            				/home/coder/.local/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:115
                    	Error:      	elements differ

                    	            	extra elements in list A:
                    	            	([]interface {}) (len=1) {
                    	            	 (database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) {
                    	            	  ProvisionerJob: (database.ProvisionerJob) {
                    	            	   ID: (uuid.UUID) (len=16) {
                    	            	    00000000  50 f1 fb 9f 9e 38 45 52  b8 5a 10 72 6b f5 4e 64  |P....8ER.Z.rk.Nd|
                    	            	   },
                    	            	   CreatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   UpdatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   StartedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CanceledAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CompletedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   Error: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   OrganizationID: (uuid.UUID) (len=16) {
                    	            	    00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	   },
                    	            	   InitiatorID: (uuid.UUID) (len=16) {
                    	            	    00000000  1f 3a f2 fd c5 65 49 28  b2 45 92 2f 5c 44 d1 4a  |.:...eI(.E./\D.J|
                    	            	   },
                    	            	   Provisioner: (database.ProvisionerType) (len=4) "echo",
                    	            	   StorageMethod: (database.ProvisionerStorageMethod) (len=4) "file",
                    	            	   Type: (database.ProvisionerJobType) (len=15) "workspace_build",
                    	            	   Input: (json.RawMessage) (len=61) {
                    	            	    00000000  7b 22 77 6f 72 6b 73 70  61 63 65 5f 62 75 69 6c  |{"workspace_buil|
                    	            	    00000010  64 5f 69 64 22 3a 22 64  62 38 33 64 31 36 61 2d  |d_id":"db83d16a-|
                    	            	    00000020  65 62 33 36 2d 34 32 34  30 2d 62 34 30 36 2d 33  |eb36-4240-b406-3|
                    	            	    00000030  63 36 35 31 34 62 64 35  31 36 39 22 7d           |c6514bd5169"}|
                    	            	   },
                    	            	   WorkerID: (uuid.NullUUID) {
                    	            	    UUID: (uuid.UUID) (len=16) {
                    	            	     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   FileID: (uuid.UUID) (len=16) {
                    	            	    00000000  35 7b 4e f8 7b a5 4d c0  9d 32 c3 11 4d 80 b4 3e  |5{N.{.M..2..M..>|
                    	            	   },
                    	            	   Tags: (database.StringMap) (len=1) {
                    	            	    (string) (len=5) "scope": (string) (len=12) "organization"
                    	            	   },
                    	            	   ErrorCode: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   TraceMetadata: (pqtype.NullRawMessage) {
                    	            	    RawMessage: (json.RawMessage) <nil>,
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   JobStatus: (database.ProvisionerJobStatus) (len=7) "pending"
                    	            	  },
                    	            	  QueuePosition: (int64) 2,
                    	            	  QueueSize: (int64) 2,
                    	            	  AvailableWorkers: ([]uuid.UUID) <nil>
                    	            	 }
                    	            	}


                    	            	extra elements in list B:
                    	            	([]interface {}) (len=2) {
                    	            	 (database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) {
                    	            	  ProvisionerJob: (database.ProvisionerJob) {
                    	            	   ID: (uuid.UUID) (len=16) {
                    	            	    00000000  50 f1 fb 9f 9e 38 45 52  b8 5a 10 72 6b f5 4e 64  |P....8ER.Z.rk.Nd|
                    	            	   },
                    	            	   CreatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   UpdatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   StartedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CanceledAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CompletedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   Error: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   OrganizationID: (uuid.UUID) (len=16) {
                    	            	    00000000  70 81 ae 72 a4 69 42 84  b6 c0 6f af 85 a0 06 10  |p..r.iB...o.....|
                    	            	   },
                    	            	   InitiatorID: (uuid.UUID) (len=16) {
                    	            	    00000000  1f 3a f2 fd c5 65 49 28  b2 45 92 2f 5c 44 d1 4a  |.:...eI(.E./\D.J|
                    	            	   },
                    	            	   Provisioner: (database.ProvisionerType) (len=4) "echo",
                    	            	   StorageMethod: (database.ProvisionerStorageMethod) (len=4) "file",
                    	            	   Type: (database.ProvisionerJobType) (len=15) "workspace_build",
                    	            	   Input: (json.RawMessage) (len=61) {
                    	            	    00000000  7b 22 77 6f 72 6b 73 70  61 63 65 5f 62 75 69 6c  |{"workspace_buil|
                    	            	    00000010  64 5f 69 64 22 3a 22 64  62 38 33 64 31 36 61 2d  |d_id":"db83d16a-|
                    	            	    00000020  65 62 33 36 2d 34 32 34  30 2d 62 34 30 36 2d 33  |eb36-4240-b406-3|
                    	            	    00000030  63 36 35 31 34 62 64 35  31 36 39 22 7d           |c6514bd5169"}|
                    	            	   },
                    	            	   WorkerID: (uuid.NullUUID) {
                    	            	    UUID: (uuid.UUID) (len=16) {
                    	            	     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   FileID: (uuid.UUID) (len=16) {
                    	            	    00000000  35 7b 4e f8 7b a5 4d c0  9d 32 c3 11 4d 80 b4 3e  |5{N.{.M..2..M..>|
                    	            	   },
                    	            	   Tags: (database.StringMap) (len=1) {
                    	            	    (string) (len=5) "scope": (string) (len=12) "organization"
                    	            	   },
                    	            	   ErrorCode: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   TraceMetadata: (pqtype.NullRawMessage) {
                    	            	    RawMessage: (json.RawMessage) <nil>,
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   JobStatus: (database.ProvisionerJobStatus) (len=7) "pending"
                    	            	  },
                    	            	  QueuePosition: (int64) 2,
                    	            	  QueueSize: (int64) 2,
                    	            	  AvailableWorkers: ([]uuid.UUID) <nil>
                    	            	 },
                    	            	 (database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) {
                    	            	  ProvisionerJob: (database.ProvisionerJob) {
                    	            	   ID: (uuid.UUID) (len=16) {
                    	            	    00000000  83 cb 01 26 93 7e 4d e7  80 a0 cc a9 50 ad 3a b5  |...&.~M.....P.:.|
                    	            	   },
                    	            	   CreatedAt: (time.Time) {
                    	            	    wall: (uint64) 867959000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   UpdatedAt: (time.Time) {
                    	            	    wall: (uint64) 867959000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   StartedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CanceledAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CompletedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   Error: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   OrganizationID: (uuid.UUID) (len=16) {
                    	            	    00000000  70 81 ae 72 a4 69 42 84  b6 c0 6f af 85 a0 06 10  |p..r.iB...o.....|
                    	            	   },
                    	            	   InitiatorID: (uuid.UUID) (len=16) {
                    	            	    00000000  bc fd a8 93 c7 8e 4c c7  a3 55 7c dd ff 38 ca 20  |......L..U|..8. |
                    	            	   },
                    	            	   Provisioner: (database.ProvisionerType) (len=4) "echo",
                    	            	   StorageMethod: (database.ProvisionerStorageMethod) (len=4) "file",
                    	            	   Type: (database.ProvisionerJobType) (len=23) "template_version_import",
                    	            	   Input: (json.RawMessage) (len=62) {
                    	            	    00000000  7b 22 74 65 6d 70 6c 61  74 65 5f 76 65 72 73 69  |{"template_versi|
                    	            	    00000010  6f 6e 5f 69 64 22 3a 22  62 62 36 62 30 61 64 65  |on_id":"bb6b0ade|
                    	            	    00000020  2d 32 30 63 38 2d 34 66  36 39 2d 39 61 66 31 2d  |-20c8-4f69-9af1-|
                    	            	    00000030  38 35 66 61 36 34 33 38  32 32 31 38 22 7d        |85fa64382218"}|
                    	            	   },
                    	            	   WorkerID: (uuid.NullUUID) {
                    	            	    UUID: (uuid.UUID) (len=16) {
                    	            	     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   FileID: (uuid.UUID) (len=16) {
                    	            	    00000000  be 72 0a 61 64 e1 40 ec  8d 98 85 1c 5a 2c 50 dc  |.r.ad.@.....Z,P.|
                    	            	   },
                    	            	   Tags: (database.StringMap) (len=1) {
                    	            	    (string) (len=5) "scope": (string) (len=12) "organization"
                    	            	   },
                    	            	   ErrorCode: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   TraceMetadata: (pqtype.NullRawMessage) {
                    	            	    RawMessage: (json.RawMessage) <nil>,
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   JobStatus: (database.ProvisionerJobStatus) (len=7) "pending"
                    	            	  },
                    	            	  QueuePosition: (int64) 1,
                    	            	  QueueSize: (int64) 2,
                    	            	  AvailableWorkers: ([]uuid.UUID) <nil>
                    	            	 }
                    	            	}


                    	            	listA:
                    	            	([]database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) (len=1) {
                    	            	 (database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) {
                    	            	  ProvisionerJob: (database.ProvisionerJob) {
                    	            	   ID: (uuid.UUID) (len=16) {
                    	            	    00000000  50 f1 fb 9f 9e 38 45 52  b8 5a 10 72 6b f5 4e 64  |P....8ER.Z.rk.Nd|
                    	            	   },
                    	            	   CreatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   UpdatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   StartedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CanceledAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CompletedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   Error: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   OrganizationID: (uuid.UUID) (len=16) {
                    	            	    00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	   },
                    	            	   InitiatorID: (uuid.UUID) (len=16) {
                    	            	    00000000  1f 3a f2 fd c5 65 49 28  b2 45 92 2f 5c 44 d1 4a  |.:...eI(.E./\D.J|
                    	            	   },
                    	            	   Provisioner: (database.ProvisionerType) (len=4) "echo",
                    	            	   StorageMethod: (database.ProvisionerStorageMethod) (len=4) "file",
                    	            	   Type: (database.ProvisionerJobType) (len=15) "workspace_build",
                    	            	   Input: (json.RawMessage) (len=61) {
                    	            	    00000000  7b 22 77 6f 72 6b 73 70  61 63 65 5f 62 75 69 6c  |{"workspace_buil|
                    	            	    00000010  64 5f 69 64 22 3a 22 64  62 38 33 64 31 36 61 2d  |d_id":"db83d16a-|
                    	            	    00000020  65 62 33 36 2d 34 32 34  30 2d 62 34 30 36 2d 33  |eb36-4240-b406-3|
                    	            	    00000030  63 36 35 31 34 62 64 35  31 36 39 22 7d           |c6514bd5169"}|
                    	            	   },
                    	            	   WorkerID: (uuid.NullUUID) {
                    	            	    UUID: (uuid.UUID) (len=16) {
                    	            	     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   FileID: (uuid.UUID) (len=16) {
                    	            	    00000000  35 7b 4e f8 7b a5 4d c0  9d 32 c3 11 4d 80 b4 3e  |5{N.{.M..2..M..>|
                    	            	   },
                    	            	   Tags: (database.StringMap) (len=1) {
                    	            	    (string) (len=5) "scope": (string) (len=12) "organization"
                    	            	   },
                    	            	   ErrorCode: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   TraceMetadata: (pqtype.NullRawMessage) {
                    	            	    RawMessage: (json.RawMessage) <nil>,
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   JobStatus: (database.ProvisionerJobStatus) (len=7) "pending"
                    	            	  },
                    	            	  QueuePosition: (int64) 2,
                    	            	  QueueSize: (int64) 2,
                    	            	  AvailableWorkers: ([]uuid.UUID) <nil>
                    	            	 }
                    	            	}


                    	            	listB:
                    	            	([]database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) (len=2) {
                    	            	 (database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) {
                    	            	  ProvisionerJob: (database.ProvisionerJob) {
                    	            	   ID: (uuid.UUID) (len=16) {
                    	            	    00000000  50 f1 fb 9f 9e 38 45 52  b8 5a 10 72 6b f5 4e 64  |P....8ER.Z.rk.Nd|
                    	            	   },
                    	            	   CreatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   UpdatedAt: (time.Time) {
                    	            	    wall: (uint64) 868000000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   StartedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CanceledAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CompletedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   Error: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   OrganizationID: (uuid.UUID) (len=16) {
                    	            	    00000000  70 81 ae 72 a4 69 42 84  b6 c0 6f af 85 a0 06 10  |p..r.iB...o.....|
                    	            	   },
                    	            	   InitiatorID: (uuid.UUID) (len=16) {
                    	            	    00000000  1f 3a f2 fd c5 65 49 28  b2 45 92 2f 5c 44 d1 4a  |.:...eI(.E./\D.J|
                    	            	   },
                    	            	   Provisioner: (database.ProvisionerType) (len=4) "echo",
                    	            	   StorageMethod: (database.ProvisionerStorageMethod) (len=4) "file",
                    	            	   Type: (database.ProvisionerJobType) (len=15) "workspace_build",
                    	            	   Input: (json.RawMessage) (len=61) {
                    	            	    00000000  7b 22 77 6f 72 6b 73 70  61 63 65 5f 62 75 69 6c  |{"workspace_buil|
                    	            	    00000010  64 5f 69 64 22 3a 22 64  62 38 33 64 31 36 61 2d  |d_id":"db83d16a-|
                    	            	    00000020  65 62 33 36 2d 34 32 34  30 2d 62 34 30 36 2d 33  |eb36-4240-b406-3|
                    	            	    00000030  63 36 35 31 34 62 64 35  31 36 39 22 7d           |c6514bd5169"}|
                    	            	   },
                    	            	   WorkerID: (uuid.NullUUID) {
                    	            	    UUID: (uuid.UUID) (len=16) {
                    	            	     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   FileID: (uuid.UUID) (len=16) {
                    	            	    00000000  35 7b 4e f8 7b a5 4d c0  9d 32 c3 11 4d 80 b4 3e  |5{N.{.M..2..M..>|
                    	            	   },
                    	            	   Tags: (database.StringMap) (len=1) {
                    	            	    (string) (len=5) "scope": (string) (len=12) "organization"
                    	            	   },
                    	            	   ErrorCode: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   TraceMetadata: (pqtype.NullRawMessage) {
                    	            	    RawMessage: (json.RawMessage) <nil>,
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   JobStatus: (database.ProvisionerJobStatus) (len=7) "pending"
                    	            	  },
                    	            	  QueuePosition: (int64) 2,
                    	            	  QueueSize: (int64) 2,
                    	            	  AvailableWorkers: ([]uuid.UUID) <nil>
                    	            	 },
                    	            	 (database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow) {
                    	            	  ProvisionerJob: (database.ProvisionerJob) {
                    	            	   ID: (uuid.UUID) (len=16) {
                    	            	    00000000  83 cb 01 26 93 7e 4d e7  80 a0 cc a9 50 ad 3a b5  |...&.~M.....P.:.|
                    	            	   },
                    	            	   CreatedAt: (time.Time) {
                    	            	    wall: (uint64) 867959000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   UpdatedAt: (time.Time) {
                    	            	    wall: (uint64) 867959000,
                    	            	    ext: (int64) 63872632120,
                    	            	    loc: (*time.Location)(<nil>)
                    	            	   },
                    	            	   StartedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CanceledAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   CompletedAt: (sql.NullTime) {
                    	            	    Time: (time.Time) {
                    	            	     wall: (uint64) 0,
                    	            	     ext: (int64) 0,
                    	            	     loc: (*time.Location)(<nil>)
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   Error: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   OrganizationID: (uuid.UUID) (len=16) {
                    	            	    00000000  70 81 ae 72 a4 69 42 84  b6 c0 6f af 85 a0 06 10  |p..r.iB...o.....|
                    	            	   },
                    	            	   InitiatorID: (uuid.UUID) (len=16) {
                    	            	    00000000  bc fd a8 93 c7 8e 4c c7  a3 55 7c dd ff 38 ca 20  |......L..U|..8. |
                    	            	   },
                    	            	   Provisioner: (database.ProvisionerType) (len=4) "echo",
                    	            	   StorageMethod: (database.ProvisionerStorageMethod) (len=4) "file",
                    	            	   Type: (database.ProvisionerJobType) (len=23) "template_version_import",
                    	            	   Input: (json.RawMessage) (len=62) {
                    	            	    00000000  7b 22 74 65 6d 70 6c 61  74 65 5f 76 65 72 73 69  |{"template_versi|
                    	            	    00000010  6f 6e 5f 69 64 22 3a 22  62 62 36 62 30 61 64 65  |on_id":"bb6b0ade|
                    	            	    00000020  2d 32 30 63 38 2d 34 66  36 39 2d 39 61 66 31 2d  |-20c8-4f69-9af1-|
                    	            	    00000030  38 35 66 61 36 34 33 38  32 32 31 38 22 7d        |85fa64382218"}|
                    	            	   },
                    	            	   WorkerID: (uuid.NullUUID) {
                    	            	    UUID: (uuid.UUID) (len=16) {
                    	            	     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
                    	            	    },
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   FileID: (uuid.UUID) (len=16) {
                    	            	    00000000  be 72 0a 61 64 e1 40 ec  8d 98 85 1c 5a 2c 50 dc  |.r.ad.@.....Z,P.|
                    	            	   },
                    	            	   Tags: (database.StringMap) (len=1) {
                    	            	    (string) (len=5) "scope": (string) (len=12) "organization"
                    	            	   },
                    	            	   ErrorCode: (sql.NullString) {
                    	            	    String: (string) "",
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   TraceMetadata: (pqtype.NullRawMessage) {
                    	            	    RawMessage: (json.RawMessage) <nil>,
                    	            	    Valid: (bool) false
                    	            	   },
                    	            	   JobStatus: (database.ProvisionerJobStatus) (len=7) "pending"
                    	            	  },
                    	            	  QueuePosition: (int64) 1,
                    	            	  QueueSize: (int64) 2,
                    	            	  AvailableWorkers: ([]uuid.UUID) <nil>
                    	            	 }
                    	            	}
                    	Test:       	TestMethodTestSuite/TestExtraMethods/GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner/Success
                    	Messages:   	method "GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner" returned unexpected output 0
FAIL
FAIL	github.com/coder/coder/v2/coderd/database/dbauthz	0.044s
FAIL
```
