### PR TITLE
chore(provisionerd): use correct log levels for template provisioner logs

### DIFF
--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -613,7 +613,7 @@ func (r *Runner) runTemplateImportParse(ctx context.Context) (
 		}
 		switch msgType := msg.Type.(type) {
 		case *sdkproto.Response_Log:
-			r.logger.Debug(context.Background(), "parse job logged",
+			r.logProvisionerJobLog(context.Background(), msgType.Log.Level, "parse job logged",
 				slog.F("level", msgType.Log.Level),
 				slog.F("output", msgType.Log.Output),
 			)
@@ -711,7 +711,7 @@ func (r *Runner) runTemplateImportProvisionWithRichParameters(
 		}
 		switch msgType := msg.Type.(type) {
 		case *sdkproto.Response_Log:
-			r.logger.Debug(context.Background(), "template import provision job logged",
+			r.logProvisionerJobLog(context.Background(), msgType.Log.Level, "template import provision job logged",
 				slog.F("level", msgType.Log.Level),
 				slog.F("output", msgType.Log.Output),
 			)


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/14062

Previously a `logProvisionerJobLog` helper was added in https://github.com/coder/coder/pull/6508 to forward logs from the provisioner at the correct log level, but this was only used for logs produced in `buildWorkspace`. 

This PR uses this helper for forwarding logs produced in `runTemplateImportParse` and `runTemplateImportProvisionWithRichParameters` at the correct log level.