### PR TITLE
chore: enable forward ports to Coder UI using any host for Vite dev server

### DIFF
--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -84,6 +84,7 @@ export default defineConfig({
 				secure: process.env.NODE_ENV === "production",
 			},
 		},
+		allowedHosts: true,
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
This enables forward ports to Coder UI using custom domains.