### PR TITLE
feat: improve coder connect tunnel handling on reconnect

### DIFF
--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -898,7 +898,7 @@ type Workspace struct {
 }
 
 func (w *Workspace) Clone() Workspace {
-	agents := make(map[uuid.UUID]*Agent, len(a.agents))
+	agents := make(map[uuid.UUID]*Agent, len(w.agents))
 	for k, v := range w.agents {
 		clone := v.Clone()
 		agents[k] = &clone

--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -897,6 +897,21 @@ type Workspace struct {
 	agents        map[uuid.UUID]*Agent
 }
 
+func (a *Workspace) Clone() Workspace {
+	agents := make(map[uuid.UUID]*Agent, len(a.agents))
+	for k, v := range a.agents {
+		clone := v.Clone()
+		agents[k] = &clone
+	}
+	return Workspace{
+		ID:            a.ID,
+		Name:          a.Name,
+		Status:        a.Status,
+		ownerUsername: a.ownerUsername,
+		agents:        agents,
+	}
+}
+
 type DNSNameOptions struct {
 	Suffix string
 }

--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -897,17 +897,17 @@ type Workspace struct {
 	agents        map[uuid.UUID]*Agent
 }
 
-func (a *Workspace) Clone() Workspace {
+func (w *Workspace) Clone() Workspace {
 	agents := make(map[uuid.UUID]*Agent, len(a.agents))
-	for k, v := range a.agents {
+	for k, v := range w.agents {
 		clone := v.Clone()
 		agents[k] = &clone
 	}
 	return Workspace{
-		ID:            a.ID,
-		Name:          a.Name,
-		Status:        a.Status,
-		ownerUsername: a.ownerUsername,
+		ID:            w.ID,
+		Name:          w.Name,
+		Status:        w.Status,
+		ownerUsername: w.ownerUsername,
 		agents:        agents,
 	}
 }

--- a/tailnet/controllers_test.go
+++ b/tailnet/controllers_test.go
@@ -1611,13 +1611,15 @@ func TestTunnelAllWorkspaceUpdatesController_Initial(t *testing.T) {
 		},
 		DeletedWorkspaces: []*tailnet.Workspace{},
 		DeletedAgents:     []*tailnet.Agent{},
+		FreshState:        true,
 	}
 
 	// And the callback
 	cbUpdate := testutil.TryReceive(ctx, t, fUH.ch)
 	require.Equal(t, currentState, cbUpdate)
 
-	// Current recvState should match
+	// Current recvState should match but shouldn't be a fresh state
+	currentState.FreshState = false
 	recvState, err := updateCtrl.CurrentState()
 	require.NoError(t, err)
 	slices.SortFunc(recvState.UpsertedWorkspaces, func(a, b *tailnet.Workspace) int {
@@ -1692,12 +1694,14 @@ func TestTunnelAllWorkspaceUpdatesController_DeleteAgent(t *testing.T) {
 		},
 		DeletedWorkspaces: []*tailnet.Workspace{},
 		DeletedAgents:     []*tailnet.Agent{},
+		FreshState:        true,
 	}
 
 	cbUpdate := testutil.TryReceive(ctx, t, fUH.ch)
 	require.Equal(t, initRecvUp, cbUpdate)
 
-	// Current state should match initial
+	// Current state should match initial but shouldn't be a fresh state
+	initRecvUp.FreshState = false
 	state, err := updateCtrl.CurrentState()
 	require.NoError(t, err)
 	require.Equal(t, initRecvUp, state)
@@ -1753,6 +1757,7 @@ func TestTunnelAllWorkspaceUpdatesController_DeleteAgent(t *testing.T) {
 				"w1.coder.":            {ws1a1IP},
 			}},
 		},
+		FreshState: false,
 	}
 	require.Equal(t, sndRecvUpdate, cbUpdate)
 
@@ -1771,6 +1776,7 @@ func TestTunnelAllWorkspaceUpdatesController_DeleteAgent(t *testing.T) {
 		},
 		DeletedWorkspaces: []*tailnet.Workspace{},
 		DeletedAgents:     []*tailnet.Agent{},
+		FreshState:        false,
 	}, state)
 }
 

--- a/tailnet/controllers_test.go
+++ b/tailnet/controllers_test.go
@@ -1618,7 +1618,7 @@ func TestTunnelAllWorkspaceUpdatesController_Initial(t *testing.T) {
 	cbUpdate := testutil.TryReceive(ctx, t, fUH.ch)
 	require.Equal(t, currentState, cbUpdate)
 
-	// Current recvState should match but shouldn't be a fresh state
+	// Current recvState should match
 	recvState, err := updateCtrl.CurrentState()
 	require.NoError(t, err)
 	slices.SortFunc(recvState.UpsertedWorkspaces, func(a, b *tailnet.Workspace) int {

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -394,48 +394,12 @@ func (u *updater) sendUpdateResponse(req *request[*TunnelMessage, *ManagerMessag
 	return nil
 }
 
-// processFreshState handles the logic for when a fresh state update is received.
-func (u *updater) processFreshState(update *tailnet.WorkspaceUpdate) {
-	// ignoredWorkspaces is initially populated with the workspaces that are
-	// in the current update. Later on we populate it with the deleted workspaces too
-	// so that we don't send duplicate updates. Same applies to ignoredAgents.
-	ignoredWorkspaces := make(map[uuid.UUID]struct{}, len(update.UpsertedWorkspaces))
-	ignoredAgents := make(map[uuid.UUID]struct{}, len(update.UpsertedAgents))
-
-	for _, workspace := range update.UpsertedWorkspaces {
-		ignoredWorkspaces[workspace.ID] = struct{}{}
-	}
-	for _, agent := range update.UpsertedAgents {
-		ignoredAgents[agent.ID] = struct{}{}
-	}
-	for _, agent := range u.agents {
-		if _, ok := ignoredAgents[agent.ID]; !ok {
-			// delete any current agents that are not in the new update
-			update.DeletedAgents = append(update.DeletedAgents, &tailnet.Agent{
-				ID:          agent.ID,
-				Name:        agent.Name,
-				WorkspaceID: agent.WorkspaceID,
-			})
-			// if the workspace connected to an agent we're deleting,
-			// is not present in the fresh state, add it to the deleted workspaces
-			if _, ok := ignoredWorkspaces[agent.WorkspaceID]; !ok {
-				update.DeletedWorkspaces = append(update.DeletedWorkspaces, &tailnet.Workspace{
-					// other fields cannot be populated because the tunnel
-					// only stores agents and corresponding workspaceIDs
-					ID: agent.WorkspaceID,
-				})
-				ignoredWorkspaces[agent.WorkspaceID] = struct{}{}
-			}
-		}
-	}
-}
-
 // createPeerUpdateLocked creates a PeerUpdate message from a workspace update, populating
 // the network status of the agents.
 func (u *updater) createPeerUpdateLocked(update tailnet.WorkspaceUpdate) *PeerUpdate {
 	// this flag is true on the first update after a reconnect
 	if update.FreshState {
-		u.processFreshState(&update)
+		processFreshState(&update, u.agents)
 	}
 
 	out := &PeerUpdate{
@@ -586,6 +550,42 @@ func (u *updater) netStatusLoop() {
 			return
 		case <-ticker.C:
 			u.sendAgentUpdate()
+		}
+	}
+}
+
+// processFreshState handles the logic for when a fresh state update is received.
+func processFreshState(update *tailnet.WorkspaceUpdate, agents map[uuid.UUID]tailnet.Agent) {
+	// ignoredWorkspaces is initially populated with the workspaces that are
+	// in the current update. Later on we populate it with the deleted workspaces too
+	// so that we don't send duplicate updates. Same applies to ignoredAgents.
+	ignoredWorkspaces := make(map[uuid.UUID]struct{}, len(update.UpsertedWorkspaces))
+	ignoredAgents := make(map[uuid.UUID]struct{}, len(update.UpsertedAgents))
+
+	for _, workspace := range update.UpsertedWorkspaces {
+		ignoredWorkspaces[workspace.ID] = struct{}{}
+	}
+	for _, agent := range update.UpsertedAgents {
+		ignoredAgents[agent.ID] = struct{}{}
+	}
+	for _, agent := range agents {
+		if _, ok := ignoredAgents[agent.ID]; !ok {
+			// delete any current agents that are not in the new update
+			update.DeletedAgents = append(update.DeletedAgents, &tailnet.Agent{
+				ID:          agent.ID,
+				Name:        agent.Name,
+				WorkspaceID: agent.WorkspaceID,
+			})
+			// if the workspace connected to an agent we're deleting,
+			// is not present in the fresh state, add it to the deleted workspaces
+			if _, ok := ignoredWorkspaces[agent.WorkspaceID]; !ok {
+				update.DeletedWorkspaces = append(update.DeletedWorkspaces, &tailnet.Workspace{
+					// other fields cannot be populated because the tunnel
+					// only stores agents and corresponding workspaceIDs
+					ID: agent.WorkspaceID,
+				})
+				ignoredWorkspaces[agent.WorkspaceID] = struct{}{}
+			}
 		}
 	}
 }

--- a/vpn/tunnel_internal_test.go
+++ b/vpn/tunnel_internal_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/coder/quartz"
 
+	"maps"
+
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/testutil"
@@ -880,9 +882,7 @@ func TestProcessFreshState(t *testing.T) {
 			originalDeletedWorkspacesLen := len(tt.update.DeletedWorkspaces)
 
 			agentsCopy := make(map[uuid.UUID]tailnet.Agent)
-			for k, v := range tt.initialAgents {
-				agentsCopy[k] = v
-			}
+			maps.Copy(agentsCopy, tt.initialAgents)
 
 			processFreshState(tt.update, agentsCopy)
 

--- a/vpn/tunnel_internal_test.go
+++ b/vpn/tunnel_internal_test.go
@@ -2,6 +2,7 @@ package vpn
 
 import (
 	"context"
+	"maps"
 	"net"
 	"net/netip"
 	"net/url"
@@ -18,8 +19,6 @@ import (
 	"tailscale.com/util/dnsname"
 
 	"github.com/coder/quartz"
-
-	"maps"
 
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/563

The [Coder Connect tunnel](https://github.com/coder/coder/blob/main/vpn/tunnel.go) receives workspace state from the Coder server over a [dRPC stream.](https://github.com/coder/coder/blob/114ba4593b2a82dfd41cdcb7fd6eb70d866e7b86/tailnet/controllers.go#L1029) When first connecting to this stream, the current state of the user's workspaces is received, with subsequent messages being diffs on top of that state.

However, if the client disconnects from this stream, such as when the user's device is suspended, and then reconnects later, no mechanism exists for the tunnel to differentiate that message containing the entire initial state from another diff, and so that state is incorrectly applied as a diff.

In practice:
- Tunnel connects, receives a workspace update containing all the existing workspaces & agents.
- Tunnel loses connection, but isn't completely stopped.
- All the user's workspaces are restarted, producing a new set of agents.
- Tunnel regains connection, and receives a workspace update containing all the existing workspaces & agents.
- This initial update is incorrectly applied as a diff, with the Tunnel's state containing both the old & new agents.

This PR introduces a solution in which tunnelUpdater, when created, sends a FreshState flag with the WorkspaceUpdate type. This flag is handled in the vpn tunnel in the following fashion:
- Preserve existing Agents
- Remove current Agents in the tunnel that are not present in the WorkspaceUpdate
- Remove unreferenced Workspaces 