### PR TITLE
chore(Makefile): fix apidoc dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ site/e2e/.auth.json
 site/playwright-report/*
 site/.swc
 
-# Make target for updating golden files (any dir).
+# Make target for updating generated/golden files (any dir).
+.gen
 .gen-golden
 
 # Build

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ site/node_modules/.installed: site/package.json site/pnpm-lock.yaml
 	(cd site/ && ../scripts/pnpm_install.sh)
 	touch "$@"
 
-scripts/apidocgen/.installed: scripts/apidocgen/package.json scripts/apidocgen/pnpm-lock.yaml
+scripts/apidocgen/node_modules/.installed: scripts/apidocgen/package.json scripts/apidocgen/pnpm-lock.yaml
 	(cd scripts/apidocgen && ../../scripts/pnpm_install.sh)
 	touch "$@"
 
@@ -768,7 +768,7 @@ docs/admin/security/audit-logs.md: node_modules/.installed coderd/database/queri
 
 coderd/apidoc/.gen: \
 	node_modules/.installed \
-	scripts/apidocgen/.installed \
+	scripts/apidocgen/node_modules/.installed \
 	$(wildcard coderd/*.go) \
 	$(wildcard enterprise/coderd/*.go) \
 	$(wildcard codersdk/*.go) \

--- a/Makefile
+++ b/Makefile
@@ -754,7 +754,7 @@ docs/admin/integrations/prometheus.md: node_modules/.installed scripts/metricsdo
 	pnpm exec markdown-table-formatter ./docs/admin/integrations/prometheus.md
 	touch "$@"
 
-docs/reference/cli/index.md: node_modules/.installed site/node_modules/.installed scripts/clidocgen/main.go examples/examples.gen.json $(GO_SRC_FILES)
+docs/reference/cli/index.md: node_modules/.installed scripts/clidocgen/main.go examples/examples.gen.json $(GO_SRC_FILES)
 	CI=true BASE_PATH="." go run ./scripts/clidocgen
 	pnpm exec markdownlint-cli2 --fix ./docs/reference/cli/*.md
 	pnpm exec markdown-table-formatter ./docs/reference/cli/*.md

--- a/scripts/apidocgen/generate.sh
+++ b/scripts/apidocgen/generate.sh
@@ -27,7 +27,6 @@ go run github.com/swaggo/swag/cmd/swag@v1.8.9 init \
 popd
 
 pushd "${APIDOCGEN_DIR}"
-pnpm i
 
 # Make sure that widdershins is installed correctly.
 pnpm exec -- widdershins --version


### PR DESCRIPTION
Our apidoc generation had some circular dependencies, this change splits them up into separate Makefile targets.