### PR TITLE
fix(agent): filter out `GOTRACEBACK=none`

### DIFF
--- a/agent/agentexec/cli_linux.go
+++ b/agent/agentexec/cli_linux.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
+
+	"github.com/coder/coder/v2/agent/usershell"
 )
 
 // CLI runs the agent-exec command. It should only be called by the cli package.
@@ -114,7 +116,8 @@ func CLI() error {
 
 	// Remove environment variables specific to the agentexec command. This is
 	// especially important for environments that are attempting to develop Coder in Coder.
-	env := os.Environ()
+	ei := usershell.SystemEnvInfo{}
+	env := ei.Environ()
 	env = slices.DeleteFunc(env, func(e string) bool {
 		return strings.HasPrefix(e, EnvProcPrioMgmt) ||
 			strings.HasPrefix(e, EnvProcOOMScore) ||

--- a/agent/usershell/usershell.go
+++ b/agent/usershell/usershell.go
@@ -50,7 +50,17 @@ func (SystemEnvInfo) User() (*user.User, error) {
 }
 
 func (SystemEnvInfo) Environ() []string {
-	return os.Environ()
+	var env []string
+	for _, e := range os.Environ() {
+		// Ignore GOTRACEBACK=none, as it disables stack traces, it can
+		// be set on the agent due to changes in capabilities.
+		// https://pkg.go.dev/runtime#hdr-Security.
+		if e == "GOTRACEBACK=none" {
+			continue
+		}
+		env = append(env, e)
+	}
+	return env
 }
 
 func (SystemEnvInfo) HomeDir() (string, error) {

--- a/agent/usershell/usershell_test.go
+++ b/agent/usershell/usershell_test.go
@@ -43,4 +43,13 @@ func TestGet(t *testing.T) {
 			require.NotEmpty(t, shell)
 		})
 	})
+
+	t.Run("Remove GOTRACEBACK=none", func(t *testing.T) {
+		t.Setenv("GOTRACEBACK", "none")
+		ei := usershell.SystemEnvInfo{}
+		env := ei.Environ()
+		for _, e := range env {
+			require.NotEqual(t, "GOTRACEBACK=none", e)
+		}
+	})
 }


### PR DESCRIPTION
With the switch to Go 1.24.1, our dogfood workspaces started setting
`GOTRACEBACK=none` in the environment, resulting in missing stacktraces
for users.

This is due to the capability changes we do when
`USE_CAP_NET_ADMIN=true`.

https://github.com/coder/coder/blob/564b387262e5b768c503e5317242d9ab576395d6/provisionersdk/scripts/bootstrap_linux.sh#L60-L76

This most likely triggers a change in securitybits which sets
`_AT_SECURE` for the process.

https://github.com/golang/go/blob/a1ddbdd3ef8b739aab53f20d6ed0a61c3474cf12/src/runtime/os_linux.go#L297-L327

Which in turn triggers secure mode:

https://github.com/golang/go/blob/a1ddbdd3ef8b739aab53f20d6ed0a61c3474cf12/src/runtime/security_unix.go

A better fix may be to read `/proc/self/environ` to figure out if this
was set by the runtime or manually, but I'm not sure we should care
about that. A template author can still set the environment on the agent
resource.

See https://pkg.go.dev/runtime#hdr-Security
