### PR TITLE
chore: update actions/cache to v4.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,7 +178,7 @@ jobs:
           echo "LINT_CACHE_DIR=$dir" >> $GITHUB_ENV
 
       - name: golangci-lint cache
-        uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ${{ env.LINT_CACHE_DIR }}

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,7 @@
             drpc.defaultPackage.${system}
             formatter
             fzf
+            gawk
             gcc13
             gdk
             getopt
@@ -114,6 +115,7 @@
             gnumake
             gnused
             gnugrep
+            gnutar
             go_1_22
             go-migrate
             (pinnedPkgs.golangci-lint)
@@ -147,6 +149,7 @@
             sqlc
             terraform
             typos
+            which
             # Needed for many LD system libs!
             (lib.optional stdenv.isLinux util-linux)
             vim
@@ -274,8 +277,10 @@
                     docker_26
                     shadow.out
                     su
-                    ncurses # clear
+                    ncurses.out # clear
                     unzip
+                    zip
+                    gzip
                   ])
                   ++ oldAttrs.buildInputs;
               });


### PR DESCRIPTION
This updates actions/cache to v4.2.0 and adds missing development dependencies (gawk, gnutar, which, zip, gzip) to the Nix flake.

Change-Id: I1156810c9e02f0cef8e1345a1cbf2b6ba484974a
Signed-off-by: Thomas Kosiewski <tk@coder.com>