### PR TITLE
feat(coderd/httpapi): add QueryParamParser.JSONStringMap

### DIFF
--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -473,6 +473,70 @@ func TestParseQueryParams(t *testing.T) {
 		testQueryParams(t, expParams, parser, parser.UUIDs)
 	})
 
+	t.Run("JSONStringMap", func(t *testing.T) {
+		t.Parallel()
+
+		expParams := []queryParamTestCase[map[string]string]{
+			{
+				QueryParam: "valid_map",
+				Value:      `{"key1": "value1", "key2": "value2"}`,
+				Expected: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			{
+				QueryParam: "empty",
+				Value:      "{}",
+				Default:    map[string]string{},
+				Expected:   map[string]string{},
+			},
+			{
+				QueryParam: "no_value",
+				NoSet:      true,
+				Default:    map[string]string{},
+				Expected:   map[string]string{},
+			},
+			{
+				QueryParam: "default",
+				NoSet:      true,
+				Default:    map[string]string{"key": "value"},
+				Expected:   map[string]string{"key": "value"},
+			},
+			{
+				QueryParam: "null",
+				Value:      "null",
+				Expected:   map[string]string(nil),
+			},
+			{
+				QueryParam: "undefined",
+				Value:      "undefined",
+				Expected:   map[string]string(nil),
+			},
+			{
+				QueryParam:            "invalid_map",
+				Value:                 `{"key1": "value1", "key2": "value2"`, // missing closing brace
+				Expected:              map[string]string(nil),
+				Default:               map[string]string{},
+				ExpectedErrorContains: `Query param "invalid_map" must be a valid JSON object: unexpected EOF`,
+			},
+			{
+				QueryParam:            "incorrect_type",
+				Value:                 `{"key1": 1, "key2": true}`,
+				Expected:              map[string]string(nil),
+				ExpectedErrorContains: `Query param "incorrect_type" must be a valid JSON object: json: cannot unmarshal number into Go value of type string`,
+			},
+			{
+				QueryParam:            "multiple_keys",
+				Values:                []string{`{"key1": "value1"}`, `{"key2": "value2"}`},
+				Expected:              map[string]string(nil),
+				ExpectedErrorContains: `Query param "multiple_keys" provided more than once, found 2 times.`,
+			},
+		}
+		parser := httpapi.NewQueryParamParser()
+		testQueryParams(t, expParams, parser, parser.JSONStringMap)
+	})
+
 	t.Run("Required", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -44,7 +44,7 @@ func (api *API) provisionerDaemons(rw http.ResponseWriter, r *http.Request) {
 	p := httpapi.NewQueryParamParser()
 	limit := p.PositiveInt32(qp, 50, "limit")
 	ids := p.UUIDs(qp, nil, "ids")
-	tagsRaw := p.String(qp, "", "tags")
+	tags := p.JSONStringMap(qp, nil, "tags")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -52,17 +52,6 @@ func (api *API) provisionerDaemons(rw http.ResponseWriter, r *http.Request) {
 			Validations: p.Errors,
 		})
 		return
-	}
-
-	tags := database.StringMap{}
-	if tagsRaw != "" {
-		if err := tags.Scan([]byte(tagsRaw)); err != nil {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Invalid tags query parameter",
-				Detail:  err.Error(),
-			})
-			return
-		}
 	}
 
 	daemons, err := api.Database.GetProvisionerDaemonsWithStatusByOrganization(

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -44,7 +44,7 @@ func (api *API) provisionerDaemons(rw http.ResponseWriter, r *http.Request) {
 	p := httpapi.NewQueryParamParser()
 	limit := p.PositiveInt32(qp, 50, "limit")
 	ids := p.UUIDs(qp, nil, "ids")
-	tags := p.JSONStringMap(qp, nil, "tags")
+	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -108,7 +108,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 	if ids == nil {
 		ids = p.UUIDs(qp, nil, "ids")
 	}
-	tagsRaw := p.String(qp, "", "tags")
+	tags := p.JSONStringMap(qp, nil, "tags")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -116,17 +116,6 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 			Validations: p.Errors,
 		})
 		return nil, false
-	}
-
-	tags := database.StringMap{}
-	if tagsRaw != "" {
-		if err := tags.Scan([]byte(tagsRaw)); err != nil {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Invalid tags query parameter",
-				Detail:  err.Error(),
-			})
-			return nil, false
-		}
 	}
 
 	jobs, err := api.Database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(ctx, database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -108,7 +108,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 	if ids == nil {
 		ids = p.UUIDs(qp, nil, "ids")
 	}
-	tags := p.JSONStringMap(qp, nil, "tags")
+	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{


### PR DESCRIPTION
This PR provides a convenience function for parsing a `map[string]string` from a query parameter.

Context: https://github.com/coder/coder/pull/16558#discussion_r1956190615