### PR TITLE
test: fix flake in TestRoleSyncTable with test cases sharing resources

### DIFF
--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -225,9 +225,8 @@ func TestRoleSyncTable(t *testing.T) {
 	// deployment. This tests all organizations being synced together.
 	// The reason we do them individually, is that it is much easier to
 	// debug a single test case.
+	//nolint:paralleltest, tparallel // This should run after all the individual tests
 	t.Run("AllTogether", func(t *testing.T) {
-		t.Parallel()
-
 		db, _ := dbtestutil.NewDB(t)
 		manager := runtimeconfig.NewManager()
 		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{


### PR DESCRIPTION
The test case definition shares maps that can have concurrent access if run in parallel. This fixes that
Flake: https://github.com/coder/coder/actions/runs/14504014498/job/40689907014?pr=17439