### PR TITLE
refactor: refactor activity in workspace page

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -15,6 +15,7 @@ import { DropdownArrow } from "components/DropdownArrow/DropdownArrow";
 import type { Line } from "components/Logs/LogLine";
 import { Stack } from "components/Stack/Stack";
 import { useProxy } from "contexts/ProxyContext";
+import { AppStatuses } from "pages/WorkspacePage/AppStatuses";
 import {
 	type FC,
 	useCallback,
@@ -225,6 +226,13 @@ export const AgentRow: FC<AgentRowProps> = ({
 			</header>
 
 			<div css={styles.content}>
+				{workspace.latest_app_status?.agent_id === agent.id && (
+					<section>
+						<h3 className="sr-only">App statuses</h3>
+						<AppStatuses workspace={workspace} agent={agent} />
+					</section>
+				)}
+
 				{agent.status === "connected" && (
 					<section css={styles.apps}>
 						{shouldDisplayApps && (

--- a/site/src/pages/WorkspacePage/AppStatuses.stories.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.stories.tsx
@@ -12,6 +12,9 @@ import { AppStatuses } from "./AppStatuses";
 const meta: Meta<typeof AppStatuses> = {
 	title: "pages/WorkspacePage/AppStatuses",
 	component: AppStatuses,
+	args: {
+		referenceDate: new Date("2024-03-26T15:15:00Z"),
+	},
 	// Add decorator for ProxyContext
 	decorators: [
 		(Story) => (
@@ -43,106 +46,95 @@ export default meta;
 
 type Story = StoryObj<typeof AppStatuses>;
 
-// Helper function to create timestamps easily
-const createTimestamp = (
-	minuteOffset: number,
-	secondOffset: number,
-): string => {
-	const baseDate = new Date("2024-03-26T15:00:00Z");
-	baseDate.setMinutes(baseDate.getMinutes() + minuteOffset);
-	baseDate.setSeconds(baseDate.getSeconds() + secondOffset);
-	return baseDate.toISOString();
-};
-
-// Define a fixed reference date for Storybook, slightly after the last status
-const storyReferenceDate = new Date("2024-03-26T15:15:00Z"); // 15 minutes after base
-
 export const Default: Story = {
 	args: {
 		workspace: MockWorkspace,
-		agents: [MockWorkspaceAgent],
-		apps: [
-			{
-				...MockWorkspaceApp,
-				statuses: [
-					{
-						// This is the latest status chronologically (15:04:38)
-						...MockWorkspaceAppStatus,
-						id: "status-7",
-						icon: "/emojis/1f4dd.png", // 📝
-						message: "Creating PR with gh CLI",
-						created_at: createTimestamp(4, 38), // 15:04:38
-						uri: "https://github.com/coder/coder/pull/5678",
-						state: "complete" as const,
-					},
-					{
-						// (15:03:56)
-						...MockWorkspaceAppStatus,
-						id: "status-6",
-						icon: "/emojis/1f680.png", // 🚀
-						message: "Pushing branch to remote",
-						created_at: createTimestamp(3, 56), // 15:03:56
-						uri: "",
-						state: "complete" as const,
-					},
-					{
-						// (15:02:29)
-						...MockWorkspaceAppStatus,
-						id: "status-5",
-						icon: "/emojis/1f527.png", // 🔧
-						message: "Configuring git identity",
-						created_at: createTimestamp(2, 29), // 15:02:29
-						uri: "",
-						state: "complete" as const,
-					},
-					{
-						// (15:02:04)
-						...MockWorkspaceAppStatus,
-						id: "status-4",
-						icon: "/emojis/1f4be.png", // 💾
-						message: "Committing changes",
-						created_at: createTimestamp(2, 4), // 15:02:04
-						uri: "",
-						state: "complete" as const,
-					},
-					{
-						// (15:01:44)
-						...MockWorkspaceAppStatus,
-						id: "status-3",
-						icon: "/emojis/2795.png", // +
-						message: "Adding files to staging",
-						created_at: createTimestamp(1, 44), // 15:01:44
-						uri: "",
-						state: "complete" as const,
-					},
-					{
-						// (15:01:32)
-						...MockWorkspaceAppStatus,
-						id: "status-2",
-						icon: "/emojis/1f33f.png", // 🌿
-						message: "Creating a new branch for PR",
-						created_at: createTimestamp(1, 32), // 15:01:32
-						uri: "",
-						state: "complete" as const,
-					},
-					{
-						// (15:01:00) - Oldest
-						...MockWorkspaceAppStatus,
-						id: "status-1",
-						icon: "/emojis/1f680.png", // 🚀
-						message: "Starting to create a PR",
-						created_at: createTimestamp(1, 0), // 15:01:00
-						uri: "",
-						state: "complete" as const,
-					},
-				].sort(
-					(a, b) =>
-						new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-				), // Ensure sorted correctly for component input if needed
-			},
-		],
+		agent: {
+			...MockWorkspaceAgent,
+			apps: [
+				{
+					...MockWorkspaceApp,
+					statuses: [
+						{
+							// This is the latest status chronologically (15:04:38)
+							...MockWorkspaceAppStatus,
+							id: "status-7",
+							icon: "/emojis/1f4dd.png", // 📝
+							message: "Creating PR with gh CLI",
+							created_at: createTimestamp(4, 38), // 15:04:38
+							uri: "https://github.com/coder/coder/pull/5678",
+							state: "complete" as const,
+						},
+						{
+							// (15:03:56)
+							...MockWorkspaceAppStatus,
+							id: "status-6",
+							icon: "/emojis/1f680.png", // 🚀
+							message: "Pushing branch to remote",
+							created_at: createTimestamp(3, 56), // 15:03:56
+							uri: "",
+							state: "complete" as const,
+						},
+						{
+							// (15:02:29)
+							...MockWorkspaceAppStatus,
+							id: "status-5",
+							icon: "/emojis/1f527.png", // 🔧
+							message: "Configuring git identity",
+							created_at: createTimestamp(2, 29), // 15:02:29
+							uri: "",
+							state: "complete" as const,
+						},
+						{
+							// (15:02:04)
+							...MockWorkspaceAppStatus,
+							id: "status-4",
+							icon: "/emojis/1f4be.png", // 💾
+							message: "Committing changes",
+							created_at: createTimestamp(2, 4), // 15:02:04
+							uri: "",
+							state: "complete" as const,
+						},
+						{
+							// (15:01:44)
+							...MockWorkspaceAppStatus,
+							id: "status-3",
+							icon: "/emojis/2795.png", // +
+							message: "Adding files to staging",
+							created_at: createTimestamp(1, 44), // 15:01:44
+							uri: "",
+							state: "complete" as const,
+						},
+						{
+							// (15:01:32)
+							...MockWorkspaceAppStatus,
+							id: "status-2",
+							icon: "/emojis/1f33f.png", // 🌿
+							message: "Creating a new branch for PR",
+							created_at: createTimestamp(1, 32), // 15:01:32
+							uri: "",
+							state: "complete" as const,
+						},
+						{
+							// (15:01:00) - Oldest
+							...MockWorkspaceAppStatus,
+							id: "status-1",
+							icon: "/emojis/1f680.png", // 🚀
+							message: "Starting to create a PR",
+							created_at: createTimestamp(1, 0), // 15:01:00
+							uri: "",
+							state: "complete" as const,
+						},
+					].sort(
+						(a, b) =>
+							new Date(b.created_at).getTime() -
+							new Date(a.created_at).getTime(),
+					), // Ensure sorted correctly for component input if needed
+				},
+			],
+		},
+
 		// Pass the reference date to the component for Storybook rendering
-		referenceDate: storyReferenceDate,
 	},
 };
 
@@ -150,58 +142,67 @@ export const Default: Story = {
 export const WorkingState: Story = {
 	args: {
 		workspace: MockWorkspace,
-		agents: [MockWorkspaceAgent],
-		apps: [
-			{
-				...MockWorkspaceApp,
-				statuses: [
-					{
-						// This is now the latest (15:05:15) and is "working"
-						...MockWorkspaceAppStatus,
-						id: "status-8",
-						icon: "", // Let the component handle the spinner icon
-						message: "Processing final checks...",
-						created_at: createTimestamp(5, 15), // 15:05:15 (after referenceDate)
-						uri: "",
-						state: "working" as const,
-					},
-					{
-						// Previous latest (15:04:38)
-						...MockWorkspaceAppStatus,
-						id: "status-7",
-						icon: "/emojis/1f4dd.png", // 📝
-						message: "Creating PR with gh CLI",
-						created_at: createTimestamp(4, 38), // 15:04:38
-						uri: "https://github.com/coder/coder/pull/5678",
-						state: "complete" as const,
-					},
-					{
-						// (15:03:56)
-						...MockWorkspaceAppStatus,
-						id: "status-6",
-						icon: "/emojis/1f680.png", // 🚀
-						message: "Pushing branch to remote",
-						created_at: createTimestamp(3, 56), // 15:03:56
-						uri: "",
-						state: "complete" as const,
-					},
-					// ... include other older statuses if desired ...
-					{
-						// (15:01:00) - Oldest
-						...MockWorkspaceAppStatus,
-						id: "status-1",
-						icon: "/emojis/1f680.png", // 🚀
-						message: "Starting to create a PR",
-						created_at: createTimestamp(1, 0), // 15:01:00
-						uri: "",
-						state: "complete" as const,
-					},
-				].sort(
-					(a, b) =>
-						new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-				),
-			},
-		],
-		referenceDate: storyReferenceDate, // Use the same reference date
+		agent: {
+			...MockWorkspaceAgent,
+			apps: [
+				{
+					...MockWorkspaceApp,
+					statuses: [
+						{
+							// This is now the latest (15:05:15) and is "working"
+							...MockWorkspaceAppStatus,
+							id: "status-8",
+							icon: "", // Let the component handle the spinner icon
+							message: "Processing final checks...",
+							created_at: createTimestamp(5, 15), // 15:05:15 (after referenceDate)
+							uri: "",
+							state: "working" as const,
+						},
+						{
+							// Previous latest (15:04:38)
+							...MockWorkspaceAppStatus,
+							id: "status-7",
+							icon: "/emojis/1f4dd.png", // 📝
+							message: "Creating PR with gh CLI",
+							created_at: createTimestamp(4, 38), // 15:04:38
+							uri: "https://github.com/coder/coder/pull/5678",
+							state: "complete" as const,
+						},
+						{
+							// (15:03:56)
+							...MockWorkspaceAppStatus,
+							id: "status-6",
+							icon: "/emojis/1f680.png", // 🚀
+							message: "Pushing branch to remote",
+							created_at: createTimestamp(3, 56), // 15:03:56
+							uri: "",
+							state: "complete" as const,
+						},
+						// ... include other older statuses if desired ...
+						{
+							// (15:01:00) - Oldest
+							...MockWorkspaceAppStatus,
+							id: "status-1",
+							icon: "/emojis/1f680.png", // 🚀
+							message: "Starting to create a PR",
+							created_at: createTimestamp(1, 0), // 15:01:00
+							uri: "",
+							state: "complete" as const,
+						},
+					].sort(
+						(a, b) =>
+							new Date(b.created_at).getTime() -
+							new Date(a.created_at).getTime(),
+					),
+				},
+			],
+		},
 	},
 };
+
+function createTimestamp(minuteOffset: number, secondOffset: number) {
+	const baseDate = new Date("2024-03-26T15:00:00Z");
+	baseDate.setMinutes(baseDate.getMinutes() + minuteOffset);
+	baseDate.setSeconds(baseDate.getSeconds() + secondOffset);
+	return baseDate.toISOString();
+}

--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -22,6 +22,7 @@ import {
 	ExternalLinkIcon,
 	FileIcon,
 	HourglassIcon,
+	LayoutGridIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
 import { useAppLink } from "modules/apps/useAppLink";
@@ -264,7 +265,7 @@ const AppLink: FC<AppLinkProps> = ({ app, agent, workspace }) => {
 				target="_blank"
 				rel="noreferrer"
 			>
-				<ExternalImage src={app.icon} />
+				{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
 				{link.label}
 			</a>
 		</Button>

--- a/site/src/pages/WorkspacePage/Workspace.stories.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.stories.tsx
@@ -234,6 +234,10 @@ export const RunningWithAppStatuses: Story = {
 					available: 1,
 				},
 			},
+			latest_app_status: {
+				...Mocks.MockWorkspaceAppStatus,
+				agent_id: Mocks.MockWorkspaceAgent.id,
+			},
 		},
 		handleStart: action("start"),
 		handleStop: action("stop"),

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -4,17 +4,15 @@ import HistoryOutlined from "@mui/icons-material/HistoryOutlined";
 import HubOutlined from "@mui/icons-material/HubOutlined";
 import AlertTitle from "@mui/material/AlertTitle";
 import type * as TypesGen from "api/typesGenerated";
-import type { WorkspaceApp } from "api/typesGenerated";
 import { Alert, AlertDetail } from "components/Alert/Alert";
 import { SidebarIconButton } from "components/FullPageLayout/Sidebar";
 import { useSearchParamsKey } from "hooks/useSearchParamsKey";
 import { ProvisionerStatusAlert } from "modules/provisioners/ProvisionerStatusAlert";
 import { AgentRow } from "modules/resources/AgentRow";
 import { WorkspaceTimings } from "modules/workspaces/WorkspaceTiming/WorkspaceTimings";
-import { type FC, useMemo } from "react";
+import type { FC } from "react";
 import { useNavigate } from "react-router-dom";
 import type { WorkspacePermissions } from "../../modules/workspaces/permissions";
-import { AppStatuses } from "./AppStatuses";
 import { HistorySidebar } from "./HistorySidebar";
 import { ResourceMetadata } from "./ResourceMetadata";
 import { ResourcesSidebar } from "./ResourcesSidebar";
@@ -108,14 +106,6 @@ export const Workspace: FC<WorkspaceProps> = ({
 		(workspace.latest_build.matched_provisioners?.available ?? 1) > 0;
 	const shouldShowProvisionerAlert =
 		workspacePending && !haveBuildLogs && !provisionersHealthy && !isRestarting;
-
-	const hasAppStatus = useMemo(() => {
-		return selectedResource?.agents?.some((agent) => {
-			return agent.apps?.some((app) => {
-				return app.statuses?.length > 0;
-			});
-		});
-	}, [selectedResource]);
 
 	return (
 		<div
@@ -291,36 +281,6 @@ export const Workspace: FC<WorkspaceProps> = ({
 									</div>
 								</div>
 							)}
-						</section>
-					)}
-
-					{selectedResource && hasAppStatus && (
-						<section className="border border-solid border-border rounded-lg bg-surface-primary">
-							<header className="p-4 border-0 border-b border-border border-solid flex items-center justify-between">
-								<h3 className="m-0 text-sm font-medium">Activity</h3>
-								<div className="text-content-secondary text-xs">
-									{
-										// Calculate total status count
-										selectedResource.agents
-											?.flatMap((agent) => agent.apps ?? [])
-											.reduce(
-												(count, app) => count + (app.statuses?.length ?? 0),
-												0,
-											)
-									}{" "}
-									Total
-								</div>
-							</header>
-
-							<AppStatuses
-								apps={
-									selectedResource.agents?.flatMap(
-										(agent) => agent.apps ?? [],
-									) as WorkspaceApp[]
-								}
-								workspace={workspace}
-								agents={selectedResource.agents || []}
-							/>
 						</section>
 					)}
 

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -240,150 +240,88 @@ export const Workspace: FC<WorkspaceProps> = ({
 						<WorkspaceBuildLogsSection logs={buildLogs} />
 					)}
 
-					{/* Container for Agent Rows + Activity Sidebar */}
 					{selectedResource && (
-						<div css={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
-							{/* Left Side: Agent Rows */}
-							<section
-								css={{
-									display: "flex",
-									flexDirection: "column",
-									gap: 24,
-									flexGrow: 1,
-									minWidth: 0 /* Prevent overflow */,
-								}}
-							>
-								{selectedResource.agents
-									// If an agent has a `parent_id`, that means it is
-									// child of another agent. We do not want these agents
-									// to be displayed at the top-level on this page. We
-									// want them to display _as children_ of their parents.
-									?.filter((agent) => agent.parent_id === null)
-									.map((agent) => (
-										<AgentRow
-											key={agent.id}
-											agent={agent}
-											workspace={workspace}
-											template={template}
-											sshPrefix={sshPrefix}
-											showApps={permissions.updateWorkspace}
-											showBuiltinApps={permissions.updateWorkspace}
-											hideSSHButton={hideSSHButton}
-											hideVSCodeDesktopButton={hideVSCodeDesktopButton}
-											serverVersion={buildInfo?.version || ""}
-											serverAPIVersion={buildInfo?.agent_api_version || ""}
-											onUpdateAgent={handleUpdate} // On updating the workspace the agent version is also updated
-										/>
-									))}
+						<section
+							css={{
+								display: "flex",
+								flexDirection: "column",
+								gap: 24,
+								flexGrow: 1,
+								minWidth: 0 /* Prevent overflow */,
+							}}
+						>
+							{selectedResource.agents
+								// If an agent has a `parent_id`, that means it is
+								// child of another agent. We do not want these agents
+								// to be displayed at the top-level on this page. We
+								// want them to display _as children_ of their parents.
+								?.filter((agent) => agent.parent_id === null)
+								.map((agent) => (
+									<AgentRow
+										key={agent.id}
+										agent={agent}
+										workspace={workspace}
+										template={template}
+										sshPrefix={sshPrefix}
+										showApps={permissions.updateWorkspace}
+										showBuiltinApps={permissions.updateWorkspace}
+										hideSSHButton={hideSSHButton}
+										hideVSCodeDesktopButton={hideVSCodeDesktopButton}
+										serverVersion={buildInfo?.version || ""}
+										serverAPIVersion={buildInfo?.agent_api_version || ""}
+										onUpdateAgent={handleUpdate} // On updating the workspace the agent version is also updated
+									/>
+								))}
 
-								{(!selectedResource.agents ||
-									selectedResource.agents?.length === 0) && (
-									<div
-										css={{
-											display: "flex",
-											justifyContent: "center",
-											alignItems: "center",
-											width: "100%",
-											height: "100%",
-										}}
-									>
-										<div>
-											<h4 css={{ fontSize: 16, fontWeight: 500 }}>
-												No agents are currently assigned to this resource.
-											</h4>
-										</div>
-									</div>
-								)}
-							</section>
-
-							{/* Right Side: Activity Box */}
-							{hasAppStatus && (
+							{(!selectedResource.agents ||
+								selectedResource.agents?.length === 0) && (
 								<div
 									css={{
-										// Mimic AgentRow styling but with subtler border
-										border: `1px solid ${theme.palette.divider}`, // Use divider color
-										borderRadius: "8px",
-										boxShadow: theme.shadows[3],
-										width: 360,
-										flexShrink: 0,
-										backgroundColor: theme.palette.background.default, // Add background color
-										overflow: "hidden",
+										display: "flex",
+										justifyContent: "center",
+										alignItems: "center",
+										width: "100%",
+										height: "100%",
 									}}
 								>
-									{/* Activity Header */}
-									<div
-										css={{
-											display: "flex",
-											justifyContent: "space-between",
-											alignItems: "center",
-											backgroundColor: theme.palette.background.paper,
-											paddingLeft: 16,
-											paddingRight: 16,
-											paddingTop: 12,
-											paddingBottom: 12,
-											borderBottom: `1px solid ${theme.palette.divider}`, // Add separator
-										}}
-									>
-										<div
-											css={{
-												fontWeight: 500,
-												fontSize: 14,
-											}}
-										>
-											Activity
-										</div>
-										<div
-											css={{
-												fontSize: 12,
-												color: theme.palette.text.secondary,
-											}}
-										>
-											{
-												// Calculate total status count
-												selectedResource.agents
-													?.flatMap((agent) => agent.apps ?? [])
-													.reduce(
-														(count, app) => count + (app.statuses?.length ?? 0),
-														0,
-													)
-											}{" "}
-											Total
-										</div>
-									</div>
-
-									<div
-										css={{
-											maxHeight: 800,
-											overflowY: "auto",
-											// Thin scrollbar styles
-											"&::-webkit-scrollbar": {
-												width: "6px",
-											},
-											"&::-webkit-scrollbar-track": {
-												background: theme.palette.background.paper, // Match header background
-											},
-											"&::-webkit-scrollbar-thumb": {
-												backgroundColor: theme.palette.divider, // Use divider color
-												borderRadius: "3px",
-											},
-											"&::-webkit-scrollbar-thumb:hover": {
-												backgroundColor: theme.palette.text.secondary, // Darken on hover
-											},
-										}}
-									>
-										<AppStatuses
-											apps={
-												selectedResource.agents?.flatMap(
-													(agent) => agent.apps ?? [],
-												) as WorkspaceApp[]
-											}
-											workspace={workspace}
-											agents={selectedResource.agents || []}
-										/>
+									<div>
+										<h4 css={{ fontSize: 16, fontWeight: 500 }}>
+											No agents are currently assigned to this resource.
+										</h4>
 									</div>
 								</div>
 							)}
-						</div>
+						</section>
+					)}
+
+					{selectedResource && hasAppStatus && (
+						<section className="border border-solid border-border rounded-lg bg-surface-primary">
+							<header className="p-4 border-0 border-b border-border border-solid flex items-center justify-between">
+								<h3 className="m-0 text-sm font-medium">Activity</h3>
+								<div className="text-content-secondary text-xs">
+									{
+										// Calculate total status count
+										selectedResource.agents
+											?.flatMap((agent) => agent.apps ?? [])
+											.reduce(
+												(count, app) => count + (app.statuses?.length ?? 0),
+												0,
+											)
+									}{" "}
+									Total
+								</div>
+							</header>
+
+							<AppStatuses
+								apps={
+									selectedResource.agents?.flatMap(
+										(agent) => agent.apps ?? [],
+									) as WorkspaceApp[]
+								}
+								workspace={workspace}
+								agents={selectedResource.agents || []}
+							/>
+						</section>
 					)}
 
 					<WorkspaceTimings


### PR DESCRIPTION
Changing the activity in the workspace page. It is more boring, but more reliable and extensible. By moving it to the bottom of the agent card, we have more space to display longer messages and more items. It also give us some space for interactivity controls in case we want them in the future. 

**Before:**
<img width="1512" alt="Screenshot 2025-05-21 at 19 09 41" src="https://github.com/user-attachments/assets/c25aa848-b496-4a78-8d19-0b0efeae6115" />

**After:**

https://github.com/user-attachments/assets/3e88eb63-e082-4e5c-a6a3-79a6fe3d46b6


