### PR TITLE
test(coderd/database/awsiamrds): fix unclosed pubsub

### DIFF
--- a/coderd/database/awsiamrds/awsiamrds_test.go
+++ b/coderd/database/awsiamrds/awsiamrds_test.go
@@ -52,13 +52,14 @@ func TestDriver(t *testing.T) {
 
 	ps, err := pubsub.New(ctx, logger, db, url)
 	require.NoError(t, err)
+	defer ps.Close()
 
 	gotChan := make(chan struct{})
 	subCancel, err := ps.Subscribe("test", func(_ context.Context, _ []byte) {
 		close(gotChan)
 	})
-	defer subCancel()
 	require.NoError(t, err)
+	defer subCancel()
 
 	err = ps.Publish("test", []byte("hello"))
 	require.NoError(t, err)


### PR DESCRIPTION
I ran into this flake: https://github.com/coder/coder/actions/runs/12872577144/job/35888367523?pr=16030

So I looked at our uses of `pubsub.New` and this is the only culprit I could find.

```
=== FAIL: cli  (0.00s)
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 179662 in state chan send, with github.com/coder/coder/v2/coderd/database/pubsub.(*PGPubsub).startListener.func1 on top of the stack:
github.com/coder/coder/v2/coderd/database/pubsub.(*PGPubsub).startListener.func1(0xc03b1f7480?, {0x0, 0x0})
	/home/runner/work/coder/coder/coderd/database/pubsub/pubsub.go:549 +0x3f0
github.com/lib/pq.(*Listener).emitEvent(...)
	/home/runner/go/pkg/mod/github.com/coder/pq@v1.10.5-0.20240813183442-0c420cb5a048/notify.go:825
github.com/lib/pq.(*Listener).listenerConnLoop(0xc03b1f7480)
	/home/runner/go/pkg/mod/github.com/coder/pq@v1.10.5-0.20240813183442-0c420cb5a048/notify.go:855 +0xd0
github.com/lib/pq.(*Listener).listenerMain(...)
	/home/runner/go/pkg/mod/github.com/coder/pq@v1.10.5-0.20240813183442-0c420cb5a048/notify.go:884
created by github.com/lib/pq.listener in goroutine 141375
	/home/runner/go/pkg/mod/github.com/coder/pq@v1.10.5-0.20240813183442-0c420cb5a048/notify.go:553 +0x1a7
]
FAIL	github.com/coder/coder/v2/cli	74.586s
```