### PR TITLE
feat: add combobox for selecting claim field value for group/role idp sync

### DIFF
--- a/site/src/components/Table/Table.tsx
+++ b/site/src/components/Table/Table.tsx
@@ -68,7 +68,7 @@ export const TableRow = React.forwardRef<
 		ref={ref}
 		className={cn(
 			"border-0 border-b border-solid border-border transition-colors",
-			"hover:bg-muted/50 data-[state=selected]:bg-muted",
+			"data-[state=selected]:bg-muted",
 			className,
 		)}
 		{...props}

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.tsx
@@ -367,7 +367,7 @@ const IdpMappingTable: FC<IdpMappingTableProps> = ({ isEmpty, children }) => {
 				<TableRow>
 					<TableCell width="45%">IdP organization</TableCell>
 					<TableCell width="55%">Coder organization</TableCell>
-					<TableCell width="10%" />
+					<TableCell width="5%" />
 				</TableRow>
 			</TableHeader>
 			<TableBody>

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
@@ -21,16 +21,16 @@ import {
 } from "components/MultiSelectCombobox/MultiSelectCombobox";
 import { Spinner } from "components/Spinner/Spinner";
 import { Switch } from "components/Switch/Switch";
+import { TableCell, TableRow } from "components/Table/Table";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { TableCell, TableRow } from "components/Table/Table";
 import { useFormik } from "formik";
 import { Plus, Trash, TriangleAlert } from "lucide-react";
-import { type FC, useId, useState, type KeyboardEventHandler } from "react";
+import { type FC, type KeyboardEventHandler, useId, useState } from "react";
 import { docs } from "utils/docs";
 import { isUUID } from "utils/uuid";
 import * as Yup from "yup";

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
@@ -226,7 +226,7 @@ export const IdpGroupSyncForm: FC<IdpGroupSyncFormProps> = ({
 							<Combobox
 								value={idpGroupName}
 								options={claimFieldValues}
-								placeholder="Select IdP organization"
+								placeholder="Select IdP group"
 								open={open}
 								onOpenChange={setOpen}
 								inputValue={comboInputValue}

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
@@ -1,5 +1,3 @@
-import TableCell from "@mui/material/TableCell";
-import TableRow from "@mui/material/TableRow";
 import type {
 	Group,
 	GroupSyncSettings,
@@ -29,6 +27,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
+import { TableCell, TableRow } from "components/Table/Table";
 import { useFormik } from "formik";
 import { Plus, Trash, TriangleAlert } from "lucide-react";
 import { type FC, useId, useState, type KeyboardEventHandler } from "react";
@@ -125,7 +124,9 @@ export const IdpGroupSyncForm: FC<IdpGroupSyncFormProps> = ({
 		if (
 			event.key === "Enter" &&
 			comboInputValue &&
-			!claimFieldValues?.some((value) => value === comboInputValue.toLowerCase())
+			!claimFieldValues?.some(
+				(value) => value === comboInputValue.toLowerCase(),
+			)
 		) {
 			event.preventDefault();
 			setIdpGroupName(comboInputValue);

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
@@ -232,7 +232,7 @@ export const IdpGroupSyncForm: FC<IdpGroupSyncFormProps> = ({
 								inputValue={comboInputValue}
 								onInputChange={setComboInputValue}
 								onKeyDown={handleKeyDown}
-								onSelect={(value: string) => {
+								onSelect={(value) => {
 									setIdpGroupName(value);
 									setOpen(false);
 								}}

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpMappingTable.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpMappingTable.tsx
@@ -60,7 +60,7 @@ export const IdpMappingTable: FC<IdpMappingTableProps> = ({
 			<div className="flex justify-end">
 				<div className="text-content-secondary text-xs">
 					Showing <strong className="text-content-primary">{rowCount}</strong>{" "}
-					groups
+					{type.toLocaleLowerCase()}{(rowCount === 0 || rowCount > 1) && "s"}
 				</div>
 			</div>
 		</div>

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpMappingTable.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpMappingTable.tsx
@@ -60,7 +60,8 @@ export const IdpMappingTable: FC<IdpMappingTableProps> = ({
 			<div className="flex justify-end">
 				<div className="text-content-secondary text-xs">
 					Showing <strong className="text-content-primary">{rowCount}</strong>{" "}
-					{type.toLocaleLowerCase()}{(rowCount === 0 || rowCount > 1) && "s"}
+					{type.toLocaleLowerCase()}
+					{(rowCount === 0 || rowCount > 1) && "s"}
 				</div>
 			</div>
 		</div>

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpMappingTable.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpMappingTable.tsx
@@ -1,12 +1,13 @@
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Link } from "components/Link/Link";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHeader,
+	TableRow,
+} from "components/Table/Table";
 import type { FC } from "react";
 import { docs } from "utils/docs";
 
@@ -22,44 +23,40 @@ export const IdpMappingTable: FC<IdpMappingTableProps> = ({
 	children,
 }) => {
 	return (
-		<div className="flex flex-col w-full gap-2">
-			<TableContainer>
-				<Table>
-					<TableHead>
-						<TableRow>
-							<TableCell width="45%">IdP {type.toLocaleLowerCase()}</TableCell>
-							<TableCell width="55%">
-								Coder {type.toLocaleLowerCase()}
-							</TableCell>
-							<TableCell width="10%" />
-						</TableRow>
-					</TableHead>
-					<TableBody>
-						<ChooseOne>
-							<Cond condition={rowCount === 0}>
-								<TableRow>
-									<TableCell colSpan={999}>
-										<EmptyState
-											message={`No ${type.toLocaleLowerCase()} mappings`}
-											isCompact
-											cta={
-												<Link
-													href={docs(
-														`/admin/users/idp-sync#${type.toLocaleLowerCase()}-sync`,
-													)}
-												>
-													How to setup IdP {type.toLocaleLowerCase()} sync
-												</Link>
-											}
-										/>
-									</TableCell>
-								</TableRow>
-							</Cond>
-							<Cond>{children}</Cond>
-						</ChooseOne>
-					</TableBody>
-				</Table>
-			</TableContainer>
+		<div className="flex flex-col gap-2">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableCell width="45%">IdP {type.toLocaleLowerCase()}</TableCell>
+						<TableCell width="55%">Coder {type.toLocaleLowerCase()}</TableCell>
+						<TableCell width="5%" />
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					<ChooseOne>
+						<Cond condition={rowCount === 0}>
+							<TableRow>
+								<TableCell colSpan={999}>
+									<EmptyState
+										message={`No ${type.toLocaleLowerCase()} mappings`}
+										isCompact
+										cta={
+											<Link
+												href={docs(
+													`/admin/users/idp-sync#${type.toLocaleLowerCase()}-sync`,
+												)}
+											>
+												How to setup IdP {type.toLocaleLowerCase()} sync
+											</Link>
+										}
+									/>
+								</TableCell>
+							</TableRow>
+						</Cond>
+						<Cond>{children}</Cond>
+					</ChooseOne>
+				</TableBody>
+			</Table>
 			<div className="flex justify-end">
 				<div className="text-content-secondary text-xs">
 					Showing <strong className="text-content-primary">{rowCount}</strong>{" "}

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
@@ -1,5 +1,3 @@
-import TableCell from "@mui/material/TableCell";
-import TableRow from "@mui/material/TableRow";
 import type { Organization, Role, RoleSyncSettings } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import { Combobox } from "components/Combobox/Combobox";
@@ -16,6 +14,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
+import { TableCell, TableRow } from "components/Table/Table";
 import { useFormik } from "formik";
 import { Plus, Trash, TriangleAlert } from "lucide-react";
 import { type FC, type KeyboardEventHandler, useId, useState } from "react";
@@ -99,7 +98,9 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 		if (
 			event.key === "Enter" &&
 			comboInputValue &&
-			!claimFieldValues?.some((value) => value === comboInputValue.toLowerCase())
+			!claimFieldValues?.some(
+				(value) => value === comboInputValue.toLowerCase(),
+			)
 		) {
 			event.preventDefault();
 			setIdpRoleName(comboInputValue);

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
@@ -8,13 +8,13 @@ import {
 	type Option,
 } from "components/MultiSelectCombobox/MultiSelectCombobox";
 import { Spinner } from "components/Spinner/Spinner";
+import { TableCell, TableRow } from "components/Table/Table";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { TableCell, TableRow } from "components/Table/Table";
 import { useFormik } from "formik";
 import { Plus, Trash, TriangleAlert } from "lucide-react";
 import { type FC, type KeyboardEventHandler, useId, useState } from "react";

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
@@ -2,6 +2,7 @@ import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import type { Organization, Role, RoleSyncSettings } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
+import { Combobox } from "components/Combobox/Combobox";
 import { Input } from "components/Input/Input";
 import { Label } from "components/Label/Label";
 import {
@@ -17,7 +18,7 @@ import {
 } from "components/Tooltip/Tooltip";
 import { useFormik } from "formik";
 import { Plus, Trash, TriangleAlert } from "lucide-react";
-import { type FC, useId, useState } from "react";
+import { type FC, type KeyboardEventHandler, useId, useState } from "react";
 import * as Yup from "yup";
 import { ExportPolicyButton } from "./ExportPolicyButton";
 import { IdpMappingTable } from "./IdpMappingTable";
@@ -53,6 +54,7 @@ interface IdpRoleSyncFormProps {
 	organization: Organization;
 	roles: Role[];
 	onSubmit: (data: RoleSyncSettings) => void;
+	onSyncFieldChange: (value: string) => void;
 }
 
 export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
@@ -62,6 +64,7 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 	organization,
 	roles,
 	onSubmit,
+	onSyncFieldChange,
 }) => {
 	const form = useFormik<RoleSyncSettings>({
 		initialValues: {
@@ -75,6 +78,8 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 	const [idpRoleName, setIdpRoleName] = useState("");
 	const [coderRoles, setCoderRoles] = useState<Option[]>([]);
 	const id = useId();
+	const [comboInputValue, setComboInputValue] = useState("");
+	const [open, setOpen] = useState(false);
 
 	const handleDelete = async (idpOrg: string) => {
 		const newMapping = Object.fromEntries(
@@ -88,6 +93,19 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 		};
 		void form.setFieldValue("mapping", newSyncSettings.mapping);
 		form.handleSubmit();
+	};
+
+	const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+		if (
+			event.key === "Enter" &&
+			comboInputValue &&
+			!claimFieldValues?.some((value) => value === comboInputValue.toLowerCase())
+		) {
+			event.preventDefault();
+			setIdpRoleName(comboInputValue);
+			setComboInputValue("");
+			setOpen(false);
+		}
 	};
 
 	return (
@@ -114,6 +132,7 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 								value={form.values.field}
 								onChange={(event) => {
 									void form.setFieldValue("field", event.target.value);
+									onSyncFieldChange(event.target.value);
 								}}
 								className="w-72"
 							/>
@@ -143,14 +162,31 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 						<Label className="text-sm" htmlFor={`${id}-idp-role-name`}>
 							IdP role name
 						</Label>
-						<Input
-							id={`${id}-idp-role-name`}
-							value={idpRoleName}
-							className="w-72"
-							onChange={(event) => {
-								setIdpRoleName(event.target.value);
-							}}
-						/>
+						{claimFieldValues ? (
+							<Combobox
+								value={idpRoleName}
+								options={claimFieldValues}
+								placeholder="Select IdP organization"
+								open={open}
+								onOpenChange={setOpen}
+								inputValue={comboInputValue}
+								onInputChange={setComboInputValue}
+								onKeyDown={handleKeyDown}
+								onSelect={(value: string) => {
+									setIdpRoleName(value);
+									setOpen(false);
+								}}
+							/>
+						) : (
+							<Input
+								id={`${id}-idp-role-name`}
+								value={idpRoleName}
+								className="w-72"
+								onChange={(event) => {
+									setIdpRoleName(event.target.value);
+								}}
+							/>
+						)}
 					</div>
 					<div className="grid items-center gap-1 flex-1">
 						<Label className="text-sm" htmlFor={`${id}-coder-role`}>

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
@@ -173,7 +173,7 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 								inputValue={comboInputValue}
 								onInputChange={setComboInputValue}
 								onKeyDown={handleKeyDown}
-								onSelect={(value: string) => {
+								onSelect={(value) => {
 									setIdpRoleName(value);
 									setOpen(false);
 								}}

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpRoleSyncForm.tsx
@@ -167,7 +167,7 @@ export const IdpRoleSyncForm: FC<IdpRoleSyncFormProps> = ({
 							<Combobox
 								value={idpRoleName}
 								options={claimFieldValues}
-								placeholder="Select IdP organization"
+								placeholder="Select IdP role"
 								open={open}
 								onOpenChange={setOpen}
 								inputValue={comboInputValue}

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -44,22 +44,8 @@ export const IdpSyncPage: FC = () => {
 		rolesQuery,
 	] = useQueries({
 		queries: [
-			{
-				...groupIdpSyncSettings(organizationName),
-				onSuccess: (data: GroupSyncSettings) => {
-					if (data?.field) {
-						setGroupField(data.field);
-					}
-				},
-			},
-			{
-				...roleIdpSyncSettings(organizationName),
-				onSuccess: (data: RoleSyncSettings) => {
-					if (data?.field) {
-						setRoleField(data.field);
-					}
-				},
-			},
+			groupIdpSyncSettings(organizationName),
+			roleIdpSyncSettings(organizationName),
 			groupsByOrganization(organizationName),
 			organizationRoles(organizationName),
 		],

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -21,6 +21,8 @@ interface IdpSyncPageViewProps {
 	groupsMap: Map<string, string>;
 	roles: Role[] | undefined;
 	organization: Organization;
+	onGroupSyncFieldChange: (value: string) => void;
+	onRoleSyncFieldChange: (value: string) => void;
 	error?: unknown;
 	onSubmitGroupSyncSettings: (data: GroupSyncSettings) => void;
 	onSubmitRoleSyncSettings: (data: RoleSyncSettings) => void;
@@ -35,6 +37,8 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 	groupsMap,
 	roles,
 	organization,
+	onGroupSyncFieldChange,
+	onRoleSyncFieldChange,
 	error,
 	onSubmitGroupSyncSettings,
 	onSubmitRoleSyncSettings,
@@ -76,6 +80,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 					groupsMap={groupsMap}
 					organization={organization}
 					onSubmit={onSubmitGroupSyncSettings}
+					onSyncFieldChange={onGroupSyncFieldChange}
 				/>
 			) : (
 				<IdpRoleSyncForm
@@ -85,6 +90,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 					roles={roles || []}
 					organization={organization}
 					onSubmit={onSubmitRoleSyncSettings}
+					onSyncFieldChange={onRoleSyncFieldChange}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
contributes to coder/internal#330

This is a followup to coder/coder#16335

This adds a combobox that swaps with the input for the idp group and idp role names when the sync field returns claim values from the claim field values endpoint. If no claim field values are returned then the input remains instead of the combobox.


<img width="806" alt="Screenshot 2025-02-05 at 20 50 48" src="https://github.com/user-attachments/assets/bff839f5-1a2f-4cc1-8933-73fde942bc75" />
<img width="803" alt="Screenshot 2025-02-05 at 20 51 00" src="https://github.com/user-attachments/assets/e9c7ca33-136a-4962-b924-770a64658dc8" />
