### PR TITLE
fix: open link with search params

### DIFF
--- a/site/src/utils/portForward.test.ts
+++ b/site/src/utils/portForward.test.ts
@@ -1,0 +1,67 @@
+import { portForwardURL } from "./portForward";
+
+describe("port forward URL", () => {
+	const proxyHostWildcard = "*.proxy-host.tld";
+	const samplePort = 12345;
+	const sampleAgent = "my-agent";
+	const sampleWorkspace = "my-workspace";
+	const sampleUsername = "my-username";
+
+	it("https, host and port", () => {
+		const forwarded = portForwardURL(
+			proxyHostWildcard,
+			samplePort,
+			sampleAgent,
+			sampleWorkspace,
+			sampleUsername,
+			"https",
+		);
+		expect(forwarded).toEqual(
+			"http://12345s--my-agent--my-workspace--my-username.proxy-host.tld/",
+		);
+	});
+	it("http, host, port and path", () => {
+		const forwarded = portForwardURL(
+			proxyHostWildcard,
+			samplePort,
+			sampleAgent,
+			sampleWorkspace,
+			sampleUsername,
+			"http",
+			"/path1/path2",
+		);
+		expect(forwarded).toEqual(
+			"http://12345--my-agent--my-workspace--my-username.proxy-host.tld/path1/path2",
+		);
+	});
+	it("https, host, port, path and empty params", () => {
+		const forwarded = portForwardURL(
+			proxyHostWildcard,
+			samplePort,
+			sampleAgent,
+			sampleWorkspace,
+			sampleUsername,
+			"https",
+			"/path1/path2",
+			"?",
+		);
+		expect(forwarded).toEqual(
+			"http://12345s--my-agent--my-workspace--my-username.proxy-host.tld/path1/path2?",
+		);
+	});
+	it("http, host, port, path and query params", () => {
+		const forwarded = portForwardURL(
+			proxyHostWildcard,
+			samplePort,
+			sampleAgent,
+			sampleWorkspace,
+			sampleUsername,
+			"http",
+			"/path1/path2",
+			"?key1=value1&key2=value2",
+		);
+		expect(forwarded).toEqual(
+			"http://12345--my-agent--my-workspace--my-username.proxy-host.tld/path1/path2?key1=value1&key2=value2",
+		);
+	});
+});

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -7,6 +7,8 @@ export const portForwardURL = (
 	workspaceName: string,
 	username: string,
 	protocol: WorkspaceAgentPortShareProtocol,
+	pathname?: string,
+	search?: string,
 ): string => {
 	const { location } = window;
 	const suffix = protocol === "https" ? "s" : "";
@@ -15,7 +17,12 @@ export const portForwardURL = (
 
 	const baseUrl = `${location.protocol}//${host.replace("*", subdomain)}`;
 	const url = new URL(baseUrl);
-
+	if (pathname) {
+		url.pathname = pathname;
+	}
+	if (search) {
+		url.search = search;
+	}
 	return url.toString();
 };
 
@@ -63,7 +70,9 @@ export const openMaybePortForwardedURL = (
 				workspaceName,
 				username,
 				url.protocol.replace(":", "") as WorkspaceAgentPortShareProtocol,
-			) + url.pathname,
+				url.pathname,
+				url.search,
+			),
 		);
 	} catch (ex) {
 		open(uri);


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/16501

This PR adjusts WebTerminal's logic to include search params while opening links.