### PR TITLE
fix: return http 204 on test notification

### DIFF
--- a/coderd/notifications.go
+++ b/coderd/notifications.go
@@ -210,7 +210,7 @@ func (api *API) postTestNotification(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, nil)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // @Summary Get user notification preferences

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -200,10 +200,9 @@ func (c *Client) PostTestNotification(ctx context.Context) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusNoContent {
 		return ReadBodyAsError(res)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR changes the API response for `/api/v2/notifications/test` endpoint to HTTP 204 / No Content.