### PR TITLE
chore: add x-authz-checks debug header when running in dev mode

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -315,6 +315,9 @@ func New(options *Options) *API {
 	if options.Authorizer == nil {
 		options.Authorizer = rbac.NewCachingAuthorizer(options.PrometheusRegistry)
 	}
+	if buildinfo.IsDev() {
+		options.Authorizer = rbac.Recorder(options.Authorizer)
+	}
 
 	if options.AccessControlStore == nil {
 		options.AccessControlStore = &atomic.Pointer[dbauthz.AccessControlStore]{}
@@ -456,8 +459,14 @@ func New(options *Options) *API {
 		options.NotificationsEnqueuer = notifications.NewNoopEnqueuer()
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
 	r := chi.NewRouter()
+	// We add this middleware early, to make sure that authorization checks made
+	// by other middleware get recorded.
+	if buildinfo.IsDev() {
+		r.Use(httpmw.RecordAuthzChecks)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	// nolint:gocritic // Load deployment ID. This never changes
 	depID, err := options.Database.GetDeploymentID(dbauthz.AsSystemRestricted(ctx))

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -314,9 +314,9 @@ func New(options *Options) *API {
 
 	if options.Authorizer == nil {
 		options.Authorizer = rbac.NewCachingAuthorizer(options.PrometheusRegistry)
-	}
-	if buildinfo.IsDev() {
-		options.Authorizer = rbac.Recorder(options.Authorizer)
+		if buildinfo.IsDev() {
+			options.Authorizer = rbac.Recorder(options.Authorizer)
+		}
 	}
 
 	if options.AccessControlStore == nil {

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -210,8 +210,6 @@ func Write(ctx context.Context, rw http.ResponseWriter, status int, response int
 		//   configured on server startup for development and testing builds.
 		// - If this header is missing from a response, make sure the response is
 		//   being written by calling `httpapi.Write`!
-		// - An empty x-authz-checks header can be valid! Some requests don't
-		//   require authorization.
 		rw.Header().Set("x-authz-checks", rec.String())
 	}
 
@@ -231,7 +229,7 @@ func WriteIndent(ctx context.Context, rw http.ResponseWriter, status int, respon
 	defer span.End()
 
 	if rec, ok := rbac.GetAuthzCheckRecorder(ctx); ok {
-		rw.Header().Set("x-dbauthz-checks", rec.String())
+		rw.Header().Set("x-authz-checks", rec.String())
 	}
 
 	rw.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/websocket/wsjson"
 
 	"github.com/coder/coder/v2/coderd/httpapi/httpapiconstraints"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -198,6 +199,22 @@ func Write(ctx context.Context, rw http.ResponseWriter, status int, response int
 	_, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	if rec, ok := rbac.GetAuthzCheckRecorder(ctx); ok {
+		// If you're here because you saw this header in a response, and you're
+		// trying to investigate the code, here are a couple of notable things
+		// for you to know:
+		// - If any of the checks are `false`, they might not represent the whole
+		//   picture. There could be additional checks that weren't performed,
+		//   because processing stopped after the failure.
+		// - The checks are recorded by the `authzRecorder` type, which is
+		//   configured on server startup for development and testing builds.
+		// - If this header is missing from a response, make sure the response is
+		//   being written by calling `httpapi.Write`!
+		// - An empty x-authz-checks header can be valid! Some requests don't
+		//   require authorization.
+		rw.Header().Set("x-authz-checks", rec.String())
+	}
+
 	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 	rw.WriteHeader(status)
 
@@ -212,6 +229,10 @@ func Write(ctx context.Context, rw http.ResponseWriter, status int, response int
 func WriteIndent(ctx context.Context, rw http.ResponseWriter, status int, response interface{}) {
 	_, span := tracing.StartSpan(ctx)
 	defer span.End()
+
+	if rec, ok := rbac.GetAuthzCheckRecorder(ctx); ok {
+		rw.Header().Set("x-dbauthz-checks", rec.String())
+	}
 
 	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 	rw.WriteHeader(status)

--- a/coderd/httpmw/authz.go
+++ b/coderd/httpmw/authz.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/rbac"
 )
 
 // AsAuthzSystem is a chained handler that temporarily sets the dbauthz context
@@ -34,4 +35,16 @@ func AsAuthzSystem(mws ...func(http.Handler) http.Handler) func(http.Handler) ht
 			})).ServeHTTP(rw, r)
 		})
 	}
+}
+
+// RecordAuthzChecks enables recording all of the authorization checks that
+// occurred in the processing of a request. This is mostly helpful for debugging
+// and understanding what permissions are required for a given action.
+//
+// Requires using a Recorder Authorizer.
+func RecordAuthzChecks(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(rbac.WithAuthzCheckRecorder(r.Context()))
+		next.ServeHTTP(rw, r)
+	})
 }

--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +24,9 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac/regosql"
 	"github.com/coder/coder/v2/coderd/rbac/regosql/sqltypes"
 	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/util/slice"
+	"github.com/coder/coder/v2/coderd/util/syncmap"
 )
 
 type AuthCall struct {
@@ -362,11 +365,11 @@ func (a RegoAuthorizer) Authorize(ctx context.Context, subject Subject, action p
 	defer span.End()
 
 	err := a.authorize(ctx, subject, action, object)
-
-	span.SetAttributes(attribute.Bool("authorized", err == nil))
+	authorized := err == nil
+	span.SetAttributes(attribute.Bool("authorized", authorized))
 
 	dur := time.Since(start)
-	if err != nil {
+	if !authorized {
 		a.authorizeHist.WithLabelValues("false").Observe(dur.Seconds())
 		return err
 	}
@@ -740,4 +743,99 @@ func rbacTraceAttributes(actor Subject, action policy.Action, objectType string,
 			attribute.String("action", string(action)),
 			attribute.String("object_type", objectType),
 		)...)
+}
+
+type authRecorder struct {
+	authz Authorizer
+}
+
+// Recorder returns an Authorizer that records any authorization checks made
+// on the Context provided for the authorization check.
+//
+// Requires using the RecordAuthzChecks middleware.
+func Recorder(authz Authorizer) Authorizer {
+	return &authRecorder{authz: authz}
+}
+
+func (c *authRecorder) Authorize(ctx context.Context, subject Subject, action policy.Action, object Object) error {
+	err := c.authz.Authorize(ctx, subject, action, object)
+	authorized := err == nil
+	recordAuthzCheck(ctx, action, object, authorized)
+	return err
+}
+
+func (c *authRecorder) Prepare(ctx context.Context, subject Subject, action policy.Action, objectType string) (PreparedAuthorized, error) {
+	return c.authz.Prepare(ctx, subject, action, objectType)
+}
+
+type authzCheckRecorderKey struct{}
+
+func WithAuthzCheckRecorder(ctx context.Context) context.Context {
+	return context.WithValue(ctx, authzCheckRecorderKey{}, ptr.Ref(AuthzCheckRecorder{
+		checks: syncmap.Map[string, bool]{},
+	}))
+}
+
+type AuthzCheckRecorder struct {
+	// Checks is a map from preformatted authz check IDs to their authorization
+	// status (true => authorized, false => not authorized)
+	checks syncmap.Map[string, bool]
+}
+
+func recordAuthzCheck(ctx context.Context, action policy.Action, object Object, authorized bool) {
+	r, ok := ctx.Value(authzCheckRecorderKey{}).(*AuthzCheckRecorder)
+	if !ok {
+		return
+	}
+
+	// We serialize the check using the following syntax
+	var b strings.Builder
+	if object.OrgID != "" {
+		_, err := fmt.Fprintf(&b, "organization:%v::", object.OrgID)
+		if err != nil {
+			return
+		}
+	}
+	if object.AnyOrgOwner {
+		_, err := fmt.Fprint(&b, "organization:any::")
+		if err != nil {
+			return
+		}
+	}
+	if object.Owner != "" {
+		_, err := fmt.Fprintf(&b, "owner:%v::", object.Owner)
+		if err != nil {
+			return
+		}
+	}
+	if object.ID != "" {
+		_, err := fmt.Fprintf(&b, "id:%v::", object.ID)
+		if err != nil {
+			return
+		}
+	}
+	_, err := fmt.Fprintf(&b, "%v.%v", object.RBACObject().Type, action)
+	if err != nil {
+		return
+	}
+
+	r.checks.Store(b.String(), authorized)
+}
+
+func GetAuthzCheckRecorder(ctx context.Context) (*AuthzCheckRecorder, bool) {
+	checks, ok := ctx.Value(authzCheckRecorderKey{}).(*AuthzCheckRecorder)
+	if !ok {
+		return nil, false
+	}
+
+	return checks, true
+}
+
+// String serializes all of the checks recorded, using the following syntax:
+func (r *AuthzCheckRecorder) String() string {
+	checks := make([]string, 0)
+	for check, result := range r.checks.Seq() {
+		checks = append(checks, fmt.Sprintf("%v=%v", check, result))
+	}
+	return strings.Join(checks, "; ")
 }

--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -846,8 +846,8 @@ func (r *AuthzCheckRecorder) String() string {
 	}
 
 	checks := make([]string, 0, len(r.checks))
-	for check, result := range r.checks {
-		checks = append(checks, fmt.Sprintf("%v=%v", check, result))
+	for _, check := range r.checks {
+		checks = append(checks, fmt.Sprintf("%v=%v", check.name, check.result))
 	}
 	return strings.Join(checks, "; ")
 }

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/render"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
@@ -273,8 +272,7 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 		organizationIDsByUserID[organizationIDsByMemberIDsRow.UserID] = organizationIDsByMemberIDsRow.OrganizationIDs
 	}
 
-	render.Status(r, http.StatusOK)
-	render.JSON(rw, r, codersdk.GetUsersResponse{
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.GetUsersResponse{
 		Users: convertUsers(users, organizationIDsByUserID),
 		Count: int(userCount),
 	})

--- a/coderd/util/syncmap/map.go
+++ b/coderd/util/syncmap/map.go
@@ -1,7 +1,6 @@
 package syncmap
 
 import (
-	"iter"
 	"sync"
 )
 
@@ -77,10 +76,4 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 	m.m.Range(func(key, value interface{}) bool {
 		return f(key.(K), value.(V))
 	})
-}
-
-func (m *Map[K, V]) Seq() iter.Seq2[K, V] {
-	return func(yield func(K, V) bool) {
-		m.Range(yield)
-	}
 }

--- a/coderd/util/syncmap/map.go
+++ b/coderd/util/syncmap/map.go
@@ -1,6 +1,9 @@
 package syncmap
 
-import "sync"
+import (
+	"iter"
+	"sync"
+)
 
 // Map is a type safe sync.Map
 type Map[K, V any] struct {
@@ -74,4 +77,10 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 	m.m.Range(func(key, value interface{}) bool {
 		return f(key.(K), value.(V))
 	})
+}
+
+func (m *Map[K, V]) Seq() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		m.Range(yield)
+	}
 }

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -71,6 +71,9 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 	}
 	if options.Options.Authorizer == nil {
 		options.Options.Authorizer = rbac.NewCachingAuthorizer(options.PrometheusRegistry)
+		if buildinfo.IsDev() {
+			options.Authorizer = rbac.Recorder(options.Authorizer)
+		}
 	}
 	if options.ReplicaErrorGracePeriod == 0 {
 		// This will prevent the error from being shown for a minute

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,6 @@ require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/httprate v0.15.0
-	github.com/go-chi/render v1.0.1
 	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-logr/logr v1.4.2
 	github.com/go-playground/validator/v10 v10.26.0

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,6 @@ github.com/go-chi/hostrouter v0.2.0 h1:GwC7TZz8+SlJN/tV/aeJgx4F+mI5+sp+5H1PelQUj
 github.com/go-chi/hostrouter v0.2.0/go.mod h1:pJ49vWVmtsKRKZivQx0YMYv4h0aX+Gcn6V23Np9Wf1s=
 github.com/go-chi/httprate v0.15.0 h1:j54xcWV9KGmPf/X4H32/aTH+wBlrvxL7P+SdnRqxh5g=
 github.com/go-chi/httprate v0.15.0/go.mod h1:rzGHhVrsBn3IMLYDOZQsSU4fJNWcjui4fWKJcCId1R4=
-github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
-github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=


### PR DESCRIPTION
In development builds...

- Adds a middleware that configures every request context with a set of authorization checks which have been made
- Adds a recording authorizer that stores every authorization check in that request context set
- Updates `httpapi.Write` to put this information in a response header

The header will look something like:

```
x-authz-checks: debug_info.read=true; template.update=true; deployment_config.read=true; idpsync_settings.read=true; notification_template.read=true; system.read=true; workspace_proxy.read=true; organization:any::organization.update=true; organization:any::group.update=true; organization:any::idpsync_settings.read=true; organization:any::assign_org_role.assign=true; group.read=true; user.update=true; deployment_stats.read=true; user.read=true; license.read=true; owner:0b974b9c-b357-4994-aa5e-532d9609625e::id:vQinIfz28C::api_key.read=true; group.create=true; organization.create=true; deployment_config.update=true; workspace_proxy.create=true; template.delete=true; user.create=true; organization:any::audit_log.read=true; organization:any::template.create=true; organization:any::organization_member.read=true
```

The syntax may look a bit weird, but I think it's important to have distinct separators for everything.

- "attribute names" and "attribute values" are separated by `:`
- "attributes" are separated by `::`
- "object type" and "action type" are separated by "."
- "authorization check" and "authorization result" are separated by `=`
- "authorizations" are separated by `; `

This can totally be changed in the future if people think it's too confusing, but I think it's pretty good.