### PR TITLE
fix: update setup-go to match go.mod

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.22.8"
+    default: "1.22.9"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Update setup-go action to match go.mod.

This avoids making our CI runners download the 1.22.9 toolchain separately, e.g.

```
Setup go version spec 1.22.8
Attempting to download 1.22.8...
matching 1.22.8...
Acquiring 1.22.8 from https://github.com/actions/go-versions/releases/download/1.22.8-11145926346/go-1.22.8-win32-x64.zip
Extracting Go...
"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\a\_temp\go-1.22.8-win32-x64.zip', 'C:\a\_temp\185c5ddd-9781-4702-8d2a-53b9105c987d', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'C:\a\_temp\go-1.22.8-win32-x64.zip' -DestinationPath 'C:\a\_temp\185c5ddd-9781-4702-8d2a-53b9105c987d' -Force } else { throw $_ } } ;"
Successfully extracted go to C:\a\_temp\185c5ddd-9781-4702-8d2a-53b9105c987d
Adding to the cache ...
Successfully cached go to C:\hostedtoolcache\windows\go\1.22.8\x64
Added go to the path
Successfully set up Go version 1.22.8
go: downloading go1.22.9 (windows/amd64)
C:\hostedtoolcache\windows\go\1.22.8\x64\bin\go.exe env GOCACHE
C:\hostedtoolcache\windows\go\1.22.8\x64\bin\go.exe env GOMODCACHE
C:\Users\runneradmin\AppData\Local\go-build
C:\Users\runneradmin\go\pkg\mod
Received 339738624 of 1277901573 (26.6%), 323.7 MBs/sec
Received 717225984 of 1277901573 (56.1%), 341.8 MBs/sec
Received 1061158912 of 1277901573 (83.0%), 337.1 MBs/sec
Cache Size: ~1219 MB (1277901573 B)
"C:\Program Files\Git\usr\bin\tar.exe" -xf C:/a/_temp/d200c279-8931-4ebd-8601-d7c09c85c0a6/cache.tzst -P -C C:/a/coder/coder --force-local --use-compress-program "zstd -d"
Received 1277901573 of 1277901573 (100.0%), 304.2 MBs/sec
Cache restored successfully
Cache restored from key: setup-go-Windows-go-1.22.9-9cf4a9bb4247a74b1eba0559dd255a4f06b74e35c17397db099a434c5acedd2b
go version go1.22.9 windows/amd64
```