### PR TITLE
fix: fix empty workspaces result

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
@@ -1,7 +1,7 @@
 import type { Template } from "api/typesGenerated";
 import { Avatar } from "components/Avatar/Avatar";
 import { Button } from "components/Button/Button";
-import { TableEmpty } from "components/TableEmpty/TableEmpty";
+import { EmptyState } from "components/EmptyState/EmptyState";
 import { linkToTemplate, useLinks } from "modules/navigation";
 import type { FC } from "react";
 import { Link } from "react-router-dom";
@@ -31,12 +31,12 @@ export const WorkspacesEmpty: FC<WorkspacesEmptyProps> = ({
 	);
 
 	if (isUsingFilter) {
-		return <TableEmpty message="No results matched your search" />;
+		return <EmptyState message="No results matched your search" />;
 	}
 
 	if (templates && templates.length === 0 && canCreateTemplate) {
 		return (
-			<TableEmpty
+			<EmptyState
 				message={defaultTitle}
 				description={`${defaultMessage} To create a workspace, you first need to create a template.`}
 				cta={
@@ -52,7 +52,7 @@ export const WorkspacesEmpty: FC<WorkspacesEmptyProps> = ({
 
 	if (templates && templates.length === 0 && !canCreateTemplate) {
 		return (
-			<TableEmpty
+			<EmptyState
 				message={defaultTitle}
 				description={`${defaultMessage} There are no templates available, but you will see them here once your admin adds them.`}
 				className="pb-0"
@@ -62,7 +62,7 @@ export const WorkspacesEmpty: FC<WorkspacesEmptyProps> = ({
 	}
 
 	return (
-		<TableEmpty
+		<EmptyState
 			message={defaultTitle}
 			description={`${defaultMessage} Select one template below to start.`}
 			cta={


### PR DESCRIPTION
After refactoring the workspaces table to use the new table components://github.com/coder/coder/pull/17404), the empty styles got broken. You can see the related PR [here](https://github.com/coder/coder/pull/17404).

Before:
![image](https://github.com/user-attachments/assets/9592d65c-9a63-4d22-8a01-8a1ce174422e)

After:
<img width="1210" alt="Screenshot 2025-04-21 at 10 34 19" src="https://github.com/user-attachments/assets/6545d078-80f1-4251-8816-04eb0f41e848" />
