### PR TITLE
fix(agent): log correct error variable in createTailnet

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1408,7 +1408,7 @@ func (a *agent) createTailnet(
 		if rPTYServeErr != nil &&
 			a.gracefulCtx.Err() == nil &&
 			!strings.Contains(rPTYServeErr.Error(), "use of closed network connection") {
-			a.logger.Error(ctx, "error serving reconnecting PTY", slog.Error(err))
+			a.logger.Error(ctx, "error serving reconnecting PTY", slog.Error(rPTYServeErr))
 		}
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
After noticing #17265, I asked Claude Code if it could find similar bugs. It identified this one, which appears to be a valid bug.