### PR TITLE
fix(flake.nix): readd grep for agent startup script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,7 @@
             (lib.optionalDrvAttr stdenv.isLinux glibcLocales)
             gnumake
             gnused
+            gnugrep
             go_1_22
             go-migrate
             (pinnedPkgs.golangci-lint)


### PR DESCRIPTION
Added `gnugrep` to the development shell dependencies, as its a dependency of the bootstrap script for an agent.

Change-Id: Ia56e16a831bb94af2324e33ae5274833d0123d47
Signed-off-by: Thomas Kosiewski <tk@coder.com>