### PR TITLE
fix: consider tag sets when calculating queue position part 2

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1170,6 +1170,11 @@ func (q *FakeQuerier) getProvisionerJobsByIDsWithQueuePositionLockedTagBasedQueu
 				filteredJobs[job.ID] = job
 			}
 		}
+
+		// Don't filter by jobIDs if it is nil.
+		if jobIDs == nil {
+			filteredJobs[job.ID] = job
+		}
 	}
 
 	// Step 2: Identify pending jobs
@@ -1256,100 +1261,10 @@ func (q *FakeQuerier) getProvisionerJobsByIDsWithQueuePositionLockedTagBasedQueu
 
 	// Step 7: Sort results by CreatedAt
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].CreatedAt.Before(results[j].CreatedAt)
+		return results[i].CreatedAt.After(results[j].CreatedAt)
 	})
 
 	return results, nil
-}
-
-func (q *FakeQuerier) getProvisionerJobsByIDsWithQueuePositionLockedGlobalQueue(_ context.Context, ids []uuid.UUID) ([]database.GetProvisionerJobsByIDsWithQueuePositionRow, error) {
-	//	WITH pending_jobs AS (
-	//		SELECT
-	//			id, created_at
-	//		FROM
-	//			provisioner_jobs
-	//		WHERE
-	//			started_at IS NULL
-	//		AND
-	//			canceled_at IS NULL
-	//		AND
-	//			completed_at IS NULL
-	//		AND
-	//			error IS NULL
-	//	),
-	type pendingJobRow struct {
-		ID        uuid.UUID
-		CreatedAt time.Time
-	}
-	pendingJobs := make([]pendingJobRow, 0)
-	for _, job := range q.provisionerJobs {
-		if job.StartedAt.Valid ||
-			job.CanceledAt.Valid ||
-			job.CompletedAt.Valid ||
-			job.Error.Valid {
-			continue
-		}
-		pendingJobs = append(pendingJobs, pendingJobRow{
-			ID:        job.ID,
-			CreatedAt: job.CreatedAt,
-		})
-	}
-
-	//	queue_position AS (
-	//		SELECT
-	//			id,
-	//				ROW_NUMBER() OVER (ORDER BY created_at ASC) AS queue_position
-	//		FROM
-	//			pending_jobs
-	// 	),
-	slices.SortFunc(pendingJobs, func(a, b pendingJobRow) int {
-		c := a.CreatedAt.Compare(b.CreatedAt)
-		return c
-	})
-
-	queuePosition := make(map[uuid.UUID]int64)
-	for idx, pj := range pendingJobs {
-		queuePosition[pj.ID] = int64(idx + 1)
-	}
-
-	//	queue_size AS (
-	//		SELECT COUNT(*) AS count FROM pending_jobs
-	//	),
-	queueSize := len(pendingJobs)
-
-	//	SELECT
-	//		sqlc.embed(pj),
-	//		COALESCE(qp.queue_position, 0) AS queue_position,
-	//		COALESCE(qs.count, 0) AS queue_size
-	// 	FROM
-	//		provisioner_jobs pj
-	//	LEFT JOIN
-	//		queue_position qp ON pj.id = qp.id
-	//	LEFT JOIN
-	//		queue_size qs ON TRUE
-	//	WHERE
-	//		pj.id IN (...)
-	jobs := make([]database.GetProvisionerJobsByIDsWithQueuePositionRow, 0)
-	for _, job := range q.provisionerJobs {
-		if ids != nil && !slices.Contains(ids, job.ID) {
-			continue
-		}
-		// clone the Tags before appending, since maps are reference types and
-		// we don't want the caller to be able to mutate the map we have inside
-		// dbmem!
-		job.Tags = maps.Clone(job.Tags)
-		job := database.GetProvisionerJobsByIDsWithQueuePositionRow{
-			//	sqlc.embed(pj),
-			ProvisionerJob: job,
-			//	COALESCE(qp.queue_position, 0) AS queue_position,
-			QueuePosition: queuePosition[job.ID],
-			//	COALESCE(qs.count, 0) AS queue_size
-			QueueSize: int64(queueSize),
-		}
-		jobs = append(jobs, job)
-	}
-
-	return jobs, nil
 }
 
 func (*FakeQuerier) AcquireLock(_ context.Context, _ int64) error {
@@ -4445,7 +4360,7 @@ func (q *FakeQuerier) GetProvisionerJobsByOrganizationAndStatusWithQueuePosition
 		LIMIT
 			sqlc.narg('limit')::int;
 	*/
-	rowsWithQueuePosition, err := q.getProvisionerJobsByIDsWithQueuePositionLockedGlobalQueue(ctx, nil)
+	rowsWithQueuePosition, err := q.getProvisionerJobsByIDsWithQueuePositionLockedTagBasedQueue(ctx, arg.IDs)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -2402,7 +2402,6 @@ func TestGetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisione
 
 			// Create provisioner jobs based on provided tags:
 			allJobs := make([]database.ProvisionerJob, len(tc.jobTags))
-			// daemonOrgIDs := make([]uuid.UUID, len(tc.daemonTags))
 			for idx, tags := range tc.jobTags {
 				// Make sure jobs are stored in correct order, first job should have the earliest createdAt timestamp.
 				// Example for 3 jobs:

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -57,7 +57,7 @@ WITH filtered_provisioner_jobs AS (
 	FROM
 		provisioner_jobs
 	WHERE
-		id = ANY(@ids :: uuid [ ]) -- Apply filter early to reduce dataset size before expensive JOIN
+		COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR id = ANY(@ids::uuid[]) -- Apply filter early to reduce dataset size before expensive JOIN
 ),
 pending_jobs AS (
 	-- Step 2: Extract only pending jobs
@@ -90,7 +90,7 @@ final_jobs AS (
 	FROM
 		filtered_provisioner_jobs fpj -- Use the pre-filtered dataset instead of full provisioner_jobs
 			LEFT JOIN ranked_jobs rj
-					ON fpj.id = rj.id -- Join with the ranking jobs CTE to assign a rank to each specified provisioner job.
+				 ON fpj.id = rj.id -- Join with the ranking jobs CTE to assign a rank to each specified provisioner job.
 	GROUP BY
 		fpj.id, fpj.created_at
 )
@@ -107,37 +107,57 @@ FROM
 				ON fj.id = pj.id -- Ensure we retrieve full details from `provisioner_jobs`.
                                  -- JOIN with pj is required for sqlc.embed(pj) to compile successfully.
 ORDER BY
-	fj.created_at;
+	fj.created_at DESC;
 
 -- name: GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner :many
-WITH pending_jobs AS (
-    SELECT
-        id, created_at
-    FROM
-        provisioner_jobs
-    WHERE
-        started_at IS NULL
-    AND
-        canceled_at IS NULL
-    AND
-        completed_at IS NULL
-    AND
-        error IS NULL
+WITH filtered_provisioner_jobs AS (
+	-- Step 1: Filter provisioner_jobs
+	SELECT
+		id, created_at
+	FROM
+		provisioner_jobs
+	WHERE
+		COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR id = ANY(@ids::uuid[]) -- Apply filter early to reduce dataset size before expensive JOIN
 ),
-queue_position AS (
-    SELECT
-        id,
-        ROW_NUMBER() OVER (ORDER BY created_at ASC) AS queue_position
-    FROM
-        pending_jobs
+pending_jobs AS (
+	-- Step 2: Extract only pending jobs
+	SELECT
+		id, created_at, tags
+	FROM
+		provisioner_jobs
+	WHERE
+		job_status = 'pending'
 ),
-queue_size AS (
-	SELECT COUNT(*) AS count FROM pending_jobs
+ranked_jobs AS (
+	-- Step 3: Rank only pending jobs based on provisioner availability
+	SELECT
+		pj.id,
+		pj.created_at,
+		ROW_NUMBER() OVER (PARTITION BY pd.id ORDER BY pj.created_at ASC) AS queue_position,
+		COUNT(*) OVER (PARTITION BY pd.id) AS queue_size
+	FROM
+		pending_jobs pj
+			INNER JOIN provisioner_daemons pd
+					ON provisioner_tagset_contains(pd.tags, pj.tags) -- Join only on the small pending set
+),
+final_jobs AS (
+	-- Step 4: Compute best queue position and max queue size per job
+	SELECT
+		fpj.id,
+		fpj.created_at,
+		COALESCE(MIN(rj.queue_position), 0) :: BIGINT AS queue_position, -- Best queue position across provisioners
+		COALESCE(MAX(rj.queue_size), 0) :: BIGINT AS queue_size -- Max queue size across provisioners
+	FROM
+		filtered_provisioner_jobs fpj -- Use the pre-filtered dataset instead of full provisioner_jobs
+			LEFT JOIN ranked_jobs rj
+				 ON fpj.id = rj.id -- Join with the ranking jobs CTE to assign a rank to each specified provisioner job.
+	GROUP BY
+		fpj.id, fpj.created_at
 )
 SELECT
 	sqlc.embed(pj),
-    COALESCE(qp.queue_position, 0) AS queue_position,
-    COALESCE(qs.count, 0) AS queue_size,
+    COALESCE(fj.queue_position, 0) AS queue_position,
+    COALESCE(fj.queue_size, 0) AS queue_size,
 	-- Use subquery to utilize ORDER BY in array_agg since it cannot be
 	-- combined with FILTER.
 	(
@@ -162,11 +182,11 @@ SELECT
 	w.id AS workspace_id,
 	COALESCE(w.name, '') AS workspace_name
 FROM
+	final_jobs fj
+INNER JOIN
 	provisioner_jobs pj
-LEFT JOIN
-	queue_position qp ON qp.id = pj.id
-LEFT JOIN
-	queue_size qs ON TRUE
+		ON fj.id = pj.id -- Ensure we retrieve full details from `provisioner_jobs`.
+						 -- JOIN with pj is required for sqlc.embed(pj) to compile successfully.
 LEFT JOIN
 	workspace_builds wb ON wb.id = CASE WHEN pj.input ? 'workspace_build_id' THEN (pj.input->>'workspace_build_id')::uuid END
 LEFT JOIN
@@ -192,8 +212,8 @@ WHERE
 	AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
 GROUP BY
 	pj.id,
-	qp.queue_position,
-	qs.count,
+	fj.queue_position,
+	fj.queue_size,
 	tv.name,
 	t.id,
 	t.name,

--- a/coderd/database/testcases/queue_position.go
+++ b/coderd/database/testcases/queue_position.go
@@ -1,0 +1,245 @@
+package testcases
+
+import "github.com/coder/coder/v2/coderd/database"
+
+type QueuePositionTestCase struct {
+	Name           string
+	JobTags        []database.StringMap
+	DaemonTags     []database.StringMap
+	QueueSizes     []int64
+	QueuePositions []int64
+	// GetProvisionerJobsByIDsWithQueuePosition takes jobIDs as a parameter.
+	// If SkipJobIDs is empty, all jobs are passed to the function; otherwise, the specified jobs are skipped.
+	// NOTE: Skipping job IDs means they will be excluded from the result,
+	// but this should not affect the queue position or queue size of other jobs.
+	SkipJobIDs map[int]struct{}
+	// Set `RequiresEmptyEnvironment` to true if the test requires an environment
+	// without any provisioner daemons or jobs present.
+	// In API-level tests, a default provisioner daemon is often included,
+	// so we may opt to skip such tests.
+	RequiresEmptyEnvironment bool
+}
+
+func GetDBLevelQueuePositionTestCases() []QueuePositionTestCase {
+	return queuePositionTestCases
+}
+
+func GetAPILevelQueuePositionTestCases() []QueuePositionTestCase {
+	testCases := make([]QueuePositionTestCase, 0)
+	for _, tc := range queuePositionTestCases {
+		if tc.RequiresEmptyEnvironment {
+			continue
+		}
+
+		testCases = append(testCases, tc)
+	}
+
+	return testCases
+}
+
+// queuePositionTestCases contains shared test cases used across multiple tests.
+var queuePositionTestCases = []QueuePositionTestCase{
+	// Baseline test case
+	{
+		Name: "test-case-1",
+		JobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+		},
+		QueueSizes:     []int64{0, 2, 2},
+		QueuePositions: []int64{0, 1, 1},
+	},
+	// Includes an additional provisioner
+	{
+		Name: "test-case-2",
+		JobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{3, 3, 3},
+		QueuePositions: []int64{3, 1, 1},
+	},
+	// Skips job at index 0
+	{
+		Name: "test-case-3",
+		JobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{3, 3},
+		QueuePositions: []int64{3, 1},
+		SkipJobIDs: map[int]struct{}{
+			0: {},
+		},
+	},
+	// Skips job at index 1
+	{
+		Name: "test-case-4",
+		JobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{3, 3},
+		QueuePositions: []int64{3, 1},
+		SkipJobIDs: map[int]struct{}{
+			1: {},
+		},
+	},
+	// Skips job at index 2
+	{
+		Name: "test-case-5",
+		JobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{3, 3},
+		QueuePositions: []int64{1, 1},
+		SkipJobIDs: map[int]struct{}{
+			2: {},
+		},
+	},
+	// Skips jobs at indexes 0 and 2
+	{
+		Name: "test-case-6",
+		JobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{3},
+		QueuePositions: []int64{1},
+		SkipJobIDs: map[int]struct{}{
+			0: {},
+			2: {},
+		},
+	},
+	// Includes two additional jobs that any provisioner can execute.
+	{
+		Name: "test-case-7",
+		JobTags: []database.StringMap{
+			{},
+			{},
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{5, 5, 5, 5, 5},
+		QueuePositions: []int64{5, 3, 3, 2, 1},
+	},
+	// Includes two additional jobs that any provisioner can execute, but they are intentionally skipped.
+	{
+		Name: "test-case-8",
+		JobTags: []database.StringMap{
+			{},
+			{},
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		DaemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		QueueSizes:     []int64{5, 5, 5},
+		QueuePositions: []int64{5, 3, 3},
+		SkipJobIDs: map[int]struct{}{
+			0: {},
+			1: {},
+		},
+	},
+	// N jobs (1 job with 0 tags) & 0 provisioners exist
+	{
+		Name: "test-case-9",
+		JobTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		DaemonTags:               []database.StringMap{},
+		QueueSizes:               []int64{0, 0, 0},
+		QueuePositions:           []int64{0, 0, 0},
+		RequiresEmptyEnvironment: true,
+	},
+	// N jobs (1 job with 0 tags) & N provisioners
+	{
+		Name: "test-case-10",
+		JobTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		DaemonTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		QueueSizes:     []int64{2, 2, 2},
+		QueuePositions: []int64{2, 2, 1},
+	},
+	// (N + 1) jobs (1 job with 0 tags) & N provisioners
+	// 1 job not matching any provisioner (first in the list)
+	{
+		Name: "test-case-11",
+		JobTags: []database.StringMap{
+			{"c": "3"},
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		DaemonTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		QueueSizes:     []int64{2, 2, 2, 0},
+		QueuePositions: []int64{2, 2, 1, 0},
+	},
+	// 0 jobs & 0 provisioners
+	{
+		Name:           "test-case-12",
+		JobTags:        []database.StringMap{},
+		DaemonTags:     []database.StringMap{},
+		QueueSizes:     nil, // TODO(yevhenii): should it be empty array instead?
+		QueuePositions: nil,
+	},
+}

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -29,6 +29,7 @@ import (
 
 // TestProvisionerJob_MultipleJobsAndProvisioners tests OrganizationProvisionerJob single job endpoint by repeatedly
 // calling it for every jobID and comparing with expected result.
+// nolint:paralleltest
 func TestProvisionerJob_MultipleJobsAndProvisioners(t *testing.T) {
 	t.Parallel()
 
@@ -41,7 +42,6 @@ func TestProvisionerJob_MultipleJobsAndProvisioners(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // Capture loop variable to avoid data races
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			now := dbtime.Now()
@@ -159,6 +159,7 @@ func TestProvisionerJob_MultipleJobsAndProvisioners(t *testing.T) {
 
 // TestProvisionerJobs_MultipleJobsAndProvisioners tests OrganizationProvisionerJobs multiple job endpoint by
 // calling it once and comparing with expected result.
+// nolint:paralleltest
 func TestProvisionerJobs_MultipleJobsAndProvisioners(t *testing.T) {
 	t.Parallel()
 
@@ -171,7 +172,6 @@ func TestProvisionerJobs_MultipleJobsAndProvisioners(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // Capture loop variable to avoid data races
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			now := dbtime.Now()

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -23,6 +25,473 @@ import (
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
+
+// defaultQueuePositionTestCases contains shared test cases used across multiple tests.
+var defaultQueuePositionTestCases = []struct {
+	name           string
+	jobTags        []database.StringMap
+	daemonTags     []database.StringMap
+	queueSizes     []int64
+	queuePositions []int64
+	// GetProvisionerJobsByIDsWithQueuePosition takes jobIDs as a parameter.
+	// If skipJobIDs is empty, all jobs are passed to the function; otherwise, the specified jobs are skipped.
+	// NOTE: Skipping job IDs means they will be excluded from the result,
+	// but this should not affect the queue position or queue size of other jobs.
+	skipJobIDs map[int]struct{}
+}{
+	// Baseline test case
+	{
+		name: "test-case-1",
+		jobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+		},
+		queueSizes:     []int64{0, 2, 2},
+		queuePositions: []int64{0, 1, 1},
+	},
+	// Includes an additional provisioner
+	{
+		name: "test-case-2",
+		jobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{3, 3, 3},
+		queuePositions: []int64{3, 1, 1},
+	},
+	// Skips job at index 0
+	{
+		name: "test-case-3",
+		jobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{3, 3},
+		queuePositions: []int64{3, 1},
+		skipJobIDs: map[int]struct{}{
+			0: {},
+		},
+	},
+	// Skips job at index 1
+	{
+		name: "test-case-4",
+		jobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{3, 3},
+		queuePositions: []int64{3, 1},
+		skipJobIDs: map[int]struct{}{
+			1: {},
+		},
+	},
+	// Skips job at index 2
+	{
+		name: "test-case-5",
+		jobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{3, 3},
+		queuePositions: []int64{1, 1},
+		skipJobIDs: map[int]struct{}{
+			2: {},
+		},
+	},
+	// Skips jobs at indexes 0 and 2
+	{
+		name: "test-case-6",
+		jobTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{3},
+		queuePositions: []int64{1},
+		skipJobIDs: map[int]struct{}{
+			0: {},
+			2: {},
+		},
+	},
+	// Includes two additional jobs that any provisioner can execute.
+	{
+		name: "test-case-7",
+		jobTags: []database.StringMap{
+			{},
+			{},
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{5, 5, 5, 5, 5},
+		queuePositions: []int64{5, 3, 3, 2, 1},
+	},
+	// Includes two additional jobs that any provisioner can execute, but they are intentionally skipped.
+	{
+		name: "test-case-8",
+		jobTags: []database.StringMap{
+			{},
+			{},
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "c": "3"},
+		},
+		daemonTags: []database.StringMap{
+			{"a": "1", "b": "2"},
+			{"a": "1"},
+			{"a": "1", "b": "2", "c": "3"},
+		},
+		queueSizes:     []int64{5, 5, 5},
+		queuePositions: []int64{5, 3, 3},
+		skipJobIDs: map[int]struct{}{
+			0: {},
+			1: {},
+		},
+	},
+	// N jobs (1 job with 0 tags) & N provisioners
+	{
+		name: "test-case-10",
+		jobTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		daemonTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		queueSizes:     []int64{2, 2, 2},
+		queuePositions: []int64{2, 2, 1},
+	},
+	// (N + 1) jobs (1 job with 0 tags) & N provisioners
+	// 1 job not matching any provisioner (first in the list)
+	{
+		name: "test-case-11",
+		jobTags: []database.StringMap{
+			{"c": "3"},
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		daemonTags: []database.StringMap{
+			{},
+			{"a": "1"},
+			{"b": "2"},
+		},
+		queueSizes:     []int64{2, 2, 2, 0},
+		queuePositions: []int64{2, 2, 1, 0},
+	},
+	// 0 jobs & 0 provisioners
+	{
+		name:           "test-case-12",
+		jobTags:        []database.StringMap{},
+		daemonTags:     []database.StringMap{},
+		queueSizes:     nil, // TODO(yevhenii): should it be empty array instead?
+		queuePositions: nil,
+	},
+}
+
+// TestProvisionerJob_MultipleJobsAndProvisioners tests OrganizationProvisionerJob single job endpoint by repeatedly
+// calling it for every jobID and comparing with expected result.
+func TestProvisionerJob_MultipleJobsAndProvisioners(t *testing.T) {
+	t.Parallel()
+
+	testCases := defaultQueuePositionTestCases
+
+	// ExtJob contains provisioner-job and related objects
+	type ExtJob struct {
+		database.ProvisionerJob
+		workspace database.WorkspaceTable
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture loop variable to avoid data races
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			now := dbtime.Now()
+			ctx := testutil.Context(t, testutil.WaitShort)
+
+			db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+			client := coderdtest.New(t, &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+				Database:                 db,
+				Pubsub:                   ps,
+			})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdminClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.ScopedRoleOrgTemplateAdmin(owner.OrganizationID))
+			_, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+			version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+			template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+			defaultOrg, err := db.GetDefaultOrganization(ctx)
+			require.NoError(t, err)
+			defaultOrgID := defaultOrg.ID
+
+			// Create provisioner jobs based on provided tags:
+			allExtJobs := make([]ExtJob, len(tc.jobTags))
+			for idx, tags := range tc.jobTags {
+				// Make sure jobs are stored in correct order, first job should have the earliest createdAt timestamp.
+				// Example for 3 jobs:
+				// job_1 createdAt: now - 3 minutes
+				// job_2 createdAt: now - 2 minutes
+				// job_3 createdAt: now - 1 minute
+				timeOffsetInMinutes := len(tc.jobTags) - idx
+				timeOffset := time.Duration(timeOffsetInMinutes) * time.Minute
+				createdAt := now.Add(-timeOffset)
+
+				// Create provisioner job and related objects
+				w := dbgen.Workspace(t, db, database.WorkspaceTable{
+					OrganizationID: owner.OrganizationID,
+					OwnerID:        member.ID,
+					TemplateID:     template.ID,
+				})
+				wbID := uuid.New()
+				job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+					CreatedAt:      createdAt,
+					Tags:           tags,
+					OrganizationID: w.OrganizationID,
+					Type:           database.ProvisionerJobTypeWorkspaceBuild,
+					Input:          json.RawMessage(`{"workspace_build_id":"` + wbID.String() + `"}`),
+				})
+				dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+					ID:                wbID,
+					JobID:             job.ID,
+					WorkspaceID:       w.ID,
+					TemplateVersionID: version.ID,
+				})
+
+				allExtJobs[idx] = ExtJob{
+					ProvisionerJob: job,
+					workspace:      w,
+				}
+
+				// Ensure that all jobs and daemons share the same OrganizationID
+				require.Equal(t, defaultOrgID, allExtJobs[idx].OrganizationID, "all jobs and daemons should be associated with the same organization")
+			}
+
+			// Create provisioner daemons based on provided tags:
+			for idx, tags := range tc.daemonTags {
+				daemon := dbgen.ProvisionerDaemon(t, db, database.ProvisionerDaemon{
+					Name:         fmt.Sprintf("prov_%v", idx),
+					Provisioners: []database.ProvisionerType{database.ProvisionerTypeEcho},
+					Tags:         tags,
+				})
+
+				// Ensure that all jobs and daemons share the same OrganizationID
+				require.Equal(t, defaultOrgID, daemon.OrganizationID, "all jobs and daemons should be associated with the same organization")
+			}
+
+			filteredJobs := make([]ExtJob, 0)
+			for idx, job := range allExtJobs {
+				if _, skip := tc.skipJobIDs[idx]; skip {
+					continue
+				}
+
+				filteredJobs = append(filteredJobs, job)
+			}
+
+			// Then: the jobs should be returned in the correct order (sorted by createdAt in descending order)
+			sort.Slice(filteredJobs, func(i, j int) bool {
+				return filteredJobs[i].CreatedAt.After(filteredJobs[j].CreatedAt)
+			})
+
+			for idx, extJob := range filteredJobs {
+				// Note this calls the single job endpoint.
+				job2, err := templateAdminClient.OrganizationProvisionerJob(ctx, owner.OrganizationID, extJob.ID)
+				require.NoError(t, err)
+				require.Equal(t, extJob.ID, job2.ID)
+
+				// Verify that job metadata is correct.
+				assert.Equal(t, job2.Metadata, codersdk.ProvisionerJobMetadata{
+					TemplateVersionName: version.Name,
+					TemplateID:          template.ID,
+					TemplateName:        template.Name,
+					TemplateDisplayName: template.DisplayName,
+					TemplateIcon:        template.Icon,
+					WorkspaceID:         &extJob.workspace.ID,
+					WorkspaceName:       extJob.workspace.Name,
+				})
+
+				require.Equal(t, tc.queuePositions[idx], int64(job2.QueuePosition))
+				require.Equal(t, tc.queueSizes[idx], int64(job2.QueueSize))
+			}
+		})
+	}
+}
+
+// TestProvisionerJobs_MultipleJobsAndProvisioners tests OrganizationProvisionerJobs multiple job endpoint by
+// calling it once and comparing with expected result.
+func TestProvisionerJobs_MultipleJobsAndProvisioners(t *testing.T) {
+	t.Parallel()
+
+	testCases := defaultQueuePositionTestCases
+
+	// ExtJob contains provisioner-job and related objects
+	type ExtJob struct {
+		database.ProvisionerJob
+		workspace database.WorkspaceTable
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture loop variable to avoid data races
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			now := dbtime.Now()
+			ctx := testutil.Context(t, testutil.WaitShort)
+
+			db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+			client := coderdtest.New(t, &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+				Database:                 db,
+				Pubsub:                   ps,
+			})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdminClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.ScopedRoleOrgTemplateAdmin(owner.OrganizationID))
+			_, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+			version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+			template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+			defaultOrg, err := db.GetDefaultOrganization(ctx)
+			require.NoError(t, err)
+			defaultOrgID := defaultOrg.ID
+
+			// Create provisioner jobs based on provided tags:
+			allExtJobs := make([]ExtJob, len(tc.jobTags))
+			for idx, tags := range tc.jobTags {
+				// Make sure jobs are stored in correct order, first job should have the earliest createdAt timestamp.
+				// Example for 3 jobs:
+				// job_1 createdAt: now - 3 minutes
+				// job_2 createdAt: now - 2 minutes
+				// job_3 createdAt: now - 1 minute
+				timeOffsetInMinutes := len(tc.jobTags) - idx
+				timeOffset := time.Duration(timeOffsetInMinutes) * time.Minute
+				createdAt := now.Add(-timeOffset)
+
+				// Create provisioner job and related objects
+				w := dbgen.Workspace(t, db, database.WorkspaceTable{
+					OrganizationID: owner.OrganizationID,
+					OwnerID:        member.ID,
+					TemplateID:     template.ID,
+				})
+				wbID := uuid.New()
+				job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+					CreatedAt:      createdAt,
+					Tags:           tags,
+					OrganizationID: w.OrganizationID,
+					Type:           database.ProvisionerJobTypeWorkspaceBuild,
+					Input:          json.RawMessage(`{"workspace_build_id":"` + wbID.String() + `"}`),
+				})
+				dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+					ID:                wbID,
+					JobID:             job.ID,
+					WorkspaceID:       w.ID,
+					TemplateVersionID: version.ID,
+				})
+
+				allExtJobs[idx] = ExtJob{
+					ProvisionerJob: job,
+					workspace:      w,
+				}
+
+				// Ensure that all jobs and daemons share the same OrganizationID
+				require.Equal(t, defaultOrgID, allExtJobs[idx].OrganizationID, "all jobs and daemons should be associated with the same organization")
+			}
+
+			// Create provisioner daemons based on provided tags:
+			for idx, tags := range tc.daemonTags {
+				daemon := dbgen.ProvisionerDaemon(t, db, database.ProvisionerDaemon{
+					Name:         fmt.Sprintf("prov_%v", idx),
+					Provisioners: []database.ProvisionerType{database.ProvisionerTypeEcho},
+					Tags:         tags,
+				})
+
+				// Ensure that all jobs and daemons share the same OrganizationID
+				require.Equal(t, defaultOrgID, daemon.OrganizationID, "all jobs and daemons should be associated with the same organization")
+			}
+
+			filteredJobs := make([]ExtJob, 0)
+			filteredJobIDs := make([]uuid.UUID, 0)
+			for idx, job := range allExtJobs {
+				if _, skip := tc.skipJobIDs[idx]; skip {
+					continue
+				}
+
+				filteredJobs = append(filteredJobs, job)
+				filteredJobIDs = append(filteredJobIDs, job.ID)
+			}
+
+			// Then: the jobs should be returned in the correct order (sorted by createdAt in descending order)
+			sort.Slice(filteredJobs, func(i, j int) bool {
+				return filteredJobs[i].CreatedAt.After(filteredJobs[j].CreatedAt)
+			})
+
+			actualJobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
+				IDs: filteredJobIDs,
+			})
+			require.NoError(t, err)
+
+			for idx, extJob := range filteredJobs {
+				// Verify that job metadata is correct.
+				assert.Equal(t, actualJobs[idx].Metadata, codersdk.ProvisionerJobMetadata{
+					TemplateVersionName: version.Name,
+					TemplateID:          template.ID,
+					TemplateName:        template.Name,
+					TemplateDisplayName: template.DisplayName,
+					TemplateIcon:        template.Icon,
+					WorkspaceID:         &extJob.workspace.ID,
+					WorkspaceName:       extJob.workspace.Name,
+				})
+
+				require.Equal(t, tc.queuePositions[idx], int64(actualJobs[idx].QueuePosition))
+				require.Equal(t, tc.queueSizes[idx], int64(actualJobs[idx].QueueSize))
+			}
+		})
+	}
+}
 
 func TestProvisionerJobs(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Context:
- original issue: https://github.com/coder/coder/issues/15843
- PR (part 1): https://github.com/coder/coder/pull/16685

### PR Contents:
- Updating of the `GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner` SQL query to take into account` provisioner job tags` and `provisioner daemon tags`. Make it consistent with previously fixed `GetProvisionerJobsByIDsWithQueuePosition` query.
  - NOTE: `GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner` is kind of an extension on top of `GetProvisionerJobsByIDsWithQueuePosition`
  - Later I'm going to introduce postgres function to avoid copy-pasting of common parts
- Added test case on database level for this query: `TestGetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner`, previously we didn't have one.
- Added additional API level tests:
  - `TestProvisionerJob_MultipleJobsAndProvisioners`
  - `TestProvisionerJobs_MultipleJobsAndProvisioners`
  - They reuse same test case list (as on db-level), but test it on API level which allows to add some additional checks.

### Notes:
- For both queries I'm using: `ORDER BY pj.created_at DESC`
- For both queries if `IDs` are not specified - return everything: `WHERE COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR id = ANY(@ids::uuid[])`

### Implementation
The intention was to extend `GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner` with correct `queue_size` and `queue_pos` calculation, but don't touch rest of the query and try to preserve previous behavior in all other aspects.

### Questions
- We can consider to eliminate duplication of test case list, because the same list is used for both DB-level and API-level tests. But I don't know how to do without introducing import dependency between `db_test` and `api_test` packages.