### PR TITLE
fix(examples/templates/kubernetes-devcontainer): update coder provider

### DIFF
--- a/examples/templates/kubernetes-devcontainer/main.tf
+++ b/examples/templates/kubernetes-devcontainer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "~> 1.0.0"
+      version = "~> 2.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
The latest version of the `code-server` module uses Coder provider `~> 2.0`, which causes the build to fail.

Related to #17553