### PR TITLE
chore: update docker starter template `jetbrains_ides` option to match module default

### DIFF
--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -139,7 +139,7 @@ module "jetbrains_gateway" {
   source = "registry.coder.com/modules/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
-  jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
+  jetbrains_ides = ["IU", "PS", "WS", "PY", "CL", "GO", "RM", "RD", "RR"]
   default        = "IU"
 
   # Default folder to open when starting a JetBrains IDE


### PR DESCRIPTION
Taken from https://github.com/coder/modules/blob/fd5dd375f7f8740226e798fc60a4a5d271b294d4/jetbrains-gateway/main.tf#L134

The order got shuffled a little, but the main difference is that the new list includes RustRover, which is nice. :)