### PR TITLE
revert: "chore: enable SBOM attestation for image builds"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -361,7 +361,6 @@ jobs:
           file: scripts/Dockerfile.base
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: true
-          sbom: true
           pull: true
           no-cache: true
           push: true

--- a/dogfood/contents/files/etc/docker/daemon.json
+++ b/dogfood/contents/files/etc/docker/daemon.json
@@ -1,6 +1,3 @@
 {
-	"registry-mirrors": ["https://mirror.gcr.io"],
-	"features": {
-		"containerd-snapshotter": true
-	}
+	"registry-mirrors": ["https://mirror.gcr.io"]
 }

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -136,12 +136,10 @@ fi
 
 log "--- Building Docker image for $arch ($image_tag)"
 
-docker buildx build \
+docker build \
 	--platform "$arch" \
 	--build-arg "BASE_IMAGE=$base_image" \
 	--build-arg "CODER_VERSION=$version" \
-	--provenance true \
-	--sbom true \
 	--no-cache \
 	--tag "$image_tag" \
 	-f Dockerfile \


### PR DESCRIPTION
Reverts coder/coder#16852

The CI failed to create the multi-arch manifest.
https://github.com/coder/coder/actions/runs/13773079355/job/38516182819#step:18:341

I personally think we should move to a [multi-arch Dockerfile](https://docs.docker.com/build/building/multi-platform/#cross-compilation) instead of creating the manifest manually. 

