### PR TITLE
ci: change PR merge strategy to squash in contrib workflow

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -44,7 +44,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Seen: `GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)`
So we need to change the method to `--squash`.

Hopefully, this is the last one to get this working. 