### PR TITLE
feat: modify config-ssh to check for Coder Connect

### DIFF
--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -615,13 +615,21 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			name: "Hostname Suffix",
 			args: []string{
 				"--yes",
+				"--ssh-option", "Foo=bar",
 				"--hostname-suffix", "testy",
 			},
 			wantErr:  false,
 			hasAgent: true,
 			wantConfig: wantConfig{
-				ssh:        []string{"Host coder.* *.testy"},
-				regexMatch: `ProxyCommand .* ssh .* --hostname-suffix testy %h`,
+				ssh: []string{
+					"Host *.testy",
+					"Foo=bar",
+					"ConnectTimeout=0",
+					"StrictHostKeyChecking=no",
+					"UserKnownHostsFile=/dev/null",
+					"LogLevel ERROR",
+				},
+				regexMatch: `Match host \*\.testy !exec ".* connect exists %h"\n\tProxyCommand .* ssh .* --hostname-suffix testy %h`,
 			},
 		},
 		{
@@ -634,8 +642,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			wantErr:  false,
 			hasAgent: true,
 			wantConfig: wantConfig{
-				ssh:        []string{"Host presto.* *.testy"},
-				regexMatch: `ProxyCommand .* ssh .* --ssh-host-prefix presto\. --hostname-suffix testy %h`,
+				ssh: []string{"Host presto.*", "Match host *.testy !exec"},
 			},
 		},
 	}


### PR DESCRIPTION
relates to #16828

Changes SSH config so that suffixes only match if Coder Connect is not running / available. This means that we will use the existing Coder Connect tunnel if it is available, rather than creating a new tunnel via `coder ssh --stdio`.