### PR TITLE
fix: allow access to provisioners page in OSS deployments

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage.tsx
@@ -20,7 +20,12 @@ const OrganizationProvisionersPage: FC = () => {
 	const { entitlements } = useDashboard();
 	const { metadata } = useEmbeddedMetadata();
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
-	const provisionersQuery = useQuery(provisionerDaemonGroups(organizationName));
+	
+	// Only query for provisioners if we have a valid organization
+	const provisionersQuery = useQuery({
+		...provisionerDaemonGroups(organizationName),
+		enabled: !!organization
+	});
 
 	if (!organization) {
 		return <EmptyState message="Organization not found" />;
@@ -46,11 +51,14 @@ const OrganizationProvisionersPage: FC = () => {
 		);
 	}
 
+	// In OSS mode, we should always show the provisioners page without a paywall
+	const showPaywall = entitlements.has_license && !entitlements.features.multiple_organizations.enabled;
+
 	return (
 		<>
 			{helmet}
 			<OrganizationProvisionersPageView
-				showPaywall={!entitlements.features.multiple_organizations.enabled}
+				showPaywall={showPaywall}
 				error={provisionersQuery.error}
 				buildInfo={buildInfoQuery.data}
 				provisioners={provisionersQuery.data}


### PR DESCRIPTION
## Summary
- Fixes bug where the provisioners page is inaccessible in OSS deployments without multiple organizations
- Prevents API call when the organization doesn't exist
- Only shows paywall for paid instances without multiple organizations feature
- Fixes issue #16921

## Test plan
1. Start an OSS deployment without multiple organizations
2. Verify access to the provisioners page works correctly
3. Verify no paywall is shown on OSS deployments

🤖 Generated with [Claude Code](https://claude.ai/code)