### PR TITLE
docs: add warning for multiple Coder Desktop mac installations

### DIFF
--- a/docs/user-guides/desktop/index.md
+++ b/docs/user-guides/desktop/index.md
@@ -34,6 +34,9 @@ You can install Coder Desktop on macOS or Windows.
 
 1. Continue to the [configuration section](#configure).
 
+> [!WARNING]
+> To avoid system VPN configuration conflicts, only one copy of `Coder Desktop.app` should exist on your Mac, and it must remain in `/Applications`.
+
 ### Windows
 
 1. Download the latest `CoderDesktop` installer executable (`.exe`) from the [coder-desktop-windows release page](https://github.com/coder/coder-desktop-windows/releases).

--- a/docs/user-guides/desktop/index.md
+++ b/docs/user-guides/desktop/index.md
@@ -34,7 +34,9 @@ You can install Coder Desktop on macOS or Windows.
 
 1. Continue to the [configuration section](#configure).
 
-> [!WARNING]
+> [!IMPORTANT]
+> Do not install more than one copy of Coder Desktop.
+>
 > To avoid system VPN configuration conflicts, only one copy of `Coder Desktop.app` should exist on your Mac, and it must remain in `/Applications`.
 
 ### Windows


### PR DESCRIPTION
I realised we should advise against installing multiple copies, as I'm sure someone will try and get confused by Apple's obtuse error messaging.

Tailscale also has a similar warning: https://pkgs.tailscale.com/stable/#macos