### PR TITLE
chore: remove notifications beta label

### DIFF
--- a/site/src/modules/management/DeploymentSidebarView.tsx
+++ b/site/src/modules/management/DeploymentSidebarView.tsx
@@ -87,7 +87,6 @@ export const DeploymentSidebarView: FC<DeploymentSidebarViewProps> = ({
 					<SidebarNavItem href="/deployment/notifications">
 						<div className="flex flex-row items-center gap-2">
 							<span>Notifications</span>
-							<FeatureStageBadge contentType="beta" size="sm" />
 						</div>
 					</SidebarNavItem>
 				)}

--- a/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -99,7 +99,6 @@ export const NotificationsPage: FC = () => {
 				title="Notifications"
 				description="Control which notifications you receive."
 				layout="fluid"
-				featureStage="beta"
 			>
 				{ready ? (
 					<Stack spacing={4}>


### PR DESCRIPTION
Some notifications `beta` label were remaining after the previous PR - removing it.