### PR TITLE
fix: update create template button styling

### DIFF
--- a/site/src/pages/TemplatesPage/CreateTemplateButton.tsx
+++ b/site/src/pages/TemplatesPage/CreateTemplateButton.tsx
@@ -1,14 +1,14 @@
-import AddIcon from "@mui/icons-material/AddOutlined";
 import Inventory2 from "@mui/icons-material/Inventory2";
 import NoteAddOutlined from "@mui/icons-material/NoteAddOutlined";
 import UploadOutlined from "@mui/icons-material/UploadOutlined";
-import Button from "@mui/material/Button";
+import { Button } from "components/Button/Button";
 import {
 	MoreMenu,
 	MoreMenuContent,
 	MoreMenuItem,
 	MoreMenuTrigger,
 } from "components/MoreMenu/MoreMenu";
+import { PlusIcon } from "lucide-react";
 import type { FC } from "react";
 
 type CreateTemplateButtonProps = {
@@ -21,8 +21,9 @@ export const CreateTemplateButton: FC<CreateTemplateButtonProps> = ({
 	return (
 		<MoreMenu>
 			<MoreMenuTrigger>
-				<Button startIcon={<AddIcon />} variant="contained">
-					Create Template
+				<Button>
+					<PlusIcon />
+					Create template
 				</Button>
 			</MoreMenuTrigger>
 			<MoreMenuContent>


### PR DESCRIPTION
resolves #16697 

Fix styling of create template button for non-premium users to match new template button for premium users.

## Previous behavior
With premium license
![image](https://github.com/user-attachments/assets/41a55a3b-0d4d-4b11-bbda-ae31c09f64b9)

Without license
![image](https://github.com/user-attachments/assets/7439d139-9514-4f05-aa93-3701105b2776)