### PR TITLE
fix: fix script timings spam in the workspace UI

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -166,13 +166,15 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 		// Sometimes, the timings can be fetched before the agent script timings are
 		// done or saved in the database so we need to conditionally refetch the
 		// timings. To refetch the timings, I found the best way was to compare the
-		// expected amount of script timings with the current amount of script
-		// timings returned in the response.
+		// expected amount of script timings that run on start, with the current
+		// amount of script timings returned in the response.
 		refetchInterval: (data) => {
 			const expectedScriptTimingsCount = workspace.latest_build.resources
 				.flatMap((r) => r.agents)
-				.flatMap((a) => a?.scripts ?? []).length;
+				.flatMap((a) => a?.scripts ?? [])
+				.filter((script) => script.run_on_start).length;
 			const currentScriptTimingsCount = data?.agent_script_timings?.length ?? 0;
+
 			return expectedScriptTimingsCount === currentScriptTimingsCount
 				? false
 				: 1_000;


### PR DESCRIPTION
Fix https://github.com/coder/coder/issues/17188

We forgot to filter the scripts by `run_on_start`, since we only calculate timings in the start phase, which was causing the miss match between the expected script timings count, and the loop in the refetch logic.

While I think this fix is enough for now, I think the server should be responsible to telling the client when to stop fetching. It could be a simple attribute such as `done: false | true` or a websocket endpoint as suggested by @dannykopping [here](https://github.com/coder/coder/issues/17188#issuecomment-2788235333).