### PR TITLE
chore: don't autofocus `OrganizationAutocomplete` on user creation page

### DIFF
--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -108,7 +108,6 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					fullWidth
 					size={size}
 					label={label}
-					autoFocus
 					placeholder="Organization name"
 					css={{
 						"&:not(:has(label))": {


### PR DESCRIPTION
I don't know how this got put so deep in the component, but it's particularly annoying on the user creation page