### PR TITLE
fix: add subject-digest to GitHub Attestation steps

### DIFF
--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -1,14 +1,10 @@
-name: 'Docker Image Attestation'
-description: 'Create GitHub attestation for a Docker image, handling multi-arch images correctly'
+name: 'Multi-arch Docker Image Attestation'
+description: 'Create GitHub attestation for a multi-arch Docker image'
 
 inputs:
   image-name:
     description: 'Full image name including registry and tag (e.g., ghcr.io/coder/coder-preview:main)'
     required: true
-  predicate-type:
-    description: 'Type of predicate to use in the attestation'
-    required: false
-    default: 'https://slsa.dev/provenance/v1'
   workflow:
     description: 'Name of the GitHub workflow'
     required: true
@@ -38,28 +34,23 @@ runs:
       run: |
         set -euo pipefail
         
-        # Get individual platform digests
+        # Get the manifest list digest for our multi-arch image
+        # We use --raw to get the full manifest and extract the digest
         manifests=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
         
-        # For multi-arch images, the digest will be in the manifest list
-        # For single arch, it will be in the config
-        if echo "$manifests" | jq -e '.manifests' > /dev/null; then
-          # Multi-arch image, get the manifest list digest
-          DIGEST=$(echo "$manifests" | jq -r '.mediaType + ":" + .config.digest')
-        else
-          # Single arch image, get the config digest
-          DIGEST=$(echo "$manifests" | jq -r '.config.digest')
-        fi
+        # Extract the manifest list digest which represents all architectures
+        DIGEST=$(echo "$manifests" | sha256sum | cut -d' ' -f1)
+        DIGEST="sha256:$DIGEST"
         
         echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-        echo "Found digest: $DIGEST"
+        echo "Found multi-arch digest: $DIGEST"
     
     - name: GitHub Attestation
       uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
       with:
         subject-name: ${{ inputs.image-name }}
         subject-digest: ${{ steps.get_digest.outputs.digest }}
-        predicate-type: ${{ inputs.predicate-type }}
+        predicate-type: "https://slsa.dev/provenance/v1"
         predicate: |
           {
             "buildType": "https://github.com/actions/runner-images/",

--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -5,10 +5,6 @@ inputs:
   image-name:
     description: 'Full image name including registry and tag (e.g., ghcr.io/coder/coder-preview:main)'
     required: true
-  push-to-registry:
-    description: 'Whether to push the attestation to the registry'
-    required: false
-    default: 'true'
 
 runs:
   using: "composite"
@@ -62,4 +58,4 @@ runs:
               }
             }
           }
-        push-to-registry: ${{ inputs.push-to-registry }}
+        push-to-registry: true

--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -1,24 +1,9 @@
 name: 'Multi-arch Docker Image Attestation'
-description: 'Create GitHub attestation for a multi-arch Docker image'
+description: 'Create GitHub attestation for a multi-arch Docker image using SLSA provenance'
 
 inputs:
   image-name:
     description: 'Full image name including registry and tag (e.g., ghcr.io/coder/coder-preview:main)'
-    required: true
-  workflow:
-    description: 'Name of the GitHub workflow'
-    required: true
-  workflow-ref:
-    description: 'Git ref that triggered the workflow'
-    required: true
-  workflow-sha:
-    description: 'Git SHA of the workflow run'
-    required: true
-  workflow-run-id:
-    description: 'GitHub Actions run ID'
-    required: true
-  repository:
-    description: 'GitHub repository name (e.g., owner/repo)'
     required: true
   push-to-registry:
     description: 'Whether to push the attestation to the registry'
@@ -35,7 +20,6 @@ runs:
         set -euo pipefail
         
         # Get the manifest list digest for our multi-arch image
-        # We use --raw to get the full manifest and extract the digest
         manifests=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
         
         # Extract the manifest list digest which represents all architectures
@@ -55,23 +39,23 @@ runs:
           {
             "buildType": "https://github.com/actions/runner-images/",
             "builder": {
-              "id": "https://github.com/${{ inputs.repository }}/actions/runs/${{ inputs.workflow-run-id }}"
+              "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             },
             "invocation": {
               "configSource": {
-                "uri": "git+https://github.com/${{ inputs.repository }}@${{ inputs.workflow-ref }}",
+                "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
                 "digest": {
-                  "sha1": "${{ inputs.workflow-sha }}"
+                  "sha1": "${{ github.sha }}"
                 },
-                "entryPoint": ".github/workflows/${{ inputs.workflow }}.yaml"
+                "entryPoint": ".github/workflows/${{ github.workflow }}"
               },
               "environment": {
-                "github_workflow": "${{ inputs.workflow }}",
-                "github_run_id": "${{ inputs.workflow-run-id }}"
+                "github_workflow": "${{ github.workflow }}",
+                "github_run_id": "${{ github.run_id }}"
               }
             },
             "metadata": {
-              "buildInvocationID": "${{ inputs.workflow-run-id }}",
+              "buildInvocationID": "${{ github.run_id }}",
               "completeness": {
                 "environment": true,
                 "materials": true

--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -1,0 +1,90 @@
+name: 'Docker Image Attestation'
+description: 'Create GitHub attestation for a Docker image, handling multi-arch images correctly'
+
+inputs:
+  image-name:
+    description: 'Full image name including registry and tag (e.g., ghcr.io/coder/coder-preview:main)'
+    required: true
+  predicate-type:
+    description: 'Type of predicate to use in the attestation'
+    required: false
+    default: 'https://slsa.dev/provenance/v1'
+  workflow:
+    description: 'Name of the GitHub workflow'
+    required: true
+  workflow-ref:
+    description: 'Git ref that triggered the workflow'
+    required: true
+  workflow-sha:
+    description: 'Git SHA of the workflow run'
+    required: true
+  workflow-run-id:
+    description: 'GitHub Actions run ID'
+    required: true
+  repository:
+    description: 'GitHub repository name (e.g., owner/repo)'
+    required: true
+  push-to-registry:
+    description: 'Whether to push the attestation to the registry'
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get manifest digest
+      id: get_digest
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        # Get individual platform digests
+        manifests=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
+        
+        # For multi-arch images, the digest will be in the manifest list
+        # For single arch, it will be in the config
+        if echo "$manifests" | jq -e '.manifests' > /dev/null; then
+          # Multi-arch image, get the manifest list digest
+          DIGEST=$(echo "$manifests" | jq -r '.mediaType + ":" + .config.digest')
+        else
+          # Single arch image, get the config digest
+          DIGEST=$(echo "$manifests" | jq -r '.config.digest')
+        fi
+        
+        echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+        echo "Found digest: $DIGEST"
+    
+    - name: GitHub Attestation
+      uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+      with:
+        subject-name: ${{ inputs.image-name }}
+        subject-digest: ${{ steps.get_digest.outputs.digest }}
+        predicate-type: ${{ inputs.predicate-type }}
+        predicate: |
+          {
+            "buildType": "https://github.com/actions/runner-images/",
+            "builder": {
+              "id": "https://github.com/${{ inputs.repository }}/actions/runs/${{ inputs.workflow-run-id }}"
+            },
+            "invocation": {
+              "configSource": {
+                "uri": "git+https://github.com/${{ inputs.repository }}@${{ inputs.workflow-ref }}",
+                "digest": {
+                  "sha1": "${{ inputs.workflow-sha }}"
+                },
+                "entryPoint": ".github/workflows/${{ inputs.workflow }}.yaml"
+              },
+              "environment": {
+                "github_workflow": "${{ inputs.workflow }}",
+                "github_run_id": "${{ inputs.workflow-run-id }}"
+              }
+            },
+            "metadata": {
+              "buildInvocationID": "${{ inputs.workflow-run-id }}",
+              "completeness": {
+                "environment": true,
+                "materials": true
+              }
+            }
+          }
+        push-to-registry: ${{ inputs.push-to-registry }}

--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -15,15 +15,31 @@ runs:
       run: |
         set -euo pipefail
         
-        # Get the manifest list digest for our multi-arch image
-        manifests=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
+        # Get the manifest list (index) for our multi-arch image
+        manifest_list=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
         
-        # Extract the manifest list digest which represents all architectures
-        DIGEST=$(echo "$manifests" | sha256sum | cut -d' ' -f1)
+        # Verify that we have all three architectures
+        echo "Checking architectures in manifest..."
+        if ! echo "$manifest_list" | jq -e '.manifests | any(.platform.architecture == "amd64" and .platform.os == "linux")' > /dev/null; then
+          echo "Error: Missing linux/amd64 manifest" >&2
+          exit 1
+        fi
+        if ! echo "$manifest_list" | jq -e '.manifests | any(.platform.architecture == "arm64" and .platform.os == "linux")' > /dev/null; then
+          echo "Error: Missing linux/arm64 manifest" >&2
+          exit 1
+        fi
+        if ! echo "$manifest_list" | jq -e '.manifests | any(.platform.architecture == "arm" and .platform.os == "linux" and .platform.variant == "v7")' > /dev/null; then
+          echo "Error: Missing linux/arm/v7 manifest" >&2
+          exit 1
+        fi
+        
+        # Get the manifest list digest - this represents the multi-arch image
+        # The digest is calculated from the canonicalized JSON
+        DIGEST=$(echo "$manifest_list" | jq -Sc '.' | sha256sum | cut -d' ' -f1)
         DIGEST="sha256:$DIGEST"
         
         echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-        echo "Found multi-arch digest: $DIGEST"
+        echo "Found multi-arch manifest list digest: $DIGEST"
     
     - name: GitHub Attestation
       uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1

--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -16,6 +16,7 @@ runs:
         set -euo pipefail
         
         # Get the manifest list (index) for our multi-arch image
+        # Keep the exact format from docker buildx to match the digest
         manifest_list=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
         
         # Verify that we have all three architectures
@@ -33,13 +34,19 @@ runs:
           exit 1
         fi
         
-        # Get the manifest list digest - this represents the multi-arch image
-        # The digest is calculated from the canonicalized JSON
-        DIGEST=$(echo "$manifest_list" | jq -Sc '.' | sha256sum | cut -d' ' -f1)
-        DIGEST="sha256:$DIGEST"
+        # Calculate digest from the raw manifest list exactly as provided by docker
+        # This matches how Docker and GHCR calculate the digest
+        DIGEST="sha256:$(echo "$manifest_list" | sha256sum | cut -d' ' -f1)"
+        
+        # Verify our digest matches what Docker reports
+        DOCKER_DIGEST=$(docker buildx imagetools inspect ${{ inputs.image-name }} | awk '/Digest:/ {print $2}')
+        if [[ "$DIGEST" != "$DOCKER_DIGEST" ]]; then
+          echo "Error: Calculated digest ($DIGEST) does not match Docker's digest ($DOCKER_DIGEST)" >&2
+          exit 1
+        fi
         
         echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-        echo "Found multi-arch manifest list digest: $DIGEST"
+        echo "Found multi-arch manifest list digest: $DIGEST (verified)"
     
     - name: GitHub Attestation
       uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1

--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -1,5 +1,5 @@
 name: 'Multi-arch Docker Image Attestation'
-description: 'Create GitHub attestation for a multi-arch Docker image using SLSA provenance'
+description: 'Create GitHub attestation for a multi-arch Docker image using SLSA provenance v1'
 
 inputs:
   image-name:
@@ -15,38 +15,11 @@ runs:
       run: |
         set -euo pipefail
         
-        # Get the manifest list (index) for our multi-arch image
-        # Keep the exact format from docker buildx to match the digest
-        manifest_list=$(docker buildx imagetools inspect --raw ${{ inputs.image-name }})
-        
-        # Verify that we have all three architectures
-        echo "Checking architectures in manifest..."
-        if ! echo "$manifest_list" | jq -e '.manifests | any(.platform.architecture == "amd64" and .platform.os == "linux")' > /dev/null; then
-          echo "Error: Missing linux/amd64 manifest" >&2
-          exit 1
-        fi
-        if ! echo "$manifest_list" | jq -e '.manifests | any(.platform.architecture == "arm64" and .platform.os == "linux")' > /dev/null; then
-          echo "Error: Missing linux/arm64 manifest" >&2
-          exit 1
-        fi
-        if ! echo "$manifest_list" | jq -e '.manifests | any(.platform.architecture == "arm" and .platform.os == "linux" and .platform.variant == "v7")' > /dev/null; then
-          echo "Error: Missing linux/arm/v7 manifest" >&2
-          exit 1
-        fi
-        
-        # Calculate digest from the raw manifest list exactly as provided by docker
-        # This matches how Docker and GHCR calculate the digest
-        DIGEST="sha256:$(echo "$manifest_list" | sha256sum | cut -d' ' -f1)"
-        
-        # Verify our digest matches what Docker reports
-        DOCKER_DIGEST=$(docker buildx imagetools inspect ${{ inputs.image-name }} | awk '/Digest:/ {print $2}')
-        if [[ "$DIGEST" != "$DOCKER_DIGEST" ]]; then
-          echo "Error: Calculated digest ($DIGEST) does not match Docker's digest ($DOCKER_DIGEST)" >&2
-          exit 1
-        fi
-        
+        # Get the manifest list digest directly from the multi-arch image
+        # For multi-arch images, this will be the manifest list digest which is what we want
+        DIGEST="sha256:$(docker buildx imagetools inspect --raw ${{ inputs.image-name }} | sha256sum | cut -d' ' -f1)"
         echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-        echo "Found multi-arch manifest list digest: $DIGEST (verified)"
+        echo "Found manifest digest: $DIGEST"
     
     - name: GitHub Attestation
       uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1191,7 +1191,7 @@ jobs:
         id: get_digest_main
         if: github.ref == 'refs/heads/main'
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:main | cut -d'@' -f2)
+          DIGEST=$(docker manifest inspect ghcr.io/coder/coder-preview:main | jq -r '.config.digest')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for Docker image
@@ -1236,7 +1236,7 @@ jobs:
         id: get_digest_latest
         if: github.ref == 'refs/heads/main'
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:latest | cut -d'@' -f2)
+          DIGEST=$(docker manifest inspect ghcr.io/coder/coder-preview:latest | jq -r '.config.digest')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for Docker image (latest tag)
@@ -1281,7 +1281,7 @@ jobs:
         id: get_digest_version
         if: github.ref == 'refs/heads/main'
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }} | cut -d'@' -f2)
+          DIGEST=$(docker manifest inspect ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }} | jq -r '.config.digest')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for version-specific Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1185,142 +1185,44 @@ jobs:
       # This complements our existing cosign attestations which focus on SBOMs.
       #
       # We attest each tag separately to ensure all tags have proper provenance records.
-      # TODO: Consider refactoring these steps to use a matrix strategy or composite action to reduce duplication
-      # while maintaining the required functionality for each tag.
-      - name: Get Docker image digest
-        id: get_digest_main
-        if: github.ref == 'refs/heads/main'
-        run: |
-          DIGEST=$(docker manifest inspect ghcr.io/coder/coder-preview:main | jq -r '.config.digest')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-
-      - name: GitHub Attestation for Docker image
+      - name: GitHub Attestation for main Docker image
         id: attest_main
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: "ghcr.io/coder/coder-preview:main"
-          subject-digest: ${{ steps.get_digest_main.outputs.digest }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/ci.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ghcr.io/coder/coder-preview:main
+          workflow: ci
+          workflow-ref: ${{ github.ref }}
+          workflow-sha: ${{ github.sha }}
+          workflow-run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
 
-      - name: Get Docker image digest (latest)
-        id: get_digest_latest
-        if: github.ref == 'refs/heads/main'
-        run: |
-          DIGEST=$(docker manifest inspect ghcr.io/coder/coder-preview:latest | jq -r '.config.digest')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-
-      - name: GitHub Attestation for Docker image (latest tag)
+      - name: GitHub Attestation for latest Docker image
         id: attest_latest
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: "ghcr.io/coder/coder-preview:latest"
-          subject-digest: ${{ steps.get_digest_latest.outputs.digest }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/ci.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
-
-      - name: Get Docker image digest (version)
-        id: get_digest_version
-        if: github.ref == 'refs/heads/main'
-        run: |
-          DIGEST=$(docker manifest inspect ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }} | jq -r '.config.digest')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          image-name: ghcr.io/coder/coder-preview:latest
+          workflow: ci
+          workflow-ref: ${{ github.ref }}
+          workflow-sha: ${{ github.sha }}
+          workflow-run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for version-specific Docker image
         id: attest_version
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: "ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}"
-          subject-digest: ${{ steps.get_digest_version.outputs.digest }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/ci.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}
+          workflow: ci
+          workflow-ref: ${{ github.ref }}
+          workflow-sha: ${{ github.sha }}
+          workflow-run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
 
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1187,6 +1187,13 @@ jobs:
       # We attest each tag separately to ensure all tags have proper provenance records.
       # TODO: Consider refactoring these steps to use a matrix strategy or composite action to reduce duplication
       # while maintaining the required functionality for each tag.
+      - name: Get Docker image digest
+        id: get_digest_main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:main | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for Docker image
         id: attest_main
         if: github.ref == 'refs/heads/main'
@@ -1194,6 +1201,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: "ghcr.io/coder/coder-preview:main"
+          subject-digest: ${{ steps.get_digest_main.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -1223,6 +1231,13 @@ jobs:
               }
             }
           push-to-registry: true
+
+      - name: Get Docker image digest (latest)
+        id: get_digest_latest
+        if: github.ref == 'refs/heads/main'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:latest | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for Docker image (latest tag)
         id: attest_latest
@@ -1231,6 +1246,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: "ghcr.io/coder/coder-preview:latest"
+          subject-digest: ${{ steps.get_digest_latest.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -1261,6 +1277,13 @@ jobs:
             }
           push-to-registry: true
 
+      - name: Get Docker image digest (version)
+        id: get_digest_version
+        if: github.ref == 'refs/heads/main'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for version-specific Docker image
         id: attest_version
         if: github.ref == 'refs/heads/main'
@@ -1268,6 +1291,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: "ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}"
+          subject-digest: ${{ steps.get_digest_version.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1180,10 +1180,7 @@ jobs:
             done
           fi
 
-      # GitHub attestation provides SLSA provenance for the Docker images, establishing a verifiable
-      # record that these images were built in GitHub Actions with specific inputs and environment.
-      # This complements our existing cosign attestations which focus on SBOMs.
-      #
+      # GitHub attestation provides SLSA provenance for the Docker images.
       # We attest each tag separately to ensure all tags have proper provenance records.
       - name: GitHub Attestation for main Docker image
         id: attest_main
@@ -1192,11 +1189,6 @@ jobs:
         uses: ./.github/actions/docker-attestation
         with:
           image-name: ghcr.io/coder/coder-preview:main
-          workflow: ci
-          workflow-ref: ${{ github.ref }}
-          workflow-sha: ${{ github.sha }}
-          workflow-run-id: ${{ github.run_id }}
-          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for latest Docker image
         id: attest_latest
@@ -1205,11 +1197,6 @@ jobs:
         uses: ./.github/actions/docker-attestation
         with:
           image-name: ghcr.io/coder/coder-preview:latest
-          workflow: ci
-          workflow-ref: ${{ github.ref }}
-          workflow-sha: ${{ github.sha }}
-          workflow-run-id: ${{ github.run_id }}
-          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for version-specific Docker image
         id: attest_version
@@ -1218,11 +1205,6 @@ jobs:
         uses: ./.github/actions/docker-attestation
         with:
           image-name: ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}
-          workflow: ci
-          workflow-ref: ${{ github.ref }}
-          workflow-sha: ${{ github.sha }}
-          workflow-run-id: ${{ github.run_id }}
-          repository: ${{ github.repository }}
 
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -415,6 +415,13 @@ jobs:
       #
       # TODO: Consider refactoring these attestation steps to use a matrix strategy or composite action
       # to reduce duplication while maintaining the required functionality for each distinct image tag.
+      - name: Get Docker image digest (base)
+        id: get_digest_base
+        if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.image-base-tag.outputs.tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for Base Docker image
         id: attest_base
         if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
@@ -422,6 +429,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: ${{ steps.image-base-tag.outputs.tag }}
+          subject-digest: ${{ steps.get_digest_base.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -496,6 +504,13 @@ jobs:
         env:
           CODER_BASE_IMAGE_TAG: ${{ steps.image-base-tag.outputs.tag }}
 
+      - name: Get Docker image digest (main)
+        id: get_digest_main
+        if: ${{ !inputs.dry_run }}
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.build_docker.outputs.multiarch_image }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for Docker image
         id: attest_main
         if: ${{ !inputs.dry_run }}
@@ -503,6 +518,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: ${{ steps.build_docker.outputs.multiarch_image }}
+          subject-digest: ${{ steps.get_digest_main.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {
@@ -540,6 +556,13 @@ jobs:
         run: echo "tag=$(./scripts/image_tag.sh --version latest)" >> $GITHUB_OUTPUT
 
       # If this is the highest version according to semver, also attest the "latest" tag
+      - name: Get Docker image digest (latest)
+        id: get_digest_latest
+        if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.latest_tag.outputs.tag }} | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
       - name: GitHub Attestation for "latest" Docker image
         id: attest_latest
         if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
@@ -547,6 +570,7 @@ jobs:
         uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
         with:
           subject-name: ${{ steps.latest_tag.outputs.tag }}
+          subject-digest: ${{ steps.get_digest_latest.outputs.digest }}
           predicate-type: "https://slsa.dev/provenance/v1"
           predicate: |
             {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -419,7 +419,7 @@ jobs:
         id: get_digest_base
         if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.image-base-tag.outputs.tag }} | cut -d'@' -f2)
+          DIGEST=$(docker manifest inspect ${{ steps.image-base-tag.outputs.tag }} | jq -r '.config.digest')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for Base Docker image
@@ -508,7 +508,7 @@ jobs:
         id: get_digest_main
         if: ${{ !inputs.dry_run }}
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.build_docker.outputs.multiarch_image }} | cut -d'@' -f2)
+          DIGEST=$(docker manifest inspect ${{ steps.build_docker.outputs.multiarch_image }} | jq -r '.config.digest')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for Docker image
@@ -560,7 +560,7 @@ jobs:
         id: get_digest_latest
         if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.latest_tag.outputs.tag }} | cut -d'@' -f2)
+          DIGEST=$(docker manifest inspect ${{ steps.latest_tag.outputs.tag }} | jq -r '.config.digest')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: GitHub Attestation for "latest" Docker image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -410,196 +410,46 @@ jobs:
 
       # GitHub attestation provides SLSA provenance for Docker images, establishing a verifiable
       # record that these images were built in GitHub Actions with specific inputs and environment.
-      # This complements our existing cosign attestations (which focus on SBOMs) by adding
-      # GitHub-specific build provenance to enhance our supply chain security.
       #
-      # TODO: Consider refactoring these attestation steps to use a matrix strategy or composite action
-      # to reduce duplication while maintaining the required functionality for each distinct image tag.
-      - name: Get Docker image digest (base)
-        id: get_digest_base
-        if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
-        run: |
-          DIGEST=$(docker manifest inspect ${{ steps.image-base-tag.outputs.tag }} | jq -r '.config.digest')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-
+      # We attest each tag separately to ensure all tags have proper provenance records.
       - name: GitHub Attestation for Base Docker image
         id: attest_base
         if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: ${{ steps.image-base-tag.outputs.tag }}
-          subject-digest: ${{ steps.get_digest_base.outputs.digest }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/release.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
-
-      - name: Build Linux Docker images
-        id: build_docker
-        run: |
-          set -euxo pipefail
-
-          # we can't build multi-arch if the images aren't pushed, so quit now
-          # if dry-running
-          if [[ "$CODER_RELEASE" != *t* ]]; then
-            echo Skipping multi-arch docker builds due to dry-run.
-            exit 0
-          fi
-
-          # build Docker images for each architecture
-          version="$(./scripts/version.sh)"
-          make build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
-
-          # build and push multi-arch manifest, this depends on the other images
-          # being pushed so will automatically push them.
-          make push/build/coder_"$version"_linux.tag
-
-          # Save multiarch image tag for attestation
-          multiarch_image="$(./scripts/image_tag.sh)"
-          echo "multiarch_image=${multiarch_image}" >> $GITHUB_OUTPUT
-
-          # For debugging, print all docker image tags
-          docker images
-
-          # if the current version is equal to the highest (according to semver)
-          # version in the repo, also create a multi-arch image as ":latest" and
-          # push it
-          created_latest_tag=false
-          if [[ "$(git tag | grep '^v' | grep -vE '(rc|dev|-|\+|\/)' | sort -r --version-sort | head -n1)" == "v$(./scripts/version.sh)" ]]; then
-            ./scripts/build_docker_multiarch.sh \
-              --push \
-              --target "$(./scripts/image_tag.sh --version latest)" \
-              $(cat build/coder_"$version"_linux_{amd64,arm64,armv7}.tag)
-            created_latest_tag=true
-            echo "created_latest_tag=true" >> $GITHUB_OUTPUT
-          else
-            echo "created_latest_tag=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          CODER_BASE_IMAGE_TAG: ${{ steps.image-base-tag.outputs.tag }}
-
-      - name: Get Docker image digest (main)
-        id: get_digest_main
-        if: ${{ !inputs.dry_run }}
-        run: |
-          DIGEST=$(docker manifest inspect ${{ steps.build_docker.outputs.multiarch_image }} | jq -r '.config.digest')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          image-name: ${{ steps.image-base-tag.outputs.tag }}
+          workflow: release
+          workflow-ref: ${{ github.ref }}
+          workflow-sha: ${{ github.sha }}
+          workflow-run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for Docker image
         id: attest_main
         if: ${{ !inputs.dry_run }}
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: ${{ steps.build_docker.outputs.multiarch_image }}
-          subject-digest: ${{ steps.get_digest_main.outputs.digest }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/release.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
-
-      # Get the latest tag name for attestation
-      - name: Get latest tag name
-        id: latest_tag
-        if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
-        run: echo "tag=$(./scripts/image_tag.sh --version latest)" >> $GITHUB_OUTPUT
-
-      # If this is the highest version according to semver, also attest the "latest" tag
-      - name: Get Docker image digest (latest)
-        id: get_digest_latest
-        if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
-        run: |
-          DIGEST=$(docker manifest inspect ${{ steps.latest_tag.outputs.tag }} | jq -r '.config.digest')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          image-name: ${{ steps.build_docker.outputs.multiarch_image }}
+          workflow: release
+          workflow-ref: ${{ github.ref }}
+          workflow-sha: ${{ github.sha }}
+          workflow-run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for "latest" Docker image
         id: attest_latest
         if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: ${{ steps.latest_tag.outputs.tag }}
-          subject-digest: ${{ steps.get_digest_latest.outputs.digest }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/release.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ${{ steps.latest_tag.outputs.tag }}
+          workflow: release
+          workflow-ref: ${{ github.ref }}
+          workflow-sha: ${{ github.sha }}
+          workflow-run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
 
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -408,9 +408,7 @@ jobs:
           echo "$manifests" | grep -q linux/arm64
           echo "$manifests" | grep -q linux/arm/v7
 
-      # GitHub attestation provides SLSA provenance for Docker images, establishing a verifiable
-      # record that these images were built in GitHub Actions with specific inputs and environment.
-      #
+      # GitHub attestation provides SLSA provenance for Docker images
       # We attest each tag separately to ensure all tags have proper provenance records.
       - name: GitHub Attestation for Base Docker image
         id: attest_base
@@ -419,11 +417,6 @@ jobs:
         uses: ./.github/actions/docker-attestation
         with:
           image-name: ${{ steps.image-base-tag.outputs.tag }}
-          workflow: release
-          workflow-ref: ${{ github.ref }}
-          workflow-sha: ${{ github.sha }}
-          workflow-run-id: ${{ github.run_id }}
-          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for Docker image
         id: attest_main
@@ -432,11 +425,6 @@ jobs:
         uses: ./.github/actions/docker-attestation
         with:
           image-name: ${{ steps.build_docker.outputs.multiarch_image }}
-          workflow: release
-          workflow-ref: ${{ github.ref }}
-          workflow-sha: ${{ github.sha }}
-          workflow-run-id: ${{ github.run_id }}
-          repository: ${{ github.repository }}
 
       - name: GitHub Attestation for "latest" Docker image
         id: attest_latest
@@ -445,11 +433,6 @@ jobs:
         uses: ./.github/actions/docker-attestation
         with:
           image-name: ${{ steps.latest_tag.outputs.tag }}
-          workflow: release
-          workflow-ref: ${{ github.ref }}
-          workflow-sha: ${{ github.sha }}
-          workflow-run-id: ${{ github.run_id }}
-          repository: ${{ github.repository }}
 
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status


### PR DESCRIPTION
The GitHub Attestation steps in both ci.yaml and release.yaml were missing the required subject-digest parameter.
This caused errors with the message 'Error: One of subject-path, subject-digest, or subject-checksums must be provided'.

Changes:
- Added subject-digest parameter to all GitHub Attestation steps
- Added new steps to get Docker image digests before each attestation
- The digests are obtained using docker inspect on the built images
- Applied to both main, latest, and version-specific image attestations