### PR TITLE
fix: retry provisionerd connection to coderd when coderd is down

### DIFF
--- a/codersdk/health.go
+++ b/codersdk/health.go
@@ -1,0 +1,33 @@
+package codersdk
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+
+	"golang.org/x/xerrors"
+)
+
+func (c *Client) CheckLiveness(ctx context.Context) error {
+	res, err := c.Request(ctx, http.MethodGet, "/healthz", nil)
+	if err != nil {
+		return xerrors.Errorf("liveness check failed to create request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return xerrors.Errorf("liveness check returned non-200 response: HTTP %d", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return xerrors.Errorf("failed to read liveness check response body: %w", err)
+	}
+
+	if !bytes.Equal(body, []byte("OK")) {
+		return xerrors.Errorf("liveness check returned non-OK body: %s", body)
+	}
+
+	return nil
+}

--- a/codersdk/health_test.go
+++ b/codersdk/health_test.go
@@ -1,0 +1,102 @@
+package codersdk_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestLivenessCheck(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		accessURLFn func(t *testing.T) *url.URL
+		expectedErr string
+	}{
+		{
+			name: "OK",
+			accessURLFn: func(t *testing.T) *url.URL {
+				mux := http.NewServeMux()
+				mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write([]byte("OK"))
+					require.NoError(t, err)
+				})
+
+				srv := httptest.NewServer(mux)
+				t.Cleanup(srv.Close)
+
+				u, err := url.Parse(srv.URL)
+				require.NoError(t, err)
+				return u
+			},
+		},
+		{
+			name: "server not running",
+			accessURLFn: func(t *testing.T) *url.URL {
+				// See coderd/workspaceapps/apptest/setup.go.
+				u, err := url.Parse("http://127.1.0.1:396")
+				require.NoError(t, err)
+				return u
+			},
+			expectedErr: "liveness check failed",
+		},
+		{
+			name: "server is not yet live",
+			accessURLFn: func(t *testing.T) *url.URL {
+				mux := http.NewServeMux()
+				mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write([]byte("NOK"))
+					require.NoError(t, err)
+				})
+
+				srv := httptest.NewServer(mux)
+				t.Cleanup(srv.Close)
+
+				u, err := url.Parse(srv.URL)
+				require.NoError(t, err)
+				return u
+			},
+			expectedErr: "liveness check returned non-OK body",
+		},
+		{
+			name: "liveness check route not found",
+			accessURLFn: func(t *testing.T) *url.URL {
+				srv := httptest.NewServer(http.NewServeMux())
+				t.Cleanup(srv.Close)
+
+				u, err := url.Parse(srv.URL)
+				require.NoError(t, err)
+				return u
+			},
+			expectedErr: "liveness check returned non-200 response: HTTP 404",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+
+			u := tc.accessURLFn(t)
+			client := codersdk.New(u)
+			err := client.CheckLiveness(ctx)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -98,10 +98,9 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			retryCtx, retryCancel := context.WithTimeout(ctx, time.Hour)
 			defer retryCancel()
 			for retrier := retry.New(100*time.Millisecond, 10*time.Second); retrier.Wait(retryCtx); {
-				lcCtx, lcCancel := context.WithTimeout(inv.Context(), time.Second*30)
+				lcCtx, lcCancel := context.WithTimeout(retryCtx, time.Second*30)
 				err = client.CheckLiveness(lcCtx)
 				lcCancel() // We shouldn't defer in loops.
-
 				if err == nil {
 					break
 				}


### PR DESCRIPTION
Currently, if a `provisionerd` process starts up and `coderd` is not yet available, it will exit immediately with an obtuse error:

```
Encountered an error running "coder provisioner start", see "coder provisioner start --help" for more information
error: current organization: get organizations: Get "http://localhost:3000/api/v2/users/me/organizations": dial tcp [::1]:3000: connect: connection refused
```

We should instead be retrying for a period of time. I've picked _1 hour_ for now, which is short enough to notice a problem but long enough to smooth over temporary connection issues.