### PR TITLE
ci: ignore 503s on wiki.ubuntu.com

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -20,5 +20,6 @@ ignorePatterns:
   - pattern: "www.emacswiki.org"
   - pattern: "linux.die.net/man"
   - pattern: "www.gnu.org"
+  - pattern: "wiki.ubuntu.com"
 aliveStatusCodes:
   - 200


### PR DESCRIPTION
```
  message:"Cannot reach https://wiki.ubuntu.com/UncomplicatedFirewall. Status: 503" location:{path:"docs/tutorials/reverse-proxy-caddy.md" range:{start:{line:171 column:20} end:{line:171 column:72}}} severity:ERROR source:{name:"linkspector" url:"https://github.com/UmbrellaDocs/linkspector"}
  reviewdog: found at least one issue with severity greater than or equal to the given level: any
  Error: [Linkspector] reported by reviewdog 🐶
  Cannot reach https://wiki.ubuntu.com/UncomplicatedFirewall. Status: 503
```