### PR TITLE
fix: increase context timeout in `TestProvisionerd/MaliciousTar` to avoid flake

### DIFF
--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -174,7 +174,7 @@ func TestProvisionerd(t *testing.T) {
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{}),
 		})
-		require.Condition(t, closedWithin(completeChan, testutil.WaitShort))
+		require.Condition(t, closedWithin(completeChan, testutil.WaitMedium))
 		require.NoError(t, closer.Close())
 	})
 


### PR DESCRIPTION
Fixing a flake seen here: https://github.com/coder/coder/actions/runs/14465389766/job/40566518088