### PR TITLE
fix(site): fix agent and web terminal troubleshooting links

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -120,7 +120,7 @@ func Agent(ctx context.Context, writer io.Writer, agentID uuid.UUID, opts AgentO
 			if agent.Status == codersdk.WorkspaceAgentTimeout {
 				now := time.Now()
 				sw.Log(now, codersdk.LogLevelInfo, "The workspace agent is having trouble connecting, wait for it to connect or restart your workspace.")
-				sw.Log(now, codersdk.LogLevelInfo, troubleshootingMessage(agent, fmt.Sprintf("%s/templates#agent-connection-issues", opts.DocsURL)))
+				sw.Log(now, codersdk.LogLevelInfo, troubleshootingMessage(agent, fmt.Sprintf("%s/admin/templates/troubleshooting#agent-connection-issues", opts.DocsURL)))
 				for agent.Status == codersdk.WorkspaceAgentTimeout {
 					if agent, err = fetch(); err != nil {
 						return xerrors.Errorf("fetch: %w", err)
@@ -225,13 +225,13 @@ func Agent(ctx context.Context, writer io.Writer, agentID uuid.UUID, opts AgentO
 				sw.Fail(stage, safeDuration(sw, agent.ReadyAt, agent.StartedAt))
 				// Use zero time (omitted) to separate these from the startup logs.
 				sw.Log(time.Time{}, codersdk.LogLevelWarn, "Warning: A startup script exited with an error and your workspace may be incomplete.")
-				sw.Log(time.Time{}, codersdk.LogLevelWarn, troubleshootingMessage(agent, fmt.Sprintf("%s/templates#startup-script-exited-with-an-error", opts.DocsURL)))
+				sw.Log(time.Time{}, codersdk.LogLevelWarn, troubleshootingMessage(agent, fmt.Sprintf("%s/admin/templates/troubleshooting#startup-script-exited-with-an-error", opts.DocsURL)))
 			default:
 				switch {
 				case agent.LifecycleState.Starting():
 					// Use zero time (omitted) to separate these from the startup logs.
 					sw.Log(time.Time{}, codersdk.LogLevelWarn, "Notice: The startup scripts are still running and your workspace may be incomplete.")
-					sw.Log(time.Time{}, codersdk.LogLevelWarn, troubleshootingMessage(agent, fmt.Sprintf("%s/templates#your-workspace-may-be-incomplete", opts.DocsURL)))
+					sw.Log(time.Time{}, codersdk.LogLevelWarn, troubleshootingMessage(agent, fmt.Sprintf("%s/admin/templates/troubleshooting#your-workspace-may-be-incomplete", opts.DocsURL)))
 					// Note: We don't complete or fail the stage here, it's
 					// intentionally left open to indicate this stage didn't
 					// complete.
@@ -253,7 +253,7 @@ func Agent(ctx context.Context, writer io.Writer, agentID uuid.UUID, opts AgentO
 			stage := "The workspace agent lost connection"
 			sw.Start(stage)
 			sw.Log(time.Now(), codersdk.LogLevelWarn, "Wait for it to reconnect or restart your workspace.")
-			sw.Log(time.Now(), codersdk.LogLevelWarn, troubleshootingMessage(agent, fmt.Sprintf("%s/templates#agent-connection-issues", opts.DocsURL)))
+			sw.Log(time.Now(), codersdk.LogLevelWarn, troubleshootingMessage(agent, fmt.Sprintf("%s/admin/templates/troubleshooting#agent-connection-issues", opts.DocsURL)))
 
 			disconnectedAt := agent.DisconnectedAt
 			for agent.Status == codersdk.WorkspaceAgentDisconnected {

--- a/site/src/pages/TerminalPage/TerminalAlerts.tsx
+++ b/site/src/pages/TerminalPage/TerminalAlerts.tsx
@@ -72,7 +72,7 @@ export const ErrorScriptAlert: FC = () => {
 			The workspace{" "}
 			<Link
 				title="startup script has exited with an error"
-				href={docs("/templates#startup-script-exited-with-an-error")}
+				href={docs("/admin/templates/troubleshooting#startup-script-exited-with-an-error")}
 				target="_blank"
 				rel="noreferrer"
 			>

--- a/site/src/pages/TerminalPage/TerminalAlerts.tsx
+++ b/site/src/pages/TerminalPage/TerminalAlerts.tsx
@@ -72,7 +72,9 @@ export const ErrorScriptAlert: FC = () => {
 			The workspace{" "}
 			<Link
 				title="startup script has exited with an error"
-				href={docs("/admin/templates/troubleshooting#startup-script-exited-with-an-error")}
+				href={docs(
+					"/admin/templates/troubleshooting#startup-script-exited-with-an-error",
+				)}
 				target="_blank"
 				rel="noreferrer"
 			>


### PR DESCRIPTION
This change updates the agent-related logs and terminal page links to point specifically to the troubleshooting section under admin templates. At least 1 of them had previously given 404.

This is a leftover from the docs restructure work we did in #13434.