### PR TITLE
fix: add continue-on-error to SBOM generation and force flag to cosign clean

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1182,6 +1182,7 @@ jobs:
 
       - name: SBOM Generation and Attestation
         if: github.ref == 'refs/heads/main'
+        continue-on-error: true
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
@@ -1200,7 +1201,7 @@ jobs:
             syft "${IMAGE}" -o spdx-json > "${SBOM_FILE}"
 
             echo "Attesting SBOM to image: ${IMAGE}"
-            cosign clean "${IMAGE}"
+            cosign clean --force=true "${IMAGE}"
             cosign attest --type spdxjson \
               --predicate "${SBOM_FILE}" \
               --yes \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -509,7 +509,7 @@ jobs:
 
           # Attest SBOM to multi-arch image
           echo "Attesting SBOM to multi-arch image: ${{ steps.build_docker.outputs.multiarch_image }}"
-          cosign clean "${{ steps.build_docker.outputs.multiarch_image }}"
+          cosign clean --force=true "${{ steps.build_docker.outputs.multiarch_image }}"
           cosign attest --type spdxjson \
             --predicate coder_${{ steps.version.outputs.version }}_sbom.spdx.json \
             --yes \
@@ -522,7 +522,7 @@ jobs:
             syft "${latest_tag}" -o spdx-json > coder_latest_sbom.spdx.json
 
             echo "Attesting SBOM to latest image: ${latest_tag}"
-            cosign clean "${latest_tag}"
+            cosign clean --force=true "${latest_tag}"
             cosign attest --type spdxjson \
               --predicate coder_latest_sbom.spdx.json \
               --yes \


### PR DESCRIPTION
This PR makes the SBOM generation and attestation process more resilient by:

1. Adding `continue-on-error: true` to the SBOM generation steps in both CI and release workflows
2. Adding `--force=true` flag to all `cosign clean` commands to ensure they don't fail if in a non-interactive shell (which is the case for CI)

Change-Id: Ide303c059b1a3d0e3fd77863310e99668325bc69
Signed-off-by: Thomas Kosiewski <tk@coder.com>