### PR TITLE
feat(agent): add devcontainer autostart support

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1121,11 +1121,9 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 			)
 			if a.experimentalDevcontainersEnabled {
 				var dcScripts []codersdk.WorkspaceAgentScript
-				scripts, dcScripts = agentcontainers.ExtractDevcontainerScripts(a.logger, expandPathToAbs, manifest.Devcontainers, scripts)
-				// The post-start scripts are used to autostart Dev Containers
-				// after the start scripts have completed. This is necessary
-				// because the Dev Container may depend on the workspace being
-				// initialized (git clone, etc).
+				scripts, dcScripts = agentcontainers.ExtractAndInitializeDevcontainerScripts(a.logger, expandPathToAbs, manifest.Devcontainers, scripts)
+				// See ExtractAndInitializeDevcontainerScripts for motivation
+				// behind running dcScripts as post start scripts.
 				scriptRunnerOpts = append(scriptRunnerOpts, agentscripts.WithPostStartScripts(dcScripts...))
 			}
 			err = a.scriptRunner.Init(scripts, aAPI.ScriptCompleted, scriptRunnerOpts...)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1124,21 +1124,21 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				// initialized (git clone, etc).
 				postStartScripts []codersdk.WorkspaceAgentScript
 			)
-			for _, dc := range manifest.Devcontainers {
-				// TODO(mafredri): Verify `@devcontainers/cli` presence.
-				// TODO(mafredri): Verify workspace folder exists.
-				// TODO(mafredri): If set, verify config path exists.
-				dc = expandDevcontainerPaths(a.logger, dc)
+			if a.experimentalDevcontainersEnabled {
+				for _, dc := range manifest.Devcontainers {
+					// TODO(mafredri): Verify `@devcontainers/cli` presence.
+					// TODO(mafredri): Verify workspace folder exists.
+					// TODO(mafredri): If set, verify config path exists.
+					dc = expandDevcontainerPaths(a.logger, dc)
 
-				for i, s := range scripts {
-					// The devcontainer scripts match the devcontainer ID for
-					// identification.
-					if s.ID == dc.ID {
-						scripts = slices.Delete(scripts, i, i+1)
-						if a.experimentalDevcontainersEnabled {
+					for i, s := range scripts {
+						// The devcontainer scripts match the devcontainer ID for
+						// identification.
+						if s.ID == dc.ID {
+							scripts = slices.Delete(scripts, i, i+1)
 							postStartScripts = append(postStartScripts, agentcontainers.DevcontainerStartupScript(dc, s))
+							break
 						}
-						break
 					}
 				}
 			}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1937,6 +1937,134 @@ func TestAgent_ReconnectingPTYContainer(t *testing.T) {
 	require.ErrorIs(t, tr.ReadUntil(ctx, nil), io.EOF)
 }
 
+// This tests end-to-end functionality of auto-starting a devcontainer.
+// It runs "devcontainer up" which creates a real Docker container. As
+// such, it does not run by default in CI.
+//
+// You can run it manually as follows:
+//
+// CODER_TEST_USE_DOCKER=1 go test -count=1 ./agent -run TestAgent_DevcontainerAutostart
+func TestAgent_DevcontainerAutostart(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CODER_TEST_USE_DOCKER") != "1" {
+		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
+	}
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// Connect to Docker
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err, "Could not connect to docker")
+
+	// Prepare temporary devcontainer for test (mywork).
+	devcontainerID := uuid.New()
+	tempWorkspaceFolder := t.TempDir()
+	tempWorkspaceFolder = filepath.Join(tempWorkspaceFolder, "mywork")
+	t.Logf("Workspace folder: %s", tempWorkspaceFolder)
+	devcontainerPath := filepath.Join(tempWorkspaceFolder, ".devcontainer")
+	err = os.MkdirAll(devcontainerPath, 0o755)
+	require.NoError(t, err, "create devcontainer directory")
+	devcontainerFile := filepath.Join(devcontainerPath, "devcontainer.json")
+	err = os.WriteFile(devcontainerFile, []byte(`{
+        "name": "mywork",
+        "image": "busybox:latest",
+        "cmd": ["sleep", "infinity"]
+    }`), 0o600)
+	require.NoError(t, err, "write devcontainer.json")
+
+	manifest := agentsdk.Manifest{
+		// Set up pre-conditions for auto-starting a devcontainer, the script
+		// is expected to be prepared by the provisioner normally.
+		Devcontainers: []codersdk.WorkspaceAgentDevcontainer{
+			{
+				ID:              devcontainerID,
+				Name:            "test",
+				WorkspaceFolder: tempWorkspaceFolder,
+			},
+		},
+		Scripts: []codersdk.WorkspaceAgentScript{
+			{
+				ID:          devcontainerID,
+				LogSourceID: agentsdk.ExternalLogSourceID,
+				RunOnStart:  true,
+				Script:      "echo this-will-be-replaced",
+				DisplayName: "Dev Container (test)",
+			},
+		},
+	}
+	// nolint: dogsled
+	conn, _, _, _, _ := setupAgent(t, manifest, 0, func(_ *agenttest.Client, o *agent.Options) {
+		o.ExperimentalDevcontainersEnabled = true
+	})
+
+	t.Logf("Waiting for container with label: devcontainer.local_folder=%s", tempWorkspaceFolder)
+
+	var container docker.APIContainers
+	require.Eventually(t, func() bool {
+		containers, err := pool.Client.ListContainers(docker.ListContainersOptions{All: true})
+		if err != nil {
+			t.Logf("Error listing containers: %v", err)
+			return false
+		}
+
+		for _, c := range containers {
+			t.Logf("Found container: %s with labels: %v", c.ID[:12], c.Labels)
+			if labelValue, ok := c.Labels["devcontainer.local_folder"]; ok {
+				if labelValue == tempWorkspaceFolder {
+					t.Logf("Found matching container: %s", c.ID[:12])
+					container = c
+					return true
+				}
+			}
+		}
+
+		return false
+	}, testutil.WaitSuperLong, testutil.IntervalMedium, "no container with workspace folder label found")
+
+	t.Cleanup(func() {
+		// We can't rely on pool here because the container is not
+		// managed by it (it is managed by @devcontainer/cli).
+		err := pool.Client.RemoveContainer(docker.RemoveContainerOptions{
+			ID:            container.ID,
+			RemoveVolumes: true,
+			Force:         true,
+		})
+		assert.NoError(t, err, "remove container")
+	})
+
+	containerInfo, err := pool.Client.InspectContainer(container.ID)
+	require.NoError(t, err, "inspect container")
+	t.Logf("Container state: status: %v", containerInfo.State.Status)
+	require.True(t, containerInfo.State.Running, "container should be running")
+
+	ac, err := conn.ReconnectingPTY(ctx, uuid.New(), 80, 80, "", func(opts *workspacesdk.AgentReconnectingPTYInit) {
+		opts.Container = container.ID
+	})
+	require.NoError(t, err, "failed to create ReconnectingPTY")
+	defer ac.Close()
+
+	// Use terminal reader so we can see output in case somethin goes wrong.
+	tr := testutil.NewTerminalReader(t, ac)
+
+	require.NoError(t, tr.ReadUntil(ctx, func(line string) bool {
+		return strings.Contains(line, "#") || strings.Contains(line, "$")
+	}), "find prompt")
+
+	wantFileName := "file-from-devcontainer"
+	wantFile := filepath.Join(tempWorkspaceFolder, wantFileName)
+
+	require.NoError(t, json.NewEncoder(ac).Encode(workspacesdk.ReconnectingPTYRequest{
+		// NOTE(mafredri): We must use absolute path here for some reason.
+		Data: fmt.Sprintf("touch /workspaces/mywork/%s; exit\r", wantFileName),
+	}), "create file inside devcontainer")
+
+	// Wait for the connection to close to ensure the touch was executed.
+	require.ErrorIs(t, tr.ReadUntil(ctx, nil), io.EOF)
+
+	_, err = os.Stat(wantFile)
+	require.NoError(t, err, "file should exist outside devcontainer")
+}
+
 func TestAgent_Dial(t *testing.T) {
 	t.Parallel()
 

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -11,6 +11,7 @@ func DevcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer, script co
 	if dc.ConfigPath != "" {
 		cmd = fmt.Sprintf("%s --config %q", cmd, dc.ConfigPath)
 	}
+	script.RunOnStart = false
 	script.Script = cmd
 	return script
 }

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -75,7 +75,7 @@ func expandDevcontainerPaths(logger slog.Logger, expandPath func(string) (string
 	}
 	if dc.ConfigPath != "" {
 		// Let expandPath handle home directory, otherwise assume relative to
-		// workspace folder or absoulte.
+		// workspace folder or absolute.
 		if dc.ConfigPath[0] == '~' {
 			if cp, err := expandPath(dc.ConfigPath); err != nil {
 				logger.Warn(context.Background(), "expand devcontainer config path failed", slog.Error(err))

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -1,7 +1,10 @@
 package agentcontainers
 
 import (
+	"context"
 	"fmt"
+
+	"cdr.dev/slog"
 
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -14,4 +17,39 @@ func DevcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer, script co
 	script.RunOnStart = false
 	script.Script = cmd
 	return script
+}
+
+func ExtractDevcontainerScripts(
+	logger slog.Logger,
+	expandPath func(string) (string, error),
+	devcontainers []codersdk.WorkspaceAgentDevcontainer,
+	scripts []codersdk.WorkspaceAgentScript,
+) (other []codersdk.WorkspaceAgentScript, devcontainerScripts []codersdk.WorkspaceAgentScript) {
+	for _, dc := range devcontainers {
+		dc = expandDevcontainerPaths(logger, expandPath, dc)
+		for _, script := range scripts {
+			// The devcontainer scripts match the devcontainer ID for
+			// identification.
+			if script.ID == dc.ID {
+				devcontainerScripts = append(devcontainerScripts, DevcontainerStartupScript(dc, script))
+			} else {
+				other = append(other, script)
+			}
+		}
+	}
+
+	return other, devcontainerScripts
+}
+
+func expandDevcontainerPaths(logger slog.Logger, expandPath func(string) (string, error), dc codersdk.WorkspaceAgentDevcontainer) codersdk.WorkspaceAgentDevcontainer {
+	var err error
+	if dc.WorkspaceFolder, err = expandPath(dc.WorkspaceFolder); err != nil {
+		logger.Warn(context.Background(), "expand devcontainer workspace folder failed", slog.Error(err))
+	}
+	if dc.ConfigPath != "" {
+		if dc.ConfigPath, err = expandPath(dc.ConfigPath); err != nil {
+			logger.Warn(context.Background(), "expand devcontainer config path failed", slog.Error(err))
+		}
+	}
+	return dc
 }

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -3,23 +3,14 @@ package agentcontainers
 import (
 	"fmt"
 
-	"github.com/google/uuid"
-
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func DevcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer) codersdk.WorkspaceAgentScript {
-	script := fmt.Sprintf("devcontainer up --workspace-folder %q", dc.WorkspaceFolder)
+func DevcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer, script codersdk.WorkspaceAgentScript) codersdk.WorkspaceAgentScript {
+	cmd := fmt.Sprintf("devcontainer up --workspace-folder %q", dc.WorkspaceFolder)
 	if dc.ConfigPath != "" {
-		script = fmt.Sprintf("%s --config %q", script, dc.ConfigPath)
+		cmd = fmt.Sprintf("%s --config %q", cmd, dc.ConfigPath)
 	}
-	return codersdk.WorkspaceAgentScript{
-		ID:          uuid.New(),
-		LogSourceID: uuid.Nil, // TODO(mafredri): Add a devcontainer log source?
-		LogPath:     "",
-		Script:      script,
-		Cron:        "",
-		Timeout:     0,
-		DisplayName: fmt.Sprintf("Dev Container (%s)", dc.WorkspaceFolder),
-	}
+	script.Script = cmd
+	return script
 }

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -1,0 +1,25 @@
+package agentcontainers
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func DevcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer) codersdk.WorkspaceAgentScript {
+	script := fmt.Sprintf("devcontainer up --workspace-folder %q", dc.WorkspaceFolder)
+	if dc.ConfigPath != "" {
+		script = fmt.Sprintf("%s --config %q", script, dc.ConfigPath)
+	}
+	return codersdk.WorkspaceAgentScript{
+		ID:          uuid.New(),
+		LogSourceID: uuid.Nil, // TODO(mafredri): Add a devcontainer log source?
+		LogPath:     "",
+		Script:      script,
+		Cron:        "",
+		Timeout:     0,
+		DisplayName: fmt.Sprintf("Dev Container (%s)", dc.WorkspaceFolder),
+	}
+}

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -64,13 +64,16 @@ func devcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer, script co
 }
 
 func expandDevcontainerPaths(logger slog.Logger, expandPath func(string) (string, error), dc codersdk.WorkspaceAgentDevcontainer) codersdk.WorkspaceAgentDevcontainer {
-	var err error
-	if dc.WorkspaceFolder, err = expandPath(dc.WorkspaceFolder); err != nil {
+	if wf, err := expandPath(dc.WorkspaceFolder); err != nil {
 		logger.Warn(context.Background(), "expand devcontainer workspace folder failed", slog.Error(err))
+	} else {
+		dc.WorkspaceFolder = wf
 	}
 	if dc.ConfigPath != "" {
-		if dc.ConfigPath, err = expandPath(dc.ConfigPath); err != nil {
+		if cp, err := expandPath(dc.ConfigPath); err != nil {
 			logger.Warn(context.Background(), "expand devcontainer config path failed", slog.Error(err))
+		} else {
+			dc.ConfigPath = cp
 		}
 	}
 	return dc

--- a/agent/agentcontainers/devcontainer_test.go
+++ b/agent/agentcontainers/devcontainer_test.go
@@ -1,0 +1,226 @@
+package agentcontainers_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentcontainers"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
+	t.Parallel()
+
+	scriptIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	devcontainerIDs := []uuid.UUID{uuid.New(), uuid.New()}
+
+	type args struct {
+		expandPath    func(string) (string, error)
+		devcontainers []codersdk.WorkspaceAgentDevcontainer
+		scripts       []codersdk.WorkspaceAgentScript
+	}
+	tests := []struct {
+		name                    string
+		args                    args
+		wantFilteredScripts     []codersdk.WorkspaceAgentScript
+		wantDevcontainerScripts []codersdk.WorkspaceAgentScript
+	}{
+		{
+			name: "no scripts",
+			args: args{
+				expandPath:    nil,
+				devcontainers: nil,
+				scripts:       nil,
+			},
+			wantFilteredScripts:     nil,
+			wantDevcontainerScripts: nil,
+		},
+		{
+			name: "no devcontainers",
+			args: args{
+				expandPath:    nil,
+				devcontainers: nil,
+				scripts: []codersdk.WorkspaceAgentScript{
+					{ID: scriptIDs[0]},
+					{ID: scriptIDs[1]},
+				},
+			},
+			wantFilteredScripts: []codersdk.WorkspaceAgentScript{
+				{ID: scriptIDs[0]},
+				{ID: scriptIDs[1]},
+			},
+			wantDevcontainerScripts: nil,
+		},
+		{
+			name: "no scripts match devcontainers",
+			args: args{
+				expandPath: nil,
+				devcontainers: []codersdk.WorkspaceAgentDevcontainer{
+					{ID: devcontainerIDs[0]},
+					{ID: devcontainerIDs[1]},
+				},
+				scripts: []codersdk.WorkspaceAgentScript{
+					{ID: scriptIDs[0]},
+					{ID: scriptIDs[1]},
+				},
+			},
+			wantFilteredScripts: []codersdk.WorkspaceAgentScript{
+				{ID: scriptIDs[0]},
+				{ID: scriptIDs[1]},
+			},
+			wantDevcontainerScripts: nil,
+		},
+		{
+			name: "scripts match devcontainers and sets RunOnStart=false",
+			args: args{
+				expandPath: nil,
+				devcontainers: []codersdk.WorkspaceAgentDevcontainer{
+					{ID: devcontainerIDs[0], WorkspaceFolder: "workspace1"},
+					{ID: devcontainerIDs[1], WorkspaceFolder: "workspace2"},
+				},
+				scripts: []codersdk.WorkspaceAgentScript{
+					{ID: scriptIDs[0], RunOnStart: true},
+					{ID: scriptIDs[1], RunOnStart: true},
+					{ID: devcontainerIDs[0], RunOnStart: true},
+					{ID: devcontainerIDs[1], RunOnStart: true},
+				},
+			},
+			wantFilteredScripts: []codersdk.WorkspaceAgentScript{
+				{ID: scriptIDs[0], RunOnStart: true},
+				{ID: scriptIDs[1], RunOnStart: true},
+			},
+			wantDevcontainerScripts: []codersdk.WorkspaceAgentScript{
+				{
+					ID:         devcontainerIDs[0],
+					Script:     "devcontainer up --workspace-folder \"workspace1\"",
+					RunOnStart: false,
+				},
+				{
+					ID:         devcontainerIDs[1],
+					Script:     "devcontainer up --workspace-folder \"workspace2\"",
+					RunOnStart: false,
+				},
+			},
+		},
+		{
+			name: "scripts match devcontainers with config path",
+			args: args{
+				expandPath: nil,
+				devcontainers: []codersdk.WorkspaceAgentDevcontainer{
+					{
+						ID:              devcontainerIDs[0],
+						WorkspaceFolder: "workspace1",
+						ConfigPath:      "config1",
+					},
+					{
+						ID:              devcontainerIDs[1],
+						WorkspaceFolder: "workspace2",
+						ConfigPath:      "config2",
+					},
+				},
+				scripts: []codersdk.WorkspaceAgentScript{
+					{ID: devcontainerIDs[0]},
+					{ID: devcontainerIDs[1]},
+				},
+			},
+			wantFilteredScripts: []codersdk.WorkspaceAgentScript{},
+			wantDevcontainerScripts: []codersdk.WorkspaceAgentScript{
+				{
+					ID:         devcontainerIDs[0],
+					Script:     "devcontainer up --workspace-folder \"workspace1\" --config \"config1\"",
+					RunOnStart: false,
+				},
+				{
+					ID:         devcontainerIDs[1],
+					Script:     "devcontainer up --workspace-folder \"workspace2\" --config \"config2\"",
+					RunOnStart: false,
+				},
+			},
+		},
+		{
+			name: "scripts match devcontainers with expand path",
+			args: args{
+				expandPath: func(s string) (string, error) {
+					return "expanded/" + s, nil
+				},
+				devcontainers: []codersdk.WorkspaceAgentDevcontainer{
+					{
+						ID:              devcontainerIDs[0],
+						WorkspaceFolder: "workspace1",
+						ConfigPath:      "config1",
+					},
+					{
+						ID:              devcontainerIDs[1],
+						WorkspaceFolder: "workspace2",
+						ConfigPath:      "config2",
+					},
+				},
+				scripts: []codersdk.WorkspaceAgentScript{
+					{ID: devcontainerIDs[0], RunOnStart: true},
+					{ID: devcontainerIDs[1], RunOnStart: true},
+				},
+			},
+			wantFilteredScripts: []codersdk.WorkspaceAgentScript{},
+			wantDevcontainerScripts: []codersdk.WorkspaceAgentScript{
+				{
+					ID:         devcontainerIDs[0],
+					Script:     "devcontainer up --workspace-folder \"expanded/workspace1\" --config \"expanded/config1\"",
+					RunOnStart: false,
+				},
+				{
+					ID:         devcontainerIDs[1],
+					Script:     "devcontainer up --workspace-folder \"expanded/workspace2\" --config \"expanded/config2\"",
+					RunOnStart: false,
+				},
+			},
+		},
+	}
+	// nolint:foo
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			logger := slogtest.Make(t, nil)
+			if tt.args.expandPath == nil {
+				tt.args.expandPath = func(s string) (string, error) {
+					return s, nil
+				}
+			}
+			gotFilteredScripts, gotDevcontainerScripts := agentcontainers.ExtractAndInitializeDevcontainerScripts(
+				logger,
+				tt.args.expandPath,
+				tt.args.devcontainers,
+				tt.args.scripts,
+			)
+
+			if diff := cmp.Diff(tt.wantFilteredScripts, gotFilteredScripts, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("ExtractAndInitializeDevcontainerScripts() gotFilteredScripts mismatch (-want +got):\n%s", diff)
+			}
+
+			// Preprocess the devcontainer scripts to remove scripting part.
+			for i := range gotDevcontainerScripts {
+				gotDevcontainerScripts[i].Script = textGrep("devcontainer up", gotDevcontainerScripts[i].Script)
+				require.NotEmpty(t, gotDevcontainerScripts[i].Script, "devcontainer up script not found")
+			}
+			if diff := cmp.Diff(tt.wantDevcontainerScripts, gotDevcontainerScripts); diff != "" {
+				t.Errorf("ExtractAndInitializeDevcontainerScripts() gotDevcontainerScripts mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// textGrep returns matching lines from multiline string.
+func textGrep(want, got string) (filtered string) {
+	var lines []string
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, want) {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/agent/agentcontainers/devcontainer_test.go
+++ b/agent/agentcontainers/devcontainer_test.go
@@ -181,7 +181,6 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 			},
 		},
 	}
-	// nolint:foo
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/agent/agentcontainers/devcontainer_test.go
+++ b/agent/agentcontainers/devcontainer_test.go
@@ -31,6 +31,8 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 		args                    args
 		wantFilteredScripts     []codersdk.WorkspaceAgentScript
 		wantDevcontainerScripts []codersdk.WorkspaceAgentScript
+
+		skipOnWindowsDueToPathSeparator bool
 	}{
 		{
 			name: "no scripts",
@@ -143,6 +145,7 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 					RunOnStart: false,
 				},
 			},
+			skipOnWindowsDueToPathSeparator: true,
 		},
 		{
 			name: "scripts match devcontainers with expand path",
@@ -180,6 +183,7 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 					RunOnStart: false,
 				},
 			},
+			skipOnWindowsDueToPathSeparator: true,
 		},
 		{
 			name: "expand config path when ~",
@@ -221,11 +225,16 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 					RunOnStart: false,
 				},
 			},
+			skipOnWindowsDueToPathSeparator: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			if tt.skipOnWindowsDueToPathSeparator && filepath.Separator == '\\' {
+				t.Skip("Skipping test on Windows due to path separator difference.")
+			}
+
 			logger := slogtest.Make(t, nil)
 			if tt.args.expandPath == nil {
 				tt.args.expandPath = func(s string) (string, error) {

--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -80,6 +80,21 @@ func New(opts Options) *Runner {
 
 type ScriptCompletedFunc func(context.Context, *proto.WorkspaceAgentScriptCompletedRequest) (*proto.WorkspaceAgentScriptCompletedResponse, error)
 
+type runnerScript struct {
+	runOnPostStart bool
+	codersdk.WorkspaceAgentScript
+}
+
+func toRunnerScript(scripts ...codersdk.WorkspaceAgentScript) []runnerScript {
+	var rs []runnerScript
+	for _, s := range scripts {
+		rs = append(rs, runnerScript{
+			WorkspaceAgentScript: s,
+		})
+	}
+	return rs
+}
+
 type Runner struct {
 	Options
 
@@ -90,7 +105,7 @@ type Runner struct {
 	closeMutex      sync.Mutex
 	cron            *cron.Cron
 	initialized     atomic.Bool
-	scripts         []codersdk.WorkspaceAgentScript
+	scripts         []runnerScript
 	dataDir         string
 	scriptCompleted ScriptCompletedFunc
 
@@ -119,16 +134,35 @@ func (r *Runner) RegisterMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(r.scriptsExecuted)
 }
 
+// InitOption describes an option for the runner initialization.
+type InitOption func(*Runner)
+
+// WithPostStartScripts adds scripts that should be run after the workspace
+// start scripts but before the workspace is marked as started.
+func WithPostStartScripts(scripts ...codersdk.WorkspaceAgentScript) InitOption {
+	return func(r *Runner) {
+		for _, s := range scripts {
+			r.scripts = append(r.scripts, runnerScript{
+				runOnPostStart:       true,
+				WorkspaceAgentScript: s,
+			})
+		}
+	}
+}
+
 // Init initializes the runner with the provided scripts.
 // It also schedules any scripts that have a schedule.
 // This function must be called before Execute.
-func (r *Runner) Init(scripts []codersdk.WorkspaceAgentScript, scriptCompleted ScriptCompletedFunc) error {
+func (r *Runner) Init(scripts []codersdk.WorkspaceAgentScript, scriptCompleted ScriptCompletedFunc, opts ...InitOption) error {
 	if r.initialized.Load() {
 		return xerrors.New("init: already initialized")
 	}
 	r.initialized.Store(true)
-	r.scripts = scripts
+	r.scripts = toRunnerScript(scripts...)
 	r.scriptCompleted = scriptCompleted
+	for _, opt := range opts {
+		opt(r)
+	}
 	r.Logger.Info(r.cronCtx, "initializing agent scripts", slog.F("script_count", len(scripts)), slog.F("log_dir", r.LogDir))
 
 	err := r.Filesystem.MkdirAll(r.ScriptBinDir(), 0o700)
@@ -136,13 +170,13 @@ func (r *Runner) Init(scripts []codersdk.WorkspaceAgentScript, scriptCompleted S
 		return xerrors.Errorf("create script bin dir: %w", err)
 	}
 
-	for _, script := range scripts {
+	for _, script := range r.scripts {
 		if script.Cron == "" {
 			continue
 		}
 		script := script
 		_, err := r.cron.AddFunc(script.Cron, func() {
-			err := r.trackRun(r.cronCtx, script, ExecuteCronScripts)
+			err := r.trackRun(r.cronCtx, script.WorkspaceAgentScript, ExecuteCronScripts)
 			if err != nil {
 				r.Logger.Warn(context.Background(), "run agent script on schedule", slog.Error(err))
 			}
@@ -186,6 +220,7 @@ type ExecuteOption int
 const (
 	ExecuteAllScripts ExecuteOption = iota
 	ExecuteStartScripts
+	ExecutePostStartScripts
 	ExecuteStopScripts
 	ExecuteCronScripts
 )
@@ -196,6 +231,7 @@ func (r *Runner) Execute(ctx context.Context, option ExecuteOption) error {
 	for _, script := range r.scripts {
 		runScript := (option == ExecuteStartScripts && script.RunOnStart) ||
 			(option == ExecuteStopScripts && script.RunOnStop) ||
+			(option == ExecutePostStartScripts && script.runOnPostStart) ||
 			(option == ExecuteCronScripts && script.Cron != "") ||
 			option == ExecuteAllScripts
 
@@ -205,7 +241,7 @@ func (r *Runner) Execute(ctx context.Context, option ExecuteOption) error {
 
 		script := script
 		eg.Go(func() error {
-			err := r.trackRun(ctx, script, option)
+			err := r.trackRun(ctx, script.WorkspaceAgentScript, option)
 			if err != nil {
 				return xerrors.Errorf("run agent script %q: %w", script.LogSourceID, err)
 			}

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -151,11 +153,160 @@ func TestCronClose(t *testing.T) {
 	require.NoError(t, runner.Close(), "close runner")
 }
 
+func TestExecuteOptions(t *testing.T) {
+	t.Parallel()
+
+	startScript := codersdk.WorkspaceAgentScript{
+		ID:          uuid.New(),
+		LogSourceID: uuid.New(),
+		Script:      "echo start",
+		RunOnStart:  true,
+	}
+	stopScript := codersdk.WorkspaceAgentScript{
+		ID:          uuid.New(),
+		LogSourceID: uuid.New(),
+		Script:      "echo stop",
+		RunOnStop:   true,
+	}
+	postStartScript := codersdk.WorkspaceAgentScript{
+		ID:          uuid.New(),
+		LogSourceID: uuid.New(),
+		Script:      "echo poststart",
+	}
+	regularScript := codersdk.WorkspaceAgentScript{
+		ID:          uuid.New(),
+		LogSourceID: uuid.New(),
+		Script:      "echo regular",
+	}
+
+	scripts := []codersdk.WorkspaceAgentScript{
+		startScript,
+		stopScript,
+		regularScript,
+	}
+	allScripts := append(slices.Clone(scripts), postStartScript)
+
+	scriptByID := func(t *testing.T, id uuid.UUID) codersdk.WorkspaceAgentScript {
+		for _, script := range allScripts {
+			if script.ID == id {
+				return script
+			}
+		}
+		t.Fatal("script not found")
+		return codersdk.WorkspaceAgentScript{}
+	}
+
+	wantOutput := map[uuid.UUID]string{
+		startScript.ID:     "start",
+		stopScript.ID:      "stop",
+		postStartScript.ID: "poststart",
+		regularScript.ID:   "regular",
+	}
+
+	testCases := []struct {
+		name    string
+		option  agentscripts.ExecuteOption
+		wantRun []uuid.UUID
+	}{
+		{
+			name:    "ExecuteAllScripts",
+			option:  agentscripts.ExecuteAllScripts,
+			wantRun: []uuid.UUID{startScript.ID, stopScript.ID, regularScript.ID, postStartScript.ID},
+		},
+		{
+			name:    "ExecuteStartScripts",
+			option:  agentscripts.ExecuteStartScripts,
+			wantRun: []uuid.UUID{startScript.ID},
+		},
+		{
+			name:    "ExecutePostStartScripts",
+			option:  agentscripts.ExecutePostStartScripts,
+			wantRun: []uuid.UUID{postStartScript.ID},
+		},
+		{
+			name:    "ExecuteStopScripts",
+			option:  agentscripts.ExecuteStopScripts,
+			wantRun: []uuid.UUID{stopScript.ID},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			executedScripts := make(map[uuid.UUID]bool)
+			fLogger := &executeOptionTestLogger{
+				tb:              t,
+				executedScripts: executedScripts,
+				wantOutput:      wantOutput,
+			}
+
+			runner := setup(t, func(uuid.UUID) agentscripts.ScriptLogger {
+				return fLogger
+			})
+			defer runner.Close()
+
+			aAPI := agenttest.NewFakeAgentAPI(t, testutil.Logger(t), nil, nil)
+			err := runner.Init(
+				scripts,
+				aAPI.ScriptCompleted,
+				agentscripts.WithPostStartScripts(postStartScript),
+			)
+			require.NoError(t, err)
+
+			err = runner.Execute(ctx, tc.option)
+			require.NoError(t, err)
+
+			gotRun := map[uuid.UUID]bool{}
+			for _, id := range tc.wantRun {
+				gotRun[id] = true
+				require.True(t, executedScripts[id],
+					"script %s should have run when using filter %s", scriptByID(t, id).Script, tc.name)
+			}
+
+			for _, script := range allScripts {
+				if _, ok := gotRun[script.ID]; ok {
+					continue
+				}
+				require.False(t, executedScripts[script.ID],
+					"script %s should not have run when using filter %s", script.Script, tc.name)
+			}
+		})
+	}
+}
+
+type executeOptionTestLogger struct {
+	tb              testing.TB
+	executedScripts map[uuid.UUID]bool
+	wantOutput      map[uuid.UUID]string
+	mu              sync.Mutex
+}
+
+func (l *executeOptionTestLogger) Send(_ context.Context, logs ...agentsdk.Log) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, log := range logs {
+		l.tb.Log(log.Output)
+		for id, output := range l.wantOutput {
+			if log.Output == output {
+				l.executedScripts[id] = true
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (*executeOptionTestLogger) Flush(context.Context) error {
+	return nil
+}
+
 func setup(t *testing.T, getScriptLogger func(logSourceID uuid.UUID) agentscripts.ScriptLogger) *agentscripts.Runner {
 	t.Helper()
 	if getScriptLogger == nil {
 		// noop
-		getScriptLogger = func(uuid uuid.UUID) agentscripts.ScriptLogger {
+		getScriptLogger = func(uuid.UUID) agentscripts.ScriptLogger {
 			return noopScriptLogger{}
 		}
 	}


### PR DESCRIPTION
This change adds support for devcontainer autostart in workspaces. The preconditions for utilizing this feature are:
1. The `coder_devcontainer` resource must be defined in Terraform
2. By the time the startup scripts have completed,
	- The `@devcontainers/cli` tool must be installed
	- The given workspace folder must contain a devcontainer configuration

Example Terraform:

```tf
resource "coder_devcontainer" "coder" {
  agent_id         = coder_agent.main.id
  workspace_folder = "/home/coder/coder"
  config_path      = ".devcontainer/devcontainer.json" # (optional)
}
```

Closes #16423

Demo of an auto-started Dev Container (logs, timings):

<img width="1327" alt="image" src="https://github.com/user-attachments/assets/373204a0-ee93-4529-b343-b7560ee62123" />

Demo of devcontainer defined in Terraform, but not enabled on the agent:

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/015e06b8-0367-4982-be56-e9035ffeb96d" />

Demo of errors being propagated via script:

<img width="1285" alt="image" src="https://github.com/user-attachments/assets/7077a02c-433c-4ca5-b2bc-474c4e76e4d5" />
