### PR TITLE
fix: display banner when no matching templates found

### DIFF
--- a/site/src/components/Filter/storyHelpers.ts
+++ b/site/src/components/Filter/storyHelpers.ts
@@ -17,17 +17,19 @@ export const getDefaultFilterProps = <TFilterProps>({
 	query = "",
 	values,
 	menus,
+	used = false,
 }: {
 	query?: string;
 	values: Record<string, string | undefined>;
 	menus: Record<string, UseFilterMenuResult>;
+	used?: boolean;
 }) =>
 	({
 		filter: {
 			query,
 			update: () => action("update"),
 			debounceUpdate: action("debounce") as UseFilterResult["debounceUpdate"],
-			used: false,
+			used: used,
 			values,
 		},
 		menus,

--- a/site/src/pages/TemplatesPage/EmptyTemplates.tsx
+++ b/site/src/pages/TemplatesPage/EmptyTemplates.tsx
@@ -38,12 +38,18 @@ const findFeaturedExamples = (examples: TemplateExample[]) => {
 interface EmptyTemplatesProps {
 	canCreateTemplates: boolean;
 	examples: TemplateExample[];
+	isUsingFilter: boolean;
 }
 
 export const EmptyTemplates: FC<EmptyTemplatesProps> = ({
 	canCreateTemplates,
 	examples,
+	isUsingFilter,
 }) => {
+	if (isUsingFilter) {
+		return <TableEmpty message="No results matched your search" />;
+	}
+
 	const featuredExamples = findFeaturedExamples(examples);
 
 	if (canCreateTemplates) {

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -84,6 +84,19 @@ export const MultipleOrganizations: Story = {
 	},
 };
 
+export const WithFilteredAllTemplates: Story = {
+	args: {
+		...WithTemplates.args,
+		templates: [],
+		...getDefaultFilterProps({
+			query: "deprecated:false searchnotfound",
+			menus: {},
+			values: {},
+			used: true,
+		}),
+	},
+};
+
 export const EmptyCanCreate: Story = {
 	args: {
 		canCreateTemplates: true,

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -246,6 +246,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 							<EmptyTemplates
 								canCreateTemplates={canCreateTemplates}
 								examples={examples ?? []}
+								isUsingFilter={filter.used}
 							/>
 						) : (
 							templates?.map((template) => (


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/16077

This PR modifies the TemplatePage view to indicate that all template have been filtered out rather than asking to create a new template. It is consistent with WorkspacesPage view.

<img width="1248" alt="Screenshot 2025-02-25 at 14 22 26" src="https://github.com/user-attachments/assets/12f4c785-51cf-40a0-869e-913604f46637" />
