### PR TITLE
docs: remove official cloud installation methods from the unofficial page

### DIFF
--- a/docs/install/other/index.md
+++ b/docs/install/other/index.md
@@ -5,8 +5,6 @@ welcome!
 
 | Platform Name                                                                     | Status     | Documentation                                                                                |
 |-----------------------------------------------------------------------------------|------------|----------------------------------------------------------------------------------------------|
-| AWS EC2                                                                           | Official   | [Guide: AWS](../cloud/ec2.md)                                                                |
-| Google Compute Engine                                                             | Official   | [Guide: Google Compute Engine](../cloud/compute-engine.md)                                   |
 | Azure AKS                                                                         | Unofficial | [GitHub: coder-aks](https://github.com/ericpaulsen/coder-aks)                                |
 | Terraform (GKE, AKS, LKE, DOKS, IBMCloud K8s, OVHCloud K8s, Scaleway K8s Kapsule) | Unofficial | [GitHub: coder-oss-terraform](https://github.com/ElliotG/coder-oss-tf)                       |
 | Fly.io                                                                            | Unofficial | [Blog: Run Coder on Fly.io](https://coder.com/blog/remote-developer-environments-on-fly-io)  |


### PR DESCRIPTION
They are already covered in https://coder.com/docs/install/cloud