### PR TITLE
feat(mcp): add resource templates for users, workspaces, and templates

### DIFF
--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -418,6 +418,9 @@ func mcpServerHandler(inv *serpent.Invocation, client *codersdk.Client, instruct
 		cliui.Warnf(inv.Stderr, "CODER_MCP_APP_STATUS_SLUG is not set, task reporting will not be available.")
 	}
 
+	// Register all resources with the MCP server.
+	codermcp.RegisterResources(mcpSrv, toolDeps)
+
 	// Register tools based on the allowlist (if specified)
 	reg := codermcp.AllTools()
 	if len(allowedTools) > 0 {

--- a/cli/exp_mcp_test.go
+++ b/cli/exp_mcp_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,7 +38,7 @@ func TestExpMcpServer(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client)
 
 		// Given: we run the exp mcp command with allowed tools set
-		inv, root := clitest.New(t, "exp", "mcp", "server", "--allowed-tools=coder_whoami,coder_list_templates")
+		inv, root := clitest.New(t, "exp", "mcp", "server", "--allowed-tools=coder_report_task")
 		inv = inv.WithContext(cancelCtx)
 
 		pty := ptytest.New(t)
@@ -73,13 +72,14 @@ func TestExpMcpServer(t *testing.T) {
 		}
 		err := json.Unmarshal([]byte(output), &toolsResponse)
 		require.NoError(t, err)
-		require.Len(t, toolsResponse.Result.Tools, 2, "should have exactly 2 tools")
-		foundTools := make([]string, 0, 2)
+		require.Len(t, toolsResponse.Result.Tools, 1, "should have exactly 1 tool")
+		var found bool
 		for _, tool := range toolsResponse.Result.Tools {
-			foundTools = append(foundTools, tool.Name)
+			if tool.Name == "coder_report_task" {
+				found = true
+			}
 		}
-		slices.Sort(foundTools)
-		require.Equal(t, []string{"coder_list_templates", "coder_whoami"}, foundTools)
+		require.True(t, found, "should have found coder_report_task tool")
 	})
 
 	t.Run("OK", func(t *testing.T) {

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -1,4 +1,4 @@
-package codermcp
+package mcp
 
 import (
 	"bytes"
@@ -32,7 +32,7 @@ Use this tool to keep the user informed about your progress with their request.
 For long-running operations, call this periodically to provide status updates.
 This is especially useful when performing multi-step operations like workspace creation or deployment.`),
 			mcp.WithString("summary", mcp.Description(`A concise summary of your current progress on the task.
-		
+
 Good Summaries:
 - "Taking a look at the login page..."
 - "Found a bug! Fixing it now..."
@@ -151,7 +151,7 @@ Common errors:
 - Agent not connected: The workspace may still be starting up`),
 			mcp.WithString("workspace", mcp.Description(`The workspace ID (UUID) or name where the command will execute.
 Can be specified as either:
-- Full UUID: e.g., "8a0b9c7d-1e2f-3a4b-5c6d-7e8f9a0b1c2d" 
+- Full UUID: e.g., "8a0b9c7d-1e2f-3a4b-5c6d-7e8f9a0b1c2d"
 - Workspace name: e.g., "dev", "python-project"
 The workspace must be running with a connected agent.
 Use coder_get_workspace first to check the workspace status.`), mcp.Required()),

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,7 +32,7 @@ Use this tool to keep the user informed about your progress with their request.
 For long-running operations, call this periodically to provide status updates.
 This is especially useful when performing multi-step operations like workspace creation or deployment.`),
 			mcp.WithString("summary", mcp.Description(`A concise summary of your current progress on the task.
-
+		
 Good Summaries:
 - "Taking a look at the login page..."
 - "Found a bug! Fixing it now..."
@@ -60,6 +61,80 @@ Set to true if the task is in a failed state or if the user needs to take action
 		MakeHandler: handleCoderReportTask,
 	},
 	{
+		Tool: mcp.NewTool("coder_whoami",
+			mcp.WithDescription(`Get information about the currently logged-in Coder user.
+Returns JSON with the user's profile including fields: id, username, email, created_at, status, roles, etc.
+Use this to identify the current user context before performing workspace operations.
+This tool is useful for verifying permissions and checking the user's identity.
+
+Common errors:
+- Authentication failure: The session may have expired
+- Server unavailable: The Coder deployment may be unreachable`),
+		),
+		MakeHandler: handleCoderWhoami,
+	},
+	{
+		Tool: mcp.NewTool("coder_list_templates",
+			mcp.WithDescription(`List all templates available on the Coder deployment.
+Returns JSON with detailed information about each template, including:
+- Template name, ID, and description
+- Creation/modification timestamps
+- Version information
+- Associated organization
+
+Use this tool to discover available templates before creating workspaces.
+Templates define the infrastructure and configuration for workspaces.
+
+Common errors:
+- Authentication failure: Check user permissions
+- No templates available: The deployment may not have any templates configured`),
+		),
+		MakeHandler: handleCoderListTemplates,
+	},
+	{
+		Tool: mcp.NewTool("coder_list_workspaces",
+			mcp.WithDescription(`List workspaces available on the Coder deployment.
+Returns JSON with workspace metadata including status, resources, and configurations.
+Use this before other workspace operations to find valid workspace names/IDs.
+Results are paginated - use offset and limit parameters for large deployments.
+
+Common errors:
+- Authentication failure: Check user permissions
+- Invalid owner parameter: Ensure the owner exists`),
+			mcp.WithString(`owner`, mcp.Description(`The username of the workspace owner to filter by.
+Defaults to "me" which represents the currently authenticated user.
+Use this to view workspaces belonging to other users (requires appropriate permissions).
+Special value: "me" - List workspaces owned by the authenticated user.`), mcp.DefaultString(codersdk.Me)),
+			mcp.WithNumber(`offset`, mcp.Description(`Pagination offset - the starting index for listing workspaces.
+Used with the 'limit' parameter to implement pagination.
+For example, to get the second page of results with 10 items per page, use offset=10.
+Defaults to 0 (first page).`), mcp.DefaultNumber(0)),
+			mcp.WithNumber(`limit`, mcp.Description(`Maximum number of workspaces to return in a single request.
+Used with the 'offset' parameter to implement pagination.
+Higher values return more results but may increase response time.
+Valid range: 1-100. Defaults to 10.`), mcp.DefaultNumber(10)),
+		),
+		MakeHandler: handleCoderListWorkspaces,
+	},
+	{
+		Tool: mcp.NewTool("coder_get_workspace",
+			mcp.WithDescription(`Get detailed information about a specific Coder workspace.
+Returns comprehensive JSON with the workspace's configuration, status, and resources.
+Use this to check workspace status before performing operations like exec or start/stop.
+The response includes the latest build status, agent connectivity, and resource details.
+
+Common errors:
+- Workspace not found: Check the workspace name or ID
+- Permission denied: The user may not have access to this workspace`),
+			mcp.WithString("workspace", mcp.Description(`The workspace ID (UUID) or name to retrieve.
+Can be specified as either:
+- Full UUID: e.g., "8a0b9c7d-1e2f-3a4b-5c6d-7e8f9a0b1c2d"
+- Workspace name: e.g., "dev", "python-project"
+Use coder_list_workspaces first if you're not sure about available workspace names.`), mcp.Required()),
+		),
+		MakeHandler: handleCoderGetWorkspace,
+	},
+	{
 		Tool: mcp.NewTool("coder_workspace_exec",
 			mcp.WithDescription(`Execute a shell command in a remote Coder workspace.
 Runs the specified command and returns the complete output (stdout/stderr).
@@ -76,7 +151,7 @@ Common errors:
 - Agent not connected: The workspace may still be starting up`),
 			mcp.WithString("workspace", mcp.Description(`The workspace ID (UUID) or name where the command will execute.
 Can be specified as either:
-- Full UUID: e.g., "8a0b9c7d-1e2f-3a4b-5c6d-7e8f9a0b1c2d"
+- Full UUID: e.g., "8a0b9c7d-1e2f-3a4b-5c6d-7e8f9a0b1c2d" 
 - Workspace name: e.g., "dev", "python-project"
 The workspace must be running with a connected agent.
 Use coder_get_workspace first to check the workspace status.`), mcp.Required()),
@@ -239,6 +314,106 @@ func handleCoderReportTask(deps ToolDeps) server.ToolHandlerFunc {
 	}
 }
 
+// Example payload:
+// {"jsonrpc":"2.0","id":1,"method":"tools/call", "params": {"name": "coder_whoami", "arguments": {}}}
+func handleCoderWhoami(deps ToolDeps) server.ToolHandlerFunc {
+	return func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+		me, err := deps.Client.User(ctx, codersdk.Me)
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to fetch the current user: %s", err.Error())
+		}
+
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(me); err != nil {
+			return nil, xerrors.Errorf("Failed to encode the current user: %s", err.Error())
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.NewTextContent(strings.TrimSpace(buf.String())),
+			},
+		}, nil
+	}
+}
+
+type handleCoderListWorkspacesArgs struct {
+	Owner  string `json:"owner"`
+	Offset int    `json:"offset"`
+	Limit  int    `json:"limit"`
+}
+
+// Example payload:
+// {"jsonrpc":"2.0","id":1,"method":"tools/call", "params": {"name": "coder_list_workspaces", "arguments": {"owner": "me", "offset": 0, "limit": 10}}}
+func handleCoderListWorkspaces(deps ToolDeps) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+		args, err := unmarshalArgs[handleCoderListWorkspacesArgs](request.Params.Arguments)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to unmarshal arguments: %w", err)
+		}
+
+		workspaces, err := deps.Client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Owner:  args.Owner,
+			Offset: args.Offset,
+			Limit:  args.Limit,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch workspaces: %w", err)
+		}
+
+		// Encode it as JSON. TODO: It might be nicer for the agent to have a tabulated response.
+		data, err := json.Marshal(workspaces)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode workspaces: %s", err.Error())
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.NewTextContent(string(data)),
+			},
+		}, nil
+	}
+}
+
+type handleCoderGetWorkspaceArgs struct {
+	Workspace string `json:"workspace"`
+}
+
+// Example payload:
+// {"jsonrpc":"2.0","id":1,"method":"tools/call", "params": {"name": "coder_get_workspace", "arguments": {"workspace": "dev"}}}
+func handleCoderGetWorkspace(deps ToolDeps) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+		args, err := unmarshalArgs[handleCoderGetWorkspaceArgs](request.Params.Arguments)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to unmarshal arguments: %w", err)
+		}
+
+		workspace, err := getWorkspaceByIDOrOwnerName(ctx, deps.Client, args.Workspace)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch workspace: %w", err)
+		}
+
+		workspaceJSON, err := json.Marshal(workspace)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode workspace: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.NewTextContent(string(workspaceJSON)),
+			},
+		}, nil
+	}
+}
+
 type handleCoderWorkspaceExecArgs struct {
 	Workspace string `json:"workspace"`
 	Command   string `json:"command"`
@@ -319,6 +494,31 @@ func handleCoderWorkspaceExec(deps ToolDeps) server.ToolHandlerFunc {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				mcp.NewTextContent(string(respJSON)),
+			},
+		}, nil
+	}
+}
+
+// Example payload:
+// {"jsonrpc":"2.0","id":1,"method":"tools/call", "params": {"name": "coder_list_templates", "arguments": {}}}
+func handleCoderListTemplates(deps ToolDeps) server.ToolHandlerFunc {
+	return func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+		templates, err := deps.Client.Templates(ctx, codersdk.TemplateFilter{})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch templates: %w", err)
+		}
+
+		templateJSON, err := json.Marshal(templates)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode templates: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.NewTextContent(string(templateJSON)),
 			},
 		}, nil
 	}

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -1,4 +1,4 @@
-package codermcp_test
+package mcp_test
 
 import (
 	"context"

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -49,11 +49,21 @@ func TestCoderTools(t *testing.T) {
 		}
 		return agents
 	}).Do()
-	agt := agenttest.New(t, client.URL, r.AgentToken)
-	t.Cleanup(func() {
-		_ = agt.Close()
-	})
-	_ = coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).Wait()
+
+	// Note: we want to test the list_workspaces tool before starting the
+	// workspace agent. Starting the workspace agent will modify the workspace
+	// state, which will affect the results of the list_workspaces tool.
+	listWorkspacesDone := make(chan struct{})
+	agentStarted := make(chan struct{})
+	go func() {
+		defer close(agentStarted)
+		<-listWorkspacesDone
+		agt := agenttest.New(t, client.URL, r.AgentToken)
+		t.Cleanup(func() {
+			_ = agt.Close()
+		})
+		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).Wait()
+	}()
 
 	// Given: a MCP server listening on a pty.
 	pty := ptytest.New(t)
@@ -70,6 +80,21 @@ func TestCoderTools(t *testing.T) {
 		Logger:        &logger,
 		AppStatusSlug: "some-agent-app",
 		AgentClient:   agentClient,
+	})
+
+	t.Run("coder_list_templates", func(t *testing.T) {
+		// When: the coder_list_templates tool is called
+		ctr := makeJSONRPCRequest(t, "tools/call", "coder_list_templates", map[string]any{})
+
+		pty.WriteLine(ctr)
+		_ = pty.ReadLine(ctx) // skip the echo
+
+		// Then: the response is a list of expected visible to the user.
+		expected, err := memberClient.Templates(ctx, codersdk.TemplateFilter{})
+		require.NoError(t, err)
+		actual := unmarshalFromCallToolResult[[]codersdk.Template](t, pty.ReadLine(ctx))
+		require.Len(t, actual, 1)
+		require.Equal(t, expected[0].ID, actual[0].ID)
 	})
 
 	t.Run("coder_report_task", func(t *testing.T) {
@@ -113,8 +138,62 @@ func TestCoderTools(t *testing.T) {
 		require.True(t, st.NeedsUserAttention, "workspace app status should need user attention")
 	})
 
+	t.Run("coder_whoami", func(t *testing.T) {
+		// When: the coder_whoami tool is called
+		ctr := makeJSONRPCRequest(t, "tools/call", "coder_whoami", map[string]any{})
+
+		pty.WriteLine(ctr)
+		_ = pty.ReadLine(ctx) // skip the echo
+
+		// Then: the response is a valid JSON respresentation of the calling user.
+		expected, err := memberClient.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		actual := unmarshalFromCallToolResult[codersdk.User](t, pty.ReadLine(ctx))
+		require.Equal(t, expected.ID, actual.ID)
+	})
+
+	t.Run("coder_list_workspaces", func(t *testing.T) {
+		defer close(listWorkspacesDone)
+		// When: the coder_list_workspaces tool is called
+		ctr := makeJSONRPCRequest(t, "tools/call", "coder_list_workspaces", map[string]any{
+			"coder_url":           client.URL.String(),
+			"coder_session_token": client.SessionToken(),
+		})
+
+		pty.WriteLine(ctr)
+		_ = pty.ReadLine(ctx) // skip the echo
+
+		// Then: the response is a valid JSON respresentation of the calling user's workspaces.
+		actual := unmarshalFromCallToolResult[codersdk.WorkspacesResponse](t, pty.ReadLine(ctx))
+		require.Len(t, actual.Workspaces, 1, "expected 1 workspace")
+		require.Equal(t, r.Workspace.ID, actual.Workspaces[0].ID, "expected the workspace to be the one we created in setup")
+	})
+
+	t.Run("coder_get_workspace", func(t *testing.T) {
+		// Given: the workspace agent is connected.
+		// The act of starting the agent will modify the workspace state.
+		<-agentStarted
+		// When: the coder_get_workspace tool is called
+		ctr := makeJSONRPCRequest(t, "tools/call", "coder_get_workspace", map[string]any{
+			"workspace": r.Workspace.ID.String(),
+		})
+
+		pty.WriteLine(ctr)
+		_ = pty.ReadLine(ctx) // skip the echo
+
+		expected, err := memberClient.Workspace(ctx, r.Workspace.ID)
+		require.NoError(t, err)
+
+		// Then: the response is a valid JSON respresentation of the workspace.
+		actual := unmarshalFromCallToolResult[codersdk.Workspace](t, pty.ReadLine(ctx))
+		require.Equal(t, expected.ID, actual.ID)
+	})
+
 	// NOTE: this test runs after the list_workspaces tool is called.
 	t.Run("coder_workspace_exec", func(t *testing.T) {
+		// Given: the workspace agent is connected
+		<-agentStarted
+
 		// When: the coder_workspace_exec tools is called with a command
 		randString := testutil.GetRandomName(t)
 		ctr := makeJSONRPCRequest(t, "tools/call", "coder_workspace_exec", map[string]any{
@@ -134,6 +213,9 @@ func TestCoderTools(t *testing.T) {
 
 	// NOTE: this test runs after the list_workspaces tool is called.
 	t.Run("tool_restrictions", func(t *testing.T) {
+		// Given: the workspace agent is connected
+		<-agentStarted
+
 		// Given: a restricted MCP server with only allowed tools and commands
 		restrictedPty := ptytest.New(t)
 		allowedTools := []string{"coder_workspace_exec"}
@@ -255,6 +337,25 @@ func makeJSONRPCTextResponse(t *testing.T, text string) string {
 	bs, err := json.Marshal(resp)
 	require.NoError(t, err, "failed to marshal JSON RPC response")
 	return string(bs)
+}
+
+func unmarshalFromCallToolResult[T any](t *testing.T, raw string) T {
+	t.Helper()
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp), "failed to unmarshal JSON RPC response")
+	res, ok := resp["result"].(map[string]any)
+	require.True(t, ok, "expected a result field in the response")
+	ct, ok := res["content"].([]any)
+	require.True(t, ok, "expected a content field in the result")
+	require.Len(t, ct, 1, "expected a single content item in the result")
+	ct0, ok := ct[0].(map[string]any)
+	require.True(t, ok, "expected a content item in the result")
+	txt, ok := ct0["text"].(string)
+	require.True(t, ok, "expected a text field in the content item")
+	var actual T
+	require.NoError(t, json.Unmarshal([]byte(txt), &actual), "failed to unmarshal content")
+	return actual
 }
 
 // startTestMCPServer is a helper function that starts a MCP server listening on

--- a/mcp/resource.go
+++ b/mcp/resource.go
@@ -1,0 +1,245 @@
+package codermcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// ResourceHandler associates a resource with its handler creation function
+type ResourceHandler struct {
+	ResourceTemplate mcp.ResourceTemplate
+	MakeHandler      func(ToolDeps) server.ResourceTemplateHandlerFunc
+}
+
+// allResources is the list of all available resources.
+var allResources = []ResourceHandler{
+	{
+		ResourceTemplate: mcp.NewResourceTemplate(
+			`coder://user/{id}`,
+			"Coder User By ID",
+			mcp.WithTemplateDescription("Information about a given Coder user. The string {id} is replaced with the user ID. Alternatively, you can use the pre-defined alias 'me' to get information about the current user."),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		MakeHandler: handleCoderUser,
+	},
+	{
+		ResourceTemplate: mcp.NewResourceTemplate(
+			`coder://templates`,
+			"Coder Templates",
+			mcp.WithTemplateDescription("List of all Coder templates available to the current user"),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		MakeHandler: handleCoderTemplates,
+	},
+	{
+		ResourceTemplate: mcp.NewResourceTemplate(
+			`coder://workspaces{?limit,offset,owner}`,
+			"Coder Workspaces",
+			mcp.WithTemplateDescription("List of Coder workspaces with optional filtering parameters owner, limit, and offset. The owner parameter can be 'me' or a username. The limit and offset parameters are used for pagination. The default values are limit=10, offset=0, and owner=me. Note that only a subset of fields is returned. To get detailed information about a specific workspace, use the Coder Workspace by ID resource."),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		MakeHandler: handleCoderWorkspaces,
+	},
+	{
+		ResourceTemplate: mcp.NewResourceTemplate(
+			`coder://workspace/{id}`,
+			"Coder Workspace by ID",
+			mcp.WithTemplateDescription("Detailed information about a specific Coder workspace by ID. The {id} parameter is replaced with the workspace UUID."),
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		MakeHandler: handleCoderWorkspaceByID,
+	},
+}
+
+// RegisterResources registers all resources with the given server.
+func RegisterResources(srv *server.MCPServer, deps ToolDeps) {
+	for _, entry := range allResources {
+		srv.AddResourceTemplate(entry.ResourceTemplate, entry.MakeHandler(deps))
+	}
+}
+
+type handleCoderUserParams struct {
+	IDs []string `json:"id"`
+}
+
+// handleCoderUser handles requests for the user resource.
+func handleCoderUser(deps ToolDeps) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+
+		args, err := unmarshalArgs[handleCoderUserParams](request.Params.Arguments)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to unmarshal arguments: %w", err)
+		}
+
+		if len(args.IDs) < 1 {
+			return nil, xerrors.Errorf("missing required {id} argument")
+		}
+		fetchedUser, err := deps.Client.User(ctx, args.IDs[0])
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch the current user: %w", err)
+		}
+
+		data, err := json.Marshal(fetchedUser)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode the current user: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			&mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(data),
+			},
+		}, nil
+	}
+}
+
+// handleCoderTemplates handles requests for the templates resource.
+func handleCoderTemplates(deps ToolDeps) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+
+		templates, err := deps.Client.Templates(ctx, codersdk.TemplateFilter{})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch templates: %w", err)
+		}
+
+		data, err := json.Marshal(templates)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode templates: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			&mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(data),
+			},
+		}, nil
+	}
+}
+
+// handleCoderWorkspaces handles requests for the workspaces resource.
+func handleCoderWorkspaces(deps ToolDeps) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+
+		// Unfortunately there appears to be an issue with the uritemplate library
+		// when parsing multiple query parameters (e.g. {?foo,bar})
+		// See here: https://github.com/yosida95/uritemplate/issues/12
+		// Parsing the arguments manually for now.
+		u, err := url.Parse(request.Params.URI)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse request URI: %w", err)
+		}
+		queryParams := u.Query()
+		wf := codersdk.WorkspaceFilter{ // Set some sensible defaults
+			Owner:  codersdk.Me,
+			Offset: 0,
+			Limit:  10,
+		}
+		if limitArg, ok := queryParams["limit"]; ok && len(limitArg) > 0 {
+			limit, err := strconv.Atoi(limitArg[0])
+			if err != nil {
+				return nil, xerrors.Errorf("failed to parse limit: %w", err)
+			}
+			wf.Limit = limit
+		}
+		if offsetArg, ok := queryParams["offset"]; ok && len(offsetArg) > 0 {
+			offset, err := strconv.Atoi(offsetArg[0])
+			if err != nil {
+				return nil, xerrors.Errorf("failed to parse offset: %w", err)
+			}
+			wf.Offset = offset
+		}
+		if ownerArg, err := queryParams["owner"]; err && len(ownerArg) > 0 {
+			wf.Owner = ownerArg[0]
+		}
+
+		workspaces, err := deps.Client.Workspaces(ctx, wf)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch workspaces: %w", err)
+		}
+
+		// To reduce the amount of data returned, we only return a subset of the
+		// fields of the workspace response.
+		reduced := make([]codersdk.ReducedWorkspace, 0, len(workspaces.Workspaces))
+		for _, ws := range workspaces.Workspaces {
+			reduced = append(reduced, ws.Reduced())
+		}
+
+		data, err := json.Marshal(reduced)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode workspaces: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			&mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(data),
+			},
+		}, nil
+	}
+}
+
+type handleCoderWorkspaceByIDParams struct {
+	IDs []string `json:"id"`
+}
+
+// handleCoderWorkspaceByID handles requests for the workspace by ID resource.
+func handleCoderWorkspaceByID(deps ToolDeps) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		if deps.Client == nil {
+			return nil, xerrors.New("developer error: client is required")
+		}
+
+		args, err := unmarshalArgs[handleCoderWorkspaceByIDParams](request.Params.Arguments)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to unmarshal arguments: %w", err)
+		}
+
+		var wsID uuid.UUID
+		if len(args.IDs) > 0 {
+			wsID, err = uuid.Parse(args.IDs[0])
+			if err != nil {
+				return nil, xerrors.Errorf("failed to parse workspace ID: %w", err)
+			}
+		}
+
+		// Fetch the workspace
+		workspace, err := deps.Client.Workspace(ctx, wsID)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to fetch workspace by ID: %w", err)
+		}
+
+		data, err := json.Marshal(workspace)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to encode workspace: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			&mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(data),
+			},
+		}, nil
+	}
+}

--- a/mcp/resource.go
+++ b/mcp/resource.go
@@ -1,4 +1,4 @@
-package codermcp
+package mcp
 
 import (
 	"context"

--- a/mcp/resource_test.go
+++ b/mcp/resource_test.go
@@ -117,9 +117,27 @@ func TestCoderResources(t *testing.T) {
 	})
 
 	t.Run("resources_read_user", func(t *testing.T) {
-		t.Run("OK", func(t *testing.T) {
+		t.Run("me", func(t *testing.T) {
 			// When: the resources/read endpoint is called for user
 			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://user/me")
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response contains the user data
+			response := pty.ReadLine(ctx)
+			actual := unmarshalFromResourceReadResult[codersdk.User](t, response)
+
+			// Check user data
+			expected, err := memberClient.User(ctx, codersdk.Me)
+			require.NoError(t, err)
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("user mismatch (-want +got):\n%s", diff)
+			}
+		})
+
+		t.Run("id", func(t *testing.T) {
+			// When: the resources/read endpoint is called for user
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://user/"+member.ID.String())
 			pty.WriteLine(rReadReq)
 			_ = pty.ReadLine(ctx) // skip the echo
 

--- a/mcp/resource_test.go
+++ b/mcp/resource_test.go
@@ -1,0 +1,302 @@
+package codermcp_test
+
+import (
+	"encoding/json"
+	"runtime"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	codermcp "github.com/coder/coder/v2/mcp"
+	"github.com/coder/coder/v2/provisionersdk/proto"
+	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// These tests are dependent on the state of the coder server.
+// Running them in parallel is prone to racy behavior.
+// nolint:tparallel,paralleltest
+func TestCoderResources(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping on non-linux due to pty issues")
+	}
+	ctx := testutil.Context(t, testutil.WaitLong)
+	// Given: a coder server, workspace, and agent.
+	client, store := coderdtest.NewWithDatabase(t, nil)
+	owner := coderdtest.CreateFirstUser(t, client)
+	// Given: a member user with which to test the resources.
+	memberClient, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	// Given: a workspace with an agent.
+	r := dbfake.WorkspaceBuild(t, store, database.WorkspaceTable{
+		OrganizationID: owner.OrganizationID,
+		OwnerID:        member.ID,
+	}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
+		agents[0].Apps = []*proto.App{
+			{
+				Slug: "some-agent-app",
+			},
+		}
+		return agents
+	}).Do()
+
+	agt := agenttest.New(t, client.URL, r.AgentToken)
+	t.Cleanup(func() {
+		_ = agt.Close()
+	})
+	_ = coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).Wait()
+
+	// Given: a MCP server listening on a pty.
+	pty := ptytest.New(t)
+	mcpSrv, closeSrv := startTestMCPServer(ctx, t, pty.Input(), pty.Output())
+	t.Cleanup(func() {
+		_ = closeSrv()
+	})
+
+	logger := slogtest.Make(t, nil)
+	agentClient := agentsdk.New(memberClient.URL)
+	codermcp.RegisterResources(mcpSrv, codermcp.ToolDeps{
+		Client:        memberClient,
+		Logger:        &logger,
+		AppStatusSlug: "some-agent-app",
+		AgentClient:   agentClient,
+	})
+
+	t.Run("resources_list", func(t *testing.T) {
+		// When: the resources/templates/list endpoint is called
+		rListReq := makeResourceJSONRPCRequest(t, "resources/templates/list", "")
+		pty.WriteLine(rListReq)
+		_ = pty.ReadLine(ctx) // skip the echo
+
+		// Then: the response is a valid ResourcesListResponse
+		resp := struct {
+			Result struct {
+				ResourceTemplates []struct {
+					URITemplate string `json:"uriTemplate"`
+					Name        string `json:"name"`
+					Description string `json:"description,omitempty"`
+					MIMEType    string `json:"mimeType,omitempty"`
+				} `json:"resourceTemplates"`
+			} `json:"result"`
+		}{}
+		response := pty.ReadLine(ctx)
+		err := json.Unmarshal([]byte(response), &resp)
+		require.NoError(t, err)
+
+		// Then: the response contains our expected resources
+		var hasUserResource, hasTemplatesResource, hasWorkspacesResource, hasWorkspaceResource bool
+		for _, resource := range resp.Result.ResourceTemplates {
+			switch resource.URITemplate {
+			case "coder://user/{id}":
+				hasUserResource = true
+			case "coder://templates":
+				hasTemplatesResource = true
+			case "coder://workspaces{?limit,offset,owner}":
+				hasWorkspacesResource = true
+			case "coder://workspace/{id}":
+				hasWorkspaceResource = true
+			default:
+				assert.Failf(t, "unexpected resource %q", resource.URITemplate)
+			}
+		}
+
+		require.True(t, hasUserResource, "expected coder://user resource")
+		require.True(t, hasTemplatesResource, "expected coder://templates resource")
+		require.True(t, hasWorkspacesResource, "expected coder://workspaces resource")
+		require.True(t, hasWorkspaceResource, "expected coder://workspace/{id} resource")
+	})
+
+	t.Run("resources_read_user", func(t *testing.T) {
+		t.Run("OK", func(t *testing.T) {
+			// When: the resources/read endpoint is called for user
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://user/me")
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response contains the user data
+			response := pty.ReadLine(ctx)
+			actual := unmarshalFromResourceReadResult[codersdk.User](t, response)
+
+			// Check user data
+			expected, err := memberClient.User(ctx, codersdk.Me)
+			require.NoError(t, err)
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("user mismatch (-want +got):\n%s", diff)
+			}
+		})
+
+		t.Run("NotFound", func(t *testing.T) {
+			// When: the resources/read endpoint is called for a user for which we do
+			// not have permission (a.k.a. not found)
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://user/"+owner.UserID.String())
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response is an error
+			response := pty.ReadLine(ctx)
+			err := unmarshalErrorResponse(response)
+			require.ErrorContains(t, err, "must be an existing uuid or username")
+		})
+	})
+
+	t.Run("resources_read_templates", func(t *testing.T) {
+		// When: the resources/read endpoint is called for templates
+		rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://templates")
+		pty.WriteLine(rReadReq)
+		_ = pty.ReadLine(ctx) // skip the echo
+
+		// Then: the response contains the templates data
+		response := pty.ReadLine(ctx)
+		templatesData := unmarshalFromResourceReadResult[[]codersdk.Template](t, response)
+
+		// Check templates data
+		expected, err := memberClient.Templates(ctx, codersdk.TemplateFilter{})
+		require.NoError(t, err)
+		require.Len(t, templatesData, 1)
+		require.Equal(t, expected[0].ID, templatesData[0].ID)
+		require.Equal(t, expected[0].Name, templatesData[0].Name)
+	})
+
+	t.Run("resources_read_workspaces", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			// When: the resources/read endpoint is called for workspaces with no query parameters
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://workspaces")
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response contains the workspaces data
+			response := pty.ReadLine(ctx)
+			workspacesData := unmarshalFromResourceReadResult[[]codersdk.ReducedWorkspace](t, response)
+
+			// Check workspaces data
+			require.Len(t, workspacesData, 1)
+			require.Equal(t, r.Workspace.ID, workspacesData[0].ID)
+		})
+		t.Run("filter", func(t *testing.T) {
+			// When: the resources/read endpoint is called for workspaces with query parameters
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://workspaces?offset=1&limit=1&owner=me")
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response should contain no workspaces as we paginated past
+			response := pty.ReadLine(ctx)
+			workspacesData := unmarshalFromResourceReadResult[[]codersdk.ReducedWorkspace](t, response)
+
+			// Check workspaces data
+			require.Len(t, workspacesData, 0)
+		})
+	})
+
+	t.Run("resources_read_workspace", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			// When: the resources/read endpoint is called for a specific workspace
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://workspace/"+r.Workspace.ID.String())
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response contains the workspace data
+			response := pty.ReadLine(ctx)
+			workspaceData := unmarshalFromResourceReadResult[codersdk.Workspace](t, response)
+
+			// Check workspace data
+			expected, err := memberClient.Workspace(ctx, r.Workspace.ID)
+			require.NoError(t, err)
+			require.Equal(t, expected.ID, workspaceData.ID)
+			require.Equal(t, expected.Name, workspaceData.Name)
+		})
+
+		t.Run("notfound", func(t *testing.T) {
+			// When: the resources/read endpoint is called for a non-existent workspace
+			rReadReq := makeResourceJSONRPCRequest(t, "resources/read", "coder://workspace/"+uuid.New().String())
+			pty.WriteLine(rReadReq)
+			_ = pty.ReadLine(ctx) // skip the echo
+
+			// Then: the response contains an error
+			response := pty.ReadLine(ctx)
+			require.Contains(t, response, "error")
+			require.Contains(t, response, "not found")
+		})
+	})
+}
+
+// makeResourceJSONRPCRequest is a helper function that makes a JSON RPC request for resources.
+func makeResourceJSONRPCRequest(t *testing.T, method string, uri string) string {
+	t.Helper()
+	req := struct {
+		ID      string `json:"id"`
+		JSONRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+		Params  struct {
+			URI string `json:"uri"`
+		} `json:"params"`
+	}{
+		ID:      "1",
+		JSONRPC: "2.0",
+		Method:  method,
+		Params: struct {
+			URI string `json:"uri"`
+		}{
+			URI: uri,
+		},
+	}
+	bs, err := json.Marshal(req)
+	require.NoError(t, err, "failed to marshal JSON RPC request")
+	return string(bs)
+}
+
+func unmarshalErrorResponse(raw string) error {
+	var errResp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw), &errResp); err != nil {
+		return nil
+	}
+
+	if errResp.Error.Message == "" {
+		return nil
+	}
+
+	return xerrors.New(errResp.Error.Message)
+}
+
+// unmarshalFromResourceReadResult is a helper to unmarshal the resources/read response
+func unmarshalFromResourceReadResult[T any](t *testing.T, raw string) T {
+	t.Helper()
+
+	// First check if there is an error response in the raw string.
+	if err := unmarshalErrorResponse(raw); err != nil {
+		assert.NoError(t, err, "expected no error")
+		t.FailNow()
+	}
+
+	var resp struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Result  struct {
+			Contents []struct {
+				URI      string `json:"uri"`
+				MIMEType string `json:"mimeType"`
+				Text     string `json:"text"`
+			} `json:"contents"`
+		} `json:"result"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp), "failed to unmarshal JSON RPC response")
+	require.NotEmpty(t, resp.Result.Contents, "expected non-empty contents")
+
+	var actual T
+	require.NoError(t, json.Unmarshal([]byte(resp.Result.Contents[0].Text), &actual), "failed to unmarshal text content")
+	return actual
+}

--- a/mcp/resource_test.go
+++ b/mcp/resource_test.go
@@ -1,4 +1,4 @@
-package codermcp_test
+package mcp_test
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Depends on https://github.com/coder/coder/pull/17245

* ~Removes tools `coder_whoami`, `coder_list_templates`, `coder_list_workspaces`, `coder_get_workspace`.~ EDIT: keeping these due to limited support for resource templates
* Adds resource URI handlers for `coder://users`, `coder://templates`, `coder://workspaces`, and `coder://workspace`.