### PR TITLE
chore(dogfood): update dogfood Go version to 1.24.1

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -9,7 +9,7 @@ RUN cargo install typos-cli watchexec-cli && \
 FROM ubuntu:jammy@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.22.12
+ARG GO_VERSION=1.24.1
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
             gnused
             gnugrep
             gnutar
-            go_1_22
+            go_1_24
             go-migrate
             (pinnedPkgs.golangci-lint)
             gopls

--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
             gnused
             gnugrep
             gnutar
-            go_1_24
+            go_1_22
             go-migrate
             (pinnedPkgs.golangci-lint)
             gopls


### PR DESCRIPTION
https://github.com/coder/coder/pull/17035 updated the Go version in `go.mod` and in GH actions but not in `dogfood/coder/Dockerfile` or `flake.nix`.

This updates the Go version to 1.24 in `dogfood/coder/Dockerfile`.
Unfortunately at the time of writing, Go 1.24 is not available in NixOS. So that will have to wait.