### PR TITLE
fix: sync websocket params with form params

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
@@ -136,7 +136,7 @@ const CreateWorkspacePageExperimental: FC = () => {
 			return;
 		}
 
-		if (!initialParamsSentRef.current && response.parameters.length > 0) {
+		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
 			sendInitialParameters([...response.parameters]);
 		}
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -602,7 +602,7 @@ type UseSyncFormParametersProps = {
 	) => void;
 };
 
-export function useSyncFormParameters({
+function useSyncFormParameters({
 	parameters,
 	formValues,
 	setFieldValue,


### PR DESCRIPTION
The current issue is that when multiple parameters are added or removed from a form because a user change in a conditional parameter value. The websocket parameters response gets out of sync with the state of the parameters in the form.

The form state needs to be maintained because this is what gets submitted when the user attempts to create a workspace.

Fixes:

1. When autofill params are set from the url, mark these params as touched in the form. This is necessary as only touched params are sent in the request to the websocket. These params should technically count as being touched because they were preset from the url params.

2. Create a hook to synchronize the parameters from the websocket response with the current state of the parameters stored in the form.