### PR TITLE
feat: display quiet hours using 24-hour time format

### DIFF
--- a/site/src/utils/schedule.test.ts
+++ b/site/src/utils/schedule.test.ts
@@ -78,14 +78,38 @@ describe("util/schedule", () => {
 	});
 
 	describe("quietHoursDisplay", () => {
-		const quietHoursStart = quietHoursDisplay(
-			"00:00",
-			"Australia/Sydney",
-			new Date("2023-09-06T15:00:00.000+10:00"),
-		);
+		it("midnight", () => {
+			const quietHoursStart = quietHoursDisplay(
+				"00:00",
+				"Australia/Sydney",
+				new Date("2023-09-06T15:00:00.000+10:00"),
+			);
 
-		expect(quietHoursStart).toBe(
-			"12:00AM tomorrow (in 9 hours) in Australia/Sydney",
-		);
+			expect(quietHoursStart).toBe(
+				"00:00 tomorrow (in 9 hours) in Australia/Sydney",
+			);
+		});
+		it("five o'clock today", () => {
+			const quietHoursStart = quietHoursDisplay(
+				"17:00",
+				"Europe/London",
+				new Date("2023-09-06T15:00:00.000+10:00"),
+			);
+
+			expect(quietHoursStart).toBe(
+				"17:00 today (in 11 hours) in Europe/London",
+			);
+		});
+		it("lunch tomorrow", () => {
+			const quietHoursStart = quietHoursDisplay(
+				"13:00",
+				"US/Central",
+				new Date("2023-09-06T08:00:00.000+10:00"),
+			);
+
+			expect(quietHoursStart).toBe(
+				"13:00 tomorrow (in 20 hours) in US/Central",
+			);
+		});
 	});
 });

--- a/site/src/utils/schedule.tsx
+++ b/site/src/utils/schedule.tsx
@@ -276,7 +276,7 @@ export const quietHoursDisplay = (
 
 	const today = dayjs(now).tz(tz);
 	const day = dayjs(parsed.next().toDate()).tz(tz);
-	let display = day.format("h:mmA");
+	let display = day.format("HH:mm");
 
 	if (day.isSame(today, "day")) {
 		display += " today";


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/15452

Apparently, Coder interface uses 24-hour time in general, so quiet hours may the only place still using AM/PM format.

<img width="490" alt="Screenshot 2025-03-20 at 10 07 39" src="https://github.com/user-attachments/assets/741677f5-93b8-4e37-9166-742d0a14407c" />
