### PR TITLE
fix: fix IsGithubDotComURL check

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1096,7 +1096,10 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 	}
 	// If the user is logging in with github.com we update their associated
 	// GitHub user ID to the new one.
-	if externalauth.IsGithubDotComURL(api.GithubOAuth2Config.AuthCodeURL("")) && user.GithubComUserID.Int64 != ghUser.GetID() {
+	// We use AuthCodeURL from the OAuth2Config field instead of the one on
+	// GithubOAuth2Config because when device flow is configured, AuthCodeURL
+	// is overridden and returns a value that doesn't pass the URL check.
+	if externalauth.IsGithubDotComURL(api.GithubOAuth2Config.OAuth2Config.AuthCodeURL("")) && user.GithubComUserID.Int64 != ghUser.GetID() {
 		err = api.Database.UpdateUserGithubComUserID(ctx, database.UpdateUserGithubComUserIDParams{
 			ID: user.ID,
 			GithubComUserID: sql.NullInt64{


### PR DESCRIPTION
When DeviceFlow with GitHub OAuth2 is configured, the `api.GithubOAuth2Config.AuthCode` is [overridden](https://github.com/coder/coder/blob/b08c8c9e1ee8edf18e9ba575098d99533062a240/coderd/userauth.go#L779) and returns a value that doesn't pass the `IsGithubDotComURL` check. This PR ensures the original `AuthCodeURL` method is used instead.