### PR TITLE
fix(agent/agentcontainers): remove empty warning if no containers exist

### DIFF
--- a/agent/agentcontainers/containers_dockercli.go
+++ b/agent/agentcontainers/containers_dockercli.go
@@ -278,10 +278,10 @@ func (dcl *DockerCLILister) List(ctx context.Context) (codersdk.WorkspaceAgentLi
 		return codersdk.WorkspaceAgentListContainersResponse{}, xerrors.Errorf("run docker inspect: %w", err)
 	}
 
-	for idx, in := range ins {
+	for _, in := range ins {
 		out, warns := convertDockerInspect(in)
 		res.Warnings = append(res.Warnings, warns...)
-		res.Containers[idx] = out
+		res.Containers = append(res.Containers, out)
 	}
 
 	if dockerPsStderr != "" {


### PR DESCRIPTION
Fixes the current annoying response if no containers are running:
```
{"containers":null,"warnings":[""]}
```