### PR TITLE
chore: bump debounce from 5 minutes to 30 minutes

### DIFF
--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -121,7 +121,7 @@ func New(opts Options) *API {
 		Clock:                 opts.Clock,
 		Database:              opts.Database,
 		NotificationsEnqueuer: opts.NotificationsEnqueuer,
-		Debounce:              5 * time.Minute,
+		Debounce:              30 * time.Minute,
 
 		Config: resourcesmonitor.Config{
 			NumDatapoints:      20,


### PR DESCRIPTION
To ensure OOM/OOD isn't too spammy we want to have a debounce period of 30 minutes.