### PR TITLE
chore(coderd/notifications/notificationstest): enqueue messages in FakeEnqueuer

### DIFF
--- a/cli/notifications_test.go
+++ b/cli/notifications_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/codersdk"
@@ -118,12 +119,15 @@ func TestNotificationsTest(t *testing.T) {
 	t.Run("OwnerCanSendTestNotification", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		// Given: An owner user.
 		ownerClient := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:      coderdtest.DeploymentValues(t),
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		_ = coderdtest.CreateFirstUser(t, ownerClient)
 
@@ -142,12 +146,15 @@ func TestNotificationsTest(t *testing.T) {
 	t.Run("MemberCannotSendTestNotification", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		// Given: A member user.
 		ownerClient := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:      coderdtest.DeploymentValues(t),
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		ownerUser := coderdtest.CreateFirstUser(t, ownerClient)
 		memberClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, ownerUser.OrganizationID)

--- a/coderd/agentapi/resources_monitoring_test.go
+++ b/coderd/agentapi/resources_monitoring_test.go
@@ -55,7 +55,7 @@ func resourceMonitorAPI(t *testing.T) (*agentapi.ResourcesMonitoringAPI, databas
 		ResourceID: resource.ID,
 	})
 
-	notifyEnq := &notificationstest.FakeEnqueuer{}
+	notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 	clock := quartz.NewMock(t)
 
 	return &agentapi.ResourcesMonitoringAPI{

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -262,7 +262,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	}
 
 	if options.NotificationsEnqueuer == nil {
-		options.NotificationsEnqueuer = &notificationstest.FakeEnqueuer{}
+		options.NotificationsEnqueuer = &notificationstest.FakeEnqueuer{Store: options.Database}
 	}
 
 	accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
@@ -331,7 +331,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		t.Cleanup(closeBatcher)
 	}
 	if options.NotificationsEnqueuer == nil {
-		options.NotificationsEnqueuer = &notificationstest.FakeEnqueuer{}
+		options.NotificationsEnqueuer = &notificationstest.FakeEnqueuer{Store: options.Database}
 	}
 
 	if options.OneTimePasscodeValidityPeriod == 0 {

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -509,7 +509,7 @@ func setup(t *testing.T) (context.Context, slog.Logger, database.Store, pubsub.P
 	ctx := dbauthz.AsSystemRestricted(context.Background())
 	logger := slogtest.Make(t, &slogtest.Options{})
 	db, ps := dbtestutil.NewDB(t)
-	notifyEnq := &notificationstest.FakeEnqueuer{}
+	notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 	clk := quartz.NewMock(t)
 	return ctx, logger, db, ps, notifyEnq, clk
 }

--- a/coderd/notifications_test.go
+++ b/coderd/notifications_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/codersdk"
@@ -330,10 +331,13 @@ func TestNotificationTest(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		ownerClient := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:      coderdtest.DeploymentValues(t),
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 
 		// Given: A user with owner permissions.
@@ -353,10 +357,13 @@ func TestNotificationTest(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		ownerClient := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:      coderdtest.DeploymentValues(t),
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 
 		// Given: A user without owner permissions.

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -65,7 +65,7 @@ func testUserQuietHoursScheduleStore() *atomic.Pointer[schedule.UserQuietHoursSc
 func TestAcquireJob_LongPoll(t *testing.T) {
 	t.Parallel()
 	//nolint:dogsled
-	srv, _, _, _ := setup(t, false, &overrides{acquireJobLongPollDuration: time.Microsecond})
+	srv, _, _, _, _ := setup(t, false, &overrides{acquireJobLongPollDuration: time.Microsecond})
 	job, err := srv.AcquireJob(context.Background(), nil)
 	require.NoError(t, err)
 	require.Equal(t, &proto.AcquiredJob{}, job)
@@ -74,7 +74,7 @@ func TestAcquireJob_LongPoll(t *testing.T) {
 func TestAcquireJobWithCancel_Cancel(t *testing.T) {
 	t.Parallel()
 	//nolint:dogsled
-	srv, _, _, _ := setup(t, false, nil)
+	srv, _, _, _, _ := setup(t, false, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 	defer cancel()
 	fs := newFakeStream(ctx)
@@ -111,7 +111,7 @@ func TestHeartbeat(t *testing.T) {
 		}
 	}
 	//nolint:dogsled
-	_, _, _, _ = setup(t, false, &overrides{
+	_, _, _, _, _ = setup(t, false, &overrides{
 		ctx:               ctx,
 		heartbeatFn:       heartbeatFn,
 		heartbeatInterval: testutil.IntervalFast,
@@ -148,7 +148,7 @@ func TestAcquireJob(t *testing.T) {
 		tc := tc
 		t.Run(tc.name+"_InitiatorNotFound", func(t *testing.T) {
 			t.Parallel()
-			srv, db, _, pd := setup(t, false, nil)
+			srv, db, _, pd, _ := setup(t, false, nil)
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 			defer cancel()
 
@@ -180,7 +180,7 @@ func TestAcquireJob(t *testing.T) {
 					Id: "github",
 				}
 
-				srv, db, ps, pd := setup(t, false, &overrides{
+				srv, db, ps, pd, _ := setup(t, false, &overrides{
 					deploymentValues: dv,
 					externalAuthConfigs: []*externalauth.Config{{
 						ID:                       gitAuthProvider.Id,
@@ -446,7 +446,7 @@ func TestAcquireJob(t *testing.T) {
 		}
 		t.Run(tc.name+"_TemplateVersionDryRun", func(t *testing.T) {
 			t.Parallel()
-			srv, db, ps, _ := setup(t, false, nil)
+			srv, db, ps, _, _ := setup(t, false, nil)
 			ctx := context.Background()
 
 			user := dbgen.User(t, db, database.User{})
@@ -483,7 +483,7 @@ func TestAcquireJob(t *testing.T) {
 		})
 		t.Run(tc.name+"_TemplateVersionImport", func(t *testing.T) {
 			t.Parallel()
-			srv, db, ps, _ := setup(t, false, nil)
+			srv, db, ps, _, _ := setup(t, false, nil)
 			ctx := context.Background()
 
 			user := dbgen.User(t, db, database.User{})
@@ -514,7 +514,7 @@ func TestAcquireJob(t *testing.T) {
 		})
 		t.Run(tc.name+"_TemplateVersionImportWithUserVariable", func(t *testing.T) {
 			t.Parallel()
-			srv, db, ps, _ := setup(t, false, nil)
+			srv, db, ps, _, _ := setup(t, false, nil)
 
 			user := dbgen.User(t, db, database.User{})
 			version := dbgen.TemplateVersion(t, db, database.TemplateVersion{})
@@ -563,7 +563,7 @@ func TestUpdateJob(t *testing.T) {
 	ctx := context.Background()
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
-		srv, _, _, _ := setup(t, false, nil)
+		srv, _, _, _, _ := setup(t, false, nil)
 		_, err := srv.UpdateJob(ctx, &proto.UpdateJobRequest{
 			JobId: "hello",
 		})
@@ -576,7 +576,7 @@ func TestUpdateJob(t *testing.T) {
 	})
 	t.Run("NotRunning", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, _ := setup(t, false, nil)
+		srv, db, _, _, _ := setup(t, false, nil)
 		job, err := db.InsertProvisionerJob(ctx, database.InsertProvisionerJobParams{
 			ID:            uuid.New(),
 			Provisioner:   database.ProvisionerTypeEcho,
@@ -592,7 +592,7 @@ func TestUpdateJob(t *testing.T) {
 	// This test prevents runners from updating jobs they don't own!
 	t.Run("NotOwner", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, _ := setup(t, false, nil)
+		srv, db, _, _, _ := setup(t, false, nil)
 		job, err := db.InsertProvisionerJob(ctx, database.InsertProvisionerJobParams{
 			ID:            uuid.New(),
 			Provisioner:   database.ProvisionerTypeEcho,
@@ -635,7 +635,7 @@ func TestUpdateJob(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, &overrides{})
+		srv, db, _, pd, _ := setup(t, false, &overrides{})
 		job := setupJob(t, db, pd.ID)
 		_, err := srv.UpdateJob(ctx, &proto.UpdateJobRequest{
 			JobId: job.String(),
@@ -645,7 +645,7 @@ func TestUpdateJob(t *testing.T) {
 
 	t.Run("Logs", func(t *testing.T) {
 		t.Parallel()
-		srv, db, ps, pd := setup(t, false, &overrides{})
+		srv, db, ps, pd, _ := setup(t, false, &overrides{})
 		job := setupJob(t, db, pd.ID)
 
 		published := make(chan struct{})
@@ -670,7 +670,7 @@ func TestUpdateJob(t *testing.T) {
 	})
 	t.Run("Readme", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, &overrides{})
+		srv, db, _, pd, _ := setup(t, false, &overrides{})
 		job := setupJob(t, db, pd.ID)
 		versionID := uuid.New()
 		err := db.InsertTemplateVersion(ctx, database.InsertTemplateVersionParams{
@@ -696,7 +696,7 @@ func TestUpdateJob(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()
 
-			srv, db, _, pd := setup(t, false, &overrides{})
+			srv, db, _, pd, _ := setup(t, false, &overrides{})
 			job := setupJob(t, db, pd.ID)
 			versionID := uuid.New()
 			err := db.InsertTemplateVersion(ctx, database.InsertTemplateVersionParams{
@@ -743,7 +743,7 @@ func TestUpdateJob(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()
 
-			srv, db, _, pd := setup(t, false, &overrides{})
+			srv, db, _, pd, _ := setup(t, false, &overrides{})
 			job := setupJob(t, db, pd.ID)
 			versionID := uuid.New()
 			err := db.InsertTemplateVersion(ctx, database.InsertTemplateVersionParams{
@@ -789,7 +789,7 @@ func TestUpdateJob(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		srv, db, _, pd := setup(t, false, &overrides{})
+		srv, db, _, pd, _ := setup(t, false, &overrides{})
 		job := setupJob(t, db, pd.ID)
 		versionID := uuid.New()
 		err := db.InsertTemplateVersion(ctx, database.InsertTemplateVersionParams{
@@ -821,7 +821,7 @@ func TestFailJob(t *testing.T) {
 	ctx := context.Background()
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
-		srv, _, _, _ := setup(t, false, nil)
+		srv, _, _, _, _ := setup(t, false, nil)
 		_, err := srv.FailJob(ctx, &proto.FailedJob{
 			JobId: "hello",
 		})
@@ -835,7 +835,7 @@ func TestFailJob(t *testing.T) {
 	// This test prevents runners from updating jobs they don't own!
 	t.Run("NotOwner", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, _ := setup(t, false, nil)
+		srv, db, _, _, _ := setup(t, false, nil)
 		job, err := db.InsertProvisionerJob(ctx, database.InsertProvisionerJobParams{
 			ID:            uuid.New(),
 			Provisioner:   database.ProvisionerTypeEcho,
@@ -858,7 +858,7 @@ func TestFailJob(t *testing.T) {
 	})
 	t.Run("AlreadyCompleted", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, &overrides{})
+		srv, db, _, pd, _ := setup(t, false, &overrides{})
 		job, err := db.InsertProvisionerJob(ctx, database.InsertProvisionerJobParams{
 			ID:            uuid.New(),
 			Provisioner:   database.ProvisionerTypeEcho,
@@ -894,7 +894,7 @@ func TestFailJob(t *testing.T) {
 		//	(*Server).FailJob       audit log - get build {"error": "sql: no rows in result set"}
 		ignoreLogErrors := true
 		auditor := audit.NewMock()
-		srv, db, ps, pd := setup(t, ignoreLogErrors, &overrides{
+		srv, db, ps, pd, _ := setup(t, ignoreLogErrors, &overrides{
 			auditor: auditor,
 		})
 		org := dbgen.Organization(t, db, database.Organization{})
@@ -987,7 +987,7 @@ func TestCompleteJob(t *testing.T) {
 	ctx := context.Background()
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
-		srv, _, _, _ := setup(t, false, nil)
+		srv, _, _, _, _ := setup(t, false, nil)
 		_, err := srv.CompleteJob(ctx, &proto.CompletedJob{
 			JobId: "hello",
 		})
@@ -1001,7 +1001,7 @@ func TestCompleteJob(t *testing.T) {
 	// This test prevents runners from updating jobs they don't own!
 	t.Run("NotOwner", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, nil)
+		srv, db, _, pd, _ := setup(t, false, nil)
 		job, err := db.InsertProvisionerJob(ctx, database.InsertProvisionerJobParams{
 			ID:             uuid.New(),
 			Provisioner:    database.ProvisionerTypeEcho,
@@ -1027,7 +1027,7 @@ func TestCompleteJob(t *testing.T) {
 
 	t.Run("TemplateImport_MissingGitAuth", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, &overrides{})
+		srv, db, _, pd, _ := setup(t, false, &overrides{})
 		jobID := uuid.New()
 		versionID := uuid.New()
 		err := db.InsertTemplateVersion(ctx, database.InsertTemplateVersionParams{
@@ -1081,7 +1081,7 @@ func TestCompleteJob(t *testing.T) {
 
 	t.Run("TemplateImport_WithGitAuth", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, &overrides{
+		srv, db, _, pd, _ := setup(t, false, &overrides{
 			externalAuthConfigs: []*externalauth.Config{{
 				ID: "github",
 			}},
@@ -1228,7 +1228,7 @@ func TestCompleteJob(t *testing.T) {
 				tss := &atomic.Pointer[schedule.TemplateScheduleStore]{}
 				uqhss := &atomic.Pointer[schedule.UserQuietHoursScheduleStore]{}
 				auditor := audit.NewMock()
-				srv, db, ps, pd := setup(t, false, &overrides{
+				srv, db, ps, pd, _ := setup(t, false, &overrides{
 					clock:                       clock,
 					templateScheduleStore:       tss,
 					userQuietHoursScheduleStore: uqhss,
@@ -1408,7 +1408,7 @@ func TestCompleteJob(t *testing.T) {
 	})
 	t.Run("TemplateDryRun", func(t *testing.T) {
 		t.Parallel()
-		srv, db, _, pd := setup(t, false, &overrides{})
+		srv, db, _, pd, _ := setup(t, false, &overrides{})
 		job, err := db.InsertProvisionerJob(ctx, database.InsertProvisionerJobParams{
 			ID:            uuid.New(),
 			Provisioner:   database.ProvisionerTypeEcho,
@@ -1633,7 +1633,7 @@ func TestCompleteJob(t *testing.T) {
 			t.Run(c.name, func(t *testing.T) {
 				t.Parallel()
 
-				srv, db, _, pd := setup(t, false, &overrides{})
+				srv, db, _, pd, _ := setup(t, false, &overrides{})
 				jobParams := c.provisionerJobParams
 				if jobParams.ID == uuid.Nil {
 					jobParams.ID = uuid.New()
@@ -2320,10 +2320,10 @@ func TestNotifications(t *testing.T) {
 				t.Parallel()
 
 				ctx := context.Background()
-				notifEnq := &notificationstest.FakeEnqueuer{}
+				// notifEnq := &notificationstest.FakeEnqueuer{}
 
-				srv, db, ps, pd := setup(t, false, &overrides{
-					notificationEnqueuer: notifEnq,
+				srv, db, ps, pd, notifEnq := setup(t, false, &overrides{
+					// notificationEnqueuer: notifEnq,
 				})
 
 				user := dbgen.User(t, db, database.User{})
@@ -2442,13 +2442,13 @@ func TestNotifications(t *testing.T) {
 				t.Parallel()
 
 				ctx := context.Background()
-				notifEnq := &notificationstest.FakeEnqueuer{}
+				// notifEnq := &notificationstest.FakeEnqueuer{}
 
 				//	Otherwise `(*Server).FailJob` fails with:
 				// audit log - get build {"error": "sql: no rows in result set"}
 				ignoreLogErrors := true
-				srv, db, ps, pd := setup(t, ignoreLogErrors, &overrides{
-					notificationEnqueuer: notifEnq,
+				srv, db, ps, pd, notifEnq := setup(t, ignoreLogErrors, &overrides{
+					// notificationEnqueuer: notifEnq,
 				})
 
 				user := dbgen.User(t, db, database.User{})
@@ -2532,8 +2532,10 @@ func TestNotifications(t *testing.T) {
 		ctx := context.Background()
 
 		// given
-		notifEnq := &notificationstest.FakeEnqueuer{}
-		srv, db, ps, pd := setup(t, true /* ignoreLogErrors */, &overrides{notificationEnqueuer: notifEnq})
+		// notifEnq := &notificationstest.FakeEnqueuer{}
+		srv, db, ps, pd, notifEnq := setup(t, true /* ignoreLogErrors */, &overrides{
+			// notificationEnqueuer: notifEnq
+		})
 
 		templateAdmin := dbgen.User(t, db, database.User{RBACRoles: []string{codersdk.RoleTemplateAdmin}})
 		_ /* other template admin, should not receive notification */ = dbgen.User(t, db, database.User{RBACRoles: []string{codersdk.RoleTemplateAdmin}})
@@ -2602,10 +2604,10 @@ type overrides struct {
 	heartbeatFn                 func(ctx context.Context) error
 	heartbeatInterval           time.Duration
 	auditor                     audit.Auditor
-	notificationEnqueuer        notifications.Enqueuer
+	// notificationEnqueuer        notifications.Enqueuer
 }
 
-func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisionerDaemonServer, database.Store, pubsub.Pubsub, database.ProvisionerDaemon) {
+func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisionerDaemonServer, database.Store, pubsub.Pubsub, database.ProvisionerDaemon, *notificationstest.FakeEnqueuer) {
 	t.Helper()
 	logger := testutil.Logger(t)
 	db := dbmem.New()
@@ -2664,12 +2666,12 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 	}
 	auditPtr.Store(&auditor)
 	pollDur = ov.acquireJobLongPollDuration
-	var notifEnq notifications.Enqueuer
-	if ov.notificationEnqueuer != nil {
-		notifEnq = ov.notificationEnqueuer
-	} else {
-		notifEnq = notifications.NewNoopEnqueuer()
-	}
+	notifEnq := &notificationstest.FakeEnqueuer{Store: db}
+	// if ov.notificationEnqueuer != nil {
+	// notifEnq = ov.notificationEnqueuer
+	// } else {
+	// notifEnq = notifications.NewNoopEnqueuer()
+	// }
 
 	daemon, err := db.UpsertProvisionerDaemon(ov.ctx, database.UpsertProvisionerDaemonParams{
 		Name:           "test",
@@ -2713,7 +2715,7 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 		notifEnq,
 	)
 	require.NoError(t, err)
-	return srv, db, ps, daemon
+	return srv, db, ps, daemon, notifEnq
 }
 
 func must[T any](value T, err error) T {

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -2442,14 +2442,11 @@ func TestNotifications(t *testing.T) {
 				t.Parallel()
 
 				ctx := context.Background()
-				// notifEnq := &notificationstest.FakeEnqueuer{}
 
 				//	Otherwise `(*Server).FailJob` fails with:
 				// audit log - get build {"error": "sql: no rows in result set"}
 				ignoreLogErrors := true
-				srv, db, ps, pd, notifEnq := setup(t, ignoreLogErrors, &overrides{
-					// notificationEnqueuer: notifEnq,
-				})
+				srv, db, ps, pd, notifEnq := setup(t, ignoreLogErrors, &overrides{})
 
 				user := dbgen.User(t, db, database.User{})
 				initiator := user
@@ -2532,10 +2529,7 @@ func TestNotifications(t *testing.T) {
 		ctx := context.Background()
 
 		// given
-		// notifEnq := &notificationstest.FakeEnqueuer{}
-		srv, db, ps, pd, notifEnq := setup(t, true /* ignoreLogErrors */, &overrides{
-			// notificationEnqueuer: notifEnq
-		})
+		srv, db, ps, pd, notifEnq := setup(t, true /* ignoreLogErrors */, &overrides{})
 
 		templateAdmin := dbgen.User(t, db, database.User{RBACRoles: []string{codersdk.RoleTemplateAdmin}})
 		_ /* other template admin, should not receive notification */ = dbgen.User(t, db, database.User{RBACRoles: []string{codersdk.RoleTemplateAdmin}})
@@ -2667,11 +2661,6 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 	auditPtr.Store(&auditor)
 	pollDur = ov.acquireJobLongPollDuration
 	notifEnq := &notificationstest.FakeEnqueuer{Store: db}
-	// if ov.notificationEnqueuer != nil {
-	// notifEnq = ov.notificationEnqueuer
-	// } else {
-	// notifEnq = notifications.NewNoopEnqueuer()
-	// }
 
 	daemon, err := db.UpsertProvisionerDaemon(ov.ctx, database.UpsertProvisionerDaemonParams{
 		Name:           "test",

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -1403,10 +1403,13 @@ func TestTemplateNotifications(t *testing.T) {
 
 			// Given: an initiator
 			var (
-				notifyEnq = &notificationstest.FakeEnqueuer{}
+				db, ps    = dbtestutil.NewDB(t)
+				notifyEnq = &notificationstest.FakeEnqueuer{Store: db}
 				client    = coderdtest.New(t, &coderdtest.Options{
 					IncludeProvisionerDaemon: true,
 					NotificationsEnqueuer:    notifyEnq,
+					Database:                 db,
+					Pubsub:                   ps,
 				})
 				initiator = coderdtest.CreateFirstUser(t, client)
 				version   = coderdtest.CreateTemplateVersion(t, client, initiator.OrganizationID, nil)
@@ -1434,10 +1437,13 @@ func TestTemplateNotifications(t *testing.T) {
 
 			// Given: multiple users with different roles
 			var (
-				notifyEnq = &notificationstest.FakeEnqueuer{}
+				db, ps    = dbtestutil.NewDB(t)
+				notifyEnq = &notificationstest.FakeEnqueuer{Store: db}
 				client    = coderdtest.New(t, &coderdtest.Options{
 					IncludeProvisionerDaemon: true,
 					NotificationsEnqueuer:    notifyEnq,
+					Database:                 db,
+					Pubsub:                   ps,
 				})
 				initiator = coderdtest.CreateFirstUser(t, client)
 				ctx       = testutil.Context(t, testutil.WaitLong)

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -2184,10 +2184,12 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("CanChangePassword", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
-
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2225,11 +2227,14 @@ func TestUserForgotPassword(t *testing.T) {
 
 		const oneTimePasscodeValidityPeriod = 1 * time.Millisecond
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer:         notifyEnq,
 			OneTimePasscodeValidityPeriod: oneTimePasscodeValidityPeriod,
+			Database:                      db,
+			Pubsub:                        ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2262,10 +2267,13 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("CannotChangePasswordWithoutRequestingOneTimePasscode", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2291,10 +2299,13 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("CannotChangePasswordWithInvalidOneTimePasscode", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2322,10 +2333,13 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("CannotChangePasswordWithNoOneTimePasscode", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2355,10 +2369,13 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("CannotChangePasswordWithWeakPassword", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2388,10 +2405,13 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("CannotChangePasswordOfAnotherUser", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 
@@ -2423,10 +2443,13 @@ func TestUserForgotPassword(t *testing.T) {
 	t.Run("GivenOKResponseWithInvalidEmail", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 
 		client := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -417,9 +417,12 @@ func TestNotifyUserStatusChanged(t *testing.T) {
 	t.Run("Account suspended", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		adminClient := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 
@@ -454,9 +457,12 @@ func TestNotifyUserStatusChanged(t *testing.T) {
 		t.Parallel()
 
 		// given
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		adminClient := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 
@@ -498,9 +504,12 @@ func TestNotifyDeletedUser(t *testing.T) {
 		t.Parallel()
 
 		// given
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		adminClient := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		firstUserResponse := coderdtest.CreateFirstUser(t, adminClient)
 
@@ -537,9 +546,12 @@ func TestNotifyDeletedUser(t *testing.T) {
 		t.Parallel()
 
 		// given
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		adminClient := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 
@@ -849,9 +861,12 @@ func TestNotifyCreatedUser(t *testing.T) {
 		t.Parallel()
 
 		// given
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		adminClient := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 
@@ -886,9 +901,12 @@ func TestNotifyCreatedUser(t *testing.T) {
 		t.Parallel()
 
 		// given
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		adminClient := coderdtest.New(t, &coderdtest.Options{
 			NotificationsEnqueuer: notifyEnq,
+			Database:              db,
+			Pubsub:                ps,
 		})
 		firstUser := coderdtest.CreateFirstUser(t, adminClient)
 

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -569,9 +569,10 @@ func TestWorkspaceBuildWithUpdatedTemplateVersionSendsNotification(t *testing.T)
 	t.Run("NoRepeatedNotifications", func(t *testing.T) {
 		t.Parallel()
 
-		notify := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notify := &notificationstest.FakeEnqueuer{Store: db}
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: notify})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: notify, Database: db, Pubsub: ps})
 		first := coderdtest.CreateFirstUser(t, client)
 		templateAdminClient, templateAdmin := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, rbac.RoleTemplateAdmin())
 		userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
@@ -643,9 +644,10 @@ func TestWorkspaceBuildWithUpdatedTemplateVersionSendsNotification(t *testing.T)
 	t.Run("ToCorrectUser", func(t *testing.T) {
 		t.Parallel()
 
-		notify := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notify := &notificationstest.FakeEnqueuer{Store: db}
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: notify})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: notify, Database: db, Pubsub: ps})
 		first := coderdtest.CreateFirstUser(t, client)
 		templateAdminClient, templateAdmin := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, rbac.RoleTemplateAdmin())
 		userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -669,8 +669,14 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 	t.Run("CreateSendsNotification", func(t *testing.T) {
 		t.Parallel()
 
-		enqueuer := notificationstest.FakeEnqueuer{}
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: &enqueuer})
+		db, ps := dbtestutil.NewDB(t)
+		enqueuer := notificationstest.FakeEnqueuer{Store: db}
+		client := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			NotificationsEnqueuer:    &enqueuer,
+			Database:                 db,
+			Pubsub:                   ps,
+		})
 		user := coderdtest.CreateFirstUser(t, client)
 		templateAdminClient, templateAdmin := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleTemplateAdmin())
 		memberClient, memberUser := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
@@ -709,8 +715,14 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 	t.Run("CreateSendsNotificationToCorrectUser", func(t *testing.T) {
 		t.Parallel()
 
-		enqueuer := notificationstest.FakeEnqueuer{}
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, NotificationsEnqueuer: &enqueuer})
+		db, ps := dbtestutil.NewDB(t)
+		enqueuer := notificationstest.FakeEnqueuer{Store: db}
+		client := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			NotificationsEnqueuer:    &enqueuer,
+			Database:                 db,
+			Pubsub:                   ps,
+		})
 		user := coderdtest.CreateFirstUser(t, client)
 		templateAdminClient, _ := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleTemplateAdmin(), rbac.RoleOwner())
 		_, memberUser := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
@@ -3536,7 +3548,7 @@ func TestWorkspaceDormant(t *testing.T) {
 		)
 
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
-			ctr.TimeTilDormantAutoDeleteMillis = ptr.Ref[int64](timeTilDormantAutoDelete.Milliseconds())
+			ctr.TimeTilDormantAutoDeleteMillis = ptr.Ref(timeTilDormantAutoDelete.Milliseconds())
 		})
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		_ = coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
@@ -3835,10 +3847,13 @@ func TestWorkspaceNotifications(t *testing.T) {
 
 			// Given
 			var (
-				notifyEnq = &notificationstest.FakeEnqueuer{}
+				db, ps    = dbtestutil.NewDB(t)
+				notifyEnq = &notificationstest.FakeEnqueuer{Store: db}
 				client    = coderdtest.New(t, &coderdtest.Options{
 					IncludeProvisionerDaemon: true,
 					NotificationsEnqueuer:    notifyEnq,
+					Database:                 db,
+					Pubsub:                   ps,
 				})
 				user            = coderdtest.CreateFirstUser(t, client)
 				memberClient, _ = coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleOwner())
@@ -3874,10 +3889,13 @@ func TestWorkspaceNotifications(t *testing.T) {
 
 			// Given
 			var (
-				notifyEnq = &notificationstest.FakeEnqueuer{}
+				db, ps    = dbtestutil.NewDB(t)
+				notifyEnq = &notificationstest.FakeEnqueuer{Store: db}
 				client    = coderdtest.New(t, &coderdtest.Options{
 					IncludeProvisionerDaemon: true,
 					NotificationsEnqueuer:    notifyEnq,
+					Database:                 db,
+					Pubsub:                   ps,
 				})
 				user      = coderdtest.CreateFirstUser(t, client)
 				version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -3905,10 +3923,13 @@ func TestWorkspaceNotifications(t *testing.T) {
 
 			// Given
 			var (
-				notifyEnq = &notificationstest.FakeEnqueuer{}
+				db, ps    = dbtestutil.NewDB(t)
+				notifyEnq = &notificationstest.FakeEnqueuer{Store: db}
 				client    = coderdtest.New(t, &coderdtest.Options{
 					IncludeProvisionerDaemon: true,
 					NotificationsEnqueuer:    notifyEnq,
+					Database:                 db,
+					Pubsub:                   ps,
 				})
 				user      = coderdtest.CreateFirstUser(t, client)
 				version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -677,7 +677,7 @@ func TestNotifications(t *testing.T) {
 		}
 
 		// Setup dependencies
-		notifyEnq := notificationstest.FakeEnqueuer{}
+		notifyEnq := notificationstest.FakeEnqueuer{Store: db}
 		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 		const userQuietHoursSchedule = "CRON_TZ=UTC 0 0 * * *" // midnight UTC
 		userQuietHoursStore, err := schedule.NewEnterpriseUserQuietHoursScheduleStore(userQuietHoursSchedule, true)

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
@@ -131,11 +132,14 @@ func TestScim(t *testing.T) {
 			// given
 			scimAPIKey := []byte("hi")
 			mockAudit := audit.NewMock()
-			notifyEnq := &notificationstest.FakeEnqueuer{}
+			db, ps := dbtestutil.NewDB(t)
+			notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 			client, _ := coderdenttest.New(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
 					Auditor:               mockAudit,
 					NotificationsEnqueuer: notifyEnq,
+					Database:              db,
+					Pubsub:                ps,
 				},
 				SCIMAPIKey:   scimAPIKey,
 				AuditLogging: true,
@@ -193,11 +197,14 @@ func TestScim(t *testing.T) {
 			// given
 			scimAPIKey := []byte("hi")
 			mockAudit := audit.NewMock()
-			notifyEnq := &notificationstest.FakeEnqueuer{}
+			db, ps := dbtestutil.NewDB(t)
+			notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 			client, _ := coderdenttest.New(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
 					Auditor:               mockAudit,
 					NotificationsEnqueuer: notifyEnq,
+					Database:              db,
+					Pubsub:                ps,
 				},
 				SCIMAPIKey:   scimAPIKey,
 				AuditLogging: true,
@@ -249,7 +256,8 @@ func TestScim(t *testing.T) {
 			// given
 			scimAPIKey := []byte("hi")
 			mockAudit := audit.NewMock()
-			notifyEnq := &notificationstest.FakeEnqueuer{}
+			db, ps := dbtestutil.NewDB(t)
+			notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 			dv := coderdtest.DeploymentValues(t)
 			dv.OIDC.OrganizationAssignDefault = false
 			client, _ := coderdenttest.New(t, &coderdenttest.Options{
@@ -257,6 +265,8 @@ func TestScim(t *testing.T) {
 					Auditor:               mockAudit,
 					NotificationsEnqueuer: notifyEnq,
 					DeploymentValues:      dv,
+					Database:              db,
+					Pubsub:                ps,
 				},
 				SCIMAPIKey:   scimAPIKey,
 				AuditLogging: true,

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
@@ -40,11 +41,14 @@ func TestTemplates(t *testing.T) {
 	t.Run("Deprecated", func(t *testing.T) {
 		t.Parallel()
 
-		notifyEnq := &notificationstest.FakeEnqueuer{}
+		db, ps := dbtestutil.NewDB(t)
+		notifyEnq := &notificationstest.FakeEnqueuer{Store: db}
 		owner, user := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				IncludeProvisionerDaemon: true,
 				NotificationsEnqueuer:    notifyEnq,
+				Database:                 db,
+				Pubsub:                   ps,
 			},
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{


### PR DESCRIPTION
Goes part of the way towards https://github.com/coder/coder/issues/15481

We now insert notification messages in `FakeEnqueuer` which should still have the desired effect of testing RBAC while also exercising these code paths in the rest of our tests.

As part of https://github.com/coder/coder/pull/17412 I'll want to be testing that pubsub notifications are actually sent, and this should ensure that the code path gets hit.

Longer-term, I'd like to phase out `FakeEnqueuer` entirely, but this would require all of the below tests to be rewritten.

Right now this doesn't work with dbmem due to a re-entrant lock when attempting to call `EnqueueNotificationMessage()`.