### PR TITLE
feat: add hidden `CODER_AGENT_IS_SUB_AGENT` flag to `coder agent`

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -89,6 +89,7 @@ type Options struct {
 	ServiceBannerRefreshInterval time.Duration
 	BlockFileTransfer            bool
 	Execer                       agentexec.Execer
+	SubAgent                     bool
 
 	ExperimentalDevcontainersEnabled bool
 	ContainerAPIOptions              []agentcontainers.Option // Enable ExperimentalDevcontainersEnabled for these to be effective.
@@ -190,6 +191,8 @@ func New(options Options) Agent {
 		metrics:            newAgentMetrics(prometheusRegistry),
 		execer:             options.Execer,
 
+		subAgent: options.SubAgent,
+
 		experimentalDevcontainersEnabled: options.ExperimentalDevcontainersEnabled,
 		containerAPIOptions:              options.ContainerAPIOptions,
 	}
@@ -271,6 +274,8 @@ type agent struct {
 	// labeled in Coder with the agent + workspace.
 	metrics *agentMetrics
 	execer  agentexec.Execer
+
+	subAgent bool
 
 	experimentalDevcontainersEnabled bool
 	containerAPIOptions              []agentcontainers.Option

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -53,6 +53,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 		blockFileTransfer   bool
 		agentHeaderCommand  string
 		agentHeader         []string
+		subAgent            bool
 
 		experimentalDevcontainersEnabled bool
 	)
@@ -350,6 +351,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 				PrometheusRegistry: prometheusRegistry,
 				BlockFileTransfer:  blockFileTransfer,
 				Execer:             execer,
+				SubAgent:           subAgent,
 
 				ExperimentalDevcontainersEnabled: experimentalDevcontainersEnabled,
 			})
@@ -480,6 +482,17 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 			Env:         "CODER_AGENT_DEVCONTAINERS_ENABLE",
 			Description: "Allow the agent to automatically detect running devcontainers.",
 			Value:       serpent.BoolOf(&experimentalDevcontainersEnabled),
+		},
+		{
+			Flag:        "is-sub-agent",
+			Default:     "false",
+			Env:         "CODER_AGENT_IS_SUB_AGENT",
+			Description: "Specify whether this is a sub agent or not.",
+			Value:       serpent.BoolOf(&subAgent),
+			// As `coderd` handles the creation of sub-agents, it does not make
+			// sense for this to be exposed. We do not want people setting an
+			// agent as a sub-agent if it is not.
+			Hidden: true,
 		},
 	}
 


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/620

Adds a new, hidden, flag `CODER_AGENT_IS_SUB_AGENT` to the `coder agent` command.