### PR TITLE
docs: remove enterprise from docs

### DIFF
--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -252,7 +252,7 @@ CODER_EXTERNAL_AUTH_0_SCOPES="repo:read repo:write write:gpg_key"
 
    ![Install GitHub App](../images/admin/github-app-install.png)
 
-## Multiple External Providers (Enterprise)(Premium)
+## Multiple External Providers (Premium)
 
 Below is an example configuration with multiple providers:
 

--- a/docs/admin/monitoring/notifications/index.md
+++ b/docs/admin/monitoring/notifications/index.md
@@ -250,7 +250,7 @@ notification is indicated on the right hand side of this table.
 ## Delivery Preferences
 
 > [!NOTE]
-> Delivery preferences is an Enterprise and Premium feature.
+> Delivery preferences is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Administrators can configure which delivery methods are used for each different

--- a/docs/admin/networking/index.md
+++ b/docs/admin/networking/index.md
@@ -175,7 +175,7 @@ more.
 ## Browser-only connections
 
 > [!NOTE]
-> Browser-only connections is an Enterprise and Premium feature.
+> Browser-only connections is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Some Coder deployments require that all access is through the browser to comply
@@ -189,10 +189,10 @@ via the web terminal and
 ### Workspace Proxies
 
 > [!NOTE]
-> Workspace proxies are an Enterprise and Premium feature.
+> Workspace proxies are a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
-Workspace proxies are a Coder Enterprise feature that allows you to provide
+Workspace proxies are a Coder Premium feature that allows you to provide
 low-latency browser experiences for geo-distributed teams.
 
 To learn more, see [Workspace Proxies](./workspace-proxies.md).

--- a/docs/admin/networking/port-forwarding.md
+++ b/docs/admin/networking/port-forwarding.md
@@ -132,7 +132,7 @@ to the app.
 ### Configure maximum port sharing level
 
 > [!NOTE]
-> Configuring port sharing level is an Enterprise and Premium feature.
+> Configuring port sharing level is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Premium-licensed template admins can control the maximum port sharing level for

--- a/docs/admin/security/audit-logs.md
+++ b/docs/admin/security/audit-logs.md
@@ -127,5 +127,5 @@ log entry:
 
 ## Enabling this feature
 
-This feature is only available with an premium license.
+This feature is only available with a premium license.
 [Learn more](../licensing/index.md)

--- a/docs/admin/setup/appearance.md
+++ b/docs/admin/setup/appearance.md
@@ -1,7 +1,7 @@
 # Appearance
 
 > [!NOTE]
-> Customizing Coder's appearance is an Enterprise and Premium feature.
+> Customizing Coder's appearance is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Customize the look of your Coder deployment to meet your enterprise

--- a/docs/admin/templates/extending-templates/process-logging.md
+++ b/docs/admin/templates/extending-templates/process-logging.md
@@ -7,7 +7,7 @@ This feature is only available on Linux in Kubernetes. There are
 additional requirements outlined further in this document.
 
 > [!NOTE]
-> Workspace process logging is an Enterprise and Premium feature.
+> Workspace process logging is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Workspace process logging adds a sidecar container to workspace pods that will

--- a/docs/admin/templates/managing-templates/index.md
+++ b/docs/admin/templates/managing-templates/index.md
@@ -62,7 +62,7 @@ infrastructure, software, or security patches. Learn more about
 ### Template update policies
 
 > [!NOTE]
-> Template update policies are an Enterprise and Premium feature.
+> Template update policies are a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Licensed template admins may want workspaces to always remain on the latest

--- a/docs/admin/templates/managing-templates/schedule.md
+++ b/docs/admin/templates/managing-templates/schedule.md
@@ -28,7 +28,7 @@ manage infrastructure costs.
 ## Failure cleanup
 
 > [!NOTE]
-> Failure cleanup is an Enterprise and Premium feature.
+> Failure cleanup is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Failure cleanup defines how long a workspace is permitted to remain in the
@@ -38,7 +38,7 @@ available for licensed customers.
 ## Dormancy threshold
 
 > [!NOTE]
-> Dormancy threshold is an Enterprise and Premium feature.
+> Dormancy threshold is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Dormancy Threshold defines how long Coder allows a workspace to remain inactive
@@ -52,7 +52,7 @@ only available for licensed customers.
 ## Dormancy auto-deletion
 
 > [!NOTE]
-> Dormancy auto-deletion is an Enterprise and Premium feature.
+> Dormancy auto-deletion is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Dormancy Auto-Deletion allows a template admin to dictate how long a workspace
@@ -62,7 +62,7 @@ Auto-Deletion is only available for licensed customers.
 ## Autostop requirement
 
 > [!NOTE]
-> Autostop requirement is an Enterprise and Premium feature.
+> Autostop requirement is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Autostop requirement is a template setting that determines how often workspaces
@@ -96,7 +96,7 @@ requirement during the deprecation period, but only one can be used at a time.
 ## User quiet hours
 
 > [!NOTE]
-> User quiet hours are an Enterprise and Premium feature.
+> User quiet hours are a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 User quiet hours can be configured in the user's schedule settings page.

--- a/docs/admin/users/groups-roles.md
+++ b/docs/admin/users/groups-roles.md
@@ -19,7 +19,7 @@ Roles determine which actions users can take within the platform.
 |                                                                 | Auditor | User Admin | Template Admin | Owner |
 |-----------------------------------------------------------------|---------|------------|----------------|-------|
 | Add and remove Users                                            |         | ✅          |                | ✅     |
-| Manage groups (enterprise) (premium)                            |         | ✅          |                | ✅     |
+| Manage groups (premium)                                         |         | ✅          |                | ✅     |
 | Change User roles                                               |         |            |                | ✅     |
 | Manage **ALL** Templates                                        |         |            | ✅              | ✅     |
 | View **ALL** Workspaces                                         |         |            | ✅              | ✅     |

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -2,7 +2,7 @@
 # IdP Sync
 
 > [!NOTE]
-> IdP sync is an Enterprise and Premium feature.
+> IdP sync is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 IdP (Identity provider) sync allows you to use OpenID Connect (OIDC) to

--- a/docs/admin/users/oidc-auth.md
+++ b/docs/admin/users/oidc-auth.md
@@ -104,7 +104,7 @@ CODER_DISABLE_PASSWORD_AUTH=true
 ## SCIM
 
 > [!NOTE]
-> SCIM is an Enterprise and Premium feature.
+> SCIM is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Coder supports user provisioning and deprovisioning via SCIM 2.0 with header

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -236,7 +236,7 @@
 							"title": "Appearance",
 							"description": "Learn how to configure the appearance of Coder",
 							"path": "./admin/setup/appearance.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "Telemetry",
@@ -317,12 +317,12 @@
 						{
 							"title": "Groups \u0026 Roles",
 							"path": "./admin/users/groups-roles.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "IdP Sync",
 							"path": "./admin/users/idp-sync.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "Organizations",
@@ -332,7 +332,7 @@
 						{
 							"title": "Quotas",
 							"path": "./admin/users/quotas.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "Sessions \u0026 API Tokens",
@@ -474,7 +474,7 @@
 									"title": "Process Logging",
 									"description": "Log workspace processes",
 									"path": "./admin/templates/extending-templates/process-logging.md",
-									"state": ["enterprise", "premium"]
+									"state": ["premium"]
 								}
 							]
 						},
@@ -487,7 +487,7 @@
 							"title": "Permissions \u0026 Policies",
 							"description": "Learn how to create templates with Terraform",
 							"path": "./admin/templates/template-permissions.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "Troubleshooting Templates",
@@ -501,13 +501,13 @@
 					"description": "Learn how to run external provisioners with Coder",
 					"path": "./admin/provisioners/index.md",
 					"icon_path": "./images/icons/key.svg",
-					"state": ["enterprise", "premium"],
+					"state": ["premium"],
 					"children": [
 						{
 							"title": "Manage Provisioner Jobs",
 							"description": "Learn how to run external provisioners with Coder",
 							"path": "./admin/provisioners/manage-provisioner-jobs.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						}
 					]
 				},
@@ -585,13 +585,13 @@
 							"title": "Workspace Proxies",
 							"description": "Run geo distributed workspace proxies",
 							"path": "./admin/networking/workspace-proxies.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "High Availability",
 							"description": "Learn how to configure Coder for High Availability",
 							"path": "./admin/networking/high-availability.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "Troubleshooting",
@@ -650,7 +650,7 @@
 							"title": "Audit Logs",
 							"description": "Audit actions taken inside Coder",
 							"path": "./admin/security/audit-logs.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						},
 						{
 							"title": "Secrets",
@@ -661,7 +661,7 @@
 							"title": "Database Encryption",
 							"description": "Encrypt the database to prevent unauthorized access",
 							"path": "./admin/security/database-encryption.md",
-							"state": ["enterprise", "premium"]
+							"state": ["premium"]
 						}
 					]
 				},

--- a/docs/user-guides/workspace-management.md
+++ b/docs/user-guides/workspace-management.md
@@ -91,7 +91,7 @@ manually updated the workspace.
 ## Bulk operations
 
 > [!NOTE]
-> Bulk operations are an Enterprise and Premium feature.
+> Bulk operations are a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Licensed admins may apply bulk operations (update, delete, start, stop) in the

--- a/docs/user-guides/workspace-scheduling.md
+++ b/docs/user-guides/workspace-scheduling.md
@@ -71,7 +71,7 @@ To avoid unexpected cloud costs, close your connections, this includes IDE windo
 ## Autostop requirement
 
 > [!NOTE]
-> Autostop requirement is an Enterprise and Premium feature.
+> Autostop requirement is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Licensed template admins may enforce a required stop for workspaces to apply
@@ -87,7 +87,7 @@ Autostop Requirement.
 ### User quiet hours
 
 > [!NOTE]
-> User quiet hours are an Enterprise and Premium feature.
+> User quiet hours are a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 User quiet hours can be configured in the user's schedule settings page.
@@ -130,7 +130,7 @@ hours of inactivity.
 ## Dormancy
 
 > [!NOTE]
-> Dormancy is an Enterprise and Premium feature.
+> Dormancy is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
 Dormancy automatically deletes workspaces that remain unused for long

--- a/helm/provisioner/README.md
+++ b/helm/provisioner/README.md
@@ -3,7 +3,7 @@
 This directory contains the Helm chart used to deploy Coder provisioner daemons onto a Kubernetes
 cluster.
 
-External provisioner daemons are an Enterprise feature. Contact sales@coder.com.
+External provisioner daemons are a Premium feature. Contact sales@coder.com.
 
 ## Getting Started
 


### PR DESCRIPTION
Enterprise is a legacy plan that has been replaced by Premium.

[preview](https://coder.com/docs/@enterprise-feats)