### PR TITLE
chore: add presets with prebuilds to our dogfood template

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -33,12 +33,12 @@ locals {
 data "coder_workspace_preset" "cpt" {
   name = "Cape Town"
   parameters = {
-    (data.coder_parameter.region.name) = "za-cpt"
-    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
-    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.region.name)                   = "za-cpt"
+    (data.coder_parameter.image_type.name)               = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name)            = "~"
     (data.coder_parameter.res_mon_memory_threshold.name) = 80
     (data.coder_parameter.res_mon_volume_threshold.name) = 90
-    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+    (data.coder_parameter.res_mon_volume_path.name)      = "/home/coder"
   }
   prebuilds {
     instances = 1
@@ -48,12 +48,12 @@ data "coder_workspace_preset" "cpt" {
 data "coder_workspace_preset" "pittsburgh" {
   name = "Pittsburgh"
   parameters = {
-    (data.coder_parameter.region.name) = "us-pittsburgh"
-    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
-    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.region.name)                   = "us-pittsburgh"
+    (data.coder_parameter.image_type.name)               = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name)            = "~"
     (data.coder_parameter.res_mon_memory_threshold.name) = 80
     (data.coder_parameter.res_mon_volume_threshold.name) = 90
-    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+    (data.coder_parameter.res_mon_volume_path.name)      = "/home/coder"
   }
   prebuilds {
     instances = 2
@@ -63,12 +63,12 @@ data "coder_workspace_preset" "pittsburgh" {
 data "coder_workspace_preset" "falkenstein" {
   name = "Falkenstein"
   parameters = {
-    (data.coder_parameter.region.name) = "eu-helsinki"
-    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
-    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.region.name)                   = "eu-helsinki"
+    (data.coder_parameter.image_type.name)               = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name)            = "~"
     (data.coder_parameter.res_mon_memory_threshold.name) = 80
     (data.coder_parameter.res_mon_volume_threshold.name) = 90
-    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+    (data.coder_parameter.res_mon_volume_path.name)      = "/home/coder"
   }
   prebuilds {
     instances = 1
@@ -78,12 +78,12 @@ data "coder_workspace_preset" "falkenstein" {
 data "coder_workspace_preset" "sydney" {
   name = "Sydney"
   parameters = {
-    (data.coder_parameter.region.name) = "ap-sydney"
-    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
-    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.region.name)                   = "ap-sydney"
+    (data.coder_parameter.image_type.name)               = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name)            = "~"
     (data.coder_parameter.res_mon_memory_threshold.name) = 80
     (data.coder_parameter.res_mon_volume_threshold.name) = 90
-    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+    (data.coder_parameter.res_mon_volume_path.name)      = "/home/coder"
   }
   prebuilds {
     instances = 1
@@ -93,12 +93,12 @@ data "coder_workspace_preset" "sydney" {
 data "coder_workspace_preset" "saopaulo" {
   name = "São Paulo"
   parameters = {
-    (data.coder_parameter.region.name) = "sa-saopaulo"
-    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
-    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.region.name)                   = "sa-saopaulo"
+    (data.coder_parameter.image_type.name)               = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name)            = "~"
     (data.coder_parameter.res_mon_memory_threshold.name) = 80
     (data.coder_parameter.res_mon_volume_threshold.name) = 90
-    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+    (data.coder_parameter.res_mon_volume_path.name)      = "/home/coder"
   }
   prebuilds {
     instances = 1

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -30,6 +30,81 @@ locals {
   container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
 }
 
+data "coder_workspace_preset" "cpt" {
+  name = "Cape Town"
+  parameters = {
+    (data.coder_parameter.region.name) = "za-cpt"
+    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.res_mon_memory_threshold.name) = 80
+    (data.coder_parameter.res_mon_volume_threshold.name) = 90
+    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+  }
+  prebuilds {
+    instances = 1
+  }
+}
+
+data "coder_workspace_preset" "pittsburgh" {
+  name = "Pittsburgh"
+  parameters = {
+    (data.coder_parameter.region.name) = "us-pittsburgh"
+    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.res_mon_memory_threshold.name) = 80
+    (data.coder_parameter.res_mon_volume_threshold.name) = 90
+    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+  }
+  prebuilds {
+    instances = 2
+  }
+}
+
+data "coder_workspace_preset" "falkenstein" {
+  name = "Falkenstein"
+  parameters = {
+    (data.coder_parameter.region.name) = "eu-helsinki"
+    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.res_mon_memory_threshold.name) = 80
+    (data.coder_parameter.res_mon_volume_threshold.name) = 90
+    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+  }
+  prebuilds {
+    instances = 1
+  }
+}
+
+data "coder_workspace_preset" "sydney" {
+  name = "Sydney"
+  parameters = {
+    (data.coder_parameter.region.name) = "ap-sydney"
+    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.res_mon_memory_threshold.name) = 80
+    (data.coder_parameter.res_mon_volume_threshold.name) = 90
+    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+  }
+  prebuilds {
+    instances = 1
+  }
+}
+
+data "coder_workspace_preset" "saopaulo" {
+  name = "São Paulo"
+  parameters = {
+    (data.coder_parameter.region.name) = "sa-saopaulo"
+    (data.coder_parameter.image_type.name) = "codercom/oss-dogfood:latest"
+    (data.coder_parameter.repo_base_dir.name) = "~"
+    (data.coder_parameter.res_mon_memory_threshold.name) = 80
+    (data.coder_parameter.res_mon_volume_threshold.name) = 90
+    (data.coder_parameter.res_mon_volume_path.name) = "/home/coder"
+  }
+  prebuilds {
+    instances = 1
+  }
+}
+
 data "coder_parameter" "repo_base_dir" {
   type        = "string"
   name        = "Coder Repository Base Directory"
@@ -438,6 +513,14 @@ resource "docker_image" "dogfood" {
 }
 
 resource "docker_container" "workspace" {
+  lifecycle {
+    // Ignore changes that would invalidate prebuilds
+    ignore_changes = [
+      name,
+      hostname,
+      labels,
+    ]
+  }
   count = data.coder_workspace.me.start_count
   image = docker_image.dogfood.name
   name  = local.container_name


### PR DESCRIPTION
This PR adds a preset with prebuilds for each region to our dogfood template. Creating a workspace based on a preset should now save time compared to creating a workspace from scratch