### PR TITLE
chore: typescript to accept `null` golang maps

### DIFF
--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -67,9 +67,6 @@ func main() {
 
 func TsMutations(ts *guts.Typescript) {
 	ts.ApplyMutations(
-		// TODO: Remove 'NotNullMaps'. This is hiding potential bugs
-		//   of referencing maps that are actually null.
-		config.NotNullMaps,
 		FixSerpentStruct,
 		// Prefer enums as types
 		config.EnumAsTypes,

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -159,21 +159,22 @@ export const getURLWithSearchParams = (
 // withDefaultFeatures sets all unspecified features to not_entitled and
 // disabled.
 export const withDefaultFeatures = (
-	fs: Partial<TypesGen.Entitlements["features"]>,
+	fs: Partial<TypesGen.Entitlements["features"]> | null,
 ): TypesGen.Entitlements["features"] => {
+	const features = fs || {};
 	for (const feature of TypesGen.FeatureNames) {
 		// Skip fields that are already filled.
-		if (fs[feature] !== undefined) {
+		if (features[feature] !== undefined) {
 			continue;
 		}
 
-		fs[feature] = {
+		features[feature] = {
 			enabled: false,
 			entitlement: "not_entitled",
 		};
 	}
 
-	return fs as TypesGen.Entitlements["features"];
+	return features as TypesGen.Entitlements["features"];
 };
 
 type WatchBuildLogsByTemplateVersionIdOptions = {

--- a/site/src/api/queries/notifications.ts
+++ b/site/src/api/queries/notifications.ts
@@ -32,7 +32,7 @@ export const updateUserNotificationPreferences = (
 		onMutate: (data) => {
 			queryClient.setQueryData(
 				userNotificationPreferencesKey(userId),
-				Object.entries(data.template_disabled_map).map(
+				Object.entries(data.template_disabled_map || {}).map(
 					([id, disabled]) =>
 						({
 							id,

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -295,7 +295,7 @@ export const organizationsPermissions = (
 			});
 
 			// Now we can unflatten by parsing out the org ID from each check.
-			return Object.entries(response).reduce(
+			return Object.entries(response || {}).reduce(
 				(acc, [key, value]) => {
 					const index = key.indexOf(".");
 					const orgId = key.substring(0, index);
@@ -333,7 +333,7 @@ export const workspacePermissionsByOrganization = (
 				checks: Object.fromEntries(prefixedChecks),
 			});
 
-			return Object.entries(response).reduce(
+			return Object.entries(response || {}).reduce(
 				(acc, [key, value]) => {
 					const index = key.indexOf(".");
 					const orgId = key.substring(0, index);

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -146,7 +146,7 @@ export const AuditActions: AuditAction[] = [
 ];
 
 // From codersdk/audit.go
-export type AuditDiff = Record<string, AuditDiffField>;
+export type AuditDiff = Record<string, AuditDiffField> | null;
 
 // From codersdk/audit.go
 export interface AuditDiffField {
@@ -171,7 +171,7 @@ export interface AuditLog {
 	readonly action: AuditAction;
 	readonly diff: AuditDiff;
 	readonly status_code: number;
-	readonly additional_fields: Record<string, string>;
+	readonly additional_fields: Record<string, string> | null;
 	readonly description: string;
 	readonly resource_link: string;
 	readonly is_deleted: boolean;
@@ -221,11 +221,11 @@ export interface AuthorizationObject {
 
 // From codersdk/authorization.go
 export interface AuthorizationRequest {
-	readonly checks: Record<string, AuthorizationCheck>;
+	readonly checks: Record<string, AuthorizationCheck> | null;
 }
 
 // From codersdk/authorization.go
-export type AuthorizationResponse = Record<string, boolean>;
+export type AuthorizationResponse = Record<string, boolean> | null;
 
 // From codersdk/workspaces.go
 export type AutomaticUpdates = "always" | "never";
@@ -358,7 +358,7 @@ export interface CreateOrganizationRequest {
 // From codersdk/provisionerdaemons.go
 export interface CreateProvisionerKeyRequest {
 	readonly name: string;
-	readonly tags: Record<string, string>;
+	readonly tags: Record<string, string> | null;
 }
 
 // From codersdk/provisionerdaemons.go
@@ -404,7 +404,7 @@ export interface CreateTemplateVersionRequest {
 	readonly file_id?: string;
 	readonly example_id?: string;
 	readonly provisioner: ProvisionerType;
-	readonly tags: Record<string, string>;
+	readonly tags: Record<string, string> | null;
 	readonly user_variable_values?: readonly VariableValue[];
 }
 
@@ -536,7 +536,7 @@ export interface DERPConfig {
 // From healthsdk/healthsdk.go
 export interface DERPHealthReport extends BaseReport {
 	readonly healthy: boolean;
-	readonly regions: Record<number, DERPRegionReport | null>;
+	readonly regions: Record<number, DERPRegionReport | null> | null;
 	readonly netcheck?: NetcheckReport;
 	readonly netcheck_err?: string;
 	readonly netcheck_logs: readonly string[];
@@ -716,7 +716,7 @@ export const DisplayApps: DisplayApp[] = [
 // From codersdk/templateversions.go
 export interface DynamicParametersRequest {
 	readonly id: number;
-	readonly inputs: Record<string, string>;
+	readonly inputs: Record<string, string> | null;
 }
 
 // From codersdk/templateversions.go
@@ -755,7 +755,7 @@ export type Entitlement = "entitled" | "grace_period" | "not_entitled";
 
 // From codersdk/deployment.go
 export interface Entitlements {
-	readonly features: Record<FeatureName, Feature>;
+	readonly features: Record<FeatureName, Feature> | null;
 	readonly warnings: readonly string[];
 	readonly errors: readonly string[];
 	readonly has_license: boolean;
@@ -947,7 +947,7 @@ export interface GetUserStatusCountsRequest {
 
 // From codersdk/insights.go
 export interface GetUserStatusCountsResponse {
-	readonly status_counts: Record<UserStatus, UserStatusChangeCount[]>;
+	readonly status_counts: Record<UserStatus, UserStatusChangeCount[]> | null;
 }
 
 // From codersdk/users.go
@@ -1000,7 +1000,7 @@ export const GroupSources: GroupSource[] = ["oidc", "user"];
 // From codersdk/idpsync.go
 export interface GroupSyncSettings {
 	readonly field: string;
-	readonly mapping: Record<string, string[]>;
+	readonly mapping: Record<string, string[]> | null;
 	readonly regex_filter: string | null;
 	readonly auto_create_missing_groups: boolean;
 	readonly legacy_group_name_mapping?: Record<string, string>;
@@ -1192,7 +1192,7 @@ export interface License {
 	readonly uuid: string;
 	readonly uploaded_at: string;
 	// empty interface{} type, falling back to unknown
-	readonly claims: Record<string, unknown>;
+	readonly claims: Record<string, unknown> | null;
 }
 
 // From codersdk/licenses.go
@@ -1313,9 +1313,9 @@ export interface NetcheckReport {
 	readonly PMP: boolean | null;
 	readonly PCP: boolean | null;
 	readonly PreferredDERP: number;
-	readonly RegionLatency: Record<number, number>;
-	readonly RegionV4Latency: Record<number, number>;
-	readonly RegionV6Latency: Record<number, number>;
+	readonly RegionLatency: Record<number, number> | null;
+	readonly RegionV4Latency: Record<number, number> | null;
+	readonly RegionV6Latency: Record<number, number> | null;
 	readonly GlobalV4: string;
 	readonly GlobalV6: string;
 	readonly CaptivePortal: boolean | null;
@@ -1518,19 +1518,19 @@ export interface OIDCConfig {
 	readonly username_field: string;
 	readonly name_field: string;
 	readonly email_field: string;
-	readonly auth_url_params: SerpentStruct<Record<string, string>>;
+	readonly auth_url_params: SerpentStruct<Record<string, string> | null>;
 	readonly ignore_user_info: boolean;
 	readonly source_user_info_from_access_token: boolean;
 	readonly organization_field: string;
-	readonly organization_mapping: SerpentStruct<Record<string, string[]>>;
+	readonly organization_mapping: SerpentStruct<Record<string, string[]> | null>;
 	readonly organization_assign_default: boolean;
 	readonly group_auto_create: boolean;
 	readonly group_regex_filter: string;
 	readonly group_allow_list: string;
 	readonly groups_field: string;
-	readonly group_mapping: SerpentStruct<Record<string, string>>;
+	readonly group_mapping: SerpentStruct<Record<string, string> | null>;
 	readonly user_role_field: string;
-	readonly user_role_mapping: SerpentStruct<Record<string, string[]>>;
+	readonly user_role_mapping: SerpentStruct<Record<string, string[]> | null>;
 	readonly user_roles_default: string;
 	readonly sign_in_text: string;
 	readonly icon_url: string;
@@ -1568,7 +1568,7 @@ export interface OrganizationMemberWithUserData extends OrganizationMember {
 export interface OrganizationProvisionerDaemonsOptions {
 	readonly Limit: number;
 	readonly IDs: readonly string[];
-	readonly Tags: Record<string, string>;
+	readonly Tags: Record<string, string> | null;
 }
 
 // From codersdk/organizations.go
@@ -1576,13 +1576,13 @@ export interface OrganizationProvisionerJobsOptions {
 	readonly Limit: number;
 	readonly IDs: readonly string[];
 	readonly Status: readonly ProvisionerJobStatus[];
-	readonly Tags: Record<string, string>;
+	readonly Tags: Record<string, string> | null;
 }
 
 // From codersdk/idpsync.go
 export interface OrganizationSyncSettings {
 	readonly field: string;
-	readonly mapping: Record<string, string[]>;
+	readonly mapping: Record<string, string[]> | null;
 	readonly organization_assign_default: boolean;
 }
 
@@ -1803,7 +1803,7 @@ export interface ProvisionerDaemon {
 	readonly version: string;
 	readonly api_version: string;
 	readonly provisioners: readonly ProvisionerType[];
-	readonly tags: Record<string, string>;
+	readonly tags: Record<string, string> | null;
 	readonly key_name: string | null;
 	readonly status: ProvisionerDaemonStatus | null;
 	readonly current_job: ProvisionerDaemonJob | null;
@@ -1857,7 +1857,7 @@ export interface ProvisionerJob {
 	readonly status: ProvisionerJobStatus;
 	readonly worker_id?: string;
 	readonly file_id: string;
-	readonly tags: Record<string, string>;
+	readonly tags: Record<string, string> | null;
 	readonly queue_position: number;
 	readonly queue_size: number;
 	readonly organization_id: string;
@@ -1961,7 +1961,7 @@ export const ProvisionerKeyNamePSK = "psk";
 export const ProvisionerKeyNameUserAuth = "user-auth";
 
 // From codersdk/provisionerdaemons.go
-export type ProvisionerKeyTags = Record<string, string>;
+export type ProvisionerKeyTags = Record<string, string> | null;
 
 // From codersdk/workspaces.go
 export type ProvisionerLogLevel = "debug";
@@ -2293,7 +2293,7 @@ export const RoleOwner = "owner";
 // From codersdk/idpsync.go
 export interface RoleSyncSettings {
 	readonly field: string;
-	readonly mapping: Record<string, string[]>;
+	readonly mapping: Record<string, string[]> | null;
 }
 
 // From codersdk/rbacroles.go
@@ -2312,7 +2312,7 @@ export interface SSHConfig {
 export interface SSHConfigResponse {
 	readonly hostname_prefix: string;
 	readonly hostname_suffix: string;
-	readonly ssh_config_options: Record<string, string>;
+	readonly ssh_config_options: Record<string, string> | null;
 }
 
 // From healthsdk/healthsdk.go
@@ -2323,7 +2323,7 @@ export interface STUNReport {
 }
 
 // From serpent/serpent.go
-export type SerpentAnnotations = Record<string, string>;
+export type SerpentAnnotations = Record<string, string> | null;
 
 // From serpent/serpent.go
 export interface SerpentGroup {
@@ -2562,7 +2562,7 @@ export interface TemplateAutostopRequirement {
 export type TemplateBuildTimeStats = Record<
 	WorkspaceTransition,
 	TransitionStats
->;
+> | null;
 
 // From codersdk/insights.go
 export const TemplateBuiltinAppDisplayNameJetBrains = "JetBrains";
@@ -2903,7 +2903,7 @@ export interface UpdateUserAppearanceSettingsRequest {
 
 // From codersdk/notifications.go
 export interface UpdateUserNotificationPreferences {
-	readonly template_disabled_map: Record<string, boolean>;
+	readonly template_disabled_map: Record<string, boolean> | null;
 }
 
 // From codersdk/users.go
@@ -3077,7 +3077,7 @@ export interface UserQuietHoursScheduleResponse {
 // From codersdk/users.go
 export interface UserRoles {
 	readonly roles: readonly string[];
-	readonly organization_roles: Record<string, string[]>;
+	readonly organization_roles: Record<string, string[]> | null;
 }
 
 // From codersdk/users.go
@@ -3204,7 +3204,7 @@ export interface WorkspaceAgent {
 	readonly resource_id: string;
 	readonly instance_id?: string;
 	readonly architecture: string;
-	readonly environment_variables: Record<string, string>;
+	readonly environment_variables: Record<string, string> | null;
 	readonly operating_system: string;
 	readonly logs_length: number;
 	readonly logs_overflowed: boolean;
@@ -3230,11 +3230,11 @@ export interface WorkspaceAgentContainer {
 	readonly id: string;
 	readonly name: string;
 	readonly image: string;
-	readonly labels: Record<string, string>;
+	readonly labels: Record<string, string> | null;
 	readonly running: boolean;
 	readonly ports: readonly WorkspaceAgentContainerPort[];
 	readonly status: string;
-	readonly volumes: Record<string, string>;
+	readonly volumes: Record<string, string> | null;
 }
 
 // From codersdk/workspaceagents.go

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -53,7 +53,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	let options = organizationsQuery.data ?? [];
 	if (check) {
 		options = permissionsQuery.data
-			? options.filter((org) => permissionsQuery.data[org.id])
+			? options.filter((org) => permissionsQuery.data?.[org.id])
 			: [];
 	}
 

--- a/site/src/modules/dashboard/AnnouncementBanners/AnnouncementBanners.tsx
+++ b/site/src/modules/dashboard/AnnouncementBanners/AnnouncementBanners.tsx
@@ -7,7 +7,7 @@ export const AnnouncementBanners: FC = () => {
 	const announcementBanners = appearance.announcement_banners;
 
 	const isEntitled =
-		entitlements.features.appearance.entitlement !== "not_entitled";
+		entitlements.features?.appearance?.entitlement !== "not_entitled";
 	if (!isEntitled) {
 		return null;
 	}

--- a/site/src/modules/dashboard/entitlements.ts
+++ b/site/src/modules/dashboard/entitlements.ts
@@ -26,5 +26,8 @@ export const getFeatureVisibility = (
 export const selectFeatureVisibility = (
 	entitlements: Entitlements,
 ): Record<FeatureName, boolean> => {
-	return getFeatureVisibility(entitlements.has_license, entitlements.features);
+	return getFeatureVisibility(
+		entitlements.has_license,
+		entitlements.features || {},
+	);
 };

--- a/site/src/modules/management/DeploymentSidebar.tsx
+++ b/site/src/modules/management/DeploymentSidebar.tsx
@@ -10,7 +10,7 @@ export const DeploymentSidebar: FC = () => {
 	const { permissions } = useAuthenticated();
 	const { entitlements, showOrganizations } = useDashboard();
 	const hasPremiumLicense =
-		entitlements.features.multiple_organizations.enabled;
+		entitlements.features?.multiple_organizations?.enabled ?? false;
 
 	return (
 		<DeploymentSidebarView

--- a/site/src/modules/provisioners/Provisioner.tsx
+++ b/site/src/modules/provisioners/Provisioner.tsx
@@ -18,10 +18,10 @@ export const Provisioner: FC<ProvisionerProps> = ({
 	warnings,
 }) => {
 	const theme = useTheme();
-	const daemonScope = provisioner.tags.scope || "organization";
+	const daemonScope = provisioner.tags?.scope || "organization";
 	const iconScope = daemonScope === "organization" ? <Business /> : <Person />;
 
-	const extraTags = Object.entries(provisioner.tags).filter(
+	const extraTags = Object.entries(provisioner.tags || {}).filter(
 		([key]) => key !== "scope" && key !== "owner",
 	);
 	const isWarning = warnings && warnings.length > 0;

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -32,12 +32,15 @@ type ProvisionerGroupType = "builtin" | "userAuth" | "psk" | "key";
 interface ProvisionerGroupProps {
 	readonly buildInfo: BuildInfoResponse;
 	readonly keyName: string;
-	readonly keyTags: Record<string, string>;
+	readonly keyTags: Record<string, string> | null;
 	readonly type: ProvisionerGroupType;
 	readonly provisioners: readonly ProvisionerDaemon[];
 }
 
-function isSimpleTagSet(tags: Record<string, string>) {
+function isSimpleTagSet(tags: Record<string, string> | null) {
+	if (!tags) {
+		return true;
+	}
 	const numberOfExtraTags = Object.keys(tags).filter(
 		(key) => key !== "scope" && key !== "owner",
 	).length;
@@ -62,7 +65,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		return null;
 	}
 
-	const daemonScope = firstProvisioner.tags.scope || "organization";
+	const daemonScope = firstProvisioner.tags?.scope || "organization";
 	const allProvisionersAreSameVersion = provisioners.every(
 		(it) => it.version === firstProvisioner.version,
 	);
@@ -73,7 +76,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		provisioners.length === 1
 			? "1 provisioner"
 			: `${provisioners.length} provisioners`;
-	const extraTags = Object.entries(keyTags).filter(
+	const extraTags = Object.entries(keyTags || {}).filter(
 		([key]) => key !== "scope" && key !== "owner",
 	);
 
@@ -339,15 +342,15 @@ const ProvisionerVersionPopover: FC<ProvisionerVersionPopoverProps> = ({
 };
 
 interface InlineProvisionerTagsProps {
-	tags: Record<string, string>;
+	tags: Record<string, string> | null;
 }
 
 const InlineProvisionerTags: FC<InlineProvisionerTagsProps> = ({ tags }) => {
-	const daemonScope = tags.scope || "organization";
+	const daemonScope = tags?.scope || "organization";
 	const iconScope =
 		daemonScope === "organization" ? <BusinessIcon /> : <PersonIcon />;
 
-	const extraTags = Object.entries(tags).filter(
+	const extraTags = Object.entries(tags || {}).filter(
 		([tag]) => tag !== "scope" && tag !== "owner",
 	);
 

--- a/site/src/modules/provisioners/ProvisionerStatusAlert.stories.tsx
+++ b/site/src/modules/provisioners/ProvisionerStatusAlert.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof ProvisionerStatusAlert> = {
 	args: {
 		matchingProvisioners: 0,
 		availableProvisioners: 0,
-		tags: MockTemplateVersion.job.tags,
+		tags: MockTemplateVersion.job.tags || undefined,
 	},
 };
 

--- a/site/src/modules/provisioners/ProvisionerTags.tsx
+++ b/site/src/modules/provisioners/ProvisionerTags.tsx
@@ -29,18 +29,18 @@ export const ProvisionerTag: FC<ProvisionerTagProps> = ({ label, value }) => {
 };
 
 type ProvisionerTagsProps = {
-	tags: Record<string, string>;
+	tags: Record<string, string> | null;
 };
 
 export const ProvisionerTruncateTags: FC<ProvisionerTagsProps> = ({ tags }) => {
-	const keys = Object.keys(tags);
+	const keys = Object.keys(tags || {});
 
 	if (keys.length === 0) {
 		return null;
 	}
 
 	const firstKey = keys[0];
-	const firstValue = tags[firstKey];
+	const firstValue = tags ? tags[firstKey] : "";
 	const remainderCount = keys.length - 1;
 
 	return (

--- a/site/src/modules/provisioners/ProvisionerTagsField.tsx
+++ b/site/src/modules/provisioners/ProvisionerTagsField.tsx
@@ -13,8 +13,8 @@ const REQUIRED_TAGS = ["scope", "organization", "user"];
 const IMMUTABLE_TAGS = ["owner"];
 
 type ProvisionerTagsFieldProps = {
-	value: ProvisionerDaemon["tags"];
-	onChange: (value: ProvisionerDaemon["tags"]) => void;
+	value: Record<string, string> | null;
+	onChange: (value: Record<string, string> | null) => void;
 };
 
 export const ProvisionerTagsField: FC<ProvisionerTagsFieldProps> = ({
@@ -24,13 +24,15 @@ export const ProvisionerTagsField: FC<ProvisionerTagsFieldProps> = ({
 	return (
 		<div className="flex flex-col gap-3">
 			<div className="flex items-center gap-2 flex-wrap">
-				{Object.entries(fieldValue)
+				{Object.entries(fieldValue || {})
 					// Filter out since users cannot override it
 					.filter(([key]) => !IMMUTABLE_TAGS.includes(key))
 					.map(([key, value]) => {
 						const onDelete = (key: string) => {
-							const { [key]: _, ...newFieldValue } = fieldValue;
-							onChange(newFieldValue);
+							if (fieldValue) {
+								const { [key]: _, ...newFieldValue } = fieldValue;
+								onChange(newFieldValue);
+							}
 						};
 
 						return (
@@ -47,7 +49,7 @@ export const ProvisionerTagsField: FC<ProvisionerTagsFieldProps> = ({
 
 			<NewTagControl
 				onAdd={(tag) => {
-					onChange({ ...fieldValue, [tag.key]: tag.value });
+					onChange({ ...(fieldValue || {}), [tag.key]: tag.value });
 				}}
 			/>
 		</div>

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -26,8 +26,10 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 	workspace,
 	wildcardHostname,
 }) => {
-	const folderPath = container.labels["devcontainer.local_folder"];
-	const containerFolder = container.volumes[folderPath];
+	const folderPath = container.labels?.["devcontainer.local_folder"];
+	const containerFolder = folderPath
+		? container.volumes?.[folderPath]
+		: undefined;
 
 	return (
 		<section
@@ -52,7 +54,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 					userName={workspace.owner_name}
 					workspaceName={workspace.name}
 					devContainerName={container.name}
-					devContainerFolder={containerFolder}
+					devContainerFolder={containerFolder || ""}
 					displayApps={agent.display_apps}
 					agentName={agent.name}
 				/>

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -104,7 +104,7 @@ export const PortForwardButton: FC<PortForwardButtonProps> = (props) => {
 					{...props}
 					listeningPorts={portsQuery.data?.ports}
 					portSharingControlsEnabled={
-						entitlements.features.control_shared_ports.enabled
+						entitlements.features?.control_shared_ports?.enabled ?? false
 					}
 				/>
 			</PopoverContent>

--- a/site/src/modules/tableFiltering/options.tsx
+++ b/site/src/modules/tableFiltering/options.tsx
@@ -69,7 +69,7 @@ export const useOrganizationsFilterMenu = ({
 				),
 			});
 			return organizations
-				.filter((organization) => permissions[organization.id])
+				.filter((organization) => permissions?.[organization.id])
 				.map<SelectFilterOption>((organization) => ({
 					label: organization.display_name || organization.name,
 					value: organization.name,

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/AuditLogDescription.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDescription/AuditLogDescription.tsx
@@ -42,9 +42,9 @@ export const AuditLogDescription: FC<AuditLogDescriptionProps> = ({
 
 	// logs for workspaces created on behalf of other users indicate ownership in the description
 	const onBehalfOf =
-		auditLog.additional_fields.workspace_owner &&
-		auditLog.additional_fields.workspace_owner !== "unknown" &&
-		auditLog.additional_fields.workspace_owner.trim() !== user
+		auditLog.additional_fields?.workspace_owner &&
+		auditLog.additional_fields?.workspace_owner !== "unknown" &&
+		auditLog.additional_fields?.workspace_owner.trim() !== user
 			? ` on behalf of ${auditLog.additional_fields.workspace_owner}`
 			: "";
 
@@ -64,8 +64,8 @@ export const AuditLogDescription: FC<AuditLogDescriptionProps> = ({
 };
 
 function AppSessionAuditLogDescription({ auditLog }: AuditLogDescriptionProps) {
-	const { connection_type, workspace_owner, workspace_name } =
-		auditLog.additional_fields;
+	const additionalFields = auditLog.additional_fields || {};
+	const { connection_type, workspace_owner, workspace_name } = additionalFields;
 
 	return (
 		<>

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDiff/AuditLogDiff.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDiff/AuditLogDiff.tsx
@@ -47,7 +47,7 @@ interface AuditLogDiffProps {
 }
 
 export const AuditLogDiff: FC<AuditLogDiffProps> = ({ diff }) => {
-	const diffEntries = Object.entries(diff);
+	const diffEntries = Object.entries(diff || {});
 
 	return (
 		<div css={styles.diff}>

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDiff/auditUtils.ts
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDiff/auditUtils.ts
@@ -11,6 +11,10 @@ interface GroupMember {
  * @returns a diff with the 'members' key flattened to be an array of user_ids
  */
 export const determineGroupDiff = (auditLogDiff: AuditDiff): AuditDiff => {
+	if (!auditLogDiff) {
+		return {};
+	}
+
 	const old = auditLogDiff.members?.old as GroupMember[] | undefined;
 	const new_ = auditLogDiff.members?.new as GroupMember[] | undefined;
 
@@ -32,6 +36,10 @@ export const determineGroupDiff = (auditLogDiff: AuditDiff): AuditDiff => {
 export const determineIdPSyncMappingDiff = (
 	auditLogDiff: AuditDiff,
 ): AuditDiff => {
+	if (!auditLogDiff) {
+		return {};
+	}
+
 	const old = auditLogDiff.mapping?.old as Record<string, string[]> | undefined;
 	const new_ = auditLogDiff.mapping?.new as
 		| Record<string, string[]>

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
@@ -50,7 +50,7 @@ export const AuditLogRow: FC<AuditLogRowProps> = ({
 	showOrgDetails,
 }) => {
 	const [isDiffOpen, setIsDiffOpen] = useState(defaultIsDiffOpen);
-	const diffs = Object.entries(auditLog.diff);
+	const diffs = Object.entries(auditLog.diff || {});
 	const shouldDisplayDiff = diffs.length > 0;
 	const userAgent = auditLog.user_agent
 		? userAgentParser(auditLog.user_agent)

--- a/site/src/pages/CreateTemplatePage/utils.ts
+++ b/site/src/pages/CreateTemplatePage/utils.ts
@@ -17,7 +17,7 @@ export const newTemplate = (
 
 	const safeTemplateData = {
 		name: formData.name,
-		max_port_share_level: null,
+		max_port_share_level: "public" as const, // Default to most permissive setting
 		display_name: formData.display_name,
 		description: formData.description,
 		icon: formData.icon,
@@ -47,7 +47,7 @@ export const newTemplate = (
 
 export const getFormPermissions = (entitlements: Entitlements) => {
 	const allowAdvancedScheduling =
-		entitlements.features.advanced_template_scheduling.enabled;
+		entitlements.features?.advanced_template_scheduling?.enabled ?? false;
 
 	return {
 		allowAdvancedScheduling,

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPage.tsx
@@ -46,7 +46,7 @@ const AppearanceSettingsPage: FC = () => {
 				appearance={appearance}
 				onSaveAppearance={onSaveAppearance}
 				isEntitled={
-					entitlements.features.appearance.entitlement !== "not_entitled"
+					entitlements.features?.appearance?.entitlement !== "not_entitled"
 				}
 				isPremium={hasPremiumLicense}
 			/>

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/ExportPolicyButton.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/ExportPolicyButton.tsx
@@ -17,7 +17,7 @@ export const ExportPolicyButton: FC<ExportPolicyButtonProps> = ({
 	const [isDownloading, setIsDownloading] = useState(false);
 
 	const canCreatePolicyJson =
-		syncSettings?.field && Object.keys(syncSettings?.mapping).length > 0;
+		syncSettings?.field && Object.keys(syncSettings?.mapping || {}).length > 0;
 
 	return (
 		<Button

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof IdpOrgSyncPageView> = {
 	component: IdpOrgSyncPageView,
 	args: {
 		organizationSyncSettings: MockOrganizationSyncSettings2,
-		claimFieldValues: Object.keys(MockOrganizationSyncSettings2.mapping),
+		claimFieldValues: Object.keys(MockOrganizationSyncSettings2.mapping || {}),
 		organizations: [MockOrganization, MockOrganization2],
 		error: undefined,
 	},
@@ -40,7 +40,7 @@ export const HasError: Story = {
 export const MissingGroups: Story = {
 	args: {
 		organizationSyncSettings: MockOrganizationSyncSettings,
-		claimFieldValues: Object.keys(MockOrganizationSyncSettings.mapping),
+		claimFieldValues: Object.keys(MockOrganizationSyncSettings.mapping || {}),
 		organizations: [],
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
@@ -78,8 +78,8 @@ const LicensesSettingsPage: FC = () => {
 				showConfetti={confettiOn}
 				isLoading={isLoading}
 				isRefreshing={refreshEntitlementsMutation.isLoading}
-				userLimitActual={entitlementsQuery.data?.features.user_limit.actual}
-				userLimitLimit={entitlementsQuery.data?.features.user_limit.limit}
+				userLimitActual={entitlementsQuery.data?.features?.user_limit?.actual}
+				userLimitLimit={entitlementsQuery.data?.features?.user_limit?.limit}
 				licenses={licenses}
 				isRemovingLicense={isRemovingLicense}
 				removeLicense={(licenseId: number) => removeLicenseApi(licenseId)}

--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPage.tsx
@@ -18,7 +18,9 @@ const ObservabilitySettingsPage: FC = () => {
 			</Helmet>
 			<ObservabilitySettingsPageView
 				options={deploymentConfig.options}
-				featureAuditLogEnabled={entitlements.features.audit_log.enabled}
+				featureAuditLogEnabled={
+					entitlements.features?.audit_log?.enabled ?? false
+				}
 				isPremium={hasPremiumLicense}
 			/>
 		</>

--- a/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/SecuritySettingsPage/SecuritySettingsPage.tsx
@@ -16,7 +16,9 @@ const SecuritySettingsPage: FC = () => {
 			</Helmet>
 			<SecuritySettingsPageView
 				options={deploymentConfig.options}
-				featureBrowserOnlyEnabled={entitlements.features.browser_only.enabled}
+				featureBrowserOnlyEnabled={
+					entitlements.features?.browser_only?.enabled ?? false
+				}
 			/>
 		</>
 	);

--- a/site/src/pages/HealthPage/DERPRegionPage.stories.tsx
+++ b/site/src/pages/HealthPage/DERPRegionPage.stories.tsx
@@ -3,7 +3,7 @@ import { MockHealth } from "testHelpers/entities";
 import { DERPRegionPage } from "./DERPRegionPage";
 import { generateMeta } from "./storybook";
 
-const firstRegionId = Object.values(MockHealth.derp.regions)[0]!.region
+const firstRegionId = Object.values(MockHealth.derp.regions || {})[0]?.region
 	?.RegionID;
 
 const meta: Meta = {

--- a/site/src/pages/HealthPage/DERPRegionPage.tsx
+++ b/site/src/pages/HealthPage/DERPRegionPage.tsx
@@ -37,7 +37,7 @@ export const DERPRegionPage: FC = () => {
 		node_reports: reports,
 		warnings,
 		severity,
-	} = healthStatus.derp.regions[regionId] as DERPRegionReport;
+	} = healthStatus.derp.regions?.[regionId] as DERPRegionReport;
 
 	return (
 		<>

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
@@ -25,7 +25,7 @@ export const ExportPolicyButton: FC<DownloadPolicyButtonProps> = ({
 	const [isDownloading, setIsDownloading] = useState(false);
 
 	const canCreatePolicyJson =
-		syncSettings?.field && Object.keys(syncSettings?.mapping).length > 0;
+		syncSettings?.field && Object.keys(syncSettings?.mapping || {}).length > 0;
 
 	return (
 		<Button

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
@@ -24,8 +24,8 @@ const meta: Meta<typeof IdpSyncPageView> = {
 		groupSyncSettings: MockGroupSyncSettings,
 		roleSyncSettings: MockRoleSyncSettings,
 		claimFieldValues: [
-			...Object.keys(MockGroupSyncSettings.mapping),
-			...Object.keys(MockRoleSyncSettings.mapping),
+			...Object.keys(MockGroupSyncSettings.mapping || {}),
+			...Object.keys(MockRoleSyncSettings.mapping || {}),
 		],
 		groups: [MockGroup, MockGroup2],
 		groupsMap,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/CancelJobConfirmationDialog.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/CancelJobConfirmationDialog.tsx
@@ -31,7 +31,7 @@ export const CancelJobConfirmationDialog: FC<
 				provisionerJobsQueryKey(job.organization_id),
 			);
 			queryClient.invalidateQueries(
-				getProvisionerDaemonsKey(job.organization_id, job.tags),
+				getProvisionerDaemonsKey(job.organization_id, job.tags || undefined),
 			);
 		},
 	});

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
@@ -150,7 +150,7 @@ export const JobRow: FC<JobRowProps> = ({ job, defaultIsOpen = false }) => {
 							<dt>Tags:</dt>
 							<dd>
 								<ProvisionerTags>
-									{Object.entries(job.tags).map(([key, value]) => (
+									{Object.entries(job.tags || {}).map(([key, value]) => (
 										<ProvisionerTag key={key} label={key} value={value} />
 									))}
 								</ProvisionerTags>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
@@ -60,7 +60,9 @@ const OrganizationProvisionersPage: FC = () => {
 		<>
 			{helmet}
 			<OrganizationProvisionersPageView
-				showPaywall={!entitlements.features.multiple_organizations.enabled}
+				showPaywall={
+					!(entitlements.features?.multiple_organizations?.enabled ?? false)
+				}
 				error={provisionersQuery.error}
 				provisioners={provisionersQuery.data}
 				buildVersion={buildInfoQuery.data?.version}

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -129,9 +129,11 @@ export const ProvisionerRow: FC<ProvisionerRowProps> = ({
 							<dt>Tags:</dt>
 							<dd>
 								<ProvisionerTags>
-									{Object.entries(provisioner.tags).map(([key, value]) => (
-										<ProvisionerTag key={key} label={key} value={value} />
-									))}
+									{Object.entries(provisioner.tags || {}).map(
+										([key, value]) => (
+											<ProvisionerTag key={key} label={key} value={value} />
+										),
+									)}
 								</ProvisionerTags>
 							</dd>
 

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -212,8 +212,8 @@ export const TemplateInsightsPageView: FC<TemplateInsightsPageViewProps> = ({
 					css={{ gridColumn: "span 2" }}
 					interval={interval}
 					userLimit={
-						entitlements?.features.user_limit.enabled
-							? entitlements?.features.user_limit.limit
+						entitlements?.features?.user_limit?.enabled
+							? entitlements?.features?.user_limit?.limit
 							: undefined
 					}
 					data={templateInsights?.interval_reports}

--- a/site/src/pages/TemplatePage/TemplateLayout.tsx
+++ b/site/src/pages/TemplatePage/TemplateLayout.tsx
@@ -138,7 +138,7 @@ export const TemplateLayout: FC<PropsWithChildren> = ({
 						<TabLink to="docs" value="docs">
 							Docs
 						</TabLink>
-						{data.permissions.canUpdateTemplate && (
+						{data.permissions?.canUpdateTemplate && (
 							<TabLink to="files" value="files">
 								Source Code
 							</TabLink>

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -192,7 +192,7 @@ export const TemplatePageHeader: FC<TemplatePageHeaderProps> = ({
 								</Button>
 							)}
 
-						{permissions.canUpdateTemplate && (
+						{permissions?.canUpdateTemplate && (
 							<TemplateMenu
 								organizationName={template.organization_name}
 								templateId={template.id}

--- a/site/src/pages/TemplatePage/TemplateSummaryPage/TemplateStats.tsx
+++ b/site/src/pages/TemplatePage/TemplateSummaryPage/TemplateStats.tsx
@@ -42,7 +42,7 @@ export const TemplateStats: FC<TemplateStatsProps> = ({
 			/>
 			<StatsItem
 				label={Language.buildTimeLabel}
-				value={formatTemplateBuildTime(template.build_time_stats.start.P50)}
+				value={formatTemplateBuildTime(template.build_time_stats?.start.P50)}
 			/>
 			<StatsItem
 				label={Language.activeVersionLabel}

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/TemplateVersionsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/TemplateVersionsPage.tsx
@@ -68,12 +68,12 @@ const TemplateVersionsPage = () => {
 			<VersionsTable
 				versions={data}
 				onPromoteClick={
-					permissions.canUpdateTemplate
+					permissions?.canUpdateTemplate
 						? setSelectedVersionIdToPromote
 						: undefined
 				}
 				onArchiveClick={
-					permissions.canUpdateTemplate
+					permissions?.canUpdateTemplate
 						? setSelectedVersionIdToArchive
 						: undefined
 				}

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
@@ -20,11 +20,12 @@ export const TemplateSettingsPage: FC = () => {
 	const { template } = useTemplateSettings();
 	const queryClient = useQueryClient();
 	const { entitlements } = useDashboard();
-	const accessControlEnabled = entitlements.features.access_control.enabled;
+	const accessControlEnabled =
+		entitlements.features?.access_control?.enabled ?? false;
 	const advancedSchedulingEnabled =
-		entitlements.features.advanced_template_scheduling.enabled;
+		entitlements.features?.advanced_template_scheduling?.enabled ?? false;
 	const sharedPortControlsEnabled =
-		entitlements.features.control_shared_ports.enabled;
+		entitlements.features?.control_shared_ports?.enabled ?? false;
 
 	const {
 		mutate: updateTemplate,

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.tsx
@@ -21,7 +21,7 @@ const TemplateSchedulePage: FC = () => {
 	const { organization: organizationName = "default", template: templateName } =
 		useParams() as { organization?: string; template: string };
 	const allowAdvancedScheduling =
-		entitlements.features.advanced_template_scheduling.enabled;
+		entitlements.features?.advanced_template_scheduling?.enabled ?? false;
 
 	const {
 		mutate: updateTemplate,

--- a/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ProvisionerTagsPopover.tsx
@@ -14,8 +14,8 @@ import type { FC } from "react";
 import { docs } from "utils/docs";
 
 export interface ProvisionerTagsPopoverProps {
-	tags: ProvisionerDaemon["tags"];
-	onTagsChange: (values: ProvisionerDaemon["tags"]) => void;
+	tags: Record<string, string> | null;
+	onTagsChange: (values: Record<string, string> | null) => void;
 }
 
 export const ProvisionerTagsPopover: FC<ProvisionerTagsPopoverProps> = ({

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -89,7 +89,7 @@ export interface TemplateVersionEditorProps {
 	onCancelSubmitMissingVariableValues: () => void;
 	defaultTab?: Tab;
 	provisionerTags: Record<string, string>;
-	onUpdateProvisionerTags: (tags: Record<string, string>) => void;
+	onUpdateProvisionerTags: (tags: Record<string, string> | null) => void;
 	activePath: string | undefined;
 	onActivePathChange: (path: string | undefined) => void;
 }
@@ -583,7 +583,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 												title="Error during the build"
 												detail={templateVersion.job.error}
 												severity="error"
-												tags={templateVersion.job.tags}
+												tags={templateVersion.job.tags || {}}
 												variant={AlertVariant.Inline}
 											/>
 										</div>
@@ -593,7 +593,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 												<ProvisionerStatusAlert
 													matchingProvisioners={matchingProvisioners}
 													availableProvisioners={availableProvisioners}
-													tags={templateVersion.job.tags}
+													tags={templateVersion.job.tags || {}}
 													variant={AlertVariant.Inline}
 												/>
 												<Loader css={{ height: "100%" }} />

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -232,7 +232,7 @@ export const TemplateVersionEditorPage: FC = () => {
 					}}
 					provisionerTags={provisionerTags}
 					onUpdateProvisionerTags={(tags) => {
-						setProvisionerTags(tags);
+						setProvisionerTags(tags || {});
 					}}
 				/>
 			)}

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -149,7 +149,7 @@ const TemplateRow: FC<TemplateRowProps> = ({
 			</TableCell>
 
 			<TableCell css={styles.secondary}>
-				{formatTemplateBuildTime(template.build_time_stats.start.P50)}
+				{formatTemplateBuildTime(template.build_time_stats?.start.P50)}
 			</TableCell>
 
 			<TableCell data-chromatic="ignore" css={styles.secondary}>

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -15,7 +15,8 @@ export const AccountPage: FC = () => {
 		useAuthContext();
 	const { entitlements } = useDashboard();
 
-	const hasGroupsFeature = entitlements.features.user_role_management.enabled;
+	const hasGroupsFeature =
+		entitlements.features?.user_role_management?.enabled ?? false;
 	const groupsQuery = useQuery({
 		...groupsForUser(me.id),
 		enabled: hasGroupsFeature,

--- a/site/src/pages/UserSettingsPage/Sidebar.tsx
+++ b/site/src/pages/UserSettingsPage/Sidebar.tsx
@@ -24,7 +24,7 @@ interface SidebarProps {
 export const Sidebar: FC<SidebarProps> = ({ user }) => {
 	const { entitlements } = useDashboard();
 	const showSchedulePage =
-		entitlements.features.advanced_template_scheduling.enabled;
+		entitlements.features?.advanced_template_scheduling?.enabled ?? false;
 
 	return (
 		<BaseSidebar>

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -146,7 +146,7 @@ const UsersPage: FC<UserPageProps> = ({ defaultNewPassword }) => {
 				isUpdatingUserRoles={updateRolesMutation.isLoading}
 				isLoading={isLoading}
 				canEditUsers={canEditUsers}
-				canViewActivity={entitlements.features.audit_log.enabled}
+				canViewActivity={entitlements.features?.audit_log?.enabled ?? false}
 				isNonInitialPage={isNonInitialPage(searchParams)}
 				actorID={me.id}
 				filterProps={{

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -237,7 +237,7 @@ export const Workspace: FC<WorkspaceProps> = ({
 							availableProvisioners={
 								workspace.latest_build.matched_provisioners?.available ?? 0
 							}
-							tags={workspace.latest_build.job.tags}
+							tags={workspace.latest_build.job.tags || {}}
 						/>
 					)}
 

--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -19,11 +19,11 @@ export const ActiveTransition = (
 
 	switch (status) {
 		case "starting":
-			return template.build_time_stats.start;
+			return template.build_time_stats?.start;
 		case "stopping":
-			return template.build_time_stats.stop;
+			return template.build_time_stats?.stop;
 		case "deleting":
-			return template.build_time_stats.delete;
+			return template.build_time_stats?.delete;
 		default:
 			return undefined;
 	}

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
@@ -124,7 +124,7 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
 	// Dormant
 	const { entitlements } = useDashboard();
 	const advancedSchedulingEnabled =
-		entitlements.features.advanced_template_scheduling.enabled;
+		entitlements.features?.advanced_template_scheduling?.enabled ?? false;
 	if (advancedSchedulingEnabled && workspace.dormant_at) {
 		const formatDate = (dateStr: string, timestamp: boolean): string => {
 			const date = new Date(dateStr);

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -103,7 +103,7 @@ export const WorkspaceTopbar: FC<WorkspaceProps> = ({
 
 	// Dormant
 	const allowAdvancedScheduling =
-		entitlements.features.advanced_template_scheduling.enabled;
+		entitlements.features?.advanced_template_scheduling?.enabled ?? false;
 	// This check can be removed when https://github.com/coder/coder/milestone/19
 	// is merged up
 	const shouldDisplayDormantData = displayDormantDeletion(

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -84,7 +84,7 @@ const WorkspacesPage: FC = () => {
 	>(null);
 	const [urlSearchParams] = searchParamsResult;
 	const canCheckWorkspaces =
-		entitlements.features.workspace_batch_actions.enabled;
+		entitlements.features?.workspace_batch_actions?.enabled ?? false;
 	const batchActions = useBatchActions({
 		onSuccess: async () => {
 			await refetch();

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -80,9 +80,10 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 }) => {
 	const { entitlements, showOrganizations } = useDashboard();
 	const width = showOrganizations ? 175 : undefined;
-	const presets = entitlements.features.advanced_template_scheduling.enabled
-		? PRESETS_WITH_DORMANT
-		: PRESET_FILTERS;
+	const presets =
+		(entitlements.features?.advanced_template_scheduling?.enabled ?? false)
+			? PRESETS_WITH_DORMANT
+			: PRESET_FILTERS;
 
 	return (
 		<Filter


### PR DESCRIPTION
Golang can encode maps as `null`. The `Record` type is therefore not sufficient to fully describe the data.

https://go.dev/play/p/N2BJVhMCKXu

We can get errors like this: https://github.com/coder/coder/pull/17430
![Screenshot From 2025-04-16 15-40-44](https://github.com/user-attachments/assets/4d5a9080-d535-4ba0-881c-6efe3f07aebf)

