### PR TITLE
chore(cli): apply printf fixes enforced by updated go tools

### DIFF
--- a/cli/clilog/clilog_test.go
+++ b/cli/clilog/clilog_test.go
@@ -181,7 +181,7 @@ func assertLogs(t testing.TB, path string, expected ...string) {
 
 	logs := strings.Split(strings.TrimSpace(string(data)), "\n")
 	if !assert.Len(t, logs, len(expected)) {
-		t.Logf(string(data))
+		t.Log(string(data))
 		t.FailNow()
 	}
 	for i, log := range logs {
@@ -202,7 +202,7 @@ func assertLogsJSON(t testing.TB, path string, levelExpected ...string) {
 
 	logs := strings.Split(strings.TrimSpace(string(data)), "\n")
 	if !assert.Len(t, logs, len(levelExpected)/2) {
-		t.Logf(string(data))
+		t.Log(string(data))
 		t.FailNow()
 	}
 	for i, log := range logs {

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -92,7 +92,7 @@ func (r *RootCmd) gitssh() *serpent.Command {
 					_, _ = fmt.Fprintln(inv.Stderr,
 						"\n"+pretty.Sprintf(
 							cliui.DefaultStyles.Wrap,
-							"Coder authenticates with "+pretty.Sprint(cliui.DefaultStyles.Field, "git")+
+							"%s", "Coder authenticates with "+pretty.Sprint(cliui.DefaultStyles.Field, "git")+
 								" using the public key below. All clones with SSH are authenticated automatically 🪄.")+"\n",
 					)
 					_, _ = fmt.Fprintln(inv.Stderr, pretty.Sprint(cliui.DefaultStyles.Code, strings.TrimSpace(key.PublicKey))+"\n")

--- a/cli/login.go
+++ b/cli/login.go
@@ -209,7 +209,7 @@ func (r *RootCmd) login() *serpent.Command {
 
 			// nolint: nestif
 			if !hasFirstUser {
-				_, _ = fmt.Fprintf(inv.Stdout, Caret+"Your Coder deployment hasn't been set up!\n")
+				_, _ = fmt.Fprintf(inv.Stdout, "%s", Caret+"Your Coder deployment hasn't been set up!\n")
 
 				if username == "" {
 					if !isTTYIn(inv) {

--- a/cli/logout.go
+++ b/cli/logout.go
@@ -68,7 +68,7 @@ func (r *RootCmd) logout() *serpent.Command {
 				errorString := strings.TrimRight(errorStringBuilder.String(), "\n")
 				return xerrors.New("Failed to log out.\n" + errorString)
 			}
-			_, _ = fmt.Fprintf(inv.Stdout, Caret+"You are no longer logged in. You can log in using 'coder login <url>'.\n")
+			_, _ = fmt.Fprintf(inv.Stdout, "%s", Caret+"You are no longer logged in. You can log in using 'coder login <url>'.\n")
 			return nil
 		},
 	}

--- a/cli/publickey.go
+++ b/cli/publickey.go
@@ -46,10 +46,10 @@ func (r *RootCmd) publickey() *serpent.Command {
 			}
 
 			cliui.Infof(inv.Stdout,
-				"This is your public key for using "+pretty.Sprint(cliui.DefaultStyles.Field, "git")+" in "+
+				"%s", "This is your public key for using "+pretty.Sprint(cliui.DefaultStyles.Field, "git")+" in "+
 					"Coder. All clones with SSH will be authenticated automatically 🪄.",
 			)
-			cliui.Infof(inv.Stdout, pretty.Sprint(cliui.DefaultStyles.Code, strings.TrimSpace(key.PublicKey))+"\n")
+			cliui.Infof(inv.Stdout, "%s", pretty.Sprint(cliui.DefaultStyles.Code, strings.TrimSpace(key.PublicKey))+"\n")
 			cliui.Infof(inv.Stdout, "Add to GitHub and GitLab:")
 			cliui.Infof(inv.Stdout, "> https://github.com/settings/ssh/new")
 			cliui.Infof(inv.Stdout, "> https://gitlab.com/-/profile/keys")

--- a/cli/server.go
+++ b/cli/server.go
@@ -513,7 +513,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			}
 
 			accessURL := vals.AccessURL.String()
-			cliui.Infof(inv.Stdout, lipgloss.NewStyle().
+			cliui.Infof(inv.Stdout, "%s", lipgloss.NewStyle().
 				Border(lipgloss.DoubleBorder()).
 				Align(lipgloss.Center).
 				Padding(0, 3).

--- a/cli/templateversionarchive.go
+++ b/cli/templateversionarchive.go
@@ -76,7 +76,7 @@ func (r *RootCmd) setArchiveTemplateVersion(archive bool) *serpent.Command {
 			for _, version := range versions {
 				if version.Archived == archive {
 					_, _ = fmt.Fprintln(
-						inv.Stdout, fmt.Sprintf("Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" already "+pastVerb),
+						inv.Stdout, fmt.Sprintf("%s", "Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" already "+pastVerb),
 					)
 					continue
 				}
@@ -87,7 +87,7 @@ func (r *RootCmd) setArchiveTemplateVersion(archive bool) *serpent.Command {
 				}
 
 				_, _ = fmt.Fprintln(
-					inv.Stdout, fmt.Sprintf("Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" "+pastVerb+" at "+cliui.Timestamp(time.Now())),
+					inv.Stdout, fmt.Sprintf("%s", "Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" "+pastVerb+" at "+cliui.Timestamp(time.Now())),
 				)
 			}
 			return nil


### PR DESCRIPTION
I don't know which tool is making these changes when using VS Code, but all seem correct.