### PR TITLE
chore(site): log errors when page fails with `not_available` in e2e tests

### DIFF
--- a/site/e2e/hooks.ts
+++ b/site/e2e/hooks.ts
@@ -35,6 +35,7 @@ export const beforeCoderTest = (page: Page) => {
 				responseText = "skipped...";
 			}
 		} catch (error) {
+			console.error(error);
 			responseText = "not_available";
 		}
 


### PR DESCRIPTION
https://github.com/coder/internal/issues/279 tracks a flake we've been seeing of late.

I noticed log lines like these:

```
[onResponse] url=http://localhost:3111/api/v2/workspaces/2fedd3ad-58a9-49be-9e61-177878be7611/watch status=200 body=not_available
[onResponse] url=http://localhost:3111/api/v2/workspaceagents/753ee86d-46cb-4641-97f6-7b4c9c9a9e27/watch-metadata status=200 body=not_available
```

No other debugging info seems to be available for these responses, so let's add some.