### PR TITLE
fix: fix audit log search

### DIFF
--- a/site/src/pages/AuditPage/AuditPage.tsx
+++ b/site/src/pages/AuditPage/AuditPage.tsx
@@ -74,14 +74,6 @@ const AuditPage: FC = () => {
 			}),
 	});
 
-	if (auditsQuery.error) {
-		return (
-			<div className="p-6">
-				<ErrorAlert error={auditsQuery.error} />
-			</div>
-		);
-	}
-
 	return (
 		<>
 			<Helmet>


### PR DESCRIPTION
this recently added early return means that any "invalid" query (including a partial one while typing) will entirely crash the audit logs page. the parsing logic on the backend is incredibly strict currently, and so trying to type anything into the search bar will break the entire page.

there is logic in the `AuditPageView` component that is supposed to render this error value, and that will do so without removing the search bar from the page. we can just let that code do what it's supposed to, and don't need to do any handling here.