### PR TITLE
fix: explicitly set encoding to UTF8 on embedded postgres

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2022,6 +2022,7 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 			Username("coder").
 			Password(pgPassword).
 			Database("coder").
+			Encoding("UTF8").
 			Port(uint32(pgPort)).
 			Logger(stdlibLogger.Writer()),
 	)


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/16228.

I've verified that the setting does not affect existing databases.