### PR TITLE
fix: rename build.workspace_owner_name to build.workspace_owner_username

### DIFF
--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -104,7 +104,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 						label="Workspace"
 						value={
 							<Link
-								to={`/@${build.workspace_owner_name}/${build.workspace_name}`}
+								to={`/@${build.workspace_owner_username}/${build.workspace_name}`}
 							>
 								{build.workspace_name}
 							</Link>
@@ -158,7 +158,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 					{builds?.map((build) => (
 						<Link
 							key={build.id}
-							to={`/@${build.workspace_owner_name}/${build.workspace_name}/builds/${build.build_number}`}
+							to={`/@${build.workspace_owner_username}/${build.workspace_name}/builds/${build.build_number}`}
 						>
 							<SidebarItem active={build.build_number === activeBuildNumber}>
 								<WorkspaceBuildData build={build} />

--- a/site/src/pages/WorkspacePage/HistorySidebar.tsx
+++ b/site/src/pages/WorkspacePage/HistorySidebar.tsx
@@ -35,7 +35,7 @@ export const HistorySidebar: FC<HistorySidebarProps> = ({ workspace }) => {
 						<SidebarLink
 							target="_blank"
 							key={build.id}
-							to={`/@${build.workspace_owner_name}/${build.workspace_name}/builds/${build.build_number}`}
+							to={`/@${build.workspace_owner_username}/${build.workspace_name}/builds/${build.build_number}`}
 						>
 							<WorkspaceBuildData build={build} />
 						</SidebarLink>


### PR DESCRIPTION
I forgot to update the the build logs to use username instead of name.

Introduced on: https://github.com/coder/coder/pull/18025