### PR TITLE
chore(coderd/autobuild): use dbtestutil.WillUsePostgres instead of os.Getenv in test

### DIFF
--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -2,7 +2,6 @@ package autobuild_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -741,7 +740,7 @@ func TestExecutorWorkspaceAutostopNoWaitChangedMyMind(t *testing.T) {
 }
 
 func TestExecutorAutostartMultipleOK(t *testing.T) {
-	if os.Getenv("DB") == "" {
+	if !dbtestutil.WillUsePostgres() {
 		t.Skip(`This test only really works when using a "real" database, similar to a HA setup`)
 	}
 


### PR DESCRIPTION
Standardizing on `WillUsePostgres` will make it easier to remove the check entirely once dbmem is removed.

Related to https://github.com/coder/coder/issues/15109.