### PR TITLE
chore: show server install.sh on cli version mismatch

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -1217,7 +1217,8 @@ func wrapTransportWithVersionMismatchCheck(rt http.RoundTripper, inv *serpent.In
 				switch {
 				case serverInfo.UpgradeMessage != "":
 					upgradeMessage = serverInfo.UpgradeMessage
-				case serverInfo.DashboardURL != "":
+				// The site-local `install.sh` was introduced in v2.19.0
+				case serverInfo.DashboardURL != "" && semver.Compare(semver.MajorMinor(serverVersion), "v2.19") >= 0:
 					upgradeMessage = fmt.Sprintf("download the server version with: 'curl -fsSL %s/install.sh | sh'", serverInfo.DashboardURL)
 				}
 			}

--- a/cli/root.go
+++ b/cli/root.go
@@ -1219,7 +1219,7 @@ func wrapTransportWithVersionMismatchCheck(rt http.RoundTripper, inv *serpent.In
 					upgradeMessage = serverInfo.UpgradeMessage
 				// The site-local `install.sh` was introduced in v2.19.0
 				case serverInfo.DashboardURL != "" && semver.Compare(semver.MajorMinor(serverVersion), "v2.19") >= 0:
-					upgradeMessage = fmt.Sprintf("download the server version with: 'curl -fsSL %s/install.sh | sh'", serverInfo.DashboardURL)
+					upgradeMessage = fmt.Sprintf("download %s with: 'curl -fsSL %s/install.sh | sh'", serverVersion, serverInfo.DashboardURL)
 				}
 			}
 			fmtWarningText := "version mismatch: client %s, server %s\n%s"

--- a/cli/root.go
+++ b/cli/root.go
@@ -1213,9 +1213,13 @@ func wrapTransportWithVersionMismatchCheck(rt http.RoundTripper, inv *serpent.In
 				return
 			}
 			upgradeMessage := defaultUpgradeMessage(semver.Canonical(serverVersion))
-			serverInfo, err := getBuildInfo(inv.Context())
-			if err == nil && serverInfo.UpgradeMessage != "" {
-				upgradeMessage = serverInfo.UpgradeMessage
+			if serverInfo, err := getBuildInfo(inv.Context()); err == nil {
+				switch {
+				case serverInfo.UpgradeMessage != "":
+					upgradeMessage = serverInfo.UpgradeMessage
+				case serverInfo.DashboardURL != "":
+					upgradeMessage = fmt.Sprintf("download the server version with: 'curl -fsSL %s/install.sh | sh'", serverInfo.DashboardURL)
+				}
 			}
 			fmtWarningText := "version mismatch: client %s, server %s\n%s"
 			fmtWarn := pretty.Sprint(cliui.DefaultStyles.Warn, fmtWarningText)


### PR DESCRIPTION
This PR has the CLI show the server's own `install.sh` script if there's a version mismatch, and if the deployment doesn't have an custom upgrade message configured.

```
$ coder ls
version mismatch: client {version}, server {version}
download {server_version} with: 'curl -fsSL https://dev.coder.com/install.sh | sh'
[ ... ]
```