### PR TITLE
fix: apply autofocus to workspace button search

### DIFF
--- a/site/src/components/SearchField/SearchField.stories.tsx
+++ b/site/src/components/SearchField/SearchField.stories.tsx
@@ -20,6 +20,12 @@ type Story = StoryObj<typeof SearchField>;
 
 export const Empty: Story = {};
 
+export const Focused: Story = {
+	args: {
+		autoFocused: true,
+	},
+};
+
 export const DefaultValue: Story = {
 	args: {
 		value: "owner:me",

--- a/site/src/components/SearchField/SearchField.stories.tsx
+++ b/site/src/components/SearchField/SearchField.stories.tsx
@@ -22,7 +22,7 @@ export const Empty: Story = {};
 
 export const Focused: Story = {
 	args: {
-		autoFocused: true,
+		autoFocus: true,
 	},
 };
 

--- a/site/src/components/SearchField/SearchField.tsx
+++ b/site/src/components/SearchField/SearchField.tsx
@@ -10,20 +10,20 @@ import { type FC, useEffect, useRef } from "react";
 
 export type SearchFieldProps = Omit<TextFieldProps, "onChange"> & {
 	onChange: (query: string) => void;
-	autoFocused?: boolean;
+	autoFocus?: boolean;
 };
 
 export const SearchField: FC<SearchFieldProps> = ({
 	value = "",
 	onChange,
-	autoFocused = false,
+	autoFocus = false,
 	InputProps,
 	...textFieldProps
 }) => {
 	const theme = useTheme();
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	if (autoFocused) {
+	if (autoFocus) {
 		useEffect(() => {
 			inputRef.current?.focus();
 		});

--- a/site/src/components/SearchField/SearchField.tsx
+++ b/site/src/components/SearchField/SearchField.tsx
@@ -6,19 +6,28 @@ import InputAdornment from "@mui/material/InputAdornment";
 import TextField, { type TextFieldProps } from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import visuallyHidden from "@mui/utils/visuallyHidden";
-import type { FC } from "react";
+import { type FC, useEffect, useRef } from "react";
 
 export type SearchFieldProps = Omit<TextFieldProps, "onChange"> & {
 	onChange: (query: string) => void;
+	autoFocused?: boolean;
 };
 
 export const SearchField: FC<SearchFieldProps> = ({
 	value = "",
 	onChange,
+	autoFocused = false,
 	InputProps,
 	...textFieldProps
 }) => {
 	const theme = useTheme();
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	if (autoFocused) {
+		useEffect(() => {
+			inputRef.current?.focus();
+		});
+	}
 	return (
 		<TextField
 			// Specifying `minWidth` so that the text box can't shrink so much
@@ -27,6 +36,7 @@ export const SearchField: FC<SearchFieldProps> = ({
 			size="small"
 			value={value}
 			onChange={(e) => onChange(e.target.value)}
+			inputRef={inputRef}
 			InputProps={{
 				startAdornment: (
 					<InputAdornment position="start">

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -69,6 +69,7 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 			>
 				<MenuSearch
 					value={searchTerm}
+					autoFocused={true}
 					onChange={setSearchTerm}
 					placeholder="Type/select a workspace template"
 					aria-label="Template select for workspace"

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -69,7 +69,7 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 			>
 				<MenuSearch
 					value={searchTerm}
-					autoFocused={true}
+					autoFocus={true}
 					onChange={setSearchTerm}
 					placeholder="Type/select a workspace template"
 					aria-label="Template select for workspace"


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14816

When user clicks on the "New workspace" button, the focus will automatically switch to the text field.

<img width="353" alt="Screenshot 2025-03-13 at 13 40 46" src="https://github.com/user-attachments/assets/fb9e5465-facf-4fcf-bafc-9e96d8ec72d6" />