### PR TITLE
fix(vpn): pass dup'd FDs to tunnel

### DIFF
--- a/vpn/dylib/lib.go
+++ b/vpn/dylib/lib.go
@@ -39,7 +39,7 @@ func OpenTunnel(cReadFD, cWriteFD int32) int32 {
 		return ErrDupWriteFD
 	}
 
-	conn, err := vpn.NewBidirectionalPipe(uintptr(cReadFD), uintptr(cWriteFD))
+	conn, err := vpn.NewBidirectionalPipe(uintptr(readFD), uintptr(writeFD))
 	if err != nil {
 		unix.Close(readFD)
 		unix.Close(writeFD)


### PR DESCRIPTION
We were duping the passed FDs and then not using the result.