### PR TITLE
chore: fix regex bug in migration number fixer

### DIFF
--- a/coderd/database/migrations/fix_migration_numbers.sh
+++ b/coderd/database/migrations/fix_migration_numbers.sh
@@ -11,7 +11,7 @@ list_migrations() {
 main() {
 	cd "${SCRIPT_DIR}"
 
-	origin=$(git remote -v | grep "github.com[:/]coder/coder.*(fetch)" | cut -f1)
+	origin=$(git remote -v | grep "github.com[:/]*coder/coder.*(fetch)" | cut -f1)
 
 	echo "Fetching ${origin}/main..."
 	git fetch -u "${origin}" main


### PR DESCRIPTION
This fixes a slight regex bug on Bash 5, where `[:/]` would only match `:` but not both `:/`.

```bash
$ git remote -v | grep "github.com[:/]coder/coder.*(fetch)" | cut -f1

$ git remote -v | grep "github.com[:/]*coder/coder.*(fetch)" | cut -f1
origin
```

The former will actually cause the whole script to bork because of `pipefail`, since `grep` exits 1.