### PR TITLE
chore(dogfood): add lsof

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -162,6 +162,7 @@ RUN apt-get update --quiet && apt-get install --yes \
 	libgbm-dev \
 	libssl-dev \
 	lsb-release \
+	lsof \
 	man \
 	meld \
 	ncdu \


### PR DESCRIPTION
because lsof is a standard linux utility