### PR TITLE
feat: refactor SSH prefix into a workspace suffix

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -554,7 +554,6 @@ func (r *RootCmd) configSSH() *serpent.Command {
 			Env:         "CODER_CONFIGSSH_SSH_HOST_PREFIX",
 			Description: "Override the default host prefix.\nDEPRECATED: Use --ssh-hostname-suffix instead.",
 			Value:       serpent.StringOf(&sshConfigOpts.userHostPrefix),
-			Deprecated:  true,
 		},
 		{
 			Flag:        "ssh-hostname-suffix",

--- a/cli/server.go
+++ b/cli/server.go
@@ -650,6 +650,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				UserQuietHoursScheduleStore: &atomic.Pointer[schedule.UserQuietHoursScheduleStore]{},
 				SSHConfig: codersdk.SSHConfigResponse{
 					HostnamePrefix:   vals.SSHConfig.DeploymentName.String(),
+					HostnameSuffix:   vals.SSHConfig.HostnameSuffix.String(),
 					SSHConfigOptions: configSSHOptions,
 				},
 				AllowWorkspaceRenames: vals.AllowWorkspaceRenames.Value(),

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -575,7 +575,6 @@ func (r *RootCmd) ssh() *serpent.Command {
 			Env:         "CODER_SSH_SSH_HOST_PREFIX",
 			Description: "Strip this prefix from the provided hostname to determine the workspace name.\nDEPRECATED: Use --ssh-hostname-suffix instead.",
 			Value:       serpent.StringOf(&hostPrefix),
-			Deprecated:  true,
 		},
 		{
 			Flag:        "ssh-hostname-suffix",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2539,7 +2539,6 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.SSHConfig.DeploymentName,
 			Hidden:      false,
 			Default:     "coder.",
-			Deprecated:  true,
 		},
 		{
 			Name:        "SSH Host Suffix",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -405,7 +405,10 @@ type DeploymentValues struct {
 // ssh connections.
 type SSHConfig struct {
 	// DeploymentName is the config-ssh Hostname prefix
+	// DEPRECATED: Use HostnameSuffix instead.
 	DeploymentName serpent.String
+	// HostnameSuffix is the config-ssh hostname suffix that will be used for workspace hostnames
+	HostnameSuffix serpent.String
 	// SSHConfigOptions are additional options to add to the ssh config file.
 	// This will override defaults.
 	SSHConfigOptions serpent.StringArray
@@ -2528,7 +2531,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "SSH Host Prefix",
-			Description: "The SSH deployment prefix is used in the Host of the ssh config.",
+			Description: "The SSH deployment prefix is used in the Host of the ssh config.\nDEPRECATED: Use --ssh-hostname-suffix instead.",
 			Flag:        "ssh-hostname-prefix",
 			Env:         "CODER_SSH_HOSTNAME_PREFIX",
 			YAML:        "sshHostnamePrefix",
@@ -2536,6 +2539,18 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.SSHConfig.DeploymentName,
 			Hidden:      false,
 			Default:     "coder.",
+			Deprecated:  true,
+		},
+		{
+			Name:        "SSH Host Suffix",
+			Description: "The SSH hostname suffix used as the domain part of workspace hostnames in the SSH config.",
+			Flag:        "ssh-hostname-suffix",
+			Env:         "CODER_SSH_HOSTNAME_SUFFIX",
+			YAML:        "sshHostnameSuffix",
+			Group:       &deploymentGroupClient,
+			Value:       &c.SSHConfig.HostnameSuffix,
+			Hidden:      false,
+			Default:     "coder",
 		},
 		{
 			Name: "SSH Config Options",
@@ -3353,7 +3368,11 @@ type DeploymentStats struct {
 }
 
 type SSHConfigResponse struct {
+	// HostnamePrefix is the deprecated prefix for workspace SSH hostnames
+	// DEPRECATED: Use HostnameSuffix instead
 	HostnamePrefix   string            `json:"hostname_prefix"`
+	// HostnameSuffix is the suffix used for workspace SSH hostnames (e.g., workspace.coder)
+	HostnameSuffix   string            `json:"hostname_suffix"`
 	SSHConfigOptions map[string]string `json:"ssh_config_options"`
 }
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3015,6 +3015,7 @@ export const MockDeploymentStats: TypesGen.DeploymentStats = {
 
 export const MockDeploymentSSH: TypesGen.SSHConfigResponse = {
 	hostname_prefix: " coder.",
+	hostname_suffix: "coder",
 	ssh_config_options: {},
 };
 

--- a/vpn/client.go
+++ b/vpn/client.go
@@ -65,6 +65,7 @@ type Options struct {
 	TUNDevice        tun.Device
 	WireguardMonitor *netmon.Monitor
 	UpdateHandler    tailnet.UpdatesHandler
+	DomainSuffix     string
 }
 
 func (*client) NewConn(initCtx context.Context, serverURL *url.URL, token string, options *Options) (vpnC Conn, err error) {
@@ -145,10 +146,15 @@ func (*client) NewConn(initCtx context.Context, serverURL *url.URL, token string
 	controller.ResumeTokenCtrl = tailnet.NewBasicResumeTokenController(options.Logger, clk)
 	controller.CoordCtrl = coordCtrl
 	controller.DERPCtrl = tailnet.NewBasicDERPController(options.Logger, conn)
+	// Default to "coder" if no domain suffix is provided
+	domainSuffix := "coder"
+	if options.DomainSuffix != "" {
+		domainSuffix = options.DomainSuffix
+	}
 	updatesCtrl := tailnet.NewTunnelAllWorkspaceUpdatesController(
 		options.Logger,
 		coordCtrl,
-		tailnet.WithDNS(conn, me.Username),
+		tailnet.WithDNS(conn, me.Username, domainSuffix),
 		tailnet.WithHandler(options.UpdateHandler),
 	)
 	controller.WorkspaceUpdatesCtrl = updatesCtrl

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -47,6 +47,7 @@ type Tunnel struct {
 	logs  []*TunnelMessage
 
 	client Client
+	options *Options
 
 	// clientLogger is a separate logger than `logger` when the `UseAsLogger`
 	// option is used, to avoid the tunnel using itself as a sink for it's own


### PR DESCRIPTION
## Summary
- Add a new `--ssh-hostname-suffix` flag to replace the old `--ssh-hostname-prefix`
- Deprecate the existing hostname prefix option but maintain backward compatibility
- Update SSH config generation to use suffix-based approach (`workspace.coder` instead of `coder.workspace`)
- Configure VPN DNS to use the suffix for hostname resolution
- Update the tailnet controllers to use the new suffix for DNS names

This refactoring enables Coder Desktop to implement one-click buttons for native applications which require a suffix-based approach for deep linking and native app launches.

## Test plan
- Set up Coder server with the new `--ssh-hostname-suffix` option
- Run `coder config-ssh` and verify it generates config with `Host *.coder` pattern
- Connect to a workspace using `ssh workspace.coder`
- Verify that both old-style (prefix-based) and new-style (suffix-based) hostnames work

Fixes #16828

🤖 Generated with [Claude Code](https://claude.ai/code)