### PR TITLE
docs: update Coder version in Kubernetes doc

### DIFF
--- a/docs/admin/integrations/kubernetes-logs.md
+++ b/docs/admin/integrations/kubernetes-logs.md
@@ -8,29 +8,6 @@ or deployment, such as:
 - Causes of pod provisioning failures, or why a pod is stuck in a pending state.
 - Visibility into when pods are OOMKilled, or when they are evicted.
 
-## Prerequisites
-
-`coder-logstream-kube` works best with the
-[`kubernetes_deployment`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment)
-Terraform resource, which requires the `coder` service account to have
-permission to create deployments. For example, if you use
-[Helm](../../install/kubernetes.md#4-install-coder-with-helm) to install Coder,
-you should set `coder.serviceAccount.enableDeployments=true` in your
-`values.yaml`
-
-```diff
-coder:
-serviceAccount:
-    workspacePerms: true
--   enableDeployments: false
-+   enableDeployments: true
-    annotations: {}
-    name: coder
-```
-
-> Note: This is only required for Coder versions < 0.28.0, as this will be the
-> default value for Coder versions >= 0.28.0
-
 ## Installation
 
 Install the `coder-logstream-kube` helm chart on the cluster where the

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -129,7 +129,7 @@ We support two release channels: mainline and stable - read the
   helm install coder coder-v2/coder \
       --namespace coder \
       --values values.yaml \
-      --version 2.18.0
+      --version 2.19.0
   ```
 
 - **Stable** Coder release:
@@ -140,7 +140,7 @@ We support two release channels: mainline and stable - read the
   helm install coder coder-v2/coder \
       --namespace coder \
       --values values.yaml \
-      --version 2.17.2
+      --version 2.18.5
   ```
 
 You can watch Coder start up by running `kubectl get pods -n coder`. Once Coder

--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -77,5 +77,4 @@ pages.
 
 v2.18 was promoted to stable on January 7th, 2025.
 
-Effective starting January, 2025 we will skip the January release each year because most of our engineering team is out for the December holiday period.
-We'll return to our regular release cadence on February 4th.
+As of January, 2025 we skip the January release each year because most of our engineering team is out for the December holiday period.

--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -10,7 +10,7 @@ deployment.
 ## Release channels
 
 We support two release channels:
-[mainline](https://github.com/coder/coder/releases/tag/v2.16.0) for the bleeding
+[mainline](https://github.com/coder/coder/releases/tag/v2.19.0) for the bleeding
 edge version of Coder and
 [stable](https://github.com/coder/coder/releases/latest) for those with lower
 tolerance for fault. We field our mainline releases publicly for one month


### PR DESCRIPTION
closes #16570 

thanks @Cjkjvfnby !


@matifali I think there is/was an automation, but I'm not sure if it's been dropped. `kubernetes.md` has:

```md
<!-- autoversion(mainline): "--version [version]" -->
...
<!-- autoversion(stable): "--version [version]" -->
```

~additionally, I removed the `## Prerequisites` section from `kubernetes-logs.md` because if it's only a requirement for Coder versions earlier than 0.28.0, it's probably more confusing than useful to the majority of readers.~