### PR TITLE
fix: handle invalid provisioning timings in ui

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/StagesChart.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/StagesChart.tsx
@@ -141,6 +141,7 @@ export const StagesChart: FC<StagesChartProps> = ({
 
 									const value = calcDuration(t.range);
 									const offset = calcOffset(t.range, totalRange);
+									const validDuration = value > 0 && !Number.isNaN(value);
 
 									return (
 										<XAxisRow
@@ -172,7 +173,17 @@ export const StagesChart: FC<StagesChartProps> = ({
 											) : (
 												<Bar scale={scale} value={value} offset={offset} />
 											)}
-											{formatTime(calcDuration(t.range))}
+											{validDuration ? (
+												<span>{formatTime(value)}</span>
+											) : (
+												<span
+													css={(theme) => ({
+														color: theme.palette.error.main,
+													})}
+												>
+													Invalid
+												</span>
+											)}
 										</XAxisRow>
 									);
 								})}

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -228,3 +228,52 @@ export const MissedAction: Story = {
 		await canvas.findByText("missed action");
 	},
 };
+
+// Ref: #15432
+export const InvalidTimeRange: Story = {
+	args: {
+		provisionerTimings: [
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "init",
+				started_at: "2025-01-01T00:00:00Z",
+				ended_at: "2025-01-01T00:01:00Z",
+			},
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "plan",
+				started_at: "2025-01-01T00:01:00Z",
+				ended_at: "0001-01-01T00:00:00Z",
+			},
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "graph",
+				started_at: "0001-01-01T00:00:00Z",
+				ended_at: "2025-01-01T00:03:00Z",
+			},
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "apply",
+				started_at: "2025-01-01T00:03:00Z",
+				ended_at: "2025-01-01T00:04:00Z",
+			},
+		],
+		agentConnectionTimings: [
+			{
+				started_at: "2025-01-01T00:05:00Z",
+				ended_at: "2025-01-01T00:06:00Z",
+				stage: "connect",
+				workspace_agent_id: "67e37a9d-ccac-497e-8f48-4093bcc4f3e7",
+				workspace_agent_name: "main",
+			},
+		],
+		agentScriptTimings: [
+			{
+				...WorkspaceTimingsResponse.agent_script_timings[0],
+				display_name: "Startup Script 1",
+				started_at: "0001-01-01T00:00:00Z",
+				ended_at: "2025-01-01T00:10:00Z",
+			},
+		],
+	},
+};


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/15432

* Adds a storybook entry for zero values in provisioner timings.
* Coerces a 'zero' start time to an 'instant'.
* Improves timing chart handling for large timeframes. Previously, this would have caused the tab to run out of memory when encountering a `time.Time{}`.
* Render 'instants' as 'invalid' in timing chart.

