### PR TITLE
feat: mark notification as read when action is clicked

### DIFF
--- a/site/src/modules/notifications/NotificationsInbox/InboxItem.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxItem.tsx
@@ -40,7 +40,14 @@ export const InboxItem: FC<InboxItemProps> = ({
 					{notification.actions.map((action) => {
 						return (
 							<Button variant="outline" size="sm" key={action.label} asChild>
-								<RouterLink to={action.url}>{action.label}</RouterLink>
+								<RouterLink
+									to={action.url}
+									onClick={() => {
+										onMarkNotificationAsRead(notification.id);
+									}}
+								>
+									{action.label}
+								</RouterLink>
 							</Button>
 						);
 					})}


### PR DESCRIPTION
When a user clicks in a notification action we can infer the notification was read. 