### PR TITLE
fix: enrich the `notLoggedInMessage` error message with the full path to the coder

### DIFF
--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -90,11 +90,11 @@ func TestLogout(t *testing.T) {
 		logout.Stdin = pty.Input()
 		logout.Stdout = pty.Output()
 
-		go func() {
-			executable, err := os.Executable()
-			require.NoError(t, err)
-			require.NotEqual(t, "", executable)
+		executable, err := os.Executable()
+		require.NoError(t, err)
+		require.NotEqual(t, "", executable)
 
+		go func() {
 			defer close(logoutChan)
 			err = logout.Run()
 			require.Contains(t, err.Error(), fmt.Sprintf("Try logging in using '%s login <url>'.", executable))

--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -90,9 +91,13 @@ func TestLogout(t *testing.T) {
 		logout.Stdout = pty.Output()
 
 		go func() {
+			executable, err := os.Executable()
+			require.NoError(t, err)
+			require.NotEqual(t, "", executable)
+
 			defer close(logoutChan)
-			err := logout.Run()
-			assert.ErrorContains(t, err, "You are not logged in. Try logging in using 'coder login <url>'.")
+			err = logout.Run()
+			require.Contains(t, err.Error(), fmt.Sprintf("Try logging in using '%s login <url>'.", executable))
 		}()
 
 		<-logoutChan

--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -97,7 +97,7 @@ func TestLogout(t *testing.T) {
 		go func() {
 			defer close(logoutChan)
 			err = logout.Run()
-			require.Contains(t, err.Error(), fmt.Sprintf("Try logging in using '%s login <url>'.", executable))
+			assert.Contains(t, err.Error(), fmt.Sprintf("Try logging in using '%s login <url>'.", executable))
 		}()
 
 		<-logoutChan

--- a/cli/root.go
+++ b/cli/root.go
@@ -72,7 +72,7 @@ const (
 	varDisableDirect           = "disable-direct-connections"
 	varDisableNetworkTelemetry = "disable-network-telemetry"
 
-	notLoggedInMessage = "You are not logged in. Try logging in using 'coder login <url>'."
+	notLoggedInMessage = "You are not logged in. Try logging in using '%s login <url>'."
 
 	envNoVersionCheck   = "CODER_NO_VERSION_WARNING"
 	envNoFeatureWarning = "CODER_NO_FEATURE_WARNING"
@@ -534,7 +534,11 @@ func (r *RootCmd) InitClient(client *codersdk.Client) serpent.MiddlewareFunc {
 				rawURL, err := conf.URL().Read()
 				// If the configuration files are absent, the user is logged out
 				if os.IsNotExist(err) {
-					return xerrors.New(notLoggedInMessage)
+					binPath, err := os.Executable()
+					if err != nil {
+						binPath = "coder"
+					}
+					return xerrors.Errorf(notLoggedInMessage, binPath)
 				}
 				if err != nil {
 					return err

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,9 +71,12 @@ func TestUserList(t *testing.T) {
 	t.Run("NoURLFileErrorHasHelperText", func(t *testing.T) {
 		t.Parallel()
 
+		executable, err := os.Executable()
+		require.NoError(t, err)
+
 		inv, _ := clitest.New(t, "users", "list")
-		err := inv.Run()
-		require.Contains(t, err.Error(), "Try logging in using 'coder login <url>'.")
+		err = inv.Run()
+		require.Contains(t, err.Error(), fmt.Sprintf("Try logging in using '%s login <url>'.", executable))
 	})
 	t.Run("SessionAuthErrorHasHelperText", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Opening as a draft for now since I'm not really sure this actually provides any value. We set out to resolve https://github.com/coder/coder/issues/11505 but for this specific login error, if you are not logged in but any of the CLI arg, env var, or config file values are set for the URL you should instead get the `SignedOutErrorMessage` related to there not being a login token rather than this `notLoggedInMessage`.

So at the moment, it really seems like all we can do is change `coder` to `os.Executable()` which would give the full path to the coder executable just in case it's not already somewhere that is in the users path.