### PR TITLE
fix(cli/cliui): handle ptr to custom type

### DIFF
--- a/cli/cliui/table.go
+++ b/cli/cliui/table.go
@@ -203,6 +203,10 @@ func renderTable(out any, sort string, headers table.Row, filterColumns []string
 				} else {
 					v = nil
 				}
+			case *string:
+				if val != nil {
+					v = *val
+				}
 			case *int64:
 				if val != nil {
 					v = *val
@@ -238,6 +242,18 @@ func renderTable(out any, sort string, headers table.Row, filterColumns []string
 				default:
 					// Leave it as it is
 				}
+			}
+
+			// Last resort, just get the interface value to avoid printing
+			// pointer values. For example, if we have a `*MyType("value")`
+			// which is defined as `type MyType string`, we want to print
+			// the string value, not the pointer.
+			if v != nil {
+				vv := reflect.ValueOf(v)
+				for vv.Kind() == reflect.Ptr && !vv.IsNil() {
+					vv = vv.Elem()
+				}
+				v = vv.Interface()
 			}
 
 			rowSlice[i] = v

--- a/cli/cliui/table_test.go
+++ b/cli/cliui/table_test.go
@@ -25,6 +25,8 @@ func (s stringWrapper) String() string {
 	return s.str
 }
 
+type myString string
+
 type tableTest1 struct {
 	Name        string         `table:"name,default_sort"`
 	AltName     *stringWrapper `table:"alt_name"`
@@ -40,6 +42,7 @@ type tableTest1 struct {
 	Time     time.Time         `table:"time"`
 	TimePtr  *time.Time        `table:"time_ptr"`
 	NullTime codersdk.NullTime `table:"null_time"`
+	MyString *myString         `table:"my_string"`
 }
 
 type tableTest2 struct {
@@ -62,6 +65,7 @@ func Test_DisplayTable(t *testing.T) {
 	t.Parallel()
 
 	someTime := time.Date(2022, 8, 2, 15, 49, 10, 0, time.UTC)
+	myStr := myString("my string")
 
 	// Not sorted by name or age to test sorting.
 	in := []tableTest1{
@@ -93,6 +97,7 @@ func Test_DisplayTable(t *testing.T) {
 					Valid: true,
 				},
 			},
+			MyString: &myStr,
 		},
 		{
 			Name:  "foo",
@@ -149,10 +154,10 @@ func Test_DisplayTable(t *testing.T) {
 		t.Parallel()
 
 		expected := `
-NAME  ALT NAME  AGE  ROLES      SUB 1 NAME  SUB 1 AGE  SUB 2 NAME  SUB 2 AGE  SUB 3 INNER NAME  SUB 3 INNER AGE  SUB 4       TIME                  TIME PTR              NULL TIME
-bar   bar alt    20  [a]        bar1               21  <nil>       <nil>      bar3                           23  {bar4 24 }  2022-08-02T15:49:10Z  <nil>                 2022-08-02T15:49:10Z
-baz   <nil>      30  []         baz1               31  <nil>       <nil>      baz3                           33  {baz4 34 }  2022-08-02T15:49:10Z  <nil>                 <nil>
-foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         foo3                           13  {foo4 14 }  2022-08-02T15:49:10Z  2022-08-02T15:49:10Z  <nil>
+NAME  ALT NAME  AGE  ROLES      SUB 1 NAME  SUB 1 AGE  SUB 2 NAME  SUB 2 AGE  SUB 3 INNER NAME  SUB 3 INNER AGE  SUB 4       TIME                  TIME PTR              NULL TIME             MY STRING
+bar   bar alt    20  [a]        bar1               21  <nil>       <nil>      bar3                           23  {bar4 24 }  2022-08-02T15:49:10Z  <nil>                 2022-08-02T15:49:10Z  my string
+baz   <nil>      30  []         baz1               31  <nil>       <nil>      baz3                           33  {baz4 34 }  2022-08-02T15:49:10Z  <nil>                 <nil>                 <nil>
+foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         foo3                           13  {foo4 14 }  2022-08-02T15:49:10Z  2022-08-02T15:49:10Z  <nil>                 <nil>
 		`
 
 		// Test with non-pointer values.
@@ -176,10 +181,10 @@ foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         fo
 		t.Parallel()
 
 		expected := `
-NAME  ALT NAME  AGE  ROLES      SUB 1 NAME  SUB 1 AGE  SUB 2 NAME  SUB 2 AGE  SUB 3 INNER NAME  SUB 3 INNER AGE  SUB 4       TIME                  TIME PTR              NULL TIME
-foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         foo3                           13  {foo4 14 }  2022-08-02T15:49:10Z  2022-08-02T15:49:10Z  <nil>
-bar   bar alt    20  [a]        bar1               21  <nil>       <nil>      bar3                           23  {bar4 24 }  2022-08-02T15:49:10Z  <nil>                 2022-08-02T15:49:10Z
-baz   <nil>      30  []         baz1               31  <nil>       <nil>      baz3                           33  {baz4 34 }  2022-08-02T15:49:10Z  <nil>                 <nil>
+NAME  ALT NAME  AGE  ROLES      SUB 1 NAME  SUB 1 AGE  SUB 2 NAME  SUB 2 AGE  SUB 3 INNER NAME  SUB 3 INNER AGE  SUB 4       TIME                  TIME PTR              NULL TIME             MY STRING
+foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         foo3                           13  {foo4 14 }  2022-08-02T15:49:10Z  2022-08-02T15:49:10Z  <nil>                 <nil>
+bar   bar alt    20  [a]        bar1               21  <nil>       <nil>      bar3                           23  {bar4 24 }  2022-08-02T15:49:10Z  <nil>                 2022-08-02T15:49:10Z  my string
+baz   <nil>      30  []         baz1               31  <nil>       <nil>      baz3                           33  {baz4 34 }  2022-08-02T15:49:10Z  <nil>                 <nil>                 <nil>
 		`
 
 		out, err := cliui.DisplayTable(in, "age", nil)
@@ -246,12 +251,12 @@ Alice   25
 	t.Run("WithSeparator", func(t *testing.T) {
 		t.Parallel()
 		expected := `
-NAME  ALT NAME  AGE  ROLES      SUB 1 NAME  SUB 1 AGE  SUB 2 NAME  SUB 2 AGE  SUB 3 INNER NAME  SUB 3 INNER AGE  SUB 4       TIME                  TIME PTR              NULL TIME
-bar   bar alt    20  [a]        bar1               21  <nil>       <nil>      bar3                           23  {bar4 24 }  2022-08-02T15:49:10Z  <nil>                 2022-08-02T15:49:10Z
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-baz   <nil>      30  []         baz1               31  <nil>       <nil>      baz3                           33  {baz4 34 }  2022-08-02T15:49:10Z  <nil>                 <nil>
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         foo3                           13  {foo4 14 }  2022-08-02T15:49:10Z  2022-08-02T15:49:10Z  <nil>
+NAME  ALT NAME  AGE  ROLES      SUB 1 NAME  SUB 1 AGE  SUB 2 NAME  SUB 2 AGE  SUB 3 INNER NAME  SUB 3 INNER AGE  SUB 4       TIME                  TIME PTR              NULL TIME               MY STRING
+bar   bar alt    20  [a]        bar1               21  <nil>       <nil>      bar3                           23  {bar4 24 }  2022-08-02T15:49:10Z  <nil>                 2022-08-02T15:49:10Z    my string
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+baz   <nil>      30  []         baz1               31  <nil>       <nil>      baz3                           33  {baz4 34 }  2022-08-02T15:49:10Z  <nil>                 <nil>                   <nil>
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+foo   <nil>      10  [a, b, c]  foo1               11  foo2        12         foo3                           13  {foo4 14 }  2022-08-02T15:49:10Z  2022-08-02T15:49:10Z  <nil>                   <nil>
 		`
 
 		var inlineIn []any


### PR DESCRIPTION
The optional fields introduced in #16028 required some additional handling, attempted to do this in a somewhat generic way that should benefit future API alterations.
