### PR TITLE
feat(agent/agentcontainers): add ContainerEnvInfoer

### DIFF
--- a/agent/agentcontainers/containers.go
+++ b/agent/agentcontainers/containers.go
@@ -144,6 +144,8 @@ type Lister interface {
 // NoopLister is a Lister interface that never returns any containers.
 type NoopLister struct{}
 
+var _ Lister = NoopLister{}
+
 func (NoopLister) List(_ context.Context) (codersdk.WorkspaceAgentListContainersResponse, error) {
 	return codersdk.WorkspaceAgentListContainersResponse{}, nil
 }

--- a/agent/agentcontainers/containers_dockercli.go
+++ b/agent/agentcontainers/containers_dockercli.go
@@ -228,7 +228,7 @@ func wrapDockerExec(containerName, userName, cmd string, args ...string) (string
 // We also want to differentiate between a command running successfully with
 // output to stderr and a non-zero exit code.
 func run(ctx context.Context, execer agentexec.Execer, cmd string, args ...string) (stdout, stderr string, err error) {
-	var stdoutBuf, stderrBuf bytes.Buffer
+	var stdoutBuf, stderrBuf strings.Builder
 	execCmd := execer.CommandContext(ctx, cmd, args...)
 	execCmd.Stdout = &stdoutBuf
 	execCmd.Stderr = &stderrBuf

--- a/agent/agentcontainers/containers_dockercli.go
+++ b/agent/agentcontainers/containers_dockercli.go
@@ -98,7 +98,7 @@ func EnvInfo(ctx context.Context, execer agentexec.Execer, container, containerU
 	// Parse the output of /etc/passwd. It looks like this:
 	// postgres:x:999:999::/var/lib/postgresql:/bin/bash
 	passwdFields := strings.Split(foundLine, ":")
-	if len(passwdFields) < 7 {
+	if len(passwdFields) != 7 {
 		return nil, xerrors.Errorf("get container user: invalid line in /etc/passwd: %q", foundLine)
 	}
 
@@ -144,14 +144,8 @@ func EnvInfo(ctx context.Context, execer agentexec.Execer, container, containerU
 
 func (dei *ContainerEnvInfoer) CurrentUser() (*user.User, error) {
 	// Clone the user so that the caller can't modify it
-	u := &user.User{
-		Gid:      dei.user.Gid,
-		HomeDir:  dei.user.HomeDir,
-		Name:     dei.user.Name,
-		Uid:      dei.user.Uid,
-		Username: dei.user.Username,
-	}
-	return u, nil
+	u := *dei.user
+	return &u, nil
 }
 
 func (dei *ContainerEnvInfoer) Environ() []string {

--- a/agent/agentcontainers/containers_internal_test.go
+++ b/agent/agentcontainers/containers_internal_test.go
@@ -2,7 +2,7 @@ package agentcontainers
 
 import (
 	"fmt"
-	"runtime"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,10 +29,14 @@ import (
 // label, lists the containers, and verifies that the expected container is
 // returned. It also executes a sample command inside the container.
 // The container is deleted after the test is complete.
+// As this test creates containers, it is skipped by default.
+// It can be run manually as follows:
+//
+// CODER_TEST_USE_DOCKER=1 go test ./agent/agentcontainers -run TestDockerCLIContainerLister
 func TestIntegrationDocker(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "linux" {
-		t.Skip("This test creates containers, which can be flaky in non-Linux CI environments.")
+	if ctud, ok := os.LookupEnv("CODER_TEST_USE_DOCKER"); !ok || ctud != "1" {
+		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
 	}
 
 	pool, err := dockertest.NewPool("")
@@ -419,10 +423,16 @@ func TestConvertDockerVolume(t *testing.T) {
 	}
 }
 
+// TestDockerEnvInfoer tests the ability of EnvInfo to extract information from
+// running containers. Containers are deleted after the test is complete.
+// As this test creates containers, it is skipped by default.
+// It can be run manually as follows:
+//
+// CODER_TEST_USE_DOCKER=1 go test ./agent/agentcontainers -run TestDockerEnvInfoer
 func TestDockerEnvInfoer(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "linux" {
-		t.Skip("This test creates containers, which can be flaky in non-Linux CI environments.")
+	if ctud, ok := os.LookupEnv("CODER_TEST_USE_DOCKER"); !ok || ctud != "1" {
+		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
 	}
 
 	pool, err := dockertest.NewPool("")

--- a/agent/agentcontainers/containers_internal_test.go
+++ b/agent/agentcontainers/containers_internal_test.go
@@ -420,9 +420,9 @@ func TestConvertDockerVolume(t *testing.T) {
 // CODER_TEST_USE_DOCKER=1 go test ./agent/agentcontainers -run TestDockerEnvInfoer
 func TestDockerEnvInfoer(t *testing.T) {
 	t.Parallel()
-	// if ctud, ok := os.LookupEnv("CODER_TEST_USE_DOCKER"); !ok || ctud != "1" {
-	// 	t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
-	// }
+	if ctud, ok := os.LookupEnv("CODER_TEST_USE_DOCKER"); !ok || ctud != "1" {
+		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
+	}
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err, "Could not connect to docker")

--- a/agent/agentcontainers/containers_internal_test.go
+++ b/agent/agentcontainers/containers_internal_test.go
@@ -445,50 +445,44 @@ func TestDockerEnvInfoer(t *testing.T) {
 		expectedUsername    string
 		expectedUserHomedir string
 		expectedUserShell   string
-		expectedEnviron     []string
 	}{
 		{
 			image:               "busybox:latest",
-			env:                 []string{"FOO=bar"},
+			env:                 []string{"FOO=bar", "MULTILINE=foo\nbar\nbaz"},
 			expectedUsername:    "root",
 			expectedUserHomedir: "/root",
 			expectedUserShell:   "/bin/sh",
-			expectedEnviron:     []string{"FOO=bar"},
 		},
 		{
 			image:               "busybox:latest",
-			env:                 []string{"FOO=bar"},
+			env:                 []string{"FOO=bar", "MULTILINE=foo\nbar\nbaz"},
 			containerUser:       "root",
 			expectedUsername:    "root",
 			expectedUserHomedir: "/root",
 			expectedUserShell:   "/bin/sh",
-			expectedEnviron:     []string{"FOO=bar"},
 		},
 		{
 			image:               "codercom/enterprise-minimal:ubuntu",
-			env:                 []string{"FOO=bar"},
+			env:                 []string{"FOO=bar", "MULTILINE=foo\nbar\nbaz"},
 			expectedUsername:    "coder",
 			expectedUserHomedir: "/home/coder",
 			expectedUserShell:   "/bin/bash",
-			expectedEnviron:     []string{"FOO=bar"},
 		},
 		{
 			image:               "codercom/enterprise-minimal:ubuntu",
-			env:                 []string{"FOO=bar"},
+			env:                 []string{"FOO=bar", "MULTILINE=foo\nbar\nbaz"},
 			containerUser:       "coder",
 			expectedUsername:    "coder",
 			expectedUserHomedir: "/home/coder",
 			expectedUserShell:   "/bin/bash",
-			expectedEnviron:     []string{"FOO=bar"},
 		},
 		{
 			image:               "codercom/enterprise-minimal:ubuntu",
-			env:                 []string{"FOO=bar"},
+			env:                 []string{"FOO=bar", "MULTILINE=foo\nbar\nbaz"},
 			containerUser:       "root",
 			expectedUsername:    "root",
 			expectedUserHomedir: "/root",
 			expectedUserShell:   "/bin/bash",
-			expectedEnviron:     []string{"FOO=bar"},
 		},
 	} {
 		t.Run(fmt.Sprintf("#%d", idx), func(t *testing.T) {
@@ -531,7 +525,7 @@ func TestDockerEnvInfoer(t *testing.T) {
 			require.Equal(t, tt.expectedUserShell, sh, "Expected user shell to match")
 
 			environ := dei.Environ()
-			require.Subset(t, environ, tt.expectedEnviron, "Expected environment to match")
+			require.Subset(t, environ, tt.env, "Expected environment to match")
 		})
 	}
 }


### PR DESCRIPTION
This PR adds an alternative implementation of EnvInfo (https://github.com/coder/coder/pull/16603) that reads information from a running container.

NOTE: the new tests aren't run in CI by default; you'll have to just "trust" me that they work or run them yourself.