### PR TITLE
feat: support --hostname-suffix flag on coder ssh

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -620,6 +620,15 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				return xerrors.Errorf("parse ssh config options %q: %w", vals.SSHConfig.SSHConfigOptions.String(), err)
 			}
 
+			// The workspace hostname suffix is always interpreted as implicitly beginning with a single dot, so it is
+			// a config error to explicitly include the dot. This ensures that we always interpret the suffix as a
+			// separate DNS label, and not just an ordinary string suffix. E.g. a suffix of 'coder' will match
+			// 'en.coder' but not 'encoder'.
+			if strings.HasPrefix(vals.WorkspaceHostnameSuffix.String(), ".") {
+				return xerrors.Errorf("you must omit any leading . in workspace hostname suffix: %s",
+					vals.WorkspaceHostnameSuffix.String())
+			}
+
 			options := &coderd.Options{
 				AccessURL:                   vals.AccessURL.Value(),
 				AppHostname:                 appHostname,

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -572,7 +572,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 		{
 			Flag:        "hostname-suffix",
 			Env:         "CODER_SSH_HOSTNAME_SUFFIX",
-			Description: "Strip this suffix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command. The suffix should be specified WITHOUT a leading . character.",
+			Description: "Strip this suffix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command. The suffix must be specified without a leading . character.",
 			Value:       serpent.StringOf(&hostnameSuffix),
 		},
 		{

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -65,6 +65,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 	var (
 		stdio               bool
 		hostPrefix          string
+		hostnameSuffix      string
 		forwardAgent        bool
 		forwardGPG          bool
 		identityAgent       string
@@ -202,10 +203,14 @@ func (r *RootCmd) ssh() *serpent.Command {
 				parsedEnv = append(parsedEnv, [2]string{k, v})
 			}
 
-			workspaceInput := strings.TrimPrefix(inv.Args[0], hostPrefix)
-			// convert workspace name format into owner/workspace.agent
-			namedWorkspace := normalizeWorkspaceInput(workspaceInput)
-			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, namedWorkspace)
+			deploymentSSHConfig := codersdk.SSHConfigResponse{
+				HostnamePrefix: hostPrefix,
+				HostnameSuffix: hostnameSuffix,
+			}
+
+			workspace, workspaceAgent, err := findWorkspaceAndAgentByHostname(
+				ctx, inv, client,
+				inv.Args[0], deploymentSSHConfig, disableAutostart)
 			if err != nil {
 				return err
 			}
@@ -565,6 +570,12 @@ func (r *RootCmd) ssh() *serpent.Command {
 			Value:       serpent.StringOf(&hostPrefix),
 		},
 		{
+			Flag:        "hostname-suffix",
+			Env:         "CODER_SSH_HOSTNAME_SUFFIX",
+			Description: "Strip this suffix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command. The suffix should be specified WITHOUT a leading . character.",
+			Value:       serpent.StringOf(&hostnameSuffix),
+		},
+		{
 			Flag:          "forward-agent",
 			FlagShorthand: "A",
 			Env:           "CODER_SSH_FORWARD_AGENT",
@@ -654,6 +665,30 @@ func (r *RootCmd) ssh() *serpent.Command {
 		sshDisableAutostartOption(serpent.BoolOf(&disableAutostart)),
 	}
 	return cmd
+}
+
+// findWorkspaceAndAgentByHostname parses the hostname from the commandline and finds the workspace and agent it
+// corresponds to, taking into account any name prefixes or suffixes configured (e.g. myworkspace.coder, or
+// vscode-coder--myusername--myworkspace).
+func findWorkspaceAndAgentByHostname(
+	ctx context.Context, inv *serpent.Invocation, client *codersdk.Client,
+	hostname string, config codersdk.SSHConfigResponse, disableAutostart bool,
+) (
+	codersdk.Workspace, codersdk.WorkspaceAgent, error,
+) {
+	// for suffixes, we don't explicitly get the . and must add it. This is to ensure that the suffix is always
+	// interpreted as a dotted label in DNS names, not just any string suffix. That is, a suffix of 'coder' will
+	// match a hostname like 'en.coder', but not 'encoder'.
+	qualifiedSuffix := "." + config.HostnameSuffix
+
+	switch {
+	case config.HostnamePrefix != "" && strings.HasPrefix(hostname, config.HostnamePrefix):
+		hostname = strings.TrimPrefix(hostname, config.HostnamePrefix)
+	case config.HostnameSuffix != "" && strings.HasSuffix(hostname, qualifiedSuffix):
+		hostname = strings.TrimSuffix(hostname, qualifiedSuffix)
+	}
+	hostname = normalizeWorkspaceInput(hostname)
+	return getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, hostname)
 }
 
 // watchAndClose ensures closer is called if the context is canceled or

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1690,67 +1690,85 @@ func TestSSH(t *testing.T) {
 		}
 	})
 
-	t.Run("SSHHostPrefix", func(t *testing.T) {
+	t.Run("SSHHost", func(t *testing.T) {
 		t.Parallel()
-		client, workspace, agentToken := setupWorkspaceForAgent(t)
-		_, _ = tGoContext(t, func(ctx context.Context) {
-			// Run this async so the SSH command has to wait for
-			// the build and agent to connect!
-			_ = agenttest.New(t, client.URL, agentToken)
-			<-ctx.Done()
-		})
 
-		clientOutput, clientInput := io.Pipe()
-		serverOutput, serverInput := io.Pipe()
-		defer func() {
-			for _, c := range []io.Closer{clientOutput, clientInput, serverOutput, serverInput} {
-				_ = c.Close()
-			}
-		}()
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		user, err := client.User(ctx, codersdk.Me)
-		require.NoError(t, err)
-
-		inv, root := clitest.New(t, "ssh", "--stdio", "--ssh-host-prefix", "coder.dummy.com--", fmt.Sprintf("coder.dummy.com--%s--%s", user.Username, workspace.Name))
-		clitest.SetupConfig(t, client, root)
-		inv.Stdin = clientOutput
-		inv.Stdout = serverInput
-		inv.Stderr = io.Discard
-
-		cmdDone := tGo(t, func() {
-			err := inv.WithContext(ctx).Run()
-			assert.NoError(t, err)
-		})
-
-		conn, channels, requests, err := ssh.NewClientConn(&stdioConn{
-			Reader: serverOutput,
-			Writer: clientInput,
-		}, "", &ssh.ClientConfig{
-			// #nosec
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		})
-		require.NoError(t, err)
-		defer conn.Close()
-
-		sshClient := ssh.NewClient(conn, channels, requests)
-		session, err := sshClient.NewSession()
-		require.NoError(t, err)
-		defer session.Close()
-
-		command := "sh -c exit"
-		if runtime.GOOS == "windows" {
-			command = "cmd.exe /c exit"
+		testCases := []struct {
+			name, hostnameFormat string
+			flags                []string
+		}{
+			{"Prefix", "coder.dummy.com--%s--%s", []string{"--ssh-host-prefix", "coder.dummy.com--"}},
+			{"Suffix", "%s--%s.coder", []string{"--hostname-suffix", "coder"}},
+			{"Both", "%s--%s.coder", []string{"--hostname-suffix", "coder", "--ssh-host-prefix", "coder.dummy.com--"}},
 		}
-		err = session.Run(command)
-		require.NoError(t, err)
-		err = sshClient.Close()
-		require.NoError(t, err)
-		_ = clientOutput.Close()
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 
-		<-cmdDone
+				client, workspace, agentToken := setupWorkspaceForAgent(t)
+				_, _ = tGoContext(t, func(ctx context.Context) {
+					// Run this async so the SSH command has to wait for
+					// the build and agent to connect!
+					_ = agenttest.New(t, client.URL, agentToken)
+					<-ctx.Done()
+				})
+
+				clientOutput, clientInput := io.Pipe()
+				serverOutput, serverInput := io.Pipe()
+				defer func() {
+					for _, c := range []io.Closer{clientOutput, clientInput, serverOutput, serverInput} {
+						_ = c.Close()
+					}
+				}()
+
+				ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+				defer cancel()
+
+				user, err := client.User(ctx, codersdk.Me)
+				require.NoError(t, err)
+
+				args := []string{"ssh", "--stdio"}
+				args = append(args, tc.flags...)
+				args = append(args, fmt.Sprintf(tc.hostnameFormat, user.Username, workspace.Name))
+				inv, root := clitest.New(t, args...)
+				clitest.SetupConfig(t, client, root)
+				inv.Stdin = clientOutput
+				inv.Stdout = serverInput
+				inv.Stderr = io.Discard
+
+				cmdDone := tGo(t, func() {
+					err := inv.WithContext(ctx).Run()
+					assert.NoError(t, err)
+				})
+
+				conn, channels, requests, err := ssh.NewClientConn(&stdioConn{
+					Reader: serverOutput,
+					Writer: clientInput,
+				}, "", &ssh.ClientConfig{
+					// #nosec
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				})
+				require.NoError(t, err)
+				defer conn.Close()
+
+				sshClient := ssh.NewClient(conn, channels, requests)
+				session, err := sshClient.NewSession()
+				require.NoError(t, err)
+				defer session.Close()
+
+				command := "sh -c exit"
+				if runtime.GOOS == "windows" {
+					command = "cmd.exe /c exit"
+				}
+				err = session.Run(command)
+				require.NoError(t, err)
+				err = sshClient.Close()
+				require.NoError(t, err)
+				_ = clientOutput.Close()
+
+				<-cmdDone
+			})
+		}
 	})
 }
 

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -23,6 +23,11 @@ OPTIONS:
           locally and will not be started for you. If a GPG agent is already
           running in the workspace, it will be attempted to be killed.
 
+      --hostname-suffix string, $CODER_SSH_HOSTNAME_SUFFIX
+          Strip this suffix from the provided hostname to determine the
+          workspace name. This is useful when used as part of an OpenSSH proxy
+          command. The suffix should be specified WITHOUT a leading . character.
+
       --identity-agent string, $CODER_SSH_IDENTITY_AGENT
           Specifies which identity agent to use (overrides $SSH_AUTH_SOCK),
           forward agent must also be enabled.

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -26,7 +26,7 @@ OPTIONS:
       --hostname-suffix string, $CODER_SSH_HOSTNAME_SUFFIX
           Strip this suffix from the provided hostname to determine the
           workspace name. This is useful when used as part of an OpenSSH proxy
-          command. The suffix should be specified WITHOUT a leading . character.
+          command. The suffix must be specified without a leading . character.
 
       --identity-agent string, $CODER_SSH_IDENTITY_AGENT
           Specifies which identity agent to use (overrides $SSH_AUTH_SOCK),

--- a/docs/reference/cli/ssh.md
+++ b/docs/reference/cli/ssh.md
@@ -29,6 +29,15 @@ Specifies whether to emit SSH output over stdin/stdout.
 
 Strip this prefix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command.
 
+### --hostname-suffix
+
+|             |                                         |
+|-------------|-----------------------------------------|
+| Type        | <code>string</code>                     |
+| Environment | <code>$CODER_SSH_HOSTNAME_SUFFIX</code> |
+
+Strip this suffix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command. The suffix should be specified WITHOUT a leading . character.
+
 ### -A, --forward-agent
 
 |             |                                       |

--- a/docs/reference/cli/ssh.md
+++ b/docs/reference/cli/ssh.md
@@ -36,7 +36,7 @@ Strip this prefix from the provided hostname to determine the workspace name. Th
 | Type        | <code>string</code>                     |
 | Environment | <code>$CODER_SSH_HOSTNAME_SUFFIX</code> |
 
-Strip this suffix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command. The suffix should be specified WITHOUT a leading . character.
+Strip this suffix from the provided hostname to determine the workspace name. This is useful when used as part of an OpenSSH proxy command. The suffix must be specified without a leading . character.
 
 ### -A, --forward-agent
 


### PR DESCRIPTION
Adds `hostname-suffix` flag to `coder ssh` command for use in SSH Config ProxyCommands.

Also enforces that Coder server doesn't start the suffix with a dot.

part of: #16828
