### PR TITLE
feat: add API endpoint for retrieving OIDC logout URL

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -592,6 +592,12 @@ OIDC OPTIONS:
       --oidc-username-field string, $CODER_OIDC_USERNAME_FIELD (default: preferred_username)
           OIDC claim field to use as the username.
 
+      --logout-endpoint string, $CODER_OIDC_LOGOUT_ENDPOINT
+          OIDC endpoint for logout.
+
+      --logout-redirect-uri string, $CODER_OIDC_LOGOUT_URI
+          OIDC redirect URI after logout.
+
       --oidc-sign-in-text string, $CODER_OIDC_SIGN_IN_TEXT (default: OpenID Connect)
           The text to show on the OpenID Connect sign in button.
 

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -592,10 +592,7 @@ OIDC OPTIONS:
       --oidc-username-field string, $CODER_OIDC_USERNAME_FIELD (default: preferred_username)
           OIDC claim field to use as the username.
 
-      --logout-endpoint string, $CODER_OIDC_LOGOUT_ENDPOINT
-          OIDC endpoint for logout.
-
-      --logout-redirect-uri string, $CODER_OIDC_LOGOUT_URI
+      --oidc-logout-redirect-uri string, $CODER_OIDC_LOGOUT_URI
           OIDC redirect URI after logout.
 
       --oidc-sign-in-text string, $CODER_OIDC_SIGN_IN_TEXT (default: OpenID Connect)

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -401,6 +401,12 @@ oidc:
   # an insecure OIDC configuration. It is not recommended to use this flag.
   # (default: <unset>, type: bool)
   dangerousSkipIssuerChecks: false
+  # OIDC endpoint for logout.
+  # (default: <unset>, type: string)
+  logoutEndpoint: ""
+  # OIDC redirect URI after logout.
+  # (default: <unset>, type: string)
+  logoutRedirectURI: ""
 # Telemetry is critical to our ability to improve Coder. We strip all personal
 #  information before sending data to our servers. Please only disable telemetry
 #  when required by your organization's security policy.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -401,9 +401,6 @@ oidc:
   # an insecure OIDC configuration. It is not recommended to use this flag.
   # (default: <unset>, type: bool)
   dangerousSkipIssuerChecks: false
-  # OIDC endpoint for logout.
-  # (default: <unset>, type: string)
-  logoutEndpoint: ""
   # OIDC redirect URI after logout.
   # (default: <unset>, type: string)
   logoutRedirectURI: ""

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6402,6 +6402,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/oidc-logout": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Returns URL for the OIDC logout",
+                "operationId": "user-oidc-logout",
+                "responses": {
+                    "200": {
+                        "description": "Returns a map containing the OIDC logout URL",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.OIDCLogoutResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/oidc/callback": {
             "get": {
                 "security": [
@@ -13013,6 +13038,12 @@ const docTemplate = `{
                 "issuer_url": {
                     "type": "string"
                 },
+                "logout_endpoint": {
+                    "type": "string"
+                },
+                "logout_redirect_uri": {
+                    "type": "string"
+                },
                 "name_field": {
                     "type": "string"
                 },
@@ -13057,6 +13088,14 @@ const docTemplate = `{
                     }
                 },
                 "username_field": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.OIDCLogoutResponse": {
+            "type": "object",
+            "properties": {
+                "oidc_logout_url": {
                     "type": "string"
                 }
             }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6415,8 +6415,8 @@ const docTemplate = `{
                 "tags": [
                     "Users"
                 ],
-                "summary": "Returns URL for the OIDC logout",
-                "operationId": "user-oidc-logout",
+                "summary": "Get user OIDC logout URL",
+                "operationId": "get-user-oidc-logout-url",
                 "responses": {
                     "200": {
                         "description": "Returns a map containing the OIDC logout URL",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5659,6 +5659,27 @@
 				}
 			}
 		},
+		"/users/oidc-logout": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["Users"],
+				"summary": "Returns URL for the OIDC logout",
+				"operationId": "user-oidc-logout",
+				"responses": {
+					"200": {
+						"description": "Returns a map containing the OIDC logout URL",
+						"schema": {
+							"$ref": "#/definitions/codersdk.OIDCLogoutResponse"
+						}
+					}
+				}
+			}
+		},
 		"/users/oidc/callback": {
 			"get": {
 				"security": [
@@ -11724,6 +11745,12 @@
 				"issuer_url": {
 					"type": "string"
 				},
+				"logout_endpoint": {
+					"type": "string"
+				},
+				"logout_redirect_uri": {
+					"type": "string"
+				},
 				"name_field": {
 					"type": "string"
 				},
@@ -11768,6 +11795,14 @@
 					}
 				},
 				"username_field": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.OIDCLogoutResponse": {
+			"type": "object",
+			"properties": {
+				"oidc_logout_url": {
 					"type": "string"
 				}
 			}

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5668,8 +5668,8 @@
 				],
 				"produces": ["application/json"],
 				"tags": ["Users"],
-				"summary": "Returns URL for the OIDC logout",
-				"operationId": "user-oidc-logout",
+				"summary": "Get user OIDC logout URL",
+				"operationId": "get-user-oidc-logout-url",
 				"responses": {
 					"200": {
 						"description": "Returns a map containing the OIDC logout URL",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1136,6 +1136,7 @@ func New(options *Options) *API {
 				r.Post("/", api.postUser)
 				r.Get("/", api.users)
 				r.Post("/logout", api.postLogout)
+				r.Get("/oidc-logout", api.userOIDCLogoutURL)
 				// These routes query information about site wide roles.
 				r.Route("/roles", func(r chi.Router) {
 					r.Get("/", api.AssignableSiteRoles)

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -744,10 +744,10 @@ func (api *API) postLogout(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Returns the OIDC logout URL.
+// Returns URL for the OIDC logout.
 //
-// @Summary Returns URL for the OIDC logout
-// @ID user-oidc-logout
+// @Summary Get user OIDC logout URL
+// @ID get-user-oidc-logout-url
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Users

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/mail"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -741,6 +742,95 @@ func (api *API) postLogout(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.Response{
 		Message: "Logged out!",
 	})
+}
+
+// Returns the OIDC logout URL.
+//
+// @Summary Returns URL for the OIDC logout
+// @ID user-oidc-logout
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Users
+// @Success 200 {object} map[string]string "Returns a map containing the OIDC logout URL"
+// @Router /users/oidc-logout [get]
+func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Get logged-in user
+	apiKey := httpmw.APIKey(r)
+	user, err := api.Database.GetUserByID(ctx, apiKey.UserID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusUnauthorized, codersdk.Response{
+			Message: "Failed to retrieve user information.",
+		})
+		return
+	}
+
+	// Retrieve the user's OAuthAccessToken for logout
+	// nolint:gocritic // We only can get user link by user ID and login type with the system auth.
+	link, err := api.Database.GetUserLinkByUserIDLoginType(dbauthz.AsSystemRestricted(ctx),
+		database.GetUserLinkByUserIDLoginTypeParams{
+			UserID:    user.ID,
+			LoginType: user.LoginType,
+		})
+	if err != nil {
+		api.Logger.Error(ctx, "failed to retrieve OIDC user link", "error", err)
+		if xerrors.Is(err, sql.ErrNoRows) {
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+				Message: "No OIDC link found for this user.",
+			})
+		} else {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to retrieve user authentication data.",
+			})
+		}
+		return
+	}
+
+	rawIDToken := link.OAuthAccessToken
+
+	// Retrieve OIDC environment variables
+	dvOIDC := api.DeploymentValues.OIDC
+	oidcEndpoint := dvOIDC.LogoutEndpoint.Value()
+	oidcClientID := dvOIDC.ClientID.Value()
+	logoutURI := dvOIDC.LogoutRedirectURI.Value()
+
+	if oidcEndpoint == "" {
+		api.Logger.Error(ctx, "missing OIDC logout endpoint")
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "OIDC configuration is missing.",
+		})
+		return
+	}
+
+	// Construct OIDC Logout URL
+	logoutURL, err := url.Parse(oidcEndpoint)
+	if err != nil {
+		api.Logger.Error(ctx, "failed to parse OIDC endpoint", "error", err)
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Invalid OIDC endpoint.",
+		})
+		return
+	}
+
+	// Build parameters
+	q := url.Values{}
+
+	if oidcClientID != "" {
+		q.Set("client_id", oidcClientID)
+	}
+	if rawIDToken != "" {
+		q.Set("id_token_hint", rawIDToken)
+	}
+	if logoutURI != "" {
+		q.Set("logout_uri", logoutURI)
+	}
+
+	logoutURL.RawQuery = q.Encode()
+
+	// Return full logout URL
+	response := map[string]string{"oidc_logout_url": logoutURL.String()}
+	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
 // GithubOAuth2Team represents a team scoped to an organization.

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -3,8 +3,10 @@ package coderd
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/mail"
 	"net/url"
@@ -744,7 +746,78 @@ func (api *API) postLogout(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Returns URL for the OIDC logout.
+// getDiscoveryEndpoints will return endpoints for end session and revocation
+func (api *API) getDiscoveryEndpoints() (endSessionEndpoint string, revocationEndpoint string, err error) {
+	oidcProvider := api.OIDCConfig.Provider
+
+	var discoveryConfig struct {
+		EndSessionEndpoint string `json:"end_session_endpoint"`
+		RevocationEndpoint string `json:"revocation_endpoint"`
+	}
+
+	// Extract endpoints
+	if err := oidcProvider.Claims(&discoveryConfig); err != nil {
+		return "", "", xerrors.Errorf("failed to extract endpoints from OIDC provider discovery claims: %w", err)
+	}
+
+	return discoveryConfig.EndSessionEndpoint, discoveryConfig.RevocationEndpoint, nil
+}
+
+// revokeOAuthToken will revoke a particular token
+func (api *API) revokeOAuthToken(ctx context.Context, token string, revocationEndpoint string) error {
+	logger := api.Logger.Named(userAuthLoggerName)
+
+	if token == "" || revocationEndpoint == "" {
+		logger.Warn(ctx, "skip OAuth token revocation")
+		return nil
+	}
+
+	dvOIDC := api.DeploymentValues.OIDC
+	oidcClientID := dvOIDC.ClientID.Value()
+	oidcClientSecret := dvOIDC.ClientSecret.Value()
+
+	if oidcClientID == "" || oidcClientSecret == "" {
+		return xerrors.New("missing required configs for revocation (endpoint, client ID, or secret)")
+	}
+
+	data := url.Values{}
+	data.Set("token", token)
+
+	revokeReq, err := http.NewRequestWithContext(ctx, http.MethodPost, revocationEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return xerrors.Errorf("failed to create revoke request object: %w", err)
+	}
+
+	revokeReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	auth := base64.StdEncoding.EncodeToString([]byte(oidcClientID + ":" + oidcClientSecret))
+	revokeReq.Header.Set("Authorization", "Basic "+auth)
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(revokeReq)
+	if err != nil {
+		return xerrors.Errorf("failed to send revoke request to %s: %w", revocationEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBodyBytes, _ := io.ReadAll(resp.Body)
+		respBodyStr := string(respBodyBytes)
+
+		logger.Warn(ctx, "failed to request OAuth token revocation",
+			slog.F("status_code", resp.StatusCode),
+			slog.F("response_body", respBodyStr),
+			slog.F("endpoint", revocationEndpoint),
+			slog.F("client_id", oidcClientID),
+		)
+
+		return xerrors.Errorf("failed to revoke with status %d: %s", resp.StatusCode, respBodyStr)
+	}
+
+	logger.Info(ctx, "success to revoke OAuth token", slog.F("status_code", resp.StatusCode))
+	return nil // Success
+}
+
+// Returns URL for the OIDC logout after token revocation.
 //
 // @Summary Get user OIDC logout URL
 // @ID get-user-oidc-logout-url
@@ -754,7 +827,17 @@ func (api *API) postLogout(rw http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} codersdk.OIDCLogoutResponse "Returns a map containing the OIDC logout URL"
 // @Router /users/oidc-logout [get]
 func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
+	logger := api.Logger.Named(userAuthLoggerName)
 	ctx := r.Context()
+
+	// Check if OIDC is configured
+	if api.OIDCConfig == nil || api.OIDCConfig.Provider == nil {
+		logger.Warn(ctx, "unable to support OIDC logout with current configuration")
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to retrieve OIDC configuration.",
+		})
+		return
+	}
 
 	// Get logged-in user
 	apiKey := httpmw.APIKey(r)
@@ -765,8 +848,6 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-
-	logger := api.Logger.Named(userAuthLoggerName)
 
 	// Default response: empty URL if OIDC logout is not supported
 	response := codersdk.OIDCLogoutResponse{URL: ""}
@@ -793,22 +874,39 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rawIDToken := link.OAuthAccessToken
+	accessToken := link.OAuthAccessToken
+	refreshToken := link.OAuthRefreshToken
 
 	// Retrieve OIDC environment variables
 	dvOIDC := api.DeploymentValues.OIDC
-	oidcEndpoint := dvOIDC.LogoutEndpoint.Value()
 	oidcClientID := dvOIDC.ClientID.Value()
 	logoutURI := dvOIDC.LogoutRedirectURI.Value()
 
-	if oidcEndpoint == "" {
+	endSessionEndpoint, revocationEndpoint, err := api.getDiscoveryEndpoints()
+	if err != nil {
+		logger.Error(ctx, "failed to get OIDC discovery endpoints", slog.Error(err))
+
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to process OIDC configuration.",
+		})
+		return
+	}
+
+	// Perform token revocation first
+	err = api.revokeOAuthToken(ctx, refreshToken, revocationEndpoint)
+	if err != nil {
+		// Do not return since this step is optional
+		logger.Warn(ctx, "failed to revoke OAuth token during logout", slog.Error(err))
+	}
+
+	if endSessionEndpoint == "" {
 		logger.Warn(ctx, "missing OIDC logout endpoint")
 		httpapi.Write(ctx, rw, http.StatusOK, response)
 		return
 	}
 
 	// Construct OIDC Logout URL
-	logoutURL, err := url.Parse(oidcEndpoint)
+	logoutURL, err := url.Parse(endSessionEndpoint)
 	if err != nil {
 		logger.Error(ctx, "failed to parse OIDC endpoint", "error", err)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -821,11 +919,11 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 	// Build parameters
 	q := url.Values{}
 
+	if accessToken != "" {
+		q.Set("id_token_hint", accessToken)
+	}
 	if oidcClientID != "" {
 		q.Set("client_id", oidcClientID)
-	}
-	if rawIDToken != "" {
-		q.Set("id_token_hint", rawIDToken)
 	}
 	if logoutURI != "" {
 		q.Set("logout_uri", logoutURI)

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -751,7 +751,7 @@ func (api *API) postLogout(rw http.ResponseWriter, r *http.Request) {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Users
-// @Success 200 {object} map[string]string "Returns a map containing the OIDC logout URL"
+// @Success 200 {object} codersdk.OIDCLogoutResponse "Returns a map containing the OIDC logout URL"
 // @Router /users/oidc-logout [get]
 func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -766,6 +766,11 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logger := api.Logger.Named(userAuthLoggerName)
+
+	// Default response: empty URL if OIDC logout is not supported
+	response := codersdk.OIDCLogoutResponse{URL: ""}
+
 	// Retrieve the user's OAuthAccessToken for logout
 	// nolint:gocritic // We only can get user link by user ID and login type with the system auth.
 	link, err := api.Database.GetUserLinkByUserIDLoginType(dbauthz.AsSystemRestricted(ctx),
@@ -774,16 +779,17 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 			LoginType: user.LoginType,
 		})
 	if err != nil {
-		api.Logger.Error(ctx, "failed to retrieve OIDC user link", "error", err)
 		if xerrors.Is(err, sql.ErrNoRows) {
-			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
-				Message: "No OIDC link found for this user.",
-			})
-		} else {
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Failed to retrieve user authentication data.",
-			})
+			logger.Warn(ctx, "no OIDC link found for this user")
+			httpapi.Write(ctx, rw, http.StatusOK, response)
+			return
 		}
+
+		logger.Error(ctx, "failed to retrieve OIDC user link", "error", err)
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to retrieve user authentication data.",
+			Detail:  err.Error(),
+		})
 		return
 	}
 
@@ -796,19 +802,18 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 	logoutURI := dvOIDC.LogoutRedirectURI.Value()
 
 	if oidcEndpoint == "" {
-		api.Logger.Error(ctx, "missing OIDC logout endpoint")
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "OIDC configuration is missing.",
-		})
+		logger.Warn(ctx, "missing OIDC logout endpoint")
+		httpapi.Write(ctx, rw, http.StatusOK, response)
 		return
 	}
 
 	// Construct OIDC Logout URL
 	logoutURL, err := url.Parse(oidcEndpoint)
 	if err != nil {
-		api.Logger.Error(ctx, "failed to parse OIDC endpoint", "error", err)
+		logger.Error(ctx, "failed to parse OIDC endpoint", "error", err)
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Invalid OIDC endpoint.",
+			Detail:  err.Error(),
 		})
 		return
 	}
@@ -829,7 +834,7 @@ func (api *API) userOIDCLogoutURL(rw http.ResponseWriter, r *http.Request) {
 	logoutURL.RawQuery = q.Encode()
 
 	// Return full logout URL
-	response := map[string]string{"oidc_logout_url": logoutURL.String()}
+	response.URL = logoutURL.String()
 	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -555,6 +555,8 @@ type OIDCConfig struct {
 	IconURL                   serpent.URL                            `json:"icon_url" typescript:",notnull"`
 	SignupsDisabledText       serpent.String                         `json:"signups_disabled_text" typescript:",notnull"`
 	SkipIssuerChecks          serpent.Bool                           `json:"skip_issuer_checks" typescript:",notnull"`
+	LogoutEndpoint            serpent.String                         `json:"logout_endpoint" typescript:",notnull"`
+	LogoutRedirectURI         serpent.String                         `json:"logout_redirect_uri" typescript:",notnull"`
 }
 
 type TelemetryConfig struct {
@@ -1965,6 +1967,26 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value: &c.OIDC.SkipIssuerChecks,
 			Group: &deploymentGroupOIDC,
 			YAML:  "dangerousSkipIssuerChecks",
+		},
+		{
+			Name:        "OIDC logout endpoint",
+			Description: "OIDC endpoint for logout.",
+			Flag:        "logout-endpoint",
+			Env:         "CODER_OIDC_LOGOUT_ENDPOINT",
+			Default:     "",
+			Value:       &c.OIDC.LogoutEndpoint,
+			Group:       &deploymentGroupOIDC,
+			YAML:        "logoutEndpoint",
+		},
+		{
+			Name:        "OIDC logout redirect URI",
+			Description: "OIDC redirect URI after logout.",
+			Flag:        "logout-redirect-uri",
+			Env:         "CODER_OIDC_LOGOUT_URI",
+			Default:     "",
+			Value:       &c.OIDC.LogoutRedirectURI,
+			Group:       &deploymentGroupOIDC,
+			YAML:        "logoutRedirectURI",
 		},
 		// Telemetry settings
 		telemetryEnable,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1981,7 +1981,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		{
 			Name:        "OIDC logout redirect URI",
 			Description: "OIDC redirect URI after logout.",
-			Flag:        "logout-redirect-uri",
+			Flag:        "oidc-logout-redirect-uri",
 			Env:         "CODER_OIDC_LOGOUT_URI",
 			Default:     "",
 			Value:       &c.OIDC.LogoutRedirectURI,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1969,16 +1969,6 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			YAML:  "dangerousSkipIssuerChecks",
 		},
 		{
-			Name:        "OIDC logout endpoint",
-			Description: "OIDC endpoint for logout.",
-			Flag:        "logout-endpoint",
-			Env:         "CODER_OIDC_LOGOUT_ENDPOINT",
-			Default:     "",
-			Value:       &c.OIDC.LogoutEndpoint,
-			Group:       &deploymentGroupOIDC,
-			YAML:        "logoutEndpoint",
-		},
-		{
 			Name:        "OIDC logout redirect URI",
 			Description: "OIDC redirect URI after logout.",
 			Flag:        "oidc-logout-redirect-uri",

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -311,6 +311,11 @@ type UserParameter struct {
 	Value string `json:"value"`
 }
 
+// OIDCLogoutResponse represents the response for an OIDC logout request
+type OIDCLogoutResponse struct {
+	URL string `json:"oidc_logout_url"`
+}
+
 // UserAutofillParameters returns all recently used parameters for the given user.
 func (c *Client) UserAutofillParameters(ctx context.Context, user string, templateID uuid.UUID) ([]UserParameter, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/autofill-parameters?template_id=%s", user, templateID), nil)

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -367,6 +367,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "ignore_email_verified": true,
       "ignore_user_info": true,
       "issuer_url": "string",
+      "logout_endpoint": "string",
+      "logout_redirect_uri": "string",
       "name_field": "string",
       "organization_assign_default": true,
       "organization_field": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2017,6 +2017,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "ignore_email_verified": true,
       "ignore_user_info": true,
       "issuer_url": "string",
+      "logout_endpoint": "string",
+      "logout_redirect_uri": "string",
       "name_field": "string",
       "organization_assign_default": true,
       "organization_field": "string",
@@ -2490,6 +2492,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "ignore_email_verified": true,
     "ignore_user_info": true,
     "issuer_url": "string",
+    "logout_endpoint": "string",
+    "logout_redirect_uri": "string",
     "name_field": "string",
     "organization_assign_default": true,
     "organization_field": "string",
@@ -4133,6 +4137,8 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
   "ignore_email_verified": true,
   "ignore_user_info": true,
   "issuer_url": "string",
+  "logout_endpoint": "string",
+  "logout_redirect_uri": "string",
   "name_field": "string",
   "organization_assign_default": true,
   "organization_field": "string",
@@ -4174,6 +4180,8 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `ignore_email_verified`              | boolean                          | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
 | `ignore_user_info`                   | boolean                          | false    |              | Ignore user info & UserInfoFromAccessToken are mutually exclusive. Only 1 can be set to true. Ideally this would be an enum with 3 states, ['none', 'userinfo', 'access_token']. However, for backward compatibility, `ignore_user_info` must remain. And `access_token` is a niche, non-spec compliant edge case. So it's use is rare, and should not be advised. |
 | `issuer_url`                         | string                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
+| `logout_endpoint`                    | string                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
+| `logout_redirect_uri`                | string                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
 | `name_field`                         | string                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
 | `organization_assign_default`        | boolean                          | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
 | `organization_field`                 | string                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
@@ -4187,6 +4195,20 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `user_role_mapping`                  | object                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
 | `user_roles_default`                 | array of string                  | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
 | `username_field`                     | string                           | false    |              |                                                                                                                                                                                                                                                                                                                                                                    |
+
+## codersdk.OIDCLogoutResponse
+
+```json
+{
+  "oidc_logout_url": "string"
+}
+```
+
+### Properties
+
+| Name              | Type   | Required | Restrictions | Description |
+|-------------------|--------|----------|--------------|-------------|
+| `oidc_logout_url` | string | false    |              |             |
 
 ## codersdk.Organization
 

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -373,6 +373,37 @@ curl -X GET http://coder-server:8080/api/v2/users/oauth2/github/device \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Returns URL for the OIDC logout
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/users/oidc-logout \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /users/oidc-logout`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "oidc_logout_url": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description                                  | Schema                                                               |
+|--------|---------------------------------------------------------|----------------------------------------------|----------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | Returns a map containing the OIDC logout URL | [codersdk.OIDCLogoutResponse](schemas.md#codersdkoidclogoutresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## OpenID Connect Callback
 
 ### Code samples

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -373,7 +373,7 @@ curl -X GET http://coder-server:8080/api/v2/users/oauth2/github/device \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Returns URL for the OIDC logout
+## Get user OIDC logout URL
 
 ### Code samples
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -705,17 +705,7 @@ The custom text to show on the error page informing about disabled OIDC signups.
 
 OIDC issuer urls must match in the request, the id_token 'iss' claim, and in the well-known configuration. This flag disables that requirement, and can lead to an insecure OIDC configuration. It is not recommended to use this flag.
 
-### --logout-endpoint
-
-|             |                                          |
-|-------------|------------------------------------------|
-| Type        | <code>string</code>                      |
-| Environment | <code>$CODER_OIDC_LOGOUT_ENDPOINT</code> |
-| YAML        | <code>oidc.logoutEndpoint</code>         |
-
-OIDC endpoint for logout.
-
-### --logout-redirect-uri
+### --oidc-logout-redirect-uri
 
 |             |                                     |
 |-------------|-------------------------------------|

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -705,6 +705,26 @@ The custom text to show on the error page informing about disabled OIDC signups.
 
 OIDC issuer urls must match in the request, the id_token 'iss' claim, and in the well-known configuration. This flag disables that requirement, and can lead to an insecure OIDC configuration. It is not recommended to use this flag.
 
+### --logout-endpoint
+
+|             |                                          |
+|-------------|------------------------------------------|
+| Type        | <code>string</code>                      |
+| Environment | <code>$CODER_OIDC_LOGOUT_ENDPOINT</code> |
+| YAML        | <code>oidc.logoutEndpoint</code>         |
+
+OIDC endpoint for logout.
+
+### --logout-redirect-uri
+
+|             |                                     |
+|-------------|-------------------------------------|
+| Type        | <code>string</code>                 |
+| Environment | <code>$CODER_OIDC_LOGOUT_URI</code> |
+| YAML        | <code>oidc.logoutRedirectURI</code> |
+
+OIDC redirect URI after logout.
+
 ### --telemetry
 
 |             |                                      |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -593,6 +593,12 @@ OIDC OPTIONS:
       --oidc-username-field string, $CODER_OIDC_USERNAME_FIELD (default: preferred_username)
           OIDC claim field to use as the username.
 
+      --logout-endpoint string, $CODER_OIDC_LOGOUT_ENDPOINT
+          OIDC endpoint for logout.
+
+      --logout-redirect-uri string, $CODER_OIDC_LOGOUT_URI
+          OIDC redirect URI after logout.
+
       --oidc-sign-in-text string, $CODER_OIDC_SIGN_IN_TEXT (default: OpenID Connect)
           The text to show on the OpenID Connect sign in button.
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -593,10 +593,7 @@ OIDC OPTIONS:
       --oidc-username-field string, $CODER_OIDC_USERNAME_FIELD (default: preferred_username)
           OIDC claim field to use as the username.
 
-      --logout-endpoint string, $CODER_OIDC_LOGOUT_ENDPOINT
-          OIDC endpoint for logout.
-
-      --logout-redirect-uri string, $CODER_OIDC_LOGOUT_URI
+      --oidc-logout-redirect-uri string, $CODER_OIDC_LOGOUT_URI
           OIDC redirect URI after logout.
 
       --oidc-sign-in-text string, $CODER_OIDC_SIGN_IN_TEXT (default: OpenID Connect)

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -457,26 +457,28 @@ class ApiMethods {
 	};
 
 	logout = async (): Promise<void> => {
-    try {
-      // Fetch the stored ID token from the backend
-      const response = await this.axios.get("/api/v2/users/oidc-logout");
+		try {
+			// Fetch the stored ID token from the backend
+			const response = await this.axios.get("/api/v2/users/oidc-logout");
 
-      // Redirect to OIDC logout after Coder logout
-      if (response.data.oidc_logout_url) {
-        // Coder session logout
-        await this.axios.post("/api/v2/users/logout");
+			// Redirect to OIDC logout after Coder logout
+			if (response.data.oidc_logout_url) {
+				// Coder session logout
+				await this.axios.post("/api/v2/users/logout");
 
-        // OIDC logout
-        window.location.href = response.data.oidc_logout_url;
-      } else {
-        // Redirect normally if no token is available
-        console.warn("No ID token found, continuing logout without OIDC logout.");
-        return this.axios.post("/api/v2/users/logout");
-      }
-    } catch (error) {
-      console.error("Logout failed", error);
-      return this.axios.post("/api/v2/users/logout");
-    }
+				// OIDC logout
+				window.location.href = response.data.oidc_logout_url;
+			} else {
+				// Redirect normally if no token is available
+				console.warn(
+					"No ID token found, continuing logout without OIDC logout.",
+				);
+				return this.axios.post("/api/v2/users/logout");
+			}
+		} catch (error) {
+			console.error("Logout failed", error);
+			return this.axios.post("/api/v2/users/logout");
+		}
 	};
 
 	getAuthenticatedUser = async () => {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -457,7 +457,26 @@ class ApiMethods {
 	};
 
 	logout = async (): Promise<void> => {
-		return this.axios.post("/api/v2/users/logout");
+    try {
+      // Fetch the stored ID token from the backend
+      const response = await this.axios.get("/api/v2/users/oidc-logout");
+
+      // Redirect to OIDC logout after Coder logout
+      if (response.data.oidc_logout_url) {
+        // Coder session logout
+        await this.axios.post("/api/v2/users/logout");
+
+        // OIDC logout
+        window.location.href = response.data.oidc_logout_url;
+      } else {
+        // Redirect normally if no token is available
+        console.warn("No ID token found, continuing logout without OIDC logout.");
+        return this.axios.post("/api/v2/users/logout");
+      }
+    } catch (error) {
+      console.error("Logout failed", error);
+      return this.axios.post("/api/v2/users/logout");
+    }
 	};
 
 	getAuthenticatedUser = async () => {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1478,6 +1478,11 @@ export interface OIDCConfig {
 	readonly logout_redirect_uri: string;
 }
 
+// From codersdk/users.go
+export interface OIDCLogoutResponse {
+	readonly oidc_logout_url: string;
+}
+
 // From codersdk/organizations.go
 export interface Organization extends MinimalOrganization {
 	readonly description: string;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1474,6 +1474,8 @@ export interface OIDCConfig {
 	readonly icon_url: string;
 	readonly signups_disabled_text: string;
 	readonly skip_issuer_checks: boolean;
+	readonly logout_endpoint: string;
+	readonly logout_redirect_uri: string;
 }
 
 // From codersdk/organizations.go


### PR DESCRIPTION
### PR description
Introduces a new API endpoint `/api/v2/users/oidc-logout` that constructs and returns the full OIDC logout URL.
The endpoint retrieves necessary OIDC configuration (e.g., logout endpoint, client ID, logout redirect URI) from environment variables.
This URL is enabling the frontend to redirect the user for complete session logout on the OIDC provider side.

### Motivation
Currently, when a user signs out, only the Coder's session is cleared, but the OIDC provider's session remains active.
This means that a user can immediately sign in again with their OIDC account without truly logging out of the provider. This behavior can be problematic in scenarios where a complete logout is required such as changing user.
With this new endpoint (`/api/v2/users/oidc-logout`), if the coder server is run with specific arguments to enable OIDC session logout, the full logout URL will support the termination of the OIDC session.

### Concerns
This PR intentionally does not modify existing CSP or CORS policies.
Instead, it returns the full URL so that the frontend can perform the redirect.
While this avoids cross-origin issues, it means that the complete URL is exposed in the response.
However, because the endpoint is protected and the URL is intended solely for redirection, this design is acceptable for the intended use case (in my opinion).