### PR TITLE
docs: document steps for adding cert to JetBrains plugin settings

### DIFF
--- a/docs/user-guides/workspace-access/jetbrains.md
+++ b/docs/user-guides/workspace-access/jetbrains.md
@@ -94,44 +94,57 @@ Failed to configure connection to https://coder.internal.enterprise/: PKIX path 
 ```
 
 To resolve this issue, you will need to add Coder's certificate to the Java
-trust store present on your local machine. Here is the default location of the
-trust store for each OS:
+trust store present on your local machine as well as to the Coder plugin settings.
 
-```console
-# Linux
-<Gateway installation directory>/jbr/lib/security/cacerts
+1. Add the certificate to the Java trust store:
 
-# macOS
-<Gateway installation directory>/jbr/lib/security/cacerts
-/Library/Application Support/JetBrains/Toolbox/apps/JetBrainsGateway/ch-0/<app-id>/JetBrains Gateway.app/Contents/jbr/Contents/Home/lib/security/cacerts # Path for Toolbox installation
+   <div class="tabs">
 
-# Windows
-C:\Program Files (x86)\<Gateway installation directory>\jre\lib\security\cacerts
-%USERPROFILE%\AppData\Local\JetBrains\Toolbox\bin\jre\lib\security\cacerts # Path for Toolbox installation
-```
+   #### Linux
 
-To add the certificate to the keystore, you can use the `keytool` utility that
-ships with Java:
+   ```none
+   <Gateway installation directory>/jbr/lib/security/cacerts
+   ```
 
-```console
-keytool -import -alias coder -file <certificate> -keystore /path/to/trust/store
-```
+   Use the `keytool` utility that ships with Java:
 
-You can use `keytool` that ships with the JetBrains Gateway installation.
-Windows example:
+   ```shell
+   keytool -import -alias coder -file <certificate> -keystore /path/to/trust/store
+   ```
 
-```powershell
-& 'C:\Program Files\JetBrains\JetBrains Gateway <version>/jbr/bin/keytool.exe' 'C:\Program Files\JetBrains\JetBrains Gateway <version>/jre/lib/security/cacerts' -import -alias coder -file <cert>
+   #### macOS
 
-# command for Toolbox installation
-& '%USERPROFILE%\AppData\Local\JetBrains\Toolbox\apps\Gateway\ch-0\<VERSION>\jbr\bin\keytool.exe' '%USERPROFILE%\AppData\Local\JetBrains\Toolbox\bin\jre\lib\security\cacerts' -import -alias coder -file <cert>
-```
+   ```none
+   <Gateway installation directory>/jbr/lib/security/cacerts
+   /Library/Application Support/JetBrains/Toolbox/apps/JetBrainsGateway/ch-0/<app-id>/JetBrains Gateway.app/Contents/jbr/Contents/Home/lib/security/cacerts # Path for Toolbox installation
+   ```
 
-macOS example:
+   Use the `keytool` included in the JetBrains Gateway installation:
 
-```shell
-keytool -import -alias coder -file cacert.pem -keystore /Applications/JetBrains\ Gateway.app/Contents/jbr/Contents/Home/lib/security/cacerts
-```
+   ```shell
+   keytool -import -alias coder -file cacert.pem -keystore /Applications/JetBrains\ Gateway.app/Contents/jbr/Contents/Home/lib/security/cacerts
+   ```
+
+   #### Windows
+
+   ```none
+   C:\Program Files (x86)\<Gateway installation directory>\jre\lib\security\cacerts\%USERPROFILE%\AppData\Local\JetBrains\Toolbox\bin\jre\lib\security\cacerts # Path for Toolbox installation
+   ```
+
+   Use the `keytool` included in the JetBrains Gateway installation:
+
+   ```powershell
+   & 'C:\Program Files\JetBrains\JetBrains Gateway <version>/jbr/bin/keytool.exe' 'C:\Program Files\JetBrains\JetBrains Gateway <version>/jre/lib/security/cacerts' -import -alias coder -file <cert>
+
+   # command for Toolbox installation
+   & '%USERPROFILE%\AppData\Local\JetBrains\Toolbox\apps\Gateway\ch-0\<VERSION>\jbr\bin\keytool.exe' '%USERPROFILE%\AppData\Local\JetBrains\Toolbox\bin\jre\lib\security\cacerts' -import -alias coder -file <cert>
+   ```
+
+   </div>
+
+1. In JetBrains, go to **Settings** > **Tools** > **Coder**.
+
+1. Paste the path to the certificate in **CA Path**.
 
 ## Manually Configuring A JetBrains Gateway Connection
 
@@ -185,7 +198,7 @@ This is in lieu of using Coder's Gateway plugin which automatically performs the
 
    ![Gateway Choose IDE](../../images/gateway/gateway-choose-ide.png)
 
-   The JetBrains IDE is remotely installed into `~/. cache/JetBrains/RemoteDev/dist`
+   The JetBrains IDE is remotely installed into `~/.cache/JetBrains/RemoteDev/dist`
 
 1. Click **Download and Start IDE** to connect.
 


### PR DESCRIPTION
- document the steps from @stirby in ticket
- separate the different OSs in a way that's easier to look at
- fix typo

[preview](https://coder.com/docs/@593-ca-cert-plugin/user-guides/workspace-access/jetbrains#configuring-the-gateway-plugin-to-use-internal-certificates)