### PR TITLE
feat: make notifications header sticky

### DIFF
--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof InboxPopover> = {
 	},
 	render: (args) => {
 		return (
-			<div className="w-full max-w-screen-xl p-6 h-[720px]">
+			<div className="w-full max-w-screen-xl py-2 px-6">
 				<header className="flex justify-end">
 					<InboxPopover {...args} />
 				</header>

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, userEvent, within } from "@storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "@storybook/test";
 import { MockNotifications } from "testHelpers/entities";
 import { daysAgo } from "utils/time";
 import { InboxPopover } from "./InboxPopover";
@@ -47,12 +47,13 @@ export const Scrollable: Story = {
 		if (!content) {
 			throw new Error("ScrollArea content not found");
 		}
-		const openAnimationDuration = 250;
-		setTimeout(() => {
+		await waitFor(() => {
+			const distanceToBottom = content?.children[0].clientHeight;
 			content.scroll({
-				top: content?.children[0].clientHeight,
+				top: distanceToBottom,
 			});
-		}, openAnimationDuration);
+			expect(content.scrollTop).not.toBe(0);
+		});
 	},
 };
 

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -11,18 +11,12 @@ const meta: Meta<typeof InboxPopover> = {
 	},
 	render: (args) => {
 		return (
-			<div className="w-full max-w-screen-xl py-2 px-6">
+			<div className="w-full max-w-screen-xl p-6 h-[720px]">
 				<header className="flex justify-end">
 					<InboxPopover {...args} />
 				</header>
 			</div>
 		);
-	},
-	parameters: {
-		layout: "fullscreen",
-		chromatic: {
-			desktop: { name: "Custom", styles: { width: "640px", height: "720px" } },
-		},
 	},
 };
 

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -12,12 +12,15 @@ const meta: Meta<typeof InboxPopover> = {
 	},
 	render: (args) => {
 		return (
-			<div className="w-full max-w-screen-xl p-6 h-[720px]">
+			<div className="w-full max-w-screen-xl p-6 h-[320px]">
 				<header className="flex justify-end">
 					<InboxPopover {...args} />
 				</header>
 			</div>
 		);
+	},
+	parameters: {
+		layout: "fullscreen",
 	},
 };
 
@@ -33,7 +36,7 @@ export const Default: Story = {
 
 export const Scrollable: Story = {
 	args: {
-		unreadCount: 0,
+		unreadCount: 2,
 		notifications: MockNotifications,
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -36,29 +36,6 @@ export const Default: Story = {
 	},
 };
 
-export const Scrollable: Story = {
-	args: {
-		unreadCount: 2,
-		notifications: MockNotifications,
-	},
-	play: async ({ canvasElement }) => {
-		const body = canvasElement.ownerDocument.body;
-		const content = body.querySelector<HTMLDivElement>(
-			"[data-radix-scroll-area-viewport]",
-		);
-		if (!content) {
-			throw new Error("ScrollArea content not found");
-		}
-		await waitFor(() => {
-			const distanceToBottom = content?.children[0].clientHeight;
-			content.scroll({
-				top: distanceToBottom,
-			});
-			expect(content.scrollTop).not.toBe(0);
-		});
-	},
-};
-
 export const Loading: Story = {
 	args: {
 		unreadCount: 0,

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, fn, userEvent, within } from "@storybook/test";
 import { MockNotifications } from "testHelpers/entities";
-import { InboxPopover } from "./InboxPopover";
 import { daysAgo } from "utils/time";
+import { InboxPopover } from "./InboxPopover";
 
 const meta: Meta<typeof InboxPopover> = {
 	title: "modules/notifications/NotificationsInbox/InboxPopover",

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { expect, fn, userEvent, within } from "@storybook/test";
 import { MockNotifications } from "testHelpers/entities";
 import { InboxPopover } from "./InboxPopover";
+import { daysAgo } from "utils/time";
 
 const meta: Meta<typeof InboxPopover> = {
 	title: "modules/notifications/NotificationsInbox/InboxPopover",
@@ -32,8 +33,23 @@ export const Default: Story = {
 
 export const Scrollable: Story = {
 	args: {
-		unreadCount: 2,
+		unreadCount: 0,
 		notifications: MockNotifications,
+	},
+	play: async ({ canvasElement }) => {
+		const body = canvasElement.ownerDocument.body;
+		const content = body.querySelector<HTMLDivElement>(
+			"[data-radix-scroll-area-viewport]",
+		);
+		if (!content) {
+			throw new Error("ScrollArea content not found");
+		}
+		const openAnimationDuration = 250;
+		setTimeout(() => {
+			content.scroll({
+				top: content?.children[0].clientHeight,
+			});
+		}, openAnimationDuration);
 	},
 };
 

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, fn, userEvent, waitFor, within } from "@storybook/test";
 import { MockNotifications } from "testHelpers/entities";
-import { daysAgo } from "utils/time";
 import { InboxPopover } from "./InboxPopover";
 
 const meta: Meta<typeof InboxPopover> = {
@@ -12,7 +11,7 @@ const meta: Meta<typeof InboxPopover> = {
 	},
 	render: (args) => {
 		return (
-			<div className="w-full max-w-screen-xl p-6 h-[320px]">
+			<div className="w-full max-w-screen-xl p-6 h-[720px]">
 				<header className="flex justify-end">
 					<InboxPopover {...args} />
 				</header>
@@ -21,6 +20,9 @@ const meta: Meta<typeof InboxPopover> = {
 	},
 	parameters: {
 		layout: "fullscreen",
+		chromatic: {
+			desktop: { name: "Custom", styles: { width: "640px", height: "720px" } },
+		},
 	},
 };
 

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.tsx
@@ -47,7 +47,12 @@ export const InboxPopover: FC<InboxPopoverProps> = ({
 				 * https://github.com/shadcn-ui/ui/issues/542#issuecomment-2339361283
 				 */}
 				<ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(var(--radix-popover-content-available-height)-24px)]">
-					<div className="flex items-center justify-between p-3 border-0 border-b border-solid border-border">
+					<div
+						className={cn([
+							"flex items-center justify-between p-3 border-0 border-b border-solid border-border",
+							"sticky top-0 bg-surface-primary z-10 rounded-t",
+						])}
+					>
 						<div className="flex items-center gap-2">
 							<span className="text-xl font-semibold">Inbox</span>
 							{unreadCount > 0 && <UnreadBadge count={unreadCount} />}


### PR DESCRIPTION
When having a bunch of notifications and the user is scrolling down the content it is helpful to keep the header visible so the user can easily mark all of them as read if they want to.