### PR TITLE
fix: handle null value for experiments

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/optionValue.test.ts
+++ b/site/src/pages/DeploymentSettingsPage/optionValue.test.ts
@@ -123,6 +123,15 @@ describe("optionValue", () => {
 		{
 			option: {
 				...defaultOption,
+				name: "Experiments",
+				value: null,
+			},
+			additionalValues: ["single_tailnet"],
+			expected: "",
+		},
+		{
+			option: {
+				...defaultOption,
 				name: "Some Go Duration We Want To Show As A String",
 				value: 30 * 1e9,
 				annotations: { format_duration: "true" },

--- a/site/src/pages/DeploymentSettingsPage/optionValue.ts
+++ b/site/src/pages/DeploymentSettingsPage/optionValue.ts
@@ -40,8 +40,10 @@ export function optionValue(
 		case "Experiments": {
 			const experimentMap = additionalValues?.reduce<Record<string, boolean>>(
 				(acc, v) => {
-					// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
-					acc[v] = (option.value as any).includes("*");
+					const isIncluded = Array.isArray(option.value)
+						? option.value.includes("*")
+						: false;
+					acc[v] = isIncluded;
 					return acc;
 				},
 				{},
@@ -57,10 +59,11 @@ export function optionValue(
 
 			// We show all experiments (including unsafe) that are currently enabled on a deployment
 			// but only show safe experiments that are not.
-			// biome-ignore lint/suspicious/noExplicitAny: opt.value is any
-			for (const v of option.value as any) {
-				if (v !== "*") {
-					experimentMap[v] = true;
+			if (Array.isArray(option.value)) {
+				for (const v of option.value) {
+					if (v !== "*") {
+						experimentMap[v] = true;
+					}
 				}
 			}
 			return experimentMap;


### PR DESCRIPTION
Fix https://github.com/coder/coder/issues/17583

**Relevant info**
- `option.value` can be `null`
- It is always better to use `unknown` instead of `any`, and use type assertion functions  as `Array.isArray()` before using/accessing object properties and functions