### PR TITLE
chore: track disabled telemetry

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -821,22 +821,22 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			}
 
 			if !vals.Telemetry.Enable.Value() {
-				go func() {
-					reporter, err := telemetry.New(telemetry.Options{
-						DeploymentID: deploymentID,
-						Database:     options.Database,
-						Logger:       logger.Named("telemetry"),
-						URL:          vals.Telemetry.URL.Value(),
-					})
-					if err != nil {
-						logger.Debug(ctx, "create telemetry reporter (disabled)", slog.Error(err))
-						return
-					}
-					defer reporter.Close()
-					if err := reporter.ReportDisabledIfNeeded(); err != nil {
-						logger.Debug(ctx, "failed to report disabled telemetry", slog.Error(err))
-					}
-				}()
+				reporter, err := telemetry.New(telemetry.Options{
+					DeploymentID: deploymentID,
+					Database:     options.Database,
+					Logger:       logger.Named("telemetry"),
+					URL:          vals.Telemetry.URL.Value(),
+				})
+				if err != nil {
+					logger.Debug(ctx, "create telemetry reporter (disabled)", slog.Error(err))
+				} else {
+					go func() {
+						defer reporter.Close()
+						if err := reporter.ReportDisabledIfNeeded(); err != nil {
+							logger.Debug(ctx, "failed to report disabled telemetry", slog.Error(err))
+						}
+					}()
+				}
 			}
 
 			// This prevents the pprof import from being accidentally deleted.

--- a/cli/server.go
+++ b/cli/server.go
@@ -786,7 +786,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				return xerrors.Errorf("remove secrets from deployment values: %w", err)
 			}
 			telemetryReporter, err := telemetry.New(telemetry.Options{
-				Enabled:          vals.Telemetry.Enable.Value(),
+				Disabled:         !vals.Telemetry.Enable.Value(),
 				BuiltinPostgres:  builtinPostgres,
 				DeploymentID:     deploymentID,
 				Database:         options.Database,

--- a/cli/server.go
+++ b/cli/server.go
@@ -822,10 +822,11 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 
 			if !vals.Telemetry.Enable.Value() {
 				reporter, err := telemetry.New(telemetry.Options{
-					DeploymentID: deploymentID,
-					Database:     options.Database,
-					Logger:       logger.Named("telemetry"),
-					URL:          vals.Telemetry.URL.Value(),
+					DeploymentID:         deploymentID,
+					Database:             options.Database,
+					Logger:               logger.Named("telemetry"),
+					URL:                  vals.Telemetry.URL.Value(),
+					DisableReportOnClose: true,
 				})
 				if err != nil {
 					logger.Debug(ctx, "create telemetry reporter (disabled)", slog.Error(err))

--- a/cli/server.go
+++ b/cli/server.go
@@ -836,6 +836,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 						if err := reporter.ReportDisabledIfNeeded(); err != nil {
 							logger.Debug(ctx, "failed to report disabled telemetry", slog.Error(err))
 						}
+						logger.Debug(ctx, "finished disabled telemetry check")
 					}()
 				}
 			}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -39,6 +39,7 @@ import (
 	"tailscale.com/types/key"
 
 	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/cli/config"
@@ -947,22 +948,7 @@ func TestServer(t *testing.T) {
 	t.Run("Telemetry", func(t *testing.T) {
 		t.Parallel()
 
-		deployment := make(chan struct{}, 64)
-		snapshot := make(chan *telemetry.Snapshot, 64)
-		r := chi.NewRouter()
-		r.Post("/deployment", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusAccepted)
-			deployment <- struct{}{}
-		})
-		r.Post("/snapshot", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusAccepted)
-			ss := &telemetry.Snapshot{}
-			err := json.NewDecoder(r.Body).Decode(ss)
-			require.NoError(t, err)
-			snapshot <- ss
-		})
-		server := httptest.NewServer(r)
-		defer server.Close()
+		telemetryServerURL, deployment, snapshot := mockTelemetryServer(t)
 
 		inv, cfg := clitest.New(t,
 			"server",
@@ -970,7 +956,7 @@ func TestServer(t *testing.T) {
 			"--http-address", ":0",
 			"--access-url", "http://example.com",
 			"--telemetry",
-			"--telemetry-url", server.URL,
+			"--telemetry-url", telemetryServerURL.String(),
 			"--cache-dir", t.TempDir(),
 		)
 		clitest.Start(t, inv)
@@ -2008,4 +1994,149 @@ func TestServer_DisabledDERP(t *testing.T) {
 	// DERP should fail to connect
 	err = c.Connect(ctx)
 	require.Error(t, err)
+}
+
+type runServerOpts struct {
+	waitForSnapshot               bool
+	telemetryDisabled             bool
+	waitForTelemetryDisabledCheck bool
+}
+
+func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
+	t.Parallel()
+
+	if !dbtestutil.WillUsePostgres() {
+		t.Skip("this test requires postgres")
+	}
+
+	telemetryServerURL, deployment, snapshot := mockTelemetryServer(t)
+	dbConnURL, err := dbtestutil.Open(t)
+	require.NoError(t, err)
+
+	cacheDir := t.TempDir()
+	runServer := func(t *testing.T, opts runServerOpts) (chan error, context.CancelFunc) {
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		inv, _ := clitest.New(t,
+			"server",
+			"--postgres-url", dbConnURL,
+			"--http-address", ":0",
+			"--access-url", "http://example.com",
+			"--telemetry="+strconv.FormatBool(!opts.telemetryDisabled),
+			"--telemetry-url", telemetryServerURL.String(),
+			"--cache-dir", cacheDir,
+			"--log-filter", ".*",
+		)
+		finished := make(chan bool, 2)
+		errChan := make(chan error, 1)
+		pty := ptytest.New(t).Attach(inv)
+		go func() {
+			errChan <- inv.WithContext(ctx).Run()
+			finished <- true
+		}()
+		go func() {
+			defer func() {
+				finished <- true
+			}()
+			if opts.waitForSnapshot {
+				pty.ExpectMatchContext(testutil.Context(t, testutil.WaitLong), "submitted snapshot")
+			}
+			if opts.waitForTelemetryDisabledCheck {
+				pty.ExpectMatchContext(testutil.Context(t, testutil.WaitLong), "finished disabled telemetry check")
+			}
+		}()
+		<-finished
+		return errChan, cancelFunc
+	}
+	waitForShutdown := func(t *testing.T, errChan chan error) error {
+		t.Helper()
+		select {
+		case err := <-errChan:
+			return err
+		case <-time.After(testutil.WaitMedium):
+			t.Fatalf("timed out waiting for server to shutdown")
+		}
+		return nil
+	}
+
+	errChan, cancelFunc := runServer(t, runServerOpts{telemetryDisabled: true, waitForTelemetryDisabledCheck: true})
+	cancelFunc()
+	require.NoError(t, waitForShutdown(t, errChan))
+
+	// Since telemetry was disabled, we expect no deployments or snapshots.
+	require.Empty(t, deployment)
+	require.Empty(t, snapshot)
+
+	errChan, cancelFunc = runServer(t, runServerOpts{waitForSnapshot: true})
+	cancelFunc()
+	require.NoError(t, waitForShutdown(t, errChan))
+	// we expect to see a deployment and a snapshot twice:
+	// 1. the first pair is sent when the server starts
+	// 2. the second pair is sent when the server shuts down
+	for i := 0; i < 2; i++ {
+		select {
+		case ss := <-snapshot:
+			t.Logf("got this fun snapshot: %+v", ss)
+		case <-time.After(testutil.WaitShort / 2):
+			t.Fatalf("timed out waiting for snapshot")
+		}
+		select {
+		case <-deployment:
+		case <-time.After(testutil.WaitShort / 2):
+			t.Fatalf("timed out waiting for deployment")
+		}
+	}
+
+	errChan, cancelFunc = runServer(t, runServerOpts{telemetryDisabled: true, waitForTelemetryDisabledCheck: true})
+	cancelFunc()
+	require.NoError(t, waitForShutdown(t, errChan))
+
+	// Since telemetry is disabled, we expect no deployment. We expect a snapshot
+	// with the telemetry disabled item.
+	require.Empty(t, deployment)
+	select {
+	case ss := <-snapshot:
+		require.Len(t, ss.TelemetryItems, 1)
+		require.Equal(t, string(telemetry.TelemetryItemKeyTelemetryDisabled), ss.TelemetryItems[0].Key)
+	case <-time.After(testutil.WaitShort / 2):
+		t.Fatalf("timed out waiting for snapshot")
+	}
+
+	errChan, cancelFunc = runServer(t, runServerOpts{telemetryDisabled: true, waitForTelemetryDisabledCheck: true})
+	cancelFunc()
+	require.NoError(t, waitForShutdown(t, errChan))
+	// Since telemetry is disabled and we've already sent a snapshot, we expect no
+	// new deployments or snapshots.
+	require.Empty(t, deployment)
+	require.Empty(t, snapshot)
+}
+
+func mockTelemetryServer(t *testing.T) (*url.URL, chan *telemetry.Deployment, chan *telemetry.Snapshot) {
+	t.Helper()
+	deployment := make(chan *telemetry.Deployment, 64)
+	snapshot := make(chan *telemetry.Snapshot, 64)
+	r := chi.NewRouter()
+	r.Post("/deployment", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, buildinfo.Version(), r.Header.Get(telemetry.VersionHeader))
+		dd := &telemetry.Deployment{}
+		err := json.NewDecoder(r.Body).Decode(dd)
+		require.NoError(t, err)
+		deployment <- dd
+		// Ensure the header is sent only after deployment is sent
+		w.WriteHeader(http.StatusAccepted)
+	})
+	r.Post("/snapshot", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, buildinfo.Version(), r.Header.Get(telemetry.VersionHeader))
+		ss := &telemetry.Snapshot{}
+		err := json.NewDecoder(r.Body).Decode(ss)
+		require.NoError(t, err)
+		snapshot <- ss
+		// Ensure the header is sent only after snapshot is sent
+		w.WriteHeader(http.StatusAccepted)
+	})
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	return serverURL, deployment, snapshot
 }

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -2041,7 +2041,7 @@ func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
 				pty.ExpectMatchContext(testutil.Context(t, testutil.WaitLong), "submitted snapshot")
 			}
 			if opts.waitForTelemetryDisabledCheck {
-				pty.ExpectMatchContext(testutil.Context(t, testutil.WaitLong), "finished disabled telemetry check")
+				pty.ExpectMatchContext(testutil.Context(t, testutil.WaitLong), "finished telemetry status check")
 			}
 		}()
 		<-finished
@@ -2074,8 +2074,7 @@ func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
 	// 2. the second pair is sent when the server shuts down
 	for i := 0; i < 2; i++ {
 		select {
-		case ss := <-snapshot:
-			t.Logf("got this fun snapshot: %+v", ss)
+		case <-snapshot:
 		case <-time.After(testutil.WaitShort / 2):
 			t.Fatalf("timed out waiting for snapshot")
 		}
@@ -2096,7 +2095,8 @@ func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
 	select {
 	case ss := <-snapshot:
 		require.Len(t, ss.TelemetryItems, 1)
-		require.Equal(t, string(telemetry.TelemetryItemKeyTelemetryDisabled), ss.TelemetryItems[0].Key)
+		require.Equal(t, string(telemetry.TelemetryItemKeyTelemetryEnabled), ss.TelemetryItems[0].Key)
+		require.Equal(t, "0", ss.TelemetryItems[0].Value)
 	case <-time.After(testutil.WaitShort / 2):
 		t.Fatalf("timed out waiting for snapshot")
 	}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -2096,7 +2096,7 @@ func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
 	case ss := <-snapshot:
 		require.Len(t, ss.TelemetryItems, 1)
 		require.Equal(t, string(telemetry.TelemetryItemKeyTelemetryEnabled), ss.TelemetryItems[0].Key)
-		require.Equal(t, "0", ss.TelemetryItems[0].Value)
+		require.Equal(t, "false", ss.TelemetryItems[0].Value)
 	case <-time.After(testutil.WaitShort / 2):
 		t.Fatalf("timed out waiting for snapshot")
 	}

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -47,10 +47,11 @@ type Options struct {
 	// URL is an endpoint to direct telemetry towards!
 	URL *url.URL
 
-	DeploymentID     string
-	DeploymentConfig *codersdk.DeploymentValues
-	BuiltinPostgres  bool
-	Tunnel           bool
+	DeploymentID         string
+	DeploymentConfig     *codersdk.DeploymentValues
+	BuiltinPostgres      bool
+	Tunnel               bool
+	DisableReportOnClose bool
 
 	SnapshotFrequency time.Duration
 	ParseLicenseJWT   func(lic *License) error
@@ -175,10 +176,12 @@ func (r *remoteReporter) Close() {
 	close(r.closed)
 	now := dbtime.Now()
 	r.shutdownAt = &now
-	// Report a final collection of telemetry prior to close!
-	// This could indicate final actions a user has taken, and
-	// the time the deployment was shutdown.
-	r.reportWithDeployment()
+	if !r.options.DisableReportOnClose {
+		// Report a final collection of telemetry prior to close!
+		// This could indicate final actions a user has taken, and
+		// the time the deployment was shutdown.
+		r.reportWithDeployment()
+	}
 	r.closeFunc()
 }
 

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -107,7 +107,7 @@ type Reporter interface {
 	// RunSnapshotter runs reporting in a loop. It should be called in a
 	// goroutine to avoid blocking the caller.
 	RunSnapshotter()
-	// ReportDisabledIfNeeded reports telemetry in the following scenarios:
+	// ReportDisabledIfNeeded reports that the telemetry was disabled in the following scenarios:
 	// 1. The telemetry was enabled at some point, and we haven't reported the disabled telemetry yet.
 	// 2. The telemetry was enabled at some point, we reported the disabled telemetry, the telemetry
 	//    was enabled again, then disabled again, and we haven't reported it yet.

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -107,8 +107,10 @@ type Reporter interface {
 	// RunSnapshotter runs reporting in a loop. It should be called in a
 	// goroutine to avoid blocking the caller.
 	RunSnapshotter()
-	// ReportDisabledIfNeeded reports disabled telemetry if there was at least one report sent
-	// before the telemetry was disabled, and we haven't sent a report since the telemetry was disabled.
+	// ReportDisabledIfNeeded reports telemetry in the following scenarios:
+	// 1. The telemetry was enabled at some point, and we haven't reported the disabled telemetry yet.
+	// 2. The telemetry was enabled at some point, we reported the disabled telemetry, the telemetry
+	//    was enabled again, then disabled again, and we haven't reported it yet.
 	ReportDisabledIfNeeded() error
 }
 
@@ -365,7 +367,7 @@ func (r *remoteReporter) ReportDisabledIfNeeded() error {
 	// There are 2 scenarios in which we want to report the disabled telemetry:
 	// 1. The telemetry was enabled at some point, and we haven't reported the disabled telemetry yet.
 	// 2. The telemetry was enabled at some point, we reported the disabled telemetry, the telemetry
-	//    was enabled again, and then disabled again.
+	//    was enabled again, then disabled again, and we haven't reported it yet.
 	//
 	// - In both cases, the TelemetryEnabled item will be present.
 	// - In case 1. the TelemetryDisabled item will not be present.

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -197,7 +197,7 @@ func (r *remoteReporter) recordTelemetryEnabled() {
 		Key:   string(TelemetryItemKeyTelemetryEnabled),
 		Value: "",
 	}); err != nil {
-		r.options.Logger.Debug(r.ctx, "upsert last telemetry report", slog.Error(err))
+		r.options.Logger.Debug(r.ctx, "upsert telemetry enabled", slog.Error(err))
 	}
 }
 

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -185,10 +185,10 @@ func ShouldReportTelemetryDisabled(recordedTelemetryEnabled *bool, telemetryEnab
 	return recordedTelemetryEnabled != nil && *recordedTelemetryEnabled && !telemetryEnabled
 }
 
-// RecordTelemetryStatusChange records the telemetry status change in the database.
-// If the change should be reported, meaning that the status changed from enabled to disabled,
-// returns a snapshot to be sent to the telemetry server.
-func RecordTelemetryStatusChange( //nolint:revive
+// RecordTelemetryStatus records the telemetry status in the database.
+// If the status changed from enabled to disabled, returns a snapshot to
+// be sent to the telemetry server.
+func RecordTelemetryStatus( //nolint:revive
 	ctx context.Context,
 	db database.Store,
 	telemetryEnabled bool,
@@ -235,7 +235,7 @@ func RecordTelemetryStatusChange( //nolint:revive
 }
 
 func (r *remoteReporter) runSnapshotter() {
-	telemetryDisabledSnapshot, err := RecordTelemetryStatusChange(r.ctx, r.options.Database, r.Enabled())
+	telemetryDisabledSnapshot, err := RecordTelemetryStatus(r.ctx, r.options.Database, r.Enabled())
 	if err != nil {
 		r.options.Logger.Debug(r.ctx, "record and maybe report telemetry status", slog.Error(err))
 	}

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -357,10 +357,9 @@ func (r *remoteReporter) ReportDisabledIfNeeded() error {
 	if telemetryDisabledErr != nil && !errors.Is(telemetryDisabledErr, sql.ErrNoRows) {
 		r.options.Logger.Debug(r.ctx, "get telemetry disabled", slog.Error(telemetryDisabledErr))
 	}
-	shouldReportDisabledTelemetry :=
-		telemetryUpdateErr == nil &&
-			((telemetryDisabledErr == nil && lastTelemetryUpdate.UpdatedAt.Before(telemetryDisabled.UpdatedAt)) ||
-				errors.Is(telemetryDisabledErr, sql.ErrNoRows))
+	shouldReportDisabledTelemetry := telemetryUpdateErr == nil &&
+		((telemetryDisabledErr == nil && lastTelemetryUpdate.UpdatedAt.Before(telemetryDisabled.UpdatedAt)) ||
+			errors.Is(telemetryDisabledErr, sql.ErrNoRows))
 	if !shouldReportDisabledTelemetry {
 		return nil
 	}

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -390,8 +390,7 @@ func (r *remoteReporter) ReportDisabledIfNeeded() error {
 	}
 	// If any of the following calls fail, we will never report the disabled telemetry.
 	// Subsequent ReportDisabledIfNeeded calls will see the TelemetryDisabled item
-	// and quit early. This is okay. We only want to ping the telemetry server once
-	// at the time when the Coder server is first started with telemetry disabled,
+	// and quit early. This is okay. We only want to ping the telemetry server once,
 	// and never again. If that attempt fails, so be it.
 	item, err := db.GetTelemetryItem(r.ctx, string(TelemetryItemKeyTelemetryDisabled))
 	if err != nil {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -111,6 +111,8 @@ type Reporter interface {
 	// 1. The telemetry was enabled at some point, and we haven't reported the disabled telemetry yet.
 	// 2. The telemetry was enabled at some point, we reported the disabled telemetry, the telemetry
 	//    was enabled again, then disabled again, and we haven't reported it yet.
+	//
+	// In particular, it does nothing if the telemetry was never enabled.
 	ReportDisabledIfNeeded() error
 }
 

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -347,11 +347,11 @@ func checkIDPOrgSync(ctx context.Context, db database.Store, values *codersdk.De
 func (r *remoteReporter) ReportDisabledIfNeeded() error {
 	db := r.options.Database
 	lastTelemetryUpdate, telemetryUpdateErr := db.GetTelemetryItem(r.ctx, string(TelemetryItemKeyLastTelemetryUpdate))
-	if telemetryUpdateErr != nil {
+	if telemetryUpdateErr != nil && !errors.Is(telemetryUpdateErr, sql.ErrNoRows) {
 		r.options.Logger.Debug(r.ctx, "get last telemetry update at", slog.Error(telemetryUpdateErr))
 	}
 	telemetryDisabled, telemetryDisabledErr := db.GetTelemetryItem(r.ctx, string(TelemetryItemKeyTelemetryDisabled))
-	if telemetryDisabledErr != nil {
+	if telemetryDisabledErr != nil && !errors.Is(telemetryDisabledErr, sql.ErrNoRows) {
 		r.options.Logger.Debug(r.ctx, "get telemetry disabled", slog.Error(telemetryDisabledErr))
 	}
 	shouldReportDisabledTelemetry :=

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -159,7 +159,7 @@ func (r *remoteReporter) reportSync(snapshot *Snapshot) {
 	}
 	if err := r.options.Database.UpsertTelemetryItem(r.ctx, database.UpsertTelemetryItemParams{
 		Key:   string(TelemetryItemKeyLastTelemetryUpdate),
-		Value: dbtime.Now().Format(time.RFC3339),
+		Value: "",
 	}); err != nil {
 		r.options.Logger.Debug(r.ctx, "upsert last telemetry update", slog.Error(err))
 	}
@@ -364,7 +364,7 @@ func (r *remoteReporter) ReportDisabledIfNeeded() error {
 
 	if err := db.UpsertTelemetryItem(r.ctx, database.UpsertTelemetryItemParams{
 		Key:   string(TelemetryItemKeyTelemetryDisabled),
-		Value: time.Now().Format(time.RFC3339),
+		Value: "",
 	}); err != nil {
 		return xerrors.Errorf("upsert telemetry disabled: %w", err)
 	}

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -388,6 +388,11 @@ func (r *remoteReporter) ReportDisabledIfNeeded() error {
 	}); err != nil {
 		return xerrors.Errorf("upsert telemetry disabled: %w", err)
 	}
+	// If any of the following calls fail, we will never report the disabled telemetry.
+	// Subsequent ReportDisabledIfNeeded calls will see the TelemetryDisabled item
+	// and quit early. This is okay. We only want to ping the telemetry server once
+	// at the time when the Coder server is first started with telemetry disabled,
+	// and never again. If that attempt fails, so be it.
 	item, err := db.GetTelemetryItem(r.ctx, string(TelemetryItemKeyTelemetryDisabled))
 	if err != nil {
 		return xerrors.Errorf("get telemetry disabled: %w", err)

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -219,10 +219,9 @@ func RecordTelemetryStatus( //nolint:revive
 	if !shouldReport {
 		return nil, nil //nolint:nilnil
 	}
-	// If any of the following calls fail, we will never report the disabled telemetry.
-	// Subsequent function calls will see the TelemetryDisabled item
-	// and quit early. This is okay. We only want to ping the telemetry server once,
-	// and never again. If that attempt fails, so be it.
+	// If any of the following calls fail, we will never report that telemetry changed
+	// from enabled to disabled. This is okay. We only want to ping the telemetry server
+	// once, and never again. If that attempt fails, so be it.
 	item, err = db.GetTelemetryItem(ctx, string(TelemetryItemKeyTelemetryEnabled))
 	if err != nil {
 		return nil, xerrors.Errorf("get telemetry enabled after upsert: %w", err)

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -42,7 +42,7 @@ const (
 )
 
 type Options struct {
-	Enabled  bool
+	Disabled bool
 	Database database.Store
 	Logger   slog.Logger
 	// URL is an endpoint to direct telemetry towards!
@@ -118,7 +118,7 @@ type remoteReporter struct {
 }
 
 func (r *remoteReporter) Enabled() bool {
-	return r.options.Enabled
+	return !r.options.Disabled
 }
 
 func (r *remoteReporter) Report(snapshot *Snapshot) {

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -398,6 +398,7 @@ func collectSnapshot(t *testing.T, db database.Store, addOptionsFn func(opts tel
 
 	reporter, err := telemetry.New(options)
 	require.NoError(t, err)
+	go reporter.RunSnapshotter()
 	t.Cleanup(reporter.Close)
 	return <-deployment, <-snapshot
 }

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -386,7 +386,7 @@ func TestReportDisabledIfNeeded(t *testing.T) {
 	// Report should be sent
 	_ = dbgen.TelemetryItem(t, db, database.TelemetryItem{
 		Key:   string(telemetry.TelemetryItemKeyLastTelemetryUpdate),
-		Value: time.Now().Format(time.RFC3339),
+		Value: "",
 	})
 	require.NoError(t, reporter.ReportDisabledIfNeeded())
 	select {
@@ -410,7 +410,7 @@ func TestReportDisabledIfNeeded(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, db.UpsertTelemetryItem(ctx, database.UpsertTelemetryItemParams{
 		Key:   string(telemetry.TelemetryItemKeyTelemetryDisabled),
-		Value: time.Now().Format(time.RFC3339),
+		Value: "",
 	}))
 	require.NoError(t, reporter.ReportDisabledIfNeeded())
 	select {

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -131,7 +131,8 @@ func TestTelemetry(t *testing.T) {
 		require.Len(t, snapshot.WorkspaceProxies, 1)
 		require.Len(t, snapshot.WorkspaceModules, 1)
 		require.Len(t, snapshot.Organizations, 1)
-		require.Len(t, snapshot.TelemetryItems, 1)
+		// We create one item manually above. The other is TelemetryEnabled, created by the snapshotter.
+		require.Len(t, snapshot.TelemetryItems, 2)
 		wsa := snapshot.WorkspaceAgents[0]
 		require.Len(t, wsa.Subsystems, 2)
 		require.Equal(t, string(database.WorkspaceAgentSubsystemEnvbox), wsa.Subsystems[0])

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -397,6 +397,7 @@ func TestRecordTelemetryStatus(t *testing.T) {
 		{name: "Telemetry was disabled now is enabled", recordedTelemetryEnabled: "0", telemetryEnabled: true, shouldReport: false},
 		{name: "Telemetry was disabled still disabled", recordedTelemetryEnabled: "0", telemetryEnabled: false, shouldReport: false},
 	} {
+		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -406,7 +406,7 @@ func TestReportDisabledIfNeeded(t *testing.T) {
 
 	// Telemetry enabled item present, and a less recent telemetry disabled item present
 	// Report should be sent
-	// Wait a bit to ensure UpdatedAt is bigger when we upsert the telemetry enabled item
+	// Wait a bit to ensure UpdatedAt is greater when we upsert the telemetry enabled item
 	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, db.UpsertTelemetryItem(ctx, database.UpsertTelemetryItemParams{
 		Key:   string(telemetry.TelemetryItemKeyTelemetryEnabled),

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -382,7 +382,7 @@ func TestShouldReportTelemetryDisabled(t *testing.T) {
 	require.False(t, telemetry.ShouldReportTelemetryDisabled(&boolFalse, false))
 }
 
-func TestRecordTelemetryStatusChange(t *testing.T) {
+func TestRecordTelemetryStatus(t *testing.T) {
 	t.Parallel()
 	for _, testCase := range []struct {
 		name                     string
@@ -408,7 +408,7 @@ func TestRecordTelemetryStatusChange(t *testing.T) {
 					Value: testCase.recordedTelemetryEnabled,
 				})
 			}
-			snapshot1, err := telemetry.RecordTelemetryStatusChange(ctx, db, testCase.telemetryEnabled)
+			snapshot1, err := telemetry.RecordTelemetryStatus(ctx, db, testCase.telemetryEnabled)
 			require.NoError(t, err)
 
 			if testCase.shouldReport {
@@ -421,7 +421,7 @@ func TestRecordTelemetryStatusChange(t *testing.T) {
 
 			for i := 0; i < 3; i++ {
 				// Whatever happens, subsequent calls should not report if telemetryEnabled didn't change
-				snapshot2, err := telemetry.RecordTelemetryStatusChange(ctx, db, testCase.telemetryEnabled)
+				snapshot2, err := telemetry.RecordTelemetryStatus(ctx, db, testCase.telemetryEnabled)
 				require.NoError(t, err)
 				require.Nil(t, snapshot2)
 			}


### PR DESCRIPTION
Addresses https://github.com/coder/nexus/issues/116.

## Core Concept

Send one final telemetry report after the user disables telemetry with the message that the telemetry was disabled. No other information about the deployment is sent in this report.

This final report is submitted only if the deployment ever had telemetry on.

## Changes

1. Refactored how our telemetry is initialized.
2. Introduced the `TelemetryEnabled` telemetry item, which allows to decide whether a final report should be sent.
3. Added the `RecordTelemetryStatus` telemetry method, which decides whether a final report should be sent and updates the telemetry item.
4. Added tests to ensure the implementation is correct.