### PR TITLE
refactor: refactor activity column in the workspaces table

### DIFF
--- a/site/src/modules/workspaces/WorkspaceAppStatus/WorkspaceAppStatus.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceAppStatus/WorkspaceAppStatus.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ProxyContext, getPreferredProxy } from "contexts/ProxyContext";
 import {
 	MockProxyLatencies,
-	MockWorkspace,
-	MockWorkspaceAgent,
-	MockWorkspaceApp,
 	MockWorkspaceAppStatus,
 } from "testHelpers/entities";
 import { WorkspaceAppStatus } from "./WorkspaceAppStatus";
@@ -68,24 +65,6 @@ export const Working: Story = {
 	},
 };
 
-export const LongURI: Story = {
-	args: {
-		status: {
-			...MockWorkspaceAppStatus,
-			uri: "https://www.google.com/search?q=hello+world+plus+a+lot+of+other+words",
-		},
-	},
-};
-
-export const FileURI: Story = {
-	args: {
-		status: {
-			...MockWorkspaceAppStatus,
-			uri: "file:///Users/jason/Desktop/test.txt",
-		},
-	},
-};
-
 export const LongMessage: Story = {
 	args: {
 		status: {
@@ -93,16 +72,5 @@ export const LongMessage: Story = {
 			message:
 				"This is a long message that will wrap around the component. It should wrap many times because this is very very very very very long.",
 		},
-	},
-};
-
-export const WithApp: Story = {
-	args: {
-		status: MockWorkspaceAppStatus,
-		app: {
-			...MockWorkspaceApp,
-		},
-		agent: MockWorkspaceAgent,
-		workspace: MockWorkspace,
 	},
 };

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -43,7 +43,7 @@ import {
 } from "components/Tooltip/Tooltip";
 import { useAuthenticated } from "hooks";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
-import { StarIcon } from "lucide-react";
+import { ExternalLinkIcon, FileIcon, StarIcon } from "lucide-react";
 import { EllipsisVertical } from "lucide-react";
 import {
 	BanIcon,
@@ -138,16 +138,22 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 			) || {}
 		);
 	}, [workspaces]);
-	const hasAppStatus = useMemo(
+	const hasActivity = useMemo(
 		() => Object.keys(workspaceIDToAppByStatus).length > 0,
 		[workspaceIDToAppByStatus],
 	);
+	const tableColumnSize = {
+		name: "w-2/6",
+		template: hasActivity ? "w-1/6" : "w-2/6",
+		status: hasActivity ? "w-1/6" : "w-2/6",
+		activity: "w-2/6",
+	};
 
 	return (
 		<Table>
 			<TableHeader>
 				<TableRow>
-					<TableHead className={hasAppStatus ? "w-1/6" : "w-2/6"}>
+					<TableHead className={tableColumnSize.name}>
 						<div className="flex items-center gap-2">
 							{canCheckWorkspaces && (
 								<Checkbox
@@ -171,10 +177,14 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 							Name
 						</div>
 					</TableHead>
-					{hasAppStatus && <TableHead className="w-2/6">Activity</TableHead>}
-					<TableHead className="w-2/6">Template</TableHead>
-					<TableHead className="w-2/6">Status</TableHead>
-					<TableHead className="w-0" />
+					<TableHead className={tableColumnSize.template}>Template</TableHead>
+					<TableHead className={tableColumnSize.status}>Status</TableHead>
+					{hasActivity && (
+						<TableHead className={tableColumnSize.activity}>Activity</TableHead>
+					)}
+					<TableHead className="w-0">
+						<span className="sr-only">Actions</span>
+					</TableHead>
 				</TableRow>
 			</TableHeader>
 			<TableBody className="[&_td]:h-[72px]">
@@ -229,7 +239,9 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 									<AvatarData
 										title={
 											<Stack direction="row" spacing={0.5} alignItems="center">
-												{workspace.name}
+												<span className="whitespace-nowrap">
+													{workspace.name}
+												</span>
 												{workspace.favorite && (
 													<StarIcon className="size-icon-xs" />
 												)}
@@ -255,20 +267,13 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 								</div>
 							</TableCell>
 
-							{hasAppStatus && (
-								<TableCell>
-									<WorkspaceAppStatus
-										workspace={workspace}
-										agent={workspaceIDToAppByStatus[workspace.id]?.agent}
-										app={workspaceIDToAppByStatus[workspace.id]?.app}
-										status={workspace.latest_app_status}
-									/>
-								</TableCell>
-							)}
-
 							<TableCell>
 								<AvatarData
-									title={getDisplayWorkspaceTemplateName(workspace)}
+									title={
+										<span className="whitespace-nowrap block max-w-52 text-ellipsis overflow-hidden">
+											{getDisplayWorkspaceTemplateName(workspace)}
+										</span>
+									}
 									subtitle={
 										dashboard.showOrganizations && (
 											<>
@@ -289,6 +294,12 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 							</TableCell>
 
 							<WorkspaceStatusCell workspace={workspace} />
+
+							{hasActivity && (
+								<TableCell>
+									<WorkspaceAppStatus status={workspace.latest_app_status} />
+								</TableCell>
+							)}
 
 							<WorkspaceActionsCell
 								workspace={workspace}
@@ -399,7 +410,7 @@ const WorkspaceStatusCell: FC<WorkspaceStatusCellProps> = ({ workspace }) => {
 						<WorkspaceDormantBadge workspace={workspace} />
 					)}
 				</WorkspaceStatusIndicator>
-				<span className="text-xs font-medium text-content-secondary ml-6">
+				<span className="text-xs font-medium text-content-secondary ml-6 whitespace-nowrap">
 					{lastUsedMessage(workspace.last_used_at)}
 				</span>
 			</div>
@@ -504,9 +515,12 @@ const WorkspaceActionsCell: FC<WorkspaceActionsCellProps> = ({
 			}}
 		>
 			<div className="flex gap-1 justify-end">
-				{workspace.latest_build.status === "running" && (
-					<WorkspaceApps workspace={workspace} />
-				)}
+				{workspace.latest_build.status === "running" &&
+					(workspace.latest_app_status ? (
+						<WorkspaceAppStatusLinks workspace={workspace} />
+					) : (
+						<WorkspaceApps workspace={workspace} />
+					))}
 
 				{abilities.actions.includes("start") && (
 					<PrimaryAction
@@ -701,6 +715,38 @@ const WorkspaceApps: FC<WorkspaceAppsProps> = ({ workspace }) => {
 	return buttons;
 };
 
+type WorkspaceAppStatusLinksProps = {
+	workspace: Workspace;
+};
+
+const WorkspaceAppStatusLinks: FC<WorkspaceAppStatusLinksProps> = ({
+	workspace,
+}) => {
+	const status = workspace.latest_app_status;
+	const agent = workspace.latest_build.resources
+		.flatMap((r) => r.agents)
+		.find((a) => a?.id === status?.agent_id);
+	const app = agent?.apps.find((a) => a.id === status?.app_id);
+
+	return (
+		<>
+			{agent && app && (
+				<IconAppLink app={app} workspace={workspace} agent={agent} />
+			)}
+
+			{status?.uri && (
+				<BaseIconLink label={status.uri} href={status.uri} target="_blank">
+					{status.uri.startsWith("file://") ? (
+						<FileIcon />
+					) : (
+						<ExternalLinkIcon />
+					)}
+				</BaseIconLink>
+			)}
+		</>
+	);
+};
+
 type IconAppLinkProps = {
 	app: WorkspaceApp;
 	workspace: Workspace;
@@ -730,6 +776,7 @@ type BaseIconLinkProps = PropsWithChildren<{
 	href: string;
 	isLoading?: boolean;
 	onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+	target?: string;
 }>;
 
 const BaseIconLink: FC<BaseIconLinkProps> = ({
@@ -737,6 +784,7 @@ const BaseIconLink: FC<BaseIconLinkProps> = ({
 	isLoading,
 	label,
 	children,
+	target,
 	onClick,
 }) => {
 	return (
@@ -745,6 +793,7 @@ const BaseIconLink: FC<BaseIconLinkProps> = ({
 				<TooltipTrigger asChild>
 					<Button variant="outline" size="icon-lg" asChild>
 						<a
+							target={target}
 							className={isLoading ? "animate-pulse" : ""}
 							href={href}
 							onClick={(e) => {

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -734,7 +734,7 @@ const WorkspaceAppStatusLinks: FC<WorkspaceAppStatusLinksProps> = ({
 				<IconAppLink app={app} workspace={workspace} agent={agent} />
 			)}
 
-			{status?.uri && (
+			{status?.uri && status?.uri !== "n/a" && (
 				<BaseIconLink label={status.uri} href={status.uri} target="_blank">
 					{status.uri.startsWith("file://") ? (
 						<FileIcon />


### PR DESCRIPTION
The goal is to better integrate the activity column data with the existent data:
- Make the message one line, the full message is in the tooltip, and display the state at the bottom. This way, it is visually consistent with the other columns like status, name and template.
- Moved the app, and uri, to the actions column, instead of showing them together with the message in the activity column.

**Previous:**
<img width="1512" alt="Screenshot 2025-05-21 at 17 28 46" src="https://github.com/user-attachments/assets/ea9188a5-d82e-416c-b961-edf0104f66c6" />

**After:**
<img width="1512" alt="Screenshot 2025-05-21 at 17 28 57" src="https://github.com/user-attachments/assets/f50dbe82-cd3e-4448-9fa2-bde9193166d6" />
