### PR TITLE
chore: track usage of organizations in telemetry

### DIFF
--- a/coderd/idpsync/organization.go
+++ b/coderd/idpsync/organization.go
@@ -45,6 +45,8 @@ func (s AGPLIDPSync) UpdateOrganizationSettings(ctx context.Context, db database
 }
 
 func (s AGPLIDPSync) OrganizationSyncSettings(ctx context.Context, db database.Store) (*OrganizationSyncSettings, error) {
+	// If this logic is ever updated, make sure to update the corresponding
+	// checkIDPOrgSync in coderd/telemetry/telemetry.go.
 	rlv := s.Manager.Resolver(db)
 	orgSettings, err := s.SyncSettings.Organization.Resolve(ctx, rlv)
 	if err != nil {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -269,7 +269,7 @@ func (r *remoteReporter) deployment() error {
 		MachineID:       sysInfo.UniqueID,
 		StartedAt:       r.startedAt,
 		ShutdownAt:      r.shutdownAt,
-		IDPOrgSync:      idpOrgSync,
+		IDPOrgSync:      &idpOrgSync,
 	})
 	if err != nil {
 		return xerrors.Errorf("marshal deployment: %w", err)
@@ -1034,7 +1034,9 @@ type Deployment struct {
 	MachineID       string                     `json:"machine_id"`
 	StartedAt       time.Time                  `json:"started_at"`
 	ShutdownAt      *time.Time                 `json:"shutdown_at"`
-	IDPOrgSync      bool                       `json:"idp_org_sync"`
+	// While IDPOrgSync will always be set, it's nullable to make
+	// the struct backwards compatible with older coder versions.
+	IDPOrgSync *bool `json:"idp_org_sync"`
 }
 
 type APIKey struct {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -298,11 +298,10 @@ type idpOrgSyncConfig struct {
 	Field string `json:"field"`
 }
 
-// checkIDPOrgSync checks if IDP org sync is configured by checking the runtime
-// config. It's based on the OrganizationSyncEnabled function from
-// enterprise/coderd/enidpsync/organizations.go. It has one distinct difference:
-// it doesn't check if the license entitles to the feature, it only checks if the
-// feature is configured.
+// checkIDPOrgSync inspects the server flags and the runtime config. It's based on
+// the OrganizationSyncEnabled function from enterprise/coderd/enidpsync/organizations.go.
+// It has one distinct difference: it doesn't check if the license entitles to the
+// feature, it only checks if the feature is configured.
 //
 // The above function is not used because it's very hard to make it available in
 // the telemetry package due to coder/coder package structure and initialization

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -308,7 +308,7 @@ type idpOrgSyncConfig struct {
 // order of the coder server.
 //
 // We don't check license entitlements because it's also hard to do from the
-// telemetry package, and the config check is sufficient for telemetry purposes.
+// telemetry package, and the config check should be sufficient for telemetry purposes.
 //
 // While this approach duplicates code, it's simpler than the alternative.
 //

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -30,7 +30,6 @@ import (
 	"github.com/coder/coder/v2/buildinfo"
 	clitelemetry "github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	tailnetproto "github.com/coder/coder/v2/tailnet/proto"
@@ -570,9 +569,7 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 		// the database. It will no longer be reported, and there will be no other
 		// indicator that it was deleted. This requires special handling when
 		// interpreting the telemetry data later.
-		// nolint:gocritic // AsSystemRestricted is fine here because it's a read-only operation
-		// used for telemetry reporting.
-		orgs, err := r.options.Database.GetOrganizations(dbauthz.AsSystemRestricted(r.ctx), database.GetOrganizationsParams{})
+		orgs, err := r.options.Database.GetOrganizations(r.ctx, database.GetOrganizationsParams{})
 		if err != nil {
 			return xerrors.Errorf("get organizations: %w", err)
 		}

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -22,7 +22,12 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmem"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/entitlements"
+	"github.com/coder/coder/v2/coderd/idpsync"
+	"github.com/coder/coder/v2/coderd/runtimeconfig"
 	"github.com/coder/coder/v2/coderd/telemetry"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/enidpsync"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -267,6 +272,51 @@ func TestTelemetry(t *testing.T) {
 		for _, c := range cases {
 			require.Equal(t, c.want, telemetry.GetModuleSourceType(c.source))
 		}
+	})
+	t.Run("IDPOrgSync", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		db, _ := dbtestutil.NewDB(t)
+
+		// 1. No org sync settings
+		deployment, _ := collectSnapshot(t, db, nil)
+		require.False(t, deployment.IDPOrgSync)
+
+		// 2. Org sync settings set in server flags
+		deployment, _ = collectSnapshot(t, db, func(opts telemetry.Options) telemetry.Options {
+			opts.DeploymentConfig = &codersdk.DeploymentValues{
+				OIDC: codersdk.OIDCConfig{
+					OrganizationField: "organizations",
+				},
+			}
+			return opts
+		})
+		require.True(t, deployment.IDPOrgSync)
+
+		// 3. Org sync settings set in runtime config
+		entitled := entitlements.New()
+		entitled.Modify(func(entitlements *codersdk.Entitlements) {
+			entitlements.Features[codersdk.FeatureMultipleOrganizations] = codersdk.Feature{
+				Entitlement: codersdk.EntitlementEntitled,
+				Enabled:     true,
+				Limit:       nil,
+				Actual:      nil,
+			}
+		})
+		org, err := db.GetDefaultOrganization(ctx)
+		require.NoError(t, err)
+		sync := enidpsync.NewSync(testutil.Logger(t), runtimeconfig.NewManager(), entitled, idpsync.DeploymentSyncSettings{})
+		err = sync.UpdateOrganizationSettings(ctx, db, idpsync.OrganizationSyncSettings{
+			Field: "organizations",
+			Mapping: map[string][]uuid.UUID{
+				"first": {org.ID},
+			},
+			AssignDefault: true,
+		})
+		require.NoError(t, err)
+		require.True(t, sync.OrganizationSyncEnabled(ctx, db))
+		deployment, _ = collectSnapshot(t, db, nil)
+		require.True(t, deployment.IDPOrgSync)
 	})
 }
 

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -278,7 +278,7 @@ func TestTelemetry(t *testing.T) {
 
 		// 1. No org sync settings
 		deployment, _ := collectSnapshot(t, db, nil)
-		require.False(t, deployment.IDPOrgSync)
+		require.False(t, *deployment.IDPOrgSync)
 
 		// 2. Org sync settings set in server flags
 		deployment, _ = collectSnapshot(t, db, func(opts telemetry.Options) telemetry.Options {
@@ -289,7 +289,7 @@ func TestTelemetry(t *testing.T) {
 			}
 			return opts
 		})
-		require.True(t, deployment.IDPOrgSync)
+		require.True(t, *deployment.IDPOrgSync)
 
 		// 3. Org sync settings set in runtime config
 		org, err := db.GetDefaultOrganization(ctx)
@@ -304,7 +304,7 @@ func TestTelemetry(t *testing.T) {
 		})
 		require.NoError(t, err)
 		deployment, _ = collectSnapshot(t, db, nil)
-		require.True(t, deployment.IDPOrgSync)
+		require.True(t, *deployment.IDPOrgSync)
 	})
 }
 

--- a/enterprise/coderd/enidpsync/organizations.go
+++ b/enterprise/coderd/enidpsync/organizations.go
@@ -19,6 +19,8 @@ func (e EnterpriseIDPSync) OrganizationSyncEnabled(ctx context.Context, db datab
 		return false
 	}
 
+	// If this logic is ever updated, make sure to update the corresponding
+	// checkIDPOrgSync in coderd/telemetry/telemetry.go.
 	settings, err := e.OrganizationSyncSettings(ctx, db)
 	if err == nil && settings.Field != "" {
 		return true


### PR DESCRIPTION
Addresses https://github.com/coder/internal/issues/317.

## Changes

Requirements are quoted below:

> how many orgs does deployment have

Adds the Organization entity to telemetry.

> ensuring resources are associated with orgs

All resources that reference an org already report the org id to telemetry. Adds a test to check that.

> whether org sync is configured

Adds the `IDPOrgSync` boolean field to the Deployment entity.

## Implementation of the org sync check

While there's an `OrganizationSyncEnabled` method on the IDPSync interface, I decided not to use it directly and implemented a counterpart just for telemetry purposes. It's a compromise I'm not happy about, but I found that it's a simpler approach than the alternative. There are multiple reasons:

1. The telemetry package cannot statically access the IDPSync interface due to a circular import. 
2. We can't dynamically pass a reference to the `OrganizationSyncEnabled` function at the time of instantiating the telemetry object, because our server initialization logic depends on the telemetry object being created before the IDPSync object.
3. If we circumvent that problem by passing the reference as an initially empty pointer, initializing telemetry, then IDPSync, then updating the pointer to point to `OrganizationSyncEnabled`, we have to refactor the initialization logic of the telemetry object itself to avoid a race condition where the first telemetry report is performed without a valid reference.

I actually implemented that approach in https://github.com/coder/coder/pull/16307, but realized I'm unable to fully test it. It changed the initialization order in the server command, and I wanted to test our CLI with Org Sync configured with a premium license. As far as I'm aware, we don't have the tooling to do that. I couldn't figure out a way to start the CLI with a mock license, and I didn't want to go down further into the refactoring rabbit hole.

So I decided that reimplementing the org sync checking logic is simpler.