### PR TITLE
chore: run `make clean` on workspace startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ endif
 
 clean:
 	rm -rf build/ site/build/ site/out/
-	mkdir -p build/ site/out/bin/
+	mkdir -p build/
 	git restore site/out/
 .PHONY: clean
 

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -342,7 +342,15 @@ resource "coder_agent" "dev" {
     while ! [[ -f "${local.repo_dir}/site/package.json" ]]; do
       sleep 1
     done
+    make clean
     cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
+  EOT
+
+  shutdown_script = <<-EOT
+    #!/usr/bin/env bash
+    set -eux -o pipefail
+
+    cd "${local.repo_dir}" && make clean
   EOT
 }
 

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -342,15 +342,8 @@ resource "coder_agent" "dev" {
     while ! [[ -f "${local.repo_dir}/site/package.json" ]]; do
       sleep 1
     done
-    make clean
-    cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
-  EOT
-
-  shutdown_script = <<-EOT
-    #!/usr/bin/env bash
-    set -eux -o pipefail
-
     cd "${local.repo_dir}" && make clean
+    cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
   EOT
 }
 

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -96,7 +96,7 @@ data "coder_parameter" "res_mon_memory_threshold" {
 data "coder_parameter" "res_mon_volume_threshold" {
   type        = "number"
   name        = "Volume usage threshold"
-  default     = 80
+  default     = 90
   description = "The volume usage threshold used in resources monitoring to trigger notifications."
   mutable     = true
 }


### PR DESCRIPTION
I originally thought using `shutdown_script` would be better, but after some testing it seems like `shutdown_script`s don't get run nearly as consistently. Idk what's going on there, but running this on startup shouldn't be too bad because it should always be fast, at least.

Our various build outputs can easily take up dozens of gigabytes per workspace. Multiply that across dozens of engineers, and it's considerable. We've been seeing a lot of disk utilization warnings lately because some of our disks are getting "too" full (even though in reality they often have hundreds of gigabytes of spare capacity). This is an easy way to quiet those warnings, and leave us with plenty of capacity to onboard additional engineers without needing to upgrade our actual storage resources.

Also bumps threshold to 90%, because realistically that's still a _ton_ of spare capacity.