### PR TITLE
fix: prevent invalid render output for build logs

### DIFF
--- a/site/src/components/Logs/LogLine.tsx
+++ b/site/src/components/Logs/LogLine.tsx
@@ -6,6 +6,7 @@ import { MONOSPACE_FONT_FAMILY } from "theme/constants";
 export const DEFAULT_LOG_LINE_SIDE_PADDING = 24;
 
 export interface Line {
+	id: string;
 	time: string;
 	output: string;
 	level: LogLevel;

--- a/site/src/components/Logs/LogLine.tsx
+++ b/site/src/components/Logs/LogLine.tsx
@@ -6,7 +6,7 @@ import { MONOSPACE_FONT_FAMILY } from "theme/constants";
 export const DEFAULT_LOG_LINE_SIDE_PADDING = 24;
 
 export interface Line {
-	id: string;
+	id: number;
 	time: string;
 	output: string;
 	level: LogLevel;

--- a/site/src/components/Logs/Logs.stories.tsx
+++ b/site/src/components/Logs/Logs.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { chromatic } from "testHelpers/chromatic";
 import { MockWorkspaceBuildLogs } from "testHelpers/entities";
+import type { Line } from "./LogLine";
 import { Logs } from "./Logs";
 
 const meta: Meta<typeof Logs> = {
@@ -8,7 +9,8 @@ const meta: Meta<typeof Logs> = {
 	parameters: { chromatic },
 	component: Logs,
 	args: {
-		lines: MockWorkspaceBuildLogs.map((log) => ({
+		lines: MockWorkspaceBuildLogs.map<Line>((log) => ({
+			id: String(log.id),
 			level: log.log_level,
 			time: log.created_at,
 			output: log.output,

--- a/site/src/components/Logs/Logs.stories.tsx
+++ b/site/src/components/Logs/Logs.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Logs> = {
 	component: Logs,
 	args: {
 		lines: MockWorkspaceBuildLogs.map<Line>((log) => ({
-			id: String(log.id),
+			id: log.id,
 			level: log.log_level,
 			time: log.created_at,
 			output: log.output,

--- a/site/src/components/Logs/Logs.tsx
+++ b/site/src/components/Logs/Logs.tsx
@@ -20,7 +20,7 @@ export const Logs: FC<LogsProps> = ({
 		<div css={styles.root} className={`${className} logs-container`}>
 			<div css={{ minWidth: "fit-content" }}>
 				{lines.map((line) => (
-					<LogLine key={line.output} level={line.level}>
+					<LogLine key={line.id} level={line.level}>
 						{!hideTimestamps && (
 							<LogLinePrefix>
 								{dayjs(line.time).format("HH:mm:ss.SSS")}

--- a/site/src/modules/resources/AgentLogs/AgentLogLine.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogLine.tsx
@@ -3,13 +3,6 @@ import AnsiToHTML from "ansi-to-html";
 import { type Line, LogLine, LogLinePrefix } from "components/Logs/LogLine";
 import { type FC, type ReactNode, useMemo } from "react";
 
-// Logs are stored as the Line interface to make rendering
-// much more efficient. Instead of mapping objects each time, we're
-// able to just pass the array of logs to the component.
-export interface LineWithID extends Line {
-	id: number;
-}
-
 // Approximate height of a log line. Used to control virtualized list height.
 export const AGENT_LOG_LINE_HEIGHT = 20;
 

--- a/site/src/modules/resources/AgentLogs/AgentLogs.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogs.tsx
@@ -1,19 +1,16 @@
 import type { Interpolation, Theme } from "@emotion/react";
 import Tooltip from "@mui/material/Tooltip";
 import type { WorkspaceAgentLogSource } from "api/typesGenerated";
+import type { Line } from "components/Logs/LogLine";
 import { type ComponentProps, forwardRef, useMemo } from "react";
 import { FixedSizeList as List } from "react-window";
-import {
-	AGENT_LOG_LINE_HEIGHT,
-	AgentLogLine,
-	type LineWithID,
-} from "./AgentLogLine";
+import { AGENT_LOG_LINE_HEIGHT, AgentLogLine } from "./AgentLogLine";
 
 type AgentLogsProps = Omit<
 	ComponentProps<typeof List>,
 	"children" | "itemSize" | "itemCount"
 > & {
-	logs: readonly LineWithID[];
+	logs: readonly Line[];
 	sources: readonly WorkspaceAgentLogSource[];
 };
 

--- a/site/src/modules/resources/AgentLogs/mocks.tsx
+++ b/site/src/modules/resources/AgentLogs/mocks.tsx
@@ -63,42 +63,42 @@ export const MockSources = [
 
 export const MockLogs = [
 	{
-		id: "3295730",
+		id: 3295730,
 		level: "info",
 		output: "\u001b[0;1mLogging into Coder...",
 		time: "2024-03-14T11:31:04.090715Z",
 		sourceId: "8e2c562c-3361-4eee-b45a-96a3df4b9760",
 	},
 	{
-		id: "3295731",
+		id: 3295731,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.090715Z",
 		sourceId: "8e2c562c-3361-4eee-b45a-96a3df4b9760",
 	},
 	{
-		id: "3295732",
+		id: 3295732,
 		level: "info",
 		output: "/home/coder/coder already exists and isn't empty, skipping clone!",
 		time: "2024-03-14T11:31:04.239194Z",
 		sourceId: "310562c2-5a1d-4e0b-9a32-d214dadd1624",
 	},
 	{
-		id: "3295735",
+		id: 3295735,
 		level: "info",
 		output: "✨ \u001b[0;1mYou don't have a personalize script!",
 		time: "2024-03-14T11:31:04.383656Z",
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: "3295736",
+		id: 3295736,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.383656Z",
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: "3295737",
+		id: 3295737,
 		level: "info",
 		output:
 			"Run \u001b[36;40;1mtouch /home/coder/personalize && chmod +x /home/coder/personalize\u001b[0m to create one.",
@@ -106,7 +106,7 @@ export const MockLogs = [
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: "3295738",
+		id: 3295738,
 		level: "info",
 		output:
 			"It will run every time your workspace starts. Use it to install personal packages!",
@@ -114,91 +114,91 @@ export const MockLogs = [
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: "3295739",
+		id: 3295739,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.383656Z",
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: "3295740",
+		id: 3295740,
 		level: "info",
 		output: "\u001b[0;1mInstalling code-server!",
 		time: "2024-03-14T11:31:04.529726Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: "3295741",
+		id: 3295741,
 		level: "info",
 		output: " * Starting Docker: docker",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295742",
+		id: 3295742,
 		level: "info",
 		output: "   ...done.",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295743",
+		id: 3295743,
 		level: "error",
 		output: "+ trap 'touch /tmp/.coder-startup-script.done' EXIT",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295744",
+		id: 3295744,
 		level: "error",
 		output: "+ sudo service docker start",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295745",
+		id: 3295745,
 		level: "error",
 		output: "+ [[ -f /home/coder/coder/site/package.json ]]",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295746",
+		id: 3295746,
 		level: "error",
 		output: "+ cd /home/coder/coder/site",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295747",
+		id: 3295747,
 		level: "error",
 		output: "+ pnpm install",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295748",
+		id: 3295748,
 		level: "info",
 		output: "\u001b[0;1mInstalling filebrowser ",
 		time: "2024-03-14T11:31:04.818334Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295749",
+		id: 3295749,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.818334Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295750",
+		id: 3295750,
 		level: "info",
 		output: "Downloading File Browser for linux/amd64...",
 		time: "2024-03-14T11:31:04.818334Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295751",
+		id: 3295751,
 		level: "info",
 		output:
 			"https://github.com/filebrowser/filebrowser/releases/download/v2.27.0/linux-amd64-filebrowser.tar.gz",
@@ -206,35 +206,35 @@ export const MockLogs = [
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295752",
+		id: 3295752,
 		level: "info",
 		output: "You are already authenticated with coder.",
 		time: "2024-03-14T11:31:05.070816Z",
 		sourceId: "8e2c562c-3361-4eee-b45a-96a3df4b9760",
 	},
 	{
-		id: "3295755",
+		id: 3295755,
 		level: "info",
 		output: "Lockfile is up to date, resolution step is skipped",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295756",
+		id: 3295756,
 		level: "info",
 		output: "Already up to date",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295757",
+		id: 3295757,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295758",
+		id: 3295758,
 		level: "info",
 		output:
 			"   ╭──────────────────────────────────────────────────────────────────╮",
@@ -242,7 +242,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295759",
+		id: 3295759,
 		level: "info",
 		output:
 			"   │                                                                  │",
@@ -250,7 +250,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295760",
+		id: 3295760,
 		level: "info",
 		output:
 			"   │                Update available! 8.14.0 → 8.15.4.                │",
@@ -258,7 +258,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295761",
+		id: 3295761,
 		level: "info",
 		output:
 			"   │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v8.15.4   │",
@@ -266,7 +266,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295762",
+		id: 3295762,
 		level: "info",
 		output:
 			'   │     Run "corepack prepare pnpm@8.15.4 --activate" to update.     │',
@@ -274,7 +274,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295763",
+		id: 3295763,
 		level: "info",
 		output:
 			"   │                                                                  │",
@@ -282,7 +282,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295764",
+		id: 3295764,
 		level: "info",
 		output:
 			"   │      Follow @pnpmjs for updates: https://twitter.com/pnpmjs      │",
@@ -290,7 +290,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295765",
+		id: 3295765,
 		level: "info",
 		output:
 			"   │                                                                  │",
@@ -298,7 +298,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295766",
+		id: 3295766,
 		level: "info",
 		output:
 			"   ╰──────────────────────────────────────────────────────────────────╯",
@@ -306,203 +306,203 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295767",
+		id: 3295767,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295768",
+		id: 3295768,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295769",
+		id: 3295769,
 		level: "info",
 		output: "Done in 1.5s",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295770",
+		id: 3295770,
 		level: "error",
 		output: "+ pnpm playwright:install",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295771",
+		id: 3295771,
 		level: "info",
 		output: "Extracting...",
 		time: "2024-03-14T11:31:06.203103Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295774",
+		id: 3295774,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295775",
+		id: 3295775,
 		level: "info",
 		output: "> coder-v2@ playwright:install /home/coder/coder/site",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295776",
+		id: 3295776,
 		level: "info",
 		output: "> playwright install --with-deps chromium",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295777",
+		id: 3295777,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295778",
+		id: 3295778,
 		level: "info",
 		output: "Putting filemanager in /usr/local/bin (may require password)",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295779",
+		id: 3295779,
 		level: "info",
 		output: "Successfully installed",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295780",
+		id: 3295780,
 		level: "info",
 		output: "🥳 Installation complete! ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295781",
+		id: 3295781,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295782",
+		id: 3295782,
 		level: "info",
 		output: "👷 Starting filebrowser in background... ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295783",
+		id: 3295783,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295784",
+		id: 3295784,
 		level: "info",
 		output: "📂 Serving /home/coder at http://localhost:13339 ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295785",
+		id: 3295785,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295786",
+		id: 3295786,
 		level: "info",
 		output: "Running 'filebrowser --noauth --root /home/coder --port 13339' ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295787",
+		id: 3295787,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295788",
+		id: 3295788,
 		level: "info",
 		output: "📝 Logs at /tmp/filebrowser.log ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295789",
+		id: 3295789,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: "3295790",
+		id: 3295790,
 		level: "info",
 		output: "🥳 code-server has been installed in /tmp/code-server",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: "3295791",
+		id: 3295791,
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: "3295792",
+		id: 3295792,
 		level: "info",
 		output: "👷 Running code-server in the background...",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: "3295793",
+		id: 3295793,
 		level: "info",
 		output: "Check logs at /tmp/code-server.log!",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: "3295796",
+		id: 3295796,
 		level: "info",
 		output: "Installing dependencies...",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295797",
+		id: 3295797,
 		level: "info",
 		output: "Switching to root user to install dependencies...",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295798",
+		id: 3295798,
 		level: "info",
 		output: "Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295799",
+		id: 3295799,
 		level: "info",
 		output:
 			"Get:2 https://apt.releases.hashicorp.com jammy InRelease [12.9 kB]",
@@ -510,21 +510,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295800",
+		id: 3295800,
 		level: "info",
 		output: "Hit:3 https://packages.microsoft.com/repos/edge stable InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295801",
+		id: 3295801,
 		level: "info",
 		output: "Hit:4 https://deb.nodesource.com/node_18.x nodistro InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295802",
+		id: 3295802,
 		level: "info",
 		output:
 			"Get:5 https://dl.google.com/linux/chrome/deb stable InRelease [1825 B]",
@@ -532,7 +532,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295803",
+		id: 3295803,
 		level: "info",
 		output:
 			"Get:6 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]",
@@ -540,7 +540,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295804",
+		id: 3295804,
 		level: "info",
 		output:
 			"Get:7 https://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1082 B]",
@@ -548,28 +548,28 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295805",
+		id: 3295805,
 		level: "info",
 		output: "Hit:8 http://archive.ubuntu.com/ubuntu jammy InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295806",
+		id: 3295806,
 		level: "info",
 		output: "Hit:9 https://dl.yarnpkg.com/debian stable InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295807",
+		id: 3295807,
 		level: "info",
 		output: "Hit:10 https://packages.cloud.google.com/apt cloud-sdk InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295808",
+		id: 3295808,
 		level: "info",
 		output:
 			"Get:11 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]",
@@ -577,7 +577,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295809",
+		id: 3295809,
 		level: "info",
 		output:
 			"Get:12 https://apt.releases.hashicorp.com jammy/main amd64 Packages [150 kB]",
@@ -585,7 +585,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295810",
+		id: 3295810,
 		level: "info",
 		output:
 			"Hit:13 https://apt.postgresql.org/pub/repos/apt jammy-pgdg InRelease",
@@ -593,7 +593,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295811",
+		id: 3295811,
 		level: "info",
 		output:
 			"Get:14 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1079 kB]",
@@ -601,7 +601,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295812",
+		id: 3295812,
 		level: "info",
 		output:
 			"Hit:15 https://ppa.launchpadcontent.net/ansible/ansible/ubuntu jammy InRelease",
@@ -609,7 +609,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295813",
+		id: 3295813,
 		level: "info",
 		output:
 			"Hit:16 https://ppa.launchpadcontent.net/fish-shell/release-3/ubuntu jammy InRelease",
@@ -617,7 +617,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295816",
+		id: 3295816,
 		level: "info",
 		output:
 			"Get:17 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]",
@@ -625,7 +625,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295817",
+		id: 3295817,
 		level: "info",
 		output:
 			"Get:18 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1569 kB]",
@@ -633,7 +633,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295818",
+		id: 3295818,
 		level: "info",
 		output:
 			"Hit:19 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu jammy InRelease",
@@ -641,7 +641,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295819",
+		id: 3295819,
 		level: "info",
 		output:
 			"Get:20 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1352 kB]",
@@ -649,7 +649,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295820",
+		id: 3295820,
 		level: "info",
 		output:
 			"Hit:21 https://ppa.launchpadcontent.net/maveonair/helix-editor/ubuntu jammy InRelease",
@@ -657,7 +657,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295821",
+		id: 3295821,
 		level: "info",
 		output:
 			"Hit:22 https://ppa.launchpadcontent.net/neovim-ppa/stable/ubuntu jammy InRelease",
@@ -665,7 +665,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295822",
+		id: 3295822,
 		level: "info",
 		output:
 			"Get:23 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1848 kB]",
@@ -673,7 +673,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295823",
+		id: 3295823,
 		level: "info",
 		output:
 			"Get:24 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [33.3 kB]",
@@ -681,7 +681,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295824",
+		id: 3295824,
 		level: "info",
 		output:
 			"Get:25 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [80.9 kB]",
@@ -689,21 +689,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295827",
+		id: 3295827,
 		level: "info",
 		output: "Fetched 6466 kB in 3s (2549 kB/s)",
 		time: "2024-03-14T11:31:10.224434Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295828",
+		id: 3295828,
 		level: "info",
 		output: "Reading package lists...",
 		time: "2024-03-14T11:31:10.224434Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295829",
+		id: 3295829,
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -711,7 +711,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295830",
+		id: 3295830,
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -719,7 +719,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295831",
+		id: 3295831,
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -727,7 +727,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295832",
+		id: 3295832,
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -735,7 +735,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295833",
+		id: 3295833,
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -743,7 +743,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295834",
+		id: 3295834,
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -751,7 +751,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295835",
+		id: 3295835,
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -759,7 +759,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295836",
+		id: 3295836,
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -767,7 +767,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295837",
+		id: 3295837,
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -775,7 +775,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295838",
+		id: 3295838,
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -783,7 +783,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295839",
+		id: 3295839,
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -791,7 +791,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295840",
+		id: 3295840,
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -799,28 +799,28 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295843",
+		id: 3295843,
 		level: "info",
 		output: "Reading package lists...",
 		time: "2024-03-14T11:31:10.572831Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295844",
+		id: 3295844,
 		level: "info",
 		output: "Building dependency tree...",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295845",
+		id: 3295845,
 		level: "info",
 		output: "Reading state information...",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295846",
+		id: 3295846,
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -828,7 +828,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295847",
+		id: 3295847,
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -836,7 +836,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295848",
+		id: 3295848,
 		level: "info",
 		output:
 			"fonts-freefont-ttf is already the newest version (20120503-10build1).",
@@ -844,112 +844,112 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295849",
+		id: 3295849,
 		level: "info",
 		output: "fonts-liberation is already the newest version (1:1.07.4-11).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295850",
+		id: 3295850,
 		level: "info",
 		output: "libasound2 is already the newest version (1.2.6.1-1ubuntu1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295851",
+		id: 3295851,
 		level: "info",
 		output: "libatk-bridge2.0-0 is already the newest version (2.38.0-3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295852",
+		id: 3295852,
 		level: "info",
 		output: "libatk1.0-0 is already the newest version (2.36.0-3build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295853",
+		id: 3295853,
 		level: "info",
 		output: "libatspi2.0-0 is already the newest version (2.44.0-3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295854",
+		id: 3295854,
 		level: "info",
 		output: "libcairo2 is already the newest version (1.16.0-5ubuntu2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295855",
+		id: 3295855,
 		level: "info",
 		output: "libfontconfig1 is already the newest version (2.13.1-4.2ubuntu5).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295856",
+		id: 3295856,
 		level: "info",
 		output: "libnspr4 is already the newest version (2:4.32-3build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295857",
+		id: 3295857,
 		level: "info",
 		output: "libxcb1 is already the newest version (1.14-3ubuntu3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295858",
+		id: 3295858,
 		level: "info",
 		output: "libxcomposite1 is already the newest version (1:0.4.5-1build2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295859",
+		id: 3295859,
 		level: "info",
 		output: "libxdamage1 is already the newest version (1:1.1.5-2build2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295860",
+		id: 3295860,
 		level: "info",
 		output: "libxext6 is already the newest version (2:1.3.4-1build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295861",
+		id: 3295861,
 		level: "info",
 		output: "libxfixes3 is already the newest version (1:6.0.0-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295862",
+		id: 3295862,
 		level: "info",
 		output: "libxkbcommon0 is already the newest version (1.4.0-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295863",
+		id: 3295863,
 		level: "info",
 		output: "libxrandr2 is already the newest version (2:1.5.2-1build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295864",
+		id: 3295864,
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -957,7 +957,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295865",
+		id: 3295865,
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -965,7 +965,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295866",
+		id: 3295866,
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -973,7 +973,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295867",
+		id: 3295867,
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -981,7 +981,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295868",
+		id: 3295868,
 		level: "info",
 		output:
 			"xfonts-scalable is already the newest version (1:1.0.3-1.2ubuntu1).",
@@ -989,7 +989,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295869",
+		id: 3295869,
 		level: "info",
 		output:
 			"fonts-ipafont-gothic is already the newest version (00303-21ubuntu1).",
@@ -997,35 +997,35 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295870",
+		id: 3295870,
 		level: "info",
 		output: "fonts-tlwg-loma-otf is already the newest version (1:0.7.3-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295871",
+		id: 3295871,
 		level: "info",
 		output: "fonts-unifont is already the newest version (1:14.0.01-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295872",
+		id: 3295872,
 		level: "info",
 		output: "fonts-wqy-zenhei is already the newest version (0.9.45-8).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295873",
+		id: 3295873,
 		level: "info",
 		output: "xfonts-cyrillic is already the newest version (1:1.0.5).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295874",
+		id: 3295874,
 		level: "info",
 		output:
 			"fonts-noto-color-emoji is already the newest version (2.042-0ubuntu0.22.04.1).",
@@ -1033,21 +1033,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295875",
+		id: 3295875,
 		level: "info",
 		output: "libcups2 is already the newest version (2.4.1op1-1ubuntu4.8).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295876",
+		id: 3295876,
 		level: "info",
 		output: "libdbus-1-3 is already the newest version (1.12.20-2ubuntu4.1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295877",
+		id: 3295877,
 		level: "info",
 		output:
 			"libdrm2 is already the newest version (2.4.113-2~ubuntu0.22.04.1).",
@@ -1055,7 +1055,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295878",
+		id: 3295878,
 		level: "info",
 		output:
 			"libfreetype6 is already the newest version (2.11.1+dfsg-1ubuntu0.2).",
@@ -1063,7 +1063,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295879",
+		id: 3295879,
 		level: "info",
 		output:
 			"libgbm1 is already the newest version (23.2.1-1ubuntu3.1~22.04.2).",
@@ -1071,21 +1071,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295880",
+		id: 3295880,
 		level: "info",
 		output: "libglib2.0-0 is already the newest version (2.72.4-0ubuntu2.2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295881",
+		id: 3295881,
 		level: "info",
 		output: "libnss3 is already the newest version (2:3.68.2-0ubuntu1.2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295882",
+		id: 3295882,
 		level: "info",
 		output:
 			"libpango-1.0-0 is already the newest version (1.50.6+ds-2ubuntu1).",
@@ -1093,7 +1093,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295883",
+		id: 3295883,
 		level: "info",
 		output:
 			"libwayland-client0 is already the newest version (1.20.0-1ubuntu0.1).",
@@ -1101,28 +1101,28 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295884",
+		id: 3295884,
 		level: "info",
 		output: "libx11-6 is already the newest version (2:1.7.5-1ubuntu0.3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295885",
+		id: 3295885,
 		level: "info",
 		output: "xvfb is already the newest version (2:21.1.4-2ubuntu1.7~22.04.8).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295886",
+		id: 3295886,
 		level: "info",
 		output: "0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: "3295887",
+		id: 3295887,
 		level: "error",
 		output: "+ touch /tmp/.coder-startup-script.done",
 		time: "2024-03-14T11:31:10.859531Z",

--- a/site/src/modules/resources/AgentLogs/mocks.tsx
+++ b/site/src/modules/resources/AgentLogs/mocks.tsx
@@ -1,6 +1,6 @@
 // Those mocks are fetched from the Coder API in dev.coder.com
 
-import type { LineWithID } from "./AgentLogLine";
+import type { Line } from "components/Logs/LogLine";
 
 export const MockSources = [
 	{
@@ -63,42 +63,42 @@ export const MockSources = [
 
 export const MockLogs = [
 	{
-		id: 3295730,
+		id: "3295730",
 		level: "info",
 		output: "\u001b[0;1mLogging into Coder...",
 		time: "2024-03-14T11:31:04.090715Z",
 		sourceId: "8e2c562c-3361-4eee-b45a-96a3df4b9760",
 	},
 	{
-		id: 3295731,
+		id: "3295731",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.090715Z",
 		sourceId: "8e2c562c-3361-4eee-b45a-96a3df4b9760",
 	},
 	{
-		id: 3295732,
+		id: "3295732",
 		level: "info",
 		output: "/home/coder/coder already exists and isn't empty, skipping clone!",
 		time: "2024-03-14T11:31:04.239194Z",
 		sourceId: "310562c2-5a1d-4e0b-9a32-d214dadd1624",
 	},
 	{
-		id: 3295735,
+		id: "3295735",
 		level: "info",
 		output: "✨ \u001b[0;1mYou don't have a personalize script!",
 		time: "2024-03-14T11:31:04.383656Z",
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: 3295736,
+		id: "3295736",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.383656Z",
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: 3295737,
+		id: "3295737",
 		level: "info",
 		output:
 			"Run \u001b[36;40;1mtouch /home/coder/personalize && chmod +x /home/coder/personalize\u001b[0m to create one.",
@@ -106,7 +106,7 @@ export const MockLogs = [
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: 3295738,
+		id: "3295738",
 		level: "info",
 		output:
 			"It will run every time your workspace starts. Use it to install personal packages!",
@@ -114,91 +114,91 @@ export const MockLogs = [
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: 3295739,
+		id: "3295739",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.383656Z",
 		sourceId: "db9e2fdc-a227-42e4-a1a3-e534c1511eb7",
 	},
 	{
-		id: 3295740,
+		id: "3295740",
 		level: "info",
 		output: "\u001b[0;1mInstalling code-server!",
 		time: "2024-03-14T11:31:04.529726Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: 3295741,
+		id: "3295741",
 		level: "info",
 		output: " * Starting Docker: docker",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295742,
+		id: "3295742",
 		level: "info",
 		output: "   ...done.",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295743,
+		id: "3295743",
 		level: "error",
 		output: "+ trap 'touch /tmp/.coder-startup-script.done' EXIT",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295744,
+		id: "3295744",
 		level: "error",
 		output: "+ sudo service docker start",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295745,
+		id: "3295745",
 		level: "error",
 		output: "+ [[ -f /home/coder/coder/site/package.json ]]",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295746,
+		id: "3295746",
 		level: "error",
 		output: "+ cd /home/coder/coder/site",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295747,
+		id: "3295747",
 		level: "error",
 		output: "+ pnpm install",
 		time: "2024-03-14T11:31:04.67431Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295748,
+		id: "3295748",
 		level: "info",
 		output: "\u001b[0;1mInstalling filebrowser ",
 		time: "2024-03-14T11:31:04.818334Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295749,
+		id: "3295749",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:04.818334Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295750,
+		id: "3295750",
 		level: "info",
 		output: "Downloading File Browser for linux/amd64...",
 		time: "2024-03-14T11:31:04.818334Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295751,
+		id: "3295751",
 		level: "info",
 		output:
 			"https://github.com/filebrowser/filebrowser/releases/download/v2.27.0/linux-amd64-filebrowser.tar.gz",
@@ -206,35 +206,35 @@ export const MockLogs = [
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295752,
+		id: "3295752",
 		level: "info",
 		output: "You are already authenticated with coder.",
 		time: "2024-03-14T11:31:05.070816Z",
 		sourceId: "8e2c562c-3361-4eee-b45a-96a3df4b9760",
 	},
 	{
-		id: 3295755,
+		id: "3295755",
 		level: "info",
 		output: "Lockfile is up to date, resolution step is skipped",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295756,
+		id: "3295756",
 		level: "info",
 		output: "Already up to date",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295757,
+		id: "3295757",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295758,
+		id: "3295758",
 		level: "info",
 		output:
 			"   ╭──────────────────────────────────────────────────────────────────╮",
@@ -242,7 +242,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295759,
+		id: "3295759",
 		level: "info",
 		output:
 			"   │                                                                  │",
@@ -250,7 +250,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295760,
+		id: "3295760",
 		level: "info",
 		output:
 			"   │                Update available! 8.14.0 → 8.15.4.                │",
@@ -258,7 +258,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295761,
+		id: "3295761",
 		level: "info",
 		output:
 			"   │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v8.15.4   │",
@@ -266,7 +266,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295762,
+		id: "3295762",
 		level: "info",
 		output:
 			'   │     Run "corepack prepare pnpm@8.15.4 --activate" to update.     │',
@@ -274,7 +274,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295763,
+		id: "3295763",
 		level: "info",
 		output:
 			"   │                                                                  │",
@@ -282,7 +282,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295764,
+		id: "3295764",
 		level: "info",
 		output:
 			"   │      Follow @pnpmjs for updates: https://twitter.com/pnpmjs      │",
@@ -290,7 +290,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295765,
+		id: "3295765",
 		level: "info",
 		output:
 			"   │                                                                  │",
@@ -298,7 +298,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295766,
+		id: "3295766",
 		level: "info",
 		output:
 			"   ╰──────────────────────────────────────────────────────────────────╯",
@@ -306,203 +306,203 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295767,
+		id: "3295767",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295768,
+		id: "3295768",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295769,
+		id: "3295769",
 		level: "info",
 		output: "Done in 1.5s",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295770,
+		id: "3295770",
 		level: "error",
 		output: "+ pnpm playwright:install",
 		time: "2024-03-14T11:31:05.973518Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295771,
+		id: "3295771",
 		level: "info",
 		output: "Extracting...",
 		time: "2024-03-14T11:31:06.203103Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295774,
+		id: "3295774",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295775,
+		id: "3295775",
 		level: "info",
 		output: "> coder-v2@ playwright:install /home/coder/coder/site",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295776,
+		id: "3295776",
 		level: "info",
 		output: "> playwright install --with-deps chromium",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295777,
+		id: "3295777",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.349058Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295778,
+		id: "3295778",
 		level: "info",
 		output: "Putting filemanager in /usr/local/bin (may require password)",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295779,
+		id: "3295779",
 		level: "info",
 		output: "Successfully installed",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295780,
+		id: "3295780",
 		level: "info",
 		output: "🥳 Installation complete! ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295781,
+		id: "3295781",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295782,
+		id: "3295782",
 		level: "info",
 		output: "👷 Starting filebrowser in background... ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295783,
+		id: "3295783",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295784,
+		id: "3295784",
 		level: "info",
 		output: "📂 Serving /home/coder at http://localhost:13339 ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295785,
+		id: "3295785",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295786,
+		id: "3295786",
 		level: "info",
 		output: "Running 'filebrowser --noauth --root /home/coder --port 13339' ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295787,
+		id: "3295787",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295788,
+		id: "3295788",
 		level: "info",
 		output: "📝 Logs at /tmp/filebrowser.log ",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295789,
+		id: "3295789",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.494535Z",
 		sourceId: "f0df7490-1be9-4722-96b6-45037b011c93",
 	},
 	{
-		id: 3295790,
+		id: "3295790",
 		level: "info",
 		output: "🥳 code-server has been installed in /tmp/code-server",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: 3295791,
+		id: "3295791",
 		level: "info",
 		output: "",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: 3295792,
+		id: "3295792",
 		level: "info",
 		output: "👷 Running code-server in the background...",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: 3295793,
+		id: "3295793",
 		level: "info",
 		output: "Check logs at /tmp/code-server.log!",
 		time: "2024-03-14T11:31:06.99008Z",
 		sourceId: "5baf5687-7c10-47c1-a283-e70bc2b7e4eb",
 	},
 	{
-		id: 3295796,
+		id: "3295796",
 		level: "info",
 		output: "Installing dependencies...",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295797,
+		id: "3295797",
 		level: "info",
 		output: "Switching to root user to install dependencies...",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295798,
+		id: "3295798",
 		level: "info",
 		output: "Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295799,
+		id: "3295799",
 		level: "info",
 		output:
 			"Get:2 https://apt.releases.hashicorp.com jammy InRelease [12.9 kB]",
@@ -510,21 +510,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295800,
+		id: "3295800",
 		level: "info",
 		output: "Hit:3 https://packages.microsoft.com/repos/edge stable InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295801,
+		id: "3295801",
 		level: "info",
 		output: "Hit:4 https://deb.nodesource.com/node_18.x nodistro InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295802,
+		id: "3295802",
 		level: "info",
 		output:
 			"Get:5 https://dl.google.com/linux/chrome/deb stable InRelease [1825 B]",
@@ -532,7 +532,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295803,
+		id: "3295803",
 		level: "info",
 		output:
 			"Get:6 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]",
@@ -540,7 +540,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295804,
+		id: "3295804",
 		level: "info",
 		output:
 			"Get:7 https://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1082 B]",
@@ -548,28 +548,28 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295805,
+		id: "3295805",
 		level: "info",
 		output: "Hit:8 http://archive.ubuntu.com/ubuntu jammy InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295806,
+		id: "3295806",
 		level: "info",
 		output: "Hit:9 https://dl.yarnpkg.com/debian stable InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295807,
+		id: "3295807",
 		level: "info",
 		output: "Hit:10 https://packages.cloud.google.com/apt cloud-sdk InRelease",
 		time: "2024-03-14T11:31:07.59125Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295808,
+		id: "3295808",
 		level: "info",
 		output:
 			"Get:11 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]",
@@ -577,7 +577,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295809,
+		id: "3295809",
 		level: "info",
 		output:
 			"Get:12 https://apt.releases.hashicorp.com jammy/main amd64 Packages [150 kB]",
@@ -585,7 +585,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295810,
+		id: "3295810",
 		level: "info",
 		output:
 			"Hit:13 https://apt.postgresql.org/pub/repos/apt jammy-pgdg InRelease",
@@ -593,7 +593,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295811,
+		id: "3295811",
 		level: "info",
 		output:
 			"Get:14 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1079 kB]",
@@ -601,7 +601,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295812,
+		id: "3295812",
 		level: "info",
 		output:
 			"Hit:15 https://ppa.launchpadcontent.net/ansible/ansible/ubuntu jammy InRelease",
@@ -609,7 +609,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295813,
+		id: "3295813",
 		level: "info",
 		output:
 			"Hit:16 https://ppa.launchpadcontent.net/fish-shell/release-3/ubuntu jammy InRelease",
@@ -617,7 +617,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295816,
+		id: "3295816",
 		level: "info",
 		output:
 			"Get:17 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]",
@@ -625,7 +625,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295817,
+		id: "3295817",
 		level: "info",
 		output:
 			"Get:18 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1569 kB]",
@@ -633,7 +633,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295818,
+		id: "3295818",
 		level: "info",
 		output:
 			"Hit:19 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu jammy InRelease",
@@ -641,7 +641,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295819,
+		id: "3295819",
 		level: "info",
 		output:
 			"Get:20 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1352 kB]",
@@ -649,7 +649,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295820,
+		id: "3295820",
 		level: "info",
 		output:
 			"Hit:21 https://ppa.launchpadcontent.net/maveonair/helix-editor/ubuntu jammy InRelease",
@@ -657,7 +657,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295821,
+		id: "3295821",
 		level: "info",
 		output:
 			"Hit:22 https://ppa.launchpadcontent.net/neovim-ppa/stable/ubuntu jammy InRelease",
@@ -665,7 +665,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295822,
+		id: "3295822",
 		level: "info",
 		output:
 			"Get:23 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1848 kB]",
@@ -673,7 +673,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295823,
+		id: "3295823",
 		level: "info",
 		output:
 			"Get:24 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [33.3 kB]",
@@ -681,7 +681,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295824,
+		id: "3295824",
 		level: "info",
 		output:
 			"Get:25 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [80.9 kB]",
@@ -689,21 +689,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295827,
+		id: "3295827",
 		level: "info",
 		output: "Fetched 6466 kB in 3s (2549 kB/s)",
 		time: "2024-03-14T11:31:10.224434Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295828,
+		id: "3295828",
 		level: "info",
 		output: "Reading package lists...",
 		time: "2024-03-14T11:31:10.224434Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295829,
+		id: "3295829",
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -711,7 +711,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295830,
+		id: "3295830",
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -719,7 +719,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295831,
+		id: "3295831",
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -727,7 +727,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295832,
+		id: "3295832",
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -735,7 +735,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295833,
+		id: "3295833",
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -743,7 +743,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295834,
+		id: "3295834",
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -751,7 +751,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295835,
+		id: "3295835",
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -759,7 +759,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295836,
+		id: "3295836",
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -767,7 +767,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295837,
+		id: "3295837",
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -775,7 +775,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295838,
+		id: "3295838",
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -783,7 +783,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295839,
+		id: "3295839",
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -791,7 +791,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295840,
+		id: "3295840",
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -799,28 +799,28 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295843,
+		id: "3295843",
 		level: "info",
 		output: "Reading package lists...",
 		time: "2024-03-14T11:31:10.572831Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295844,
+		id: "3295844",
 		level: "info",
 		output: "Building dependency tree...",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295845,
+		id: "3295845",
 		level: "info",
 		output: "Reading state information...",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295846,
+		id: "3295846",
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -828,7 +828,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295847,
+		id: "3295847",
 		level: "error",
 		output:
 			"W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -836,7 +836,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295848,
+		id: "3295848",
 		level: "info",
 		output:
 			"fonts-freefont-ttf is already the newest version (20120503-10build1).",
@@ -844,112 +844,112 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295849,
+		id: "3295849",
 		level: "info",
 		output: "fonts-liberation is already the newest version (1:1.07.4-11).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295850,
+		id: "3295850",
 		level: "info",
 		output: "libasound2 is already the newest version (1.2.6.1-1ubuntu1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295851,
+		id: "3295851",
 		level: "info",
 		output: "libatk-bridge2.0-0 is already the newest version (2.38.0-3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295852,
+		id: "3295852",
 		level: "info",
 		output: "libatk1.0-0 is already the newest version (2.36.0-3build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295853,
+		id: "3295853",
 		level: "info",
 		output: "libatspi2.0-0 is already the newest version (2.44.0-3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295854,
+		id: "3295854",
 		level: "info",
 		output: "libcairo2 is already the newest version (1.16.0-5ubuntu2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295855,
+		id: "3295855",
 		level: "info",
 		output: "libfontconfig1 is already the newest version (2.13.1-4.2ubuntu5).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295856,
+		id: "3295856",
 		level: "info",
 		output: "libnspr4 is already the newest version (2:4.32-3build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295857,
+		id: "3295857",
 		level: "info",
 		output: "libxcb1 is already the newest version (1.14-3ubuntu3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295858,
+		id: "3295858",
 		level: "info",
 		output: "libxcomposite1 is already the newest version (1:0.4.5-1build2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295859,
+		id: "3295859",
 		level: "info",
 		output: "libxdamage1 is already the newest version (1:1.1.5-2build2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295860,
+		id: "3295860",
 		level: "info",
 		output: "libxext6 is already the newest version (2:1.3.4-1build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295861,
+		id: "3295861",
 		level: "info",
 		output: "libxfixes3 is already the newest version (1:6.0.0-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295862,
+		id: "3295862",
 		level: "info",
 		output: "libxkbcommon0 is already the newest version (1.4.0-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295863,
+		id: "3295863",
 		level: "info",
 		output: "libxrandr2 is already the newest version (2:1.5.2-1build1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295864,
+		id: "3295864",
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -957,7 +957,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295865,
+		id: "3295865",
 		level: "error",
 		output:
 			"W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1",
@@ -965,7 +965,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295866,
+		id: "3295866",
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -973,7 +973,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295867,
+		id: "3295867",
 		level: "error",
 		output:
 			"W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1",
@@ -981,7 +981,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295868,
+		id: "3295868",
 		level: "info",
 		output:
 			"xfonts-scalable is already the newest version (1:1.0.3-1.2ubuntu1).",
@@ -989,7 +989,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295869,
+		id: "3295869",
 		level: "info",
 		output:
 			"fonts-ipafont-gothic is already the newest version (00303-21ubuntu1).",
@@ -997,35 +997,35 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295870,
+		id: "3295870",
 		level: "info",
 		output: "fonts-tlwg-loma-otf is already the newest version (1:0.7.3-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295871,
+		id: "3295871",
 		level: "info",
 		output: "fonts-unifont is already the newest version (1:14.0.01-1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295872,
+		id: "3295872",
 		level: "info",
 		output: "fonts-wqy-zenhei is already the newest version (0.9.45-8).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295873,
+		id: "3295873",
 		level: "info",
 		output: "xfonts-cyrillic is already the newest version (1:1.0.5).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295874,
+		id: "3295874",
 		level: "info",
 		output:
 			"fonts-noto-color-emoji is already the newest version (2.042-0ubuntu0.22.04.1).",
@@ -1033,21 +1033,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295875,
+		id: "3295875",
 		level: "info",
 		output: "libcups2 is already the newest version (2.4.1op1-1ubuntu4.8).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295876,
+		id: "3295876",
 		level: "info",
 		output: "libdbus-1-3 is already the newest version (1.12.20-2ubuntu4.1).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295877,
+		id: "3295877",
 		level: "info",
 		output:
 			"libdrm2 is already the newest version (2.4.113-2~ubuntu0.22.04.1).",
@@ -1055,7 +1055,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295878,
+		id: "3295878",
 		level: "info",
 		output:
 			"libfreetype6 is already the newest version (2.11.1+dfsg-1ubuntu0.2).",
@@ -1063,7 +1063,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295879,
+		id: "3295879",
 		level: "info",
 		output:
 			"libgbm1 is already the newest version (23.2.1-1ubuntu3.1~22.04.2).",
@@ -1071,21 +1071,21 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295880,
+		id: "3295880",
 		level: "info",
 		output: "libglib2.0-0 is already the newest version (2.72.4-0ubuntu2.2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295881,
+		id: "3295881",
 		level: "info",
 		output: "libnss3 is already the newest version (2:3.68.2-0ubuntu1.2).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295882,
+		id: "3295882",
 		level: "info",
 		output:
 			"libpango-1.0-0 is already the newest version (1.50.6+ds-2ubuntu1).",
@@ -1093,7 +1093,7 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295883,
+		id: "3295883",
 		level: "info",
 		output:
 			"libwayland-client0 is already the newest version (1.20.0-1ubuntu0.1).",
@@ -1101,31 +1101,31 @@ export const MockLogs = [
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295884,
+		id: "3295884",
 		level: "info",
 		output: "libx11-6 is already the newest version (2:1.7.5-1ubuntu0.3).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295885,
+		id: "3295885",
 		level: "info",
 		output: "xvfb is already the newest version (2:21.1.4-2ubuntu1.7~22.04.8).",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295886,
+		id: "3295886",
 		level: "info",
 		output: "0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
 	{
-		id: 3295887,
+		id: "3295887",
 		level: "error",
 		output: "+ touch /tmp/.coder-startup-script.done",
 		time: "2024-03-14T11:31:10.859531Z",
 		sourceId: "d9475581-8a42-4bce-b4d0-e4d2791d5c98",
 	},
-] satisfies LineWithID[];
+] satisfies Line[];

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -12,6 +12,7 @@ import type {
 	WorkspaceAgentMetadata,
 } from "api/typesGenerated";
 import { DropdownArrow } from "components/DropdownArrow/DropdownArrow";
+import type { Line } from "components/Logs/LogLine";
 import { Stack } from "components/Stack/Stack";
 import { useProxy } from "contexts/ProxyContext";
 import {
@@ -318,8 +319,8 @@ export const AgentRow: FC<AgentRowProps> = ({
 									width={width}
 									css={styles.startupLogs}
 									onScroll={handleLogScroll}
-									logs={startupLogs.map((l) => ({
-										id: l.id,
+									logs={startupLogs.map<Line>((l) => ({
+										id: String(l.id),
 										level: l.level,
 										output: l.output,
 										sourceId: l.source_id,

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -320,7 +320,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 									css={styles.startupLogs}
 									onScroll={handleLogScroll}
 									logs={startupLogs.map<Line>((l) => ({
-										id: String(l.id),
+										id: l.id,
 										level: l.level,
 										output: l.output,
 										sourceId: l.source_id,

--- a/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -1,5 +1,6 @@
 import { type Interpolation, type Theme, useTheme } from "@emotion/react";
 import type { ProvisionerJobLog } from "api/typesGenerated";
+import type { Line } from "components/Logs/LogLine";
 import { DEFAULT_LOG_LINE_SIDE_PADDING, Logs } from "components/Logs/Logs";
 import dayjs from "dayjs";
 import { type FC, Fragment, type HTMLAttributes } from "react";
@@ -63,7 +64,8 @@ export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({
 		>
 			{Object.entries(groupedLogsByStage).map(([stage, logs]) => {
 				const isEmpty = logs.every((log) => log.output === "");
-				const lines = logs.map((log) => ({
+				const lines = logs.map<Line>((log) => ({
+					id: String(log.id),
 					time: log.created_at,
 					output: log.output,
 					level: log.log_level,

--- a/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -65,7 +65,7 @@ export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({
 			{Object.entries(groupedLogsByStage).map(([stage, logs]) => {
 				const isEmpty = logs.every((log) => log.output === "");
 				const lines = logs.map<Line>((log) => ({
-					id: String(log.id),
+					id: log.id,
 					time: log.created_at,
 					output: log.output,
 					level: log.log_level,

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -304,7 +304,7 @@ const AgentLogsContent: FC<{ workspaceId: string; agent: WorkspaceAgent }> = ({
 		<AgentLogs
 			sources={agent.log_sources}
 			logs={logs.map<Line>((l) => ({
-				id: String(l.id),
+				id: l.id,
 				output: l.output,
 				time: l.created_at,
 				level: l.level,

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -7,6 +7,7 @@ import type {
 import { Alert } from "components/Alert/Alert";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Loader } from "components/Loader/Loader";
+import type { Line } from "components/Logs/LogLine";
 import { Margins } from "components/Margins/Margins";
 import {
 	FullWidthPageHeader,
@@ -302,8 +303,8 @@ const AgentLogsContent: FC<{ workspaceId: string; agent: WorkspaceAgent }> = ({
 	return (
 		<AgentLogs
 			sources={agent.log_sources}
-			logs={logs.map((l) => ({
-				id: l.id,
+			logs={logs.map<Line>((l) => ({
+				id: String(l.id),
 				output: l.output,
 				time: l.created_at,
 				level: l.level,


### PR DESCRIPTION
No issue to link – fixing this because it was making it harder to diagnose some of the potential problems with our switch over to One-Way Web Sockets in the UI. There were too many extra errors being logged to the console

## Changes made
- Updated `Line` type in `LogLine.tsx` to support an ID value to prevent key conflicts during React rendering. Also deleted the `LineWithID` type, which became redundant after the change
- Updated the `Logs` component to use the ID to avoid render key conflicts
- Updated any component calls to add the ID as a prop

## Notes
- This does prevent a bunch of extra `console.error` calls that React will automatically spit out, so this should help us a good bit in the future
- Beyond being a little annoying, there was a chance (that was tiny for now) that React could accidentally mix up component instances during re-renders (meaning logs could suddenly jump out of order in the UI). That wasn't my main goal with this PR (I just wanted less noisy logs), but that should now be impossible