### PR TITLE
docs: adjust order of options in external-auth

### DIFF
--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -59,7 +59,7 @@ Inside your Terraform code, you now have access to authentication variables. Ref
 Use [`external-auth`](../reference/cli/external-auth.md) in the Coder CLI to access a token within the workspace:
 
 ```shell
-coder external-auth <USER_DEFINED_ID> access-token
+coder external-auth access-token <USER_DEFINED_ID>
 ```
 
 ## Git-provider specific env variables


### PR DESCRIPTION
from @NickSquangler 

> ($customer) noticed when setting up external auth with Gitlab that the command listed in the docs is in the incorrect order, as `coder external-auth <USER_DEFINED_ID> access-token` should be `coder external-auth  access-token <USER_DEFINED_ID>`

[preview](https://coder.com/docs/@external-auth-access-token/admin/external-auth#workspace-cli)

<details><summary>coder external-auth access-token --help</summary>

```shell
coder external-auth access-token --help
coder v2.20.0+03b5012

USAGE:
  coder external-auth access-token [flags] <provider>

  Print auth for an external provider

  Print an access-token for an external auth provider. The access-token will be validated and sent
  to stdout with exit code 0. If a valid access-token cannot be obtained, the URL to authenticate
  will be sent to stdout with exit code 1
    - Ensure that the user is authenticated with GitHub before cloning.:

        $ #!/usr/bin/env sh

  OUTPUT=$(coder external-auth access-token github)
  if [ $? -eq 0 ]; then
    echo "Authenticated with GitHub"
  else
    echo "Please authenticate with GitHub:"
    echo $OUTPUT
  fi


    - Obtain an extra property of an access token for additional metadata.:

        $ coder external-auth access-token slack --extra "authed_user.id"


OPTIONS:
      --extra string
          Extract a field from the "extra" properties of the OAuth token.

———
Run `coder --help` for a list of global options.
```

</details>