### PR TITLE
fix: log unsuccessful webhook response body as a string

### DIFF
--- a/coderd/notifications/dispatch/webhook.go
+++ b/coderd/notifications/dispatch/webhook.go
@@ -106,7 +106,7 @@ func (w *WebhookHandler) dispatch(msgPayload types.MessagePayload, titlePlaintex
 				return true, xerrors.Errorf("non-2xx response (%d), read body: %w", resp.StatusCode, err)
 			}
 			w.log.Warn(ctx, "unsuccessful delivery", slog.F("status_code", resp.StatusCode),
-				slog.F("response", respBody[:n]), slog.F("msg_id", msgID))
+				slog.F("response", string(respBody[:n])), slog.F("msg_id", msgID))
 			return true, xerrors.Errorf("non-2xx response (%d)", resp.StatusCode)
 		}
 


### PR DESCRIPTION
Currently this gets logged as a byte sequence:

```
{"ts":"2025-02-04T23:50:06.447896724Z","level":"WARN","msg":"unsuccessful delivery","caller":"/home/runner/work/coder/coder/coderd/notifications/dispatch/webhook.go:108","func":"github.com/coder/coder/v2/coderd/notifications/dispatch.(*WebhookHandler).Dispatcher.(*WebhookHandler).dispatch.func1","logger_names":["notifications.manager","dispatcher.webhook"],"fields":{"status_code":400,"response":[123,34,109,101,115,115,97,103,101,34,58,34,102,97,105,108,101,100,32,116,111,32,115,101,110,100,32,83,108,97,99,107,32,109,101,115,115,97,103,101,34,44,34,100,101,116,97,105,108,34,58,34,102,97,105,108,101,100,32,116,111,32,103,101,116,32,115,108,97,99,107,32,117,115,101,114,32,105,100,32,102,111,114,32,101,109,97,105,108,32,92,34,100,101,118,45,115,112,97,99,101,115,45,116,101,97,109,64,110,101,116,102,108,105,120,46,99,111,109,92,34,58,32,102,97,105,108,101,100,32,116,111,32,114,101,116,114,105,101,118,101,32,112,97,110,100,111,114,97,32,117,115,101,114,32,105,110,102,111,32,102,111,114,32,92,34,100,101,118,45,115,112,97,99,101,115,45,116,101,97,109,64,110,101,116,102,108,105,120,46,99,111,109,92,34,58,32,69,79,70,34,125,10],"msg_id":"e9be5aab-d5fe-456b-93ec-7ed18a5a5887"}}
```