### PR TITLE
fix: create directory before writing coder connect network info file

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -1542,6 +1542,10 @@ func writeCoderConnectNetInfo(ctx context.Context, networkInfoDir string) error 
 	if !ok {
 		fs = afero.NewOsFs()
 	}
+	if err := fs.MkdirAll(networkInfoDir, 0o700); err != nil {
+		return xerrors.Errorf("mkdir: %w", err)
+	}
+
 	// The VS Code extension obtains the PID of the SSH process to
 	// find the log file associated with a SSH session.
 	//


### PR DESCRIPTION
The regular network info file creation code also calls `Mkdirall`.

Wasn't picked up in manual testing as I already had the `/net` folder in my VSCode.

Wasn't picked up in automated testing because we use an in-memory FS, which for some reason does this implicitly:

```
func (m *MemMapFs) registerWithParent(f *mem.FileData, perm os.FileMode) {
	if f == nil {
		return
	}
	parent := m.findParent(f)
	if parent == nil {
		pdir := filepath.Dir(filepath.Clean(f.Name()))
		err := m.lockfreeMkdir(pdir, perm)
[...]
```