### PR TITLE
ci: avoid cancelling other nightly-gauntlet jobs on failure

### DIFF
--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -20,6 +20,7 @@ jobs:
     # even if some of the preceding steps are slow.
     timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest


### PR DESCRIPTION
I saw in a failing nightly-gauntlet that the macOS+Postgres tests failing caused the Windows tests to get cancelled: https://github.com/coder/coder/actions/runs/13645971060

There's no harm in letting the other test run, and will let us catch additional flakes & failures. If one job fails, the whole matrix will still fail (once the remaining tests in the matrix have completed) and the slack notification will still be sent. 
[We previously made this change](https://github.com/coder/coder/pull/8624) on our on-push `ci` workflow.

Relevant documentation:
> jobs.<job_id>.strategy.fail-fast applies to the entire matrix. If jobs.<job_id>.strategy.fail-fast is set to true or its expression evaluates to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails. This property defaults to true.

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast