### PR TITLE
feat: add ConvertUserLoginType func to codersdk

### DIFF
--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -663,7 +663,14 @@ func (c *Client) ChangePasswordWithOneTimePasscode(ctx context.Context, req Chan
 // based authentication to oauth based. The response has the oauth state code
 // to use in the oauth flow.
 func (c *Client) ConvertLoginType(ctx context.Context, req ConvertLoginRequest) (OAuthConversionResponse, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/v2/users/me/convert-login", req)
+	return c.ConvertUserLoginType(ctx, Me, req)
+}
+
+// ConvertUserLoginType will send a request to convert the user from password
+// based authentication to oauth based. The response has the oauth state code
+// to use in the oauth flow.
+func (c *Client) ConvertUserLoginType(ctx context.Context, user string, req ConvertLoginRequest) (OAuthConversionResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/users/%s/convert-login", user), req)
 	if err != nil {
 		return OAuthConversionResponse{}, err
 	}


### PR DESCRIPTION
🚀 New Feature

Added `ConvertUserLoginType(ctx, user, req)` method to support converting the login type for a specified user.

📌 Background

The existing `ConvertLoginType` method only supports converting the current user's login type (via the /api/v2/users/me/convert-login endpoint).

In our use case, we needed to convert the login type for other users programmatically, which the SDK did not support.

This new method constructs the endpoint dynamically using the provided username, enabling conversion for any user.

✅ Compatibility

This is an additive change and does not modify any existing functionality.

The original ConvertLoginType remains unchanged.