### PR TITLE
feat(cli): add display of open ports in coder show

### DIFF
--- a/cli/cliui/resources.go
+++ b/cli/cliui/resources.go
@@ -96,7 +96,7 @@ func WorkspaceResources(writer io.Writer, resources []codersdk.WorkspaceResource
 		for index, agent := range resource.Agents {
 			tableWriter.AppendRow(renderAgentRow(agent, index, totalAgents, options))
 			if options.ListeningPorts != nil {
-				if lp, ok := options.ListeningPorts[agent.ID]; ok {
+				if lp, ok := options.ListeningPorts[agent.ID]; ok && len(lp.Ports) > 0 {
 					tableWriter.AppendRow(table.Row{
 						fmt.Sprintf("   %s─ %s", renderPipe(index, totalAgents), "Open Ports"),
 					})


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/16418 -- devcontainers will be shown in a similar manner.

Without ports (status quo):
![Screenshot 2025-02-10 at 12 50 46](https://github.com/user-attachments/assets/c25fd532-2e35-469c-bb28-26e59ded3eb4)

With ports:
![Screenshot 2025-02-10 at 12 50 06](https://github.com/user-attachments/assets/a4671349-5866-4e1e-848e-a6e819479793)
