### PR TITLE
fix: hide Create Workspace button for deleted templates

### DIFF
--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -1079,6 +1079,7 @@ func (api *API) convertTemplate(
 		DeprecationMessage:      templateAccessControl.Deprecated,
 		MaxPortShareLevel:       maxPortShareLevel,
 		UseClassicParameterFlow: template.UseClassicParameterFlow,
+		Deleted:                 template.Deleted,
 	}
 }
 

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -63,6 +63,9 @@ type Template struct {
 	MaxPortShareLevel    WorkspaceAgentPortShareLevel `json:"max_port_share_level"`
 
 	UseClassicParameterFlow bool `json:"use_classic_parameter_flow"`
+
+	// Deleted indicates whether the template has been deleted.
+	Deleted bool `json:"deleted"`
 }
 
 // WeekdaysToBitmap converts a list of weekdays to a bitmap in accordance with

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2636,6 +2636,7 @@ export interface Template {
 	readonly require_active_version: boolean;
 	readonly max_port_share_level: WorkspaceAgentPortShareLevel;
 	readonly use_classic_parameter_flow: boolean;
+	readonly deleted: boolean;
 }
 
 // From codersdk/templates.go

--- a/site/src/components/Badges/Badges.tsx
+++ b/site/src/components/Badges/Badges.tsx
@@ -191,6 +191,12 @@ export const DeprecatedBadge: FC = () => {
 	);
 };
 
+export const DeletedBadge: FC = () => {
+	return (
+		<span css={[styles.badge, styles.errorBadge]}>Deleted</span>
+	);
+};
+
 export const Badges: FC<PropsWithChildren> = ({ children }) => {
 	return (
 		<Stack

--- a/site/src/pages/TemplatesPage/TemplatesFilter.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.tsx
@@ -42,6 +42,7 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 			presets={[
 				{ query: "", name: "All templates" },
 				{ query: "deprecated:true", name: "Deprecated templates" },
+				{ query: "deleted:true", name: "Deleted templates" },
 			]}
 			// TODO: Add docs for this
 			// learnMoreLink={docs("/templates#template-filtering")}

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -7,7 +7,7 @@ import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Avatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/Avatar/AvatarData";
 import { AvatarDataSkeleton } from "components/Avatar/AvatarDataSkeleton";
-import { DeprecatedBadge } from "components/Badges/Badges";
+import { DeletedBadge, DeprecatedBadge } from "components/Badges/Badges";
 import { Button } from "components/Button/Button";
 import type { useFilter } from "components/Filter/Filter";
 import {
@@ -158,7 +158,9 @@ const TemplateRow: FC<TemplateRowProps> = ({
 			</TableCell>
 
 			<TableCell css={styles.actionCell}>
-				{template.deprecated ? (
+				{template.deleted ? (
+					<DeletedBadge />
+				) : template.deprecated ? (
 					<DeprecatedBadge />
 				) : workspacePermissions?.[template.organization_id]
 						?.createWorkspaceForUserID ? (

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -823,6 +823,7 @@ export const MockTemplate: TypesGen.Template = {
 	require_active_version: false,
 	deprecated: false,
 	deprecation_message: "",
+	deleted: false,
 	max_port_share_level: "public",
 	use_classic_parameter_flow: false,
 };


### PR DESCRIPTION
This change prevents users from creating workspaces from deleted templates by:
- Exposing the deleted status of templates in the API
- Adding a "Deleted" badge to identify deleted templates
- Hiding the Create Workspace button for deleted templates
- Adding a filter option to view deleted templates
- Fixes #17417 

https://github.com/user-attachments/assets/a4c6c4bd-0a57-4c88-b2ff-540ed4a6e91f

