### PR TITLE
chore: add agent endpoint for querying file system

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -41,6 +41,7 @@ func (a *agent) apiHandler() http.Handler {
 	r.Get("/api/v0/containers", ch.ServeHTTP)
 	r.Get("/api/v0/listening-ports", lp.handler)
 	r.Get("/api/v0/netcheck", a.HandleNetcheck)
+	r.Post("/api/v0/ls", a.HandleLS)
 	r.Get("/debug/logs", a.HandleHTTPDebugLogs)
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)

--- a/agent/api.go
+++ b/agent/api.go
@@ -41,7 +41,7 @@ func (a *agent) apiHandler() http.Handler {
 	r.Get("/api/v0/containers", ch.ServeHTTP)
 	r.Get("/api/v0/listening-ports", lp.handler)
 	r.Get("/api/v0/netcheck", a.HandleNetcheck)
-	r.Post("/api/v0/ls", a.HandleLS)
+	r.Post("/api/v0/list-directory", a.HandleLS)
 	r.Get("/debug/logs", a.HandleHTTPDebugLogs)
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)

--- a/agent/ls.go
+++ b/agent/ls.go
@@ -95,7 +95,7 @@ func listFiles(query LSRequest) (LSResponse, error) {
 			AbsolutePathString: absolutePathString,
 			Contents: []LSFile{
 				{
-					Name:               f.Name(),
+					Name:               filepath.Base(f.Name()),
 					AbsolutePathString: absolutePathString,
 					IsDir:              false,
 				},

--- a/agent/ls.go
+++ b/agent/ls.go
@@ -75,7 +75,6 @@ func listFiles(query LSRequest) (LSResponse, error) {
 	if err != nil {
 		return LSResponse{}, xerrors.Errorf("failed to get absolute path of %q: %w", fullPathRelative, err)
 	}
-	absolutePath := pathToArray(absolutePathString)
 
 	f, err := os.Open(absolutePathString)
 	if err != nil {
@@ -89,18 +88,7 @@ func listFiles(query LSRequest) (LSResponse, error) {
 	}
 
 	if !stat.IsDir() {
-		// `ls` on a file should return just that file.
-		return LSResponse{
-			AbsolutePath:       absolutePath,
-			AbsolutePathString: absolutePathString,
-			Contents: []LSFile{
-				{
-					Name:               filepath.Base(f.Name()),
-					AbsolutePathString: absolutePathString,
-					IsDir:              false,
-				},
-			},
-		}, nil
+		return LSResponse{}, xerrors.Errorf("path %q is not a directory", absolutePathString)
 	}
 
 	// `contents` may be partially populated even if the operation fails midway.
@@ -113,6 +101,8 @@ func listFiles(query LSRequest) (LSResponse, error) {
 			IsDir:              file.IsDir(),
 		})
 	}
+
+	absolutePath := pathToArray(absolutePathString)
 
 	return LSResponse{
 		AbsolutePath:       absolutePath,

--- a/agent/ls.go
+++ b/agent/ls.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/shirou/gopsutil/v4/disk"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -118,6 +118,8 @@ func listDrives() (LSResponse, error) {
 	}
 	contents := make([]LSFile, 0, len(partitionStats))
 	for _, a := range partitionStats {
+		// Drive letters on Windows have a trailing separator as part of their name.
+		// i.e. `os.Open("C:")` does not work, but `os.Open("C:\\")` does.
 		name := a.Mountpoint + string(os.PathSeparator)
 		contents = append(contents, LSFile{
 			Name:               name,
@@ -137,7 +139,8 @@ func pathToArray(path string) []string {
 	out := strings.FieldsFunc(path, func(r rune) bool {
 		return r == os.PathSeparator
 	})
-	// Drive letters on Windows should have a trailing separator.
+	// Drive letters on Windows have a trailing separator as part of their name.
+	// i.e. `os.Open("C:")` does not work, but `os.Open("C:\\")` does.
 	if runtime.GOOS == "windows" && len(out) > 0 {
 		out[0] += string(os.PathSeparator)
 	}

--- a/agent/ls.go
+++ b/agent/ls.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func (*agent) HandleLS(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var query LSQuery
+	if !httpapi.Read(ctx, rw, r, &query) {
+		return
+	}
+
+	resp, err := listFiles(query)
+	if err != nil {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+				Message: "Directory does not exist",
+			})
+		case errors.Is(err, os.ErrPermission):
+			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+				Message: "Permission denied",
+			})
+		default:
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: err.Error(),
+			})
+		}
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+func listFiles(query LSQuery) (LSResponse, error) {
+	var base string
+	switch query.Relativity {
+	case LSRelativityHome:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return LSResponse{}, xerrors.Errorf("failed to get user home directory: %w", err)
+		}
+		base = home
+	case LSRelativityRoot:
+		if runtime.GOOS == "windows" {
+			// TODO: Eventually, we could have a empty path with a root base
+			// return all drives.
+			// C drive should be good enough for now.
+			base = "C:\\"
+		} else {
+			base = "/"
+		}
+	default:
+		return LSResponse{}, xerrors.Errorf("unsupported relativity type %q", query.Relativity)
+	}
+
+	fullPath := append([]string{base}, query.Path...)
+	absolutePathString, err := filepath.Abs(filepath.Join(fullPath...))
+	if err != nil {
+		return LSResponse{}, xerrors.Errorf("failed to get absolute path: %w", err)
+	}
+
+	f, err := os.Open(absolutePathString)
+	if err != nil {
+		return LSResponse{}, xerrors.Errorf("failed to open directory: %w", err)
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return LSResponse{}, xerrors.Errorf("failed to stat directory: %w", err)
+	}
+
+	if !stat.IsDir() {
+		return LSResponse{}, xerrors.New("path is not a directory")
+	}
+
+	// `contents` may be partially populated even if the operation fails midway.
+	contents, _ := f.Readdir(-1)
+	respContents := make([]LSFile, 0, len(contents))
+	for _, file := range contents {
+		respContents = append(respContents, LSFile{
+			Name:               file.Name(),
+			AbsolutePathString: filepath.Join(absolutePathString, file.Name()),
+			IsDir:              file.IsDir(),
+		})
+	}
+
+	return LSResponse{
+		AbsolutePathString: absolutePathString,
+		Contents:           respContents,
+	}, nil
+}
+
+type LSQuery struct {
+	// e.g. [], ["repos", "coder"],
+	Path []string `json:"path"`
+	// Whether the supplied path is relative to the user's home directory,
+	// or the root directory.
+	Relativity LSRelativity `json:"relativity"`
+}
+
+type LSResponse struct {
+	// Returned so clients can display the full path to the user, and
+	// copy it to configure file sync
+	// e.g. Windows: "C:\\Users\\coder"
+	//      Linux: "/home/coder"
+	AbsolutePathString string   `json:"absolute_path_string"`
+	Contents           []LSFile `json:"contents"`
+}
+
+type LSFile struct {
+	Name string `json:"name"`
+	// e.g. "C:\\Users\\coder\\hello.txt"
+	//      "/home/coder/hello.txt"
+	AbsolutePathString string `json:"absolute_path_string"`
+	IsDir              bool   `json:"is_dir"`
+}
+
+type LSRelativity string
+
+const (
+	LSRelativityRoot LSRelativity = "root"
+	LSRelativityHome LSRelativity = "home"
+)

--- a/agent/ls_internal_test.go
+++ b/agent/ls_internal_test.go
@@ -190,6 +190,12 @@ func TestListFilesListDrives(t *testing.T) {
 	}
 	resp, err = listFiles(query)
 	require.NoError(t, err)
+	// System directory should always exist
+	require.Contains(t, resp.Contents, LSFile{
+		Name:               "Windows",
+		AbsolutePathString: "C:\\Windows",
+		IsDir:              true,
+	})
 
 	query = LSRequest{
 		// Network drives are not supported.

--- a/agent/ls_internal_test.go
+++ b/agent/ls_internal_test.go
@@ -66,8 +66,16 @@ func TestListFilesNotADirectory(t *testing.T) {
 		Path:       pathToArray(rel),
 		Relativity: LSRelativityHome,
 	}
-	_, err = listFiles(query)
-	require.ErrorContains(t, err, "is not a directory")
+	resp, err := listFiles(query)
+	require.NoError(t, err)
+	require.Equal(t, filePath, resp.AbsolutePathString)
+	require.ElementsMatch(t, []LSFile{
+		{
+			Name:               "file.txt",
+			AbsolutePathString: filePath,
+			IsDir:              false,
+		},
+	}, resp.Contents)
 }
 
 func TestListFilesSuccess(t *testing.T) {

--- a/agent/ls_internal_test.go
+++ b/agent/ls_internal_test.go
@@ -66,16 +66,8 @@ func TestListFilesNotADirectory(t *testing.T) {
 		Path:       pathToArray(rel),
 		Relativity: LSRelativityHome,
 	}
-	resp, err := listFiles(query)
-	require.NoError(t, err)
-	require.Equal(t, filePath, resp.AbsolutePathString)
-	require.ElementsMatch(t, []LSFile{
-		{
-			Name:               "file.txt",
-			AbsolutePathString: filePath,
-			IsDir:              false,
-		},
-	}, resp.Contents)
+	_, err = listFiles(query)
+	require.ErrorContains(t, err, "is not a directory")
 }
 
 func TestListFilesSuccess(t *testing.T) {

--- a/agent/ls_internal_test.go
+++ b/agent/ls_internal_test.go
@@ -1,0 +1,172 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListFilesNonExistentDirectory(t *testing.T) {
+	t.Parallel()
+
+	query := LSQuery{
+		Path:       []string{"idontexist"},
+		Relativity: LSRelativityHome,
+	}
+	_, err := listFiles(query)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestListFilesPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("creating an unreadable-by-user directory is non-trivial on Windows")
+	}
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	reposDir := filepath.Join(tmpDir, "repos")
+	err = os.Mkdir(reposDir, 0o000)
+	require.NoError(t, err)
+
+	rel, err := filepath.Rel(home, reposDir)
+	require.NoError(t, err)
+
+	query := LSQuery{
+		Path:       pathToArray(rel),
+		Relativity: LSRelativityHome,
+	}
+	_, err = listFiles(query)
+	require.ErrorIs(t, err, os.ErrPermission)
+}
+
+func TestListFilesNotADirectory(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	filePath := filepath.Join(tmpDir, "file.txt")
+	err = os.WriteFile(filePath, []byte("content"), 0o600)
+	require.NoError(t, err)
+
+	rel, err := filepath.Rel(home, filePath)
+	require.NoError(t, err)
+
+	query := LSQuery{
+		Path:       pathToArray(rel),
+		Relativity: LSRelativityHome,
+	}
+	_, err = listFiles(query)
+	require.ErrorContains(t, err, "path is not a directory")
+}
+
+func TestListFilesSuccess(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name       string
+		baseFunc   func(t *testing.T) string
+		relativity LSRelativity
+	}{
+		{
+			name: "home",
+			baseFunc: func(t *testing.T) string {
+				home, err := os.UserHomeDir()
+				require.NoError(t, err)
+				return home
+			},
+			relativity: LSRelativityHome,
+		},
+		{
+			name: "root",
+			baseFunc: func(t *testing.T) string {
+				if runtime.GOOS == "windows" {
+					return "C:\\"
+				}
+				return "/"
+			},
+			relativity: LSRelativityRoot,
+		},
+	}
+
+	// nolint:paralleltest // Not since Go v1.22.
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := tc.baseFunc(t)
+			tmpDir := t.TempDir()
+
+			reposDir := filepath.Join(tmpDir, "repos")
+			err := os.Mkdir(reposDir, 0o755)
+			require.NoError(t, err)
+
+			downloadsDir := filepath.Join(tmpDir, "Downloads")
+			err = os.Mkdir(downloadsDir, 0o755)
+			require.NoError(t, err)
+
+			rel, err := filepath.Rel(base, tmpDir)
+			require.NoError(t, err)
+			relComponents := pathToArray(rel)
+
+			query := LSQuery{
+				Path:       relComponents,
+				Relativity: tc.relativity,
+			}
+			resp, err := listFiles(query)
+			require.NoError(t, err)
+
+			require.Equal(t, tmpDir, resp.AbsolutePathString)
+
+			var foundRepos, foundDownloads bool
+			for _, file := range resp.Contents {
+				switch file.Name {
+				case "repos":
+					foundRepos = true
+					expectedPath := filepath.Join(tmpDir, "repos")
+					require.Equal(t, expectedPath, file.AbsolutePathString)
+					require.True(t, file.IsDir)
+				case "Downloads":
+					foundDownloads = true
+					expectedPath := filepath.Join(tmpDir, "Downloads")
+					require.Equal(t, expectedPath, file.AbsolutePathString)
+					require.True(t, file.IsDir)
+				}
+			}
+			require.True(t, foundRepos && foundDownloads, "expected to find both repos and Downloads directories, got: %+v", resp.Contents)
+		})
+	}
+}
+
+func TestListFilesWindowsRoot(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("skipping test on non-Windows OS")
+	}
+
+	query := LSQuery{
+		Path:       []string{},
+		Relativity: LSRelativityRoot,
+	}
+	resp, err := listFiles(query)
+	require.NoError(t, err)
+	require.Equal(t, "C:\\", resp.AbsolutePathString)
+}
+
+func pathToArray(path string) []string {
+	return strings.FieldsFunc(path, func(r rune) bool {
+		return r == os.PathSeparator
+	})
+}

--- a/agent/ls_internal_test.go
+++ b/agent/ls_internal_test.go
@@ -12,7 +12,7 @@ import (
 func TestListFilesNonExistentDirectory(t *testing.T) {
 	t.Parallel()
 
-	query := LSQuery{
+	query := LSRequest{
 		Path:       []string{"idontexist"},
 		Relativity: LSRelativityHome,
 	}
@@ -39,7 +39,7 @@ func TestListFilesPermissionDenied(t *testing.T) {
 	rel, err := filepath.Rel(home, reposDir)
 	require.NoError(t, err)
 
-	query := LSQuery{
+	query := LSRequest{
 		Path:       pathToArray(rel),
 		Relativity: LSRelativityHome,
 	}
@@ -62,12 +62,12 @@ func TestListFilesNotADirectory(t *testing.T) {
 	rel, err := filepath.Rel(home, filePath)
 	require.NoError(t, err)
 
-	query := LSQuery{
+	query := LSRequest{
 		Path:       pathToArray(rel),
 		Relativity: LSRelativityHome,
 	}
 	_, err = listFiles(query)
-	require.ErrorContains(t, err, "path is not a directory")
+	require.ErrorContains(t, err, "is not a directory")
 }
 
 func TestListFilesSuccess(t *testing.T) {
@@ -125,7 +125,7 @@ func TestListFilesSuccess(t *testing.T) {
 				queryComponents = pathToArray(rel)
 			}
 
-			query := LSQuery{
+			query := LSRequest{
 				Path:       queryComponents,
 				Relativity: tc.relativity,
 			}
@@ -161,7 +161,7 @@ func TestListFilesListDrives(t *testing.T) {
 		t.Skip("skipping test on non-Windows OS")
 	}
 
-	query := LSQuery{
+	query := LSRequest{
 		Path:       []string{},
 		Relativity: LSRelativityRoot,
 	}
@@ -173,14 +173,14 @@ func TestListFilesListDrives(t *testing.T) {
 		IsDir:              true,
 	})
 
-	query = LSQuery{
+	query = LSRequest{
 		Path:       []string{"C:\\"},
 		Relativity: LSRelativityRoot,
 	}
 	resp, err = listFiles(query)
 	require.NoError(t, err)
 
-	query = LSQuery{
+	query = LSRequest{
 		Path:       resp.AbsolutePath,
 		Relativity: LSRelativityRoot,
 	}

--- a/go.mod
+++ b/go.mod
@@ -401,7 +401,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
-	github.com/shirou/gopsutil/v3 v3.24.4 // indirect
+	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -164,6 +164,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.21
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/afero v1.12.0
 	github.com/spf13/pflag v1.0.5
@@ -401,7 +402,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
-	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.21
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/shirou/gopsutil/v3 v3.24.4
+	github.com/shirou/gopsutil/v4 v4.25.2
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/afero v1.12.0
 	github.com/spf13/pflag v1.0.5
@@ -286,7 +286,7 @@ require (
 	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd // indirect
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 // indirect
-	github.com/ebitengine/purego v0.6.0-alpha.5 // indirect
+	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/elastic/go-windows v1.0.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -402,6 +402,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
+	github.com/shirou/gopsutil/v3 v3.24.4 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4 h1:8EXxF+tCLqaVk8AOC29zl2mnhQjwyLxxOTuhUazWRsg=
 github.com/eapache/queue/v2 v2.0.0-20230407133247-75960ed334e4/go.mod h1:I5sHm0Y0T1u5YjlyqC5GVArM7aNZRUYtTjmJ8mPJFds=
-github.com/ebitengine/purego v0.6.0-alpha.5 h1:EYID3JOAdmQ4SNZYJHu9V6IqOeRQDBYxqKAg9PyoHFY=
-github.com/ebitengine/purego v0.6.0-alpha.5/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
+github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elastic/go-sysinfo v1.15.0 h1:54pRFlAYUlVNQ2HbXzLVZlV+fxS7Eax49stzg95M4Xw=
 github.com/elastic/go-sysinfo v1.15.0/go.mod h1:jPSuTgXG+dhhh0GKIyI2Cso+w5lPJ5PvVqKlL8LV/Hk=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=
@@ -825,6 +825,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shirou/gopsutil/v3 v3.24.4 h1:dEHgzZXt4LMNm+oYELpzl9YCqV65Yr/6SfrvgRBtXeU=
 github.com/shirou/gopsutil/v3 v3.24.4/go.mod h1:lTd2mdiOspcqLgAnr9/nGi71NkeMpWKdmhuxm9GusH8=
+github.com/shirou/gopsutil/v4 v4.25.2 h1:NMscG3l2CqtWFS86kj3vP7soOczqrQYIEhO/pMvvQkk=
+github.com/shirou/gopsutil/v4 v4.25.2/go.mod h1:34gBYJzyqCDT11b6bMHP0XCvWeU3J61XRT7a2EmCRTA=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/382

The API differs slightly from the RFC, in the interest of making consumption of the API agnostic to the host operating system of the agent.

Queries supply the requested path as an array:
```json
{
  "path": ["home", "coder"],
  "relativity": "root" 
}
```

Whilst the agent returns the requested path as an OS-specific path string but also as an array, both absolute. (`relativity = root`)

Linux:
```json
{
    "absolute_path_string": "/home/coder",
    "absolute_path": ["home", "coder"],
    "contents": [
        {
            "absolute_path_string": "/home/coder/.bash_logout",
            "is_dir": false,
            "name": ".bash_logout"
        },
        ...
    ]
}
```

Windows:
```json
{
    "absolute_path_string": "C:\\Users\\coder",
    "absolute_path": ["C:\\", "Users", "coder"],
    "contents": [
        {
            "absolute_path_string": "C:\\Users\\coder\\Documents",
            "is_dir": true,
            "name": "Documents"
        },
        ...
    ]
}
```

API consumers need only append the `name` of a contents to the existing path array in order to query a subdirectory.
To traverse backwards from `path: [], relativity=home`, the `absolute_path` array returned can be used, popping the last element off the array, and changing the relativity to `root`.
Once the consumer has a target, they can use the `absolute_path_string` - at no point do they need to know the workspace OS.

Example Usage:

```
$ http POST localhost:4/api/v0/list-directory path:='["home", "coder"]' relativity=root
HTTP/1.1 200 OK
Content-Length: 649
Content-Type: application/json; charset=utf-8
Date: Fri, 28 Feb 2025 05:53:40 GMT

{
    "absolute_path": [
        "home",
        "coder"
    ],
    "absolute_path_string": "/home/coder",
    "contents": [
        {
            "absolute_path_string": "/home/coder/.bash_logout",
            "is_dir": false,
            "name": ".bash_logout"
        },
        ...
    ]
}
```