### PR TITLE
feat: make all parts of a `CodeExample` copy inner code upon click

### DIFF
--- a/site/src/components/CodeExample/CodeExample.tsx
+++ b/site/src/components/CodeExample/CodeExample.tsx
@@ -1,4 +1,5 @@
 import type { Interpolation, Theme } from "@emotion/react";
+import { useClipboard } from "hooks";
 import type { FC } from "react";
 import { MONOSPACE_FONT_FAMILY } from "theme/constants";
 import { CopyButton } from "../CopyButton/CopyButton";
@@ -20,8 +21,17 @@ export const CodeExample: FC<CodeExampleProps> = ({
 	// the secure option, not remember to opt in
 	secret = true,
 }) => {
+	const { showCopiedSuccess, copyToClipboard } = useClipboard({
+		textToCopy: code,
+	});
+
 	return (
-		<div css={styles.container} className={className}>
+		// biome-ignore lint/a11y/useKeyWithClickEvents: The on click here is to make it easier/more clear for mouse users to copy the code. The button within the code is still focusable via keyboard for the same functionality.
+		<div
+			css={styles.container}
+			className={className}
+			onClick={copyToClipboard}
+		>
 			<code css={[styles.code, secret && styles.secret]}>
 				{secret ? (
 					<>
@@ -43,7 +53,11 @@ export const CodeExample: FC<CodeExampleProps> = ({
 				)}
 			</code>
 
-			<CopyButton text={code} label="Copy code" />
+			<CopyButton
+				text={code}
+				label="Copy code"
+				outerCopiedSuccess={showCopiedSuccess}
+			/>
 		</div>
 	);
 };

--- a/site/src/components/CodeExample/CodeExample.tsx
+++ b/site/src/components/CodeExample/CodeExample.tsx
@@ -27,11 +27,7 @@ export const CodeExample: FC<CodeExampleProps> = ({
 
 	return (
 		// biome-ignore lint/a11y/useKeyWithClickEvents: The on click here is to make it easier/more clear for mouse users to copy the code. The button within the code is still focusable via keyboard for the same functionality.
-		<div
-			css={styles.container}
-			className={className}
-			onClick={copyToClipboard}
-		>
+		<div css={styles.container} className={className} onClick={copyToClipboard}>
 			<code css={[styles.code, secret && styles.secret]}>
 				{secret ? (
 					<>

--- a/site/src/components/CopyButton/CopyButton.tsx
+++ b/site/src/components/CopyButton/CopyButton.tsx
@@ -12,11 +12,13 @@ import type { FC } from "react";
 type CopyButtonProps = ButtonProps & {
 	text: string;
 	label: string;
+	outerCopiedSuccess?: boolean;
 };
 
 export const CopyButton: FC<CopyButtonProps> = ({
 	text,
 	label,
+	outerCopiedSuccess,
 	...buttonProps
 }) => {
 	const { showCopiedSuccess, copyToClipboard } = useClipboard({
@@ -30,10 +32,17 @@ export const CopyButton: FC<CopyButtonProps> = ({
 					<Button
 						size="icon"
 						variant="subtle"
-						onClick={copyToClipboard}
+						onClick={(e) => {
+							e.stopPropagation();
+							copyToClipboard();
+						}}
 						{...buttonProps}
 					>
-						{showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}
+						{outerCopiedSuccess || showCopiedSuccess ? (
+							<CheckIcon />
+						) : (
+							<CopyIcon />
+						)}
 						<span className="sr-only">{label}</span>
 					</Button>
 				</TooltipTrigger>

--- a/site/src/pages/CliAuthPage/CliAuthPageView.tsx
+++ b/site/src/pages/CliAuthPage/CliAuthPageView.tsx
@@ -18,8 +18,7 @@ export const CliAuthPageView: FC<CliAuthPageViewProps> = ({ sessionToken }) => {
 	}
 
 	return (
-		<div className="flex justify-between h-dvh flex-col items-center py-6">
-			<div />
+		<div className="relative flex justify-center h-dvh flex-col items-center py-6">
 			<div className="flex items-center justify-center flex-col">
 				<Welcome className="pb-3">Session token</Welcome>
 
@@ -42,7 +41,7 @@ export const CliAuthPageView: FC<CliAuthPageViewProps> = ({ sessionToken }) => {
 					</RouterLink>
 				</div>
 			</div>
-			<div className="text-xs text-content-secondary">
+			<div className="fixed bottom-6 text-xs text-content-secondary">
 				{"\u00a9"} {new Date().getFullYear()} Coder Technologies, Inc.
 			</div>
 		</div>

--- a/site/src/pages/CliAuthPage/CliAuthPageView.tsx
+++ b/site/src/pages/CliAuthPage/CliAuthPageView.tsx
@@ -19,28 +19,34 @@ export const CliAuthPageView: FC<CliAuthPageViewProps> = ({ sessionToken }) => {
 	}
 
 	return (
-		<SignInLayout>
-			<Welcome className="pb-3">Session token</Welcome>
+		<div className="flex justify-between h-dvh flex-col items-center py-6">
+				<div />
+			<div className="flex items-center justify-center flex-col">
+				<Welcome className="pb-3">Session token</Welcome>
 
-			<p css={styles.instructions}>
-				Copy the session token below and
-				{/*
-				 * This looks silly, but it's a case where you want to hide the space
-				 * visually because it messes up the centering, but you want the space
-				 * to still be available to screen readers
-				 */}
-				<span css={{ ...visuallyHidden }}>{VISUALLY_HIDDEN_SPACE}</span>
-				<strong css={{ display: "block" }}>paste it in your terminal.</strong>
-			</p>
+				<p css={styles.instructions}>
+					Copy the session token below and
+					{/*
+					 * This looks silly, but it's a case where you want to hide the space
+					 * visually because it messes up the centering, but you want the space
+					 * to still be available to screen readers
+					 */}
+					<span css={{ ...visuallyHidden }}>{VISUALLY_HIDDEN_SPACE}</span>
+					<strong css={{ display: "block" }}>paste it in your terminal.</strong>
+				</p>
 
-			<CodeExample code={sessionToken} secret />
+				<CodeExample code={sessionToken} secret />
 
-			<div css={{ paddingTop: 16 }}>
-				<RouterLink to="/workspaces" css={styles.backLink}>
-					Go to workspaces
-				</RouterLink>
+				<div css={{ paddingTop: 16 }}>
+					<RouterLink to="/workspaces" css={styles.backLink}>
+						Go to workspaces
+					</RouterLink>
+				</div>
 			</div>
-		</SignInLayout>
+			<div className="text-xs text-content-secondary">
+				{"\u00a9"} {new Date().getFullYear()} Coder Technologies, Inc.
+			</div>
+		</div>
 	);
 };
 

--- a/site/src/pages/CliAuthPage/CliAuthPageView.tsx
+++ b/site/src/pages/CliAuthPage/CliAuthPageView.tsx
@@ -2,7 +2,6 @@ import type { Interpolation, Theme } from "@emotion/react";
 import { visuallyHidden } from "@mui/utils";
 import { CodeExample } from "components/CodeExample/CodeExample";
 import { Loader } from "components/Loader/Loader";
-import { SignInLayout } from "components/SignInLayout/SignInLayout";
 import { Welcome } from "components/Welcome/Welcome";
 import type { FC } from "react";
 import { Link as RouterLink } from "react-router-dom";
@@ -20,7 +19,7 @@ export const CliAuthPageView: FC<CliAuthPageViewProps> = ({ sessionToken }) => {
 
 	return (
 		<div className="flex justify-between h-dvh flex-col items-center py-6">
-				<div />
+			<div />
 			<div className="flex items-center justify-center flex-col">
 				<Welcome className="pb-3">Session token</Welcome>
 


### PR DESCRIPTION
Closes [coder/internal#649](https://github.com/coder/internal/issues/649)


https://github.com/user-attachments/assets/6f987fb2-6d8a-42e0-821c-f9d5927e5c7d

---

I also notice that the screen itself doesn't look great right now. The issue stems from the `SignInLayout` implementation but investigating it/fixing it while also making sure it didn't affect any other pages using it seemed out of the scope of this PR. Would be happier to revert this bit of code if necessary.

**Before: (Everything on top, no top margin)**

![CleanShot 2025-05-19 at 11 04 59@2x](https://github.com/user-attachments/assets/39adf669-7ef9-453d-be87-1dbacc068a56)

**After: (Main content properly centered in page, copyright on bottom)**

![CleanShot 2025-05-19 at 11 04 25@2x](https://github.com/user-attachments/assets/0f5f810f-b6b8-4994-8b1b-d2d6d9700e0e)
