### PR TITLE
test(cryptorand): re-enable number error tests

### DIFF
--- a/cryptorand/errors_go123_test.go
+++ b/cryptorand/errors_go123_test.go
@@ -1,0 +1,35 @@
+//go:build !go1.24
+
+package cryptorand_test
+
+import (
+	"crypto/rand"
+	"io"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cryptorand"
+)
+
+// TestRandError_pre_Go1_24 checks that the code handles errors when
+// reading from the rand.Reader.
+//
+// This test replaces the global rand.Reader, so cannot be parallelized
+//
+//nolint:paralleltest
+func TestRandError_pre_Go1_24(t *testing.T) {
+	origReader := rand.Reader
+	t.Cleanup(func() {
+		rand.Reader = origReader
+	})
+
+	rand.Reader = iotest.ErrReader(io.ErrShortBuffer)
+
+	// Testing `rand.Reader.Read` for errors will panic in Go 1.24 and later.
+	t.Run("StringCharset", func(t *testing.T) {
+		_, err := cryptorand.HexString(10)
+		require.ErrorIs(t, err, io.ErrShortBuffer, "expected HexString error")
+	})
+}

--- a/cryptorand/errors_test.go
+++ b/cryptorand/errors_test.go
@@ -1,7 +1,3 @@
-//go:build !go1.24
-
-// Testing `rand.Reader.Read` for errors will panic in Go 1.24 and later.
-
 package cryptorand_test
 
 import (
@@ -49,8 +45,5 @@ func TestRandError(t *testing.T) {
 		require.ErrorIs(t, err, io.ErrShortBuffer, "expected Float64 error")
 	})
 
-	t.Run("StringCharset", func(t *testing.T) {
-		_, err := cryptorand.HexString(10)
-		require.ErrorIs(t, err, io.ErrShortBuffer, "expected HexString error")
-	})
+	// See errors_go123_test.go for the StringCharset test.
 }


### PR DESCRIPTION
Realized it was only the `StringCharset` test that lead to panic, the
number tests bypass it by reading via the `binary` package.
