### PR TITLE
feat: setup url autofill for dynamic parameters

### DIFF
--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -514,6 +514,7 @@ export const MultiSelectCombobox = forwardRef<
 							})}
 							{/* Avoid having the "Search" Icon */}
 							<CommandPrimitive.Input
+								id={inputProps?.id}
 								{...inputProps}
 								ref={inputRef}
 								value={inputValue}

--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -514,7 +514,6 @@ export const MultiSelectCombobox = forwardRef<
 							})}
 							{/* Avoid having the "Search" Icon */}
 							<CommandPrimitive.Input
-								id={inputProps?.id}
 								{...inputProps}
 								ref={inputRef}
 								value={inputValue}

--- a/site/src/components/Select/Select.tsx
+++ b/site/src/components/Select/Select.tsx
@@ -15,7 +15,9 @@ export const SelectValue = SelectPrimitive.Value;
 
 export const SelectTrigger = React.forwardRef<
 	React.ElementRef<typeof SelectPrimitive.Trigger>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & { id?: string }
+	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+		id?: string;
+	}
 >(({ className, children, id, ...props }, ref) => (
 	<SelectPrimitive.Trigger
 		ref={ref}

--- a/site/src/components/Select/Select.tsx
+++ b/site/src/components/Select/Select.tsx
@@ -15,10 +15,11 @@ export const SelectValue = SelectPrimitive.Value;
 
 export const SelectTrigger = React.forwardRef<
 	React.ElementRef<typeof SelectPrimitive.Trigger>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & { id?: string }
+>(({ className, children, id, ...props }, ref) => (
 	<SelectPrimitive.Trigger
 		ref={ref}
+		id={id}
 		className={cn(
 			`flex h-10 w-full font-medium items-center justify-between whitespace-nowrap rounded-md
 			border border-border border-solid bg-transparent px-3 py-2 text-sm shadow-sm

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -62,6 +62,7 @@ export const DynamicParameter: FC<DynamicParameterProps> = ({
 			data-testid={`parameter-field-${parameter.name}`}
 		>
 			<ParameterLabel
+				id={id}
 				parameter={parameter}
 				isPreset={isPreset}
 				autofill={autofill}
@@ -86,12 +87,14 @@ interface ParameterLabelProps {
 	parameter: PreviewParameter;
 	isPreset?: boolean;
 	autofill?: AutofillBuildParameter;
+	id: string;
 }
 
 const ParameterLabel: FC<ParameterLabelProps> = ({
 	parameter,
 	isPreset,
 	autofill,
+	id,
 }) => {
 	const hasDescription = parameter.description && parameter.description !== "";
 	const displayName = parameter.display_name
@@ -109,7 +112,10 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 			)}
 
 			<div className="flex flex-col w-full gap-1">
-				<Label className="flex gap-2 flex-wrap text-sm font-medium">
+				<Label
+					htmlFor={id}
+					className="flex gap-2 flex-wrap text-sm font-medium"
+				>
 					<span className="flex">
 						{displayName}
 						{parameter.required && (
@@ -197,15 +203,12 @@ const ParameterField: FC<ParameterFieldProps> = ({
 	disabled,
 	id,
 }) => {
-	const initialValue =
-		value !== undefined ? value : validValue(parameter.value);
-	const [localValue, setLocalValue] = useState(initialValue);
-
-	useEffect(() => {
-		if (value !== undefined) {
-			setLocalValue(value);
-		}
-	}, [value]);
+	const [localValue, setLocalValue] = useState(
+		value !== undefined ? value : validValue(parameter.value)
+	);
+	if (value !== undefined && value !== localValue) {
+		setLocalValue(value);
+	}
 
 	switch (parameter.form_type) {
 		case "dropdown":
@@ -216,7 +219,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					disabled={disabled}
 					required={parameter.required}
 				>
-					<SelectTrigger>
+					<SelectTrigger id={id}>
 						<SelectValue
 							placeholder={parameter.styling?.placeholder || "Select option"}
 						/>
@@ -256,7 +259,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			return (
 				<MultiSelectCombobox
 					inputProps={{
-						id: `${id}-${parameter.name}`,
+						id: id,
 					}}
 					options={options}
 					defaultOptions={selectedOptions}
@@ -281,7 +284,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 
 			return (
 				<TagInput
-					id={parameter.name}
+					id={id}
 					label={parameter.display_name || parameter.name}
 					values={values}
 					onChange={(values) => {
@@ -294,6 +297,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 		case "switch":
 			return (
 				<Switch
+					id={id}
 					checked={value === "true"}
 					onCheckedChange={(checked) => {
 						onChange(checked ? "true" : "false");
@@ -329,14 +333,14 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			return (
 				<div className="flex items-center space-x-2">
 					<Checkbox
-						id={parameter.name}
+						id={id}
 						checked={value === "true"}
 						onCheckedChange={(checked) => {
 							onChange(checked ? "true" : "false");
 						}}
 						disabled={disabled}
 					/>
-					<Label htmlFor={parameter.name}>{parameter.styling?.label}</Label>
+					<Label htmlFor={id}>{parameter.styling?.label}</Label>
 				</div>
 			);
 
@@ -344,8 +348,9 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			return (
 				<div className="flex flex-row items-baseline gap-3">
 					<Slider
+						id={id}
 						className="mt-2"
-						value={[Number(localValue ?? 0)]}
+						value={[Number(localValue)]}
 						onValueChange={([value]) => {
 							setLocalValue(value.toString());
 							onChange(value.toString());
@@ -361,6 +366,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 		case "textarea":
 			return (
 				<Textarea
+					id={id}
 					className="max-w-2xl"
 					value={localValue}
 					onChange={(e) => {
@@ -397,6 +403,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 
 			return (
 				<Input
+					id={id}
 					type={inputType}
 					value={localValue}
 					onChange={(e) => {

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -32,8 +32,8 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { Info, Link, Settings, TriangleAlert } from "lucide-react";
-import { type FC, useEffect, useId, useState } from "react";
+import { Info, LinkIcon, Settings, TriangleAlert } from "lucide-react";
+import { type FC, useId, useState } from "react";
 import type { AutofillBuildParameter } from "utils/richParameters";
 import * as Yup from "yup";
 
@@ -96,7 +96,6 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 	autofill,
 	id,
 }) => {
-	const hasDescription = parameter.description && parameter.description !== "";
 	const displayName = parameter.display_name
 		? parameter.display_name
 		: parameter.name;
@@ -163,7 +162,7 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 								<TooltipTrigger asChild>
 									<span className="flex items-center">
 										<Badge size="sm">
-											<Link />
+											<LinkIcon />
 											URL Autofill
 										</Badge>
 									</span>
@@ -176,7 +175,7 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 					)}
 				</Label>
 
-				{hasDescription && (
+				{Boolean(parameter.description) && (
 					<div className="text-content-secondary">
 						<MemoizedMarkdown className="text-xs">
 							{parameter.description}
@@ -204,7 +203,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 	id,
 }) => {
 	const [localValue, setLocalValue] = useState(
-		value !== undefined ? value : validValue(parameter.value)
+		value !== undefined ? value : validValue(parameter.value),
 	);
 	if (value !== undefined && value !== localValue) {
 		setLocalValue(value);
@@ -215,7 +214,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			return (
 				<Select
 					onValueChange={onChange}
-					value={value}
+					value={localValue}
 					disabled={disabled}
 					required={parameter.required}
 				>
@@ -235,7 +234,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			);
 
 		case "multi-select": {
-			const values = parseStringArrayValue(value ?? "");
+			const values = parseStringArrayValue(localValue ?? "");
 
 			// Map parameter options to MultiSelectCombobox options format
 			const options: Option[] = parameter.options.map((opt) => ({
@@ -280,7 +279,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 		}
 
 		case "tag-select": {
-			const values = parseStringArrayValue(value ?? "");
+			const values = parseStringArrayValue(localValue ?? "");
 
 			return (
 				<TagInput
@@ -298,7 +297,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			return (
 				<Switch
 					id={id}
-					checked={value === "true"}
+					checked={localValue === "true"}
 					onCheckedChange={(checked) => {
 						onChange(checked ? "true" : "false");
 					}}
@@ -308,7 +307,11 @@ const ParameterField: FC<ParameterFieldProps> = ({
 
 		case "radio":
 			return (
-				<RadioGroup onValueChange={onChange} disabled={disabled} value={value}>
+				<RadioGroup
+					onValueChange={onChange}
+					disabled={disabled}
+					value={localValue}
+				>
 					{parameter.options.map((option) => (
 						<div
 							key={option.value.value}
@@ -334,7 +337,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 				<div className="flex items-center space-x-2">
 					<Checkbox
 						id={id}
-						checked={value === "true"}
+						checked={localValue === "true"}
 						onCheckedChange={(checked) => {
 							onChange(checked ? "true" : "false");
 						}}
@@ -513,9 +516,7 @@ export const getInitialParameterValues = (
 		);
 
 		const useAutofill =
-			autofillParam &&
-			isValidParameterOption(parameter, autofillParam) &&
-			autofillParam.value;
+			autofillParam?.value && isValidParameterOption(parameter, autofillParam);
 
 		return {
 			name: parameter.name,

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -43,7 +43,7 @@ export interface DynamicParameterProps {
 	onChange: (value: string) => void;
 	disabled?: boolean;
 	isPreset?: boolean;
-	autofill?: AutofillBuildParameter;
+	autofill: boolean;
 }
 
 export const DynamicParameter: FC<DynamicParameterProps> = ({
@@ -52,7 +52,7 @@ export const DynamicParameter: FC<DynamicParameterProps> = ({
 	onChange,
 	disabled,
 	isPreset,
-	autofill,
+	autofill = false,
 }) => {
 	const id = useId();
 
@@ -86,7 +86,7 @@ export const DynamicParameter: FC<DynamicParameterProps> = ({
 interface ParameterLabelProps {
 	parameter: PreviewParameter;
 	isPreset?: boolean;
-	autofill?: AutofillBuildParameter;
+	autofill: boolean;
 	id: string;
 }
 

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -232,7 +232,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			);
 
 		case "multi-select": {
-			const values = parseStringArrayValue(value);
+			const values = parseStringArrayValue(value ?? "");
 
 			// Map parameter options to MultiSelectCombobox options format
 			const options: Option[] = parameter.options.map((opt) => ({
@@ -277,7 +277,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 		}
 
 		case "tag-select": {
-			const values = parseStringArrayValue(value);
+			const values = parseStringArrayValue(value ?? "");
 
 			return (
 				<TagInput
@@ -525,8 +525,8 @@ const isValidParameterOption = (
 	previewParam: PreviewParameter,
 	buildParam: WorkspaceBuildParameter,
 ) => {
+	// multi-select is the only list(string) type with options
 	if (previewParam.form_type === "multi-select") {
-		console.log("buildParam.value", buildParam.value);
 		let values: string[] = [];
 		try {
 			const parsed = JSON.parse(buildParam.value);
@@ -541,16 +541,16 @@ const isValidParameterOption = (
 			return false;
 		}
 
-		// If options exist, validate each value
 		if (previewParam.options.length > 0) {
 			const validValues = previewParam.options.map(
 				(option) => option.value.value,
 			);
-			return values.every((value) => validValues.includes(value));
+			return values.some((value) => validValues.includes(value));
 		}
 		return false;
 	}
-	// For parameters with options (dropdown, radio, etc.)
+
+	// For parameters with options (dropdown, radio)
 	if (previewParam.options.length > 0) {
 		const validValues = previewParam.options.map(
 			(option) => option.value.value,
@@ -558,7 +558,7 @@ const isValidParameterOption = (
 		return validValues.includes(buildParam.value);
 	}
 
-	// For parameters without options (input, textarea, etc.)
+	// For parameters without options (input,textarea,switch,checkbox,tag-select)
 	return true;
 };
 

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -42,7 +42,7 @@ import * as Yup from "yup";
 export interface DynamicParameterProps {
 	parameter: PreviewParameter;
 	value?: string;
-	onChange: (value: string) => Promise<void>;
+	onChange: (value: string) => void;
 	disabled?: boolean;
 	isPreset?: boolean;
 	autofill: boolean;
@@ -203,7 +203,7 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 interface DebouncedParameterFieldProps {
 	parameter: PreviewParameter;
 	value?: string;
-	onChange: (value: string) => Promise<void>;
+	onChange: (value: string) => void;
 	disabled?: boolean;
 	id: string;
 }
@@ -239,12 +239,12 @@ const DebouncedParameterField: FC<DebouncedParameterFieldProps> = ({
 					className="max-w-2xl"
 					value={localValue}
 					onChange={(e) => {
-						setLocalValue(e.target.value);
-					}}
-					onInput={(e) => {
 						const target = e.currentTarget;
+						target.style.height = "auto";
 						target.style.maxHeight = "700px";
 						target.style.height = `${target.scrollHeight}px`;
+
+						setLocalValue(e.target.value);
 					}}
 					disabled={disabled}
 					placeholder={parameter.styling?.placeholder}
@@ -290,7 +290,7 @@ const DebouncedParameterField: FC<DebouncedParameterFieldProps> = ({
 interface ParameterFieldProps {
 	parameter: PreviewParameter;
 	value?: string;
-	onChange: (value: string) => Promise<void>;
+	onChange: (value: string) => void;
 	disabled?: boolean;
 	id: string;
 }

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
@@ -91,14 +91,14 @@ const CreateWorkspacePageExperimental: FC = () => {
 	const autofillParameters = getAutofillParameters(searchParams);
 
 	const sendMessage = useCallback((formValues: Record<string, string>) => {
-			const request: DynamicParametersRequest = {
-				id: wsResponseId.current + 1,
-				inputs: formValues,
-			};
-			if (ws.current && ws.current.readyState === WebSocket.OPEN) {
-				ws.current.send(JSON.stringify(request));
-				wsResponseId.current = wsResponseId.current + 1;
-			}
+		const request: DynamicParametersRequest = {
+			id: wsResponseId.current + 1,
+			inputs: formValues,
+		};
+		if (ws.current && ws.current.readyState === WebSocket.OPEN) {
+			ws.current.send(JSON.stringify(request));
+			wsResponseId.current = wsResponseId.current + 1;
+		}
 	}, []);
 
 	// On sends all initial parameter values to the websocket

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -141,30 +141,6 @@ export const CreateWorkspacePageViewExperimental: FC<
 			},
 		});
 
-	// On component mount, sends all initial parameter values to the websocket
-	// (including defaults and autofilled from the url)
-	// This ensures the backend has the complete initial state of the form,
-	// which is vital for correctly rendering dynamic UI elements where parameter visibility
-	// or options might depend on the initial values of other parameters.
-	const hasInitializedWebsocket = useRef(false);
-	useEffect(() => {
-		if (hasInitializedWebsocket.current) return;
-
-		const formValues = form.values.rich_parameter_values;
-		if (parameters.length > 0 && formValues && formValues.length > 0) {
-			const initialParams: Record<string, string> = {};
-			for (const param of formValues) {
-				if (param.name && param.value) {
-					initialParams[param.name] = param.value;
-				}
-			}
-			if (Object.keys(initialParams).length > 0) {
-				sendMessage(initialParams);
-				hasInitializedWebsocket.current = true;
-			}
-		}
-	}, [parameters, form.values.rich_parameter_values, sendMessage]);
-
 	const autofillByName = Object.fromEntries(
 		autofillParameters.map((param) => [param.name, param]),
 	);

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -33,6 +33,7 @@ import {
 	useContext,
 	useEffect,
 	useId,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -140,6 +141,14 @@ export const CreateWorkspacePageViewExperimental: FC<
 				onSubmit(request, owner);
 			},
 		});
+
+	const autofillByName = useMemo(
+		() =>
+			Object.fromEntries(
+				autofillParameters.map((param) => [param.name, param]),
+			),
+		[autofillParameters],
+	);
 
 	useEffect(() => {
 		if (error) {
@@ -509,6 +518,9 @@ export const CreateWorkspacePageViewExperimental: FC<
 										return null;
 									}
 
+									const formValue =
+										form.values?.rich_parameter_values?.[index]?.value || "";
+
 									return (
 										<DynamicParameter
 											key={parameter.name}
@@ -518,6 +530,8 @@ export const CreateWorkspacePageViewExperimental: FC<
 											}
 											disabled={isDisabled}
 											isPreset={isPresetParameter}
+											autofill={autofillByName[parameter.name]}
+											value={formValue}
 										/>
 									);
 								})}

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -554,7 +554,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 											}
 											disabled={isDisabled}
 											isPreset={isPresetParameter}
-											autofill={autofillByName[parameter.name]}
+											autofill={autofillByName[parameter.name] !== undefined}
 											value={formValue}
 										/>
 									);

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -142,6 +142,30 @@ export const CreateWorkspacePageViewExperimental: FC<
 			},
 		});
 
+	// On component mount, sends all initial parameter values to the websocket
+	// (including defaults and autofilled from the url)
+	// This ensures the backend has the complete initial state of the form,
+	// which is vital for correctly rendering dynamic UI elements where parameter visibility
+	// or options might depend on the initial values of other parameters.
+	const hasInitializedWebsocket = useRef(false);
+	useEffect(() => {
+		if (hasInitializedWebsocket.current) return;
+
+		const formValues = form.values.rich_parameter_values;
+		if (parameters.length > 0 && formValues && formValues.length > 0) {
+			const initialParams: { [k: string]: string } = {};
+			for (const param of formValues) {
+				if (param.name && param.value) {
+					initialParams[param.name] = param.value;
+				}
+			}
+			if (Object.keys(initialParams).length > 0) {
+				sendMessage(initialParams);
+				hasInitializedWebsocket.current = true;
+			}
+		}
+	}, [parameters, form.values.rich_parameter_values, sendMessage]);
+
 	const autofillByName = useMemo(
 		() =>
 			Object.fromEntries(

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -33,7 +33,6 @@ import {
 	useContext,
 	useEffect,
 	useId,
-	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -153,7 +152,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 
 		const formValues = form.values.rich_parameter_values;
 		if (parameters.length > 0 && formValues && formValues.length > 0) {
-			const initialParams: { [k: string]: string } = {};
+			const initialParams: Record<string, string> = {};
 			for (const param of formValues) {
 				if (param.name && param.value) {
 					initialParams[param.name] = param.value;
@@ -166,12 +165,8 @@ export const CreateWorkspacePageViewExperimental: FC<
 		}
 	}, [parameters, form.values.rich_parameter_values, sendMessage]);
 
-	const autofillByName = useMemo(
-		() =>
-			Object.fromEntries(
-				autofillParameters.map((param) => [param.name, param]),
-			),
-		[autofillParameters],
+	const autofillByName = Object.fromEntries(
+		autofillParameters.map((param) => [param.name, param]),
 	);
 
 	useEffect(() => {
@@ -251,7 +246,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 		parameter: PreviewParameter,
 		value: string,
 	) => {
-		const formInputs: { [k: string]: string } = {};
+		const formInputs: Record<string, string> = {};
 		formInputs[parameter.name] = value;
 		const parameters = form.values.rich_parameter_values ?? [];
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -19,7 +19,6 @@ import { Spinner } from "components/Spinner/Spinner";
 import { Switch } from "components/Switch/Switch";
 import { UserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
 import { type FormikContextType, useFormik } from "formik";
-import { useDebouncedFunction } from "hooks/debounce";
 import { ArrowLeft, CircleAlert, TriangleAlert } from "lucide-react";
 import {
 	DynamicParameter,
@@ -238,37 +237,17 @@ export const CreateWorkspacePageViewExperimental: FC<
 		sendMessage(formInputs);
 	};
 
-	const { debounced: handleChangeDebounced } = useDebouncedFunction(
-		async (
-			parameter: PreviewParameter,
-			parameterField: string,
-			value: string,
-		) => {
-			await form.setFieldValue(parameterField, {
-				name: parameter.name,
-				value,
-			});
-			form.setFieldTouched(parameter.name, true);
-			sendDynamicParamsRequest(parameter, value);
-		},
-		500,
-	);
-
 	const handleChange = async (
 		parameter: PreviewParameter,
 		parameterField: string,
 		value: string,
 	) => {
-		if (parameter.form_type === "input" || parameter.form_type === "textarea") {
-			handleChangeDebounced(parameter, parameterField, value);
-		} else {
-			await form.setFieldValue(parameterField, {
-				name: parameter.name,
-				value,
-			});
-			form.setFieldTouched(parameter.name, true);
-			sendDynamicParamsRequest(parameter, value);
-		}
+		await form.setFieldValue(parameterField, {
+			name: parameter.name,
+			value,
+		});
+		form.setFieldTouched(parameter.name, true);
+		sendDynamicParamsRequest(parameter, value);
 	};
 
 	return (


### PR DESCRIPTION
resolves coder/preview#80

Parameter autofill allows setting parameters from the url using the format param.[param name]=["purple","green"]

Example:
http://localhost:8080/templates/coder/scratch/workspace?param.list=%5b%22purple%22%2c%22green%22%5d%0a

The goal is to maintain feature parity of for autofill with dynamic parameters.

Note: user history autofill is no longer being used and is being removed.