### PR TITLE
fix(vpn): handle sending nil router config

### DIFF
--- a/vpn/router.go
+++ b/vpn/router.go
@@ -22,7 +22,10 @@ func (*vpnRouter) Up() error {
 }
 
 func (v *vpnRouter) Set(cfg *router.Config) error {
-	req := convertRouterConfig(cfg)
+	if cfg == nil {
+		return nil
+	}
+	req := convertRouterConfig(*cfg)
 	return v.tunnel.ApplyNetworkSettings(v.tunnel.ctx, req)
 }
 
@@ -31,7 +34,7 @@ func (*vpnRouter) Close() error {
 	return nil
 }
 
-func convertRouterConfig(cfg *router.Config) *NetworkSettingsRequest {
+func convertRouterConfig(cfg router.Config) *NetworkSettingsRequest {
 	v4LocalAddrs := make([]string, 0)
 	v6LocalAddrs := make([]string, 0)
 	for _, addrs := range cfg.LocalAddrs {

--- a/vpn/router_internal_test.go
+++ b/vpn/router_internal_test.go
@@ -13,12 +13,12 @@ func TestConvertRouterConfig(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		cfg      *router.Config
+		cfg      router.Config
 		expected *NetworkSettingsRequest
 	}{
 		{
 			name: "IPv4 and IPv6 configuration",
-			cfg: &router.Config{
+			cfg: router.Config{
 				LocalAddrs:  []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32"), netip.MustParsePrefix("fd7a:115c:a1e0::1/128")},
 				Routes:      []netip.Prefix{netip.MustParsePrefix("192.168.0.0/24"), netip.MustParsePrefix("fd00::/64")},
 				LocalRoutes: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8"), netip.MustParsePrefix("2001:db8::/32")},
@@ -48,7 +48,7 @@ func TestConvertRouterConfig(t *testing.T) {
 		},
 		{
 			name: "Empty",
-			cfg:  &router.Config{},
+			cfg:  router.Config{},
 			expected: &NetworkSettingsRequest{
 				Ipv4Settings: &NetworkSettingsRequest_IPv4Settings{
 					Addrs:          []string{},


### PR DESCRIPTION
Previously, a `nil` Router config would cause a panic in the dylib. Normally, a nil Router config would indicate a shutdown of the service, and that settings should be reset. However, for Coder Desktop macOS the network configuration will be reset by the disconnecting of the system VPN, so we'll instead do nothing.