### PR TITLE
fix: display the correct response for coder list

### DIFF
--- a/cli/cliui/output.go
+++ b/cli/cliui/output.go
@@ -83,6 +83,10 @@ func (f *OutputFormatter) Format(ctx context.Context, data any) (string, error) 
 	return "", xerrors.Errorf("unknown output format %q", f.formatID)
 }
 
+func (f *OutputFormatter) FormatID() string {
+	return f.formatID
+}
+
 type tableFormat struct {
 	defaultColumns []string
 	allColumns     []string

--- a/cli/cliui/output.go
+++ b/cli/cliui/output.go
@@ -83,6 +83,8 @@ func (f *OutputFormatter) Format(ctx context.Context, data any) (string, error) 
 	return "", xerrors.Errorf("unknown output format %q", f.formatID)
 }
 
+// FormatID will return the ID of the format selected by `--output`.
+// If no flag is present, it returns the 'default' formatter.
 func (f *OutputFormatter) FormatID() string {
 	return f.formatID
 }

--- a/cli/list.go
+++ b/cli/list.go
@@ -112,7 +112,7 @@ func (r *RootCmd) list() *serpent.Command {
 				return err
 			}
 
-			if len(res) == 0 {
+			if len(res) == 0 && formatter.FormatID() != cliui.JSONFormat().ID() {
 				pretty.Fprintf(inv.Stderr, cliui.DefaultStyles.Prompt, "No workspaces found! Create one:\n")
 				_, _ = fmt.Fprintln(inv.Stderr)
 				_, _ = fmt.Fprintln(inv.Stderr, "  "+pretty.Sprint(cliui.DefaultStyles.Code, "coder create <name>"))


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/16312

We intend to modify the behavior of the CLI handler based on the specified output format. However, the output format is currently only accessible within the `OutputFormatter` structure. Therefore, I propose extending `OutputFormatter` by introducing a public `FormatID` method, which will allow us to retrieve the format identifier and use it to customize the behavior of the CLI handler accordingly.

An alternative approach would be to make the implementation more generic. Instead of defining a `FormatID` method, we could introduce an `IsMachineReadableFormat() bool` method. This method would indicate whether the output format is machine-readable, allowing us to adjust the CLI handler's behavior accordingly.