### PR TITLE
feat: add prebuilt workspaces telemetry

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -864,6 +864,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				BuiltinPostgres:  builtinPostgres,
 				DeploymentID:     deploymentID,
 				Database:         options.Database,
+				Experiments:      coderd.ReadExperiments(options.Logger, options.DeploymentValues.Experiments.Value()),
 				Logger:           logger.Named("telemetry"),
 				URL:              vals.Telemetry.URL.Value(),
 				Tunnel:           tunnel != nil,

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -683,6 +683,48 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 		}
 		return nil
 	})
+	eg.Go(func() error {
+		metrics, err := r.options.Database.GetPrebuildMetrics(ctx)
+		if err != nil {
+			return xerrors.Errorf("get prebuild metrics: %w", err)
+		}
+
+		var totalCreated, totalFailed, totalClaimed int64
+		for _, metric := range metrics {
+			totalCreated += metric.CreatedCount
+			totalFailed += metric.FailedCount
+			totalClaimed += metric.ClaimedCount
+		}
+
+		snapshot.PrebuiltWorkspaces = make([]PrebuiltWorkspace, 0, 3)
+		now := dbtime.Now()
+
+		if totalCreated > 0 {
+			snapshot.PrebuiltWorkspaces = append(snapshot.PrebuiltWorkspaces, PrebuiltWorkspace{
+				ID:        uuid.New(),
+				CreatedAt: now,
+				EventType: PrebuiltWorkspaceEventTypeCreated,
+				Count:     int(totalCreated),
+			})
+		}
+		if totalFailed > 0 {
+			snapshot.PrebuiltWorkspaces = append(snapshot.PrebuiltWorkspaces, PrebuiltWorkspace{
+				ID:        uuid.New(),
+				CreatedAt: now,
+				EventType: PrebuiltWorkspaceEventTypeFailed,
+				Count:     int(totalFailed),
+			})
+		}
+		if totalClaimed > 0 {
+			snapshot.PrebuiltWorkspaces = append(snapshot.PrebuiltWorkspaces, PrebuiltWorkspace{
+				ID:        uuid.New(),
+				CreatedAt: now,
+				EventType: PrebuiltWorkspaceEventTypeClaimed,
+				Count:     int(totalClaimed),
+			})
+		}
+		return nil
+	})
 
 	err := eg.Wait()
 	if err != nil {
@@ -1152,6 +1194,7 @@ type Snapshot struct {
 	Organizations                        []Organization                        `json:"organizations"`
 	TelemetryItems                       []TelemetryItem                       `json:"telemetry_items"`
 	UserTailnetConnections               []UserTailnetConnection               `json:"user_tailnet_connections"`
+	PrebuiltWorkspaces                   []PrebuiltWorkspace                   `json:"prebuilt_workspaces"`
 }
 
 // Deployment contains information about the host running Coder.
@@ -1722,6 +1765,21 @@ type UserTailnetConnection struct {
 	DeviceID            *string    `json:"device_id"`
 	DeviceOS            *string    `json:"device_os"`
 	CoderDesktopVersion *string    `json:"coder_desktop_version"`
+}
+
+type PrebuiltWorkspaceEventType string
+
+const (
+	PrebuiltWorkspaceEventTypeCreated PrebuiltWorkspaceEventType = "created"
+	PrebuiltWorkspaceEventTypeFailed  PrebuiltWorkspaceEventType = "failed"
+	PrebuiltWorkspaceEventTypeClaimed PrebuiltWorkspaceEventType = "claimed"
+)
+
+type PrebuiltWorkspace struct {
+	ID        uuid.UUID                  `json:"id"`
+	CreatedAt time.Time                  `json:"created_at"`
+	EventType PrebuiltWorkspaceEventType `json:"event_type"`
+	Count     int                        `json:"count"`
 }
 
 type noopReporter struct{}

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -448,7 +448,7 @@ type mockDB struct {
 	database.Store
 }
 
-func (m *mockDB) GetPrebuildMetrics(context.Context) ([]database.GetPrebuildMetricsRow, error) {
+func (*mockDB) GetPrebuildMetrics(context.Context) ([]database.GetPrebuildMetricsRow, error) {
 	return []database.GetPrebuildMetricsRow{
 		{
 			TemplateName:     "template1",
@@ -473,7 +473,7 @@ type emptyMockDB struct {
 	database.Store
 }
 
-func (m *emptyMockDB) GetPrebuildMetrics(context.Context) ([]database.GetPrebuildMetricsRow, error) {
+func (*emptyMockDB) GetPrebuildMetrics(context.Context) ([]database.GetPrebuildMetricsRow, error) {
 	return []database.GetPrebuildMetricsRow{}, nil
 }
 

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -373,7 +373,7 @@ func TestTelemetryItem(t *testing.T) {
 func TestPrebuiltWorkspacesTelemetry(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitMedium)
-	db := dbmem.New()
+	db, _ := dbtestutil.NewDB(t)
 
 	cases := []struct {
 		name                    string


### PR DESCRIPTION
Adds telemetry for a _global_ account of prebuilt workspaces created, failed to build, and claimed.

Partitioning this data by template/preset tuple is not currently in scope.