### PR TITLE
fix: use `dbtime` in `dbmem` query to fix flake

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -7014,7 +7014,7 @@ func (q *FakeQuerier) GetWorkspaceAgentUsageStatsAndLabels(_ context.Context, cr
 		}
 		// WHERE usage = true AND created_at > now() - '1 minute'::interval
 		// GROUP BY user_id, agent_id, workspace_id
-		if agentStat.Usage && agentStat.CreatedAt.After(time.Now().Add(-time.Minute)) {
+		if agentStat.Usage && agentStat.CreatedAt.After(dbtime.Now().Add(-time.Minute)) {
 			val, ok := latestAgentStats[key]
 			if !ok {
 				latestAgentStats[key] = agentStat


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/447.

The test was failing 30% of the time on Windows without the rounding applied by `dbtime`. `dbtime` was used on the timestamps inserted into the DB, but not within the query. Once using `dbtime` within the query there were no failures in 200 runs.