### PR TITLE
chore: notify on auto merged dependabot PRs

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -24,30 +24,73 @@ concurrency: pr-${{ github.ref }}
 
 jobs:
   # Dependabot is annoying, but this makes it a bit less so.
-  dependabot:
+  dependabot-automerge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder'
     permissions:
       pull-requests: write
-    steps:  
+    steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d # v2.2.0
+        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 # v2.2.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-  
+
       - name: Approve the PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          
+
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  dependabot-automerge-notify:
+    # Send a slack notification when a dependabot PR is merged.
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder' && github.event.pull_request.merged
+    steps:
+      - name: Send Slack notification
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":pr-merged: Dependabot PR auto merged",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ github.event.pull_request.title }}"
+                  }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View PR"
+                    },
+                    "url": "${{ github.event.pull_request.html_url }}"
+                  }
+                ]
+              }
+            ]
+          }' ${{ secrets.DEPENDABOT_PRS_SLACK_WEBHOOK }}
 
   cla:
     runs-on: ubuntu-latest

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -62,6 +62,8 @@ jobs:
         run: |
           curl -X POST -H 'Content-type: application/json' \
           --data '{
+            "username": "dependabot",
+            "icon_url": "https://avatars.githubusercontent.com/u/27347476",
             "blocks": [
               {
                 "type": "header",

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -63,7 +63,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": ":pr-merged: Dependabot PR auto merged",
+                  "text": ":pr-merged: Auto merged Dependabot PR #${{ github.event.pull_request.number }}",
                   "emoji": true
                 }
               },

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -55,6 +55,10 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder' && github.event.pull_request.merged
     steps:
       - name: Send Slack notification
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          PR_TITLE: ${{github.event.pull_request.title}}
+          PR_NUMBER: ${{github.event.pull_request.number}}
         run: |
           curl -X POST -H 'Content-type: application/json' \
           --data '{
@@ -63,7 +67,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": ":pr-merged: Auto merged Dependabot PR #${{ github.event.pull_request.number }}",
+                  "text": ":pr-merged: Auto merged Dependabot PR #${{ env.PR_NUMBER }}",
                   "emoji": true
                 }
               },
@@ -72,7 +76,7 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "${{ github.event.pull_request.title }}"
+                    "text": "${{ env.PR_TITLE }}"
                   }
                 ]
               },
@@ -85,7 +89,7 @@ jobs:
                       "type": "plain_text",
                       "text": "View PR"
                     },
-                    "url": "${{ github.event.pull_request.html_url }}"
+                    "url": "${{ env.PR_URL }}"
                   }
                 ]
               }


### PR DESCRIPTION
Implement a notification system that sends a Slack message when a Dependabot pull request is automatically merged. This enhances visibility and tracking of automated updates.

The notification will look like this.
<img width="429" alt="image" src="https://github.com/user-attachments/assets/543bdfff-2be3-44be-9c5b-654b9a888d03" />


Continues #16222