### PR TITLE
ci: fix not setting breaking label on `ready_for_review`

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -84,7 +84,7 @@ jobs:
               repo: context.repo.repo,
             }
 
-            if (action === "opened" || action === "reopened") {
+            if (action === "opened" || action === "reopened" || action === "ready_for_review") {
               if (isBreakingTitle && !labels.includes(releaseLabels.breaking)) {
                 console.log('Add "%s" label', releaseLabels.breaking)
                 await github.rest.issues.addLabels({


### PR DESCRIPTION
Noticed in my PR this wasn't getting added when I moved it out of draft: https://github.com/coder/coder/actions/runs/13406348393/job/37446868622

Related to https://github.com/coder/coder/pull/14667