### PR TITLE
fix(cli): handle nil unwrap errors when formatting

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -1060,11 +1060,12 @@ func cliHumanFormatError(from string, err error, opts *formatOpts) (string, bool
 		return formatRunCommandError(cmdErr, opts), true
 	}
 
-	uw, ok := err.(interface{ Unwrap() error })
-	if ok {
-		msg, special := cliHumanFormatError(from+traceError(err), uw.Unwrap(), opts)
-		if special {
-			return msg, special
+	if uw, ok := err.(interface{ Unwrap() error }); ok {
+		if unwrapped := uw.Unwrap(); unwrapped != nil {
+			msg, special := cliHumanFormatError(from+traceError(err), unwrapped, opts)
+			if special {
+				return msg, special
+			}
 		}
 	}
 	// If we got here, that means that the wrapped error chain does not have


### PR DESCRIPTION
Discovered an unhelpful error when running a CLI command without internet (I didn't know I didn't have internet!):

```
$ coder ls
Encountered an error running "coder list", see "coder list --help" for more information
error: <nil>
```

The source of this was that calling `Unwrap()` on `net.DNSError` can return nil, causing the whole error trace to get replaced by it. Instead, we'll just treat a nil `Unwrap()` return value as if there was nothing to unwrap.

The result is:
```
$ coder ls
Encountered an error running "coder list", see "coder list --help" for more information
error: query workspaces: Get "https://dev.coder.com/api/v2/workspaces?q=owner%3Ame": dial tcp: lookup dev.coder.com: no such host
```