### PR TITLE
docs: highlight the tip in coder-preview section and move step

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -81,11 +81,17 @@ Coder's [configuration options](../admin/setup/index.md).
 
 <blockquote class="admonition tip">
 
-You can install and test a [preview release of Coder](https://github.com/coder/coder/pkgs/container/coder-preview) by using the `ghcr.io/coder/coder-preview:latest` image tag. This image gets updated with the latest changes from the `main` branch.
+We do not recommend using preview releases in production environments.
 
 </blockquote>
 
-_We do not recommend using preview releases in production environments._
+You can install and test a
+[preview release of Coder](https://github.com/coder/coder/pkgs/container/coder-preview)
+by using the `coder-preview:latest` image tag.
+This image is automatically updated with the latest changes from the `main` branch.
+
+Replace `ghcr.io/coder/coder:latest` in the `docker run` command in the
+[steps above](#install-coder-via-docker-run) with `ghcr.io/coder/coder-preview:latest`.
 
 ## Troubleshooting
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -79,7 +79,7 @@ Coder's [configuration options](../admin/setup/index.md).
 
 ## Install the preview release
 
-<blockquote class="admonition tip">
+<blockquote class="tip">
 
 We do not recommend using preview releases in production environments.
 


### PR DESCRIPTION
- moves the step out of the tip and the tip into the step
- adds some context to what to do with the URL