### PR TITLE
chore: correct typo in "Logs" page

### DIFF
--- a/docs/admin/monitoring/logs.md
+++ b/docs/admin/monitoring/logs.md
@@ -13,7 +13,7 @@ machine/VM.
 
 - To change the log format/location, you can set
   [`CODER_LOGGING_HUMAN`](../../reference/cli/server.md#--log-human) and
-  [`CODER_LOGGING_JSON](../../reference/cli/server.md#--log-json) server config.
+  [`CODER_LOGGING_JSON`](../../reference/cli/server.md#--log-json) server config.
   options.
 - To only display certain types of logs, use
   the[`CODER_LOG_FILTER`](../../reference/cli/server.md#-l---log-filter) server


### PR DESCRIPTION
I saw this typo when looking at the docs, quick fix.

https://coder.com/docs/admin/monitoring/logs