### PR TITLE
fix: hide "last seen" when user is suspended

### DIFF
--- a/site/src/pages/UsersPage/UsersTable/UsersTableBody.tsx
+++ b/site/src/pages/UsersPage/UsersTable/UsersTableBody.tsx
@@ -176,7 +176,9 @@ export const UsersTableBody: FC<UsersTableBodyProps> = ({
 							]}
 						>
 							<div>{user.status}</div>
-							<LastSeen at={user.last_seen_at} css={{ fontSize: 12 }} />
+							{(user.status === "active" || user.status === "dormant") && (
+								<LastSeen at={user.last_seen_at} css={{ fontSize: 12 }} />
+							)}
 						</TableCell>
 
 						{canEditUsers && (


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14887

This PR hides the "last seen" information in the Users table for suspended accounts.

<img width="1193" alt="Screenshot 2025-03-05 at 13 02 38" src="https://github.com/user-attachments/assets/62ee8685-8eaa-4441-87a8-2d7ee11b6094" />


