### PR TITLE
chore(cli): fix test flake caused by agent connect race

### DIFF
--- a/cli/exp_rpty_test.go
+++ b/cli/exp_rpty_test.go
@@ -87,6 +87,11 @@ func TestExpRpty(t *testing.T) {
 			require.NoError(t, err, "Could not stop container")
 		})
 
+		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
+			o.ExperimentalContainersEnabled = true
+		})
+		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
+
 		inv, root := clitest.New(t, "exp", "rpty", workspace.Name, "-c", ct.Container.ID)
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
@@ -95,11 +100,6 @@ func TestExpRpty(t *testing.T) {
 			err := inv.WithContext(ctx).Run()
 			assert.NoError(t, err)
 		})
-
-		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-			o.ExperimentalContainersEnabled = true
-		})
-		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
 
 		pty.ExpectMatch(fmt.Sprintf("Connected to %s", workspace.Name))
 		pty.ExpectMatch("Reconnect ID: ")


### PR DESCRIPTION
Fixes test flake seen here: https://github.com/coder/coder/actions/runs/13552012547/job/37877778883

```
    exp_rpty_test.go:96: 
        	Error Trace:	/home/runner/work/coder/coder/cli/exp_rpty_test.go:96
        	            				/home/runner/work/coder/coder/cli/ssh_test.go:1963
        	            				/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.9.linux-amd64/src/runtime/asm_amd64.s:1695
        	Error:      	Received unexpected error:
        	            	running command "coder exp rpty": GET http://localhost:37991/api/v2/workspaceagents/3785b98f-0589-47d2-a3c8-33a55a6c5b29/containers: unexpected status code 400: Agent state is "connecting", it must be in the "connected" state.
        	Test:       	TestExpRpty/Container
```