### PR TITLE
chore: reduce `ignore_changes` suggestion scope

### DIFF
--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -142,7 +142,7 @@ To prevent this, add a `lifecycle` block with `ignore_changes`:
 ```hcl
 resource "docker_container" "workspace" {
   lifecycle {
-    ignore_changes = all
+    ignore_changes = [env, image] # include all fields which caused drift
   }
 
   count = data.coder_workspace.me.start_count
@@ -151,19 +151,9 @@ resource "docker_container" "workspace" {
 }
 ```
 
-For more targeted control, specify which attributes to ignore:
-
-```hcl
-resource "docker_container" "workspace" {
-  lifecycle {
-    ignore_changes = [name]
-  }
-
-  count = data.coder_workspace.me.start_count
-  name  = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
-  ...
-}
-```
+Try to keep `ignore_changes` scoped to just the fields which were called out in the notification. Excessive use of
+`ignore_changes` can lead to undesirable outcomes in Terraform, like innocuous changes (which wouldn't cause replacements)
+to be ignored.
 
 Learn more about `ignore_changes` in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
 

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -151,9 +151,8 @@ resource "docker_container" "workspace" {
 }
 ```
 
-Try to keep `ignore_changes` scoped to just the fields which were called out in the notification. Excessive use of
-`ignore_changes` can lead to undesirable outcomes in Terraform, like innocuous changes (which wouldn't cause replacements)
-to be ignored.
+Limit the scope of `ignore_changes` to include only the fields specified in the notification.
+If you include too many fields, Terraform might ignore changes that wouldn't otherwise cause drift.
 
 Learn more about `ignore_changes` in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
 


### PR DESCRIPTION
We probably shouldn't be suggesting `ignore_changes = all`. Only the attributes which cause drift in prebuilds should be ignored; everything else can behave as normal.