### PR TITLE
fix(examples/templates/docker-devcontainer): update folder path and provider version constraint

### DIFF
--- a/examples/templates/docker-devcontainer/main.tf
+++ b/examples/templates/docker-devcontainer/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     coder = {
-      source = "coder/coder"
+      source  = "coder/coder"
+      version = "~> 2.0"
     }
     docker = {
       source = "kreuzwerker/docker"

--- a/examples/templates/docker-devcontainer/main.tf
+++ b/examples/templates/docker-devcontainer/main.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     coder = {
-      source  = "coder/coder"
-      version = "~> 1.0.0"
+      source = "coder/coder"
     }
     docker = {
       source = "kreuzwerker/docker"

--- a/examples/templates/docker-devcontainer/main.tf
+++ b/examples/templates/docker-devcontainer/main.tf
@@ -339,11 +339,11 @@ module "jetbrains_gateway" {
   source = "registry.coder.com/modules/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
-  jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
+  jetbrains_ides = ["IU", "PS", "WS", "PY", "CL", "GO", "RM", "RD", "RR"]
   default        = "IU"
 
   # Default folder to open when starting a JetBrains IDE
-  folder = "/home/coder"
+  folder = "/workspaces"
 
   # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = ">= 1.0.0"


### PR DESCRIPTION
[fix(examples): set jetbrains default folder to workspaces](https://github.com/coder/coder/commit/52149a1fe17f382b16443a34ac1e946df3130c5c)
- `jetbrains_ide` to match `docker` tf (was out of sync)
- default folder should be `/workspaces` since `/home/coder` doesn't exist 

[fix(examples): remove version specification](https://github.com/coder/coder/commit/3b0e2b4bd6482cdf91c0f19c952fd29b08dfc101)
- after removing version line, this error went away when trying to start/stop.
- `docker` tf file doesn't have the version line.
![image](https://github.com/user-attachments/assets/3585b534-9fdf-4db9-8ef6-43c178282baf)
