### PR TITLE
fix(cli): remove loading indicator when pinging with verbose logs

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -120,7 +120,9 @@ func (r *RootCmd) ping() *serpent.Command {
 			spin := spinner.New(spinner.CharSets[5], 100*time.Millisecond)
 			spin.Writer = inv.Stderr
 			spin.Suffix = pretty.Sprint(cliui.DefaultStyles.Keyword, " Collecting diagnostics...")
-			spin.Start()
+			if !r.verbose {
+				spin.Start()
+			}
 
 			opts := &workspacesdk.DialAgentOptions{}
 


### PR DESCRIPTION
This was causing some verbose log lines to be prepended with the spinner message, e.g.
```
◱ Collecting diagnostics...2025-01-28 10:26:27.502
```
which doesnt look very good. Presumably anyone running it with verbose will know it takes a moment to collect diagnostics first.