### PR TITLE
ci!: set pr write perms on `release-labels`

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -46,6 +46,8 @@ jobs:
 
   release-labels:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     # Skip tagging for draft PRs.
     if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
     steps:


### PR DESCRIPTION
*Not actually a breaking change, I just forgot to change the title before merging...

I'm pretty sure this is the fix, but I can't test it without merging it, as `pull_request_target` causes the workflow to run using the workflow on `main` (where the permissions aren't set). 

This comment would seem to indicate that `pull_request_target` with PR write perms does the trick: https://github.com/actions/labeler/issues/136#issuecomment-1357839196

From what I can tell this job has been broken since ~nov '24, which leads me to believe it was the permissions change made that month: https://github.com/coder/coder/actions/runs/11915659159/job/33206435274
