### PR TITLE
feat(codersdk): add ReducedWorkspace

### DIFF
--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -67,6 +67,39 @@ type Workspace struct {
 	NextStartAt      *time.Time       `json:"next_start_at" format:"date-time"`
 }
 
+func (w Workspace) Reduced() ReducedWorkspace {
+	return ReducedWorkspace{
+		Favorite:          w.Favorite,
+		Health:            w.Health,
+		ID:                w.ID,
+		LastBuiltAt:       w.LatestBuild.UpdatedAt,
+		LatestBuildStatus: string(w.LatestBuild.Status),
+		Outdated:          w.Outdated,
+		OwnerID:           w.OwnerID,
+		OwnerName:         w.OwnerName,
+		TemplateID:        w.TemplateID,
+		TemplateName:      w.TemplateName,
+		AutostartSchedule: w.AutostartSchedule,
+		TTLMillis:         w.TTLMillis,
+	}
+}
+
+// ReducedWorkspace is a subset of fields of a codersdk.Workspace.
+type ReducedWorkspace struct {
+	Favorite          bool            `json:"favorite"`
+	Health            WorkspaceHealth `json:"health"`
+	ID                uuid.UUID       `json:"id" format:"uuid"`
+	LastBuiltAt       time.Time       `json:"last_built_at" format:"date-time"`
+	LatestBuildStatus string          `json:"latest_build_status"`
+	Outdated          bool            `json:"outdated"`
+	OwnerID           uuid.UUID       `json:"owner_id" format:"uuid"`
+	OwnerName         string          `json:"owner_name"`
+	TemplateID        uuid.UUID       `json:"template_id" format:"uuid"`
+	TemplateName      string          `json:"template_name"`
+	AutostartSchedule *string         `json:"autostart_schedule"`
+	TTLMillis         *int64          `json:"ttl_ms,omitempty"`
+}
+
 func (w Workspace) FullName() string {
 	return fmt.Sprintf("%s/%s", w.OwnerName, w.Name)
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2057,6 +2057,22 @@ export interface ReducedUser extends MinimalUser {
 	readonly theme_preference?: string;
 }
 
+// From codersdk/workspaces.go
+export interface ReducedWorkspace {
+	readonly favorite: boolean;
+	readonly health: WorkspaceHealth;
+	readonly id: string;
+	readonly last_built_at: string;
+	readonly latest_build_status: string;
+	readonly outdated: boolean;
+	readonly owner_id: string;
+	readonly owner_name: string;
+	readonly template_id: string;
+	readonly template_name: string;
+	readonly autostart_schedule: string | null;
+	readonly ttl_ms?: number;
+}
+
 // From codersdk/workspaceproxy.go
 export interface Region {
 	readonly id: string;


### PR DESCRIPTION
Adds a new type `codersdk.ReducedWorkspace` which is a subset of `codersdk.Workspace`. I picked the default fields from the `coder list` command.