### PR TITLE
feat: add template export functionality to UI

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1114,6 +1114,7 @@ func New(options *Options) *API {
 				r.Get("/", api.template)
 				r.Delete("/", api.deleteTemplate)
 				r.Patch("/", api.patchTemplateMeta)
+				r.Get("/export", api.exportTemplate)
 				r.Route("/versions", func(r chi.Router) {
 					r.Post("/archive", api.postArchiveTemplateVersions)
 					r.Get("/", api.templateVersionsByTemplate)

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -1,4 +1,5 @@
 import EditIcon from "@mui/icons-material/EditOutlined";
+import DownloadIcon from "@mui/icons-material/Download";
 import Button from "@mui/material/Button";
 import { workspaces } from "api/queries/workspaces";
 import type {
@@ -102,6 +103,16 @@ const TemplateMenu: FC<TemplateMenuProps> = ({
 						<CopyIcon className="size-icon-sm" />
 						Duplicate&hellip;
 					</DropdownMenuItem>
+
+					<DropdownMenuItem
+						onClick={() => {
+							window.location.href = `/api/v2/templates/${templateId}/export`;
+						}}
+					>
+						<DownloadIcon className="size-icon-sm" />
+						Export template
+					</DropdownMenuItem>
+
 					<DropdownMenuSeparator />
 					<DropdownMenuItem
 						className="text-content-destructive focus:text-content-destructive"


### PR DESCRIPTION
This PR adds the ability to export templates directly from the Coder UI, making it easier for users to backup, share, and version control their template configurations.

### Changes
- Added "Export template" button to the template menu dropdown
- Implemented `/api/v2/templates/{template}/export` endpoint that:
  - Gets the latest version of the template
  - Creates a gzipped tar archive containing:
    - `main.tf` with the template's Terraform configuration
    - `README.md` with the template's description
  - Sets appropriate headers for file download
  - Streams the archive to the client


### Related Issues
Closes #17859

