### PR TITLE
chore(codersdk/toolsdk): improve static analyzability of toolsdk.Tools

### DIFF
--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -695,7 +695,7 @@ func getAgentToken(fs afero.Fs) (string, error) {
 
 // mcpFromSDK adapts a toolsdk.Tool to go-mcp's server.ServerTool.
 // It assumes that the tool responds with a valid JSON object.
-func mcpFromSDK(sdkTool toolsdk.Tool[any]) server.ServerTool {
+func mcpFromSDK(sdkTool toolsdk.Tool[any, any]) server.ServerTool {
 	// NOTE: some clients will silently refuse to use tools if there is an issue
 	// with the tool's schema or configuration.
 	if sdkTool.Schema.Properties == nil {

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -713,8 +713,8 @@ func mcpFromSDK(sdkTool toolsdk.Tool[any, any], tb toolsdk.Deps) server.ServerTo
 				Required:   sdkTool.Schema.Required,
 			},
 		},
-		Handler: func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			result, err := sdkTool.Handler(tb, request.Params.Arguments)
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			result, err := sdkTool.Handler(ctx, tb, request.Params.Arguments)
 			if err != nil {
 				return nil, err
 			}

--- a/cli/exp_mcp_test.go
+++ b/cli/exp_mcp_test.go
@@ -33,10 +33,6 @@ func TestExpMcpServer(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		cmdDone := make(chan struct{})
 		cancelCtx, cancel := context.WithCancel(ctx)
-		t.Cleanup(func() {
-			cancel()
-			<-cmdDone
-		})
 
 		// Given: a running coder deployment
 		client := coderdtest.New(t, nil)
@@ -93,6 +89,8 @@ func TestExpMcpServer(t *testing.T) {
 		require.NoError(t, err, "should have received a valid JSON response from the tool")
 		// Ensure the tool returns the expected user
 		require.Contains(t, output, owner.UserID.String(), "should have received the expected user ID")
+		cancel()
+		<-cmdDone
 	})
 
 	t.Run("OK", func(t *testing.T) {

--- a/cli/exp_mcp_test.go
+++ b/cli/exp_mcp_test.go
@@ -31,12 +31,16 @@ func TestExpMcpServer(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
+		cmdDone := make(chan struct{})
 		cancelCtx, cancel := context.WithCancel(ctx)
-		t.Cleanup(cancel)
+		t.Cleanup(func() {
+			cancel()
+			<-cmdDone
+		})
 
 		// Given: a running coder deployment
 		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
+		owner := coderdtest.CreateFirstUser(t, client)
 
 		// Given: we run the exp mcp command with allowed tools set
 		inv, root := clitest.New(t, "exp", "mcp", "server", "--allowed-tools=coder_get_authenticated_user")
@@ -48,7 +52,6 @@ func TestExpMcpServer(t *testing.T) {
 		// nolint: gocritic // not the focus of this test
 		clitest.SetupConfig(t, client, root)
 
-		cmdDone := make(chan struct{})
 		go func() {
 			defer close(cmdDone)
 			err := inv.Run()
@@ -60,9 +63,6 @@ func TestExpMcpServer(t *testing.T) {
 		pty.WriteLine(toolsPayload)
 		_ = pty.ReadLine(ctx) // ignore echoed output
 		output := pty.ReadLine(ctx)
-
-		cancel()
-		<-cmdDone
 
 		// Then: we should only see the allowed tools in the response
 		var toolsResponse struct {
@@ -81,6 +81,18 @@ func TestExpMcpServer(t *testing.T) {
 		}
 		slices.Sort(foundTools)
 		require.Equal(t, []string{"coder_get_authenticated_user"}, foundTools)
+
+		// Call the tool and ensure it works.
+		toolPayload := `{"jsonrpc":"2.0","id":3,"method":"tools/call", "params": {"name": "coder_get_authenticated_user", "arguments": {}}}`
+		pty.WriteLine(toolPayload)
+		_ = pty.ReadLine(ctx) // ignore echoed output
+		output = pty.ReadLine(ctx)
+		require.NotEmpty(t, output, "should have received a response from the tool")
+		// Ensure it's valid JSON
+		_, err = json.Marshal(output)
+		require.NoError(t, err, "should have received a valid JSON response from the tool")
+		// Ensure the tool returns the expected user
+		require.Contains(t, output, owner.UserID.String(), "should have received the expected user ID")
 	})
 
 	t.Run("OK", func(t *testing.T) {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -338,9 +338,9 @@ func (api *API) patchWorkspaceAgentAppStatus(rw http.ResponseWriter, r *http.Req
 		Slug:    req.AppSlug,
 	})
 	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to get workspace app.",
-			Detail:  err.Error(),
+			Detail:  fmt.Sprintf("No app found with slug %q", req.AppSlug),
 		})
 		return
 	}

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -341,7 +341,6 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 
 func TestWorkspaceAgentAppStatus(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitMedium)
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	user := coderdtest.CreateFirstUser(t, client)
 	client, user2 := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
@@ -362,6 +361,7 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 	agentClient.SetSessionToken(r.AgentToken)
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
 			AppSlug: "vscode",
 			Message: "testing",
@@ -385,6 +385,7 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 
 	t.Run("FailUnknownApp", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
 			AppSlug: "unknown",
 			Message: "testing",
@@ -399,6 +400,7 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 
 	t.Run("FailUnknownState", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
 			AppSlug: "vscode",
 			Message: "testing",
@@ -413,6 +415,7 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 
 	t.Run("FailTooLong", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
 			AppSlug: "vscode",
 			Message: strings.Repeat("a", 161),

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -341,27 +341,27 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 
 func TestWorkspaceAgentAppStatus(t *testing.T) {
 	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitMedium)
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+	client, user2 := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user2.ID,
+	}).WithAgent(func(a []*proto.Agent) []*proto.Agent {
+		a[0].Apps = []*proto.App{
+			{
+				Slug: "vscode",
+			},
+		}
+		return a
+	}).Do()
+
+	agentClient := agentsdk.New(client.URL)
+	agentClient.SetSessionToken(r.AgentToken)
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
-		client, db := coderdtest.NewWithDatabase(t, nil)
-		user := coderdtest.CreateFirstUser(t, client)
-		client, user2 := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
-
-		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-			OrganizationID: user.OrganizationID,
-			OwnerID:        user2.ID,
-		}).WithAgent(func(a []*proto.Agent) []*proto.Agent {
-			a[0].Apps = []*proto.App{
-				{
-					Slug: "vscode",
-				},
-			}
-			return a
-		}).Do()
-
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
 		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
 			AppSlug: "vscode",
 			Message: "testing",
@@ -381,6 +381,48 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 		// Deprecated fields should be ignored.
 		require.Empty(t, agent.Apps[0].Statuses[0].Icon)
 		require.False(t, agent.Apps[0].Statuses[0].NeedsUserAttention)
+	})
+
+	t.Run("FailUnknownApp", func(t *testing.T) {
+		t.Parallel()
+		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
+			AppSlug: "unknown",
+			Message: "testing",
+			URI:     "https://example.com",
+			State:   codersdk.WorkspaceAppStatusStateComplete,
+		})
+		require.ErrorContains(t, err, "No app found with slug")
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("FailUnknownState", func(t *testing.T) {
+		t.Parallel()
+		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
+			AppSlug: "vscode",
+			Message: "testing",
+			URI:     "https://example.com",
+			State:   "unknown",
+		})
+		require.ErrorContains(t, err, "Invalid state")
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("FailTooLong", func(t *testing.T) {
+		t.Parallel()
+		err := agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
+			AppSlug: "vscode",
+			Message: strings.Repeat("a", 161),
+			URI:     "https://example.com",
+			State:   codersdk.WorkspaceAppStatusStateComplete,
+		})
+		require.ErrorContains(t, err, "Message is too long")
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
 	})
 }
 

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -13,52 +13,15 @@ import (
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 )
 
-// Toolbox provides access to tool dependencies.
-type Toolbox interface {
-	CoderClient() *codersdk.Client
-	AgentClient() (*agentsdk.Client, bool)
-	AppStatusSlug() (string, bool)
-
-	WithAgentClient(*agentsdk.Client) Toolbox
-	WithAppStatusSlug(string) Toolbox
-}
-
-// toolbox is the concrete implementation of Toolbox.
-type toolbox struct {
-	coderClient   *codersdk.Client
-	agentClient   *agentsdk.Client
-	appStatusSlug string
-}
-
-// NewToolbox constructs a Toolbox with a required CoderClient.
-func NewToolbox(coder *codersdk.Client) Toolbox {
-	return &toolbox{coderClient: coder}
-}
-
-func (tb *toolbox) CoderClient() *codersdk.Client {
-	return tb.coderClient
-}
-
-func (tb *toolbox) AgentClient() (*agentsdk.Client, bool) {
-	return tb.agentClient, tb.agentClient != nil
-}
-
-func (tb *toolbox) AppStatusSlug() (string, bool) {
-	return tb.appStatusSlug, tb.appStatusSlug != ""
-}
-
-func (tb *toolbox) WithAgentClient(agent *agentsdk.Client) Toolbox {
-	tb.agentClient = agent
-	return tb
-}
-
-func (tb *toolbox) WithAppStatusSlug(slug string) Toolbox {
-	tb.appStatusSlug = slug
-	return tb
+// Deps provides access to tool dependencies.
+type Deps struct {
+	CoderClient   *codersdk.Client
+	AgentClient   *agentsdk.Client
+	AppStatusSlug string
 }
 
 // HandlerFunc is a function that handles a tool call.
-type HandlerFunc[Arg, Ret any] func(tb Toolbox, args Arg) (Ret, error)
+type HandlerFunc[Arg, Ret any] func(tb Deps, args Arg) (Ret, error)
 
 type Tool[Arg, Ret any] struct {
 	aisdk.Tool
@@ -69,7 +32,7 @@ type Tool[Arg, Ret any] struct {
 func (t Tool[Arg, Ret]) Generic() Tool[any, any] {
 	return Tool[any, any]{
 		Tool: t.Tool,
-		Handler: func(tb Toolbox, args any) (any, error) {
+		Handler: func(tb Deps, args any) (any, error) {
 			typedArg, ok := args.(Arg)
 			if !ok {
 				return nil, xerrors.Errorf("developer error: invalid argument type for tool %s", t.Tool.Name)
@@ -152,7 +115,7 @@ type UploadTarFileArgs struct {
 
 // WithRecover wraps a HandlerFunc to recover from panics and return an error.
 func WithRecover[Arg, Ret any](h HandlerFunc[Arg, Ret]) HandlerFunc[Arg, Ret] {
-	return func(tb Toolbox, args Arg) (ret Ret, err error) {
+	return func(tb Deps, args Arg) (ret Ret, err error) {
 		defer func() {
 			if r := recover(); r != nil {
 				err = xerrors.Errorf("tool handler panic: %v", r)
@@ -220,17 +183,15 @@ var (
 				Required: []string{"summary", "link", "state"},
 			},
 		},
-		Handler: func(tb Toolbox, args ReportTaskArgs) (string, error) {
-			agentClient, ok := tb.AgentClient()
-			if !ok {
+		Handler: func(tb Deps, args ReportTaskArgs) (string, error) {
+			if tb.AgentClient == nil {
 				return "", xerrors.New("tool unavailable as CODER_AGENT_TOKEN or CODER_AGENT_TOKEN_FILE not set")
 			}
-			appStatusSlug, ok := tb.AppStatusSlug()
-			if !ok {
+			if tb.AppStatusSlug == "" {
 				return "", xerrors.New("workspace app status slug not found in toolbox")
 			}
-			if err := agentClient.PatchAppStatus(context.TODO(), agentsdk.PatchAppStatus{
-				AppSlug: appStatusSlug,
+			if err := tb.AgentClient.PatchAppStatus(context.TODO(), agentsdk.PatchAppStatus{
+				AppSlug: tb.AppStatusSlug,
 				Message: args.Summary,
 				URI:     args.Link,
 				State:   codersdk.WorkspaceAppStatusState(args.State),
@@ -256,12 +217,12 @@ This returns more data than list_workspaces to reduce token usage.`,
 				Required: []string{"workspace_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args GetWorkspaceArgs) (codersdk.Workspace, error) {
+		Handler: func(tb Deps, args GetWorkspaceArgs) (codersdk.Workspace, error) {
 			wsID, err := uuid.Parse(args.WorkspaceID)
 			if err != nil {
 				return codersdk.Workspace{}, xerrors.New("workspace_id must be a valid UUID")
 			}
-			return tb.CoderClient().Workspace(context.TODO(), wsID)
+			return tb.CoderClient.Workspace(context.TODO(), wsID)
 		},
 	}
 
@@ -296,7 +257,7 @@ is provisioned correctly and the agent can connect to the control plane.
 				Required: []string{"user", "template_version_id", "name", "rich_parameters"},
 			},
 		},
-		Handler: func(tb Toolbox, args CreateWorkspaceArgs) (codersdk.Workspace, error) {
+		Handler: func(tb Deps, args CreateWorkspaceArgs) (codersdk.Workspace, error) {
 			tvID, err := uuid.Parse(args.TemplateVersionID)
 			if err != nil {
 				return codersdk.Workspace{}, xerrors.New("template_version_id must be a valid UUID")
@@ -311,7 +272,7 @@ is provisioned correctly and the agent can connect to the control plane.
 					Value: v,
 				})
 			}
-			workspace, err := tb.CoderClient().CreateUserWorkspace(context.TODO(), args.User, codersdk.CreateWorkspaceRequest{
+			workspace, err := tb.CoderClient.CreateUserWorkspace(context.TODO(), args.User, codersdk.CreateWorkspaceRequest{
 				TemplateVersionID:   tvID,
 				Name:                args.Name,
 				RichParameterValues: buildParams,
@@ -336,12 +297,12 @@ is provisioned correctly and the agent can connect to the control plane.
 				},
 			},
 		},
-		Handler: func(tb Toolbox, args ListWorkspacesArgs) ([]MinimalWorkspace, error) {
+		Handler: func(tb Deps, args ListWorkspacesArgs) ([]MinimalWorkspace, error) {
 			owner := args.Owner
 			if owner == "" {
 				owner = codersdk.Me
 			}
-			workspaces, err := tb.CoderClient().Workspaces(context.TODO(), codersdk.WorkspaceFilter{
+			workspaces, err := tb.CoderClient.Workspaces(context.TODO(), codersdk.WorkspaceFilter{
 				Owner: owner,
 			})
 			if err != nil {
@@ -373,8 +334,8 @@ is provisioned correctly and the agent can connect to the control plane.
 				Required:   []string{},
 			},
 		},
-		Handler: func(tb Toolbox, _ NoArgs) ([]MinimalTemplate, error) {
-			templates, err := tb.CoderClient().Templates(context.TODO(), codersdk.TemplateFilter{})
+		Handler: func(tb Deps, _ NoArgs) ([]MinimalTemplate, error) {
+			templates, err := tb.CoderClient.Templates(context.TODO(), codersdk.TemplateFilter{})
 			if err != nil {
 				return nil, err
 			}
@@ -406,12 +367,12 @@ is provisioned correctly and the agent can connect to the control plane.
 				Required: []string{"template_version_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args ListTemplateVersionParametersArgs) ([]codersdk.TemplateVersionParameter, error) {
+		Handler: func(tb Deps, args ListTemplateVersionParametersArgs) ([]codersdk.TemplateVersionParameter, error) {
 			templateVersionID, err := uuid.Parse(args.TemplateVersionID)
 			if err != nil {
 				return nil, xerrors.Errorf("template_version_id must be a valid UUID: %w", err)
 			}
-			parameters, err := tb.CoderClient().TemplateVersionRichParameters(context.TODO(), templateVersionID)
+			parameters, err := tb.CoderClient.TemplateVersionRichParameters(context.TODO(), templateVersionID)
 			if err != nil {
 				return nil, err
 			}
@@ -428,8 +389,8 @@ is provisioned correctly and the agent can connect to the control plane.
 				Required:   []string{},
 			},
 		},
-		Handler: func(tb Toolbox, _ NoArgs) (codersdk.User, error) {
-			return tb.CoderClient().User(context.TODO(), "me")
+		Handler: func(tb Deps, _ NoArgs) (codersdk.User, error) {
+			return tb.CoderClient.User(context.TODO(), "me")
 		},
 	}
 
@@ -455,7 +416,7 @@ is provisioned correctly and the agent can connect to the control plane.
 				Required: []string{"workspace_id", "transition"},
 			},
 		},
-		Handler: func(tb Toolbox, args CreateWorkspaceBuildArgs) (codersdk.WorkspaceBuild, error) {
+		Handler: func(tb Deps, args CreateWorkspaceBuildArgs) (codersdk.WorkspaceBuild, error) {
 			workspaceID, err := uuid.Parse(args.WorkspaceID)
 			if err != nil {
 				return codersdk.WorkspaceBuild{}, xerrors.Errorf("workspace_id must be a valid UUID: %w", err)
@@ -474,7 +435,7 @@ is provisioned correctly and the agent can connect to the control plane.
 			if templateVersionID != uuid.Nil {
 				cbr.TemplateVersionID = templateVersionID
 			}
-			return tb.CoderClient().CreateWorkspaceBuild(context.TODO(), workspaceID, cbr)
+			return tb.CoderClient.CreateWorkspaceBuild(context.TODO(), workspaceID, cbr)
 		},
 	}
 
@@ -936,8 +897,8 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"file_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args CreateTemplateVersionArgs) (codersdk.TemplateVersion, error) {
-			me, err := tb.CoderClient().User(context.TODO(), "me")
+		Handler: func(tb Deps, args CreateTemplateVersionArgs) (codersdk.TemplateVersion, error) {
+			me, err := tb.CoderClient.User(context.TODO(), "me")
 			if err != nil {
 				return codersdk.TemplateVersion{}, err
 			}
@@ -949,7 +910,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 			if err != nil {
 				return codersdk.TemplateVersion{}, xerrors.Errorf("template_id must be a valid UUID: %w", err)
 			}
-			templateVersion, err := tb.CoderClient().CreateTemplateVersion(context.TODO(), me.OrganizationIDs[0], codersdk.CreateTemplateVersionRequest{
+			templateVersion, err := tb.CoderClient.CreateTemplateVersion(context.TODO(), me.OrganizationIDs[0], codersdk.CreateTemplateVersionRequest{
 				Message:       "Created by AI",
 				StorageMethod: codersdk.ProvisionerStorageMethodFile,
 				FileID:        fileID,
@@ -978,12 +939,12 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"workspace_agent_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args GetWorkspaceAgentLogsArgs) ([]string, error) {
+		Handler: func(tb Deps, args GetWorkspaceAgentLogsArgs) ([]string, error) {
 			workspaceAgentID, err := uuid.Parse(args.WorkspaceAgentID)
 			if err != nil {
 				return nil, xerrors.Errorf("workspace_agent_id must be a valid UUID: %w", err)
 			}
-			logs, closer, err := tb.CoderClient().WorkspaceAgentLogsAfter(context.TODO(), workspaceAgentID, 0, false)
+			logs, closer, err := tb.CoderClient.WorkspaceAgentLogsAfter(context.TODO(), workspaceAgentID, 0, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1013,12 +974,12 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"workspace_build_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args GetWorkspaceBuildLogsArgs) ([]string, error) {
+		Handler: func(tb Deps, args GetWorkspaceBuildLogsArgs) ([]string, error) {
 			workspaceBuildID, err := uuid.Parse(args.WorkspaceBuildID)
 			if err != nil {
 				return nil, xerrors.Errorf("workspace_build_id must be a valid UUID: %w", err)
 			}
-			logs, closer, err := tb.CoderClient().WorkspaceBuildLogsAfter(context.TODO(), workspaceBuildID, 0)
+			logs, closer, err := tb.CoderClient.WorkspaceBuildLogsAfter(context.TODO(), workspaceBuildID, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -1044,13 +1005,13 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"template_version_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args GetTemplateVersionLogsArgs) ([]string, error) {
+		Handler: func(tb Deps, args GetTemplateVersionLogsArgs) ([]string, error) {
 			templateVersionID, err := uuid.Parse(args.TemplateVersionID)
 			if err != nil {
 				return nil, xerrors.Errorf("template_version_id must be a valid UUID: %w", err)
 			}
 
-			logs, closer, err := tb.CoderClient().TemplateVersionLogsAfter(context.TODO(), templateVersionID, 0)
+			logs, closer, err := tb.CoderClient.TemplateVersionLogsAfter(context.TODO(), templateVersionID, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -1079,7 +1040,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"template_id", "template_version_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args UpdateTemplateActiveVersionArgs) (string, error) {
+		Handler: func(tb Deps, args UpdateTemplateActiveVersionArgs) (string, error) {
 			templateID, err := uuid.Parse(args.TemplateID)
 			if err != nil {
 				return "", xerrors.Errorf("template_id must be a valid UUID: %w", err)
@@ -1088,7 +1049,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 			if err != nil {
 				return "", xerrors.Errorf("template_version_id must be a valid UUID: %w", err)
 			}
-			err = tb.CoderClient().UpdateActiveTemplateVersion(context.TODO(), templateID, codersdk.UpdateActiveTemplateVersion{
+			err = tb.CoderClient.UpdateActiveTemplateVersion(context.TODO(), templateID, codersdk.UpdateActiveTemplateVersion{
 				ID: templateVersionID,
 			})
 			if err != nil {
@@ -1112,7 +1073,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"mime_type", "files"},
 			},
 		},
-		Handler: func(tb Toolbox, args UploadTarFileArgs) (codersdk.UploadResponse, error) {
+		Handler: func(tb Deps, args UploadTarFileArgs) (codersdk.UploadResponse, error) {
 			pipeReader, pipeWriter := io.Pipe()
 			go func() {
 				defer pipeWriter.Close()
@@ -1137,7 +1098,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				}
 			}()
 
-			resp, err := tb.CoderClient().Upload(context.TODO(), codersdk.ContentTypeTar, pipeReader)
+			resp, err := tb.CoderClient.Upload(context.TODO(), codersdk.ContentTypeTar, pipeReader)
 			if err != nil {
 				return codersdk.UploadResponse{}, err
 			}
@@ -1172,8 +1133,8 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				Required: []string{"name", "display_name", "description", "version_id"},
 			},
 		},
-		Handler: func(tb Toolbox, args CreateTemplateArgs) (codersdk.Template, error) {
-			me, err := tb.CoderClient().User(context.TODO(), "me")
+		Handler: func(tb Deps, args CreateTemplateArgs) (codersdk.Template, error) {
+			me, err := tb.CoderClient.User(context.TODO(), "me")
 			if err != nil {
 				return codersdk.Template{}, err
 			}
@@ -1181,7 +1142,7 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 			if err != nil {
 				return codersdk.Template{}, xerrors.Errorf("version_id must be a valid UUID: %w", err)
 			}
-			template, err := tb.CoderClient().CreateTemplate(context.TODO(), me.OrganizationIDs[0], codersdk.CreateTemplateRequest{
+			template, err := tb.CoderClient.CreateTemplate(context.TODO(), me.OrganizationIDs[0], codersdk.CreateTemplateRequest{
 				Name:        args.Name,
 				DisplayName: args.DisplayName,
 				Description: args.Description,
@@ -1206,12 +1167,12 @@ The file_id provided is a reference to a tar file you have uploaded containing t
 				},
 			},
 		},
-		Handler: func(tb Toolbox, args DeleteTemplateArgs) (string, error) {
+		Handler: func(tb Deps, args DeleteTemplateArgs) (string, error) {
 			templateID, err := uuid.Parse(args.TemplateID)
 			if err != nil {
 				return "", xerrors.Errorf("template_id must be a valid UUID: %w", err)
 			}
-			err = tb.CoderClient().DeleteTemplate(context.TODO(), templateID)
+			err = tb.CoderClient.DeleteTemplate(context.TODO(), templateID)
 			if err != nil {
 				return "", err
 			}

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -15,6 +15,31 @@ import (
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 )
 
+func NewDeps(client *codersdk.Client, opts ...func(*Deps)) (Deps, error) {
+	d := Deps{
+		CoderClient: client,
+	}
+	for _, opt := range opts {
+		opt(&d)
+	}
+	if d.CoderClient == nil {
+		return Deps{}, xerrors.New("developer error: coder client may not be nil")
+	}
+	return d, nil
+}
+
+func WithAgentClient(client *agentsdk.Client) func(*Deps) {
+	return func(d *Deps) {
+		d.AgentClient = client
+	}
+}
+
+func WithAppStatusSlug(slug string) func(*Deps) {
+	return func(d *Deps) {
+		d.AppStatusSlug = slug
+	}
+}
+
 // Deps provides access to tool dependencies.
 type Deps struct {
 	CoderClient   *codersdk.Client
@@ -175,7 +200,7 @@ var ReportTask = Tool[ReportTaskArgs, codersdk.Response]{
 			return codersdk.Response{}, xerrors.New("tool unavailable as CODER_AGENT_TOKEN or CODER_AGENT_TOKEN_FILE not set")
 		}
 		if deps.AppStatusSlug == "" {
-			return codersdk.Response{}, xerrors.New("workspace app status slug not found in toolbox")
+			return codersdk.Response{}, xerrors.New("tool unavailable as CODER_MCP_APP_STATUS_SLUG is not set")
 		}
 		if len(args.Summary) > 160 {
 			return codersdk.Response{}, xerrors.New("summary must be less than 160 characters")

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -70,7 +70,11 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ReportTask", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient).WithAgentClient(agentClient).WithAppStatusSlug("some-agent-app")
+		tb := toolsdk.Deps{
+			CoderClient:   memberClient,
+			AgentClient:   agentClient,
+			AppStatusSlug: "some-agent-app",
+		}
 		_, err := testTool(t, toolsdk.ReportTask, tb, toolsdk.ReportTaskArgs{
 			Summary: "test summary",
 			State:   "complete",
@@ -80,7 +84,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetWorkspace", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		result, err := testTool(t, toolsdk.GetWorkspace, tb, toolsdk.GetWorkspaceArgs{
 			WorkspaceID: r.Workspace.ID.String(),
 		})
@@ -90,7 +94,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ListTemplates", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		// Get the templates directly for comparison
 		expected, err := memberClient.Templates(context.Background(), codersdk.TemplateFilter{})
 		require.NoError(t, err)
@@ -113,7 +117,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("Whoami", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		result, err := testTool(t, toolsdk.GetAuthenticatedUser, tb, toolsdk.NoArgs{})
 
 		require.NoError(t, err)
@@ -122,7 +126,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ListWorkspaces", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		result, err := testTool(t, toolsdk.ListWorkspaces, tb, toolsdk.ListWorkspacesArgs{})
 
 		require.NoError(t, err)
@@ -134,7 +138,7 @@ func TestTools(t *testing.T) {
 	t.Run("CreateWorkspaceBuild", func(t *testing.T) {
 		t.Run("Stop", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
-			tb := toolsdk.NewToolbox(memberClient)
+			tb := toolsdk.Deps{CoderClient: memberClient}
 			result, err := testTool(t, toolsdk.CreateWorkspaceBuild, tb, toolsdk.CreateWorkspaceBuildArgs{
 				WorkspaceID: r.Workspace.ID.String(),
 				Transition:  "stop",
@@ -153,7 +157,7 @@ func TestTools(t *testing.T) {
 
 		t.Run("Start", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
-			tb := toolsdk.NewToolbox(memberClient)
+			tb := toolsdk.Deps{CoderClient: memberClient}
 			result, err := testTool(t, toolsdk.CreateWorkspaceBuild, tb, toolsdk.CreateWorkspaceBuildArgs{
 				WorkspaceID: r.Workspace.ID.String(),
 				Transition:  "start",
@@ -172,7 +176,7 @@ func TestTools(t *testing.T) {
 
 		t.Run("TemplateVersionChange", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
-			tb := toolsdk.NewToolbox(memberClient)
+			tb := toolsdk.Deps{CoderClient: memberClient}
 			// Get the current template version ID before updating
 			workspace, err := memberClient.Workspace(ctx, r.Workspace.ID)
 			require.NoError(t, err)
@@ -216,7 +220,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ListTemplateVersionParameters", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		params, err := testTool(t, toolsdk.ListTemplateVersionParameters, tb, toolsdk.ListTemplateVersionParametersArgs{
 			TemplateVersionID: r.TemplateVersion.ID.String(),
 		})
@@ -226,7 +230,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetWorkspaceAgentLogs", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(client)
+		tb := toolsdk.Deps{CoderClient: client}
 		logs, err := testTool(t, toolsdk.GetWorkspaceAgentLogs, tb, toolsdk.GetWorkspaceAgentLogsArgs{
 			WorkspaceAgentID: agentID.String(),
 		})
@@ -236,7 +240,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetWorkspaceBuildLogs", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		logs, err := testTool(t, toolsdk.GetWorkspaceBuildLogs, tb, toolsdk.GetWorkspaceBuildLogsArgs{
 			WorkspaceBuildID: r.Build.ID.String(),
 		})
@@ -246,7 +250,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetTemplateVersionLogs", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		logs, err := testTool(t, toolsdk.GetTemplateVersionLogs, tb, toolsdk.GetTemplateVersionLogsArgs{
 			TemplateVersionID: r.TemplateVersion.ID.String(),
 		})
@@ -256,7 +260,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("UpdateTemplateActiveVersion", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(client)
+		tb := toolsdk.Deps{CoderClient: client}
 		result, err := testTool(t, toolsdk.UpdateTemplateActiveVersion, tb, toolsdk.UpdateTemplateActiveVersionArgs{
 			TemplateID:        r.Template.ID.String(),
 			TemplateVersionID: r.TemplateVersion.ID.String(),
@@ -267,7 +271,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("DeleteTemplate", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(client)
+		tb := toolsdk.Deps{CoderClient: client}
 		_, err := testTool(t, toolsdk.DeleteTemplate, tb, toolsdk.DeleteTemplateArgs{
 			TemplateID: r.Template.ID.String(),
 		})
@@ -277,7 +281,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("UploadTarFile", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(client)
+		tb := toolsdk.Deps{CoderClient: client}
 		files := map[string]string{
 			"main.tf": `resource "null_resource" "example" {}`,
 		}
@@ -291,7 +295,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("CreateTemplateVersion", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(client)
+		tb := toolsdk.Deps{CoderClient: client}
 		// nolint:gocritic // This is in a test package and does not end up in the build
 		file := dbgen.File(t, store, database.File{})
 
@@ -304,7 +308,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("CreateTemplate", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(client)
+		tb := toolsdk.Deps{CoderClient: client}
 		// Create a new template version for use here.
 		tv := dbfake.TemplateVersion(t, store).
 			// nolint:gocritic // This is in a test package and does not end up in the build
@@ -323,7 +327,7 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("CreateWorkspace", func(t *testing.T) {
-		tb := toolsdk.NewToolbox(memberClient)
+		tb := toolsdk.Deps{CoderClient: memberClient}
 		// We need a template version ID to create a workspace
 		res, err := testTool(t, toolsdk.CreateWorkspace, tb, toolsdk.CreateWorkspaceArgs{
 			User:              "me",
@@ -343,7 +347,7 @@ func TestTools(t *testing.T) {
 var testedTools sync.Map
 
 // testTool is a helper function to test a tool and mark it as tested.
-func testTool[Arg, Ret any](t *testing.T, tool toolsdk.Tool[Arg, Ret], tb toolsdk.Toolbox, args Arg) (Ret, error) {
+func testTool[Arg, Ret any](t *testing.T, tool toolsdk.Tool[Arg, Ret], tb toolsdk.Deps, args Arg) (Ret, error) {
 	t.Helper()
 	testedTools.Store(tool.Tool.Name, true)
 	result, err := tool.Handler(tb, args)
@@ -391,14 +395,14 @@ func TestWithRecovery(t *testing.T) {
 				Name:        "fake_tool",
 				Description: "Returns a string for testing.",
 			},
-			Handler: func(tb toolsdk.Toolbox, args string) (string, error) {
+			Handler: func(tb toolsdk.Deps, args string) (string, error) {
 				require.Equal(t, "test", args)
 				return "ok", nil
 			},
 		}
 
 		wrapped := toolsdk.WithRecover(fakeTool.Handler)
-		v, err := wrapped(nil, "test")
+		v, err := wrapped(toolsdk.Deps{}, "test")
 		require.NoError(t, err)
 		require.Equal(t, "ok", v)
 	})
@@ -410,13 +414,13 @@ func TestWithRecovery(t *testing.T) {
 				Name:        "fake_tool",
 				Description: "Returns an error for testing.",
 			},
-			Handler: func(tb toolsdk.Toolbox, args string) (string, error) {
+			Handler: func(tb toolsdk.Deps, args string) (string, error) {
 				require.Equal(t, "test", args)
 				return "", assert.AnError
 			},
 		}
 		wrapped := toolsdk.WithRecover(fakeTool.Handler)
-		v, err := wrapped(nil, "test")
+		v, err := wrapped(toolsdk.Deps{}, "test")
 		require.Empty(t, v)
 		require.ErrorIs(t, err, assert.AnError)
 	})
@@ -428,13 +432,13 @@ func TestWithRecovery(t *testing.T) {
 				Name:        "panic_tool",
 				Description: "Panics for testing.",
 			},
-			Handler: func(tb toolsdk.Toolbox, args string) (string, error) {
+			Handler: func(tb toolsdk.Deps, args string) (string, error) {
 				panic("you can't sweat this fever out")
 			},
 		}
 
 		wrapped := toolsdk.WithRecover(panicTool.Handler)
-		v, err := wrapped(nil, "disco")
+		v, err := wrapped(toolsdk.Deps{}, "disco")
 		require.Empty(t, v)
 		require.ErrorContains(t, err, "you can't sweat this fever out")
 	})

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -72,12 +72,9 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ReportTask", func(t *testing.T) {
-		tb := toolsdk.Deps{
-			CoderClient:   memberClient,
-			AgentClient:   agentClient,
-			AppStatusSlug: "some-agent-app",
-		}
-		_, err := testTool(t, toolsdk.ReportTask, tb, toolsdk.ReportTaskArgs{
+		tb, err := toolsdk.NewDeps(memberClient, toolsdk.WithAgentClient(agentClient), toolsdk.WithAppStatusSlug("some-agent-app"))
+		require.NoError(t, err)
+		_, err = testTool(t, toolsdk.ReportTask, tb, toolsdk.ReportTaskArgs{
 			Summary: "test summary",
 			State:   "complete",
 			Link:    "https://example.com",
@@ -86,7 +83,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetWorkspace", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		result, err := testTool(t, toolsdk.GetWorkspace, tb, toolsdk.GetWorkspaceArgs{
 			WorkspaceID: r.Workspace.ID.String(),
 		})
@@ -96,7 +94,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ListTemplates", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		// Get the templates directly for comparison
 		expected, err := memberClient.Templates(context.Background(), codersdk.TemplateFilter{})
 		require.NoError(t, err)
@@ -119,7 +118,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("Whoami", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		result, err := testTool(t, toolsdk.GetAuthenticatedUser, tb, toolsdk.NoArgs{})
 
 		require.NoError(t, err)
@@ -128,7 +128,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ListWorkspaces", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		result, err := testTool(t, toolsdk.ListWorkspaces, tb, toolsdk.ListWorkspacesArgs{})
 
 		require.NoError(t, err)
@@ -140,7 +141,8 @@ func TestTools(t *testing.T) {
 	t.Run("CreateWorkspaceBuild", func(t *testing.T) {
 		t.Run("Stop", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
-			tb := toolsdk.Deps{CoderClient: memberClient}
+			tb, err := toolsdk.NewDeps(memberClient)
+			require.NoError(t, err)
 			result, err := testTool(t, toolsdk.CreateWorkspaceBuild, tb, toolsdk.CreateWorkspaceBuildArgs{
 				WorkspaceID: r.Workspace.ID.String(),
 				Transition:  "stop",
@@ -159,7 +161,8 @@ func TestTools(t *testing.T) {
 
 		t.Run("Start", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
-			tb := toolsdk.Deps{CoderClient: memberClient}
+			tb, err := toolsdk.NewDeps(memberClient)
+			require.NoError(t, err)
 			result, err := testTool(t, toolsdk.CreateWorkspaceBuild, tb, toolsdk.CreateWorkspaceBuildArgs{
 				WorkspaceID: r.Workspace.ID.String(),
 				Transition:  "start",
@@ -178,7 +181,8 @@ func TestTools(t *testing.T) {
 
 		t.Run("TemplateVersionChange", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
-			tb := toolsdk.Deps{CoderClient: memberClient}
+			tb, err := toolsdk.NewDeps(memberClient)
+			require.NoError(t, err)
 			// Get the current template version ID before updating
 			workspace, err := memberClient.Workspace(ctx, r.Workspace.ID)
 			require.NoError(t, err)
@@ -222,7 +226,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ListTemplateVersionParameters", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		params, err := testTool(t, toolsdk.ListTemplateVersionParameters, tb, toolsdk.ListTemplateVersionParametersArgs{
 			TemplateVersionID: r.TemplateVersion.ID.String(),
 		})
@@ -232,7 +237,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetWorkspaceAgentLogs", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: client}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		logs, err := testTool(t, toolsdk.GetWorkspaceAgentLogs, tb, toolsdk.GetWorkspaceAgentLogsArgs{
 			WorkspaceAgentID: agentID.String(),
 		})
@@ -242,7 +248,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetWorkspaceBuildLogs", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		logs, err := testTool(t, toolsdk.GetWorkspaceBuildLogs, tb, toolsdk.GetWorkspaceBuildLogsArgs{
 			WorkspaceBuildID: r.Build.ID.String(),
 		})
@@ -252,7 +259,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("GetTemplateVersionLogs", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 		logs, err := testTool(t, toolsdk.GetTemplateVersionLogs, tb, toolsdk.GetTemplateVersionLogsArgs{
 			TemplateVersionID: r.TemplateVersion.ID.String(),
 		})
@@ -262,7 +270,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("UpdateTemplateActiveVersion", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: client}
+		tb, err := toolsdk.NewDeps(client)
+		require.NoError(t, err)
 		result, err := testTool(t, toolsdk.UpdateTemplateActiveVersion, tb, toolsdk.UpdateTemplateActiveVersionArgs{
 			TemplateID:        r.Template.ID.String(),
 			TemplateVersionID: r.TemplateVersion.ID.String(),
@@ -273,8 +282,9 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("DeleteTemplate", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: client}
-		_, err := testTool(t, toolsdk.DeleteTemplate, tb, toolsdk.DeleteTemplateArgs{
+		tb, err := toolsdk.NewDeps(client)
+		require.NoError(t, err)
+		_, err = testTool(t, toolsdk.DeleteTemplate, tb, toolsdk.DeleteTemplateArgs{
 			TemplateID: r.Template.ID.String(),
 		})
 
@@ -283,10 +293,11 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("UploadTarFile", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: client}
 		files := map[string]string{
 			"main.tf": `resource "null_resource" "example" {}`,
 		}
+		tb, err := toolsdk.NewDeps(memberClient)
+		require.NoError(t, err)
 
 		result, err := testTool(t, toolsdk.UploadTarFile, tb, toolsdk.UploadTarFileArgs{
 			Files: files,
@@ -297,7 +308,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("CreateTemplateVersion", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: client}
+		tb, err := toolsdk.NewDeps(client)
+		require.NoError(t, err)
 		// nolint:gocritic // This is in a test package and does not end up in the build
 		file := dbgen.File(t, store, database.File{})
 		t.Run("WithoutTemplateID", func(t *testing.T) {
@@ -308,7 +320,6 @@ func TestTools(t *testing.T) {
 			require.NotEmpty(t, tv)
 		})
 		t.Run("WithTemplateID", func(t *testing.T) {
-			tb := toolsdk.Deps{CoderClient: client}
 			tv, err := testTool(t, toolsdk.CreateTemplateVersion, tb, toolsdk.CreateTemplateVersionArgs{
 				FileID:     file.ID.String(),
 				TemplateID: r.Template.ID.String(),
@@ -319,7 +330,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("CreateTemplate", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: client}
+		tb, err := toolsdk.NewDeps(client)
+		require.NoError(t, err)
 		// Create a new template version for use here.
 		tv := dbfake.TemplateVersion(t, store).
 			// nolint:gocritic // This is in a test package and does not end up in the build
@@ -327,7 +339,7 @@ func TestTools(t *testing.T) {
 			SkipCreateTemplate().Do()
 
 		// We're going to re-use the pre-existing template version
-		_, err := testTool(t, toolsdk.CreateTemplate, tb, toolsdk.CreateTemplateArgs{
+		_, err = testTool(t, toolsdk.CreateTemplate, tb, toolsdk.CreateTemplateArgs{
 			Name:        testutil.GetRandomNameHyphenated(t),
 			DisplayName: "Test Template",
 			Description: "This is a test template",
@@ -338,7 +350,8 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("CreateWorkspace", func(t *testing.T) {
-		tb := toolsdk.Deps{CoderClient: memberClient}
+		tb, err := toolsdk.NewDeps(client)
+		require.NoError(t, err)
 		// We need a template version ID to create a workspace
 		res, err := testTool(t, toolsdk.CreateWorkspace, tb, toolsdk.CreateWorkspaceArgs{
 			User:              "me",


### PR DESCRIPTION
* Refactors toolsdk.Tools to remove opaque `map[string]any` argument in favour of typed args structs.
* Refactors toolsdk.Tools to remove opaque passing of dependencies via `context.Context` in favour of a tool dependencies struct.
* Adds panic recovery and clean context middleware to all tools.
* Adds `GenericTool` implementation to allow keeping `toolsdk.All` with uniform type signature while maintaining type information in handlers.
* Adds stricter checks to `patchWorkspaceAgentAppStatus` handler.