### PR TITLE
fix: replace both colons and slashes in SBOM filename for Docker image

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -154,14 +154,14 @@ if [[ "$push" == 1 ]]; then
 fi
 
 log "--- Generating SBOM for Docker image ($image_tag)"
-syft "$image_tag" -o spdx-json >"${image_tag//:/_}.spdx.json"
+syft "$image_tag" -o spdx-json >"${image_tag//[:\/]/_}.spdx.json"
 
 if [[ "$push" == 1 ]]; then
 	log "--- Attesting SBOM to Docker image for $arch ($image_tag)"
 	COSIGN_EXPERIMENTAL=1 cosign clean "$image_tag"
 
 	COSIGN_EXPERIMENTAL=1 cosign attest --type spdxjson \
-		--predicate "${image_tag//:/_}.spdx.json" \
+		--predicate "${image_tag//[:\/]/_}.spdx.json" \
 		--yes \
 		"$image_tag"
 fi


### PR DESCRIPTION
This PR fixes the SBOM filename generation in the Docker build script to properly handle image tags that contain slashes. The current implementation only replaces colons with underscores, but fails when image tags include slashes (common in registry paths). 

The fix updates the string replacement to handle both colons and slashes in the image tag when generating the SBOM filename.

Change-Id: Ifd7bad6d165393e11202e5bf070a4cb26eaa6a6a
Signed-off-by: Thomas Kosiewski <tk@coder.com>