### PR TITLE
docs: update licensing steps in faq

### DIFF
--- a/docs/admin/licensing/index.md
+++ b/docs/admin/licensing/index.md
@@ -47,9 +47,17 @@ There are two ways to add a license to a Coder deployment:
 
 1. Run `coder licenses add`:
 
-   ```shell
-   coder licenses add -f <path to your license key>
-   ```
+   - For a `.jwt` license file:
+
+     ```shell
+     coder licenses add -f <path to your license key>
+     ```
+
+   - For a text string:
+
+     ```sh
+     coder licenses add -l 1f5...765
+     ```
 
 </div>
 

--- a/docs/tutorials/faqs.md
+++ b/docs/tutorials/faqs.md
@@ -11,28 +11,57 @@ For other community resources, see our
 ## How do I add a Premium trial license?
 
 Visit <https://coder.com/trial> or contact
-
 [sales@coder.com](mailto:sales@coder.com?subject=License) to get a trial key.
 
-You can add a license through the UI or CLI.
+You can add a license through the UI or CLI:
 
-In the UI, click the Deployment tab -> Licenses and upload the `jwt` license
-file.
+<!-- copied from docs/admin/licensing/index.md -->
 
-> To add the license with the CLI, first
-> [install the Coder CLI](../install/cli.md) and server to the latest release.
+<div class="tabs">
 
-If the license is a text string:
+### Coder UI
 
-```sh
-coder licenses add -l 1f5...765
-```
+1. With an `Owner` account, go to **Admin settings** > **Deployment**.
 
-If the license is in a file:
+1. Select **Licenses** from the sidebar, then **Add a license**:
 
-```sh
-coder licenses add -f <path/filename>
-```
+   ![Add a license from the licenses screen](../images/admin/licenses/licenses-nolicense.png)
+
+1. On the **Add a license** screen, drag your `.jwt` license file into the
+   **Upload Your License** section, or paste your license in the
+   **Paste Your License** text box, then select **Upload License**:
+
+   ![Add a license screen](../images/admin/licenses/add-license-ui.png)
+
+### Coder CLI
+
+1. Ensure you have the [Coder CLI](../../install/cli.md) installed.
+1. Save your license key to disk and make note of the path.
+1. Open a terminal.
+1. Log in to your Coder deployment:
+
+   ```shell
+   coder login <access url>
+   ```
+
+1. Run `coder licenses add`:
+
+   - For a `.jwt` license file:
+
+     ```shell
+     coder licenses add -f <path to your license key>
+     ```
+
+   - For a text string:
+
+     ```sh
+     coder licenses add -l 1f5...765
+     ```
+
+</div>
+
+Visit the [licensing documentation](../admin/licensing/index.md) for more
+information about licenses.
 
 ## I'm experiencing networking issues, so want to disable Tailscale, STUN, Direct connections and force use of websocket
 

--- a/docs/tutorials/faqs.md
+++ b/docs/tutorials/faqs.md
@@ -35,7 +35,7 @@ You can add a license through the UI or CLI:
 
 ### Coder CLI
 
-1. Ensure you have the [Coder CLI](../../install/cli.md) installed.
+1. Ensure you have the [Coder CLI](../install/cli.md) installed.
 1. Save your license key to disk and make note of the path.
 1. Open a terminal.
 1. Log in to your Coder deployment:

--- a/docs/tutorials/faqs.md
+++ b/docs/tutorials/faqs.md
@@ -13,7 +13,9 @@ For other community resources, see our
 Visit <https://coder.com/trial> or contact
 [sales@coder.com](mailto:sales@coder.com?subject=License) to get a trial key.
 
-You can add a license through the UI or CLI:
+<details>
+
+<summary>You can add a license through the UI or CLI</summary>
 
 <!-- copied from docs/admin/licensing/index.md -->
 
@@ -59,6 +61,8 @@ You can add a license through the UI or CLI:
      ```
 
 </div>
+
+</details>
 
 Visit the [licensing documentation](../admin/licensing/index.md) for more
 information about licenses.


### PR DESCRIPTION
<details>

<summary>this would be a good candidate for an expand component</summary>

but I don't think they work in our docs yet

</details>

[preview](https://coder.com/docs/@licensing-faq/tutorials/faqs#how-do-i-add-a-premium-trial-license)