### PR TITLE
docs: cleanup Zed editor connection docs

### DIFF
--- a/docs/user-guides/workspace-access/zed.md
+++ b/docs/user-guides/workspace-access/zed.md
@@ -27,11 +27,6 @@ Use the Coder CLI to log in and configure SSH, then connect to your workspace wi
 
    ### Windows
 
-   > **Important:** If you plan to use the built-in PostgreSQL database, you will
-   > need to ensure that the
-   > [Visual C++ Runtime](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist#latest-microsoft-visual-c-redistributable-version)
-   > is installed.
-
    Use [GitHub releases](https://github.com/coder/coder/releases) to download the
    Windows installer (`.msi`) or standalone binary (`.exe`).
 


### PR DESCRIPTION
Removes the un-needed instructions for Windows installation for IDE access use case.