### PR TITLE
fix: prevent password reset notifications ending up in coder inbox

### DIFF
--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -116,6 +116,13 @@ func (s *StoreEnqueuer) EnqueueWithData(ctx context.Context, userID, templateID 
 
 	uuids := make([]uuid.UUID, 0, 2)
 	for _, method := range methods {
+		// TODO(DanielleMaywood):
+		// We should have a more permanent solution in the future, but for now this will work.
+		// We do not want password reset notifications to end up in Coder Inbox.
+		if method == database.NotificationMethodInbox && templateID == TemplateUserRequestedOneTimePasscode {
+			continue
+		}
+
 		id := uuid.New()
 		err = s.store.EnqueueNotificationMessage(ctx, database.EnqueueNotificationMessageParams{
 			ID:                     id,


### PR DESCRIPTION
We do not want password reset notifications to end up in Coder Inbox as this doesn't make much sense. This implements the logic to ensure they are not delivered if the method is Coder Inbox.

In the future we might want to investigate a better solution but for now this works.