### PR TITLE
docs: remove link to closed Remote Desktop issue

### DIFF
--- a/docs/user-guides/workspace-access/remote-desktops.md
+++ b/docs/user-guides/workspace-access/remote-desktops.md
@@ -1,8 +1,5 @@
 # Remote Desktops
 
-Built-in remote desktop is on the roadmap
-([#2106](https://github.com/coder/coder/issues/2106)).
-
 ## VNC Desktop
 
 The common way to use remote desktops with Coder is through VNC.


### PR DESCRIPTION
There is a link in our docs saying Remote Desktop is on the roadmap, but the issue is closed.