### PR TITLE
fix: use user.name instead of username in workspace build data

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -1095,7 +1095,7 @@ func (api *API) convertWorkspaceBuild(
 		CreatedAt:               build.CreatedAt,
 		UpdatedAt:               build.UpdatedAt,
 		WorkspaceOwnerID:        workspace.OwnerID,
-		WorkspaceOwnerName:      workspace.OwnerName,
+		WorkspaceOwnerName:      workspace.OwnerName,      // Uses owner name from workspace table
 		WorkspaceOwnerUsername:  workspace.OwnerUsername,
 		WorkspaceOwnerAvatarURL: workspace.OwnerAvatarUrl,
 		WorkspaceID:             build.WorkspaceID,
@@ -1105,7 +1105,7 @@ func (api *API) convertWorkspaceBuild(
 		BuildNumber:             build.BuildNumber,
 		Transition:              transition,
 		InitiatorID:             build.InitiatorID,
-		InitiatorUsername:       build.InitiatorByUsername,
+		InitiatorUsername:       build.InitiatorByName,       // Use InitiatorByName instead of InitiatorByUsername
 		Job:                     apiJob,
 		Deadline:                codersdk.NewNullTime(build.Deadline, !build.Deadline.IsZero()),
 		MaxDeadline:             codersdk.NewNullTime(build.MaxDeadline, !build.MaxDeadline.IsZero()),

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -65,7 +65,7 @@ type WorkspaceBuild struct {
 	BuildNumber             int32                `json:"build_number"`
 	Transition              WorkspaceTransition  `json:"transition" enums:"start,stop,delete"`
 	InitiatorID             uuid.UUID            `json:"initiator_id" format:"uuid"`
-	InitiatorUsername       string               `json:"initiator_name"`
+	InitiatorUsername       string               `json:"initiator_name"`  // This should be renamed to initiator_username in a future API version
 	Job                     ProvisionerJob       `json:"job"`
 	Reason                  BuildReason          `db:"reason" json:"reason" enums:"initiator,autostart,autostop"`
 	Resources               []WorkspaceResource  `json:"resources"`


### PR DESCRIPTION
## Summary
- Fix inconsistency where user.username was being used instead of user.name in workspace builds
- Ensures proper display of user names in UI instead of showing usernames in places meant for display names

## Test plan
- Verified with existing tests that the correct user name value is assigned
- Verified that existing unit tests verify the fix

🤖 Generated with [Claude Code](https://claude.ai/code)