### PR TITLE
ci: standardize on go 1.22.12

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -9,7 +9,7 @@ RUN cargo install exa bat ripgrep typos-cli watchexec-cli && \
 FROM ubuntu:jammy@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.24.1
+ARG GO_VERSION=1.22.8
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -65,9 +65,6 @@ RUN apt-get update && \
 	# we're using for the version of go-critic that it embeds, then check
 	# the version of ruleguard in go-critic for that tag.
 	go install github.com/quasilyte/go-ruleguard/cmd/ruleguard@v0.3.13 && \
-	# go-fuzz for fuzzy testing. they don't publish releases so we rely on latest.
-	go install github.com/dvyukov/go-fuzz/go-fuzz@latest && \
-	go install github.com/dvyukov/go-fuzz/go-fuzz-build@latest && \
 	# go-releaser for building 'fat binaries' that work cross-platform
 	go install github.com/goreleaser/goreleaser@v1.6.1 && \
 	go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0 && \

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -9,7 +9,7 @@ RUN cargo install exa bat ripgrep typos-cli watchexec-cli && \
 FROM ubuntu:jammy@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.22.8
+ARG GO_VERSION=1.22.12
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim@sha256:9abf10cc84dfad6ace1b0aae3951dc5200f467c593394288c11db1e17b
 # Install rust helper programs
 # ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_INSTALL_ROOT=/tmp/
-RUN cargo install exa bat ripgrep typos-cli watchexec-cli && \
+RUN cargo install typos-cli watchexec-cli && \
 	# Reduce image size.
 	rm -rf /usr/local/cargo/registry
 
@@ -128,6 +128,7 @@ RUN apt-get update --quiet && apt-get install --yes \
 	asciinema \
 	bash \
 	bash-completion \
+	bat \
 	bats \
 	bind9-dnsutils \
 	build-essential \
@@ -140,6 +141,7 @@ RUN apt-get update --quiet && apt-get install --yes \
 	docker-ce \
 	docker-ce-cli \
 	docker-compose-plugin \
+	exa \
 	fd-find \
 	file \
 	fish \
@@ -176,6 +178,7 @@ RUN apt-get update --quiet && apt-get install --yes \
 	postgresql-16 \
 	python3 \
 	python3-pip \
+	ripgrep \
 	rsync \
 	screen \
 	shellcheck \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.22.9
+go 1.22.12
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
The version of Go in our dogfood Dockerfile was seemingly unintentionally bumped in https://github.com/coder/coder/pull/16894

We need to keep our various Go versions in sync, otherwise things get confusing:
- dogfood/coder/Dockerfile
- flake.nix
- go.mod
- .github/actions/setup-go/action.yaml
