### PR TITLE
test(agent): fix channel timeout in TestNewServer_CloseActiveConnections

### DIFF
--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -214,7 +214,11 @@ func TestNewServer_CloseActiveConnections(t *testing.T) {
 		}
 
 		for _, ch := range waitConns {
-			testutil.RequireReceive(ctx, t, ch)
+			select {
+			case <-ctx.Done():
+				t.Fatal("timeout")
+			case <-ch:
+			}
 		}
 
 		return s, wg.Wait

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -214,7 +214,7 @@ func TestNewServer_CloseActiveConnections(t *testing.T) {
 		}
 
 		for _, ch := range waitConns {
-			<-ch
+			testutil.RequireReceive(ctx, t, ch)
 		}
 
 		return s, wg.Wait


### PR DESCRIPTION
This fixes a test issue where we were waiting on a channel indefinitely and the test timed out instead of failing due to earlier error.

Updates coder/internal#558