### PR TITLE
fix: fix workspace creation on template page

### DIFF
--- a/site/src/pages/TemplatePage/TemplateLayout.tsx
+++ b/site/src/pages/TemplatePage/TemplateLayout.tsx
@@ -85,9 +85,14 @@ export const TemplateLayout: FC<PropsWithChildren> = ({
 		queryFn: () => fetchTemplate(organizationName, templateName),
 	});
 	const workspacePermissionsQuery = useQuery(
-		checkAuthorization({
-			checks: workspacePermissionChecks(organizationName, me.id),
-		}),
+		data
+			? checkAuthorization({
+					checks: workspacePermissionChecks(
+						data.template.organization_id,
+						me.id,
+					),
+				})
+			: { enabled: false },
 	);
 
 	const location = useLocation();


### PR DESCRIPTION
Closes #17470

You can't use names in permission checks; they always expect IDs. The permission check on this page was using a name, resulting in the backend not always answering the question correctly.