### PR TITLE
feat: modify config-ssh to set the host suffix

### DIFF
--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -611,6 +611,18 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 				regexMatch: "RemoteForward 2222 192.168.11.1:2222.*\n.*RemoteForward 2223 192.168.11.1:2223",
 			},
 		},
+		{
+			name: "Hostname Suffix",
+			args: []string{
+				"--yes",
+				"--hostname-suffix", "testy",
+			},
+			wantErr:  false,
+			hasAgent: true,
+			wantConfig: wantConfig{
+				regexMatch: `ProxyCommand .* ssh .* --hostname-suffix testy %h`,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -509,7 +509,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			},
 		},
 		{
-			name:    "Start/End out of order",
+			name: "Start/End out of order",
 			matches: []match{
 				// {match: "Continue?", write: "yes"},
 			},
@@ -524,7 +524,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "Multiple sections",
+			name: "Multiple sections",
 			matches: []match{
 				// {match: "Continue?", write: "yes"},
 			},
@@ -620,7 +620,22 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			wantErr:  false,
 			hasAgent: true,
 			wantConfig: wantConfig{
+				ssh:        []string{"Host coder.* *.testy"},
 				regexMatch: `ProxyCommand .* ssh .* --hostname-suffix testy %h`,
+			},
+		},
+		{
+			name: "Hostname Prefix and Suffix",
+			args: []string{
+				"--yes",
+				"--ssh-host-prefix", "presto.",
+				"--hostname-suffix", "testy",
+			},
+			wantErr:  false,
+			hasAgent: true,
+			wantConfig: wantConfig{
+				ssh:        []string{"Host presto.* *.testy"},
+				regexMatch: `ProxyCommand .* ssh .* --ssh-host-prefix presto\. --hostname-suffix testy %h`,
 			},
 		},
 	}

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -509,7 +509,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			},
 		},
 		{
-			name: "Start/End out of order",
+			name:    "Start/End out of order",
 			matches: []match{
 				// {match: "Continue?", write: "yes"},
 			},
@@ -524,7 +524,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Multiple sections",
+			name:    "Multiple sections",
 			matches: []match{
 				// {match: "Continue?", write: "yes"},
 			},


### PR DESCRIPTION
Wires up `config-ssh` command to use a hostname suffix if configured.

part of: #16828


e.g. `coder config-ssh --hostname-suffix spiketest` gives:

```
# ------------START-CODER-----------
# This section is managed by coder. DO NOT EDIT.
#
# You should not hand-edit this section unless you are removing it, all
# changes will be lost when running "coder config-ssh".
#
# Last config-ssh options:
# :hostname-suffix=spiketest
#
Host coder.* *.spiketest
        ConnectTimeout=0
        StrictHostKeyChecking=no
        UserKnownHostsFile=/dev/null
        LogLevel ERROR
        ProxyCommand /home/coder/repos/coder/build/coder_config_ssh --global-config /home/coder/.config/coderv2 ssh --stdio --ssh-host-prefix coder. --hostname-suffix spiketest %h
# ------------END-CODER------------
```