### PR TITLE
fix: add link to troubleshooting

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
@@ -100,7 +100,10 @@ export const NotificationActionButton: FC<ButtonProps> = (props) => {
 			variant="text"
 			css={{
 				textDecoration: "underline",
-				padding: 0,
+				paddingLeft: 0,
+				paddingRight: 8,
+				paddingTop: 0,
+				paddingBottom: 0,
 				height: "auto",
 				minWidth: "auto",
 				"&:hover": { background: "none", textDecoration: "underline" },


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14933

This PR extends the _Unhealthy_ workspace notification with the troubleshooting link (if defined).

<img width="421" alt="Screenshot 2025-02-17 at 13 21 34" src="https://github.com/user-attachments/assets/70b20625-a838-4a68-98f2-a005b2657d9e" />
