### PR TITLE
fix: fill session token when app is external

### DIFF
--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -106,12 +106,7 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
 
 					event.preventDefault();
 
-					// This is an external URI like "vscode://", so
-					// it needs to be opened with the browser protocol handler.
-					const shouldOpenAppExternally =
-						app.external && app.url?.startsWith("http");
-
-					if (shouldOpenAppExternally) {
+					if (app.external) {
 						// This is a magic undocumented string that is replaced
 						// with a brand-new session token from the backend.
 						// This only exists for external URLs, and should only
@@ -137,6 +132,7 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
 							clearTimeout(openAppExternallyFailed);
 						});
 
+						console.log("URL", url);
 						window.location.href = url;
 						return;
 					}

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -132,7 +132,6 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
 							clearTimeout(openAppExternallyFailed);
 						});
 
-						console.log("URL", url);
 						window.location.href = url;
 						return;
 					}


### PR DESCRIPTION
Fix https://github.com/coder/coder/issues/17704

During the [refactoring of WorkspaceApp response type](https://github.com/coder/coder/pull/17700/files#diff-a7e67944708c3c914a24a02d515a89ecd414bfe61890468dac08abde55ba8e96R112), I updated the logic to check if the session token should be injected causing external apps to not load correctly.

To also avoid future confusions, we are only going to rely on the `app.external` prop to open apps externally instead of verifying if the URL does not use the HTTP protocol. I did some research and I didn't find out a use case where it would be a problem. 

I'm going to refactor this code very soon to allow opening apps from the workspaces page, so I will write the tests to cover this use case there. 

**Not included:**
During my next refactoring I'm also going to change the code to support token injections directly in the HREF instead of making it happen during the click event.