### PR TITLE
chore: fix agent tests on Windows 11

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1263,10 +1263,6 @@ func TestAgent_SSHConnectionLoginVars(t *testing.T) {
 			want: u.Username,
 		},
 		{
-			key:  "HOME",
-			want: u.HomeDir,
-		},
-		{
 			key:  "SHELL",
 			want: shell,
 		},
@@ -1502,7 +1498,7 @@ func TestAgent_Lifecycle(t *testing.T) {
 
 		_, client, _, _, _ := setupAgent(t, agentsdk.Manifest{
 			Scripts: []codersdk.WorkspaceAgentScript{{
-				Script:     "true",
+				Script:     "echo foo",
 				Timeout:    30 * time.Second,
 				RunOnStart: true,
 			}},


### PR DESCRIPTION
Fixes a couple agent tests so that they work correctly on Windows.

`HOME` is not a standard Windows environment variable, and we don't have any specific Code in Coder to set it on SSH, so I've removed the test case. Amazingly/bizarrely the Windows test runners set this variable, but this is not standard Windows behavior so we shouldn't be including it in our tests.

Also the command `true` is not valid on a default Windows install.

```
true: The term 'true' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

I'm not really sure how the CI runners are allowing this test to pass, but again, it's not standard so we shouldn't be doing it.