### PR TITLE
docs: comment out optional lines in `values.yaml`

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -104,8 +104,8 @@ coder:
 
     # (Optional) For production deployments the access URL should be set.
     # If you're just trying Coder, access the dashboard via the service IP.
-    - name: CODER_ACCESS_URL
-      value: "https://coder.example.com"
+    # - name: CODER_ACCESS_URL
+    #   value: "https://coder.example.com"
 
   #tls:
   #  secretNames:


### PR DESCRIPTION
@michaelvp411 pointed out that some optional lines in `values.yaml` could lead to errors if the user doesn't opt to use them. This PR comments out those lines so that they're opt-in

[preview](https://coder.com/docs/@k8s-values-comment-opt/install/kubernetes) (once cache catches up)