### PR TITLE
chore(provisioner/terraform): allow generating individual modules

### DIFF
--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -55,11 +55,23 @@ run() {
 	exit 0
 }
 
+if [[ " $* " == *" --help "* || " $* " == *" -h "* ]]; then
+	echo "Usage: $0 [module1 module2 ...]"
+	exit 0
+fi
+
 declare -a jobs=()
-for d in */; do
-	run "$d" &
-	jobs+=($!)
-done
+if [[ $# -gt 0 ]]; then
+	for d in "$@"; do
+		run "$d" &
+		jobs+=($!)
+	done
+else
+	for d in */; do
+		run "$d" &
+		jobs+=($!)
+	done
+fi
 
 err=0
 for job in "${jobs[@]}"; do


### PR DESCRIPTION
While I was researching coder/terraform-provider-coder#306 I found myself wanting o keep the noise down, so I added support for (re-)generating individual modules.

Added a help too while I was at it.

```
❯ ./provisioner/terraform/testdata/generate.sh -h
Usage: ./provisioner/terraform/testdata/generate.sh [module1 module2 ...]
```

```
❯ ./provisioner/terraform/testdata/generate.sh resource-metadata
== Generating test data for: resource-metadata
== Done generating test data for: resource-metadata
```
