### PR TITLE
chore: update module sources in templates to new format

### DIFF
--- a/dogfood/coder-envbuilder/main.tf
+++ b/dogfood/coder-envbuilder/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 3.0.0"
+      version = "~> 3.0"
     }
     envbuilder = {
       source = "coder/envbuilder"
@@ -109,35 +109,35 @@ data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
 
 module "slackme" {
-  source           = "registry.coder.com/modules/slackme/coder"
+  source           = "registry.coder.com/coder/slackme/coder"
   version          = "1.0.2"
   agent_id         = coder_agent.dev.id
   auth_provider_id = "slack"
 }
 
 module "dotfiles" {
-  source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.15"
+  source   = "registry.coder.com/coder/dotfiles/coder"
+  version  = "1.0.29"
   agent_id = coder_agent.dev.id
 }
 
 module "personalize" {
-  source   = "registry.coder.com/modules/personalize/coder"
+  source   = "registry.coder.com/coder/personalize/coder"
   version  = "1.0.2"
   agent_id = coder_agent.dev.id
 }
 
 module "code-server" {
-  source                  = "registry.coder.com/modules/code-server/coder"
-  version                 = "1.0.15"
+  source                  = "registry.coder.com/coder/code-server/coder"
+  version                 = "1.2.0"
   agent_id                = coder_agent.dev.id
   folder                  = local.repo_dir
   auto_install_extensions = true
 }
 
 module "jetbrains_gateway" {
-  source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.13"
+  source         = "registry.coder.com/coder/jetbrains-gateway/coder"
+  version        = "1.1.1"
   agent_id       = coder_agent.dev.id
   agent_name     = "dev"
   folder         = local.repo_dir
@@ -147,13 +147,13 @@ module "jetbrains_gateway" {
 }
 
 module "filebrowser" {
-  source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.8"
+  source   = "registry.coder.com/coder/filebrowser/coder"
+  version  = "1.0.31"
   agent_id = coder_agent.dev.id
 }
 
 module "coder-login" {
-  source   = "registry.coder.com/modules/coder-login/coder"
+  source   = "registry.coder.com/coder/coder-login/coder"
   version  = "1.0.15"
   agent_id = coder_agent.dev.id
 }

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -217,23 +217,23 @@ data "coder_workspace_tags" "tags" {
 
 module "slackme" {
   count            = data.coder_workspace.me.start_count
-  source           = "dev.registry.coder.com/modules/slackme/coder"
-  version          = ">= 1.0.0"
+  source           = "dev.registry.coder.com/coder/slackme/coder"
+  version          = "1.0.2"
   agent_id         = coder_agent.dev.id
   auth_provider_id = "slack"
 }
 
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/modules/dotfiles/coder"
-  version  = ">= 1.0.0"
+  source   = "dev.registry.coder.com/coder/dotfiles/coder"
+  version  = "1.0.29"
   agent_id = coder_agent.dev.id
 }
 
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/modules/git-clone/coder"
-  version  = ">= 1.0.0"
+  source   = "dev.registry.coder.com/coder/git-clone/coder"
+  version  = "1.0.18"
   agent_id = coder_agent.dev.id
   url      = "https://github.com/coder/coder"
   base_dir = local.repo_base_dir
@@ -241,15 +241,15 @@ module "git-clone" {
 
 module "personalize" {
   count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/modules/personalize/coder"
-  version  = ">= 1.0.0"
+  source   = "dev.registry.coder.com/coder/personalize/coder"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
 }
 
 module "code-server" {
   count                   = data.coder_workspace.me.start_count
-  source                  = "dev.registry.coder.com/modules/code-server/coder"
-  version                 = ">= 1.0.0"
+  source                  = "dev.registry.coder.com/coder/code-server/coder"
+  version                 = "1.2.0"
   agent_id                = coder_agent.dev.id
   folder                  = local.repo_dir
   auto_install_extensions = true
@@ -257,8 +257,8 @@ module "code-server" {
 
 module "vscode-web" {
   count                   = data.coder_workspace.me.start_count
-  source                  = "registry.coder.com/modules/vscode-web/coder"
-  version                 = ">= 1.0.0"
+  source                  = "dev.registry.coder.com/coder/vscode-web/coder"
+  version                 = "1.1.0"
   agent_id                = coder_agent.dev.id
   folder                  = local.repo_dir
   extensions              = ["github.copilot"]
@@ -279,31 +279,31 @@ module "jetbrains" {
 
 module "filebrowser" {
   count      = data.coder_workspace.me.start_count
-  source     = "dev.registry.coder.com/modules/filebrowser/coder"
-  version    = ">= 1.0.0"
+  source     = "dev.registry.coder.com/coder/filebrowser/coder"
+  version    = "1.0.31"
   agent_id   = coder_agent.dev.id
   agent_name = "dev"
 }
 
 module "coder-login" {
   count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/modules/coder-login/coder"
-  version  = ">= 1.0.0"
+  source   = "dev.registry.coder.com/coder/coder-login/coder"
+  version  = "1.0.15"
   agent_id = coder_agent.dev.id
 }
 
 module "cursor" {
   count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/modules/cursor/coder"
-  version  = ">= 1.0.0"
+  source   = "dev.registry.coder.com/coder/cursor/coder"
+  version  = "1.1.0"
   agent_id = coder_agent.dev.id
   folder   = local.repo_dir
 }
 
 module "windsurf" {
   count    = data.coder_workspace.me.start_count
-  source   = "registry.coder.com/modules/windsurf/coder"
-  version  = ">= 1.0.0"
+  source   = "registry.coder.com/coder/windsurf/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.dev.id
   folder   = local.repo_dir
 }

--- a/examples/templates/aws-devcontainer/main.tf
+++ b/examples/templates/aws-devcontainer/main.tf
@@ -321,9 +321,11 @@ resource "coder_metadata" "info" {
   }
 }
 
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
-  count    = data.coder_workspace.me.start_count
-  source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.18"
+  count  = data.coder_workspace.me.start_count
+  source = "registry.coder.com/coder/code-server/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version  = "~> 1.0"
   agent_id = coder_agent.dev[0].id
 }

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -193,13 +193,13 @@ resource "coder_agent" "dev" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
   source = "registry.coder.com/modules/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.dev[0].id
   order    = 1
@@ -217,8 +217,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.dev[0].id
   agent_name = "dev"

--- a/examples/templates/azure-linux/main.tf
+++ b/examples/templates/azure-linux/main.tf
@@ -12,12 +12,12 @@ terraform {
   }
 }
 
-# See https://registry.coder.com/modules/azure-region
+# See https://registry.coder.com/modules/coder/azure-region
 module "azure_region" {
-  source = "registry.coder.com/modules/azure-region/coder"
+  source = "registry.coder.com/coder/azure-region/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   default = "eastus"
 }
@@ -136,22 +136,22 @@ resource "coder_agent" "main" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
@@ -160,8 +160,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/azure-windows/main.tf
+++ b/examples/templates/azure-windows/main.tf
@@ -16,22 +16,22 @@ provider "azurerm" {
 provider "coder" {}
 data "coder_workspace" "me" {}
 
-# See https://registry.coder.com/modules/azure-region
+# See https://registry.coder.com/modules/coder/azure-region
 module "azure_region" {
-  source = "registry.coder.com/modules/azure-region/coder"
+  source = "registry.coder.com/coder/azure-region/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   default = "eastus"
 }
 
-# See https://registry.coder.com/modules/windows-rdp
+# See https://registry.coder.com/modules/coder/windows-rdp
 module "windows_rdp" {
-  source = "registry.coder.com/modules/windows-rdp/coder"
+  source = "registry.coder.com/coder/windows-rdp/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   admin_username = local.admin_username
   admin_password = random_password.admin_password.result

--- a/examples/templates/digitalocean-linux/main.tf
+++ b/examples/templates/digitalocean-linux/main.tf
@@ -264,22 +264,22 @@ resource "coder_agent" "main" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
@@ -288,8 +288,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/docker-devcontainer/main.tf
+++ b/examples/templates/docker-devcontainer/main.tf
@@ -322,22 +322,22 @@ resource "coder_agent" "main" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PS", "WS", "PY", "CL", "GO", "RM", "RD", "RR"]
@@ -346,8 +346,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/workspaces"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -121,22 +121,22 @@ resource "coder_agent" "main" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PS", "WS", "PY", "CL", "GO", "RM", "RD", "RR"]
@@ -145,8 +145,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/gcp-devcontainer/main.tf
+++ b/examples/templates/gcp-devcontainer/main.tf
@@ -41,9 +41,11 @@ variable "cache_repo_docker_config_path" {
   type        = string
 }
 
+# See https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
-  source  = "registry.coder.com/modules/gcp-region/coder"
-  version = "1.0.12"
+  source = "registry.coder.com/coder/gcp-region/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
   regions = ["us", "europe"]
 }
 
@@ -281,32 +283,32 @@ resource "coder_agent" "dev" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
   default        = "IU"
 
   # Default folder to open when starting a JetBrains IDE
-  folder = "/home/coder"
+  folder = "/workspaces"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -15,12 +15,12 @@ variable "project_id" {
   description = "Which Google Compute Project should your workspace live in?"
 }
 
-# See https://registry.coder.com/modules/gcp-region
+# See https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
-  source = "registry.coder.com/modules/gcp-region/coder"
+  source = "registry.coder.com/coder/gcp-region/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   regions = ["us", "europe"]
   default = "us-central1-a"
@@ -91,22 +91,22 @@ resource "coder_agent" "main" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
@@ -115,8 +115,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -15,9 +15,11 @@ variable "project_id" {
   description = "Which Google Compute Project should your workspace live in?"
 }
 
+# https://registry.coder.com/modules/coder/gcp-region/coder
 module "gcp_region" {
-  source  = "registry.coder.com/modules/gcp-region/coder"
-  version = "1.0.12"
+  source = "registry.coder.com/coder/gcp-region/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
   regions = ["us", "europe"]
 }
 
@@ -42,22 +44,22 @@ resource "coder_agent" "main" {
   EOT
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
@@ -66,8 +68,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -15,12 +15,12 @@ variable "project_id" {
   description = "Which Google Compute Project should your workspace live in?"
 }
 
-# See https://registry.coder.com/modules/gcp-region
+# See https://registry.coder.com/modules/coder/gcp-region
 module "gcp_region" {
-  source = "registry.coder.com/modules/gcp-region/coder"
+  source = "registry.coder.com/coder/gcp-region/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   regions = ["us", "europe"]
   default = "us-central1-a"

--- a/examples/templates/incus/main.tf
+++ b/examples/templates/incus/main.tf
@@ -103,30 +103,38 @@ resource "coder_agent" "main" {
   }
 }
 
+# https://registry.coder.com/modules/coder/git-clone
 module "git-clone" {
-  source   = "registry.coder.com/modules/git-clone/coder"
-  version  = "1.0.2"
+  source = "registry.coder.com/coder/git-clone/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version  = "~> 1.0"
   agent_id = local.agent_id
   url      = data.coder_parameter.git_repo.value
   base_dir = local.repo_base_dir
 }
 
+# https://registry.coder.com/modules/coder/code-server
 module "code-server" {
-  source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.2"
+  source = "registry.coder.com/coder/code-server/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version  = "~> 1.0"
   agent_id = local.agent_id
   folder   = local.repo_base_dir
 }
 
+# https://registry.coder.com/modules/coder/filebrowser
 module "filebrowser" {
-  source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.2"
+  source = "registry.coder.com/coder/filebrowser/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version  = "~> 1.0"
   agent_id = local.agent_id
 }
 
+# https://registry.coder.com/modules/coder/coder-login
 module "coder-login" {
-  source   = "registry.coder.com/modules/coder-login/coder"
-  version  = "1.0.2"
+  source = "registry.coder.com/coder/coder-login/coder"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version  = "~> 1.0"
   agent_id = local.agent_id
 }
 
@@ -307,4 +315,3 @@ resource "coder_metadata" "info" {
     value = substr(incus_cached_image.image.fingerprint, 0, 12)
   }
 }
-

--- a/examples/templates/kubernetes-devcontainer/main.tf
+++ b/examples/templates/kubernetes-devcontainer/main.tf
@@ -416,22 +416,22 @@ resource "coder_agent" "main" {
   }
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
@@ -440,8 +440,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/kubernetes-envbox/main.tf
+++ b/examples/templates/kubernetes-envbox/main.tf
@@ -98,22 +98,22 @@ resource "coder_agent" "main" {
   EOT
 }
 
-# See https://registry.coder.com/modules/code-server
+# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/code-server/coder"
+  source = "registry.coder.com/coder/code-server/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id = coder_agent.main.id
   order    = 1
 }
 
-# See https://registry.coder.com/modules/jetbrains-gateway
+# See https://registry.coder.com/modules/coder/jetbrains-gateway
 module "jetbrains_gateway" {
   count  = data.coder_workspace.me.start_count
-  source = "registry.coder.com/modules/jetbrains-gateway/coder"
+  source = "registry.coder.com/coder/jetbrains-gateway/coder"
 
   # JetBrains IDEs to make available for the user to select
   jetbrains_ides = ["IU", "PY", "WS", "PS", "RD", "CL", "GO", "RM"]
@@ -122,8 +122,8 @@ module "jetbrains_gateway" {
   # Default folder to open when starting a JetBrains IDE
   folder = "/home/coder"
 
-  # This ensures that the latest version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version = ">= 1.0.0"
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
 
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/examples/templates/nomad-docker/main.tf
+++ b/examples/templates/nomad-docker/main.tf
@@ -110,21 +110,16 @@ resource "coder_agent" "main" {
   }
 }
 
-# code-server
-resource "coder_app" "code-server" {
-  agent_id     = coder_agent.main.id
-  slug         = "code-server"
-  display_name = "code-server"
-  icon         = "/icon/code.svg"
-  url          = "http://localhost:13337?folder=/home/coder"
-  subdomain    = false
-  share        = "owner"
+# See https://registry.coder.com/modules/coder/code-server
+module "code-server" {
+  count  = data.coder_workspace.me.start_count
+  source = "registry.coder.com/coder/code-server/coder"
 
-  healthcheck {
-    url       = "http://localhost:13337/healthz"
-    interval  = 3
-    threshold = 10
-  }
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
+
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 locals {

--- a/examples/templates/scratch/main.tf
+++ b/examples/templates/scratch/main.tf
@@ -40,10 +40,14 @@ resource "coder_env" "welcome_message" {
 }
 
 # Adds code-server
-# See all available modules at https://registry.coder.com
+# See all available modules at https://registry.coder.com/modules
 module "code-server" {
-  source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.2"
+  count  = data.coder_workspace.me.start_count
+  source = "registry.coder.com/coder/code-server/coder"
+
+  # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
+  version = "~> 1.0"
+
   agent_id = coder_agent.main.id
 }
 


### PR DESCRIPTION
- Changed module source URLs in dogfood and example templates to the new standard format (`registry.coder.com/NAMESPACE/MODULE-NAME/coder`).