### PR TITLE
fix: remove provisioners from deployment sidebar

### DIFF
--- a/site/src/modules/management/DeploymentSidebarView.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.tsx
@@ -94,11 +94,6 @@ export const DeploymentSidebarView: FC<DeploymentSidebarViewProps> = ({
 						IdP Organization Sync
 					</SidebarNavItem>
 				)}
-				{permissions.viewDeploymentValues && (
-					<SidebarNavItem href="/deployment/provisioners">
-						Provisioners
-					</SidebarNavItem>
-				)}
 				{!hasPremiumLicense && (
 					<SidebarNavItem href="/deployment/premium">Premium</SidebarNavItem>
 				)}


### PR DESCRIPTION
Provisioners should be only under orgs. This is a left over from a previous provisioner refactoring.