### PR TITLE
fix: display all available settings

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/OptionsTable.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OptionsTable.tsx
@@ -49,13 +49,6 @@ const OptionsTable: FC<OptionsTableProps> = ({ options, additionalValues }) => {
 				</TableHead>
 				<TableBody>
 					{Object.values(options).map((option) => {
-						if (
-							option.value === null ||
-							option.value === "" ||
-							option.value === undefined
-						) {
-							return null;
-						}
 						return (
 							<TableRow key={option.flag} className={`option-${option.flag}`}>
 								<TableCell>

--- a/site/src/pages/DeploymentSettingsPage/optionValue.ts
+++ b/site/src/pages/DeploymentSettingsPage/optionValue.ts
@@ -6,6 +6,9 @@ export function optionValue(
 	option: SerpentOption,
 	additionalValues?: readonly string[],
 ) {
+	if (!option.value) {
+		return "";
+	}
 	// If option annotations are present, use them to format the value.
 	if (option.annotations) {
 		for (const [k, v] of Object.entries(option.annotations)) {

--- a/site/src/pages/DeploymentSettingsPage/optionValue.ts
+++ b/site/src/pages/DeploymentSettingsPage/optionValue.ts
@@ -6,9 +6,6 @@ export function optionValue(
 	option: SerpentOption,
 	additionalValues?: readonly string[],
 ) {
-	if (!option.value) {
-		return "";
-	}
 	// If option annotations are present, use them to format the value.
 	if (option.annotations) {
 		for (const [k, v] of Object.entries(option.annotations)) {
@@ -54,6 +51,10 @@ export function optionValue(
 				break;
 			}
 
+			if (!option.value) {
+				return "";
+			}
+
 			// We show all experiments (including unsafe) that are currently enabled on a deployment
 			// but only show safe experiments that are not.
 			// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
@@ -62,7 +63,6 @@ export function optionValue(
 					experimentMap[v] = true;
 				}
 			}
-
 			return experimentMap;
 		}
 		default:


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15420

This must have been a regression since OptionValue is able to display [Not set](https://github.com/coder/coder/blob/d8561a62fc65eb4429bc7e678a97e7ff2014ef2e/site/src/pages/DeploymentSettingsPage/Option.tsx#L55) when the value is undefined.

<img width="1500" alt="Screenshot 2025-03-04 at 13 00 55" src="https://github.com/user-attachments/assets/ded1a2f2-e2f1-4ed0-8120-181dac9ddf23" />
