### PR TITLE
feat(coderd): add format option to inbox notifications watch endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1696,6 +1696,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "format": "uuid",
                         "description": "ID of the last notification from the current page. Notifications returned will be older than the associated one",
                         "name": "starting_before",
                         "in": "query"
@@ -1765,8 +1766,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "plaintext",
+                            "markdown"
+                        ],
                         "type": "string",
-                        "description": "Define the output format for notifications title and body. Possible values: plaintext, markdown",
+                        "description": "Define the output format for notifications title and body.",
                         "name": "format",
                         "in": "query"
                     }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1763,6 +1763,12 @@ const docTemplate = `{
                         "description": "Filter notifications by read status. Possible values: read, unread, all",
                         "name": "read_status",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Define the output format for notifications title and body. Possible values: plaintext, markdown",
+                        "name": "format",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1693,6 +1693,12 @@ const docTemplate = `{
                         "description": "Filter notifications by read status. Possible values: read, unread, all",
                         "name": "read_status",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "ID of the last notification from the current page. Notifications returned will be older than the associated one",
+                        "name": "starting_before",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1538,6 +1538,12 @@
 						"description": "Filter notifications by read status. Possible values: read, unread, all",
 						"name": "read_status",
 						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "Define the output format for notifications title and body. Possible values: plaintext, markdown",
+						"name": "format",
+						"in": "query"
 					}
 				],
 				"responses": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1474,6 +1474,12 @@
 						"description": "Filter notifications by read status. Possible values: read, unread, all",
 						"name": "read_status",
 						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "ID of the last notification from the current page. Notifications returned will be older than the associated one",
+						"name": "starting_before",
+						"in": "query"
 					}
 				],
 				"responses": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1477,6 +1477,7 @@
 					},
 					{
 						"type": "string",
+						"format": "uuid",
 						"description": "ID of the last notification from the current page. Notifications returned will be older than the associated one",
 						"name": "starting_before",
 						"in": "query"
@@ -1540,8 +1541,9 @@
 						"in": "query"
 					},
 					{
+						"enum": ["plaintext", "markdown"],
 						"type": "string",
-						"description": "Define the output format for notifications title and body. Possible values: plaintext, markdown",
+						"description": "Define the output format for notifications title and body.",
 						"name": "format",
 						"in": "query"
 					}

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -196,6 +196,7 @@ func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request)
 // @Param targets query string false "Comma-separated list of target IDs to filter notifications"
 // @Param templates query string false "Comma-separated list of template IDs to filter notifications"
 // @Param read_status query string false "Filter notifications by read status. Possible values: read, unread, all"
+// @Param starting_before query string false "ID of the last notification from the current page. Notifications returned will be older than the associated one"
 // @Success 200 {object} codersdk.ListInboxNotificationsResponse
 // @Router /notifications/inbox [get]
 func (api *API) listInboxNotifications(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -66,7 +66,7 @@ func convertInboxNotificationResponse(ctx context.Context, logger slog.Logger, n
 // @Param targets query string false "Comma-separated list of target IDs to filter notifications"
 // @Param templates query string false "Comma-separated list of template IDs to filter notifications"
 // @Param read_status query string false "Filter notifications by read status. Possible values: read, unread, all"
-// @Param format query string false "Define the output format for notifications title and body. Possible values: plaintext, markdown"
+// @Param format query string false "Define the output format for notifications title and body." enums(plaintext,markdown)
 // @Success 200 {object} codersdk.GetInboxNotificationResponse
 // @Router /notifications/inbox/watch [get]
 func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request) {
@@ -221,7 +221,7 @@ func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request)
 // @Param targets query string false "Comma-separated list of target IDs to filter notifications"
 // @Param templates query string false "Comma-separated list of template IDs to filter notifications"
 // @Param read_status query string false "Filter notifications by read status. Possible values: read, unread, all"
-// @Param starting_before query string false "ID of the last notification from the current page. Notifications returned will be older than the associated one"
+// @Param starting_before query string false "ID of the last notification from the current page. Notifications returned will be older than the associated one" format(uuid)
 // @Success 200 {object} codersdk.ListInboxNotificationsResponse
 // @Router /notifications/inbox [get]
 func (api *API) listInboxNotifications(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -17,9 +17,15 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/pubsub"
+	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
 	"github.com/coder/websocket"
+)
+
+const (
+	notificationFormatMarkdown  = "markdown"
+	notificationFormatPlaintext = "plaintext"
 )
 
 // convertInboxNotificationResponse works as a util function to transform a database.InboxNotification to codersdk.InboxNotification
@@ -60,6 +66,7 @@ func convertInboxNotificationResponse(ctx context.Context, logger slog.Logger, n
 // @Param targets query string false "Comma-separated list of target IDs to filter notifications"
 // @Param templates query string false "Comma-separated list of template IDs to filter notifications"
 // @Param read_status query string false "Filter notifications by read status. Possible values: read, unread, all"
+// @Param format query string false "Define the output format for notifications title and body. Possible values: plaintext, markdown"
 // @Success 200 {object} codersdk.GetInboxNotificationResponse
 // @Router /notifications/inbox/watch [get]
 func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request) {
@@ -73,6 +80,7 @@ func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request)
 		targets    = p.UUIDs(vals, []uuid.UUID{}, "targets")
 		templates  = p.UUIDs(vals, []uuid.UUID{}, "templates")
 		readStatus = p.String(vals, "all", "read_status")
+		format     = p.String(vals, notificationFormatMarkdown, "format")
 	)
 	p.ErrorExcessParams(vals)
 	if len(p.Errors) > 0 {
@@ -176,6 +184,23 @@ func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request)
 				api.Logger.Error(ctx, "failed to count unread inbox notifications", slog.Error(err))
 				return
 			}
+
+			// By default, notifications are stored as markdown
+			// We can change the format based on parameter if required
+			if format == notificationFormatPlaintext {
+				notif.Title, err = markdown.PlaintextFromMarkdown(notif.Title)
+				if err != nil {
+					api.Logger.Error(ctx, "failed to convert notification title to plain text", slog.Error(err))
+					return
+				}
+
+				notif.Content, err = markdown.PlaintextFromMarkdown(notif.Content)
+				if err != nil {
+					api.Logger.Error(ctx, "failed to convert notification content to plain text", slog.Error(err))
+					return
+				}
+			}
+
 			if err := encoder.Encode(codersdk.GetInboxNotificationResponse{
 				Notification: notif,
 				UnreadCount:  int(unreadCount),

--- a/coderd/notifications/dispatch/inbox.go
+++ b/coderd/notifications/dispatch/inbox.go
@@ -16,7 +16,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/notifications/types"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
-	markdown "github.com/coder/coder/v2/coderd/render"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -36,17 +35,7 @@ func NewInboxHandler(log slog.Logger, store InboxStore, ps pubsub.Pubsub) *Inbox
 }
 
 func (s *InboxHandler) Dispatcher(payload types.MessagePayload, titleTmpl, bodyTmpl string, _ template.FuncMap) (DeliveryFunc, error) {
-	subject, err := markdown.PlaintextFromMarkdown(titleTmpl)
-	if err != nil {
-		return nil, xerrors.Errorf("render subject: %w", err)
-	}
-
-	htmlBody, err := markdown.PlaintextFromMarkdown(bodyTmpl)
-	if err != nil {
-		return nil, xerrors.Errorf("render html body: %w", err)
-	}
-
-	return s.dispatch(payload, subject, htmlBody), nil
+	return s.dispatch(payload, titleTmpl, bodyTmpl), nil
 }
 
 func (s *InboxHandler) dispatch(payload types.MessagePayload, title, body string) DeliveryFunc {

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -61,11 +61,12 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox \
 
 ### Parameters
 
-| Name          | In    | Type   | Required | Description                                                             |
-|---------------|-------|--------|----------|-------------------------------------------------------------------------|
-| `targets`     | query | string | false    | Comma-separated list of target IDs to filter notifications              |
-| `templates`   | query | string | false    | Comma-separated list of template IDs to filter notifications            |
-| `read_status` | query | string | false    | Filter notifications by read status. Possible values: read, unread, all |
+| Name              | In    | Type   | Required | Description                                                                                                     |
+|-------------------|-------|--------|----------|-----------------------------------------------------------------------------------------------------------------|
+| `targets`         | query | string | false    | Comma-separated list of target IDs to filter notifications                                                      |
+| `templates`       | query | string | false    | Comma-separated list of template IDs to filter notifications                                                    |
+| `read_status`     | query | string | false    | Filter notifications by read status. Possible values: read, unread, all                                         |
+| `starting_before` | query | string | false    | ID of the last notification from the current page. Notifications returned will be older than the associated one |
 
 ### Example responses
 

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -142,11 +142,12 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox/watch \
 
 ### Parameters
 
-| Name          | In    | Type   | Required | Description                                                             |
-|---------------|-------|--------|----------|-------------------------------------------------------------------------|
-| `targets`     | query | string | false    | Comma-separated list of target IDs to filter notifications              |
-| `templates`   | query | string | false    | Comma-separated list of template IDs to filter notifications            |
-| `read_status` | query | string | false    | Filter notifications by read status. Possible values: read, unread, all |
+| Name          | In    | Type   | Required | Description                                                                                     |
+|---------------|-------|--------|----------|-------------------------------------------------------------------------------------------------|
+| `targets`     | query | string | false    | Comma-separated list of target IDs to filter notifications                                      |
+| `templates`   | query | string | false    | Comma-separated list of template IDs to filter notifications                                    |
+| `read_status` | query | string | false    | Filter notifications by read status. Possible values: read, unread, all                         |
+| `format`      | query | string | false    | Define the output format for notifications title and body. Possible values: plaintext, markdown |
 
 ### Example responses
 

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -61,12 +61,12 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox \
 
 ### Parameters
 
-| Name              | In    | Type   | Required | Description                                                                                                     |
-|-------------------|-------|--------|----------|-----------------------------------------------------------------------------------------------------------------|
-| `targets`         | query | string | false    | Comma-separated list of target IDs to filter notifications                                                      |
-| `templates`       | query | string | false    | Comma-separated list of template IDs to filter notifications                                                    |
-| `read_status`     | query | string | false    | Filter notifications by read status. Possible values: read, unread, all                                         |
-| `starting_before` | query | string | false    | ID of the last notification from the current page. Notifications returned will be older than the associated one |
+| Name              | In    | Type         | Required | Description                                                                                                     |
+|-------------------|-------|--------------|----------|-----------------------------------------------------------------------------------------------------------------|
+| `targets`         | query | string       | false    | Comma-separated list of target IDs to filter notifications                                                      |
+| `templates`       | query | string       | false    | Comma-separated list of template IDs to filter notifications                                                    |
+| `read_status`     | query | string       | false    | Filter notifications by read status. Possible values: read, unread, all                                         |
+| `starting_before` | query | string(uuid) | false    | ID of the last notification from the current page. Notifications returned will be older than the associated one |
 
 ### Example responses
 
@@ -142,12 +142,19 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox/watch \
 
 ### Parameters
 
-| Name          | In    | Type   | Required | Description                                                                                     |
-|---------------|-------|--------|----------|-------------------------------------------------------------------------------------------------|
-| `targets`     | query | string | false    | Comma-separated list of target IDs to filter notifications                                      |
-| `templates`   | query | string | false    | Comma-separated list of template IDs to filter notifications                                    |
-| `read_status` | query | string | false    | Filter notifications by read status. Possible values: read, unread, all                         |
-| `format`      | query | string | false    | Define the output format for notifications title and body. Possible values: plaintext, markdown |
+| Name          | In    | Type   | Required | Description                                                             |
+|---------------|-------|--------|----------|-------------------------------------------------------------------------|
+| `targets`     | query | string | false    | Comma-separated list of target IDs to filter notifications              |
+| `templates`   | query | string | false    | Comma-separated list of template IDs to filter notifications            |
+| `read_status` | query | string | false    | Filter notifications by read status. Possible values: read, unread, all |
+| `format`      | query | string | false    | Define the output format for notifications title and body.              |
+
+#### Enumerated Values
+
+| Parameter | Value       |
+|-----------|-------------|
+| `format`  | `plaintext` |
+| `format`  | `markdown`  |
 
 ### Example responses
 


### PR DESCRIPTION
This PR aims to allow clients to use different format for the title and content of inbox notifications - on the watch endpoint.

This solution will help to have it working and formatted differently on VSCode, WebUI ... 
[Related to this issue](https://github.com/coder/internal/issues/523)