### PR TITLE
fix(site): update Spinner component to avoid UI edge cases

### DIFF
--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -152,9 +152,9 @@ function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 	// Be very careful with this logic; React only bails out of redundant state
 	// updates if they happen outside of a render. Inside a render, if you keep
 	// calling a state dispatch, you will get an infinite render loop, no matter
-	// what the value you dispatch. There must be a "base case" in the render
-	// path that causes state dispatches to stop entirely so that React can
-	// move on to the next component in the Fiber subtree
+	// what value you dispatch. There must be a "base case" in the render path
+	// that causes state dispatches to stop entirely so that React can move on
+	// to the next component in the Fiber subtree
 	const [delayLapsed, setDelayLapsed] = useState(safeDelay === 0);
 	const [renderCache, setRenderCache] = useState({ loading, safeDelay });
 	const canResetLapseOnRerender =

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -1,6 +1,6 @@
 /**
- * @file This component was inspired by Radix's Spinner component and developed
- * using help from Vercel's V0.
+ * @file This component was inspired by Radix's Spinner component. The animation
+ * settings were developed using Vercel's v0.
  *
  * @see {@link https://www.radix-ui.com/themes/docs/components/spinner}
  * @see {@link https://v0.dev/}
@@ -128,9 +128,9 @@ export const Spinner: FC<SpinnerProps> = ({
 			 */}
 			{(!showSpinner || !unmountChildrenWhileLoading) && (
 				<>
-					<span className={showSpinner ? "sr-only" : "hidden"}>
-						This content is loading:{" "}
-					</span>
+					{showSpinner && (
+						<span className="sr-only">This content is loading: </span>
+					)}
 					<span className={showSpinner ? "sr-only" : "inline"}>{children}</span>
 				</>
 			)}
@@ -156,29 +156,20 @@ function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 	/**
 	 * Doing a bunch of mid-render state syncs to minimize risks of UI tearing
 	 * during re-renders. It's ugly, but it's what the React team officially
-	 * recommends (even though this specific case is extra nasty).
+	 * recommends.
 	 * @see {@link https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes}
-	 *
-	 * Be very careful with this logic; React only bails out of redundant state
-	 * updates if they happen outside of a render. Inside a render, if you keep
-	 * calling a state dispatch, you will get an infinite render loop, no matter
-	 * what value you dispatch. There must be a "base case" in the render path
-	 * that causes state dispatches to stop entirely so that React can move on
-	 * to the next component in the Fiber subtree
 	 */
 	const [delayLapsed, setDelayLapsed] = useState(safeDelay === 0);
-	const [renderCache, setRenderCache] = useState({ loading, safeDelay });
-	const canResetLapseOnRerender =
-		delayLapsed && !loading && loading !== renderCache.loading;
+	const [cachedDelay, setCachedDelay] = useState(safeDelay);
+	const canResetLapseOnRerender = delayLapsed && !loading;
 	if (canResetLapseOnRerender) {
 		setDelayLapsed(false);
-		setRenderCache((current) => ({ ...current, loading }));
 	}
 	const delayWasRemovedOnRerender =
-		!delayLapsed && safeDelay === 0 && renderCache.safeDelay !== safeDelay;
+		!delayLapsed && safeDelay === 0 && safeDelay !== cachedDelay;
 	if (delayWasRemovedOnRerender) {
 		setDelayLapsed(true);
-		setRenderCache((current) => ({ ...current, safeDelay }));
+		setCachedDelay(safeDelay);
 	}
 	useEffect(() => {
 		if (safeDelay === 0) {

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -12,6 +12,7 @@ import { type CSSProperties, type FC, useEffect, useState } from "react";
 import { cn } from "utils/cn";
 
 const SPINNER_LEAF_COUNT = 8;
+const MAX_SPINNER_DELAY_MS = 2_000;
 
 const spinnerVariants = cva("", {
 	variants: {
@@ -140,7 +141,9 @@ function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 	// Disallow negative timeout values and fractional values, but also round
 	// the delay down if it's small enough that it might as well be immediate
 	// from a user perspective
-	let safeDelay = Math.trunc(spinnerDelayMs);
+	let safeDelay = Number.isNaN(spinnerDelayMs)
+		? 0
+		: Math.min(MAX_SPINNER_DELAY_MS, Math.trunc(spinnerDelayMs));
 	if (safeDelay < 100) {
 		safeDelay = 0;
 	}

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -2,8 +2,8 @@
  * @file This component was inspired by Radix's Spinner component. The animation
  * settings were developed using Vercel's v0.
  *
- * @see {@link https://www.radix-ui.com/themes/docs/components/spinner}
- * @see {@link https://v0.dev/}
+ * {@link https://www.radix-ui.com/themes/docs/components/spinner}
+ * {@link https://v0.dev/}
  */
 
 import isChromatic from "chromatic/isChromatic";
@@ -50,7 +50,9 @@ type SpinnerProps = Readonly<
 			 * If you do need reset all the state after a loading transition
 			 * and you can't unmount the component without creating invalid
 			 * HTML, use a render key to reset the state.
-			 * @see {@link https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes}
+			 *
+			 * ---
+			 * {@link https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes}
 			 */
 			unmountChildrenWhileLoading?: boolean;
 
@@ -89,9 +91,9 @@ const animationSettings: CSSProperties = isChromatic()
 
 export const Spinner: FC<SpinnerProps> = ({
 	className,
-	size,
 	loading,
 	children,
+	size = "lg",
 	spinnerDelayMs = 0,
 	unmountChildrenWhileLoading = false,
 	...delegatedProps
@@ -109,7 +111,7 @@ export const Spinner: FC<SpinnerProps> = ({
 	 * Doing a bunch of mid-render state syncs to minimize risks of UI tearing
 	 * during re-renders. It's ugly, but it's what the React team officially
 	 * recommends.
-	 * @see {@link https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes}
+	 * {@link https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes}
 	 */
 	const [delayLapsed, setDelayLapsed] = useState(safeDelay === 0);
 	const canResetLapseOnRerender = delayLapsed && !loading;

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -145,16 +145,19 @@ function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 		safeDelay = 0;
 	}
 
-	// Doing a bunch of mid-render state syncs to minimize risks of UI tearing
-	// during re-renders. It's ugly, but it's what the React team officially
-	// recommends (even though this specific case is extra nasty).
-	//
-	// Be very careful with this logic; React only bails out of redundant state
-	// updates if they happen outside of a render. Inside a render, if you keep
-	// calling a state dispatch, you will get an infinite render loop, no matter
-	// what value you dispatch. There must be a "base case" in the render path
-	// that causes state dispatches to stop entirely so that React can move on
-	// to the next component in the Fiber subtree
+	/**
+	 * Doing a bunch of mid-render state syncs to minimize risks of UI tearing
+	 * during re-renders. It's ugly, but it's what the React team officially
+	 * recommends (even though this specific case is extra nasty).
+	 * @see {@link https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes}
+	 *
+	 * Be very careful with this logic; React only bails out of redundant state
+	 * updates if they happen outside of a render. Inside a render, if you keep
+	 * calling a state dispatch, you will get an infinite render loop, no matter
+	 * what value you dispatch. There must be a "base case" in the render path
+	 * that causes state dispatches to stop entirely so that React can move on
+	 * to the next component in the Fiber subtree
+	 */
 	const [delayLapsed, setDelayLapsed] = useState(safeDelay === 0);
 	const [renderCache, setRenderCache] = useState({ loading, safeDelay });
 	const canResetLapseOnRerender =

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -6,10 +6,10 @@
 
 import isChromatic from "chromatic/isChromatic";
 import { type VariantProps, cva } from "class-variance-authority";
-import type { ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 import { cn } from "utils/cn";
 
-const leaves = 8;
+const SPINNER_LEAF_COUNT = 8;
 
 const spinnerVariants = cva("", {
 	variants: {
@@ -23,19 +23,25 @@ const spinnerVariants = cva("", {
 	},
 });
 
-type SpinnerProps = React.SVGProps<SVGSVGElement> &
-	VariantProps<typeof spinnerVariants> & {
-		children?: ReactNode;
-		loading?: boolean;
-	};
+type SpinnerProps = Readonly<
+	React.SVGProps<SVGSVGElement> &
+		VariantProps<typeof spinnerVariants> & {
+			children?: ReactNode;
+			loading?: boolean;
+			unmountedWhileLoading?: boolean;
+			spinnerStartDelayMs?: number;
+		}
+>;
 
-export function Spinner({
+const leavesIterable = Array.from({ length: SPINNER_LEAF_COUNT }, (_, i) => i);
+
+export const Spinner: FC<SpinnerProps> = ({
 	className,
 	size,
 	loading,
 	children,
 	...props
-}: SpinnerProps) {
+}) => {
 	if (!loading) {
 		return children;
 	}
@@ -45,33 +51,29 @@ export function Spinner({
 			viewBox="0 0 24 24"
 			xmlns="http://www.w3.org/2000/svg"
 			fill="currentColor"
-			className={cn(spinnerVariants({ size, className }))}
+			className={cn(className, spinnerVariants({ size }))}
 			{...props}
 		>
 			<title>Loading spinner</title>
-			{[...Array(leaves)].map((_, i) => {
-				const rotation = i * (360 / leaves);
-
-				return (
-					<rect
-						key={i}
-						x="10.9"
-						y="2"
-						width="2"
-						height="5.5"
-						rx="1"
-						// 0.8 = leaves * 0.1
-						className={
-							isChromatic() ? "" : "animate-[loading_0.8s_ease-in-out_infinite]"
-						}
-						style={{
-							transform: `rotate(${rotation}deg)`,
-							transformOrigin: "center",
-							animationDelay: `${-i * 0.1}s`,
-						}}
-					/>
-				);
-			})}
+			{leavesIterable.map((leafIndex) => (
+				<rect
+					key={leafIndex}
+					x="10.9"
+					y="2"
+					width="2"
+					height="5.5"
+					rx="1"
+					// 0.8 = leaves * 0.1
+					className={
+						isChromatic() ? "" : "animate-[loading_0.8s_ease-in-out_infinite]"
+					}
+					style={{
+						transform: `rotate(${leafIndex * (360 / SPINNER_LEAF_COUNT)}deg)`,
+						transformOrigin: "center",
+						animationDelay: `${-leafIndex * 0.1}s`,
+					}}
+				/>
+			))}
 		</svg>
 	);
-}
+};

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -6,7 +6,7 @@
 
 import isChromatic from "chromatic/isChromatic";
 import { type VariantProps, cva } from "class-variance-authority";
-import { type FC, useEffect, useState } from "react";
+import { type CSSProperties, type FC, useEffect, useState } from "react";
 import { cn } from "utils/cn";
 
 const SPINNER_LEAF_COUNT = 8;
@@ -27,12 +27,44 @@ type SpinnerProps = Readonly<
 	React.SVGProps<SVGSVGElement> &
 		VariantProps<typeof spinnerVariants> & {
 			loading: boolean;
+
+			/**
+			 * Indicates whether the children prop should be unmounted during
+			 * a loading state. Defaults to false - unmounting HTML elements
+			 * like form controls can lead to invalid HTML, so this prop should
+			 * be used with care and only if it prevents render performance
+			 * issues.
+			 */
 			unmountedWhileLoading?: boolean;
+
+			/**
+			 * Specifies whether there should be a delay before the spinner
+			 * appears on screen. If not specified, the spinner always appears
+			 * immediately.
+			 *
+			 * Can help avoid page flickering issues. (e.g., You have a modal
+			 * that takes a moment to close, and it has Spinner content inside
+			 * it. The user triggers a loading transition, and you want to show
+			 * the spinner at some point if a transition takes long enough, but
+			 * if the spinner mounting and modal closing happen in too quick of
+			 * a succession, the UI looks janky. So even though you might flip
+			 * the loading state immediately, you want to wait a second to show
+			 * it in case the modal can close quickly enough. It's lying to the
+			 * user in a way that makes the UI feel more polished.)
+			 */
 			spinnerStartDelayMs?: number;
 		}
 >;
 
 const leavesIterable = Array.from({ length: SPINNER_LEAF_COUNT }, (_, i) => i);
+const animationSettings: CSSProperties = isChromatic()
+	? {}
+	: {
+			transitionDuration: `${0.1 * SPINNER_LEAF_COUNT}s`,
+			transitionTimingFunction: "ease-in-out",
+			animationIterationCount: "infinite",
+		};
+
 export const Spinner: FC<SpinnerProps> = ({
 	className,
 	size,
@@ -42,6 +74,11 @@ export const Spinner: FC<SpinnerProps> = ({
 	unmountedWhileLoading = false,
 	...delegatedProps
 }) => {
+	/**
+	 * @todo Figure out if this conditional logic causes a component to lose
+	 * state. I would hope not, since the children prop is the same in both
+	 * cases, but I need to test this out
+	 */
 	const showSpinner = useShowSpinner(loading, spinnerStartDelayMs);
 	if (!showSpinner) {
 		return children;
@@ -67,12 +104,8 @@ export const Spinner: FC<SpinnerProps> = ({
 						width="2"
 						height="5.5"
 						rx="1"
-						className={
-							// 0.8 is hard-coded because of Tailwind; the value
-							// should always be (0.1 * SPINNER_LEAF_COUNT)
-							isChromatic() ? "" : "animate-[loading_0.8s_ease-in-out_infinite]"
-						}
 						style={{
+							...animationSettings,
 							transform: `rotate(${leafIndex * (360 / SPINNER_LEAF_COUNT)}deg)`,
 							transformOrigin: "center",
 							animationDelay: `${-leafIndex * 0.1}s`,
@@ -80,13 +113,19 @@ export const Spinner: FC<SpinnerProps> = ({
 					/>
 				))}
 			</svg>
-			{!unmountedWhileLoading && <div className="sr-only">{children}</div>}
+
+			{!unmountedWhileLoading && (
+				<div className="sr-only">
+					This content is loading:
+					{children}
+				</div>
+			)}
 		</>
 	);
 };
 
 // Not a big fan of one-time custom hooks, but it helps insulate the main
-// component from the chaos of handling all these states, when the ultimate
+// component from the chaos of handling all these state syncs, when the ultimate
 // result is a simple boolean. V8 will be able to inline the function definition
 // in some cases anyway
 function useShowSpinner(

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -37,7 +37,7 @@ type SpinnerProps = Readonly<
 			 * be used with care and only if it prevents render performance
 			 * issues.
 			 */
-			unmountedWhileLoading?: boolean;
+			unmountChildrenWhileLoading?: boolean;
 
 			/**
 			 * Specifies whether there should be a delay before the spinner
@@ -54,7 +54,7 @@ type SpinnerProps = Readonly<
 			 * it in case the modal can close quickly enough. It's lying to the
 			 * user in a way that makes the UI feel more polished.)
 			 */
-			spinnerStartDelayMs?: number;
+			spinnerDelayMs?: number;
 		}
 >;
 
@@ -72,14 +72,14 @@ export const Spinner: FC<SpinnerProps> = ({
 	size,
 	loading,
 	children,
-	spinnerStartDelayMs = 0,
-	unmountedWhileLoading = false,
+	spinnerDelayMs = 0,
+	unmountChildrenWhileLoading = false,
 	...delegatedProps
 }) => {
 	// Disallow negative timeout values and fractional values, but also round
 	// the delay down if it's small enough that it might as well be immediate
 	// from a user perspective
-	let safeDelay = Math.trunc(spinnerStartDelayMs);
+	let safeDelay = Math.trunc(spinnerDelayMs);
 	if (safeDelay < 100) {
 		safeDelay = 0;
 	}
@@ -95,7 +95,9 @@ export const Spinner: FC<SpinnerProps> = ({
 	if (delayLapsed && !loading) {
 		setDelayLapsed(false);
 	}
-	if (!delayLapsed && safeDelay === 0 && cachedDelay !== safeDelay) {
+	const delayWasRemovedOnRerender =
+		!delayLapsed && safeDelay === 0 && cachedDelay !== safeDelay;
+	if (delayWasRemovedOnRerender) {
 		setDelayLapsed(true);
 		setCachedDelay(safeDelay);
 	}
@@ -148,7 +150,7 @@ export const Spinner: FC<SpinnerProps> = ({
 				))}
 			</svg>
 
-			{!unmountedWhileLoading && (
+			{!unmountChildrenWhileLoading && (
 				<div className="sr-only">
 					This content is loading:
 					{children}

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -139,13 +139,16 @@ function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 		safeDelay = 0;
 	}
 
-	// Doing a bunch of mid-render state syncs to minimize risks of
-	// contradictory states during re-renders. It's ugly, but it's what the
-	// React team officially recommends. Be very careful with this logic; React
-	// only bails out of redundant state updates if they happen outside of a
-	// render. Inside a render, if you keep calling a state dispatch, you will
-	// get an infinite render loop, no matter what the state value is. There
-	// must be a "base case" that causes re-renders to stabilize/stop
+	// Doing a bunch of mid-render state syncs to minimize risks of UI tearing
+	// during re-renders. It's ugly, but it's what the React team officially
+	// recommends (even though this specific case is extra nasty).
+	//
+	// Be very careful with this logic; React only bails out of redundant state
+	// updates if they happen outside of a render. Inside a render, if you keep
+	// calling a state dispatch, you will get an infinite render loop, no matter
+	// what the value you dispatch. There must be a "base case" in the render
+	// path that causes state dispatches to stop eventually so that React can
+	// move on to the next component in the tree
 	const [delayLapsed, setDelayLapsed] = useState(safeDelay === 0);
 	const [renderCache, setRenderCache] = useState({ loading, safeDelay });
 	const resetOnRerender =

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -42,8 +42,60 @@ export const Spinner: FC<SpinnerProps> = ({
 	unmountedWhileLoading = false,
 	...delegatedProps
 }) => {
-	// Doing some mid-render state syncs to minimize re-renders and risks of
-	// contradictory states. It's ugly, but it's what the React team recommends
+	const showSpinner = useShowSpinner(loading, spinnerStartDelayMs);
+	if (!showSpinner) {
+		return children;
+	}
+
+	return (
+		<>
+			<svg
+				// Fill is the only prop that should be allowed to be
+				// overridden; all other props must come after destructuring
+				fill="currentColor"
+				{...delegatedProps}
+				viewBox="0 0 24 24"
+				xmlns="http://www.w3.org/2000/svg"
+				className={cn(className, spinnerVariants({ size }))}
+			>
+				<title>Loading&hellip;</title>
+				{leavesIterable.map((leafIndex) => (
+					<rect
+						key={leafIndex}
+						x="10.9"
+						y="2"
+						width="2"
+						height="5.5"
+						rx="1"
+						className={
+							// 0.8 is hard-coded because of Tailwind; the value
+							// should always be (0.1 * SPINNER_LEAF_COUNT)
+							isChromatic() ? "" : "animate-[loading_0.8s_ease-in-out_infinite]"
+						}
+						style={{
+							transform: `rotate(${leafIndex * (360 / SPINNER_LEAF_COUNT)}deg)`,
+							transformOrigin: "center",
+							animationDelay: `${-leafIndex * 0.1}s`,
+						}}
+					/>
+				))}
+			</svg>
+			{!unmountedWhileLoading && <div className="sr-only">{children}</div>}
+		</>
+	);
+};
+
+// Not a big fan of one-time custom hooks, but it helps insulate the main
+// component from the chaos of handling all these states, when the ultimate
+// result is a simple boolean. V8 will be able to inline the function definition
+// in some cases anyway
+function useShowSpinner(
+	loading: boolean,
+	spinnerStartDelayMs: number,
+): boolean {
+	// Doing a bunch of mid-render state syncs to minimize risks of
+	// contradictory states during re-renders. It's ugly, but it's what the
+	// React team officially recommends
 	const noDelay = spinnerStartDelayMs === 0;
 	const [mountSpinner, setMountSpinner] = useState(noDelay);
 	const unmountImmediatelyOnRerender = mountSpinner && !loading;
@@ -65,42 +117,5 @@ export const Spinner: FC<SpinnerProps> = ({
 		return () => window.clearTimeout(delayId);
 	}, [spinnerStartDelayMs]);
 
-	// Past this point, only showSpinner should need to be referenced
-	const showSpinner = loading && mountSpinner;
-	if (!showSpinner) {
-		return children;
-	}
-
-	return (
-		<svg
-			// Fill is the only prop that should be allowed to be overridden;
-			// all other props must come after destructuring
-			fill="currentColor"
-			{...delegatedProps}
-			viewBox="0 0 24 24"
-			xmlns="http://www.w3.org/2000/svg"
-			className={cn(className, spinnerVariants({ size }))}
-		>
-			<title>Loading&hellip;</title>
-			{leavesIterable.map((leafIndex) => (
-				<rect
-					key={leafIndex}
-					x="10.9"
-					y="2"
-					width="2"
-					height="5.5"
-					rx="1"
-					// 0.8 = leaves * 0.1
-					className={
-						isChromatic() ? "" : "animate-[loading_0.8s_ease-in-out_infinite]"
-					}
-					style={{
-						transform: `rotate(${leafIndex * (360 / SPINNER_LEAF_COUNT)}deg)`,
-						transformOrigin: "center",
-						animationDelay: `${-leafIndex * 0.1}s`,
-					}}
-				/>
-			))}
-		</svg>
-	);
-};
+	return loading && mountSpinner;
+}

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -90,12 +90,12 @@ export const Spinner: FC<SpinnerProps> = ({
 	// only bails out of redundant state updates if they happen outside of a
 	// render. Inside a render, if you keep calling a state dispatch, you will
 	// get an infinite render loop, no matter what the state value is.
-	const [delayDone, setDelayDone] = useState(safeDelay === 0);
-	if (delayDone && !loading) {
-		setDelayDone(false);
+	const [delayExpired, setDelayExpired] = useState(safeDelay === 0);
+	if (delayExpired && !loading) {
+		setDelayExpired(false);
 	}
-	if (!delayDone && loading && safeDelay === 0) {
-		setDelayDone(true);
+	if (!delayExpired && safeDelay === 0) {
+		setDelayExpired(true);
 	}
 	useEffect(() => {
 		if (safeDelay === 0) {
@@ -103,17 +103,18 @@ export const Spinner: FC<SpinnerProps> = ({
 		}
 
 		const delayId = window.setTimeout(() => {
-			setDelayDone(true);
+			setDelayExpired(true);
 		}, safeDelay);
 		return () => window.clearTimeout(delayId);
 	}, [safeDelay]);
 
 	/**
 	 * @todo Figure out if this conditional logic can ever cause a component to
-	 * lose state. I would hope not, since the children prop is the same in both
-	 * cases, but I need to test this out
+	 * lose state when showSpinner flips from false to true while
+	 * unmountedWhileLoading is false. I would hope not, since the children prop
+	 * is the same in both cases, but I need to test this out
 	 */
-	const showSpinner = delayDone && loading;
+	const showSpinner = loading && delayExpired;
 	if (!showSpinner) {
 		return children;
 	}

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -127,9 +127,9 @@ export const Spinner: FC<SpinnerProps> = ({
 	);
 };
 
-// Split off logic into custom hook so that the main component is insulated from
-// some of the necessary chaos from handling re-render logic. A lot of browsers
-// should be able to inline this function call anyway
+// Splitting off logic into custom hook so that we can abstract away the chaos
+// of handling Spinner's re-render logic. Not worried about overhead; a lot of
+// browsers should be able to inline this function call
 function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 	// Disallow negative timeout values and fractional values, but also round
 	// the delay down if it's small enough that it might as well be immediate

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -1,7 +1,9 @@
 /**
- * This component was inspired by
- * https://www.radix-ui.com/themes/docs/components/spinner and developed using
- * https://v0.dev/ help.
+ * @file This component was inspired by Radix's Spinner component and developed
+ * using help from Vercel's V0.
+ *
+ * @see {@link https://www.radix-ui.com/themes/docs/components/spinner}
+ * @se {@link https://v0.dev/}
  */
 
 import isChromatic from "chromatic/isChromatic";

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -3,7 +3,7 @@
  * using help from Vercel's V0.
  *
  * @see {@link https://www.radix-ui.com/themes/docs/components/spinner}
- * @se {@link https://v0.dev/}
+ * @see {@link https://v0.dev/}
  */
 
 import isChromatic from "chromatic/isChromatic";

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -146,16 +146,19 @@ function useShowSpinner(loading: boolean, spinnerDelayMs: number): boolean {
 	// render. Inside a render, if you keep calling a state dispatch, you will
 	// get an infinite render loop, no matter what the state value is. There
 	// must be a "base case" that causes re-renders to stabilize/stop
-	const [cachedDelay, setCachedDelay] = useState(safeDelay);
 	const [delayLapsed, setDelayLapsed] = useState(safeDelay === 0);
-	if (delayLapsed && !loading) {
+	const [renderCache, setRenderCache] = useState({ loading, safeDelay });
+	const resetOnRerender =
+		delayLapsed && !loading && loading !== renderCache.loading;
+	if (resetOnRerender) {
 		setDelayLapsed(false);
+		setRenderCache((current) => ({ ...current, loading }));
 	}
 	const delayWasRemovedOnRerender =
-		!delayLapsed && safeDelay === 0 && cachedDelay !== safeDelay;
+		!delayLapsed && safeDelay === 0 && renderCache.safeDelay !== safeDelay;
 	if (delayWasRemovedOnRerender) {
 		setDelayLapsed(true);
-		setCachedDelay(safeDelay);
+		setRenderCache((current) => ({ ...current, safeDelay }));
 	}
 	useEffect(() => {
 		if (safeDelay === 0) {

--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
@@ -155,7 +155,7 @@ export const CreateOrganizationPageView: FC<
 								</fieldset>
 								<div className="flex flex-row gap-2">
 									<Button type="submit" disabled={form.isSubmitting}>
-										{form.isSubmitting && <Spinner />}
+										<Spinner loading={form.isSubmitting} />
 										Save
 									</Button>
 									<Button


### PR DESCRIPTION
No issue to link – spurred by some of the conversations in https://github.com/coder/coder/pull/16098

Still WIP

## Changes made
- Updated component API so that `loading` is no longer optional. I don't think it *ever* makes sense to have a spinner without a loading state.
- Added support for delaying when the spinner appears on screen when `loading` flips to `true`. This can help minimize UI jank during state transitions
- Added support for defining how the spinner `children` prop is hidden (hiding the content via CSS vs unmounting the component entirely)
- Cleaned up code in general, to make sure that there are fully-dependent links between constants and the rest of the UI, and also to minimize how often values are reconstructed on re-renders
- Made sure that by default, state isn't wiped for the `children` prop when `loading` toggles between `true` and `false`

## Videos
(Todo: Fill these in when the PR is done)