### PR TITLE
fix: get presets working correctly with dynamic params

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -222,6 +222,15 @@ const DebouncedParameterField: FC<DebouncedParameterFieldProps> = ({
 	const onChangeEvent = useEffectEvent(onChange);
 	// prevDebouncedValueRef is to prevent calling the onChangeEvent on the initial render
 	const prevDebouncedValueRef = useRef<string | undefined>();
+	const prevValueRef = useRef(value);
+
+	// This is necessary in the case of fields being set by preset parameters
+	useEffect(() => {
+		if (value !== undefined && value !== prevValueRef.current) {
+			setLocalValue(value);
+			prevValueRef.current = value;
+		}
+	}, [value]);
 
 	useEffect(() => {
 		if (prevDebouncedValueRef.current !== undefined) {
@@ -458,7 +467,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					<Slider
 						id={id}
 						className="mt-2"
-						value={[Number(value)]}
+						value={[Number.isNaN(Number(value)) ? 0 : Number(value)]}
 						onValueChange={([value]) => {
 							onChange(value.toString());
 						}}

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -467,7 +467,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 					<Slider
 						id={id}
 						className="mt-2"
-						value={[Number.isNaN(Number(value)) ? 0 : Number(value)]}
+						value={[Number.isFinite(Number(value)) ? Number(value) : 0]}
 						onValueChange={([value]) => {
 							onChange(value.toString());
 						}}

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
@@ -101,7 +101,7 @@ const CreateWorkspacePageExperimental: FC = () => {
 		}
 	}, []);
 
-	// On sends all initial parameter values to the websocket
+	// On page load, sends all initial parameter values to the websocket
 	// (including defaults and autofilled from the url)
 	// This ensures the backend has the complete initial state of the form,
 	// which is vital for correctly rendering dynamic UI elements where parameter visibility

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -215,11 +215,18 @@ export const CreateWorkspacePageViewExperimental: FC<
 
 		const currentValues = form.values.rich_parameter_values ?? [];
 
-		const updates = selectedPreset.Parameters.map((presetParameter) => {
+		const updates: Array<{
+			field: string;
+			fieldValue: TypesGen.WorkspaceBuildParameter;
+			parameter: PreviewParameter;
+			presetValue: string;
+		}> = [];
+
+		for (const presetParameter of selectedPreset.Parameters) {
 			const parameterIndex = parameters.findIndex(
 				(p) => p.name === presetParameter.Name,
 			);
-			if (parameterIndex === -1) return null;
+			if (parameterIndex === -1) continue;
 
 			const parameterField = `rich_parameter_values.${parameterIndex}`;
 			const parameter = parameters[parameterIndex];
@@ -228,7 +235,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 			)?.value;
 
 			if (currentValue !== presetParameter.Value) {
-				return {
+				updates.push({
 					field: parameterField,
 					fieldValue: {
 						name: presetParameter.Name,
@@ -236,12 +243,9 @@ export const CreateWorkspacePageViewExperimental: FC<
 					},
 					parameter,
 					presetValue: presetParameter.Value,
-				};
+				});
 			}
-			return null;
-		}).filter(
-			(update): update is NonNullable<typeof update> => update !== null,
-		);
+		}
 
 		if (updates.length > 0) {
 			for (const update of updates) {


### PR DESCRIPTION
This adds a few fixes to get presets working correctly with dynamic params

1. Changes to preset params need to be rendered and displayed correctly
2. Changes to preset params need to be sent to the websocket
3. Changes to preset params need to be marked as touched so they won't be automatically changed later because of dynamic defaults. Dynamic defaults means any default parameter value can be changed by the websocket response unless edited by the user, set by autofill or set by a preset.