### PR TITLE
feat(coderd/notifications): notify pubsub on enqueue

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -928,6 +928,37 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			options.StatsBatcher = batcher
 			defer closeBatcher()
 
+			// Manage notifications.
+			var (
+				notificationsCfg     = options.DeploymentValues.Notifications
+				notificationsManager *notifications.Manager
+			)
+
+			metrics := notifications.NewMetrics(options.PrometheusRegistry)
+			helpers := templateHelpers(options)
+
+			// The enqueuer is responsible for enqueueing notifications to the given store.
+			enqueuer, err := notifications.NewStoreEnqueuer(notificationsCfg, options.Database, options.Pubsub, helpers, logger.Named("notifications.enqueuer"), quartz.NewReal())
+			if err != nil {
+				return xerrors.Errorf("failed to instantiate notification store enqueuer: %w", err)
+			}
+			options.NotificationsEnqueuer = enqueuer
+
+			// The notification manager is responsible for:
+			//   - creating notifiers and managing their lifecycles (notifiers are responsible for dequeueing/sending notifications)
+			//   - keeping the store updated with status updates
+			notificationsManager, err = notifications.NewManager(notificationsCfg, options.Database, options.Pubsub, helpers, metrics, logger.Named("notifications.manager"))
+			if err != nil {
+				return xerrors.Errorf("failed to instantiate notification manager: %w", err)
+			}
+
+			// nolint:gocritic // We need to run the manager in a notifier context.
+			notificationsManager.Run(dbauthz.AsNotifier(ctx))
+
+			// Run report generator to distribute periodic reports.
+			notificationReportGenerator := reports.NewReportGenerator(ctx, logger.Named("notifications.report_generator"), options.Database, options.NotificationsEnqueuer, quartz.NewReal())
+			defer notificationReportGenerator.Close()
+
 			// We use a separate coderAPICloser so the Enterprise API
 			// can have its own close functions. This is cleaner
 			// than abstracting the Coder API itself.
@@ -974,37 +1005,6 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			if err != nil && flag.Lookup("test.v") != nil {
 				return xerrors.Errorf("write config url: %w", err)
 			}
-
-			// Manage notifications.
-			var (
-				notificationsCfg     = options.DeploymentValues.Notifications
-				notificationsManager *notifications.Manager
-			)
-
-			metrics := notifications.NewMetrics(options.PrometheusRegistry)
-			helpers := templateHelpers(options)
-
-			// The enqueuer is responsible for enqueueing notifications to the given store.
-			enqueuer, err := notifications.NewStoreEnqueuer(notificationsCfg, options.Database, options.Pubsub, helpers, logger.Named("notifications.enqueuer"), quartz.NewReal())
-			if err != nil {
-				return xerrors.Errorf("failed to instantiate notification store enqueuer: %w", err)
-			}
-			options.NotificationsEnqueuer = enqueuer
-
-			// The notification manager is responsible for:
-			//   - creating notifiers and managing their lifecycles (notifiers are responsible for dequeueing/sending notifications)
-			//   - keeping the store updated with status updates
-			notificationsManager, err = notifications.NewManager(notificationsCfg, options.Database, options.Pubsub, helpers, metrics, logger.Named("notifications.manager"))
-			if err != nil {
-				return xerrors.Errorf("failed to instantiate notification manager: %w", err)
-			}
-
-			// nolint:gocritic // We need to run the manager in a notifier context.
-			notificationsManager.Run(dbauthz.AsNotifier(ctx))
-
-			// Run report generator to distribute periodic reports.
-			notificationReportGenerator := reports.NewReportGenerator(ctx, logger.Named("notifications.report_generator"), options.Database, options.NotificationsEnqueuer, quartz.NewReal())
-			defer notificationReportGenerator.Close()
 
 			// Since errCh only has one buffered slot, all routines
 			// sending on it must be wrapped in a select/default to

--- a/cli/server.go
+++ b/cli/server.go
@@ -928,37 +928,6 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			options.StatsBatcher = batcher
 			defer closeBatcher()
 
-			// Manage notifications.
-			var (
-				notificationsCfg     = options.DeploymentValues.Notifications
-				notificationsManager *notifications.Manager
-			)
-
-			metrics := notifications.NewMetrics(options.PrometheusRegistry)
-			helpers := templateHelpers(options)
-
-			// The enqueuer is responsible for enqueueing notifications to the given store.
-			enqueuer, err := notifications.NewStoreEnqueuer(notificationsCfg, options.Database, helpers, logger.Named("notifications.enqueuer"), quartz.NewReal())
-			if err != nil {
-				return xerrors.Errorf("failed to instantiate notification store enqueuer: %w", err)
-			}
-			options.NotificationsEnqueuer = enqueuer
-
-			// The notification manager is responsible for:
-			//   - creating notifiers and managing their lifecycles (notifiers are responsible for dequeueing/sending notifications)
-			//   - keeping the store updated with status updates
-			notificationsManager, err = notifications.NewManager(notificationsCfg, options.Database, options.Pubsub, helpers, metrics, logger.Named("notifications.manager"))
-			if err != nil {
-				return xerrors.Errorf("failed to instantiate notification manager: %w", err)
-			}
-
-			// nolint:gocritic // We need to run the manager in a notifier context.
-			notificationsManager.Run(dbauthz.AsNotifier(ctx))
-
-			// Run report generator to distribute periodic reports.
-			notificationReportGenerator := reports.NewReportGenerator(ctx, logger.Named("notifications.report_generator"), options.Database, options.NotificationsEnqueuer, quartz.NewReal())
-			defer notificationReportGenerator.Close()
-
 			// We use a separate coderAPICloser so the Enterprise API
 			// can have its own close functions. This is cleaner
 			// than abstracting the Coder API itself.
@@ -1005,6 +974,37 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			if err != nil && flag.Lookup("test.v") != nil {
 				return xerrors.Errorf("write config url: %w", err)
 			}
+
+			// Manage notifications.
+			var (
+				notificationsCfg     = options.DeploymentValues.Notifications
+				notificationsManager *notifications.Manager
+			)
+
+			metrics := notifications.NewMetrics(options.PrometheusRegistry)
+			helpers := templateHelpers(options)
+
+			// The enqueuer is responsible for enqueueing notifications to the given store.
+			enqueuer, err := notifications.NewStoreEnqueuer(notificationsCfg, options.Database, options.Pubsub, helpers, logger.Named("notifications.enqueuer"), quartz.NewReal())
+			if err != nil {
+				return xerrors.Errorf("failed to instantiate notification store enqueuer: %w", err)
+			}
+			options.NotificationsEnqueuer = enqueuer
+
+			// The notification manager is responsible for:
+			//   - creating notifiers and managing their lifecycles (notifiers are responsible for dequeueing/sending notifications)
+			//   - keeping the store updated with status updates
+			notificationsManager, err = notifications.NewManager(notificationsCfg, options.Database, options.Pubsub, helpers, metrics, logger.Named("notifications.manager"))
+			if err != nil {
+				return xerrors.Errorf("failed to instantiate notification manager: %w", err)
+			}
+
+			// nolint:gocritic // We need to run the manager in a notifier context.
+			notificationsManager.Run(dbauthz.AsNotifier(ctx))
+
+			// Run report generator to distribute periodic reports.
+			notificationReportGenerator := reports.NewReportGenerator(ctx, logger.Named("notifications.report_generator"), options.Database, options.NotificationsEnqueuer, quartz.NewReal())
+			defer notificationReportGenerator.Close()
 
 			// Since errCh only has one buffered slot, all routines
 			// sending on it must be wrapped in a select/default to

--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
 	"github.com/coder/coder/v2/codersdk"
@@ -36,6 +37,7 @@ func (e InvalidDefaultNotificationMethodError) Error() string {
 
 type StoreEnqueuer struct {
 	store Store
+	ps    pubsub.Pubsub
 	log   slog.Logger
 
 	defaultMethod  database.NotificationMethod
@@ -50,7 +52,7 @@ type StoreEnqueuer struct {
 }
 
 // NewStoreEnqueuer creates an Enqueuer implementation which can persist notification messages in the store.
-func NewStoreEnqueuer(cfg codersdk.NotificationsConfig, store Store, helpers template.FuncMap, log slog.Logger, clock quartz.Clock) (*StoreEnqueuer, error) {
+func NewStoreEnqueuer(cfg codersdk.NotificationsConfig, store Store, ps pubsub.Pubsub, helpers template.FuncMap, log slog.Logger, clock quartz.Clock) (*StoreEnqueuer, error) {
 	var method database.NotificationMethod
 	// TODO(DanielleMaywood):
 	// Currently we do not want to allow setting `inbox` as the default notification method.
@@ -63,6 +65,7 @@ func NewStoreEnqueuer(cfg codersdk.NotificationsConfig, store Store, helpers tem
 
 	return &StoreEnqueuer{
 		store:          store,
+		ps:             ps,
 		log:            log,
 		defaultMethod:  method,
 		defaultEnabled: cfg.Enabled(),

--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -85,13 +85,6 @@ func (s *StoreEnqueuer) Enqueue(ctx context.Context, userID, templateID uuid.UUI
 // Enqueue queues a notification message for later delivery.
 // Messages will be dequeued by a notifier later and dispatched.
 func (s *StoreEnqueuer) EnqueueWithData(ctx context.Context, userID, templateID uuid.UUID, labels map[string]string, data map[string]any, createdBy string, targets ...uuid.UUID) ([]uuid.UUID, error) {
-	defer func() {
-		// Publish an event to notify that a notification has been enqueued.
-		// Failure to publish is acceptable, as the fetcher will still process the
-		// message on its next run.
-		// TODO(Cian): debounce this to maybe once per second or so?
-		_ = s.ps.Publish(EventNotificationEnqueued, nil)
-	}()
 	metadata, err := s.store.FetchNewMessageMetadata(ctx, database.FetchNewMessageMetadataParams{
 		UserID:                 userID,
 		NotificationTemplateID: templateID,
@@ -171,6 +164,11 @@ func (s *StoreEnqueuer) EnqueueWithData(ctx context.Context, userID, templateID 
 	}
 
 	s.log.Debug(ctx, "enqueued notification", slog.F("msg_ids", uuids))
+	// Publish an event to notify that a notification has been enqueued.
+	// Failure to publish is acceptable, as the fetcher will still process the
+	// message on its next run.
+	// TODO(Cian): debounce this to maybe once per second or so?
+	_ = s.ps.Publish(EventNotificationEnqueued, nil)
 	return uuids, nil
 }
 

--- a/coderd/notifications/fetcher_internal_test.go
+++ b/coderd/notifications/fetcher_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/database/pubsub/psmock"
 )
 
 func TestNotifier_FetchHelpers(t *testing.T) {
@@ -21,9 +22,11 @@ func TestNotifier_FetchHelpers(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store:   dbmock,
+			ps:      psmock,
 			helpers: template.FuncMap{},
 		}
 
@@ -48,9 +51,11 @@ func TestNotifier_FetchHelpers(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store:   dbmock,
+			ps:      psmock,
 			helpers: template.FuncMap{},
 		}
 
@@ -67,9 +72,11 @@ func TestNotifier_FetchHelpers(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store:   dbmock,
+			ps:      psmock,
 			helpers: template.FuncMap{},
 		}
 
@@ -90,9 +97,11 @@ func TestNotifier_FetchAppName(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetApplicationName(gomock.Any()).Return("ACME Inc.", nil)
@@ -107,9 +116,11 @@ func TestNotifier_FetchAppName(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetApplicationName(gomock.Any()).Return("", sql.ErrNoRows)
@@ -125,9 +136,11 @@ func TestNotifier_FetchAppName(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetApplicationName(gomock.Any()).Return("", nil)
@@ -143,9 +156,11 @@ func TestNotifier_FetchAppName(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetApplicationName(gomock.Any()).Return("", xerrors.New("internal error"))
@@ -164,9 +179,11 @@ func TestNotifier_FetchLogoURL(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetLogoURL(gomock.Any()).Return("https://example.com/logo.png", nil)
@@ -181,9 +198,11 @@ func TestNotifier_FetchLogoURL(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetLogoURL(gomock.Any()).Return("", sql.ErrNoRows)
@@ -199,9 +218,11 @@ func TestNotifier_FetchLogoURL(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetLogoURL(gomock.Any()).Return("", nil)
@@ -217,9 +238,11 @@ func TestNotifier_FetchLogoURL(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		dbmock := dbmock.NewMockStore(ctrl)
+		psmock := psmock.NewMockPubsub(ctrl)
 
 		n := &notifier{
 			store: dbmock,
+			ps:    psmock,
 		}
 
 		dbmock.EXPECT().GetLogoURL(gomock.Any()).Return("", xerrors.New("internal error"))

--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -95,6 +95,7 @@ func NewManager(cfg codersdk.NotificationsConfig, store Store, ps pubsub.Pubsub,
 		log:   log,
 		cfg:   cfg,
 		store: store,
+		ps:    ps,
 
 		// Buffer successful/failed notification dispatches in memory to reduce load on the store.
 		//

--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -42,6 +42,7 @@ type Manager struct {
 	cfg codersdk.NotificationsConfig
 
 	store Store
+	ps    pubsub.Pubsub
 	log   slog.Logger
 
 	handlers map[database.NotificationMethod]Handler
@@ -168,7 +169,8 @@ func (m *Manager) loop(ctx context.Context) error {
 
 	var eg errgroup.Group
 
-	m.notifier = newNotifier(ctx, m.cfg, uuid.New(), m.log, m.store, m.handlers, m.helpers, m.metrics, m.clock)
+	// Create a notifier to run concurrently, which will handle dequeueing and dispatching notifications.
+	m.notifier = newNotifier(ctx, m.cfg, uuid.New(), m.log, m.store, m.ps, m.handlers, m.helpers, m.metrics, m.clock)
 	eg.Go(func() error {
 		// run the notifier which will handle dequeueing and dispatching notifications.
 		return m.notifier.run(m.success, m.failure)

--- a/coderd/notifications/manager_test.go
+++ b/coderd/notifications/manager_test.go
@@ -53,7 +53,7 @@ func TestBufferedUpdates(t *testing.T) {
 	}
 
 	mgr.WithHandlers(handlers)
-	enq, err := notifications.NewStoreEnqueuer(cfg, interceptor, defaultHelpers(), logger.Named("notifications-enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, interceptor, ps, defaultHelpers(), logger.Named("notifications-enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := dbgen.User(t, store, database.User{})
@@ -110,7 +110,7 @@ func TestBuildPayload(t *testing.T) {
 
 	// nolint:gocritic // Unit test.
 	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
-	store, _ := dbtestutil.NewDB(t)
+	store, ps := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
 	// GIVEN: a set of helpers to be injected into the templates
@@ -145,7 +145,7 @@ func TestBuildPayload(t *testing.T) {
 			}
 		})
 
-	enq, err := notifications.NewStoreEnqueuer(defaultNotificationsConfig(database.NotificationMethodSmtp), interceptor, helpers, logger.Named("notifications-enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(defaultNotificationsConfig(database.NotificationMethodSmtp), interceptor, ps, helpers, logger.Named("notifications-enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	// WHEN: a notification is enqueued

--- a/coderd/notifications/metrics_test.go
+++ b/coderd/notifications/metrics_test.go
@@ -71,7 +71,7 @@ func TestMetrics(t *testing.T) {
 		database.NotificationMethodInbox: &fakeHandler{},
 	})
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -264,7 +264,7 @@ func TestPendingUpdatesMetric(t *testing.T) {
 		database.NotificationMethodInbox: inboxHandler,
 	})
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -354,7 +354,7 @@ func TestInflightDispatchesMetric(t *testing.T) {
 		database.NotificationMethodInbox: &fakeHandler{},
 	})
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -441,7 +441,7 @@ func TestCustomMethodMetricCollection(t *testing.T) {
 		database.NotificationMethodInbox: &fakeHandler{},
 	})
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -90,7 +90,7 @@ func TestBasicNotificationRoundtrip(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -171,7 +171,7 @@ func TestSMTPDispatch(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -236,7 +236,7 @@ func TestWebhookDispatch(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	const (
@@ -327,7 +327,7 @@ func TestBackpressure(t *testing.T) {
 		method:                           handler,
 		database.NotificationMethodInbox: handler,
 	})
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), mClock)
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), mClock)
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -478,7 +478,7 @@ func TestRetries(t *testing.T) {
 		method:                           handler,
 		database.NotificationMethodInbox: &fakeHandler{},
 	})
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -542,7 +542,7 @@ func TestExpiredLeaseIsRequeued(t *testing.T) {
 
 	mgr, err := notifications.NewManager(cfg, noopInterceptor, pubsub, defaultHelpers(), createMetrics(), logger.Named("manager"))
 	require.NoError(t, err)
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	user := createSampleUser(t, store)
@@ -667,7 +667,7 @@ func TestNotifierPaused(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	// Pause the notifier.
@@ -1410,6 +1410,7 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 				smtpEnqueuer, err := notifications.NewStoreEnqueuer(
 					notificationCfg,
 					*db,
+					pubsub,
 					defaultHelpers(),
 					logger.Named("enqueuer"),
 					quartz.NewReal(),
@@ -1535,6 +1536,7 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 				httpEnqueuer, err := notifications.NewStoreEnqueuer(
 					defaultNotificationsConfig(database.NotificationMethodWebhook),
 					*db,
+					pubsub,
 					defaultHelpers(),
 					logger.Named("enqueuer"),
 					quartz.NewReal(),
@@ -1638,11 +1640,11 @@ func TestDisabledByDefaultBeforeEnqueue(t *testing.T) {
 
 	// nolint:gocritic // Unit test.
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
-	store, _ := dbtestutil.NewDB(t)
+	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
 	cfg := defaultNotificationsConfig(database.NotificationMethodSmtp)
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 	user := createSampleUser(t, store)
 
@@ -1664,12 +1666,12 @@ func TestDisabledBeforeEnqueue(t *testing.T) {
 
 	// nolint:gocritic // Unit test.
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
-	store, _ := dbtestutil.NewDB(t)
+	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
 	// GIVEN: an enqueuer & a sample user
 	cfg := defaultNotificationsConfig(database.NotificationMethodSmtp)
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 	user := createSampleUser(t, store)
 
@@ -1712,7 +1714,7 @@ func TestDisabledAfterEnqueue(t *testing.T) {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 	user := createSampleUser(t, store)
 
@@ -1821,7 +1823,7 @@ func TestCustomNotificationMethod(t *testing.T) {
 		_ = mgr.Stop(ctx)
 	})
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewReal())
 	require.NoError(t, err)
 
 	// WHEN: a notification of that template is enqueued, it should be delivered with the configured method - not the default.
@@ -1914,7 +1916,7 @@ func TestNotificationDuplicates(t *testing.T) {
 	mClock := quartz.NewMock(t)
 	mClock.Set(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC))
 
-	enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), mClock)
+	enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), mClock)
 	require.NoError(t, err)
 	user := createSampleUser(t, store)
 
@@ -1940,12 +1942,12 @@ func TestNotificationDuplicates(t *testing.T) {
 func TestNotificationMethodCannotDefaultToInbox(t *testing.T) {
 	t.Parallel()
 
-	store, _ := dbtestutil.NewDB(t)
+	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
 	cfg := defaultNotificationsConfig(database.NotificationMethodInbox)
 
-	_, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
+	_, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
 	require.ErrorIs(t, err, notifications.InvalidDefaultNotificationMethodError{Method: string(database.NotificationMethodInbox)})
 }
 
@@ -2020,7 +2022,7 @@ func TestNotificationTargetMatrix(t *testing.T) {
 			mClock := quartz.NewMock(t)
 			mClock.Set(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC))
 
-			enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), mClock)
+			enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), mClock)
 			require.NoError(t, err)
 			user := createSampleUser(t, store)
 
@@ -2041,7 +2043,7 @@ func TestNotificationOneTimePasswordDeliveryTargets(t *testing.T) {
 
 		// nolint:gocritic // Unit test.
 		ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
-		store, _ := dbtestutil.NewDB(t)
+		store, pubsub := dbtestutil.NewDB(t)
 		logger := testutil.Logger(t)
 
 		// Given: Coder Inbox is enabled and SMTP/Webhook are disabled.
@@ -2050,7 +2052,7 @@ func TestNotificationOneTimePasswordDeliveryTargets(t *testing.T) {
 		cfg.SMTP = codersdk.NotificationsEmailConfig{}
 		cfg.Webhook = codersdk.NotificationsWebhookConfig{}
 
-		enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
+		enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
 		require.NoError(t, err)
 		user := createSampleUser(t, store)
 
@@ -2066,7 +2068,7 @@ func TestNotificationOneTimePasswordDeliveryTargets(t *testing.T) {
 
 		// nolint:gocritic // Unit test.
 		ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
-		store, _ := dbtestutil.NewDB(t)
+		store, pubsub := dbtestutil.NewDB(t)
 		logger := testutil.Logger(t)
 
 		// Given: Coder Inbox/Webhook are disabled and SMTP is enabled.
@@ -2074,7 +2076,7 @@ func TestNotificationOneTimePasswordDeliveryTargets(t *testing.T) {
 		cfg.Inbox.Enabled = false
 		cfg.Webhook = codersdk.NotificationsWebhookConfig{}
 
-		enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
+		enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
 		require.NoError(t, err)
 		user := createSampleUser(t, store)
 
@@ -2090,7 +2092,7 @@ func TestNotificationOneTimePasswordDeliveryTargets(t *testing.T) {
 
 		// nolint:gocritic // Unit test.
 		ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
-		store, _ := dbtestutil.NewDB(t)
+		store, pubsub := dbtestutil.NewDB(t)
 		logger := testutil.Logger(t)
 
 		// Given: Coder Inbox/SMTP are disabled and Webhook is enabled.
@@ -2098,7 +2100,7 @@ func TestNotificationOneTimePasswordDeliveryTargets(t *testing.T) {
 		cfg.Inbox.Enabled = false
 		cfg.SMTP = codersdk.NotificationsEmailConfig{}
 
-		enq, err := notifications.NewStoreEnqueuer(cfg, store, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
+		enq, err := notifications.NewStoreEnqueuer(cfg, store, pubsub, defaultHelpers(), logger.Named("enqueuer"), quartz.NewMock(t))
 		require.NoError(t, err)
 		user := createSampleUser(t, store)
 

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -2173,6 +2173,8 @@ func TestNotificationEnqueuePubsubNotify(t *testing.T) {
 		}
 	}()
 	_ = testutil.TryReceive(ctx, t, recvDone)
+	// TODO: this sometimes fails with
+	//     t.go:106: 2025-04-22 16:55:04.153 [warn]  manager: content canceled with pending updates in buffer, these messages will be sent again after lease expires  success_count=6  failure_count=0
 }
 
 type fakeHandler struct {

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -153,7 +153,7 @@ func (n *notifier) run(success chan<- dispatchResult, failure chan<- dispatchRes
 			return
 		// This is a no-op if the notifier is paused.
 		case loopTick <- c:
-			<-c // Wait for the processing loop to finish.
+			// We do not wait for the processing loop to finish here.
 		default:
 			// If the loop is busy, don't send a notification.
 			n.log.Debug(ctx, "notifier busy, skipping notification")


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/573

* Decouples notifier processing loop from ticker
* Plumbs through pubsub into enqueuer and dispatcher
* Adds pubsub NOTIFY for message enqueuing
* Modifies notifier to LISTEN for message enqueue events