### PR TITLE
chore: fixup typegen for preview types

### DIFF
--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -141,6 +141,14 @@ type DynamicParametersResponse struct {
 	// TODO: Workspace tags
 }
 
+// FriendlyDiagnostic is included to guarantee it is generated in the output
+// types. This is used as the type override for `previewtypes.Diagnostic`.
+type FriendlyDiagnostic = previewtypes.FriendlyDiagnostic
+
+// NullHCLString is included to guarantee it is generated in the output
+// types. This is used as the type override for `previewtypes.HCLString`.
+type NullHCLString = previewtypes.NullHCLString
+
 func (c *Client) TemplateVersionDynamicParameters(ctx context.Context, version uuid.UUID) (*wsjson.Stream[DynamicParametersResponse, DynamicParametersRequest], error) {
 	conn, err := c.Dial(ctx, fmt.Sprintf("/api/v2/templateversions/%s/dynamic-parameters", version), nil)
 	if err != nil {

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -32,10 +32,9 @@ func main() {
 	// Serpent has some types referenced in the codersdk.
 	// We want the referenced types generated.
 	referencePackages := map[string]string{
-		"github.com/coder/preview":    "",
-		"github.com/coder/serpent":    "Serpent",
-		"github.com/hashicorp/hcl/v2": "Hcl",
-		"tailscale.com/derp":          "",
+		"github.com/coder/preview/types": "Preview",
+		"github.com/coder/serpent":       "Serpent",
+		"tailscale.com/derp":             "",
 		// Conflicting name "DERPRegion"
 		"tailscale.com/tailcfg":      "Tail",
 		"tailscale.com/net/netcheck": "Netcheck",
@@ -90,8 +89,22 @@ func TypeMappings(gen *guts.GoParser) error {
 	gen.IncludeCustomDeclaration(map[string]guts.TypeOverride{
 		"github.com/coder/coder/v2/codersdk.NullTime": config.OverrideNullable(config.OverrideLiteral(bindings.KeywordString)),
 		// opt.Bool can return 'null' if unset
-		"tailscale.com/types/opt.Bool":           config.OverrideNullable(config.OverrideLiteral(bindings.KeywordBoolean)),
-		"github.com/hashicorp/hcl/v2.Expression": config.OverrideLiteral(bindings.KeywordUnknown),
+		"tailscale.com/types/opt.Bool": config.OverrideNullable(config.OverrideLiteral(bindings.KeywordBoolean)),
+		// hcl diagnostics should be cast to `preview.FriendlyDiagnostic`
+		"github.com/hashicorp/hcl/v2.Diagnostic": func() bindings.ExpressionType {
+			return bindings.Reference(bindings.Identifier{
+				Name:    "FriendlyDiagnostic",
+				Package: nil,
+				Prefix:  "",
+			})
+		},
+		"github.com/coder/preview/types.HCLString": func() bindings.ExpressionType {
+			return bindings.Reference(bindings.Identifier{
+				Name:    "NullHCLString",
+				Package: nil,
+				Prefix:  "",
+			})
+		},
 	})
 
 	err := gen.IncludeCustom(map[string]string{

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -715,10 +715,8 @@ export interface DynamicParametersRequest {
 // From codersdk/templateversions.go
 export interface DynamicParametersResponse {
 	readonly id: number;
-	// this is likely an enum in an external package "github.com/coder/preview/types.Diagnostics"
-	readonly diagnostics: readonly (HclDiagnostic | null)[];
-	// external type "github.com/coder/preview/types.Parameter", to include this type the package must be explicitly included in the parsing
-	readonly parameters: readonly unknown[];
+	readonly diagnostics: PreviewDiagnostics;
+	readonly parameters: readonly PreviewParameter[];
 }
 
 // From codersdk/externalauth.go
@@ -914,6 +912,13 @@ export const FeatureSets: FeatureSet[] = ["enterprise", "", "premium"];
 // From codersdk/files.go
 export const FormatZip = "zip";
 
+// From codersdk/templateversions.go
+export interface FriendlyDiagnostic {
+	readonly severity: PreviewDiagnosticSeverityString;
+	readonly summary: string;
+	readonly detail: string;
+}
+
 // From codersdk/apikey.go
 export interface GenerateAPIKeyResponse {
 	readonly key: string;
@@ -995,44 +1000,6 @@ export interface GroupSyncSettings {
 export interface HTTPCookieConfig {
 	readonly secure_auth_cookie?: boolean;
 	readonly same_site?: string;
-}
-
-// From hcl/diagnostic.go
-export interface HclDiagnostic {
-	readonly Severity: HclDiagnosticSeverity;
-	readonly Summary: string;
-	readonly Detail: string;
-	readonly Subject: HclRange | null;
-	readonly Context: HclRange | null;
-	readonly Expression: unknown;
-	readonly EvalContext: HclEvalContext | null;
-	// empty interface{} type, falling back to unknown
-	readonly Extra: unknown;
-}
-
-// From hcl/diagnostic.go
-export type HclDiagnosticSeverity = number;
-
-// From hcl/eval_context.go
-export interface HclEvalContext {
-	// external type "github.com/zclconf/go-cty/cty.Value", to include this type the package must be explicitly included in the parsing
-	readonly Variables: Record<string, unknown>;
-	// external type "github.com/zclconf/go-cty/cty/function.Function", to include this type the package must be explicitly included in the parsing
-	readonly Functions: Record<string, unknown>;
-}
-
-// From hcl/pos.go
-export interface HclPos {
-	readonly Line: number;
-	readonly Column: number;
-	readonly Byte: number;
-}
-
-// From hcl/pos.go
-export interface HclRange {
-	readonly Filename: string;
-	readonly Start: HclPos;
-	readonly End: HclPos;
 }
 
 // From health/model.go
@@ -1439,6 +1406,12 @@ export interface NotificationsWebhookConfig {
 	readonly endpoint: string;
 }
 
+// From codersdk/templateversions.go
+export interface NullHCLString {
+	readonly value: string;
+	readonly valid: boolean;
+}
+
 // From codersdk/oauth2.go
 export interface OAuth2AppEndpoints {
 	readonly authorization: string;
@@ -1738,6 +1711,59 @@ export interface Preset {
 export interface PresetParameter {
 	readonly Name: string;
 	readonly Value: string;
+}
+
+// From types/diagnostics.go
+export type PreviewDiagnosticSeverityString = string;
+
+// From types/diagnostics.go
+export type PreviewDiagnostics = readonly (FriendlyDiagnostic | null)[];
+
+// From types/parameter.go
+export interface PreviewParameter extends PreviewParameterData {
+	readonly value: NullHCLString;
+	readonly diagnostics: PreviewDiagnostics;
+}
+
+// From types/parameter.go
+export interface PreviewParameterData {
+	readonly name: string;
+	readonly display_name: string;
+	readonly description: string;
+	readonly type: PreviewParameterType;
+	// this is likely an enum in an external package "github.com/coder/terraform-provider-coder/v2/provider.ParameterFormType"
+	readonly form_type: string;
+	// empty interface{} type, falling back to unknown
+	readonly styling: unknown;
+	readonly mutable: boolean;
+	readonly default_value: NullHCLString;
+	readonly icon: string;
+	readonly options: readonly (PreviewParameterOption | null)[];
+	readonly validations: readonly (PreviewParameterValidation | null)[];
+	readonly required: boolean;
+	readonly order: number;
+	readonly ephemeral: boolean;
+}
+
+// From types/parameter.go
+export interface PreviewParameterOption {
+	readonly name: string;
+	readonly description: string;
+	readonly value: NullHCLString;
+	readonly icon: string;
+}
+
+// From types/enum.go
+export type PreviewParameterType = string;
+
+// From types/parameter.go
+export interface PreviewParameterValidation {
+	readonly validation_error: string;
+	readonly validation_regex: string | null;
+	readonly validation_min: number | null;
+	readonly validation_max: number | null;
+	readonly validation_monotonic: string | null;
+	readonly validation_invalid: boolean | null;
 }
 
 // From codersdk/deployment.go


### PR DESCRIPTION
Preview types override the json marshal behavior. Guts should get some upstream changes to make this work more natively.

## Guts ideas

These type overrides should be settable by the `preview` package for `guts` to inherit. Rather then this unfortunate behavior.

Guts is also not picking up the enums from the `preview` package entirely. So... that should be fixed at some point.