### PR TITLE
fix: use manifest list digest for github attestation

### DIFF
--- a/.github/actions/docker-attestation/action.yaml
+++ b/.github/actions/docker-attestation/action.yaml
@@ -1,0 +1,57 @@
+name: 'Multi-arch Docker Image Attestation'
+description: 'Create GitHub attestation for a multi-arch Docker image using SLSA provenance v1'
+
+inputs:
+  image-name:
+    description: 'Full image name including registry and tag (e.g., ghcr.io/coder/coder-preview:main)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get manifest digest
+      id: get_digest
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        # Get the manifest list digest directly from the multi-arch image
+        # For multi-arch images, this will be the manifest list digest which is what we want
+        DIGEST="sha256:$(docker buildx imagetools inspect --raw ${{ inputs.image-name }} | sha256sum | cut -d' ' -f1)"
+        echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+        echo "Found manifest digest: $DIGEST"
+    
+    - name: GitHub Attestation
+      uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+      with:
+        subject-name: ${{ inputs.image-name }}
+        subject-digest: ${{ steps.get_digest.outputs.digest }}
+        predicate-type: "https://slsa.dev/provenance/v1"
+        predicate: |
+          {
+            "buildType": "https://github.com/actions/runner-images/",
+            "builder": {
+              "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            },
+            "invocation": {
+              "configSource": {
+                "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
+                "digest": {
+                  "sha1": "${{ github.sha }}"
+                },
+                "entryPoint": ".github/workflows/${{ github.workflow }}"
+              },
+              "environment": {
+                "github_workflow": "${{ github.workflow }}",
+                "github_run_id": "${{ github.run_id }}"
+              }
+            },
+            "metadata": {
+              "buildInvocationID": "${{ github.run_id }}",
+              "completeness": {
+                "environment": true,
+                "materials": true
+              }
+            }
+          }
+        push-to-registry: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1180,123 +1180,31 @@ jobs:
             done
           fi
 
-      # GitHub attestation provides SLSA provenance for the Docker images, establishing a verifiable
-      # record that these images were built in GitHub Actions with specific inputs and environment.
-      # This complements our existing cosign attestations which focus on SBOMs.
-      #
+      # GitHub attestation provides SLSA provenance for the Docker images.
       # We attest each tag separately to ensure all tags have proper provenance records.
-      # TODO: Consider refactoring these steps to use a matrix strategy or composite action to reduce duplication
-      # while maintaining the required functionality for each tag.
-      - name: GitHub Attestation for Docker image
+      - name: GitHub Attestation for main Docker image
         id: attest_main
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: "ghcr.io/coder/coder-preview:main"
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/ci.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ghcr.io/coder/coder-preview:main
 
-      - name: GitHub Attestation for Docker image (latest tag)
+      - name: GitHub Attestation for latest Docker image
         id: attest_latest
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: "ghcr.io/coder/coder-preview:latest"
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/ci.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ghcr.io/coder/coder-preview:latest
 
       - name: GitHub Attestation for version-specific Docker image
         id: attest_version
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: "ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}"
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/ci.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ghcr.io/coder/coder-preview:${{ steps.build-docker.outputs.tag }}
 
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -408,174 +408,31 @@ jobs:
           echo "$manifests" | grep -q linux/arm64
           echo "$manifests" | grep -q linux/arm/v7
 
-      # GitHub attestation provides SLSA provenance for Docker images, establishing a verifiable
-      # record that these images were built in GitHub Actions with specific inputs and environment.
-      # This complements our existing cosign attestations (which focus on SBOMs) by adding
-      # GitHub-specific build provenance to enhance our supply chain security.
-      #
-      # TODO: Consider refactoring these attestation steps to use a matrix strategy or composite action
-      # to reduce duplication while maintaining the required functionality for each distinct image tag.
+      # GitHub attestation provides SLSA provenance for Docker images
+      # We attest each tag separately to ensure all tags have proper provenance records.
       - name: GitHub Attestation for Base Docker image
         id: attest_base
         if: ${{ !inputs.dry_run && steps.image-base-tag.outputs.tag != '' }}
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: ${{ steps.image-base-tag.outputs.tag }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/release.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
-
-      - name: Build Linux Docker images
-        id: build_docker
-        run: |
-          set -euxo pipefail
-
-          # we can't build multi-arch if the images aren't pushed, so quit now
-          # if dry-running
-          if [[ "$CODER_RELEASE" != *t* ]]; then
-            echo Skipping multi-arch docker builds due to dry-run.
-            exit 0
-          fi
-
-          # build Docker images for each architecture
-          version="$(./scripts/version.sh)"
-          make build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
-
-          # build and push multi-arch manifest, this depends on the other images
-          # being pushed so will automatically push them.
-          make push/build/coder_"$version"_linux.tag
-
-          # Save multiarch image tag for attestation
-          multiarch_image="$(./scripts/image_tag.sh)"
-          echo "multiarch_image=${multiarch_image}" >> $GITHUB_OUTPUT
-
-          # For debugging, print all docker image tags
-          docker images
-
-          # if the current version is equal to the highest (according to semver)
-          # version in the repo, also create a multi-arch image as ":latest" and
-          # push it
-          created_latest_tag=false
-          if [[ "$(git tag | grep '^v' | grep -vE '(rc|dev|-|\+|\/)' | sort -r --version-sort | head -n1)" == "v$(./scripts/version.sh)" ]]; then
-            ./scripts/build_docker_multiarch.sh \
-              --push \
-              --target "$(./scripts/image_tag.sh --version latest)" \
-              $(cat build/coder_"$version"_linux_{amd64,arm64,armv7}.tag)
-            created_latest_tag=true
-            echo "created_latest_tag=true" >> $GITHUB_OUTPUT
-          else
-            echo "created_latest_tag=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          CODER_BASE_IMAGE_TAG: ${{ steps.image-base-tag.outputs.tag }}
+          image-name: ${{ steps.image-base-tag.outputs.tag }}
 
       - name: GitHub Attestation for Docker image
         id: attest_main
         if: ${{ !inputs.dry_run }}
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: ${{ steps.build_docker.outputs.multiarch_image }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/release.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ${{ steps.build_docker.outputs.multiarch_image }}
 
-      # Get the latest tag name for attestation
-      - name: Get latest tag name
-        id: latest_tag
-        if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
-        run: echo "tag=$(./scripts/image_tag.sh --version latest)" >> $GITHUB_OUTPUT
-
-      # If this is the highest version according to semver, also attest the "latest" tag
       - name: GitHub Attestation for "latest" Docker image
         id: attest_latest
         if: ${{ !inputs.dry_run && steps.build_docker.outputs.created_latest_tag == 'true' }}
         continue-on-error: true
-        uses: actions/attest@a63cfcc7d1aab266ee064c58250cfc2c7d07bc31 # v2.2.1
+        uses: ./.github/actions/docker-attestation
         with:
-          subject-name: ${{ steps.latest_tag.outputs.tag }}
-          predicate-type: "https://slsa.dev/provenance/v1"
-          predicate: |
-            {
-              "buildType": "https://github.com/actions/runner-images/",
-              "builder": {
-                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              },
-              "invocation": {
-                "configSource": {
-                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
-                  "digest": {
-                    "sha1": "${{ github.sha }}"
-                  },
-                  "entryPoint": ".github/workflows/release.yaml"
-                },
-                "environment": {
-                  "github_workflow": "${{ github.workflow }}",
-                  "github_run_id": "${{ github.run_id }}"
-                }
-              },
-              "metadata": {
-                "buildInvocationID": "${{ github.run_id }}",
-                "completeness": {
-                  "environment": true,
-                  "materials": true
-                }
-              }
-            }
-          push-to-registry: true
+          image-name: ${{ steps.latest_tag.outputs.tag }}
 
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status


### PR DESCRIPTION
This commit:
1. Creates a reusable composite action for Docker attestation
2. Uses correct manifest list digest for multi-arch images
3. Simplifies workflow usage to a single input

The attestation now correctly uses the manifest list digest that matches what GHCR uses, ensuring proper supply chain security for our multi-arch images.