### PR TITLE
feat(agent/agentcontainers): update containers periodically

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1176,12 +1176,6 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				}
 				a.metrics.startupScriptSeconds.WithLabelValues(label).Set(dur)
 				a.scriptRunner.StartCron()
-				if containerAPI := a.containerAPI.Load(); containerAPI != nil {
-					// Inform the container API that the agent is ready.
-					// This allows us to start watching for changes to
-					// the devcontainer configuration files.
-					containerAPI.SignalReady()
-				}
 			})
 			if err != nil {
 				return xerrors.Errorf("track conn goroutine: %w", err)

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -677,9 +677,15 @@ func (api *API) markDevcontainerDirty(configPath string, modifiedAt time.Time) {
 				slog.F("modified_at", modifiedAt),
 			)
 			api.knownDevcontainers[i].Dirty = true
-			if api.knownDevcontainers[i].Container != nil {
-				api.knownDevcontainers[i].Container.DevcontainerDirty = true
-			}
+		}
+		if api.knownDevcontainers[i].Container != nil && !api.knownDevcontainers[i].Container.DevcontainerDirty {
+			api.logger.Info(api.ctx, "marking devcontainer container as dirty",
+				slog.F("file", configPath),
+				slog.F("name", api.knownDevcontainers[i].Name),
+				slog.F("workspace_folder", api.knownDevcontainers[i].WorkspaceFolder),
+				slog.F("modified_at", modifiedAt),
+			)
+			api.knownDevcontainers[i].Container.DevcontainerDirty = true
 		}
 	}
 }

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -25,35 +26,35 @@ import (
 )
 
 const (
-	defaultGetContainersCacheDuration = 10 * time.Second
-	dockerCreatedAtTimeFormat         = "2006-01-02 15:04:05 -0700 MST"
-	getContainersTimeout              = 5 * time.Second
+	defaultUpdateInterval = 10 * time.Second
+	listContainersTimeout = 15 * time.Second
 )
 
 // API is responsible for container-related operations in the agent.
 // It provides methods to list and manage containers.
 type API struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	done    chan struct{}
-	logger  slog.Logger
-	watcher watcher.Watcher
+	ctx               context.Context
+	cancel            context.CancelFunc
+	watcherDone       chan struct{}
+	updaterDone       chan struct{}
+	initialUpdateDone chan struct{}   // Closed after first update in updaterLoop.
+	refreshTrigger    chan chan error // Channel to trigger manual refresh.
+	updateInterval    time.Duration   // Interval for periodic container updates.
+	logger            slog.Logger
+	watcher           watcher.Watcher
+	execer            agentexec.Execer
+	cl                Lister
+	dccli             DevcontainerCLI
+	clock             quartz.Clock
+	scriptLogger      func(logSourceID uuid.UUID) ScriptLogger
 
-	cacheDuration time.Duration
-	execer        agentexec.Execer
-	cl            Lister
-	dccli         DevcontainerCLI
-	clock         quartz.Clock
-	scriptLogger  func(logSourceID uuid.UUID) ScriptLogger
-
-	// lockCh protects the below fields. We use a channel instead of a
-	// mutex so we can handle cancellation properly.
-	lockCh                  chan struct{}
-	containers              codersdk.WorkspaceAgentListContainersResponse
-	mtime                   time.Time
-	devcontainerNames       map[string]struct{}                   // Track devcontainer names to avoid duplicates.
-	knownDevcontainers      []codersdk.WorkspaceAgentDevcontainer // Track predefined and runtime-detected devcontainers.
-	configFileModifiedTimes map[string]time.Time                  // Track when config files were last modified.
+	mu                      sync.RWMutex
+	closed                  bool
+	containers              codersdk.WorkspaceAgentListContainersResponse // Output from the last list operation.
+	containersErr           error                                         // Error from the last list operation.
+	devcontainerNames       map[string]struct{}
+	knownDevcontainers      []codersdk.WorkspaceAgentDevcontainer
+	configFileModifiedTimes map[string]time.Time
 
 	devcontainerLogSourceIDs map[string]uuid.UUID // Track devcontainer log source IDs.
 }
@@ -66,15 +67,6 @@ type Option func(*API)
 func WithClock(clock quartz.Clock) Option {
 	return func(api *API) {
 		api.clock = clock
-	}
-}
-
-// WithCacheDuration sets the cache duration for the API.
-// This is used to control how often the API refreshes the list of
-// containers. The default is 10 seconds.
-func WithCacheDuration(d time.Duration) Option {
-	return func(api *API) {
-		api.cacheDuration = d
 	}
 }
 
@@ -169,12 +161,14 @@ func NewAPI(logger slog.Logger, options ...Option) *API {
 	api := &API{
 		ctx:                     ctx,
 		cancel:                  cancel,
-		done:                    make(chan struct{}),
+		watcherDone:             make(chan struct{}),
+		updaterDone:             make(chan struct{}),
+		initialUpdateDone:       make(chan struct{}),
+		refreshTrigger:          make(chan chan error),
+		updateInterval:          defaultUpdateInterval,
 		logger:                  logger,
 		clock:                   quartz.NewReal(),
 		execer:                  agentexec.DefaultExecer,
-		cacheDuration:           defaultGetContainersCacheDuration,
-		lockCh:                  make(chan struct{}, 1),
 		devcontainerNames:       make(map[string]struct{}),
 		knownDevcontainers:      []codersdk.WorkspaceAgentDevcontainer{},
 		configFileModifiedTimes: make(map[string]time.Time),
@@ -200,33 +194,16 @@ func NewAPI(logger slog.Logger, options ...Option) *API {
 		}
 	}
 
-	go api.loop()
+	go api.watcherLoop()
+	go api.updaterLoop()
 
 	return api
 }
 
-// SignalReady signals the API that we are ready to begin watching for
-// file changes. This is used to prime the cache with the current list
-// of containers and to start watching the devcontainer config files for
-// changes. It should be called after the agent ready.
-func (api *API) SignalReady() {
-	// Prime the cache with the current list of containers.
-	_, _ = api.cl.List(api.ctx)
-
-	// Make sure we watch the devcontainer config files for changes.
-	for _, devcontainer := range api.knownDevcontainers {
-		if devcontainer.ConfigPath == "" {
-			continue
-		}
-
-		if err := api.watcher.Add(devcontainer.ConfigPath); err != nil {
-			api.logger.Error(api.ctx, "watch devcontainer config file failed", slog.Error(err), slog.F("file", devcontainer.ConfigPath))
-		}
-	}
-}
-
-func (api *API) loop() {
-	defer close(api.done)
+func (api *API) watcherLoop() {
+	defer close(api.watcherDone)
+	defer api.logger.Debug(api.ctx, "watcher loop stopped")
+	api.logger.Debug(api.ctx, "watcher loop started")
 
 	for {
 		event, err := api.watcher.Next(api.ctx)
@@ -263,9 +240,101 @@ func (api *API) loop() {
 	}
 }
 
+// updaterLoop is responsible for periodically updating the container
+// list and handling manual refresh requests.
+func (api *API) updaterLoop() {
+	defer close(api.updaterDone)
+	defer api.logger.Debug(api.ctx, "updater loop stopped")
+	api.logger.Debug(api.ctx, "updater loop started")
+
+	// Ensure that only once instance of the updateContainers is running
+	// at a time. This is a workaround since quartz.Ticker does not
+	// allow us to know if the routine has completed.
+	sema := make(chan struct{}, 1)
+	sema <- struct{}{}
+
+	// Ensure only one updateContainers is running at a time, others are
+	// queued.
+	doUpdate := func() error {
+		select {
+		case <-api.ctx.Done():
+			return api.ctx.Err()
+		case <-sema:
+		}
+		defer func() { sema <- struct{}{} }()
+
+		return api.updateContainers(api.ctx)
+	}
+
+	api.logger.Debug(api.ctx, "performing initial containers update")
+	if err := doUpdate(); err != nil {
+		api.logger.Error(api.ctx, "initial containers update failed", slog.Error(err))
+	} else {
+		api.logger.Debug(api.ctx, "initial containers update complete")
+	}
+	// Signal that the initial update attempt (successful or not) is done.
+	// Other services can wait on this if they need the first data to be available.
+	close(api.initialUpdateDone)
+
+	// Use a ticker func to ensure that doUpdate has run to completion
+	// when advancing time.
+	waiter := api.clock.TickerFunc(api.ctx, api.updateInterval, func() error {
+		err := doUpdate()
+		if err != nil {
+			api.logger.Error(api.ctx, "periodic containers update failed", slog.Error(err))
+		}
+		return nil // Always nil, keep going.
+	})
+	defer func() {
+		if err := waiter.Wait(); err != nil {
+			api.logger.Error(api.ctx, "updater loop ticker failed", slog.Error(err))
+		}
+	}()
+
+	for {
+		select {
+		case <-api.ctx.Done():
+			api.logger.Debug(api.ctx, "updater loop context canceled")
+			return
+		case ch := <-api.refreshTrigger:
+			api.logger.Debug(api.ctx, "manual containers update triggered")
+			err := doUpdate()
+			if err != nil {
+				api.logger.Error(api.ctx, "manual containers update failed", slog.Error(err))
+			}
+			ch <- err
+			close(ch)
+		}
+	}
+}
+
 // Routes returns the HTTP handler for container-related routes.
 func (api *API) Routes() http.Handler {
 	r := chi.NewRouter()
+
+	ensureInitialUpdateDoneMW := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			select {
+			case <-api.ctx.Done():
+				httpapi.Write(r.Context(), rw, http.StatusServiceUnavailable, codersdk.Response{
+					Message: "API closed",
+					Detail:  "The API is closed and cannot process requests.",
+				})
+				return
+			case <-r.Context().Done():
+				return
+			case <-api.initialUpdateDone:
+				// Initial update is done, we can start processing
+				// requests.
+			}
+			next.ServeHTTP(rw, r)
+		})
+	}
+
+	// For now, all endpoints require the initial update to be done.
+	// If we want to allow some endpoints to be available before
+	// the initial update, we can enable this per-route.
+	r.Use(ensureInitialUpdateDoneMW)
 
 	r.Get("/", api.handleList)
 	r.Route("/devcontainers", func(r chi.Router) {
@@ -278,62 +347,53 @@ func (api *API) Routes() http.Handler {
 
 // handleList handles the HTTP request to list containers.
 func (api *API) handleList(rw http.ResponseWriter, r *http.Request) {
-	select {
-	case <-r.Context().Done():
-		// Client went away.
+	ct, err := api.getContainers()
+	if err != nil {
+		httpapi.Write(r.Context(), rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Could not get containers",
+			Detail:  err.Error(),
+		})
 		return
-	default:
-		ct, err := api.getContainers(r.Context())
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				httpapi.Write(r.Context(), rw, http.StatusRequestTimeout, codersdk.Response{
-					Message: "Could not get containers.",
-					Detail:  "Took too long to list containers.",
-				})
-				return
-			}
-			httpapi.Write(r.Context(), rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Could not get containers.",
-				Detail:  err.Error(),
-			})
-			return
+	}
+	httpapi.Write(r.Context(), rw, http.StatusOK, ct)
+}
+
+// updateContainers fetches the latest container list, processes it, and
+// updates the cache. It performs locking for updating shared API state.
+func (api *API) updateContainers(ctx context.Context) error {
+	listCtx, listCancel := context.WithTimeout(ctx, listContainersTimeout)
+	defer listCancel()
+
+	updated, err := api.cl.List(listCtx)
+	if err != nil {
+		// If the context was canceled, we hold off on clearing the
+		// containers cache. This is to avoid clearing the cache if
+		// the update was canceled due to a timeout. Hopefully this
+		// will clear up on the next update.
+		if !errors.Is(err, context.Canceled) {
+			api.mu.Lock()
+			api.containers = codersdk.WorkspaceAgentListContainersResponse{}
+			api.containersErr = err
+			api.mu.Unlock()
 		}
 
-		httpapi.Write(r.Context(), rw, http.StatusOK, ct)
+		return xerrors.Errorf("list containers failed: %w", err)
 	}
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+
+	api.processUpdatedContainersLocked(ctx, updated)
+
+	api.logger.Debug(ctx, "containers updated successfully", slog.F("container_count", len(api.containers.Containers)), slog.F("warning_count", len(api.containers.Warnings)), slog.F("devcontainer_count", len(api.knownDevcontainers)))
+
+	return nil
 }
 
-func copyListContainersResponse(resp codersdk.WorkspaceAgentListContainersResponse) codersdk.WorkspaceAgentListContainersResponse {
-	return codersdk.WorkspaceAgentListContainersResponse{
-		Containers: slices.Clone(resp.Containers),
-		Warnings:   slices.Clone(resp.Warnings),
-	}
-}
-
-func (api *API) getContainers(ctx context.Context) (codersdk.WorkspaceAgentListContainersResponse, error) {
-	select {
-	case <-api.ctx.Done():
-		return codersdk.WorkspaceAgentListContainersResponse{}, api.ctx.Err()
-	case <-ctx.Done():
-		return codersdk.WorkspaceAgentListContainersResponse{}, ctx.Err()
-	case api.lockCh <- struct{}{}:
-		defer func() { <-api.lockCh }()
-	}
-
-	now := api.clock.Now()
-	if now.Sub(api.mtime) < api.cacheDuration {
-		return copyListContainersResponse(api.containers), nil
-	}
-
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, getContainersTimeout)
-	defer timeoutCancel()
-	updated, err := api.cl.List(timeoutCtx)
-	if err != nil {
-		return codersdk.WorkspaceAgentListContainersResponse{}, xerrors.Errorf("get containers: %w", err)
-	}
-	api.containers = updated
-	api.mtime = now
-
+// processUpdatedContainersLocked updates the devcontainer state based
+// on the latest list of containers. This method assumes that api.mu is
+// held.
+func (api *API) processUpdatedContainersLocked(ctx context.Context, updated codersdk.WorkspaceAgentListContainersResponse) {
 	dirtyStates := make(map[string]bool)
 	// Reset all known devcontainers to not running.
 	for i := range api.knownDevcontainers {
@@ -345,6 +405,7 @@ func (api *API) getContainers(ctx context.Context) (codersdk.WorkspaceAgentListC
 	}
 
 	// Check if the container is running and update the known devcontainers.
+	updatedDevcontainers := make(map[string]bool)
 	for i := range updated.Containers {
 		container := &updated.Containers[i]
 		workspaceFolder := container.Labels[DevcontainerLocalFolderLabel]
@@ -354,18 +415,16 @@ func (api *API) getContainers(ctx context.Context) (codersdk.WorkspaceAgentListC
 			continue
 		}
 
-		container.DevcontainerDirty = dirtyStates[workspaceFolder]
-		if container.DevcontainerDirty {
-			lastModified, hasModTime := api.configFileModifiedTimes[configFile]
-			if hasModTime && container.CreatedAt.After(lastModified) {
-				api.logger.Info(ctx, "new container created after config modification, not marking as dirty",
-					slog.F("container", container.ID),
-					slog.F("created_at", container.CreatedAt),
-					slog.F("config_modified_at", lastModified),
-					slog.F("file", configFile),
-				)
-				container.DevcontainerDirty = false
-			}
+		if lastModified, hasModTime := api.configFileModifiedTimes[configFile]; !hasModTime || container.CreatedAt.Before(lastModified) {
+			api.logger.Debug(ctx, "container created before config modification, setting dirty state from devcontainer",
+				slog.F("container", container.ID),
+				slog.F("created_at", container.CreatedAt),
+				slog.F("config_modified_at", lastModified),
+				slog.F("file", configFile),
+				slog.F("workspace_folder", workspaceFolder),
+				slog.F("dirty", dirtyStates[workspaceFolder]),
+			)
+			container.DevcontainerDirty = dirtyStates[workspaceFolder]
 		}
 
 		// Check if this is already in our known list.
@@ -373,29 +432,17 @@ func (api *API) getContainers(ctx context.Context) (codersdk.WorkspaceAgentListC
 			return dc.WorkspaceFolder == workspaceFolder
 		}); knownIndex != -1 {
 			// Update existing entry with runtime information.
-			if configFile != "" && api.knownDevcontainers[knownIndex].ConfigPath == "" {
-				api.knownDevcontainers[knownIndex].ConfigPath = configFile
+			dc := &api.knownDevcontainers[knownIndex]
+			if configFile != "" && dc.ConfigPath == "" {
+				dc.ConfigPath = configFile
 				if err := api.watcher.Add(configFile); err != nil {
 					api.logger.Error(ctx, "watch devcontainer config file failed", slog.Error(err), slog.F("file", configFile))
 				}
 			}
-			api.knownDevcontainers[knownIndex].Running = container.Running
-			api.knownDevcontainers[knownIndex].Container = container
-
-			// Check if this container was created after the config
-			// file was modified.
-			if configFile != "" && api.knownDevcontainers[knownIndex].Dirty {
-				lastModified, hasModTime := api.configFileModifiedTimes[configFile]
-				if hasModTime && container.CreatedAt.After(lastModified) {
-					api.logger.Info(ctx, "clearing dirty flag for container created after config modification",
-						slog.F("container", container.ID),
-						slog.F("created_at", container.CreatedAt),
-						slog.F("config_modified_at", lastModified),
-						slog.F("file", configFile),
-					)
-					api.knownDevcontainers[knownIndex].Dirty = false
-				}
-			}
+			dc.Running = container.Running
+			dc.Container = container
+			dc.Dirty = container.DevcontainerDirty
+			updatedDevcontainers[workspaceFolder] = true
 			continue
 		}
 
@@ -428,9 +475,67 @@ func (api *API) getContainers(ctx context.Context) (codersdk.WorkspaceAgentListC
 			Dirty:           container.DevcontainerDirty,
 			Container:       container,
 		})
+		updatedDevcontainers[workspaceFolder] = true
 	}
 
-	return copyListContainersResponse(api.containers), nil
+	for i := range api.knownDevcontainers {
+		if _, ok := updatedDevcontainers[api.knownDevcontainers[i].WorkspaceFolder]; ok {
+			continue
+		}
+
+		dc := &api.knownDevcontainers[i]
+
+		if !dc.Running && !dc.Dirty && dc.Container == nil {
+			// Already marked as not running, skip.
+			continue
+		}
+
+		api.logger.Debug(ctx, "devcontainer is not running anymore, marking as not running",
+			slog.F("workspace_folder", dc.WorkspaceFolder),
+			slog.F("config_path", dc.ConfigPath),
+			slog.F("name", dc.Name),
+		)
+		dc.Running = false
+		dc.Dirty = false
+		dc.Container = nil
+	}
+
+	api.containers = updated
+	api.containersErr = nil
+}
+
+// refreshContainers triggers an immediate update of the container list
+// and waits for it to complete.
+func (api *API) refreshContainers(ctx context.Context) error {
+	done := make(chan error, 1)
+	select {
+	case <-api.ctx.Done():
+		return xerrors.Errorf("API closed, cannot send refresh trigger: %w", api.ctx.Err())
+	case <-ctx.Done():
+		return ctx.Err()
+	case api.refreshTrigger <- done:
+		select {
+		case <-api.ctx.Done():
+			return xerrors.Errorf("API closed, cannot wait for refresh: %w", api.ctx.Err())
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-done:
+			return err
+		}
+	}
+}
+
+func (api *API) getContainers() (codersdk.WorkspaceAgentListContainersResponse, error) {
+	api.mu.RLock()
+	defer api.mu.RUnlock()
+
+	if api.containersErr != nil {
+		return codersdk.WorkspaceAgentListContainersResponse{}, api.containersErr
+	}
+	return codersdk.WorkspaceAgentListContainersResponse{
+		Containers: slices.Clone(api.containers.Containers),
+		Warnings:   slices.Clone(api.containers.Warnings),
+	}, nil
 }
 
 // handleDevcontainerRecreate handles the HTTP request to recreate a
@@ -447,7 +552,7 @@ func (api *API) handleDevcontainerRecreate(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	containers, err := api.getContainers(ctx)
+	containers, err := api.getContainers()
 	if err != nil {
 		httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
 			Message: "Could not list containers",
@@ -509,30 +614,9 @@ func (api *API) handleDevcontainerRecreate(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// TODO(mafredri): Temporarily handle clearing the dirty state after
-	// recreation, later on this should be handled by a "container watcher".
-	if !api.doLockedHandler(w, r, func() {
-		for i := range api.knownDevcontainers {
-			if api.knownDevcontainers[i].WorkspaceFolder == workspaceFolder {
-				if api.knownDevcontainers[i].Dirty {
-					api.logger.Info(ctx, "clearing dirty flag after recreation",
-						slog.F("workspace_folder", workspaceFolder),
-						slog.F("name", api.knownDevcontainers[i].Name),
-					)
-					api.knownDevcontainers[i].Dirty = false
-					// TODO(mafredri): This should be handled by a service that
-					// updates the devcontainer state periodically and on-demand.
-					api.knownDevcontainers[i].Container = nil
-					// Set the modified time to the zero value to indicate that
-					// the containers list must be refreshed. This will see to
-					// it that the new container is re-assigned.
-					api.mtime = time.Time{}
-				}
-				return
-			}
-		}
-	}) {
-		return
+	// NOTE(mafredri): This won't be needed once recreation is done async.
+	if err := api.refreshContainers(r.Context()); err != nil {
+		api.logger.Error(ctx, "failed to trigger immediate refresh after devcontainer recreation", slog.Error(err))
 	}
 
 	w.WriteHeader(http.StatusNoContent)
@@ -542,20 +626,15 @@ func (api *API) handleDevcontainerRecreate(w http.ResponseWriter, r *http.Reques
 func (api *API) handleDevcontainersList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Run getContainers to detect the latest devcontainers and their state.
-	_, err := api.getContainers(ctx)
+	api.mu.RLock()
+	err := api.containersErr
+	devcontainers := slices.Clone(api.knownDevcontainers)
+	api.mu.RUnlock()
 	if err != nil {
 		httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
 			Message: "Could not list containers",
 			Detail:  err.Error(),
 		})
-		return
-	}
-
-	var devcontainers []codersdk.WorkspaceAgentDevcontainer
-	if !api.doLockedHandler(w, r, func() {
-		devcontainers = slices.Clone(api.knownDevcontainers)
-	}) {
 		return
 	}
 
@@ -576,75 +655,52 @@ func (api *API) handleDevcontainersList(w http.ResponseWriter, r *http.Request) 
 // markDevcontainerDirty finds the devcontainer with the given config file path
 // and marks it as dirty. It acquires the lock before modifying the state.
 func (api *API) markDevcontainerDirty(configPath string, modifiedAt time.Time) {
-	ok := api.doLocked(func() {
-		// Record the timestamp of when this configuration file was modified.
-		api.configFileModifiedTimes[configPath] = modifiedAt
+	api.mu.Lock()
+	defer api.mu.Unlock()
 
-		for i := range api.knownDevcontainers {
-			if api.knownDevcontainers[i].ConfigPath != configPath {
-				continue
-			}
+	// Record the timestamp of when this configuration file was modified.
+	api.configFileModifiedTimes[configPath] = modifiedAt
 
-			// TODO(mafredri): Simplistic mark for now, we should check if the
-			// container is running and if the config file was modified after
-			// the container was created.
-			if !api.knownDevcontainers[i].Dirty {
-				api.logger.Info(api.ctx, "marking devcontainer as dirty",
-					slog.F("file", configPath),
-					slog.F("name", api.knownDevcontainers[i].Name),
-					slog.F("workspace_folder", api.knownDevcontainers[i].WorkspaceFolder),
-					slog.F("modified_at", modifiedAt),
-				)
-				api.knownDevcontainers[i].Dirty = true
-				if api.knownDevcontainers[i].Container != nil {
-					api.knownDevcontainers[i].Container.DevcontainerDirty = true
-				}
+	for i := range api.knownDevcontainers {
+		if api.knownDevcontainers[i].ConfigPath != configPath {
+			continue
+		}
+
+		// TODO(mafredri): Simplistic mark for now, we should check if the
+		// container is running and if the config file was modified after
+		// the container was created.
+		if !api.knownDevcontainers[i].Dirty {
+			api.logger.Info(api.ctx, "marking devcontainer as dirty",
+				slog.F("file", configPath),
+				slog.F("name", api.knownDevcontainers[i].Name),
+				slog.F("workspace_folder", api.knownDevcontainers[i].WorkspaceFolder),
+				slog.F("modified_at", modifiedAt),
+			)
+			api.knownDevcontainers[i].Dirty = true
+			if api.knownDevcontainers[i].Container != nil {
+				api.knownDevcontainers[i].Container.DevcontainerDirty = true
 			}
 		}
-	})
-	if !ok {
-		api.logger.Debug(api.ctx, "mark devcontainer dirty failed", slog.F("file", configPath))
 	}
-}
-
-func (api *API) doLockedHandler(w http.ResponseWriter, r *http.Request, f func()) bool {
-	select {
-	case <-r.Context().Done():
-		httpapi.Write(r.Context(), w, http.StatusRequestTimeout, codersdk.Response{
-			Message: "Request canceled",
-			Detail:  "Request was canceled before we could process it.",
-		})
-		return false
-	case <-api.ctx.Done():
-		httpapi.Write(r.Context(), w, http.StatusServiceUnavailable, codersdk.Response{
-			Message: "API closed",
-			Detail:  "The API is closed and cannot process requests.",
-		})
-		return false
-	case api.lockCh <- struct{}{}:
-		defer func() { <-api.lockCh }()
-	}
-	f()
-	return true
-}
-
-func (api *API) doLocked(f func()) bool {
-	select {
-	case <-api.ctx.Done():
-		return false
-	case api.lockCh <- struct{}{}:
-		defer func() { <-api.lockCh }()
-	}
-	f()
-	return true
 }
 
 func (api *API) Close() error {
-	api.cancel()
-	<-api.done
-	err := api.watcher.Close()
-	if err != nil {
-		return err
+	api.mu.Lock()
+	if api.closed {
+		api.mu.Unlock()
+		return nil
 	}
-	return nil
+	api.closed = true
+
+	api.logger.Debug(api.ctx, "closing API")
+	defer api.logger.Debug(api.ctx, "closed API")
+
+	api.cancel()
+	err := api.watcher.Close()
+
+	api.mu.Unlock()
+	<-api.watcherDone
+	<-api.updaterDone
+
+	return err
 }

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -293,6 +293,8 @@ func (api *API) updaterLoop() {
 		case <-api.ctx.Done():
 			return
 		case done := <-api.updateTrigger:
+			// Note that although we pass api.ctx here, updateContainers
+			// has an internal timeout to prevent long blocking calls.
 			done <- api.updateContainers(api.ctx)
 		}
 	}

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -662,30 +662,28 @@ func (api *API) markDevcontainerDirty(configPath string, modifiedAt time.Time) {
 	api.configFileModifiedTimes[configPath] = modifiedAt
 
 	for i := range api.knownDevcontainers {
-		if api.knownDevcontainers[i].ConfigPath != configPath {
+		dc := &api.knownDevcontainers[i]
+		if dc.ConfigPath != configPath {
 			continue
 		}
+
+		logger := api.logger.With(
+			slog.F("file", configPath),
+			slog.F("name", dc.Name),
+			slog.F("workspace_folder", dc.WorkspaceFolder),
+			slog.F("modified_at", modifiedAt),
+		)
 
 		// TODO(mafredri): Simplistic mark for now, we should check if the
 		// container is running and if the config file was modified after
 		// the container was created.
-		if !api.knownDevcontainers[i].Dirty {
-			api.logger.Info(api.ctx, "marking devcontainer as dirty",
-				slog.F("file", configPath),
-				slog.F("name", api.knownDevcontainers[i].Name),
-				slog.F("workspace_folder", api.knownDevcontainers[i].WorkspaceFolder),
-				slog.F("modified_at", modifiedAt),
-			)
-			api.knownDevcontainers[i].Dirty = true
+		if !dc.Dirty {
+			logger.Info(api.ctx, "marking devcontainer as dirty")
+			dc.Dirty = true
 		}
-		if api.knownDevcontainers[i].Container != nil && !api.knownDevcontainers[i].Container.DevcontainerDirty {
-			api.logger.Info(api.ctx, "marking devcontainer container as dirty",
-				slog.F("file", configPath),
-				slog.F("name", api.knownDevcontainers[i].Name),
-				slog.F("workspace_folder", api.knownDevcontainers[i].WorkspaceFolder),
-				slog.F("modified_at", modifiedAt),
-			)
-			api.knownDevcontainers[i].Container.DevcontainerDirty = true
+		if dc.Container != nil && !dc.Container.DevcontainerDirty {
+			logger.Info(api.ctx, "marking devcontainer container as dirty")
+			dc.Container.DevcontainerDirty = true
 		}
 	}
 }

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -773,6 +773,9 @@ func TestAPI(t *testing.T) {
 
 		clk.Set(time.Now()).MustWait(ctx)
 
+		// Make sure the start loop has been called.
+		watcher.waitNext(ctx)
+
 		// Simulate a file modification event to make the devcontainer dirty.
 		watcher.sendEventWaitNextCalled(ctx, fsnotify.Event{
 			Name: "/home/coder/project/.devcontainer/devcontainer.json",

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -202,7 +202,7 @@ func TestAPI(t *testing.T) {
 				setupMock: func(mcl *acmock.MockLister, preReq *gomock.Call) {
 					mcl.EXPECT().List(gomock.Any()).Return(makeResponse(fakeCt), nil).After(preReq).AnyTimes()
 				},
-				expectedErr: assert.AnError.Error(),
+				expected: makeResponse(fakeCt),
 			},
 			{
 				name:        "lister error after initial data",
@@ -263,7 +263,6 @@ func TestAPI(t *testing.T) {
 					err := json.NewDecoder(rec.Body).Decode(got)
 					require.NoError(t, err, "unmarshal response failed")
 					require.ErrorContains(t, got, tc.initialData.err.Error(), "want error")
-					return
 				} else {
 					var got codersdk.WorkspaceAgentListContainersResponse
 					err := json.NewDecoder(rec.Body).Decode(&got)

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -737,7 +737,7 @@ func TestAPI(t *testing.T) {
 			ID:           "container-id",
 			FriendlyName: "container-name",
 			Running:      true,
-			CreatedAt:    time.Now(),
+			CreatedAt:    time.Now().Add(-1 * time.Minute),
 			Labels: map[string]string{
 				agentcontainers.DevcontainerLocalFolderLabel: "/home/coder/project",
 				agentcontainers.DevcontainerConfigFileLabel:  "/home/coder/project/.devcontainer/devcontainer.json",
@@ -770,6 +770,8 @@ func TestAPI(t *testing.T) {
 		defer api.Close()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
+
+		clk.Set(time.Now()).MustWait(ctx)
 
 		// Simulate a file modification event to make the devcontainer dirty.
 		watcher.sendEventWaitNextCalled(ctx, fsnotify.Event{

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -286,12 +286,13 @@ func TestAPI(t *testing.T) {
 					err := json.NewDecoder(rec.Body).Decode(got)
 					require.NoError(t, err, "unmarshal response failed")
 					require.ErrorContains(t, got, tc.expectedErr, "want error")
-				} else {
-					var got codersdk.WorkspaceAgentListContainersResponse
-					err := json.NewDecoder(rec.Body).Decode(&got)
-					require.NoError(t, err, "unmarshal response failed")
-					require.Equal(t, tc.expected, got, "want updated data")
+					return
 				}
+
+				var got codersdk.WorkspaceAgentListContainersResponse
+				err := json.NewDecoder(rec.Body).Decode(&got)
+				require.NoError(t, err, "unmarshal response failed")
+				require.Equal(t, tc.expected, got, "want updated data")
 			})
 		}
 	})

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -326,7 +326,7 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 				},
 			},
 		}, nil,
-	)
+	).AnyTimes()
 
 	client, workspace, agentToken := setupWorkspaceForAgent(t, func(agents []*proto.Agent) []*proto.Agent {
 		agents[0].Directory = agentDir
@@ -501,7 +501,7 @@ func TestOpenVSCodeDevContainer_NoAgentDirectory(t *testing.T) {
 				},
 			},
 		}, nil,
-	)
+	).AnyTimes()
 
 	client, workspace, agentToken := setupWorkspaceForAgent(t, func(agents []*proto.Agent) []*proto.Agent {
 		agents[0].Name = agentName

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2056,12 +2056,6 @@ func TestSSH_Container(t *testing.T) {
 		client, workspace, agentToken := setupWorkspaceForAgent(t)
 		ctrl := gomock.NewController(t)
 		mLister := acmock.NewMockLister(ctrl)
-		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-			o.ExperimentalDevcontainersEnabled = true
-			o.ContainerAPIOptions = append(o.ContainerAPIOptions, agentcontainers.WithLister(mLister))
-		})
-		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
-
 		mLister.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
 			Containers: []codersdk.WorkspaceAgentContainer{
 				{
@@ -2071,6 +2065,11 @@ func TestSSH_Container(t *testing.T) {
 			},
 			Warnings: nil,
 		}, nil)
+		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
+			o.ExperimentalDevcontainersEnabled = true
+			o.ContainerAPIOptions = append(o.ContainerAPIOptions, agentcontainers.WithLister(mLister))
+		})
+		_ = coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
 
 		cID := uuid.NewString()
 		inv, root := clitest.New(t, "ssh", workspace.Name, "-c", cID)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2064,7 +2064,7 @@ func TestSSH_Container(t *testing.T) {
 				},
 			},
 			Warnings: nil,
-		}, nil)
+		}, nil).AnyTimes()
 		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
 			o.ExperimentalDevcontainersEnabled = true
 			o.ContainerAPIOptions = append(o.ContainerAPIOptions, agentcontainers.WithLister(mLister))

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1295,14 +1295,14 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 			{
 				name: "test response",
 				setupMock: func(mcl *acmock.MockLister) (codersdk.WorkspaceAgentListContainersResponse, error) {
-					mcl.EXPECT().List(gomock.Any()).Return(testResponse, nil).Times(1)
+					mcl.EXPECT().List(gomock.Any()).Return(testResponse, nil).AnyTimes()
 					return testResponse, nil
 				},
 			},
 			{
 				name: "error response",
 				setupMock: func(mcl *acmock.MockLister) (codersdk.WorkspaceAgentListContainersResponse, error) {
-					mcl.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{}, assert.AnError).Times(1)
+					mcl.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{}, assert.AnError).AnyTimes()
 					return codersdk.WorkspaceAgentListContainersResponse{}, assert.AnError
 				},
 			},
@@ -1314,7 +1314,10 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mcl := acmock.NewMockLister(ctrl)
 				expected, expectedErr := tc.setupMock(mcl)
-				client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+					Logger: &logger,
+				})
 				user := coderdtest.CreateFirstUser(t, client)
 				r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 					OrganizationID: user.OrganizationID,
@@ -1323,6 +1326,7 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 					return agents
 				}).Do()
 				_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
+					o.Logger = logger.Named("agent")
 					o.ExperimentalDevcontainersEnabled = true
 					o.ContainerAPIOptions = append(o.ContainerAPIOptions, agentcontainers.WithLister(mcl))
 				})
@@ -1392,7 +1396,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 				setupMock: func(mcl *acmock.MockLister, mdccli *acmock.MockDevcontainerCLI) int {
 					mcl.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
 						Containers: []codersdk.WorkspaceAgentContainer{devContainer},
-					}, nil).Times(1)
+					}, nil).AnyTimes()
 					mdccli.EXPECT().Up(gomock.Any(), workspaceFolder, configFile, gomock.Any()).Return("someid", nil).Times(1)
 					return 0
 				},
@@ -1400,7 +1404,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 			{
 				name: "Container does not exist",
 				setupMock: func(mcl *acmock.MockLister, mdccli *acmock.MockDevcontainerCLI) int {
-					mcl.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{}, nil).Times(1)
+					mcl.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{}, nil).AnyTimes()
 					return http.StatusNotFound
 				},
 			},
@@ -1409,7 +1413,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 				setupMock: func(mcl *acmock.MockLister, mdccli *acmock.MockDevcontainerCLI) int {
 					mcl.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
 						Containers: []codersdk.WorkspaceAgentContainer{plainContainer},
-					}, nil).Times(1)
+					}, nil).AnyTimes()
 					return http.StatusNotFound
 				},
 			},
@@ -1421,7 +1425,10 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 				mcl := acmock.NewMockLister(ctrl)
 				mdccli := acmock.NewMockDevcontainerCLI(ctrl)
 				wantStatus := tc.setupMock(mcl, mdccli)
-				client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+					Logger: &logger,
+				})
 				user := coderdtest.CreateFirstUser(t, client)
 				r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 					OrganizationID: user.OrganizationID,
@@ -1430,6 +1437,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 					return agents
 				}).Do()
 				_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
+					o.Logger = logger.Named("agent")
 					o.ExperimentalDevcontainersEnabled = true
 					o.ContainerAPIOptions = append(
 						o.ContainerAPIOptions,


### PR DESCRIPTION
This change introduces a significant refactor to the agentcontainers API
and enables periodic updates of Docker containers rather than on-demand.
Consequently this change also allows us to move away from using a
locking channel and replace it with a mutex, which simplifies usage.

Additionally a previous oversight was fixed, and testing added, to clear
devcontainer running/dirty status when the container has been removed.

Updates coder/coder#16424
Updates coder/internal#621
