### PR TITLE
feat: add run_as_non_root=True to Kubernetes Starter template

### DIFF
--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -264,7 +264,7 @@ resource "kubernetes_deployment" "main" {
         security_context {
           run_as_user     = 1000
           fs_group        = 1000
-          run_as_non_root = True
+          run_as_non_root = true
         }
 
         container {

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -262,8 +262,9 @@ resource "kubernetes_deployment" "main" {
       }
       spec {
         security_context {
-          run_as_user = 1000
-          fs_group    = 1000
+          run_as_user     = 1000
+          fs_group        = 1000
+          run_as_non_root = True
         }
 
         container {


### PR DESCRIPTION
This document sounds like `run_as_non_root=True` should be enabled for workspaces. 

https://coder.com/docs/install/kubernetes#kubernetes-security-reference
> All containers must run as non-root user
>  - Control plane - ...
> - Workspaces - Workspace pod UID is [set in the Terraform template here](https://github.com/coder/coder/blob/f57ce97b5aadd825ddb9a9a129bb823a3725252b/examples/templates/kubernetes/main.tf#L274-L276), and are not required to run as root.

Administrators of the Kubernetes of a cluster I am working on have added a security check on it, and prevent creating pods, without `run_as_non_root=True`.   So, I need to set it every time I create a template. 

According to the docs used with `run_as_user=1000` it should not have negative effects and could be safely added. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/
