### PR TITLE
feat: make database connection settings configurable

### DIFF
--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -9,10 +9,11 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
-	"github.com/coder/coder/v2/coderd/database/awsiamrds"
-	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/pretty"
 	"github.com/coder/serpent"
+
+	"github.com/coder/coder/v2/coderd/database/awsiamrds"
+	"github.com/coder/coder/v2/codersdk"
 
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/database"
@@ -46,7 +47,7 @@ func (*RootCmd) resetPassword() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := ConnectToPostgres(inv.Context(), logger, sqlDriver, postgresURL, nil)
+			sqlDB, err := ConnectToPostgres(inv.Context(), logger, sqlDriver, postgresURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 			if err != nil {
 				return xerrors.Errorf("dial postgres: %w", err)
 			}

--- a/cli/server.go
+++ b/cli/server.go
@@ -2392,6 +2392,13 @@ func ConnectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 	sqlDB.SetMaxOpenConns(maxConns)
 	sqlDB.SetMaxIdleConns(idleConns)
 
+	if maxConns == 0 {
+		logger.Warn(ctx, "unlimited max postgres connections configured, this is discouraged")
+	}
+	if idleConns == 0 {
+		logger.Warn(ctx, "unlimited idle postgres connections configured, this is discouraged")
+	}
+
 	return sqlDB, nil
 }
 

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -11,6 +11,8 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
+	"github.com/coder/serpent"
+
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/awsiamrds"
@@ -20,7 +22,6 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/userpassword"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/serpent"
 )
 
 func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
@@ -72,7 +73,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := ConnectToPostgres(ctx, logger, sqlDriver, newUserDBURL, nil)
+			sqlDB, err := ConnectToPostgres(ctx, logger, sqlDriver, newUserDBURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}

--- a/cli/server_regenerate_vapid_keypair.go
+++ b/cli/server_regenerate_vapid_keypair.go
@@ -10,12 +10,13 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
 
+	"github.com/coder/serpent"
+
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/awsiamrds"
 	"github.com/coder/coder/v2/coderd/webpush"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/serpent"
 )
 
 func (r *RootCmd) newRegenerateVapidKeypairCommand() *serpent.Command {
@@ -60,7 +61,7 @@ func (r *RootCmd) newRegenerateVapidKeypairCommand() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := ConnectToPostgres(ctx, logger, sqlDriver, regenVapidKeypairDBURL, nil)
+			sqlDB, err := ConnectToPostgres(ctx, logger, sqlDriver, regenVapidKeypairDBURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -40,6 +40,7 @@ import (
 	"tailscale.com/types/key"
 
 	"cdr.dev/slog/sloggers/slogtest"
+
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clitest"
@@ -2150,7 +2151,7 @@ func TestConnectToPostgres(t *testing.T) {
 		dbURL, err := dbtestutil.Open(t)
 		require.NoError(t, err)
 
-		sqlDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL, migrations.Up)
+		sqlDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL, migrations.Up, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			_ = sqlDB.Close()
@@ -2169,7 +2170,7 @@ func TestConnectToPostgres(t *testing.T) {
 		dbURL, err := dbtestutil.Open(t)
 		require.NoError(t, err)
 
-		okDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL, nil)
+		okDB, err := cli.ConnectToPostgres(ctx, log, "postgres", dbURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 		require.NoError(t, err)
 		defer okDB.Close()
 
@@ -2177,7 +2178,7 @@ func TestConnectToPostgres(t *testing.T) {
 		_, err = okDB.Exec(`UPDATE schema_migrations SET version = version + 1`)
 		require.NoError(t, err)
 
-		_, err = cli.ConnectToPostgres(ctx, log, "postgres", dbURL, nil)
+		_, err = cli.ConnectToPostgres(ctx, log, "postgres", dbURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "database needs migration")
 

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -63,11 +63,11 @@ OPTIONS:
 
       --postgres-idle-conns int, $CODER_PG_IDLE_CONNS (default: 3)
           The number of idle connections to maintain in the connection pool. 0
-          is unlimited.
+          is unlimited, but we advise against using this.
 
       --postgres-max-conns int, $CODER_PG_MAX_CONNS (default: 10)
           The maximum number of connections to maintain in the connection pool.
-          0 is unlimited.
+          0 is unlimited, but we advise against using this.
 
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -62,10 +62,12 @@ OPTIONS:
           URL must be URL-encoded.
 
       --postgres-idle-conns int, $CODER_PG_IDLE_CONNS (default: 3)
-          The number of idle connections to maintain in the connection pool.
+          The number of idle connections to maintain in the connection pool. 0
+          is unlimited.
 
       --postgres-max-conns int, $CODER_PG_MAX_CONNS (default: 10)
           The maximum number of connections to maintain in the connection pool.
+          0 is unlimited.
 
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -61,6 +61,12 @@ OPTIONS:
           server postgres-builtin-url". Note that any special characters in the
           URL must be URL-encoded.
 
+      --postgres-idle-conns int, $CODER_PG_IDLE_CONNS (default: 3)
+          The number of idle connections to maintain in the connection pool.
+
+      --postgres-max-conns int, $CODER_PG_MAX_CONNS (default: 10)
+          The maximum number of connections to maintain in the connection pool.
+
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are
           "ed25519", "ecdsa", or "rsa4096".

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -469,10 +469,12 @@ ephemeralDeployment: false
 # authentication (awsiamrds) is recommended.
 # (default: password, type: enum[password\|awsiamrds])
 pgAuth: password
-# The maximum number of connections to maintain in the connection pool.
+# The maximum number of connections to maintain in the connection pool. 0 is
+# unlimited.
 # (default: 10, type: int)
 pgMaxConns: 10
-# The number of idle connections to maintain in the connection pool.
+# The number of idle connections to maintain in the connection pool. 0 is
+# unlimited.
 # (default: 3, type: int)
 pgIdleConns: 3
 # A URL to an external Terms of Service that must be accepted by users when

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -470,11 +470,11 @@ ephemeralDeployment: false
 # (default: password, type: enum[password\|awsiamrds])
 pgAuth: password
 # The maximum number of connections to maintain in the connection pool. 0 is
-# unlimited.
+# unlimited, but we advise against using this.
 # (default: 10, type: int)
 pgMaxConns: 10
 # The number of idle connections to maintain in the connection pool. 0 is
-# unlimited.
+# unlimited, but we advise against using this.
 # (default: 3, type: int)
 pgIdleConns: 3
 # A URL to an external Terms of Service that must be accepted by users when

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -469,6 +469,12 @@ ephemeralDeployment: false
 # authentication (awsiamrds) is recommended.
 # (default: password, type: enum[password\|awsiamrds])
 pgAuth: password
+# The maximum number of connections to maintain in the connection pool.
+# (default: 10, type: int)
+pgMaxConns: 10
+# The number of idle connections to maintain in the connection pool.
+# (default: 3, type: int)
+pgIdleConns: 3
 # A URL to an external Terms of Service that must be accepted by users when
 # logging in.
 # (default: <unset>, type: string)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12432,6 +12432,12 @@ const docTemplate = `{
                 "pg_connection_url": {
                     "type": "string"
                 },
+                "pg_idle_conns": {
+                    "type": "integer"
+                },
+                "pg_max_conns": {
+                    "type": "integer"
+                },
                 "pprof": {
                     "$ref": "#/definitions/codersdk.PprofConfig"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -11142,6 +11142,12 @@
 				"pg_connection_url": {
 					"type": "string"
 				},
+				"pg_idle_conns": {
+					"type": "integer"
+				},
+				"pg_max_conns": {
+					"type": "integer"
+				},
 				"pprof": {
 					"$ref": "#/definitions/codersdk.PprofConfig"
 				},

--- a/coderd/database/awsiamrds/awsiamrds_test.go
+++ b/coderd/database/awsiamrds/awsiamrds_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/awsiamrds"
 	"github.com/coder/coder/v2/coderd/database/migrations"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -33,7 +34,7 @@ func TestDriver(t *testing.T) {
 	sqlDriver, err := awsiamrds.Register(ctx, "postgres")
 	require.NoError(t, err)
 
-	db, err := cli.ConnectToPostgres(ctx, testutil.Logger(t), sqlDriver, url, migrations.Up)
+	db, err := cli.ConnectToPostgres(ctx, testutil.Logger(t), sqlDriver, url, migrations.Up, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 	require.NoError(t, err)
 	defer func() {
 		_ = db.Close()

--- a/codersdk/database.go
+++ b/codersdk/database.go
@@ -6,6 +6,8 @@ const DatabaseNotReachable = "database not reachable"
 
 var ErrDatabaseNotReachable = xerrors.New(DatabaseNotReachable)
 
+// @typescript-ignore DefaultMaxConns
+// @typescript-ignore DefaultIdleConns
 const (
 	DefaultMaxConns = 10
 	// DefaultIdleConns is set to 3 idle connections because lower values end up

--- a/codersdk/database.go
+++ b/codersdk/database.go
@@ -5,3 +5,19 @@ import "golang.org/x/xerrors"
 const DatabaseNotReachable = "database not reachable"
 
 var ErrDatabaseNotReachable = xerrors.New(DatabaseNotReachable)
+
+const (
+	DefaultMaxConns = 10
+	// DefaultIdleConns is set to 3 idle connections because lower values end up
+	// creating a lot of connection churn. Since each connection uses about
+	// 10MB of memory, we're allocating 30MB to Postgres connections per
+	// replica, but is better than causing Postgres to spawn a thread 15-20
+	// times/sec. PGBouncer's transaction pooling is not the greatest so
+	// it's not optimal for us to deploy.
+	//
+	// This was set to 10 before we started doing HA deployments, but 3 was
+	// later determined to be a better middle ground as to not use up all
+	// of PGs default connection limit while simultaneously avoiding a lot
+	// of connection churn.
+	DefaultIdleConns = 3
+)

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2422,7 +2422,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "Postgres Max Connections",
-			Description: "The maximum number of connections to maintain in the connection pool.",
+			Description: "The maximum number of connections to maintain in the connection pool. 0 is unlimited.",
 			Flag:        "postgres-max-conns",
 			Env:         "CODER_PG_MAX_CONNS",
 			Default:     strconv.Itoa(DefaultMaxConns),
@@ -2431,7 +2431,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "Postgres Idle Connections",
-			Description: "The number of idle connections to maintain in the connection pool.",
+			Description: "The number of idle connections to maintain in the connection pool. 0 is unlimited.",
 			Flag:        "postgres-idle-conns",
 			Env:         "CODER_PG_IDLE_CONNS",
 			Default:     strconv.Itoa(DefaultIdleConns),

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2426,7 +2426,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Flag:        "postgres-max-conns",
 			Env:         "CODER_PG_MAX_CONNS",
 			Default:     strconv.Itoa(DefaultMaxConns),
-			Value:       &c.PostgresMaxConns,
+			Value:       serpent.Validate(&c.PostgresMaxConns, ensureNonNegative),
 			YAML:        "pgMaxConns",
 		},
 		{
@@ -2435,7 +2435,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Flag:        "postgres-idle-conns",
 			Env:         "CODER_PG_IDLE_CONNS",
 			Default:     strconv.Itoa(DefaultIdleConns),
-			Value:       &c.PostgresIdleConns,
+			Value:       serpent.Validate(&c.PostgresIdleConns, ensureNonNegative),
 			YAML:        "pgIdleConns",
 		},
 		{
@@ -3109,6 +3109,18 @@ Write out the current server config as YAML to stdout.`,
 	}
 
 	return opts
+}
+
+func ensureNonNegative(value *serpent.Int64) error {
+	if value == nil {
+		return nil
+	}
+
+	if *value < 0 {
+		return xerrors.Errorf("value cannot be negative: %v", *value)
+	}
+
+	return nil
 }
 
 type AIProviderConfig struct {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -356,6 +356,8 @@ type DeploymentValues struct {
 	EphemeralDeployment             serpent.Bool                         `json:"ephemeral_deployment,omitempty" typescript:",notnull"`
 	PostgresURL                     serpent.String                       `json:"pg_connection_url,omitempty" typescript:",notnull"`
 	PostgresAuth                    string                               `json:"pg_auth,omitempty" typescript:",notnull"`
+	PostgresMaxConns                serpent.Int64                        `json:"pg_max_conns,omitempty" typescript:",notnull"`
+	PostgresIdleConns               serpent.Int64                        `json:"pg_idle_conns,omitempty" typescript:",notnull"`
 	OAuth2                          OAuth2Config                         `json:"oauth2,omitempty" typescript:",notnull"`
 	OIDC                            OIDCConfig                           `json:"oidc,omitempty" typescript:",notnull"`
 	Telemetry                       TelemetryConfig                      `json:"telemetry,omitempty" typescript:",notnull"`
@@ -2417,6 +2419,24 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Default:     "password",
 			Value:       serpent.EnumOf(&c.PostgresAuth, PostgresAuthDrivers...),
 			YAML:        "pgAuth",
+		},
+		{
+			Name:        "Postgres Max Connections",
+			Description: "The maximum number of connections to maintain in the connection pool.",
+			Flag:        "postgres-max-conns",
+			Env:         "CODER_PG_MAX_CONNS",
+			Default:     strconv.Itoa(DefaultMaxConns),
+			Value:       &c.PostgresMaxConns,
+			YAML:        "pgMaxConns",
+		},
+		{
+			Name:        "Postgres Idle Connections",
+			Description: "The number of idle connections to maintain in the connection pool.",
+			Flag:        "postgres-idle-conns",
+			Env:         "CODER_PG_IDLE_CONNS",
+			Default:     strconv.Itoa(DefaultIdleConns),
+			Value:       &c.PostgresIdleConns,
+			YAML:        "pgIdleConns",
 		},
 		{
 			Name:        "Secure Auth Cookie",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2422,7 +2422,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "Postgres Max Connections",
-			Description: "The maximum number of connections to maintain in the connection pool. 0 is unlimited.",
+			Description: "The maximum number of connections to maintain in the connection pool. 0 is unlimited, but we advise against using this.",
 			Flag:        "postgres-max-conns",
 			Env:         "CODER_PG_MAX_CONNS",
 			Default:     strconv.Itoa(DefaultMaxConns),
@@ -2431,7 +2431,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "Postgres Idle Connections",
-			Description: "The number of idle connections to maintain in the connection pool. 0 is unlimited.",
+			Description: "The number of idle connections to maintain in the connection pool. 0 is unlimited, but we advise against using this.",
 			Flag:        "postgres-idle-conns",
 			Env:         "CODER_PG_IDLE_CONNS",
 			Default:     strconv.Itoa(DefaultIdleConns),

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -408,6 +408,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     },
     "pg_auth": "string",
     "pg_connection_url": "string",
+    "pg_idle_conns": 0,
+    "pg_max_conns": 0,
     "pprof": {
       "address": {
         "host": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2577,6 +2577,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     },
     "pg_auth": "string",
     "pg_connection_url": "string",
+    "pg_idle_conns": 0,
+    "pg_max_conns": 0,
     "pprof": {
       "address": {
         "host": "string",
@@ -3075,6 +3077,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   },
   "pg_auth": "string",
   "pg_connection_url": "string",
+  "pg_idle_conns": 0,
+  "pg_max_conns": 0,
   "pprof": {
     "address": {
       "host": "string",
@@ -3248,6 +3252,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `oidc`                               | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                           | false    |              |                                                                    |
 | `pg_auth`                            | string                                                                                               | false    |              |                                                                    |
 | `pg_connection_url`                  | string                                                                                               | false    |              |                                                                    |
+| `pg_idle_conns`                      | integer                                                                                              | false    |              |                                                                    |
+| `pg_max_conns`                       | integer                                                                                              | false    |              |                                                                    |
 | `pprof`                              | [codersdk.PprofConfig](#codersdkpprofconfig)                                                         | false    |              |                                                                    |
 | `prometheus`                         | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                               | false    |              |                                                                    |
 | `provisioner`                        | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                             | false    |              |                                                                    |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -991,7 +991,7 @@ Type of auth to use when connecting to postgres. For AWS RDS, using IAM authenti
 | YAML        | <code>pgMaxConns</code>          |
 | Default     | <code>10</code>                  |
 
-The maximum number of connections to maintain in the connection pool. 0 is unlimited.
+The maximum number of connections to maintain in the connection pool. 0 is unlimited, but we advise against using this.
 
 ### --postgres-idle-conns
 
@@ -1002,7 +1002,7 @@ The maximum number of connections to maintain in the connection pool. 0 is unlim
 | YAML        | <code>pgIdleConns</code>          |
 | Default     | <code>3</code>                    |
 
-The number of idle connections to maintain in the connection pool. 0 is unlimited.
+The number of idle connections to maintain in the connection pool. 0 is unlimited, but we advise against using this.
 
 ### --secure-auth-cookie
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -991,7 +991,7 @@ Type of auth to use when connecting to postgres. For AWS RDS, using IAM authenti
 | YAML        | <code>pgMaxConns</code>          |
 | Default     | <code>10</code>                  |
 
-The maximum number of connections to maintain in the connection pool.
+The maximum number of connections to maintain in the connection pool. 0 is unlimited.
 
 ### --postgres-idle-conns
 
@@ -1002,7 +1002,7 @@ The maximum number of connections to maintain in the connection pool.
 | YAML        | <code>pgIdleConns</code>          |
 | Default     | <code>3</code>                    |
 
-The number of idle connections to maintain in the connection pool.
+The number of idle connections to maintain in the connection pool. 0 is unlimited.
 
 ### --secure-auth-cookie
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -982,6 +982,28 @@ URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded f
 
 Type of auth to use when connecting to postgres. For AWS RDS, using IAM authentication (awsiamrds) is recommended.
 
+### --postgres-max-conns
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>int</code>                 |
+| Environment | <code>$CODER_PG_MAX_CONNS</code> |
+| YAML        | <code>pgMaxConns</code>          |
+| Default     | <code>10</code>                  |
+
+The maximum number of connections to maintain in the connection pool.
+
+### --postgres-idle-conns
+
+|             |                                   |
+|-------------|-----------------------------------|
+| Type        | <code>int</code>                  |
+| Environment | <code>$CODER_PG_IDLE_CONNS</code> |
+| YAML        | <code>pgIdleConns</code>          |
+| Default     | <code>3</code>                    |
+
+The number of idle connections to maintain in the connection pool.
+
 ### --secure-auth-cookie
 
 |             |                                          |

--- a/enterprise/cli/server_dbcrypt.go
+++ b/enterprise/cli/server_dbcrypt.go
@@ -10,12 +10,13 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
+	"github.com/coder/serpent"
+
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/database/awsiamrds"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/dbcrypt"
-	"github.com/coder/serpent"
 
 	"golang.org/x/xerrors"
 )
@@ -98,7 +99,7 @@ func (*RootCmd) dbcryptRotateCmd() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}
@@ -163,7 +164,7 @@ func (*RootCmd) dbcryptDecryptCmd() *serpent.Command {
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}
@@ -219,7 +220,7 @@ Are you sure you want to continue?`
 				}
 			}
 
-			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil)
+			sqlDB, err := cli.ConnectToPostgres(inv.Context(), logger, sqlDriver, flags.PostgresURL, nil, codersdk.DefaultMaxConns, codersdk.DefaultIdleConns)
 			if err != nil {
 				return xerrors.Errorf("connect to postgres: %w", err)
 			}

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -64,11 +64,11 @@ OPTIONS:
 
       --postgres-idle-conns int, $CODER_PG_IDLE_CONNS (default: 3)
           The number of idle connections to maintain in the connection pool. 0
-          is unlimited.
+          is unlimited, but we advise against using this.
 
       --postgres-max-conns int, $CODER_PG_MAX_CONNS (default: 10)
           The maximum number of connections to maintain in the connection pool.
-          0 is unlimited.
+          0 is unlimited, but we advise against using this.
 
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -62,6 +62,12 @@ OPTIONS:
           server postgres-builtin-url". Note that any special characters in the
           URL must be URL-encoded.
 
+      --postgres-idle-conns int, $CODER_PG_IDLE_CONNS (default: 3)
+          The number of idle connections to maintain in the connection pool.
+
+      --postgres-max-conns int, $CODER_PG_MAX_CONNS (default: 10)
+          The maximum number of connections to maintain in the connection pool.
+
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are
           "ed25519", "ecdsa", or "rsa4096".

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -63,10 +63,12 @@ OPTIONS:
           URL must be URL-encoded.
 
       --postgres-idle-conns int, $CODER_PG_IDLE_CONNS (default: 3)
-          The number of idle connections to maintain in the connection pool.
+          The number of idle connections to maintain in the connection pool. 0
+          is unlimited.
 
       --postgres-max-conns int, $CODER_PG_MAX_CONNS (default: 10)
           The maximum number of connections to maintain in the connection pool.
+          0 is unlimited.
 
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -646,6 +646,12 @@ export interface DatabaseReport extends BaseReport {
 	readonly threshold_ms: number;
 }
 
+// From codersdk/database.go
+export const DefaultIdleConns = 3;
+
+// From codersdk/database.go
+export const DefaultMaxConns = 10;
+
 // From codersdk/notifications.go
 export interface DeleteWebpushSubscription {
 	readonly endpoint: string;
@@ -692,6 +698,8 @@ export interface DeploymentValues {
 	readonly ephemeral_deployment?: boolean;
 	readonly pg_connection_url?: string;
 	readonly pg_auth?: string;
+	readonly pg_max_conns?: number;
+	readonly pg_idle_conns?: number;
 	readonly oauth2?: OAuth2Config;
 	readonly oidc?: OIDCConfig;
 	readonly telemetry?: TelemetryConfig;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -646,12 +646,6 @@ export interface DatabaseReport extends BaseReport {
 	readonly threshold_ms: number;
 }
 
-// From codersdk/database.go
-export const DefaultIdleConns = 3;
-
-// From codersdk/database.go
-export const DefaultMaxConns = 10;
-
 // From codersdk/notifications.go
 export interface DeleteWebpushSubscription {
 	readonly endpoint: string;


### PR DESCRIPTION
We've had 10 open & 3 idle connections configured since https://github.com/coder/coder/pull/4981.

We should make these values configurable because a) we should allow operators to decide how much Postgres memory they're willing to use for Coder, b) this is not a one-size-fits-all setting, and c) Coder makes extensive use of pubsub via Postgres and exhausting connections has a pathological impact on the server's behaviour and performance.

---

Recently https://github.com/coder/coder/pull/17635 added database metrics, after a suspicion that there was some contention for connections in our dogfood environment.

After creating a dashboard with these metrics, we found this suspicion to be confirmed:

```promql
sum by (pod) (increase(go_sql_wait_duration_seconds_total[1m]))
/
sum by (pod) (clamp_min(increase(go_sql_wait_count_total[1m]), 1))
```
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/e8c13653-d348-4236-9a29-b34bd3e2205b" />

```promql
sum by(pod) (go_sql_wait_count_total)
```
<img width="1482" alt="image" src="https://github.com/user-attachments/assets/e8ef5883-6a44-4b2a-97b0-e53a11346b98" />

```promql
sum by (pod) (go_sql_wait_duration_seconds_total)
```
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/b2c457e5-ed58-467d-b4c8-edf232d4851d" />

---

If we zoom into one spike, the impact is pretty clear:

**Before spike:**
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/bb68c6cb-1057-4a76-b87c-73ee82a9bec2" />

**During spike:**

<img width="1487" alt="image" src="https://github.com/user-attachments/assets/f4d9d205-1dbc-45a4-b3b9-6a1c14805a93" />

---

Keep in mind that we scrape every 15s and Prometheus' aggregation functions extrapolate between intervals, so the values are not precise but they are directionally useful.
