### PR TITLE
chore: upgrade msw to 2.4.3

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -174,7 +174,7 @@
 		"jest-location-mock": "2.0.0",
 		"jest-websocket-mock": "2.5.0",
 		"jest_workaround": "0.1.14",
-		"msw": "2.3.5",
+		"msw": "2.4.3",
 		"postcss": "8.5.1",
 		"protobufjs": "7.4.0",
 		"rxjs": "7.8.1",
@@ -191,7 +191,11 @@
 		"vite-plugin-checker": "0.8.0",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
+	"browserslist": [
+		"chrome 110",
+		"firefox 111",
+		"safari 16.0"
+	],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/package.json
+++ b/site/package.json
@@ -191,11 +191,7 @@
 		"vite-plugin-checker": "0.8.0",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": [
-		"chrome 110",
-		"firefox 111",
-		"safari 16.0"
-	],
+	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -428,8 +428,8 @@ importers:
         specifier: 0.1.14
         version: 0.1.14(@swc/core@1.3.38)(@swc/jest@0.2.37(@swc/core@1.3.38))
       msw:
-        specifier: 2.3.5
-        version: 2.3.5(typescript@5.6.3)
+        specifier: 2.4.3
+        version: 2.4.3(typescript@5.6.3)
       postcss:
         specifier: 8.5.1
         version: 8.5.1
@@ -5008,12 +5008,12 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
 
-  msw@2.3.5:
-    resolution: {integrity: sha512-+GUI4gX5YC5Bv33epBrD+BGdmDvBg2XGruiWnI3GbIbRmMMBeZ5gs3mJ51OWSGHgJKztZ8AtZeYMMNMVrje2/Q==, tarball: https://registry.npmjs.org/msw/-/msw-2.3.5.tgz}
+  msw@2.4.3:
+    resolution: {integrity: sha512-PXK3wOQHwDtz6JYVyAVlQtzrLr6bOAJxggw5UHm3CId79+W7238aNBD1zJVkFY53o/DMacuIfgesW2nv9yCO3Q==, tarball: https://registry.npmjs.org/msw/-/msw-2.4.3.tgz}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      typescript: '>= 4.7.x'
+      typescript: '>= 4.8.x'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -11791,7 +11791,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.3.5(typescript@5.6.3):
+  msw@2.4.3(typescript@5.6.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1


### PR DESCRIPTION
Fixes a transitive High severity dependency in path-to-regexp. 

We've tried to [upgrade to 2.5.0](https://github.com/coder/coder/pull/17124) (currently, the latest version) but there are some known bugs related to polyfills as [this one](https://github.com/mswjs/msw/discussions/2288). As shared in the comments, the latest version without this issue is 2.4.3.