### PR TITLE
fix(agent): ensure SSH server shutdown with process groups

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1773,10 +1773,12 @@ func (a *agent) Close() error {
 	a.setLifecycle(codersdk.WorkspaceAgentLifecycleShuttingDown)
 
 	// Attempt to gracefully shut down all active SSH connections and
-	// stop accepting new ones. If all processes have not exited after
-	// 10 seconds, we just log it and move on as it's more important
-	// to run the shutdown scripts.
-	sshShutdownCtx, sshShutdownCancel := context.WithTimeout(a.hardCtx, 10*time.Second)
+	// stop accepting new ones. If all processes have not exited after 5
+	// seconds, we just log it and move on as it's more important to run
+	// the shutdown scripts. A typical shutdown time for containers is
+	// 10 seconds, so this still leaves a bit of time to run the
+	// shutdown scripts in the worst-case.
+	sshShutdownCtx, sshShutdownCancel := context.WithTimeout(a.hardCtx, 5*time.Second)
 	defer sshShutdownCancel()
 	err := a.sshServer.Shutdown(sshShutdownCtx)
 	if err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1773,15 +1773,20 @@ func (a *agent) Close() error {
 	a.setLifecycle(codersdk.WorkspaceAgentLifecycleShuttingDown)
 
 	// Attempt to gracefully shut down all active SSH connections and
-	// stop accepting new ones.
-	err := a.sshServer.Shutdown(a.hardCtx)
+	// stop accepting new ones. If all processes have not exited after
+	// 10 seconds, we just log it and move on as it's more important
+	// to run the shutdown scripts.
+	sshShutdownCtx, sshShutdownCancel := context.WithTimeout(a.hardCtx, 10*time.Second)
+	defer sshShutdownCancel()
+	err := a.sshServer.Shutdown(sshShutdownCtx)
 	if err != nil {
-		a.logger.Error(a.hardCtx, "ssh server shutdown", slog.Error(err))
+		if errors.Is(err, context.DeadlineExceeded) {
+			a.logger.Warn(sshShutdownCtx, "ssh server shutdown timeout", slog.Error(err))
+		} else {
+			a.logger.Error(sshShutdownCtx, "ssh server shutdown", slog.Error(err))
+		}
 	}
-	err = a.sshServer.Close()
-	if err != nil {
-		a.logger.Error(a.hardCtx, "ssh server close", slog.Error(err))
-	}
+
 	// wait for SSH to shut down before the general graceful cancel, because
 	// this triggers a disconnect in the tailnet layer, telling all clients to
 	// shut down their wireguard tunnels to us. If SSH sessions are still up,

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -1109,7 +1109,8 @@ func (s *Server) Close() error {
 
 // Shutdown stops accepting new connections. The current implementation
 // calls Close() for simplicity instead of waiting for existing
-// connections to close.
+// connections to close. If the context times out, Shutdown will return
+// but Close() may not have completed.
 func (s *Server) Shutdown(ctx context.Context) error {
 	ch := make(chan error, 1)
 	go func() {

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/goleak"
 	"golang.org/x/crypto/ssh"
 
+	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 
 	"github.com/coder/coder/v2/agent/agentexec"
@@ -147,51 +148,92 @@ func (*fakeEnvInfoer) ModifyCommand(cmd string, args ...string) (string, []strin
 func TestNewServer_CloseActiveConnections(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	s, err := agentssh.NewServer(ctx, logger, prometheus.NewRegistry(), afero.NewMemMapFs(), agentexec.DefaultExecer, nil)
-	require.NoError(t, err)
-	defer s.Close()
-	err = s.UpdateHostSigner(42)
-	assert.NoError(t, err)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		err := s.Serve(ln)
-		assert.Error(t, err) // Server is closed.
-	}()
-
-	pty := ptytest.New(t)
-
-	doClose := make(chan struct{})
-	go func() {
-		defer wg.Done()
-		c := sshClient(t, ln.Addr().String())
-		sess, err := c.NewSession()
-		assert.NoError(t, err)
-		sess.Stdin = pty.Input()
-		sess.Stdout = pty.Output()
-		sess.Stderr = pty.Output()
-
-		assert.NoError(t, err)
-		err = sess.Start("")
+	prepare := func(ctx context.Context, t *testing.T) (*agentssh.Server, func()) {
+		t.Helper()
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		s, err := agentssh.NewServer(ctx, logger, prometheus.NewRegistry(), afero.NewMemMapFs(), agentexec.DefaultExecer, nil)
+		require.NoError(t, err)
+		defer s.Close()
+		err = s.UpdateHostSigner(42)
 		assert.NoError(t, err)
 
-		close(doClose)
-		err = sess.Wait()
-		assert.Error(t, err)
-	}()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
 
-	<-doClose
-	err = s.Close()
-	require.NoError(t, err)
+		waitConns := make([]chan struct{}, 4)
 
-	wg.Wait()
+		var wg sync.WaitGroup
+		wg.Add(1 + len(waitConns))
+
+		go func() {
+			defer wg.Done()
+			err := s.Serve(ln)
+			assert.Error(t, err) // Server is closed.
+		}()
+
+		for i := 0; i < len(waitConns); i++ {
+			waitConns[i] = make(chan struct{})
+			go func(ch chan struct{}) {
+				defer wg.Done()
+				c := sshClient(t, ln.Addr().String())
+				sess, err := c.NewSession()
+				assert.NoError(t, err)
+				pty := ptytest.New(t)
+				sess.Stdin = pty.Input()
+				sess.Stdout = pty.Output()
+				sess.Stderr = pty.Output()
+
+				// Every other session will request a PTY.
+				if i%2 == 0 {
+					err = sess.RequestPty("xterm", 80, 80, nil)
+					assert.NoError(t, err)
+				}
+				// The 60 seconds here is intended to be longer than the
+				// test. The shutdown should propagate.
+				err = sess.Start("/bin/bash -c 'trap \"sleep 60\" SIGTERM; sleep 60'")
+				assert.NoError(t, err)
+
+				close(ch)
+				err = sess.Wait()
+				assert.Error(t, err)
+			}(waitConns[i])
+		}
+
+		for _, ch := range waitConns {
+			<-ch
+		}
+
+		return s, wg.Wait
+	}
+
+	t.Run("Close", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		s, wait := prepare(ctx, t)
+		err := s.Close()
+		require.NoError(t, err)
+		wait()
+	})
+
+	t.Run("Shutdown", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		s, wait := prepare(ctx, t)
+		err := s.Shutdown(ctx)
+		require.NoError(t, err)
+		wait()
+	})
+
+	t.Run("Shutdown Early", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		s, wait := prepare(ctx, t)
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := s.Shutdown(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		wait()
+	})
 }
 
 func TestNewServer_Signal(t *testing.T) {

--- a/agent/agentssh/exec_other.go
+++ b/agent/agentssh/exec_other.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package agentssh
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+
+	"cdr.dev/slog"
+)
+
+func cmdSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setsid: true,
+	}
+}
+
+func cmdCancel(ctx context.Context, logger slog.Logger, cmd *exec.Cmd) func() error {
+	return func() error {
+		logger.Debug(ctx, "cmdCancel: sending SIGHUP to process and children", slog.F("pid", cmd.Process.Pid))
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGHUP)
+	}
+}

--- a/agent/agentssh/exec_windows.go
+++ b/agent/agentssh/exec_windows.go
@@ -1,0 +1,21 @@
+package agentssh
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"cdr.dev/slog"
+)
+
+func cmdSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func cmdCancel(ctx context.Context, logger slog.Logger, cmd *exec.Cmd) func() error {
+	return func() error {
+		logger.Debug(ctx, "cmdCancel: sending interrupt to process", slog.F("pid", cmd.Process.Pid))
+		return cmd.Process.Signal(os.Interrupt)
+	}
+}


### PR DESCRIPTION
After closer inspection of logs mentioned in #17108, it looks like the "connecting to coderd" loop was a red herring and the final log line from `(*agentssh.Server).Close` is missing.

PTY's already create a process group, so they seem to have been unaffected. But non-PTY SSH sessions were able to prevent SSH server close from completing when child processes were left running. For good measure, I added a timeout mechanism just so we don't ever block on SSH server shutdown longer than 10s.

This can be verified on current `main` by starting a workspace that has a shutdown script, and running the following command:

```
ssh coder.testa "/bin/bash -c 'trap \"sleep 6000\" SIGTERM; sleep 6000'"
```

The stopping the workspace. Shutdown scripts won't run. With this change, they do.

Fixes #17108
