### PR TITLE
docs: clarify that parameter autofill requires experimental flag

### DIFF
--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -381,6 +381,7 @@ You need to enable `auto-fill-parameters` first:
 ```shell
 coder server --experiments=auto-fill-parameters
 ```
+
 Or set the [environment variable](../../setup/index.md), `CODER_EXPERIMENTS=auto-fill-parameters`
 With the feature enabled:
 

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -374,7 +374,9 @@ data "coder_parameter" "jetbrains_ide" {
 ## Create Autofill
 
 When the template doesn't specify default values, Coder may still autofill
-parameters. To enable this feature, run the Coder server with:
+parameters.
+
+Enable this feature with the `--experiments` flag:
 
 ```shell
 coder server --experiments=auto-fill-parameters

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -381,7 +381,7 @@ You need to enable `auto-fill-parameters` first:
 ```shell
 coder server --experiments=auto-fill-parameters
 ```
-
+Or set the [environment variable](../../setup/index.md), `CODER_EXPERIMENTS=auto-fill-parameters`
 With the feature enabled:
 
 1. Coder will look for URL query parameters with form `param.<name>=<value>`.

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -374,7 +374,13 @@ data "coder_parameter" "jetbrains_ide" {
 ## Create Autofill
 
 When the template doesn't specify default values, Coder may still autofill
-parameters.
+parameters. To enable this feature, run the Coder server with:
+
+```shell
+coder server --experiments=auto-fill-parameters
+```
+
+With the feature enabled:
 
 1. Coder will look for URL query parameters with form `param.<name>=<value>`.
    This feature enables platform teams to create pre-filled template creation

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -376,7 +376,7 @@ data "coder_parameter" "jetbrains_ide" {
 When the template doesn't specify default values, Coder may still autofill
 parameters.
 
-Enable this feature with the `--experiments` flag:
+You need to enable `auto-fill-parameters` first:
 
 ```shell
 coder server --experiments=auto-fill-parameters


### PR DESCRIPTION
Update documentation to indicate that parameter autofill requires `--experiments=auto-fill-parameters` enabled

Fixes #14673