### PR TITLE
chore: fix swagger type of AuditLog AdditionalFields

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10734,10 +10734,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.AuditAction"
                 },
                 "additional_fields": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object"
                 },
                 "description": {
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9543,10 +9543,7 @@
 					"$ref": "#/definitions/codersdk.AuditAction"
 				},
 				"additional_fields": {
-					"type": "array",
-					"items": {
-						"type": "integer"
-					}
+					"type": "object"
 				},
 				"description": {
 					"type": "string"

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -171,7 +171,7 @@ type AuditLog struct {
 	Action           AuditAction     `json:"action"`
 	Diff             AuditDiff       `json:"diff"`
 	StatusCode       int32           `json:"status_code"`
-	AdditionalFields json.RawMessage `json:"additional_fields"`
+	AdditionalFields json.RawMessage `json:"additional_fields" swaggertype:"object"`
 	Description      string          `json:"description"`
 	ResourceLink     string          `json:"resource_link"`
 	IsDeleted        bool            `json:"is_deleted"`

--- a/docs/reference/api/audit.md
+++ b/docs/reference/api/audit.md
@@ -30,9 +30,7 @@ curl -X GET http://coder-server:8080/api/v2/audit?limit=0 \
   "audit_logs": [
     {
       "action": "create",
-      "additional_fields": [
-        0
-      ],
+      "additional_fields": {},
       "description": "string",
       "diff": {
         "property1": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -629,9 +629,7 @@
 ```json
 {
   "action": "create",
-  "additional_fields": [
-    0
-  ],
+  "additional_fields": {},
   "description": "string",
   "diff": {
     "property1": {
@@ -695,7 +693,7 @@
 | Name                | Type                                                         | Required | Restrictions | Description                                  |
 |---------------------|--------------------------------------------------------------|----------|--------------|----------------------------------------------|
 | `action`            | [codersdk.AuditAction](#codersdkauditaction)                 | false    |              |                                              |
-| `additional_fields` | array of integer                                             | false    |              |                                              |
+| `additional_fields` | object                                                       | false    |              |                                              |
 | `description`       | string                                                       | false    |              |                                              |
 | `diff`              | [codersdk.AuditDiff](#codersdkauditdiff)                     | false    |              |                                              |
 | `id`                | string                                                       | false    |              |                                              |
@@ -721,9 +719,7 @@
   "audit_logs": [
     {
       "action": "create",
-      "additional_fields": [
-        0
-      ],
+      "additional_fields": {},
       "description": "string",
       "diff": {
         "property1": {


### PR DESCRIPTION
swagger currently interprets this field as a `number[]` in terms of typescript, which is actually not at all how it actually gets serialized by go. `object` is much more correct.