### PR TITLE
fix: rewrite login type migrations

### DIFF
--- a/coderd/database/migrations/000126_login_type_none.up.sql
+++ b/coderd/database/migrations/000126_login_type_none.up.sql
@@ -1,11 +1,8 @@
 -- This migration has been modified after its initial commit.
--- The original disregarded the warning in create_migration.sh.
--- As a result, it was not possible to insert a user with the "none" login type
--- in a migration.
 -- The new implementation makes the same changes as the original, but
--- adhered to the warning in create_migration.sh to allow the insertion of
--- a user with the "none" login type. This was necessary for prebuilds.
--- For more information, see: https://github.com/coder/coder/pull/16916#discussion_r1998758887
+-- takes into account the message in create_migration.sh. This is done
+-- to allow the insertion of a user with the "none" login type in later migrations.
+
 CREATE TYPE new_logintype AS ENUM (
   'password',
   'github',

--- a/coderd/database/migrations/000126_login_type_none.up.sql
+++ b/coderd/database/migrations/000126_login_type_none.up.sql
@@ -1,3 +1,34 @@
-ALTER TYPE login_type ADD VALUE IF NOT EXISTS 'none';
+-- This migration has been modified after its initial commit.
+-- The original disregarded the warning in create_migration.sh.
+-- As a result, it was not possible to insert a user with the "none" login type
+-- in a migration.
+-- The new implementation makes the same changes as the original, but
+-- adhered to the warning in create_migration.sh to allow the insertion of
+-- a user with the "none" login type. This was necessary for prebuilds.
+-- For more information, see: https://github.com/coder/coder/pull/16916#discussion_r1998758887
+CREATE TYPE new_logintype AS ENUM (
+  'password',
+  'github',
+  'oidc',
+  'token',
+  'none'
+);
+COMMENT ON TYPE new_logintype IS 'Specifies the method of authentication. "none" is a special case in which no authentication method is allowed.';
 
-COMMENT ON TYPE login_type IS 'Specifies the method of authentication. "none" is a special case in which no authentication method is allowed.';
+ALTER TABLE users
+	ALTER COLUMN login_type DROP DEFAULT,
+	ALTER COLUMN login_type TYPE new_logintype USING (login_type::text::new_logintype),
+	ALTER COLUMN login_type SET DEFAULT 'password'::new_logintype;
+
+DROP INDEX IF EXISTS idx_api_key_name;
+ALTER TABLE api_keys
+	ALTER COLUMN login_type TYPE new_logintype USING (login_type::text::new_logintype);
+CREATE UNIQUE INDEX idx_api_key_name
+ON api_keys (user_id, token_name)
+WHERE (login_type = 'token'::new_logintype);
+
+ALTER TABLE user_links
+	ALTER COLUMN login_type TYPE new_logintype USING (login_type::text::new_logintype);
+
+DROP TYPE login_type;
+ALTER TYPE new_logintype RENAME TO login_type;

--- a/coderd/database/migrations/000195_oauth2_provider_codes.up.sql
+++ b/coderd/database/migrations/000195_oauth2_provider_codes.up.sql
@@ -43,7 +43,33 @@ AFTER DELETE ON oauth2_provider_app_tokens
 FOR EACH ROW
 EXECUTE PROCEDURE delete_deleted_oauth2_provider_app_token_api_key();
 
-ALTER TYPE login_type ADD VALUE IF NOT EXISTS 'oauth2_provider_app';
+CREATE TYPE new_logintype AS ENUM (
+  'password',
+  'github',
+  'oidc',
+  'token',
+  'none',
+  'oauth2_provider_app'
+);
+COMMENT ON TYPE new_logintype IS 'Specifies the method of authentication. "none" is a special case in which no authentication method is allowed.';
+
+ALTER TABLE users
+	ALTER COLUMN login_type DROP DEFAULT,
+	ALTER COLUMN login_type TYPE new_logintype USING (login_type::text::new_logintype),
+	ALTER COLUMN login_type SET DEFAULT 'password'::new_logintype;
+
+DROP INDEX IF EXISTS idx_api_key_name;
+ALTER TABLE api_keys
+	ALTER COLUMN login_type TYPE new_logintype USING (login_type::text::new_logintype);
+CREATE UNIQUE INDEX idx_api_key_name
+ON api_keys (user_id, token_name)
+WHERE (login_type = 'token'::new_logintype);
+
+ALTER TABLE user_links
+	ALTER COLUMN login_type TYPE new_logintype USING (login_type::text::new_logintype);
+
+DROP TYPE login_type;
+ALTER TYPE new_logintype RENAME TO login_type;
 
 -- Switch to an ID we will prefix to the raw secret that we give to the user
 -- (instead of matching on the entire secret as the ID, since they will be


### PR DESCRIPTION
When trying to add [system users](https://github.com/coder/coder/pull/16916), we discovered an issue in two migrations that added values to the login_type enum.
After some [consideration](https://github.com/coder/coder/pull/16916#discussion_r1998758887), we decided to retroactively correct them.