### PR TITLE
chore: reuse syft and cosign install actions across workflows

### DIFF
--- a/.github/actions/install-cosign/action.yaml
+++ b/.github/actions/install-cosign/action.yaml
@@ -1,0 +1,14 @@
+name: "Install cosign"
+description: |
+  Cosign Github Action.
+inputs:
+  version:
+    description: "cosign release"
+    default: "v2.4.3"
+runs:
+  using: "composite"
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+      with:
+        cosign-release: {{ inputs.version }}

--- a/.github/actions/install-cosign/action.yaml
+++ b/.github/actions/install-cosign/action.yaml
@@ -1,14 +1,10 @@
 name: "Install cosign"
 description: |
   Cosign Github Action.
-inputs:
-  version:
-    description: "cosign release"
-    default: "v2.4.3"
 runs:
   using: "composite"
   steps:
     - name: Install cosign
       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
       with:
-        cosign-release: {{ inputs.version }}
+        cosign-release: "v2.4.3"

--- a/.github/actions/install-syft/action.yaml
+++ b/.github/actions/install-syft/action.yaml
@@ -7,4 +7,4 @@ runs:
     - name: Install syft
       uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
       with:
-        syft-version: "1.22.8"
+        syft-version: "v1.20.0"

--- a/.github/actions/install-syft/action.yaml
+++ b/.github/actions/install-syft/action.yaml
@@ -1,0 +1,14 @@
+name: "Install syft"
+description: |
+  Downloads Syft to the Action tool cache and provides a reference.
+inputs:
+  version:
+    description: "syft version."
+    default: "1.22.8"
+runs:
+  using: "composite"
+  steps:
+    - name: Install syft
+      uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+      with:
+        syft-version: {{ inputs.version }}

--- a/.github/actions/install-syft/action.yaml
+++ b/.github/actions/install-syft/action.yaml
@@ -1,14 +1,10 @@
 name: "Install syft"
 description: |
   Downloads Syft to the Action tool cache and provides a reference.
-inputs:
-  version:
-    description: "syft version."
-    default: "1.22.8"
 runs:
   using: "composite"
   steps:
     - name: Install syft
       uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
       with:
-        syft-version: {{ inputs.version }}
+        syft-version: "1.22.8"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1074,14 +1074,10 @@ jobs:
         run: sudo apt-get install -y zstd
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
-        with:
-          cosign-release: "v2.4.3"
+        uses: ./.github/action/install-cosign
 
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
-        with:
-          syft-version: "v1.20.0"
+        uses: ./.github/action/install-syft
 
       - name: Setup Windows EV Signing Certificate
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1074,10 +1074,10 @@ jobs:
         run: sudo apt-get install -y zstd
 
       - name: Install cosign
-        uses: ./.github/action/install-cosign
+        uses: ./.github/actions/install-cosign
 
       - name: Install syft
-        uses: ./.github/action/install-syft
+        uses: ./.github/actions/install-syft
 
       - name: Setup Windows EV Signing Certificate
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -251,10 +251,10 @@ jobs:
           rm /tmp/rcodesign.tar.gz
 
       - name: Install cosign
-        uses: ./.github/action/install-cosign
+        uses: ./.github/actions/install-cosign
 
       - name: Install syft
-        uses: ./.github/action/install-syft
+        uses: ./.github/actions/install-syft
 
       - name: Setup Apple Developer certificate and API key
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -251,14 +251,10 @@ jobs:
           rm /tmp/rcodesign.tar.gz
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
-        with:
-          cosign-release: "v2.4.3"
+        uses: ./.github/action/install-cosign
 
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
-        with:
-          syft-version: "v1.20.0"
+        uses: ./.github/action/install-syft
 
       - name: Setup Apple Developer certificate and API key
         run: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -85,6 +85,12 @@ jobs:
       - name: Setup sqlc
         uses: ./.github/actions/setup-sqlc
 
+      - name: Install cosign
+        uses: ./.github/action/install-cosign
+
+      - name: Install syft
+        uses: ./.github/action/install-syft
+
       - name: Install yq
         run: go run github.com/mikefarah/yq/v4@v4.44.3
       - name: Install mockgen

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -86,10 +86,10 @@ jobs:
         uses: ./.github/actions/setup-sqlc
 
       - name: Install cosign
-        uses: ./.github/action/install-cosign
+        uses: ./.github/actions/install-cosign
 
       - name: Install syft
-        uses: ./.github/action/install-syft
+        uses: ./.github/actions/install-syft
 
       - name: Install yq
         run: go run github.com/mikefarah/yq/v4@v4.44.3


### PR DESCRIPTION
This pull request adds new GitHub Actions for installing `cosign` and `syft`, and updates the CI, release, and security workflows.  

**New Actions:**  
- [`install-cosign`](.github/actions/install-cosign/action.yaml): Installs `cosign` with a configurable version.  
- [`install-syft`](.github/actions/install-syft/action.yaml): Installs `syft` with a configurable version.  

**Workflow Updates:**  
- CI, release, and security workflows now use `install-cosign` and `install-syft`.