### PR TITLE
feat(agent): set additional login vars, LOGNAME and SHELL

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1225,6 +1225,7 @@ func TestAgent_SSHConnectionLoginVars(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.key, func(t *testing.T) {
 			t.Parallel()
 

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -900,7 +900,7 @@ func (s *Server) CreateCommand(ctx context.Context, script string, env []string,
 		cmd.Dir = homedir
 	}
 	cmd.Env = append(ei.Environ(), env...)
-	// Set login variables.
+	// Set login variables (see `man login`).
 	cmd.Env = append(cmd.Env, fmt.Sprintf("USER=%s", username))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("LOGNAME=%s", username))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("SHELL=%s", shell))

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -900,7 +900,10 @@ func (s *Server) CreateCommand(ctx context.Context, script string, env []string,
 		cmd.Dir = homedir
 	}
 	cmd.Env = append(ei.Environ(), env...)
+	// Set login variables.
 	cmd.Env = append(cmd.Env, fmt.Sprintf("USER=%s", username))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("LOGNAME=%s", username))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("SHELL=%s", shell))
 
 	// Set SSH connection environment variables (these are also set by OpenSSH
 	// and thus expected to be present by SSH clients). Since the agent does


### PR DESCRIPTION
This change stes additional env vars. This is useful for programs that
assume their presence (for instance, Zed remote relies on SHELL).

See `man login`.
