### PR TITLE
fix: show user-auth provisioners for all organizations

### DIFF
--- a/cli/provisioners_test.go
+++ b/cli/provisioners_test.go
@@ -95,7 +95,7 @@ func TestProvisioners_Golden(t *testing.T) {
 		Name:       "provisioner-1",
 		CreatedAt:  dbtime.Now().Add(1 * time.Second),
 		LastSeenAt: sql.NullTime{Time: coderdAPI.Clock.Now().Add(time.Hour), Valid: true}, // Stale interval can't be adjusted, keep online.
-		KeyID:      uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:      codersdk.ProvisionerKeyUUIDBuiltIn,
 		Tags:       database.StringMap{"owner": "", "scope": "organization", "foo": "bar"},
 	})
 	w1 := dbgen.Workspace(t, coderdAPI.Database, database.WorkspaceTable{
@@ -122,7 +122,7 @@ func TestProvisioners_Golden(t *testing.T) {
 		Name:       "provisioner-2",
 		CreatedAt:  dbtime.Now().Add(2 * time.Second),
 		LastSeenAt: sql.NullTime{Time: coderdAPI.Clock.Now().Add(-time.Hour), Valid: true},
-		KeyID:      uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:      codersdk.ProvisionerKeyUUIDBuiltIn,
 		Tags:       database.StringMap{"owner": "", "scope": "organization"},
 	})
 	w2 := dbgen.Workspace(t, coderdAPI.Database, database.WorkspaceTable{
@@ -168,7 +168,7 @@ func TestProvisioners_Golden(t *testing.T) {
 		Name:       "provisioner-3",
 		CreatedAt:  dbtime.Now().Add(3 * time.Second),
 		LastSeenAt: sql.NullTime{Time: coderdAPI.Clock.Now().Add(time.Hour), Valid: true}, // Stale interval can't be adjusted, keep online.
-		KeyID:      uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:      codersdk.ProvisionerKeyUUIDBuiltIn,
 		Tags:       database.StringMap{"owner": "", "scope": "organization"},
 	})
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -114,7 +114,7 @@ func New() database.Store {
 	q.defaultProxyIconURL = "/emojis/1f3e1.png"
 
 	_, err = q.InsertProvisionerKey(context.Background(), database.InsertProvisionerKeyParams{
-		ID:             uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		ID:             codersdk.ProvisionerKeyUUIDBuiltIn,
 		OrganizationID: defaultOrg.ID,
 		CreatedAt:      dbtime.Now(),
 		HashedSecret:   []byte{},
@@ -125,7 +125,7 @@ func New() database.Store {
 		panic(xerrors.Errorf("failed to create built-in provisioner key: %w", err))
 	}
 	_, err = q.InsertProvisionerKey(context.Background(), database.InsertProvisionerKeyParams{
-		ID:             uuid.MustParse(codersdk.ProvisionerKeyIDUserAuth),
+		ID:             codersdk.ProvisionerKeyUUIDUserAuth,
 		OrganizationID: defaultOrg.ID,
 		CreatedAt:      dbtime.Now(),
 		HashedSecret:   []byte{},
@@ -136,7 +136,7 @@ func New() database.Store {
 		panic(xerrors.Errorf("failed to create user-auth provisioner key: %w", err))
 	}
 	_, err = q.InsertProvisionerKey(context.Background(), database.InsertProvisionerKeyParams{
-		ID:             uuid.MustParse(codersdk.ProvisionerKeyIDPSK),
+		ID:             codersdk.ProvisionerKeyUUIDPSK,
 		OrganizationID: defaultOrg.ID,
 		CreatedAt:      dbtime.Now(),
 		HashedSecret:   []byte{},

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -413,7 +413,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Version:        "1.0.0",
 		APIVersion:     proto.CurrentVersion.String(),
 		OrganizationID: defaultOrg.ID,
-		KeyID:          uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:          codersdk.ProvisionerKeyUUIDBuiltIn,
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -426,7 +426,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Version:        "1.0.0",
 		APIVersion:     proto.CurrentVersion.String(),
 		OrganizationID: defaultOrg.ID,
-		KeyID:          uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:          codersdk.ProvisionerKeyUUIDBuiltIn,
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -441,7 +441,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Version:        "1.0.0",
 		APIVersion:     proto.CurrentVersion.String(),
 		OrganizationID: defaultOrg.ID,
-		KeyID:          uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:          codersdk.ProvisionerKeyUUIDBuiltIn,
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -457,7 +457,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Version:        "1.0.0",
 		APIVersion:     proto.CurrentVersion.String(),
 		OrganizationID: defaultOrg.ID,
-		KeyID:          uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:          codersdk.ProvisionerKeyUUIDBuiltIn,
 	})
 	require.NoError(t, err)
 

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -2272,7 +2272,7 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 		Version:        buildinfo.Version(),
 		APIVersion:     proto.CurrentVersion.String(),
 		OrganizationID: defOrg.ID,
-		KeyID:          uuid.MustParse(codersdk.ProvisionerKeyIDBuiltIn),
+		KeyID:          codersdk.ProvisionerKeyUUIDBuiltIn,
 	})
 	require.NoError(t, err)
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -352,6 +352,12 @@ const (
 	ProvisionerKeyIDPSK      = "00000000-0000-0000-0000-000000000003"
 )
 
+var (
+	ProvisionerKeyUUIDBuiltIn  = uuid.MustParse(ProvisionerKeyIDBuiltIn)
+	ProvisionerKeyUUIDUserAuth = uuid.MustParse(ProvisionerKeyIDUserAuth)
+	ProvisionerKeyUUIDPSK      = uuid.MustParse(ProvisionerKeyIDPSK)
+)
+
 const (
 	ProvisionerKeyNameBuiltIn  = "built-in"
 	ProvisionerKeyNameUserAuth = "user-auth"

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -782,10 +782,14 @@ func TestGetProvisionerDaemons(t *testing.T) {
 		pkDaemons, err := orgAdmin.ListProvisionerKeyDaemons(ctx, org.ID)
 		require.NoError(t, err)
 
-		require.Len(t, pkDaemons, 1)
+		require.Len(t, pkDaemons, 2)
 		require.Len(t, pkDaemons[0].Daemons, 1)
 		assert.Equal(t, keys[0].ID, pkDaemons[0].Key.ID)
 		assert.Equal(t, keys[0].Name, pkDaemons[0].Key.Name)
+		// user-auth provisioners
+		require.Len(t, pkDaemons[1].Daemons, 0)
+		assert.Equal(t, codersdk.ProvisionerKeyUUIDUserAuth, pkDaemons[1].Key.ID)
+		assert.Equal(t, codersdk.ProvisionerKeyNameUserAuth, pkDaemons[1].Key.Name)
 
 		assert.Equal(t, daemonName, pkDaemons[0].Daemons[0].Name)
 		assert.Equal(t, buildinfo.Version(), pkDaemons[0].Daemons[0].Version)

--- a/enterprise/coderd/provisionerkeys.go
+++ b/enterprise/coderd/provisionerkeys.go
@@ -244,5 +244,19 @@ func convertProvisionerKeys(dbKeys []database.ProvisionerKey) []codersdk.Provisi
 		return key1.CreatedAt.Compare(key2.CreatedAt)
 	})
 
+	// For the default organization, we insert three rows for the special provisioner
+	// key types (built-in, user-auth, and psk). We _don't_ insert those into the
+	// database for any other org, but we still need to include the user-auth key
+	// in this list, so we just insert it manually.
+	if !slices.ContainsFunc(keys, func(key codersdk.ProvisionerKey) bool {
+		return key.ID == codersdk.ProvisionerKeyUUIDUserAuth
+	}) {
+		keys = append(keys, codersdk.ProvisionerKey{
+			ID:   codersdk.ProvisionerKeyUUIDUserAuth,
+			Name: codersdk.ProvisionerKeyNameUserAuth,
+			Tags: make(map[string]string),
+		})
+	}
+
 	return keys
 }


### PR DESCRIPTION
Closes #14867

Ensure that the special user-auth provisioner key is always present in the normalized list of provisioner keys when grouping provisioner daemons by key.

This allows user-auth provisioners to show up in the `OrganizationProvisionersPage` view.