### PR TITLE
fix: pass secure auth cookies to all cookies set

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -856,7 +856,7 @@ func New(options *Options) *API {
 				r.Route(fmt.Sprintf("/%s/callback", externalAuthConfig.ID), func(r chi.Router) {
 					r.Use(
 						apiKeyMiddlewareRedirect,
-						httpmw.ExtractOAuth2(externalAuthConfig, options.HTTPClient, nil),
+						httpmw.ExtractOAuth2(externalAuthConfig, options.HTTPClient, nil, options.SecureAuthCookie),
 					)
 					r.Get("/", api.externalAuthCallback(externalAuthConfig))
 				})
@@ -1111,14 +1111,14 @@ func New(options *Options) *API {
 					r.Get("/github/device", api.userOAuth2GithubDevice)
 					r.Route("/github", func(r chi.Router) {
 						r.Use(
-							httpmw.ExtractOAuth2(options.GithubOAuth2Config, options.HTTPClient, nil),
+							httpmw.ExtractOAuth2(options.GithubOAuth2Config, options.HTTPClient, nil, options.SecureAuthCookie),
 						)
 						r.Get("/callback", api.userOAuth2Github)
 					})
 				})
 				r.Route("/oidc/callback", func(r chi.Router) {
 					r.Use(
-						httpmw.ExtractOAuth2(options.OIDCConfig, options.HTTPClient, oidcAuthURLParams),
+						httpmw.ExtractOAuth2(options.OIDCConfig, options.HTTPClient, oidcAuthURLParams, options.SecureAuthCookie),
 					)
 					r.Get("/", api.userOIDC)
 				})

--- a/coderd/httpmw/oauth2.go
+++ b/coderd/httpmw/oauth2.go
@@ -40,7 +40,7 @@ func OAuth2(r *http.Request) OAuth2State {
 // a "code" URL parameter will be redirected.
 // AuthURLOpts are passed to the AuthCodeURL function. If this is nil,
 // the default option oauth2.AccessTypeOffline will be used.
-func ExtractOAuth2(config promoauth.OAuth2Config, client *http.Client, authURLOpts map[string]string) func(http.Handler) http.Handler {
+func ExtractOAuth2(config promoauth.OAuth2Config, client *http.Client, authURLOpts map[string]string, secureCookie bool) func(http.Handler) http.Handler {
 	opts := make([]oauth2.AuthCodeOption, 0, len(authURLOpts)+1)
 	opts = append(opts, oauth2.AccessTypeOffline)
 	for k, v := range authURLOpts {
@@ -124,6 +124,7 @@ func ExtractOAuth2(config promoauth.OAuth2Config, client *http.Client, authURLOp
 					Path:     "/",
 					HttpOnly: true,
 					SameSite: http.SameSiteLaxMode,
+					Secure:   secureCookie,
 				})
 				// Redirect must always be specified, otherwise
 				// an old redirect could apply!
@@ -133,6 +134,7 @@ func ExtractOAuth2(config promoauth.OAuth2Config, client *http.Client, authURLOp
 					Path:     "/",
 					HttpOnly: true,
 					SameSite: http.SameSiteLaxMode,
+					Secure:   secureCookie,
 				})
 
 				http.Redirect(rw, r, config.AuthCodeURL(state, opts...), http.StatusTemporaryRedirect)

--- a/coderd/workspaceapps/provider.go
+++ b/coderd/workspaceapps/provider.go
@@ -22,6 +22,7 @@ const (
 type ResolveRequestOptions struct {
 	Logger              slog.Logger
 	SignedTokenProvider SignedTokenProvider
+	SecureCookie        bool
 
 	DashboardURL   *url.URL
 	PathAppBaseURL *url.URL
@@ -80,6 +81,7 @@ func ResolveRequest(rw http.ResponseWriter, r *http.Request, opts ResolveRequest
 		Value:   tokenStr,
 		Path:    appReq.BasePath,
 		Expires: token.Expiry.Time(),
+		Secure:  opts.SecureCookie,
 	})
 
 	return token, true

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -301,6 +301,7 @@ func (s *Server) workspaceAppsProxyPath(rw http.ResponseWriter, r *http.Request)
 	token, ok := ResolveRequest(rw, r, ResolveRequestOptions{
 		Logger:              s.Logger,
 		SignedTokenProvider: s.SignedTokenProvider,
+		SecureCookie:        s.SecureAuthCookie,
 		DashboardURL:        s.DashboardURL,
 		PathAppBaseURL:      s.AccessURL,
 		AppHostname:         s.Hostname,
@@ -406,6 +407,7 @@ func (s *Server) HandleSubdomain(middlewares ...func(http.Handler) http.Handler)
 				token, ok := ResolveRequest(rw, r, ResolveRequestOptions{
 					Logger:              s.Logger,
 					SignedTokenProvider: s.SignedTokenProvider,
+					SecureCookie:        s.SecureAuthCookie,
 					DashboardURL:        s.DashboardURL,
 					PathAppBaseURL:      s.AccessURL,
 					AppHostname:         s.Hostname,
@@ -631,6 +633,7 @@ func (s *Server) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 	appToken, ok := ResolveRequest(rw, r, ResolveRequestOptions{
 		Logger:              s.Logger,
 		SignedTokenProvider: s.SignedTokenProvider,
+		SecureCookie:        s.SecureAuthCookie,
 		DashboardURL:        s.DashboardURL,
 		PathAppBaseURL:      s.AccessURL,
 		AppHostname:         s.Hostname,


### PR DESCRIPTION
Some cookies slipped through the cracks

I want to implement something more standard for setting cookies to catch this.