### PR TITLE
fix: resolve flakey inbox tests

### DIFF
--- a/coderd/inboxnotifications_test.go
+++ b/coderd/inboxnotifications_test.go
@@ -122,7 +122,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "notification title", "notification content", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		_, message, err := wsConn.Read(ctx)
 		require.NoError(t, err)
@@ -174,7 +175,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "memory related title", "memory related content", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		_, message, err := wsConn.Read(ctx)
 		require.NoError(t, err)
@@ -193,7 +195,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "disk related title", "disk related title", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		dispatchFunc, err = inboxHandler.Dispatcher(types.MessagePayload{
 			UserID:                 memberClient.ID.String(),
@@ -201,7 +204,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "second memory related title", "second memory related title", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		_, message, err = wsConn.Read(ctx)
 		require.NoError(t, err)
@@ -256,7 +260,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "memory related title", "memory related content", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		_, message, err := wsConn.Read(ctx)
 		require.NoError(t, err)
@@ -276,7 +281,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "second memory related title", "second memory related title", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		dispatchFunc, err = inboxHandler.Dispatcher(types.MessagePayload{
 			UserID:                 memberClient.ID.String(),
@@ -285,7 +291,8 @@ func TestInboxNotification_Watch(t *testing.T) {
 		}, "another memory related title", "another memory related title", nil)
 		require.NoError(t, err)
 
-		dispatchFunc(ctx, uuid.New())
+		_, err = dispatchFunc(ctx, uuid.New())
+		require.NoError(t, err)
 
 		_, message, err = wsConn.Read(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
Fix flakey Coder Inbox tests by opening database subscriber before accepting the web socket request.