### PR TITLE
docs: document that default GitHub app requires device flow

### DIFF
--- a/docs/admin/users/github-auth.md
+++ b/docs/admin/users/github-auth.md
@@ -18,8 +18,7 @@ to this data by administering the GitHub app.
 > [!IMPORTANT]
 > The default GitHub app requires [device flow](#device-flow) to authenticate.
 > This is enabled by default when using the default GitHub app. If you disable
-> device flow using `CODER_OAUTH2_GITHUB_DEVICE_FLOW=false`, it will be ignored
-> for the default GitHub app and device flow will still be used.
+> device flow using `CODER_OAUTH2_GITHUB_DEVICE_FLOW=false`, it will be ignored.
 
 By default, only the admin user can sign up. To allow additional users to sign
 up with GitHub, add the following environment variable:

--- a/docs/admin/users/github-auth.md
+++ b/docs/admin/users/github-auth.md
@@ -130,14 +130,14 @@ organizations. This can be enforced from the organization settings page in the
 
 Coder supports
 [device flow](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow)
-for GitHub OAuth. This is enabled by default for the default GitHub app and cannot be disabled 
+for GitHub OAuth. This is enabled by default for the default GitHub app and cannot be disabled
 for that app. For your own custom GitHub OAuth app, you can enable device flow by setting:
 
 ```env
 CODER_OAUTH2_GITHUB_DEVICE_FLOW=true
 ```
 
-Device flow is optional for custom GitHub OAuth apps. We generally recommend using 
+Device flow is optional for custom GitHub OAuth apps. We generally recommend using
 the standard OAuth flow instead, as it is more convenient for end users.
 
 > [!NOTE]

--- a/docs/admin/users/github-auth.md
+++ b/docs/admin/users/github-auth.md
@@ -15,6 +15,12 @@ This access is necessary for the Coder server to complete the authentication
 process. To the best of our knowledge, Coder, the company, does not gain access
 to this data by administering the GitHub app.
 
+> [!IMPORTANT]
+> The default GitHub app requires [device flow](#device-flow) to authenticate.
+> This is enabled by default when using the default GitHub app. If you disable
+> device flow using `CODER_OAUTH2_GITHUB_DEVICE_FLOW=false`, it will be ignored
+> for the default GitHub app and device flow will still be used.
+
 By default, only the admin user can sign up. To allow additional users to sign
 up with GitHub, add the following environment variable:
 
@@ -124,11 +130,16 @@ organizations. This can be enforced from the organization settings page in the
 
 Coder supports
 [device flow](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow)
-for GitHub OAuth. To enable it, set:
+for GitHub OAuth. This is enabled by default for the default GitHub app and cannot be disabled 
+for that app. For your own custom GitHub OAuth app, you can enable device flow by setting:
 
 ```env
 CODER_OAUTH2_GITHUB_DEVICE_FLOW=true
 ```
 
-This is optional. We recommend using the standard OAuth flow instead, as it is
-more convenient for end users.
+Device flow is optional for custom GitHub OAuth apps. We generally recommend using 
+the standard OAuth flow instead, as it is more convenient for end users.
+
+> [!NOTE]
+> If you're using the default GitHub app, device flow is always enabled regardless of
+> the `CODER_OAUTH2_GITHUB_DEVICE_FLOW` setting.


### PR DESCRIPTION
## Issue

Closes #16824

Document that the default GitHub authentication app provided by Coder requires device flow, and that this behavior cannot be overridden.

## Changes Made

Claude updated the GitHub authentication documentation to:

1. Add a prominent warning in the Default Configuration section explaining that the default GitHub app requires device flow and ignores the `CODER_OAUTH2_GITHUB_DEVICE_FLOW` setting
2. Clarify the Device Flow section to indicate that:
   - Device flow is always enabled for the default GitHub app
   - Device flow is optional for custom GitHub OAuth apps
   - The `CODER_OAUTH2_GITHUB_DEVICE_FLOW` setting is ignored when using the default app

[preview](https://coder.com/docs/@16824-github-device-flow/admin/users/github-auth)

<sub>🤖 Generated with [Claude Code](https://claude.ai/code)</sub>