### PR TITLE
chore: deprecate ResourceSystem

### DIFF
--- a/coderd/rbac/object_gen.go
+++ b/coderd/rbac/object_gen.go
@@ -242,6 +242,9 @@ var (
 	//  - "ActionDelete" :: delete system resources
 	//  - "ActionRead" :: view system resources
 	//  - "ActionUpdate" :: update system resources
+	// DEPRECATED: New resources should be created for new things, rather than adding them to System, which has become
+	//             an unmanaged collection of things that don't relate to one another. We can't effectively enforce
+	//             least privilege access control when unrelated resources are grouped together.
 	ResourceSystem = Object{
 		Type: "system",
 	}

--- a/coderd/rbac/policy/policy.go
+++ b/coderd/rbac/policy/policy.go
@@ -33,6 +33,8 @@ type PermissionDefinition struct {
 	// should represent. The key in the actions map is the verb to use
 	// in the rbac policy.
 	Actions map[Action]ActionDefinition
+	// Comment is additional text to include in the generated object comment.
+	Comment string
 }
 
 type ActionDefinition struct {
@@ -203,6 +205,10 @@ var RBACPermissions = map[string]PermissionDefinition{
 			ActionUpdate: actDef("update system resources"),
 			ActionDelete: actDef("delete system resources"),
 		},
+		Comment: `
+	// DEPRECATED: New resources should be created for new things, rather than adding them to System, which has become
+	//             an unmanaged collection of things that don't relate to one another. We can't effectively enforce
+	//             least privilege access control when unrelated resources are grouped together.`,
 	},
 	"api_key": {
 		Actions: map[Action]ActionDefinition{

--- a/scripts/typegen/rbacobject.gotmpl
+++ b/scripts/typegen/rbacobject.gotmpl
@@ -16,6 +16,7 @@ var (
 		{{- range $action, $value := .Actions }}
 		//  - "{{ actionEnum $action }}" :: {{ $value.Description }}
 		{{- end }}
+		{{- .Comment }}
 		Resource{{ $Name }} = Object {
 			Type: "{{ $element.Type }}",
 		}


### PR DESCRIPTION
Deprecates `ResourceSystem`. It's a large collection of unrelated things, and violates the principle of least privilege because to get access to low-security stuff like various statistics, you also get access to serious-security stuff like crypto keys.

We should eventually break it up and remove it, but the least we can do for now is not make the problem worse.