### PR TITLE
ci: re-enable revive and gosec linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -164,6 +164,7 @@ linters-settings:
       - name: unnecessary-stmt
       - name: unreachable-code
       - name: unused-parameter
+        exclude: "**/*_test.go"
       - name: unused-receiver
       - name: var-declaration
       - name: var-naming
@@ -195,8 +196,6 @@ issues:
         - errcheck
         - forcetypeassert
         - exhaustruct # This is unhelpful in tests.
-        - revive # TODO(JonA): disabling in order to update golangci-lint
-        - gosec # TODO(JonA): disabling in order to update golangci-lint
     - path: scripts/*
       linters:
         - exhaustruct

--- a/coderd/agentapi/logs_test.go
+++ b/coderd/agentapi/logs_test.go
@@ -118,7 +118,7 @@ func TestBatchCreateLogs(t *testing.T) {
 				level = database.LogLevel(strings.ToLower(logEntry.Level.String()))
 			}
 			insertWorkspaceAgentLogsParams.Level[i] = level
-			insertWorkspaceAgentLogsParams.OutputLength += int32(len(logEntry.Output))
+			insertWorkspaceAgentLogsParams.OutputLength += int32(len(logEntry.Output)) // nolint:gosec
 
 			insertWorkspaceAgentLogsReturn[i] = database.WorkspaceAgentLog{
 				AgentID:     agent.ID,
@@ -270,7 +270,7 @@ func TestBatchCreateLogs(t *testing.T) {
 			CreatedAt:    now,
 			Output:       []string{"hello world"},
 			Level:        []database.LogLevel{database.LogLevelInfo},
-			OutputLength: int32(len(req.Logs[0].Output)),
+			OutputLength: int32(len(req.Logs[0].Output)), // nolint:gosec
 		}
 		dbInsertRes := []database.WorkspaceAgentLog{
 			{

--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -872,7 +872,7 @@ func (o orgSetupDefinition) Assert(t *testing.T, orgID uuid.UUID, db database.St
 	}
 }
 
-func (o orgGroupAssert) Assert(t *testing.T, orgID uuid.UUID, db database.Store, user database.User) {
+func (o *orgGroupAssert) Assert(t *testing.T, orgID uuid.UUID, db database.Store, user database.User) {
 	t.Helper()
 
 	ctx := context.Background()

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -249,7 +249,7 @@ func TestCache_BuildTime(t *testing.T) {
 				})
 
 				dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-					BuildNumber:       int32(1 + buildNumber),
+					BuildNumber:       int32(1 + buildNumber), // nolint:gosec
 					WorkspaceID:       workspace.ID,
 					InitiatorID:       user.ID,
 					TemplateVersionID: templateVersion.ID,

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -354,10 +354,10 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 			at := now.Add(-time.Duration(i) * time.Hour)
 
 			pj1 := dbgen.ProvisionerJob(t, db, ps, database.ProvisionerJob{OrganizationID: org.ID, Error: jobError, ErrorCode: jobErrorCode, CompletedAt: sql.NullTime{Time: at, Valid: true}})
-			_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{WorkspaceID: w1.ID, BuildNumber: int32(i), TemplateVersionID: t1v1.ID, JobID: pj1.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator})
+			_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{WorkspaceID: w1.ID, BuildNumber: int32(i), TemplateVersionID: t1v1.ID, JobID: pj1.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}) // nolint:gosec
 
 			pj2 := dbgen.ProvisionerJob(t, db, ps, database.ProvisionerJob{OrganizationID: org.ID, Error: jobError, ErrorCode: jobErrorCode, CompletedAt: sql.NullTime{Time: at, Valid: true}})
-			_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{WorkspaceID: w1.ID, BuildNumber: int32(i) + 100, TemplateVersionID: t1v2.ID, JobID: pj2.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator})
+			_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{WorkspaceID: w1.ID, BuildNumber: int32(i) + 100, TemplateVersionID: t1v2.ID, JobID: pj2.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}) // nolint:gosec
 		}
 
 		// When

--- a/coderd/util/xio/limitwriter_test.go
+++ b/coderd/util/xio/limitwriter_test.go
@@ -121,7 +121,7 @@ func TestLimitWriter(t *testing.T) {
 				n, err := cryptorand.Read(data)
 				require.NoError(t, err, "crand read")
 				require.Equal(t, wc.N, n, "correct bytes read")
-				max := data[:wc.ExpN]
+				maxSeen := data[:wc.ExpN]
 				n, err = w.Write(data)
 				if wc.Err {
 					require.Error(t, err, "exp error")
@@ -131,7 +131,7 @@ func TestLimitWriter(t *testing.T) {
 
 				// Need to use this to compare across multiple writes.
 				// Each write appends to the expected output.
-				allBuff.Write(max)
+				allBuff.Write(maxSeen)
 
 				require.Equal(t, wc.ExpN, n, "correct bytes written")
 				require.Equal(t, allBuff.Bytes(), buf.Bytes(), "expected data")

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -856,7 +856,7 @@ func TestLicenseEntitlements(t *testing.T) {
 			generatedLicenses := make([]database.License, 0, len(tc.Licenses))
 			for i, lo := range tc.Licenses {
 				generatedLicenses = append(generatedLicenses, database.License{
-					ID:         int32(i),
+					ID:         int32(i), // nolint:gosec
 					UploadedAt: time.Now().Add(time.Hour * -1),
 					JWT:        lo.Generate(t),
 					Exp:        lo.GraceAt,

--- a/enterprise/coderd/workspacequota_test.go
+++ b/enterprise/coderd/workspacequota_test.go
@@ -73,9 +73,9 @@ func TestWorkspaceQuota(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
-		max := 1
+		maxWorkspaces := 1
 		client, _, api, user := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
-			UserWorkspaceQuota: max,
+			UserWorkspaceQuota: maxWorkspaces,
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{
 					codersdk.FeatureTemplateRBAC: 1,
@@ -195,9 +195,9 @@ func TestWorkspaceQuota(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
-		max := 1
+		maxWorkspaces := 1
 		client, _, api, user := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
-			UserWorkspaceQuota: max,
+			UserWorkspaceQuota: maxWorkspaces,
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{
 					codersdk.FeatureTemplateRBAC: 1,

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -306,11 +306,11 @@ func makeJSONRPCRequest(t *testing.T, method, name string, args map[string]any) 
 		JSONRPC: "2.0",
 		Request: mcp.Request{Method: method},
 		Params: struct { // Unfortunately, there is no type for this yet.
-			Name      string         "json:\"name\""
-			Arguments map[string]any "json:\"arguments,omitempty\""
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments,omitempty"`
 			Meta      *struct {
-				ProgressToken mcp.ProgressToken "json:\"progressToken,omitempty\""
-			} "json:\"_meta,omitempty\""
+				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
+			} `json:"_meta,omitempty"`
 		}{
 			Name:      name,
 			Arguments: args,


### PR DESCRIPTION
* Reenables revive linter for test files (with an exception for the `unused-parameter` rule)
* Reenables gosec linter for test files