### PR TITLE
fix: fix data race in echo provisioner

### DIFF
--- a/provisioner/echo/serve.go
+++ b/provisioner/echo/serve.go
@@ -254,7 +254,7 @@ func TarWithOptions(ctx context.Context, logger slog.Logger, responses *Response
 			continue
 		}
 
-		if len(plan.Plan) == 0 {
+		if plan.Error == "" && len(plan.Plan) == 0 {
 			plan.Plan = []byte("{}")
 		}
 	}
@@ -316,7 +316,7 @@ func TarWithOptions(ctx context.Context, logger slog.Logger, responses *Response
 		for i, resp := range m {
 			plan := resp.GetPlan()
 			if plan != nil {
-				if len(plan.Plan) == 0 {
+				if plan.Error == "" && len(plan.Plan) == 0 {
 					plan.Plan = []byte("{}")
 				}
 			}


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/546
Closes https://github.com/coder/internal/issues/543

Fixes a data race in the echo provisioner

### What happened

If you're curious, two things:

- I was under the assumption that the incoming responses would always be under the ownership of the provisioner (no need to worry about synchronization or locking) because it would be coming from freshly decoded protobuf messages. Apparently this is very wrong, because we just call the echo provisioner functions directly using protobuf types in a bunch of tests. Serialization/deserialization doesn't happen anywhere in the process, we're just passing pointers around.

- The incoming responses are a mixture of values which could be interpreted as "transferring ownership", and a few global/"static" values that we have around for common scenarios. Mutating the unique "owned" responses is fine, but mutating those global helpers is where the data race was occurring. The code was checking to see if the plan was "empty" (as in `len(plan.Plan) == 0`) and then replacing it with a "valid empty" plan (as in `[]byte("{}")`, empty JSON object). The problem with this is that there should not be a valid plan if `plan.Error` is set. The "valid empty" plan was already added as a field to the `PlanComplete` static helper, but was intentionally omitted from a few other helpers that have `Error` values.

So with all that context, the fix is to just not mutate `plan.Plan` if `plan.Error` is set.

Also, since in production environments the data _will actually be owned_ by this code, freshly deserialized from a protobuf message, I don't think there's any way this write could affect a real deployment.