### PR TITLE
test: create unit test to match nil deref behavior

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -515,7 +515,9 @@ func (s *server) acquireProtoJob(ctx context.Context, job database.ProvisionerJo
 		}
 
 		var workspaceOwnerOIDCAccessToken string
-		if s.OIDCConfig != nil {
+		// The check `s.OIDCConfig != nil` is not as strict, since it can be an interface
+		// pointing to a typed nil.
+		if !reflect.ValueOf(s.OIDCConfig).IsNil() {
 			workspaceOwnerOIDCAccessToken, err = obtainOIDCAccessToken(ctx, s.Database, s.OIDCConfig, owner.ID)
 			if err != nil {
 				return nil, failJob(fmt.Sprintf("obtain OIDC access token: %s", err))

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -23,6 +23,7 @@ import (
 	"storj.io/drpc"
 
 	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/quartz"
 	"github.com/coder/serpent"
@@ -123,6 +124,19 @@ func TestHeartbeat(t *testing.T) {
 		testutil.TryReceive(ctx, t, heartbeatChan)
 	}
 	// goleak.VerifyTestMain ensures that the heartbeat goroutine does not leak
+}
+
+func TestOptionsOIDCConfig(t *testing.T) {
+	t.Parallel()
+
+	var cfg *coderd.OIDCConfig
+	opts := provisionerdserver.Options{
+		// We pass in the oidc config like so, causing the interface
+		// to be not nil.
+		OIDCConfig: cfg,
+	}
+
+	require.True(t, opts.OIDCConfig == nil)
 }
 
 func TestAcquireJob(t *testing.T) {

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -23,7 +23,6 @@ import (
 	"storj.io/drpc"
 
 	"cdr.dev/slog/sloggers/slogtest"
-	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/quartz"
 	"github.com/coder/serpent"
@@ -124,19 +123,6 @@ func TestHeartbeat(t *testing.T) {
 		testutil.TryReceive(ctx, t, heartbeatChan)
 	}
 	// goleak.VerifyTestMain ensures that the heartbeat goroutine does not leak
-}
-
-func TestOptionsOIDCConfig(t *testing.T) {
-	t.Parallel()
-
-	var cfg *coderd.OIDCConfig
-	opts := provisionerdserver.Options{
-		// We pass in the oidc config like so, causing the interface
-		// to be not nil.
-		OIDCConfig: cfg,
-	}
-
-	require.True(t, opts.OIDCConfig == nil)
 }
 
 func TestAcquireJob(t *testing.T) {


### PR DESCRIPTION
Hit this panic in a deployment:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x322d541]

goroutine 50263 [running]:
github.com/coder/coder/v2/coderd.(*OIDCConfig).TokenSource(0x103e2078?, {0x13dd2590?, 0xc013de1e60?}, 0x28748d58?)
	<autogenerated>:1 +0x21
github.com/coder/coder/v2/coderd/provisionerdserver.obtainOIDCAccessToken({0x13dd2590, 0xc013de1e60}, {0x13e8e1f8, 0xc000f31950}, {0x13dc7fc0, 0x0}, {0x24, 0xec, 0x29, 0x28, ...})
	/home/steven/go/src/github.com/coder/coder/coderd/provisionerdserver/provisionerdserver.go:2355 +0x322
github.com/coder/coder/v2/coderd/provisionerdserver.(*server).acquireProtoJob(_, {_, _}, {{0x43, 0xa3, 0xff, 0x87, 0x50, 0x60, 0x4c, ...}, ...})
	/home/steven/go/src/github.com/coder/coder/coderd/provisionerdserver/provisionerdserver.go:519 +0x2191
github.com/coder/coder/v2/coderd/provisionerdserver.(*server).AcquireJobWithCancel(0xc000d3a1a0, {0x13de5e10, 0xc0036f40f0})
	/home/steven/go/src/github.com/coder/coder/coderd/provisionerdserver/provisionerdserver.go:398 +0xb7a
github.com/coder/coder/v2/provisionerd/proto.DRPCProvisionerDaemonDescription.Method.func2({0x4286da0?, 0xc000d3a1a0}, {0xc000c60380?, 0x16599c60?}, {0x430bc40?, 0xc001601b08}, {0x531a94?, 0x13dd2408?})
	/home/steven/go/src/github.com/coder/coder/provisionerd/proto/provisionerd_drpc.pb.go:197 +0x134
storj.io/drpc/drpcmux.(*Mux).HandleRPC(0xc000600008?, {0x13dde280, 0xc001601b08}, {0xc000c60380, 0x34})
	/home/steven/go/pkg/mod/storj.io/drpc@v0.0.33/drpcmux/handle_rpc.go:33 +0x207
github.com/coder/coder/v2/coderd/tracing.(*DRPCHandler).HandleRPC(0xc013bbf1c0, {0x13dde280, 0xc001601b08}, {0xc000c60380, 0x34})
	/home/steven/go/src/github.com/coder/coder/coderd/tracing/drpc.go:23 +0x1bb
storj.io/drpc/drpcserver.(*Server).handleRPC(0xc001b421c0?, 0xc001601b08, {0xc000c60380?, 0x16599c60?})
	/home/steven/go/pkg/mod/storj.io/drpc@v0.0.33/drpcserver/server.go:124 +0x36
storj.io/drpc/drpcserver.(*Server).ServeOne(0xc00072f500, {0x13dd6f58, 0xc013b62690}, {0x7465634314a8?, 0xc002065860?})
	/home/steven/go/pkg/mod/storj.io/drpc@v0.0.33/drpcserver/server.go:66 +0x1b3
storj.io/drpc/drpcserver.(*Server).Serve.func2({0x13dd6f58?, 0xc013b62690?})
	/home/steven/go/pkg/mod/storj.io/drpc@v0.0.33/drpcserver/server.go:114 +0x57
storj.io/drpc/drpcctx.(*Tracker).track(0xc013b62690, 0xc013bb76c0?)
	/home/steven/go/pkg/mod/storj.io/drpc@v0.0.33/drpcctx/tracker.go:35 +0x25
created by storj.io/drpc/drpcctx.(*Tracker).Run in goroutine 549
	/home/steven/go/pkg/mod/storj.io/drpc@v0.0.33/drpcctx/tracker.go:30 +0x76

```