### PR TITLE
fix: change validation error for workspace name

### DIFF
--- a/site/src/utils/formUtils.ts
+++ b/site/src/utils/formUtils.ts
@@ -12,8 +12,8 @@ const Language = {
 	nameRequired: (name: string): string => {
 		return name ? `Please enter a ${name.toLowerCase()}.` : "Required";
 	},
-	nameInvalidChars: (name: string): string => {
-		return `${name} must start with a-Z or 0-9 and can contain a-Z, 0-9 or -`;
+	nameInvalidChars: (): string => {
+		return `Special characters (e.g.: !, @, #) are not supported`;
 	},
 	nameTooLong: (name: string, len: number): string => {
 		return `${name} cannot be longer than ${len} characters`;
@@ -119,7 +119,7 @@ const displayNameRE = /^[^\s](.*[^\s])?$/;
 export const nameValidator = (name: string): Yup.StringSchema =>
 	Yup.string()
 		.required(Language.nameRequired(name))
-		.matches(usernameRE, Language.nameInvalidChars(name))
+		.matches(usernameRE, Language.nameInvalidChars())
 		.max(maxLenName, Language.nameTooLong(name, maxLenName));
 
 export const displayNameValidator = (displayName: string): Yup.StringSchema =>

--- a/site/src/utils/formUtils.ts
+++ b/site/src/utils/formUtils.ts
@@ -13,7 +13,7 @@ const Language = {
 		return name ? `Please enter a ${name.toLowerCase()}.` : "Required";
 	},
 	nameInvalidChars: (): string => {
-		return `Special characters (e.g.: !, @, #) are not supported`;
+		return "Special characters (e.g.: !, @, #) are not supported";
 	},
 	nameTooLong: (name: string, len: number): string => {
 		return `${name} cannot be longer than ${len} characters`;


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14824

This PR changes the validation message to make it easier to comprehend:

<img width="644" alt="Screenshot 2025-02-20 at 11 47 40" src="https://github.com/user-attachments/assets/381ec3cb-f3f1-43ad-9a41-68255f3b10a9" />


**Notice**: some edge cases may be confusing:

<img width="637" alt="Screenshot 2025-02-20 at 11 48 01" src="https://github.com/user-attachments/assets/84607844-2fe0-48f6-b738-04ec10059f1c" /> (`-` is unsupported)

<img width="632" alt="Screenshot 2025-02-20 at 11 48 19" src="https://github.com/user-attachments/assets/850bb1b2-06a7-420c-ba5a-8227b4f74f4c" /> (but now it is supported?)

