### PR TITLE
chore: add resources_monitoring to dogfood

### DIFF
--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder"
+      source  = "coder/coder"
+      version = "2.2.0-pre0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder"
+      source  = "coder/coder"
       version = "~> 2.2.0"
     }
     docker = {

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     coder = {
       source = "coder/coder"
+      version = "~> 2.2.0"
     }
     docker = {
       source  = "kreuzwerker/docker"
@@ -82,6 +83,30 @@ data "coder_parameter" "region" {
     name  = "Cape Town"
     value = "za-cpt"
   }
+}
+
+data "coder_parameter" "res_mon_memory_threshold" {
+  type        = "number"
+  name        = "Memory usage threshold"
+  default     = 80
+  description = "The memory usage threshold used in resources monitoring to trigger notifications."
+  mutable     = true
+}
+
+data "coder_parameter" "res_mon_volume_threshold" {
+  type        = "number"
+  name        = "Volume usage threshold"
+  default     = 80
+  description = "The volume usage threshold used in resources monitoring to trigger notifications."
+  mutable     = true
+}
+
+data "coder_parameter" "res_mon_volume_path" {
+  type        = "string"
+  name        = "Volume path"
+  default     = "/home/coder"
+  description = "The path monitored in resources monitoring to trigger notifications."
+  mutable     = true
 }
 
 provider "docker" {
@@ -292,13 +317,13 @@ resource "coder_agent" "dev" {
 
   resources_monitoring {
     memory {
-      enabled = true
-      threshold = 80
+      enabled   = true
+      threshold = data.coder_parameter.res_mon_memory_threshold.value
     }
     volume {
-      enabled = true
-      threshold = 80
-      path = "/"
+      enabled   = true
+      threshold = data.coder_parameter.res_mon_volume_threshold.value
+      path      = data.coder_parameter.res_mon_volume_path.value
     }
   }
 

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     coder = {
-      source  = "coder/coder"
+      source = "coder/coder"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -290,6 +290,13 @@ resource "coder_agent" "dev" {
     timeout      = 5
   }
 
+  resources_monitoring {
+    memory {
+      enabled = true
+      threshold = 80
+    }
+  }
+
   startup_script = <<-EOT
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -295,6 +295,11 @@ resource "coder_agent" "dev" {
       enabled = true
       threshold = 80
     }
+    volume {
+      enabled = true
+      threshold = 80
+      path = "/"
+    }
   }
 
   startup_script = <<-EOT

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "~> 2.2.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
As we recently merged OOM & OOD Notifications - we can now enable it in the dogfood instance and workspaces so everyone can use it and help testing it.