### PR TITLE
fix: hide app icon if not found

### DIFF
--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -69,7 +69,7 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
 	// longer block access to apps if they are unhealthy/initializing.
 	let canClick = true;
 	let icon = !iconError && (
-		<BaseIcon app={app} onError={() => setIconError(true)} />
+		<BaseIcon app={app} onIconPathError={() => setIconError(true)} />
 	);
 
 	let primaryTooltip = "";

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -37,6 +37,7 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
 	const preferredPathBase = proxy.preferredPathAppURL;
 	const appsHost = proxy.preferredWildcardHostname;
 	const [fetchingSessionToken, setFetchingSessionToken] = useState(false);
+	const [iconError, setIconError] = useState(false);
 
 	const theme = useTheme();
 	const username = workspace.owner_name;
@@ -67,7 +68,9 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
 	// To avoid bugs in the healthcheck code locking users out of apps, we no
 	// longer block access to apps if they are unhealthy/initializing.
 	let canClick = true;
-	let icon = <BaseIcon app={app} />;
+	let icon = !iconError && (
+		<BaseIcon app={app} onError={() => setIconError(true)} />
+	);
 
 	let primaryTooltip = "";
 	if (app.health === "initializing") {

--- a/site/src/modules/resources/AppLink/BaseIcon.tsx
+++ b/site/src/modules/resources/AppLink/BaseIcon.tsx
@@ -4,17 +4,17 @@ import type { FC } from "react";
 
 interface BaseIconProps {
 	app: WorkspaceApp;
-	onError?: () => void;
+	onIconPathError?: () => void;
 }
 
-export const BaseIcon: FC<BaseIconProps> = ({ app, onError }) => {
+export const BaseIcon: FC<BaseIconProps> = ({ app, onIconPathError }) => {
 	return app.icon ? (
 		<img
 			alt={`${app.display_name} Icon`}
 			src={app.icon}
 			style={{ pointerEvents: "none" }}
 			onError={() => {
-				onError?.();
+				onIconPathError?.();
 			}}
 		/>
 	) : (

--- a/site/src/modules/resources/AppLink/BaseIcon.tsx
+++ b/site/src/modules/resources/AppLink/BaseIcon.tsx
@@ -14,6 +14,9 @@ export const BaseIcon: FC<BaseIconProps> = ({ app, onIconPathError }) => {
 			src={app.icon}
 			style={{ pointerEvents: "none" }}
 			onError={() => {
+				console.warn(
+					`Application icon for "${app.id}" has invalid source "${app.icon}".`,
+				);
 				onIconPathError?.();
 			}}
 		/>

--- a/site/src/modules/resources/AppLink/BaseIcon.tsx
+++ b/site/src/modules/resources/AppLink/BaseIcon.tsx
@@ -4,14 +4,18 @@ import type { FC } from "react";
 
 interface BaseIconProps {
 	app: WorkspaceApp;
+	onError?: () => void;
 }
 
-export const BaseIcon: FC<BaseIconProps> = ({ app }) => {
+export const BaseIcon: FC<BaseIconProps> = ({ app, onError }) => {
 	return app.icon ? (
 		<img
 			alt={`${app.display_name} Icon`}
 			src={app.icon}
 			style={{ pointerEvents: "none" }}
+			onError={() => {
+				onError?.();
+			}}
 		/>
 	) : (
 		<ComputerIcon />

--- a/site/src/pages/WorkspacePage/Workspace.stories.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.stories.tsx
@@ -96,17 +96,16 @@ export const AppIcons: Story = {
 								apps: [
 									{
 										...Mocks.MockWorkspaceApp,
+										id: "test-app-1",
+										slug: "test-app-1",
 										display_name: "Default Icon",
 									},
 									{
 										...Mocks.MockWorkspaceApp,
+										id: "test-app-2",
+										slug: "test-app-2",
 										display_name: "Broken Icon",
 										icon: "/foobar/broken.png",
-									},
-									{
-										...Mocks.MockWorkspaceApp,
-										display_name: "Icon OK",
-										icon: "/favicon.ico",
 									},
 								],
 							},

--- a/site/src/pages/WorkspacePage/Workspace.stories.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.stories.tsx
@@ -80,6 +80,44 @@ export const Running: Story = {
 	},
 };
 
+export const AppIcons: Story = {
+	args: {
+		...Running.args,
+		workspace: {
+			...Mocks.MockWorkspace,
+			latest_build: {
+				...Mocks.MockWorkspace.latest_build,
+				resources: [
+					{
+						...Mocks.MockWorkspaceResource,
+						agents: [
+							{
+								...Mocks.MockWorkspaceAgent,
+								apps: [
+									{
+										...Mocks.MockWorkspaceApp,
+										display_name: "Default Icon",
+									},
+									{
+										...Mocks.MockWorkspaceApp,
+										display_name: "Broken Icon",
+										icon: "/foobar/broken.png",
+									},
+									{
+										...Mocks.MockWorkspaceApp,
+										display_name: "Icon OK",
+										icon: "/favicon.ico",
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		},
+	},
+};
+
 export const Favorite: Story = {
 	args: {
 		...Running.args,


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14759

This PR dynamically hides icon's `<img>` tag if the image can't be loaded (HTTP 404). 

<img width="1237" alt="Screenshot 2025-02-24 at 17 08 25" src="https://github.com/user-attachments/assets/becf63f9-1f8f-46ec-a77c-7e36bf3af90a" />

<img width="541" alt="Screenshot 2025-02-25 at 11 20 56" src="https://github.com/user-attachments/assets/ae77d27a-ff6c-4399-9530-d7987c086ba2" />

