### PR TITLE
docs: add documentation for VS Code in air-gapped environments

### DIFF
--- a/docs/admin/air-gapped/index.md
+++ b/docs/admin/air-gapped/index.md
@@ -1,0 +1,9 @@
+# Air-gapped
+
+Coder can be deployed in air-gapped or offline environment.
+
+Use the [air-gapped deployments documentation](../../install/offline.md) for
+deployment considerations and configuration, and use the docs in this section
+for more specific reference and tutorials.
+
+<children></children>

--- a/docs/admin/air-gapped/vs-code.md
+++ b/docs/admin/air-gapped/vs-code.md
@@ -1,0 +1,13 @@
+# Visual Studio Code in air-gapped environments
+
+Many Coder administrators deploy Coder in [air-gapped environments](../../install/offline.md) where the server or workspaces do not have network access to external websites such as `registry.terraform.com` or `code.visualstudio.com`.
+
+## Allow network access to the VS Code Extension Marketplace
+
+If some network access is allowed, you can allow users access to `code.visualstudio.com`.
+
+When they connect to a workspace with VS Code Remote SSH, their desktop will download the server and scp it into the workspace.
+
+## Portable mode
+
+VS Code [Portable mode](https://code.visualstudio.com/docs/editor/portable) is a self-contained, or "portable," installation of VS Code that uses local files for both installation and application data such as extensions.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -620,6 +620,24 @@
 					]
 				},
 				{
+					"title": "Air-gapped",
+					"description": "Configure your air-gapped or offline Coder deployment",
+					"path": "./admin/air-gapped/index.md",
+					"icon_path": "./images/icons/plug.svg",
+					"children": [
+						{
+							"title": "Air-gapped configuration",
+							"description": "Run Coder in offline / air-gapped environments",
+							"path": "./install/offline.md"
+						},
+						{
+							"title": "VS Code",
+							"description": "How to use VS Code in your air-gapped deployment",
+							"path": "./admin/air-gapped/vs-code.md"
+						}
+					]
+				},
+				{
 					"title": "Licensing",
 					"description": "Configure licensing for your deployment",
 					"path": "./admin/licensing/index.md",

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -1,13 +1,13 @@
 # Visual Studio Code
 
 You can develop in your Coder workspace remotely with
-[VSCode](https://code.visualstudio.com/download). We support connecting with the
-desktop client and VSCode in the browser with
+[VS Code](https://code.visualstudio.com/download). We support connecting with the
+desktop client and VS Code in the browser with
 [code-server](https://github.com/coder/code-server).
 
-## VSCode Desktop
+## VS Code Desktop
 
-VSCode desktop is a default app for workspaces.
+VS Code desktop is a default app for workspaces.
 
 Click `VS Code Desktop` in the dashboard to one-click enter a workspace. This
 automatically installs the [Coder Remote](https://github.com/coder/vscode-coder)
@@ -20,9 +20,9 @@ extension, authenticates with Coder, and connects to the workspace.
 
 ### Manual Installation
 
-You can install our extension manually in VSCode using the command palette.
-Launch VS Code Quick Open (Ctrl+P), paste the following command, and press
-enter.
+You can install our extension manually in VS Code using the command palette.
+Launch VS Code Quick Open (<kbd>Ctrl</kbd>+<kbd>P</kbd>), paste the following command, and press
+enter:
 
 ```text
 ext install coder.coder-remote


### PR DESCRIPTION
closes #8946 

- [ ] does extension work when the client/server is entirely offline?
- [ ] document the different ways that vscode-server is installed on the workspace
- [ ] workarounds for downloading vscode-server manually on the client or workspace
- [ ] potential known issues with air-gapped deployments (what happens if the client updates their VS Code instance and there is a version mismatch from client/server)

[preview](https://coder.com/docs/@8946-vscode-offline/admin/air-gapped/vs-code)