### PR TITLE
chore: improve error logging in TestServer/EphemeralDeployment

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -221,6 +221,7 @@ func TestServer(t *testing.T) {
 
 		matchCh2 := make(chan string, 1)
 		go func() {
+			// The "View the Web UI" log is a decent indicator that the server was successfully started.
 			matchCh2 <- pty.ExpectMatchContext(ctx, "View the Web UI")
 		}()
 		select {


### PR DESCRIPTION
There's a flake reported in https://github.com/coder/internal/issues/549 that was caused by the built-in Postgres failing to start. However, the test was written in a way that didn't log the actual error which caused Postgres to fail. This PR improves error logging in the affected test so that the next time the error happens, we know what it is.