### PR TITLE
docs: add a table to feature stages doc

### DIFF
--- a/docs/about/feature-stages.md
+++ b/docs/about/feature-stages.md
@@ -7,6 +7,14 @@ If you encounter an issue with any Coder feature, please submit a
 [GitHub issue](https://github.com/coder/coder/issues) or join the
 [Coder Discord](https://discord.gg/coder).
 
+## Feature stages
+
+| Feature stage                          | Stable | Production-ready | Support               | Description                                                                                                                    |
+|----------------------------------------|--------|------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| [Early Access](#early-access-features) | No     | No               | GitHub issues         | For staging only. Not feature-complete or stable. Disabled by default.                                                         |
+| [Beta](#beta)                          | No     | Not fully        | Docs, Discord, GitHub | Publicly available. In active developement with minor bugs. Suitable for staging; optional for production. Not covered by SLA. |
+| [GA](#general-availability-ga)         | Yes    | Yes              | License-based         | Stable and tested. Enabled by default. Fully documented. Support based on license.                                             |
+
 ## Early access features
 
 - **Stable**: No

--- a/docs/about/feature-stages.md
+++ b/docs/about/feature-stages.md
@@ -9,11 +9,11 @@ If you encounter an issue with any Coder feature, please submit a
 
 ## Feature stages
 
-| Feature stage                          | Stable | Production-ready | Support               | Description                                                                                                                    |
-|----------------------------------------|--------|------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| [Early Access](#early-access-features) | No     | No               | GitHub issues         | For staging only. Not feature-complete or stable. Disabled by default.                                                         |
-| [Beta](#beta)                          | No     | Not fully        | Docs, Discord, GitHub | Publicly available. In active developement with minor bugs. Suitable for staging; optional for production. Not covered by SLA. |
-| [GA](#general-availability-ga)         | Yes    | Yes              | License-based         | Stable and tested. Enabled by default. Fully documented. Support based on license.                                             |
+| Feature stage                          | Stable | Production-ready | Support               | Description                                                                                                                   |
+|----------------------------------------|--------|------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| [Early Access](#early-access-features) | No     | No               | GitHub issues         | For staging only. Not feature-complete or stable. Disabled by default.                                                        |
+| [Beta](#beta)                          | No     | Not fully        | Docs, Discord, GitHub | Publicly available. In active development with minor bugs. Suitable for staging; optional for production. Not covered by SLA. |
+| [GA](#general-availability-ga)         | Yes    | Yes              | License-based         | Stable and tested. Enabled by default. Fully documented. Support based on license.                                            |
 
 ## Early access features
 


### PR DESCRIPTION
adds a table to the feature stages doc to summarize the stages + links to the heading below for more info

[preview](https://coder.com/docs/@feature-stages-table/about/feature-stages)