### PR TITLE
ci: grant 'contents' write permission to auto-merge dependabot PRs

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -29,6 +29,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder'
     permissions:
       pull-requests: write
+      contents: write
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
This was a mistake in #16222, as `contents: write` permission is required to merge a PR.

See the GitHub [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request) for an example.