### PR TITLE
fix: display error on deleted workspace build

### DIFF
--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.tsx
@@ -49,6 +49,7 @@ export const WorkspaceBuildPage: FC = () => {
 			<WorkspaceBuildPageView
 				logs={logs}
 				build={build}
+				buildError={wsBuildQuery.error}
 				builds={buildsQuery.data}
 				activeBuildNumber={buildNumber}
 			/>

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -5,7 +5,9 @@ import type {
 	WorkspaceBuild,
 } from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Loader } from "components/Loader/Loader";
+import { Margins } from "components/Margins/Margins";
 import {
 	FullWidthPageHeader,
 	PageHeaderSubtitle,
@@ -48,6 +50,7 @@ const sortLogsByCreatedAt = (logs: ProvisionerJobLog[]) => {
 export interface WorkspaceBuildPageViewProps {
 	logs: ProvisionerJobLog[] | undefined;
 	build: WorkspaceBuild | undefined;
+	buildError?: unknown;
 	builds: WorkspaceBuild[] | undefined;
 	activeBuildNumber: number;
 }
@@ -55,6 +58,7 @@ export interface WorkspaceBuildPageViewProps {
 export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 	logs,
 	build,
+	buildError,
 	builds,
 	activeBuildNumber,
 }) => {
@@ -63,6 +67,17 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 		key: LOGS_TAB_KEY,
 		defaultValue: "build",
 	});
+
+	if (buildError) {
+		return (
+			<Margins>
+				<ErrorAlert
+					error={buildError}
+					css={{ marginTop: 16, marginBottom: 16 }}
+				/>
+			</Margins>
+		);
+	}
 
 	if (!build) {
 		return <Loader />;


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15058

This PR modifies WorkspaceBuildPageView to display an error if the related workspace build cannot be accessed or is deleted. The error alert component is consistent with one on the workspace page.

<img width="921" alt="Screenshot 2025-02-12 at 11 56 55" src="https://github.com/user-attachments/assets/47395ab6-feab-4dff-bb38-b8b5acbf78f0" />
