### PR TITLE
chore(dogfood): allow provider minor version updates

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "2.3.0"
+      version = "~> 2.0"
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
Noticed we were not using the latest Docker provider. https://github.com/kreuzwerker/terraform-provider-docker/releases/tag/v3.3.0