### PR TITLE
feat: enable agent connection reports by default, remove flag

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -91,7 +91,6 @@ type Options struct {
 	Execer                       agentexec.Execer
 	ContainerLister              agentcontainers.Lister
 
-	ExperimentalConnectionReports    bool
 	ExperimentalDevcontainersEnabled bool
 }
 
@@ -196,7 +195,6 @@ func New(options Options) Agent {
 		lister:             options.ContainerLister,
 
 		experimentalDevcontainersEnabled: options.ExperimentalDevcontainersEnabled,
-		experimentalConnectionReports:    options.ExperimentalConnectionReports,
 	}
 	// Initially, we have a closed channel, reflecting the fact that we are not initially connected.
 	// Each time we connect we replace the channel (while holding the closeMutex) with a new one
@@ -273,7 +271,6 @@ type agent struct {
 	lister  agentcontainers.Lister
 
 	experimentalDevcontainersEnabled bool
-	experimentalConnectionReports    bool
 }
 
 func (a *agent) TailnetConn() *tailnet.Conn {
@@ -797,11 +794,6 @@ const (
 )
 
 func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_Type, ip string) (disconnected func(code int, reason string)) {
-	// If the experiment hasn't been enabled, we don't report connections.
-	if !a.experimentalConnectionReports {
-		return func(int, string) {} // Noop.
-	}
-
 	// Remove the port from the IP because ports are not supported in coderd.
 	if host, _, err := net.SplitHostPort(ip); err != nil {
 		a.logger.Error(a.hardCtx, "split host and port for connection report failed", slog.F("ip", ip), slog.Error(err))

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -173,9 +173,7 @@ func TestAgent_Stats_Magic(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 		//nolint:dogsled
-		conn, agentClient, stats, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
-			o.ExperimentalConnectionReports = true
-		})
+		conn, agentClient, stats, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
 		sshClient, err := conn.SSHClient(ctx)
 		require.NoError(t, err)
 		defer sshClient.Close()
@@ -243,9 +241,7 @@ func TestAgent_Stats_Magic(t *testing.T) {
 		remotePort := sc.Text()
 
 		//nolint:dogsled
-		conn, agentClient, stats, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
-			o.ExperimentalConnectionReports = true
-		})
+		conn, agentClient, stats, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
 		sshClient, err := conn.SSHClient(ctx)
 		require.NoError(t, err)
 
@@ -960,9 +956,7 @@ func TestAgent_SFTP(t *testing.T) {
 		home = "/" + strings.ReplaceAll(home, "\\", "/")
 	}
 	//nolint:dogsled
-	conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
-		o.ExperimentalConnectionReports = true
-	})
+	conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
 	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
 	defer sshClient.Close()
@@ -998,9 +992,7 @@ func TestAgent_SCP(t *testing.T) {
 	defer cancel()
 
 	//nolint:dogsled
-	conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
-		o.ExperimentalConnectionReports = true
-	})
+	conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
 	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
 	defer sshClient.Close()
@@ -1043,7 +1035,6 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 		//nolint:dogsled
 		conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
 			o.BlockFileTransfer = true
-			o.ExperimentalConnectionReports = true
 		})
 		sshClient, err := conn.SSHClient(ctx)
 		require.NoError(t, err)
@@ -1064,7 +1055,6 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 		//nolint:dogsled
 		conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
 			o.BlockFileTransfer = true
-			o.ExperimentalConnectionReports = true
 		})
 		sshClient, err := conn.SSHClient(ctx)
 		require.NoError(t, err)
@@ -1093,7 +1083,6 @@ func TestAgent_FileTransferBlocked(t *testing.T) {
 				//nolint:dogsled
 				conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
 					o.BlockFileTransfer = true
-					o.ExperimentalConnectionReports = true
 				})
 				sshClient, err := conn.SSHClient(ctx)
 				require.NoError(t, err)
@@ -1724,9 +1713,7 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 			defer cancel()
 
 			//nolint:dogsled
-			conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
-				o.ExperimentalConnectionReports = true
-			})
+			conn, agentClient, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
 			id := uuid.New()
 
 			// Test that the connection is reported. This must be tested in the

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -54,7 +54,6 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 		agentHeaderCommand  string
 		agentHeader         []string
 
-		experimentalConnectionReports    bool
 		experimentalDevcontainersEnabled bool
 	)
 	cmd := &serpent.Command{
@@ -327,10 +326,6 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 				containerLister = agentcontainers.NewDocker(execer)
 			}
 
-			if experimentalConnectionReports {
-				logger.Info(ctx, "experimental connection reports enabled")
-			}
-
 			agnt := agent.New(agent.Options{
 				Client:            client,
 				Logger:            logger,
@@ -359,7 +354,6 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 				ContainerLister:    containerLister,
 
 				ExperimentalDevcontainersEnabled: experimentalDevcontainersEnabled,
-				ExperimentalConnectionReports:    experimentalConnectionReports,
 			})
 
 			promHandler := agent.PrometheusMetricsHandler(prometheusRegistry, logger)
@@ -488,14 +482,6 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 			Env:         "CODER_AGENT_DEVCONTAINERS_ENABLE",
 			Description: "Allow the agent to automatically detect running devcontainers.",
 			Value:       serpent.BoolOf(&experimentalDevcontainersEnabled),
-		},
-		{
-			Flag:        "experimental-connection-reports-enable",
-			Hidden:      true,
-			Default:     "false",
-			Env:         "CODER_AGENT_EXPERIMENTAL_CONNECTION_REPORTS_ENABLE",
-			Description: "Enable experimental connection reports.",
-			Value:       serpent.BoolOf(&experimentalConnectionReports),
 		},
 	}
 


### PR DESCRIPTION
This change enables agent connection reports by default and removes the experimental flag for enabling them.

Updates #15139
