### PR TITLE
chore: add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -62,7 +62,6 @@ body:
       value: |
         - Host OS:
         - Coder version:
-    render: markdown
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -1,0 +1,79 @@
+name: "🐞 Bug"
+description: "File a bug report."
+title: "<title>"
+labels: ["needs-triage"]
+body:
+  - type: checkboxes
+    id: existing_issues
+    attributes:
+      label: "Is there an existing issue for this?"
+      description: "Please search to see if an issue already exists for the bug you encountered."
+      options:
+        - label: "I have searched the existing issues"
+          required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: "Current Behavior"
+      description: "A concise description of what you're experiencing."
+      placeholder: "Tell us what you see!"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Relevant Log Output"
+      description: "Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks."
+      render: shell
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected Behavior"
+      description: "A concise description of what you expected to happen."
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: "Steps to Reproduce"
+      description: "Provide step-by-step instructions to reproduce the issue."
+      placeholder: |
+        1. First step
+        2. Second step
+        3. Another step
+        4. Issue occurs
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      description: |
+        Provide details about your environment:
+        - **Host OS**: (e.g., Ubuntu 24.04, Debian 12)
+        - **Coder Version**: (e.g., v2.18.4)
+      placeholder: |
+        Run `coder version` to get Coder version
+      value: |
+        - Host OS:
+        - Coder version:
+    render: markdown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: additional_info
+    attributes:
+      label: "Additional Context"
+      description: "Select any applicable options:"
+      multiple: true
+      options:
+        - "The issue occurs consistently"
+        - "The issue is new (previously worked fine)"
+        - "The issue happens on multiple deployments"
+        - "I have tested this on the latest version"

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+contact_links:
+  - name: Features, Bug Reports, Questions?
+    url: https://github.com/coder/coder/discussions/new/choose
+    about: Our preferred starting point if you have any questions or suggestions about configuration, features or unexpected behavior.
+  - name: Coder Discord Community
+    url: https://discord.gg/coder
+    about: Connect with Coder commmunity, share feedback, and get interactive support.
+    

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,8 +1,11 @@
 contact_links:
-  - name: Features, Bug Reports, Questions?
+  - name: Questions, Suggestion or Feature requests?
     url: https://github.com/coder/coder/discussions/new/choose
     about: Our preferred starting point if you have any questions or suggestions about configuration, features or unexpected behavior.
+  - name: Coder Docs
+    url: https://coder.com/docs
+    about: Check our docs.
   - name: Coder Discord Community
     url: https://discord.gg/coder
-    about: Connect with Coder commmunity, share feedback, and get interactive support.
+    about: Get in touch with the FreeOrion developers and community for support.
     

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -8,4 +8,3 @@ contact_links:
   - name: Coder Discord Community
     url: https://discord.gg/coder
     about: Get in touch with the Coder developers and community for support.
-    

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -7,5 +7,5 @@ contact_links:
     about: Check our docs.
   - name: Coder Discord Community
     url: https://discord.gg/coder
-    about: Get in touch with the FreeOrion developers and community for support.
+    about: Get in touch with the Coder developers and community for support.
     

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,5 @@
 contact_links:
-  - name: Questions, Suggestion or Feature requests?
+  - name: Questions, suggestion or feature requests?
     url: https://github.com/coder/coder/discussions/new/choose
     about: Our preferred starting point if you have any questions or suggestions about configuration, features or unexpected behavior.
   - name: Coder Docs


### PR DESCRIPTION
Adds a GitHub issue template to make it easy to file bug reports.

You can test it here: https://github.com/matifali/test-github-issue-template/issues/new/choose
