### PR TITLE
fix(agent): fix unexpanded devcontainer paths for agentcontainers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1129,7 +1129,7 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 			)
 			if a.experimentalDevcontainersEnabled {
 				var dcScripts []codersdk.WorkspaceAgentScript
-				scripts, dcScripts = agentcontainers.ExtractAndInitializeDevcontainerScripts(a.logger, manifest.Devcontainers, scripts)
+				scripts, dcScripts = agentcontainers.ExtractAndInitializeDevcontainerScripts(manifest.Devcontainers, scripts)
 				// See ExtractAndInitializeDevcontainerScripts for motivation
 				// behind running dcScripts as post start scripts.
 				scriptRunnerOpts = append(scriptRunnerOpts, agentscripts.WithPostStartScripts(dcScripts...))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1085,6 +1085,8 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 		if err != nil {
 			return xerrors.Errorf("expand directory: %w", err)
 		}
+		// Normalize all devcontainer paths by making them absolute.
+		manifest.Devcontainers = agentcontainers.ExpandAllDevcontainerPaths(a.logger, expandPathToAbs, manifest.Devcontainers)
 		subsys, err := agentsdk.ProtoFromSubsystems(a.subsystems)
 		if err != nil {
 			a.logger.Critical(ctx, "failed to convert subsystems", slog.Error(err))
@@ -1127,7 +1129,7 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 			)
 			if a.experimentalDevcontainersEnabled {
 				var dcScripts []codersdk.WorkspaceAgentScript
-				scripts, dcScripts = agentcontainers.ExtractAndInitializeDevcontainerScripts(a.logger, expandPathToAbs, manifest.Devcontainers, scripts)
+				scripts, dcScripts = agentcontainers.ExtractAndInitializeDevcontainerScripts(a.logger, manifest.Devcontainers, scripts)
 				// See ExtractAndInitializeDevcontainerScripts for motivation
 				// behind running dcScripts as post start scripts.
 				scriptRunnerOpts = append(scriptRunnerOpts, agentscripts.WithPostStartScripts(dcScripts...))

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1998,7 +1998,8 @@ func TestAgent_ReconnectingPTYContainer(t *testing.T) {
 // You can run it manually as follows:
 //
 // CODER_TEST_USE_DOCKER=1 go test -count=1 ./agent -run TestAgent_DevcontainerAutostart
-// nolint: paralleltest // This test sets an environment variable.
+//
+//nolint:paralleltest // This test sets an environment variable.
 func TestAgent_DevcontainerAutostart(t *testing.T) {
 	if os.Getenv("CODER_TEST_USE_DOCKER") != "1" {
 		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -36,7 +36,6 @@ devcontainer up %s
 // initialize the workspace (e.g. git clone, npm install, etc). This is
 // important if e.g. a Coder module to install @devcontainer/cli is used.
 func ExtractAndInitializeDevcontainerScripts(
-	logger slog.Logger,
 	devcontainers []codersdk.WorkspaceAgentDevcontainer,
 	scripts []codersdk.WorkspaceAgentScript,
 ) (filteredScripts []codersdk.WorkspaceAgentScript, devcontainerScripts []codersdk.WorkspaceAgentScript) {

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -37,7 +37,6 @@ devcontainer up %s
 // important if e.g. a Coder module to install @devcontainer/cli is used.
 func ExtractAndInitializeDevcontainerScripts(
 	logger slog.Logger,
-	expandPath func(string) (string, error),
 	devcontainers []codersdk.WorkspaceAgentDevcontainer,
 	scripts []codersdk.WorkspaceAgentScript,
 ) (filteredScripts []codersdk.WorkspaceAgentScript, devcontainerScripts []codersdk.WorkspaceAgentScript) {
@@ -47,7 +46,6 @@ ScriptLoop:
 			// The devcontainer scripts match the devcontainer ID for
 			// identification.
 			if script.ID == dc.ID {
-				dc = expandDevcontainerPaths(logger, expandPath, dc)
 				devcontainerScripts = append(devcontainerScripts, devcontainerStartupScript(dc, script))
 				continue ScriptLoop
 			}
@@ -73,6 +71,17 @@ func devcontainerStartupScript(dc codersdk.WorkspaceAgentDevcontainer, script co
 	// have not been enabled, a warning will be surfaced in the agent logs.
 	script.RunOnStart = false
 	return script
+}
+
+// ExpandAllDevcontainerPaths expands all devcontainer paths in the given
+// devcontainers. This is required by the devcontainer CLI, which requires
+// absolute paths for the workspace folder and config path.
+func ExpandAllDevcontainerPaths(logger slog.Logger, expandPath func(string) (string, error), devcontainers []codersdk.WorkspaceAgentDevcontainer) []codersdk.WorkspaceAgentDevcontainer {
+	expanded := make([]codersdk.WorkspaceAgentDevcontainer, 0, len(devcontainers))
+	for _, dc := range devcontainers {
+		expanded = append(expanded, expandDevcontainerPaths(logger, expandPath, dc))
+	}
+	return expanded
 }
 
 func expandDevcontainerPaths(logger slog.Logger, expandPath func(string) (string, error), dc codersdk.WorkspaceAgentDevcontainer) codersdk.WorkspaceAgentDevcontainer {

--- a/agent/agentcontainers/devcontainer_test.go
+++ b/agent/agentcontainers/devcontainer_test.go
@@ -243,8 +243,7 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 			}
 			gotFilteredScripts, gotDevcontainerScripts := agentcontainers.ExtractAndInitializeDevcontainerScripts(
 				logger,
-				tt.args.expandPath,
-				tt.args.devcontainers,
+				agentcontainers.ExpandAllDevcontainerPaths(logger, tt.args.expandPath, tt.args.devcontainers),
 				tt.args.scripts,
 			)
 

--- a/agent/agentcontainers/devcontainer_test.go
+++ b/agent/agentcontainers/devcontainer_test.go
@@ -242,7 +242,6 @@ func TestExtractAndInitializeDevcontainerScripts(t *testing.T) {
 				}
 			}
 			gotFilteredScripts, gotDevcontainerScripts := agentcontainers.ExtractAndInitializeDevcontainerScripts(
-				logger,
 				agentcontainers.ExpandAllDevcontainerPaths(logger, tt.args.expandPath, tt.args.devcontainers),
 				tt.args.scripts,
 			)


### PR DESCRIPTION
I noticed devcontainers were duplicated in the API because paths weren't absolute, so now we normalize them early on to keep it simple.

Updates #16424
