### PR TITLE
test(cli): improve TestServer/SpammyLogs line count

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -253,7 +253,7 @@ func TestServer(t *testing.T) {
 			"--cache-dir", t.TempDir(),
 		)
 		pty := ptytest.New(t).Attach(inv)
-		require.NoError(t, pty.Resize(80, 80))
+		require.NoError(t, pty.Resize(20, 80))
 		clitest.Start(t, inv)
 
 		// Wait for startup

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -25,7 +25,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2348,23 +2347,4 @@ func mockTelemetryServer(t *testing.T) (*url.URL, chan *telemetry.Deployment, ch
 	require.NoError(t, err)
 
 	return serverURL, deployment, snapshot
-}
-
-// syncWriter provides a thread-safe io.ReadWriter implementation
-type syncReaderWriter struct {
-	buf bytes.Buffer
-	mu  sync.Mutex
-}
-
-func (w *syncReaderWriter) Write(p []byte) (n int, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.buf.Write(p)
-}
-
-func (w *syncReaderWriter) Read(p []byte) (n int, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	return w.buf.Read(p)
 }

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -319,6 +319,11 @@ func (e *outExpecter) ReadLine(ctx context.Context) string {
 	return buffer.String()
 }
 
+func (e *outExpecter) ReadAll() []byte {
+	e.t.Helper()
+	return e.out.ReadAll()
+}
+
 func (e *outExpecter) doMatchWithDeadline(ctx context.Context, name string, fn func(*bufio.Reader) error) error {
 	e.t.Helper()
 
@@ -458,6 +463,18 @@ type stdbuf struct {
 
 func newStdbuf() *stdbuf {
 	return &stdbuf{more: make(chan struct{}, 1)}
+}
+
+func (b *stdbuf) ReadAll() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.err != nil {
+		return nil
+	}
+	p := append([]byte(nil), b.b...)
+	b.b = b.b[len(b.b):]
+	return p
 }
 
 func (b *stdbuf) Read(p []byte) (int, error) {


### PR DESCRIPTION
This test was failing for me in dogfood (23 > 20).

I noticed that 1) the message for install.sh had changed and 2) we were counting lines incorrectly because of how the pty can move the cursor.

I also added the tf newer than expected to the ignore list, since it isn't something we should normally print, and if we do it's legit.

This is what the test log output now looks like:

```
=== NAME  TestServer/SpammyLogs
    server_test.go:288: Counting: "Started HTTP listener at http://[::]:37815\r"
    server_test.go:284: Ignoring: "WARN: The access URL  http://localhost:3000/  isn't externally reachable, this may cause unexpected problems when creating workspaces. Generate a unique *.try.coder.app URL by not specifying an access URL.\r"
    server_test.go:288: Counting: "\r\r"
    server_test.go:288: Counting: "╔════════════════════════════╗\r"
    server_test.go:288: Counting: "║      View the Web UI:      ║\r"
    server_test.go:288: Counting: "║   \x1b[4mhttp://localhost:3000/\x1b[0m   ║\r"
    server_test.go:288: Counting: "╚════════════════════════════╝\r\r"
    server_test.go:288: Counting: "\r"
    server_test.go:288: Counting: "==> Logs will stream in below (press ctrl+c to gracefully exit):\r\r"
    server_test.go:284: Ignoring: "2025-03-05 14:13:39.608 [warn]  cli: telemetry disabled, unable to notify of security issues. Read more: https://coder.com/docs/admin/setup/telemetry\r"
    server_test.go:284: Ignoring: "2025-03-05 14:13:39.634 [warn]  cli.coderd.site: could not parse install.sh, it will be unavailable  error=\"open install.sh: file does not exist\"\r"
    server_test.go:284: Ignoring: "2025-03-05 14:13:39.689 [warn]  cli.provisionerd-w-1: installed terraform version newer than expected, you may experience bugs  installed_version=1.11.0  max_version=1.10.9\r"
    server_test.go:284: Ignoring: "2025-03-05 14:13:39.689 [warn]  cli.provisionerd-w-0: installed terraform version newer than expected, you may experience bugs  installed_version=1.11.0  max_version=1.10.9\r"
    server_test.go:284: Ignoring: "2025-03-05 14:13:39.691 [warn]  cli.provisionerd-w-2: installed terraform version newer than expected, you may experience bugs  installed_version=1.11.0  max_version=1.10.9\r"
    server_test.go:288: Counting: ""
    server_test.go:301: numLines: 11
```
