### PR TITLE
chore: load 'assign_default' value from legacy value

### DIFF
--- a/coderd/idpsync/organization.go
+++ b/coderd/idpsync/organization.go
@@ -216,7 +216,7 @@ func (s *OrganizationSyncSettings) Set(v string) error {
 	legacyCheck := make(map[string]any)
 	err := json.Unmarshal([]byte(v), &legacyCheck)
 	if assign, ok := legacyCheck["AssignDefault"]; err == nil && ok {
-		// the legacy json was 'AssignDefault' instead of 'assign_default'
+		// The legacy JSON key was 'AssignDefault' instead of 'assign_default'
 		// Set the default value from the legacy if it exists.
 		isBool, ok := assign.(bool)
 		if ok {

--- a/coderd/idpsync/organization.go
+++ b/coderd/idpsync/organization.go
@@ -213,6 +213,17 @@ type OrganizationSyncSettings struct {
 }
 
 func (s *OrganizationSyncSettings) Set(v string) error {
+	legacyCheck := make(map[string]any)
+	err := json.Unmarshal([]byte(v), &legacyCheck)
+	if assign, ok := legacyCheck["AssignDefault"]; err == nil && ok {
+		// the legacy json was 'AssignDefault' instead of 'assign_default'
+		// Set the default value from the legacy if it exists.
+		isBool, ok := assign.(bool)
+		if ok {
+			s.AssignDefault = isBool
+		}
+	}
+
 	return json.Unmarshal([]byte(v), s)
 }
 

--- a/coderd/idpsync/organizations_test.go
+++ b/coderd/idpsync/organizations_test.go
@@ -20,7 +20,10 @@ import (
 )
 
 func TestFromLegacySettings(t *testing.T) {
+	t.Parallel()
+
 	t.Run("AssignDefault,True", func(t *testing.T) {
+		t.Parallel()
 		legacy := `{
    "Field":"groups",
    "Mapping":{
@@ -46,6 +49,7 @@ func TestFromLegacySettings(t *testing.T) {
 	})
 
 	t.Run("AssignDefault,False", func(t *testing.T) {
+		t.Parallel()
 		legacy := `{
    "Field":"groups",
    "Mapping":{
@@ -71,6 +75,7 @@ func TestFromLegacySettings(t *testing.T) {
 	})
 
 	t.Run("CorrectAssign", func(t *testing.T) {
+		t.Parallel()
 		legacy := `{
    "Field":"groups",
    "Mapping":{

--- a/coderd/idpsync/organizations_test.go
+++ b/coderd/idpsync/organizations_test.go
@@ -2,6 +2,7 @@ package idpsync_test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -22,21 +23,24 @@ import (
 func TestFromLegacySettings(t *testing.T) {
 	t.Parallel()
 
+	legacy := func(assignDefault bool) string {
+		return fmt.Sprintf(`{
+		   "Field":"groups",
+		   "Mapping":{
+			  "engineering":[
+				 "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
+			  ]
+		   },
+		   "AssignDefault":%t
+		}`, assignDefault)
+	}
+
 	t.Run("AssignDefault,True", func(t *testing.T) {
 		t.Parallel()
-		legacy := `{
-   "Field":"groups",
-   "Mapping":{
-      "engineering":[
-         "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
-      ]
-   },
-   "AssignDefault":true
-}`
 
 		var settings idpsync.OrganizationSyncSettings
 		settings.AssignDefault = true
-		err := settings.Set(legacy)
+		err := settings.Set(legacy(true))
 		require.NoError(t, err)
 
 		require.Equal(t, settings.Field, "groups", "field")
@@ -50,19 +54,10 @@ func TestFromLegacySettings(t *testing.T) {
 
 	t.Run("AssignDefault,False", func(t *testing.T) {
 		t.Parallel()
-		legacy := `{
-   "Field":"groups",
-   "Mapping":{
-      "engineering":[
-         "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
-      ]
-   },
-   "AssignDefault":false
-}`
 
 		var settings idpsync.OrganizationSyncSettings
 		settings.AssignDefault = true
-		err := settings.Set(legacy)
+		err := settings.Set(legacy(false))
 		require.NoError(t, err)
 
 		require.Equal(t, settings.Field, "groups", "field")
@@ -76,19 +71,10 @@ func TestFromLegacySettings(t *testing.T) {
 
 	t.Run("CorrectAssign", func(t *testing.T) {
 		t.Parallel()
-		legacy := `{
-   "Field":"groups",
-   "Mapping":{
-      "engineering":[
-         "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
-      ]
-   },
-   "AssignDefault":false
-}`
 
 		var settings idpsync.OrganizationSyncSettings
 		settings.AssignDefault = true
-		err := settings.Set(legacy)
+		err := settings.Set(legacy(false))
 		require.NoError(t, err)
 
 		require.Equal(t, settings.Field, "groups", "field")

--- a/coderd/idpsync/organizations_test.go
+++ b/coderd/idpsync/organizations_test.go
@@ -19,6 +19,83 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+func TestFromLegacySettings(t *testing.T) {
+	t.Run("AssignDefault,True", func(t *testing.T) {
+		legacy := `{
+   "Field":"groups",
+   "Mapping":{
+      "engineering":[
+         "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
+      ]
+   },
+   "AssignDefault":true
+}`
+
+		var settings idpsync.OrganizationSyncSettings
+		settings.AssignDefault = true
+		err := settings.Set(legacy)
+		require.NoError(t, err)
+
+		require.Equal(t, settings.Field, "groups", "field")
+		require.Equal(t, settings.Mapping, map[string][]uuid.UUID{
+			"engineering": {
+				uuid.MustParse("10b2bd19-f5ca-4905-919f-bf02e95e3b6a"),
+			},
+		}, "mapping")
+		require.True(t, settings.AssignDefault, "assign default")
+	})
+
+	t.Run("AssignDefault,False", func(t *testing.T) {
+		legacy := `{
+   "Field":"groups",
+   "Mapping":{
+      "engineering":[
+         "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
+      ]
+   },
+   "AssignDefault":false
+}`
+
+		var settings idpsync.OrganizationSyncSettings
+		settings.AssignDefault = true
+		err := settings.Set(legacy)
+		require.NoError(t, err)
+
+		require.Equal(t, settings.Field, "groups", "field")
+		require.Equal(t, settings.Mapping, map[string][]uuid.UUID{
+			"engineering": {
+				uuid.MustParse("10b2bd19-f5ca-4905-919f-bf02e95e3b6a"),
+			},
+		}, "mapping")
+		require.False(t, settings.AssignDefault, "assign default")
+	})
+
+	t.Run("CorrectAssign", func(t *testing.T) {
+		legacy := `{
+   "Field":"groups",
+   "Mapping":{
+      "engineering":[
+         "10b2bd19-f5ca-4905-919f-bf02e95e3b6a"
+      ]
+   },
+   "AssignDefault":false
+}`
+
+		var settings idpsync.OrganizationSyncSettings
+		settings.AssignDefault = true
+		err := settings.Set(legacy)
+		require.NoError(t, err)
+
+		require.Equal(t, settings.Field, "groups", "field")
+		require.Equal(t, settings.Mapping, map[string][]uuid.UUID{
+			"engineering": {
+				uuid.MustParse("10b2bd19-f5ca-4905-919f-bf02e95e3b6a"),
+			},
+		}, "mapping")
+		require.False(t, settings.AssignDefault, "assign default")
+	})
+}
+
 func TestParseOrganizationClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
If this value was set before v2.19.0, then assign_default was in a json field that would not match. And it would default to `false`. This corrects that.