### PR TITLE
fix: use owner username instead of owner name in tasks list links

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -318,7 +318,7 @@ const TasksTable: FC<TasksTableProps> = ({ templates }) => {
 												{prompt}
 											</span>
 											<RouterLink
-												to={`/tasks/${workspace.owner_name}/${workspace.name}`}
+												to={`/tasks/${workspace.owner_username}/${workspace.name}`}
 												className="absolute inset-0"
 											>
 												<span className="sr-only">Access task</span>


### PR DESCRIPTION
Fixes a bug where if you click on a task in the tasks list, you see:
![image (4)](https://github.com/user-attachments/assets/db392425-3ec8-441c-9f19-6860b85374a5)
