### PR TITLE
chore(site/e2e): increase timeout for waitForPort from 30s to 60s

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -762,7 +762,7 @@ export const createServer = async (
 async function waitForPort(
 	port: number,
 	host = "0.0.0.0",
-	timeout = 30000,
+	timeout = 60_000,
 ): Promise<void> {
 	const start = Date.now();
 	while (Date.now() - start < timeout) {


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/356

This is just a temporary fix; we may need to remove the hardcoded ports to avoid this flake entirely.