### PR TITLE
feat(cli): add open app <workspace> <app-slug> command

### DIFF
--- a/cli/open.go
+++ b/cli/open.go
@@ -253,6 +253,7 @@ func (r *RootCmd) openApp() *serpent.Command {
 			for i, app := range agt.Apps {
 				allAppSlugs[i] = app.Slug
 			}
+			slices.Sort(allAppSlugs)
 
 			// If a user doesn't specify an app slug, we'll just list the available
 			// apps and exit.

--- a/cli/open.go
+++ b/cli/open.go
@@ -232,9 +232,8 @@ func (r *RootCmd) openApp() *serpent.Command {
 			ctx, cancel := context.WithCancel(inv.Context())
 			defer cancel()
 
-			// Check if we're inside a workspace, and especially inside _this_
-			// workspace so we can perform path resolution/expansion. Generally,
-			// we know that if we're inside a workspace, `open` can't be used.
+			// Check if we're inside a workspace.  Generally, we know
+			// that if we're inside a workspace, `open` can't be used.
 			insideAWorkspace := inv.Environ.Get("CODER") == "true"
 
 			// Fetch the preferred region.

--- a/cli/open.go
+++ b/cli/open.go
@@ -322,7 +322,7 @@ func (r *RootCmd) openApp() *serpent.Command {
 	cmd.Options = serpent.OptionSet{
 		{
 			Flag: "region",
-			Env:  "CODER_OPEN_APP_PREFERRED_REGION",
+			Env:  "CODER_OPEN_APP_REGION",
 			Description: fmt.Sprintf("Region to use when opening the app." +
 				" By default, the app will be opened using the main Coder deployment (a.k.a. \"primary\")."),
 			Value:   serpent.StringOf(&regionArg),

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -311,6 +312,36 @@ func TestOpenApp(t *testing.T) {
 		w.RequireContains("test.open-error")
 	})
 
+	t.Run("OnlyWorkspaceName", func(t *testing.T) {
+		t.Parallel()
+
+		client, ws, _ := setupWorkspaceForAgent(t)
+		inv, root := clitest.New(t, "open", "app", ws.Name)
+		clitest.SetupConfig(t, client, root)
+		var sb strings.Builder
+		inv.Stdout = &sb
+		inv.Stderr = &sb
+
+		w := clitest.StartWithWaiter(t, inv)
+		w.RequireSuccess()
+
+		require.Contains(t, sb.String(), "Available apps in")
+	})
+
+	t.Run("WorkspaceNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, _ := setupWorkspaceForAgent(t)
+		inv, root := clitest.New(t, "open", "app", "not-a-workspace", "app1")
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t)
+		inv.Stdin = pty.Input()
+		inv.Stdout = pty.Output()
+		w := clitest.StartWithWaiter(t, inv)
+		w.RequireError()
+		w.RequireContains("Resource not found or you do not have access to this resource")
+	})
+
 	t.Run("AppNotFound", func(t *testing.T) {
 		t.Parallel()
 
@@ -340,7 +371,7 @@ func TestOpenApp(t *testing.T) {
 			return agents
 		})
 
-		inv, root := clitest.New(t, "open", "app", ws.Name, "app1", "--preferred-region", "bad-region")
+		inv, root := clitest.New(t, "open", "app", ws.Name, "app1", "--region", "bad-region")
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
 		inv.Stdin = pty.Input()

--- a/cli/testdata/coder_open_--help.golden
+++ b/cli/testdata/coder_open_--help.golden
@@ -6,6 +6,7 @@ USAGE:
   Open a workspace
 
 SUBCOMMANDS:
+    app       Open a workspace application.
     vscode    Open a workspace in VS Code Desktop
 
 ———

--- a/cli/testdata/coder_open_app_--help.golden
+++ b/cli/testdata/coder_open_app_--help.golden
@@ -1,0 +1,14 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder open app [flags] <workspace> <app slug>
+
+  Open a workspace application.
+
+OPTIONS:
+      --preferred-region string, $CODER_OPEN_APP_PREFERRED_REGION (default: primary)
+          Preferred region to use when opening the app. By default, the app will
+          be opened using the main Coder deployment (a.k.a. "primary").
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_open_app_--help.golden
+++ b/cli/testdata/coder_open_app_--help.golden
@@ -6,9 +6,9 @@ USAGE:
   Open a workspace application.
 
 OPTIONS:
-      --preferred-region string, $CODER_OPEN_APP_PREFERRED_REGION (default: primary)
-          Preferred region to use when opening the app. By default, the app will
-          be opened using the main Coder deployment (a.k.a. "primary").
+      --region string, $CODER_OPEN_APP_REGION (default: primary)
+          Region to use when opening the app. By default, the app will be opened
+          using the main Coder deployment (a.k.a. "primary").
 
 ———
 Run `coder --help` for a list of global options.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1066,6 +1066,11 @@
 							"path": "reference/cli/open.md"
 						},
 						{
+							"title": "open app",
+							"description": "Open a workspace application.",
+							"path": "reference/cli/open_app.md"
+						},
+						{
 							"title": "open vscode",
 							"description": "Open a workspace in VS Code Desktop",
 							"path": "reference/cli/open_vscode.md"

--- a/docs/reference/cli/open.md
+++ b/docs/reference/cli/open.md
@@ -14,3 +14,4 @@ coder open
 | Name                                    | Purpose                             |
 |-----------------------------------------|-------------------------------------|
 | [<code>vscode</code>](./open_vscode.md) | Open a workspace in VS Code Desktop |
+| [<code>app</code>](./open_app.md)       | Open a workspace application.       |

--- a/docs/reference/cli/open_app.md
+++ b/docs/reference/cli/open_app.md
@@ -11,12 +11,12 @@ coder open app [flags] <workspace> <app slug>
 
 ## Options
 
-### --preferred-region
+### --region
 
-|             |                                               |
-|-------------|-----------------------------------------------|
-| Type        | <code>string</code>                           |
-| Environment | <code>$CODER_OPEN_APP_PREFERRED_REGION</code> |
-| Default     | <code>primary</code>                          |
+|             |                                     |
+|-------------|-------------------------------------|
+| Type        | <code>string</code>                 |
+| Environment | <code>$CODER_OPEN_APP_REGION</code> |
+| Default     | <code>primary</code>                |
 
-Preferred region to use when opening the app. By default, the app will be opened using the main Coder deployment (a.k.a. "primary").
+Region to use when opening the app. By default, the app will be opened using the main Coder deployment (a.k.a. "primary").

--- a/docs/reference/cli/open_app.md
+++ b/docs/reference/cli/open_app.md
@@ -1,0 +1,22 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+# open app
+
+Open a workspace application.
+
+## Usage
+
+```console
+coder open app [flags] <workspace> <app slug>
+```
+
+## Options
+
+### --preferred-region
+
+|             |                                               |
+|-------------|-----------------------------------------------|
+| Type        | <code>string</code>                           |
+| Environment | <code>$CODER_OPEN_APP_PREFERRED_REGION</code> |
+| Default     | <code>primary</code>                          |
+
+Preferred region to use when opening the app. By default, the app will be opened using the main Coder deployment (a.k.a. "primary").


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/17009

Adds a CLI command `coder open app <workspace> <app-slug>` that allows opening arbitrary `coder_apps` via the CLI.

Users can optionally specify a preferred region for workspace applications.