### PR TITLE
docs: remove broken gfm alert

### DIFF
--- a/docs/user-guides/desktop/index.md
+++ b/docs/user-guides/desktop/index.md
@@ -34,7 +34,6 @@ You can install Coder Desktop on macOS or Windows.
 
 1. Continue to the [configuration section](#configure).
 
-> [!IMPORTANT]
 > Do not install more than one copy of Coder Desktop.
 >
 > To avoid system VPN configuration conflicts, only one copy of `Coder Desktop.app` should exist on your Mac, and it must remain in `/Applications`.


### PR DESCRIPTION
It looks like GFM does not respect the `![]` alert syntax when it's enclosed within a div. This is true for both the coder.com GFM renderer, and GitHub's (though I assume they're the same internally).

When the section is surrounded by a `<div class="tabs">`:
![image](https://github.com/user-attachments/assets/0f7d4029-a0a5-4d38-a489-f3b893c68dd8)

When it's not:
![image](https://github.com/user-attachments/assets/765d3629-0108-43cc-8047-972dfd806c7d)

Presumably same deal on Coder.com:
![image](https://github.com/user-attachments/assets/6c2c3ed6-f9e5-41b0-bfb4-a84809ecf611)



In our case, we really want the tabs, and the alert block is less important, so we'll downgrade it to a regular quote.

cc @aqandrew for visibility, in case you're aware of a workaround. Merging this for now to remove the broken line.