### PR TITLE
chore: linkspector: ignore 503s from docs.github.com

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -22,5 +22,6 @@ ignorePatterns:
   - pattern: "www.gnu.org"
   - pattern: "wiki.ubuntu.com"
   - pattern: "mutagen.io"
+  - pattern: "docs.github.com"
 aliveStatusCodes:
   - 200


### PR DESCRIPTION
Fixes a 503 seen here: https://github.com/coder/coder/actions/runs/14094256166/job/39478147255?pr=17091