### PR TITLE
chore: hide classic workspace checkbox when experiment is not enabled

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -24,7 +24,6 @@ import {
 	StackLabelHelperText,
 } from "components/StackLabel/StackLabel";
 import { type FormikTouched, useFormik } from "formik";
-import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import {
 	displayNameValidator,
@@ -64,6 +63,7 @@ export interface TemplateSettingsForm {
 	accessControlEnabled: boolean;
 	advancedSchedulingEnabled: boolean;
 	portSharingControlsEnabled: boolean;
+	isDynamicParametersEnabled: boolean;
 }
 
 export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
@@ -76,6 +76,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 	accessControlEnabled,
 	advancedSchedulingEnabled,
 	portSharingControlsEnabled,
+	isDynamicParametersEnabled,
 }) => {
 	const form = useFormik<UpdateTemplateMeta>({
 		initialValues: {
@@ -98,8 +99,6 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 		initialTouched,
 	});
 	const getFieldHelpers = getFormHelpers(form, error);
-	const { experiments } = useDashboard();
-	const dynamicParametersEnabled = experiments.includes("dynamic-parameters");
 
 	return (
 		<HorizontalForm
@@ -227,7 +226,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 							</StackLabel>
 						}
 					/>
-					{dynamicParametersEnabled && (
+					{isDynamicParametersEnabled && (
 						<FormControlLabel
 							control={
 								<Checkbox

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -24,6 +24,7 @@ import {
 	StackLabelHelperText,
 } from "components/StackLabel/StackLabel";
 import { type FormikTouched, useFormik } from "formik";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import {
 	displayNameValidator,
@@ -97,6 +98,8 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 		initialTouched,
 	});
 	const getFieldHelpers = getFormHelpers(form, error);
+	const { experiments } = useDashboard();
+	const dynamicParametersEnabled = experiments.includes("dynamic-parameters");
 
 	return (
 		<HorizontalForm
@@ -224,34 +227,37 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 							</StackLabel>
 						}
 					/>
-					<FormControlLabel
-						control={
-							<Checkbox
-								size="small"
-								id="use_classic_parameter_flow"
-								name="use_classic_parameter_flow"
-								checked={form.values.use_classic_parameter_flow}
-								onChange={form.handleChange}
-								disabled={false}
-							/>
-						}
-						label={
-							<StackLabel>
-								Use classic workspace creation form
-								<StackLabelHelperText>
-									<span>
-										Show the original workspace creation form without dynamic
-										parameters or live updates. Recommended if your provisioners
-										aren't updated or the new form causes issues.{" "}
-										<strong>
-											Users can always manually switch experiences in the
-											workspace creation form.
-										</strong>
-									</span>
-								</StackLabelHelperText>
-							</StackLabel>
-						}
-					/>
+					{dynamicParametersEnabled && (
+						<FormControlLabel
+							control={
+								<Checkbox
+									size="small"
+									id="use_classic_parameter_flow"
+									name="use_classic_parameter_flow"
+									checked={form.values.use_classic_parameter_flow}
+									onChange={form.handleChange}
+									disabled={false}
+								/>
+							}
+							label={
+								<StackLabel>
+									Use classic workspace creation form
+									<StackLabelHelperText>
+										<span>
+											Show the original workspace creation form and workspace
+											parameters settings form without dynamic parameters or
+											live updates. Recommended if your provisioners aren't
+											updated or the new form causes issues.{" "}
+											<strong>
+												Users can always manually switch experiences in the
+												workspace creation form.
+											</strong>
+										</span>
+									</StackLabelHelperText>
+								</StackLabel>
+							}
+						/>
+					)}
 				</FormFields>
 			</FormSection>
 

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
@@ -14,6 +14,8 @@ import { useTemplateSettings } from "../TemplateSettingsLayout";
 import { TemplateSettingsPageView } from "./TemplateSettingsPageView";
 
 const TemplateSettingsPage: FC = () => {
+	const { experiments } = useDashboard();
+	const isDynamicParametersEnabled = experiments.includes("dynamic-parameters");
 	const { template: templateName } = useParams() as { template: string };
 	const navigate = useNavigate();
 	const getLink = useLinks();
@@ -79,6 +81,7 @@ const TemplateSettingsPage: FC = () => {
 				accessControlEnabled={accessControlEnabled}
 				advancedSchedulingEnabled={advancedSchedulingEnabled}
 				sharedPortControlsEnabled={sharedPortControlsEnabled}
+				isDynamicParametersEnabled={isDynamicParametersEnabled}
 			/>
 		</>
 	);

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPageView.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPageView.tsx
@@ -15,6 +15,7 @@ interface TemplateSettingsPageViewProps {
 	accessControlEnabled: boolean;
 	advancedSchedulingEnabled: boolean;
 	sharedPortControlsEnabled: boolean;
+	isDynamicParametersEnabled: boolean;
 }
 
 export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
@@ -27,6 +28,7 @@ export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
 	accessControlEnabled,
 	advancedSchedulingEnabled,
 	sharedPortControlsEnabled,
+	isDynamicParametersEnabled,
 }) => {
 	return (
 		<>
@@ -44,6 +46,7 @@ export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
 				accessControlEnabled={accessControlEnabled}
 				advancedSchedulingEnabled={advancedSchedulingEnabled}
 				portSharingControlsEnabled={sharedPortControlsEnabled}
+				isDynamicParametersEnabled={isDynamicParametersEnabled}
 			/>
 		</>
 	);


### PR DESCRIPTION
resolves coder/preview#137

This hides the `Use classic workspace creation form` checkbox on the template settings page if the dynamic-parameters experiment is not enabled

Add mention of "workspace parameters settings form" in the checkbox description as this is also affected.