### PR TITLE
fix(flake.nix): synchronize playwright version in nix and package.json

### DIFF
--- a/dogfood/contents/Dockerfile
+++ b/dogfood/contents/Dockerfile
@@ -244,6 +244,8 @@ ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN npm install -g npm@^10.8
 RUN npm install -g pnpm@^9.6
 
+RUN pnpx playwright@1.47.0 install --with-deps chromium
+
 # Ensure PostgreSQL binaries are in the users $PATH.
 RUN update-alternatives --install /usr/local/bin/initdb initdb /usr/lib/postgresql/16/bin/initdb 100 && \
 	update-alternatives --install /usr/local/bin/postgres postgres /usr/lib/postgresql/16/bin/postgres 100

--- a/dogfood/contents/main.tf
+++ b/dogfood/contents/main.tf
@@ -351,7 +351,7 @@ resource "coder_agent" "dev" {
       sleep 1
     done
     cd "${local.repo_dir}" && make clean
-    cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
+    cd "${local.repo_dir}/site" && pnpm install
   EOT
 }
 

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -50,10 +50,6 @@ let
     experimental-features = nix-command flakes
   '';
 
-  etcReleaseName = writeTextDir "etc/coderniximage-release" ''
-    0.0.0
-  '';
-
   etcPamdSudoFile = writeText "pam-sudo" ''
     # Allow root to bypass authentication (optional)
     auth      sufficient pam_rootok.so
@@ -115,6 +111,7 @@ let
       run ? null,
       maxLayers ? 100,
       uname ? "nixbld",
+      releaseName ? "0.0.0",
     }:
     assert lib.assertMsg (!(drv.drvAttrs.__structuredAttrs or false))
       "streamNixShellImage: Does not work with the derivation ${drv.name} because it uses __structuredAttrs";
@@ -206,6 +203,10 @@ let
           exit 0
         '';
       };
+
+      etcReleaseName = writeTextDir "etc/coderniximage-release" ''
+        ${releaseName}
+      '';
 
       # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/globals.hh#L464-L465
       sandboxBuildDir = "/build";

--- a/site/package.json
+++ b/site/package.json
@@ -126,7 +126,7 @@
 		"@biomejs/biome": "1.9.4",
 		"@chromatic-com/storybook": "3.2.2",
 		"@octokit/types": "12.3.0",
-		"@playwright/test": "1.47.2",
+		"@playwright/test": "1.47.0",
 		"@storybook/addon-actions": "8.5.2",
 		"@storybook/addon-essentials": "8.4.6",
 		"@storybook/addon-interactions": "8.5.3",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -284,8 +284,8 @@ importers:
         specifier: 12.3.0
         version: 12.3.0
       '@playwright/test':
-        specifier: 1.47.2
-        version: 1.47.2
+        specifier: 1.47.0
+        version: 1.47.0
       '@storybook/addon-actions':
         specifier: 8.5.2
         version: 8.5.2(storybook@8.5.3(prettier@3.4.1))
@@ -1528,8 +1528,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.47.2':
-    resolution: {integrity: sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==, tarball: https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz}
+  '@playwright/test@1.47.0':
+    resolution: {integrity: sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==, tarball: https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3694,6 +3694,7 @@ packages:
   eslint@8.52.0:
     resolution: {integrity: sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==, tarball: https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -5173,13 +5174,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==, tarball: https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz}
     engines: {node: '>=8'}
 
-  playwright-core@1.47.2:
-    resolution: {integrity: sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==, tarball: https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz}
+  playwright-core@1.47.0:
+    resolution: {integrity: sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==, tarball: https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.47.2:
-    resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==, tarball: https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz}
+  playwright@1.47.0:
+    resolution: {integrity: sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==, tarball: https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7588,9 +7589,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.47.2':
+  '@playwright/test@1.47.0':
     dependencies:
-      playwright: 1.47.2
+      playwright: 1.47.0
 
   '@popperjs/core@2.11.8': {}
 
@@ -11898,11 +11899,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.47.2: {}
+  playwright-core@1.47.0: {}
 
-  playwright@1.47.2:
+  playwright@1.47.0:
     dependencies:
-      playwright-core: 1.47.2
+      playwright-core: 1.47.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Ensure that the version of Playwright installed with the Nix flake is equal to the one specified in `site/package.json.` -- This assertion ensures that `pnpm playwright:install` will not attempt to download newer browser versions not present in the Nix image, fixing the startup script and reducing the startup time, as `pnpm playwright:install` will not download or install anything.

We also pre-install the required Playwright web browsers in the dogfood Dockerfile. This change prevents us from redownloading system dependencies and Google Chrome each time a workspace starts.

Change-Id: I8cc78e842f7d0b1d2a90a4517a186a03636c5559
Signed-off-by: Thomas Kosiewski <tk@coder.com>
