### PR TITLE
fix: editor: fallback to default entrypoint

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
@@ -27,6 +27,7 @@ import type { MonacoEditorProps } from "./MonacoEditor";
 import { Language } from "./PublishTemplateVersionDialog";
 import TemplateVersionEditorPage, {
 	findEntrypointFile,
+	getActivePath,
 } from "./TemplateVersionEditorPage";
 
 const { API } = apiModule;
@@ -412,6 +413,34 @@ function renderEditorPage(queryClient: QueryClient) {
 		</AppProviders>,
 	);
 }
+
+describe("Get active path", () => {
+	it("empty path", () => {
+		const ft: FileTree = {
+			"main.tf": "foobar",
+		};
+		const searchParams = new URLSearchParams({ path: "" });
+		const activePath = getActivePath(searchParams, ft);
+		expect(activePath).toBe("main.tf");
+	});
+	it("invalid path", () => {
+		const ft: FileTree = {
+			"main.tf": "foobar",
+		};
+		const searchParams = new URLSearchParams({ path: "foobaz" });
+		const activePath = getActivePath(searchParams, ft);
+		expect(activePath).toBe("main.tf");
+	});
+	it("valid path", () => {
+		const ft: FileTree = {
+			"main.tf": "foobar",
+			"foobar.tf": "foobaz",
+		};
+		const searchParams = new URLSearchParams({ path: "foobar.tf" });
+		const activePath = getActivePath(searchParams, ft);
+		expect(activePath).toBe("foobar.tf");
+	});
+});
 
 describe("Find entrypoint", () => {
 	it("empty tree", () => {

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -20,7 +20,7 @@ import { type FC, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { type FileTree, traverse } from "utils/filetree";
+import { type FileTree, existsFile, traverse } from "utils/filetree";
 import { pageTitle } from "utils/page";
 import { TarReader, TarWriter } from "utils/tar";
 import { createTemplateVersionFileTree } from "utils/templateVersion";
@@ -88,9 +88,8 @@ export const TemplateVersionEditorPage: FC = () => {
 		useState<TemplateVersion>();
 
 	// File navigation
-	// It can be undefined when a selected file is deleted
-	const activePath: string | undefined =
-		searchParams.get("path") ?? findEntrypointFile(fileTree ?? {});
+	const activePath = getActivePath(searchParams, fileTree || {});
+
 	const onActivePathChange = (path: string | undefined) => {
 		if (path) {
 			searchParams.set("path", path);
@@ -390,6 +389,17 @@ export const findEntrypointFile = (fileTree: FileTree): string | undefined => {
 	});
 
 	return initialFile;
+};
+
+export const getActivePath = (
+	searchParams: URLSearchParams,
+	fileTree: FileTree,
+): string | undefined => {
+	const selectedPath = searchParams.get("path");
+	if (selectedPath && existsFile(selectedPath, fileTree)) {
+		return selectedPath;
+	}
+	return findEntrypointFile(fileTree);
 };
 
 export default TemplateVersionEditorPage;


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/16753#discussion_r1975558383

This PR adjusts logic to select an active file in the template version editor, so the editor does not crash.