### PR TITLE
fix: configure start workspace action after version upgrade

### DIFF
--- a/.github/workflows/start-workspace.yaml
+++ b/.github/workflows/start-workspace.yaml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@coder')) || 
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@coder'))
     environment: aidev
     timeout-minutes: 5
     steps:
@@ -19,14 +22,16 @@ jobs:
         uses: coder/start-workspace-action@35a4608cefc7e8cc56573cae7c3b85304575cb72
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          trigger-phrase: "@coder"
+          github-username: >-
+            ${{
+              (github.event_name == 'issue_comment' && github.event.comment.user.login) || 
+              (github.event_name == 'issues' && github.event.issue.user.login)
+            }}
           coder-url: ${{ secrets.CODER_URL }}
           coder-token: ${{ secrets.CODER_TOKEN }}
           template-name: ${{ secrets.CODER_TEMPLATE_NAME }}
-          workspace-name: issue-${{ github.event.issue.number }}
           parameters: |-
             Coder Image: codercom/oss-dogfood:latest
             Coder Repository Base Directory: "~"
             AI Code Prompt: "Use the gh CLI tool to read the details of issue https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }} and then address it."
             Region: us-pittsburgh
-          user-mapping: ${{ secrets.CODER_USER_MAPPING }}


### PR DESCRIPTION
Dependabot recently upgraded `coder/start-workspace-action` to the latest version. Compared to the version we were using previously, the new version expects a different configuration.