### PR TITLE
fix(coderd/database/dbmem): fill `DisplayGroup` field for `InsertWorkspaceApp`

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -9964,6 +9964,7 @@ func (q *FakeQuerier) InsertWorkspaceApp(_ context.Context, arg database.InsertW
 		Hidden:               arg.Hidden,
 		DisplayOrder:         arg.DisplayOrder,
 		OpenIn:               arg.OpenIn,
+		DisplayGroup:         arg.DisplayGroup,
 	}
 	q.workspaceApps = append(q.workspaceApps, workspaceApp)
 	return workspaceApp, nil


### PR DESCRIPTION
It appears `dbmem` was missed in the new app groups feature https://github.com/coder/coder/pull/17977.