### PR TITLE
chore: reduce log volume on server startup

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -938,7 +938,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				notificationReportGenerator := reports.NewReportGenerator(ctx, logger.Named("notifications.report_generator"), options.Database, options.NotificationsEnqueuer, quartz.NewReal())
 				defer notificationReportGenerator.Close()
 			} else {
-				cliui.Info(inv.Stdout, "Notifications are currently disabled as there are no configured delivery methods. See https://coder.com/docs/admin/monitoring/notifications#delivery-methods for more details.")
+				logger.Debug(ctx, "notifications are currently disabled as there are no configured delivery methods. See https://coder.com/docs/admin/monitoring/notifications#delivery-methods for more details")
 			}
 
 			// Since errCh only has one buffered slot, all routines

--- a/coderd/cryptokeys/rotate.go
+++ b/coderd/cryptokeys/rotate.go
@@ -152,7 +152,7 @@ func (k *rotator) rotateKeys(ctx context.Context) error {
 					}
 				}
 				if validKeys == 0 {
-					k.logger.Info(ctx, "no valid keys detected, inserting new key",
+					k.logger.Debug(ctx, "no valid keys detected, inserting new key",
 						slog.F("feature", feature),
 					)
 					_, err := k.insertNewKey(ctx, tx, feature, now)
@@ -194,7 +194,7 @@ func (k *rotator) insertNewKey(ctx context.Context, tx database.Store, feature d
 		return database.CryptoKey{}, xerrors.Errorf("inserting new key: %w", err)
 	}
 
-	k.logger.Info(ctx, "inserted new key for feature", slog.F("feature", feature))
+	k.logger.Debug(ctx, "inserted new key for feature", slog.F("feature", feature))
 	return newKey, nil
 }
 

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -63,7 +63,7 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, clk quartz.
 				return xerrors.Errorf("failed to delete old notification messages: %w", err)
 			}
 
-			logger.Info(ctx, "purged old database entries", slog.F("duration", clk.Since(start)))
+			logger.Debug(ctx, "purged old database entries", slog.F("duration", clk.Since(start)))
 
 			return nil
 		}, database.DefaultTXOptions().WithID("db_purge")); err != nil {

--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -236,10 +236,11 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 					ProvisionerKey: provisionerKey,
 				})
 			}, &provisionerd.Options{
-				Logger:         logger,
-				UpdateInterval: 500 * time.Millisecond,
-				Connector:      connector,
-				Metrics:        metrics,
+				Logger:              logger,
+				UpdateInterval:      500 * time.Millisecond,
+				Connector:           connector,
+				Metrics:             metrics,
+				ExternalProvisioner: true,
 			})
 
 			waitForProvisionerJobs := false

--- a/provisioner/terraform/install_test.go
+++ b/provisioner/terraform/install_test.go
@@ -40,7 +40,7 @@ func TestInstall(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				p, err := terraform.Install(ctx, log, dir, version)
+				p, err := terraform.Install(ctx, log, false, dir, version)
 				assert.NoError(t, err)
 				paths <- p
 			}()

--- a/provisioner/terraform/serve_internal_test.go
+++ b/provisioner/terraform/serve_internal_test.go
@@ -54,7 +54,6 @@ func Test_absoluteBinaryPath(t *testing.T) {
 				t.Skip("Dummy terraform executable on Windows requires sh which isn't very practical.")
 			}
 
-			log := testutil.Logger(t)
 			// Create a temp dir with the binary
 			tempDir := t.TempDir()
 			terraformBinaryOutput := fmt.Sprintf(`#!/bin/sh
@@ -85,11 +84,12 @@ func Test_absoluteBinaryPath(t *testing.T) {
 			}
 
 			ctx := testutil.Context(t, testutil.WaitShort)
-			actualAbsoluteBinary, actualErr := absoluteBinaryPath(ctx, log)
+			actualBinaryDetails, actualErr := systemBinary(ctx)
 
-			require.Equal(t, expectedAbsoluteBinary, actualAbsoluteBinary)
 			if tt.expectedErr == nil {
 				require.NoError(t, actualErr)
+				require.Equal(t, expectedAbsoluteBinary, actualBinaryDetails.absolutePath)
+				require.Equal(t, tt.terraformVersion, actualBinaryDetails.version.String())
 			} else {
 				require.EqualError(t, actualErr, tt.expectedErr.Error())
 			}

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -56,6 +56,7 @@ type Options struct {
 	TracerProvider trace.TracerProvider
 	Metrics        *Metrics
 
+	ExternalProvisioner bool
 	ForceCancelInterval time.Duration
 	UpdateInterval      time.Duration
 	LogBufferInterval   time.Duration
@@ -97,12 +98,13 @@ func New(clientDialer Dialer, opts *Options) *Server {
 		clientDialer: clientDialer,
 		clientCh:     make(chan proto.DRPCProvisionerDaemonClient),
 
-		closeContext:     ctx,
-		closeCancel:      ctxCancel,
-		closedCh:         make(chan struct{}),
-		shuttingDownCh:   make(chan struct{}),
-		acquireDoneCh:    make(chan struct{}),
-		initConnectionCh: opts.InitConnectionCh,
+		closeContext:        ctx,
+		closeCancel:         ctxCancel,
+		closedCh:            make(chan struct{}),
+		shuttingDownCh:      make(chan struct{}),
+		acquireDoneCh:       make(chan struct{}),
+		initConnectionCh:    opts.InitConnectionCh,
+		externalProvisioner: opts.ExternalProvisioner,
 	}
 
 	daemon.wg.Add(2)
@@ -141,8 +143,9 @@ type Server struct {
 	// shuttingDownCh will receive when we start graceful shutdown
 	shuttingDownCh chan struct{}
 	// acquireDoneCh will receive when the acquireLoop exits
-	acquireDoneCh chan struct{}
-	activeJob     *runner.Runner
+	acquireDoneCh       chan struct{}
+	activeJob           *runner.Runner
+	externalProvisioner bool
 }
 
 type Metrics struct {
@@ -212,6 +215,10 @@ func NewMetrics(reg prometheus.Registerer) Metrics {
 func (p *Server) connect() {
 	defer p.opts.Logger.Debug(p.closeContext, "connect loop exited")
 	defer p.wg.Done()
+	logConnect := p.opts.Logger.Debug
+	if p.externalProvisioner {
+		logConnect = p.opts.Logger.Info
+	}
 	// An exponential back-off occurs when the connection is failing to dial.
 	// This is to prevent server spam in case of a coderd outage.
 connectLoop:
@@ -239,7 +246,12 @@ connectLoop:
 			p.opts.Logger.Warn(p.closeContext, "coderd client failed to dial", slog.Error(err))
 			continue
 		}
-		p.opts.Logger.Info(p.closeContext, "successfully connected to coderd")
+		// This log is useful to verify that an external provisioner daemon is
+		// successfully connecting to coderd. It doesn't add much value if the
+		// daemon is built-in, so we only log it on the info level if p.externalProvisioner
+		// is true. This log message is mentioned in the docs:
+		// https://github.com/coder/coder/blob/5bd86cb1c06561d1d3e90ce689da220467e525c0/docs/admin/provisioners.md#L346
+		logConnect(p.closeContext, "successfully connected to coderd")
 		retrier.Reset()
 		p.initConnectionOnce.Do(func() {
 			close(p.initConnectionCh)
@@ -252,7 +264,7 @@ connectLoop:
 				client.DRPCConn().Close()
 				return
 			case <-client.DRPCConn().Closed():
-				p.opts.Logger.Info(p.closeContext, "connection to coderd closed")
+				logConnect(p.closeContext, "connection to coderd closed")
 				continue connectLoop
 			case p.clientCh <- client:
 				continue

--- a/provisionersdk/serve.go
+++ b/provisionersdk/serve.go
@@ -25,9 +25,10 @@ type ServeOptions struct {
 	// Listener serves multiple connections. Cannot be combined with Conn.
 	Listener net.Listener
 	// Conn is a single connection to serve. Cannot be combined with Listener.
-	Conn          drpc.Transport
-	Logger        slog.Logger
-	WorkDirectory string
+	Conn                drpc.Transport
+	Logger              slog.Logger
+	WorkDirectory       string
+	ExternalProvisioner bool
 }
 
 type Server interface {

--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -1370,7 +1370,7 @@ func (c *Controller) Run(ctx context.Context) {
 				c.logger.Error(c.ctx, "failed to dial tailnet v2+ API", errF)
 				continue
 			}
-			c.logger.Info(c.ctx, "obtained tailnet API v2+ client")
+			c.logger.Debug(c.ctx, "obtained tailnet API v2+ client")
 			err = c.precheckClientsAndControllers(tailnetClients)
 			if err != nil {
 				c.logger.Critical(c.ctx, "failed precheck", slog.Error(err))
@@ -1379,7 +1379,7 @@ func (c *Controller) Run(ctx context.Context) {
 			}
 			retrier.Reset()
 			c.runControllersOnce(tailnetClients)
-			c.logger.Info(c.ctx, "tailnet API v2+ connection lost")
+			c.logger.Debug(c.ctx, "tailnet API v2+ connection lost")
 		}
 	}()
 }


### PR DESCRIPTION
Addresses https://github.com/coder/coder/issues/16231.

This PR reduces the volume of logs we print after server startup in order to surface the web UI URL better.

Here are the logs after the changes a couple of seconds after starting the server:

<img width="868" alt="Screenshot 2025-02-18 at 16 31 32" src="https://github.com/user-attachments/assets/786dc4b8-7383-48c8-a5c3-a997c01ca915" />

The warning is due to running a development site-less build. It wouldn't show in a release build.