### PR TITLE
fix: conform to stricter printf usage in Go 1.24

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -977,7 +977,7 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 		isErr := strings.Contains(errorMessage, agentssh.BlockedFileTransferErrorMessage) ||
 			strings.Contains(errorMessage, "EOF") ||
 			strings.Contains(errorMessage, "Process exited with status 65")
-		require.True(t, isErr, fmt.Sprintf("Message: "+errorMessage))
+		require.True(t, isErr, "Message: "+errorMessage)
 	}
 
 	t.Run("SFTP", func(t *testing.T) {

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -91,7 +91,7 @@ func (r *RootCmd) gitssh() *serpent.Command {
 				if xerrors.As(err, &exitErr) && exitErr.ExitCode() == 255 {
 					_, _ = fmt.Fprintln(inv.Stderr,
 						"\n"+pretty.Sprintf(
-							cliui.DefaultStyles.Wrap,
+							cliui.DefaultStyles.Wrap, "%s",
 							"Coder authenticates with "+pretty.Sprint(cliui.DefaultStyles.Field, "git")+
 								" using the public key below. All clones with SSH are authenticated automatically 🪄.")+"\n",
 					)

--- a/cli/login.go
+++ b/cli/login.go
@@ -209,7 +209,7 @@ func (r *RootCmd) login() *serpent.Command {
 
 			// nolint: nestif
 			if !hasFirstUser {
-				_, _ = fmt.Fprintf(inv.Stdout, Caret+"Your Coder deployment hasn't been set up!\n")
+				_, _ = fmt.Fprint(inv.Stdout, Caret+"Your Coder deployment hasn't been set up!\n")
 
 				if username == "" {
 					if !isTTYIn(inv) {

--- a/cli/logout.go
+++ b/cli/logout.go
@@ -68,7 +68,7 @@ func (r *RootCmd) logout() *serpent.Command {
 				errorString := strings.TrimRight(errorStringBuilder.String(), "\n")
 				return xerrors.New("Failed to log out.\n" + errorString)
 			}
-			_, _ = fmt.Fprintf(inv.Stdout, Caret+"You are no longer logged in. You can log in using 'coder login <url>'.\n")
+			_, _ = fmt.Fprint(inv.Stdout, Caret+"You are no longer logged in. You can log in using 'coder login <url>'.\n")
 			return nil
 		},
 	}

--- a/cli/publickey.go
+++ b/cli/publickey.go
@@ -45,14 +45,14 @@ func (r *RootCmd) publickey() *serpent.Command {
 				return xerrors.Errorf("create codersdk client: %w", err)
 			}
 
-			cliui.Infof(inv.Stdout,
+			cliui.Info(inv.Stdout,
 				"This is your public key for using "+pretty.Sprint(cliui.DefaultStyles.Field, "git")+" in "+
 					"Coder. All clones with SSH will be authenticated automatically 🪄.",
 			)
-			cliui.Infof(inv.Stdout, pretty.Sprint(cliui.DefaultStyles.Code, strings.TrimSpace(key.PublicKey))+"\n")
-			cliui.Infof(inv.Stdout, "Add to GitHub and GitLab:")
-			cliui.Infof(inv.Stdout, "> https://github.com/settings/ssh/new")
-			cliui.Infof(inv.Stdout, "> https://gitlab.com/-/profile/keys")
+			cliui.Info(inv.Stdout, pretty.Sprint(cliui.DefaultStyles.Code, strings.TrimSpace(key.PublicKey))+"\n")
+			cliui.Info(inv.Stdout, "Add to GitHub and GitLab:")
+			cliui.Info(inv.Stdout, "> https://github.com/settings/ssh/new")
+			cliui.Info(inv.Stdout, "> https://gitlab.com/-/profile/keys")
 
 			return nil
 		},

--- a/cli/server.go
+++ b/cli/server.go
@@ -513,7 +513,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			}
 
 			accessURL := vals.AccessURL.String()
-			cliui.Infof(inv.Stdout, lipgloss.NewStyle().
+			cliui.Info(inv.Stdout, lipgloss.NewStyle().
 				Border(lipgloss.DoubleBorder()).
 				Align(lipgloss.Center).
 				Padding(0, 3).

--- a/cli/templateversionarchive.go
+++ b/cli/templateversionarchive.go
@@ -76,7 +76,7 @@ func (r *RootCmd) setArchiveTemplateVersion(archive bool) *serpent.Command {
 			for _, version := range versions {
 				if version.Archived == archive {
 					_, _ = fmt.Fprintln(
-						inv.Stdout, fmt.Sprintf("Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" already "+pastVerb),
+						inv.Stdout, "Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" already "+pastVerb,
 					)
 					continue
 				}
@@ -87,7 +87,7 @@ func (r *RootCmd) setArchiveTemplateVersion(archive bool) *serpent.Command {
 				}
 
 				_, _ = fmt.Fprintln(
-					inv.Stdout, fmt.Sprintf("Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" "+pastVerb+" at "+cliui.Timestamp(time.Now())),
+					inv.Stdout, "Version "+pretty.Sprint(cliui.DefaultStyles.Keyword, version.Name)+" "+pastVerb+" at "+cliui.Timestamp(time.Now()),
 				)
 			}
 			return nil

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -100,9 +100,9 @@ func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyRepo
 	for _, err := range errs {
 		switch r.Severity {
 		case health.SeverityWarning, health.SeverityOK:
-			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProxyUnhealthy, err))
+			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProxyUnhealthy, "%s", err))
 		case health.SeverityError:
-			r.appendError(*health.Errorf(health.CodeProxyUnhealthy, err))
+			r.appendError(*health.Errorf(health.CodeProxyUnhealthy, "%s", err))
 		}
 	}
 }

--- a/coderd/httpapi/httpapi_test.go
+++ b/coderd/httpapi/httpapi_test.go
@@ -143,7 +143,7 @@ func TestWebsocketCloseMsg(t *testing.T) {
 		t.Parallel()
 
 		msg := strings.Repeat("d", 255)
-		trunc := httpapi.WebsocketCloseSprintf(msg)
+		trunc := httpapi.WebsocketCloseSprintf("%s", msg)
 		assert.Equal(t, len(trunc), 123)
 	})
 
@@ -151,7 +151,7 @@ func TestWebsocketCloseMsg(t *testing.T) {
 		t.Parallel()
 
 		msg := strings.Repeat("こんにちは", 10)
-		trunc := httpapi.WebsocketCloseSprintf(msg)
+		trunc := httpapi.WebsocketCloseSprintf("%s", msg)
 		assert.Equal(t, len(trunc), 123)
 	})
 }

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -205,7 +205,7 @@ func (r *RootCmd) proxyServer() *serpent.Command {
 			httpClient.Transport = headerTransport
 
 			accessURL := cfg.AccessURL.String()
-			cliui.Infof(inv.Stdout, lipgloss.NewStyle().
+			cliui.Info(inv.Stdout, lipgloss.NewStyle().
 				Border(lipgloss.DoubleBorder()).
 				Align(lipgloss.Center).
 				Padding(0, 3).

--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -78,7 +78,7 @@ func (s *server) Plan(
 
 	e := s.executor(sess.WorkDirectory, database.ProvisionerJobTimingStagePlan)
 	if err := e.checkMinVersion(ctx); err != nil {
-		return provisionersdk.PlanErrorf(err.Error())
+		return provisionersdk.PlanErrorf("%s", err.Error())
 	}
 	logTerraformEnvVars(sess)
 
@@ -113,7 +113,6 @@ func (s *server) Plan(
 	initTimings.ingest(createInitTimingsEvent(timingInitStart))
 
 	err = e.init(ctx, killCtx, sess)
-
 	if err != nil {
 		initTimings.ingest(createInitTimingsEvent(timingInitErrored))
 
@@ -168,7 +167,7 @@ func (s *server) Plan(
 		request.Metadata.GetWorkspaceTransition() == proto.WorkspaceTransition_DESTROY,
 	)
 	if err != nil {
-		return provisionersdk.PlanErrorf(err.Error())
+		return provisionersdk.PlanErrorf("%s", err.Error())
 	}
 
 	// Prepend init timings since they occur prior to plan timings.
@@ -189,7 +188,7 @@ func (s *server) Apply(
 
 	e := s.executor(sess.WorkDirectory, database.ProvisionerJobTimingStageApply)
 	if err := e.checkMinVersion(ctx); err != nil {
-		return provisionersdk.ApplyErrorf(err.Error())
+		return provisionersdk.ApplyErrorf("%s", err.Error())
 	}
 	logTerraformEnvVars(sess)
 

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -252,6 +252,7 @@ func (e *outExpecter) Peek(ctx context.Context, n int) []byte {
 	return slices.Clone(out)
 }
 
+//nolint:govet // We don't care about conforming to ReadRune() (rune, int, error).
 func (e *outExpecter) ReadRune(ctx context.Context) rune {
 	e.t.Helper()
 

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -71,7 +71,7 @@ func NewTunnel(
 		return nil, err
 	}
 	t := &Tunnel{
-		// nolint: govet // safe to copy the locks here because we haven't started the speaker
+		//nolint:govet // safe to copy the locks here because we haven't started the speaker
 		speaker:         *(s),
 		ctx:             ctx,
 		logger:          logger,


### PR DESCRIPTION
This are being auto-fixed by VS Code so I decided to fix them all:

With Go 1.24rc2:

```
❯ go vet ./...
# github.com/coder/coder/v2/pty/ptytest
# [github.com/coder/coder/v2/pty/ptytest]
pty/ptytest/ptytest.go:255:23: method ReadRune(ctx context.Context) rune should have signature ReadRune() (rune, int, error)
# github.com/coder/coder/v2/coderd/httpapi_test
# [github.com/coder/coder/v2/coderd/httpapi_test]
coderd/httpapi/httpapi_test.go:146:42: non-constant format string in call to github.com/coder/coder/v2/coderd/httpapi.WebsocketCloseSprintf
coderd/httpapi/httpapi_test.go:154:42: non-constant format string in call to github.com/coder/coder/v2/coderd/httpapi.WebsocketCloseSprintf
# github.com/coder/coder/v2/vpn
# [github.com/coder/coder/v2/vpn]
vpn/tunnel.go:75:20: literal copies lock value from *(s): github.com/coder/coder/v2/vpn.speaker[*github.com/coder/coder/v2/vpn.TunnelMessage, *github.com/coder/coder/v2/vpn.ManagerMessage, github.com/coder/coder/v2/vpn.ManagerMessage] contains sync.Mutex
# github.com/coder/coder/v2/provisioner/terraform
# [github.com/coder/coder/v2/provisioner/terraform]
provisioner/terraform/provision.go:81:36: non-constant format string in call to github.com/coder/coder/v2/provisionersdk.PlanErrorf
provisioner/terraform/provision.go:171:36: non-constant format string in call to github.com/coder/coder/v2/provisionersdk.PlanErrorf
provisioner/terraform/provision.go:192:37: non-constant format string in call to github.com/coder/coder/v2/provisionersdk.ApplyErrorf
# github.com/coder/coder/v2/coderd/healthcheck
# [github.com/coder/coder/v2/coderd/healthcheck]
coderd/healthcheck/workspaceproxy.go:103:79: non-constant format string in call to github.com/coder/coder/v2/coderd/healthcheck/health.Messagef
coderd/healthcheck/workspaceproxy.go:105:60: non-constant format string in call to github.com/coder/coder/v2/coderd/healthcheck/health.Errorf
# github.com/coder/coder/v2/agent_test
# [github.com/coder/coder/v2/agent_test]
agent/agent_test.go:980:38: non-constant format string in call to fmt.Sprintf
# github.com/coder/coder/v2/cli
# [github.com/coder/coder/v2/cli]
cli/gitssh.go:95:8: non-constant format string in call to github.com/coder/pretty.Sprintf
cli/login.go:212:36: non-constant format string in call to fmt.Fprintf
cli/logout.go:71:35: non-constant format string in call to fmt.Fprintf
cli/publickey.go:49:5: non-constant format string in call to github.com/coder/coder/v2/cli/cliui.Infof
cli/publickey.go:52:28: non-constant format string in call to github.com/coder/coder/v2/cli/cliui.Infof
cli/server.go:516:28: non-constant format string in call to github.com/coder/coder/v2/cli/cliui.Infof
cli/templateversionarchive.go:79:31: non-constant format string in call to fmt.Sprintf
cli/templateversionarchive.go:90:30: non-constant format string in call to fmt.Sprintf
# github.com/coder/coder/v2/enterprise/cli
# [github.com/coder/coder/v2/enterprise/cli]
enterprise/cli/proxyserver.go:208:28: non-constant format string in call to github.com/coder/coder/v2/cli/cliui.Infof
```

After:

```
# github.com/coder/coder/v2/pty/ptytest
# [github.com/coder/coder/v2/pty/ptytest]
pty/ptytest/ptytest.go:256:23: method ReadRune(ctx context.Context) rune should have signature ReadRune() (rune, int, error)
# github.com/coder/coder/v2/vpn
# [github.com/coder/coder/v2/vpn]
vpn/tunnel.go:75:20: literal copies lock value from *(s): github.com/coder/coder/v2/vpn.speaker[*github.com/coder/coder/v2/vpn.TunnelMessage, *github.com/coder/coder/v2/vpn.ManagerMessage, github.com/coder/coder/v2/vpn.ManagerMessage] contains sync.Mutex
```

These have `nolint`s but the `go vet` command doesn't care about them.