### PR TITLE
chore: test metricscache on postgres

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -422,6 +422,7 @@ func New(options *Options) *API {
 	metricsCache := metricscache.New(
 		options.Database,
 		options.Logger.Named("metrics_cache"),
+		options.Clock,
 		metricscache.Intervals{
 			TemplateBuildTimes: options.MetricsCacheRefreshInterval,
 			DeploymentStats:    options.AgentStatsRefreshInterval,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -16184,13 +16184,11 @@ func (q *sqlQuerier) GetWorkspaceByWorkspaceAppID(ctx context.Context, workspace
 }
 
 const getWorkspaceUniqueOwnerCountByTemplateIDs = `-- name: GetWorkspaceUniqueOwnerCountByTemplateIDs :many
-SELECT
-	template_id, COUNT(DISTINCT owner_id) AS unique_owners_sum
-FROM
-	workspaces
-WHERE
-	template_id = ANY($1 :: uuid[]) AND deleted = false
-GROUP BY template_id
+SELECT templates.id AS template_id, COUNT(DISTINCT workspaces.owner_id) AS unique_owners_sum
+FROM templates
+LEFT JOIN workspaces ON workspaces.template_id = templates.id AND workspaces.deleted = false
+WHERE templates.id = ANY($1 :: uuid[])
+GROUP BY templates.id
 `
 
 type GetWorkspaceUniqueOwnerCountByTemplateIDsRow struct {

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -415,13 +415,11 @@ WHERE
 ORDER BY created_at DESC;
 
 -- name: GetWorkspaceUniqueOwnerCountByTemplateIDs :many
-SELECT
-	template_id, COUNT(DISTINCT owner_id) AS unique_owners_sum
-FROM
-	workspaces
-WHERE
-	template_id = ANY(@template_ids :: uuid[]) AND deleted = false
-GROUP BY template_id;
+SELECT templates.id AS template_id, COUNT(DISTINCT workspaces.owner_id) AS unique_owners_sum
+FROM templates
+LEFT JOIN workspaces ON workspaces.template_id = templates.id AND workspaces.deleted = false
+WHERE templates.id = ANY(@template_ids :: uuid[])
+GROUP BY templates.id;
 
 -- name: InsertWorkspace :one
 INSERT INTO

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -158,8 +158,8 @@ func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 	}
 	c.deploymentStatsResponse.Store(&codersdk.DeploymentStats{
 		AggregatedFrom: from,
-		CollectedAt:    c.clock.Now(),
-		NextUpdateAt:   c.clock.Now().Add(c.intervals.DeploymentStats),
+		CollectedAt:    dbtime.Time(c.clock.Now()),
+		NextUpdateAt:   dbtime.Time(c.clock.Now().Add(c.intervals.DeploymentStats)),
 		Workspaces: codersdk.WorkspaceDeploymentStats{
 			Pending:  workspaceStats.PendingWorkspaces,
 			Building: workspaceStats.BuildingWorkspaces,

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/quartz"
 	"github.com/coder/retry"
 )
 
@@ -26,6 +27,7 @@ import (
 type Cache struct {
 	database  database.Store
 	log       slog.Logger
+	clock     quartz.Clock
 	intervals Intervals
 
 	templateWorkspaceOwners  atomic.Pointer[map[uuid.UUID]int]
@@ -45,7 +47,7 @@ type Intervals struct {
 	DeploymentStats    time.Duration
 }
 
-func New(db database.Store, log slog.Logger, intervals Intervals, usage bool) *Cache {
+func New(db database.Store, log slog.Logger, clock quartz.Clock, intervals Intervals, usage bool) *Cache {
 	if intervals.TemplateBuildTimes <= 0 {
 		intervals.TemplateBuildTimes = time.Hour
 	}
@@ -55,6 +57,7 @@ func New(db database.Store, log slog.Logger, intervals Intervals, usage bool) *C
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &Cache{
+		clock:     clock,
 		database:  db,
 		intervals: intervals,
 		log:       log,
@@ -84,7 +87,7 @@ func (c *Cache) refreshTemplateBuildTimes(ctx context.Context) error {
 	//nolint:gocritic // This is a system service.
 	ctx = dbauthz.AsSystemRestricted(ctx)
 
-	templates, err := c.database.GetTemplates(ctx)
+	templates, err := c.database.GetTemplatesWithFilter(ctx, database.GetTemplatesWithFilterParams{})
 	if err != nil {
 		return err
 	}
@@ -104,7 +107,7 @@ func (c *Cache) refreshTemplateBuildTimes(ctx context.Context) error {
 				Valid: true,
 			},
 			StartTime: sql.NullTime{
-				Time:  dbtime.Time(time.Now().AddDate(0, 0, -30)),
+				Time:  dbtime.Time(c.clock.Now().AddDate(0, 0, -30)),
 				Valid: true,
 			},
 		})
@@ -131,7 +134,7 @@ func (c *Cache) refreshTemplateBuildTimes(ctx context.Context) error {
 
 func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 	var (
-		from       = dbtime.Now().Add(-15 * time.Minute)
+		from       = c.clock.Now().Add(-15 * time.Minute)
 		agentStats database.GetDeploymentWorkspaceAgentStatsRow
 		err        error
 	)
@@ -155,8 +158,8 @@ func (c *Cache) refreshDeploymentStats(ctx context.Context) error {
 	}
 	c.deploymentStatsResponse.Store(&codersdk.DeploymentStats{
 		AggregatedFrom: from,
-		CollectedAt:    dbtime.Now(),
-		NextUpdateAt:   dbtime.Now().Add(c.intervals.DeploymentStats),
+		CollectedAt:    c.clock.Now(),
+		NextUpdateAt:   c.clock.Now().Add(c.intervals.DeploymentStats),
 		Workspaces: codersdk.WorkspaceDeploymentStats{
 			Pending:  workspaceStats.PendingWorkspaces,
 			Building: workspaceStats.BuildingWorkspaces,

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -87,7 +87,7 @@ func (c *Cache) refreshTemplateBuildTimes(ctx context.Context) error {
 	//nolint:gocritic // This is a system service.
 	ctx = dbauthz.AsSystemRestricted(ctx)
 
-	templates, err := c.database.GetTemplatesWithFilter(ctx, database.GetTemplatesWithFilterParams{})
+	templates, err := c.database.GetTemplates(ctx)
 	if err != nil {
 		return err
 	}

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"cdr.dev/slog"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/16710

metricscache_test has been running tests against dbmem only, instead of against postgres. Unfortunately the implementations of GetTemplateAverageBuildTime have diverged between dbmem and postgres. This change gets the tests working on Postgres and test for the behaviour postgres provides.