### PR TITLE
test(provisioner/terraform): use cmp.Diff instead of require.Equal

### DIFF
--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/require"
 	protobuf "google.golang.org/protobuf/proto"
@@ -842,7 +843,9 @@ func TestConvertResources(t *testing.T) {
 				var resourcesMap []map[string]interface{}
 				err = json.Unmarshal(data, &resourcesMap)
 				require.NoError(t, err)
-				require.Equal(t, expectedNoMetadataMap, resourcesMap)
+				if diff := cmp.Diff(expectedNoMetadataMap, resourcesMap); diff != "" {
+					require.Failf(t, "unexpected resources", "diff (-want +got):\n%s", diff)
+				}
 
 				expectedParams := expected.parameters
 				if expectedParams == nil {
@@ -897,7 +900,9 @@ func TestConvertResources(t *testing.T) {
 				var resourcesMap []map[string]interface{}
 				err = json.Unmarshal(data, &resourcesMap)
 				require.NoError(t, err)
-				require.Equal(t, expectedMap, resourcesMap)
+				if diff := cmp.Diff(expectedMap, resourcesMap); diff != "" {
+					require.Failf(t, "unexpected resources", "diff (-want +got):\n%s", diff)
+				}
 				require.ElementsMatch(t, expected.externalAuthProviders, state.ExternalAuthProviders)
 			})
 		})


### PR DESCRIPTION
I would like to swap out `require.Equal` for `cmp.Diff` in the terraform tests as I find it produces more easy to understand diffs.

Here's an example where `cmp.Diff` is clearer, but `require.Equal` performs not-super-terribly. But there are also many cases where `require.Equal` is really hard to understand.

`cmp.Diff`:

```
coder@w ~/coder mafredri/test-provisioner-terraform-improve-diff*
❯ go test ./provisioner/terraform -run=TestConvertResources -count=1
--- FAIL: TestConvertResources (0.00s)
    --- FAIL: TestConvertResources/multiple-apps (0.00s)
        --- FAIL: TestConvertResources/multiple-apps/Plan (0.02s)
            resources_test.go:847:
                        Error Trace:    /home/coder/coder/provisioner/terraform/resources_test.go:847
                        Error:          unexpected resources
                        Test:           TestConvertResources/multiple-apps/Plan
                        Messages:       diff (-want +got):
                                          []map[string]any{
                                                {
                                                        "agents": []any{
                                                                map[string]any{
                                                                        "Auth": map[string]any{"Token": string("")},
                                                                        "apps": []any{
                                                                                map[string]any{
                                        -                                               "display_name": string("app0"),
                                        +                                               "display_name": string("app1"),
                                                                                        "open_in":      float64(1),
                                        -                                               "slug":         string("app0"),
                                        +                                               "slug":         string("app1"),
                                                                                },
                                                                                map[string]any{"display_name": string("app2"), "healthcheck": map[string]any{"interval": float64(5), "threshold": float64(6), "url": string("http://localhost:13337/healthz")}, "open_in": float64(1), "slug": string("app2"), ...},
                                                                                map[string]any{
                                        -                                               "display_name": string("app4"),
                                        +                                               "display_name": string("app3"),
                                                                                        "open_in":      float64(1),
                                        -                                               "slug":         string("app4"),
                                        +                                               "slug":         string("app3"),
                                                                                },
                                                                        },
                                                                        "architecture":               string("amd64"),
                                                                        "connection_timeout_seconds": float64(120),
                                                                        ... // 4 identical entries
                                                                },
                                                        },
                                                        "name": string("dev"),
                                                        "type": string("null_resource"),
                                                },
                                          }
        --- FAIL: TestConvertResources/multiple-apps/Provision (0.02s)
            resources_test.go:904:
                        Error Trace:    /home/coder/coder/provisioner/terraform/resources_test.go:904
                        Error:          unexpected resources
                        Test:           TestConvertResources/multiple-apps/Provision
                        Messages:       diff (-want +got):
                                          []map[string]any{
                                                {
                                                        "agents": []any{
                                                                map[string]any{
                                                                        "Auth": map[string]any{"Token": string("")},
                                                                        "apps": []any{
                                                                                map[string]any{
                                        -                                               "display_name": string("app0"),
                                        +                                               "display_name": string("app1"),
                                                                                        "open_in":      float64(1),
                                        -                                               "slug":         string("app0"),
                                        +                                               "slug":         string("app1"),
                                                                                },
                                                                                map[string]any{"display_name": string("app2"), "healthcheck": map[string]any{"interval": float64(5), "threshold": float64(6), "url": string("http://localhost:13337/healthz")}, "open_in": float64(1), "slug": string("app2"), ...},
                                                                                map[string]any{
                                        -                                               "display_name": string("app4"),
                                        +                                               "display_name": string("app3"),
                                                                                        "open_in":      float64(1),
                                        -                                               "slug":         string("app4"),
                                        +                                               "slug":         string("app3"),
                                                                                },
                                                                        },
                                                                        "architecture":               string("amd64"),
                                                                        "connection_timeout_seconds": float64(120),
                                                                        ... // 4 identical entries
                                                                },
                                                        },
                                                        "name": string("dev"),
                                                        "type": string("null_resource"),
                                                },
                                          }
FAIL
FAIL    github.com/coder/coder/v2/provisioner/terraform 0.043s
FAIL
```

`require.Equal`:

```
coder@w ~/coder mafredri/test-provisioner-terraform-improve-diff* 6s
❯ go test ./provisioner/terraform -run=TestConvertResources -count=1
--- FAIL: TestConvertResources (0.00s)
    --- FAIL: TestConvertResources/multiple-apps (0.00s)
        --- FAIL: TestConvertResources/multiple-apps/Provision (0.01s)
            resources_test.go:900:
                        Error Trace:    /home/coder/coder/provisioner/terraform/resources_test.go:900
                        Error:          Not equal:
                                        expected: []map[string]interface {}{map[string]interface {}{"agents":[]interface {}{map[string]interface {}{"Auth":map[string]interface {}{"Token":""}, "apps":[]interface {}{map[string]interface {}{"display_name":"app0", "open_in":1, "slug":"app0"}, map[string]interface {}{"display_name":"app2", "healthcheck":map[string]interface {}{"interval":5, "threshold":6, "url":"http://localhost:13337/healthz"}, "open_in":1, "slug":"app2", "subdomain":true}, map[string]interface {}{"display_name":"app4", "open_in":1, "slug":"app4"}}, "architecture":"amd64", "connection_timeout_seconds":120, "display_apps":map[string]interface {}{"port_forwarding_helper":true, "ssh_helper":true, "vscode":true, "web_terminal":true}, "name":"dev1", "operating_system":"linux", "resources_monitoring":map[string]interface {}{}}}, "name":"dev", "type":"null_resource"}}
                                        actual  : []map[string]interface {}{map[string]interface {}{"agents":[]interface {}{map[string]interface {}{"Auth":map[string]interface {}{"Token":""}, "apps":[]interface {}{map[string]interface {}{"display_name":"app1", "open_in":1, "slug":"app1"}, map[string]interface {}{"display_name":"app2", "healthcheck":map[string]interface {}{"interval":5, "threshold":6, "url":"http://localhost:13337/healthz"}, "open_in":1, "slug":"app2", "subdomain":true}, map[string]interface {}{"display_name":"app3", "open_in":1, "slug":"app3"}}, "architecture":"amd64", "connection_timeout_seconds":120, "display_apps":map[string]interface {}{"port_forwarding_helper":true, "ssh_helper":true, "vscode":true, "web_terminal":true}, "name":"dev1", "operating_system":"linux", "resources_monitoring":map[string]interface {}{}}}, "name":"dev", "type":"null_resource"}}

                                        Diff:
                                        --- Expected
                                        +++ Actual
                                        @@ -9,5 +9,5 @@
                                              (map[string]interface {}) (len=3) {
                                        -      (string) (len=12) "display_name": (string) (len=4) "app0",
                                        +      (string) (len=12) "display_name": (string) (len=4) "app1",
                                               (string) (len=7) "open_in": (float64) 1,
                                        -      (string) (len=4) "slug": (string) (len=4) "app0"
                                        +      (string) (len=4) "slug": (string) (len=4) "app1"
                                              },
                                        @@ -25,5 +25,5 @@
                                              (map[string]interface {}) (len=3) {
                                        -      (string) (len=12) "display_name": (string) (len=4) "app4",
                                        +      (string) (len=12) "display_name": (string) (len=4) "app3",
                                               (string) (len=7) "open_in": (float64) 1,
                                        -      (string) (len=4) "slug": (string) (len=4) "app4"
                                        +      (string) (len=4) "slug": (string) (len=4) "app3"
                                              }
                        Test:           TestConvertResources/multiple-apps/Provision
        --- FAIL: TestConvertResources/multiple-apps/Plan (0.01s)
            resources_test.go:845:
                        Error Trace:    /home/coder/coder/provisioner/terraform/resources_test.go:845
                        Error:          Not equal:
                                        expected: []map[string]interface {}{map[string]interface {}{"agents":[]interface {}{map[string]interface {}{"Auth":map[string]interface {}{"Token":""}, "apps":[]interface {}{map[string]interface {}{"display_name":"app0", "open_in":1, "slug":"app0"}, map[string]interface {}{"display_name":"app2", "healthcheck":map[string]interface {}{"interval":5, "threshold":6, "url":"http://localhost:13337/healthz"}, "open_in":1, "slug":"app2", "subdomain":true}, map[string]interface {}{"display_name":"app4", "open_in":1, "slug":"app4"}}, "architecture":"amd64", "connection_timeout_seconds":120, "display_apps":map[string]interface {}{"port_forwarding_helper":true, "ssh_helper":true, "vscode":true, "web_terminal":true}, "name":"dev1", "operating_system":"linux", "resources_monitoring":map[string]interface {}{}}}, "name":"dev", "type":"null_resource"}}
                                        actual  : []map[string]interface {}{map[string]interface {}{"agents":[]interface {}{map[string]interface {}{"Auth":map[string]interface {}{"Token":""}, "apps":[]interface {}{map[string]interface {}{"display_name":"app1", "open_in":1, "slug":"app1"}, map[string]interface {}{"display_name":"app2", "healthcheck":map[string]interface {}{"interval":5, "threshold":6, "url":"http://localhost:13337/healthz"}, "open_in":1, "slug":"app2", "subdomain":true}, map[string]interface {}{"display_name":"app3", "open_in":1, "slug":"app3"}}, "architecture":"amd64", "connection_timeout_seconds":120, "display_apps":map[string]interface {}{"port_forwarding_helper":true, "ssh_helper":true, "vscode":true, "web_terminal":true}, "name":"dev1", "operating_system":"linux", "resources_monitoring":map[string]interface {}{}}}, "name":"dev", "type":"null_resource"}}

                                        Diff:
                                        --- Expected
                                        +++ Actual
                                        @@ -9,5 +9,5 @@
                                              (map[string]interface {}) (len=3) {
                                        -      (string) (len=12) "display_name": (string) (len=4) "app0",
                                        +      (string) (len=12) "display_name": (string) (len=4) "app1",
                                               (string) (len=7) "open_in": (float64) 1,                                                                                                                                     -      (string) (len=4) "slug": (string) (len=4) "app0"
                                        +      (string) (len=4) "slug": (string) (len=4) "app1"
                                              },
                                        @@ -25,5 +25,5 @@
                                              (map[string]interface {}) (len=3) {
                                        -      (string) (len=12) "display_name": (string) (len=4) "app4",
                                        +      (string) (len=12) "display_name": (string) (len=4) "app3",
                                               (string) (len=7) "open_in": (float64) 1,
                                        -      (string) (len=4) "slug": (string) (len=4) "app4"
                                        +      (string) (len=4) "slug": (string) (len=4) "app3"
                                              }
                        Test:           TestConvertResources/multiple-apps/Plan
FAIL
FAIL    github.com/coder/coder/v2/provisioner/terraform 0.042s
FAIL
```
