### PR TITLE
test(cli): fix context init in TestSupportBundle

### DIFF
--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -45,7 +45,7 @@ func TestSupportBundle(t *testing.T) {
 
 	t.Run("Workspace", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitShort)
+
 		var dc codersdk.DeploymentConfig
 		secretValue := uuid.NewString()
 		seedSecretDeploymentOptions(t, &dc, secretValue)
@@ -61,6 +61,8 @@ func TestSupportBundle(t *testing.T) {
 			agents[0].Env["SECRET_VALUE"] = secretValue
 			return agents
 		}).Do()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
 		ws, err := client.Workspace(ctx, r.Workspace.ID)
 		require.NoError(t, err)
 		tempDir := t.TempDir()
@@ -71,6 +73,8 @@ func TestSupportBundle(t *testing.T) {
 		})
 		defer agt.Close()
 		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).Wait()
+
+		ctx = testutil.Context(t, testutil.WaitShort) // Reset timeout after waiting for agent.
 
 		// Insert a provisioner job log
 		_, err = db.InsertProvisionerJobLogs(ctx, database.InsertProvisionerJobLogsParams{


### PR DESCRIPTION
Saw this flake but I didn't discern the exact cause: https://github.com/coder/coder/actions/runs/12828659209/job/35773186400?pr=16170

So I fixed the contexts here just in case.

This was suspicious:

```
    t.go:106: 2025-01-17 12:06:10.009 [debu]  coderd.coord: peerReadLoop context done  peer_id=80ca93ed-5546-4698-920d-046008c5b74d  peer_name=client  request_id=b6fc52b2-538e-48fa-b50c-8e349eb74d48
```

And given the even round number of 30s here:

```
    t.go:106: 2025-01-17 12:06:39.926 [debu]  coderd: GET  host=localhost:51586  path=/api/v2/debug/health  proto=HTTP/1.1  remote_addr=127.0.0.1  start="2025-01-17T12:06:09.925865Z"  took=30.000337625s  status_code=404  latency_ms=30000  request_id=45adda5d-d9d8-4dc0-98b0-317b0ddf625a
```