### PR TITLE
fix: fix broken img layout

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -86,13 +86,11 @@ const ParameterLabel: FC<ParameterLabelProps> = ({ parameter, isPreset }) => {
 	return (
 		<div className="flex items-start gap-2">
 			{parameter.icon && (
-				<span className="w-5 h-5">
-					<ExternalImage
-						className="w-full h-full mt-0.5 object-contain"
-						alt="Parameter icon"
-						src={parameter.icon}
-					/>
-				</span>
+				<ExternalImage
+					className="w-5 h-5 mt-0.5 object-contain"
+					alt="Parameter icon"
+					src={parameter.icon}
+				/>
 			)}
 
 			<div className="flex flex-col w-full gap-1">


### PR DESCRIPTION
resolves #17507 

Before

<img width="629" alt="Screenshot 2025-04-23 at 11 01 55" src="https://github.com/user-attachments/assets/79e2945b-0301-4cf5-9b25-f112bac9c2ff" />

After

<img width="629" alt="Screenshot 2025-04-23 at 11 02 45" src="https://github.com/user-attachments/assets/c74d3c03-ebee-42e6-bd16-b4610139cb86" />
