### PR TITLE
chore: install `libgbm-dev` to allow headless chrome e2e tests to run

### DIFF
--- a/dogfood/contents/Dockerfile
+++ b/dogfood/contents/Dockerfile
@@ -160,6 +160,7 @@ RUN apt-get update --quiet && apt-get install --yes \
 	kubectl \
 	language-pack-en \
 	less \
+	libgbm-dev \
 	libssl-dev \
 	lsb-release \
 	man \


### PR DESCRIPTION
Without this lib, Chrome can’t set up its offscreen rendering buffers - apparently.

I've validated this manually in my workspace.