### PR TITLE
feat(agent/reconnectingpty): allow selecting backend type

### DIFF
--- a/agent/reconnectingpty/reconnectingpty.go
+++ b/agent/reconnectingpty/reconnectingpty.go
@@ -32,6 +32,8 @@ type Options struct {
 	Timeout time.Duration
 	// Metrics tracks various error counters.
 	Metrics *prometheus.CounterVec
+	// BackendType specifies the ReconnectingPTY backend to use.
+	BackendType string
 }
 
 // ReconnectingPTY is a pty that can be reconnected within a timeout and to
@@ -64,12 +66,19 @@ func New(ctx context.Context, logger slog.Logger, execer agentexec.Execer, cmd *
 	// runs) but in CI screen often incorrectly claims the session name does not
 	// exist even though screen -list shows it.  For now, restrict screen to
 	// Linux.
-	backendType := "buffered"
+	autoBackendType := "buffered"
 	if runtime.GOOS == "linux" {
 		_, err := exec.LookPath("screen")
 		if err == nil {
-			backendType = "screen"
+			autoBackendType = "screen"
 		}
+	}
+	var backendType string
+	switch options.BackendType {
+	case "":
+		backendType = autoBackendType
+	default:
+		backendType = options.BackendType
 	}
 
 	logger.Info(ctx, "start reconnecting pty", slog.F("backend_type", backendType))

--- a/agent/reconnectingpty/server.go
+++ b/agent/reconnectingpty/server.go
@@ -207,8 +207,9 @@ func (s *Server) handleConn(ctx context.Context, logger slog.Logger, conn net.Co
 			s.commandCreator.Execer,
 			cmd,
 			&Options{
-				Timeout: s.timeout,
-				Metrics: s.errorsTotal,
+				Timeout:     s.timeout,
+				Metrics:     s.errorsTotal,
+				BackendType: msg.BackendType,
 			},
 		)
 

--- a/cli/exp_rpty_test.go
+++ b/cli/exp_rpty_test.go
@@ -1,10 +1,10 @@
 package cli_test
 
 import (
-	"fmt"
 	"runtime"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 
@@ -23,7 +23,7 @@ import (
 func TestExpRpty(t *testing.T) {
 	t.Parallel()
 
-	t.Run("OK", func(t *testing.T) {
+	t.Run("DefaultCommand", func(t *testing.T) {
 		t.Parallel()
 
 		client, workspace, agentToken := setupWorkspaceForAgent(t)
@@ -41,8 +41,30 @@ func TestExpRpty(t *testing.T) {
 		_ = agenttest.New(t, client.URL, agentToken)
 		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
 
-		pty.ExpectMatch(fmt.Sprintf("Connected to %s", workspace.Name))
 		pty.WriteLine("exit")
+		<-cmdDone
+	})
+
+	t.Run("Command", func(t *testing.T) {
+		t.Parallel()
+
+		client, workspace, agentToken := setupWorkspaceForAgent(t)
+		randStr := uuid.NewString()
+		inv, root := clitest.New(t, "exp", "rpty", workspace.Name, "echo", randStr)
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t).Attach(inv)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		cmdDone := tGo(t, func() {
+			err := inv.WithContext(ctx).Run()
+			assert.NoError(t, err)
+		})
+
+		_ = agenttest.New(t, client.URL, agentToken)
+		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
+
+		pty.ExpectMatch(randStr)
 		<-cmdDone
 	})
 
@@ -103,8 +125,6 @@ func TestExpRpty(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		pty.ExpectMatch(fmt.Sprintf("Connected to %s", workspace.Name))
-		pty.ExpectMatch("Reconnect ID: ")
 		pty.ExpectMatch(" #")
 		pty.WriteLine("hostname")
 		pty.ExpectMatch(ct.Container.Config.Hostname)

--- a/coderd/workspaceapps/proxy.go
+++ b/coderd/workspaceapps/proxy.go
@@ -655,6 +655,7 @@ func (s *Server) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 	width := parser.UInt(values, 80, "width")
 	container := parser.String(values, "", "container")
 	containerUser := parser.String(values, "", "container_user")
+	backendType := parser.String(values, "", "backend_type")
 	if len(parser.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message:     "Invalid query parameters.",
@@ -695,6 +696,7 @@ func (s *Server) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 	ptNetConn, err := agentConn.ReconnectingPTY(ctx, reconnect, uint16(height), uint16(width), r.URL.Query().Get("command"), func(arp *workspacesdk.AgentReconnectingPTYInit) {
 		arp.Container = container
 		arp.ContainerUser = containerUser
+		arp.BackendType = backendType
 	})
 	if err != nil {
 		log.Debug(ctx, "dial reconnecting pty server in workspace agent", slog.Error(err))

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -100,6 +100,8 @@ type AgentReconnectingPTYInit struct {
 	// This can be a username or UID, depending on the underlying implementation.
 	// This is ignored if Container is not set.
 	ContainerUser string
+
+	BackendType string
 }
 
 // AgentReconnectingPTYInitOption is a functional option for AgentReconnectingPTYInit.

--- a/codersdk/workspacesdk/workspacesdk.go
+++ b/codersdk/workspacesdk/workspacesdk.go
@@ -318,6 +318,11 @@ type WorkspaceAgentReconnectingPTYOpts struct {
 	// CODER_AGENT_DEVCONTAINERS_ENABLE set to "true".
 	Container     string
 	ContainerUser string
+
+	// BackendType is the type of backend to use for the PTY. If not set, the
+	// workspace agent will attempt to determine the preferred backend type.
+	// Supported values are "screen" and "buffered".
+	BackendType string
 }
 
 // AgentReconnectingPTY spawns a PTY that reconnects using the token provided.
@@ -338,6 +343,9 @@ func (c *Client) AgentReconnectingPTY(ctx context.Context, opts WorkspaceAgentRe
 	}
 	if opts.ContainerUser != "" {
 		q.Set("container_user", opts.ContainerUser)
+	}
+	if opts.BackendType != "" {
+		q.Set("backend_type", opts.BackendType)
 	}
 	// If we're using a signed token, set the query parameter.
 	if opts.SignedToken != "" {


### PR DESCRIPTION
In #8640 we added an alternative 'screen' backend for our reconnectingpty endpoint used by our web terminal.
This opportunistically checks for the presence of `screen` in `$PATH` and selects the screen backend if screen is available, falling back to the default "buffered" backend.

This is fantastic for long-lived shell sessions, but another use case for rpty is just executing "one-off" commands (basically, anything that isn't a shell).
In these cases, the screen backend is actually kind of annoying, as you get the following output:

```
<output of command>






[screen is terminating]
```

I considered the alternative of stripping the extraneous output, but decided it made more sense to skip the overhead of executing screen if it won't be needed anyway for a simple one-shot command.

The definition of a "one-shot" command is somewhat open to interpretation.
This should not affect any existing usage, as omitting `BackendType` should result in the same behaviour as before.

Note: this also loses the extra "Connected to agent" and "reconnect ID" output from the `exp rpty` command. I didn't find them especially useful, but can easily add these back if needed.