### PR TITLE
chore: rename the prebuild system user reference

### DIFF
--- a/coderd/prebuilds/id.go
+++ b/coderd/prebuilds/id.go
@@ -2,4 +2,4 @@ package prebuilds
 
 import "github.com/google/uuid"
 
-var OwnerID = uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0")
+var SystemUserID = uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0")

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -2460,7 +2460,7 @@ func TestSystemUserBehaviour(t *testing.T) {
 	require.NotNil(t, regularUser)
 
 	require.True(t, systemUser.IsSystem.Bool)
-	require.Equal(t, systemUser.ID, prebuilds.OwnerID)
+	require.Equal(t, systemUser.ID, prebuilds.SystemUserID)
 	require.False(t, regularUser.IsSystem.Bool)
 	require.Equal(t, regularUser.ID, other.ID)
 

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -840,7 +840,7 @@ func TestGroup(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// nolint:gocritic // "This client is operating as the owner user" is fine in this case.
-		prebuildsUser, err := client.User(ctx, prebuilds.OwnerID.String())
+		prebuildsUser, err := client.User(ctx, prebuilds.SystemUserID.String())
 		require.NoError(t, err)
 		// The 'Everyone' group always has an ID that matches the organization ID.
 		group, err := userAdminClient.Group(ctx, user.OrganizationID)


### PR DESCRIPTION
This PR renames `prebuilds.OwnerID` to `prebuilds.SystemUserID`. This is because the well known ID for the prebuilds system user is used more generally than as an owner in terms of the database. In some cases the name prebuilds.OwnerID was confusing. 