### PR TITLE
chore: bump go version to 1.24.1

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.22.8"
+    default: "1.24.1"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
We already use 1.24.1 in the dogfood image.