### PR TITLE
feat: add notifications troubleshooting tab

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2298,7 +2298,7 @@ class ApiMethods {
 	};
 
 	postTestNotification = async () => {
-		await this.axios.post<void>(`/api/v2/notifications/test`);
+		await this.axios.post<void>("/api/v2/notifications/test");
 	};
 
 	requestOneTimePassword = async (

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2297,6 +2297,10 @@ class ApiMethods {
 		return res.data;
 	};
 
+	postTestNotification = async () => {
+		await this.axios.post<void>(`/api/v2/notifications/test`);
+	};
+
 	requestOneTimePassword = async (
 		req: TypesGen.RequestOneTimePasscodeRequest,
 	) => {

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -17,6 +17,10 @@ import { deploymentGroupHasParent } from "utils/deployOptions";
 import { pageTitle } from "utils/page";
 import OptionsTable from "../OptionsTable";
 import { NotificationEvents } from "./NotificationEvents";
+import { Troubleshooting } from "./Troubleshooting";
+import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
+import { docs } from "utils/docs";
+import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
 
 export const NotificationsPage: FC = () => {
 	const { deploymentConfig } = useDeploymentSettings();
@@ -40,48 +44,62 @@ export const NotificationsPage: FC = () => {
 			<Helmet>
 				<title>{pageTitle("Notifications Settings")}</title>
 			</Helmet>
-			<Section
-				title="Notifications"
+			<SettingsHeader
+				title={
+					<>
+						Notifications
+						<span css={{ position: "relative", top: "-6px" }}>
+							<FeatureStageBadge
+								contentType={"beta"}
+								size="lg"
+								css={{ marginBottom: "5px", fontSize: "0.75rem" }}
+							/>
+						</span>
+					</>
+				}
 				description="Control delivery methods for notifications on this deployment."
-				layout="fluid"
-				featureStage={"beta"}
-			>
-				<Tabs active={tabState.value}>
-					<TabsList>
-						<TabLink to="?tab=events" value="events">
-							Events
-						</TabLink>
-						<TabLink to="?tab=settings" value="settings">
-							Settings
-						</TabLink>
-					</TabsList>
-				</Tabs>
+				docsHref={docs("/admin/monitoring/notifications")}
+			/>
+			<Tabs active={tabState.value}>
+				<TabsList>
+					<TabLink to="?tab=events" value="events">
+						Events
+					</TabLink>
+					<TabLink to="?tab=settings" value="settings">
+						Settings
+					</TabLink>
+					<TabLink to="?tab=troubleshooting" value="troubleshooting">
+						Troubleshooting
+					</TabLink>
+				</TabsList>
+			</Tabs>
 
-				<div css={styles.content}>
-					{ready ? (
-						tabState.value === "events" ? (
-							<NotificationEvents
-								templatesByGroup={templatesByGroup.data}
-								deploymentConfig={deploymentConfig.config}
-								defaultMethod={castNotificationMethod(
-									dispatchMethods.data.default,
-								)}
-								availableMethods={dispatchMethods.data.available.map(
-									castNotificationMethod,
-								)}
-							/>
-						) : (
-							<OptionsTable
-								options={deploymentConfig.options.filter((o) =>
-									deploymentGroupHasParent(o.group, "Notifications"),
-								)}
-							/>
-						)
+			<div css={styles.content}>
+				{ready ? (
+					tabState.value === "events" ? (
+						<NotificationEvents
+							templatesByGroup={templatesByGroup.data}
+							deploymentConfig={deploymentConfig.config}
+							defaultMethod={castNotificationMethod(
+								dispatchMethods.data.default,
+							)}
+							availableMethods={dispatchMethods.data.available.map(
+								castNotificationMethod,
+							)}
+						/>
+					) : tabState.value === "troubleshooting" ? (
+						<Troubleshooting />
 					) : (
-						<Loader />
-					)}
-				</div>
-			</Section>
+						<OptionsTable
+							options={deploymentConfig.options.filter((o) =>
+								deploymentGroupHasParent(o.group, "Notifications"),
+							)}
+						/>
+					)
+				) : (
+					<Loader />
+				)}
+			</div>
 		</>
 	);
 };

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -4,7 +4,9 @@ import {
 	selectTemplatesByGroup,
 	systemNotificationTemplates,
 } from "api/queries/notifications";
+import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
 import { Loader } from "components/Loader/Loader";
+import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { TabLink, Tabs, TabsList } from "components/Tabs/Tabs";
 import { useSearchParamsKey } from "hooks/useSearchParamsKey";
 import { useDeploymentSettings } from "modules/management/DeploymentSettingsProvider";
@@ -14,13 +16,11 @@ import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQueries } from "react-query";
 import { deploymentGroupHasParent } from "utils/deployOptions";
+import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
 import OptionsTable from "../OptionsTable";
 import { NotificationEvents } from "./NotificationEvents";
 import { Troubleshooting } from "./Troubleshooting";
-import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
-import { docs } from "utils/docs";
-import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
 
 export const NotificationsPage: FC = () => {
 	const { deploymentConfig } = useDeploymentSettings();

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Troubleshooting } from "./Troubleshooting";
+import { API } from "api/api";
+import { spyOn, userEvent, within } from "@storybook/test";
+import { baseMeta } from "./storybookUtils";
+
+const meta: Meta<typeof Troubleshooting> = {
+	title: "pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting",
+	component: Troubleshooting,
+	...baseMeta,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Troubleshooting>;
+
+export const TestNotification: Story = {
+	play: async ({ canvasElement }) => {
+		spyOn(API, "postTestNotification").mockResolvedValue();
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+
+		const sendButton = canvas.getByRole("button", {
+			name: "Send notification",
+		});
+		await user.click(sendButton);
+		await within(document.body).findByText("Test notification sent");
+	},
+};

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Troubleshooting } from "./Troubleshooting";
-import { API } from "api/api";
 import { spyOn, userEvent, within } from "@storybook/test";
+import { API } from "api/api";
+import { Troubleshooting } from "./Troubleshooting";
 import { baseMeta } from "./storybookUtils";
 
 const meta: Meta<typeof Troubleshooting> = {

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
@@ -1,0 +1,52 @@
+import type { Interpolation, Theme } from "@emotion/react";
+import { useTheme } from "@emotion/react";
+import { API } from "api/api";
+import { type FC } from "react";
+import { useMutation } from "react-query";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
+import LoadingButton from "@mui/lab/LoadingButton";
+
+type TroubleshootingProps = {};
+
+export const Troubleshooting: FC<TroubleshootingProps> = ({}) => {
+	const { mutate: sendTestNotificationApi, isLoading: isLoading } = useMutation(
+		API.postTestNotification,
+		{
+			onSuccess: () => displaySuccess("Test notification sent"),
+			onError: () => displayError("Failed to send test notification"),
+		},
+	);
+
+	const theme = useTheme();
+	return (
+		<>
+			<div
+				css={{
+					fontSize: 14,
+					color: theme.palette.text.secondary,
+					lineHeight: "160%",
+					marginBottom: 16,
+				}}
+			>
+				Send a test notification to troubleshoot your notification settings.
+			</div>
+			<div>
+				<span>
+					<LoadingButton
+						variant="outlined"
+						loading={isLoading}
+						size="small"
+						css={{ minWidth: "auto", aspectRatio: "1" }}
+						onClick={() => {
+							sendTestNotificationApi();
+						}}
+					>
+						Send notification
+					</LoadingButton>
+				</span>
+			</div>
+		</>
+	);
+};
+
+const styles = {} as Record<string, Interpolation<Theme>>;

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
@@ -6,9 +6,7 @@ import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
 import type { FC } from "react";
 import { useMutation } from "react-query";
 
-type TroubleshootingProps = {};
-
-export const Troubleshooting: FC<TroubleshootingProps> = ({}) => {
+export const Troubleshooting: FC = () => {
 	const { mutate: sendTestNotificationApi, isLoading } = useMutation(
 		API.postTestNotification,
 		{

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
@@ -1,15 +1,15 @@
 import type { Interpolation, Theme } from "@emotion/react";
 import { useTheme } from "@emotion/react";
-import { API } from "api/api";
-import { type FC } from "react";
-import { useMutation } from "react-query";
-import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
 import LoadingButton from "@mui/lab/LoadingButton";
+import { API } from "api/api";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
+import type { FC } from "react";
+import { useMutation } from "react-query";
 
 type TroubleshootingProps = {};
 
 export const Troubleshooting: FC<TroubleshootingProps> = ({}) => {
-	const { mutate: sendTestNotificationApi, isLoading: isLoading } = useMutation(
+	const { mutate: sendTestNotificationApi, isLoading } = useMutation(
 		API.postTestNotification,
 		{
 			onSuccess: () => displaySuccess("Test notification sent"),

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/Troubleshooting.tsx
@@ -1,4 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
 import { useTheme } from "@emotion/react";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { API } from "api/api";
@@ -46,5 +45,3 @@ export const Troubleshooting: FC = () => {
 		</>
 	);
 };
-
-const styles = {} as Record<string, Interpolation<Theme>>;


### PR DESCRIPTION
Changes:
* refactor Notifications page to include "Read the docs" button
* add "Troubleshooting" tab with a button to send test notifications

Screenshots:

<img width="1508" alt="Screenshot 2025-02-21 at 12 53 30" src="https://github.com/user-attachments/assets/e94b78a8-950c-4329-85b1-904f5762968c" />
<img width="1111" alt="Screenshot 2025-02-21 at 12 42 07" src="https://github.com/user-attachments/assets/f637d232-0b3b-4c8a-9760-295a697aa235" />
<img width="1122" alt="Screenshot 2025-02-21 at 12 46 01" src="https://github.com/user-attachments/assets/16f1fd8a-16d1-4fb3-b7d3-ea816a54f774" />
