### PR TITLE
chore(provisioner/terraform): make testdata generate.sh parallel

### DIFF
--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -3,37 +3,73 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-for d in */; do
-	pushd "$d"
+generate() {
+	local name="$1"
+
+	echo "=== BEGIN: $name"
+	terraform init -upgrade &&
+		terraform plan -out terraform.tfplan &&
+		terraform show -json ./terraform.tfplan | jq >"$name".tfplan.json &&
+		terraform graph -type=plan >"$name".tfplan.dot &&
+		rm terraform.tfplan &&
+		terraform apply -auto-approve &&
+		terraform show -json ./terraform.tfstate | jq >"$name".tfstate.json &&
+		rm terraform.tfstate &&
+		terraform graph -type=plan >"$name".tfstate.dot
+	ret=$?
+	echo "=== END: $name"
+	if [[ $ret -ne 0 ]]; then
+		return $ret
+	fi
+}
+
+run() {
+	d="$1"
+	cd "$d"
 	name=$(basename "$(pwd)")
 
 	# This needs care to update correctly.
 	if [[ $name == "kubernetes-metadata" ]]; then
-		popd
-		continue
+		echo "== Skipping: $name"
+		return 0
 	fi
 
 	# This directory is used for a different purpose (quick workaround).
 	if [[ $name == "cleanup-stale-plugins" ]]; then
-		popd
-		continue
+		echo "== Skipping: $name"
+		return 0
 	fi
 
 	if [[ $name == "timings-aggregation" ]]; then
-		popd
-		continue
+		echo "== Skipping: $name"
+		return 0
 	fi
 
-	terraform init -upgrade
-	terraform plan -out terraform.tfplan
-	terraform show -json ./terraform.tfplan | jq >"$name".tfplan.json
-	terraform graph -type=plan >"$name".tfplan.dot
-	rm terraform.tfplan
-	terraform apply -auto-approve
-	terraform show -json ./terraform.tfstate | jq >"$name".tfstate.json
-	rm terraform.tfstate
-	terraform graph -type=plan >"$name".tfstate.dot
-	popd
+	echo "== Generating test data for: $name"
+	if ! out="$(generate "$name" 2>&1)"; then
+		echo "$out"
+		echo "== Error generating test data for: $name"
+		return 1
+	fi
+	echo "== Done generating test data for: $name"
+	exit 0
+}
+
+declare -a jobs=()
+for d in */; do
+	run "$d" &
+	jobs+=($!)
 done
+
+err=0
+for job in "${jobs[@]}"; do
+	if ! wait "$job"; then
+		err=$((err + 1))
+	fi
+done
+if [[ $err -ne 0 ]]; then
+	echo "ERROR: Failed to generate test data for $err modules"
+	exit 1
+fi
 
 terraform version -json | jq -r '.terraform_version' >version.txt


### PR DESCRIPTION
I got tired of waiting for this script to complete and being filled with scary output, so I made it parallel and hide output on the happy path:

Before:

```
# Lots and lots of output, not sure what's going on...
./provisioner/terraform/testdata/generate.sh  45.85s user 11.82s system 141% cpu 40.680 total
```

After:

```
❯ time ./provisioner/terraform/testdata/generate.sh
== Generating test data for: chaining-resources
== Skipping: cleanup-stale-plugins
== Generating test data for: calling-module
== Generating test data for: display-apps
== Generating test data for: conflicting-resources
== Generating test data for: display-apps-disabled
== Skipping: kubernetes-metadata
== Generating test data for: git-auth-providers
== Generating test data for: instance-id
== Generating test data for: external-auth-providers
== Generating test data for: mapped-apps
== Generating test data for: multiple-agents-multiple-apps
== Generating test data for: multiple-agents-multiple-envs
== Generating test data for: multiple-agents-multiple-scripts
== Generating test data for: multiple-apps
== Generating test data for: multiple-agents
== Generating test data for: resource-metadata-duplicate
== Generating test data for: resource-metadata
== Generating test data for: rich-parameters
== Generating test data for: rich-parameters-order
== Skipping: timings-aggregation
== Generating test data for: rich-parameters-validation
== Done generating test data for: display-apps-disabled
== Done generating test data for: external-auth-providers
== Done generating test data for: resource-metadata-duplicate
== Done generating test data for: mapped-apps
== Done generating test data for: display-apps
== Done generating test data for: instance-id
== Done generating test data for: multiple-agents-multiple-scripts
== Done generating test data for: git-auth-providers
== Done generating test data for: conflicting-resources
== Done generating test data for: multiple-apps
== Done generating test data for: rich-parameters-order
== Done generating test data for: resource-metadata
== Done generating test data for: chaining-resources
== Done generating test data for: multiple-agents
== Done generating test data for: multiple-agents-multiple-apps
== Done generating test data for: multiple-agents-multiple-envs
== Done generating test data for: calling-module
== Done generating test data for: rich-parameters-validation
== Done generating test data for: rich-parameters
./provisioner/terraform/testdata/generate.sh  35.37s user 10.56s system 2087% cpu 2.200 total
```

Unhappy path:

```
❯ time ./provisioner/terraform/testdata/generate.sh
== Generating test data for: calling-module
== Generating test data for: conflicting-resources
== Skipping: cleanup-stale-plugins
== Generating test data for: chaining-resources
== Generating test data for: display-apps
== Generating test data for: display-apps-disabled
== Generating test data for: external-auth-providers
== Generating test data for: mapped-apps
== Skipping: kubernetes-metadata
== Generating test data for: git-auth-providers
== Generating test data for: instance-id
== Generating test data for: multiple-agents-multiple-apps
== Generating test data for: multiple-agents-multiple-envs
== Generating test data for: multiple-agents-multiple-scripts
== Generating test data for: multiple-apps
== Generating test data for: multiple-agents
== Generating test data for: resource-metadata-assignment
== Generating test data for: resource-metadata
== Generating test data for: resource-metadata-duplicate
== Generating test data for: rich-parameters-order
== Skipping: timings-aggregation
== Generating test data for: rich-parameters-validation
== Generating test data for: rich-parameters
=== BEGIN: resource-metadata-assignment
Terraform initialized in an empty directory!

The directory has no Terraform configuration files. You may begin working
with Terraform immediately by creating Terraform configuration files.
╷
│ Error: No configuration files
│
│ Plan requires configuration to be present. Planning without a configuration
│ would mark everything for destruction, which is normally not what is
│ desired. If you would like to destroy everything, run plan with the
│ -destroy option. Otherwise, create a Terraform configuration file (.tf
│ file) and try again.
╵
=== END: resource-metadata-assignment
== Error generating test data for: resource-metadata-assignment
== Done generating test data for: display-apps-disabled
== Done generating test data for: multiple-agents-multiple-apps
== Done generating test data for: instance-id
== Done generating test data for: external-auth-providers
== Done generating test data for: multiple-apps
== Done generating test data for: rich-parameters-order
== Done generating test data for: resource-metadata
== Done generating test data for: display-apps
== Done generating test data for: conflicting-resources
== Done generating test data for: git-auth-providers
== Done generating test data for: multiple-agents
== Done generating test data for: multiple-agents-multiple-scripts
== Done generating test data for: multiple-agents-multiple-envs
== Done generating test data for: mapped-apps
== Done generating test data for: resource-metadata-duplicate
== Done generating test data for: chaining-resources
== Done generating test data for: calling-module
== Done generating test data for: rich-parameters-validation
== Done generating test data for: rich-parameters
ERROR: Failed to generate test data for 1 modules
./provisioner/terraform/testdata/generate.sh  35.37s user 10.54s system 2091% cpu 2.195 total
```
