### PR TITLE
fix: display notification on schedule update

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.test.tsx
@@ -291,6 +291,12 @@ describe("WorkspaceSchedulePage", () => {
 				name: /save/i,
 			});
 			await user.click(submitButton);
+
+			const notification = await screen.findByText(
+				"Workspace schedule updated",
+			);
+			expect(notification).toBeInTheDocument();
+
 			const dialog = await screen.findByText("Restart workspace?");
 			expect(dialog).toBeInTheDocument();
 		});
@@ -312,6 +318,12 @@ describe("WorkspaceSchedulePage", () => {
 				name: /save/i,
 			});
 			await user.click(submitButton);
+
+			const notification = await screen.findByText(
+				"Workspace schedule updated",
+			);
+			expect(notification).toBeInTheDocument();
+
 			const dialog = screen.queryByText("Restart workspace?");
 			expect(dialog).not.toBeInTheDocument();
 		});

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -6,6 +6,7 @@ import type * as TypesGen from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
 import { Loader } from "components/Loader/Loader";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import dayjs from "dayjs";
@@ -25,7 +26,6 @@ import {
 	formValuesToAutostartRequest,
 	formValuesToTTLRequest,
 } from "./formToRequest";
-import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
 
 const permissionsToCheck = (workspace: TypesGen.Workspace) =>
 	({

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -25,6 +25,7 @@ import {
 	formValuesToAutostartRequest,
 	formValuesToTTLRequest,
 } from "./formToRequest";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
 
 const permissionsToCheck = (workspace: TypesGen.Workspace) =>
 	({
@@ -60,7 +61,9 @@ export const WorkspaceSchedulePage: FC = () => {
 					params.workspace,
 				),
 			);
+			displaySuccess("Workspace schedule updated");
 		},
+		onError: () => displayError("Failed to update workspace schedule"),
 	});
 	const error = checkPermissionsError || getTemplateError;
 	const isLoading = !template || !permissions;


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15214

This PR adds a subtle notification displayed on submitting workspace schedule changes.

<img width="1596" alt="Screenshot 2025-02-24 at 13 47 22" src="https://github.com/user-attachments/assets/393b88a8-9909-47d6-bc07-fdd710b21e27" />
