### PR TITLE
fix: change resource icon colors in the delete modal based on the set theme

### DIFF
--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
@@ -4,6 +4,7 @@ import ScheduleIcon from "@mui/icons-material/Schedule";
 import { visuallyHidden } from "@mui/utils";
 import type { Workspace } from "api/typesGenerated";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
+import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { Stack } from "components/Stack/Stack";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -247,15 +248,10 @@ const Resources: FC<StageProps> = ({ workspaces }) => {
 			>
 				{Object.entries(resources).map(([type, summary]) => (
 					<Stack key={type} direction="row" alignItems="center" spacing={1}>
-						<div
-							aria-hidden={true}
-							className="bg-content-primary"
-							style={{
-								width: styles.summaryIcon.width,
-								height: styles.summaryIcon.height,
-								WebkitMask: `url('${summary.icon}') no-repeat center / contain`,
-								mask: `url('${summary.icon}') no-repeat center / contain`,
-							}}
+						<ExternalImage
+							src={summary.icon}
+							width={styles.summaryIcon.width}
+							height={styles.summaryIcon.height}
 						/>
 						<span>
 							{summary.count} <code>{type}</code>

--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
@@ -45,9 +45,8 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 		}
 	};
 
-	const workspaceCount = `${checkedWorkspaces.length} ${
-		checkedWorkspaces.length === 1 ? "workspace" : "workspaces"
-	}`;
+	const workspaceCount = `${checkedWorkspaces.length} ${checkedWorkspaces.length === 1 ? "workspace" : "workspaces"
+		}`;
 
 	let confirmText: ReactNode = <>Review selected workspaces&hellip;</>;
 	if (stage === "workspaces") {
@@ -57,9 +56,8 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 		const resources = checkedWorkspaces
 			.map((workspace) => workspace.latest_build.resources.length)
 			.reduce((a, b) => a + b, 0);
-		const resourceCount = `${resources} ${
-			resources === 1 ? "resource" : "resources"
-		}`;
+		const resourceCount = `${resources} ${resources === 1 ? "resource" : "resources"
+			}`;
 		confirmText = (
 			<>
 				Delete {workspaceCount} and {resourceCount}
@@ -247,7 +245,12 @@ const Resources: FC<StageProps> = ({ workspaces }) => {
 			>
 				{Object.entries(resources).map(([type, summary]) => (
 					<Stack key={type} direction="row" alignItems="center" spacing={1}>
-						<img alt="" src={summary.icon} css={styles.summaryIcon} />
+						<div aria-hidden={true} className="bg-content-primary" style={{
+							width: styles.summaryIcon.width,
+							height: styles.summaryIcon.height,
+							WebkitMask: `url('${summary.icon}') no-repeat center / contain`,
+							mask: `url('${summary.icon}') no-repeat center / contain`,
+						}} />
 						<span>
 							{summary.count} <code>{type}</code>
 						</span>

--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
@@ -45,8 +45,9 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 		}
 	};
 
-	const workspaceCount = `${checkedWorkspaces.length} ${checkedWorkspaces.length === 1 ? "workspace" : "workspaces"
-		}`;
+	const workspaceCount = `${checkedWorkspaces.length} ${
+		checkedWorkspaces.length === 1 ? "workspace" : "workspaces"
+	}`;
 
 	let confirmText: ReactNode = <>Review selected workspaces&hellip;</>;
 	if (stage === "workspaces") {
@@ -56,8 +57,9 @@ export const BatchDeleteConfirmation: FC<BatchDeleteConfirmationProps> = ({
 		const resources = checkedWorkspaces
 			.map((workspace) => workspace.latest_build.resources.length)
 			.reduce((a, b) => a + b, 0);
-		const resourceCount = `${resources} ${resources === 1 ? "resource" : "resources"
-			}`;
+		const resourceCount = `${resources} ${
+			resources === 1 ? "resource" : "resources"
+		}`;
 		confirmText = (
 			<>
 				Delete {workspaceCount} and {resourceCount}
@@ -245,12 +247,16 @@ const Resources: FC<StageProps> = ({ workspaces }) => {
 			>
 				{Object.entries(resources).map(([type, summary]) => (
 					<Stack key={type} direction="row" alignItems="center" spacing={1}>
-						<div aria-hidden={true} className="bg-content-primary" style={{
-							width: styles.summaryIcon.width,
-							height: styles.summaryIcon.height,
-							WebkitMask: `url('${summary.icon}') no-repeat center / contain`,
-							mask: `url('${summary.icon}') no-repeat center / contain`,
-						}} />
+						<div
+							aria-hidden={true}
+							className="bg-content-primary"
+							style={{
+								width: styles.summaryIcon.width,
+								height: styles.summaryIcon.height,
+								WebkitMask: `url('${summary.icon}') no-repeat center / contain`,
+								mask: `url('${summary.icon}') no-repeat center / contain`,
+							}}
+						/>
 						<span>
 							{summary.count} <code>{type}</code>
 						</span>


### PR DESCRIPTION
Closes #16191 

I've gone and solved this in a potentially strange way, and I feel like there is a better/more obvious way.

![Screenshot 2025-02-12 at 6 50 49 PM](https://github.com/user-attachments/assets/0c44d235-8d92-483a-9ad8-ed08ff26c3e9)

![Screenshot 2025-02-12 at 6 51 42 PM](https://github.com/user-attachments/assets/343615d2-e31c-4a80-b023-9de8e2525c6f)
