### PR TITLE
chore: prevent null loading sync settings

### DIFF
--- a/coderd/idpsync/group.go
+++ b/coderd/idpsync/group.go
@@ -268,6 +268,9 @@ func (s *GroupSyncSettings) Set(v string) error {
 }
 
 func (s *GroupSyncSettings) String() string {
+	if s.Mapping == nil {
+		s.Mapping = make(map[string][]uuid.UUID)
+	}
 	return runtimeconfig.JSONString(s)
 }
 

--- a/coderd/idpsync/organization.go
+++ b/coderd/idpsync/organization.go
@@ -217,6 +217,9 @@ func (s *OrganizationSyncSettings) Set(v string) error {
 }
 
 func (s *OrganizationSyncSettings) String() string {
+	if s.Mapping == nil {
+		s.Mapping = make(map[string][]uuid.UUID)
+	}
 	return runtimeconfig.JSONString(s)
 }
 

--- a/coderd/idpsync/role.go
+++ b/coderd/idpsync/role.go
@@ -286,5 +286,8 @@ func (s *RoleSyncSettings) Set(v string) error {
 }
 
 func (s *RoleSyncSettings) String() string {
+	if s.Mapping == nil {
+		s.Mapping = make(map[string][]string)
+	}
 	return runtimeconfig.JSONString(s)
 }


### PR DESCRIPTION
Nulls passed to the frontend caused a page to fail to load.

`Record<string,string>` can be `nil` in golang :cry: 

![Screenshot From 2025-04-16 15-40-44](https://github.com/user-attachments/assets/34eb3797-5ff2-4d08-aece-c26bd172bfe4)

