### PR TITLE
feat(coderd): add support for provisioner job id and tag filter

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3056,6 +3056,16 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "array",
+                        "format": "uuid",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Filter results by job IDs",
+                        "name": "ids",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "pending",
                             "running",
@@ -3074,6 +3084,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter results by status",
                         "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "object",
+                        "description": "Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'})",
+                        "name": "tags",
                         "in": "query"
                     }
                 ],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -2684,6 +2684,16 @@
 						"in": "query"
 					},
 					{
+						"type": "array",
+						"format": "uuid",
+						"items": {
+							"type": "string"
+						},
+						"description": "Filter results by job IDs",
+						"name": "ids",
+						"in": "query"
+					},
+					{
 						"enum": [
 							"pending",
 							"running",
@@ -2702,6 +2712,12 @@
 						"type": "string",
 						"description": "Filter results by status",
 						"name": "status",
+						"in": "query"
+					},
+					{
+						"type": "object",
+						"description": "Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'})",
+						"name": "tags",
 						"in": "query"
 					}
 				],

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -4170,6 +4170,9 @@ func (q *FakeQuerier) GetProvisionerJobsByOrganizationAndStatusWithQueuePosition
 		if len(arg.IDs) > 0 && !slices.Contains(arg.IDs, job.ID) {
 			continue
 		}
+		if len(arg.Tags) > 0 && !tagsSubset(job.Tags, arg.Tags) {
+			continue
+		}
 
 		row := database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerRow{
 			ProvisionerJob: rowQP.ProvisionerJob,

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -158,6 +158,7 @@ WHERE
 	(sqlc.narg('organization_id')::uuid IS NULL OR pj.organization_id = @organization_id)
 	AND (COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR pj.id = ANY(@ids::uuid[]))
 	AND (COALESCE(array_length(@status::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY(@status::provisioner_job_status[]))
+	AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
 GROUP BY
 	pj.id,
 	qp.queue_position,

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -359,11 +359,13 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 
 ### Parameters
 
-| Name           | In    | Type         | Required | Description              |
-|----------------|-------|--------------|----------|--------------------------|
-| `organization` | path  | string(uuid) | true     | Organization ID          |
-| `limit`        | query | integer      | false    | Page limit               |
-| `status`       | query | string       | false    | Filter results by status |
+| Name           | In    | Type         | Required | Description                                                                        |
+|----------------|-------|--------------|----------|------------------------------------------------------------------------------------|
+| `organization` | path  | string(uuid) | true     | Organization ID                                                                    |
+| `limit`        | query | integer      | false    | Page limit                                                                         |
+| `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                          |
+| `status`       | query | string       | false    | Filter results by status                                                           |
+| `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'}) |
 
 #### Enumerated Values
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1438,7 +1438,9 @@ export interface OrganizationMemberWithUserData extends OrganizationMember {
 // From codersdk/organizations.go
 export interface OrganizationProvisionerJobsOptions {
 	readonly Limit: number;
+	readonly IDs: readonly string[];
 	readonly Status: readonly ProvisionerJobStatus[];
+	readonly Tags: Record<string, string>;
 }
 
 // From codersdk/idpsync.go


### PR DESCRIPTION
This change adds to new filters to the provisionerjobs endpoint, id
(array) and tags (map).

Updates #15084
Updates #15192
Related #16532