### PR TITLE
chore: ignore 'session shutdown' yamux error in tests

### DIFF
--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -2,10 +2,10 @@ package testutil
 
 import (
 	"context"
-	"github.com/hashicorp/yamux"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/yamux"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"github.com/hashicorp/yamux"
 	"strings"
 	"testing"
 
@@ -23,6 +24,11 @@ func IgnoreLoggedError(entry slog.SinkEntry) bool {
 	err, ok := slogtest.FindFirstError(entry)
 	if !ok {
 		return false
+	}
+	// Yamux sessions get shut down when we are shutting down tests, so ignoring
+	// them should reduce flakiness.
+	if xerrors.Is(err, yamux.ErrSessionShutdown) {
+		return true
 	}
 	// Canceled queries usually happen when we're shutting down tests, and so
 	// ignoring them should reduce flakiness.  This also includes


### PR DESCRIPTION
Fixes flake seen here: https://github.com/coder/coder/actions/runs/15154327939/job/42606133069?pr=17960

Error log dropped when the dRPC server is being shut down right as we are (re)dialing.