### PR TITLE
chore: enable dependabot for terraform modules

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -104,3 +104,21 @@ updates:
         update-types:
           - version-update:semver-major
     open-pull-requests-limit: 15
+
+  - package-ecosystem: "terraform"
+    directories:
+      - "dogfood/*/"
+      - "examples/templates/*/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      coder:
+        patterns:
+          - "registry.coder.com/coder/*/coder"
+    labels: []
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
#18027 got merged to the wrong branch

Merge after #18026 