### PR TITLE
chore: disallow inbox as default method

### DIFF
--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -52,7 +52,11 @@ type StoreEnqueuer struct {
 // NewStoreEnqueuer creates an Enqueuer implementation which can persist notification messages in the store.
 func NewStoreEnqueuer(cfg codersdk.NotificationsConfig, store Store, helpers template.FuncMap, log slog.Logger, clock quartz.Clock) (*StoreEnqueuer, error) {
 	var method database.NotificationMethod
-	// We do not allow setting Coder Inbox as the default method.
+	// TODO(DanielleMaywood):
+	// Currently we do not want to allow setting `inbox` as the default notification method.
+	// As of 2025-03-25, setting this to `inbox` would cause a crash on the deployment
+	// notification settings page. Until we make a future decision on this we want to disallow
+	// setting it.
 	if err := method.Scan(cfg.Method.String()); err != nil || method == database.NotificationMethodInbox {
 		return nil, InvalidDefaultNotificationMethodError{Method: cfg.Method.String()}
 	}

--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -26,12 +26,12 @@ var (
 	ErrDuplicate                         = xerrors.New("duplicate notification")
 )
 
-type InvalidNotificationMethodError struct {
+type InvalidDefaultNotificationMethodError struct {
 	Method string
 }
 
-func (e InvalidNotificationMethodError) Error() string {
-	return fmt.Sprintf("given notification method %q is invalid", e.Method)
+func (e InvalidDefaultNotificationMethodError) Error() string {
+	return fmt.Sprintf("given default notification method %q is invalid", e.Method)
 }
 
 type StoreEnqueuer struct {
@@ -54,7 +54,7 @@ func NewStoreEnqueuer(cfg codersdk.NotificationsConfig, store Store, helpers tem
 	var method database.NotificationMethod
 	// We do not allow setting Coder Inbox as the default method.
 	if err := method.Scan(cfg.Method.String()); err != nil || method == database.NotificationMethodInbox {
-		return nil, InvalidNotificationMethodError{Method: cfg.Method.String()}
+		return nil, InvalidDefaultNotificationMethodError{Method: cfg.Method.String()}
 	}
 
 	return &StoreEnqueuer{

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -1864,11 +1864,7 @@ func TestNotificationMethodCannotDefaultToInbox(t *testing.T) {
 
 	cfg := defaultNotificationsConfig(database.NotificationMethodInbox)
 
-	// Set the time to a known value.
-	mClock := quartz.NewMock(t)
-	mClock.Set(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC))
-
-	_, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), mClock)
+	_, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
 	require.ErrorIs(t, err, notifications.InvalidDefaultNotificationMethodError{Method: string(database.NotificationMethodInbox)})
 }
 

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -1869,7 +1869,7 @@ func TestNotificationMethodCannotDefaultToInbox(t *testing.T) {
 	mClock.Set(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC))
 
 	_, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), mClock)
-	require.ErrorIs(t, err, notifications.InvalidNotificationMethodError{Method: string(database.NotificationMethodInbox)})
+	require.ErrorIs(t, err, notifications.InvalidDefaultNotificationMethodError{Method: string(database.NotificationMethodInbox)})
 }
 
 func TestNotificationTargetMatrix(t *testing.T) {

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -1856,6 +1856,22 @@ func TestNotificationDuplicates(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNotificationMethodCannotDefaultToInbox(t *testing.T) {
+	t.Parallel()
+
+	store, _ := dbtestutil.NewDB(t)
+	logger := testutil.Logger(t)
+
+	cfg := defaultNotificationsConfig(database.NotificationMethodInbox)
+
+	// Set the time to a known value.
+	mClock := quartz.NewMock(t)
+	mClock.Set(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC))
+
+	_, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), mClock)
+	require.ErrorIs(t, err, notifications.InvalidNotificationMethodError{Method: string(database.NotificationMethodInbox)})
+}
+
 func TestNotificationTargetMatrix(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Disallow setting `inbox` as the default notifications method.