### PR TITLE
docs: update SMTP configuration in notifications docs

### DIFF
--- a/docs/admin/monitoring/notifications/index.md
+++ b/docs/admin/monitoring/notifications/index.md
@@ -95,11 +95,11 @@ existing one.
 
 **Server Settings:**
 
-| Required | CLI                 | Env                     | Type     | Description                               | Default   |
-|:--------:|---------------------|-------------------------|----------|-------------------------------------------|-----------|
-|    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use.              |           |
-|    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages           |           |
-|    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server. | localhost |
+| Required | CLI                 | Env                     | Type     | Description                                                     | Default   |
+|:--------:|---------------------|-------------------------|---------|-----------------------------------------------------------------|-----------|
+|    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use.                                    |           |
+|    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages (format: `hostname:port`)       |           |
+|    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server.                       | localhost |
 
 **Authentication Settings:**
 
@@ -115,7 +115,7 @@ existing one.
 | Required | CLI                         | Env                           | Type     | Description                                                                                                                                                        | Default |
 |:--------:|-----------------------------|-------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 |    -     | `--email-force-tls`         | `CODER_EMAIL_FORCE_TLS`       | `bool`   | Force a TLS connection to the configured SMTP smarthost. If port 465 is used, TLS will be forced. See <https://datatracker.ietf.org/doc/html/rfc8314#section-3.3>. | false   |
-|    -     | `--email-tls-starttls`      | `CODER_EMAIL_TLS_STARTTLS`    | `bool`   | Enable STARTTLS to upgrade insecure SMTP connections using TLS. Ignored if `CODER_NOTIFICATIONS_EMAIL_FORCE_TLS` is set.                                           | false   |
+|    -     | `--email-tls-starttls`      | `CODER_EMAIL_TLS_STARTTLS`    | `bool`   | Enable STARTTLS to upgrade insecure SMTP connections using TLS. Ignored if `CODER_EMAIL_FORCE_TLS` is set.                                           | false   |
 |    -     | `--email-tls-skip-verify`   | `CODER_EMAIL_TLS_SKIPVERIFY`  | `bool`   | Skip verification of the target server's certificate (**insecure**).                                                                                               | false   |
 |    -     | `--email-tls-server-name`   | `CODER_EMAIL_TLS_SERVERNAME`  | `string` | Server name to verify against the target certificate.                                                                                                              |         |
 |    -     | `--email-tls-cert-file`     | `CODER_EMAIL_TLS_CERTFILE`    | `string` | Certificate file to use.                                                                                                                                           |         |

--- a/docs/admin/monitoring/notifications/index.md
+++ b/docs/admin/monitoring/notifications/index.md
@@ -95,11 +95,11 @@ existing one.
 
 **Server Settings:**
 
-| Required | CLI                 | Env                     | Type     | Description                                                     | Default   |
-|:--------:|---------------------|-------------------------|---------|-----------------------------------------------------------------|-----------|
-|    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use.                                    |           |
-|    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages (format: `hostname:port`)       |           |
-|    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server.                       | localhost |
+| Required | CLI                 | Env                     | Type     | Description                                               | Default   |
+|:--------:|---------------------|-------------------------|----------|-----------------------------------------------------------|-----------|
+|    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use.                              |           |
+|    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages (format: `hostname:port`) |           |
+|    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server.                 | localhost |
 
 **Authentication Settings:**
 
@@ -115,7 +115,7 @@ existing one.
 | Required | CLI                         | Env                           | Type     | Description                                                                                                                                                        | Default |
 |:--------:|-----------------------------|-------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 |    -     | `--email-force-tls`         | `CODER_EMAIL_FORCE_TLS`       | `bool`   | Force a TLS connection to the configured SMTP smarthost. If port 465 is used, TLS will be forced. See <https://datatracker.ietf.org/doc/html/rfc8314#section-3.3>. | false   |
-|    -     | `--email-tls-starttls`      | `CODER_EMAIL_TLS_STARTTLS`    | `bool`   | Enable STARTTLS to upgrade insecure SMTP connections using TLS. Ignored if `CODER_EMAIL_FORCE_TLS` is set.                                           | false   |
+|    -     | `--email-tls-starttls`      | `CODER_EMAIL_TLS_STARTTLS`    | `bool`   | Enable STARTTLS to upgrade insecure SMTP connections using TLS. Ignored if `CODER_EMAIL_FORCE_TLS` is set.                                                         | false   |
 |    -     | `--email-tls-skip-verify`   | `CODER_EMAIL_TLS_SKIPVERIFY`  | `bool`   | Skip verification of the target server's certificate (**insecure**).                                                                                               | false   |
 |    -     | `--email-tls-server-name`   | `CODER_EMAIL_TLS_SERVERNAME`  | `string` | Server name to verify against the target certificate.                                                                                                              |         |
 |    -     | `--email-tls-cert-file`     | `CODER_EMAIL_TLS_CERTFILE`    | `string` | Certificate file to use.                                                                                                                                           |         |


### PR DESCRIPTION
## Issue

Closes #16206

(thanks @bjornrobertsson - not sure why I can't tag you as a reviewer)

Mismatch between the SMTP configuration UI and the documentation.

## Verification

Claude verified this issue by examining:

1. The current SMTP configuration code in the codebase
2. The CLI help documentation for the server command
3. The examples provided in the notifications documentation

The issue was confirmed by finding:
- A reference to a deprecated variable `CODER_NOTIFICATIONS_EMAIL_FORCE_TLS` instead of the current `CODER_EMAIL_FORCE_TLS`
- Missing information about the port format required for the SMTP smarthost

## Changes made

1. Updated the `--email-smarthost` description to clarify that the format should include both hostname and port: `(format:
     hostname:port)`
2. Fixed the reference to the TLS environment variable in the STARTTLS description, replacing the deprecated
     `CODER_NOTIFICATIONS_EMAIL_FORCE_TLS` with the correct `CODER_EMAIL_FORCE_TLS`

## Additional information

The Gmail and Outlook examples in the documentation already correctly show the port included in the smarthost configuration, but the main description table needed to be updated to explicitly mention this requirement.

[preview](https://coder.com/docs/@16206-smtp-required-components/admin/monitoring/notifications)

<sub>🤖 Generated with [Claude Code](https://claude.ai/code)</sub>