### PR TITLE
fix(vpn): configure dns hosts with username

### DIFF
--- a/vpn/client.go
+++ b/vpn/client.go
@@ -148,7 +148,7 @@ func (*client) NewConn(initCtx context.Context, serverURL *url.URL, token string
 	updatesCtrl := tailnet.NewTunnelAllWorkspaceUpdatesController(
 		options.Logger,
 		coordCtrl,
-		tailnet.WithDNS(conn, me.Name),
+		tailnet.WithDNS(conn, me.Username),
 		tailnet.WithHandler(options.UpdateHandler),
 	)
 	controller.WorkspaceUpdatesCtrl = updatesCtrl

--- a/vpn/tun_darwin.go
+++ b/vpn/tun_darwin.go
@@ -5,10 +5,11 @@ package vpn
 import (
 	"os"
 
-	"cdr.dev/slog"
 	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
 )
 
 func GetNetworkingStack(t *Tunnel, req *StartRequest, _ slog.Logger) (NetworkStack, error) {


### PR DESCRIPTION
Previously we were configuring using the display name of the user, which may contain spaces, special characters, and isn't unique. This was always supposed to be the username.