### PR TITLE
fix: fix size for non-squared app icons

### DIFF
--- a/site/src/modules/resources/AgentButton.tsx
+++ b/site/src/modules/resources/AgentButton.tsx
@@ -19,7 +19,8 @@ export const AgentButton = forwardRef<HTMLButtonElement, ButtonProps>(
 					"& .MuiButton-startIcon, & .MuiButton-endIcon": {
 						width: 16,
 						height: 16,
-						"& svg": { width: "100%", height: "100%" },
+
+						"& svg, & img": { width: "100%", height: "100%" },
 					},
 				})}
 			>

--- a/site/src/modules/resources/AppLink/AppLink.stories.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.stories.tsx
@@ -62,6 +62,19 @@ export const WithIcon: Story = {
 	},
 };
 
+export const WithNonSquaredIcon: Story = {
+	args: {
+		workspace: MockWorkspace,
+		app: {
+			...MockWorkspaceApp,
+			icon: "/icon/windsurf.svg",
+			sharing_level: "owner",
+			health: "healthy",
+		},
+		agent: MockWorkspaceAgent,
+	},
+};
+
 export const ExternalApp: Story = {
 	args: {
 		workspace: MockWorkspace,


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/e7544b00-24b0-405c-b763-49a9a009c1d2)

**After:**
<img width="192" alt="Screenshot 2025-05-02 at 14 36 19" src="https://github.com/user-attachments/assets/59cb4531-06fd-44bc-b4b9-4441f2dce79a" />
