### PR TITLE
fix: handle urls with multiple slashes

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1749,10 +1749,12 @@ func singleSlashMW(next http.Handler) http.Handler {
 		newPath := multipleSlashesRe.ReplaceAllString(path, "/")
 
 		// Apply the cleaned path
+		// The approach is consistent with: https://github.com/go-chi/chi/blob/e846b8304c769c4f1a51c9de06bebfaa4576bd88/middleware/strip.go#L24-L28
 		if rctx != nil {
 			rctx.RoutePath = newPath
+		} else {
+			r.URL.Path = newPath
 		}
-		r.URL.Path = newPath
 
 		next.ServeHTTP(w, r)
 	}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -1738,10 +1737,6 @@ var multipleSlashesRe = regexp.MustCompile(`/+`)
 
 func singleSlashMW(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "test-app-owner") {
-			log.Println(r.URL.Path)
-		}
-
 		var path string
 		rctx := chi.RouteContext(r.Context())
 		if rctx != nil && rctx.RoutePath != "" {

--- a/coderd/coderd_internal_test.go
+++ b/coderd/coderd_internal_test.go
@@ -19,9 +19,8 @@ func TestStripSlashesMW(t *testing.T) {
 		wantPath  string
 	}{
 		{"No changes", "/api/v1/buildinfo", "/api/v1/buildinfo"},
-		{"Single trailing slash", "/api/v2/buildinfo/", "/api/v2/buildinfo"},
 		{"Double slashes", "/api//v2//buildinfo", "/api/v2/buildinfo"},
-		{"Triple slashes", "/api///v2///buildinfo///", "/api/v2/buildinfo"},
+		{"Triple slashes", "/api///v2///buildinfo", "/api/v2/buildinfo"},
 		{"Leading slashes", "///api/v2/buildinfo", "/api/v2/buildinfo"},
 		{"Root path", "/", "/"},
 		{"Double slashes root", "//", "/"},
@@ -46,7 +45,7 @@ func TestStripSlashesMW(t *testing.T) {
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 			// Pass the request through the middleware
-			stripSlashesMW(handler).ServeHTTP(rec, req)
+			singleSlashMW(handler).ServeHTTP(rec, req)
 
 			// Get the updated chi RouteContext after middleware processing
 			updatedCtx := chi.RouteContext(req.Context())

--- a/coderd/coderd_internal_test.go
+++ b/coderd/coderd_internal_test.go
@@ -33,26 +33,37 @@ func TestStripSlashesMW(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
+		t.Run("chi/"+tt.name, func(t *testing.T) {
+			t.Parallel()
 			req := httptest.NewRequest("GET", tt.inputPath, nil)
 			rec := httptest.NewRecorder()
 
-			// Create a chi RouteContext and attach it to the request
+			// given
 			rctx := chi.NewRouteContext()
-			rctx.RoutePath = tt.inputPath // Simulate chi route path
+			rctx.RoutePath = tt.inputPath
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-			// Pass the request through the middleware
+			// when
 			singleSlashMW(handler).ServeHTTP(rec, req)
-
-			// Get the updated chi RouteContext after middleware processing
 			updatedCtx := chi.RouteContext(req.Context())
 
-			// Validate URL path
-			assert.Equal(t, tt.wantPath, req.URL.Path)
+			// then
+			assert.Equal(t, tt.inputPath, req.URL.Path)
 			assert.Equal(t, tt.wantPath, updatedCtx.RoutePath)
+		})
+
+		t.Run("stdlib/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest("GET", tt.inputPath, nil)
+			rec := httptest.NewRecorder()
+
+			// when
+			singleSlashMW(handler).ServeHTTP(rec, req)
+
+			// then
+			assert.Equal(t, tt.wantPath, req.URL.Path)
+			assert.Nil(t, chi.RouteContext(req.Context()))
 		})
 	}
 }

--- a/coderd/coderd_internal_test.go
+++ b/coderd/coderd_internal_test.go
@@ -1,0 +1,47 @@
+package coderd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStripSlashesMW(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		inputPath string
+		wantPath  string
+	}{
+		{"No changes", "/api/v1/buildinfo", "/api/v1/buildinfo"},
+		{"Single trailing slash", "/api/v2/buildinfo/", "/api/v2/buildinfo"},
+		{"Double slashes", "/api//v2//buildinfo", "/api/v2/buildinfo"},
+		{"Triple slashes", "/api///v2///buildinfo///", "/api/v2/buildinfo"},
+		{"Leading slashes", "///api/v2/buildinfo", "/api/v2/buildinfo"},
+		{"Root path", "/", "/"},
+		{"Double slashes root", "//", "/"},
+		{"Only slashes", "/////", "/"},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest("GET", tt.inputPath, nil)
+			rec := httptest.NewRecorder()
+
+			stripSlashesMW(handler).ServeHTTP(rec, req)
+
+			if req.URL.Path != tt.wantPath {
+				t.Errorf("stripSlashesMW got path = %q, want %q", req.URL.Path, tt.wantPath)
+			}
+		})
+	}
+}

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -52,6 +52,12 @@ export default defineConfig({
 				"csrf_token=JXm9hOUdZctWt0ZZGAy9xiS/gxMKYOThdxjjMnMUyn4=; Path=/; HttpOnly; SameSite=Lax",
 		},
 		proxy: {
+			"//": {
+				changeOrigin: true,
+				target: process.env.CODER_HOST || "http://localhost:3000",
+				secure: process.env.NODE_ENV === "production",
+				rewrite: (path) => path.replace(/\/+/g, "/"),
+			},
 			"/api": {
 				ws: true,
 				changeOrigin: true,


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/9877

This PR introduces another middleware to rewrite URLs when multiple slashes are used.

Testing:

```
curl http://localhost:8080//api///v2/buildinfo
curl http://localhost:8080/api//v2/buildinfo
curl http://localhost:3000//api/////v2
curl http://localhost:3000/api//v2
```
