### PR TITLE
fix: include a link and more useful error details for 403 response codes

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -154,7 +154,7 @@ func ResourceNotFound(rw http.ResponseWriter) {
 func Forbidden(rw http.ResponseWriter) {
 	Write(context.Background(), rw, http.StatusForbidden, codersdk.Response{
 		Message: "Forbidden.",
-		Detail:  "You don't have permission to view this page. If you believe this is a mistake, please contact your administrator or try signing in with different credentials.",
+		Detail:  "You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials.",
 	})
 }
 

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -154,6 +154,7 @@ func ResourceNotFound(rw http.ResponseWriter) {
 func Forbidden(rw http.ResponseWriter) {
 	Write(context.Background(), rw, http.StatusForbidden, codersdk.Response{
 		Message: "Forbidden.",
+		Detail:  "You don't have permission to view this page. If you believe this is a mistake, please contact your administrator or try signing in with different credentials.",
 	})
 }
 

--- a/site/e2e/setup/addUsersAndLicense.spec.ts
+++ b/site/e2e/setup/addUsersAndLicense.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { API } from "api/api";
-import { Language } from "pages/CreateUserPage/CreateUserForm";
+import { Language } from "pages/CreateUserPage/Language";
 import { coderPort, license, premiumTestsRequired, users } from "../constants";
 import { expectUrl } from "../expectUrl";
 import { createUser } from "../helpers";

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -133,6 +133,14 @@ export const getErrorDetail = (error: unknown): string | undefined => {
 	return undefined;
 };
 
+export const getErrorStatus = (error: unknown): number | undefined => {
+	if (isApiError(error)) {
+		return error.status;
+	}
+
+	return undefined;
+};
+
 export class DetailedError extends Error {
 	constructor(
 		message: string,

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -24,10 +24,9 @@ export const ErrorAlert: FC<
 		if (status === 403) {
 			return (
 				<>
-					<AlertTitle>You don't have permission to view this page</AlertTitle>
+					<AlertTitle>{message}</AlertTitle>
 					<AlertDetail>
-						If you believe this is a mistake, please contact your administrator
-						or try signing in with different credentials.{" "}
+						{detail}{" "}
 						<Link href="/workspaces" className="w-fit">
 							Go to workspaces
 						</Link>

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -1,5 +1,6 @@
 import AlertTitle from "@mui/material/AlertTitle";
-import { getErrorDetail, getErrorMessage } from "api/errors";
+import { getErrorDetail, getErrorMessage, getErrorStatus } from "api/errors";
+import { Link } from "components/Link/Link";
 import type { FC } from "react";
 import { Alert, AlertDetail, type AlertProps } from "./Alert";
 
@@ -8,21 +9,48 @@ export const ErrorAlert: FC<
 > = ({ error, ...alertProps }) => {
 	const message = getErrorMessage(error, "Something went wrong.");
 	const detail = getErrorDetail(error);
+	const status = getErrorStatus(error);
 
 	// For some reason, the message and detail can be the same on the BE, but does
 	// not make sense in the FE to showing them duplicated
 	const shouldDisplayDetail = message !== detail;
 
-	return (
-		<Alert severity="error" {...alertProps}>
-			{detail ? (
+	const body = () => {
+		// When the error is a Forbidden response we include a link for the user to 
+		// go back to a known viewable page.
+		// Additionally since the error messages and details from the server can be
+		// missing or confusing for an end user we render a friendlier message
+		// regardless of the response from the server.
+		if (status === 403) {
+			return (
+				<>
+					<AlertTitle>You don't have permission to view this page</AlertTitle>
+					<AlertDetail>
+						If you believe this is a mistake, please contact your administrator
+						or try signing in with different credentials.{" "}
+						<Link href="/workspaces" className="w-fit">
+							Go to workspaces
+						</Link>
+					</AlertDetail>
+				</>
+			);
+		}
+
+		if (detail) {
+			return (
 				<>
 					<AlertTitle>{message}</AlertTitle>
 					{shouldDisplayDetail && <AlertDetail>{detail}</AlertDetail>}
 				</>
-			) : (
-				message
-			)}
+			);
+		}
+
+		return message;
+	};
+
+	return (
+		<Alert severity="error" {...alertProps}>
+			{body()}
 		</Alert>
 	);
 };

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -15,41 +15,30 @@ export const ErrorAlert: FC<
 	// not make sense in the FE to showing them duplicated
 	const shouldDisplayDetail = message !== detail;
 
-	const body = () => {
-		// When the error is a Forbidden response we include a link for the user to
-		// go back to a known viewable page.
-		// Additionally since the error messages and details from the server can be
-		// missing or confusing for an end user we render a friendlier message
-		// regardless of the response from the server.
-		if (status === 403) {
-			return (
-				<>
-					<AlertTitle>{message}</AlertTitle>
-					<AlertDetail>
-						{detail}{" "}
-						<Link href="/workspaces" className="w-fit">
-							Go to workspaces
-						</Link>
-					</AlertDetail>
-				</>
-			);
-		}
-
-		if (detail) {
-			return (
-				<>
-					<AlertTitle>{message}</AlertTitle>
-					{shouldDisplayDetail && <AlertDetail>{detail}</AlertDetail>}
-				</>
-			);
-		}
-
-		return message;
-	};
-
 	return (
 		<Alert severity="error" {...alertProps}>
-			{body()}
+			{
+				// When the error is a Forbidden response we include a link for the user to
+				// go back to a known viewable page.
+				status === 403 ? (
+					<>
+						<AlertTitle>{message}</AlertTitle>
+						<AlertDetail>
+							{detail}{" "}
+							<Link href="/workspaces" className="w-fit">
+								Go to workspaces
+							</Link>
+						</AlertDetail>
+					</>
+				) : detail ? (
+					<>
+						<AlertTitle>{message}</AlertTitle>
+						{shouldDisplayDetail && <AlertDetail>{detail}</AlertDetail>}
+					</>
+				) : (
+					message
+				)
+			}
 		</Alert>
 	);
 };

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -1,7 +1,7 @@
 import AlertTitle from "@mui/material/AlertTitle";
 import { getErrorDetail, getErrorMessage, getErrorStatus } from "api/errors";
-import { Link } from "components/Link/Link";
 import type { FC } from "react";
+import { Link } from "../Link/Link";
 import { Alert, AlertDetail, type AlertProps } from "./Alert";
 
 export const ErrorAlert: FC<

--- a/site/src/components/Alert/ErrorAlert.tsx
+++ b/site/src/components/Alert/ErrorAlert.tsx
@@ -16,7 +16,7 @@ export const ErrorAlert: FC<
 	const shouldDisplayDetail = message !== detail;
 
 	const body = () => {
-		// When the error is a Forbidden response we include a link for the user to 
+		// When the error is a Forbidden response we include a link for the user to
 		// go back to a known viewable page.
 		// Additionally since the error messages and details from the server can be
 		// missing or confusing for an end user we render a friendlier message

--- a/site/src/pages/CreateUserPage/CreateUserForm.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.tsx
@@ -19,18 +19,7 @@ import {
 	onChangeTrimmed,
 } from "utils/formUtils";
 import * as Yup from "yup";
-
-export const Language = {
-	emailLabel: "Email",
-	passwordLabel: "Password",
-	usernameLabel: "Username",
-	nameLabel: "Full name",
-	emailInvalid: "Please enter a valid email address.",
-	emailRequired: "Please enter an email address.",
-	passwordRequired: "Please enter a password.",
-	createUser: "Create",
-	cancel: "Cancel",
-};
+import { Language } from "./Language";
 
 export const authMethodLanguage = {
 	password: {

--- a/site/src/pages/CreateUserPage/CreateUserPage.test.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserPage.test.tsx
@@ -4,8 +4,8 @@ import {
 	renderWithAuth,
 	waitForLoaderToBeRemoved,
 } from "testHelpers/renderHelpers";
-import { Language as FormLanguage } from "./Language";
 import { CreateUserPage } from "./CreateUserPage";
+import { Language as FormLanguage } from "./Language";
 
 const renderCreateUserPage = async () => {
 	renderWithAuth(<CreateUserPage />, {

--- a/site/src/pages/CreateUserPage/CreateUserPage.test.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserPage.test.tsx
@@ -4,7 +4,7 @@ import {
 	renderWithAuth,
 	waitForLoaderToBeRemoved,
 } from "testHelpers/renderHelpers";
-import { Language as FormLanguage } from "./CreateUserForm";
+import { Language as FormLanguage } from "./Language";
 import { CreateUserPage } from "./CreateUserPage";
 
 const renderCreateUserPage = async () => {

--- a/site/src/pages/CreateUserPage/Language.ts
+++ b/site/src/pages/CreateUserPage/Language.ts
@@ -1,0 +1,11 @@
+export const Language = {
+	emailLabel: "Email",
+	passwordLabel: "Password",
+	usernameLabel: "Username",
+	nameLabel: "Full name",
+	emailInvalid: "Please enter a valid email address.",
+	emailRequired: "Please enter an email address.",
+	passwordRequired: "Please enter a password.",
+	createUser: "Create",
+	cancel: "Cancel",
+};


### PR DESCRIPTION
Currently if a user gets to a page they don't have permission to view they're greeted with a vague error alert and no actionable items. This PR adds a link back to _/workspaces_ within the alert as well as more helpful error details.

Before:
![Screenshot 2025-02-20 at 11 06 06 AM](https://github.com/user-attachments/assets/cea5b86d-673b-482b-ac0b-f132eb518910)

After:
![Screenshot 2025-02-20 at 11 06 19 AM](https://github.com/user-attachments/assets/6bf0e9fd-fc51-4d9a-afbc-fea9f0439aff)
