### PR TITLE
fix: add subject-digest to GitHub Attestation steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1187,6 +1187,13 @@ jobs:
       # We attest each tag separately to ensure all tags have proper provenance records.
       # TODO: Consider refactoring these steps to use a matrix strategy or composite action to reduce duplication
       # while maintaining the required functionality for each tag.
+      - name: Get Docker image digest
+        id: get_digest_main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:main | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for Docker image
         id: attest_main
         if: github.ref == 'refs/heads/main'
@@ -1194,6 +1201,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: "ghcr.io/coder/coder-preview:main"
+          subject-digest: ${{ steps.get_digest_main.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -1223,6 +1231,13 @@ jobs:
               }
             }
           push-to-registry: true
+
+      - name: Get Docker image digest (latest)
+        id: get_digest_latest
+        if: github.ref == 'refs/heads/main'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:latest | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for Docker image (latest tag)
         id: attest_latest
@@ -1231,6 +1246,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: "ghcr.io/coder/coder-preview:latest"
+          subject-digest: ${{ steps.get_digest_latest.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -1261,6 +1277,13 @@ jobs:
             }
           push-to-registry: true
 
+      - name: Get Docker image digest (version)
+        id: get_digest_version
+        if: github.ref == 'refs/heads/main'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for version-specific Docker image
         id: attest_version
         if: github.ref == 'refs/heads/main'
@@ -1268,6 +1291,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: "ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}"
+          subject-digest: ${{ steps.get_digest_version.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -415,6 +415,13 @@ jobs:
       #
       # TODO: Consider refactoring these attestation steps to use a matrix strategy or composite action
       # to reduce duplication while maintaining the required functionality for each distinct image tag.
+      - name: Get Docker image digest (base)
+        id: get_digest_base
+        if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.image-base-tag.outputs.tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for Base Docker image
         id: attest_base
         if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
@@ -422,6 +429,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: ${{ steps.image-base-tag.outputs.tag }}
+          subject-digest: ${{ steps.get_digest_base.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -496,6 +504,13 @@ jobs:
         env:
           CODER_BASE_IMAGE_TAG: ${{ steps.image-base-tag.outputs.tag }}
 
+      - name: Get Docker image digest (main)
+        id: get_digest_main
+        if: ${{ !inputs.dry_run }}
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.build_docker.outputs.multiarch_image }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for Docker image
         id: attest_main
         if: ${{ !inputs.dry_run }}
@@ -503,6 +518,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: ${{ steps.build_docker.outputs.multiarch_image }}
+          subject-digest: ${{ steps.get_digest_main.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -540,6 +556,13 @@ jobs:
         run: echo "tag=$(./scripts/image_tag.sh --version latest)" >> $GITHUB_OUTPUT
 
       # If this is the highest version according to semver, also attest the "latest" tag
+      - name: Get Docker image digest (latest)
+        id: get_digest_latest
+        if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.latest_tag.outputs.tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for "latest" Docker image
         id: attest_latest
         if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
@@ -547,6 +570,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: ${{ steps.latest_tag.outputs.tag }}
+          subject-digest: ${{ steps.get_digest_latest.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {


### PR DESCRIPTION
The GitHub Attestation steps in both ci.yaml and release.yaml were missing the required subject-digest parameter. This caused errors with the message 'Error: One of subject-path, subject-digest, or subject-checksums must be provided'.

Changes:
- Added subject-digest parameter to all GitHub Attestation steps
- Added new steps to get Docker image digests before each attestation
- The digests are obtained using docker inspect on the built images
- Applied to both main, latest, and version-specific image attestations