### PR TITLE
test(cryptorand): disable error tests on Go 1.24

### DIFF
--- a/cryptorand/errors_test.go
+++ b/cryptorand/errors_test.go
@@ -1,3 +1,7 @@
+//go:build !go1.24
+
+// Testing `rand.Reader.Read` for errors will panic in Go 1.24 and later.
+
 package cryptorand_test
 
 import (


### PR DESCRIPTION
Testing `rand.Reader.Read` for errors will panic (not recoverable) in Go 1.24 and later.
