### PR TITLE
fix: allow viewOrgRoles for custom roles page

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -57,7 +57,8 @@ export const CustomRolesPage: FC = () => {
 		<RequirePermission
 			isFeatureVisible={
 				organizationPermissions.assignOrgRoles ||
-				organizationPermissions.createOrgRoles
+				organizationPermissions.createOrgRoles ||
+				organizationPermissions.viewOrgRoles
 			}
 		>
 			<Helmet>


### PR DESCRIPTION
Users with viewOrgRoles should be able to see customs roles page as this matches the left sidebar permissions.