### PR TITLE
fix(examples/templates/docker): persist `/home/coder` instead of `/home/${local.user}`

### DIFF
--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -195,7 +195,7 @@ resource "docker_container" "workspace" {
     ip   = "host-gateway"
   }
   volumes {
-    container_path = "/home/${local.username}"
+    container_path = "/home/coder"
     volume_name    = docker_volume.home_volume.name
     read_only      = false
   }


### PR DESCRIPTION
When merging https://github.com/coder/coder/pull/15504, we switched to the generic `coder` user instead of creating an user based on the Coder user's name but forgot to replace the persistent volume's path, see https://github.com/coder/coder/issues/16188#issuecomment-2599815247 for full explanation.

Fix for #16188