### PR TITLE
fix(dogfood/coder): stop docker containers and prune system on shutdown

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -373,6 +373,10 @@ resource "coder_agent" "dev" {
     #!/usr/bin/env bash
     set -eux -o pipefail
 
+    # Stop all running containers and prune the system to clean up /var/lib/docker.
+    docker ps -q | xargs docker stop
+    docker system prune -a
+
     # Stop the Docker service to prevent errors during workspace destroy.
     sudo service docker stop
   EOT

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -373,7 +373,14 @@ resource "coder_agent" "dev" {
     #!/usr/bin/env bash
     set -eux -o pipefail
 
-    # Stop all running containers and prune the system to clean up /var/lib/docker.
+    # Stop all running containers and prune the system to clean up
+    # /var/lib/docker to prevent errors during workspace destroy.
+    #
+    # WARNING! This will remove:
+    # - all containers
+    # - all networks not used by at least one container
+    # - all images without at least one container associated to them
+    # - all build cache
     docker ps -q | xargs docker stop
     docker system prune -a
 

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -378,8 +378,8 @@ resource "coder_agent" "dev" {
     #
     # WARNING! This will remove:
     # - all containers
-    # - all networks not used by at least one container
-    # - all images without at least one container associated to them
+    # - all networks
+    # - all images
     # - all build cache
     docker ps -q | xargs docker stop
     docker system prune -a


### PR DESCRIPTION
Hopefully the final update to thne fix in #17110

This change greatly speeds up workspace destruction:

```
2025-05-19 12:26:57.046+03:00 docker_container.workspace[0]: Destroying... [id=2685e2f456ba7b280c420219f19ef15384faa52c61ba7c087c7f109ffa6b1bda]
2025-05-19 12:27:07.046+03:00 docker_container.workspace[0]: Still destroying... [10s elapsed]
2025-05-19 12:27:16.734+03:00 docker_container.workspace[0]: Destruction complete after 20s
```
