### PR TITLE
fix(Makefile): fix dcspec gen dependencies and hide error output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -988,6 +988,12 @@ jobs:
           set -euxo pipefail
           go mod download
 
+          # The "build/coder-dylib" target depends on all Go source files and
+          # the target "agent/agentcontainers/dcspec/dcspec_gen.go" depends on
+          # node/pnpm tooling.
+          mkdir -p node_modules
+          touch node_modules/.installed
+
           make gen/mark-fresh
           make build/coder-dylib
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -988,12 +988,6 @@ jobs:
           set -euxo pipefail
           go mod download
 
-          # The "build/coder-dylib" target depends on all Go source files and
-          # the target "agent/agentcontainers/dcspec/dcspec_gen.go" depends on
-          # node/pnpm tooling.
-          mkdir -p node_modules
-          touch node_modules/.installed
-
           make gen/mark-fresh
           make build/coder-dylib
         env:

--- a/Makefile
+++ b/Makefile
@@ -659,8 +659,12 @@ agent/agentcontainers/acmock/acmock.go: agent/agentcontainers/containers.go
 	go generate ./agent/agentcontainers/acmock/
 	touch "$@"
 
-agent/agentcontainers/dcspec/dcspec_gen.go: agent/agentcontainers/dcspec/devContainer.base.schema.json
-	go generate ./agent/agentcontainers/dcspec/
+agent/agentcontainers/dcspec/dcspec_gen.go: \
+	node_modules/.installed \
+	agent/agentcontainers/dcspec/devContainer.base.schema.json \
+	agent/agentcontainers/dcspec/gen.sh \
+	agent/agentcontainers/dcspec/doc.go
+	DCSPEC_QUIET=true go generate ./agent/agentcontainers/dcspec/
 	touch "$@"
 
 $(TAILNETTEST_MOCKS): tailnet/coordinator.go tailnet/service.go

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,16 @@ FIND_EXCLUSIONS= \
 	-not \( \( -path '*/.git/*' -o -path './build/*' -o -path './vendor/*' -o -path './.coderv2/*' -o -path '*/node_modules/*' -o -path '*/out/*' -o -path './coderd/apidoc/*' -o -path '*/.next/*' -o -path '*/.terraform/*' \) -prune \)
 # Source files used for make targets, evaluated on use.
 GO_SRC_FILES := $(shell find . $(FIND_EXCLUSIONS) -type f -name '*.go' -not -name '*_test.go')
+# Same as GO_SRC_FILES but excluding certain files that have problematic
+# Makefile dependencies (e.g. pnpm).
+MOST_GO_SRC_FILES := $(shell \
+	find . \
+		$(FIND_EXCLUSIONS) \
+		-type f \
+		-name '*.go' \
+		-not -name '*_test.go' \
+		-not -wholename './agent/agentcontainers/dcspec/dcspec_gen.go' \
+)
 # All the shell files in the repo, excluding ignored files.
 SHELL_SRC_FILES := $(shell find . $(FIND_EXCLUSIONS) -type f -name '*.sh')
 
@@ -243,7 +253,7 @@ $(CODER_ALL_BINARIES): go.mod go.sum \
 	fi
 
 # This task builds Coder Desktop dylibs
-$(CODER_DYLIBS): go.mod go.sum $(GO_SRC_FILES)
+$(CODER_DYLIBS): go.mod go.sum $(MOST_GO_SRC_FILES)
 	@if [ "$(shell uname)" = "Darwin" ]; then
 		$(get-mode-os-arch-ext)
 		./scripts/build_go.sh \


### PR DESCRIPTION
I thought `make gen` was failing due to the red output, decided to just hide it. Fixed a few makefile deps while I was at it.

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/ea24c060-b79e-4d85-879b-948540295d98" />
