### PR TITLE
chore(agent/agentcontainers): skip TestDockerCLIContainerLister by default

### DIFF
--- a/agent/agentcontainers/containers_dockercli.go
+++ b/agent/agentcontainers/containers_dockercli.go
@@ -59,6 +59,11 @@ func (dcl *DockerCLILister) List(ctx context.Context) (codersdk.WorkspaceAgentLi
 	}
 
 	dockerPsStderr := strings.TrimSpace(stderrBuf.String())
+	if len(ids) == 0 {
+		return codersdk.WorkspaceAgentListContainersResponse{
+			Warnings: []string{dockerPsStderr},
+		}, nil
+	}
 
 	// now we can get the detailed information for each container
 	// Run `docker inspect` on each container ID

--- a/agent/agentcontainers/containers_internal_test.go
+++ b/agent/agentcontainers/containers_internal_test.go
@@ -2,8 +2,7 @@ package agentcontainers
 
 import (
 	"fmt"
-	"os/exec"
-	"runtime"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -27,15 +26,14 @@ import (
 // dockerCLIContainerLister.List method. It starts a container with a known
 // label, lists the containers, and verifies that the expected container is
 // returned. The container is deleted after the test is complete.
+// As this test creates containers, it is skipped by default.
+// It can be run manually as follows:
+//
+// CODER_TEST_USE_DOCKER=1 go test ./agent/agentcontainers -run TestDockerCLIContainerLister
 func TestDockerCLIContainerLister(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "linux" {
-		t.Skip("creating containers on non-linux runners is slow and flaky")
-	}
-
-	// Conditionally skip if Docker is not available.
-	if _, err := exec.LookPath("docker"); err != nil {
-		t.Skip("docker not found in PATH")
+	if ctud, ok := os.LookupEnv("CODER_TEST_USE_DOCKER"); !ok || ctud != "1" {
+		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
 	}
 
 	pool, err := dockertest.NewPool("")


### PR DESCRIPTION
Addresses a test flake seen here: https://github.com/coder/coder/actions/runs/13239819615/job/36952521742

Also addresses the case where we would try to run `docker inspect` with no container IDs, which is a silly thing to do.