### PR TITLE
docs: use consistent examples in prometheus doc and add namespaceSelector spec

### DIFF
--- a/docs/admin/integrations/prometheus.md
+++ b/docs/admin/integrations/prometheus.md
@@ -84,9 +84,12 @@ metadata:
   namespace: coder
 spec:
   endpoints:
-    - port: prometheus-http
+    - port: prom-http
       interval: 10s
       scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+    - coder
   selector:
     matchLabels:
       app.kubernetes.io/name: coder


### PR DESCRIPTION
closes: #15385 

- use consistent `prom-http` port (@johnstcn looks like this was changed/added in #12214 - do we prefer `prom-http` over `prometheus-http` or is it more important that they align?)
- add   `namespaceSelector:` per @francisco-mata (thanks! - sorry it took so long to get this in)

   from issue:

   >  For some reason our target was not appearing on our prometheus targets, we had to add a namespaceSelector key on the Service Monitor to successfully appear