### PR TITLE
chore: enable SBOM attestation for image builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -999,7 +999,7 @@ jobs:
           AC_CERTIFICATE_PASSWORD_FILE: /tmp/apple_cert_password.txt
 
       - name: Upload build artifacts
-        if: ${{ github.repository_owner == 'coder' }}
+        if: ${{ github.repository_owner == 'coder' && github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: dylibs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -999,7 +999,7 @@ jobs:
           AC_CERTIFICATE_PASSWORD_FILE: /tmp/apple_cert_password.txt
 
       - name: Upload build artifacts
-        if: ${{ github.repository_owner == 'coder' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository_owner == 'coder' }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: dylibs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -361,6 +361,7 @@ jobs:
           file: scripts/Dockerfile.base
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: true
+          sbom: true
           pull: true
           no-cache: true
           push: true

--- a/dogfood/contents/files/etc/docker/daemon.json
+++ b/dogfood/contents/files/etc/docker/daemon.json
@@ -1,3 +1,6 @@
 {
-	"registry-mirrors": ["https://mirror.gcr.io"]
+	"registry-mirrors": ["https://mirror.gcr.io"],
+	"features": {
+		"containerd-snapshotter': true
+	}
 }

--- a/dogfood/contents/files/etc/docker/daemon.json
+++ b/dogfood/contents/files/etc/docker/daemon.json
@@ -1,6 +1,6 @@
 {
 	"registry-mirrors": ["https://mirror.gcr.io"],
 	"features": {
-		"containerd-snapshotter': true
+		"containerd-snapshotter": true
 	}
 }

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -140,7 +140,7 @@ docker buildx build \
 	--platform "$arch" \
 	--build-arg "BASE_IMAGE=$base_image" \
 	--build-arg "CODER_VERSION=$version" \
-	--provenence true \
+	--provenance true \
 	--sbom true \
 	--no-cache \
 	--tag "$image_tag" \

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -136,10 +136,12 @@ fi
 
 log "--- Building Docker image for $arch ($image_tag)"
 
-docker build \
+docker buildx build \
 	--platform "$arch" \
 	--build-arg "BASE_IMAGE=$base_image" \
 	--build-arg "CODER_VERSION=$version" \
+	--provenence true \
+	--sbom true \
 	--no-cache \
 	--tag "$image_tag" \
 	-f Dockerfile \


### PR DESCRIPTION
- Added SBOM (Software Bill of Materials) generation during Docker build to enhance traceability. Refer to Docker documentation on SBOM: https://docs.docker.com/build/metadata/attestations/sbom/
- Updated Docker build scripts to use BuildKit for provenance and SBOM support: https://docs.docker.com/build/metadata/attestations/
- Configured Docker daemon in dogfood image to support the Containerd snapshotter feature to improve performance: https://docs.docker.com/engine/storage/containerd/

> [!Important]
> We also need to enable `containerd` on depot runners.
> <img width="587" alt="image" src="https://github.com/user-attachments/assets/1d7f87c7-fdcc-462a-babe-87ac6486ad09" />



## Testing

- Tested locally with ` docker buildx build --sbom=true --output type=local,dest=out -f Dockerfile .` to verify that an SBOM file is generated. 
- Tested in [CI](https://github.com/coder/coder/actions/runs/13731162662/job/38408790980?pr=16852#step:17:1) to ensure the image builds without any errors.


Also closes coder/internal#88