### PR TITLE
fix: fix load more notifications only working once

### DIFF
--- a/site/src/modules/notifications/NotificationsInbox/NotificationsInbox.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/NotificationsInbox.tsx
@@ -156,7 +156,7 @@ export const NotificationsInbox: FC<NotificationsInboxProps> = ({
 			error={error}
 			isLoadingMoreNotifications={isLoadingMoreNotifications}
 			hasMoreNotifications={Boolean(
-				inboxRes && inboxRes.notifications.length === NOTIFICATIONS_LIMIT,
+				inboxRes && inboxRes.notifications.length % NOTIFICATIONS_LIMIT === 0,
 			)}
 			onRetry={refetch}
 			onMarkAllAsRead={markAllAsReadMutation.mutate}


### PR DESCRIPTION
The "load more" button in the notifications inbox were only working once. After taking a look at the code the issue was found and fixed.