### PR TITLE
feat: implement WorkspaceCreationBan org role

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -151,11 +151,13 @@ func ResourceNotFound(rw http.ResponseWriter) {
 	Write(context.Background(), rw, http.StatusNotFound, ResourceNotFoundResponse)
 }
 
+var ResourceForbiddenResponse = codersdk.Response{
+	Message: "Forbidden.",
+	Detail:  "You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials.",
+}
+
 func Forbidden(rw http.ResponseWriter) {
-	Write(context.Background(), rw, http.StatusForbidden, codersdk.Response{
-		Message: "Forbidden.",
-		Detail:  "You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials.",
-	})
+	Write(context.Background(), rw, http.StatusForbidden, ResourceForbiddenResponse)
 }
 
 func InternalServerError(rw http.ResponseWriter, err error) {

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -112,6 +112,7 @@ func TestRolePermissions(t *testing.T) {
 	// Subjects to user
 	memberMe := authSubject{Name: "member_me", Actor: rbac.Subject{ID: currentUser.String(), Roles: rbac.RoleIdentifiers{rbac.RoleMember()}}}
 	orgMemberMe := authSubject{Name: "org_member_me", Actor: rbac.Subject{ID: currentUser.String(), Roles: rbac.RoleIdentifiers{rbac.RoleMember(), rbac.ScopedRoleOrgMember(orgID)}}}
+	orgMemberMeBanWorkspace := authSubject{Name: "org_member_me_workspace_ban", Actor: rbac.Subject{ID: currentUser.String(), Roles: rbac.RoleIdentifiers{rbac.RoleMember(), rbac.ScopedRoleOrgMember(orgID), rbac.ScopedRoleOrgWorkspaceCreationBan(orgID)}}}
 	groupMemberMe := authSubject{Name: "group_member_me", Actor: rbac.Subject{ID: currentUser.String(), Roles: rbac.RoleIdentifiers{rbac.RoleMember(), rbac.ScopedRoleOrgMember(orgID)}, Groups: []string{groupID.String()}}}
 
 	owner := authSubject{Name: "owner", Actor: rbac.Subject{ID: adminID.String(), Roles: rbac.RoleIdentifiers{rbac.RoleMember(), rbac.RoleOwner()}}}
@@ -181,18 +182,28 @@ func TestRolePermissions(t *testing.T) {
 			Actions:  []policy.Action{policy.ActionRead},
 			Resource: rbac.ResourceWorkspace.WithID(workspaceID).InOrg(orgID).WithOwner(currentUser.String()),
 			AuthorizeMap: map[bool][]hasAuthSubjects{
-				true:  {owner, orgMemberMe, orgAdmin, templateAdmin, orgTemplateAdmin},
+				true:  {owner, orgMemberMe, orgAdmin, templateAdmin, orgTemplateAdmin, orgMemberMeBanWorkspace},
 				false: {setOtherOrg, memberMe, userAdmin, orgAuditor, orgUserAdmin},
 			},
 		},
 		{
-			Name: "C_RDMyWorkspaceInOrg",
+			Name: "UpdateMyWorkspaceInOrg",
 			// When creating the WithID won't be set, but it does not change the result.
-			Actions:  []policy.Action{policy.ActionCreate, policy.ActionUpdate, policy.ActionDelete},
+			Actions:  []policy.Action{policy.ActionUpdate},
 			Resource: rbac.ResourceWorkspace.WithID(workspaceID).InOrg(orgID).WithOwner(currentUser.String()),
 			AuthorizeMap: map[bool][]hasAuthSubjects{
 				true:  {owner, orgMemberMe, orgAdmin},
 				false: {setOtherOrg, memberMe, userAdmin, templateAdmin, orgTemplateAdmin, orgUserAdmin, orgAuditor},
+			},
+		},
+		{
+			Name: "C__DMyWorkspaceInOrg",
+			// When creating the WithID won't be set, but it does not change the result.
+			Actions:  []policy.Action{policy.ActionCreate, policy.ActionDelete},
+			Resource: rbac.ResourceWorkspace.WithID(workspaceID).InOrg(orgID).WithOwner(currentUser.String()),
+			AuthorizeMap: map[bool][]hasAuthSubjects{
+				true:  {owner, orgMemberMe, orgAdmin},
+				false: {setOtherOrg, memberMe, userAdmin, templateAdmin, orgTemplateAdmin, orgUserAdmin, orgAuditor, orgMemberMeBanWorkspace},
 			},
 		},
 		{

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -951,6 +951,7 @@ func TestListRoles(t *testing.T) {
 		fmt.Sprintf("organization-auditor:%s", orgID.String()),
 		fmt.Sprintf("organization-user-admin:%s", orgID.String()),
 		fmt.Sprintf("organization-template-admin:%s", orgID.String()),
+		fmt.Sprintf("organization-workspace-creation-ban:%s", orgID.String()),
 	},
 		orgRoleNames)
 }

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -197,7 +197,7 @@ func TestRolePermissions(t *testing.T) {
 			},
 		},
 		{
-			Name: "C__DMyWorkspaceInOrg",
+			Name: "CreateDeleteMyWorkspaceInOrg",
 			// When creating the WithID won't be set, but it does not change the result.
 			Actions:  []policy.Action{policy.ActionCreate, policy.ActionDelete},
 			Resource: rbac.ResourceWorkspace.WithID(workspaceID).InOrg(orgID).WithOwner(currentUser.String()),

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -411,6 +411,7 @@ func TestWorkspace(t *testing.T) {
 			TemplateVersionID: uuid.UUID{},
 			Name:              "random",
 		})
+		require.NoError(t, err)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, wrk.LatestBuild.ID)
 
 		// Then: They cannot delete said workspace

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -790,6 +790,15 @@ func (b *Builder) authorize(authFunc func(action policy.Action, object rbac.Obje
 		return BuildError{http.StatusBadRequest, msg, xerrors.New(msg)}
 	}
 	if !authFunc(action, b.workspace) {
+		if authFunc(policy.ActionRead, b.workspace) {
+			// If the user can read the workspace, but not delete/create/update. Show
+			// a more helpful error. They are allowed to know the workspace exists.
+			return BuildError{
+				Status:  http.StatusForbidden,
+				Message: fmt.Sprintf("You do not have permission to %s this workspace.", action),
+				Wrapped: xerrors.New(httpapi.ResourceForbiddenResponse.Detail),
+			}
+		}
 		// We use the same wording as the httpapi to avoid leaking the existence of the workspace
 		return BuildError{http.StatusNotFound, httpapi.ResourceNotFoundResponse.Message, xerrors.New(httpapi.ResourceNotFoundResponse.Message)}
 	}

--- a/codersdk/rbacroles.go
+++ b/codersdk/rbacroles.go
@@ -8,9 +8,10 @@ const (
 	RoleUserAdmin     string = "user-admin"
 	RoleAuditor       string = "auditor"
 
-	RoleOrganizationAdmin         string = "organization-admin"
-	RoleOrganizationMember        string = "organization-member"
-	RoleOrganizationAuditor       string = "organization-auditor"
-	RoleOrganizationTemplateAdmin string = "organization-template-admin"
-	RoleOrganizationUserAdmin     string = "organization-user-admin"
+	RoleOrganizationAdmin                string = "organization-admin"
+	RoleOrganizationMember               string = "organization-member"
+	RoleOrganizationAuditor              string = "organization-auditor"
+	RoleOrganizationTemplateAdmin        string = "organization-template-admin"
+	RoleOrganizationUserAdmin            string = "organization-user-admin"
+	RoleOrganizationWorkspaceCreationBan string = "organization-workspace-creation-ban"
 )

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -441,10 +441,11 @@ func TestListRoles(t *testing.T) {
 				return member.ListOrganizationRoles(ctx, owner.OrganizationID)
 			},
 			ExpectedRoles: convertRoles(map[rbac.RoleIdentifier]bool{
-				{Name: codersdk.RoleOrganizationAdmin, OrganizationID: owner.OrganizationID}:         false,
-				{Name: codersdk.RoleOrganizationAuditor, OrganizationID: owner.OrganizationID}:       false,
-				{Name: codersdk.RoleOrganizationTemplateAdmin, OrganizationID: owner.OrganizationID}: false,
-				{Name: codersdk.RoleOrganizationUserAdmin, OrganizationID: owner.OrganizationID}:     false,
+				{Name: codersdk.RoleOrganizationAdmin, OrganizationID: owner.OrganizationID}:                false,
+				{Name: codersdk.RoleOrganizationAuditor, OrganizationID: owner.OrganizationID}:              false,
+				{Name: codersdk.RoleOrganizationTemplateAdmin, OrganizationID: owner.OrganizationID}:        false,
+				{Name: codersdk.RoleOrganizationUserAdmin, OrganizationID: owner.OrganizationID}:            false,
+				{Name: codersdk.RoleOrganizationWorkspaceCreationBan, OrganizationID: owner.OrganizationID}: false,
 			}),
 		},
 		{
@@ -473,10 +474,11 @@ func TestListRoles(t *testing.T) {
 				return orgAdmin.ListOrganizationRoles(ctx, owner.OrganizationID)
 			},
 			ExpectedRoles: convertRoles(map[rbac.RoleIdentifier]bool{
-				{Name: codersdk.RoleOrganizationAdmin, OrganizationID: owner.OrganizationID}:         true,
-				{Name: codersdk.RoleOrganizationAuditor, OrganizationID: owner.OrganizationID}:       true,
-				{Name: codersdk.RoleOrganizationTemplateAdmin, OrganizationID: owner.OrganizationID}: true,
-				{Name: codersdk.RoleOrganizationUserAdmin, OrganizationID: owner.OrganizationID}:     true,
+				{Name: codersdk.RoleOrganizationAdmin, OrganizationID: owner.OrganizationID}:                true,
+				{Name: codersdk.RoleOrganizationAuditor, OrganizationID: owner.OrganizationID}:              true,
+				{Name: codersdk.RoleOrganizationTemplateAdmin, OrganizationID: owner.OrganizationID}:        true,
+				{Name: codersdk.RoleOrganizationUserAdmin, OrganizationID: owner.OrganizationID}:            true,
+				{Name: codersdk.RoleOrganizationWorkspaceCreationBan, OrganizationID: owner.OrganizationID}: true,
 			}),
 		},
 		{
@@ -505,10 +507,11 @@ func TestListRoles(t *testing.T) {
 				return client.ListOrganizationRoles(ctx, owner.OrganizationID)
 			},
 			ExpectedRoles: convertRoles(map[rbac.RoleIdentifier]bool{
-				{Name: codersdk.RoleOrganizationAdmin, OrganizationID: owner.OrganizationID}:         true,
-				{Name: codersdk.RoleOrganizationAuditor, OrganizationID: owner.OrganizationID}:       true,
-				{Name: codersdk.RoleOrganizationTemplateAdmin, OrganizationID: owner.OrganizationID}: true,
-				{Name: codersdk.RoleOrganizationUserAdmin, OrganizationID: owner.OrganizationID}:     true,
+				{Name: codersdk.RoleOrganizationAdmin, OrganizationID: owner.OrganizationID}:                true,
+				{Name: codersdk.RoleOrganizationAuditor, OrganizationID: owner.OrganizationID}:              true,
+				{Name: codersdk.RoleOrganizationTemplateAdmin, OrganizationID: owner.OrganizationID}:        true,
+				{Name: codersdk.RoleOrganizationUserAdmin, OrganizationID: owner.OrganizationID}:            true,
+				{Name: codersdk.RoleOrganizationWorkspaceCreationBan, OrganizationID: owner.OrganizationID}: true,
 			}),
 		},
 	}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2096,6 +2096,10 @@ export const RoleOrganizationTemplateAdmin = "organization-template-admin";
 export const RoleOrganizationUserAdmin = "organization-user-admin";
 
 // From codersdk/rbacroles.go
+export const RoleOrganizationWorkspaceCreationBan =
+	"organization-workspace-creation-ban";
+
+// From codersdk/rbacroles.go
 export const RoleOwner = "owner";
 
 // From codersdk/idpsync.go

--- a/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.stories.tsx
@@ -4,6 +4,7 @@ import {
 	MockOwnerRole,
 	MockSiteRoles,
 	MockUserAdminRole,
+	MockWorkspaceCreationBanRole,
 } from "testHelpers/entities";
 import { withDesktopViewport } from "testHelpers/storybook";
 import { EditRolesButton } from "./EditRolesButton";
@@ -35,6 +36,17 @@ export const Loading: Story = {
 		isLoading: true,
 		userLoginType: "password",
 		oidcRoleSync: false,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button"));
+	},
+};
+
+export const AdvancedOpen: Story = {
+	args: {
+		selectedRoleNames: new Set([MockWorkspaceCreationBanRole.name]),
+		roles: MockSiteRoles,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.tsx
+++ b/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.tsx
@@ -141,13 +141,13 @@ export const EditRolesButton: FC<EditRolesButtonProps> = ({
 				</Tooltip>
 			</PopoverTrigger>
 
-			<PopoverContent className="w-80" disablePortal={false}>
+			<PopoverContent className="w-96" disablePortal={false}>
 				<fieldset
 					className="border-0 m-0 p-0 disabled:opacity-50"
 					disabled={isLoading}
 					title="Available roles"
 				>
-					<div className="flex flex-col gap-4 p-6">
+					<div className="flex flex-col gap-4 p-6 w-96">
 						{filteredRoles.map((role) => (
 							<Option
 								key={role.name}

--- a/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.tsx
+++ b/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.tsx
@@ -16,7 +16,9 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "components/deprecated/Popover/Popover";
-import type { FC } from "react";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { type FC, useEffect, useState } from "react";
+import { cn } from "utils/cn";
 
 const roleDescriptions: Record<string, string> = {
 	owner:
@@ -57,7 +59,7 @@ const Option: FC<OptionProps> = ({
 					}}
 				/>
 				<div className="flex flex-col">
-					<strong>{name}</strong>
+					<strong className="text-sm">{name}</strong>
 					<span className="text-xs text-content-secondary">{description}</span>
 				</div>
 			</div>
@@ -91,6 +93,7 @@ export const EditRolesButton: FC<EditRolesButtonProps> = ({
 
 		onChange([...selectedRoleNames, roleName]);
 	};
+	const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
 
 	const canSetRoles =
 		userLoginType !== "oidc" || (userLoginType === "oidc" && !oidcRoleSync);
@@ -108,6 +111,20 @@ export const EditRolesButton: FC<EditRolesButtonProps> = ({
 			</HelpTooltip>
 		);
 	}
+
+	const filteredRoles = roles.filter(
+		(role) => role.name !== "organization-workspace-creation-ban",
+	);
+	const advancedRoles = roles.filter(
+		(role) => role.name === "organization-workspace-creation-ban",
+	);
+
+	// make sure the advanced roles are always visible if the user has one of these roles
+	useEffect(() => {
+		if (selectedRoleNames.has("organization-workspace-creation-ban")) {
+			setIsAdvancedOpen(true);
+		}
+	}, [selectedRoleNames]);
 
 	return (
 		<Popover>
@@ -131,7 +148,7 @@ export const EditRolesButton: FC<EditRolesButtonProps> = ({
 					title="Available roles"
 				>
 					<div className="flex flex-col gap-4 p-6">
-						{roles.map((role) => (
+						{filteredRoles.map((role) => (
 							<Option
 								key={role.name}
 								onChange={handleChange}
@@ -141,6 +158,43 @@ export const EditRolesButton: FC<EditRolesButtonProps> = ({
 								description={roleDescriptions[role.name] ?? ""}
 							/>
 						))}
+						{advancedRoles.length > 0 && (
+							<>
+								<button
+									className={cn([
+										"flex items-center gap-1 p-0 bg-transparent border-0 text-inherit text-sm cursor-pointer",
+										"transition-colors text-content-secondary hover:text-content-primary font-medium whitespace-nowrap",
+										isAdvancedOpen && "text-content-primary",
+									])}
+									type="button"
+									onClick={() => {
+										setIsAdvancedOpen((v) => !v);
+									}}
+								>
+									{isAdvancedOpen ? (
+										<ChevronDownIcon className="size-icon-sm p-0.5" />
+									) : (
+										<ChevronRightIcon className="size-icon-sm p-0.5" />
+									)}
+									<span className="sr-only">
+										({isAdvancedOpen ? "Hide" : "Show advanced"})
+									</span>
+									<span className="[&:first-letter]:uppercase">Advanced</span>
+								</button>
+
+								{isAdvancedOpen &&
+									advancedRoles.map((role) => (
+										<Option
+											key={role.name}
+											onChange={handleChange}
+											isChecked={selectedRoleNames.has(role.name)}
+											value={role.name}
+											name={role.display_name || role.name}
+											description={roleDescriptions[role.name] ?? ""}
+										/>
+									))}
+							</>
+						)}
 					</div>
 				</fieldset>
 				<div className="p-6 border-t-1 border-solid border-border text-sm">

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -296,6 +296,15 @@ export const MockAuditorRole: TypesGen.Role = {
 	organization_id: "",
 };
 
+export const MockWorkspaceCreationBanRole: TypesGen.Role = {
+	name: "organization-workspace-creation-ban",
+	display_name: "Organization Workspace Creation Ban",
+	site_permissions: [],
+	organization_permissions: [],
+	user_permissions: [],
+	organization_id: "",
+};
+
 export const MockMemberRole: TypesGen.SlimRole = {
 	name: "member",
 	display_name: "Member",
@@ -459,10 +468,11 @@ export function assignableRole(
 	};
 }
 
-export const MockSiteRoles = [MockUserAdminRole, MockAuditorRole];
+export const MockSiteRoles = [MockUserAdminRole, MockAuditorRole, MockWorkspaceCreationBanRole];
 export const MockAssignableSiteRoles = [
 	assignableRole(MockUserAdminRole, true),
 	assignableRole(MockAuditorRole, true),
+	assignableRole(MockWorkspaceCreationBanRole, true),
 ];
 
 export const MockMemberPermissions = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -468,7 +468,11 @@ export function assignableRole(
 	};
 }
 
-export const MockSiteRoles = [MockUserAdminRole, MockAuditorRole, MockWorkspaceCreationBanRole];
+export const MockSiteRoles = [
+	MockUserAdminRole,
+	MockAuditorRole,
+	MockWorkspaceCreationBanRole,
+];
 export const MockAssignableSiteRoles = [
 	assignableRole(MockUserAdminRole, true),
 	assignableRole(MockAuditorRole, true),


### PR DESCRIPTION
Using negative permissions, this role prevents a user's ability to create & delete a workspace within a given organization.

Workspaces are uniquely owned by an org and a user, so the org has to supercede the user permission with a negative permission.

# Use case

Organizations must be able to restrict a member's ability to create a workspace. This permission is implicitly granted (see https://github.com/coder/coder/issues/16546#issuecomment-2655437860). 

To revoke this permission, the solution chosen was to use negative permissions in a built in role called `WorkspaceCreationBan`.

# Rational

Using negative permissions is new territory, and not ideal. However, workspaces are in a unique position. 

Workspaces have 2 owners. The organization and the user. To prevent users from creating a workspace in another organization, an [implied negative permission](https://github.com/coder/coder/blob/36d9f5ddb3d98029fee07d004709e1e51022e979/coderd/rbac/policy.rego#L172-L192) is used. So the truth table looks like: _how to read this table [here](https://github.com/coder/coder/blob/36d9f5ddb3d98029fee07d004709e1e51022e979/coderd/rbac/README.md#roles)_

| Role (example)  | Site | Org  | User | Result |
|-----------------|------|------|------|--------|
| non-org-member  | \_   | N    | YN\_ | N      |
| user            | \_   | \_   | Y    | Y      |
| WorkspaceBan    | \_   | N    | Y    | N      |
| unauthenticated | \_   | \_   | \_   | N      |
| org-admin       | \_   | Y    | YN\_ | Y      |


This new role, `WorkspaceCreationBan` is the same truth table condition as if the user was not a member of the organization (when doing a workspace create/delete). So this behavior **is not entirely new**.

<details>

<summary>How to do it without a negative permission</summary>

The alternate approach would be to remove the implied permission, and grant it via and  organization role. However this would add new behavior that an organizational role has the ability to grant a user permissions on their own resources?

It does not make sense for an org role to prevent user from changing their profile information for example. So the only option is to create a new truth table column for resources that are owned by both an organization and a user.

| Role (example)  | Site | Org  |User+Org| User | Result |
|-----------------|------|------|--------|------|--------|
| non-org-member  | \_   | N    |  \_    | \_   | N      |
| user            | \_   | \_   |  \_    | \_   | N      |
| WorkspaceAllow  | \_   | \_   |   Y    | \_   | Y      |
| unauthenticated | \_   | \_   |  \_    | \_   | N      |

Now a user has no opinion on if they can create a workspace, which feels a little wrong. A user should have the authority over what is theres.

There is fundamental _philosophical_ question of "Who does a workspace belong to?". The user has some set of autonomy, yet it is the organization that controls it's existence. A head scratcher :thinking: 

</details>

## Will we need more negative built in roles?

There are few resources that have shared ownership. Only `ResourceOrganizationMember` and  `ResourceGroupMember`. Since negative permissions is intended to revoke access to a shared resource, then **no.** **This is the only one we need**.

Classic resources like `ResourceTemplate` are entirely controlled by the Organization permissions. And resources entirely in the user control (like user profile) are only controlled by `User` permissions. 


<img width="804" alt="Screenshot 2025-02-26 at 22 26 52" src="https://github.com/user-attachments/assets/03b43980-405a-4d03-ac6b-a3c8ff03b61c" />

