### PR TITLE
chore(codersdk): rename WorkspaceAgent(Dev)container structs

### DIFF
--- a/agent/agentcontainers/containers_dockercli.go
+++ b/agent/agentcontainers/containers_dockercli.go
@@ -269,7 +269,7 @@ func (dcl *DockerCLILister) List(ctx context.Context) (codersdk.WorkspaceAgentLi
 	}
 
 	res := codersdk.WorkspaceAgentListContainersResponse{
-		Containers: make([]codersdk.WorkspaceAgentDevcontainer, 0, len(ids)),
+		Containers: make([]codersdk.WorkspaceAgentContainer, 0, len(ids)),
 		Warnings:   make([]string, 0),
 	}
 	dockerPsStderr := strings.TrimSpace(stderrBuf.String())
@@ -380,13 +380,13 @@ func (dis dockerInspectState) String() string {
 	return sb.String()
 }
 
-func convertDockerInspect(raw []byte) ([]codersdk.WorkspaceAgentDevcontainer, []string, error) {
+func convertDockerInspect(raw []byte) ([]codersdk.WorkspaceAgentContainer, []string, error) {
 	var warns []string
 	var ins []dockerInspect
 	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&ins); err != nil {
 		return nil, nil, xerrors.Errorf("decode docker inspect output: %w", err)
 	}
-	outs := make([]codersdk.WorkspaceAgentDevcontainer, 0, len(ins))
+	outs := make([]codersdk.WorkspaceAgentContainer, 0, len(ins))
 
 	// Say you have two containers:
 	//  - Container A with Host IP 127.0.0.1:8000 mapped to container port 8001
@@ -402,14 +402,14 @@ func convertDockerInspect(raw []byte) ([]codersdk.WorkspaceAgentDevcontainer, []
 	hostPortContainers := make(map[int][]string)
 
 	for _, in := range ins {
-		out := codersdk.WorkspaceAgentDevcontainer{
+		out := codersdk.WorkspaceAgentContainer{
 			CreatedAt: in.Created,
 			// Remove the leading slash from the container name
 			FriendlyName: strings.TrimPrefix(in.Name, "/"),
 			ID:           in.ID,
 			Image:        in.Config.Image,
 			Labels:       in.Config.Labels,
-			Ports:        make([]codersdk.WorkspaceAgentDevcontainerPort, 0),
+			Ports:        make([]codersdk.WorkspaceAgentContainerPort, 0),
 			Running:      in.State.Running,
 			Status:       in.State.String(),
 			Volumes:      make(map[string]string, len(in.Mounts)),
@@ -452,7 +452,7 @@ func convertDockerInspect(raw []byte) ([]codersdk.WorkspaceAgentDevcontainer, []
 					// Also keep track of the host port and the container ID.
 					hostPortContainers[hp] = append(hostPortContainers[hp], in.ID)
 				}
-				out.Ports = append(out.Ports, codersdk.WorkspaceAgentDevcontainerPort{
+				out.Ports = append(out.Ports, codersdk.WorkspaceAgentContainerPort{
 					Network:  network,
 					Port:     cp,
 					HostPort: uint16(hp),

--- a/agent/agentcontainers/containers_internal_test.go
+++ b/agent/agentcontainers/containers_internal_test.go
@@ -206,7 +206,7 @@ func TestContainersHandler(t *testing.T) {
 
 		fakeCt := fakeContainer(t)
 		fakeCt2 := fakeContainer(t)
-		makeResponse := func(cts ...codersdk.WorkspaceAgentDevcontainer) codersdk.WorkspaceAgentListContainersResponse {
+		makeResponse := func(cts ...codersdk.WorkspaceAgentContainer) codersdk.WorkspaceAgentListContainersResponse {
 			return codersdk.WorkspaceAgentListContainersResponse{Containers: cts}
 		}
 
@@ -425,13 +425,13 @@ func TestConvertDockerInspect(t *testing.T) {
 	//nolint:paralleltest // variable recapture no longer required
 	for _, tt := range []struct {
 		name        string
-		expect      []codersdk.WorkspaceAgentDevcontainer
+		expect      []codersdk.WorkspaceAgentContainer
 		expectWarns []string
 		expectError string
 	}{
 		{
 			name: "container_simple",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 55, 58, 91280203, time.UTC),
 					ID:           "6b539b8c60f5230b8b0fde2502cd2332d31c0d526a3e6eb6eef1cc39439b3286",
@@ -440,14 +440,14 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports:        []codersdk.WorkspaceAgentDevcontainerPort{},
+					Ports:        []codersdk.WorkspaceAgentContainerPort{},
 					Volumes:      map[string]string{},
 				},
 			},
 		},
 		{
 			name: "container_labels",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 20, 3, 28, 71706536, time.UTC),
 					ID:           "bd8818e670230fc6f36145b21cf8d6d35580355662aa4d9fe5ae1b188a4c905f",
@@ -456,14 +456,14 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{"baz": "zap", "foo": "bar"},
 					Running:      true,
 					Status:       "running",
-					Ports:        []codersdk.WorkspaceAgentDevcontainerPort{},
+					Ports:        []codersdk.WorkspaceAgentContainerPort{},
 					Volumes:      map[string]string{},
 				},
 			},
 		},
 		{
 			name: "container_binds",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 58, 43, 522505027, time.UTC),
 					ID:           "fdc75ebefdc0243c0fce959e7685931691ac7aede278664a0e2c23af8a1e8d6a",
@@ -472,7 +472,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports:        []codersdk.WorkspaceAgentDevcontainerPort{},
+					Ports:        []codersdk.WorkspaceAgentContainerPort{},
 					Volumes: map[string]string{
 						"/tmp/test/a": "/var/coder/a",
 						"/tmp/test/b": "/var/coder/b",
@@ -482,7 +482,7 @@ func TestConvertDockerInspect(t *testing.T) {
 		},
 		{
 			name: "container_sameport",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 56, 34, 842164541, time.UTC),
 					ID:           "4eac5ce199d27b2329d0ff0ce1a6fc595612ced48eba3669aadb6c57ebef3fa2",
@@ -491,7 +491,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+					Ports: []codersdk.WorkspaceAgentContainerPort{
 						{
 							Network:  "tcp",
 							Port:     12345,
@@ -505,7 +505,7 @@ func TestConvertDockerInspect(t *testing.T) {
 		},
 		{
 			name: "container_differentport",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 57, 8, 862545133, time.UTC),
 					ID:           "3090de8b72b1224758a94a11b827c82ba2b09c45524f1263dc4a2d83e19625ea",
@@ -514,7 +514,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+					Ports: []codersdk.WorkspaceAgentContainerPort{
 						{
 							Network:  "tcp",
 							Port:     23456,
@@ -528,7 +528,7 @@ func TestConvertDockerInspect(t *testing.T) {
 		},
 		{
 			name: "container_sameportdiffip",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 56, 34, 842164541, time.UTC),
 					ID:           "a",
@@ -537,7 +537,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+					Ports: []codersdk.WorkspaceAgentContainerPort{
 						{
 							Network:  "tcp",
 							Port:     8001,
@@ -555,7 +555,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+					Ports: []codersdk.WorkspaceAgentContainerPort{
 						{
 							Network:  "tcp",
 							Port:     8001,
@@ -570,7 +570,7 @@ func TestConvertDockerInspect(t *testing.T) {
 		},
 		{
 			name: "container_volume",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 59, 42, 39484134, time.UTC),
 					ID:           "b3688d98c007f53402a55e46d803f2f3ba9181d8e3f71a2eb19b392cf0377b4e",
@@ -579,7 +579,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					Labels:       map[string]string{},
 					Running:      true,
 					Status:       "running",
-					Ports:        []codersdk.WorkspaceAgentDevcontainerPort{},
+					Ports:        []codersdk.WorkspaceAgentContainerPort{},
 					Volumes: map[string]string{
 						"/var/lib/docker/volumes/testvol/_data": "/testvol",
 					},
@@ -588,7 +588,7 @@ func TestConvertDockerInspect(t *testing.T) {
 		},
 		{
 			name: "devcontainer_simple",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 1, 5, 751972661, time.UTC),
 					ID:           "0b2a9fcf5727d9562943ce47d445019f4520e37a2aa7c6d9346d01af4f4f9aed",
@@ -600,14 +600,14 @@ func TestConvertDockerInspect(t *testing.T) {
 					},
 					Running: true,
 					Status:  "running",
-					Ports:   []codersdk.WorkspaceAgentDevcontainerPort{},
+					Ports:   []codersdk.WorkspaceAgentContainerPort{},
 					Volumes: map[string]string{},
 				},
 			},
 		},
 		{
 			name: "devcontainer_forwardport",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 3, 55, 22053072, time.UTC),
 					ID:           "4a16af2293fb75dc827a6949a3905dd57ea28cc008823218ce24fab1cb66c067",
@@ -619,14 +619,14 @@ func TestConvertDockerInspect(t *testing.T) {
 					},
 					Running: true,
 					Status:  "running",
-					Ports:   []codersdk.WorkspaceAgentDevcontainerPort{},
+					Ports:   []codersdk.WorkspaceAgentContainerPort{},
 					Volumes: map[string]string{},
 				},
 			},
 		},
 		{
 			name: "devcontainer_appport",
-			expect: []codersdk.WorkspaceAgentDevcontainer{
+			expect: []codersdk.WorkspaceAgentContainer{
 				{
 					CreatedAt:    time.Date(2025, 3, 11, 17, 2, 42, 613747761, time.UTC),
 					ID:           "52d23691f4b954d083f117358ea763e20f69af584e1c08f479c5752629ee0be3",
@@ -638,7 +638,7 @@ func TestConvertDockerInspect(t *testing.T) {
 					},
 					Running: true,
 					Status:  "running",
-					Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+					Ports: []codersdk.WorkspaceAgentContainerPort{
 						{
 							Network:  "tcp",
 							Port:     8080,
@@ -809,9 +809,9 @@ func TestDockerEnvInfoer(t *testing.T) {
 	}
 }
 
-func fakeContainer(t *testing.T, mut ...func(*codersdk.WorkspaceAgentDevcontainer)) codersdk.WorkspaceAgentDevcontainer {
+func fakeContainer(t *testing.T, mut ...func(*codersdk.WorkspaceAgentContainer)) codersdk.WorkspaceAgentContainer {
 	t.Helper()
-	ct := codersdk.WorkspaceAgentDevcontainer{
+	ct := codersdk.WorkspaceAgentContainer{
 		CreatedAt:    time.Now().UTC(),
 		ID:           uuid.New().String(),
 		FriendlyName: testutil.GetRandomName(t),
@@ -820,7 +820,7 @@ func fakeContainer(t *testing.T, mut ...func(*codersdk.WorkspaceAgentDevcontaine
 			testutil.GetRandomName(t): testutil.GetRandomName(t),
 		},
 		Running: true,
-		Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+		Ports: []codersdk.WorkspaceAgentContainerPort{
 			{
 				Network:  "tcp",
 				Port:     testutil.RandomPortNoListen(t),

--- a/cli/cliui/resources.go
+++ b/cli/cliui/resources.go
@@ -182,7 +182,7 @@ func renderDevcontainers(wro WorkspaceResourcesOptions, agentID uuid.UUID, index
 	return rows
 }
 
-func renderDevcontainerRow(container codersdk.WorkspaceAgentDevcontainer, index, total int) table.Row {
+func renderDevcontainerRow(container codersdk.WorkspaceAgentContainer, index, total int) table.Row {
 	var row table.Row
 	var sb strings.Builder
 	_, _ = sb.WriteString("      ")

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1997,7 +1997,7 @@ func TestSSH_Container(t *testing.T) {
 		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
 
 		mLister.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
-			Containers: []codersdk.WorkspaceAgentDevcontainer{
+			Containers: []codersdk.WorkspaceAgentContainer{
 				{
 					ID:           uuid.NewString(),
 					FriendlyName: "something_completely_different",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16180,7 +16180,7 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.WorkspaceAgentDevcontainer": {
+        "codersdk.WorkspaceAgentContainer": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -16211,7 +16211,7 @@ const docTemplate = `{
                     "description": "Ports includes ports exposed by the container.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/codersdk.WorkspaceAgentDevcontainerPort"
+                        "$ref": "#/definitions/codersdk.WorkspaceAgentContainerPort"
                     }
                 },
                 "running": {
@@ -16231,7 +16231,7 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.WorkspaceAgentDevcontainerPort": {
+        "codersdk.WorkspaceAgentContainerPort": {
             "type": "object",
             "properties": {
                 "host_ip": {
@@ -16299,7 +16299,7 @@ const docTemplate = `{
                     "description": "Containers is a list of containers visible to the workspace agent.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/codersdk.WorkspaceAgentDevcontainer"
+                        "$ref": "#/definitions/codersdk.WorkspaceAgentContainer"
                     }
                 },
                 "warnings": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14753,7 +14753,7 @@
 				}
 			}
 		},
-		"codersdk.WorkspaceAgentDevcontainer": {
+		"codersdk.WorkspaceAgentContainer": {
 			"type": "object",
 			"properties": {
 				"created_at": {
@@ -14784,7 +14784,7 @@
 					"description": "Ports includes ports exposed by the container.",
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/codersdk.WorkspaceAgentDevcontainerPort"
+						"$ref": "#/definitions/codersdk.WorkspaceAgentContainerPort"
 					}
 				},
 				"running": {
@@ -14804,7 +14804,7 @@
 				}
 			}
 		},
-		"codersdk.WorkspaceAgentDevcontainerPort": {
+		"codersdk.WorkspaceAgentContainerPort": {
 			"type": "object",
 			"properties": {
 				"host_ip": {
@@ -14872,7 +14872,7 @@
 					"description": "Containers is a list of containers visible to the workspace agent.",
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/codersdk.WorkspaceAgentDevcontainer"
+						"$ref": "#/definitions/codersdk.WorkspaceAgentContainer"
 					}
 				},
 				"warnings": {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -765,7 +765,7 @@ func (api *API) workspaceAgentListContainers(rw http.ResponseWriter, r *http.Req
 	}
 
 	// Filter in-place by labels
-	cts.Containers = slices.DeleteFunc(cts.Containers, func(ct codersdk.WorkspaceAgentDevcontainer) bool {
+	cts.Containers = slices.DeleteFunc(cts.Containers, func(ct codersdk.WorkspaceAgentContainer) bool {
 		return !maputil.Subset(labels, ct.Labels)
 	})
 

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1164,7 +1164,7 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 			"com.coder.test": uuid.New().String(),
 		}
 		testResponse := codersdk.WorkspaceAgentListContainersResponse{
-			Containers: []codersdk.WorkspaceAgentDevcontainer{
+			Containers: []codersdk.WorkspaceAgentContainer{
 				{
 					ID:           uuid.NewString(),
 					CreatedAt:    dbtime.Now(),
@@ -1173,7 +1173,7 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 					Labels:       testLabels,
 					Running:      true,
 					Status:       "running",
-					Ports: []codersdk.WorkspaceAgentDevcontainerPort{
+					Ports: []codersdk.WorkspaceAgentContainerPort{
 						{
 							Network:  "tcp",
 							Port:     80,

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -392,11 +392,11 @@ func (c *Client) WorkspaceAgentListeningPorts(ctx context.Context, agentID uuid.
 	return listeningPorts, json.NewDecoder(res.Body).Decode(&listeningPorts)
 }
 
-// WorkspaceAgentDevcontainer describes a devcontainer of some sort
+// WorkspaceAgentContainer describes a devcontainer of some sort
 // that is visible to the workspace agent. This struct is an abstraction
 // of potentially multiple implementations, and the fields will be
 // somewhat implementation-dependent.
-type WorkspaceAgentDevcontainer struct {
+type WorkspaceAgentContainer struct {
 	// CreatedAt is the time the container was created.
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	// ID is the unique identifier of the container.
@@ -410,7 +410,7 @@ type WorkspaceAgentDevcontainer struct {
 	// Running is true if the container is currently running.
 	Running bool `json:"running"`
 	// Ports includes ports exposed by the container.
-	Ports []WorkspaceAgentDevcontainerPort `json:"ports"`
+	Ports []WorkspaceAgentContainerPort `json:"ports"`
 	// Status is the current status of the container. This is somewhat
 	// implementation-dependent, but should generally be a human-readable
 	// string.
@@ -420,8 +420,8 @@ type WorkspaceAgentDevcontainer struct {
 	Volumes map[string]string `json:"volumes"`
 }
 
-// WorkspaceAgentDevcontainerPort describes a port as exposed by a container.
-type WorkspaceAgentDevcontainerPort struct {
+// WorkspaceAgentContainerPort describes a port as exposed by a container.
+type WorkspaceAgentContainerPort struct {
 	// Port is the port number *inside* the container.
 	Port uint16 `json:"port"`
 	// Network is the network protocol used by the port (tcp, udp, etc).
@@ -437,7 +437,7 @@ type WorkspaceAgentDevcontainerPort struct {
 // request.
 type WorkspaceAgentListContainersResponse struct {
 	// Containers is a list of containers visible to the workspace agent.
-	Containers []WorkspaceAgentDevcontainer `json:"containers"`
+	Containers []WorkspaceAgentContainer `json:"containers"`
 	// Warnings is a list of warnings that may have occurred during the
 	// process of listing containers. This should not include fatal errors.
 	Warnings []string `json:"warnings,omitempty"`

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7843,7 +7843,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `updated_at`                 | string                                                                                       | false    |              |                                                                                                                                                                              |
 | `version`                    | string                                                                                       | false    |              |                                                                                                                                                                              |
 
-## codersdk.WorkspaceAgentDevcontainer
+## codersdk.WorkspaceAgentContainer
 
 ```json
 {
@@ -7874,21 +7874,21 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name               | Type                                                                                        | Required | Restrictions | Description                                                                                                                                |
-|--------------------|---------------------------------------------------------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `created_at`       | string                                                                                      | false    |              | Created at is the time the container was created.                                                                                          |
-| `id`               | string                                                                                      | false    |              | ID is the unique identifier of the container.                                                                                              |
-| `image`            | string                                                                                      | false    |              | Image is the name of the container image.                                                                                                  |
-| `labels`           | object                                                                                      | false    |              | Labels is a map of key-value pairs of container labels.                                                                                    |
-| » `[any property]` | string                                                                                      | false    |              |                                                                                                                                            |
-| `name`             | string                                                                                      | false    |              | Name is the human-readable name of the container.                                                                                          |
-| `ports`            | array of [codersdk.WorkspaceAgentDevcontainerPort](#codersdkworkspaceagentdevcontainerport) | false    |              | Ports includes ports exposed by the container.                                                                                             |
-| `running`          | boolean                                                                                     | false    |              | Running is true if the container is currently running.                                                                                     |
-| `status`           | string                                                                                      | false    |              | Status is the current status of the container. This is somewhat implementation-dependent, but should generally be a human-readable string. |
-| `volumes`          | object                                                                                      | false    |              | Volumes is a map of "things" mounted into the container. Again, this is somewhat implementation-dependent.                                 |
-| » `[any property]` | string                                                                                      | false    |              |                                                                                                                                            |
+| Name               | Type                                                                                  | Required | Restrictions | Description                                                                                                                                |
+|--------------------|---------------------------------------------------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `created_at`       | string                                                                                | false    |              | Created at is the time the container was created.                                                                                          |
+| `id`               | string                                                                                | false    |              | ID is the unique identifier of the container.                                                                                              |
+| `image`            | string                                                                                | false    |              | Image is the name of the container image.                                                                                                  |
+| `labels`           | object                                                                                | false    |              | Labels is a map of key-value pairs of container labels.                                                                                    |
+| » `[any property]` | string                                                                                | false    |              |                                                                                                                                            |
+| `name`             | string                                                                                | false    |              | Name is the human-readable name of the container.                                                                                          |
+| `ports`            | array of [codersdk.WorkspaceAgentContainerPort](#codersdkworkspaceagentcontainerport) | false    |              | Ports includes ports exposed by the container.                                                                                             |
+| `running`          | boolean                                                                               | false    |              | Running is true if the container is currently running.                                                                                     |
+| `status`           | string                                                                                | false    |              | Status is the current status of the container. This is somewhat implementation-dependent, but should generally be a human-readable string. |
+| `volumes`          | object                                                                                | false    |              | Volumes is a map of "things" mounted into the container. Again, this is somewhat implementation-dependent.                                 |
+| » `[any property]` | string                                                                                | false    |              |                                                                                                                                            |
 
-## codersdk.WorkspaceAgentDevcontainerPort
+## codersdk.WorkspaceAgentContainerPort
 
 ```json
 {
@@ -7984,10 +7984,10 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name         | Type                                                                                | Required | Restrictions | Description                                                                                                                           |
-|--------------|-------------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `containers` | array of [codersdk.WorkspaceAgentDevcontainer](#codersdkworkspaceagentdevcontainer) | false    |              | Containers is a list of containers visible to the workspace agent.                                                                    |
-| `warnings`   | array of string                                                                     | false    |              | Warnings is a list of warnings that may have occurred during the process of listing containers. This should not include fatal errors. |
+| Name         | Type                                                                          | Required | Restrictions | Description                                                                                                                           |
+|--------------|-------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `containers` | array of [codersdk.WorkspaceAgentContainer](#codersdkworkspaceagentcontainer) | false    |              | Containers is a list of containers visible to the workspace agent.                                                                    |
+| `warnings`   | array of string                                                               | false    |              | Warnings is a list of warnings that may have occurred during the process of listing containers. This should not include fatal errors. |
 
 ## codersdk.WorkspaceAgentListeningPort
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3058,20 +3058,20 @@ export interface WorkspaceAgent {
 }
 
 // From codersdk/workspaceagents.go
-export interface WorkspaceAgentDevcontainer {
+export interface WorkspaceAgentContainer {
 	readonly created_at: string;
 	readonly id: string;
 	readonly name: string;
 	readonly image: string;
 	readonly labels: Record<string, string>;
 	readonly running: boolean;
-	readonly ports: readonly WorkspaceAgentDevcontainerPort[];
+	readonly ports: readonly WorkspaceAgentContainerPort[];
 	readonly status: string;
 	readonly volumes: Record<string, string>;
 }
 
 // From codersdk/workspaceagents.go
-export interface WorkspaceAgentDevcontainerPort {
+export interface WorkspaceAgentContainerPort {
 	readonly port: number;
 	readonly network: string;
 	readonly host_ip?: string;
@@ -3110,7 +3110,7 @@ export const WorkspaceAgentLifecycles: WorkspaceAgentLifecycle[] = [
 
 // From codersdk/workspaceagents.go
 export interface WorkspaceAgentListContainersResponse {
-	readonly containers: readonly WorkspaceAgentDevcontainer[];
+	readonly containers: readonly WorkspaceAgentContainer[];
 	readonly warnings?: readonly string[];
 }
 

--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import {
 	MockWorkspace,
-	MockWorkspaceAgentDevcontainer,
-	MockWorkspaceAgentDevcontainerPorts,
+	MockWorkspaceAgentContainer,
+	MockWorkspaceAgentContainerPorts,
 } from "testHelpers/entities";
 import { AgentDevcontainerCard } from "./AgentDevcontainerCard";
 
@@ -10,7 +10,7 @@ const meta: Meta<typeof AgentDevcontainerCard> = {
 	title: "modules/resources/AgentDevcontainerCard",
 	component: AgentDevcontainerCard,
 	args: {
-		container: MockWorkspaceAgentDevcontainer,
+		container: MockWorkspaceAgentContainer,
 		workspace: MockWorkspace,
 		wildcardHostname: "*.wildcard.hostname",
 		agentName: "dev",
@@ -25,8 +25,8 @@ export const NoPorts: Story = {};
 export const WithPorts: Story = {
 	args: {
 		container: {
-			...MockWorkspaceAgentDevcontainer,
-			ports: MockWorkspaceAgentDevcontainerPorts,
+			...MockWorkspaceAgentContainer,
+			ports: MockWorkspaceAgentContainerPorts,
 		},
 	},
 };

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -1,6 +1,6 @@
 import Link from "@mui/material/Link";
 import Tooltip, { type TooltipProps } from "@mui/material/Tooltip";
-import type { Workspace, WorkspaceAgentDevcontainer } from "api/typesGenerated";
+import type { Workspace, WorkspaceAgentContainer } from "api/typesGenerated";
 import { ExternalLinkIcon } from "lucide-react";
 import type { FC } from "react";
 import { portForwardURL } from "utils/portForward";
@@ -9,7 +9,7 @@ import { AgentDevcontainerSSHButton } from "./SSHButton/SSHButton";
 import { TerminalLink } from "./TerminalLink/TerminalLink";
 
 type AgentDevcontainerCardProps = {
-	container: WorkspaceAgentDevcontainer;
+	container: WorkspaceAgentContainer;
 	workspace: Workspace;
 	wildcardHostname: string;
 	agentName: string;

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -4277,7 +4277,7 @@ function mockTwoDaysAgo() {
 	return date.toISOString();
 }
 
-export const MockWorkspaceAgentDevcontainerPorts: TypesGen.WorkspaceAgentDevcontainerPort[] =
+export const MockWorkspaceAgentContainerPorts: TypesGen.WorkspaceAgentContainerPort[] =
 	[
 		{
 			port: 1000,
@@ -4297,25 +4297,24 @@ export const MockWorkspaceAgentDevcontainerPorts: TypesGen.WorkspaceAgentDevcont
 		},
 	];
 
-export const MockWorkspaceAgentDevcontainer: TypesGen.WorkspaceAgentDevcontainer =
-	{
-		created_at: "2024-01-04T15:53:03.21563Z",
-		id: "abcd1234",
-		name: "container-1",
-		image: "ubuntu:latest",
-		labels: {
-			foo: "bar",
-		},
-		ports: [],
-		running: true,
-		status: "running",
-		volumes: {
-			"/mnt/volume1": "/volume1",
-		},
-	};
+export const MockWorkspaceAgentContainer: TypesGen.WorkspaceAgentContainer = {
+	created_at: "2024-01-04T15:53:03.21563Z",
+	id: "abcd1234",
+	name: "container-1",
+	image: "ubuntu:latest",
+	labels: {
+		foo: "bar",
+	},
+	ports: [],
+	running: true,
+	status: "running",
+	volumes: {
+		"/mnt/volume1": "/volume1",
+	},
+};
 
 export const MockWorkspaceAgentListContainersResponse: TypesGen.WorkspaceAgentListContainersResponse =
 	{
-		containers: [MockWorkspaceAgentDevcontainer],
+		containers: [MockWorkspaceAgentContainer],
 		warnings: ["This is a warning"],
 	};


### PR DESCRIPTION
This is to free up the devcontainer name space for more targeted structs.

Related #16423
