### PR TITLE
docs: update SSH command format to use suffix

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -235,7 +235,7 @@ func (r *RootCmd) configSSH() *serpent.Command {
 	cmd := &serpent.Command{
 		Annotations: workspaceCommand,
 		Use:         "config-ssh",
-		Short:       "Add an SSH Host entry for your workspaces \"ssh coder.workspace\"",
+		Short:       "Add an SSH Host entry for your workspaces \"ssh workspace.coder\"",
 		Long: FormatExamples(
 			Example{
 				Description: "You can use -o (or --ssh-option) so set SSH options to be used for all your workspaces",

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -18,7 +18,7 @@ SUBCOMMANDS:
     completion        Install or update shell completion scripts for the
                       detected or chosen shell.
     config-ssh        Add an SSH Host entry for your workspaces "ssh
-                      coder.workspace"
+                      workspace.coder"
     create            Create a workspace
     delete            Delete a workspace
     dotfiles          Personalize your workspace by applying a canonical

--- a/cli/testdata/coder_config-ssh_--help.golden
+++ b/cli/testdata/coder_config-ssh_--help.golden
@@ -3,7 +3,7 @@ coder v0.0.0-devel
 USAGE:
   coder config-ssh [flags]
 
-  Add an SSH Host entry for your workspaces "ssh coder.workspace"
+  Add an SSH Host entry for your workspaces "ssh workspace.coder"
 
     - You can use -o (or --ssh-option) so set SSH options to be used for all
   your

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1091,7 +1091,7 @@
 						},
 						{
 							"title": "config-ssh",
-							"description": "Add an SSH Host entry for your workspaces \"ssh coder.workspace\"",
+							"description": "Add an SSH Host entry for your workspaces \"ssh workspace.coder\"",
 							"path": "reference/cli/config-ssh.md"
 						},
 						{

--- a/docs/reference/cli/config-ssh.md
+++ b/docs/reference/cli/config-ssh.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT | GENERATED CONTENT -->
 # config-ssh
 
-Add an SSH Host entry for your workspaces "ssh coder.workspace"
+Add an SSH Host entry for your workspaces "ssh workspace.coder"
 
 ## Usage
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -41,7 +41,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 | [<code>users</code>](./users.md)                   | Manage users                                                                                          |
 | [<code>version</code>](./version.md)               | Show coder version                                                                                    |
 | [<code>autoupdate</code>](./autoupdate.md)         | Toggle auto-update policy for a workspace                                                             |
-| [<code>config-ssh</code>](./config-ssh.md)         | Add an SSH Host entry for your workspaces "ssh coder.workspace"                                       |
+| [<code>config-ssh</code>](./config-ssh.md)         | Add an SSH Host entry for your workspaces "ssh workspace.coder"                                       |
 | [<code>create</code>](./create.md)                 | Create a workspace                                                                                    |
 | [<code>delete</code>](./delete.md)                 | Delete a workspace                                                                                    |
 | [<code>favorite</code>](./favorite.md)             | Add a workspace to your favorites                                                                     |

--- a/docs/tutorials/testing-templates.md
+++ b/docs/tutorials/testing-templates.md
@@ -103,9 +103,8 @@ jobs:
       - name: Create a test workspace and run some example commands
         run: |
           coder create -t $TEMPLATE_NAME --template-version ${{ steps.name.outputs.version_name }} test-${{ steps.name.outputs.version_name }} --yes
-          coder config-ssh --yes
           # run some example commands
-          ssh coder.test-${{ steps.name.outputs.version_name }} -- make build
+          coder ssh test-${{ steps.name.outputs.version_name }} -- make build
 
       - name: Delete the test workspace
         if: always()

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -196,6 +196,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 						<AgentSSHButton
 							workspaceName={workspace.name}
 							agentName={agent.name}
+							workspaceOwnerUsername={workspace.owner_name}
 						/>
 					)}
 					{proxy.preferredWildcardHostname !== "" &&

--- a/site/src/modules/resources/SSHButton/SSHButton.tsx
+++ b/site/src/modules/resources/SSHButton/SSHButton.tsx
@@ -22,15 +22,17 @@ import { docs } from "utils/docs";
 interface AgentSSHButtonProps {
 	workspaceName: string;
 	agentName: string;
+	workspaceOwnerUsername: string;
 }
 
 export const AgentSSHButton: FC<AgentSSHButtonProps> = ({
 	workspaceName,
 	agentName,
+	workspaceOwnerUsername,
 }) => {
 	const paper = useClassName(classNames.paper, []);
 	const { data } = useQuery(deploymentSSHConfig());
-	const sshPrefix = data?.hostname_prefix;
+	const sshSuffix = data?.hostname_suffix;
 
 	return (
 		<Popover>
@@ -58,7 +60,7 @@ export const AgentSSHButton: FC<AgentSSHButtonProps> = ({
 						/>
 						<SSHStep
 							helpText="Connect to the agent:"
-							codeExample={`ssh ${sshPrefix}${workspaceName}.${agentName}`}
+							codeExample={`ssh ${workspaceName}.${agentName}.${workspaceOwnerUsername}.${sshSuffix}`}
 						/>
 					</Stack>
 				</ol>


### PR DESCRIPTION
Refactor the workspace SSH command syntax across the project to use the "workspace.coder" format instead of "coder.workspace". This standardizes the SSH host entries for better consistency and clarity.

This is a follow-up from #17445 and recommends using the suffix-based format for all new Coder versions.

<img width="418" alt="image" src="https://github.com/user-attachments/assets/3893f840-9ce1-4803-a013-736068feb328" />
