### PR TITLE
chore: retry failed race tests in CI

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -42,7 +42,7 @@ runs:
 
     - name: Install gotestsum
       shell: bash
-      run: go install gotest.tools/gotestsum@3f7ff0ec4aeb6f95f5d67c998b71f272aa8a8b41 # v1.12.1
+      run: go install gotest.tools/gotestsum@0d9599e513d70e5792bb9334869f82f6e8b53d4d # main as of 2025-05-15
 
     # It isn't necessary that we ever do this, but it helps
     # separate the "setup" from the "run" times.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -613,7 +613,7 @@ jobs:
       # c.f. discussion on https://github.com/coder/coder/pull/15106
       - name: Run Tests
         run: |
-          gotestsum --junitfile="gotests.xml" -- -race -parallel 4 -p 4 ./...
+          gotestsum --junitfile="gotests.xml" --packages="./..." --rerun-fails=2 --rerun-fails-abort-on-data-race -- -race -parallel 4 -p 4
 
       - name: Upload Test Cache
         uses: ./.github/actions/test-cache/upload
@@ -665,7 +665,7 @@ jobs:
           POSTGRES_VERSION: "16"
         run: |
           make test-postgres-docker
-          DB=ci gotestsum --junitfile="gotests.xml" -- -race -parallel 4 -p 4 ./...
+          DB=ci gotestsum --junitfile="gotests.xml" --packages="./..." --rerun-fails=2 --rerun-fails-abort-on-data-race -- -race -parallel 4 -p 4
 
       - name: Upload Test Cache
         uses: ./.github/actions/test-cache/upload


### PR DESCRIPTION
This PR enables retrying failed tests in the race suites unless a data race was detected. The goal is to reduce how often flakes disrupt developers' workflows.

I bumped gotestsum to a revision from the `main` branch because it includes the `--rerun-fails-abort-on-data-race` flag which [I recently contributed](https://github.com/gotestyourself/gotestsum/pull/497).

Incidentally, you can see it [in action in a CI job on this very PR](https://github.com/coder/coder/actions/runs/15040840724/job/42271999592?pr=17846#step:8:647).