### PR TITLE
chore: reduce storybook flakes

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
@@ -39,6 +39,11 @@ const meta: Meta<typeof OverviewPageView> = {
 		invalidExperiments: [],
 		safeExperiments: [],
 	},
+	parameters: {
+		chromatic: {
+			diffThreshold: 0.2,
+		},
+	},
 };
 
 export default meta;

--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof OverviewPageView> = {
 	},
 	parameters: {
 		chromatic: {
-			diffThreshold: 0.2,
+			diffThreshold: 0.5,
 		},
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/UserEngagementChart.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/UserEngagementChart.tsx
@@ -156,6 +156,7 @@ export const UserEngagementChart: FC<UserEngagementChartProps> = ({ data }) => {
 									</defs>
 
 									<Area
+										isAnimationActive={false}
 										dataKey="users"
 										type="linear"
 										fill="url(#fillUsers)"

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.stories.tsx
@@ -6,6 +6,13 @@ import { PermissionPillsList } from "./PermissionPillsList";
 const meta: Meta<typeof PermissionPillsList> = {
 	title: "pages/OrganizationCustomRolesPage/PermissionPillsList",
 	component: PermissionPillsList,
+	decorators: [
+		(Story) => (
+			<div style={{ width: "800px" }}>
+				<Story />
+			</div>
+		),
+	],
 };
 
 export default meta;

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
@@ -121,7 +121,7 @@ export const JobRow: FC<JobRowProps> = ({ job }) => {
 							<dd>{job.metadata.workspace_name ?? "null"}</dd>
 
 							<dt>Creation time:</dt>
-							<dd>{job.created_at}</dd>
+							<dd data-chromatic="ignore">{job.created_at}</dd>
 
 							<dt>Queue:</dt>
 							<dd>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -111,10 +111,10 @@ export const ProvisionerRow: FC<ProvisionerRowProps> = ({
 							])}
 						>
 							<dt>Last seen:</dt>
-							<dd>{provisioner.last_seen_at}</dd>
+							<dd data-chromatic="ignore">{provisioner.last_seen_at}</dd>
 
 							<dt>Creation time:</dt>
-							<dd>{provisioner.created_at}</dd>
+							<dd data-chromatic="ignore">{provisioner.created_at}</dd>
 
 							<dt>Version:</dt>
 							<dd>

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -14,6 +14,7 @@ import {
 	MockAuthMethodsAll,
 	MockBuildInfo,
 	MockDefaultOrganization,
+	MockDeploymentConfig,
 	MockEntitlements,
 	MockExperiments,
 	MockUser,
@@ -78,8 +79,17 @@ const meta = {
 				data: { editWorkspaceProxies: true },
 			},
 			{ key: ["me", "appearance"], data: MockUserAppearanceSettings },
+			{
+				key: ["deployment", "config"],
+				data: {
+					...MockDeploymentConfig,
+					config: {
+						...MockDeploymentConfig.config,
+						web_terminal_renderer: "canvas",
+					},
+				},
+			},
 		],
-		chromatic: { delay: 300 },
 	},
 	decorators: [
 		(Story) => (

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -97,7 +97,9 @@ const meta = {
 	decorators: [
 		(Story) => (
 			<AuthProvider>
-				<Story />
+				<div style={{ width: 1170, height: 880 }}>
+					<Story />
+				</div>
 			</AuthProvider>
 		),
 	],

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -91,7 +91,7 @@ const meta = {
 			},
 		],
 		chromatic: {
-			diffThreshold: 0.2,
+			diffThreshold: 0.3,
 		},
 	},
 	decorators: [

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -90,6 +90,9 @@ const meta = {
 				},
 			},
 		],
+		chromatic: {
+			diffThreshold: 0.2,
+		},
 	},
 	decorators: [
 		(Story) => (

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
@@ -209,6 +209,11 @@ export const WithApproachingDeadline: Story = {
 			);
 		});
 	},
+	parameters: {
+		chromatic: {
+			diffThreshold: 0.2,
+		},
+	},
 };
 
 export const WithFarAwayDeadline: Story = {
@@ -315,6 +320,11 @@ export const TemplateInfoPopover: Story = {
 				).toHaveTextContent(MockTemplate.display_name),
 			);
 		});
+	},
+	parameters: {
+		chromatic: {
+			diffThreshold: 0.2,
+		},
 	},
 };
 

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
@@ -209,11 +209,6 @@ export const WithApproachingDeadline: Story = {
 			);
 		});
 	},
-	parameters: {
-		chromatic: {
-			diffThreshold: 0.3,
-		},
-	},
 };
 
 export const WithFarAwayDeadline: Story = {

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
@@ -211,7 +211,7 @@ export const WithApproachingDeadline: Story = {
 	},
 	parameters: {
 		chromatic: {
-			diffThreshold: 0.2,
+			diffThreshold: 0.3,
 		},
 	},
 };
@@ -323,7 +323,7 @@ export const TemplateInfoPopover: Story = {
 	},
 	parameters: {
 		chromatic: {
-			diffThreshold: 0.2,
+			diffThreshold: 0.3,
 		},
 	},
 };

--- a/site/src/utils/schedule.tsx
+++ b/site/src/utils/schedule.tsx
@@ -148,7 +148,7 @@ export const autostopDisplay = (
 		if (template.autostop_requirement && template.allow_user_autostop) {
 			title = <HelpTooltipTitle>Autostop schedule</HelpTooltipTitle>;
 			reason = (
-				<>
+				<span data-chromatic="ignore">
 					{" "}
 					because this workspace has enabled autostop. You can disable autostop
 					from this workspace&apos;s{" "}
@@ -156,7 +156,7 @@ export const autostopDisplay = (
 						schedule settings
 					</Link>
 					.
-				</>
+				</span>
 			);
 		}
 		return {
@@ -165,9 +165,7 @@ export const autostopDisplay = (
 				<>
 					{title}
 					This workspace will be stopped on{" "}
-					<span data-chromatic="ignore">
-						{deadline.format("MMMM D [at] h:mm A")}
-					</span>
+					{deadline.format("MMMM D [at] h:mm A")}
 					{reason}
 				</>
 			),

--- a/site/src/utils/schedule.tsx
+++ b/site/src/utils/schedule.tsx
@@ -162,12 +162,12 @@ export const autostopDisplay = (
 		return {
 			message: `Stop ${deadline.fromNow()}`,
 			tooltip: (
-				<>
+				<span data-chromatic="ignore">
 					{title}
 					This workspace will be stopped on{" "}
 					{deadline.format("MMMM D [at] h:mm A")}
 					{reason}
-				</>
+				</span>
 			),
 			danger: isShutdownSoon(workspace),
 		};

--- a/site/src/utils/schedule.tsx
+++ b/site/src/utils/schedule.tsx
@@ -165,7 +165,9 @@ export const autostopDisplay = (
 				<>
 					{title}
 					This workspace will be stopped on{" "}
-					{deadline.format("MMMM D [at] h:mm A")}
+					<span data-chromatic="ignore">
+						{deadline.format("MMMM D [at] h:mm A")}
+					</span>
 					{reason}
 				</>
 			),


### PR DESCRIPTION
A few storybook tests have been false positives quite frequently. To reduce this noise, I'm implementing a few hacks to avoid that. We can always rollback these changes if we notice they were leading to a lack in the tests.