### PR TITLE
chore(cli): increase healthcheck timeout in TestSupportbundle

### DIFF
--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -51,7 +51,7 @@ func TestSupportBundle(t *testing.T) {
 		seedSecretDeploymentOptions(t, &dc, secretValue)
 		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 			DeploymentValues:   dc.Values,
-			HealthcheckTimeout: testutil.WaitLong,
+			HealthcheckTimeout: testutil.WaitSuperLong,
 		})
 		owner := coderdtest.CreateFirstUser(t, client)
 		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
@@ -115,7 +115,7 @@ func TestSupportBundle(t *testing.T) {
 		seedSecretDeploymentOptions(t, &dc, secretValue)
 		client := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:   dc.Values,
-			HealthcheckTimeout: testutil.WaitLong,
+			HealthcheckTimeout: testutil.WaitSuperLong,
 		})
 		_ = coderdtest.CreateFirstUser(t, client)
 
@@ -136,7 +136,7 @@ func TestSupportBundle(t *testing.T) {
 		seedSecretDeploymentOptions(t, &dc, secretValue)
 		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 			DeploymentValues:   dc.Values,
-			HealthcheckTimeout: testutil.WaitLong,
+			HealthcheckTimeout: testutil.WaitSuperLong,
 		})
 		admin := coderdtest.CreateFirstUser(t, client)
 		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{

--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -50,7 +50,8 @@ func TestSupportBundle(t *testing.T) {
 		secretValue := uuid.NewString()
 		seedSecretDeploymentOptions(t, &dc, secretValue)
 		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
-			DeploymentValues: dc.Values,
+			DeploymentValues:   dc.Values,
+			HealthcheckTimeout: testutil.WaitLong,
 		})
 		owner := coderdtest.CreateFirstUser(t, client)
 		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
@@ -113,7 +114,8 @@ func TestSupportBundle(t *testing.T) {
 		secretValue := uuid.NewString()
 		seedSecretDeploymentOptions(t, &dc, secretValue)
 		client := coderdtest.New(t, &coderdtest.Options{
-			DeploymentValues: dc.Values,
+			DeploymentValues:   dc.Values,
+			HealthcheckTimeout: testutil.WaitLong,
 		})
 		_ = coderdtest.CreateFirstUser(t, client)
 
@@ -133,7 +135,8 @@ func TestSupportBundle(t *testing.T) {
 		secretValue := uuid.NewString()
 		seedSecretDeploymentOptions(t, &dc, secretValue)
 		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
-			DeploymentValues: dc.Values,
+			DeploymentValues:   dc.Values,
+			HealthcheckTimeout: testutil.WaitLong,
 		})
 		admin := coderdtest.CreateFirstUser(t, client)
 		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -84,7 +84,9 @@ func (api *API) debugDeploymentHealth(rw http.ResponseWriter, r *http.Request) {
 		defer cancel()
 
 		report := api.HealthcheckFunc(ctx, apiKey)
-		api.healthCheckCache.Store(report)
+		if report != nil { // Only store non-nil reports.
+			api.healthCheckCache.Store(report)
+		}
 		return report, nil
 	})
 

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -92,7 +92,7 @@ func (api *API) debugDeploymentHealth(rw http.ResponseWriter, r *http.Request) {
 
 	select {
 	case <-ctx.Done():
-		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusServiceUnavailable, codersdk.Response{
 			Message: "Healthcheck is in progress and did not complete in time. Try again in a few seconds.",
 		})
 		return

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -117,7 +117,7 @@ func TestDebugHealth(t *testing.T) {
 		require.NoError(t, err)
 		defer res.Body.Close()
 		_, _ = io.ReadAll(res.Body)
-		require.Equal(t, http.StatusNotFound, res.StatusCode)
+		require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 	})
 
 	t.Run("Refresh", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/272

* Increases healthcheck timeout in tests. This seems to be the most usual cause of test failures.
* Adds a non-nilness check before caching a healthcheck report.
* Modifies the HTTP response code to 503 (was 404) when no healthcheck report is available. 503 seems to be a better indicator of the server state in this case, whereas 404 could be misinterpreted as a typo in the healthcheck URL.