### PR TITLE
docs: update aws instance recommendations

### DIFF
--- a/docs/admin/infrastructure/validated-architectures/1k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/1k-users.md
@@ -14,7 +14,7 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 | Users       | Node capacity       | Replicas                 | GCP             | AWS        | Azure             |
 |-------------|---------------------|--------------------------|-----------------|------------|-------------------|
-| Up to 1,000 | 2 vCPU, 8 GB memory | 1-2 nodes, 1 coderd each | `n1-standard-2` | `t3.large` | `Standard_D2s_v3` |
+| Up to 1,000 | 2 vCPU, 8 GB memory | 1-2 nodes, 1 coderd each | `n1-standard-2` | `m5.large` | `Standard_D2s_v3` |
 
 **Footnotes**:
 
@@ -25,7 +25,7 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 | Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
 |-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
-| Up to 1,000 | 8 vCPU, 32 GB memory | 2 nodes, 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 1,000 | 8 vCPU, 32 GB memory | 2 nodes, 30 provisioners each | `t2d-standard-8` | `c5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -35,7 +35,7 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 | Users       | Node capacity        | Replicas                     | GCP              | AWS          | Azure             |
 |-------------|----------------------|------------------------------|------------------|--------------|-------------------|
-| Up to 1,000 | 8 vCPU, 32 GB memory | 64 nodes, 16 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 1,000 | 8 vCPU, 32 GB memory | 64 nodes, 16 workspaces each | `t2d-standard-8` | `m5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -48,4 +48,11 @@ tech startups, educational units, or small to mid-sized enterprises.
 
 | Users       | Node capacity       | Replicas | Storage | GCP                | AWS           | Azure             |
 |-------------|---------------------|----------|---------|--------------------|---------------|-------------------|
-| Up to 1,000 | 2 vCPU, 8 GB memory | 1 node   | 512 GB  | `db-custom-2-7680` | `db.t3.large` | `Standard_D2s_v3` |
+| Up to 1,000 | 2 vCPU, 8 GB memory | 1 node   | 512 GB  | `db-custom-2-7680` | `db.m5.large` | `Standard_D2s_v3` |
+
+**Footnotes for AWS instance types**:
+
+- For production deployments, we recommend using non-burstable instance types,
+  such as `m5` or `c5`, instead of burstable instances, such as `t3`.
+  Burstable instances can experience significant performance degradation once
+  CPU credits are exhausted, leading to poor user experience under sustained load.

--- a/docs/admin/infrastructure/validated-architectures/2k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/2k-users.md
@@ -19,13 +19,13 @@ deployment reliability under load.
 
 | Users       | Node capacity        | Replicas               | GCP             | AWS         | Azure             |
 |-------------|----------------------|------------------------|-----------------|-------------|-------------------|
-| Up to 2,000 | 4 vCPU, 16 GB memory | 2 nodes, 1 coderd each | `n1-standard-4` | `t3.xlarge` | `Standard_D4s_v3` |
+| Up to 2,000 | 4 vCPU, 16 GB memory | 2 nodes, 1 coderd each | `n1-standard-4` | `m5.xlarge` | `Standard_D4s_v3` |
 
 ### Provisioner nodes
 
 | Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
 |-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
-| Up to 2,000 | 8 vCPU, 32 GB memory | 4 nodes, 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 2,000 | 8 vCPU, 32 GB memory | 4 nodes, 30 provisioners each | `t2d-standard-8` | `c5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -38,7 +38,7 @@ deployment reliability under load.
 
 | Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
 |-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
-| Up to 2,000 | 8 vCPU, 32 GB memory | 128 nodes, 16 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 2,000 | 8 vCPU, 32 GB memory | 128 nodes, 16 workspaces each | `t2d-standard-8` | `m5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -51,9 +51,16 @@ deployment reliability under load.
 
 | Users       | Node capacity        | Replicas | Storage | GCP                 | AWS            | Azure             |
 |-------------|----------------------|----------|---------|---------------------|----------------|-------------------|
-| Up to 2,000 | 4 vCPU, 16 GB memory | 1 node   | 1 TB    | `db-custom-4-15360` | `db.t3.xlarge` | `Standard_D4s_v3` |
+| Up to 2,000 | 4 vCPU, 16 GB memory | 1 node   | 1 TB    | `db-custom-4-15360` | `db.m5.xlarge` | `Standard_D4s_v3` |
 
 **Footnotes**:
 
 - Consider adding more replicas if the workspace activity is higher than 500
   workspace builds per day or to achieve higher RPS.
+
+**Footnotes for AWS instance types**:
+
+- For production deployments, we recommend using non-burstable instance types,
+  such as `m5` or `c5`, instead of burstable instances, such as `t3`.
+  Burstable instances can experience significant performance degradation once
+  CPU credits are exhausted, leading to poor user experience under sustained load.

--- a/docs/admin/infrastructure/validated-architectures/3k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/3k-users.md
@@ -20,13 +20,13 @@ continuously improve the reliability and performance of the platform.
 
 | Users       | Node capacity        | Replicas              | GCP             | AWS         | Azure             |
 |-------------|----------------------|-----------------------|-----------------|-------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 4 node, 1 coderd each | `n1-standard-4` | `t3.xlarge` | `Standard_D4s_v3` |
+| Up to 3,000 | 8 vCPU, 32 GB memory | 4 node, 1 coderd each | `n1-standard-4` | `m5.xlarge` | `Standard_D4s_v3` |
 
 ### Provisioner nodes
 
 | Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
 |-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 8 nodes, 30 provisioners each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 3,000 | 8 vCPU, 32 GB memory | 8 nodes, 30 provisioners each | `t2d-standard-8` | `c5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -40,7 +40,7 @@ continuously improve the reliability and performance of the platform.
 
 | Users       | Node capacity        | Replicas                      | GCP              | AWS          | Azure             |
 |-------------|----------------------|-------------------------------|------------------|--------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 256 nodes, 12 workspaces each | `t2d-standard-8` | `t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 3,000 | 8 vCPU, 32 GB memory | 256 nodes, 12 workspaces each | `t2d-standard-8` | `m5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
@@ -54,9 +54,16 @@ continuously improve the reliability and performance of the platform.
 
 | Users       | Node capacity        | Replicas | Storage | GCP                 | AWS             | Azure             |
 |-------------|----------------------|----------|---------|---------------------|-----------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 2 nodes  | 1.5 TB  | `db-custom-8-30720` | `db.t3.2xlarge` | `Standard_D8s_v3` |
+| Up to 3,000 | 8 vCPU, 32 GB memory | 2 nodes  | 1.5 TB  | `db-custom-8-30720` | `db.m5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes**:
 
 - Consider adding more replicas if the workspace activity is higher than 1500
   workspace builds per day or to achieve higher RPS.
+
+**Footnotes for AWS instance types**:
+
+- For production deployments, we recommend using non-burstable instance types,
+  such as `m5` or `c5`, instead of burstable instances, such as `t3`.
+  Burstable instances can experience significant performance degradation once
+  CPU credits are exhausted, leading to poor user experience under sustained load.

--- a/docs/admin/infrastructure/validated-architectures/index.md
+++ b/docs/admin/infrastructure/validated-architectures/index.md
@@ -227,12 +227,12 @@ such as `m5` or `c5`, instead of burstable instances, such as `t3`.
 Burstable instances can experience significant performance degradation once
 CPU credits are exhausted, leading to poor user experience under sustained load.
 
-| Component | Recommended Instance Type | Reason |
-|-----------|---------------------------|-----------|
-| coderd nodes | `m5` | Balanced compute and memory for API and UI serving. |
-| Provisioner nodes | `c5` | Compute-optimized performance for faster builds. |
-| Workspace nodes | `m5` | Balanced performance for general development workloads. |
-| Database nodes | `db.m5` | Consistent database performance for reliable operations. |
+| Component         | Recommended Instance Type | Reason                                                   |
+|-------------------|---------------------------|----------------------------------------------------------|
+| coderd nodes      | `m5`                      | Balanced compute and memory for API and UI serving.      |
+| Provisioner nodes | `c5`                      | Compute-optimized performance for faster builds.         |
+| Workspace nodes   | `m5`                      | Balanced performance for general development workloads.  |
+| Database nodes    | `db.m5`                   | Consistent database performance for reliable operations. |
 
 ### Networking
 

--- a/docs/admin/infrastructure/validated-architectures/index.md
+++ b/docs/admin/infrastructure/validated-architectures/index.md
@@ -220,6 +220,20 @@ For sizing recommendations, see the below reference architectures:
 
 - [Up to 3,000 users](3k-users.md)
 
+### AWS Instance Types
+
+For production AWS deployments, we recommend using non-burstable instance types,
+such as `m5` or `c5`, instead of burstable instances, such as `t3`.
+Burstable instances can experience significant performance degradation once
+CPU credits are exhausted, leading to poor user experience under sustained load.
+
+| Component | Recommended Instance Type | Reason |
+|-----------|---------------------------|-----------|
+| coderd nodes | `m5` | Balanced compute and memory for API and UI serving. |
+| Provisioner nodes | `c5` | Compute-optimized performance for faster builds. |
+| Workspace nodes | `m5` | Balanced performance for general development workloads. |
+| Database nodes | `db.m5` | Consistent database performance for reliable operations. |
+
 ### Networking
 
 It is likely your enterprise deploys Kubernetes clusters with various networking


### PR DESCRIPTION
from @jatcod3r on Slack:

> for the AWS recs on our [validated arch](https://coder.com/docs/admin/infrastructure/validated-architectures/1k-users) docs, should we be referencing customers to use non-T type instances?
> Once you've exceeded EC2's [CPU credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html) Coder starts performing poorly.
> We do suggest to [scale for peak demand](https://coder.com/docs/tutorials/best-practices/scale-coder#scaling-3), so does recommending something from the [cpu](https://aws.amazon.com/ec2/instance-types/#Compute_Optimized) or [memory optimized](https://aws.amazon.com/ec2/instance-types/#Memory_Optimized) types make sense?

[preview](https://coder.com/docs/@aws-ec2-arch/admin/infrastructure/validated-architectures#aws-instance-types)