### PR TITLE
refactor: redefine useAgentLogs tests as unit tests

### DIFF
--- a/site/src/modules/resources/useAgentLogs.test.ts
+++ b/site/src/modules/resources/useAgentLogs.test.ts
@@ -1,8 +1,4 @@
-import {
-	renderHook,
-	type RenderHookResult,
-	waitFor,
-} from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { WorkspaceAgentLog } from "api/typesGenerated";
 import { MockWorkspaceAgent } from "testHelpers/entities";
 import { createUseAgentLogs } from "./useAgentLogs";
@@ -22,14 +18,28 @@ function generateMockLogs(count: number): WorkspaceAgentLog[] {
 	}));
 }
 
-type MountHookResult = Readonly<
-	RenderHookResult<readonly WorkspaceAgentLog[], { enabled: boolean }> & {
-		publisher: MockWebSocketPublisher;
-	}
->;
+// A mutable object holding the most recent mock WebSocket connection. This
+// value will change as the hook opens/closes new connections
+type PublisherResult = {
+	current: MockWebSocketPublisher;
+};
+
+type MountHookResult = Readonly<{
+	// Note: the value of `current` should be readonly, but the `current`
+	// property itself should be mutable
+	hookResult: {
+		current: readonly WorkspaceAgentLog[];
+	};
+	rerender: (props: { enabled: boolean }) => void;
+	publisherResult: PublisherResult;
+}>;
 
 function mountHook(): MountHookResult {
-	let publisher!: MockWebSocketPublisher;
+	// Have to cheat the types a little bit to avoid a chicken-and-the-egg
+	// scenario. publisherResult will be initialized with an undefined current
+	// value, but it'll be guaranteed not to be undefined by the time this
+	// function returns.
+	const publisherResult: Partial<PublisherResult> = { current: undefined };
 	const useAgentLogs = createUseAgentLogs((agentId, params) => {
 		return new OneWayWebSocket({
 			apiRoute: `/api/v2/workspaceagents/${agentId}/logs`,
@@ -38,41 +48,45 @@ function mountHook(): MountHookResult {
 				after: params?.after?.toString() || "0",
 			}),
 			websocketInit: (url) => {
-				const [mockSocket, mockPub] = createMockWebSocket(url);
-				publisher = mockPub;
+				const [mockSocket, mockPublisher] = createMockWebSocket(url);
+				publisherResult.current = mockPublisher;
 				return mockSocket;
 			},
 		});
 	});
 
-	const { result, rerender, unmount } = renderHook(
+	const { result, rerender } = renderHook(
 		({ enabled }) => useAgentLogs(MockWorkspaceAgent, enabled),
 		{ initialProps: { enabled: true } },
 	);
 
-	return { result, rerender, unmount, publisher };
+	return {
+		rerender,
+		hookResult: result,
+		publisherResult: publisherResult as PublisherResult,
+	};
 }
 
 describe("useAgentLogs", () => {
 	it("clears logs when hook becomes disabled (protection to avoid duplicate logs when hook goes back to being re-enabled)", async () => {
-		const { result, rerender, publisher } = mountHook();
+		const { hookResult, publisherResult, rerender } = mountHook();
 
 		// Verify that logs can be received after mount
 		const initialLogs = generateMockLogs(3);
 		const initialEvent = new MessageEvent<string>("message", {
 			data: JSON.stringify(initialLogs),
 		});
-		publisher.publishMessage(initialEvent);
+		publisherResult.current.publishMessage(initialEvent);
 		await waitFor(() => {
 			// Using expect.arrayContaining to account for the fact that we're
 			// not guaranteed to receive WebSocket events in order
-			expect(result.current).toEqual(expect.arrayContaining(initialLogs));
+			expect(hookResult.current).toEqual(expect.arrayContaining(initialLogs));
 		});
 
 		// Disable the hook (and have the hook close the connection behind the
 		// scenes)
 		rerender({ enabled: false });
-		await waitFor(() => expect(result.current).toHaveLength(0));
+		await waitFor(() => expect(hookResult.current).toHaveLength(0));
 
 		// Re-enable the hook (creating an entirely new connection), and send
 		// new logs
@@ -81,9 +95,9 @@ describe("useAgentLogs", () => {
 		const newEvent = new MessageEvent<string>("message", {
 			data: JSON.stringify(newLogs),
 		});
-		publisher.publishMessage(newEvent);
+		publisherResult.current.publishMessage(newEvent);
 		await waitFor(() => {
-			expect(result.current).toEqual(expect.arrayContaining(newLogs));
+			expect(hookResult.current).toEqual(expect.arrayContaining(newLogs));
 		});
 	});
 });

--- a/site/src/modules/resources/useAgentLogs.test.ts
+++ b/site/src/modules/resources/useAgentLogs.test.ts
@@ -1,21 +1,32 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import type { WorkspaceAgentLog } from "api/typesGenerated";
 import { MockWorkspaceAgent } from "testHelpers/entities";
-import { createUseAgentLogs } from "./useAgentLogs";
 import {
-	createMockWebSocket,
 	type MockWebSocketPublisher,
+	createMockWebSocket,
 } from "testHelpers/websockets";
 import { OneWayWebSocket } from "utils/OneWayWebSocket";
+import { createUseAgentLogs } from "./useAgentLogs";
 
-function generateMockLogs(count: number): WorkspaceAgentLog[] {
-	return Array.from({ length: count }, (_, i) => ({
-		id: i,
-		created_at: new Date().toISOString(),
-		level: "info",
-		output: `Log ${i}`,
-		source_id: "",
-	}));
+const millisecondsInOneMinute = 60_000;
+
+function generateMockLogs(
+	logCount: number,
+	baseDate = new Date(),
+): readonly WorkspaceAgentLog[] {
+	return Array.from({ length: logCount }, (_, i) => {
+		// Make sure that the logs generated each have unique timestamps, so
+		// that we can test whether they're being sorted properly before being
+		// returned by the hook
+		const logDate = new Date(baseDate.getTime() + i * millisecondsInOneMinute);
+		return {
+			id: i,
+			created_at: logDate.toISOString(),
+			level: "info",
+			output: `Log ${i}`,
+			source_id: "",
+		};
+	});
 }
 
 // A mutable object holding the most recent mock WebSocket publisher. The inner

--- a/site/src/modules/resources/useAgentLogs.test.ts
+++ b/site/src/modules/resources/useAgentLogs.test.ts
@@ -18,7 +18,7 @@ function generateMockLogs(count: number): WorkspaceAgentLog[] {
 	}));
 }
 
-// A mutable object holding the most recent mock WebSocket connection. This
+// A mutable object holding the most recent mock WebSocket publisher. The inner
 // value will change as the hook opens/closes new connections
 type PublisherResult = {
 	current: MockWebSocketPublisher;

--- a/site/src/modules/resources/useAgentLogs.test.ts
+++ b/site/src/modules/resources/useAgentLogs.test.ts
@@ -83,7 +83,7 @@ describe("useAgentLogs", () => {
 		const { hookResult, publisherResult, rerender } = mountHook();
 
 		// Verify that logs can be received after mount
-		const initialLogs = generateMockLogs(3);
+		const initialLogs = generateMockLogs(3, new Date("april 5, 1997"));
 		const initialEvent = new MessageEvent<string>("message", {
 			data: JSON.stringify(initialLogs),
 		});
@@ -102,7 +102,7 @@ describe("useAgentLogs", () => {
 		// Re-enable the hook (creating an entirely new connection), and send
 		// new logs
 		rerender({ enabled: true });
-		const newLogs = generateMockLogs(3);
+		const newLogs = generateMockLogs(3, new Date("october 3, 2005"));
 		const newEvent = new MessageEvent<string>("message", {
 			data: JSON.stringify(newLogs),
 		});

--- a/site/src/modules/resources/useAgentLogs.test.ts
+++ b/site/src/modules/resources/useAgentLogs.test.ts
@@ -1,55 +1,18 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import {
+	renderHook,
+	type RenderHookResult,
+	waitFor,
+} from "@testing-library/react";
 import type { WorkspaceAgentLog } from "api/typesGenerated";
-import WS from "jest-websocket-mock";
 import { MockWorkspaceAgent } from "testHelpers/entities";
-import { useAgentLogs } from "./useAgentLogs";
+import { createUseAgentLogs } from "./useAgentLogs";
+import {
+	createMockWebSocket,
+	type MockWebSocketPublisher,
+} from "testHelpers/websockets";
+import { OneWayWebSocket } from "utils/OneWayWebSocket";
 
-/**
- * TODO: WS does not support multiple tests running at once in isolation so we
- * have one single test that test the most common scenario.
- * Issue: https://github.com/romgain/jest-websocket-mock/issues/172
- */
-
-describe("useAgentLogs", () => {
-	afterEach(() => {
-		WS.clean();
-	});
-
-	it("clear logs when disabled to avoid duplicates", async () => {
-		const server = new WS(
-			`ws://localhost/api/v2/workspaceagents/${
-				MockWorkspaceAgent.id
-			}/logs?follow&after=0`,
-		);
-		const { result, rerender } = renderHook(
-			({ enabled }) => useAgentLogs(MockWorkspaceAgent, enabled),
-			{ initialProps: { enabled: true } },
-		);
-		await server.connected;
-
-		// Send 3 logs
-		server.send(JSON.stringify(generateLogs(3)));
-		await waitFor(() => {
-			expect(result.current).toHaveLength(3);
-		});
-
-		// Disable the hook
-		rerender({ enabled: false });
-		await waitFor(() => {
-			expect(result.current).toHaveLength(0);
-		});
-
-		// Enable the hook again
-		rerender({ enabled: true });
-		await server.connected;
-		server.send(JSON.stringify(generateLogs(3)));
-		await waitFor(() => {
-			expect(result.current).toHaveLength(3);
-		});
-	});
-});
-
-function generateLogs(count: number): WorkspaceAgentLog[] {
+function generateMockLogs(count: number): WorkspaceAgentLog[] {
 	return Array.from({ length: count }, (_, i) => ({
 		id: i,
 		created_at: new Date().toISOString(),
@@ -58,3 +21,69 @@ function generateLogs(count: number): WorkspaceAgentLog[] {
 		source_id: "",
 	}));
 }
+
+type MountHookResult = Readonly<
+	RenderHookResult<readonly WorkspaceAgentLog[], { enabled: boolean }> & {
+		publisher: MockWebSocketPublisher;
+	}
+>;
+
+function mountHook(): MountHookResult {
+	let publisher!: MockWebSocketPublisher;
+	const useAgentLogs = createUseAgentLogs((agentId, params) => {
+		return new OneWayWebSocket({
+			apiRoute: `/api/v2/workspaceagents/${agentId}/logs`,
+			searchParams: new URLSearchParams({
+				follow: "true",
+				after: params?.after?.toString() || "0",
+			}),
+			websocketInit: (url) => {
+				const [mockSocket, mockPub] = createMockWebSocket(url);
+				publisher = mockPub;
+				return mockSocket;
+			},
+		});
+	});
+
+	const { result, rerender, unmount } = renderHook(
+		({ enabled }) => useAgentLogs(MockWorkspaceAgent, enabled),
+		{ initialProps: { enabled: true } },
+	);
+
+	return { result, rerender, unmount, publisher };
+}
+
+describe("useAgentLogs", () => {
+	it("clears logs when hook becomes disabled (protection to avoid duplicate logs when hook goes back to being re-enabled)", async () => {
+		const { result, rerender, publisher } = mountHook();
+
+		// Verify that logs can be received after mount
+		const initialLogs = generateMockLogs(3);
+		const initialEvent = new MessageEvent<string>("message", {
+			data: JSON.stringify(initialLogs),
+		});
+		publisher.publishMessage(initialEvent);
+		await waitFor(() => {
+			// Using expect.arrayContaining to account for the fact that we're
+			// not guaranteed to receive WebSocket events in order
+			expect(result.current).toEqual(expect.arrayContaining(initialLogs));
+		});
+
+		// Disable the hook (and have the hook close the connection behind the
+		// scenes)
+		rerender({ enabled: false });
+		await waitFor(() => expect(result.current).toHaveLength(0));
+
+		// Re-enable the hook (creating an entirely new connection), and send
+		// new logs
+		rerender({ enabled: true });
+		const newLogs = generateMockLogs(3);
+		const newEvent = new MessageEvent<string>("message", {
+			data: JSON.stringify(newLogs),
+		});
+		publisher.publishMessage(newEvent);
+		await waitFor(() => {
+			expect(result.current).toEqual(expect.arrayContaining(newLogs));
+		});
+	});
+});

--- a/site/src/modules/resources/useAgentLogs.ts
+++ b/site/src/modules/resources/useAgentLogs.ts
@@ -3,45 +3,63 @@ import type { WorkspaceAgent, WorkspaceAgentLog } from "api/typesGenerated";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { useEffect, useState } from "react";
 
-export function useAgentLogs(
-	agent: WorkspaceAgent,
-	enabled: boolean,
-): readonly WorkspaceAgentLog[] {
-	const [logs, setLogs] = useState<WorkspaceAgentLog[]>([]);
+export function createUseAgentLogs(
+	createSocket: typeof watchWorkspaceAgentLogs,
+) {
+	return function useAgentLogs(
+		agent: WorkspaceAgent,
+		enabled: boolean,
+	): readonly WorkspaceAgentLog[] {
+		const [logs, setLogs] = useState<readonly WorkspaceAgentLog[]>([]);
 
-	useEffect(() => {
-		if (!enabled) {
-			// Clean up the logs when the agent is not enabled. So it can receive logs
-			// from the beginning without duplicating the logs.
+		// Clean up the logs when the agent is not enabled, using a mid-render
+		// sync to remove any risk of screen flickering. Clearing the logs helps
+		// ensure that if the hook flips back to being enabled, we can receive a
+		// fresh set of logs from the beginning with zero risk of duplicates.
+		const [prevEnabled, setPrevEnabled] = useState(enabled);
+		if (!enabled && prevEnabled) {
 			setLogs([]);
-			return;
+			setPrevEnabled(false);
 		}
 
-		// Always fetch the logs from the beginning. We may want to optimize this in
-		// the future, but it would add some complexity in the code that maybe does
-		// not worth it.
-		const socket = watchWorkspaceAgentLogs(agent.id, { after: 0 });
-		socket.addEventListener("message", (e) => {
-			if (e.parseError) {
-				console.warn("Error parsing agent log: ", e.parseError);
+		useEffect(() => {
+			if (!enabled) {
 				return;
 			}
-			setLogs((logs) => [...logs, ...e.parsedMessage]);
-		});
 
-		socket.addEventListener("error", (e) => {
-			console.error("Error in agent log socket: ", e);
-			displayError(
-				"Unable to watch the agent logs",
-				"Please try refreshing the browser",
-			);
-			socket.close();
-		});
+			// Always fetch the logs from the beginning. We may want to optimize
+			// this in the future, but it would add some complexity in the code
+			// that might not be worth it.
+			const socket = createSocket(agent.id, { after: 0 });
+			socket.addEventListener("message", (e) => {
+				if (e.parseError) {
+					console.warn("Error parsing agent log: ", e.parseError);
+					return;
+				}
+				setLogs((logs) => [...logs, ...e.parsedMessage]);
+			});
 
-		return () => {
-			socket.close();
-		};
-	}, [agent.id, enabled]);
+			socket.addEventListener("error", (e) => {
+				console.error("Error in agent log socket: ", e);
+				displayError(
+					"Unable to watch the agent logs",
+					"Please try refreshing the browser",
+				);
+				socket.close();
+			});
 
-	return logs;
+			return () => socket.close();
+
+			// createSocket shouldn't ever change for the lifecycle of the hook,
+			// but Biome isn't smart enough to detect constant dependencies for
+			// higher-order hooks. Adding it to the array (even though it
+			// shouldn't ever be needed) seemed like the least fragile way to
+			// resolve the warning.
+		}, [createSocket, agent.id, enabled]);
+
+		return logs;
+	};
 }
+
+// The baseline implementation to use for production
+export const useAgentLogs = createUseAgentLogs(watchWorkspaceAgentLogs);

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -7,23 +7,6 @@ export type MockWebSocketPublisher = Readonly<{
 	publishOpen: (event: Event) => void;
 }>;
 
-export type CreateMockWebSocketOptions = Readonly<{
-	// The URL to use to initialize the mock socket. This should match the
-	// "real" URL that you would pass to the built-in WebSocket constructor.
-	url: string;
-
-	// The additional WebSocket protocols to use when initializing. This should
-	// match the real protocols that you would pass to the built-in WebSocket
-	// constructor.
-	protocols?: string | string[];
-
-	// Indicates whether the mock socket should stay open after calling the
-	// .close method, so that it can be reused for a new connection. Defaults to
-	// false (meaning that the socket becomes completely unusable the first time
-	// after .close is called).
-	persistAfterClose?: boolean;
-}>;
-
 export function createMockWebSocket(
 	url: string,
 	protocols?: string | string[],

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -1,0 +1,152 @@
+import type { WebSocketEventType } from "utils/OneWayWebSocket";
+
+export type MockWebSocketPublisher = Readonly<{
+	publishMessage: (event: MessageEvent<string>) => void;
+	publishError: (event: ErrorEvent) => void;
+	publishClose: (event: CloseEvent) => void;
+	publishOpen: (event: Event) => void;
+}>;
+
+export type CreateMockWebSocketOptions = Readonly<{
+	// The URL to use to initialize the mock socket. This should match the
+	// "real" URL that you would pass to the built-in WebSocket constructor.
+	url: string;
+
+	// The additional WebSocket protocols to use when initializing. This should
+	// match the real protocols that you would pass to the built-in WebSocket
+	// constructor.
+	protocols?: string | string[];
+
+	// Indicates whether the mock socket should stay open after calling the
+	// .close method, so that it can be reused for a new connection. Defaults to
+	// false (meaning that the socket becomes completely unusable the first time
+	// after .close is called).
+	persistAfterClose?: boolean;
+}>;
+
+export function createMockWebSocket(
+	url: string,
+	protocols?: string | string[],
+): readonly [WebSocket, MockWebSocketPublisher] {
+	type EventMap = {
+		message: MessageEvent<string>;
+		error: ErrorEvent;
+		close: CloseEvent;
+		open: Event;
+	};
+	type CallbackStore = {
+		[K in keyof EventMap]: ((event: EventMap[K]) => void)[];
+	};
+
+	let activeProtocol: string;
+	if (Array.isArray(protocols)) {
+		activeProtocol = protocols[0] ?? "";
+	} else if (typeof protocols === "string") {
+		activeProtocol = protocols;
+	} else {
+		activeProtocol = "";
+	}
+
+	let closed = false;
+	const store: CallbackStore = {
+		message: [],
+		error: [],
+		close: [],
+		open: [],
+	};
+
+	const mockSocket: WebSocket = {
+		CONNECTING: 0,
+		OPEN: 1,
+		CLOSING: 2,
+		CLOSED: 3,
+
+		url,
+		protocol: activeProtocol,
+		readyState: 1,
+		binaryType: "blob",
+		bufferedAmount: 0,
+		extensions: "",
+		onclose: null,
+		onerror: null,
+		onmessage: null,
+		onopen: null,
+		send: jest.fn(),
+		dispatchEvent: jest.fn(),
+
+		addEventListener: <E extends WebSocketEventType>(
+			eventType: E,
+			callback: WebSocketEventMap[E],
+		) => {
+			if (closed) {
+				return;
+			}
+
+			const subscribers = store[eventType];
+			const cb = callback as unknown as CallbackStore[E][0];
+			if (!subscribers.includes(cb)) {
+				subscribers.push(cb);
+			}
+		},
+
+		removeEventListener: <E extends WebSocketEventType>(
+			eventType: E,
+			callback: WebSocketEventMap[E],
+		) => {
+			if (closed) {
+				return;
+			}
+
+			const subscribers = store[eventType];
+			const cb = callback as unknown as CallbackStore[E][0];
+			if (subscribers.includes(cb)) {
+				const updated = store[eventType].filter((c) => c !== cb);
+				store[eventType] = updated as unknown as CallbackStore[E];
+			}
+		},
+
+		close: () => {
+			closed = true;
+		},
+	};
+
+	const publisher: MockWebSocketPublisher = {
+		publishOpen: (event) => {
+			if (closed) {
+				return;
+			}
+			for (const sub of store.open) {
+				sub(event);
+			}
+		},
+
+		publishError: (event) => {
+			if (closed) {
+				return;
+			}
+			for (const sub of store.error) {
+				sub(event);
+			}
+		},
+
+		publishMessage: (event) => {
+			if (closed) {
+				return;
+			}
+			for (const sub of store.message) {
+				sub(event);
+			}
+		},
+
+		publishClose: (event) => {
+			if (closed) {
+				return;
+			}
+			for (const sub of store.close) {
+				sub(event);
+			}
+		},
+	};
+
+	return [mockSocket, publisher] as const;
+}

--- a/site/src/utils/OneWayWebSocket.test.ts
+++ b/site/src/utils/OneWayWebSocket.test.ts
@@ -8,8 +8,8 @@
  */
 
 import {
-	createMockWebSocket,
 	type MockWebSocketPublisher,
+	createMockWebSocket,
 } from "testHelpers/websockets";
 import { type OneWayMessageEvent, OneWayWebSocket } from "./OneWayWebSocket";
 


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/644

## Changes made
- Redefined `useAgentLogs` to support dependency injection for how the websocket connection is created
- Redefined the test suite for `useAgentLogs` to work as a set of unit tests
- Moved our mock websocket logic into a general test helper file
- Updated the test helper for generating logs so that each log is guaranteed to have a different timestamp

## Notes
- This PR doesn't add any additional test cases, but with the new logic in place, it should be easy to add a lot more
   - If I had more time today, I would've added a test to assert that logs are sorted by timestamp before returning, since websocket messages aren't guaranteed to be in order