### PR TITLE
chore: add agent query parameter to `VSCodeDevContainerButton`

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -54,6 +54,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 					devContainerName={container.name}
 					devContainerFolder={containerFolder}
 					displayApps={agent.display_apps}
+					agentName={agent.name}
 				/>
 
 				<TerminalLink


### PR DESCRIPTION
This is less work for the VSCode extension to do, and since the workspace is running, we'll always know what agent to use.