### PR TITLE
Update useAppLink.ts

### DIFF
--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -1,4 +1,4 @@
-import { apiKey } from "api/queries/users";
+eimport { apiKey } from "api/queries/users";
 import type {
 	Workspace,
 	WorkspaceAgent,
@@ -50,7 +50,13 @@ export const useAppLink = (
 			// an error message will be displayed.
 			const openAppExternallyFailedTimeout = 500;
 			const openAppExternallyFailed = setTimeout(() => {
-				displayError(`${label} must be installed first.`);
+			        const jetBrainsApps = ["GoLand", "IntelliJ IDEA", "PyCharm", "WebStorm", "CLion"];
+					if (jetBrainsApps.includes(label)) {
+						displayError(`To open ${label}, JetBrains Toolbox must be installed along with the IDE.`);
+					} else {
+						displayError(`${label} must be installed first.`);
+					}
+
 			}, openAppExternallyFailedTimeout);
 			window.addEventListener("blur", () => {
 				clearTimeout(openAppExternallyFailed);


### PR DESCRIPTION
 #17786

fix(apps): improve error message for JetBrains IDEs requiring Toolbox

Updated the error message shown when launching JetBrains IDEs (e.g., GoLand, IntelliJ) to clarify that JetBrains Toolbox must also be installed. This improves user experience by providing more accurate guidance when the IDE fails to open from the workspace.

Affected file: useAppLink.ts