### PR TITLE
fix: remove periods from two list items in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ We are always working on new integrations. Please feel free to open an issue and
 - [**Dev Container Builder**](https://github.com/coder/envbuilder): Build development environments using `devcontainer.json` on Docker, Kubernetes, and OpenShift
 - [**Module Registry**](https://registry.coder.com): Extend development environments with common use-cases
 - [**Kubernetes Log Stream**](https://github.com/coder/coder-logstream-kube): Stream Kubernetes Pod events to the Coder startup logs
-- [**Self-Hosted VS Code Extension Marketplace**](https://github.com/coder/code-marketplace): A private extension marketplace that works in restricted or airgapped networks integrating with [code-server](https://github.com/coder/code-server).
-- [**Setup Coder**](https://github.com/marketplace/actions/setup-coder): An action to setup coder CLI in GitHub workflows.
+- [**Self-Hosted VS Code Extension Marketplace**](https://github.com/coder/code-marketplace): A private extension marketplace that works in restricted or airgapped networks integrating with [code-server](https://github.com/coder/code-server)
+- [**Setup Coder**](https://github.com/marketplace/actions/setup-coder): An action to setup coder CLI in GitHub workflows
 
 ### Community
 


### PR DESCRIPTION
## Summary
- Remove trailing periods from two list items in the Official integrations section
- Makes the formatting consistent with other items in the list

Fixes #15464

🤖 Generated with [Claude Code](https://claude.ai/code)