### PR TITLE
chore: update alpine 3.21.2 => 3.21.3

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -1,7 +1,7 @@
 # This is the base image used for Coder images. It's a multi-arch image that is
 # built in depot.dev for all supported architectures. Since it's built on real
 # hardware and not cross-compiled, it can have "RUN" commands.
-FROM alpine:3.21.2
+FROM alpine:3.21.3
 
 # We use a single RUN command to reduce the number of layers in the image.
 # NOTE: Keep the Terraform version in sync with minTerraformVersion and


### PR DESCRIPTION
Resolves 3 CVEs in base container (1 High, 2 Medium)

| CVE ID         | CVSS Score | Package / Version               |
| -------------- | ---------- | ------------------------------  |
| CVE-2025-26519 | 8.1 High   | apk / alpine/musl / 1.2.5-r8    |
| CVE-2024-12797 | 6.3 Medium | apk / alpine/openssl / 3.3.2-r4 |
| CVE-2024-13176 | 4.1 Medium | apk / alpine/openssl / 3.3.2-r4 |
