### PR TITLE
chore: optimize CI setup time on Windows

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -5,17 +5,42 @@ inputs:
   version:
     description: "The Go version to use."
     default: "1.24.2"
+  use-preinstalled-go:
+    description: "Whether to use preinstalled Go."
+    default: "false"
+  use-temp-cache-dirs:
+    description: "Whether to use temporary GOCACHE and GOMODCACHE directories."
+    default: "false"
 runs:
   using: "composite"
   steps:
+    - name: Override GOCACHE and GOMODCACHE
+      shell: bash
+      if: inputs.use-temp-cache-dirs == 'true'
+      run: |
+        # cd to another directory to ensure we're not inside a Go project.
+        # That'd trigger Go to download the toolchain for that project.
+        cd "$RUNNER_TEMP"
+        # RUNNER_TEMP should be backed by a RAM disk on Windows if
+        # coder/setup-ramdisk-action was used
+        export GOCACHE_DIR="$RUNNER_TEMP""\go-cache"
+        export GOMODCACHE_DIR="$RUNNER_TEMP""\go-mod-cache"
+        export GOPATH_DIR="$RUNNER_TEMP""\go-path"
+        mkdir -p "$GOCACHE_DIR"
+        mkdir -p "$GOMODCACHE_DIR"
+        mkdir -p "$GOPATH_DIR"
+        go env -w GOCACHE="$GOCACHE_DIR"
+        go env -w GOMODCACHE="$GOMODCACHE_DIR"
+        go env -w GOPATH="$GOPATH_DIR"
+
     - name: Setup Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: ${{ inputs.version }}
+        go-version: ${{ inputs.use-preinstalled-go == 'false' && inputs.version || '' }}
 
     - name: Install gotestsum
       shell: bash
-      run: go install gotest.tools/gotestsum@latest
+      run: go install gotest.tools/gotestsum@3f7ff0ec4aeb6f95f5d67c998b71f272aa8a8b41 # v1.12.1
 
     # It isn't necessary that we ever do this, but it helps
     # separate the "setup" from the "run" times.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,7 +313,7 @@ jobs:
         run: ./scripts/check_unstaged.sh
 
   test-go:
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'windows-latest-16-cores' || matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'depot-windows-2022-16' || matrix.os }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     timeout-minutes: 20
@@ -326,9 +326,17 @@ jobs:
           - windows-2022
     steps:
       - name: Harden Runner
+        # Harden Runner is only supported on Ubuntu runners.
+        if: runner.os == 'Linux'
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
+
+      # Set up RAM disks to speed up the rest of the job. This action is in
+      # a separate repository to allow its use before actions/checkout.
+      - name: Setup RAM Disks
+        if: runner.os == 'Windows'
+        uses: coder/setup-ramdisk-action@79dacfe70c47ad6d6c0dd7f45412368802641439
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -337,6 +345,12 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          # Runners have Go baked-in and Go will automatically
+          # download the toolchain configured in go.mod, so we don't
+          # need to reinstall it. It's faster on Windows runners.
+          use-preinstalled-go: ${{ runner.os == 'Windows' }}
+          use-temp-cache-dirs: ${{ runner.os == 'Windows' }}
 
       - name: Setup Terraform
         uses: ./.github/actions/setup-tf


### PR DESCRIPTION
This PR focuses on optimizing go-test CI times on Windows. It:

- backs the `$RUNNER_TEMP` directory with a RAM disk. This directory is used by actions like cache, setup-go, and setup-terraform as a staging area
- backs `GOCACHE` and `GOMODCACHE` with a RAM disk
- backs `$GITHUB_WORKSPACE` with a RAM disk - that's where the repository is checked out
- uses preinstalled Go on Windows runners
- starts using the depot Windows runner

From what I've seen, these changes bring test times down to be on par with Linux and macOS. The biggest improvement comes from backing frequently accessed paths with RAM disks. The C drive is surprisingly slow - I ran some performance tests with [fio](https://fio.readthedocs.io/en/latest/fio_doc.html#) where I tested IOPS on many small files, and the RAM disk was 100x faster.

Additionally, the depot runners seem to have more consistent performance than the ones provided by GitHub.