### PR TITLE
chore(enterprise/dbcrypt): adjust behaviour of TestHelpMeEncryptSomeValue

### DIFF
--- a/enterprise/dbcrypt/cipher_internal_test.go
+++ b/enterprise/dbcrypt/cipher_internal_test.go
@@ -100,9 +100,10 @@ func TestCiphersBackwardCompatibility(t *testing.T) {
 //  3. Copy the value from the test output and do what you need with it.
 func TestHelpMeEncryptSomeValue(t *testing.T) {
 	t.Parallel()
-	t.Skip("this only exists if you need to encrypt a value with dbcrypt, it does not actually test anything")
-
 	valueToEncrypt := os.Getenv("ENCRYPT_ME")
+	if valueToEncrypt == "" {
+		t.Skip("Set ENCRYPT_ME to some value you need to encrypt")
+	}
 	t.Logf("valueToEncrypt: %q", valueToEncrypt)
 	keys := os.Getenv("CODER_EXTERNAL_TOKEN_ENCRYPTION_KEYS")
 	require.NotEmpty(t, keys, "Set the CODER_EXTERNAL_TOKEN_ENCRYPTION_KEYS environment variable to use this")


### PR DESCRIPTION
This "utility test" isn't so useful if you have to uncomment the `t.Skip()` before using it.