### PR TITLE
chore(vpn/tunnel): sort outgoing fqdns by length

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"net/url"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -402,6 +403,9 @@ func (u *updater) createPeerUpdateLocked(update tailnet.WorkspaceUpdate) *PeerUp
 		for name := range agent.Hosts {
 			fqdn = append(fqdn, name.WithTrailingDot())
 		}
+		sort.Slice(fqdn, func(i, j int) bool {
+			return len(fqdn[i]) < len(fqdn[j])
+		})
 		out.DeletedAgents[i] = &Agent{
 			Id:            tailnet.UUIDToByteSlice(agent.ID),
 			Name:          agent.Name,
@@ -424,6 +428,9 @@ func (u *updater) convertAgentsLocked(agents []*tailnet.Agent) []*Agent {
 		for name := range agent.Hosts {
 			fqdn = append(fqdn, name.WithTrailingDot())
 		}
+		sort.Slice(fqdn, func(i, j int) bool {
+			return len(fqdn[i]) < len(fqdn[j])
+		})
 		protoAgent := &Agent{
 			Id:          tailnet.UUIDToByteSlice(agent.ID),
 			Name:        agent.Name,


### PR DESCRIPTION
On the Mac app, we want to display the shortest FQDN - we might as well do the sorting as they leave the tunnel.
Right now it's coming from a map, so it's they arrive in a random order each peer update.