### PR TITLE
feat: add the ability to hide preset parameters

### DIFF
--- a/site/src/components/RichParameterInput/RichParameterInput.stories.tsx
+++ b/site/src/components/RichParameterInput/RichParameterInput.stories.tsx
@@ -381,7 +381,8 @@ export const WithPreset: Story = {
 		id: "project_name",
 		parameter: createTemplateVersionParameter({
 			name: "project_name",
-			description: "Customize the name of a Google Cloud project that will be created!",
+			description:
+				"Customize the name of a Google Cloud project that will be created!",
 		}),
 		isPreset: true,
 	},
@@ -393,7 +394,8 @@ export const WithPresetAndImmutable: Story = {
 		id: "project_name",
 		parameter: createTemplateVersionParameter({
 			name: "project_name",
-			description: "Customize the name of a Google Cloud project that will be created!",
+			description:
+				"Customize the name of a Google Cloud project that will be created!",
 			mutable: false,
 		}),
 		isPreset: true,
@@ -406,7 +408,8 @@ export const WithPresetAndOptional: Story = {
 		id: "project_name",
 		parameter: createTemplateVersionParameter({
 			name: "project_name",
-			description: "Customize the name of a Google Cloud project that will be created!",
+			description:
+				"Customize the name of a Google Cloud project that will be created!",
 			required: false,
 		}),
 		isPreset: true,

--- a/site/src/components/RichParameterInput/RichParameterInput.stories.tsx
+++ b/site/src/components/RichParameterInput/RichParameterInput.stories.tsx
@@ -374,3 +374,41 @@ export const SmallBasicWithDisplayName: Story = {
 		size: "small",
 	},
 };
+
+export const WithPreset: Story = {
+	args: {
+		value: "preset-value",
+		id: "project_name",
+		parameter: createTemplateVersionParameter({
+			name: "project_name",
+			description: "Customize the name of a Google Cloud project that will be created!",
+		}),
+		isPreset: true,
+	},
+};
+
+export const WithPresetAndImmutable: Story = {
+	args: {
+		value: "preset-value",
+		id: "project_name",
+		parameter: createTemplateVersionParameter({
+			name: "project_name",
+			description: "Customize the name of a Google Cloud project that will be created!",
+			mutable: false,
+		}),
+		isPreset: true,
+	},
+};
+
+export const WithPresetAndOptional: Story = {
+	args: {
+		value: "preset-value",
+		id: "project_name",
+		parameter: createTemplateVersionParameter({
+			name: "project_name",
+			description: "Customize the name of a Google Cloud project that will be created!",
+			required: false,
+		}),
+		isPreset: true,
+	},
+};

--- a/site/src/components/RichParameterInput/RichParameterInput.tsx
+++ b/site/src/components/RichParameterInput/RichParameterInput.tsx
@@ -1,5 +1,6 @@
 import type { Interpolation, Theme } from "@emotion/react";
 import ErrorOutline from "@mui/icons-material/ErrorOutline";
+import SettingsIcon from "@mui/icons-material/Settings";
 import Button from "@mui/material/Button";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormHelperText from "@mui/material/FormHelperText";
@@ -19,7 +20,6 @@ import type {
 	AutofillSource,
 } from "utils/richParameters";
 import { MultiTextField } from "./MultiTextField";
-import SettingsIcon from "@mui/icons-material/Settings";
 
 const isBoolean = (parameter: TemplateVersionParameter) => {
 	return parameter.type === "bool";

--- a/site/src/components/RichParameterInput/RichParameterInput.tsx
+++ b/site/src/components/RichParameterInput/RichParameterInput.tsx
@@ -19,6 +19,7 @@ import type {
 	AutofillSource,
 } from "utils/richParameters";
 import { MultiTextField } from "./MultiTextField";
+import SettingsIcon from "@mui/icons-material/Settings";
 
 const isBoolean = (parameter: TemplateVersionParameter) => {
 	return parameter.type === "bool";
@@ -122,9 +123,10 @@ const styles = {
 
 export interface ParameterLabelProps {
 	parameter: TemplateVersionParameter;
+	isPreset?: boolean;
 }
 
-const ParameterLabel: FC<ParameterLabelProps> = ({ parameter }) => {
+const ParameterLabel: FC<ParameterLabelProps> = ({ parameter, isPreset }) => {
 	const hasDescription = parameter.description && parameter.description !== "";
 	const displayName = parameter.display_name
 		? parameter.display_name
@@ -143,6 +145,13 @@ const ParameterLabel: FC<ParameterLabelProps> = ({ parameter }) => {
 				<Tooltip title="This value cannot be modified after the workspace has been created.">
 					<Pill type="warning" icon={<ErrorOutline />}>
 						Immutable
+					</Pill>
+				</Tooltip>
+			)}
+			{isPreset && (
+				<Tooltip title="This value was set by a preset">
+					<Pill type="info" icon={<SettingsIcon />}>
+						Preset
 					</Pill>
 				</Tooltip>
 			)}
@@ -187,6 +196,7 @@ export type RichParameterInputProps = Omit<
 	parameterAutofill?: AutofillBuildParameter;
 	onChange: (value: string) => void;
 	size?: Size;
+	isPreset?: boolean;
 };
 
 const autofillDescription: Partial<Record<AutofillSource, ReactNode>> = {
@@ -198,6 +208,7 @@ export const RichParameterInput: FC<RichParameterInputProps> = ({
 	parameter,
 	parameterAutofill,
 	onChange,
+	isPreset,
 	...fieldProps
 }) => {
 	const autofillSource = parameterAutofill?.source;
@@ -211,7 +222,7 @@ export const RichParameterInput: FC<RichParameterInputProps> = ({
 			className={size}
 			data-testid={`parameter-field-${parameter.name}`}
 		>
-			<ParameterLabel parameter={parameter} />
+			<ParameterLabel parameter={parameter} isPreset={isPreset} />
 			<div css={{ display: "flex", flexDirection: "column" }}>
 				<RichParameterField
 					{...fieldProps}

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -166,8 +166,6 @@ export const PresetSelectedWithHiddenParameters: Story = {
 		// Select a preset
 		await userEvent.click(canvas.getByLabelText("Preset"));
 		await userEvent.click(canvas.getByText("Preset 1"));
-		// Toggle off the show preset parameters switch
-		await userEvent.click(canvas.getByLabelText("Show preset parameters"));
 	},
 };
 
@@ -178,7 +176,8 @@ export const PresetSelectedWithVisibleParameters: Story = {
 		// Select a preset
 		await userEvent.click(canvas.getByLabelText("Preset"));
 		await userEvent.click(canvas.getByText("Preset 1"));
-		// Ensure the show preset parameters switch is on (it's on by default)
+		// Toggle off the show preset parameters switch
+		await userEvent.click(canvas.getByLabelText("Show preset parameters"));
 	},
 };
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -159,6 +159,29 @@ export const PresetSelected: Story = {
 	},
 };
 
+export const PresetSelectedWithHiddenParameters: Story = {
+	args: PresetsButNoneSelected.args,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Select a preset
+		await userEvent.click(canvas.getByLabelText("Preset"));
+		await userEvent.click(canvas.getByText("Preset 1"));
+		// Toggle off the show preset parameters switch
+		await userEvent.click(canvas.getByLabelText("Show preset parameters"));
+	},
+};
+
+export const PresetSelectedWithVisibleParameters: Story = {
+	args: PresetsButNoneSelected.args,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Select a preset
+		await userEvent.click(canvas.getByLabelText("Preset"));
+		await userEvent.click(canvas.getByText("Preset 1"));
+		// Ensure the show preset parameters switch is on (it's on by default)
+	},
+};
+
 export const PresetReselected: Story = {
 	args: PresetsButNoneSelected.args,
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -276,50 +276,6 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 							</Stack>
 						)}
 
-						{presets.length > 0 && (
-							<Stack direction="column" spacing={2}>
-								<Stack direction="row" spacing={2} alignItems="center">
-									<span css={styles.description}>
-										Select a preset to get started
-									</span>
-									<FeatureStageBadge contentType={"beta"} size="md" />
-								</Stack>
-								<Stack direction="column" spacing={2}>
-									<Stack direction="row" spacing={2}>
-										<SelectFilter
-											label="Preset"
-											options={presetOptions}
-											onSelect={(option) => {
-												const index = presetOptions.findIndex(
-													(preset) => preset.value === option?.value,
-												);
-												if (index === -1) {
-													return;
-												}
-												setSelectedPresetIndex(index);
-											}}
-											placeholder="Select a preset"
-											selectedOption={presetOptions[selectedPresetIndex]}
-										/>
-									</Stack>
-									<div
-										css={{ display: "flex", alignItems: "center", gap: "8px" }}
-									>
-										<Switch
-											id="show-preset-parameters"
-											checked={showPresetParameters}
-											onCheckedChange={setShowPresetParameters}
-										/>
-										<label
-											htmlFor="show-preset-parameters"
-											css={styles.description}
-										>
-											Show preset parameters
-										</label>
-									</div>
-								</Stack>
-							</Stack>
-						)}
 						<div>
 							<TextField
 								{...getFieldHelpers("name")}
@@ -393,6 +349,55 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
                 hence they require additional vertical spacing for better readability and
                 user experience. */}
 						<FormFields css={{ gap: 36 }}>
+							{presets.length > 0 && (
+								<Stack direction="column" spacing={2}>
+									<Stack direction="row" spacing={2} alignItems="center">
+										<span css={styles.description}>
+											Select a preset to get started
+										</span>
+										<FeatureStageBadge contentType={"beta"} size="md" />
+									</Stack>
+									<Stack direction="column" spacing={2}>
+										<Stack direction="row" spacing={2}>
+											<SelectFilter
+												label="Preset"
+												options={presetOptions}
+												onSelect={(option) => {
+													const index = presetOptions.findIndex(
+														(preset) => preset.value === option?.value,
+													);
+													if (index === -1) {
+														return;
+													}
+													setSelectedPresetIndex(index);
+												}}
+												placeholder="Select a preset"
+												selectedOption={presetOptions[selectedPresetIndex]}
+											/>
+										</Stack>
+										<div
+											css={{
+												display: "flex",
+												alignItems: "center",
+												gap: "8px",
+											}}
+										>
+											<Switch
+												id="show-preset-parameters"
+												checked={showPresetParameters}
+												onCheckedChange={setShowPresetParameters}
+											/>
+											<label
+												htmlFor="show-preset-parameters"
+												css={styles.description}
+											>
+												Show preset parameters
+											</label>
+										</div>
+									</Stack>
+								</Stack>
+							)}
+
 							{parameters.map((parameter, index) => {
 								const parameterField = `rich_parameter_values.${index}`;
 								const parameterInputName = `${parameterField}.value`;

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -306,10 +306,16 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 										css={{ display: "flex", alignItems: "center", gap: "8px" }}
 									>
 										<Switch
+											id="show-preset-parameters"
 											checked={showPresetParameters}
 											onCheckedChange={setShowPresetParameters}
 										/>
-										<span css={styles.description}>Show preset parameters</span>
+										<label
+											htmlFor="show-preset-parameters"
+											css={styles.description}
+										>
+											Show preset parameters
+										</label>
 									</div>
 								</Stack>
 							</Stack>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -200,13 +200,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 				value: presetParameter.Value,
 			});
 		}
-	}, [
-		presetOptions,
-		selectedPresetIndex,
-		presets,
-		parameters,
-		form.setFieldValue,
-	]);
+	}, [presetOptions, selectedPresetIndex, presets, parameters, form.setFieldValue]);
 
 	return (
 		<Margins size="medium">
@@ -395,7 +389,8 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 									creatingWorkspace ||
 									presetParameterNames.includes(parameter.name);
 
-								// Skip rendering preset parameters if showPresetParameters is false
+								// Hide preset parameters if showPresetParameters is false
+								// but keep their values in the form
 								if (!showPresetParameters && presetParameterNames.includes(parameter.name)) {
 									return null;
 								}

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -1,6 +1,7 @@
 import type { Interpolation, Theme } from "@emotion/react";
 import FormHelperText from "@mui/material/FormHelperText";
 import TextField from "@mui/material/TextField";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import type * as TypesGen from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
@@ -45,6 +46,7 @@ import type {
 } from "./CreateWorkspacePage";
 import { ExternalAuthButton } from "./ExternalAuthButton";
 import type { CreateWSPermissions } from "./permissions";
+import { Switch } from "components/Switch/Switch";
 
 export const Language = {
 	duplicationWarning:
@@ -101,6 +103,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	const [suggestedName, setSuggestedName] = useState(() =>
 		generateWorkspaceName(),
 	);
+	const [showPresetParameters, setShowPresetParameters] = useState(true);
 
 	const rerollSuggestedName = useCallback(() => {
 		setSuggestedName(() => generateWorkspaceName());
@@ -281,22 +284,31 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 									</span>
 									<FeatureStageBadge contentType={"beta"} size="md" />
 								</Stack>
-								<Stack direction="row" spacing={2}>
-									<SelectFilter
-										label="Preset"
-										options={presetOptions}
-										onSelect={(option) => {
-											const index = presetOptions.findIndex(
-												(preset) => preset.value === option?.value,
-											);
-											if (index === -1) {
-												return;
-											}
-											setSelectedPresetIndex(index);
-										}}
-										placeholder="Select a preset"
-										selectedOption={presetOptions[selectedPresetIndex]}
-									/>
+								<Stack direction="column" spacing={2}>
+									<Stack direction="row" spacing={2}>
+										<SelectFilter
+											label="Preset"
+											options={presetOptions}
+											onSelect={(option) => {
+												const index = presetOptions.findIndex(
+													(preset) => preset.value === option?.value,
+												);
+												if (index === -1) {
+													return;
+												}
+												setSelectedPresetIndex(index);
+											}}
+											placeholder="Select a preset"
+											selectedOption={presetOptions[selectedPresetIndex]}
+										/>
+									</Stack>
+									<div css={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+										<Switch
+											checked={showPresetParameters}
+											onCheckedChange={setShowPresetParameters}
+										/>
+										<span>Show preset parameters</span>
+									</div>
 								</Stack>
 							</Stack>
 						)}
@@ -382,6 +394,11 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 									) ||
 									creatingWorkspace ||
 									presetParameterNames.includes(parameter.name);
+
+								// Skip rendering preset parameters if showPresetParameters is false
+								if (!showPresetParameters && presetParameterNames.includes(parameter.name)) {
+									return null;
+								}
 
 								return (
 									<RichParameterInput

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -103,7 +103,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	const [suggestedName, setSuggestedName] = useState(() =>
 		generateWorkspaceName(),
 	);
-	const [showPresetParameters, setShowPresetParameters] = useState(true);
+	const [showPresetParameters, setShowPresetParameters] = useState(false);
 
 	const rerollSuggestedName = useCallback(() => {
 		setSuggestedName(() => generateWorkspaceName());

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -1,7 +1,7 @@
 import type { Interpolation, Theme } from "@emotion/react";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import FormHelperText from "@mui/material/FormHelperText";
 import TextField from "@mui/material/TextField";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import type * as TypesGen from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
@@ -25,6 +25,7 @@ import { Pill } from "components/Pill/Pill";
 import { RichParameterInput } from "components/RichParameterInput/RichParameterInput";
 import { Spinner } from "components/Spinner/Spinner";
 import { Stack } from "components/Stack/Stack";
+import { Switch } from "components/Switch/Switch";
 import { UserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
 import { type FormikContextType, useFormik } from "formik";
 import { generateWorkspaceName } from "modules/workspaces/generateWorkspaceName";
@@ -46,7 +47,6 @@ import type {
 } from "./CreateWorkspacePage";
 import { ExternalAuthButton } from "./ExternalAuthButton";
 import type { CreateWSPermissions } from "./permissions";
-import { Switch } from "components/Switch/Switch";
 
 export const Language = {
 	duplicationWarning:
@@ -200,7 +200,13 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 				value: presetParameter.Value,
 			});
 		}
-	}, [presetOptions, selectedPresetIndex, presets, parameters, form.setFieldValue]);
+	}, [
+		presetOptions,
+		selectedPresetIndex,
+		presets,
+		parameters,
+		form.setFieldValue,
+	]);
 
 	return (
 		<Margins size="medium">
@@ -296,7 +302,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 											selectedOption={presetOptions[selectedPresetIndex]}
 										/>
 									</Stack>
-									<div css={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+									<div
+										css={{ display: "flex", alignItems: "center", gap: "8px" }}
+									>
 										<Switch
 											checked={showPresetParameters}
 											onCheckedChange={setShowPresetParameters}
@@ -382,7 +390,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 							{parameters.map((parameter, index) => {
 								const parameterField = `rich_parameter_values.${index}`;
 								const parameterInputName = `${parameterField}.value`;
-								const isPresetParameter = presetParameterNames.includes(parameter.name);
+								const isPresetParameter = presetParameterNames.includes(
+									parameter.name,
+								);
 								const isDisabled =
 									disabledParams?.includes(
 										parameter.name.toLowerCase().replace(/ /g, "_"),

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -382,33 +382,35 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 							{parameters.map((parameter, index) => {
 								const parameterField = `rich_parameter_values.${index}`;
 								const parameterInputName = `${parameterField}.value`;
+								const isPresetParameter = presetParameterNames.includes(parameter.name);
 								const isDisabled =
 									disabledParams?.includes(
 										parameter.name.toLowerCase().replace(/ /g, "_"),
 									) ||
 									creatingWorkspace ||
-									presetParameterNames.includes(parameter.name);
+									isPresetParameter;
 
 								// Hide preset parameters if showPresetParameters is false
-								// but keep their values in the form
-								if (!showPresetParameters && presetParameterNames.includes(parameter.name)) {
+								if (!showPresetParameters && isPresetParameter) {
 									return null;
 								}
 
 								return (
-									<RichParameterInput
-										{...getFieldHelpers(parameterInputName)}
-										onChange={async (value) => {
-											await form.setFieldValue(parameterField, {
-												name: parameter.name,
-												value,
-											});
-										}}
-										key={parameter.name}
-										parameter={parameter}
-										parameterAutofill={autofillByName[parameter.name]}
-										disabled={isDisabled}
-									/>
+									<div key={parameter.name}>
+										<RichParameterInput
+											{...getFieldHelpers(parameterInputName)}
+											onChange={async (value) => {
+												await form.setFieldValue(parameterField, {
+													name: parameter.name,
+													value,
+												});
+											}}
+											parameter={parameter}
+											parameterAutofill={autofillByName[parameter.name]}
+											disabled={isDisabled}
+											isPreset={isPresetParameter}
+										/>
+									</div>
 								);
 							})}
 						</FormFields>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -301,7 +301,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 											checked={showPresetParameters}
 											onCheckedChange={setShowPresetParameters}
 										/>
-										<span>Show preset parameters</span>
+										<span css={styles.description}>Show preset parameters</span>
 									</div>
 								</Stack>
 							</Stack>


### PR DESCRIPTION
This PR adds the ability to hide presets on the workspace creation form. When showing them, a clear indication is now made as to which inputs were preset and which weren't.

![image](https://github.com/user-attachments/assets/6c8f690c-7cf6-44a9-9657-65039b2b3cb7)
