### PR TITLE
feat(coderd): add mark-all-as-read endpoint for inbox notifications

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1712,6 +1712,9 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Notifications"
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1712,9 +1712,6 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "Notifications"
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1721,11 +1721,8 @@ const docTemplate = `{
                 "summary": "Mark all unread notifications as read",
                 "operationId": "mark-all-unread-notifications-as-read",
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Response"
-                        }
+                    "204": {
+                        "description": "No Content"
                     }
                 }
             }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1718,8 +1718,8 @@ const docTemplate = `{
                 "tags": [
                     "Notifications"
                 ],
-                "summary": "Make all unread notifications as read",
-                "operationId": "make-all-unread-notifications-as-read",
+                "summary": "Mark all unread notifications as read",
+                "operationId": "mark-all-unread-notifications-as-read",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1705,6 +1705,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/notifications/inbox/mark-all-as-read": {
+            "put": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Make all unread notifications as read",
+                "operationId": "make-all-unread-notifications-as-read",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/inbox/watch": {
             "get": {
                 "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1498,11 +1498,8 @@
 				"summary": "Mark all unread notifications as read",
 				"operationId": "mark-all-unread-notifications-as-read",
 				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Response"
-						}
+					"204": {
+						"description": "No Content"
 					}
 				}
 			}

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1495,8 +1495,8 @@
 				],
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
-				"summary": "Make all unread notifications as read",
-				"operationId": "make-all-unread-notifications-as-read",
+				"summary": "Mark all unread notifications as read",
+				"operationId": "mark-all-unread-notifications-as-read",
 				"responses": {
 					"200": {
 						"description": "OK",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1493,7 +1493,6 @@
 						"CoderSessionToken": []
 					}
 				],
-				"produces": ["application/json"],
 				"tags": ["Notifications"],
 				"summary": "Mark all unread notifications as read",
 				"operationId": "mark-all-unread-notifications-as-read",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1486,6 +1486,27 @@
 				}
 			}
 		},
+		"/notifications/inbox/mark-all-as-read": {
+			"put": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["Notifications"],
+				"summary": "Make all unread notifications as read",
+				"operationId": "make-all-unread-notifications-as-read",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				}
+			}
+		},
 		"/notifications/inbox/watch": {
 			"get": {
 				"security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1493,6 +1493,7 @@
 						"CoderSessionToken": []
 					}
 				],
+				"produces": ["application/json"],
 				"tags": ["Notifications"],
 				"summary": "Mark all unread notifications as read",
 				"operationId": "mark-all-unread-notifications-as-read",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1389,6 +1389,7 @@ func New(options *Options) *API {
 			r.Use(apiKeyMiddleware)
 			r.Route("/inbox", func(r chi.Router) {
 				r.Get("/", api.listInboxNotifications)
+				r.Put("/mark-all-as-read", api.markAllInboxNotificationsAsRead)
 				r.Get("/watch", api.watchInboxNotifications)
 				r.Put("/{id}/read-status", api.updateInboxNotificationReadStatus)
 			})

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3555,8 +3555,7 @@ func (q *querier) ListWorkspaceAgentPortShares(ctx context.Context, workspaceID 
 }
 
 func (q *querier) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
-	resource := rbac.ResourceInboxNotification
-	resource.Owner = arg.UserID.String()
+	resource := rbac.ResourceInboxNotification.WithOwner(arg.UserID.String())
 
 	if err := q.authorizeContext(ctx, policy.ActionUpdate, resource); err != nil {
 		return err

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3555,7 +3555,10 @@ func (q *querier) ListWorkspaceAgentPortShares(ctx context.Context, workspaceID 
 }
 
 func (q *querier) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceInboxNotification); err != nil {
+	resource := rbac.ResourceInboxNotification
+	resource.Owner = arg.UserID.String()
+
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, resource); err != nil {
 		return err
 	}
 

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3554,6 +3554,14 @@ func (q *querier) ListWorkspaceAgentPortShares(ctx context.Context, workspaceID 
 	return q.db.ListWorkspaceAgentPortShares(ctx, workspaceID)
 }
 
+func (q *querier) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceInboxNotification); err != nil {
+		return err
+	}
+
+	return q.db.MarkAllInboxNotificationsAsRead(ctx, arg)
+}
+
 func (q *querier) OIDCClaimFieldValues(ctx context.Context, args database.OIDCClaimFieldValuesParams) ([]string, error) {
 	resource := rbac.ResourceIdpsyncSettings
 	if args.OrganizationID != uuid.Nil {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4640,6 +4640,15 @@ func (s *MethodTestSuite) TestNotifications() {
 			ReadAt: sql.NullTime{Time: readAt, Valid: true},
 		}).Asserts(rbac.ResourceInboxNotification.WithID(notifID).WithOwner(u.ID.String()), policy.ActionUpdate)
 	}))
+
+	s.Run("MarkAllInboxNotificationsAsRead", s.Subtest(func(db database.Store, check *expects) {
+		u := dbgen.User(s.T(), db, database.User{})
+
+		check.Args(database.MarkAllInboxNotificationsAsReadParams{
+			UserID: u.ID,
+			ReadAt: sql.NullTime{Time: dbtestutil.NowInDefaultTimezone(), Valid: true},
+		}).Asserts(rbac.ResourceInboxNotification, policy.ActionUpdate)
+	}))
 }
 
 func (s *MethodTestSuite) TestOAuth2ProviderApps() {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4647,7 +4647,7 @@ func (s *MethodTestSuite) TestNotifications() {
 		check.Args(database.MarkAllInboxNotificationsAsReadParams{
 			UserID: u.ID,
 			ReadAt: sql.NullTime{Time: dbtestutil.NowInDefaultTimezone(), Valid: true},
-		}).Asserts(rbac.ResourceInboxNotification, policy.ActionUpdate)
+		}).Asserts(rbac.ResourceInboxNotification.WithOwner(u.ID.String()), policy.ActionUpdate)
 	}))
 }
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -9498,6 +9498,24 @@ func (q *FakeQuerier) ListWorkspaceAgentPortShares(_ context.Context, workspaceI
 	return shares, nil
 }
 
+func (q *FakeQuerier) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
+	err := validateDatabaseType(arg)
+	if err != nil {
+		return err
+	}
+
+	for idx, notif := range q.inboxNotifications {
+		if notif.UserID == arg.UserID && !notif.ReadAt.Valid {
+			q.inboxNotifications[idx].ReadAt = sql.NullTime{
+				Time:  dbtime.Now(),
+				Valid: true,
+			}
+		}
+	}
+
+	return nil
+}
+
 // nolint:forcetypeassert
 func (q *FakeQuerier) OIDCClaimFieldValues(_ context.Context, args database.OIDCClaimFieldValuesParams) ([]string, error) {
 	orgMembers := q.getOrganizationMemberNoLock(args.OrganizationID)

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -9506,10 +9506,7 @@ func (q *FakeQuerier) MarkAllInboxNotificationsAsRead(_ context.Context, arg dat
 
 	for idx, notif := range q.inboxNotifications {
 		if notif.UserID == arg.UserID && !notif.ReadAt.Valid {
-			q.inboxNotifications[idx].ReadAt = sql.NullTime{
-				Time:  dbtime.Now(),
-				Valid: true,
-			}
+			q.inboxNotifications[idx].ReadAt = arg.ReadAt
 		}
 	}
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -9498,7 +9498,7 @@ func (q *FakeQuerier) ListWorkspaceAgentPortShares(_ context.Context, workspaceI
 	return shares, nil
 }
 
-func (q *FakeQuerier) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
+func (q *FakeQuerier) MarkAllInboxNotificationsAsRead(_ context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
 	err := validateDatabaseType(arg)
 	if err != nil {
 		return err

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2257,6 +2257,13 @@ func (m queryMetricsStore) ListWorkspaceAgentPortShares(ctx context.Context, wor
 	return r0, r1
 }
 
+func (m queryMetricsStore) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
+	start := time.Now()
+	r0 := m.s.MarkAllInboxNotificationsAsRead(ctx, arg)
+	m.queryLatencies.WithLabelValues("MarkAllInboxNotificationsAsRead").Observe(time.Since(start).Seconds())
+	return r0
+}
+
 func (m queryMetricsStore) OIDCClaimFieldValues(ctx context.Context, organizationID database.OIDCClaimFieldValuesParams) ([]string, error) {
 	start := time.Now()
 	r0, r1 := m.s.OIDCClaimFieldValues(ctx, organizationID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -4763,6 +4763,20 @@ func (mr *MockStoreMockRecorder) ListWorkspaceAgentPortShares(ctx, workspaceID a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkspaceAgentPortShares", reflect.TypeOf((*MockStore)(nil).ListWorkspaceAgentPortShares), ctx, workspaceID)
 }
 
+// MarkAllInboxNotificationsAsRead mocks base method.
+func (m *MockStore) MarkAllInboxNotificationsAsRead(ctx context.Context, arg database.MarkAllInboxNotificationsAsReadParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkAllInboxNotificationsAsRead", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkAllInboxNotificationsAsRead indicates an expected call of MarkAllInboxNotificationsAsRead.
+func (mr *MockStoreMockRecorder) MarkAllInboxNotificationsAsRead(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAllInboxNotificationsAsRead", reflect.TypeOf((*MockStore)(nil).MarkAllInboxNotificationsAsRead), ctx, arg)
+}
+
 // OIDCClaimFieldValues mocks base method.
 func (m *MockStore) OIDCClaimFieldValues(ctx context.Context, arg database.OIDCClaimFieldValuesParams) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -469,6 +469,7 @@ type sqlcQuerier interface {
 	ListProvisionerKeysByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerKey, error)
 	ListProvisionerKeysByOrganizationExcludeReserved(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerKey, error)
 	ListWorkspaceAgentPortShares(ctx context.Context, workspaceID uuid.UUID) ([]WorkspaceAgentPortShare, error)
+	MarkAllInboxNotificationsAsRead(ctx context.Context, arg MarkAllInboxNotificationsAsReadParams) error
 	OIDCClaimFieldValues(ctx context.Context, arg OIDCClaimFieldValuesParams) ([]string, error)
 	// OIDCClaimFields returns a list of distinct keys in the the merged_claims fields.
 	// This query is used to generate the list of available sync fields for idp sync settings.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4519,7 +4519,8 @@ UPDATE
 	inbox_notifications
 SET
 	read_at = $1
-WHERE user_id = $2 and read_at IS NULL
+WHERE
+	user_id = $2 and read_at IS NULL
 `
 
 type MarkAllInboxNotificationsAsReadParams struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4514,6 +4514,24 @@ func (q *sqlQuerier) InsertInboxNotification(ctx context.Context, arg InsertInbo
 	return i, err
 }
 
+const markAllInboxNotificationsAsRead = `-- name: MarkAllInboxNotificationsAsRead :exec
+UPDATE
+	inbox_notifications
+SET
+	read_at = $1
+WHERE user_id = $2 and read_at IS NULL
+`
+
+type MarkAllInboxNotificationsAsReadParams struct {
+	ReadAt sql.NullTime `db:"read_at" json:"read_at"`
+	UserID uuid.UUID    `db:"user_id" json:"user_id"`
+}
+
+func (q *sqlQuerier) MarkAllInboxNotificationsAsRead(ctx context.Context, arg MarkAllInboxNotificationsAsReadParams) error {
+	_, err := q.db.ExecContext(ctx, markAllInboxNotificationsAsRead, arg.ReadAt, arg.UserID)
+	return err
+}
+
 const updateInboxNotificationReadStatus = `-- name: UpdateInboxNotificationReadStatus :exec
 UPDATE
     inbox_notifications

--- a/coderd/database/queries/notificationsinbox.sql
+++ b/coderd/database/queries/notificationsinbox.sql
@@ -57,3 +57,10 @@ SET
     read_at = $1
 WHERE
     id = $2;
+
+-- name: MarkAllInboxNotificationsAsRead :exec
+UPDATE
+	inbox_notifications
+SET
+	read_at = $1
+WHERE user_id = $2 and read_at IS NULL;

--- a/coderd/database/queries/notificationsinbox.sql
+++ b/coderd/database/queries/notificationsinbox.sql
@@ -63,4 +63,5 @@ UPDATE
 	inbox_notifications
 SET
 	read_at = $1
-WHERE user_id = $2 and read_at IS NULL;
+WHERE
+	user_id = $2 and read_at IS NULL;

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -350,7 +350,6 @@ func (api *API) updateInboxNotificationReadStatus(rw http.ResponseWriter, r *htt
 // @Summary Mark all unread notifications as read
 // @ID mark-all-unread-notifications-as-read
 // @Security CoderSessionToken
-// @Produce json
 // @Tags Notifications
 // @Success 204
 // @Router /notifications/inbox/mark-all-as-read [put]

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -352,7 +352,7 @@ func (api *API) updateInboxNotificationReadStatus(rw http.ResponseWriter, r *htt
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Notifications
-// @Success 200 {object} codersdk.Response
+// @Success 204
 // @Router /notifications/inbox/mark-all-as-read [put]
 func (api *API) markAllInboxNotificationsAsRead(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -372,7 +372,5 @@ func (api *API) markAllInboxNotificationsAsRead(rw http.ResponseWriter, r *http.
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateInboxNotificationReadStatusResponse{
-		UnreadCount: 0,
-	})
+	rw.WriteHeader(http.StatusNoContent)
 }

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -373,7 +373,6 @@ func (api *API) markAllInboxNotificationsAsRead(rw http.ResponseWriter, r *http.
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateInboxNotificationReadStatusResponse{
-		// Notification: convertInboxNotificationResponse(ctx, api.Logger, updatedNotification),
-		// UnreadCount:  int(unreadCount),
+		UnreadCount: 0,
 	})
 }

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -345,3 +345,35 @@ func (api *API) updateInboxNotificationReadStatus(rw http.ResponseWriter, r *htt
 		UnreadCount:  int(unreadCount),
 	})
 }
+
+// markAllInboxNotificationsAsRead marks as read all unread notifications.
+// @Summary Make all unread notifications as read
+// @ID make-all-unread-notifications-as-read
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Notifications
+// @Success 200 {object} codersdk.Response
+// @Router /notifications/inbox/mark-all-as-read [put]
+func (api *API) markAllInboxNotificationsAsRead(rw http.ResponseWriter, r *http.Request) {
+	var (
+		ctx    = r.Context()
+		apikey = httpmw.APIKey(r)
+	)
+
+	err := api.Database.MarkAllInboxNotificationsAsRead(ctx, database.MarkAllInboxNotificationsAsReadParams{
+		UserID: apikey.UserID,
+		ReadAt: sql.NullTime{Time: dbtime.Now(), Valid: true},
+	})
+	if err != nil {
+		api.Logger.Error(ctx, "failed to mark all unread notifications as read", slog.Error(err))
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to mark all unread notifications as read.",
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateInboxNotificationReadStatusResponse{
+		// Notification: convertInboxNotificationResponse(ctx, api.Logger, updatedNotification),
+		// UnreadCount:  int(unreadCount),
+	})
+}

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -346,9 +346,9 @@ func (api *API) updateInboxNotificationReadStatus(rw http.ResponseWriter, r *htt
 	})
 }
 
-// markAllInboxNotificationsAsRead marks as read all unread notifications.
-// @Summary Make all unread notifications as read
-// @ID make-all-unread-notifications-as-read
+// markAllInboxNotificationsAsRead marks as read all unread notifications for authenticated user.
+// @Summary Mark all unread notifications as read
+// @ID mark-all-unread-notifications-as-read
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Notifications

--- a/coderd/inboxnotifications_test.go
+++ b/coderd/inboxnotifications_test.go
@@ -37,7 +37,7 @@ func TestInboxNotification_Watch(t *testing.T) {
 	// I skip these tests specifically on windows as for now they are flaky - only on Windows.
 	// For now the idea is that the runner takes too long to insert the entries, could be worth
 	// investigating a manual Tx.
-	// Related issue for fix : https://github.com/coder/internal/issues/503
+	// see: https://github.com/coder/internal/issues/503
 	if runtime.GOOS == "windows" {
 		t.Skip("our runners are randomly taking too long to insert entries")
 	}
@@ -306,7 +306,7 @@ func TestInboxNotifications_List(t *testing.T) {
 	// I skip these tests specifically on windows as for now they are flaky - only on Windows.
 	// For now the idea is that the runner takes too long to insert the entries, could be worth
 	// investigating a manual Tx.
-	// Related issue for fix : https://github.com/coder/internal/issues/503
+	// see: https://github.com/coder/internal/issues/503
 	if runtime.GOOS == "windows" {
 		t.Skip("our runners are randomly taking too long to insert entries")
 	}
@@ -590,7 +590,7 @@ func TestInboxNotifications_ReadStatus(t *testing.T) {
 	// I skip these tests specifically on windows as for now they are flaky - only on Windows.
 	// For now the idea is that the runner takes too long to insert the entries, could be worth
 	// investigating a manual Tx.
-	// Related issue for fix : https://github.com/coder/internal/issues/503
+	// see: https://github.com/coder/internal/issues/503
 	if runtime.GOOS == "windows" {
 		t.Skip("our runners are randomly taking too long to insert entries")
 	}
@@ -733,7 +733,7 @@ func TestInboxNotifications_MarkAllAsRead(t *testing.T) {
 	// I skip these tests specifically on windows as for now they are flaky - only on Windows.
 	// For now the idea is that the runner takes too long to insert the entries, could be worth
 	// investigating a manual Tx.
-	// Related issue for fix : https://github.com/coder/internal/issues/503
+	// see: https://github.com/coder/internal/issues/503
 	if runtime.GOOS == "windows" {
 		t.Skip("our runners are randomly taking too long to insert entries")
 	}

--- a/coderd/inboxnotifications_test.go
+++ b/coderd/inboxnotifications_test.go
@@ -771,9 +771,8 @@ func TestInboxNotifications_MarkAllAsRead(t *testing.T) {
 		require.Equal(t, 20, notifs.UnreadCount)
 		require.Len(t, notifs.Notifications, 20)
 
-		resp, err := client.MarkAllInboxNotificationsAsRead(ctx)
+		err = client.MarkAllInboxNotificationsAsRead(ctx)
 		require.NoError(t, err)
-		require.Zero(t, resp.UnreadCount)
 
 		notifs, err = client.ListInboxNotifications(ctx, codersdk.ListInboxNotificationsRequest{})
 		require.NoError(t, err)

--- a/coderd/inboxnotifications_test.go
+++ b/coderd/inboxnotifications_test.go
@@ -723,6 +723,7 @@ func TestInboxNotifications_ReadStatus(t *testing.T) {
 		require.Empty(t, updatedNotif.Notification)
 	})
 }
+
 func TestInboxNotifications_MarkAllAsRead(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/inboxnotifications_test.go
+++ b/coderd/inboxnotifications_test.go
@@ -723,3 +723,57 @@ func TestInboxNotifications_ReadStatus(t *testing.T) {
 		require.Empty(t, updatedNotif.Notification)
 	})
 }
+func TestInboxNotifications_MarkAllAsRead(t *testing.T) {
+	t.Parallel()
+
+	// I skip these tests specifically on windows as for now they are flaky - only on Windows.
+	// For now the idea is that the runner takes too long to insert the entries, could be worth
+	// investigating a manual Tx.
+	if runtime.GOOS == "windows" {
+		t.Skip("our runners are randomly taking too long to insert entries")
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+		client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{})
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		client, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		notifs, err := client.ListInboxNotifications(ctx, codersdk.ListInboxNotificationsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, notifs)
+		require.Equal(t, 0, notifs.UnreadCount)
+		require.Empty(t, notifs.Notifications)
+
+		for i := range 20 {
+			dbgen.NotificationInbox(t, api.Database, database.InsertInboxNotificationParams{
+				ID:         uuid.New(),
+				UserID:     member.ID,
+				TemplateID: notifications.TemplateWorkspaceOutOfMemory,
+				Title:      fmt.Sprintf("Notification %d", i),
+				Actions:    json.RawMessage("[]"),
+				Content:    fmt.Sprintf("Content of the notif %d", i),
+				CreatedAt:  dbtime.Now(),
+			})
+		}
+
+		notifs, err = client.ListInboxNotifications(ctx, codersdk.ListInboxNotificationsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, notifs)
+		require.Equal(t, 20, notifs.UnreadCount)
+		require.Len(t, notifs.Notifications, 20)
+
+		resp, err := client.MarkAllInboxNotificationsAsRead(ctx)
+		require.NoError(t, err)
+		require.Zero(t, resp.UnreadCount)
+
+		notifs, err = client.ListInboxNotifications(ctx, codersdk.ListInboxNotificationsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, notifs)
+		require.Equal(t, 0, notifs.UnreadCount)
+		require.Len(t, notifs.Notifications, 20)
+	})
+}

--- a/codersdk/inboxnotification.go
+++ b/codersdk/inboxnotification.go
@@ -110,10 +110,6 @@ func (c *Client) UpdateInboxNotificationReadStatus(ctx context.Context, notifID 
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-type MarkAllInboxNotificationsAsReadResponse struct {
-	UnreadCount int `json:"unread_count"`
-}
-
 func (c *Client) MarkAllInboxNotificationsAsRead(ctx context.Context) error {
 	res, err := c.Request(
 		ctx, http.MethodPut,

--- a/codersdk/inboxnotification.go
+++ b/codersdk/inboxnotification.go
@@ -114,21 +114,20 @@ type MarkAllInboxNotificationsAsReadResponse struct {
 	UnreadCount int `json:"unread_count"`
 }
 
-func (c *Client) MarkAllInboxNotificationsAsRead(ctx context.Context) (MarkAllInboxNotificationsAsReadResponse, error) {
+func (c *Client) MarkAllInboxNotificationsAsRead(ctx context.Context) error {
 	res, err := c.Request(
 		ctx, http.MethodPut,
 		"/api/v2/notifications/inbox/mark-all-as-read",
 		nil,
 	)
 	if err != nil {
-		return MarkAllInboxNotificationsAsReadResponse{}, err
+		return err
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return MarkAllInboxNotificationsAsReadResponse{}, ReadBodyAsError(res)
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
 	}
 
-	var resp MarkAllInboxNotificationsAsReadResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+	return nil
 }

--- a/codersdk/inboxnotification.go
+++ b/codersdk/inboxnotification.go
@@ -109,3 +109,26 @@ func (c *Client) UpdateInboxNotificationReadStatus(ctx context.Context, notifID 
 	var resp UpdateInboxNotificationReadStatusResponse
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
+
+type MarkAllInboxNotificationsAsReadResponse struct {
+	UnreadCount int `json:"unread_count"`
+}
+
+func (c *Client) MarkAllInboxNotificationsAsRead(ctx context.Context) (MarkAllInboxNotificationsAsReadResponse, error) {
+	res, err := c.Request(
+		ctx, http.MethodPut,
+		"/api/v2/notifications/inbox/mark-all-as-read",
+		nil,
+	)
+	if err != nil {
+		return MarkAllInboxNotificationsAsReadResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return MarkAllInboxNotificationsAsReadResponse{}, ReadBodyAsError(res)
+	}
+
+	var resp MarkAllInboxNotificationsAsReadResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -113,34 +113,16 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 ```shell
 # Example request using curl
 curl -X PUT http://coder-server:8080/api/v2/notifications/inbox/mark-all-as-read \
-  -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
 `PUT /notifications/inbox/mark-all-as-read`
 
-### Example responses
-
-> 200 Response
-
-```json
-{
-  "detail": "string",
-  "message": "string",
-  "validations": [
-    {
-      "detail": "string",
-      "field": "string"
-    }
-  ]
-}
-```
-
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                           |
-|--------|---------------------------------------------------------|-------------|--------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Response](schemas.md#codersdkresponse) |
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -106,6 +106,44 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Make all unread notifications as read
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/v2/notifications/inbox/mark-all-as-read \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /notifications/inbox/mark-all-as-read`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "detail": "string",
+  "message": "string",
+  "validations": [
+    {
+      "detail": "string",
+      "field": "string"
+    }
+  ]
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                           |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Response](schemas.md#codersdkresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Watch for new inbox notifications
 
 ### Code samples

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -106,7 +106,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Make all unread notifications as read
+## Mark all unread notifications as read
 
 ### Code samples
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1226,6 +1226,11 @@ export interface LoginWithPasswordResponse {
 	readonly session_token: string;
 }
 
+// From codersdk/inboxnotification.go
+export interface MarkAllInboxNotificationsAsReadResponse {
+	readonly unread_count: number;
+}
+
 // From codersdk/provisionerdaemons.go
 export interface MatchedProvisioners {
 	readonly count: number;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1226,11 +1226,6 @@ export interface LoginWithPasswordResponse {
 	readonly session_token: string;
 }
 
-// From codersdk/inboxnotification.go
-export interface MarkAllInboxNotificationsAsReadResponse {
-	readonly unread_count: number;
-}
-
 // From codersdk/provisionerdaemons.go
 export interface MatchedProvisioners {
 	readonly count: number;


### PR DESCRIPTION
[Resolve this issue](https://github.com/coder/internal/issues/506)

Add a mark-all-as-read endpoint which is marking as read all notifications that are not read for the authenticated user.
Also adds the DB logic.