### PR TITLE
ci: move go install tools to separate action

### DIFF
--- a/.github/actions/setup-go-tools/action.yaml
+++ b/.github/actions/setup-go-tools/action.yaml
@@ -1,6 +1,6 @@
 name: "Setup Go tools"
 description: |
-  Set up tools for `make gen` and `offlinedocs`
+  Set up tools for `make gen`, `offlinedocs` and Schmoder CI.
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-go-tools/action.yaml
+++ b/.github/actions/setup-go-tools/action.yaml
@@ -1,0 +1,14 @@
+name: "Setup Go tools"
+description: |
+  Set up tools for `make gen` and `offlinedocs`
+runs:
+  using: "composite"
+  steps:
+    - name: go install tools
+      shell: bash
+      run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
+          go install storj.io/drpc/cmd/protoc-gen-go-drpc@v0.0.34
+          go install golang.org/x/tools/cmd/goimports@v0.31.0
+          go install github.com/mikefarah/yq/v4@v4.44.3
+          go install go.uber.org/mock/mockgen@v0.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,12 +249,7 @@ jobs:
         uses: ./.github/actions/setup-tf
 
       - name: go install tools
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
-          go install storj.io/drpc/cmd/protoc-gen-go-drpc@v0.0.34
-          go install golang.org/x/tools/cmd/goimports@v0.31.0
-          go install github.com/mikefarah/yq/v4@v4.44.3
-          go install go.uber.org/mock/mockgen@v0.5.0
+        uses: ./.github/actions/setup-go-tools
 
       - name: Install Protoc
         run: |
@@ -860,12 +855,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install go tools
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
-          go install storj.io/drpc/cmd/protoc-gen-go-drpc@v0.0.34
-          go install golang.org/x/tools/cmd/goimports@v0.31.0
-          go install github.com/mikefarah/yq/v4@v4.44.3
-          go install go.uber.org/mock/mockgen@v0.5.0
+        uses: ./.github/actions/setup-go-tools
 
       - name: Setup sqlc
         uses: ./.github/actions/setup-sqlc


### PR DESCRIPTION
I think using an older version of mockgen on the schmoder CI broke the workflow, so I'm gonna sync it via this action, like we do with the other `make build` dependencies.