### PR TITLE
chore(agent/agentscripts): log command cancellation

### DIFF
--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -290,7 +290,7 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 	cmd = cmdPty.AsExec()
 	cmd.SysProcAttr = cmdSysProcAttr()
 	cmd.WaitDelay = 10 * time.Second
-	cmd.Cancel = cmdCancel(cmd)
+	cmd.Cancel = cmdCancel(ctx, logger, cmd)
 
 	// Expose env vars that can be used in the script for storing data
 	// and binaries. In the future, we may want to expose more env vars

--- a/agent/agentscripts/agentscripts_other.go
+++ b/agent/agentscripts/agentscripts_other.go
@@ -18,7 +18,7 @@ func cmdSysProcAttr() *syscall.SysProcAttr {
 
 func cmdCancel(ctx context.Context, logger slog.Logger, cmd *exec.Cmd) func() error {
 	return func() error {
-		logger.Debug(ctx, "cmdCancel: sending SIGHUP to process", slog.F("pid", -cmd.Process.Pid))
+		logger.Debug(ctx, "cmdCancel: sending SIGHUP to process and children", slog.F("pid", cmd.Process.Pid))
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGHUP)
 	}
 }

--- a/agent/agentscripts/agentscripts_other.go
+++ b/agent/agentscripts/agentscripts_other.go
@@ -3,8 +3,11 @@
 package agentscripts
 
 import (
+	"context"
 	"os/exec"
 	"syscall"
+
+	"cdr.dev/slog"
 )
 
 func cmdSysProcAttr() *syscall.SysProcAttr {
@@ -13,8 +16,9 @@ func cmdSysProcAttr() *syscall.SysProcAttr {
 	}
 }
 
-func cmdCancel(cmd *exec.Cmd) func() error {
+func cmdCancel(ctx context.Context, logger slog.Logger, cmd *exec.Cmd) func() error {
 	return func() error {
+		logger.Debug(ctx, "cmdCancel: sending SIGHUP to process", slog.F("pid", -cmd.Process.Pid))
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGHUP)
 	}
 }

--- a/agent/agentscripts/agentscripts_windows.go
+++ b/agent/agentscripts/agentscripts_windows.go
@@ -1,17 +1,21 @@
 package agentscripts
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"syscall"
+
+	"cdr.dev/slog"
 )
 
 func cmdSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{}
 }
 
-func cmdCancel(cmd *exec.Cmd) func() error {
+func cmdCancel(ctx context.Context, logger slog.Logger, cmd *exec.Cmd) func() error {
 	return func() error {
+		logger.Debug(ctx, "cmdCancel: sending interrupt to process", slog.F("pid", cmd.Process.Pid))
 		return cmd.Process.Signal(os.Interrupt)
 	}
 }


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/329

It's currently unclear where the SIGHUP came from; adding some logging to make it more clear if it happens again in future.