### PR TITLE
fix: handle undefined job while updating build progress

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -81,6 +81,7 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	useEffect(() => {
 		const updateProgress = () => {
 			if (
+				job == undefined ||
 				job.status !== "running" ||
 				transitionStats.P50 === undefined ||
 				transitionStats.P95 === undefined ||

--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -81,7 +81,7 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	useEffect(() => {
 		const updateProgress = () => {
 			if (
-				job == undefined ||
+				job === undefined ||
 				job.status !== "running" ||
 				transitionStats.P50 === undefined ||
 				transitionStats.P95 === undefined ||


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15444

We update the build progress with `useEffect()`, so in theory, a job may somehow become undefined.

Note: TBH I'm not convinced if that prevents the root cause.