### PR TITLE
chore: fix gpg forwarding test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ result
 
 # Zed
 .zed_server
+
+# dlv debug binaries for go tests
+__debug_bin*

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1977,7 +1977,9 @@ Expire-Date: 0
 	tpty.WriteLine("gpg --list-keys && echo gpg-''-listkeys-command-done")
 	listKeysOutput := tpty.ExpectMatch("gpg--listkeys-command-done")
 	require.Contains(t, listKeysOutput, "[ultimate] Coder Test <test@coder.com>")
-	require.Contains(t, listKeysOutput, "[ultimate] Dean Sheather (work key) <dean@coder.com>")
+	// It's fine that this key is expired. We're just testing that the key trust
+	// gets synced properly.
+	require.Contains(t, listKeysOutput, "[ expired] Dean Sheather (work key) <dean@coder.com>")
 
 	// Try to sign something. This demonstrates that the forwarding is
 	// working as expected, since the workspace doesn't have access to the


### PR DESCRIPTION
Test GPG key was expired, and causing a test to fail.