### PR TITLE
chore: replace MUI icons with Lucide icons - 15

### DIFF
--- a/site/src/components/GitDeviceAuth/GitDeviceAuth.tsx
+++ b/site/src/components/GitDeviceAuth/GitDeviceAuth.tsx
@@ -1,5 +1,4 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import AlertTitle from "@mui/material/AlertTitle";
 import CircularProgress from "@mui/material/CircularProgress";
 import Link from "@mui/material/Link";
@@ -8,6 +7,7 @@ import type { ExternalAuthDevice } from "api/typesGenerated";
 import { isAxiosError } from "axios";
 import { Alert, AlertDetail } from "components/Alert/Alert";
 import { CopyButton } from "components/CopyButton/CopyButton";
+import { ExternalLinkIcon } from "lucide-react";
 import type { FC } from "react";
 
 interface GitDeviceAuthProps {
@@ -146,7 +146,7 @@ export const GitDeviceAuth: FC<GitDeviceAuthProps> = ({
 					target="_blank"
 					rel="noreferrer"
 				>
-					<OpenInNewIcon fontSize="small" />
+					<ExternalLinkIcon className="size-icon-xs" />
 					Open and Paste
 				</Link>
 			</div>

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -4,12 +4,6 @@ import {
 	type Theme,
 	css,
 } from "@emotion/react";
-import AccountIcon from "@mui/icons-material/AccountCircleOutlined";
-import BugIcon from "@mui/icons-material/BugReportOutlined";
-import ChatIcon from "@mui/icons-material/ChatOutlined";
-import LogoutIcon from "@mui/icons-material/ExitToAppOutlined";
-import LaunchIcon from "@mui/icons-material/LaunchOutlined";
-import DocsIcon from "@mui/icons-material/MenuBook";
 import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
@@ -19,7 +13,12 @@ import { CopyButton } from "components/CopyButton/CopyButton";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { Stack } from "components/Stack/Stack";
 import { usePopover } from "components/deprecated/Popover/Popover";
-import { MonitorDownIcon } from "lucide-react";
+import { BookOpenTextIcon } from "lucide-react";
+import { BugIcon } from "lucide-react";
+import { CircleUserIcon } from "lucide-react";
+import { LogOutIcon } from "lucide-react";
+import { MessageSquareIcon } from "lucide-react";
+import { MonitorDownIcon, SquareArrowOutUpRightIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link } from "react-router-dom";
 
@@ -53,9 +52,9 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 			case "bug":
 				return <BugIcon css={styles.menuItemIcon} />;
 			case "chat":
-				return <ChatIcon css={styles.menuItemIcon} />;
+				return <MessageSquareIcon css={styles.menuItemIcon} />;
 			case "docs":
-				return <DocsIcon css={styles.menuItemIcon} />;
+				return <BookOpenTextIcon css={styles.menuItemIcon} />;
 			case "star":
 				return <GithubStar css={styles.menuItemIcon} />;
 			default:
@@ -86,13 +85,13 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 
 			<Link to="/settings/account" css={styles.link}>
 				<MenuItem css={styles.menuItem} onClick={onPopoverClose}>
-					<AccountIcon css={styles.menuItemIcon} />
+					<CircleUserIcon css={styles.menuItemIcon} />
 					<span css={styles.menuItemText}>{Language.accountLabel}</span>
 				</MenuItem>
 			</Link>
 
 			<MenuItem css={styles.menuItem} onClick={onSignOut}>
-				<LogoutIcon css={styles.menuItemIcon} />
+				<LogOutIcon css={styles.menuItemIcon} />
 				<span css={styles.menuItemText}>{Language.signOutLabel}</span>
 			</MenuItem>
 
@@ -126,7 +125,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 						target="_blank"
 						rel="noreferrer"
 					>
-						{buildInfo?.version} <LaunchIcon />
+						{buildInfo?.version} <SquareArrowOutUpRightIcon />
 					</a>
 				</Tooltip>
 

--- a/site/src/modules/notifications/utils.tsx
+++ b/site/src/modules/notifications/utils.tsx
@@ -1,13 +1,13 @@
-import EmailIcon from "@mui/icons-material/EmailOutlined";
-import WebhookIcon from "@mui/icons-material/WebhookOutlined";
+import { MailIcon } from "lucide-react";
+import { WebhookIcon } from "lucide-react";
 
 // TODO: This should be provided by the auto generated types from codersdk
 const notificationMethods = ["smtp", "webhook"] as const;
 
 export type NotificationMethod = (typeof notificationMethods)[number];
 
-export const methodIcons: Record<NotificationMethod, typeof EmailIcon> = {
-	smtp: EmailIcon,
+export const methodIcons: Record<NotificationMethod, typeof MailIcon> = {
+	smtp: MailIcon,
 	webhook: WebhookIcon,
 };
 

--- a/site/src/modules/provisioners/Provisioner.tsx
+++ b/site/src/modules/provisioners/Provisioner.tsx
@@ -1,9 +1,9 @@
 import { useTheme } from "@emotion/react";
-import Business from "@mui/icons-material/Business";
-import Person from "@mui/icons-material/Person";
 import Tooltip from "@mui/material/Tooltip";
 import type { HealthMessage, ProvisionerDaemon } from "api/typesGenerated";
 import { Pill } from "components/Pill/Pill";
+import { Building2Icon } from "lucide-react";
+import { UserIcon } from "lucide-react";
 import type { FC } from "react";
 import { createDayString } from "utils/createDayString";
 import { ProvisionerTag } from "./ProvisionerTag";
@@ -19,7 +19,12 @@ export const Provisioner: FC<ProvisionerProps> = ({
 }) => {
 	const theme = useTheme();
 	const daemonScope = provisioner.tags.scope || "organization";
-	const iconScope = daemonScope === "organization" ? <Business /> : <Person />;
+	const iconScope =
+		daemonScope === "organization" ? (
+			<Building2Icon className="size-icon-sm" />
+		) : (
+			<UserIcon className="size-icon-sm" />
+		);
 
 	const extraTags = Object.entries(provisioner.tags).filter(
 		([key]) => key !== "scope" && key !== "owner",

--- a/site/src/modules/resources/AppLink/ShareIcon.tsx
+++ b/site/src/modules/resources/AppLink/ShareIcon.tsx
@@ -1,8 +1,8 @@
 import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
-import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
 import PublicOutlinedIcon from "@mui/icons-material/PublicOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import type * as TypesGen from "api/typesGenerated";
+import { SquareArrowOutUpRightIcon } from "lucide-react";
 
 export interface ShareIconProps {
 	app: TypesGen.WorkspaceApp;
@@ -12,7 +12,7 @@ export const ShareIcon = ({ app }: ShareIconProps) => {
 	if (app.external) {
 		return (
 			<Tooltip title="Open external URL">
-				<LaunchOutlinedIcon />
+				<SquareArrowOutUpRightIcon />
 			</Tooltip>
 		);
 	}

--- a/site/src/pages/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -1,5 +1,4 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import type { ApiErrorResponse } from "api/errors";
@@ -9,6 +8,7 @@ import { Avatar } from "components/Avatar/Avatar";
 import { GitDeviceAuth } from "components/GitDeviceAuth/GitDeviceAuth";
 import { SignInLayout } from "components/SignInLayout/SignInLayout";
 import { Welcome } from "components/Welcome/Welcome";
+import { ExternalLinkIcon } from "lucide-react";
 import { RotateCwIcon } from "lucide-react";
 import type { FC, ReactNode } from "react";
 
@@ -120,7 +120,7 @@ const ExternalAuthPageView: FC<ExternalAuthPageViewProps> = ({
 							rel="noreferrer"
 							css={styles.link}
 						>
-							<OpenInNewIcon fontSize="small" />
+							<ExternalLinkIcon className="size-icon-xs" />
 							{externalAuth.installations.length > 0 ? "Configure" : "Install"}{" "}
 							the {externalAuth.display_name} App
 						</Link>

--- a/site/src/pages/LoginPage/TermsOfServiceLink.tsx
+++ b/site/src/pages/LoginPage/TermsOfServiceLink.tsx
@@ -1,5 +1,5 @@
-import LaunchIcon from "@mui/icons-material/LaunchOutlined";
 import Link from "@mui/material/Link";
+import { SquareArrowOutUpRightIcon } from "lucide-react";
 import type { FC } from "react";
 
 interface TermsOfServiceLinkProps {
@@ -21,7 +21,7 @@ export const TermsOfServiceLink: FC<TermsOfServiceLinkProps> = ({
 				rel="noreferrer"
 			>
 				Terms of Service&nbsp;
-				<LaunchIcon css={{ fontSize: 12 }} />
+				<SquareArrowOutUpRightIcon className="size-icon-xs" />
 			</Link>
 		</div>
 	);

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
@@ -1,4 +1,3 @@
-import PersonAdd from "@mui/icons-material/PersonAdd";
 import { getErrorMessage } from "api/errors";
 import type {
 	Group,
@@ -35,6 +34,7 @@ import {
 } from "components/Table/Table";
 import { UserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
 import type { PaginationResultInfo } from "hooks/usePaginatedQuery";
+import { UserPlusIcon } from "lucide-react";
 import { EllipsisVertical, TriangleAlert } from "lucide-react";
 import { UserGroupsCell } from "pages/UsersPage/UsersTable/UserGroupsCell";
 import { type FC, useState } from "react";
@@ -243,7 +243,7 @@ const AddOrganizationMember: FC<AddOrganizationMemberProps> = ({
 					variant="outline"
 				>
 					<Spinner loading={isLoading}>
-						<PersonAdd />
+						<UserPlusIcon className="size-icon-sm" />
 					</Spinner>
 					Add user
 				</Button>

--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -4,7 +4,6 @@ import AppsIcon from "@mui/icons-material/Apps";
 import CheckCircle from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
-import OpenInNew from "@mui/icons-material/OpenInNew";
 import Warning from "@mui/icons-material/Warning";
 import CircularProgress from "@mui/material/CircularProgress";
 import Link from "@mui/material/Link";
@@ -16,6 +15,7 @@ import type {
 	WorkspaceApp,
 } from "api/typesGenerated";
 import { formatDistance, formatDistanceToNow } from "date-fns";
+import { ExternalLinkIcon } from "lucide-react";
 import { HourglassIcon } from "lucide-react";
 import { CircleHelpIcon } from "lucide-react";
 import { useAppLink } from "modules/apps/useAppLink";
@@ -304,7 +304,10 @@ export const AppStatuses: FC<AppStatusesProps> = ({
 													},
 												}}
 											>
-												<OpenInNew sx={{ mr: 0.5 }} />
+												<ExternalLinkIcon
+													className="size-icon-xs"
+													style={{ marginRight: "4px" }}
+												/>
 												<div
 													css={{
 														bgcolor: "transparent",


### PR DESCRIPTION
AccountCircleOutlined -> CircleUserIcon
BugReportOutlined -> BugIcon
ChatOutlined -> MessageSquareIcon
ExitToAppOutlined -> LogOutIcon
LaunchOutlined -> SquareArrowOutUpRightIcon
MenuBook -> BookOpenTextIcon
OpenInNew -> EternalLinkIcon
EmailOutlined -> MailIcon
WebhookOutlined -> WebhookIcon
Business -> Building2Icon
Person -> UserIcon