### PR TITLE
feat: fail CI when `pubsub.Publish` calls are found in db transactions

### DIFF
--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -135,7 +135,7 @@ func databaseImport(m dsl.Matcher) {
 }
 
 // publishInTransaction detects calls to Publish inside database transactions
-// which can lead to connection deadlocks or other unexpected behavior.
+// which can lead to connection starvation.
 //
 //nolint:unused,deadcode,varnamelen
 func publishInTransaction(m dsl.Matcher) {
@@ -159,7 +159,7 @@ func publishInTransaction(m dsl.Matcher) {
 	`).
 		Where(m["ps"].Type.Is("pubsub.Pubsub")).
 		At(m["ps"]).
-		Report("Avoid calling Publish inside database transactions as this may lead to connection deadlocks. Move the Publish call outside the transaction.")
+		Report("Avoid calling pubsub.Publish() inside database transactions as this may lead to connection deadlocks. Move the Publish() call outside the transaction.")
 }
 
 // doNotCallTFailNowInsideGoroutine enforces not calling t.FailNow or

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -149,8 +149,8 @@ func publishInTransaction(m dsl.Matcher) {
 			$*_
 		}, $*_)
 	`,
-	// Alternative with short variable declaration
-	`
+		// Alternative with short variable declaration
+		`
 		$x.InTx(func($y) error {
 			$*_
 			$_ := $ps.Publish($evt, $msg)

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -143,7 +143,7 @@ func publishInTransaction(m dsl.Matcher) {
 
 	// Match direct calls to the Publish method of a pubsub instance inside InTx
 	m.Match(`
-		$_.InTx(func($_) error {
+		$x.InTx(func($y) error {
 			$*_
 			$_ = $ps.Publish($evt, $msg)
 			$*_

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -149,6 +149,14 @@ func publishInTransaction(m dsl.Matcher) {
 			$*_
 		}, $*_)
 	`,
+	// Alternative with short variable declaration
+	`
+		$x.InTx(func($y) error {
+			$*_
+			$_ := $ps.Publish($evt, $msg)
+			$*_
+		}, $*_)
+	`,
 		// Without catching error return
 		`
 		$x.InTx(func($y) error {

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -143,7 +143,7 @@ func publishInTransaction(m dsl.Matcher) {
 
 	// Match direct calls to the Publish method of a pubsub instance inside InTx
 	m.Match(`
-		$x.InTx(func($y) error {
+		$_.InTx(func($x) error {
 			$*_
 			$_ = $ps.Publish($evt, $msg)
 			$*_
@@ -151,7 +151,7 @@ func publishInTransaction(m dsl.Matcher) {
 	`,
 		// Alternative with short variable declaration
 		`
-		$x.InTx(func($y) error {
+		$_.InTx(func($x) error {
 			$*_
 			$_ := $ps.Publish($evt, $msg)
 			$*_
@@ -159,7 +159,7 @@ func publishInTransaction(m dsl.Matcher) {
 	`,
 		// Without catching error return
 		`
-		$x.InTx(func($y) error {
+		$_.InTx(func($x) error {
 			$*_
 			$ps.Publish($evt, $msg)
 			$*_

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -143,7 +143,7 @@ func publishInTransaction(m dsl.Matcher) {
 
 	// Match direct calls to the Publish method of a pubsub instance inside InTx
 	m.Match(`
-		$x.InTx(func($y) error {
+		$_.InTx(func($_) error {
 			$*_
 			$_ = $ps.Publish($evt, $msg)
 			$*_


### PR DESCRIPTION
Publishing inside a db transaction can lead to database connection starvation/contention since it requires its own connection.

This ruleguard rule (one-shotted by Claude Sonnet 3.7 and finalized by @Emyrk) will detect two of the following 3 instances:

```go
type Nested struct {
	ps pubsub.Pubsub
}

func TestFail(t *testing.T) {
	t.Parallel()

	db, ps := dbtestutil.NewDB(t)
	nested := &Nested{
		ps: ps,
	}

	// will catch this
	_ = db.InTx(func(_ database.Store) error {
		_, _ = fmt.Printf("")
		_ = ps.Publish("", []byte{})
		return nil
	}, nil)

	// will catch this
	_ = db.InTx(func(_ database.Store) error {
		_ = nested.ps.Publish("", []byte{})
		return nil
	}, nil)

	// will NOT catch this
	_ = db.InTx(func(_ database.Store) error {
		blah(ps)
		return nil
	}, nil)
}

func blah(ps pubsub.Pubsub) {
	ps.Publish("", []byte{})
}
```

The ruleguard doesn't recursively introspect function calls so only the first two cases will be guarded against, but it's better than nothing.

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/8ffa0d88-16a0-41a9-9521-21211910dec9" />
