### PR TITLE
fix: block vpn tailnet endpoint when `--browser-only` is set

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -906,6 +906,7 @@ func (api *API) workspaceAgentClientCoordinate(rw http.ResponseWriter, r *http.R
 	}
 
 	// This is used by Enterprise code to control the functionality of this route.
+	// Namely, disabling the route using `CODER_BROWSER_ONLY`.
 	override := api.WorkspaceClientCoordinateOverride.Load()
 	if override != nil {
 		overrideFunc := *override
@@ -1575,6 +1576,16 @@ func (api *API) workspaceAgentsExternalAuthListen(ctx context.Context, rw http.R
 // @Router /tailnet [get]
 func (api *API) tailnetRPCConn(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	// This is used by Enterprise code to control the functionality of this route.
+	// Namely, disabling the route using `CODER_BROWSER_ONLY`.
+	override := api.WorkspaceClientCoordinateOverride.Load()
+	if override != nil {
+		overrideFunc := *override
+		if overrideFunc != nil && overrideFunc(rw) {
+			return
+		}
+	}
 
 	version := "2.0"
 	qv := r.URL.Query().Get("version")


### PR DESCRIPTION
The work on CoderVPN required a new user-scoped `/tailnet` endpoint for coordinating with multiple workspace agents, and receiving workspace updates. Much like the `/coordinate` endpoint, this needs to respect the `CODER_BROWSER_ONLY`/`--browser-only` deployment config value.