### PR TITLE
fix: add org role read permissions to site wide template admins and auditors

### DIFF
--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -307,7 +307,8 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 		Identifier:  RoleAuditor(),
 		DisplayName: "Auditor",
 		Site: Permissions(map[string][]policy.Action{
-			ResourceAuditLog.Type: {policy.ActionRead},
+			ResourceAssignOrgRole.Type: {policy.ActionRead},
+			ResourceAuditLog.Type:      {policy.ActionRead},
 			// Allow auditors to see the resources that audit logs reflect.
 			ResourceTemplate.Type:           {policy.ActionRead, policy.ActionViewInsights},
 			ResourceUser.Type:               {policy.ActionRead},
@@ -327,7 +328,8 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 		Identifier:  RoleTemplateAdmin(),
 		DisplayName: "Template Admin",
 		Site: Permissions(map[string][]policy.Action{
-			ResourceTemplate.Type: ResourceTemplate.AvailableActions(),
+			ResourceAssignOrgRole.Type: {policy.ActionRead},
+			ResourceTemplate.Type:      ResourceTemplate.AvailableActions(),
 			// CRUD all files, even those they did not upload.
 			ResourceFile.Type:      {policy.ActionCreate, policy.ActionRead},
 			ResourceWorkspace.Type: {policy.ActionRead},

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -352,8 +352,8 @@ func TestRolePermissions(t *testing.T) {
 			Actions:  []policy.Action{policy.ActionRead},
 			Resource: rbac.ResourceAssignOrgRole.InOrg(orgID),
 			AuthorizeMap: map[bool][]hasAuthSubjects{
-				true:  {owner, setOrgNotMe, orgMemberMe, userAdmin},
-				false: {setOtherOrg, memberMe, templateAdmin},
+				true:  {owner, setOrgNotMe, orgMemberMe, userAdmin, templateAdmin},
+				false: {setOtherOrg, memberMe},
 			},
 		},
 		{


### PR DESCRIPTION
resolves coder/internal#388

Since site-wide admins and auditors are able to access the members page of any org, they should have read access to org roles