### PR TITLE
fix(flake.nix): add procps to nix dogfood image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -281,6 +281,7 @@
                     unzip
                     zip
                     gzip
+                    procps # free
                   ])
                   ++ oldAttrs.buildInputs;
               });

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -50,6 +50,10 @@ let
     experimental-features = nix-command flakes
   '';
 
+  etcReleaseName = writeTextDir "etc/coderniximage-release" ''
+    0.0.0
+  '';
+
   etcPamdSudoFile = writeText "pam-sudo" ''
     # Allow root to bypass authentication (optional)
     auth      sufficient pam_rootok.so
@@ -271,6 +275,7 @@ let
         etcNixConf
         etcSudoers
         etcPamdSudo
+        etcReleaseName
         (fakeNss.override {
           # Allows programs to look up the build user's home directory
           # https://github.com/NixOS/nix/blob/ffe155abd36366a870482625543f9bf924a58281/src/libstore/build/local-derivation-goal.cc#L906-L910


### PR DESCRIPTION
Add procps to flake.nix and release name to Docker image

Adds the `procps` package to flake.nix to enable the `free` command, and includes a release name file in the Docker image at `/etc/coderniximage-release`.

Change-Id: I85432acc06a204229fa3675e0020bd3acacf775a
Signed-off-by: Thomas Kosiewski <tk@coder.com>