### PR TITLE
fix: switch engagement chart to linear

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/UserEngagementChart.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/UserEngagementChart.stories.tsx
@@ -6,12 +6,12 @@ const meta: Meta<typeof UserEngagementChart> = {
 	component: UserEngagementChart,
 	args: {
 		data: [
-			{ date: "1/1/2024", users: 150 },
-			{ date: "1/2/2024", users: 165 },
-			{ date: "1/3/2024", users: 180 },
-			{ date: "1/4/2024", users: 155 },
-			{ date: "1/5/2024", users: 190 },
-			{ date: "1/6/2024", users: 200 },
+			{ date: "1/1/2024", users: 140 },
+			{ date: "1/2/2024", users: 175 },
+			{ date: "1/3/2024", users: 120 },
+			{ date: "1/4/2024", users: 195 },
+			{ date: "1/5/2024", users: 230 },
+			{ date: "1/6/2024", users: 130 },
 			{ date: "1/7/2024", users: 210 },
 		],
 	},

--- a/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/UserEngagementChart.tsx
+++ b/site/src/pages/DeploymentSettingsPage/GeneralSettingsPage/UserEngagementChart.tsx
@@ -157,7 +157,7 @@ export const UserEngagementChart: FC<UserEngagementChartProps> = ({ data }) => {
 
 									<Area
 										dataKey="users"
-										type="natural"
+										type="linear"
 										fill="url(#fillUsers)"
 										fillOpacity={0.4}
 										stroke="var(--color-users)"


### PR DESCRIPTION
Fixes: https://github.com/coder/internal/issues/363

This PR changes the User Engagement chart type to linear.
 
<img width="770" alt="Screenshot 2025-02-14 at 14 03 03" src="https://github.com/user-attachments/assets/1f2f8566-59bf-4476-8701-fc95e6ae8c10" />
