### PR TITLE
chore: sort agent `/list-directory` output

### DIFF
--- a/agent/ls.go
+++ b/agent/ls.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/shirou/gopsutil/v4/disk"
@@ -102,6 +103,17 @@ func listFiles(query LSRequest) (LSResponse, error) {
 			IsDir:              file.IsDir(),
 		})
 	}
+
+	// Sort alphabetically: directories then files
+	slices.SortFunc(respContents, func(a, b LSFile) int {
+		if a.IsDir && !b.IsDir {
+			return -1
+		}
+		if !a.IsDir && b.IsDir {
+			return 1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	absolutePath := pathToArray(absolutePathString)
 

--- a/agent/ls_internal_test.go
+++ b/agent/ls_internal_test.go
@@ -137,15 +137,16 @@ func TestListFilesSuccess(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tmpDir, resp.AbsolutePathString)
-			require.ElementsMatch(t, []LSFile{
-				{
-					Name:               "repos",
-					AbsolutePathString: reposDir,
-					IsDir:              true,
-				},
+			// Output is sorted
+			require.Equal(t, []LSFile{
 				{
 					Name:               "Downloads",
 					AbsolutePathString: downloadsDir,
+					IsDir:              true,
+				},
+				{
+					Name:               "repos",
+					AbsolutePathString: reposDir,
 					IsDir:              true,
 				},
 				{


### PR DESCRIPTION
This sorts the `contents` list alphabetically, but with directories before everything else.
This is purely for UX on the Coder Desktop side, where the user only really cares about directories, and files are just for providing context in the file picker.