### PR TITLE
fix: display premium banner on audit page when license inactive

### DIFF
--- a/site/src/pages/AuditPage/AuditPage.tsx
+++ b/site/src/pages/AuditPage/AuditPage.tsx
@@ -16,6 +16,12 @@ import { AuditPageView } from "./AuditPageView";
 
 const AuditPage: FC = () => {
 	const feats = useFeatureVisibility();
+	// The "else false" is required if audit_log is undefined.
+	// It may happen if owner removes the license.
+	//
+	// see: https://github.com/coder/coder/issues/14798
+	const isAuditLogVisible = feats.audit_log || false;
+
 	const { showOrganizations } = useDashboard();
 
 	/**
@@ -85,7 +91,7 @@ const AuditPage: FC = () => {
 			<AuditPageView
 				auditLogs={auditsQuery.data?.audit_logs}
 				isNonInitialPage={isNonInitialPage(searchParams)}
-				isAuditLogVisible={feats.audit_log}
+				isAuditLogVisible={isAuditLogVisible}
 				auditsQuery={auditsQuery}
 				error={auditsQuery.error}
 				showOrgDetails={showOrganizations}


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14798

It is a simple fix to display the Premium banner on Audit logs page if the license is not active.

