### PR TITLE
feat: add endpoint for partial updates to org sync mapping

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4248,6 +4248,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/settings/idpsync/organization/mapping": {
+            "patch": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enterprise"
+                ],
+                "summary": "Update organization IdP Sync mapping",
+                "operationId": "update-organization-idp-sync-mapping",
+                "parameters": [
+                    {
+                        "description": "Description of the mappings to add and remove",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.PatchOrganizationIDPSyncMappingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.OrganizationSyncSettings"
+                        }
+                    }
+                }
+            }
+        },
         "/tailnet": {
             "get": {
                 "security": [
@@ -12416,6 +12455,43 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                }
+            }
+        },
+        "codersdk.PatchOrganizationIDPSyncMappingRequest": {
+            "type": "object",
+            "properties": {
+                "add": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "gets": {
+                                "description": "The ID of the Coder resource the user should be added to",
+                                "type": "string"
+                            },
+                            "given": {
+                                "description": "The IdP claim the user has",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "remove": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "gets": {
+                                "description": "The ID of the Coder resource the user should be added to",
+                                "type": "string"
+                            },
+                            "given": {
+                                "description": "The IdP claim the user has",
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3744,6 +3744,39 @@
 				}
 			}
 		},
+		"/settings/idpsync/organization/mapping": {
+			"patch": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Enterprise"],
+				"summary": "Update organization IdP Sync mapping",
+				"operationId": "update-organization-idp-sync-mapping",
+				"parameters": [
+					{
+						"description": "Description of the mappings to add and remove",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.PatchOrganizationIDPSyncMappingRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.OrganizationSyncSettings"
+						}
+					}
+				}
+			}
+		},
 		"/tailnet": {
 			"get": {
 				"security": [
@@ -11197,6 +11230,43 @@
 					"type": "array",
 					"items": {
 						"type": "string"
+					}
+				}
+			}
+		},
+		"codersdk.PatchOrganizationIDPSyncMappingRequest": {
+			"type": "object",
+			"properties": {
+				"add": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"gets": {
+								"description": "The ID of the Coder resource the user should be added to",
+								"type": "string"
+							},
+							"given": {
+								"description": "The IdP claim the user has",
+								"type": "string"
+							}
+						}
+					}
+				},
+				"remove": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"gets": {
+								"description": "The ID of the Coder resource the user should be added to",
+								"type": "string"
+							},
+							"given": {
+								"description": "The IdP claim the user has",
+								"type": "string"
+							}
+						}
 					}
 				}
 			}

--- a/coderd/idpsync/idpsync.go
+++ b/coderd/idpsync/idpsync.go
@@ -26,7 +26,7 @@ import (
 type IDPSync interface {
 	OrganizationSyncEntitled() bool
 	OrganizationSyncSettings(ctx context.Context, db database.Store) (*OrganizationSyncSettings, error)
-	UpdateOrganizationSettings(ctx context.Context, db database.Store, settings OrganizationSyncSettings) error
+	UpdateOrganizationSyncSettings(ctx context.Context, db database.Store, settings OrganizationSyncSettings) error
 	// OrganizationSyncEnabled returns true if all OIDC users are assigned
 	// to organizations via org sync settings.
 	// This is used to know when to disable manual org membership assignment.
@@ -69,6 +69,9 @@ type IDPSync interface {
 	// Site & org roles are handled in this method.
 	SyncRoles(ctx context.Context, db database.Store, user database.User, params RoleParams) error
 }
+
+// AGPLIDPSync implements the IDPSync interface
+var _ IDPSync = AGPLIDPSync{}
 
 // AGPLIDPSync is the configuration for syncing user information from an external
 // IDP. All related code to syncing user information should be in this package.

--- a/coderd/idpsync/organization.go
+++ b/coderd/idpsync/organization.go
@@ -34,7 +34,7 @@ func (AGPLIDPSync) OrganizationSyncEnabled(_ context.Context, _ database.Store) 
 	return false
 }
 
-func (s AGPLIDPSync) UpdateOrganizationSettings(ctx context.Context, db database.Store, settings OrganizationSyncSettings) error {
+func (s AGPLIDPSync) UpdateOrganizationSyncSettings(ctx context.Context, db database.Store, settings OrganizationSyncSettings) error {
 	rlv := s.Manager.Resolver(db)
 	err := s.SyncSettings.Organization.SetRuntimeValue(ctx, rlv, &settings)
 	if err != nil {

--- a/coderd/runtimeconfig/resolver.go
+++ b/coderd/runtimeconfig/resolver.go
@@ -12,6 +12,9 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 )
 
+// NoopResolver implements the Resolver interface
+var _ Resolver = &NoopResolver{}
+
 // NoopResolver is a useful test device.
 type NoopResolver struct{}
 
@@ -30,6 +33,9 @@ func (NoopResolver) UpsertRuntimeConfig(context.Context, string, string) error {
 func (NoopResolver) DeleteRuntimeConfig(context.Context, string) error {
 	return ErrEntryNotFound
 }
+
+// StoreResolver implements the Resolver interface
+var _ Resolver = &StoreResolver{}
 
 // StoreResolver uses the database as the underlying store for runtime settings.
 type StoreResolver struct {

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -295,7 +295,7 @@ func TestTelemetry(t *testing.T) {
 		org, err := db.GetDefaultOrganization(ctx)
 		require.NoError(t, err)
 		sync := idpsync.NewAGPLSync(testutil.Logger(t), runtimeconfig.NewManager(), idpsync.DeploymentSyncSettings{})
-		err = sync.UpdateOrganizationSettings(ctx, db, idpsync.OrganizationSyncSettings{
+		err = sync.UpdateOrganizationSyncSettings(ctx, db, idpsync.OrganizationSyncSettings{
 			Field: "organizations",
 			Mapping: map[string][]uuid.UUID{
 				"first": {org.ID},

--- a/codersdk/idpsync.go
+++ b/codersdk/idpsync.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// constraining to `uuid.UUID | string` here would be nice but `make gen` will
-// yell at you for it.
 type IDPSyncMapping[ResourceIdType uuid.UUID | string] struct {
 	// The IdP claim the user has
 	Given string

--- a/codersdk/idpsync.go
+++ b/codersdk/idpsync.go
@@ -12,6 +12,15 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// constraining to `uuid.UUID | string` here would be nice but `make gen` will
+// yell at you for it.
+type IDPSyncMapping[ResourceIdType uuid.UUID | string] struct {
+	// The IdP claim the user has
+	Given string
+	// The ID of the Coder resource the user should be added to
+	Gets ResourceIdType
+}
+
 type GroupSyncSettings struct {
 	// Field is the name of the claim field that specifies what groups a user
 	// should be in. If empty, no groups will be synced.
@@ -125,6 +134,26 @@ func (c *Client) OrganizationIDPSyncSettings(ctx context.Context) (OrganizationS
 
 func (c *Client) PatchOrganizationIDPSyncSettings(ctx context.Context, req OrganizationSyncSettings) (OrganizationSyncSettings, error) {
 	res, err := c.Request(ctx, http.MethodPatch, "/api/v2/settings/idpsync/organization", req)
+	if err != nil {
+		return OrganizationSyncSettings{}, xerrors.Errorf("make request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return OrganizationSyncSettings{}, ReadBodyAsError(res)
+	}
+	var resp OrganizationSyncSettings
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// If the same mapping is present in both Add and Remove, Remove will take presidence.
+type PatchOrganizationIDPSyncMappingRequest struct {
+	Add    []IDPSyncMapping[uuid.UUID]
+	Remove []IDPSyncMapping[uuid.UUID]
+}
+
+func (c *Client) PatchOrganizationIDPSyncMapping(ctx context.Context, req PatchOrganizationIDPSyncMappingRequest) (OrganizationSyncSettings, error) {
+	res, err := c.Request(ctx, http.MethodPatch, "/api/v2/settings/idpsync/organization/mapping", req)
 	if err != nil {
 		return OrganizationSyncSettings{}, xerrors.Errorf("make request: %w", err)
 	}

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -2677,6 +2677,72 @@ curl -X PATCH http://coder-server:8080/api/v2/settings/idpsync/organization \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Update organization IdP Sync mapping
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PATCH http://coder-server:8080/api/v2/settings/idpsync/organization/mapping \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PATCH /settings/idpsync/organization/mapping`
+
+> Body parameter
+
+```json
+{
+  "add": [
+    {
+      "gets": "string",
+      "given": "string"
+    }
+  ],
+  "remove": [
+    {
+      "gets": "string",
+      "given": "string"
+    }
+  ]
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                                         | Required | Description                                   |
+|--------|------|--------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------|
+| `body` | body | [codersdk.PatchOrganizationIDPSyncMappingRequest](schemas.md#codersdkpatchorganizationidpsyncmappingrequest) | true     | Description of the mappings to add and remove |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "field": "string",
+  "mapping": {
+    "property1": [
+      "string"
+    ],
+    "property2": [
+      "string"
+    ]
+  },
+  "organization_assign_default": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                           |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.OrganizationSyncSettings](schemas.md#codersdkorganizationsyncsettings) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get template ACLs
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -4180,6 +4180,36 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `quota_allowance` | integer         | false    |              |             |
 | `remove_users`    | array of string | false    |              |             |
 
+## codersdk.PatchOrganizationIDPSyncMappingRequest
+
+```json
+{
+  "add": [
+    {
+      "gets": "string",
+      "given": "string"
+    }
+  ],
+  "remove": [
+    {
+      "gets": "string",
+      "given": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name      | Type            | Required | Restrictions | Description                                              |
+|-----------|-----------------|----------|--------------|----------------------------------------------------------|
+| `add`     | array of object | false    |              |                                                          |
+| `» gets`  | string          | false    |              | The ID of the Coder resource the user should be added to |
+| `» given` | string          | false    |              | The IdP claim the user has                               |
+| `remove`  | array of object | false    |              |                                                          |
+| `» gets`  | string          | false    |              | The ID of the Coder resource the user should be added to |
+| `» given` | string          | false    |              | The IdP claim the user has                               |
+
 ## codersdk.PatchTemplateVersionRequest
 
 ```json

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -295,7 +295,9 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				r.Route("/organization", func(r chi.Router) {
 					r.Get("/", api.organizationIDPSyncSettings)
 					r.Patch("/", api.patchOrganizationIDPSyncSettings)
+					r.Patch("/mapping", api.patchOrganizationIDPSyncMapping)
 				})
+
 				r.Get("/available-fields", api.deploymentIDPSyncClaimFields)
 				r.Get("/field-values", api.deploymentIDPSyncClaimFieldValues)
 			})
@@ -307,11 +309,12 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				httpmw.ExtractOrganizationParam(api.Database),
 			)
 			r.Route("/organizations/{organization}/settings", func(r chi.Router) {
-				r.Get("/idpsync/available-fields", api.organizationIDPSyncClaimFields)
 				r.Get("/idpsync/groups", api.groupIDPSyncSettings)
 				r.Patch("/idpsync/groups", api.patchGroupIDPSyncSettings)
 				r.Get("/idpsync/roles", api.roleIDPSyncSettings)
 				r.Patch("/idpsync/roles", api.patchRoleIDPSyncSettings)
+
+				r.Get("/idpsync/available-fields", api.organizationIDPSyncClaimFields)
 				r.Get("/idpsync/field-values", api.organizationIDPSyncClaimFieldValues)
 			})
 		})

--- a/enterprise/coderd/enidpsync/enidpsync.go
+++ b/enterprise/coderd/enidpsync/enidpsync.go
@@ -7,6 +7,8 @@ import (
 	"github.com/coder/coder/v2/coderd/runtimeconfig"
 )
 
+var _ idpsync.IDPSync = &EnterpriseIDPSync{}
+
 // EnterpriseIDPSync enabled syncing user information from an external IDP.
 // The sync is an enterprise feature, so this struct wraps the AGPL implementation
 // and extends it with enterprise capabilities. These capabilities can entirely

--- a/enterprise/coderd/enidpsync/organizations_test.go
+++ b/enterprise/coderd/enidpsync/organizations_test.go
@@ -300,7 +300,7 @@ func TestOrganizationSync(t *testing.T) {
 			// Create a new sync object
 			sync := enidpsync.NewSync(logger, runtimeconfig.NewManager(), caseData.Entitlements, caseData.Settings)
 			if caseData.RuntimeSettings != nil {
-				err := sync.UpdateOrganizationSettings(ctx, rdb, *caseData.RuntimeSettings)
+				err := sync.UpdateOrganizationSyncSettings(ctx, rdb, *caseData.RuntimeSettings)
 				require.NoError(t, err)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/chromedp/chromedp v0.11.0
 	github.com/cli/safeexec v1.0.1
 	github.com/coder/flog v1.1.0
-	github.com/coder/guts v1.0.0
+	github.com/coder/guts v1.0.1
 	github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0
 	github.com/coder/quartz v0.1.2
 	github.com/coder/retry v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVp
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322/go.mod h1:rOLFDDVKVFiDqZFXoteXc97YXx7kFi9kYqR+2ETPkLQ=
 github.com/coder/go-scim/pkg/v2 v2.0.0-20230221055123-1d63c1222136 h1:0RgB61LcNs24WOxc3PBvygSNTQurm0PYPujJjLLOzs0=
 github.com/coder/go-scim/pkg/v2 v2.0.0-20230221055123-1d63c1222136/go.mod h1:VkD1P761nykiq75dz+4iFqIQIZka189tx1BQLOp0Skc=
-github.com/coder/guts v1.0.0 h1:Ba6TBOeED+96Dv8IdISjbGhCzHKicqSc4SEYVV+4zeE=
-github.com/coder/guts v1.0.0/go.mod h1:SfmxjDaSfPjzKJ9mGU4sA/1OHU+u66uRfhFF+y4BARQ=
+github.com/coder/guts v1.0.1 h1:tU9pW+1jftCSX1eBxnNHiouQBSBJIej3I+kqfjIyeJU=
+github.com/coder/guts v1.0.1/go.mod h1:z8LHbF6vwDOXQOReDvay7Rpwp/jHwCZiZwjd6wfLcJg=
 github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048 h1:3jzYUlGH7ZELIH4XggXhnTnP05FCYiAFeQpoN+gNR5I=
 github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1055,6 +1055,12 @@ export interface HealthcheckReport {
 	readonly coder_version: string;
 }
 
+// From codersdk/idpsync.go
+export interface IDPSyncMapping<ResourceIdType extends string | string> {
+	readonly Given: string;
+	readonly Gets: ResourceIdType;
+}
+
 // From codersdk/insights.go
 export type InsightsReportInterval = "day" | "week";
 
@@ -1457,6 +1463,12 @@ export interface PatchGroupRequest {
 	readonly display_name: string | null;
 	readonly avatar_url: string | null;
 	readonly quota_allowance: number | null;
+}
+
+// From codersdk/idpsync.go
+export interface PatchOrganizationIDPSyncMappingRequest {
+	readonly Add: readonly IDPSyncMapping<string>[];
+	readonly Remove: readonly IDPSyncMapping<string>[];
 }
 
 // From codersdk/templateversions.go


### PR DESCRIPTION
Part of https://github.com/coder/internal/issues/290
Part of https://github.com/coder/coder/issues/15939

Only does partial org mapping updates for now, to make sure everything passes the smell check. If we're happy with this, it will be easy to add similar endpoints for group and role sync mappings.

Also adds tests for the existing org sync endpoints since somehow those didn't get added before