### PR TITLE
feat(cli/server.go): allow the use of public OIDC clients

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -694,7 +694,12 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}
 			}
 
-			if vals.OIDC.ClientKeyFile != "" || vals.OIDC.ClientSecret != "" {
+			// As OIDC clients can be confidential or public,
+			// we should only check for a client id being set.
+			// The underlying library handles the case of no
+			// client secrets correctly. For more details on
+			// client types: https://oauth.net/2/client-types/
+			if vals.OIDC.ClientID != "" {
 				if vals.OIDC.IgnoreEmailVerified {
 					logger.Warn(ctx, "coder will not check email_verified for OIDC logins")
 				}

--- a/scripts/dev-oidc.sh
+++ b/scripts/dev-oidc.sh
@@ -49,6 +49,17 @@ cat <<EOF >/tmp/example-realm.json
       "baseUrl": "/coder",
       "redirectUris": ["*"],
       "secret": "coder"
+    },
+    {
+      "clientId": "coder-public",
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "enabled": true,
+      "fullScopeAllowed": true,
+      "baseUrl": "/coder",
+      "redirectUris": [
+        "*"
+      ]
     }
   ]
 }
@@ -79,6 +90,9 @@ hostname=$(hostname -f)
 export CODER_OIDC_ISSUER_URL="http://${hostname}:9080/realms/coder"
 export CODER_OIDC_CLIENT_ID=coder
 export CODER_OIDC_CLIENT_SECRET=coder
+# Comment out the two lines above, and comment in the line below,
+# to configure OIDC auth using a public client.
+# export CODER_OIDC_CLIENT_ID=coder-public
 export CODER_DEV_ACCESS_URL="http://${hostname}:8080"
 
 exec "${SCRIPT_DIR}/develop.sh" "$@"


### PR DESCRIPTION
Support public OIDC clients

- Enables support for public OIDC clients by only checking for a client ID being set. This allows for confidential and public clients to be used with Coder's OIDC authentication.
- Also adds a public client configuration to the development OIDC setup script.

Fixes #16135

Change-Id: Iadd85d40c2faa595a0498e25d3407a1f94b5c8a8
Signed-off-by: Thomas Kosiewski <tk@coder.com>