### PR TITLE
fix: don't open a window for external apps

### DIFF
--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -55,6 +55,10 @@ export const useAppLink = (
 			window.addEventListener("blur", () => {
 				clearTimeout(openAppExternallyFailed);
 			});
+
+			// External apps don't support open_in since they only should open
+			// external apps.
+			return;
 		}
 
 		switch (app.open_in) {


### PR DESCRIPTION
This prevents empty windows like the following to happen:
![image](https://github.com/user-attachments/assets/0a444938-316e-4d48-bdfc-770d1b4b2bf0)
