### PR TITLE
fix: include origin in support link

### DIFF
--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -1,0 +1,22 @@
+import { includeOrigin } from "./MobileMenu";
+
+describe("support link", () => {
+	it("should include origin if target starts with '/'", () => {
+		const mockOrigin = "https://example.com";
+		delete (window as any).location; // Remove the existing location object
+		(window as any).location = { origin: mockOrigin }; // Mock the location origin
+
+		expect(includeOrigin("/test")).toBe("https://example.com/test");
+		expect(includeOrigin("/path/to/resource")).toBe(
+			"https://example.com/path/to/resource",
+		);
+	});
+
+	it("should return the target unchanged if it does not start with '/'", () => {
+		expect(includeOrigin("https://example.com/page")).toBe(
+			"https://example.com/page",
+		);
+		expect(includeOrigin("../relative/path")).toBe("../relative/path");
+		expect(includeOrigin("relative/path")).toBe("relative/path");
+	});
+});

--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -4,7 +4,9 @@ const mockOrigin = "https://example.com";
 
 describe("support link", () => {
 	it("should include origin if target starts with '/'", () => {
-		(window as unknown as { location: Partial<Location> }).location = { origin: mockOrigin }; // Mock the location origin
+		(window as unknown as { location: Partial<Location> }).location = {
+			origin: mockOrigin,
+		}; // Mock the location origin
 
 		expect(includeOrigin("/test")).toBe(mockOrigin + "/test");
 		expect(includeOrigin("/path/to/resource")).toBe(

--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -8,14 +8,14 @@ describe("support link", () => {
 			origin: mockOrigin,
 		}; // Mock the location origin
 
-		expect(includeOrigin("/test")).toBe(mockOrigin + "/test");
+		expect(includeOrigin("/test")).toBe(`${mockOrigin}/test`);
 		expect(includeOrigin("/path/to/resource")).toBe(
-			mockOrigin + "/path/to/resource",
+			`${mockOrigin}/path/to/resource`,
 		);
 	});
 
 	it("should return the target unchanged if it does not start with '/'", () => {
-		expect(includeOrigin(mockOrigin + "/page")).toBe(mockOrigin + "/page");
+		expect(includeOrigin(`${mockOrigin}/page`)).toBe(`${mockOrigin}/page`);
 		expect(includeOrigin("../relative/path")).toBe("../relative/path");
 		expect(includeOrigin("relative/path")).toBe("relative/path");
 	});

--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -1,21 +1,19 @@
 import { includeOrigin } from "./MobileMenu";
 
+const mockOrigin = "https://example.com";
+
 describe("support link", () => {
 	it("should include origin if target starts with '/'", () => {
-		const mockOrigin = "https://example.com";
+		(window as unknown as { location: Partial<Location> }).location = { origin: mockOrigin }; // Mock the location origin
 
-		window.location = { origin: mockOrigin }; // Mock the location origin
-
-		expect(includeOrigin("/test")).toBe("https://example.com/test");
+		expect(includeOrigin("/test")).toBe(mockOrigin + "/test");
 		expect(includeOrigin("/path/to/resource")).toBe(
-			"https://example.com/path/to/resource",
+			mockOrigin + "/path/to/resource",
 		);
 	});
 
 	it("should return the target unchanged if it does not start with '/'", () => {
-		expect(includeOrigin("https://example.com/page")).toBe(
-			"https://example.com/page",
-		);
+		expect(includeOrigin(mockOrigin + "/page")).toBe(mockOrigin + "/page");
 		expect(includeOrigin("../relative/path")).toBe("../relative/path");
 		expect(includeOrigin("relative/path")).toBe("relative/path");
 	});

--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -4,8 +4,7 @@ describe("support link", () => {
 	it("should include origin if target starts with '/'", () => {
 		const mockOrigin = "https://example.com";
 
-		// eslint-disable-next-line
-		(window as any).location = { origin: mockOrigin }; // Mock the location origin
+		window.location = { origin: mockOrigin }; // Mock the location origin
 
 		expect(includeOrigin("/test")).toBe("https://example.com/test");
 		expect(includeOrigin("/path/to/resource")).toBe(

--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -3,7 +3,10 @@ import { includeOrigin } from "./MobileMenu";
 describe("support link", () => {
 	it("should include origin if target starts with '/'", () => {
 		const mockOrigin = "https://example.com";
+
+		// eslint-disable-next-line window object
 		delete (window as any).location; // Remove the existing location object
+		// eslint-disable-next-line window object
 		(window as any).location = { origin: mockOrigin }; // Mock the location origin
 
 		expect(includeOrigin("/test")).toBe("https://example.com/test");

--- a/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.test.tsx
@@ -4,9 +4,7 @@ describe("support link", () => {
 	it("should include origin if target starts with '/'", () => {
 		const mockOrigin = "https://example.com";
 
-		// eslint-disable-next-line window object
-		delete (window as any).location; // Remove the existing location object
-		// eslint-disable-next-line window object
+		// eslint-disable-next-line
 		(window as any).location = { origin: mockOrigin }; // Mock the location origin
 
 		expect(includeOrigin("/test")).toBe("https://example.com/test");

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -307,7 +307,11 @@ const UserSettingsSub: FC<UserSettingsSubProps> = ({
 								asChild
 								className={cn(itemStyles.default, itemStyles.sub)}
 							>
-								<a href={includeOrigin(l.target)} target="_blank" rel="noreferrer">
+								<a
+									href={includeOrigin(l.target)}
+									target="_blank"
+									rel="noreferrer"
+								>
 									{l.name}
 								</a>
 							</DropdownMenuItem>

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -323,7 +323,7 @@ const UserSettingsSub: FC<UserSettingsSubProps> = ({
 	);
 };
 
-const includeOrigin = (target: string): string => {
+export const includeOrigin = (target: string): string => {
 	if (target.startsWith("/")) {
 		const baseUrl = window.location.origin;
 		return `${baseUrl}${target}`;

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -307,7 +307,7 @@ const UserSettingsSub: FC<UserSettingsSubProps> = ({
 								asChild
 								className={cn(itemStyles.default, itemStyles.sub)}
 							>
-								<a href={l.target} target="_blank" rel="noreferrer">
+								<a href={includeOrigin(l.target)} target="_blank" rel="noreferrer">
 									{l.name}
 								</a>
 							</DropdownMenuItem>
@@ -317,4 +317,12 @@ const UserSettingsSub: FC<UserSettingsSubProps> = ({
 			</CollapsibleContent>
 		</Collapsible>
 	);
+};
+
+const includeOrigin = (target: string): string => {
+	if (target.startsWith("/")) {
+		const baseUrl = window.location.origin;
+		return `${baseUrl}${target}`;
+	}
+	return target;
 };

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -246,6 +246,11 @@ export const MockSupportLinks: TypesGen.LinkConfig[] = [
 			"https://github.com/coder/coder/issues/new?labels=needs+grooming&body={CODER_BUILD_INFO}",
 		icon: "",
 	},
+	{
+		name: "Fourth link",
+		target: "/icons",
+		icon: "",
+	},
 ];
 
 export const MockUpdateCheck: TypesGen.UpdateCheckResponse = {


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15542

This PR ensures that a support link has `window.origin` prepended (if missing)