### PR TITLE
test: do not run memory race test in parallel

### DIFF
--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -253,7 +253,6 @@ func TestGroupSyncTable(t *testing.T) {
 		// this is still fast without being in parallel.
 		//nolint:paralleltest, tparallel
 		t.Run(tc.Name, func(t *testing.T) {
-
 			db, _ := dbtestutil.NewDB(t)
 			manager := runtimeconfig.NewManager()
 			s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
@@ -294,7 +293,6 @@ func TestGroupSyncTable(t *testing.T) {
 	// debug a single test case.
 	//nolint:paralleltest, tparallel // This should run after all the individual tests
 	t.Run("AllTogether", func(t *testing.T) {
-
 		db, _ := dbtestutil.NewDB(t)
 		manager := runtimeconfig.NewManager()
 		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),

--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -248,8 +248,11 @@ func TestGroupSyncTable(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
+		// The final test, "AllTogether", cannot run in parallel.
+		// These tests are nearly instant using the memory db, so
+		// this is still fast without being in parallel.
+		//nolint:paralleltest, tparallel
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
 
 			db, _ := dbtestutil.NewDB(t)
 			manager := runtimeconfig.NewManager()
@@ -289,8 +292,8 @@ func TestGroupSyncTable(t *testing.T) {
 	// deployment. This tests all organizations being synced together.
 	// The reason we do them individually, is that it is much easier to
 	// debug a single test case.
+	//nolint:paralleltest, tparallel // This should run after all the individual tests
 	t.Run("AllTogether", func(t *testing.T) {
-		t.Parallel()
 
 		db, _ := dbtestutil.NewDB(t)
 		manager := runtimeconfig.NewManager()

--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -65,6 +65,7 @@ func TestParseGroupClaims(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest, tparallel
 func TestGroupSyncTable(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+//nolint:paralleltest, tparallel
 func TestRoleSyncTable(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -190,9 +190,11 @@ func TestRoleSyncTable(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
+		// The final test, "AllTogether", cannot run in parallel.
+		// These tests are nearly instant using the memory db, so
+		// this is still fast without being in parallel.
+		//nolint:paralleltest, tparallel
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-
 			db, _ := dbtestutil.NewDB(t)
 			manager := runtimeconfig.NewManager()
 			s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/597#issuecomment-2835262922

The parallelized tests share configs, which when accessed concurrently throw race errors. The configs are read only, so it is fine to run these tests with shared idp configs.