### PR TITLE
fix: return provisioners in desc order and add limit to cli

### DIFF
--- a/cli/provisioners.go
+++ b/cli/provisioners.go
@@ -39,6 +39,7 @@ func (r *RootCmd) provisionerList() *serpent.Command {
 			cliui.TableFormat([]provisionerDaemonRow{}, []string{"name", "organization", "status", "key name", "created at", "last seen at", "version", "tags"}),
 			cliui.JSONFormat(),
 		)
+		limit int64
 	)
 
 	cmd := &serpent.Command{
@@ -57,7 +58,9 @@ func (r *RootCmd) provisionerList() *serpent.Command {
 				return xerrors.Errorf("current organization: %w", err)
 			}
 
-			daemons, err := client.OrganizationProvisionerDaemons(ctx, org.ID, nil)
+			daemons, err := client.OrganizationProvisionerDaemons(ctx, org.ID, &codersdk.OrganizationProvisionerDaemonsOptions{
+				Limit: int(limit),
+			})
 			if err != nil {
 				return xerrors.Errorf("list provisioner daemons: %w", err)
 			}
@@ -85,6 +88,17 @@ func (r *RootCmd) provisionerList() *serpent.Command {
 			return nil
 		},
 	}
+
+	cmd.Options = append(cmd.Options, []serpent.Option{
+		{
+			Flag:          "limit",
+			FlagShorthand: "l",
+			Env:           "CODER_PROVISIONER_LIST_LIMIT",
+			Description:   "Limit the number of provisioners returned.",
+			Default:       "50",
+			Value:         serpent.Int64Of(&limit),
+		},
+	}...)
 
 	orgContext.AttachOptions(cmd)
 	formatter.AttachOptions(&cmd.Options)

--- a/cli/testdata/coder_provisioner_list_--help.golden
+++ b/cli/testdata/coder_provisioner_list_--help.golden
@@ -14,6 +14,9 @@ OPTIONS:
   -c, --column [id|organization id|created at|last seen at|name|version|api version|tags|key name|status|current job id|current job status|current job template name|current job template icon|current job template display name|previous job id|previous job status|previous job template name|previous job template icon|previous job template display name|organization] (default: name,organization,status,key name,created at,last seen at,version,tags)
           Columns to display in table output.
 
+  -l, --limit int, $CODER_PROVISIONER_LIST_LIMIT (default: 50)
+          Limit the number of provisioners returned.
+
   -o, --output table|json (default: table)
           Output format.
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -4073,7 +4073,7 @@ func (q *FakeQuerier) GetProvisionerDaemonsWithStatusByOrganization(ctx context.
 	}
 
 	slices.SortFunc(rows, func(a, b database.GetProvisionerDaemonsWithStatusByOrganizationRow) int {
-		return a.ProvisionerDaemon.CreatedAt.Compare(b.ProvisionerDaemon.CreatedAt)
+		return b.ProvisionerDaemon.CreatedAt.Compare(a.ProvisionerDaemon.CreatedAt)
 	})
 
 	if arg.Limit.Valid && arg.Limit.Int32 > 0 && len(rows) > int(arg.Limit.Int32) {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5845,7 +5845,7 @@ WHERE
 	AND (COALESCE(array_length($3::uuid[], 1), 0) = 0 OR pd.id = ANY($3::uuid[]))
 	AND ($4::tagset = 'null'::tagset OR provisioner_tagset_contains(pd.tags::tagset, $4::tagset))
 ORDER BY
-	pd.created_at ASC
+	pd.created_at DESC
 LIMIT
 	$5::int
 `

--- a/coderd/database/queries/provisionerdaemons.sql
+++ b/coderd/database/queries/provisionerdaemons.sql
@@ -111,7 +111,7 @@ WHERE
 	AND (COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR pd.id = ANY(@ids::uuid[]))
 	AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pd.tags::tagset, @tags::tagset))
 ORDER BY
-	pd.created_at ASC
+	pd.created_at DESC
 LIMIT
 	sqlc.narg('limit')::int;
 

--- a/coderd/provisionerdaemons_test.go
+++ b/coderd/provisionerdaemons_test.go
@@ -159,8 +159,8 @@ func TestProvisionerDaemons(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, daemons, 2)
-		require.Equal(t, pd1.ID, daemons[0].ID)
-		require.Equal(t, pd2.ID, daemons[1].ID)
+		require.Equal(t, pd1.ID, daemons[1].ID)
+		require.Equal(t, pd2.ID, daemons[0].ID)
 	})
 
 	t.Run("Tags", func(t *testing.T) {

--- a/docs/reference/cli/provisioner_list.md
+++ b/docs/reference/cli/provisioner_list.md
@@ -15,6 +15,16 @@ coder provisioner list [flags]
 
 ## Options
 
+### -l, --limit
+
+|             |                                            |
+|-------------|--------------------------------------------|
+| Type        | <code>int</code>                           |
+| Environment | <code>$CODER_PROVISIONER_LIST_LIMIT</code> |
+| Default     | <code>50</code>                            |
+
+Limit the number of provisioners returned.
+
 ### -O, --org
 
 |             |                                  |

--- a/enterprise/cli/testdata/coder_provisioner_list_--help.golden
+++ b/enterprise/cli/testdata/coder_provisioner_list_--help.golden
@@ -14,6 +14,9 @@ OPTIONS:
   -c, --column [id|organization id|created at|last seen at|name|version|api version|tags|key name|status|current job id|current job status|current job template name|current job template icon|current job template display name|previous job id|previous job status|previous job template name|previous job template icon|previous job template display name|organization] (default: name,organization,status,key name,created at,last seen at,version,tags)
           Columns to display in table output.
 
+  -l, --limit int, $CODER_PROVISIONER_LIST_LIMIT (default: 50)
+          Limit the number of provisioners returned.
+
   -o, --output table|json (default: table)
           Output format.
 


### PR DESCRIPTION
I was wondering why I only saw offline provisioners when I did `coder provisioner list`. Since we're limiting the result, descending order makes more sense. Added the `--limit` flag to CLI while I was at it.
