### PR TITLE
chore: add 'email' field to notifications

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -527,7 +527,7 @@ func (api *API) notifyWorkspaceUpdated(
 			"workspace":        map[string]any{"id": workspace.ID, "name": workspace.Name},
 			"template":         map[string]any{"id": template.ID, "name": template.Name},
 			"template_version": map[string]any{"id": version.ID, "name": version.Name},
-			"owner":            map[string]any{"id": owner.ID, "name": owner.Name},
+			"owner":            map[string]any{"id": owner.ID, "name": owner.Name, "email": owner.Email},
 			"parameters":       buildParameters,
 		},
 		"api-workspaces-updated",

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -648,7 +648,7 @@ func TestWorkspaceBuildWithUpdatedTemplateVersionSendsNotification(t *testing.T)
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: notify})
 		first := coderdtest.CreateFirstUser(t, client)
 		templateAdminClient, templateAdmin := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, rbac.RoleTemplateAdmin())
-		userClient, _ := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
+		userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
 
 		// Create a template with an initial version
 		version := coderdtest.CreateTemplateVersion(t, templateAdminClient, first.OrganizationID, nil)
@@ -684,6 +684,12 @@ func TestWorkspaceBuildWithUpdatedTemplateVersionSendsNotification(t *testing.T)
 		require.Contains(t, sent[0].Targets, workspace.ID)
 		require.Contains(t, sent[0].Targets, workspace.OrganizationID)
 		require.Contains(t, sent[0].Targets, workspace.OwnerID)
+
+		owner, ok := sent[0].Data["owner"].(map[string]any)
+		require.True(t, ok, "notification data should have owner")
+		require.Equal(t, user.ID, owner["id"])
+		require.Equal(t, user.Name, owner["name"])
+		require.Equal(t, user.Email, owner["email"])
 	})
 }
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -809,7 +809,7 @@ func (api *API) notifyWorkspaceCreated(
 			"workspace":        map[string]any{"id": workspace.ID, "name": workspace.Name},
 			"template":         map[string]any{"id": template.ID, "name": template.Name},
 			"template_version": map[string]any{"id": version.ID, "name": version.Name},
-			"owner":            map[string]any{"id": owner.ID, "name": owner.Name},
+			"owner":            map[string]any{"id": owner.ID, "name": owner.Name, "email": owner.Email},
 			"parameters":       buildParameters,
 		},
 		"api-workspaces-create",

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -639,6 +639,12 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 		require.Contains(t, sent[0].Targets, workspace.ID)
 		require.Contains(t, sent[0].Targets, workspace.OrganizationID)
 		require.Contains(t, sent[0].Targets, workspace.OwnerID)
+
+		owner, ok := sent[0].Data["owner"].(map[string]any)
+		require.True(t, ok, "notification data should have owner")
+		require.Equal(t, memberUser.ID, owner["id"])
+		require.Equal(t, memberUser.Name, owner["name"])
+		require.Equal(t, memberUser.Email, owner["email"])
 	})
 
 	t.Run("CreateWithAuditLogs", func(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/323

This PR adds an `email` field to the `data.owner` payload for workspace created and workspace manually updated notifications.