### PR TITLE
chore: fetch workspaces by username with organization permissions

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1076,7 +1076,7 @@ func New(options *Options) *API {
 
 						r.Group(func(r chi.Router) {
 							r.Use(
-								httpmw.ExtractOrganizationMemberParam(options.Database, api.HTTPAuth.Authorize),
+								httpmw.ExtractOrganizationMemberParam(options.Database),
 							)
 							r.Delete("/", api.deleteOrganizationMember)
 							r.Put("/roles", api.putMemberRoles)

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1076,7 +1076,7 @@ func New(options *Options) *API {
 
 						r.Group(func(r chi.Router) {
 							r.Use(
-								httpmw.ExtractOrganizationMemberParam(options.Database),
+								httpmw.ExtractOrganizationMemberParam(options.Database, api.HTTPAuth.Authorize),
 							)
 							r.Delete("/", api.deleteOrganizationMember)
 							r.Put("/roles", api.putMemberRoles)
@@ -1189,15 +1189,25 @@ func New(options *Options) *API {
 				})
 				r.Route("/{user}", func(r chi.Router) {
 					r.Group(func(r chi.Router) {
-						r.Use(httpmw.ExtractUserParamOptional(options.Database))
+						r.Use(httpmw.ExtractOrganizationMembersParam(options.Database, api.HTTPAuth.Authorize))
 						// Creating workspaces does not require permissions on the user, only the
 						// organization member. This endpoint should match the authz story of
 						// postWorkspacesByOrganization
 						r.Post("/workspaces", api.postUserWorkspaces)
+						r.Route("/workspace/{workspacename}", func(r chi.Router) {
+							r.Get("/", api.workspaceByOwnerAndName)
+							r.Get("/builds/{buildnumber}", api.workspaceBuildByBuildNumber)
+						})
+					})
+
+					r.Group(func(r chi.Router) {
+						r.Use(httpmw.ExtractUserParam(options.Database))
 
 						// Similarly to creating a workspace, evaluating parameters for a
 						// new workspace should also match the authz story of
 						// postWorkspacesByOrganization
+						// TODO: Do not require site wide read user permission. Make this work
+						//   with org member permissions.
 						r.Route("/templateversions/{templateversion}", func(r chi.Router) {
 							r.Use(
 								httpmw.ExtractTemplateVersionParam(options.Database),
@@ -1205,10 +1215,6 @@ func New(options *Options) *API {
 							)
 							r.Get("/parameters", api.templateVersionDynamicParameters)
 						})
-					})
-
-					r.Group(func(r chi.Router) {
-						r.Use(httpmw.ExtractUserParam(options.Database))
 
 						r.Post("/convert-login", api.postConvertLoginType)
 						r.Delete("/", api.deleteUser)
@@ -1250,10 +1256,7 @@ func New(options *Options) *API {
 							r.Get("/", api.organizationsByUser)
 							r.Get("/{organizationname}", api.organizationByUserAndName)
 						})
-						r.Route("/workspace/{workspacename}", func(r chi.Router) {
-							r.Get("/", api.workspaceByOwnerAndName)
-							r.Get("/builds/{buildnumber}", api.workspaceBuildByBuildNumber)
-						})
+
 						r.Get("/gitsshkey", api.gitSSHKey)
 						r.Put("/gitsshkey", api.regenerateGitSSHKey)
 						r.Route("/notifications", func(r chi.Router) {

--- a/coderd/httpmw/organizationparam.go
+++ b/coderd/httpmw/organizationparam.go
@@ -194,6 +194,7 @@ func ExtractOrganizationMember(ctx context.Context, auth func(r *http.Request, a
 		return nil, nil, true
 	}
 
+	// Only return the user data if the caller can read the user object.
 	if auth != nil && auth(r, policy.ActionRead, user) {
 		return &user, organizationMembers, false
 	}

--- a/coderd/httpmw/organizationparam.go
+++ b/coderd/httpmw/organizationparam.go
@@ -195,7 +195,7 @@ func ExtractOrganizationMember(ctx context.Context, auth func(r *http.Request, a
 	}
 
 	if auth != nil && auth(r, policy.ActionRead, user) {
-		return &user, organizationMembers, true
+		return &user, organizationMembers, false
 	}
 
 	// If the user cannot be read and 0 memberships exist, throw a 404 to not

--- a/coderd/httpmw/organizationparam_test.go
+++ b/coderd/httpmw/organizationparam_test.go
@@ -131,9 +131,7 @@ func TestOrganizationParam(t *testing.T) {
 			}),
 			httpmw.ExtractUserParam(db),
 			httpmw.ExtractOrganizationParam(db),
-			httpmw.ExtractOrganizationMemberParam(db, func(r *http.Request, _ policy.Action, _ rbac.Objecter) bool {
-				return true
-			}),
+			httpmw.ExtractOrganizationMemberParam(db),
 		)
 		rtr.Get("/", nil)
 		rtr.ServeHTTP(rw, r)
@@ -170,11 +168,10 @@ func TestOrganizationParam(t *testing.T) {
 			}),
 			httpmw.ExtractOrganizationParam(db),
 			httpmw.ExtractUserParam(db),
-			httpmw.ExtractOrganizationMemberParam(db, func(r *http.Request, _ policy.Action, _ rbac.Objecter) bool {
-				return true
-			}),
+			httpmw.ExtractOrganizationMemberParam(db),
 			httpmw.ExtractOrganizationMembersParam(db, func(r *http.Request, _ policy.Action, _ rbac.Objecter) bool {
-				return true
+				// Assume the caller cannot read the member
+				return false
 			}),
 		)
 		rtr.Get("/", func(rw http.ResponseWriter, r *http.Request) {
@@ -202,7 +199,8 @@ func TestOrganizationParam(t *testing.T) {
 
 			orgMems := httpmw.OrganizationMembersParam(r)
 			assert.NotZero(t, orgMems)
-			assert.Equal(t, orgMem.UserID, orgMems[0].UserID)
+			assert.Equal(t, orgMem.UserID, orgMems.Memberships[0].UserID)
+			assert.Nil(t, orgMems.User, "user data should not be available, hard coded false authorize")
 		})
 
 		// Try by ID

--- a/coderd/httpmw/userparam.go
+++ b/coderd/httpmw/userparam.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -127,4 +128,58 @@ func ExtractUserContext(ctx context.Context, db database.Store, rw http.Response
 		return database.User{}, false
 	}
 	return user, true
+}
+
+// ExtractUserID will work if the requester can access any OrganizationMember that
+// belongs to the user.
+func ExtractUserID(db database.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			// We need to resolve the `{user}` URL parameter so that we can get the userID and
+			// username.  We do this as SystemRestricted since the caller might have permission
+			// to access the OrganizationMember object, but *not* the User object.  So, it is
+			// very important that we do not add the User object to the request context or otherwise
+			// leak it to the API handler.
+			// nolint:gocritic
+			user, ok := ExtractUserContext(dbauthz.AsSystemRestricted(ctx), db, rw, r)
+			if !ok {
+				return
+			}
+			organization := OrganizationParam(r)
+
+			organizationMember, err := database.ExpectOne(db.OrganizationMembers(ctx, database.OrganizationMembersParams{
+				OrganizationID: organization.ID,
+				UserID:         user.ID,
+				IncludeSystem:  false,
+			}))
+			if httpapi.Is404Error(err) {
+				httpapi.ResourceNotFound(rw)
+				return
+			}
+			if err != nil {
+				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+					Message: "Internal error fetching organization member.",
+					Detail:  err.Error(),
+				})
+				return
+			}
+
+			ctx = context.WithValue(ctx, organizationMemberParamContextKey{}, OrganizationMember{
+				OrganizationMember: organizationMember.OrganizationMember,
+				// Here we're making two exceptions to the rule about not leaking data about the user
+				// to the API handler, which is to include the username and avatar URL.
+				// If the caller has permission to read the OrganizationMember, then we're explicitly
+				// saying here that they also have permission to see the member's username and avatar.
+				// This is OK!
+				//
+				// API handlers need this information for audit logging and returning the owner's
+				// username in response to creating a workspace. Additionally, the frontend consumes
+				// the Avatar URL and this allows the FE to avoid an extra request.
+				Username:  user.Username,
+				AvatarURL: user.AvatarURL,
+			})
+			next.ServeHTTP(rw, r.WithContext(ctx))
+		})
+	}
 }

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -232,7 +232,7 @@ func (api *API) workspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 // @Router /users/{user}/workspace/{workspacename}/builds/{buildnumber} [get]
 func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	owner := httpmw.UserParam(r)
+	mems := httpmw.OrganizationMembersParam(r)
 	workspaceName := chi.URLParam(r, "workspacename")
 	buildNumber, err := strconv.ParseInt(chi.URLParam(r, "buildnumber"), 10, 32)
 	if err != nil {
@@ -244,7 +244,7 @@ func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Requ
 	}
 
 	workspace, err := api.Database.GetWorkspaceByOwnerIDAndName(ctx, database.GetWorkspaceByOwnerIDAndNameParams{
-		OwnerID: owner.ID,
+		OwnerID: mems.UserID(),
 		Name:    workspaceName,
 	})
 	if httpapi.Is404Error(err) {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -447,7 +447,7 @@ func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 		// If the caller can find the organization membership in the same org
 		// as the template, then they can continue.
 		orgIndex := slices.IndexFunc(mems.Memberships, func(mem httpmw.OrganizationMember) bool {
-			return mem.OrganizationID == template.ID
+			return mem.OrganizationID == template.OrganizationID
 		})
 		if orgIndex == -1 {
 			httpapi.ResourceNotFound(rw)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -253,7 +253,8 @@ func (api *API) workspaces(rw http.ResponseWriter, r *http.Request) {
 // @Router /users/{user}/workspace/{workspacename} [get]
 func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	owner := httpmw.UserParam(r)
+
+	mems := httpmw.OrganizationMembersParam(r)
 	workspaceName := chi.URLParam(r, "workspacename")
 	apiKey := httpmw.APIKey(r)
 
@@ -273,12 +274,12 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 	}
 
 	workspace, err := api.Database.GetWorkspaceByOwnerIDAndName(ctx, database.GetWorkspaceByOwnerIDAndNameParams{
-		OwnerID: owner.ID,
+		OwnerID: mems.UserID(),
 		Name:    workspaceName,
 	})
 	if includeDeleted && errors.Is(err, sql.ErrNoRows) {
 		workspace, err = api.Database.GetWorkspaceByOwnerIDAndName(ctx, database.GetWorkspaceByOwnerIDAndNameParams{
-			OwnerID: owner.ID,
+			OwnerID: mems.UserID(),
 			Name:    workspaceName,
 			Deleted: includeDeleted,
 		})
@@ -408,6 +409,7 @@ func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 		ctx     = r.Context()
 		apiKey  = httpmw.APIKey(r)
 		auditor = api.Auditor.Load()
+		mems    = httpmw.OrganizationMembersParam(r)
 	)
 
 	var req codersdk.CreateWorkspaceRequest
@@ -416,17 +418,16 @@ func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	var owner workspaceOwner
-	// This user fetch is an optimization path for the most common case of creating a
-	// workspace for 'Me'.
-	//
-	// This is also required to allow `owners` to create workspaces for users
-	// that are not in an organization.
-	user, ok := httpmw.UserParamOptional(r)
-	if ok {
+	if mems.User != nil {
+		// This user fetch is an optimization path for the most common case of creating a
+		// workspace for 'Me'.
+		//
+		// This is also required to allow `owners` to create workspaces for users
+		// that are not in an organization.
 		owner = workspaceOwner{
-			ID:        user.ID,
-			Username:  user.Username,
-			AvatarURL: user.AvatarURL,
+			ID:        mems.User.ID,
+			Username:  mems.User.Username,
+			AvatarURL: mems.User.AvatarURL,
 		}
 	} else {
 		// A workspace can still be created if the caller can read the organization
@@ -443,35 +444,21 @@ func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// We need to fetch the original user as a system user to fetch the
-		// user_id. 'ExtractUserContext' handles all cases like usernames,
-		// 'Me', etc.
-		// nolint:gocritic // The user_id needs to be fetched. This handles all those cases.
-		user, ok := httpmw.ExtractUserContext(dbauthz.AsSystemRestricted(ctx), api.Database, rw, r)
-		if !ok {
-			return
-		}
-
-		organizationMember, err := database.ExpectOne(api.Database.OrganizationMembers(ctx, database.OrganizationMembersParams{
-			OrganizationID: template.OrganizationID,
-			UserID:         user.ID,
-			IncludeSystem:  false,
-		}))
-		if httpapi.Is404Error(err) {
+		// If the caller can find the organization membership in the same org
+		// as the template, then they can continue.
+		orgIndex := slices.IndexFunc(mems.Memberships, func(mem httpmw.OrganizationMember) bool {
+			return mem.OrganizationID == template.ID
+		})
+		if orgIndex == -1 {
 			httpapi.ResourceNotFound(rw)
 			return
 		}
-		if err != nil {
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Internal error fetching organization member.",
-				Detail:  err.Error(),
-			})
-			return
-		}
+
+		member := mems.Memberships[orgIndex]
 		owner = workspaceOwner{
-			ID:        organizationMember.OrganizationMember.UserID,
-			Username:  organizationMember.Username,
-			AvatarURL: organizationMember.AvatarURL,
+			ID:        member.UserID,
+			Username:  member.Username,
+			AvatarURL: member.AvatarURL,
 		}
 	}
 

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -289,9 +289,15 @@ func TestCreateUserWorkspace(t *testing.T) {
 
 		ctx = testutil.Context(t, testutil.WaitLong*1000) // Reset the context to avoid timeouts.
 
-		_, err = creator.CreateUserWorkspace(ctx, adminID.ID.String(), codersdk.CreateWorkspaceRequest{
+		wrk, err := creator.CreateUserWorkspace(ctx, adminID.ID.String(), codersdk.CreateWorkspaceRequest{
 			TemplateID: template.ID,
 			Name:       "workspace",
+		})
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, admin, wrk.LatestBuild.ID)
+
+		_, err = creator.WorkspaceByOwnerAndName(ctx, adminID.Username, wrk.Name, codersdk.WorkspaceOptions{
+			IncludeDeleted: false,
 		})
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/17691

`ExtractOrganizationMembersParam` will allow fetching a user with only organization permissions. It gets a bit weird because if the user belongs to 0 orgs, then the user "does not exist" from an org perspective. But if you are a site-wide admin, then the user does exist.