### PR TITLE
docs: suggest disabling the default GitHub OAuth2 provider on k8s

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -101,6 +101,10 @@ coder:
           # postgres://coder:password@postgres:5432/coder?sslmode=disable
           name: coder-db-url
           key: url
+    # For production deployments, we recommend configuring your own GitHub
+    # OAuth2 provider and disabling the default one.
+    - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+      value: "false"
 
     # (Optional) For production deployments the access URL should be set.
     # If you're just trying Coder, access the dashboard via the service IP.

--- a/helm/coder/README.md
+++ b/helm/coder/README.md
@@ -47,6 +47,10 @@ coder:
     # This env enables the Prometheus metrics endpoint.
     - name: CODER_PROMETHEUS_ADDRESS
       value: "0.0.0.0:2112"
+    # For production deployments, we recommend configuring your own GitHub
+    # OAuth2 provider and disabling the default one.
+    - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+      value: "false"
   tls:
     secretNames:
       - my-tls-secret-name


### PR DESCRIPTION
For production deployments we recommend disabling the default GitHub OAuth2 app managed by Coder. This PR mentions it in k8s installation docs and the helm README so users can stumble upon it more easily.