### PR TITLE
fix: show diagnostics if there are no parameters

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -489,6 +489,10 @@ export const CreateWorkspacePageViewExperimental: FC<
 						</section>
 					)}
 
+					{parameters.length === 0 && diagnostics.length > 0 && (
+						<Diagnostics diagnostics={diagnostics} />
+					)}
+
 					{parameters.length > 0 && (
 						<section className="flex flex-col gap-9">
 							<hgroup>


### PR DESCRIPTION
Prefer to show the top level diagnostics inside the parameters section for context but this adds a case to show diagnostics if there are no parameters.

Normally, the entire parameters section is hidden if there are no parameters.