### PR TITLE
fix: extract checkbox label from dynamic parameter styling prop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -488,7 +488,7 @@ require (
 
 require (
 	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
-	github.com/coder/preview v0.0.1
+	github.com/coder/preview v0.0.2-0.20250506154333-6f500ca7b245
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/kylecarbs/aisdk-go v0.0.8
 	github.com/mark3labs/mcp-go v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -907,8 +907,8 @@ github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048 h1:3jzYUlGH7ZELIH4XggX
 github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
-github.com/coder/preview v0.0.1 h1:2X5McKdMOZJILTIDf7qRplXKupT+91qTJBN67XUh5cA=
-github.com/coder/preview v0.0.1/go.mod h1:eInDmOdSDF8cxCvapIvYkGRzmzvcvGAFL1HYqcA4g+E=
+github.com/coder/preview v0.0.2-0.20250506154333-6f500ca7b245 h1:RGoANNubwwPZF8puiYAk2qbzhVgipBMNu8WIrY1VIbI=
+github.com/coder/preview v0.0.2-0.20250506154333-6f500ca7b245/go.mod h1:5VnO9yw7vq19hBgBqqBksE2BH53UTmNYH1QltkYLXJI=
 github.com/coder/quartz v0.1.2 h1:PVhc9sJimTdKd3VbygXtS4826EOCpB1fXoRlLnCrE+s=
 github.com/coder/quartz v0.1.2/go.mod h1:vsiCc+AHViMKH2CQpGIpFgdHIEQsxwm8yCscqKmzbRA=
 github.com/coder/retry v1.5.1 h1:iWu8YnD8YqHs3XwqrqsjoBTAVqT9ml6z9ViJ2wlMiqc=

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1796,8 +1796,7 @@ export interface PreviewParameterData {
 	readonly type: PreviewParameterType;
 	// this is likely an enum in an external package "github.com/coder/terraform-provider-coder/v2/provider.ParameterFormType"
 	readonly form_type: string;
-	// empty interface{} type, falling back to unknown
-	readonly styling: unknown;
+	readonly styling: PreviewParameterStyling;
 	readonly mutable: boolean;
 	readonly default_value: NullHCLString;
 	readonly icon: string;
@@ -1814,6 +1813,13 @@ export interface PreviewParameterOption {
 	readonly description: string;
 	readonly value: NullHCLString;
 	readonly icon: string;
+}
+
+// From types/parameter.go
+export interface PreviewParameterStyling {
+	readonly placeholder?: string;
+	readonly disabled?: boolean;
+	readonly label?: string;
 }
 
 // From types/enum.go

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -36,6 +36,12 @@ import { type FC, useEffect, useId, useState } from "react";
 import type { AutofillBuildParameter } from "utils/richParameters";
 import * as Yup from "yup";
 
+export interface ParameterStyling {
+	placeholder?: string;
+	label?: string;
+	disabled?: boolean;
+}
+
 export interface DynamicParameterProps {
 	parameter: PreviewParameter;
 	onChange: (value: string) => void;
@@ -164,6 +170,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 	id,
 }) => {
 	const value = validValue(parameter.value);
+	const styling = parameter.styling as ParameterStyling;
 	const [localValue, setLocalValue] = useState(value);
 
 	useEffect(() => {
@@ -181,10 +188,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 				>
 					<SelectTrigger>
 						<SelectValue
-							placeholder={
-								(parameter.styling as { placeholder?: string })?.placeholder ||
-								"Select option"
-							}
+							placeholder={styling?.placeholder || "Select option"}
 						/>
 					</SelectTrigger>
 					<SelectContent>
@@ -245,10 +249,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						onChange(JSON.stringify(values));
 					}}
 					hidePlaceholderWhenSelected
-					placeholder={
-						(parameter.styling as { placeholder?: string })?.placeholder ||
-						"Select option"
-					}
+					placeholder={styling?.placeholder || "Select option"}
 					emptyIndicator={
 						<p className="text-center text-md text-content-primary">
 							No results found
@@ -304,9 +305,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						}}
 						disabled={disabled}
 					/>
-					<Label htmlFor={parameter.name}>
-						{(parameter.styling as { label?: string })?.label}
-					</Label>
+					<Label htmlFor={parameter.name}>{styling?.label}</Label>
 				</div>
 			);
 
@@ -343,9 +342,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						target.style.height = `${target.scrollHeight}px`;
 					}}
 					disabled={disabled}
-					placeholder={
-						(parameter.styling as { placeholder?: string })?.placeholder
-					}
+					placeholder={styling?.placeholder}
 					required={parameter.required}
 				/>
 			);
@@ -377,9 +374,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					}}
 					disabled={disabled}
 					required={parameter.required}
-					placeholder={
-						(parameter.styling as { placeholder?: string })?.placeholder
-					}
+					placeholder={styling?.placeholder}
 					{...inputProps}
 				/>
 			);

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -305,7 +305,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						disabled={disabled}
 					/>
 					<Label htmlFor={parameter.name}>
-						{parameter.display_name || parameter.name}
+						{(parameter.styling as { label?: string })?.label}
 					</Label>
 				</div>
 			);

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -36,12 +36,6 @@ import { type FC, useEffect, useId, useState } from "react";
 import type { AutofillBuildParameter } from "utils/richParameters";
 import * as Yup from "yup";
 
-export interface ParameterStyling {
-	placeholder?: string;
-	label?: string;
-	disabled?: boolean;
-}
-
 export interface DynamicParameterProps {
 	parameter: PreviewParameter;
 	onChange: (value: string) => void;
@@ -170,7 +164,6 @@ const ParameterField: FC<ParameterFieldProps> = ({
 	id,
 }) => {
 	const value = validValue(parameter.value);
-	const styling = parameter.styling as ParameterStyling;
 	const [localValue, setLocalValue] = useState(value);
 
 	useEffect(() => {
@@ -188,7 +181,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 				>
 					<SelectTrigger>
 						<SelectValue
-							placeholder={styling?.placeholder || "Select option"}
+							placeholder={parameter.styling?.placeholder || "Select option"}
 						/>
 					</SelectTrigger>
 					<SelectContent>
@@ -249,7 +242,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						onChange(JSON.stringify(values));
 					}}
 					hidePlaceholderWhenSelected
-					placeholder={styling?.placeholder || "Select option"}
+					placeholder={parameter.styling?.placeholder || "Select option"}
 					emptyIndicator={
 						<p className="text-center text-md text-content-primary">
 							No results found
@@ -305,7 +298,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						}}
 						disabled={disabled}
 					/>
-					<Label htmlFor={parameter.name}>{styling?.label}</Label>
+					<Label htmlFor={parameter.name}>{parameter.styling?.label}</Label>
 				</div>
 			);
 
@@ -342,7 +335,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						target.style.height = `${target.scrollHeight}px`;
 					}}
 					disabled={disabled}
-					placeholder={styling?.placeholder}
+					placeholder={parameter.styling?.placeholder}
 					required={parameter.required}
 				/>
 			);
@@ -374,7 +367,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					}}
 					disabled={disabled}
 					required={parameter.required}
-					placeholder={styling?.placeholder}
+					placeholder={parameter.styling?.placeholder}
 					{...inputProps}
 				/>
 			);

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -23,7 +23,6 @@ import { useDebouncedFunction } from "hooks/debounce";
 import { ArrowLeft, CircleAlert, TriangleAlert } from "lucide-react";
 import {
 	DynamicParameter,
-	type ParameterStyling,
 	getInitialParameterValues,
 	useValidationSchemaForDynamicParameters,
 } from "modules/workspaces/DynamicParameter/DynamicParameter";
@@ -493,9 +492,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 
 							<div className="flex flex-col gap-9">
 								{parameters.map((parameter, index) => {
-									const styling = parameter.styling as ParameterStyling;
 									const parameterField = `rich_parameter_values.${index}`;
-									const parameterInputName = `${parameterField}.value`;
 									const isPresetParameter = presetParameterNames.includes(
 										parameter.name,
 									);
@@ -503,7 +500,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 										disabledParams?.includes(
 											parameter.name.toLowerCase().replace(/ /g, "_"),
 										) ||
-										styling?.disabled ||
+										parameter.styling?.disabled ||
 										creatingWorkspace ||
 										isPresetParameter;
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -23,6 +23,7 @@ import { useDebouncedFunction } from "hooks/debounce";
 import { ArrowLeft, CircleAlert, TriangleAlert } from "lucide-react";
 import {
 	DynamicParameter,
+	type ParameterStyling,
 	getInitialParameterValues,
 	useValidationSchemaForDynamicParameters,
 } from "modules/workspaces/DynamicParameter/DynamicParameter";
@@ -492,6 +493,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 
 							<div className="flex flex-col gap-9">
 								{parameters.map((parameter, index) => {
+									const styling = parameter.styling as ParameterStyling;
 									const parameterField = `rich_parameter_values.${index}`;
 									const parameterInputName = `${parameterField}.value`;
 									const isPresetParameter = presetParameterNames.includes(
@@ -501,7 +503,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 										disabledParams?.includes(
 											parameter.name.toLowerCase().replace(/ /g, "_"),
 										) ||
-										(parameter.styling as { disabled?: boolean })?.disabled ||
+										styling?.disabled ||
 										creatingWorkspace ||
 										isPresetParameter;
 


### PR DESCRIPTION
resolves #17474 

A label will only be shown next to the checkbox If there is a value for `label` in the styling prop for the dynamic parameter



<img width="457" alt="Screenshot 2025-05-01 at 21 35 32" src="https://github.com/user-attachments/assets/3b3a8160-65a2-4411-b763-0d07a4eeb699" />
