### PR TITLE
fix: use file filter in weekly-docs github action

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -36,7 +36,7 @@ jobs:
           reporter: github-pr-review
           config_file: ".github/.linkspector.yml"
           fail_on_error: "true"
-          filter_mode: "nofilter"
+          filter_mode: "file"
 
       - name: Send Slack notification
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
otherwise it ignores the instruction to only check docs/ when a file changes in that dir