### PR TITLE
feat: add prebuilt_workspace type and embed behavior to rego policy

### DIFF
--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -712,6 +712,39 @@ func TestAuthorizeDomain(t *testing.T) {
 
 			{resource: ResourceWorkspace.WithOwner("not-me")},
 		}))
+
+	// Prebuild
+	prebuildUserID := uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0").String()
+	prebuilder := Subject{
+		ID:    prebuildUserID,
+		Scope: must(ExpandScope(ScopeAll)),
+		Roles: Roles{
+			{
+				Identifier: RoleIdentifier{Name: "Prebuilder"},
+				Site:       []Permission{},
+				Org: map[string][]Permission{
+					defOrg.String(): Permissions(map[string][]policy.Action{
+						ResourcePrebuiltWorkspace.Type: ResourcePrebuiltWorkspace.AvailableActions(),
+					}),
+				},
+				User: []Permission{},
+			},
+		},
+	}
+
+	testAuthorize(t, "AllWorkspaceActions", prebuilder,
+		cases(func(c authTestCase) authTestCase {
+			c.actions = ResourceWorkspace.AvailableActions()
+			return c
+		}, []authTestCase{
+			// Prebuilder cannot access all workspaces
+			{allow: false, resource: ResourceWorkspace.InOrg(defOrg).WithOwner(user.ID)},
+			// They can access their workspaces because of the prebuild user ID
+			{allow: true, resource: ResourceWorkspace.InOrg(defOrg).WithOwner(prebuildUserID)},
+			// Also the prebuild type, although this should never be used directly.
+			{allow: true, resource: ResourcePrebuiltWorkspace.InOrg(defOrg).WithOwner(prebuildUserID)},
+		}),
+	)
 }
 
 // TestAuthorizeLevels ensures level overrides are acting appropriately

--- a/coderd/rbac/input.json
+++ b/coderd/rbac/input.json
@@ -1,46 +1,105 @@
 {
-	"action": "never-match-action",
-	"object": {
-		"id": "9046b041-58ed-47a3-9c3a-de302577875a",
-		"owner": "00000000-0000-0000-0000-000000000000",
-		"org_owner": "bf7b72bd-a2b1-4ef2-962c-1d698e0483f6",
-		"type": "workspace",
-		"acl_user_list": {
-			"f041847d-711b-40da-a89a-ede39f70dc7f": ["create"]
-		},
-		"acl_group_list": {}
+	"action":"create",
+	"object":{
+		"id":"",
+		"owner":"c42fdf75-3097-471c-8c33-fb52454d81c0",
+		"org_owner":"915066be-d016-4993-9f16-fe40b083ab98",
+		"any_org":false,
+		"type":"workspace",
+		"acl_user_list":null,
+		"acl_group_list":null
 	},
-	"subject": {
-		"id": "10d03e62-7703-4df5-a358-4f76577d4e2f",
-		"roles": [
+	"subject":{
+		"id":"c42fdf75-3097-471c-8c33-fb52454d81c0",
+		"roles":[
 			{
-				"name": "owner",
-				"display_name": "Owner",
-				"site": [
-					{
-						"negate": false,
-						"resource_type": "*",
-						"action": "*"
-					}
+				"name":"Prebuilder",
+				"display_name":"",
+				"site":[
+
 				],
-				"org": {},
-				"user": []
+				"org":{
+					"915066be-d016-4993-9f16-fe40b083ab98":[
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"read"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"update"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"delete"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"start"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"ssh"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"application_connect"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"stop"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"create_agent"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"delete_agent"
+						},
+						{
+							"negate":false,
+							"resource_type":"prebuilt_workspace",
+							"action":"create"
+						}
+					]
+				},
+				"user":[
+
+				]
 			}
 		],
-		"groups": ["b617a647-b5d0-4cbe-9e40-26f89710bf18"],
-		"scope": {
-			"name": "Scope_all",
-			"display_name": "All operations",
-			"site": [
+		"groups":null,
+		"scope":{
+			"name":{
+				"Name":"Scope_all",
+				"OrganizationID":"00000000-0000-0000-0000-000000000000"
+			},
+			"display_name":"All operations",
+			"site":[
 				{
-					"negate": false,
-					"resource_type": "*",
-					"action": "*"
+					"negate":false,
+					"resource_type":"*",
+					"action":"*"
 				}
 			],
-			"org": {},
-			"user": [],
-			"allow_list": ["*"]
+			"org":{
+
+			},
+			"user":[
+
+			],
+			"allow_list":[
+				"*"
+			]
 		}
 	}
 }

--- a/coderd/rbac/object_gen.go
+++ b/coderd/rbac/object_gen.go
@@ -222,6 +222,22 @@ var (
 		Type: "organization_member",
 	}
 
+	// ResourcePrebuiltWorkspace
+	// Valid Actions
+	//  - "ActionApplicationConnect" :: connect to workspace apps via browser
+	//  - "ActionCreate" :: create a new workspace
+	//  - "ActionCreateAgent" :: create a new workspace agent
+	//  - "ActionDelete" :: delete workspace
+	//  - "ActionDeleteAgent" :: delete an existing workspace agent
+	//  - "ActionRead" :: read workspace data to view on the UI
+	//  - "ActionSSH" :: ssh into a given workspace
+	//  - "ActionWorkspaceStart" :: allows starting a workspace
+	//  - "ActionWorkspaceStop" :: allows stopping a workspace
+	//  - "ActionUpdate" :: edit workspace settings (scheduling, permissions, parameters)
+	ResourcePrebuiltWorkspace = Object{
+		Type: "prebuilt_workspace",
+	}
+
 	// ResourceProvisionerDaemon
 	// Valid Actions
 	//  - "ActionCreate" :: create a provisioner daemon/key
@@ -389,6 +405,7 @@ func AllResources() []Objecter {
 		ResourceOauth2AppSecret,
 		ResourceOrganization,
 		ResourceOrganizationMember,
+		ResourcePrebuiltWorkspace,
 		ResourceProvisionerDaemon,
 		ResourceProvisionerJobs,
 		ResourceReplicas,

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -61,6 +61,22 @@ number(set) := c if {
 	c := 1
 }
 
+
+is_prebuild_workspace if {
+	input.object.type = "workspace"
+	input.object.owner = "c42fdf75-3097-471c-8c33-fb52454d81c0"
+}
+
+object_set := object_types if {
+	is_prebuild_workspace
+	object_types := [input.object.type, "prebuilt_workspace", "*"]
+}
+
+object_set := object_types if {
+	not is_prebuild_workspace
+	object_types := [input.object.type, "*"]
+}
+
 # site, org, and user rules are all similar. Each rule should return a number
 # from [-1, 1]. The number corresponds to "negative", "abstain", and "positive"
 # for the given level. See the 'allow' rules for how these numbers are used.
@@ -78,7 +94,7 @@ site_allow(roles) := num if {
 		# Iterate over all site permissions in all roles
 		perm := roles[_].site[_]
 		perm.action in [input.action, "*"]
-		perm.resource_type in [input.object.type, "*"]
+		perm.resource_type in object_set
 
 		# x is either 'true' or 'false' if a matching permission exists.
 		x := bool_flip(perm.negate)
@@ -117,7 +133,7 @@ org_allow_set(roles) := allow_set if {
 		set := {x |
 			perm := roles[_].org[id][_]
 			perm.action in [input.action, "*"]
-			perm.resource_type in [input.object.type, "*"]
+			perm.resource_type in object_set
 			x := bool_flip(perm.negate)
 		}
 		num := number(set)
@@ -207,7 +223,7 @@ user_allow(roles) := num if {
 	allow := {x |
 		perm := roles[_].user[_]
 		perm.action in [input.action, "*"]
-		perm.resource_type in [input.object.type, "*"]
+		perm.resource_type in object_set
 		x := bool_flip(perm.negate)
 	}
 	num := number(allow)

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -89,7 +89,19 @@ site := num if {
 
 default scope_site := 0
 
-scope_site := site_allow([input.subject.scope], default_object_set)
+
+scope_site := num if {
+	not is_prebuild_workspace
+	num := site_allow(input.subject.scope, default_object_set)
+}
+
+scope_site := num if {
+	is_prebuild_workspace
+	num := number([
+		site_allow(input.subject.scope, default_object_set),
+		site_allow(input.subject.scope, [prebuild_workspace_type])
+	])
+}
 
 site_allow(roles, object_set) := num if {
 	# allow is a set of boolean values without duplicates.
@@ -129,7 +141,18 @@ org := num if {
 
 default scope_org := 0
 
-scope_org := org_allow([input.scope], default_object_set)
+scope_org := num if {
+	not is_prebuild_workspace
+	num := org_allow(input.subject.scope, default_object_set)
+}
+
+scope_org := num if {
+	is_prebuild_workspace
+	num := number([
+		org_allow(input.subject.scope, default_object_set),
+		org_allow(input.subject.scope, [prebuild_workspace_type])
+	])
+}
 
 # org_allow_set is a helper function that iterates over all orgs that the actor
 # is a member of. For each organization it sets the numerical allow value
@@ -240,7 +263,18 @@ user := num if {
 
 default user_scope := 0
 
-scope_user := user_allow([input.scope], default_object_set)
+scope_user := num if {
+	not is_prebuild_workspace
+	num := user_allow(input.subject.scope, default_object_set)
+}
+
+scope_user := num if {
+	is_prebuild_workspace
+	num := number([
+		user_allow(input.subject.scope, default_object_set),
+		user_allow(input.subject.scope, [prebuild_workspace_type])
+	])
+}
 
 user_allow(roles, object_set) := num if {
 	input.object.owner != ""

--- a/coderd/rbac/policy/policy.go
+++ b/coderd/rbac/policy/policy.go
@@ -102,6 +102,9 @@ var RBACPermissions = map[string]PermissionDefinition{
 	"workspace_dormant": {
 		Actions: workspaceActions,
 	},
+	"prebuilt_workspace": {
+		Actions: workspaceActions,
+	},
 	"workspace_proxy": {
 		Actions: map[Action]ActionDefinition{
 			ActionCreate: actDef("create a workspace proxy"),

--- a/codersdk/rbacresources_gen.go
+++ b/codersdk/rbacresources_gen.go
@@ -28,6 +28,7 @@ const (
 	ResourceOauth2AppSecret               RBACResource = "oauth2_app_secret"
 	ResourceOrganization                  RBACResource = "organization"
 	ResourceOrganizationMember            RBACResource = "organization_member"
+	ResourcePrebuiltWorkspace             RBACResource = "prebuilt_workspace"
 	ResourceProvisionerDaemon             RBACResource = "provisioner_daemon"
 	ResourceProvisionerJobs               RBACResource = "provisioner_jobs"
 	ResourceReplicas                      RBACResource = "replicas"
@@ -91,6 +92,7 @@ var RBACResourceActions = map[RBACResource][]RBACAction{
 	ResourceOauth2AppSecret:               {ActionCreate, ActionDelete, ActionRead, ActionUpdate},
 	ResourceOrganization:                  {ActionCreate, ActionDelete, ActionRead, ActionUpdate},
 	ResourceOrganizationMember:            {ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourcePrebuiltWorkspace:             {ActionApplicationConnect, ActionCreate, ActionCreateAgent, ActionDelete, ActionDeleteAgent, ActionRead, ActionSSH, ActionWorkspaceStart, ActionWorkspaceStop, ActionUpdate},
 	ResourceProvisionerDaemon:             {ActionCreate, ActionDelete, ActionRead, ActionUpdate},
 	ResourceProvisionerJobs:               {ActionCreate, ActionRead, ActionUpdate},
 	ResourceReplicas:                      {ActionRead},


### PR DESCRIPTION
Prebuild workspaces can also be referenced by the prebuilt_workspace resource type. Allowing permissions to apply only to prebuilts

The simple policy change does not support partial queries: https://github.com/coder/coder/pull/18079/commits/a87cef91fcc2466b6a67a20d82aca78229a25ed5#diff-026b1db36da1ee251818ae67d135dd323782222180ce8fb1f6c0ec9a57bdb027