### PR TITLE
test: fix use of t.Logf where t.Log would suffice

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1962,7 +1962,7 @@ func TestAgent_UpdatedDERP(t *testing.T) {
 	// Push a new DERP map to the agent.
 	err := client.PushDERPMapUpdate(newDerpMap)
 	require.NoError(t, err)
-	t.Logf("pushed DERPMap update to agent")
+	t.Log("pushed DERPMap update to agent")
 
 	require.Eventually(t, func() bool {
 		conn := uut.TailnetConn()
@@ -1974,7 +1974,7 @@ func TestAgent_UpdatedDERP(t *testing.T) {
 		t.Logf("agent Conn DERPMap with regionIDs %v, PreferredDERP %d", regionIDs, preferredDERP)
 		return len(regionIDs) == 1 && regionIDs[0] == 2 && preferredDERP == 2
 	}, testutil.WaitLong, testutil.IntervalFast)
-	t.Logf("agent got the new DERPMap")
+	t.Log("agent got the new DERPMap")
 
 	// Connect from a second client and make sure it uses the new DERP map.
 	conn2 := newClientConn(newDerpMap, "client2")

--- a/cli/clilog/clilog_test.go
+++ b/cli/clilog/clilog_test.go
@@ -181,7 +181,7 @@ func assertLogs(t testing.TB, path string, expected ...string) {
 
 	logs := strings.Split(strings.TrimSpace(string(data)), "\n")
 	if !assert.Len(t, logs, len(expected)) {
-		t.Logf(string(data))
+		t.Log(string(data))
 		t.FailNow()
 	}
 	for i, log := range logs {
@@ -202,7 +202,7 @@ func assertLogsJSON(t testing.TB, path string, levelExpected ...string) {
 
 	logs := strings.Split(strings.TrimSpace(string(data)), "\n")
 	if !assert.Len(t, logs, len(levelExpected)/2) {
-		t.Logf(string(data))
+		t.Log(string(data))
 		t.FailNow()
 	}
 	for i, log := range logs {

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -66,7 +66,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 
 	defer func() {
 		if t.Failed() {
-			t.Logf("Test failed, printing rows...")
+			t.Log("Test failed, printing rows...")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			buf := &bytes.Buffer{}
 			enc := json.NewEncoder(buf)

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -283,9 +283,9 @@ func TestMigrateUpWithFixtures(t *testing.T) {
 			}
 		}
 		if len(emptyTables) > 0 {
-			t.Logf("The following tables have zero rows, consider adding fixtures for them or create a full database dump:")
+			t.Log("The following tables have zero rows, consider adding fixtures for them or create a full database dump:")
 			t.Errorf("tables have zero rows: %v", emptyTables)
-			t.Logf("See https://github.com/coder/coder/blob/main/docs/CONTRIBUTING.md#database-fixtures-for-testing-migrations for more information")
+			t.Log("See https://github.com/coder/coder/blob/main/docs/CONTRIBUTING.md#database-fixtures-for-testing-migrations for more information")
 		}
 	})
 

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -388,7 +388,7 @@ func TestBackpressure(t *testing.T) {
 			}, testutil.WaitShort, testutil.IntervalFast)
 		}
 	}
-	t.Logf("done advancing")
+	t.Log("done advancing")
 	// The batch completes
 	w.MustWait(ctx)
 

--- a/coderd/provisionerdserver/acquirer_test.go
+++ b/coderd/provisionerdserver/acquirer_test.go
@@ -547,8 +547,8 @@ func TestAcquirer_MatchTags(t *testing.T) {
 			s := fmt.Sprintf("| %s | %s | %s | %s |", kvs(tt.acquireJobTags), kvs(tt.provisionerJobTags), sameOrg, acquire)
 			lines = append(lines, s)
 		}
-		t.Logf("You can paste this into docs/admin/provisioners.md")
-		t.Logf(strings.Join(lines, "\n"))
+		t.Log("You can paste this into docs/admin/provisioners.md")
+		t.Log(strings.Join(lines, "\n"))
 	})
 }
 

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -101,7 +101,7 @@ func TestHeartbeat(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitShort)
 	heartbeatChan := make(chan struct{})
 	heartbeatFn := func(hbCtx context.Context) error {
-		t.Logf("heartbeat")
+		t.Log("heartbeat")
 		select {
 		case <-hbCtx.Done():
 			return hbCtx.Err()

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -53,7 +53,7 @@ func TestBatchStats(t *testing.T) {
 	tick <- t1
 	f := <-flushed
 	require.Equal(t, 0, f, "expected no data to be flushed")
-	t.Logf("flush 1 completed")
+	t.Log("flush 1 completed")
 
 	// Then: it should report no stats.
 	stats, err := store.GetWorkspaceAgentStats(ctx, t1)
@@ -62,7 +62,7 @@ func TestBatchStats(t *testing.T) {
 
 	// Given: a single data point is added for workspace
 	t2 := t1.Add(time.Second)
-	t.Logf("inserting 1 stat")
+	t.Log("inserting 1 stat")
 	b.Add(t2.Add(time.Millisecond), deps1.Agent.ID, deps1.User.ID, deps1.Template.ID, deps1.Workspace.ID, randStats(t), false)
 
 	// When: it becomes time to report stats
@@ -70,7 +70,7 @@ func TestBatchStats(t *testing.T) {
 	tick <- t2
 	f = <-flushed // Wait for a flush to complete.
 	require.Equal(t, 1, f, "expected one stat to be flushed")
-	t.Logf("flush 2 completed")
+	t.Log("flush 2 completed")
 
 	// Then: it should report a single stat.
 	stats, err = store.GetWorkspaceAgentStats(ctx, t2)
@@ -97,7 +97,7 @@ func TestBatchStats(t *testing.T) {
 	// When: the buffer comes close to capacity
 	// Then: The buffer will force-flush once.
 	f = <-flushed
-	t.Logf("flush 3 completed")
+	t.Log("flush 3 completed")
 	require.Greater(t, f, 819, "expected at least 819 stats to be flushed (>=80% of buffer)")
 	// And we should finish inserting the stats
 	<-done
@@ -110,7 +110,7 @@ func TestBatchStats(t *testing.T) {
 	t4 := t3.Add(time.Second)
 	tick <- t4
 	f2 := <-flushed
-	t.Logf("flush 4 completed")
+	t.Log("flush 4 completed")
 	expectedCount := defaultBufferSize - f
 	require.Equal(t, expectedCount, f2, "did not flush expected remaining rows")
 
@@ -119,7 +119,7 @@ func TestBatchStats(t *testing.T) {
 	tick <- t5
 	f = <-flushed
 	require.Zero(t, f, "expected zero stats to have been flushed")
-	t.Logf("flush 5 completed")
+	t.Log("flush 5 completed")
 
 	stats, err = store.GetWorkspaceAgentStats(ctx, t5)
 	require.NoError(t, err, "should not error getting stats")

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -309,8 +309,8 @@ func TestDeploymentValues_DurationFormatNanoseconds(t *testing.T) {
 			continue
 		}
 		t.Logf("Option %q is a duration but does not have the format_duration annotation.", s.Name)
-		t.Logf("To fix this, add the following to the option declaration:")
-		t.Logf(`Annotations: serpent.Annotations{}.Mark(annotationFormatDurationNS, "true"),`)
+		t.Log("To fix this, add the following to the option declaration:")
+		t.Log(`Annotations: serpent.Annotations{}.Mark(annotationFormatDurationNS, "true"),`)
 		t.FailNow()
 	}
 }

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -44,7 +44,7 @@ func TestServerDBCrypt(t *testing.T) {
 	db := database.New(sqlDB)
 
 	// Populate the database with some unencrypted data.
-	t.Logf("Generating unencrypted data")
+	t.Log("Generating unencrypted data")
 	users := genData(t, db)
 
 	// Setup an initial cipher A
@@ -57,7 +57,7 @@ func TestServerDBCrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	// Populate the database with some encrypted data using cipher A.
-	t.Logf("Generating data encrypted with cipher A")
+	t.Log("Generating data encrypted with cipher A")
 	newUsers := genData(t, cryptdb)
 
 	// Validate that newly created users were encrypted with cipher A
@@ -67,7 +67,7 @@ func TestServerDBCrypt(t *testing.T) {
 	users = append(users, newUsers...)
 
 	// Encrypt all the data with the initial cipher.
-	t.Logf("Encrypting all data with cipher A")
+	t.Log("Encrypting all data with cipher A")
 	inv, _ := newCLI(t, "server", "dbcrypt", "rotate",
 		"--postgres-url", connectionURL,
 		"--new-key", base64.StdEncoding.EncodeToString([]byte(keyA)),
@@ -89,7 +89,7 @@ func TestServerDBCrypt(t *testing.T) {
 	cipherBA, err := dbcrypt.NewCiphers([]byte(keyB), []byte(keyA))
 	require.NoError(t, err)
 
-	t.Logf("Enrypting all data with cipher B")
+	t.Log("Enrypting all data with cipher B")
 	inv, _ = newCLI(t, "server", "dbcrypt", "rotate",
 		"--postgres-url", connectionURL,
 		"--new-key", base64.StdEncoding.EncodeToString([]byte(keyB)),
@@ -108,7 +108,7 @@ func TestServerDBCrypt(t *testing.T) {
 	}
 
 	// Assert that we can revoke the old key.
-	t.Logf("Revoking cipher A")
+	t.Log("Revoking cipher A")
 	err = db.RevokeDBCryptKey(ctx, cipherA[0].HexDigest())
 	require.NoError(t, err, "failed to revoke old key")
 
@@ -124,7 +124,7 @@ func TestServerDBCrypt(t *testing.T) {
 	require.Empty(t, oldKey.ActiveKeyDigest.String, "expected the old key to not be active")
 
 	// Revoking the new key should fail.
-	t.Logf("Attempting to revoke cipher B should fail as it is still in use")
+	t.Log("Attempting to revoke cipher B should fail as it is still in use")
 	err = db.RevokeDBCryptKey(ctx, cipherBA[0].HexDigest())
 	require.Error(t, err, "expected to fail to revoke the new key")
 	var pgErr *pq.Error
@@ -132,7 +132,7 @@ func TestServerDBCrypt(t *testing.T) {
 	require.EqualValues(t, "23503", pgErr.Code, "expected a foreign key constraint violation error")
 
 	// Decrypt the data using only cipher B. This should result in the key being revoked.
-	t.Logf("Decrypting with cipher B")
+	t.Log("Decrypting with cipher B")
 	inv, _ = newCLI(t, "server", "dbcrypt", "decrypt",
 		"--postgres-url", connectionURL,
 		"--keys", base64.StdEncoding.EncodeToString([]byte(keyB)),
@@ -162,7 +162,7 @@ func TestServerDBCrypt(t *testing.T) {
 	cipherC, err := dbcrypt.NewCiphers([]byte(keyC))
 	require.NoError(t, err)
 
-	t.Logf("Re-encrypting with cipher C")
+	t.Log("Re-encrypting with cipher C")
 	inv, _ = newCLI(t, "server", "dbcrypt", "rotate",
 		"--postgres-url", connectionURL,
 		"--new-key", base64.StdEncoding.EncodeToString([]byte(keyC)),
@@ -181,7 +181,7 @@ func TestServerDBCrypt(t *testing.T) {
 	}
 
 	// Now delete all the encrypted data.
-	t.Logf("Deleting all encrypted data")
+	t.Log("Deleting all encrypted data")
 	inv, _ = newCLI(t, "server", "dbcrypt", "delete",
 		"--postgres-url", connectionURL,
 		"--external-token-encryption-keys", base64.StdEncoding.EncodeToString([]byte(keyC)),

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -2018,7 +2018,7 @@ func TestMultipleOrganizationTemplates(t *testing.T) {
 	t.Logf("Second organization: %s", second.ID.String())
 	t.Logf("Third organization: %s", third.ID.String())
 
-	t.Logf("Creating template version in second organization")
+	t.Log("Creating template version in second organization")
 
 	start := time.Now()
 	version := coderdtest.CreateTemplateVersion(t, templateAdmin, second.ID, nil)

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -462,33 +462,33 @@ func TestPGCoordinatorDual_Mainline(t *testing.T) {
 	defer client22.Close(ctx)
 	t.Logf("client22=%s", client22.ID)
 
-	t.Logf("client11 -> Node 11")
+	t.Log("client11 -> Node 11")
 	client11.UpdateDERP(11)
 	agent1.AssertEventuallyHasDERP(client11.ID, 11)
 
-	t.Logf("client21 -> Node 21")
+	t.Log("client21 -> Node 21")
 	client21.UpdateDERP(21)
 	agent1.AssertEventuallyHasDERP(client21.ID, 21)
 
-	t.Logf("client22 -> Node 22")
+	t.Log("client22 -> Node 22")
 	client22.UpdateDERP(22)
 	agent2.AssertEventuallyHasDERP(client22.ID, 22)
 
-	t.Logf("agent2 -> Node 2")
+	t.Log("agent2 -> Node 2")
 	agent2.UpdateDERP(2)
 	client22.AssertEventuallyHasDERP(agent2.ID, 2)
 	client12.AssertEventuallyHasDERP(agent2.ID, 2)
 
-	t.Logf("client12 -> Node 12")
+	t.Log("client12 -> Node 12")
 	client12.UpdateDERP(12)
 	agent2.AssertEventuallyHasDERP(client12.ID, 12)
 
-	t.Logf("agent1 -> Node 1")
+	t.Log("agent1 -> Node 1")
 	agent1.UpdateDERP(1)
 	client21.AssertEventuallyHasDERP(agent1.ID, 1)
 	client11.AssertEventuallyHasDERP(agent1.ID, 1)
 
-	t.Logf("close coord2")
+	t.Log("close coord2")
 	err = coord2.Close()
 	require.NoError(t, err)
 

--- a/provisioner/terraform/internal/timings_test_utils.go
+++ b/provisioner/terraform/internal/timings_test_utils.go
@@ -40,7 +40,7 @@ func TimingsAreEqual(t *testing.T, expected []*proto.Timing, actual []*proto.Tim
 
 	// Shortcut check.
 	if len(expected)+len(actual) == 0 {
-		t.Logf("both timings are empty")
+		t.Log("both timings are empty")
 		return true
 	}
 

--- a/provisioner/terraform/timings_test.go
+++ b/provisioner/terraform/timings_test.go
@@ -28,7 +28,7 @@ func TestTimingsFromProvision(t *testing.T) {
 	// Given: a fake terraform bin that behaves as we expect it to.
 	fakeBin := filepath.Join(cwd, "testdata", "timings-aggregation/fake-terraform.sh")
 
-	t.Logf(fakeBin)
+	t.Log(fakeBin)
 
 	ctx, api := setupProvisioner(t, &provisionerServeOptions{
 		binaryPath: fakeBin,

--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -592,7 +592,7 @@ func ExecBackground(t *testing.T, processName string, netNS *os.File, name strin
 		select {
 		case err := <-waitErr:
 			if err != nil {
-				t.Logf("subprocess exited: " + err.Error())
+				t.Log("subprocess exited: " + err.Error())
 			}
 			return
 		default:


### PR DESCRIPTION
My editor keeps correcting these (incorrectly) to:

```diff
-	t.Logf(fakeBin)
+	t.Log("%s", fakeBin)
```

So I went ahead and fixed all instances of t.Logf that should really be t.Log.
