### PR TITLE
feat: add link to provisioner jobs and daemons

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -396,7 +396,7 @@ export class MissingBuildParameters extends Error {
 }
 
 export type GetProvisionerJobsParams = {
-	status?: TypesGen.ProvisionerJobStatus;
+	status?: string;
 	limit?: number;
 	// IDs separated by comma
 	ids?: string;
@@ -405,7 +405,7 @@ export type GetProvisionerJobsParams = {
 export type GetProvisionerDaemonsParams = {
 	// IDs separated by comma
 	ids?: string;
-	// JSON Object
+	// Stringified JSON Object
 	tags?: string;
 	limit?: number;
 };

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -398,6 +398,16 @@ export class MissingBuildParameters extends Error {
 export type GetProvisionerJobsParams = {
 	status?: TypesGen.ProvisionerJobStatus;
 	limit?: number;
+	// IDs separated by comma
+	ids?: string;
+};
+
+export type GetProvisionerDaemonsParams = {
+	// IDs separated by comma
+	ids?: string;
+	// JSON Object
+	tags?: string;
+	limit?: number;
 };
 
 /**
@@ -711,22 +721,13 @@ class ApiMethods {
 		return response.data;
 	};
 
-	/**
-	 * @param organization Can be the organization's ID or name
-	 * @param tags to filter provisioner daemons by.
-	 */
 	getProvisionerDaemonsByOrganization = async (
 		organization: string,
-		tags?: Record<string, string>,
+		params?: GetProvisionerDaemonsParams,
 	): Promise<TypesGen.ProvisionerDaemon[]> => {
-		const params = new URLSearchParams();
-
-		if (tags) {
-			params.append("tags", JSON.stringify(tags));
-		}
-
 		const response = await this.axios.get<TypesGen.ProvisionerDaemon[]>(
-			`/api/v2/organizations/${organization}/provisionerdaemons?${params}`,
+			`/api/v2/organizations/${organization}/provisionerdaemons`,
+			{ params },
 		);
 		return response.data;
 	};

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -1,4 +1,8 @@
-import { API, type GetProvisionerJobsParams } from "api/api";
+import {
+	API,
+	type GetProvisionerDaemonsParams,
+	type GetProvisionerJobsParams,
+} from "api/api";
 import type {
 	CreateOrganizationRequest,
 	GroupSyncSettings,
@@ -164,16 +168,17 @@ export const organizations = () => {
 
 export const getProvisionerDaemonsKey = (
 	organization: string,
-	tags?: Record<string, string>,
-) => ["organization", organization, tags, "provisionerDaemons"];
+	params?: GetProvisionerDaemonsParams,
+) => ["organization", organization, "provisionerDaemons", params];
 
 export const provisionerDaemons = (
 	organization: string,
-	tags?: Record<string, string>,
+	params?: GetProvisionerDaemonsParams,
 ) => {
 	return {
-		queryKey: getProvisionerDaemonsKey(organization, tags),
-		queryFn: () => API.getProvisionerDaemonsByOrganization(organization, tags),
+		queryKey: getProvisionerDaemonsKey(organization, params),
+		queryFn: () =>
+			API.getProvisionerDaemonsByOrganization(organization, params),
 	};
 };
 

--- a/site/src/components/Button/Button.tsx
+++ b/site/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from "react";
 import { cn } from "utils/cn";
 
 export const buttonVariants = cva(
-	`inline-flex items-center justify-center gap-1 whitespace-nowrap
+	`inline-flex items-center justify-center gap-1 whitespace-nowrap font-sans
 	border-solid rounded-md transition-colors
 	text-sm font-semibold font-medium cursor-pointer no-underline
 	focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
@@ -30,6 +30,7 @@ export const buttonVariants = cva(
 			size: {
 				lg: "min-w-20 h-10 px-3 py-2 [&_svg]:size-icon-lg",
 				sm: "min-w-20 h-8 px-2 py-1.5 text-xs [&_svg]:size-icon-sm",
+				xs: "min-w-8 py-1 px-2 text-2xs rounded-md",
 				icon: "size-8 px-1.5 [&_svg]:size-icon-sm",
 				"icon-lg": "size-10 px-2 [&_svg]:size-icon-lg",
 			},

--- a/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
+++ b/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
@@ -119,7 +119,6 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 
 						{lifetimeDays === "custom" && (
 							<TextField
-								data-chromatic="ignore"
 								type="date"
 								label="Expires on"
 								defaultValue={dayjs().add(expDays, "day").format("YYYY-MM-DD")}
@@ -130,6 +129,7 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 									setExpDays(lt);
 								}}
 								inputProps={{
+									"data-chromatic": "ignore",
 									min: dayjs().add(1, "day").format("YYYY-MM-DD"),
 									max: maxTokenLifetime
 										? dayjs()

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof PermissionPillsList> = {
 	],
 	parameters: {
 		chromatic: {
-			diffThreshold: 0.5,
+			diffThreshold: 0.6,
 		},
 	},
 };

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
@@ -15,10 +15,10 @@ import {
 	ProvisionerTruncateTags,
 } from "modules/provisioners/ProvisionerTags";
 import { type FC, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import { cn } from "utils/cn";
 import { relativeTime } from "utils/time";
 import { CancelJobButton } from "./CancelJobButton";
-import { Link as RouterLink } from "react-router-dom";
 
 type JobRowProps = {
 	job: ProvisionerJob;

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/JobRow.tsx
@@ -18,14 +18,16 @@ import { type FC, useState } from "react";
 import { cn } from "utils/cn";
 import { relativeTime } from "utils/time";
 import { CancelJobButton } from "./CancelJobButton";
+import { Link as RouterLink } from "react-router-dom";
 
 type JobRowProps = {
 	job: ProvisionerJob;
+	defaultIsOpen: boolean;
 };
 
-export const JobRow: FC<JobRowProps> = ({ job }) => {
+export const JobRow: FC<JobRowProps> = ({ job, defaultIsOpen = false }) => {
 	const metadata = job.metadata;
-	const [isOpen, setIsOpen] = useState(false);
+	const [isOpen, setIsOpen] = useState(defaultIsOpen);
 	const queue = {
 		size: job.queue_size,
 		position: job.queue_position,
@@ -114,8 +116,21 @@ export const JobRow: FC<JobRowProps> = ({ job }) => {
 									: "[]"}
 							</dd>
 
-							<dt>Completed by provisioner:</dt>
-							<dd>{job.worker_id}</dd>
+							{job.worker_id && (
+								<>
+									<dt>Completed by provisioner:</dt>
+									<dd className="flex items-center gap-2">
+										<span>{job.worker_id}</span>
+										<Button size="xs" variant="outline" asChild>
+											<RouterLink
+												to={`../provisioners?${new URLSearchParams({ ids: job.worker_id })}`}
+											>
+												View provisioner
+											</RouterLink>
+										</Button>
+									</dd>
+								</>
+							)}
 
 							<dt>Associated workspace:</dt>
 							<dd>{job.metadata.workspace_name ?? "null"}</dd>
@@ -123,10 +138,14 @@ export const JobRow: FC<JobRowProps> = ({ job }) => {
 							<dt>Creation time:</dt>
 							<dd data-chromatic="ignore">{job.created_at}</dd>
 
-							<dt>Queue:</dt>
-							<dd>
-								{job.queue_position}/{job.queue_size}
-							</dd>
+							{job.queue_position > 0 && (
+								<>
+									<dt>Queue:</dt>
+									<dd>
+										{job.queue_position}/{job.queue_size}
+									</dd>
+								</>
+							)}
 
 							<dt>Tags:</dt>
 							<dd>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
@@ -11,18 +11,18 @@ const OrganizationProvisionerJobsPage: FC = () => {
 	const { organization } = useOrganizationSettings();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const filter = {
-		status: searchParams.get("status") || "",
-		ids: searchParams.get("ids") || "",
+		status: searchParams.get("status") ?? "",
+		ids: searchParams.get("ids") ?? "",
 	};
 	const {
 		data: jobs,
 		isLoadingError,
 		refetch,
 	} = useQuery({
-		...provisionerJobs(organization?.id || "", {
+		...provisionerJobs(organization?.id ?? "", {
 			...filter,
 			limit: 100,
-		} as GetProvisionerJobsParams),
+		}),
 		enabled: organization !== undefined,
 	});
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPage.tsx
@@ -12,17 +12,17 @@ const OrganizationProvisionerJobsPage: FC = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const filter = {
 		status: searchParams.get("status") || "",
+		ids: searchParams.get("ids") || "",
 	};
-	const queryParams = {
-		...filter,
-		limit: 100,
-	} as GetProvisionerJobsParams;
 	const {
 		data: jobs,
 		isLoadingError,
 		refetch,
 	} = useQuery({
-		...provisionerJobs(organization?.id || "", queryParams),
+		...provisionerJobs(organization?.id || "", {
+			...filter,
+			limit: 100,
+		} as GetProvisionerJobsParams),
 		enabled: organization !== undefined,
 	});
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof OrganizationProvisionerJobsPageView> = {
 	args: {
 		organization: MockOrganization,
 		jobs: MockProvisionerJobs,
-		filter: { status: "" },
+		filter: { status: "", ids: "" },
 		onRetry: fn(),
 	},
 };
@@ -81,8 +81,8 @@ export const Empty: Story = {
 export const OnFilter: Story = {
 	render: function FilterWithState({ ...args }) {
 		const [jobs, setJobs] = useState<ProvisionerJob[]>([]);
-		const [filter, setFilter] = useState({ status: "pending" });
-		const handleFilterChange = (newFilter: { status: string }) => {
+		const [filter, setFilter] = useState({ status: "pending", ids: "" });
+		const handleFilterChange = (newFilter: { status: string; ids: string }) => {
 			setFilter(newFilter);
 			const filteredJobs = MockProvisionerJobs.filter((job) =>
 				newFilter.status ? job.status === newFilter.status : true,
@@ -107,5 +107,15 @@ export const OnFilter: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 		const option = await body.findByRole("option", { name: "succeeded" });
 		await userEvent.click(option);
+	},
+};
+
+export const FilterByID: Story = {
+	args: {
+		jobs: [MockProvisionerJob],
+		filter: {
+			ids: MockProvisionerJob.id,
+			status: "",
+		},
 	},
 };

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -152,7 +152,7 @@ const OrganizationProvisionerJobsPageView: FC<
 						onValueChange={(status) => {
 							onFilterChange({
 								...filter,
-								status: status as ProvisionerJobStatus,
+								status,
 							});
 						}}
 					>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -3,6 +3,7 @@ import type {
 	ProvisionerJob,
 	ProvisionerJobStatus,
 } from "api/typesGenerated";
+import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Link } from "components/Link/Link";
@@ -33,19 +34,18 @@ import {
 	TableHeader,
 	TableRow,
 } from "components/Table/Table";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "components/Tooltip/Tooltip";
+import { XIcon } from "lucide-react";
 import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
 import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
 import { JobRow } from "./JobRow";
-import { Badge } from "components/Badge/Badge";
-import { XIcon } from "lucide-react";
-import {
-	Tooltip,
-	TooltipProvider,
-	TooltipTrigger,
-	TooltipContent,
-} from "components/Tooltip/Tooltip";
 
 const variantByStatus: Record<
 	ProvisionerJobStatus,

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerJobsPage/OrganizationProvisionerJobsPageView.tsx
@@ -38,6 +38,14 @@ import { Helmet } from "react-helmet-async";
 import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
 import { JobRow } from "./JobRow";
+import { Badge } from "components/Badge/Badge";
+import { XIcon } from "lucide-react";
+import {
+	Tooltip,
+	TooltipProvider,
+	TooltipTrigger,
+	TooltipContent,
+} from "components/Tooltip/Tooltip";
 
 const variantByStatus: Record<
 	ProvisionerJobStatus,
@@ -64,6 +72,7 @@ const StatusFilters: ProvisionerJobStatus[] = [
 
 type JobProvisionersFilter = {
 	status: string;
+	ids: string;
 };
 
 type OrganizationProvisionerJobsPageViewProps = {
@@ -110,30 +119,62 @@ const OrganizationProvisionerJobsPageView: FC<
 					</SettingsHeaderDescription>
 				</SettingsHeader>
 
-				<Select
-					value={filter.status}
-					onValueChange={(status) => {
-						onFilterChange({ status: status as ProvisionerJobStatus });
-					}}
-				>
-					<SelectTrigger className="w-[180px]" data-testid="status-filter">
-						<SelectValue placeholder="All statuses" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectGroup>
-							{StatusFilters.map((status) => (
-								<SelectItem key={status} value={status}>
-									<StatusIndicator variant={variantByStatus[status]}>
-										<StatusIndicatorDot />
-										<span className="block first-letter:uppercase">
-											{status}
-										</span>
-									</StatusIndicator>
-								</SelectItem>
-							))}
-						</SelectGroup>
-					</SelectContent>
-				</Select>
+				<div className="flex items-center gap-2">
+					{filter.ids && (
+						<div className="relative">
+							<Badge className="h-10 text-sm pl-3 pr-10 font-mono">
+								{filter.ids}
+							</Badge>
+							<div className="size-10 flex items-center justify-center absolute top-0 right-0">
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												size="icon"
+												variant="subtle"
+												onClick={() => {
+													onFilterChange({ ...filter, ids: "" });
+												}}
+											>
+												<span className="sr-only">Clear ID</span>
+												<XIcon />
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent>Clear ID</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+							</div>
+						</div>
+					)}
+
+					<Select
+						value={filter.status}
+						onValueChange={(status) => {
+							onFilterChange({
+								...filter,
+								status: status as ProvisionerJobStatus,
+							});
+						}}
+					>
+						<SelectTrigger className="w-[180px]" data-testid="status-filter">
+							<SelectValue placeholder="All statuses" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectGroup>
+								{StatusFilters.map((status) => (
+									<SelectItem key={status} value={status}>
+										<StatusIndicator variant={variantByStatus[status]}>
+											<StatusIndicatorDot />
+											<span className="block first-letter:uppercase">
+												{status}
+											</span>
+										</StatusIndicator>
+									</SelectItem>
+								))}
+							</SelectGroup>
+						</SelectContent>
+					</Select>
+				</div>
 
 				<Table className="mt-6">
 					<TableHeader>
@@ -149,7 +190,13 @@ const OrganizationProvisionerJobsPageView: FC<
 					<TableBody>
 						{jobs ? (
 							jobs.length > 0 ? (
-								jobs.map((j) => <JobRow key={j.id} job={j} />)
+								jobs.map((j) => (
+									<JobRow
+										defaultIsOpen={filter.ids.includes(j.id)}
+										key={j.id}
+										job={j}
+									/>
+								))
 							) : (
 								<TableRow>
 									<TableCell colSpan={999}>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
@@ -18,8 +18,8 @@ const OrganizationProvisionersPage: FC = () => {
 	};
 	const [searchParams, setSearchParams] = useSearchParams();
 	const queryParams = {
-		ids: searchParams.get("ids") || "",
-		tags: searchParams.get("tags") || "",
+		ids: searchParams.get("ids") ?? "",
+		tags: searchParams.get("tags") ?? "",
 	};
 	const { organization, organizationPermissions } = useOrganizationSettings();
 	const { entitlements } = useDashboard();

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.stories.tsx
@@ -60,3 +60,12 @@ export const Paywall: Story = {
 		showPaywall: true,
 	},
 };
+
+export const FilterByID: Story = {
+	args: {
+		provisioners: [MockProvisioner],
+		filter: {
+			ids: MockProvisioner.id,
+		},
+	},
+};

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.stories.tsx
@@ -24,6 +24,9 @@ const meta: Meta<typeof OrganizationProvisionersPageView> = {
 				version: "0.0.0",
 			},
 		],
+		filter: {
+			ids: "",
+		},
 	},
 };
 

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
@@ -17,23 +17,44 @@ import {
 	TableHeader,
 	TableRow,
 } from "components/Table/Table";
-import { SquareArrowOutUpRightIcon } from "lucide-react";
+import { SquareArrowOutUpRightIcon, XIcon } from "lucide-react";
 import type { FC } from "react";
 import { docs } from "utils/docs";
 import { LastConnectionHead } from "./LastConnectionHead";
 import { ProvisionerRow } from "./ProvisionerRow";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "components/Tooltip/Tooltip";
+import { Badge } from "components/Badge/Badge";
+
+type ProvisionersFilter = {
+	ids: string;
+};
 
 interface OrganizationProvisionersPageViewProps {
 	showPaywall: boolean | undefined;
 	provisioners: readonly ProvisionerDaemon[] | undefined;
 	buildVersion: string | undefined;
 	error: unknown;
+	filter: ProvisionersFilter;
 	onRetry: () => void;
+	onFilterChange: (filter: ProvisionersFilter) => void;
 }
 
 export const OrganizationProvisionersPageView: FC<
 	OrganizationProvisionersPageViewProps
-> = ({ showPaywall, error, provisioners, buildVersion, onRetry }) => {
+> = ({
+	showPaywall,
+	error,
+	provisioners,
+	buildVersion,
+	filter,
+	onFilterChange,
+	onRetry,
+}) => {
 	return (
 		<section>
 			<SettingsHeader>
@@ -44,6 +65,35 @@ export const OrganizationProvisionersPageView: FC<
 					<Link href={docs("/admin/provisioners")}>View docs</Link>
 				</SettingsHeaderDescription>
 			</SettingsHeader>
+
+			{filter.ids && (
+				<div className="flex items-center gap-2 mb-6">
+					<div className="relative">
+						<Badge className="h-10 text-sm pl-3 pr-10 font-mono">
+							{filter.ids}
+						</Badge>
+						<div className="size-10 flex items-center justify-center absolute top-0 right-0">
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											size="icon"
+											variant="subtle"
+											onClick={() => {
+												onFilterChange({ ...filter, ids: "" });
+											}}
+										>
+											<span className="sr-only">Clear ID</span>
+											<XIcon />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>Clear ID</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						</div>
+					</div>
+				</div>
+			)}
 
 			{showPaywall ? (
 				<Paywall
@@ -73,6 +123,7 @@ export const OrganizationProvisionersPageView: FC<
 										provisioner={provisioner}
 										key={provisioner.id}
 										buildVersion={buildVersion}
+										defaultIsOpen={filter.ids.includes(provisioner.id)}
 									/>
 								))
 							) : (

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
@@ -1,4 +1,5 @@
 import type { ProvisionerDaemon } from "api/typesGenerated";
+import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Link } from "components/Link/Link";
@@ -17,18 +18,17 @@ import {
 	TableHeader,
 	TableRow,
 } from "components/Table/Table";
-import { SquareArrowOutUpRightIcon, XIcon } from "lucide-react";
-import type { FC } from "react";
-import { docs } from "utils/docs";
-import { LastConnectionHead } from "./LastConnectionHead";
-import { ProvisionerRow } from "./ProvisionerRow";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { Badge } from "components/Badge/Badge";
+import { SquareArrowOutUpRightIcon, XIcon } from "lucide-react";
+import type { FC } from "react";
+import { docs } from "utils/docs";
+import { LastConnectionHead } from "./LastConnectionHead";
+import { ProvisionerRow } from "./ProvisionerRow";
 
 type ProvisionersFilter = {
 	ids: string;

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -21,6 +21,7 @@ import { type FC, useState } from "react";
 import { cn } from "utils/cn";
 import { relativeTime } from "utils/time";
 import { ProvisionerVersion } from "./ProvisionerVersion";
+import { Link as RouterLink } from "react-router-dom";
 
 const variantByStatus: Record<
 	ProvisionerDaemonStatus,
@@ -34,13 +35,15 @@ const variantByStatus: Record<
 type ProvisionerRowProps = {
 	provisioner: ProvisionerDaemon;
 	buildVersion: string | undefined;
+	defaultIsOpen: boolean;
 };
 
 export const ProvisionerRow: FC<ProvisionerRowProps> = ({
 	provisioner,
 	buildVersion,
+	defaultIsOpen = false,
 }) => {
-	const [isOpen, setIsOpen] = useState(false);
+	const [isOpen, setIsOpen] = useState(defaultIsOpen);
 
 	return (
 		<>
@@ -151,7 +154,16 @@ export const ProvisionerRow: FC<ProvisionerRowProps> = ({
 							{provisioner.previous_job && (
 								<>
 									<dt>Previous job:</dt>
-									<dd>{provisioner.previous_job.id}</dd>
+									<dd className="flex items-center gap-2">
+										<span>{provisioner.previous_job.id}</span>
+										<Button size="xs" variant="outline" asChild>
+											<RouterLink
+												to={`../provisioner-jobs?${new URLSearchParams({ ids: provisioner.previous_job.id })}`}
+											>
+												View job
+											</RouterLink>
+										</Button>
+									</dd>
 
 									<dt>Previous job status:</dt>
 									<dd>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerRow.tsx
@@ -18,10 +18,10 @@ import {
 } from "modules/provisioners/ProvisionerTags";
 import { ProvisionerKey } from "pages/OrganizationSettingsPage/OrganizationProvisionersPage/ProvisionerKey";
 import { type FC, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import { cn } from "utils/cn";
 import { relativeTime } from "utils/time";
 import { ProvisionerVersion } from "./ProvisionerVersion";
-import { Link as RouterLink } from "react-router-dom";
 
 const variantByStatus: Record<
 	ProvisionerDaemonStatus,

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -91,7 +91,7 @@ const meta = {
 			},
 		],
 		chromatic: {
-			diffThreshold: 0.5,
+			diffThreshold: 0.8,
 		},
 	},
 	decorators: [

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta<typeof WorkspaceTopbar> = {
 		layout: "fullscreen",
 		features: ["advanced_template_scheduling"],
 		chromatic: {
-			diffThreshold: 0.3,
+			diffThreshold: 0.6,
 		},
 	},
 };
@@ -321,7 +321,7 @@ export const TemplateInfoPopover: Story = {
 	},
 	parameters: {
 		chromatic: {
-			diffThreshold: 0.3,
+			diffThreshold: 0.6,
 		},
 	},
 };

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -8,6 +8,9 @@ module.exports = {
 	important: ["#root", "#storybook-root"],
 	theme: {
 		extend: {
+			fontFamily: {
+				sans: `"Inter Variable", system-ui, sans-serif`,
+			},
 			size: {
 				"icon-lg": "1.5rem",
 				"icon-sm": "1.125rem",


### PR DESCRIPTION
Close https://github.com/coder/coder/issues/17314

**Demo**

https://github.com/user-attachments/assets/db37aa67-4755-4b72-a54d-2c3f0c297b7d

**Changes**
- Added the `xs` button variant
- Display all the daemons - idle and offline - and set a size limit to 100 results (explanation in the demo)
- Filter daemons and jobs by ID