### PR TITLE
fix(coderd): set default provisionerjobs limit to 50

### DIFF
--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -101,7 +101,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 
 	qp := r.URL.Query()
 	p := httpapi.NewQueryParamParser()
-	limit := p.PositiveInt32(qp, 0, "limit")
+	limit := p.PositiveInt32(qp, 50, "limit")
 	status := p.Strings(qp, nil, "status")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -63,6 +63,13 @@ func TestProvisionerJobs(t *testing.T) {
 		TemplateVersionID: version.ID,
 	})
 
+	// Add more jobs than the default limit.
+	for range 60 {
+		dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+			OrganizationID: owner.OrganizationID,
+		})
+	}
+
 	t.Run("Single", func(t *testing.T) {
 		t.Parallel()
 		t.Run("OK", func(t *testing.T) {
@@ -82,12 +89,12 @@ func TestProvisionerJobs(t *testing.T) {
 		})
 	})
 
-	t.Run("All", func(t *testing.T) {
+	t.Run("Default limit", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, nil)
 		require.NoError(t, err)
-		require.Len(t, jobs, 3)
+		require.Len(t, jobs, 50)
 	})
 
 	t.Run("Status", func(t *testing.T) {


### PR DESCRIPTION
We defaulted to no limit, resulting in a 30MB API response when no `limit` was given.