### PR TITLE
chore(cli): fix test flake when running in coder workspace

### DIFF
--- a/cli/exp_mcp_test.go
+++ b/cli/exp_mcp_test.go
@@ -148,6 +148,7 @@ func TestExpMcpServer(t *testing.T) {
 //nolint:tparallel,paralleltest
 func TestExpMcpConfigureClaudeCode(t *testing.T) {
 	t.Run("NoReportTaskWhenNoAgentToken", func(t *testing.T) {
+		t.Setenv("CODER_AGENT_TOKEN", "")
 		ctx := testutil.Context(t, testutil.WaitShort)
 		cancelCtx, cancel := context.WithCancel(ctx)
 		t.Cleanup(cancel)


### PR DESCRIPTION
This test was failing inside a Coder workspace due to `CODER_AGENT_TOKEN` being set.