### PR TITLE
fix(provisioner/terraform/tfparse): allow empty values in coder_workspace_tag defaults

### DIFF
--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -429,9 +429,8 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 							}
 						}`,
 				},
-				reqTags: map[string]string{"a": "b"},
-				// wantTags: map[string]string{"owner": "", "scope": "organization", "a": "b"},
-				expectError: `provisioner tag "a" evaluated to an empty value`,
+				reqTags:  map[string]string{"a": "b"},
+				wantTags: map[string]string{"owner": "", "scope": "organization", "a": "b"},
 			},
 			{
 				name: "main.tf with disallowed workspace tag value",
@@ -567,6 +566,42 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 						}`,
 				},
 				wantTags: map[string]string{"owner": "", "scope": "organization"},
+			},
+			{
+				name: "main.tf with tags from parameter with default value from variable no default",
+				files: map[string]string{
+					`main.tf`: `
+						variable "provisioner" {
+						  type        = string
+						}
+						variable "default_provisioner" {
+						  type        = string
+						  default     = "" # intentionally blank, set on template creation
+						}
+						data "coder_parameter" "provisioner" {
+						  name         = "provisioner"
+						  mutable      = false
+						  default      = var.default_provisioner
+						  dynamic "option" {
+							for_each = toset(split(",", var.provisioner))
+							content {
+							  name  = option.value
+							  value = option.value
+							}
+						  }
+						}
+						data "coder_workspace_tags" "tags" {
+						  tags = {
+							"provisioner" : data.coder_parameter.provisioner.value
+						  }
+						}`,
+				},
+				reqTags: map[string]string{
+					"provisioner": "alpha",
+				},
+				wantTags: map[string]string{
+					"provisioner": "alpha", "owner": "", "scope": "organization",
+				},
 			},
 		} {
 			tt := tt

--- a/docs/admin/templates/extending-templates/workspace-tags.md
+++ b/docs/admin/templates/extending-templates/workspace-tags.md
@@ -62,11 +62,6 @@ variables and parameters. This is illustrated in the table below:
 
 ## Constraints
 
-### Default Values
-
-All template variables and `coder_parameter` data sources **must** provide a
-default value. Failure to do so will result in an error.
-
 ### Tagged provisioners
 
 It is possible to choose tag combinations that no provisioner can handle. This
@@ -127,6 +122,6 @@ variables, and references to other resources.
 
 #### Not supported
 
-- Function calls: `try(var.foo, "default")`
+- Function calls that reference files on disk: `abspath`, `file*`, `pathexpand`
 - Resources: `compute_instance.dev.name`
 - Data sources other than `coder_parameter`: `data.local_file.hostname.content`

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -389,7 +389,7 @@ func newExternalProvisionerDaemon(t testing.TB, client *codersdk.Client, org uui
 	daemon := provisionerd.New(func(ctx context.Context) (provisionerdproto.DRPCProvisionerDaemonClient, error) {
 		return client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
 			ID:           uuid.New(),
-			Name:         t.Name(),
+			Name:         testutil.GetRandomName(t),
 			Organization: org,
 			Provisioners: []codersdk.ProvisionerType{provisionerType},
 			Tags:         tags,

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -285,7 +285,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 			daemons, err := client.ProvisionerDaemons(context.Background())
 			assert.NoError(t, err, "failed to get provisioner daemons")
 			return len(daemons) > 0 &&
-				assert.Equal(t, t.Name(), daemons[0].Name) &&
+				assert.NotEmpty(t, daemons[0].Name) &&
 				assert.Equal(t, provisionersdk.ScopeUser, daemons[0].Tags[provisionersdk.TagScope]) &&
 				assert.Equal(t, user.UserID.String(), daemons[0].Tags[provisionersdk.TagOwner])
 		}, testutil.WaitShort, testutil.IntervalMedium)

--- a/examples/workspace-tags/README.md
+++ b/examples/workspace-tags/README.md
@@ -7,7 +7,7 @@ icon: /icon/docker.png
 
 ## Overview
 
-This Coder template presents use of [Workspace Tags](https://coder.com/docs/templates/workspace-tags) [Coder Parameters](https://coder.com/docs/templates/parameters).
+This Coder template presents use of [Workspace Tags](https://coder.com/docs/admin/templates/extending-templates/workspace-tags) and [Coder Parameters](https://coder.com/docs/templates/parameters).
 
 ## Use case
 
@@ -18,10 +18,8 @@ By using `coder_workspace_tags` and `coder_parameter`s, template administrators 
 ## Notes
 
 - You will need to have an [external provisioner](https://coder.com/docs/admin/provisioners#external-provisioners) with the correct tagset running in order to import this template.
-- When specifying values for the `coder_workspace_tags` data source, you are restricted to using a subset of Terraform's capabilities.
-- You must specify default values for all data sources and variables referenced by the `coder_workspace_tags` data source.
+- When specifying values for the `coder_workspace_tags` data source, you are restricted to using a subset of Terraform's capabilities. See [here](https://coder.com/docs/admin/templates/extending-templates/workspace-tags) for more details.
 
-See [Workspace Tags](https://coder.com/docs/templates/workspace-tags) for more information.
 
 ## Development
 

--- a/provisioner/terraform/tfparse/tfparse.go
+++ b/provisioner/terraform/tfparse/tfparse.go
@@ -239,13 +239,6 @@ func (p *Parser) WorkspaceTagDefaults(ctx context.Context) (map[string]string, e
 		return nil, xerrors.Errorf("eval provisioner tags: %w", err)
 	}
 
-	// Ensure that none of the tag values are empty after evaluation.
-	for k, v := range evalTags {
-		if len(strings.TrimSpace(v)) > 0 {
-			continue
-		}
-		return nil, xerrors.Errorf("provisioner tag %q evaluated to an empty value, please set a default value", k)
-	}
 	return evalTags, nil
 }
 

--- a/provisioner/terraform/tfparse/tfparse_test.go
+++ b/provisioner/terraform/tfparse/tfparse_test.go
@@ -268,7 +268,7 @@ func Test_WorkspaceTagDefaultsFromFile(t *testing.T) {
 						}
 					}`,
 			},
-			expectError: `provisioner tag "az" evaluated to an empty value, please set a default value`,
+			expectTags: map[string]string{"cluster": "developers", "az": "", "platform": "kubernetes", "region": "us"},
 		},
 		{
 			name: "main.tf with missing parameter default value outside workspace tags",


### PR DESCRIPTION
This removes a check we previously had requiring all workspace tag values sniffed in `tfparse` to have a non-empty value. This allows template authors to provide an initially empty value that is later overriden with tag values either in the request or passed in via template variables when importing the template.

Also updates documentation removing references to the non-empty default value requirement.

Also addresses an issue in our test code for starting a new external provisioner that causes an error if the test name is longer than 64 characters, which is longer than our DB schema allows.



https://github.com/user-attachments/assets/9d521fea-dc65-4a2c-973d-bfd9a75eb57a

