### PR TITLE
chore: improve tailnet integration test

### DIFF
--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -474,13 +474,15 @@ func (UDPEchoService) StartService(t *testing.T, logger slog.Logger, _ *tailnet.
 				logger.Info(context.Background(), "error reading UDPEcho listener", slog.Error(readErr))
 				return
 			}
-			logger.Info(context.Background(), "received UDP packet",
+			logger.Info(context.Background(), "received UDPEcho packet",
 				slog.F("len", n), slog.F("remote", remote))
 			n, writeErr := l.WriteToUDP(buf[:n], remote)
 			if writeErr != nil {
 				logger.Info(context.Background(), "error writing UDPEcho listener", slog.Error(writeErr))
 				return
 			}
+			logger.Info(context.Background(), "wrote UDPEcho packet",
+				slog.F("len", n), slog.F("remote", remote))
 		}
 	}()
 }

--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"tailscale.com/net/packet"
+	"tailscale.com/wgengine/capture"
 	"testing"
 	"time"
 
@@ -54,6 +56,7 @@ type Client struct {
 	ID             uuid.UUID
 	ListenPort     uint16
 	ShouldRunTests bool
+	TunnelSrc      bool
 }
 
 var Client1 = Client{
@@ -61,6 +64,7 @@ var Client1 = Client{
 	ID:             uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 	ListenPort:     client1Port,
 	ShouldRunTests: true,
+	TunnelSrc:      true,
 }
 
 var Client2 = Client{
@@ -68,21 +72,20 @@ var Client2 = Client{
 	ID:             uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 	ListenPort:     client2Port,
 	ShouldRunTests: false,
+	TunnelSrc:      false,
 }
 
 type TestTopology struct {
 	Name string
-	// SetupNetworking creates interfaces and network namespaces for the test.
-	// The most simple implementation is NetworkSetupDefault, which only creates
-	// a network namespace shared for all tests.
-	SetupNetworking func(t *testing.T, logger slog.Logger) TestNetworking
+
+	NetworkingProvider NetworkingProvider
 
 	// Server is the server starter for the test. It is executed in the server
 	// subprocess.
 	Server ServerStarter
-	// StartClient gets called in each client subprocess. It's expected to
+	// ClientStarter.StartClient gets called in each client subprocess. It's expected to
 	// create the tailnet.Conn and ensure connectivity to it's peer.
-	StartClient func(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me Client, peer Client) *tailnet.Conn
+	ClientStarter ClientStarter
 
 	// RunTests is the main test function. It's called in each of the client
 	// subprocesses. If tests can only run once, they should check the client ID
@@ -95,6 +98,17 @@ type ServerStarter interface {
 	// should not block once it's listening. Cleanup should be handled by
 	// t.Cleanup.
 	StartServer(t *testing.T, logger slog.Logger, listenAddr string)
+}
+
+type NetworkingProvider interface {
+	// SetupNetworking creates interfaces and network namespaces for the test.
+	// The most simple implementation is NetworkSetupDefault, which only creates
+	// a network namespace shared for all tests.
+	SetupNetworking(t *testing.T, logger slog.Logger) TestNetworking
+}
+
+type ClientStarter interface {
+	StartClient(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me Client, peer Client) *tailnet.Conn
 }
 
 type SimpleServerOptions struct {
@@ -369,77 +383,106 @@ http {
 	_, _ = ExecBackground(t, "server.nginx", nil, "nginx", []string{"-c", cfgPath})
 }
 
-// StartClientDERP creates a client connection to the server for coordination
-// and creates a tailnet.Conn which will only use DERP to connect to the peer.
-func StartClientDERP(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
-	return startClientOptions(t, logger, serverURL, me, peer, &tailnet.Options{
-		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.PrefixFromUUID(me.ID)},
-		DERPMap:             derpMap,
-		BlockEndpoints:      true,
-		Logger:              logger,
-		DERPForceWebSockets: false,
-		ListenPort:          me.ListenPort,
-		// These tests don't have internet connection, so we need to force
-		// magicsock to do anything.
-		ForceNetworkUp: true,
-	})
+type BasicClientStarter struct {
+	BlockEndpoints      bool
+	DERPForceWebsockets bool
+	// WaitForConnection means wait for (any) peer connection before returning from StartClient
+	WaitForConnection bool
+	// WaitForConnection means wait for a direct peer connection before returning from StartClient
+	WaitForDirect bool
+	// Service is a network service (e.g. an echo server) to start on the client. If Wait* is set, the service is
+	// started prior to waiting.
+	Service    NetworkService
+	LogPackets bool
 }
 
-// StartClientDERPWebSockets does the same thing as StartClientDERP but will
-// only use DERP WebSocket fallback.
-func StartClientDERPWebSockets(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
-	return startClientOptions(t, logger, serverURL, me, peer, &tailnet.Options{
-		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.PrefixFromUUID(me.ID)},
-		DERPMap:             derpMap,
-		BlockEndpoints:      true,
-		Logger:              logger,
-		DERPForceWebSockets: true,
-		ListenPort:          me.ListenPort,
-		// These tests don't have internet connection, so we need to force
-		// magicsock to do anything.
-		ForceNetworkUp: true,
-	})
+type NetworkService interface {
+	StartService(t *testing.T, logger slog.Logger, conn *tailnet.Conn)
 }
 
-// StartClientDirect does the same thing as StartClientDERP but disables
-// BlockEndpoints (which enables Direct connections), and waits for a direct
-// connection to be established between the two peers.
-func StartClientDirect(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
+func (b BasicClientStarter) StartClient(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
+	var hook capture.Callback
+	if b.LogPackets {
+		pktLogger := packetLogger{logger}
+		hook = pktLogger.LogPacket
+	}
 	conn := startClientOptions(t, logger, serverURL, me, peer, &tailnet.Options{
 		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.PrefixFromUUID(me.ID)},
 		DERPMap:             derpMap,
-		BlockEndpoints:      false,
+		BlockEndpoints:      b.BlockEndpoints,
 		Logger:              logger,
-		DERPForceWebSockets: true,
+		DERPForceWebSockets: b.DERPForceWebsockets,
 		ListenPort:          me.ListenPort,
 		// These tests don't have internet connection, so we need to force
 		// magicsock to do anything.
 		ForceNetworkUp: true,
+		CaptureHook:    hook,
 	})
 
-	// Wait for direct connection to be established.
-	peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
-	require.Eventually(t, func() bool {
-		t.Log("attempting ping to peer to judge direct connection")
-		ctx := testutil.Context(t, testutil.WaitShort)
-		_, p2p, pong, err := conn.Ping(ctx, peerIP)
-		if err != nil {
-			t.Logf("ping failed: %v", err)
-			return false
-		}
-		if !p2p {
-			t.Log("ping succeeded, but not direct yet")
-			return false
-		}
-		t.Logf("ping succeeded, direct connection established via %s", pong.Endpoint)
-		return true
-	}, testutil.WaitLong, testutil.IntervalMedium)
+	if b.Service != nil {
+		b.Service.StartService(t, logger, conn)
+	}
+
+	if b.WaitForConnection || b.WaitForDirect {
+		// Wait for connection to be established.
+		peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
+		require.Eventually(t, func() bool {
+			t.Log("attempting ping to peer to judge direct connection")
+			ctx := testutil.Context(t, testutil.WaitShort)
+			_, p2p, pong, err := conn.Ping(ctx, peerIP)
+			if err != nil {
+				t.Logf("ping failed: %v", err)
+				return false
+			}
+			if !p2p && b.WaitForDirect {
+				t.Log("ping succeeded, but not direct yet")
+				return false
+			}
+			t.Logf("ping succeeded, p2p=%t, endpoint=%s", p2p, pong.Endpoint)
+			return true
+		}, testutil.WaitLong, testutil.IntervalMedium)
+	}
 
 	return conn
 }
 
-type ClientStarter struct {
-	Options *tailnet.Options
+const EchoPort = 2381
+
+type UDPEchoService struct{}
+
+func (UDPEchoService) StartService(t *testing.T, logger slog.Logger, _ *tailnet.Conn) {
+	// tailnet doesn't handle UDP connections "in-process" the way we do for TCP, so we need to listen in the OS,
+	// and tailnet will forward
+	//packets.
+	l, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.IPv6zero, // all interfaces
+		Port: EchoPort,
+	})
+	require.NoError(t, err)
+	logger.Info(context.Background(), "started UDPEcho server")
+	t.Cleanup(func() {
+		lCloseErr := l.Close()
+		if lCloseErr != nil {
+			t.Logf("error closing UDPEcho listener: %v", lCloseErr)
+		}
+	})
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, remote, readErr := l.ReadFromUDP(buf)
+			if readErr != nil {
+				logger.Info(context.Background(), "error reading UDPEcho listener", slog.Error(readErr))
+				return
+			}
+			logger.Info(context.Background(), "received UDP packet",
+				slog.F("len", n), slog.F("remote", remote))
+			n, writeErr := l.WriteToUDP(buf[:n], remote)
+			if writeErr != nil {
+				logger.Info(context.Background(), "error writing UDPEcho listener", slog.Error(writeErr))
+				return
+			}
+		}
+	}()
 }
 
 func startClientOptions(t *testing.T, logger slog.Logger, serverURL *url.URL, me, peer Client, options *tailnet.Options) *tailnet.Conn {
@@ -467,9 +510,16 @@ func startClientOptions(t *testing.T, logger slog.Logger, serverURL *url.URL, me
 		_ = conn.Close()
 	})
 
-	ctrl := tailnet.NewTunnelSrcCoordController(logger, conn)
-	ctrl.AddDestination(peer.ID)
-	coordination := ctrl.New(coord)
+	var coordination tailnet.CloserWaiter
+	if me.TunnelSrc {
+		ctrl := tailnet.NewTunnelSrcCoordController(logger, conn)
+		ctrl.AddDestination(peer.ID)
+		coordination = ctrl.New(coord)
+	} else {
+		// use the "Agent" controller so that we act as a tunnel destination and send "ReadyForHandshake" acks.
+		ctrl := tailnet.NewAgentCoordinationController(logger, conn)
+		coordination = ctrl.New(coord)
+	}
 	t.Cleanup(func() {
 		cctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
@@ -492,11 +542,17 @@ func basicDERPMap(serverURLStr string) (*tailcfg.DERPMap, error) {
 	}
 
 	hostname := serverURL.Hostname()
-	ipv4 := ""
+	ipv4 := "none"
+	ipv6 := "none"
 	ip, err := netip.ParseAddr(hostname)
 	if err == nil {
 		hostname = ""
-		ipv4 = ip.String()
+		if ip.Is4() {
+			ipv4 = ip.String()
+		}
+		if ip.Is6() {
+			ipv6 = ip.String()
+		}
 	}
 
 	return &tailcfg.DERPMap{
@@ -511,7 +567,7 @@ func basicDERPMap(serverURLStr string) (*tailcfg.DERPMap, error) {
 						RegionID:         1,
 						HostName:         hostname,
 						IPv4:             ipv4,
-						IPv6:             "none",
+						IPv6:             ipv6,
 						DERPPort:         port,
 						STUNPort:         -1,
 						ForceHTTP:        true,
@@ -647,4 +703,36 @@ func (w *testWriter) Flush() {
 		w.t.Logf("%s output: \t%s", w.name, s)
 	}
 	w.capturedLines = nil
+}
+
+type packetLogger struct {
+	l slog.Logger
+}
+
+func (p packetLogger) LogPacket(path capture.Path, when time.Time, pkt []byte, _ packet.CaptureMeta) {
+	q := new(packet.Parsed)
+	q.Decode(pkt)
+	p.l.Info(context.Background(), "Packet",
+		slog.F("path", pathString(path)),
+		slog.F("when", when),
+		slog.F("decode", q.String()),
+		slog.F("len", len(pkt)),
+	)
+}
+
+func pathString(path capture.Path) string {
+	switch path {
+	case capture.FromLocal:
+		return "Local"
+	case capture.FromPeer:
+		return "Peer"
+	case capture.SynthesizedToLocal:
+		return "SynthesizedToLocal"
+	case capture.SynthesizedToPeer:
+		return "SynthesizedToPeer"
+	case capture.PathDisco:
+		return "Disco"
+	default:
+		return "<<UNKNOWN>>"
+	}
 }

--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
-	"tailscale.com/net/packet"
-	"tailscale.com/wgengine/capture"
 	"testing"
 	"time"
 
@@ -30,8 +28,10 @@ import (
 	"golang.org/x/xerrors"
 	"tailscale.com/derp"
 	"tailscale.com/derp/derphttp"
+	"tailscale.com/net/packet"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
+	"tailscale.com/wgengine/capture"
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -452,8 +452,7 @@ type UDPEchoService struct{}
 
 func (UDPEchoService) StartService(t *testing.T, logger slog.Logger, _ *tailnet.Conn) {
 	// tailnet doesn't handle UDP connections "in-process" the way we do for TCP, so we need to listen in the OS,
-	// and tailnet will forward
-	//packets.
+	// and tailnet will forward packets.
 	l, err := net.ListenUDP("udp", &net.UDPAddr{
 		IP:   net.IPv6zero, // all interfaces
 		Port: EchoPort,

--- a/tailnet/test/integration/integration_test.go
+++ b/tailnet/test/integration/integration_test.go
@@ -110,6 +110,14 @@ var topologies = []integration.TestTopology{
 		RunTests:        integration.TestSuite,
 	},
 	{
+		// Test that direct over normal MTU works.
+		Name:            "DirectMTU1500",
+		SetupNetworking: integration.SetupNetworkingWithDirectMTU1500,
+		Server:          integration.SimpleServerOptions{},
+		StartClient:     integration.StartClientDirect,
+		RunTests:        integration.TestSuite,
+	},
+	{
 		// Test that DERP over WebSocket (as well as DERPForceWebSockets works).
 		// This does not test the actual DERP failure detection code and
 		// automatic fallback.

--- a/tailnet/test/integration/integration_test.go
+++ b/tailnet/test/integration/integration_test.go
@@ -76,78 +76,90 @@ func TestMain(m *testing.M) {
 var topologies = []integration.TestTopology{
 	{
 		// Test that DERP over loopback works.
-		Name:            "BasicLoopbackDERP",
-		SetupNetworking: integration.SetupNetworkingLoopback,
-		Server:          integration.SimpleServerOptions{},
-		StartClient:     integration.StartClientDERP,
-		RunTests:        integration.TestSuite,
+		Name:               "BasicLoopbackDERP",
+		NetworkingProvider: integration.NetworkingLoopback{},
+		Server:             integration.SimpleServerOptions{},
+		ClientStarter:      integration.BasicClientStarter{BlockEndpoints: true},
+		RunTests:           integration.TestSuite,
 	},
 	{
 		// Test that DERP over "easy" NAT works. The server, client 1 and client
 		// 2 are on different networks with their own routers, which are joined
 		// by a bridge.
-		Name:            "EasyNATDERP",
-		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server:          integration.SimpleServerOptions{},
-		StartClient:     integration.StartClientDERP,
-		RunTests:        integration.TestSuite,
+		Name:               "EasyNATDERP",
+		NetworkingProvider: integration.NetworkingNAT{StunCount: 0, Client1Hard: false, Client2Hard: false},
+		Server:             integration.SimpleServerOptions{},
+		ClientStarter:      integration.BasicClientStarter{BlockEndpoints: true},
+		RunTests:           integration.TestSuite,
 	},
 	{
 		// Test that direct over "easy" NAT works with IP/ports grabbed from
 		// STUN.
-		Name:            "EasyNATDirect",
-		SetupNetworking: integration.SetupNetworkingEasyNATWithSTUN,
-		Server:          integration.SimpleServerOptions{},
-		StartClient:     integration.StartClientDirect,
-		RunTests:        integration.TestSuite,
+		Name:               "EasyNATDirect",
+		NetworkingProvider: integration.NetworkingNAT{StunCount: 1, Client1Hard: false, Client2Hard: false},
+		Server:             integration.SimpleServerOptions{},
+		ClientStarter:      integration.BasicClientStarter{WaitForDirect: true},
+		RunTests:           integration.TestSuite,
 	},
 	{
 		// Test that direct over hard NAT <=> easy NAT works.
-		Name:            "HardNATEasyNATDirect",
-		SetupNetworking: integration.SetupNetworkingHardNATEasyNATDirect,
-		Server:          integration.SimpleServerOptions{},
-		StartClient:     integration.StartClientDirect,
-		RunTests:        integration.TestSuite,
+		Name:               "HardNATEasyNATDirect",
+		NetworkingProvider: integration.NetworkingNAT{StunCount: 2, Client1Hard: true, Client2Hard: false},
+		Server:             integration.SimpleServerOptions{},
+		ClientStarter:      integration.BasicClientStarter{WaitForDirect: true},
+		RunTests:           integration.TestSuite,
 	},
 	{
 		// Test that direct over normal MTU works.
-		Name:            "DirectMTU1500",
-		SetupNetworking: integration.SetupNetworkingWithDirectMTU1500,
-		Server:          integration.SimpleServerOptions{},
-		StartClient:     integration.StartClientDirect,
-		RunTests:        integration.TestSuite,
+		Name:               "DirectMTU1500",
+		NetworkingProvider: integration.TriangleNetwork{InterClientMTU: 1500},
+		Server:             integration.SimpleServerOptions{},
+		ClientStarter: integration.BasicClientStarter{
+			WaitForDirect: true,
+			Service:       integration.UDPEchoService{},
+			LogPackets:    true,
+		},
+		RunTests: integration.TestBigUDP,
+	},
+	{
+		// Test that small MTU works.
+		Name:               "MTU1280",
+		NetworkingProvider: integration.TriangleNetwork{InterClientMTU: 1280},
+		Server:             integration.SimpleServerOptions{},
+		ClientStarter:      integration.BasicClientStarter{Service: integration.UDPEchoService{}, LogPackets: true},
+		RunTests:           integration.TestBigUDP,
 	},
 	{
 		// Test that DERP over WebSocket (as well as DERPForceWebSockets works).
 		// This does not test the actual DERP failure detection code and
 		// automatic fallback.
-		Name:            "DERPForceWebSockets",
-		SetupNetworking: integration.SetupNetworkingEasyNAT,
+		Name:               "DERPForceWebSockets",
+		NetworkingProvider: integration.NetworkingNAT{StunCount: 0, Client1Hard: false, Client2Hard: false},
 		Server: integration.SimpleServerOptions{
 			FailUpgradeDERP:   false,
 			DERPWebsocketOnly: true,
 		},
-		StartClient: integration.StartClientDERPWebSockets,
-		RunTests:    integration.TestSuite,
+		ClientStarter: integration.BasicClientStarter{BlockEndpoints: true, DERPForceWebsockets: true},
+		RunTests:      integration.TestSuite,
 	},
 	{
 		// Test that falling back to DERP over WebSocket works.
-		Name:            "DERPFallbackWebSockets",
-		SetupNetworking: integration.SetupNetworkingEasyNAT,
+		Name:               "DERPFallbackWebSockets",
+		NetworkingProvider: integration.NetworkingNAT{StunCount: 0, Client1Hard: false, Client2Hard: false},
 		Server: integration.SimpleServerOptions{
 			FailUpgradeDERP:   true,
 			DERPWebsocketOnly: false,
 		},
 		// Use a basic client that will try `Upgrade: derp` first.
-		StartClient: integration.StartClientDERP,
-		RunTests:    integration.TestSuite,
+		ClientStarter: integration.BasicClientStarter{BlockEndpoints: true},
+		RunTests:      integration.TestSuite,
 	},
 	{
-		Name:            "BasicLoopbackDERPNGINX",
-		SetupNetworking: integration.SetupNetworkingLoopback,
-		Server:          integration.NGINXServerOptions{},
-		StartClient:     integration.StartClientDERP,
-		RunTests:        integration.TestSuite,
+		Name:               "BasicLoopbackDERPNGINX",
+		NetworkingProvider: integration.NetworkingLoopback{},
+		Server:             integration.NGINXServerOptions{},
+		ClientStarter:      integration.BasicClientStarter{BlockEndpoints: true},
+		RunTests:           integration.TestSuite,
 	},
 }
 
@@ -159,7 +171,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	for _, topo := range topologies {
-		topo := topo
 		t.Run(topo.Name, func(t *testing.T) {
 			// These can run in parallel because every test should be in an
 			// isolated NetNS.
@@ -174,7 +185,11 @@ func TestIntegration(t *testing.T) {
 			}
 
 			log := testutil.Logger(t)
-			networking := topo.SetupNetworking(t, log)
+			networking := topo.NetworkingProvider.SetupNetworking(t, log)
+
+			tempDir := t.TempDir()
+			// useful for debugging:
+			// networking.Client1.Process.CapturePackets(t, "client1", tempDir)
 
 			// Useful for debugging network namespaces by avoiding cleanup.
 			// t.Cleanup(func() {
@@ -189,7 +204,6 @@ func TestIntegration(t *testing.T) {
 			}
 
 			// Write the DERP maps to a file.
-			tempDir := t.TempDir()
 			client1DERPMapPath := filepath.Join(tempDir, "client1-derp-map.json")
 			client1DERPMap, err := networking.Client1.ResolveDERPMap()
 			require.NoError(t, err, "resolve client 1 DERP map")
@@ -278,7 +292,7 @@ func handleTestSubprocess(t *testing.T) {
 
 			waitForServerAvailable(t, serverURL)
 
-			conn := topo.StartClient(t, logger, serverURL, &derpMap, me, peer)
+			conn := topo.ClientStarter.StartClient(t, logger, serverURL, &derpMap, me, peer)
 
 			if me.ShouldRunTests {
 				// Wait for connectivity.

--- a/tailnet/test/integration/network.go
+++ b/tailnet/test/integration/network.go
@@ -512,8 +512,8 @@ func (n TriangleNetwork) SetupNetworking(t *testing.T, l slog.Logger) TestNetwor
 	for _, iface := range interfaces {
 		err = setInterfaceUp(iface.netNS, iface.ifaceName)
 		require.NoErrorf(t, err, "bring up interface %q", iface.ifaceName)
-		// Note: routes are not needed as the interfaces are defined as /24, and we are fully connected, so nothing
-		// needs to forward IP to a further destination.
+		// Note: routes are not needed as we are fully connected, so nothing needs to forward IP to a further
+		// destination.
 	}
 
 	return TestNetworking{
@@ -616,8 +616,8 @@ func createNetNS(t *testing.T, name string) *os.File {
 	})
 
 	// Open /run/netns/$name to get a file descriptor to the network namespace.
-	path := fmt.Sprintf("/run/netns/%s", name)
-	file, err := os.OpenFile(path, os.O_RDONLY, 0)
+	netnsPath := fmt.Sprintf("/run/netns/%s", name)
+	file, err := os.OpenFile(netnsPath, os.O_RDONLY, 0)
 	require.NoError(t, err, "open network namespace file")
 	t.Cleanup(func() {
 		_ = file.Close()
@@ -717,8 +717,8 @@ func setInterfaceIP(netNS *os.File, ifaceName, ip string) error {
 	return nil
 }
 
-// setInterfaceIP sets the IP address on the given interface. It automatically
-// adds a /24 subnet mask.
+// setInterfaceIP6 sets the IPv6 address on the given interface. It automatically
+// adds a /64 subnet mask.
 func setInterfaceIP6(netNS *os.File, ifaceName, ip string) error {
 	_, err := commandInNetNS(netNS, "ip", []string{"addr", "add", ip + "/64", "dev", ifaceName}).Output()
 	if err != nil {

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"net/http"
+	"net/netip"
 	"net/url"
 	"testing"
 	"time"
@@ -79,4 +80,43 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer after restart")
 	})
+}
+
+func TestBigUDP(t *testing.T, logger slog.Logger, _ *url.URL, conn *tailnet.Conn, _, peer Client) {
+
+	t.Run("UDPEcho", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
+		udpConn, err := conn.DialContextUDP(ctx, netip.AddrPortFrom(peerIP, uint16(EchoPort)))
+		require.NoError(t, err)
+		defer udpConn.Close()
+
+		// 1280 max tunnel packet size
+		//  -40
+		//   -8 UDP header
+		// ----------------------------
+		// 1232 data size
+		logger.Info(ctx, "sending UDP test packet")
+		packet := make([]byte, 1232)
+		for i := range packet {
+			packet[i] = byte(i % 256)
+		}
+		err = udpConn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		require.NoError(t, err)
+		n, err := udpConn.Write(packet)
+		require.NoError(t, err)
+		require.Equal(t, len(packet), n)
+
+		// read the echo
+		logger.Info(ctx, "attempting to read UDP reply")
+		buf := make([]byte, 1280)
+		err = udpConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		require.NoError(t, err)
+		n, err = udpConn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, len(packet), n)
+		require.Equal(t, packet, buf[:n])
+	})
+
 }

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -117,5 +117,4 @@ func TestBigUDP(t *testing.T, logger slog.Logger, _ *url.URL, conn *tailnet.Conn
 		require.Equal(t, len(packet), n)
 		require.Equal(t, packet, buf[:n])
 	})
-
 }

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -83,7 +83,6 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 }
 
 func TestBigUDP(t *testing.T, logger slog.Logger, _ *url.URL, conn *tailnet.Conn, _, peer Client) {
-
 	t.Run("UDPEcho", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 


### PR DESCRIPTION
Refactors tailnet integration test and adds UDP echo tests with different MTU related to #15523

I still haven't gotten to the bottom of what's causing the issue (the added test case I expected to fail actually succeeds), but these integration test improvements are generally useful.

also:
 * consolidates networking setup with easy and hard NAT
 * consolidates client setup
 * makes Client2 act like an agent at the tailnet layer, so it will send ReadyForHandshake and speed up the tunnel establishment
 * adds support for logging tunneled packets
 * adds support for dumping outer (underlay) IP traffic
 * adds support for adjusting veth MTU
 * adds support for IPv6 in the outer (underlay) network topology