### PR TITLE
chore: disable authz-header in all builds

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -472,7 +472,7 @@ func New(options *Options) *API {
 		//   header. To opt in on a per-request basis.
 		//   Some authz calls (like filtering lists) might be able to be
 		//   summarized better to condense the header payload.
-		//r.Use(httpmw.RecordAuthzChecks)
+		// r.Use(httpmw.RecordAuthzChecks)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -464,7 +464,7 @@ func New(options *Options) *API {
 	r := chi.NewRouter()
 	// We add this middleware early, to make sure that authorization checks made
 	// by other middleware get recorded.
-	//nolint:revive // This block will be re-enabled, not going to remove it
+	//nolint:revive,staticcheck // This block will be re-enabled, not going to remove it
 	if buildinfo.IsDev() {
 		// TODO: Find another solution to opt into these checks.
 		//   If the header grows too large, it breaks `fetch()` requests.

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -464,6 +464,7 @@ func New(options *Options) *API {
 	r := chi.NewRouter()
 	// We add this middleware early, to make sure that authorization checks made
 	// by other middleware get recorded.
+	//nolint:revive // This block will be re-enabled, not going to remove it
 	if buildinfo.IsDev() {
 		// TODO: Find another solution to opt into these checks.
 		//   If the header grows too large, it breaks `fetch()` requests.

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -465,7 +465,14 @@ func New(options *Options) *API {
 	// We add this middleware early, to make sure that authorization checks made
 	// by other middleware get recorded.
 	if buildinfo.IsDev() {
-		r.Use(httpmw.RecordAuthzChecks)
+		// TODO: Find another solution to opt into these checks.
+		//   If the header grows too large, it breaks `fetch()` requests.
+		//   Temporarily disabling this until we can find a better solution.
+		//	 One idea is to include checking the request for `X-Authz-Record=true`
+		//   header. To opt in on a per-request basis.
+		//   Some authz calls (like filtering lists) might be able to be
+		//   summarized better to condense the header payload.
+		//r.Use(httpmw.RecordAuthzChecks)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Header payload being large is causing some issues in dev builds. Another method of opting in needs to be determined