### PR TITLE
fix(vpn/tunnel): fix panic when starting tunnel with headers

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -230,7 +230,7 @@ func (t *Tunnel) start(req *StartRequest) error {
 	if apiToken == "" {
 		return xerrors.New("missing api token")
 	}
-	var header http.Header
+	header := make(http.Header)
 	for _, h := range req.GetHeaders() {
 		header.Add(h.GetName(), h.GetValue())
 	}

--- a/vpn/tunnel_internal_test.go
+++ b/vpn/tunnel_internal_test.go
@@ -100,6 +100,9 @@ func TestTunnel_StartStop(t *testing.T) {
 					TunnelFileDescriptor: 2,
 					CoderUrl:             "https://coder.example.com",
 					ApiToken:             "fakeToken",
+					Headers: []*StartRequest_Header{
+						{Name: "X-Test-Header", Value: "test"},
+					},
 				},
 			},
 		})


### PR DESCRIPTION
`http.Header` is a map so it needs to be initialized ..