### PR TITLE
ci(.github/dependabot.yaml): delete dependabot ignore rules for actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,21 +9,6 @@ updates:
     labels: []
     commit-message:
       prefix: "ci"
-    ignore:
-      # These actions deliver the latest versions by updating the major
-      # release tag, so ignore minor and patch versions
-      - dependency-name: "actions/*"
-        update-types:
-          - version-update:semver-minor
-          - version-update:semver-patch
-      - dependency-name: "Apple-Actions/import-codesign-certs"
-        update-types:
-          - version-update:semver-minor
-          - version-update:semver-patch
-      - dependency-name: "marocchino/sticky-pull-request-comment"
-        update-types:
-          - version-update:semver-minor
-          - version-update:semver-patch
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Removed dependabot ignore rules for `actions/*` and `marocchino/sticky-pull-request-comment` GitHub Actions.

Change-Id: I3288c813c777e7045616f29d265c0860268ece4c
Signed-off-by: Thomas Kosiewski <tk@coder.com>