### PR TITLE
chore: remove patch condition for dependabot PRs

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -43,7 +43,6 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Many of the depdnabot PRs are minor updates, so removing this condition to make automation more useful.

We only merge if all tests pass, so this should be safe.