### PR TITLE
feat: add experimental template embed page

### DIFF
--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter.tsx
@@ -1,0 +1,81 @@
+import { templateByName } from "api/queries/templates";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { Loader } from "components/Loader/Loader";
+import { useDashboard } from "modules/dashboard/useDashboard";
+import type { FC } from "react";
+import { useQuery } from "react-query";
+import { useParams } from "react-router-dom";
+import TemplateEmbedPage from "./TemplateEmbedPage";
+import TemplateEmbedPageExperimental from "./TemplateEmbedPageExperimental";
+import { ExperimentalFormContext } from "pages/CreateWorkspacePage/ExperimentalFormContext";
+
+const TemplateEmbedExperimentRouter: FC = () => {
+    const { experiments } = useDashboard();
+    const dynamicParametersEnabled = experiments.includes("dynamic-parameters");
+
+    const { organization: organizationName = "default", template: templateName } =
+        useParams() as { organization?: string; template: string };
+    const templateQuery = useQuery(
+        dynamicParametersEnabled
+            ? templateByName(organizationName, templateName)
+            : { enabled: false },
+    );
+
+    const optOutQuery = useQuery(
+        templateQuery.data
+            ? {
+                  queryKey: [organizationName, "template", templateQuery.data.id, "optOut"],
+                  queryFn: () => {
+                      const templateId = templateQuery.data.id;
+                      const localStorageKey = optOutKey(templateId);
+                      const storedOptOutString = localStorage.getItem(localStorageKey);
+
+                      let optOutResult: boolean;
+
+                      if (storedOptOutString !== null) {
+                          optOutResult = storedOptOutString === "true";
+                      } else {
+                          optOutResult = Boolean(templateQuery.data.use_classic_parameter_flow);
+                      }
+
+                      return {
+                          templateId: templateId,
+                          optedOut: optOutResult,
+                      };
+                  },
+              }
+            : { enabled: false },
+    );
+
+    if (dynamicParametersEnabled) {
+        if (optOutQuery.isLoading) {
+            return <Loader />;
+        }
+        if (!optOutQuery.data) {
+            return <ErrorAlert error={optOutQuery.error} />;
+        }
+
+        const toggleOptedOut = () => {
+            const key = optOutKey(optOutQuery.data.templateId);
+            const storedValue = localStorage.getItem(key);
+
+            const current = storedValue
+                ? storedValue === "true"
+                : Boolean(templateQuery.data?.use_classic_parameter_flow);
+
+            localStorage.setItem(key, (!current).toString());
+            optOutQuery.refetch();
+        };
+        return (
+            <ExperimentalFormContext.Provider value={{ toggleOptedOut }}>
+                {optOutQuery.data.optedOut ? <TemplateEmbedPage /> : <TemplateEmbedPageExperimental />}
+            </ExperimentalFormContext.Provider>
+        );
+    }
+
+    return <TemplateEmbedPage />;
+};
+
+export default TemplateEmbedExperimentRouter;
+
+const optOutKey = (id: string) => `parameters.${id}.optOut`;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter.tsx
@@ -2,78 +2,89 @@ import { templateByName } from "api/queries/templates";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Loader } from "components/Loader/Loader";
 import { useDashboard } from "modules/dashboard/useDashboard";
+import { ExperimentalFormContext } from "pages/CreateWorkspacePage/ExperimentalFormContext";
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import { useParams } from "react-router-dom";
 import TemplateEmbedPage from "./TemplateEmbedPage";
 import TemplateEmbedPageExperimental from "./TemplateEmbedPageExperimental";
-import { ExperimentalFormContext } from "pages/CreateWorkspacePage/ExperimentalFormContext";
 
 const TemplateEmbedExperimentRouter: FC = () => {
-    const { experiments } = useDashboard();
-    const dynamicParametersEnabled = experiments.includes("dynamic-parameters");
+	const { experiments } = useDashboard();
+	const dynamicParametersEnabled = experiments.includes("dynamic-parameters");
 
-    const { organization: organizationName = "default", template: templateName } =
-        useParams() as { organization?: string; template: string };
-    const templateQuery = useQuery(
-        dynamicParametersEnabled
-            ? templateByName(organizationName, templateName)
-            : { enabled: false },
-    );
+	const { organization: organizationName = "default", template: templateName } =
+		useParams() as { organization?: string; template: string };
+	const templateQuery = useQuery(
+		dynamicParametersEnabled
+			? templateByName(organizationName, templateName)
+			: { enabled: false },
+	);
 
-    const optOutQuery = useQuery(
-        templateQuery.data
-            ? {
-                  queryKey: [organizationName, "template", templateQuery.data.id, "optOut"],
-                  queryFn: () => {
-                      const templateId = templateQuery.data.id;
-                      const localStorageKey = optOutKey(templateId);
-                      const storedOptOutString = localStorage.getItem(localStorageKey);
+	const optOutQuery = useQuery(
+		templateQuery.data
+			? {
+					queryKey: [
+						organizationName,
+						"template",
+						templateQuery.data.id,
+						"optOut",
+					],
+					queryFn: () => {
+						const templateId = templateQuery.data.id;
+						const localStorageKey = optOutKey(templateId);
+						const storedOptOutString = localStorage.getItem(localStorageKey);
 
-                      let optOutResult: boolean;
+						let optOutResult: boolean;
 
-                      if (storedOptOutString !== null) {
-                          optOutResult = storedOptOutString === "true";
-                      } else {
-                          optOutResult = Boolean(templateQuery.data.use_classic_parameter_flow);
-                      }
+						if (storedOptOutString !== null) {
+							optOutResult = storedOptOutString === "true";
+						} else {
+							optOutResult = Boolean(
+								templateQuery.data.use_classic_parameter_flow,
+							);
+						}
 
-                      return {
-                          templateId: templateId,
-                          optedOut: optOutResult,
-                      };
-                  },
-              }
-            : { enabled: false },
-    );
+						return {
+							templateId: templateId,
+							optedOut: optOutResult,
+						};
+					},
+				}
+			: { enabled: false },
+	);
 
-    if (dynamicParametersEnabled) {
-        if (optOutQuery.isLoading) {
-            return <Loader />;
-        }
-        if (!optOutQuery.data) {
-            return <ErrorAlert error={optOutQuery.error} />;
-        }
+	if (dynamicParametersEnabled) {
+		if (optOutQuery.isLoading) {
+			return <Loader />;
+		}
+		if (!optOutQuery.data) {
+			return <ErrorAlert error={optOutQuery.error} />;
+		}
 
-        const toggleOptedOut = () => {
-            const key = optOutKey(optOutQuery.data.templateId);
-            const storedValue = localStorage.getItem(key);
+		const toggleOptedOut = () => {
+			const key = optOutKey(optOutQuery.data.templateId);
+			const storedValue = localStorage.getItem(key);
 
-            const current = storedValue
-                ? storedValue === "true"
-                : Boolean(templateQuery.data?.use_classic_parameter_flow);
+			const current = storedValue
+				? storedValue === "true"
+				: Boolean(templateQuery.data?.use_classic_parameter_flow);
 
-            localStorage.setItem(key, (!current).toString());
-            optOutQuery.refetch();
-        };
-        return (
-            <ExperimentalFormContext.Provider value={{ toggleOptedOut }}>
-                {optOutQuery.data.optedOut ? <TemplateEmbedPage /> : <TemplateEmbedPageExperimental />}
-            </ExperimentalFormContext.Provider>
-        );
-    }
+			localStorage.setItem(key, (!current).toString());
+			optOutQuery.refetch();
+		};
+		return (
+			<ExperimentalFormContext.Provider value={{ toggleOptedOut }}>
+				{optOutQuery.data.optedOut ? (
+					<TemplateEmbedPage />
+				) : (
+					<TemplateEmbedPageExperimental />
+				)}
+			</ExperimentalFormContext.Provider>
+		);
+	}
 
-    return <TemplateEmbedPage />;
+	return <TemplateEmbedPage />;
 };
 
 export default TemplateEmbedExperimentRouter;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
@@ -1,21 +1,22 @@
-import Button from "@mui/material/Button";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import { API } from "api/api";
 import type { Template, TemplateVersionParameter } from "api/typesGenerated";
+import { Button } from "components/Button/Button";
 import { FormSection, VerticalForm } from "components/Form/Form";
 import { Loader } from "components/Loader/Loader";
 import { RichParameterInput } from "components/RichParameterInput/RichParameterInput";
 import { useClipboard } from "hooks/useClipboard";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
-import { type FC, useEffect, useState } from "react";
+import { type FC, useContext, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "react-query";
 import { pageTitle } from "utils/page";
 import { getInitialRichParameterValues } from "utils/richParameters";
 import { paramsUsedToCreateWorkspace } from "utils/workspace";
+import { ExperimentalFormContext } from "../../CreateWorkspacePage/ExperimentalFormContext";
 
 type ButtonValues = Record<string, string>;
 
@@ -64,6 +65,7 @@ export const TemplateEmbedPageView: FC<TemplateEmbedPageViewProps> = ({
 	template,
 	templateParameters,
 }) => {
+	const experimentalFormContext = useContext(ExperimentalFormContext);
 	const [buttonValues, setButtonValues] = useState<ButtonValues | undefined>();
 	const clipboard = useClipboard({
 		textToCopy: getClipboardCopyContent(
@@ -97,8 +99,19 @@ export const TemplateEmbedPageView: FC<TemplateEmbedPageViewProps> = ({
 			{!buttonValues || !templateParameters ? (
 				<Loader />
 			) : (
-				<div css={{ display: "flex", alignItems: "flex-start", gap: 48 }}>
-					<div css={{ flex: 1, maxWidth: 400 }}>
+				<div className="flex items-start gap-12">
+					<div className="max-w-3xl">
+						{experimentalFormContext && (
+							<div className="mb-4">
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={experimentalFormContext.toggleOptedOut}
+								>
+									Try out the new workspace creation flow ✨
+								</Button>
+							</div>
+						)}
 						<VerticalForm>
 							<FormSection
 								title="Creation mode"
@@ -184,17 +197,15 @@ export const TemplateEmbedPageView: FC<TemplateEmbedPageViewProps> = ({
 						>
 							<Button
 								css={{ borderRadius: 999 }}
-								startIcon={
-									clipboard.showCopiedSuccess ? (
-										<CheckIcon className="size-icon-sm" />
-									) : (
-										<CopyIcon className="size-icon-sm" />
-									)
-								}
-								variant="contained"
+								variant="outline"
 								onClick={clipboard.copyToClipboard}
 								disabled={clipboard.showCopiedSuccess}
 							>
+								{clipboard.showCopiedSuccess ? (
+									<CheckIcon className="size-icon-sm" />
+								) : (
+									<CopyIcon className="size-icon-sm" />
+								)}
 								Copy button code
 							</Button>
 						</div>

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -172,8 +172,19 @@ const TemplateEmbedPageViewExperimental: FC<
 			{!buttonValues ? (
 				<Loader />
 			) : (
-				<div css={{ display: "flex", alignItems: "flex-start", gap: 48 }}>
-					<div css={{ flex: 1, maxWidth: 400 }}>
+				<div className="flex items-start gap-12">
+					<div className="max-w-3xl ">
+						{experimentalFormContext && (
+							<div className="mb-4">
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={experimentalFormContext.toggleOptedOut}
+								>
+									Go back to the classic template embed flow
+								</Button>
+							</div>
+						)}
 						<VerticalForm>
 							<FormSection
 								title="Creation mode"
@@ -215,15 +226,7 @@ const TemplateEmbedPageViewExperimental: FC<
 									})}
 								</div>
 							)}
-							{experimentalFormContext && (
-								<Button
-									size="sm"
-									variant="subtle"
-									onClick={experimentalFormContext.toggleOptedOut}
-								>
-									Go back to the classic template embed flow
-								</Button>
-							)}
+
 							{Boolean(error) && (
 								<p className="text-content-destructive text-sm">
 									{String(error)}
@@ -231,21 +234,7 @@ const TemplateEmbedPageViewExperimental: FC<
 							)}
 						</VerticalForm>
 					</div>
-					<div
-						css={(theme) => ({
-							height: "calc(100vh - (80px + 36px))",
-							top: 40,
-							position: "sticky",
-							display: "flex",
-							padding: 64,
-							flex: 1,
-							alignItems: "center",
-							justifyContent: "center",
-							borderRadius: 8,
-							backgroundColor: theme.palette.background.paper,
-							border: `1px solid ${theme.palette.divider}`,
-						})}
-					>
+					<div className="flex-1 sticky top-16 flex h-[350px] flex-1 items-center justify-center rounded-md bg-surface-secondary p-16 border border-border border-solid">
 						<img src="/open-in-coder.svg" alt="Open in Coder button" />
 						<div
 							css={{

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -1,0 +1,260 @@
+import Button from "@mui/material/Button";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import { API } from "api/api";
+import type {
+    DynamicParametersRequest,
+    DynamicParametersResponse,
+    PreviewParameter,
+    Template,
+} from "api/typesGenerated";
+import { FormSection, VerticalForm } from "components/Form/Form";
+import { Loader } from "components/Loader/Loader";
+import { DynamicParameter, getInitialParameterValues } from "modules/workspaces/DynamicParameter/DynamicParameter";
+import { useClipboard } from "hooks/useClipboard";
+import { useAuthenticated } from "hooks";
+import { useEffectEvent } from "hooks/hookPolyfills";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
+import { ExperimentalFormContext } from "pages/CreateWorkspacePage/ExperimentalFormContext";
+import { type FC, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { pageTitle } from "utils/page";
+
+export type ButtonValues = Record<string, string>;
+
+const TemplateEmbedPageExperimental: FC = () => {
+    const { template } = useTemplateLayoutContext();
+    const { user } = useAuthenticated();
+
+    const [latestResponse, setLatestResponse] = useState<DynamicParametersResponse | null>(null);
+    const ws = useRef<WebSocket | null>(null);
+    const wsResponseId = useRef<number>(-1);
+    const initialParamsSentRef = useRef(false);
+    const [wsError, setWsError] = useState<Error | null>(null);
+
+    const sendMessage = useCallback((values: Record<string, string>) => {
+        const request: DynamicParametersRequest = {
+            id: wsResponseId.current + 1,
+            inputs: values,
+        };
+        if (ws.current && ws.current.readyState === WebSocket.OPEN) {
+            ws.current.send(JSON.stringify(request));
+            wsResponseId.current = wsResponseId.current + 1;
+        }
+    }, []);
+
+    const sendInitialParameters = useEffectEvent((params: PreviewParameter[]) => {
+        if (initialParamsSentRef.current) return;
+        if (params.length === 0) return;
+        const initial = getInitialParameterValues(params);
+        const inputs: Record<string, string> = {};
+        for (const param of initial) {
+            if (param.name && param.value) {
+                inputs[param.name] = param.value;
+            }
+        }
+        if (Object.keys(inputs).length === 0) return;
+        sendMessage(inputs);
+        initialParamsSentRef.current = true;
+    });
+
+    const onMessage = useEffectEvent((response: DynamicParametersResponse) => {
+        if (latestResponse && latestResponse.id >= response.id) {
+            return;
+        }
+        if (!initialParamsSentRef.current && response.parameters?.length > 0) {
+            sendInitialParameters([...response.parameters]);
+        }
+        setLatestResponse(response);
+    });
+
+    useEffect(() => {
+        const socket = API.templateVersionDynamicParameters(
+            user.id,
+            template.active_version_id,
+            {
+                onMessage,
+                onError: (e) => {
+                    if (ws.current === socket) {
+                        setWsError(e);
+                    }
+                },
+                onClose: () => {
+                    if (ws.current === socket) {
+                        setWsError(new Error("Websocket connection for dynamic parameters unexpectedly closed."));
+                    }
+                },
+            },
+        );
+        ws.current = socket;
+        return () => {
+            socket.close();
+        };
+    }, [user.id, template.active_version_id, onMessage]);
+
+    const parameters = useMemo(() => {
+        return latestResponse?.parameters ? [...latestResponse.parameters].sort((a, b) => a.order - b.order) : [];
+    }, [latestResponse?.parameters]);
+
+    return (
+        <TemplateEmbedPageViewExperimental
+            template={template}
+            parameters={parameters}
+            sendMessage={sendMessage}
+            error={wsError}
+        />
+    );
+};
+
+interface TemplateEmbedPageViewExperimentalProps {
+    template: Template;
+    parameters: PreviewParameter[];
+    sendMessage: (values: Record<string, string>) => void;
+    error?: unknown;
+}
+
+export const TemplateEmbedPageViewExperimental: FC<TemplateEmbedPageViewExperimentalProps> = ({
+    template,
+    parameters,
+    sendMessage,
+    error,
+}) => {
+    const experimentalFormContext = useContext(ExperimentalFormContext);
+    const [buttonValues, setButtonValues] = useState<ButtonValues>();
+    const clipboard = useClipboard({
+        textToCopy: getClipboardCopyContent(template.name, template.organization_name, buttonValues),
+    });
+
+    useEffect(() => {
+        if (parameters.length > 0 && !buttonValues) {
+            const values: ButtonValues = { mode: "manual" };
+            for (const param of getInitialParameterValues(parameters)) {
+                values[`param.${param.name}`] = param.value;
+            }
+            setButtonValues(values);
+        }
+    }, [parameters, buttonValues]);
+
+    const handleChange = (parameter: PreviewParameter, value: string) => {
+        setButtonValues((prev) => ({ ...(prev ?? {}), [`param.${parameter.name}`]: value }));
+        sendMessage({ [parameter.name]: value });
+    };
+
+    return (
+        <>
+            <Helmet>
+                <title>{pageTitle(template.name)}</title>
+            </Helmet>
+            {!buttonValues ? (
+                <Loader />
+            ) : (
+                <div css={{ display: "flex", alignItems: "flex-start", gap: 48 }}>
+                    <div css={{ flex: 1, maxWidth: 400 }}>
+                        <VerticalForm>
+                            <FormSection
+                                title="Creation mode"
+                                description="By changing the mode to automatic, when the user clicks the button, the workspace will be created automatically instead of showing a form to the user."
+                            >
+                                <RadioGroup
+                                    defaultValue={buttonValues.mode}
+                                    onChange={(_, v) => {
+                                        setButtonValues((prev) => ({ ...(prev ?? {}), mode: v }));
+                                    }}
+                                >
+                                    <FormControlLabel value="manual" control={<Radio size="small" />} label="Manual" />
+                                    <FormControlLabel value="auto" control={<Radio size="small" />} label="Automatic" />
+                                </RadioGroup>
+                            </FormSection>
+                            {parameters.length > 0 && (
+                                <div css={{ display: "flex", flexDirection: "column", gap: 36 }}>
+                                    {parameters.map((parameter) => {
+                                        const value = buttonValues[`param.${parameter.name}`] ?? "";
+                                        return (
+                                            <DynamicParameter
+                                                key={parameter.name}
+                                                parameter={parameter}
+                                                value={value}
+                                                onChange={(val) => handleChange(parameter, val)}
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            )}
+                            {experimentalFormContext && (
+                                <Button
+                                    size="sm"
+                                    variant="subtle"
+                                    onClick={experimentalFormContext.toggleOptedOut}
+                                >
+                                    Go back to the classic embed flow
+                                </Button>
+                            )}
+                            {error && (
+                                <p className="text-content-destructive text-sm">{String(error)}</p>
+                            )}
+                        </VerticalForm>
+                    </div>
+                    <div
+                        css={(theme) => ({
+                            height: "calc(100vh - (80px + 36px))",
+                            top: 40,
+                            position: "sticky",
+                            display: "flex",
+                            padding: 64,
+                            flex: 1,
+                            alignItems: "center",
+                            justifyContent: "center",
+                            borderRadius: 8,
+                            backgroundColor: theme.palette.background.paper,
+                            border: `1px solid ${theme.palette.divider}`,
+                        })}
+                    >
+                        <img src="/open-in-coder.svg" alt="Open in Coder button" />
+                        <div
+                            css={{
+                                padding: "48px 16px",
+                                position: "absolute",
+                                bottom: 0,
+                                left: 0,
+                                display: "flex",
+                                justifyContent: "center",
+                                width: "100%",
+                            }}
+                        >
+                            <Button
+                                css={{ borderRadius: 999 }}
+                                startIcon={clipboard.showCopiedSuccess ? (
+                                    <CheckIcon className="size-icon-sm" />
+                                ) : (
+                                    <CopyIcon className="size-icon-sm" />
+                                )}
+                                variant="contained"
+                                onClick={clipboard.copyToClipboard}
+                                disabled={clipboard.showCopiedSuccess}
+                            >
+                                Copy button code
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+};
+
+function getClipboardCopyContent(
+    templateName: string,
+    organization: string,
+    buttonValues: ButtonValues | undefined,
+): string {
+    const deploymentUrl = `${window.location.protocol}//${window.location.host}`;
+    const createWorkspaceUrl = `${deploymentUrl}/templates/${organization}/${templateName}/workspace`;
+    const params = new URLSearchParams(buttonValues);
+    const buttonUrl = `${createWorkspaceUrl}?${params.toString()}`;
+
+    return `[![Open in Coder](${deploymentUrl}/open-in-coder.svg)](${buttonUrl})`;
+}
+
+export default TemplateEmbedPageExperimental;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -1,256 +1,295 @@
-import { Button } from "components/Button/Button";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import { API } from "api/api";
 import type {
-    DynamicParametersRequest,
-    DynamicParametersResponse,
-    PreviewParameter,
-    Template,
+	DynamicParametersRequest,
+	DynamicParametersResponse,
+	PreviewParameter,
+	Template,
 } from "api/typesGenerated";
+import { Button } from "components/Button/Button";
 import { FormSection, VerticalForm } from "components/Form/Form";
 import { Loader } from "components/Loader/Loader";
-import { DynamicParameter, getInitialParameterValues } from "modules/workspaces/DynamicParameter/DynamicParameter";
-import { useClipboard } from "hooks/useClipboard";
 import { useAuthenticated } from "hooks";
 import { useEffectEvent } from "hooks/hookPolyfills";
+import { useClipboard } from "hooks/useClipboard";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
+import {
+	DynamicParameter,
+	getInitialParameterValues,
+} from "modules/workspaces/DynamicParameter/DynamicParameter";
 import { ExperimentalFormContext } from "pages/CreateWorkspacePage/ExperimentalFormContext";
-import { type FC, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
+import {
+	type FC,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { Helmet } from "react-helmet-async";
 import { pageTitle } from "utils/page";
 
 export type ButtonValues = Record<string, string>;
 
 const TemplateEmbedPageExperimental: FC = () => {
-    const { template } = useTemplateLayoutContext();
-    const { user } = useAuthenticated();
+	const { template } = useTemplateLayoutContext();
+	const { user } = useAuthenticated();
 
-    const [latestResponse, setLatestResponse] = useState<DynamicParametersResponse | null>(null);
-    const ws = useRef<WebSocket | null>(null);
-    const wsResponseId = useRef<number>(-1);
-    const initialParamsSentRef = useRef(false);
-    const [wsError, setWsError] = useState<Error | null>(null);
+	const [latestResponse, setLatestResponse] =
+		useState<DynamicParametersResponse | null>(null);
+	const ws = useRef<WebSocket | null>(null);
+	const wsResponseId = useRef<number>(-1);
+	const initialParamsSentRef = useRef(false);
+	const [wsError, setWsError] = useState<Error | null>(null);
 
-    const sendMessage = useCallback((values: Record<string, string>) => {
-        const request: DynamicParametersRequest = {
-            id: wsResponseId.current + 1,
-            inputs: values,
-        };
-        if (ws.current && ws.current.readyState === WebSocket.OPEN) {
-            ws.current.send(JSON.stringify(request));
-            wsResponseId.current = wsResponseId.current + 1;
-        }
-    }, []);
+	const sendMessage = useCallback((values: Record<string, string>) => {
+		const request: DynamicParametersRequest = {
+			id: wsResponseId.current + 1,
+			inputs: values,
+		};
+		if (ws.current && ws.current.readyState === WebSocket.OPEN) {
+			ws.current.send(JSON.stringify(request));
+			wsResponseId.current = wsResponseId.current + 1;
+		}
+	}, []);
 
-    const sendInitialParameters = useEffectEvent((params: PreviewParameter[]) => {
-        if (initialParamsSentRef.current) return;
-        if (params.length === 0) return;
-        const initial = getInitialParameterValues(params);
-        const inputs: Record<string, string> = {};
-        for (const param of initial) {
-            if (param.name && param.value) {
-                inputs[param.name] = param.value;
-            }
-        }
-        if (Object.keys(inputs).length === 0) return;
-        sendMessage(inputs);
-        initialParamsSentRef.current = true;
-    });
+	const sendInitialParameters = useEffectEvent((params: PreviewParameter[]) => {
+		if (initialParamsSentRef.current) return;
+		if (params.length === 0) return;
+		const initial = getInitialParameterValues(params);
+		const inputs: Record<string, string> = {};
+		for (const param of initial) {
+			if (param.name && param.value) {
+				inputs[param.name] = param.value;
+			}
+		}
+		if (Object.keys(inputs).length === 0) return;
+		sendMessage(inputs);
+		initialParamsSentRef.current = true;
+	});
 
-    const onMessage = useEffectEvent((response: DynamicParametersResponse) => {
-        if (latestResponse && latestResponse.id >= response.id) {
-            return;
-        }
-        if (!initialParamsSentRef.current && response.parameters?.length > 0) {
-            sendInitialParameters([...response.parameters]);
-        }
-        setLatestResponse(response);
-    });
+	const onMessage = useEffectEvent((response: DynamicParametersResponse) => {
+		if (latestResponse && latestResponse.id >= response.id) {
+			return;
+		}
+		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
+			sendInitialParameters([...response.parameters]);
+		}
+		setLatestResponse(response);
+	});
 
-    useEffect(() => {
-        const socket = API.templateVersionDynamicParameters(
-            user.id,
-            template.active_version_id,
-            {
-                onMessage,
-                onError: (e) => {
-                    if (ws.current === socket) {
-                        setWsError(e);
-                    }
-                },
-                onClose: () => {
-                    if (ws.current === socket) {
-                        setWsError(new Error("Websocket connection for dynamic parameters unexpectedly closed."));
-                    }
-                },
-            },
-        );
-        ws.current = socket;
-        return () => {
-            socket.close();
-        };
-    }, [user.id, template.active_version_id, onMessage]);
+	useEffect(() => {
+		const socket = API.templateVersionDynamicParameters(
+			user.id,
+			template.active_version_id,
+			{
+				onMessage,
+				onError: (e) => {
+					if (ws.current === socket) {
+						setWsError(e);
+					}
+				},
+				onClose: () => {
+					if (ws.current === socket) {
+						setWsError(
+							new Error(
+								"Websocket connection for dynamic parameters unexpectedly closed.",
+							),
+						);
+					}
+				},
+			},
+		);
+		ws.current = socket;
+		return () => {
+			socket.close();
+		};
+	}, [user.id, template.active_version_id, onMessage]);
 
-    const parameters = useMemo(() => {
-        return latestResponse?.parameters ? [...latestResponse.parameters].sort((a, b) => a.order - b.order) : [];
-    }, [latestResponse?.parameters]);
+	const parameters = useMemo(() => {
+		return latestResponse?.parameters
+			? [...latestResponse.parameters].sort((a, b) => a.order - b.order)
+			: [];
+	}, [latestResponse?.parameters]);
 
-    return (
-        <TemplateEmbedPageViewExperimental
-            template={template}
-            parameters={parameters}
-            sendMessage={sendMessage}
-            error={wsError}
-        />
-    );
+	return (
+		<TemplateEmbedPageViewExperimental
+			template={template}
+			parameters={parameters}
+			sendMessage={sendMessage}
+			error={wsError}
+		/>
+	);
 };
 
 interface TemplateEmbedPageViewExperimentalProps {
-    template: Template;
-    parameters: PreviewParameter[];
-    sendMessage: (values: Record<string, string>) => void;
-    error?: unknown;
+	template: Template;
+	parameters: PreviewParameter[];
+	sendMessage: (values: Record<string, string>) => void;
+	error?: unknown;
 }
 
-export const TemplateEmbedPageViewExperimental: FC<TemplateEmbedPageViewExperimentalProps> = ({
-    template,
-    parameters,
-    sendMessage,
-    error,
-}) => {
-    const experimentalFormContext = useContext(ExperimentalFormContext);
-    const [buttonValues, setButtonValues] = useState<ButtonValues>();
-    const clipboard = useClipboard({
-        textToCopy: getClipboardCopyContent(template.name, template.organization_name, buttonValues),
-    });
+export const TemplateEmbedPageViewExperimental: FC<
+	TemplateEmbedPageViewExperimentalProps
+> = ({ template, parameters, sendMessage, error }) => {
+	const experimentalFormContext = useContext(ExperimentalFormContext);
+	const [buttonValues, setButtonValues] = useState<ButtonValues>();
+	const clipboard = useClipboard({
+		textToCopy: getClipboardCopyContent(
+			template.name,
+			template.organization_name,
+			buttonValues,
+		),
+	});
 
-    useEffect(() => {
-        if (parameters.length > 0 && !buttonValues) {
-            const values: ButtonValues = { mode: "manual" };
-            for (const param of getInitialParameterValues(parameters)) {
-                values[`param.${param.name}`] = param.value;
-            }
-            setButtonValues(values);
-        }
-    }, [parameters, buttonValues]);
+	useEffect(() => {
+		if (parameters.length > 0 && !buttonValues) {
+			const values: ButtonValues = { mode: "manual" };
+			for (const param of getInitialParameterValues(parameters)) {
+				values[`param.${param.name}`] = param.value;
+			}
+			setButtonValues(values);
+		}
+	}, [parameters, buttonValues]);
 
-    const handleChange = (parameter: PreviewParameter, value: string) => {
-        setButtonValues((prev) => ({ ...(prev ?? {}), [`param.${parameter.name}`]: value }));
-        sendMessage({ [parameter.name]: value });
-    };
+	const handleChange = (parameter: PreviewParameter, value: string) => {
+		setButtonValues((prev) => ({
+			...(prev ?? {}),
+			[`param.${parameter.name}`]: value,
+		}));
+		sendMessage({ [parameter.name]: value });
+	};
 
-    return (
-        <>
-            <Helmet>
-                <title>{pageTitle(template.name)}</title>
-            </Helmet>
-            {!buttonValues ? (
-                <Loader />
-            ) : (
-                <div css={{ display: "flex", alignItems: "flex-start", gap: 48 }}>
-                    <div css={{ flex: 1, maxWidth: 400 }}>
-                        <VerticalForm>
-                            <FormSection
-                                title="Creation mode"
-                                description="By changing the mode to automatic, when the user clicks the button, the workspace will be created automatically instead of showing a form to the user."
-                            >
-                                <RadioGroup
-                                    defaultValue={buttonValues.mode}
-                                    onChange={(_, v) => {
-                                        setButtonValues((prev) => ({ ...(prev ?? {}), mode: v }));
-                                    }}
-                                >
-                                    <FormControlLabel value="manual" control={<Radio size="small" />} label="Manual" />
-                                    <FormControlLabel value="auto" control={<Radio size="small" />} label="Automatic" />
-                                </RadioGroup>
-                            </FormSection>
-                            {parameters.length > 0 && (
-                                <div css={{ display: "flex", flexDirection: "column", gap: 36 }}>
-                                    {parameters.map((parameter) => {
-                                        const value = buttonValues[`param.${parameter.name}`] ?? "";
-                                        return (
-                                            <DynamicParameter
-                                                key={parameter.name}
-                                                parameter={parameter}
-                                                value={value}
-                                                onChange={(val) => handleChange(parameter, val)}
+	return (
+		<>
+			<Helmet>
+				<title>{pageTitle(template.name)}</title>
+			</Helmet>
+			{!buttonValues ? (
+				<Loader />
+			) : (
+				<div css={{ display: "flex", alignItems: "flex-start", gap: 48 }}>
+					<div css={{ flex: 1, maxWidth: 400 }}>
+						<VerticalForm>
+							<FormSection
+								title="Creation mode"
+								description="By changing the mode to automatic, when the user clicks the button, the workspace will be created automatically instead of showing a form to the user."
+							>
+								<RadioGroup
+									defaultValue={buttonValues.mode}
+									onChange={(_, v) => {
+										setButtonValues((prev) => ({ ...(prev ?? {}), mode: v }));
+									}}
+								>
+									<FormControlLabel
+										value="manual"
+										control={<Radio size="small" />}
+										label="Manual"
+									/>
+									<FormControlLabel
+										value="auto"
+										control={<Radio size="small" />}
+										label="Automatic"
+									/>
+								</RadioGroup>
+							</FormSection>
+							{parameters.length > 0 && (
+								<div
+									css={{ display: "flex", flexDirection: "column", gap: 36 }}
+								>
+									{parameters.map((parameter) => {
+										const value = buttonValues[`param.${parameter.name}`] ?? "";
+										return (
+											<DynamicParameter
+												key={parameter.name}
+												parameter={parameter}
+												value={value}
+												onChange={(val) => handleChange(parameter, val)}
 												autofill={false}
-                                            />
-                                        );
-                                    })}
-                                </div>
-                            )}
-                            {experimentalFormContext && (
-                                <Button
-                                    size="sm"
-                                    variant="subtle"
-                                    onClick={experimentalFormContext.toggleOptedOut}
-                                >
-                                    Go back to the classic template embed flow
-                                </Button>
-                            )}
-                            {Boolean(error) && (
-                                <p className="text-content-destructive text-sm">{String(error)}</p>
-                            )}
-                        </VerticalForm>
-                    </div>
-                    <div
-                        css={(theme) => ({
-                            height: "calc(100vh - (80px + 36px))",
-                            top: 40,
-                            position: "sticky",
-                            display: "flex",
-                            padding: 64,
-                            flex: 1,
-                            alignItems: "center",
-                            justifyContent: "center",
-                            borderRadius: 8,
-                            backgroundColor: theme.palette.background.paper,
-                            border: `1px solid ${theme.palette.divider}`,
-                        })}
-                    >
-                        <img src="/open-in-coder.svg" alt="Open in Coder button" />
-                        <div
-                            css={{
-                                padding: "48px 16px",
-                                position: "absolute",
-                                bottom: 0,
-                                left: 0,
-                                display: "flex",
-                                justifyContent: "center",
-                                width: "100%",
-                            }}
-                        >
-                            <Button
-                                css={{ borderRadius: 999 }}
-                                variant="outline"
-                                onClick={clipboard.copyToClipboard}
-                                disabled={clipboard.showCopiedSuccess}
-                            >
-                                {clipboard.showCopiedSuccess ? <CheckIcon className="size-icon-sm" /> : <CopyIcon className="size-icon-sm" />}Copy button code
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            )}
-        </>
-    );
+											/>
+										);
+									})}
+								</div>
+							)}
+							{experimentalFormContext && (
+								<Button
+									size="sm"
+									variant="subtle"
+									onClick={experimentalFormContext.toggleOptedOut}
+								>
+									Go back to the classic template embed flow
+								</Button>
+							)}
+							{Boolean(error) && (
+								<p className="text-content-destructive text-sm">
+									{String(error)}
+								</p>
+							)}
+						</VerticalForm>
+					</div>
+					<div
+						css={(theme) => ({
+							height: "calc(100vh - (80px + 36px))",
+							top: 40,
+							position: "sticky",
+							display: "flex",
+							padding: 64,
+							flex: 1,
+							alignItems: "center",
+							justifyContent: "center",
+							borderRadius: 8,
+							backgroundColor: theme.palette.background.paper,
+							border: `1px solid ${theme.palette.divider}`,
+						})}
+					>
+						<img src="/open-in-coder.svg" alt="Open in Coder button" />
+						<div
+							css={{
+								padding: "48px 16px",
+								position: "absolute",
+								bottom: 0,
+								left: 0,
+								display: "flex",
+								justifyContent: "center",
+								width: "100%",
+							}}
+						>
+							<Button
+								css={{ borderRadius: 999 }}
+								variant="outline"
+								onClick={clipboard.copyToClipboard}
+								disabled={clipboard.showCopiedSuccess}
+							>
+								{clipboard.showCopiedSuccess ? (
+									<CheckIcon className="size-icon-sm" />
+								) : (
+									<CopyIcon className="size-icon-sm" />
+								)}
+								Copy button code
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+		</>
+	);
 };
 
 function getClipboardCopyContent(
-    templateName: string,
-    organization: string,
-    buttonValues: ButtonValues | undefined,
+	templateName: string,
+	organization: string,
+	buttonValues: ButtonValues | undefined,
 ): string {
-    const deploymentUrl = `${window.location.protocol}//${window.location.host}`;
-    const createWorkspaceUrl = `${deploymentUrl}/templates/${organization}/${templateName}/workspace`;
-    const params = new URLSearchParams(buttonValues);
-    const buttonUrl = `${createWorkspaceUrl}?${params.toString()}`;
+	const deploymentUrl = `${window.location.protocol}//${window.location.host}`;
+	const createWorkspaceUrl = `${deploymentUrl}/templates/${organization}/${templateName}/workspace`;
+	const params = new URLSearchParams(buttonValues);
+	const buttonUrl = `${createWorkspaceUrl}?${params.toString()}`;
 
-    return `[![Open in Coder](${deploymentUrl}/open-in-coder.svg)](${buttonUrl})`;
+	return `[![Open in Coder](${deploymentUrl}/open-in-coder.svg)](${buttonUrl})`;
 }
 
 export default TemplateEmbedPageExperimental;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -1,4 +1,4 @@
-import Button from "@mui/material/Button";
+import { Button } from "components/Button/Button";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
@@ -177,6 +177,7 @@ export const TemplateEmbedPageViewExperimental: FC<TemplateEmbedPageViewExperime
                                                 parameter={parameter}
                                                 value={value}
                                                 onChange={(val) => handleChange(parameter, val)}
+												autofill={false}
                                             />
                                         );
                                     })}
@@ -188,10 +189,10 @@ export const TemplateEmbedPageViewExperimental: FC<TemplateEmbedPageViewExperime
                                     variant="subtle"
                                     onClick={experimentalFormContext.toggleOptedOut}
                                 >
-                                    Go back to the classic embed flow
+                                    Go back to the classic template embed flow
                                 </Button>
                             )}
-                            {error && (
+                            {Boolean(error) && (
                                 <p className="text-content-destructive text-sm">{String(error)}</p>
                             )}
                         </VerticalForm>
@@ -225,16 +226,11 @@ export const TemplateEmbedPageViewExperimental: FC<TemplateEmbedPageViewExperime
                         >
                             <Button
                                 css={{ borderRadius: 999 }}
-                                startIcon={clipboard.showCopiedSuccess ? (
-                                    <CheckIcon className="size-icon-sm" />
-                                ) : (
-                                    <CopyIcon className="size-icon-sm" />
-                                )}
-                                variant="contained"
+                                variant="outline"
                                 onClick={clipboard.copyToClipboard}
                                 disabled={clipboard.showCopiedSuccess}
                             >
-                                Copy button code
+                                {clipboard.showCopiedSuccess ? <CheckIcon className="size-icon-sm" /> : <CopyIcon className="size-icon-sm" />}Copy button code
                             </Button>
                         </div>
                     </div>

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -133,7 +133,7 @@ interface TemplateEmbedPageViewExperimentalProps {
 	error?: unknown;
 }
 
-export const TemplateEmbedPageViewExperimental: FC<
+const TemplateEmbedPageViewExperimental: FC<
 	TemplateEmbedPageViewExperimentalProps
 > = ({ template, parameters, sendMessage, error }) => {
 	const experimentalFormContext = useContext(ExperimentalFormContext);

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -274,7 +274,13 @@ const ProvisionersPage = lazy(
 		),
 );
 const TemplateEmbedPage = lazy(
-	() => import("./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage"),
+        () => import("./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage"),
+);
+const TemplateEmbedExperimentRouter = lazy(
+        () =>
+                import(
+                        "./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter"
+                ),
 );
 const TemplateInsightsPage = lazy(
 	() =>
@@ -344,7 +350,7 @@ const templateRouter = () => {
 					<Route path="files" element={<TemplateFilesPage />} />
 					<Route path="resources" element={<TemplateResourcesPage />} />
 					<Route path="versions" element={<TemplateVersionsPage />} />
-					<Route path="embed" element={<TemplateEmbedPage />} />
+                                        <Route path="embed" element={<TemplateEmbedExperimentRouter />} />
 					<Route path="insights" element={<TemplateInsightsPage />} />
 				</Route>
 

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -274,13 +274,13 @@ const ProvisionersPage = lazy(
 		),
 );
 const TemplateEmbedPage = lazy(
-        () => import("./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage"),
+	() => import("./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage"),
 );
 const TemplateEmbedExperimentRouter = lazy(
-        () =>
-                import(
-                        "./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter"
-                ),
+	() =>
+		import(
+			"./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedExperimentRouter"
+		),
 );
 const TemplateInsightsPage = lazy(
 	() =>
@@ -350,7 +350,7 @@ const templateRouter = () => {
 					<Route path="files" element={<TemplateFilesPage />} />
 					<Route path="resources" element={<TemplateResourcesPage />} />
 					<Route path="versions" element={<TemplateVersionsPage />} />
-                                        <Route path="embed" element={<TemplateEmbedExperimentRouter />} />
+					<Route path="embed" element={<TemplateEmbedExperimentRouter />} />
 					<Route path="insights" element={<TemplateInsightsPage />} />
 				</Route>
 


### PR DESCRIPTION
## Summary
- add TemplateEmbedPageExperimental that fetches dynamic parameters via websocket and renders using `DynamicParameter`
- route embed page through TemplateEmbedExperimentRouter which decides based on the dynamic-parameters experiment
- integrate router into main router

## Codex Prompt
Create an experimental version of the TemplateEmbedPage.tsx for the dynamic-parameters experiment. This should be modeled after CreateWorkspacePageExperiemental.tsx and CreateWorkspacePageViewExperiemental.tsx. The goal is to use switch to using the DynamicParameter.tsx component and use the websocket (API.templateVersionDynamicParameters) to retrieve the parameters. Logic to decide to use the experiment can be modeled after CreateWorkspaceExperiementRouter.tsx