### PR TITLE
chore(agent/agentscripts): increase timeout in TestTimeout

### DIFF
--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -108,7 +108,7 @@ func TestTimeout(t *testing.T) {
 	err := runner.Init([]codersdk.WorkspaceAgentScript{{
 		LogSourceID: uuid.New(),
 		Script:      "sleep infinity",
-		Timeout:     time.Millisecond,
+		Timeout:     100 * time.Millisecond,
 	}}, aAPI.ScriptCompleted)
 	require.NoError(t, err)
 	require.ErrorIs(t, runner.Execute(context.Background(), agentscripts.ExecuteAllScripts), agentscripts.ErrTimeout)


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/329

This was due to a race between the process starting and the timeout of the agent startup script executor. I'm taking the 'lazy' route here and increasing the timeout to 100ms. This does technically mean that this makes the test 100 times longer to execute. However, if it takes more than 100ms to run a `sleep infinity` command on our test runner, I think we have other issues.