### PR TITLE
feat: add CODER_WORKSPACE_HOSTNAME_SUFFIX

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -78,7 +78,7 @@ OPTIONS:
 
 CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
-Clients include the coder cli, vs code extension, and the web UI.
+Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 
       --cli-upgrade-message string, $CODER_CLI_UPGRADE_MESSAGE
           The upgrade message to display to users when a client/server mismatch
@@ -97,6 +97,11 @@ Clients include the coder cli, vs code extension, and the web UI.
       --web-terminal-renderer string, $CODER_WEB_TERMINAL_RENDERER (default: canvas)
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.
+
+      --workspace-hostname-suffix string, $CODER_WORKSPACE_HOSTNAME_SUFFIX (default: coder)
+          Workspace hostnames use this suffix in SSH config and Coder Connect on
+          Coder Desktop. By default it is coder, resulting in names like
+          myworkspace.coder.
 
 CONFIG OPTIONS: 
 Use a YAML configuration file when your server launch become unwieldy.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -490,11 +490,15 @@ disablePathApps: false
 # (default: <unset>, type: bool)
 disableOwnerWorkspaceAccess: false
 # These options change the behavior of how clients interact with the Coder.
-# Clients include the coder cli, vs code extension, and the web UI.
+# Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:
   # The SSH deployment prefix is used in the Host of the ssh config.
   # (default: coder., type: string)
   sshHostnamePrefix: coder.
+  # Workspace hostnames use this suffix in SSH config and Coder Connect on Coder
+  # Desktop. By default it is coder, resulting in names like myworkspace.coder.
+  # (default: coder, type: string)
+  workspaceHostnameSuffix: coder
   # These SSH config options will override the default SSH config options. Provide
   # options in "key=value" or "key value" format separated by commas.Using this
   # incorrectly can break SSH to your deployment, use cautiously.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12019,6 +12019,9 @@ const docTemplate = `{
                 "wildcard_access_url": {
                     "type": "string"
                 },
+                "workspace_hostname_suffix": {
+                    "type": "string"
+                },
                 "write_config": {
                     "type": "boolean"
                 }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10759,6 +10759,9 @@
 				"wildcard_access_url": {
 					"type": "string"
 				},
+				"workspace_hostname_suffix": {
+					"type": "string"
+				},
 				"write_config": {
 					"type": "boolean"
 				}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -393,6 +393,7 @@ type DeploymentValues struct {
 	TermsOfServiceURL               serpent.String                       `json:"terms_of_service_url,omitempty" typescript:",notnull"`
 	Notifications                   NotificationsConfig                  `json:"notifications,omitempty" typescript:",notnull"`
 	AdditionalCSPPolicy             serpent.StringArray                  `json:"additional_csp_policy,omitempty" typescript:",notnull"`
+	WorkspaceHostnameSuffix         serpent.String                       `json:"workspace_hostname_suffix,omitempty" typescript:",notnull"`
 
 	Config      serpent.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig serpent.Bool           `json:"write_config,omitempty" typescript:",notnull"`
@@ -944,7 +945,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		deploymentGroupClient = serpent.Group{
 			Name: "Client",
 			Description: "These options change the behavior of how clients interact with the Coder. " +
-				"Clients include the coder cli, vs code extension, and the web UI.",
+				"Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.",
 			YAML: "client",
 		}
 		deploymentGroupConfig = serpent.Group{
@@ -2548,6 +2549,17 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.SSHConfig.DeploymentName,
 			Hidden:      false,
 			Default:     "coder.",
+		},
+		{
+			Name:        "Workspace Hostname Suffix",
+			Description: "Workspace hostnames use this suffix in SSH config and Coder Connect on Coder Desktop. By default it is coder, resulting in names like myworkspace.coder.",
+			Flag:        "workspace-hostname-suffix",
+			Env:         "CODER_WORKSPACE_HOSTNAME_SUFFIX",
+			YAML:        "workspaceHostnameSuffix",
+			Group:       &deploymentGroupClient,
+			Value:       &c.WorkspaceHostnameSuffix,
+			Hidden:      false,
+			Default:     "coder",
 		},
 		{
 			Name: "SSH Config Options",

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -515,6 +515,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "web_terminal_renderer": "string",
     "wgtunnel_host": "string",
     "wildcard_access_url": "string",
+    "workspace_hostname_suffix": "string",
     "write_config": true
   },
   "options": [

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2204,6 +2204,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "web_terminal_renderer": "string",
     "wgtunnel_host": "string",
     "wildcard_access_url": "string",
+    "workspace_hostname_suffix": "string",
     "write_config": true
   },
   "options": [
@@ -2680,6 +2681,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "web_terminal_renderer": "string",
   "wgtunnel_host": "string",
   "wildcard_access_url": "string",
+  "workspace_hostname_suffix": "string",
   "write_config": true
 }
 ```
@@ -2748,6 +2750,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `web_terminal_renderer`              | string                                                                                               | false    |              |                                                                    |
 | `wgtunnel_host`                      | string                                                                                               | false    |              |                                                                    |
 | `wildcard_access_url`                | string                                                                                               | false    |              |                                                                    |
+| `workspace_hostname_suffix`          | string                                                                                               | false    |              |                                                                    |
 | `write_config`                       | boolean                                                                                              | false    |              |                                                                    |
 
 ## codersdk.DisplayApp

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1133,6 +1133,17 @@ Specify a YAML file to load configuration from.
 
 The SSH deployment prefix is used in the Host of the ssh config.
 
+### --workspace-hostname-suffix
+
+|             |                                               |
+|-------------|-----------------------------------------------|
+| Type        | <code>string</code>                           |
+| Environment | <code>$CODER_WORKSPACE_HOSTNAME_SUFFIX</code> |
+| YAML        | <code>client.workspaceHostnameSuffix</code>   |
+| Default     | <code>coder</code>                            |
+
+Workspace hostnames use this suffix in SSH config and Coder Connect on Coder Desktop. By default it is coder, resulting in names like myworkspace.coder.
+
 ### --ssh-config-options
 
 |             |                                        |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -79,7 +79,7 @@ OPTIONS:
 
 CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
-Clients include the coder cli, vs code extension, and the web UI.
+Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 
       --cli-upgrade-message string, $CODER_CLI_UPGRADE_MESSAGE
           The upgrade message to display to users when a client/server mismatch
@@ -98,6 +98,11 @@ Clients include the coder cli, vs code extension, and the web UI.
       --web-terminal-renderer string, $CODER_WEB_TERMINAL_RENDERER (default: canvas)
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.
+
+      --workspace-hostname-suffix string, $CODER_WORKSPACE_HOSTNAME_SUFFIX (default: coder)
+          Workspace hostnames use this suffix in SSH config and Coder Connect on
+          Coder Desktop. By default it is coder, resulting in names like
+          myworkspace.coder.
 
 CONFIG OPTIONS: 
 Use a YAML configuration file when your server launch become unwieldy.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -684,6 +684,7 @@ export interface DeploymentValues {
 	readonly terms_of_service_url?: string;
 	readonly notifications?: NotificationsConfig;
 	readonly additional_csp_policy?: string;
+	readonly workspace_hostname_suffix?: string;
 	readonly config?: string;
 	readonly write_config?: boolean;
 	readonly address?: string;


### PR DESCRIPTION
Adds deployment option `CODER_WORKSPACE_HOSTNAME_SUFFIX`. This will eventually replace `CODER_SSH_HOSTNAME_PREFIX`, but we will do this slowly and support both for `coder ssh` for some time.

Note that the name is changed to "workspace" hostname, since this suffix will also be used for Coder Connect on Coder Desktop, which is not limited to SSH.