### PR TITLE
docs: add AWS AMI upgrade instructions

### DIFF
--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -13,7 +13,7 @@ This article walks you through how to upgrade your Coder server.
 To upgrade your Coder server, simply reinstall Coder using your original method
 of [install](../install).
 
-### install.sh
+## install.sh
 
 1. If you installed Coder using the `install.sh` script, re-run the below command
    on the host:
@@ -29,7 +29,7 @@ of [install](../install).
    systemctl restart coder
    ```
 
-### docker-compose
+## docker-compose
 
 If you installed using `docker-compose`, run the below command to upgrade the
 Coder container:
@@ -38,12 +38,12 @@ Coder container:
 docker-compose pull coder && docker-compose up -d coder
 ```
 
-### Kubernetes
+## Kubernetes
 
 See
 [Upgrading Coder via Helm](../install/kubernetes.md#upgrading-coder-via-helm).
 
-### Coder AMI on AWS
+## Coder AMI on AWS
 
 1. Run the Coder installation script on the host:
 
@@ -61,7 +61,7 @@ See
    systemctl restart coder
    ```
 
-### Windows
+## Windows
 
 Download the latest Windows installer or binary from
 [GitHub releases](https://github.com/coder/coder/releases/latest), or upgrade

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -11,7 +11,7 @@ This article describes how to upgrade your Coder server.
 To upgrade your Coder server, reinstall Coder using your original method
 of [install](../install).
 
-### install.sh
+### Coder install script
 
 1. If you installed Coder using the `install.sh` script, re-run the below command
    on the host:
@@ -26,6 +26,8 @@ of [install](../install).
    systemctl daemon-reload
    systemctl restart coder
    ```
+
+### Other methods
 
 <div class="tabs">
 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -56,7 +56,7 @@ See
    The script will unpack the new `coder` binary version over the one currently
    installed.
 
-1. If you're running Coder as a system service, you can restart it with `systemctl`:
+1. Restart the Coder system process with `systemctl`:
 
    ```shell
    systemctl daemon-reload

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -6,11 +6,15 @@ This article walks you through how to upgrade your Coder server.
 > Prior to upgrading a production Coder deployment, take a database snapshot since
 > Coder does not support rollbacks.
 
+## Reinstall Coder to upgrade
+
+<div class="tabs">
+
 To upgrade your Coder server, simply reinstall Coder using your original method
 of [install](../install). If you are using the Official Coder AMI on AWS, use the
 first option to upgrade.
 
-## Via install.sh
+### install.sh
 
 If you installed Coder using the `install.sh` script, re-run the below command
 on the host:
@@ -28,7 +32,7 @@ systemctl daemon-reload
 systemctl restart coder
 ```
 
-## Via docker-compose
+### docker-compose
 
 If you installed using `docker-compose`, run the below command to upgrade the
 Coder container:
@@ -37,12 +41,12 @@ Coder container:
 docker-compose pull coder && docker-compose up -d coder
 ```
 
-## Via Kubernetes
+### Kubernetes
 
 See
 [Upgrading Coder via Helm](../install/kubernetes.md#upgrading-coder-via-helm).
 
-## Via Windows
+### Windows
 
 Download the latest Windows installer or binary from
 [GitHub releases](https://github.com/coder/coder/releases/latest), or upgrade
@@ -51,3 +55,5 @@ from Winget.
 ```pwsh
 winget install Coder.Coder
 ```
+
+</div>

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -27,7 +27,7 @@ of [install](../install).
    systemctl restart coder
    ```
 
-### Other methods
+### Other upgrade methods
 
 <div class="tabs">
 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -7,7 +7,8 @@ This article walks you through how to upgrade your Coder server.
 > Coder does not support rollbacks.
 
 To upgrade your Coder server, simply reinstall Coder using your original method
-of [install](../install).
+of [install](../install). If you are using the Official Coder AMI on AWS, use the
+first option to upgrade.
 
 ## Via install.sh
 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -8,12 +8,10 @@ This article walks you through how to upgrade your Coder server.
 
 ## Reinstall Coder to upgrade
 
-<div class="tabs">
-
-To upgrade your Coder server, simply reinstall Coder using your original method
+To upgrade your Coder server, reinstall Coder using your original method
 of [install](../install).
 
-## install.sh
+### install.sh
 
 1. If you installed Coder using the `install.sh` script, re-run the below command
    on the host:
@@ -29,7 +27,9 @@ of [install](../install).
    systemctl restart coder
    ```
 
-## docker-compose
+<div class="tabs">
+
+### docker-compose
 
 If you installed using `docker-compose`, run the below command to upgrade the
 Coder container:
@@ -38,12 +38,12 @@ Coder container:
 docker-compose pull coder && docker-compose up -d coder
 ```
 
-## Kubernetes
+### Kubernetes
 
 See
 [Upgrading Coder via Helm](../install/kubernetes.md#upgrading-coder-via-helm).
 
-## Coder AMI on AWS
+### Coder AMI on AWS
 
 1. Run the Coder installation script on the host:
 
@@ -61,7 +61,7 @@ See
    systemctl restart coder
    ```
 
-## Windows
+### Windows
 
 Download the latest Windows installer or binary from
 [GitHub releases](https://github.com/coder/coder/releases/latest), or upgrade

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -11,26 +11,23 @@ This article walks you through how to upgrade your Coder server.
 <div class="tabs">
 
 To upgrade your Coder server, simply reinstall Coder using your original method
-of [install](../install). If you are using the Official Coder AMI on AWS, use the
-first option to upgrade.
+of [install](../install).
 
 ### install.sh
 
-If you installed Coder using the `install.sh` script, re-run the below command
-on the host:
+1. If you installed Coder using the `install.sh` script, re-run the below command
+   on the host:
 
-```shell
-curl -L https://coder.com/install.sh | sh
-```
+   ```shell
+   curl -L https://coder.com/install.sh | sh
+   ```
 
-The script will unpack the new `coder` binary version over the one currently
-installed. Next, you can restart Coder with the following commands (if running
-it as a system service):
+1. If you're running Coder as a system service, you can restart it with `systemctl`:
 
-```shell
-systemctl daemon-reload
-systemctl restart coder
-```
+   ```shell
+   systemctl daemon-reload
+   systemctl restart coder
+   ```
 
 ### docker-compose
 
@@ -45,6 +42,24 @@ docker-compose pull coder && docker-compose up -d coder
 
 See
 [Upgrading Coder via Helm](../install/kubernetes.md#upgrading-coder-via-helm).
+
+### Coder AMI on AWS
+
+1. Run the Coder installation script on the host:
+
+   ```shell
+   curl -L https://coder.com/install.sh | sh
+   ```
+
+   The script will unpack the new `coder` binary version over the one currently
+   installed.
+
+1. If you're running Coder as a system service, you can restart it with `systemctl`:
+
+   ```shell
+   systemctl daemon-reload
+   systemctl restart coder
+   ```
 
 ### Windows
 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -1,6 +1,6 @@
 # Upgrade
 
-This article walks you through how to upgrade your Coder server.
+This article describes how to upgrade your Coder server.
 
 > [!CAUTION]
 > Prior to upgrading a production Coder deployment, take a database snapshot since


### PR DESCRIPTION
followup to @d1str0's #16937 

> Adds a small note for those who just used the AWS AMI for their initial installation.

This PR rearranges the Upgrade doc to use tabs for each section + adds AWS AMI

[preview](https://coder.com/docs/@upgrade-tabs/install/upgrade)