### PR TITLE
fix: create ssh directory if it doesn't already exist when running `coder config-ssh`

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -441,7 +441,7 @@ func (r *RootCmd) configSSH() *serpent.Command {
 
 			if !bytes.Equal(configRaw, configModified) {
 				sshDir := filepath.Dir(sshConfigFile)
-				if err := os.MkdirAll(sshDir, os.ModePerm); err != nil {
+				if err := os.MkdirAll(sshDir, 0700); err != nil {
 					return xerrors.Errorf("failed to create directory %q: %w", sshDir, err)
 				}
 

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -440,6 +440,12 @@ func (r *RootCmd) configSSH() *serpent.Command {
 			}
 
 			if !bytes.Equal(configRaw, configModified) {
+				// Ensure the parent directory exists before writing the file
+				sshDir := filepath.Dir(sshConfigFile)
+				if err := os.MkdirAll(sshDir, os.ModePerm); err != nil {
+					return xerrors.Errorf("failed to create directory %q: %w", sshDir, err)
+				}
+
 				err = atomic.WriteFile(sshConfigFile, bytes.NewReader(configModified))
 				if err != nil {
 					return xerrors.Errorf("write ssh config failed: %w", err)

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -440,7 +440,6 @@ func (r *RootCmd) configSSH() *serpent.Command {
 			}
 
 			if !bytes.Equal(configRaw, configModified) {
-				// Ensure the parent directory exists before writing the file
 				sshDir := filepath.Dir(sshConfigFile)
 				if err := os.MkdirAll(sshDir, os.ModePerm); err != nil {
 					return xerrors.Errorf("failed to create directory %q: %w", sshDir, err)

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -207,7 +207,7 @@ func TestConfigSSH_MissingDirectory(t *testing.T) {
 	// Check that the directory has proper permissions (0700)
 	sshDirInfo, err := os.Stat(sshDir)
 	require.NoError(t, err)
-	require.Equal(t, os.ModePerm, sshDirInfo.Mode().Perm(), "directory should have 0700 permissions")
+	require.Equal(t, os.FileMode(0700), sshDirInfo.Mode().Perm(), "directory should have 0700 permissions")
 }
 
 func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -172,6 +172,10 @@ func TestConfigSSH(t *testing.T) {
 func TestConfigSSH_MissingDirectory(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("See coder/internal#117")
+	}
+
 	client := coderdtest.New(t, nil)
 	_ = coderdtest.CreateFirstUser(t, client)
 

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -172,10 +172,6 @@ func TestConfigSSH(t *testing.T) {
 func TestConfigSSH_MissingDirectory(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
-		t.Skip("See coder/internal#117")
-	}
-
 	client := coderdtest.New(t, nil)
 	_ = coderdtest.CreateFirstUser(t, client)
 

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -207,7 +207,7 @@ func TestConfigSSH_MissingDirectory(t *testing.T) {
 	// Check that the directory has proper permissions (0700)
 	sshDirInfo, err := os.Stat(sshDir)
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(os.ModePerm), sshDirInfo.Mode().Perm(), "directory should have 0700 permissions")
+	require.Equal(t, os.ModePerm, sshDirInfo.Mode().Perm(), "directory should have 0700 permissions")
 }
 
 func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {


### PR DESCRIPTION
Closes [coder/internal#623](https://github.com/coder/internal/issues/623)

> [!WARNING]  
> PR co-authored by Claude Code