### PR TITLE
ci: notify dependabot PR merges on `pull_request` `closed` events

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,12 +1,9 @@
 name: dependabot
+# Dependabot is annoying, but this makes it a bit less so.
 
 on:
   pull_request:
-    types:
-      - opened
-  push:
-    branches:
-      - main
+    types: [opened, closed]
 
 permissions:
   contents: read
@@ -15,10 +12,14 @@ permissions:
 concurrency: pr-${{ github.ref }}
 
 jobs:
-  # Dependabot is annoying, but this makes it a bit less so.
   dependabot-automerge:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.actor_id == 49699333 && github.repository == 'coder/coder'
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'opened' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor_id == 49699333 &&
+      github.repository == 'coder/coder'
     permissions:
       pull-requests: write
       contents: write
@@ -48,7 +49,12 @@ jobs:
   dependabot-automerge-notify:
     # Send a slack notification when a dependabot PR is merged.
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.actor == 'github-actions[bot]' && github.actor_id == 41898282 && github.repository == 'coder/coder'
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'coder/coder'
     steps:
       - name: Send Slack notification
         env:


### PR DESCRIPTION
For some reason, the workaround in #16343 did not work, although it should have. This PR changes the approach and tries to notify on PR closed events with the `pull_request` trigger.