### PR TITLE
refactor: name null users in audit logs

### DIFF
--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/AuditLogDescription.stories.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/AuditLogDescription.stories.tsx
@@ -105,3 +105,12 @@ export const SCIMUpdateUser: Story = {
 		},
 	},
 };
+
+export const UnauthenticatedUser: Story = {
+	args: {
+		auditLog: {
+			...MockAuditLog,
+			user: null,
+		},
+	},
+};

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/AuditLogDescription.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/AuditLogDescription.tsx
@@ -19,7 +19,9 @@ export const AuditLogDescription: FC<AuditLogDescriptionProps> = ({
 	}
 
 	let target = auditLog.resource_target.trim();
-	let user = auditLog.user?.username.trim();
+	let user = auditLog.user
+		? auditLog.user.username.trim()
+		: "Unauthenticated user";
 
 	// SSH key entries have no links
 	if (auditLog.resource_type === "git_ssh_key") {

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/BuildAuditDescription.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/BuildAuditDescription.tsx
@@ -16,7 +16,9 @@ export const BuildAuditDescription: FC<BuildAuditDescriptionProps> = ({
 		auditLog.additional_fields?.build_reason &&
 		auditLog.additional_fields?.build_reason !== "initiator"
 			? "Coder automatically"
-			: auditLog.user?.username.trim();
+			: auditLog.user
+				? auditLog.user.username.trim()
+				: "Unauthenticated user";
 
 	const action = useMemo(() => {
 		switch (auditLog.action) {


### PR DESCRIPTION
A few audit logs can have the user as null which means the user is not authenticated when executing the action. To make it more explicit we named than as "Unauthenticated user" in the log description instead of "undefined user".