### PR TITLE
fix: center proxy spinner

### DIFF
--- a/site/src/components/Latency/Latency.tsx
+++ b/site/src/components/Latency/Latency.tsx
@@ -10,9 +10,14 @@ import { getLatencyColor } from "utils/latency";
 interface LatencyProps {
 	latency?: number;
 	isLoading?: boolean;
+	size?: number;
 }
 
-export const Latency: FC<LatencyProps> = ({ latency, isLoading }) => {
+export const Latency: FC<LatencyProps> = ({
+	latency,
+	isLoading,
+	size = 14,
+}) => {
 	const theme = useTheme();
 	// Always use the no latency color for loading.
 	const color = getLatencyColor(theme, isLoading ? undefined : latency);
@@ -21,7 +26,7 @@ export const Latency: FC<LatencyProps> = ({ latency, isLoading }) => {
 		return (
 			<Tooltip title="Loading latency...">
 				<CircularProgress
-					size={14}
+					size={size}
 					css={{ marginLeft: "auto" }}
 					style={{ color }}
 				/>

--- a/site/src/modules/dashboard/Navbar/ProxyMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/ProxyMenu.tsx
@@ -99,6 +99,7 @@ export const ProxyMenu: FC<ProxyMenuProps> = ({ proxyContextValue }) => {
 						<Latency
 							latency={latencies?.[selectedProxy.id]?.latencyMS}
 							isLoading={proxyLatencyLoading(selectedProxy)}
+							size={24}
 						/>
 					</div>
 				) : (


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/16615

This PR adjusts the font size of the spinner to have it centered properly.

<img width="345" alt="Screenshot 2025-02-19 at 16 11 57" src="https://github.com/user-attachments/assets/e98caf0f-d7a1-4068-b02a-c9c8871a993b" />
