### PR TITLE
chore(cli): disable agent devcontainer integration by default

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -475,7 +475,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 		},
 		{
 			Flag:        "devcontainers-enable",
-			Default:     "true",
+			Default:     "false",
 			Env:         "CODER_AGENT_DEVCONTAINERS_ENABLE",
 			Description: "Allow the agent to automatically detect running devcontainers.",
 			Value:       serpent.BoolOf(&devcontainersEnabled),

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -33,7 +33,7 @@ OPTIONS:
       --debug-address string, $CODER_AGENT_DEBUG_ADDRESS (default: 127.0.0.1:2113)
           The bind address to serve a debug HTTP server.
 
-      --devcontainers-enable bool, $CODER_AGENT_DEVCONTAINERS_ENABLE (default: true)
+      --devcontainers-enable bool, $CODER_AGENT_DEVCONTAINERS_ENABLE (default: false)
           Allow the agent to automatically detect running devcontainers.
 
       --log-dir string, $CODER_AGENT_LOG_DIR (default: /tmp)

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -374,6 +374,7 @@ resource "docker_container" "workspace" {
     "CODER_PROC_PRIO_MGMT=1",
     "CODER_PROC_OOM_SCORE=10",
     "CODER_PROC_NICE_SCORE=1",
+    "CODER_AGENT_DEVCONTAINERS_ENABLE=1",
   ]
   host {
     host = "host.docker.internal"


### PR DESCRIPTION
Until we have more of the building blocks in place, disable the agent devcontainer integration by default. We'll enable it by default at a later date.