### PR TITLE
ci: fix cla and dependabot notifications jobs

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -14,12 +14,6 @@ on:
       - edited
       # For jobs that don't run on draft PRs.
       - ready_for_review
-  pull_request: # for dependabot PRs
-    types:
-      - opened
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -28,81 +22,6 @@ permissions:
 concurrency: pr-${{ github.ref }}
 
 jobs:
-  # Dependabot is annoying, but this makes it a bit less so.
-  dependabot-automerge:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder'
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Approve the PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-  dependabot-automerge-notify:
-    # Send a slack notification when a dependabot PR is merged.
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.actor == 'github-actions[bot]'
-    steps:
-      - name: Send Slack notification
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          PR_TITLE: ${{github.event.pull_request.title}}
-          PR_NUMBER: ${{github.event.pull_request.number}}
-        run: |
-          curl -X POST -H 'Content-type: application/json' \
-          --data '{
-            "username": "dependabot",
-            "icon_url": "https://avatars.githubusercontent.com/u/27347476",
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":pr-merged: Auto merged Dependabot PR #${{ env.PR_NUMBER }}",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "${{ env.PR_TITLE }}"
-                  }
-                ]
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "View PR"
-                    },
-                    "url": "${{ env.PR_URL }}"
-                  }
-                ]
-              }
-            ]
-          }' ${{ secrets.DEPENDABOT_PRS_SLACK_WEBHOOK }}
-
   cla:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -2,19 +2,24 @@ name: contrib
 
 on:
   issue_comment:
-    types: [created]
-  pull_request:
+    types: [created, edited]
+  pull_request_target: # for community 
     types:
       - opened
       - closed
       - synchronize
       - labeled
       - unlabeled
-      - opened
       - reopened
       - edited
       # For jobs that don't run on draft PRs.
       - ready_for_review
+  pull_request: # for dependabot PRs
+    types:
+      - opened
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -43,7 +48,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
@@ -52,7 +57,7 @@ jobs:
   dependabot-automerge-notify:
     # Send a slack notification when a dependabot PR is merged.
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder' && github.event.pull_request.merged
+    if: github.event_name == 'push' && github.actor == 'github-actions[bot]'
     steps:
       - name: Send Slack notification
         env:
@@ -104,7 +109,7 @@ jobs:
       pull-requests: write
     steps:
       - name: cla
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -3,7 +3,7 @@ name: contrib
 on:
   issue_comment:
     types: [created, edited]
-  pull_request_target: # for community 
+  pull_request_target:
     types:
       - opened
       - closed

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -47,7 +47,7 @@ jobs:
   release-labels:
     runs-on: ubuntu-latest
     # Skip tagging for draft PRs.
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
     steps:
       - name: release-labels
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,91 @@
+name: dependabot
+
+on:
+  pull_request:
+    types:
+      - opened
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# Only run one instance per PR to ensure in-order execution.
+concurrency: pr-${{ github.ref }}
+
+jobs:
+  # Dependabot is annoying, but this makes it a bit less so.
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder'
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  dependabot-automerge-notify:
+    # Send a slack notification when a dependabot PR is merged.
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.actor == 'github-actions[bot]'
+    steps:
+      - name: Send Slack notification
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          PR_TITLE: ${{github.event.pull_request.title}}
+          PR_NUMBER: ${{github.event.pull_request.number}}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "username": "dependabot",
+            "icon_url": "https://avatars.githubusercontent.com/u/27347476",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":pr-merged: Auto merged Dependabot PR #${{ env.PR_NUMBER }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "${{ env.PR_TITLE }}"
+                  }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View PR"
+                    },
+                    "url": "${{ env.PR_URL }}"
+                  }
+                ]
+              }
+            ]
+          }' ${{ secrets.DEPENDABOT_PRS_SLACK_WEBHOOK }}

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -18,7 +18,7 @@ jobs:
   # Dependabot is annoying, but this makes it a bit less so.
   dependabot-automerge:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'coder/coder'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.actor_id == 49699333 && github.repository == 'coder/coder'
     permissions:
       pull-requests: write
       contents: write
@@ -30,13 +30,17 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Approve the PR
-        run: gh pr review --approve "$PR_URL"
+        run: |
+          echo "Approving $PR_URL"
+          gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          echo "Enabling auto-merge for $PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -44,7 +48,7 @@ jobs:
   dependabot-automerge-notify:
     # Send a slack notification when a dependabot PR is merged.
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.actor == 'github-actions[bot]'
+    if: github.event_name == 'push' && github.actor == 'github-actions[bot]' && github.actor_id == 41898282 && github.repository == 'coder/coder'
     steps:
       - name: Send Slack notification
         env:


### PR DESCRIPTION
When we merge a PR programmatically using `gh pr merge --auto --squash,` the Github auto handles the merge after all checks are passed. So, a `pull_request` event does not get triggered, and a merge commit is pushed to `main` by `github-actions[bot].` This change handles that case.

I also extracted all dependable logic to a separate workflow for better control and restored the original state of `contrib.yaml` so that cla can work as expected for Community PRs.