### PR TITLE
fix: correct environment variable name for MCP app status slug

### DIFF
--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -255,7 +255,7 @@ func (*RootCmd) mcpConfigureClaudeCode() *serpent.Command {
 			{
 				Name:        "app-status-slug",
 				Description: "The app status slug to use when running the Coder MCP server.",
-				Env:         "CODER_MCP_CLAUDE_APP_STATUS_SLUG",
+				Env:         "CODER_MCP_APP_STATUS_SLUG",
 				Flag:        "claude-app-status-slug",
 				Value:       serpent.StringOf(&appStatusSlug),
 			},


### PR DESCRIPTION
Fixed environment variable name for app status slug in Claude MCP configuration from `CODER_MCP_CLAUDE_APP_STATUS_SLUG` to `CODER_MCP_APP_STATUS_SLUG` to maintain consistency with other MCP environment variables.

This also caused the User level Claude.md to not contain instructions to report its progress, so it did not receive status reports.