### PR TITLE
feat: modify coordinators to send errors and peers to log them

### DIFF
--- a/enterprise/tailnet/connio.go
+++ b/enterprise/tailnet/connio.go
@@ -221,7 +221,7 @@ func (c *connIO) handleRequest(req *proto.CoordinateRequest) error {
 					slog.F("dst", dst.String()),
 				)
 				_ = c.Enqueue(&proto.CoordinateResponse{
-					Error: fmt.Sprintf("you do not share a tunnel with %q", dst.String()),
+					Error: fmt.Sprintf("%s: you do not share a tunnel with %q", agpl.ReadyForHandshakeError, dst.String()),
 				})
 				return nil
 			}

--- a/enterprise/tailnet/multiagent_test.go
+++ b/enterprise/tailnet/multiagent_test.go
@@ -10,6 +10,7 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/enterprise/tailnet"
+	agpl "github.com/coder/coder/v2/tailnet"
 	agpltest "github.com/coder/coder/v2/tailnet/test"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -77,7 +78,7 @@ func TestPGCoordinator_MultiAgent_CoordClose(t *testing.T) {
 	err = coord1.Close()
 	require.NoError(t, err)
 
-	ma1.AssertEventuallyResponsesClosed()
+	ma1.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
 }
 
 // TestPGCoordinator_MultiAgent_UnsubscribeRace tests a single coordinator with

--- a/enterprise/tailnet/pgcoord_internal_test.go
+++ b/enterprise/tailnet/pgcoord_internal_test.go
@@ -427,7 +427,9 @@ func TestPGCoordinatorUnhealthy(t *testing.T) {
 
 	pID := uuid.UUID{5}
 	_, resps := coordinator.Coordinate(ctx, pID, "test", agpl.AgentCoordinateeAuth{ID: pID})
-	resp := testutil.TryReceive(ctx, t, resps)
+	resp := testutil.RequireReceive(ctx, t, resps)
+	require.Equal(t, CloseErrUnhealthy, resp.Error)
+	resp = testutil.TryReceive(ctx, t, resps)
 	require.Nil(t, resp, "channel should be closed")
 
 	// give the coordinator some time to process any pending work.  We are

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -118,15 +118,15 @@ func TestPGCoordinatorSingle_AgentInvalidIP(t *testing.T) {
 
 	agent := agpltest.NewAgent(ctx, t, coordinator, "agent")
 	defer agent.Close(ctx)
+	prefix := agpl.TailscaleServicePrefix.RandomPrefix()
 	agent.UpdateNode(&proto.Node{
-		Addresses: []string{
-			agpl.TailscaleServicePrefix.RandomPrefix().String(),
-		},
+		Addresses:     []string{prefix.String()},
 		PreferredDerp: 10,
 	})
 
 	// The agent connection should be closed immediately after sending an invalid addr
-	agent.AssertEventuallyResponsesClosed()
+	agent.AssertEventuallyResponsesClosed(
+		agpl.AuthorizationError{Wrapped: agpl.InvalidNodeAddressError{Addr: prefix.Addr().String()}}.Error())
 	assertEventuallyLost(ctx, t, store, agent.ID)
 }
 
@@ -153,7 +153,8 @@ func TestPGCoordinatorSingle_AgentInvalidIPBits(t *testing.T) {
 	})
 
 	// The agent connection should be closed immediately after sending an invalid addr
-	agent.AssertEventuallyResponsesClosed()
+	agent.AssertEventuallyResponsesClosed(
+		agpl.AuthorizationError{Wrapped: agpl.InvalidAddressBitsError{Bits: 64}}.Error())
 	assertEventuallyLost(ctx, t, store, agent.ID)
 }
 
@@ -493,9 +494,9 @@ func TestPGCoordinatorDual_Mainline(t *testing.T) {
 	require.NoError(t, err)
 
 	// this closes agent2, client22, client21
-	agent2.AssertEventuallyResponsesClosed()
-	client22.AssertEventuallyResponsesClosed()
-	client21.AssertEventuallyResponsesClosed()
+	agent2.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
+	client22.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
+	client21.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
 	assertEventuallyLost(ctx, t, store, agent2.ID)
 	assertEventuallyLost(ctx, t, store, client21.ID)
 	assertEventuallyLost(ctx, t, store, client22.ID)
@@ -503,9 +504,9 @@ func TestPGCoordinatorDual_Mainline(t *testing.T) {
 	err = coord1.Close()
 	require.NoError(t, err)
 	// this closes agent1, client12, client11
-	agent1.AssertEventuallyResponsesClosed()
-	client12.AssertEventuallyResponsesClosed()
-	client11.AssertEventuallyResponsesClosed()
+	agent1.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
+	client12.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
+	client11.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
 	assertEventuallyLost(ctx, t, store, agent1.ID)
 	assertEventuallyLost(ctx, t, store, client11.ID)
 	assertEventuallyLost(ctx, t, store, client12.ID)
@@ -636,12 +637,12 @@ func TestPGCoordinator_Unhealthy(t *testing.T) {
 		}
 	}
 	// connected agent should be disconnected
-	agent1.AssertEventuallyResponsesClosed()
+	agent1.AssertEventuallyResponsesClosed(tailnet.CloseErrUnhealthy)
 
 	// new agent should immediately disconnect
 	agent2 := agpltest.NewAgent(ctx, t, uut, "agent2")
 	defer agent2.Close(ctx)
-	agent2.AssertEventuallyResponsesClosed()
+	agent2.AssertEventuallyResponsesClosed(tailnet.CloseErrUnhealthy)
 
 	// next heartbeats succeed, so we are healthy
 	for i := 0; i < 2; i++ {
@@ -836,7 +837,7 @@ func TestPGCoordinatorDual_FailedHeartbeat(t *testing.T) {
 	// we eventually disconnect from the coordinator.
 	err = sdb1.Close()
 	require.NoError(t, err)
-	p1.AssertEventuallyResponsesClosed()
+	p1.AssertEventuallyResponsesClosed(tailnet.CloseErrUnhealthy)
 	p2.AssertEventuallyLost(p1.ID)
 	// This basically checks that peer2 had no update
 	// performed on their status since we are connected
@@ -891,7 +892,7 @@ func TestPGCoordinatorDual_PeerReconnect(t *testing.T) {
 	// never send a DISCONNECTED update.
 	err = c1.Close()
 	require.NoError(t, err)
-	p1.AssertEventuallyResponsesClosed()
+	p1.AssertEventuallyResponsesClosed(agpl.CloseErrCoordinatorClose)
 	p2.AssertEventuallyLost(p1.ID)
 	// This basically checks that peer2 had no update
 	// performed on their status since we are connected

--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -284,6 +284,11 @@ func (c *BasicCoordination) respLoop() {
 			return
 		}
 
+		if resp.Error != "" {
+			c.logger.Error(context.Background(),
+				"coordination protocol error", slog.F("error", resp.Error))
+		}
+
 		err = c.coordinatee.UpdatePeers(resp.GetPeerUpdates())
 		if err != nil {
 			c.logger.Debug(context.Background(), "failed to update peers", slog.Error(err))

--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -27,6 +27,7 @@ const (
 	RequestBufferSize        = 32
 	CloseErrOverwritten      = "peer ID overwritten by new connection"
 	CloseErrCoordinatorClose = "coordinator closed"
+	ReadyForHandshakeError   = "ready for handshake error"
 )
 
 // Coordinator exchanges nodes with agents to establish connections.
@@ -316,7 +317,7 @@ func (c *core) handleReadyForHandshakeLocked(src *peer, rfhs []*proto.Coordinate
 			// don't want to kill its connection.
 			select {
 			case src.resps <- &proto.CoordinateResponse{
-				Error: fmt.Sprintf("you do not share a tunnel with %q", dstID.String()),
+				Error: fmt.Sprintf("%s: you do not share a tunnel with %q", ReadyForHandshakeError, dstID.String()),
 			}:
 			default:
 				return ErrWouldBlock

--- a/tailnet/test/cases.go
+++ b/tailnet/test/cases.go
@@ -22,7 +22,7 @@ func GracefulDisconnectTest(ctx context.Context, t *testing.T, coordinator tailn
 
 	p2.Disconnect()
 	p1.AssertEventuallyDisconnected(p2.ID)
-	p2.AssertEventuallyResponsesClosed()
+	p2.AssertEventuallyResponsesClosed("")
 }
 
 func LostTest(ctx context.Context, t *testing.T, coordinator tailnet.CoordinatorV2) {


### PR DESCRIPTION
Adds support to our coordinator implementations to send Error updates before disconnecting clients.

I was recently debugging a connection issue where the client was getting repeatedly disconnected from the Coordinator, but since we never send any error information it was really hard without server logs.

This PR aims to correct that, by sending a CoordinateResponse with `Error` set in cases where we disconnect a client without them asking us to.

It also logs the error whenever we get one in the client controller.