### PR TITLE
fix: hide deleted users from org members query

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5202,7 +5202,7 @@ SELECT
 FROM
 	organization_members
 		INNER JOIN
-	users ON organization_members.user_id = users.id
+	users ON organization_members.user_id = users.id AND users.deleted = false
 WHERE
 	-- Filter by organization id
 	CASE

--- a/coderd/database/queries/organizationmembers.sql
+++ b/coderd/database/queries/organizationmembers.sql
@@ -9,7 +9,7 @@ SELECT
 FROM
 	organization_members
 		INNER JOIN
-	users ON organization_members.user_id = users.id
+	users ON organization_members.user_id = users.id AND users.deleted = false
 WHERE
 	-- Filter by organization id
 	CASE


### PR DESCRIPTION
Currently if you delete a user, you see a ghost of them as an organization member, because the query for listing organization members does not filter out deleted users, and the membership doesn't get deleted because users only get soft deleted. This shouldn't be a security issue, because the affected deleted user is still unable to login or take any actions.

I've updated the query to hide deleted users. In the future we may wish to remove these "dangling" records, or mark them as soft deleted as well.