### PR TITLE
chore: replace colons in SBOM filename for Docker image attestation

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -154,14 +154,14 @@ if [[ "$push" == 1 ]]; then
 fi
 
 log "--- Generating SBOM for Docker image ($image_tag)"
-syft "$image_tag" -o spdx-json >"${image_tag}.spdx.json"
+syft "$image_tag" -o spdx-json >"${image_tag//:/_}.spdx.json"
 
 if [[ "$push" == 1 ]]; then
 	log "--- Attesting SBOM to Docker image for $arch ($image_tag)"
 	COSIGN_EXPERIMENTAL=1 cosign clean "$image_tag"
 
 	COSIGN_EXPERIMENTAL=1 cosign attest --type spdxjson \
-		--predicate "${image_tag}.spdx.json" \
+		--predicate "${image_tag//:/_}.spdx.json" \
 		--yes \
 		"$image_tag"
 fi


### PR DESCRIPTION
This PR fixes an issue in the Docker build script where the SBOM file path used the image tag directly, which could contain colons. Since colons are not valid characters in filenames on many filesystems, this replaces colons with underscores in the output filename.

Change-Id: I887f4fc255d9bfa19b6c5d23ad0a5db7352aa2af
Signed-off-by: Thomas Kosiewski <tk@coder.com>