### PR TITLE
test: fix `TestWorkspaceAgentReportStats` flake

### DIFF
--- a/coderd/workspaceagentsrpc_test.go
+++ b/coderd/workspaceagentsrpc_test.go
@@ -32,6 +32,7 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
+		LastUsedAt:     dbtime.Now().Add(-time.Minute),
 	}).WithAgent().Do()
 
 	ac := agentsdk.New(client.URL)


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/609.

As seen in the below logs, the `last_used_at` time was updating, but just to the same value that it was on creation; `dbtime.Now` was called in quick succession. 

```
 t.go:106: 2025-05-05 12:11:54.166 [info]  coderd.workspace_usage_tracker: updated workspaces last_used_at  count=1  now="2025-05-05T12:11:54.161329Z"
    t.go:106: 2025-05-05 12:11:54.172 [debu]  coderd: GET  host=localhost:50422  path=/api/v2/workspaces/745b7ff3-47f2-4e1a-9452-85ea48ba5c46  proto=HTTP/1.1  remote_addr=127.0.0.1  start="2025-05-05T12:11:54.1669073Z"  workspace_name=peaceful_faraday34  requestor_id=b2cf02ae-2181-480b-bb1f-95dc6acb6497  requestor_name=testuser  requestor_email=""  took=5.2105ms  status_code=200  latency_ms=5  params_workspace=745b7ff3-47f2-4e1a-9452-85ea48ba5c46  request_id=7fd5ea90-af7b-4104-91c5-9ca64bc2d5e6
    workspaceagentsrpc_test.go:70: 
        	Error Trace:	C:/actions-runner/coder/coder/coderd/workspaceagentsrpc_test.go:70
        	Error:      	Should be true
        	Test:       	TestWorkspaceAgentReportStats
        	Messages:   	2025-05-05 12:11:54.161329 +0000 UTC is not after 2025-05-05 12:11:54.161329 +0000 UTC
```

If we change the initial `LastUsedAt` time to be a time in the past, ticking with a `dbtime.Now` will always update it to a later value. If it never updates, the condition will still fail.

