### PR TITLE
chore: update setup-ramdisk-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,7 +336,7 @@ jobs:
       # a separate repository to allow its use before actions/checkout.
       - name: Setup RAM Disks
         if: runner.os == 'Windows'
-        uses: coder/setup-ramdisk-action@79dacfe70c47ad6d6c0dd7f45412368802641439
+        uses: coder/setup-ramdisk-action@81c5c441bda00c6c3d6bcee2e5a33ed4aadbbcc1
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Update setup-ramdisk-action to [a version](https://github.com/coder/setup-ramdisk-action/commit/81c5c441bda00c6c3d6bcee2e5a33ed4aadbbcc1) that instructs curl to fail on network errors and retry them.

It should mitigate flakes like the one seen here: https://github.com/coder/coder/actions/runs/15068089742/job/42357451808#step:4:54