### PR TITLE
fix: update devcontainer data every 10s

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -158,6 +158,9 @@ export const AgentRow: FC<AgentRowProps> = ({
 			]),
 		enabled: agent.status === "connected",
 		select: (res) => res.containers.filter((c) => c.status === "running"),
+		// TODO: Implement a websocket connection to get updates on containers
+		// without having to poll.
+		refetchInterval: 10_000,
 	});
 
 	return (


### PR DESCRIPTION
Fix https://github.com/coder/internal/issues/594

**Notice:**
This is a temporary solution to get the devcontainers feature released. Maybe a better solution, to avoid pulling the API every 10 seconds, is to implement a websocket connection to get updates on containers.