### PR TITLE
fix(cli): replace $SESSION_TOKEN placeholder for external apps

### DIFF
--- a/cli/open.go
+++ b/cli/open.go
@@ -518,7 +518,7 @@ func buildAppLinkURL(baseURL *url.URL, workspace codersdk.Workspace, agent coder
 
 // replacePlaceholderExternalSessionTokenString replaces any $SESSION_TOKEN
 // strings in the URL with the actual session token.
-// This is consistent behaviour with the frontend. See: site/src/modules/resources/AppLink/AppLink.tsx
+// This is consistent behavior with the frontend. See: site/src/modules/resources/AppLink/AppLink.tsx
 func replacePlaceholderExternalSessionTokenString(client *codersdk.Client, appURL string) string {
 	if !strings.Contains(appURL, "$SESSION_TOKEN") {
 		return appURL

--- a/cli/open.go
+++ b/cli/open.go
@@ -301,6 +301,10 @@ func (r *RootCmd) openApp() *serpent.Command {
 			pathAppURL := strings.TrimPrefix(region.PathAppURL, baseURL.String())
 			appURL := buildAppLinkURL(baseURL, ws, agt, foundApp, region.WildcardHostname, pathAppURL)
 
+			if foundApp.External {
+				appURL = replacePlaceholderExternalSessionTokenString(client, appURL)
+			}
+
 			// Check if we're inside a workspace.  Generally, we know
 			// that if we're inside a workspace, `open` can't be used.
 			insideAWorkspace := inv.Environ.Get("CODER") == "true"
@@ -314,7 +318,7 @@ func (r *RootCmd) openApp() *serpent.Command {
 			if !testOpenError {
 				err = open.Run(appURL)
 			} else {
-				err = xerrors.New("test.open-error")
+				err = xerrors.New("test.open-error: " + appURL)
 			}
 			return err
 		},
@@ -510,4 +514,16 @@ func buildAppLinkURL(baseURL *url.URL, workspace codersdk.Workspace, agent coder
 		u.Path = "/"
 	}
 	return u.String()
+}
+
+// replacePlaceholderExternalSessionTokenString replaces any $SESSION_TOKEN
+// strings in the URL with the actual session token.
+// This is consistent behaviour with the frontend. See: site/src/modules/resources/AppLink/AppLink.tsx
+func replacePlaceholderExternalSessionTokenString(client *codersdk.Client, appURL string) string {
+	if !strings.Contains(appURL, "$SESSION_TOKEN") {
+		return appURL
+	}
+
+	// We will just re-use the existing session token we're already using.
+	return strings.ReplaceAll(appURL, "$SESSION_TOKEN", client.SessionToken())
 }


### PR DESCRIPTION
Fixes an oversight in https://github.com/coder/coder/pull/17032

The FE has logic to replace the string `$SESSION_TOKEN` with a newly-minted session token.
This adds corresponding logic to the `coder open app` command.