### PR TITLE
docs: reorganize tutorials section into subdirectories

### DIFF
--- a/docs/tutorials/authentication/README.md
+++ b/docs/tutorials/authentication/README.md
@@ -1,0 +1,5 @@
+# Authentication
+
+This directory contains guides for configuring identity providers and authentication:
+
+- `configuring-okta.md` - Custom claims/scopes with Okta for group/role sync

--- a/docs/tutorials/authentication/configuring-okta.md
+++ b/docs/tutorials/authentication/configuring-okta.md
@@ -1,0 +1,160 @@
+# Configuring Custom Claims/Scopes with Okta for group/role
+
+<div style="pad: 0px; margin: 0px;">
+  <span style="vertical-align:middle;">Author: </span>
+  <a href="https://github.com/Emyrk" style="text-decoration: none; color: inherit; margin-bottom: 0px;">
+    <span style="vertical-align:middle;">Steven Masley</span>
+    <img src="https://avatars.githubusercontent.com/u/5446298?v=4" alt="Steven Masley" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+December 13, 2023
+
+---
+
+Okta is an identity provider that can be used for OpenID Connect (OIDC) Single
+Sign On (SSO) on Coder.
+
+To configure custom claims in Okta to support syncing roles and groups with
+Coder, you must first have setup an Okta application with
+[OIDC working with Coder](../admin/users/oidc-auth.md).
+From here, we will add additional claims for Coder to use for syncing groups and
+roles.
+
+You may use a hybrid of the following approaches.
+
+## (Easiest) Sync using Okta Groups
+
+If the Coder roles & Coder groups can be inferred from
+[Okta groups](https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-about-groups.htm),
+Okta has a simple way to send over the groups as a `claim` in the `id_token`
+payload.
+
+In Okta, go to the application “Sign On” settings page.
+
+Applications > Select Application > General > Sign On
+
+In the “OpenID Connect ID Token” section, turn on “Groups Claim Type” and set
+the “Claim name” to `groups`. Optionally configure a filter for which groups to
+be sent.
+
+> [!IMPORTANT]
+> If the user does not belong to any groups, the claim will not be sent. Make
+> sure the user authenticating for testing is in at least one group. Defer to
+> [troubleshooting](../admin/users/index.md) with issues.
+
+![Okta OpenID Connect ID Token](../images/guides/okta/oidc_id_token.png)
+
+Configure Coder to use these claims for group sync. These claims are present in
+the `id_token`. See all configuration options for group sync in the
+[docs](https://coder.com/docs/admin/auth#group-sync-enterprise).
+
+```bash
+# Add the 'groups' scope.
+CODER_OIDC_SCOPES=openid,profile,email,groups
+# This name needs to match the "Claim name" in the configuration above.
+CODER_OIDC_GROUP_FIELD=groups
+```
+
+These groups can also be used to configure role syncing based on group
+membership.
+
+```bash
+# Requires the "groups" scope
+CODER_OIDC_SCOPES=openid,profile,email,groups
+# This name needs to match the "Claim name" in the configuration above.
+CODER_OIDC_USER_ROLE_FIELD=groups
+# Example configuration to map a group to some roles
+CODER_OIDC_USER_ROLE_MAPPING='{"admin-group":["template-admin","user-admin"]}'
+```
+
+## (Easy) Mapping Okta profile attributes
+
+If roles or groups cannot be completely inferred from Okta group memberships,
+another option is to source them from a user’s attributes. The user attribute
+list can be found in “Directory > Profile Editor > User (default)”.
+
+Coder can query an Okta profile for the application from the `/userinfo` OIDC
+endpoint. To pass attributes to Coder, create the attribute in your application,
+then add a mapping from the Okta profile to the application.
+
+“Directory > Profile Editor > {Your Application} > Add Attribute”
+
+Create the attribute for the roles, groups, or both. **Make sure the attribute
+is of type `string array`.**
+
+![Okta Add Attribute view](../images/guides/okta/add_attribute.png)
+
+On the “Okta User to {Your Application}” tab, map a `roles` or `groups`
+attribute you have configured to the application.
+
+![Okta Add Claim view](../images/guides/okta/add_claim.png)
+
+Configure using these new attributes in Coder.
+
+```bash
+# This must be set to false. Coder uses this endpoint to grab the attributes.
+CODER_OIDC_IGNORE_USERINFO=false
+# No custom scopes are required.
+CODER_OIDC_SCOPES=openid,profile,email
+# Configure the group/role field using the attribute name in the application.
+CODER_OIDC_USER_ROLE_FIELD=approles
+# See our docs for mapping okta roles to coder roles.
+CODER_OIDC_USER_ROLE_MAPPING='{"admin-group":["template-admin","user-admin"]}'
+
+# If you added an attribute for groups, set that here.
+# CODER_OIDC_GROUP_FIELD=...
+```
+
+## (Advanced) Custom scopes to retrieve custom claims
+
+Okta does not support setting custom scopes and claims in the default
+authorization server used by your application. If you require this
+functionality, you must create (or modify) an authorization server.
+
+To see your custom authorization servers go to “Security > API”. Note the
+`default` authorization server **is not the authorization server your app is
+using.** You can configure this default authorization server, or create a new
+one specifically for your application.
+
+Authorization servers also give more refined controls over things such as
+token/session lifetimes.
+
+![Okta API view](../images/guides/okta/api_view.png)
+
+To get custom claims working, we should map them to a custom scope. Click the
+authorization server you wish to use (likely just using the default).
+
+Go to “Scopes”, and “Add Scope”. Feel free to create one for roles, groups, or
+both.
+
+![Okta Add Scope view](../images/guides/okta/add_scope.png)
+
+Now create the claim to go with the said scope. Go to “Claims”, then “Add
+Claim”. Make sure to select **ID Token** for the token type. The **Value**
+expression is up to you based on where you are sourcing the role information.
+Lastly, configure it to only be a claim with the requested scope. This is so if
+other applications exist, we do not send them information they do not care
+about.
+
+![Okta Add Claim with Roles view](../images/guides/okta/add_claim_with_roles.png)
+
+Now we have a custom scope + claim configured under an authorization server, we
+need to configure coder to use this.
+
+```bash
+# Grab this value from the Authorization Server > Settings > Issuer
+# DO NOT USE the application issuer URL. Make sure to use the newly configured
+# authorization server.
+CODER_OIDC_ISSUER_URL=https://dev-12222860.okta.com/oauth2/default
+# Add the new scope you just configured
+CODER_OIDC_SCOPES=openid,profile,email,roles
+# Use the claim you just configured
+CODER_OIDC_USER_ROLE_FIELD=roles
+# See our docs for mapping okta roles to coder roles.
+CODER_OIDC_USER_ROLE_MAPPING='{"admin-group":["template-admin","user-admin"]}'
+```
+
+You can use the “Token Preview” page to verify it has been correctly configured
+and verify the `roles` is in the payload.
+
+![Okta Token Preview](../images/guides/okta/token_preview.png)

--- a/docs/tutorials/authentication/index.md
+++ b/docs/tutorials/authentication/index.md
@@ -1,0 +1,5 @@
+# Authentication
+
+Guides for configuring identity providers and authentication.
+
+<children></children>

--- a/docs/tutorials/getting-started/README.md
+++ b/docs/tutorials/getting-started/README.md
@@ -1,0 +1,10 @@
+# Getting Started
+
+This directory contains guides to help you get up and running with Coder:
+
+- `quickstart.md` - Learn how to install and run Coder quickly
+- `template-from-scratch.md` - Learn how to author Coder templates
+- `testing-templates.md` - Learn how to test and publish Coder templates in a CI/CD pipeline
+- `example-guide.md` - An example guide for reference
+- `faqs.md` - Miscellaneous FAQs from our community
+- `cloning-git-repositories.md` - Learn how to clone Git repositories in Coder

--- a/docs/tutorials/getting-started/cloning-git-repositories.md
+++ b/docs/tutorials/getting-started/cloning-git-repositories.md
@@ -1,0 +1,72 @@
+# Cloning Git Repositories
+
+<div style="padding: 0px; margin: 0px;">
+  <span style="vertical-align:middle;">Author: </span>
+  <a href="https://github.com/BrunoQuaresma" style="text-decoration: none; color: inherit; margin-bottom: 0px;">
+    <span style="vertical-align:middle;">Bruno Quaresma</span>
+    <img src="https://avatars.githubusercontent.com/u/3165839?v=4" alt="Bruno Quaresma" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+August 06, 2024
+
+---
+
+When starting to work on a project, engineers usually need to clone a Git
+repository. Even though this is often a quick step, it can be automated using
+the [Coder Registry](https://registry.coder.com/) to make a seamless Git-first
+workflow.
+
+The first step to enable Coder to clone a repository is to provide
+authorization. This can be achieved by using the Git provider, such as GitHub,
+as an authentication method. If you don't know how to do that, we have written
+documentation to help you:
+
+- [GitHub](../admin/external-auth.md#github)
+- [GitLab self-managed](../admin/external-auth.md#gitlab-self-managed)
+- [Self-managed git providers](../admin/external-auth.md#self-managed-git-providers)
+
+With the authentication in place, it is time to set up the template to use the
+[Git Clone module](https://registry.coder.com/modules/git-clone) from the
+[Coder Registry](https://registry.coder.com/) by adding it to our template's
+Terraform configuration.
+
+```tf
+module "git-clone" {
+  source   = "registry.coder.com/modules/git-clone/coder"
+  version  = "1.0.12"
+  agent_id = coder_agent.example.id
+  url      = "https://github.com/coder/coder"
+}
+```
+
+You can edit the template using an IDE or terminal of your preference, or by
+going into the
+[template editor UI](../admin/templates/creating-templates.md#web-ui).
+
+You can also use
+[template parameters](../admin/templates/extending-templates/parameters.md) to
+customize the Git URL and make it dynamic for use cases where a template
+supports multiple projects.
+
+```tf
+data "coder_parameter" "git_repo" {
+  name         = "git_repo"
+  display_name = "Git repository"
+  default      = "https://github.com/coder/coder"
+}
+
+module "git-clone" {
+  source   = "registry.coder.com/modules/git-clone/coder"
+  version  = "1.0.12"
+  agent_id = coder_agent.example.id
+  url      = data.coder_parameter.git_repo.value
+}
+```
+
+If you need more customization, you can read the
+[Git Clone module](https://registry.coder.com/modules/git-clone) documentation
+to learn more about the module.
+
+Don't forget to build and publish the template changes before creating a new
+workspace. You can check if the repository is cloned by accessing the workspace
+terminal and listing the directories.

--- a/docs/tutorials/getting-started/example-guide.md
+++ b/docs/tutorials/getting-started/example-guide.md
@@ -1,0 +1,53 @@
+# Guide Title (Only Visible in GitHub)
+
+<div>
+  <a href="https://github.com/coder" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Your Name</span>
+    <img src="https://github.com/coder.png" alt="Coder" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+December 13, 2023
+
+---
+
+This is a guide on how to make Coder guides, it is not listed on our
+[official tutorials page](../tutorials/index.md) in the docs. Intended for those
+who don't frequently contribute documentation changes to the `coder/coder`
+repository.
+
+## Content
+
+Defer to our [Contributing/Documentation](../contributing/documentation.md) page
+for rules on technical writing.
+
+### Adding Photos
+
+Use relative imports in the markdown and store photos in
+`docs/images/guides/<your_guide>/<image>.png`.
+
+### Setting the author data
+
+At the top of this example you will find a small html snippet that nicely
+renders the author's name and photo, while linking to their GitHub profile.
+Before submitting your guide in a PR, replace `your_github_handle`,
+`your_github_profile_photo_url` and "Your Name". The entire `<img>` element can
+be omitted.
+
+## Setting up the routes
+
+Once you've written your guide, you'll need to add its route to
+`docs/manifest.json` under `Guides` > `"children"` at the bottom:
+
+```json
+{
+  // Overrides the "# Guide Title" at the top of this file
+  "title": "Contributing to Guides",
+  "description": "How to add a guide",
+  "path": "./guides/my-guide-file.md"
+},
+```
+
+## Format before push
+
+Before pushing your guide to github, run `make fmt` to format the files with
+Prettier. Then, push your changes to a new branch and create a PR.

--- a/docs/tutorials/getting-started/faqs.md
+++ b/docs/tutorials/getting-started/faqs.md
@@ -1,0 +1,561 @@
+# FAQs
+
+Frequently asked questions on Coder OSS and licensed deployments. These FAQs
+come from our community and customers, feel free to
+[contribute to this page](https://github.com/coder/coder/edit/main/docs/tutorials/faqs.md).
+
+For other community resources, see our
+[GitHub discussions](https://github.com/coder/coder/discussions), or join our
+[Discord server](https://discord.gg/coder).
+
+## How do I add a Premium trial license?
+
+Visit <https://coder.com/trial> or contact
+[sales@coder.com](mailto:sales@coder.com?subject=License) to get a trial key.
+
+<details>
+
+<summary>You can add a license through the UI or CLI</summary>
+
+<!-- copied from docs/admin/licensing/index.md -->
+
+<div class="tabs">
+
+### Coder UI
+
+1. With an `Owner` account, go to **Admin settings** > **Deployment**.
+
+1. Select **Licenses** from the sidebar, then **Add a license**:
+
+   ![Add a license from the licenses screen](../images/admin/licenses/licenses-nolicense.png)
+
+1. On the **Add a license** screen, drag your `.jwt` license file into the
+   **Upload Your License** section, or paste your license in the
+   **Paste Your License** text box, then select **Upload License**:
+
+   ![Add a license screen](../images/admin/licenses/add-license-ui.png)
+
+### Coder CLI
+
+1. Ensure you have the [Coder CLI](../install/cli.md) installed.
+1. Save your license key to disk and make note of the path.
+1. Open a terminal.
+1. Log in to your Coder deployment:
+
+   ```shell
+   coder login <access url>
+   ```
+
+1. Run `coder licenses add`:
+
+   - For a `.jwt` license file:
+
+     ```shell
+     coder licenses add -f <path to your license key>
+     ```
+
+   - For a text string:
+
+     ```sh
+     coder licenses add -l 1f5...765
+     ```
+
+</div>
+
+</details>
+
+Visit the [licensing documentation](../admin/licensing/index.md) for more
+information about licenses.
+
+## I'm experiencing networking issues, so want to disable Tailscale, STUN, Direct connections and force use of websocket
+
+The primary developer use case is a local IDE connecting over SSH to a Coder
+workspace.
+
+Coder's networking stack has intelligence to attempt a peer-to-peer or
+[Direct connection](../admin/networking/index.md#direct-connections) between the
+local IDE and the workspace. However, this requires some additional protocols
+like UDP and being able to reach a STUN server to echo the IP addresses of the
+local IDE machine and workspace, for sharing using a Wireguard Coordination
+Server. By default, Coder assumes Internet and attempts to reach Google's STUN
+servers to perform this IP echo.
+
+Operators experimenting with Coder may run into networking issues if UDP (which
+STUN requires) or the STUN servers are unavailable, potentially resulting in
+lengthy local IDE and SSH connection times as the Coder control plane attempts
+to establish these direct connections.
+
+Setting the following flags as shown disables this logic to simplify
+troubleshooting.
+
+| Flag                                                                                          | Value       | Meaning                               |
+|-----------------------------------------------------------------------------------------------|-------------|---------------------------------------|
+| [`CODER_BLOCK_DIRECT`](../reference/cli/server.md#--block-direct-connections)                 | `true`      | Blocks direct connections             |
+| [`CODER_DERP_SERVER_STUN_ADDRESSES`](../reference/cli/server.md#--derp-server-stun-addresses) | `"disable"` | Disables STUN                         |
+| [`CODER_DERP_FORCE_WEBSOCKETS`](../reference/cli/server.md#--derp-force-websockets)           | `true`      | Forces websockets over Tailscale DERP |
+
+## How do I configure NGINX as the reverse proxy in front of Coder?
+
+[This tutorial](./reverse-proxy-nginx.md) in our docs explains in detail how to
+configure NGINX with Coder so that our Tailscale Wireguard networking functions
+properly.
+
+## How do I hide some of the default icons in a workspace like VS Code Desktop, Terminal, SSH, Ports?
+
+The visibility of Coder apps is configurable in the template. To change the
+default (shows all), add this block inside the
+[`coder_agent`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent)
+of a template and configure as needed:
+
+```tf
+  display_apps {
+    vscode = false
+    vscode_insiders = false
+    ssh_helper = false
+    port_forwarding_helper = false
+    web_terminal = true
+  }
+```
+
+This example will hide all built-in
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+icons except the web terminal.
+
+## I want to allow code-server to be accessible by other users in my deployment
+
+We don't recommend that you share a web IDE, but if you need to, the following
+deployment environment variable settings are required.
+
+Set deployment (Kubernetes) to allow path app sharing:
+
+```yaml
+# allow authenticated users to access path-based workspace apps
+- name: CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
+  value: "true"
+# allow Coder owner roles to access path-based workspace apps
+- name: CODER_DANGEROUS_ALLOW_PATH_APP_SITE_OWNER_ACCESS
+  value: "true"
+```
+
+In the template, set
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+[`share`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share)
+option to `authenticated` and when a workspace is built with this template, the
+pretty globe shows up next to path-based `code-server`:
+
+```tf
+resource "coder_app" "code-server" {
+  ...
+  share        = "authenticated"
+  ...
+}
+```
+
+## I installed Coder and created a workspace but the icons do not load
+
+An important concept to understand is that Coder creates workspaces which have
+an agent that must be able to reach the `coder server`.
+
+If the [`CODER_ACCESS_URL`](../admin/setup/index.md#access-url) is not
+accessible from a workspace, the workspace may build, but the agent cannot reach
+Coder, and thus the missing icons. e.g., Terminal, IDEs, Apps.
+
+By default, `coder server` automatically creates an Internet-accessible
+reverse proxy so that workspaces you create can reach the server.
+
+If you are doing a standalone install, e.g., on a MacBook and want to build
+workspaces in Docker Desktop, everything is self-contained and workspaces
+(containers in Docker Desktop) can reach the Coder server.
+
+```sh
+coder server --access-url http://localhost:3000 --address 0.0.0.0:3000
+```
+
+Even `coder server` which creates a reverse proxy, will let you use
+<http://localhost> to access Coder from a browser.
+
+## I updated a template, and an existing workspace based on that template fails to start
+
+When updating a template, be aware of potential issues with input variables. For
+example, if a template prompts users to choose options like a
+[code-server](https://github.com/coder/code-server)
+[VS Code](https://code.visualstudio.com/) IDE release, a
+[container image](https://hub.docker.com/u/codercom), or a
+[VS Code extension](https://marketplace.visualstudio.com/vscode), removing any
+of these values can lead to existing workspaces failing to start. This issue
+occurs because the Terraform state will not be in sync with the new template.
+
+However, a lesser-known CLI sub-command,
+[`coder update`](../reference/cli/update.md), can resolve this issue. This
+command re-prompts users to re-enter the input variables, potentially saving the
+workspace from a failed status.
+
+```sh
+coder update --always-prompt <workspace name>
+```
+
+## I'm running coder on a VM with systemd but latest release installed isn't showing up
+
+Take, for example, a Coder deployment on a VM with a 2 shared vCPU systemd
+service. In this scenario, it's necessary to reload the daemon and then restart
+the Coder service. This prevents the `systemd` daemon from trying to reference
+the previous Coder release service since the unit file has changed.
+
+The following commands can be used to update Coder and refresh the service:
+
+```sh
+curl -fsSL https://coder.com/install.sh | sh
+sudo systemctl daemon-reload
+sudo systemctl restart coder.service
+```
+
+## I'm using the built-in Postgres database and forgot admin email I set up
+
+1. Run the `coder server` command below to retrieve the `psql` connection URL
+   which includes the database user and password.
+2. `psql` into Postgres, and do a select query on the `users` table.
+3. Restart the `coder server`, pull up the Coder UI and log in (you will still
+   need your password)
+
+```sh
+coder server postgres-builtin-url
+psql "postgres://coder@localhost:53737/coder?sslmode=disable&password=I2S...pTk"
+```
+
+## How to find out Coder's latest Terraform provider version?
+
+[Coder is on the HashiCorp's Terraform registry](https://registry.terraform.io/providers/coder/coder/latest).
+Check this frequently to make sure you are on the latest version.
+
+Sometimes, the version may change and `resource` configurations will either
+become deprecated or new ones will be added when you get warnings or errors
+creating and pushing templates.
+
+## How can I set up TLS for my deployment and not create a signed certificate?
+
+Caddy is an easy-to-configure reverse proxy that also automatically creates
+certificates from Let's Encrypt.
+[Install docs here](https://caddyserver.com/docs/quick-starts/reverse-proxy) You
+can start Caddy as a `systemd` service.
+
+The Caddyfile configuration will appear like this where `127.0.0.1:3000` is your
+`CODER_ACCESS_URL`:
+
+```text
+coder.example.com {
+
+  reverse_proxy 127.0.0.1:3000
+
+  tls {
+
+    issuer acme {
+      email user@example.com
+    }
+
+  }
+}
+```
+
+## I'm using Caddy as my reverse proxy in front of Coder. How do I set up a wildcard domain for port forwarding?
+
+Caddy requires your DNS provider's credentials to create wildcard certificates.
+This involves building the Caddy binary
+[from source](https://github.com/caddyserver/caddy) with the DNS provider plugin
+added. e.g.,
+[Google Cloud DNS provider here](https://github.com/caddy-dns/googleclouddns)
+
+To compile Caddy, the host running Coder requires Go. Once installed, replace
+the existing Caddy binary in `usr/bin` and restart the Caddy service.
+
+The updated Caddyfile configuration will look like this:
+
+```text
+*.coder.example.com, coder.example.com {
+
+  reverse_proxy 127.0.0.1:3000
+
+  tls {
+    issuer acme {
+      email user@example.com
+      dns googleclouddns {
+        gcp_project my-gcp-project
+      }
+    }
+  }
+
+}
+```
+
+## Can I use local or remote Terraform Modules in Coder templates?
+
+One way is to reference a Terraform module from a GitHub repo to avoid
+duplication and then just extend it or pass template-specific
+parameters/resources:
+
+```tf
+# template1/main.tf
+module "central-coder-module" {
+  source = "github.com/org/central-coder-module"
+  myparam = "custom-for-template1"
+}
+
+resource "ebs_volume" "custom_template1_only_resource" {
+}
+```
+
+```tf
+# template2/main.tf
+module "central-coder-module" {
+  source = "github.com/org/central-coder-module"
+  myparam = "custom-for-template2"
+  myparam2 = "bar"
+}
+
+resource "aws_instance" "custom_template2_only_resource" {
+}
+```
+
+Another way using local modules is to symlink the module directory inside the
+template directory and then `tar` the template.
+
+```sh
+ln -s modules template_1/modules
+tar -cvh -C ./template_1 | coder templates <push|create> -d - <name>
+```
+
+References:
+
+- [Public GitHub Issue 6117](https://github.com/coder/coder/issues/6117)
+- [Public GitHub Issue 5677](https://github.com/coder/coder/issues/5677)
+- [Coder docs: Templates/Change Management](../admin/templates/managing-templates/change-management.md)
+
+## Can I run Coder in an air-gapped or offline mode? (no Internet)?
+
+Yes, Coder can be deployed in
+[air-gapped or offline mode](../install/offline.md).
+
+Our product bundles with the Terraform binary so assume access to terraform.io
+during installation. The docs outline rebuilding the Coder container with
+Terraform built-in as well as any required Terraform providers.
+
+Direct networking from local SSH to a Coder workspace needs a STUN server. Coder
+defaults to Google's STUN servers, so you can either create your STUN server in
+your network or disable and force all traffic through the control plane's DERP
+proxy.
+
+## Create a randomized computer_name for an Azure VM
+
+Azure VMs have a 15 character limit for the `computer_name` which can lead to
+duplicate name errors.
+
+This code produces a hashed value that will be difficult to replicate.
+
+```tf
+locals {
+  concatenated_string = "${data.coder_workspace.me.name}+${data.coder_workspace_owner.me.name}"
+  hashed_string = md5(local.concatenated_string)
+  truncated_hash = substr(local.hashed_string, 0, 16)
+}
+```
+
+## Do you have example JetBrains Gateway templates?
+
+In August 2023, JetBrains certified the Coder plugin signifying enhanced
+stability and reliability.
+
+The Coder plugin will appear in the Gateway UI when opened.
+
+Selecting the most suitable template depends on how the deployment manages
+JetBrains IDE versions. If downloading from
+[jetbrains.com](https://www.jetbrains.com/remote-development/gateway/) is
+acceptable, see the example templates below which specifies the product code,
+IDE version and build number in the
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share)
+resource. This will present an icon in the workspace dashboard which when
+clicked, will look for a locally installed Gateway, and open it. Alternatively,
+the IDE can be baked into the container image and manually open Gateway (or
+IntelliJ which has Gateway built-in), using a session token to Coder and then
+open the IDE.
+
+## What options do I have for adding VS Code extensions into code-server, VS Code Desktop or Microsoft's Code Server?
+
+Coder has an open-source project called
+[`code-marketplace`](https://github.com/coder/code-marketplace) which is a
+private VS Code extension marketplace. There is even integration with JFrog
+Artifactory.
+
+- [Blog post](https://coder.com/blog/running-a-private-vs-code-extension-marketplace)
+- [OSS project](https://github.com/coder/code-marketplace)
+
+You can also use Microsoft's code-server - which is like Coder's, but it
+can connect to Microsoft's extension marketplace so Copilot and chat can be
+retrieved there.
+
+Another option is to use VS Code Desktop (local) and that connects to
+Microsoft's marketplace.
+
+## I want to run Docker for my workspaces but not install Docker Desktop
+
+[Colima](https://github.com/abiosoft/colima) is a Docker Desktop alternative.
+
+This example is meant for a users who want to try out Coder on a macOS device.
+
+Install Colima and docker with:
+
+```sh
+brew install colima
+brew install docker
+```
+
+Start Colima:
+
+```sh
+colima start
+```
+
+Start Colima with specific compute options:
+
+```sh
+colima start --cpu 4 --memory 8
+```
+
+Starting Colima on a M3 MacBook Pro:
+
+```sh
+colima start --arch x86_64  --cpu 4 --memory 8 --disk 10
+```
+
+Colima will show the path to the docker socket so we have a
+[community template](https://github.com/sharkymark/v2-templates/tree/main/src/docker-code-server)
+that prompts the Coder admin to enter the Docker socket as a Terraform variable.
+
+## How to make a `coder_app` optional?
+
+An example use case is the user should decide if they want a browser-based IDE
+like code-server when creating the workspace.
+
+1. Add a `coder_parameter` with type `bool` to ask the user if they want the
+   code-server IDE
+
+    ```tf
+    data "coder_parameter" "code_server" {
+        name        = "Do you want code-server in your workspace?"
+        description = "Use VS Code in a browser."
+        type        = "bool"
+        default     = false
+        mutable     = true
+        icon        = "/icon/code.svg"
+        order       = 6
+    }
+    ```
+
+2. Add conditional logic to the `startup_script` to install and start
+   code-server depending on the value of the added `coder_parameter`
+
+    ```sh
+    # install and start code-server, VS Code in a browser
+
+    if [ ${data.coder_parameter.code_server.value} = true ]; then
+    echo "🧑🏼‍💻 Downloading and installing the latest code-server IDE..."
+    curl -fsSL https://code-server.dev/install.sh | sh
+    code-server --auth none --port 13337 >/dev/null 2>&1 &
+    fi
+    ```
+
+3. Add a Terraform meta-argument
+   [`count`](https://developer.hashicorp.com/terraform/language/meta-arguments/count)
+   in the `coder_app` resource so it will only create the resource if the
+   `coder_parameter` is `true`
+
+    ```tf
+    # code-server
+    resource "coder_app" "code-server" {
+    count         = data.coder_parameter.code_server.value ? 1 : 0
+    agent_id      = coder_agent.coder.id
+    slug          = "code-server"
+    display_name  = "code-server"
+    icon          = "/icon/code.svg"
+    url           = "http://localhost:13337?folder=/home/coder"
+    subdomain = false
+    share     = "owner"
+
+    healthcheck {
+        url       = "http://localhost:13337/healthz"
+        interval  = 3
+        threshold = 10
+    }
+    }
+    ```
+
+## Why am I getting this "remote host doesn't meet VS Code Server's prerequisites" error when opening up VSCode remote in a Linux environment?
+
+![VS Code Server prerequisite](https://github.com/coder/coder/assets/10648092/150c5996-18b1-4fae-afd0-be2b386a3239)
+
+It is because, more than likely, the supported OS of either the container image
+or VM/VPS doesn't have the proper C libraries to run the VS Code Server. For
+instance, Alpine is not supported at all. If so, you need to find a container
+image or supported OS for the VS Code Server. For more information on OS
+prerequisites for Linux, please look at the VSCode docs.
+<https://code.visualstudio.com/docs/remote/linux#_local-linux-prerequisites>
+
+## How can I resolve disconnects when connected to Coder via JetBrains Gateway?
+
+If your JetBrains IDE is disconnected for a long period of time due to a network
+change (for example turning off a VPN), you may find that the IDE will not
+reconnect once the network is re-established (for example turning a VPN back
+on). When this happens a persistent message will appear similar to the below:
+
+```console
+No internet connection. Changes in the document might be lost. Trying to reconnect…
+```
+
+To resolve this, add this entry to your SSH config file on your local machine:
+
+```console
+Host coder-jetbrains--*
+  ServerAliveInterval 5
+```
+
+This will make SSH check that it can contact the server every five seconds. If
+it fails to do so `ServerAliveCountMax` times (3 by default for a total of 15
+seconds) then it will close the connection which forces JetBrains to recreate
+the hung session. You can tweak `ServerAliveInterval` and `ServerAliveCountMax`
+to increase or decrease the total timeout.
+
+Note that the JetBrains Gateway configuration blocks for each host in your SSH
+config file will be overwritten by the JetBrains Gateway client when it
+re-authenticates to your Coder deployment so you must add the above config as a
+separate block and not add it to any existing ones.
+
+## How can I restrict inbound/outbound file transfers from Coder workspaces?
+
+In certain environments, it is essential to keep confidential files within
+workspaces and prevent users from uploading or downloading resources using tools
+like `scp` or `rsync`.
+
+To achieve this, template admins can use the environment variable
+`CODER_AGENT_BLOCK_FILE_TRANSFER` to enable additional SSH command controls.
+This variable allows the system to check if the executed application is on the
+block list, which includes `scp`, `rsync`, `ftp`, and `nc`.
+
+```tf
+resource "docker_container" "workspace" {
+  ...
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.main.token}",
+    "CODER_AGENT_BLOCK_FILE_TRANSFER=true",
+    ...
+  ]
+}
+```
+
+### Important Notice
+
+This control operates at the `ssh-exec` level or during `sftp` sessions. While
+it can help prevent automated file transfers using the specified tools, users
+can still SSH into the workspace and manually initiate file transfers. The
+primary purpose of this feature is to warn and discourage users from downloading
+confidential resources to their local machines.
+
+For more advanced security needs, consider adopting an endpoint security
+solution.

--- a/docs/tutorials/getting-started/index.md
+++ b/docs/tutorials/getting-started/index.md
@@ -1,0 +1,5 @@
+# Getting Started
+
+Guides to help you get up and running with Coder.
+
+<children></children>

--- a/docs/tutorials/getting-started/quickstart.md
+++ b/docs/tutorials/getting-started/quickstart.md
@@ -1,0 +1,233 @@
+# Quickstart
+
+Follow the steps in this guide to install Coder locally or on a cloud-hosting
+provider, set up a workspace, and connect to it from VS Code.
+
+By the end of this guide, you'll have a remote development environment that you
+can connect to from any device anywhere, so you can work on the same files in a
+persistent environment from your main device, a tablet, or your phone.
+
+## Install and start Coder
+
+<div class="tabs">
+
+## Linux/macOS
+
+1. Install Docker:
+
+   ```bash
+   curl -sSL https://get.docker.com | sh
+   ```
+
+   For more details, visit:
+
+   - [Linux instructions](https://docs.docker.com/desktop/install/linux-install/)
+   - [Mac instructions](https://docs.docker.com/desktop/install/mac-install/)
+
+1. Assign your user to the Docker group:
+
+   ```shell
+   sudo usermod -aG docker $USER
+   ```
+
+1. Run `newgrp` to activate the groups changes:
+
+   ```shell
+   newgrp docker
+   ```
+
+   You might need to log out and back in or restart the machine for changes to
+   take effect.
+
+1. Install Coder:
+
+   ```shell
+   curl -L https://coder.com/install.sh | sh
+   ```
+
+   - For standalone binaries, system packages, or other alternate installation
+     methods, refer to the
+     [latest release on GitHub](https://github.com/coder/coder/releases/latest).
+
+1. Start Coder:
+
+   ```shell
+   coder server
+   ```
+
+## Windows
+
+> [!IMPORTANT]
+> If you plan to use the built-in PostgreSQL database, ensure that the
+> [Visual C++ Runtime](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist#latest-microsoft-visual-c-redistributable-version)
+> is installed.
+
+1. [Install Docker](https://docs.docker.com/desktop/install/windows-install/).
+
+1. Use the
+   [`winget`](https://learn.microsoft.com/en-us/windows/package-manager/winget/#use-winget)
+   package manager to install Coder:
+
+   ```powershell
+   winget install Coder.Coder
+   ```
+
+1. Start Coder:
+
+   ```shell
+   coder server
+   ```
+
+</div>
+
+## Configure Coder with a new Workspace
+
+1. Coder will attempt to open the setup page in your browser. If it doesn't open
+   automatically, go to <http://localhost:3000>.
+
+   - If you get a browser warning similar to `Secure Site Not Available`, you
+     can ignore the warning and continue to the setup page.
+
+   If your Coder server is on a network or cloud device, or you are having
+   trouble viewing the page, locate the web UI URL in Coder logs in your
+   terminal. It looks like `https://<CUSTOM-STRING>.<TUNNEL>.try.coder.app`.
+   It's one of the first lines of output, so you might have to scroll up to find
+   it.
+
+1. On the **Welcome to Coder** page, to use your GitHub account to log in,
+   select **Continue with GitHub**.
+   You can also enter an email and password to create a new admin account on
+   the Coder deployment:
+
+   ![Welcome to Coder - Create admin user](../images/screenshots/welcome-create-admin-user.png)_Welcome
+   to Coder - Create admin user_
+
+1. On the **Workspaces** page, select **Go to templates** to create a new
+   template.
+
+1. For this guide, use a Docker container. Locate **Docker Containers** and
+   select **Use template**.
+
+1. Give the template a **Name** that you'll recognize both in the Coder UI and
+   in command-line calls.
+
+   The rest of the template details are optional, but will be helpful when you
+   have more templates.
+
+   ![Create template](../images/screenshots/create-template.png)_Create
+   template_
+
+1. Select **Create template**.
+
+1. After the template is ready, select **Create Workspace**.
+
+1. Give the workspace a name and select **Create Workspace**.
+
+1. Coder starts your new workspace:
+
+   ![getting-started-workspace is running](../images/screenshots/workspace-running-with-topbar.png)_Workspace
+   is running_
+
+1. Select **VS Code Desktop** to install the Coder extension and connect to your
+   Coder workspace.
+
+## Work on some code
+
+After VS Code loads the remote environment, you can select **Open Folder** to
+explore directories in the Docker container or work on something new.
+
+To clone an existing repository:
+
+1. Select **Clone Repository** and enter the repository URL.
+
+   For example, to clone the Coder repo, enter
+   `https://github.com/coder/coder.git`.
+
+   Learn more about how to find the repository URL in the
+   [GitHub documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
+
+1. Choose the folder to which VS Code should clone the repo. It will be in its
+   own directory within this folder.
+
+   Note that you cannot create a new parent directory in this step.
+
+1. After VS Code completes the clone, select **Open** to open the directory.
+
+1. You are now using VS Code in your Coder environment!
+
+## What's next?
+
+Now that you have your own workspace, use the same template to set one up for a
+teammate.
+
+Go to **Templates** and select **Create Workspace** and continue from Step 7 in
+[Configure Coder with a new workspace](#configure-coder-with-a-new-workspace).
+
+After that, you can try to:
+
+- [Customize templates](../admin/templates/extending-templates/index.md)
+- [Enable Prometheus metrics](../admin/integrations/prometheus.md)
+- [Deploy to Google Cloud Platform (GCP)](../install/cloud/compute-engine.md)
+
+## Troubleshooting
+
+### Cannot connect to the Docker daemon
+
+> Error: Error pinging Docker server: Cannot connect to the Docker daemon at
+> unix:///var/run/docker.sock. Is the docker daemon running?
+
+1. Install Docker for your system:
+
+   ```shell
+   curl -sSL https://get.docker.com | sh
+   ```
+
+1. Set up the Docker daemon in rootless mode for your user to run Docker as a
+   non-privileged user:
+
+   ```shell
+   dockerd-rootless-setuptool.sh install
+   ```
+
+   Depending on your system's dependencies, you might need to run other commands
+   before you retry this step. Read the output of this command for further
+   instructions.
+
+1. Assign your user to the Docker group:
+
+   ```shell
+   sudo usermod -aG docker $USER
+   ```
+
+1. Confirm that the user has been added:
+
+   ```console
+   $ groups
+   docker sudo users
+   ```
+
+   - Ubuntu users might not see the group membership update. In that case, run
+     the following command or reboot the machine:
+
+     ```shell
+     newgrp docker
+     ```
+
+### Can't start Coder server: Address already in use
+
+```shell
+Encountered an error running "coder server", see "coder server --help" for more information
+error: configure http(s): listen tcp 127.0.0.1:3000: bind: address already in use
+```
+
+1. Stop the process:
+
+   ```shell
+   sudo systemctl stop coder
+   ```
+
+1. Start Coder:
+
+   ```shell
+   coder server
+   ```

--- a/docs/tutorials/getting-started/template-from-scratch.md
+++ b/docs/tutorials/getting-started/template-from-scratch.md
@@ -1,0 +1,437 @@
+# Write a template from scratch
+
+A template is a common configuration that you use to deploy workspaces.
+
+This tutorial teaches you how to create a template that provisions a workspace
+as a Docker container with Ubuntu.
+
+## Before you start
+
+You'll need a computer or cloud computing instance with both
+[Docker](https://docs.docker.com/get-docker/) and [Coder](../install/index.md)
+installed on it.
+
+## What's in a template
+
+The main part of a Coder template is a [Terraform](https://terraform.io) `tf`
+file. A Coder template often has other files to configure the other resources
+that the template needs. In this tour you'll also create a `Dockerfile`.
+
+Coder can provision all Terraform modules, resources, and properties. The Coder
+server essentially runs a `terraform apply` every time a workspace is created,
+started, or stopped.
+
+> [!TIP]
+> Haven't written Terraform before? Check out Hashicorp's
+> [Getting Started Guides](https://developer.hashicorp.com/terraform/tutorials).
+
+Here's a simplified diagram that shows the main parts of the template we'll
+create:
+
+![Template architecture](../images/templates/template-architecture.png)
+
+## 1. Create template files
+
+On your local computer, create a directory for your template and create the
+`Dockerfile`. You will upload the files to your Coder instance later.
+
+```sh
+mkdir -p template-tour/build && cd $_
+```
+
+Enter content into a `Dockerfile` that starts with the
+[official Ubuntu image](https://hub.docker.com/_/ubuntu/). In your editor, enter
+and save the following text in `Dockerfile` then exit the editor:
+
+```dockerfile
+FROM ubuntu
+
+RUN apt-get update \
+    && apt-get install -y \
+    sudo \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG USER=coder
+RUN useradd --groups sudo --no-create-home --shell /bin/bash ${USER} \
+    && echo "${USER} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/${USER} \
+    && chmod 0440 /etc/sudoers.d/${USER}
+USER ${USER}
+WORKDIR /home/${USER}
+```
+
+`Dockerfile` adds a few things to the parent `ubuntu` image, which your template
+needs later:
+
+- It installs the `sudo` and `curl` packages.
+- It adds a `coder` user, including a home directory.
+
+## 2. Set up template providers
+
+Edit the Terraform `main.tf` file to provision the workspace's resources.
+
+Start by setting up the providers. At a minimum, we need the `coder` provider.
+For this template, we also need the `docker` provider:
+
+```tf
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+    }
+  }
+}
+
+locals {
+  username = data.coder_workspace_owner.me.name
+}
+
+data "coder_provisioner" "me" {
+}
+
+provider "docker" {
+}
+
+provider "coder" {
+}
+
+data "coder_workspace" "me" {
+}
+
+data "coder_workspace_owner" "me" {
+}
+```
+
+Notice that the `provider` blocks for `coder` and `docker` are empty. In a more
+practical template, you would add arguments to these blocks to configure the
+providers, if needed.
+
+The
+[`coder_workspace`](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/workspace)
+data source provides details about the state of a workspace, such as its name,
+owner, and so on. The data source also lets us know when a workspace is being
+started or stopped. We'll use this information in later steps to:
+
+- Set some environment variables based on the workspace owner.
+- Manage ephemeral and persistent storage.
+
+## 3. coder_agent
+
+All templates need to create and run a
+[Coder agent](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent).
+This lets developers connect to their workspaces. The `coder_agent` resource
+runs inside the compute aspect of your workspace, typically a VM or container.
+In our case, it will run in Docker.
+
+You do not need to have any open ports on the compute aspect, but the agent
+needs `curl` access to the Coder server.
+
+Add this snippet after the last closing `}` in `main.tf` to create the agent:
+
+```tf
+resource "coder_agent" "main" {
+  arch                   = data.coder_provisioner.me.arch
+  os                     = "linux"
+  startup_script         = <<-EOT
+    set -e
+
+    # install and start code-server
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+    /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
+  EOT
+
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
+  }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "0_cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "RAM Usage"
+    key          = "1_ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+}
+```
+
+Because Docker is running locally in the Coder server, there is no need to
+authenticate `coder_agent`. But if your `coder_agent` is running on a remote
+host, your template will need
+[authentication credentials](../admin/external-auth.md).
+
+This template's agent also runs a startup script, sets environment variables,
+and provides metadata.
+
+- [`startup script`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#startup_script)
+
+  - Installs [code-server](https://coder.com/docs/code-server), a browser-based
+    [VS Code](https://code.visualstudio.com/) app that runs in the workspace.
+
+    We'll give users access to code-server through `coder_app`, later.
+
+- [`env` block](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#env)
+
+  - Sets environments variables for the workspace.
+
+    We use the data source from `coder_workspace` to set the environment
+    variables based on the workspace's owner. This way, the owner can make git
+    commits immediately without any manual configuration.
+
+- [`metadata`](../admin/templates/extending-templates/agent-metadata.md) blocks
+
+  - Your template can use metadata to show information to the workspace owner
+    Coder displays this metadata in the Coder dashboard.
+
+    Our template has `metadata` blocks for CPU and RAM usage.
+
+## 4. coder_app
+
+A
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+resource lets a developer use an app from the workspace's Coder dashboard.
+
+![Apps in a Coder workspace](../images/templates/workspace-apps.png)
+
+This is commonly used for
+[web IDEs](../user-guides/workspace-access/web-ides.md) such as
+[code-server](https://coder.com/docs/code-server), RStudio, and JupyterLab.
+
+We installed code-server in the `startup_script` argument. To add code-server to
+the workspace, make it available in the workspace with a `coder_app` resource.
+See [web IDEs](../user-guides/workspace-access/web-ides.md) for more examples:
+
+```tf
+resource "coder_app" "code-server" {
+  agent_id     = coder_agent.main.id
+  slug         = "code-server"
+  display_name = "code-server"
+  url          = "http://localhost:13337/?folder=/home/${local.username}"
+  icon         = "/icon/code.svg"
+  subdomain    = false
+  share        = "owner"
+
+  healthcheck {
+    url       = "http://localhost:13337/healthz"
+    interval  = 5
+    threshold = 6
+  }
+}
+```
+
+You can also use a `coder_app` resource to link to external apps, such as links
+to wikis or cloud consoles:
+
+```tf
+resource "coder_app" "coder-server-doc" {
+  agent_id     = coder_agent.main.id
+  icon         = "/emojis/1f4dd.png"
+  slug         = "getting-started"
+  url          = "https://coder.com/docs/code-server"
+  external     = true
+}
+```
+
+## 5. Persistent and ephemeral resources
+
+Managing the lifecycle of template resources is important. We want to make sure
+that workspaces use computing, storage, and other services efficiently.
+
+We want our workspace's home directory to persist after the workspace is stopped
+so that a developer can continue their work when they start the workspace again.
+
+We do this in 2 parts:
+
+- Our `docker_volume` resource uses the `lifecycle` block with the
+  `ignore_changes = all` argument to prevent accidental deletions.
+- To prevent Terraform from destroying persistent Docker volumes in case of a
+  workspace name change, we use an immutable parameter, like
+  `data.coder_workspace.me.id`.
+
+Later, we use the Terraform
+[count](https://developer.hashicorp.com/terraform/language/meta-arguments/count)
+meta-argument to make sure that our Docker container is ephemeral.
+
+```tf
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+}
+```
+
+For details, see
+[Resource persistence](../admin/templates/extending-templates/resource-persistence.md).
+
+## 6. Set up the Docker container
+
+To set up our Docker container, our template has a `docker_image` resource that
+uses `build/Dockerfile`, which we created earlier:
+
+```tf
+resource "docker_image" "main" {
+  name = "coder-${data.coder_workspace.me.id}"
+  build {
+    context = "./build"
+    build_args = {
+      USER = local.username
+    }
+  }
+  triggers = {
+    dir_sha1 = sha1(join("", [for f in fileset(path.module, "build/*") : filesha1(f)]))
+  }
+}
+```
+
+Our `docker_container` resource uses `coder_workspace` `start_count` to start
+and stop the Docker container:
+
+```tf
+resource "docker_container" "workspace" {
+  count = data.coder_workspace.me.start_count
+  image = docker_image.main.name
+  # Uses lower() to avoid Docker restriction on container names.
+  name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  # Hostname makes the shell more user friendly: coder@my-workspace:~$
+  hostname = data.coder_workspace.me.name
+  # Use the docker gateway if the access URL is 127.0.0.1
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.main.token}",
+  ]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/${local.username}"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+}
+```
+
+## 7. Create the template in Coder
+
+Save `main.tf` and exit the editor.
+
+Now that we've created the files for our template, we can add them to our Coder
+deployment.
+
+We can do this with the Coder CLI or the Coder dashboard. In this example, we'll
+use the Coder CLI.
+
+1. Log in to your Coder deployment from the CLI. This is where you need the URL
+   for your deployment:
+
+   ```console
+   $ coder login https://coder.example.com
+   Attempting to authenticate with config URL: 'https://coder.example.com'
+   Open the following in your browser:
+
+       https://coder.example.com/cli-auth
+
+   > Paste your token here:
+   ```
+
+1. In your web browser, enter your credentials:
+
+   <Image height="412px" src="../images/templates/coder-login-web.png" alt="Log in to your Coder deployment" align="center" />
+
+1. Copy the session token to the clipboard:
+
+   <Image height="472px" src="../images/templates/coder-session-token.png" alt="Copy session token" align="center" />
+
+1. Paste it into the CLI:
+
+   ```output
+   > Welcome to Coder, marc! You're authenticated.
+   $
+   ```
+
+### Add the template files to Coder
+
+Add your template files to your Coder deployment. You can upload the template
+through the CLI, or through the Coder dashboard:
+
+<div class="tabs">
+
+#### CLI
+
+1. Run `coder templates create` from the directory with your template files:
+
+   ```console
+   $ pwd
+   /home/docs/template-tour
+   $ coder templates push
+   > Upload "."? (yes/no) yes
+   ```
+
+1. The Coder CLI tool gives progress information then prompts you to confirm:
+
+   ```console
+   > Confirm create? (yes/no) yes
+
+   The template-tour template has been created! Developers can provision a workspace with this template using:
+
+   coder create --template="template-tour" [workspace name]
+   ```
+
+1. In your web browser, log in to your Coder dashboard, select **Templates**.
+
+1. Once the upload completes, select **Templates** from the top to deploy it to
+   a new workspace.
+
+   ![Your new template, ready to use](../images/templates/template-tour.png)
+
+#### Dashboard
+
+1. Create a `.zip` of the template files.
+
+   - On Mac or Windows, highlight the files and then right click. A "compress"
+     option is available through the right-click context menu.
+
+   - To zip the files through the command line:
+
+     ```shell
+     zip templates.zip Dockerfile main.tf
+     ```
+
+1. Select **Templates** from the top of the Coder dashboard, then **Create
+   Template**.
+1. Select **Upload template**:
+
+   ![Upload your first template](../images/templates/upload-create-your-first-template.png)
+
+1. Drag the `.zip` file into the **Upload template** section and fill out the
+   details, then select **Create template**.
+
+   ![Upload the template files](../images/templates/upload-create-template-form.png)
+
+1. Once the upload completes, select **Templates** from the top to deploy it to
+   a new workspace.
+
+   ![Your new template, ready to use](../images/templates/template-tour.png)
+
+</div>
+
+### Next steps
+
+- [Setting up templates](../admin/templates/index.md)
+- [Customizing templates](../admin/templates/extending-templates/index.md)
+- [Troubleshooting template](../admin/templates/troubleshooting.md)

--- a/docs/tutorials/getting-started/testing-templates.md
+++ b/docs/tutorials/getting-started/testing-templates.md
@@ -1,0 +1,118 @@
+# Test and Publish Coder Templates Through CI/CD
+
+<div>
+  <a href="https://github.com/matifali" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Muhammad Atif Ali</span>
+    <img src="https://github.com/matifali.png" alt="matifali" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+
+  </a>
+</div>
+November 15, 2024
+
+---
+
+## Overview
+
+This guide demonstrates how to test and publish Coder templates in a Continuous
+Integration (CI) pipeline using the
+[coder/setup-action](https://github.com/coder/setup-coder). This workflow
+ensures your templates are validated, tested, and promoted seamlessly.
+
+## Prerequisites
+
+- Install and configure Coder CLI in your environment.
+- Install Terraform CLI in your CI environment.
+- Create a [headless user](../admin/users/headless-auth.md) with the
+  [user roles and permissions](../admin/users/groups-roles.md#roles) to manage
+  templates and run workspaces.
+
+## Creating the headless user
+
+```shell
+coder users create \
+  --username machine-user \
+  --email machine-user@example.com \
+  --login-type none
+
+coder tokens create --user machine-user --lifetime 8760h
+# Copy the token and store it in a secret in your CI environment with the name `CODER_SESSION_TOKEN`
+```
+
+## Example GitHub Action Workflow
+
+This example workflow tests and publishes a template using GitHub Actions.
+
+The workflow:
+
+1. Validates the Terraform template.
+1. Pushes the template to Coder without activating it.
+1. Tests the template by creating a workspace.
+1. Promotes the template version to active upon successful workspace creation.
+
+### Workflow File
+
+Save the following workflow file as `.github/workflows/publish-template.yaml` in
+your repository:
+
+```yaml
+name: Test and Publish Coder Template
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    env:
+      TEMPLATE_NAME: "my-template"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: latest
+
+      - name: Set up Coder CLI
+        uses: coder/setup-action@v1
+        with:
+          access_url: "https://coder.example.com"
+          coder_session_token: ${{ secrets.CODER_SESSION_TOKEN }}
+
+      - name: Validate Terraform template
+        run: terraform validate
+
+      - name: Get short commit SHA to use as template version name
+        id: name
+        run: echo "version_name=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Get latest commit title to use as template version description
+        id: message
+        run:
+          echo "pr_title=$(git log --format=%s -n 1 ${{ github.sha }})" >>
+          $GITHUB_OUTPUT
+
+      - name: Push template to Coder
+        run: |
+          coder templates push $TEMPLATE_NAME --activate=false --name ${{ steps.name.outputs.version_name }} --message "${{ steps.message.outputs.pr_title }}" --yes
+
+      - name: Create a test workspace and run some example commands
+        run: |
+          coder create -t $TEMPLATE_NAME --template-version ${{ steps.name.outputs.version_name }} test-${{ steps.name.outputs.version_name }} --yes
+          coder config-ssh --yes
+          # run some example commands
+          coder ssh test-${{ steps.name.outputs.version_name }} -- make build
+
+      - name: Delete the test workspace
+        if: always()
+        run: coder delete test-${{ steps.name.outputs.version_name }} --yes
+
+      - name: Promote template version
+        if: success()
+        run: |
+          coder template version promote --template=$TEMPLATE_NAME --template-version=${{ steps.name.outputs.version_name }} --yes
+```

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -4,6 +4,16 @@ Here you can find a list of employee-written guides on Coder. These tutorials
 are hosted on our [GitHub](https://github.com/coder/coder/) where you can leave
 feedback or request new topics to be covered.
 
+## Categories
+
+- [Getting Started](./getting-started/index.md) - Guides to help you get up and running with Coder
+- [Infrastructure](./infrastructure/index.md) - Guides related to database configuration, cloud providers, and infrastructure setup
+- [Security](./security/index.md) - Security-related tutorials for your Coder deployment
+- [Networking](./networking/index.md) - Guides related to network configuration and reverse proxies
+- [Authentication](./authentication/index.md) - Guides for configuring identity providers and authentication
+- [Operations](./operations/index.md) - Guides for day-to-day operational tasks
+- [Best Practices](./best-practices/index.md) - Guides to help you make the most of your Coder experience
+
 <children>
-  This page is rendered on <https://coder.com/docs/tutorials>. Refer to the other documents in the `docs/tutorials/` directory for specific employee-written guides.
+  This page is rendered on <https://coder.com/docs/tutorials>. Refer to the subdirectories in the `docs/tutorials/` directory for specific employee-written guides organized by category.
 </children>

--- a/docs/tutorials/infrastructure/README.md
+++ b/docs/tutorials/infrastructure/README.md
@@ -1,0 +1,8 @@
+# Infrastructure
+
+This directory contains guides related to database configuration, cloud providers, and infrastructure setup:
+
+- `external-database.md` - Use Coder with an external database
+- `postgres-ssl.md` - Configure Coder to connect to Postgres over SSL
+- `gcp-to-aws.md` - Federating a Google Cloud service account to AWS
+- `azure-federation.md` - Federating Coder to Azure

--- a/docs/tutorials/infrastructure/azure-federation.md
+++ b/docs/tutorials/infrastructure/azure-federation.md
@@ -1,0 +1,131 @@
+# Federating Coder's control plane to Azure
+
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Eric Paulsen</span>
+    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+January 26, 2024
+
+---
+
+This guide will walkthrough how to authenticate a Coder Provisioner to Microsoft
+Azure, using a Service Principal with a client certificate. You can use this
+guide for authenticating Coder to Azure, regardless of where Coder is run,
+either on-premise or in a non-Azure cloud. This method is one of several
+[recommended by Terraform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure).
+
+## Step 1: Generate Client Certificate & PKCS bundle
+
+We'll need to create the certificate Coder will use for authentication. Run the
+below command to generate a private key and self-signed certificate:
+
+```console
+openssl req -subj '/CN=myclientcertificate/O=MyCompany, Inc./ST=CA/C=US' \
+  -new -newkey rsa:4096 -sha256 -days 730 -nodes -x509 -keyout client.key -out client.crt
+```
+
+Next, generate a `.pfx` file to be used by Coder's Provisioner to authenticate
+the AzureRM provider:
+
+```console
+openssl pkcs12 -export -password pass:"Pa55w0rd123" -out client.pfx -inkey client.key -in client.crt
+```
+
+## Step 2: Create Azure Application & Service Principal
+
+Navigate to the Azure portal, and into the Microsoft Entra ID section. Select
+the App Registration blade, and register a new application. Fill in the
+following fields:
+
+- **Name**: this is a friendly identifier and can be anything (e.g. "Coder")
+- **Supported Account Types**: - set to "Accounts in this organizational
+  directory only (single-tenant)"
+
+The **Redirect URI** field does not need to be set in this case. Take note of
+the `Application (client) ID` and `Directory (tenant) ID` values, which will be
+used by Coder.
+
+## Step 3: Assign Client Certificate to the Azure Application
+
+To upload the certificate we created in Step 1, select **Certificates &
+secrets** on the left-hand side, and select **Upload Certificate**. Upload the
+public key file, which is `service-principal.crt` from the example above.
+
+## Step 4: Set Permissions on the Service Principal
+
+Now that the Application is created in Microsoft Entra ID, we need to assign
+permissions to the Service Principal so it can provision Azure resources for
+Coder users. Navigate to the Subscriptions blade in the Azure Portal, select the
+**Subscription > Access Control (IAM) > Add > Add role assignment**.
+
+Set the **Role** that grants the appropriate permissions to create the Azure
+resources you need for your Coder workspaces. `Contributor` will provide
+Read/Write on all Subscription resources. For more information on the available
+roles, see the
+[Microsoft documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).
+
+## Step 5: Configure Coder to use the Client Certificate
+
+Now that the client certificate is uploaded to Azure, we need to mount the
+certificate files into the Coder deployment. If running Coder on Kubernetes, you
+will need to create the `.pfx` file as a Kubernetes secret, and mount it into
+the Helm chart.
+
+Run the below command to create the secret:
+
+```console
+kubectl create secret generic -n coder azure-client-cert-secret --from-file=client.pfx=/path/to/your/client.pfx
+```
+
+In addition, create secrets for each of the following values from your Azure
+Application:
+
+- Client ID
+- Tenant ID
+- Subscription ID
+- Certificate password
+
+Next, set the following values in Coder's Helm chart:
+
+```yaml
+coder:
+  env:
+    - name: ARM_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          key: id
+          name: arm-client-id
+    - name: ARM_CLIENT_CERTIFICATE_PATH
+      value: /home/coder/az/
+    - name: ARM_CLIENT_CERTIFICATE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: arm-client-cert-password
+    - name: ARM_TENANT_ID
+      valueFrom:
+        secretKeyRef:
+          key: id
+          name: arm-tenant-id
+    - name: ARM_SUBSCRIPTION_ID
+      valueFrom:
+        secretKeyRef:
+          key: id
+          name: arm-subscription-id
+  volumes:
+    - name: "azure-client-cert"
+      secret:
+        secretName: "azure-client-cert-secret"
+  volumeMounts:
+    - name: "azure-client-cert"
+      mountPath: "/home/coder/az/"
+      readOnly: true
+```
+
+Upgrade the Coder deployment using the following `helm` command:
+
+```console
+helm upgrade coder coder-v2/coder -n coder -f values.yaml
+```

--- a/docs/tutorials/infrastructure/external-database.md
+++ b/docs/tutorials/infrastructure/external-database.md
@@ -1,0 +1,92 @@
+# Using Coder with an external database
+
+## Recommendation
+
+For production deployments, we recommend using an external
+[PostgreSQL](https://www.postgresql.org/) database (version 13 or higher).
+
+## Basic configuration
+
+Before starting the Coder server, prepare the database server by creating a role
+and a database. Remember that the role must have access to the created database.
+
+With `psql`:
+
+```sql
+CREATE ROLE coder LOGIN SUPERUSER PASSWORD 'secret42';
+```
+
+With `psql -U coder`:
+
+```sql
+CREATE DATABASE coder;
+```
+
+Coder configuration is defined via
+[environment variables](../admin/setup/index.md). The database client requires
+the connection string provided via the `CODER_PG_CONNECTION_URL` variable.
+
+```shell
+export CODER_PG_CONNECTION_URL="postgres://coder:secret42@localhost/coder?sslmode=disable"
+```
+
+## Custom schema
+
+For installations with elevated security requirements, it's advised to use a
+separate [schema](https://www.postgresql.org/docs/current/ddl-schemas.html)
+instead of the public one.
+
+With `psql -U coder`:
+
+```sql
+CREATE SCHEMA myschema;
+```
+
+Once the schema is created, you can list all schemas with `\dn`:
+
+```text
+List of schemas
+ Name      | Owner
+-----------+----------
+ myschema  | coder
+ public    | postgres
+(2 rows)
+```
+
+In this case the database client requires the modified connection string:
+
+```shell
+export CODER_PG_CONNECTION_URL="postgres://coder:secret42@localhost/coder?sslmode=disable&search_path=myschema"
+```
+
+The `search_path` parameter determines the order of schemas in which they are
+visited while looking for a specific table. The first schema named in the search
+path is called the current schema. By default `search_path` defines the
+following schemas:
+
+```sql
+SHOW search_path;
+
+search_path
+--------------
+ "$user", public
+```
+
+Using the `search_path` in the connection string corresponds to the following
+`psql` command:
+
+```sql
+ALTER ROLE coder SET search_path = myschema;
+```
+
+## Troubleshooting
+
+### Coder server fails startup with "current_schema: converting NULL to string is unsupported"
+
+Please make sure that the schema selected in the connection string
+`...&search_path=myschema` exists and the role has granted permissions to access
+it. The schema should be present on this listing:
+
+```shell
+psql -U coder -c '\dn'
+```

--- a/docs/tutorials/infrastructure/gcp-to-aws.md
+++ b/docs/tutorials/infrastructure/gcp-to-aws.md
@@ -1,0 +1,196 @@
+# Federating a Google Cloud service account to AWS
+
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Eric Paulsen</span>
+    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+January 4, 2024
+
+---
+
+This guide will walkthrough how to use a Google Cloud service account to
+authenticate the Coder control plane to AWS and create an EC2 workspace. The
+below steps assume your Coder control plane is running in Google Cloud and has
+the relevant service account assigned.
+
+For steps on assigning a service account to a resource like Coder, visit the
+[Google documentation](https://cloud.google.com/iam/docs/attach-service-accounts#attaching-new-resource).
+
+## 1. Get your Google service account OAuth Client ID
+
+Navigate to the Google Cloud console, and select **IAM & Admin** > **Service
+Accounts**. View the service account you want to use, and copy the **OAuth 2
+Client ID** value shown on the right-hand side of the row.
+
+Optionally: If you do not yet have a service account, use the
+[Google IAM documentation on creating a service account](https://cloud.google.com/iam/docs/service-accounts-create) to create one.
+
+## 2. Create AWS role
+
+Create an AWS role that is configured for Web Identity Federation, with Google
+as the identity provider, as shown below:
+
+![AWS Create Role](../images/guides/gcp-to-aws/aws-create-role.png)
+
+Once created, edit the **Trust Relationship** section to look like the
+following:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "accounts.google.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "accounts.google.com:aud": "<enter-OAuth-client-ID-here"
+                }
+            }
+        }
+    ]
+}
+```
+
+## 3. Assign permissions to the AWS role
+
+In this example, Coder will need permissions to create the EC2 instance. Add the
+following policy to the role:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:GetDefaultCreditSpecification",
+                "ec2:DescribeIamInstanceProfileAssociations",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypes",
+                "ec2:CreateTags",
+                "ec2:RunInstances",
+                "ec2:DescribeInstanceCreditSpecifications",
+                "ec2:DescribeImages",
+                "ec2:ModifyDefaultCreditSpecification",
+                "ec2:DescribeVolumes"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "CoderResources",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstanceAttribute",
+                "ec2:UnmonitorInstances",
+                "ec2:TerminateInstances",
+                "ec2:StartInstances",
+                "ec2:StopInstances",
+                "ec2:DeleteTags",
+                "ec2:MonitorInstances",
+                "ec2:CreateTags",
+                "ec2:RunInstances",
+                "ec2:ModifyInstanceAttribute",
+                "ec2:ModifyInstanceCreditSpecification"
+            ],
+            "Resource": "arn:aws:ec2:*:*:instance/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/Coder_Provisioned": "true"
+                }
+            }
+        }
+    ]
+}
+```
+
+## 4. Generate the identity token for the service account
+
+Run the following `gcloud` command to generate the service account identity
+token. This is a JWT token with a payload that includes the service account
+email, audience, issuer, and expiration.
+
+```console
+gcloud auth print-identity-token --audiences=https://aws.amazon.com --impersonate-service-account 12345-compute@de
+veloper.gserviceaccount.com  --include-email
+```
+
+> [!NOTE]
+> Your `gcloud` client may needed elevated permissions to run this
+> command.
+
+## 5. Set identity token in Coder control plane
+
+You will need to set the token created in the previous step on a location in the
+Coder control plane. Follow the below steps for your specific deployment type:
+
+### VM control plane
+
+- Write the token to a file on the host, preferably inside the `/home/coder`
+  directory:
+
+```console
+/home/coder/.aws/gcp-identity-token
+```
+
+### Kubernetes control plane
+
+- Create the Kubernetes secret to house the token value:
+
+```console
+kubectl create secret generic gcp-identity-token -n coder --from-literal=token=<enter-token-here>
+```
+
+Make sure the secret is created inside the same namespace where Coder is
+running.
+
+- Mount the token file into the Coder pod using the values below:
+
+```yaml
+coder:
+  volumes:
+    - name: "gcp-identity-mount"
+      secret:
+        secretName: "gcp-identity-token"
+  volumeMounts:
+    - name: "gcp-identity-mount"
+      mountPath: "/home/coder/.aws/gcp-identity-token"
+      readOnly: true
+```
+
+## 6. Configure the AWS Terraform provider
+
+Navigate to your EC2 workspace template in Coder, and configure the AWS provider
+using the block below:
+
+```tf
+provider "aws" {
+  assume_role_with_web_identity {
+    # enter role ARN here - copy from AWS console
+    role_arn = "arn:aws:iam::123456789:role/gcp-to-aws"
+    # arbitrary value for logging
+    session_name = "coder-session"
+    # define location of token file on control plane here
+    web_identity_token_file = "/home/coder/.aws/gcp-identity-token"
+  }
+}
+```
+
+This provider block is equivalent to running this `aws` CLI command:
+
+```console
+aws sts assume-role-with-web-identity \
+  --role-arn arn:aws:iam::123456789:role/gcp-to-aws \
+  --role-session-name coder-session \
+  --web-identity-token xxx
+```
+
+You can run this command with the identity token string to validate or
+troubleshoot the call to AWS.

--- a/docs/tutorials/infrastructure/index.md
+++ b/docs/tutorials/infrastructure/index.md
@@ -1,0 +1,5 @@
+# Infrastructure
+
+Guides related to database configuration, cloud providers, and infrastructure setup.
+
+<children></children>

--- a/docs/tutorials/infrastructure/postgres-ssl.md
+++ b/docs/tutorials/infrastructure/postgres-ssl.md
@@ -1,0 +1,76 @@
+# Configure Coder to connect to PostgreSQL using SSL
+
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Eric Paulsen</span>
+    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+February 24, 2024
+
+---
+
+Your organization may require connecting to the database instance over SSL. To
+supply Coder with the appropriate certificates, and have it connect over SSL,
+follow the steps below:
+
+## Client verification (server verifies the client)
+
+1. Create the certificate as a secret in your Kubernetes cluster, if not already
+   present:
+
+```shell
+kubectl create secret tls postgres-certs -n coder --key="postgres.key" --cert="postgres.crt"
+```
+
+1. Define the secret volume and volumeMounts in the Helm chart:
+
+```yaml
+coder:
+  volumes:
+    - name: "pg-certs-mount"
+      secret:
+        secretName: "postgres-certs"
+  volumeMounts:
+    - name: "pg-certs-mount"
+      mountPath: "$HOME/.postgresql"
+      readOnly: true
+```
+
+1. Lastly, your PG connection URL will look like:
+
+```shell
+postgres://<user>:<password>@databasehost:<port>/<db-name>?sslmode=require&sslcert="$HOME/.postgresql/postgres.crt&sslkey=$HOME/.postgresql/postgres.key"
+```
+
+## Server verification (client verifies the server)
+
+1. Download the CA certificate chain for your database instance, and create it
+   as a secret in your Kubernetes cluster, if not already present:
+
+```shell
+kubectl create secret tls postgres-certs -n coder --key="postgres-root.key" --cert="postgres-root.crt"
+```
+
+1. Define the secret volume and volumeMounts in the Helm chart:
+
+```yaml
+coder:
+  volumes:
+    - name: "pg-certs-mount"
+      secret:
+        secretName: "postgres-certs"
+  volumeMounts:
+    - name: "pg-certs-mount"
+      mountPath: "$HOME/.postgresql/postgres-root.crt"
+      readOnly: true
+```
+
+1. Lastly, your PG connection URL will look like:
+
+```shell
+postgres://<user>:<password>@databasehost:<port>/<db-name>?sslmode=verify-full&sslrootcert="/home/coder/.postgresql/postgres-root.crt"
+```
+
+More information on connecting to PostgreSQL databases using certificates can
+be found in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-CLIENTCERT).

--- a/docs/tutorials/networking/README.md
+++ b/docs/tutorials/networking/README.md
@@ -1,0 +1,7 @@
+# Networking
+
+This directory contains guides related to network configuration and reverse proxies:
+
+- `reverse-proxy-nginx.md` - Learn how to use NGINX as a reverse proxy
+- `reverse-proxy-apache.md` - Learn how to use Apache as a reverse proxy
+- `reverse-proxy-caddy.md` - Learn how to use Caddy as a reverse proxy

--- a/docs/tutorials/networking/index.md
+++ b/docs/tutorials/networking/index.md
@@ -1,0 +1,5 @@
+# Networking
+
+Guides related to network configuration and reverse proxies.
+
+<children></children>

--- a/docs/tutorials/networking/reverse-proxy-apache.md
+++ b/docs/tutorials/networking/reverse-proxy-apache.md
@@ -1,0 +1,172 @@
+# How to use Apache as a reverse-proxy with LetsEncrypt
+
+## Requirements
+
+1. Start a Coder deployment and be sure to set the following
+   [configuration values](../admin/setup/index.md):
+
+   ```env
+   CODER_HTTP_ADDRESS=127.0.0.1:3000
+   CODER_ACCESS_URL=https://coder.example.com
+   CODER_WILDCARD_ACCESS_URL=*coder.example.com
+   ```
+
+   Throughout the guide, be sure to replace `coder.example.com` with the domain
+   you intend to use with Coder.
+
+2. Configure your DNS provider to point your coder.example.com and
+   \*.coder.example.com to your server's public IP address.
+
+   > For example, to use `coder.example.com` as your subdomain, configure
+   > `coder.example.com` and `*.coder.example.com` to point to your server's
+   > public ip. This can be done by adding A records in your DNS provider's
+   > dashboard.
+
+3. Install Apache (assuming you're on Debian/Ubuntu):
+
+   ```shell
+   sudo apt install apache2
+   ```
+
+4. Enable the following Apache modules:
+
+   ```shell
+   sudo a2enmod proxy
+   sudo a2enmod proxy_http
+   sudo a2enmod ssl
+   sudo a2enmod rewrite
+   ```
+
+5. Stop Apache service and disable default site:
+
+   ```shell
+   sudo a2dissite 000-default.conf
+   sudo systemctl stop apache2
+   ```
+
+## Install and configure LetsEncrypt Certbot
+
+1. Install LetsEncrypt Certbot: Refer to the
+   [CertBot documentation](https://certbot.eff.org/instructions?ws=apache&os=ubuntufocal&tab=wildcard).
+   Be sure to pick the wildcard tab and select your DNS provider for
+   instructions to install the necessary DNS plugin.
+
+## Create DNS provider credentials
+
+This example assumes you're using CloudFlare as your DNS provider. For other
+providers, refer to the
+[CertBot documentation](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins).
+
+1. Create an API token for the DNS provider you're using: e.g.
+   [CloudFlare](https://developers.cloudflare.com/fundamentals/api/get-started/create-token)
+   with the following permissions:
+
+   - Zone - DNS - Edit
+
+2. Create a file in `.secrets/certbot/cloudflare.ini` with the following
+   content:
+
+   ```ini
+   dns_cloudflare_api_token = YOUR_API_TOKEN
+   ```
+
+   ```shell
+   mkdir -p ~/.secrets/certbot
+   touch ~/.secrets/certbot/cloudflare.ini
+   nano ~/.secrets/certbot/cloudflare.ini
+   ```
+
+3. Set the correct permissions:
+
+   ```shell
+   sudo chmod 600 ~/.secrets/certbot/cloudflare.ini
+   ```
+
+## Create the certificate
+
+1. Create the wildcard certificate:
+
+   ```shell
+   sudo certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -d coder.example.com -d *.coder.example.com
+   ```
+
+## Configure Apache
+
+This example assumes Coder is running locally on `127.0.0.1:3000` and that
+you're using `coder.example.com` as your subdomain.
+
+1. Create Apache configuration for Coder:
+
+   ```shell
+   sudo nano /etc/apache2/sites-available/coder.conf
+   ```
+
+2. Add the following content:
+
+   ```apache
+    # Redirect HTTP to HTTPS
+    <VirtualHost *:80>
+        ServerName coder.example.com
+        ServerAlias *.coder.example.com
+        Redirect permanent / https://coder.example.com/
+    </VirtualHost>
+
+    <VirtualHost *:443>
+        ServerName coder.example.com
+        ServerAlias *.coder.example.com
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        ProxyPass / http://127.0.0.1:3000/ upgrade=any # required for websockets
+        ProxyPassReverse / http://127.0.0.1:3000/
+        ProxyRequests Off
+        ProxyPreserveHost On
+
+        RewriteEngine On
+        # Websockets are required for workspace connectivity
+        RewriteCond %{HTTP:Connection} Upgrade [NC]
+        RewriteCond %{HTTP:Upgrade} websocket [NC]
+        RewriteRule /(.*) ws://127.0.0.1:3000/$1 [P,L]
+
+        SSLCertificateFile /etc/letsencrypt/live/coder.example.com/fullchain.pem
+        SSLCertificateKeyFile /etc/letsencrypt/live/coder.example.com/privkey.pem
+    </VirtualHost>
+   ```
+
+   > Don't forget to change: `coder.example.com` by your (sub)domain
+
+3. Enable the site:
+
+   ```shell
+   sudo a2ensite coder.conf
+   ```
+
+4. Restart Apache:
+
+   ```shell
+   sudo systemctl restart apache2
+   ```
+
+## Refresh certificates automatically
+
+1. Create a new file in `/etc/cron.weekly`:
+
+   ```shell
+   sudo touch /etc/cron.weekly/certbot
+   ```
+
+2. Make it executable:
+
+   ```shell
+   sudo chmod +x /etc/cron.weekly/certbot
+   ```
+
+3. And add this code:
+
+   ```shell
+   #!/bin/sh
+   sudo certbot renew -q
+   ```
+
+And that's it, you should now be able to access Coder at your sub(domain) e.g.
+`https://coder.example.com`.

--- a/docs/tutorials/networking/reverse-proxy-caddy.md
+++ b/docs/tutorials/networking/reverse-proxy-caddy.md
@@ -1,0 +1,269 @@
+# Caddy
+
+This is an example configuration of how to use Coder with
+[caddy](https://caddyserver.com/docs). To use Caddy to generate TLS
+certificates, you'll need a domain name that resolves to your Caddy server.
+
+## Getting started
+
+### With docker-compose
+
+1. [Install Docker](https://docs.docker.com/engine/install/) and
+   [Docker Compose](https://docs.docker.com/compose/install/)
+
+2. Create a `docker-compose.yaml` file and add the following:
+
+   ```yaml
+   services:
+   coder:
+       image: ghcr.io/coder/coder:${CODER_VERSION:-latest}
+       environment:
+           CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
+           CODER_HTTP_ADDRESS: "0.0.0.0:7080"
+           # You'll need to set CODER_ACCESS_URL to an IP or domain
+           # that workspaces can reach. This cannot be localhost
+           # or 127.0.0.1 for non-Docker templates!
+           CODER_ACCESS_URL: "${CODER_ACCESS_URL}"
+           # Optional) Enable wildcard apps/dashboard port forwarding
+           CODER_WILDCARD_ACCESS_URL: "${CODER_WILDCARD_ACCESS_URL}"
+           # If the coder user does not have write permissions on
+           # the docker socket, you can uncomment the following
+           # lines and set the group ID to one that has write
+           # permissions on the docker socket.
+           #group_add:
+           #  - "998" # docker group on host
+       volumes:
+           - /var/run/docker.sock:/var/run/docker.sock
+       depends_on:
+           database:
+           condition: service_healthy
+
+   database:
+       image: "postgres:16"
+       ports:
+           - "5432:5432"
+       environment:
+           POSTGRES_USER: ${POSTGRES_USER:-username} # The PostgreSQL user (useful to connect to the database)
+           POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password} # The PostgreSQL password (useful to connect to the database)
+           POSTGRES_DB: ${POSTGRES_DB:-coder} # The PostgreSQL default database (automatically created at first launch)
+       volumes:
+           - coder_data:/var/lib/postgresql/data # Use "docker volume rm coder_coder_data" to reset Coder
+       healthcheck:
+           test:
+           [
+               "CMD-SHELL",
+               "pg_isready -U ${POSTGRES_USER:-username} -d ${POSTGRES_DB:-coder}",
+           ]
+           interval: 5s
+           timeout: 5s
+           retries: 5
+
+   caddy:
+       image: caddy:2.6.2
+       ports:
+           - "80:80"
+           - "443:443"
+           - "443:443/udp"
+       volumes:
+           - $PWD/Caddyfile:/etc/caddy/Caddyfile
+           - caddy_data:/data
+           - caddy_config:/config
+
+   volumes:
+       coder_data:
+       caddy_data:
+       caddy_config:
+   ```
+
+3. Create a `Caddyfile` and add the following:
+
+   ```caddyfile
+   {
+       on_demand_tls {
+           ask http://example.com
+       }
+   }
+
+   coder.example.com, *.coder.example.com {
+     reverse_proxy coder:7080
+     tls {
+           on_demand
+         issuer acme {
+            email email@example.com
+         }
+         }
+   }
+   ```
+
+   Here;
+
+   - `coder:7080` is the address of the Coder container on the Docker network.
+   - `coder.example.com` is the domain name you're using for Coder.
+   - `*.coder.example.com` is the domain name for wildcard apps, commonly used
+     for [dashboard port forwarding](../admin/networking/port-forwarding.md).
+     This is optional and can be removed.
+   - `email@example.com`: Email to request certificates from LetsEncrypt/ZeroSSL
+     (does not have to be Coder admin email)
+
+4. Start Coder. Set `CODER_ACCESS_URL` and `CODER_WILDCARD_ACCESS_URL` to the
+   domain you're using in your Caddyfile.
+
+   ```shell
+   export CODER_ACCESS_URL=https://coder.example.com
+   export CODER_WILDCARD_ACCESS_URL=*.coder.example.com
+   docker compose up -d # Run on startup
+   ```
+
+### Standalone
+
+1. If you haven't already, [install Coder](../install/index.md)
+
+2. Install [Caddy Server](https://caddyserver.com/docs/install)
+
+3. Copy our sample `Caddyfile` and change the following values:
+
+   ```caddyfile
+   {
+       on_demand_tls {
+           ask http://example.com
+       }
+   }
+
+   coder.example.com, *.coder.example.com {
+     reverse_proxy coder:7080
+   }
+   ```
+
+   > If you're installed Caddy as a system package, update the default Caddyfile
+   > with `vim /etc/caddy/Caddyfile`
+
+   - `email@example.com`: Email to request certificates from LetsEncrypt/ZeroSSL
+     (does not have to be Coder admin email)
+   - `coder.example.com`: Domain name you're using for Coder.
+   - `*.coder.example.com`: Domain name for wildcard apps, commonly used for
+     [dashboard port forwarding](../admin/networking/port-forwarding.md). This
+     is optional and can be removed.
+   - `localhost:3000`: Address Coder is running on. Modify this if you changed
+     `CODER_HTTP_ADDRESS` in the Coder configuration.
+   - _DO NOT CHANGE the `ask http://example.com` line! Doing so will result in
+     your certs potentially not being generated._
+
+4. [Configure Coder](../admin/setup/index.md) and change the following values:
+
+   - `CODER_ACCESS_URL`: root domain (e.g. `https://coder.example.com`)
+   - `CODER_WILDCARD_ACCESS_URL`: wildcard domain (e.g. `*.example.com`).
+
+5. Start the Caddy server:
+
+   If you're [keeping Caddy running](https://caddyserver.com/docs/running) via a
+   system service:
+
+   ```shell
+   sudo systemctl restart caddy
+   ```
+
+   Or run a standalone server:
+
+   ```shell
+   caddy run
+   ```
+
+6. Optionally, use [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall) or
+   another firewall to disable external traffic outside of Caddy.
+
+   ```shell
+   # Check status of UncomplicatedFirewall
+   sudo ufw status
+
+   # Allow SSH
+   sudo ufw allow 22
+
+   # Allow HTTP, HTTPS (Caddy)
+   sudo ufw allow 80
+   sudo ufw allow 443
+
+   # Deny direct access to Coder server
+   sudo ufw deny 3000
+
+   # Enable UncomplicatedFirewall
+   sudo ufw enable
+   ```
+
+7. Navigate to your Coder URL! A TLS certificate should be auto-generated on
+   your first visit.
+
+## Generating wildcard certificates
+
+By default, this configuration uses Caddy's
+[on-demand TLS](https://caddyserver.com/docs/caddyfile/options#on-demand-tls) to
+generate a certificate for each subdomain (e.g. `app1.coder.example.com`,
+`app2.coder.example.com`). When users visit new subdomains, such as accessing
+[ports on a workspace](../admin/networking/port-forwarding.md), the request will
+take an additional 5-30 seconds since a new certificate is being generated.
+
+For production deployments, we recommend configuring Caddy to generate a
+wildcard certificate, which requires an explicit DNS challenge and additional
+Caddy modules.
+
+1. Install a custom Caddy build that includes the
+   [caddy-dns](https://github.com/caddy-dns) module for your DNS provider (e.g.
+   CloudFlare, Route53).
+
+   - Docker:
+     [Build an custom Caddy image](https://github.com/docker-library/docs/tree/master/caddy#adding-custom-caddy-modules)
+     with the module for your DNS provider. Be sure to reference the new image
+     in the `docker-compose.yaml`.
+
+   - Standalone:
+     [Download a custom Caddy build](https://caddyserver.com/download) with the
+     module for your DNS provider. If you're using Debian/Ubuntu, you
+     [can configure the Caddy package](https://caddyserver.com/docs/build#package-support-files-for-custom-builds-for-debianubunturaspbian)
+     to use the new build.
+
+2. Edit your `Caddyfile` and add the necessary credentials/API tokens to solve
+   the DNS challenge for wildcard certificates.
+
+   For example, for AWS Route53:
+
+   ```diff
+   tls {
+   -  on_demand
+   -  issuer acme {
+   -      email email@example.com
+   -  }
+
+   +  dns route53 {
+   +     max_retries 10
+   +     aws_profile "real-profile"
+   +     access_key_id "AKI..."
+   +     secret_access_key "wJa..."
+   +     token "TOKEN..."
+   +     region "us-east-1"
+   +  }
+   }
+   ```
+
+   > Configuration reference from
+   > [caddy-dns/route53](https://github.com/caddy-dns/route53).
+
+   And for CloudFlare:
+
+   Generate a
+   [token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token)
+   with the following permissions:
+
+   - Zone:Zone:Edit
+
+   ```diff
+   tls {
+   -  on_demand
+   -  issuer acme {
+   -      email email@example.com
+   -  }
+
+   +  dns cloudflare CLOUDFLARE_API_TOKEN
+   }
+   ```
+
+   > Configuration reference from
+   > [caddy-dns/cloudflare](https://github.com/caddy-dns/cloudflare).

--- a/docs/tutorials/networking/reverse-proxy-nginx.md
+++ b/docs/tutorials/networking/reverse-proxy-nginx.md
@@ -1,0 +1,179 @@
+# How to use NGINX as a reverse-proxy with LetsEncrypt
+
+## Requirements
+
+1. Start a Coder deployment and be sure to set the following
+   [configuration values](../admin/setup/index.md):
+
+   ```env
+   CODER_HTTP_ADDRESS=127.0.0.1:3000
+   CODER_ACCESS_URL=https://coder.example.com
+   CODER_WILDCARD_ACCESS_URL=*.coder.example.com
+   ```
+
+   Throughout the guide, be sure to replace `coder.example.com` with the domain
+   you intend to use with Coder.
+
+2. Configure your DNS provider to point your coder.example.com and
+   \*.coder.example.com to your server's public IP address.
+
+   > For example, to use `coder.example.com` as your subdomain, configure
+   > `coder.example.com` and `*.coder.example.com` to point to your server's
+   > public ip. This can be done by adding A records in your DNS provider's
+   > dashboard.
+
+3. Install NGINX (assuming you're on Debian/Ubuntu):
+
+   ```shell
+   sudo apt install nginx
+   ```
+
+4. Stop NGINX service:
+
+   ```shell
+   sudo systemctl stop nginx
+   ```
+
+## Adding Coder deployment subdomain
+
+This example assumes Coder is running locally on `127.0.0.1:3000` and that
+you're using `coder.example.com` as your subdomain.
+
+1. Create NGINX configuration for this app:
+
+   ```shell
+   sudo touch /etc/nginx/sites-available/coder.example.com
+   ```
+
+2. Activate this file:
+
+   ```shell
+   sudo ln -s /etc/nginx/sites-available/coder.example.com /etc/nginx/sites-enabled/coder.example.com
+   ```
+
+## Install and configure LetsEncrypt Certbot
+
+1. Install LetsEncrypt Certbot: Refer to the
+   [CertBot documentation](https://certbot.eff.org/instructions?ws=apache&os=ubuntufocal&tab=wildcard).
+   Be sure to pick the wildcard tab and select your DNS provider for
+   instructions to install the necessary DNS plugin.
+
+## Create DNS provider credentials
+
+This example assumes you're using CloudFlare as your DNS provider. For other
+providers, refer to the
+[CertBot documentation](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins).
+
+1. Create an API token for the DNS provider you're using: e.g.
+   [CloudFlare](https://developers.cloudflare.com/fundamentals/api/get-started/create-token)
+   with the following permissions:
+
+   - Zone - DNS - Edit
+
+2. Create a file in `.secrets/certbot/cloudflare.ini` with the following
+   content:
+
+   ```ini
+   dns_cloudflare_api_token = YOUR_API_TOKEN
+   ```
+
+   ```shell
+   mkdir -p ~/.secrets/certbot
+   touch ~/.secrets/certbot/cloudflare.ini
+   nano ~/.secrets/certbot/cloudflare.ini
+   ```
+
+3. Set the correct permissions:
+
+   ```shell
+   sudo chmod 600 ~/.secrets/certbot/cloudflare.ini
+   ```
+
+## Create the certificate
+
+1. Create the wildcard certificate:
+
+   ```shell
+   sudo certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -d coder.example.com -d *.coder.example.com
+   ```
+
+## Configure nginx
+
+1. Edit the file with:
+
+   ```shell
+   sudo nano /etc/nginx/sites-available/coder.example.com
+   ```
+
+2. Add the following content:
+
+   ```nginx
+   server {
+       server_name coder.example.com *.coder.example.com;
+
+       # HTTP configuration
+       listen 80;
+       listen [::]:80;
+
+       # HTTP to HTTPS
+       if ($scheme != "https") {
+           return 301 https://$host$request_uri;
+       }
+
+       # HTTPS configuration
+       listen [::]:443 ssl ipv6only=on;
+       listen 443 ssl;
+       ssl_certificate /etc/letsencrypt/live/coder.example.com/fullchain.pem;
+       ssl_certificate_key /etc/letsencrypt/live/coder.example.com/privkey.pem;
+
+       location / {
+           proxy_pass  http://127.0.0.1:3000; # Change this to your coder deployment port default is 3000
+           proxy_http_version 1.1;
+           proxy_set_header Upgrade $http_upgrade;
+           proxy_set_header Connection upgrade;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+           add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
+       }
+   }
+   ```
+
+   > Don't forget to change: `coder.example.com` by your (sub)domain
+
+3. Test the configuration:
+
+   ```shell
+   sudo nginx -t
+   ```
+
+## Refresh certificates automatically
+
+1. Create a new file in `/etc/cron.weekly`:
+
+   ```shell
+   sudo touch /etc/cron.weekly/certbot
+   ```
+
+2. Make it executable:
+
+   ```shell
+   sudo chmod +x /etc/cron.weekly/certbot
+   ```
+
+3. And add this code:
+
+   ```shell
+   #!/bin/sh
+   sudo certbot renew -q
+   ```
+
+## Restart NGINX
+
+```shell
+sudo systemctl restart nginx
+```
+
+And that's it, you should now be able to access Coder at your sub(domain) e.g.
+`https://coder.example.com`.

--- a/docs/tutorials/operations/README.md
+++ b/docs/tutorials/operations/README.md
@@ -1,0 +1,6 @@
+# Operations
+
+This directory contains guides for day-to-day operational tasks:
+
+- `image-pull-secret.md` - Creating ImagePullSecrets for private registries
+- `support-bundle.md` - Generate and upload a Support Bundle to Coder Support

--- a/docs/tutorials/operations/image-pull-secret.md
+++ b/docs/tutorials/operations/image-pull-secret.md
@@ -1,0 +1,100 @@
+# Defining ImagePullSecrets for Coder workspaces
+
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Eric Paulsen</span>
+    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+January 12, 2024
+
+---
+
+Coder workspaces are commonly run as Kubernetes pods. When run inside of an
+enterprise, the pod image is typically pulled from a private image registry.
+This guide walks through creating an ImagePullSecret to use for authenticating
+to your registry, and defining it in your workspace template.
+
+## 1. Create Docker Config JSON File
+
+Create a Docker configuration JSON file containing your registry credentials.
+Replace `<your-registry>`, `<your-username>`, and `<your-password>` with your
+actual Docker registry URL, username, and password.
+
+```json
+{
+    "auths": {
+        "<your-registry>": {
+            "username": "<your-username>",
+            "password": "<your-password>"
+        }
+    }
+}
+```
+
+## 2. Create Kubernetes Secret
+
+Run the below `kubectl` command in the K8s cluster where you intend to run your
+Coder workspaces:
+
+```console
+kubectl create secret generic regcred \
+  --from-file=.dockerconfigjson=<path-to-docker-config.json> \
+  --type=kubernetes.io/dockerconfigjson \
+  --namespace=<workspaces-namespace>
+```
+
+Inspect the secret to confirm its contents:
+
+```console
+kubectl get secret -n <workspaces-namespace> regcred --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
+```
+
+The output should look similar to this:
+
+```json
+{
+    "auths": {
+        "your.private.registry.com": {
+            "username": "ericpaulsen",
+            "password": "xxxx",
+            "auth": "c3R...zE2"
+        }
+    }
+}
+```
+
+## 3. Define ImagePullSecret in Terraform template
+
+With the ImagePullSecret now created, we can add the secret into the workspace
+template. In the example below, we define the secret via the
+`image_pull_secrets` argument. Note that this argument is nested at the same
+level as the `container` argument:
+
+```tf
+resource "kubernetes_pod" "dev" {
+  metadata {
+    # this must be the same namespace where workspaces will be deployed
+    namespace = "workspaces-namespace"
+  }
+
+  spec {
+    image_pull_secrets {
+      name = "regcred"
+    }
+    container {
+      name  = "dev"
+      image = "your-image:latest"
+    }
+  }
+}
+```
+
+## 4. Push New Template Version
+
+Update your template by running the following commands:
+
+```console
+coder login <access-url>
+coder templates push <template-name>
+```

--- a/docs/tutorials/operations/index.md
+++ b/docs/tutorials/operations/index.md
@@ -1,0 +1,5 @@
+# Operations
+
+Guides for day-to-day operational tasks such as managing secrets, troubleshooting, and support.
+
+<children></children>

--- a/docs/tutorials/operations/support-bundle.md
+++ b/docs/tutorials/operations/support-bundle.md
@@ -1,0 +1,90 @@
+# Generate and upload a Support Bundle to Coder Support
+
+When you engage with Coder support to diagnose an issue with your deployment,
+you may be asked to generate and upload a "Support Bundle" for offline analysis.
+This document explains the contents of a support bundle and the steps to submit
+a support bundle to Coder staff.
+
+## What is a Support Bundle?
+
+A support bundle is an archive containing a snapshot of information about your
+Coder deployment.
+
+It contains information about the workspace, the template it uses, running
+agents in the workspace, and other detailed information useful for
+troubleshooting.
+
+It is primarily intended for troubleshooting connectivity issues to workspaces,
+but can be useful for diagnosing other issues as well.
+
+**While we attempt to redact sensitive information from support bundles, they
+may contain information deemed sensitive by your organization and should be
+treated as such.**
+
+A brief overview of all files contained in the bundle is provided below:
+
+> [!NOTE]
+> Detailed descriptions of all the information available in the bundle is
+> out of scope, as support bundles are primarily intended for internal use.
+
+| Filename                          | Description                                                                                                |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------|
+| `agent/agent.json`                | The agent used to connect to the workspace with environment variables stripped.                            |
+| `agent/agent_magicsock.html`      | The contents of the HTTP debug endpoint of the agent's Tailscale Wireguard connection.                     |
+| `agent/client_magicsock.html`     | The contents of the HTTP debug endpoint of the client's Tailscale Wireguard connection.                    |
+| `agent/listening_ports.json`      | The listening ports detected by the selected agent running in the workspace.                               |
+| `agent/logs.txt`                  | The logs of the selected agent running in the workspace.                                                   |
+| `agent/manifest.json`             | The manifest of the selected agent with environment variables stripped.                                    |
+| `agent/startup_logs.txt`          | Startup logs of the workspace agent.                                                                       |
+| `agent/prometheus.txt`            | The contents of the agent's Prometheus endpoint.                                                           |
+| `cli_logs.txt`                    | Logs from running the `coder support bundle` command.                                                      |
+| `deployment/buildinfo.json`       | Coder version and build information.                                                                       |
+| `deployment/config.json`          | Deployment [configuration](../reference/api/general.md#get-deployment-config), with secret values removed. |
+| `deployment/experiments.json`     | Any [experiments](../reference/cli/server.md#--experiments) currently enabled for the deployment.          |
+| `deployment/health.json`          | A snapshot of the [health status](../admin/monitoring/health-check.md) of the deployment.                  |
+| `logs.txt`                        | Logs from the `codersdk.Client` used to generate the bundle.                                               |
+| `network/connection_info.json`    | Information used by workspace agents used to connect to Coder (DERP map etc.)                              |
+| `network/coordinator_debug.html`  | Peers currently connected to each Coder instance and the tunnels established between peers.                |
+| `network/netcheck.json`           | Results of running `coder netcheck` locally.                                                               |
+| `network/tailnet_debug.html`      | Tailnet coordinators, their heartbeat ages, connected peers, and tunnels.                                  |
+| `workspace/build_logs.txt`        | Build logs of the selected workspace.                                                                      |
+| `workspace/workspace.json`        | Details of the selected workspace.                                                                         |
+| `workspace/parameters.json`       | Build parameters of the selected workspace.                                                                |
+| `workspace/template.json`         | The template currently in use by the selected workspace.                                                   |
+| `workspace/template_file.zip`     | The source code of the template currently in use by the selected workspace.                                |
+| `workspace/template_version.json` | The template version currently in use by the selected workspace.                                           |
+
+## How do I generate a Support Bundle?
+
+1. Ensure your deployment is up and running. Generating a support bundle
+   requires the Coder deployment to be available.
+
+2. Ensure you have the Coder CLI installed on a local machine. See
+   [installation](../install/index.md) for steps on how to do this.
+
+   > [!NOTE]
+   > It is recommended to generate a support bundle from a location
+   > experiencing workspace connectivity issues.
+
+3. Ensure you are [logged in](../reference/cli/login.md#login) to your Coder
+   deployment as a user with the Owner privilege.
+
+4. Run `coder support bundle [owner/workspace]`, and respond `yes` to the
+   prompt. The support bundle will be generated in the current directory with
+   the filename `coder-support-$TIMESTAMP.zip`.
+
+   > While support bundles can be generated without a running workspace, it is
+   > recommended to specify one to maximize troubleshooting information.
+
+5. (Recommended) Extract the support bundle and review its contents, redacting
+   any information you deem necessary.
+
+6. Coder staff will provide you a link where you can upload the bundle along
+   with any other necessary supporting files.
+
+   > [!NOTE]
+   > It is helpful to leave an informative message regarding the nature of
+   > supporting files.
+
+Coder support will then review the information you provided and respond to you
+with next steps.

--- a/docs/tutorials/security/README.md
+++ b/docs/tutorials/security/README.md
@@ -1,0 +1,5 @@
+# Security
+
+This directory contains security-related tutorials for your Coder deployment.
+
+*Note: Security-related tutorials will be added to this directory as they are created.*

--- a/docs/tutorials/security/index.md
+++ b/docs/tutorials/security/index.md
@@ -1,0 +1,5 @@
+# Security
+
+Security-related tutorials for your Coder deployment.
+
+<children></children>


### PR DESCRIPTION
## Summary
- Organizes tutorials into logical subdirectory categories to improve navigation
- Creates categories: getting-started, infrastructure, security, networking, authentication, operations (plus existing best-practices)
- Adds README and index.md files for each section
- Lists all categories on main tutorials index page

Fixes #16428

## Test plan
- Ensure all tutorial files are correctly copied to subdirectories
- Verify all index files are correctly formatted
- Check that new structure matches manifest.json updates (separate PR required for manifest.json changes)