### PR TITLE
fix: add detailed gosec G115 annotations

### DIFF
--- a/coderd/database/lock.go
+++ b/coderd/database/lock.go
@@ -18,5 +18,7 @@ const (
 func GenLockID(name string) int64 {
 	hash := fnv.New64()
 	_, _ = hash.Write([]byte(name))
-	return int64(hash.Sum64())
+	// For our locking purposes, it's acceptable to have potential overflow
+	// The important part is consistency of the lock ID for a given name
+	return int64(hash.Sum64()) // #nosec G115 -- potential overflow is acceptable for lock IDs
 }

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -160,7 +160,8 @@ func (t Template) DeepCopy() Template {
 func (t Template) AutostartAllowedDays() uint8 {
 	// Just flip the binary 0s to 1s and vice versa.
 	// There is an extra day with the 8th bit that needs to be zeroed.
-	return ^uint8(t.AutostartBlockDaysOfWeek) & 0b01111111
+	// The conversion is safe because AutostartBlockDaysOfWeek is enforced to use only the lower 7 bits
+	return ^uint8(t.AutostartBlockDaysOfWeek) & 0b01111111 // #nosec G115 -- int16 to uint8 is safe as we only use 7 bits
 }
 
 func (TemplateVersion) RBACObject(template Template) rbac.Object {

--- a/coderd/schedule/template.go
+++ b/coderd/schedule/template.go
@@ -77,7 +77,7 @@ func (r TemplateAutostopRequirement) DaysMap() map[time.Weekday]bool {
 func daysMap(daysOfWeek uint8) map[time.Weekday]bool {
 	days := make(map[time.Weekday]bool)
 	for i, day := range DaysOfWeek {
-		days[day] = daysOfWeek&(1<<uint(i)) != 0
+		days[day] = daysOfWeek&(1<<uint(i)) != 0 // #nosec G115 -- int to uint is safe for small i values (< 8)
 	}
 	return days
 }

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -729,7 +729,7 @@ func ConvertWorkspaceBuild(build database.WorkspaceBuild) WorkspaceBuild {
 		WorkspaceID:       build.WorkspaceID,
 		JobID:             build.JobID,
 		TemplateVersionID: build.TemplateVersionID,
-		BuildNumber:       uint32(build.BuildNumber),
+		BuildNumber:       uint32(build.BuildNumber), // #nosec G115 -- int32 to uint32 is safe for build numbers
 	}
 }
 
@@ -1035,9 +1035,9 @@ func ConvertTemplate(dbTemplate database.Template) Template {
 		FailureTTLMillis:               time.Duration(dbTemplate.FailureTTL).Milliseconds(),
 		TimeTilDormantMillis:           time.Duration(dbTemplate.TimeTilDormant).Milliseconds(),
 		TimeTilDormantAutoDeleteMillis: time.Duration(dbTemplate.TimeTilDormantAutoDelete).Milliseconds(),
-		AutostopRequirementDaysOfWeek:  codersdk.BitmapToWeekdays(uint8(dbTemplate.AutostopRequirementDaysOfWeek)),
+		AutostopRequirementDaysOfWeek:  codersdk.BitmapToWeekdays(uint8(dbTemplate.AutostopRequirementDaysOfWeek)), // #nosec G115 -- int16 to uint8 is safe since we only use 7 bits
 		AutostopRequirementWeeks:       dbTemplate.AutostopRequirementWeeks,
-		AutostartAllowedDays:           codersdk.BitmapToWeekdays(dbTemplate.AutostartAllowedDays()),
+		AutostartAllowedDays:           codersdk.BitmapToWeekdays(dbTemplate.AutostartAllowedDays()), // #nosec G115 -- uses AutostartAllowedDays() which already ensures safe conversion
 		RequireActiveVersion:           dbTemplate.RequireActiveVersion,
 		Deprecated:                     dbTemplate.Deprecated != "",
 	}

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -886,7 +886,7 @@ func (r *Runner) commitQuota(ctx context.Context, resources []*sdkproto.Resource
 
 	resp, err := r.quotaCommitter.CommitQuota(ctx, &proto.CommitQuotaRequest{
 		JobId:     r.job.JobId,
-		DailyCost: int32(cost),
+		DailyCost: int32(cost), // #nosec G115 -- int to int32 is safe for cost values
 	})
 	if err != nil {
 		r.queueLog(ctx, &proto.Log{

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -132,7 +132,8 @@ type TelemetrySink interface {
 // NodeID creates a Tailscale NodeID from the last 8 bytes of a UUID. It ensures
 // the returned NodeID is always positive.
 func NodeID(uid uuid.UUID) tailcfg.NodeID {
-	id := int64(binary.BigEndian.Uint64(uid[8:]))
+	// This may overflow, but we handle that by ensuring the result is positive below
+	id := int64(binary.BigEndian.Uint64(uid[8:])) // #nosec G115 -- potential overflow is handled below
 
 	// ensure id is positive
 	y := id >> 63

--- a/tailnet/convert.go
+++ b/tailnet/convert.go
@@ -31,7 +31,7 @@ func NodeToProto(n *Node) (*proto.Node, error) {
 	}
 	derpForcedWebsocket := make(map[int32]string)
 	for i, s := range n.DERPForcedWebsocket {
-		derpForcedWebsocket[int32(i)] = s
+		derpForcedWebsocket[int32(i)] = s // #nosec G115 -- int to int32 is safe for indices
 	}
 	addresses := make([]string, len(n.Addresses))
 	for i, prefix := range n.Addresses {


### PR DESCRIPTION
This PR adds more detailed #nosec G115 annotations to fix gosec linting issues in various files. These annotations explain why each integer conversion is safe and how potential overflow is handled.

The changes include:
- Added explanatory comments for each integer conversion in several files
- Documented specific cases where overflow is acceptable 
- Added bounds checking context where needed

These changes should resolve the remaining lint issues in #17035.