### PR TITLE
docs: add note about sign in with GitHub button should be hidden when flow is disabled

### DIFF
--- a/docs/admin/users/github-auth.md
+++ b/docs/admin/users/github-auth.md
@@ -41,6 +41,14 @@ own app or set:
 CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE=false
 ```
 
+> [!NOTE]
+> After you disable the default GitHub provider with the setting above, the
+> **Sign in with GitHub** button might still appear on your login page even though
+> the authentication flow is disabled.
+>
+> To completely hide the GitHub sign-in button, you must both disable the default
+> provider and ensure you don't have a custom GitHub OAuth app configured.
+
 ## Step 1: Configure the OAuth application in GitHub
 
 First,


### PR DESCRIPTION
closes #17352 

thanks @atalii! let me know if this feels like it addresses the issue you encountered or if we can improve it further

[preview](https://coder.com/docs/@17352-github-auth-button-docs/admin/users/github-auth)