### PR TITLE
chore: warn user without permissions to view org members

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPage.tsx
@@ -72,6 +72,7 @@ const OrganizationMembersPage: FC = () => {
 			<OrganizationMembersPageView
 				allAvailableRoles={organizationRolesQuery.data}
 				canEditMembers={organizationPermissions.editMembers}
+				canViewMembers={organizationPermissions.viewMembers}
 				error={
 					membersQuery.error ??
 					organizationRolesQuery.error ??

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
@@ -28,6 +28,7 @@ import {
 	TableRow,
 } from "components/Table/Table";
 import { UserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
+import { TriangleAlert } from "lucide-react";
 import { UserGroupsCell } from "pages/UsersPage/UsersTable/UserGroupsCell";
 import { type FC, useState } from "react";
 import { TableColumnHelpTooltip } from "./UserTable/TableColumnHelpTooltip";
@@ -36,6 +37,7 @@ import { UserRoleCell } from "./UserTable/UserRoleCell";
 interface OrganizationMembersPageViewProps {
 	allAvailableRoles: readonly SlimRole[] | undefined;
 	canEditMembers: boolean;
+	canViewMembers: boolean;
 	error: unknown;
 	isAddingMember: boolean;
 	isUpdatingMemberRoles: boolean;
@@ -58,6 +60,7 @@ export const OrganizationMembersPageView: FC<
 > = ({
 	allAvailableRoles,
 	canEditMembers,
+	canViewMembers,
 	error,
 	isAddingMember,
 	isUpdatingMemberRoles,
@@ -70,7 +73,7 @@ export const OrganizationMembersPageView: FC<
 	return (
 		<div>
 			<SettingsHeader title="Members" />
-			<Stack>
+			<div className="flex flex-col gap-4">
 				{Boolean(error) && <ErrorAlert error={error} />}
 
 				{canEditMembers && (
@@ -78,6 +81,15 @@ export const OrganizationMembersPageView: FC<
 						isLoading={isAddingMember}
 						onSubmit={addMember}
 					/>
+				)}
+
+				{!canViewMembers && (
+					<div className="flex flex-row text-content-warning gap-2 items-center text-sm font-medium">
+						<TriangleAlert className="size-icon-sm" />
+						<p>
+							You do not have permission to view members other than yourself.
+						</p>
+					</div>
 				)}
 
 				<Table>
@@ -154,7 +166,7 @@ export const OrganizationMembersPageView: FC<
 						))}
 					</TableBody>
 				</Table>
-			</Stack>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
resolves coder/internal#392

In situations where a user accesses the org members without any permissions beyond that of a normal member, they will only be able to see themselves in the list of members.

This PR shows a warning to users who arrive at the members page in this situation.

<img width="1145" alt="Screenshot 2025-02-26 at 18 36 59" src="https://github.com/user-attachments/assets/16ad6ce1-2aa9-4719-bdae-914aff0fcd52" />
