### PR TITLE
fix: avoid pulling containers when it is not enabled

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2453,21 +2453,11 @@ class ApiMethods {
 		const params = new URLSearchParams(
 			labels?.map((label) => ["label", label]),
 		);
-
-		try {
-			const res =
-				await this.axios.get<TypesGen.WorkspaceAgentListContainersResponse>(
-					`/api/v2/workspaceagents/${agentId}/containers?${params.toString()}`,
-				);
-			return res.data;
-		} catch (err) {
-			// If the error is a 403, it means that experimental
-			// containers are not enabled on the agent.
-			if (isAxiosError(err) && err.response?.status === 403) {
-				return { containers: [] };
-			}
-			throw err;
-		}
+		const res =
+			await this.axios.get<TypesGen.WorkspaceAgentListContainersResponse>(
+				`/api/v2/workspaceagents/${agentId}/containers?${params.toString()}`,
+			);
+		return res.data;
 	};
 
 	getInboxNotifications = async (startingBeforeId?: string) => {

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -40,6 +40,7 @@ import { PortForwardButton } from "./PortForwardButton";
 import { AgentSSHButton } from "./SSHButton/SSHButton";
 import { TerminalLink } from "./TerminalLink/TerminalLink";
 import { VSCodeDesktopButton } from "./VSCodeDesktopButton/VSCodeDesktopButton";
+import { isAxiosError } from "axios";
 
 export interface AgentRowProps {
 	agent: WorkspaceAgent;
@@ -160,7 +161,12 @@ export const AgentRow: FC<AgentRowProps> = ({
 		select: (res) => res.containers.filter((c) => c.status === "running"),
 		// TODO: Implement a websocket connection to get updates on containers
 		// without having to poll.
-		refetchInterval: 10_000,
+		refetchInterval: (_, query) => {
+			const { error } = query.state;
+			return isAxiosError(error) && error.response?.status === 403
+				? false
+				: 10_000;
+		},
 	});
 
 	return (

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -10,6 +10,7 @@ import type {
 	WorkspaceAgent,
 	WorkspaceAgentMetadata,
 } from "api/typesGenerated";
+import { isAxiosError } from "axios";
 import { DropdownArrow } from "components/DropdownArrow/DropdownArrow";
 import type { Line } from "components/Logs/LogLine";
 import { Stack } from "components/Stack/Stack";
@@ -40,7 +41,6 @@ import { PortForwardButton } from "./PortForwardButton";
 import { AgentSSHButton } from "./SSHButton/SSHButton";
 import { TerminalLink } from "./TerminalLink/TerminalLink";
 import { VSCodeDesktopButton } from "./VSCodeDesktopButton/VSCodeDesktopButton";
-import { isAxiosError } from "axios";
 
 export interface AgentRowProps {
 	agent: WorkspaceAgent;


### PR DESCRIPTION
We've been continuously pulling the containers endpoint even when the agent does not support containers. To optimize the requests, we can check if it is throwing an error and stop if it is a 403 status code.