### PR TITLE
chore(coderd/idpsync): run all tests with postgres

### DIFF
--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -69,11 +69,6 @@ func TestParseGroupClaims(t *testing.T) {
 func TestGroupSyncTable(t *testing.T) {
 	t.Parallel()
 
-	// Last checked, takes 30s with postgres on a fast machine.
-	if dbtestutil.WillUsePostgres() {
-		t.Skip("Skipping test because it populates a lot of db entries, which is slow on postgres.")
-	}
-
 	userClaims := jwt.MapClaims{
 		"groups": []string{
 			"foo", "bar", "baz",
@@ -378,10 +373,6 @@ func TestGroupSyncTable(t *testing.T) {
 
 func TestSyncDisabled(t *testing.T) {
 	t.Parallel()
-
-	if dbtestutil.WillUsePostgres() {
-		t.Skip("Skipping test because it populates a lot of db entries, which is slow on postgres.")
-	}
 
 	db, _ := dbtestutil.NewDB(t)
 	manager := runtimeconfig.NewManager()

--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -27,10 +27,6 @@ import (
 func TestRoleSyncTable(t *testing.T) {
 	t.Parallel()
 
-	if dbtestutil.WillUsePostgres() {
-		t.Skip("Skipping test because it populates a lot of db entries, which is slow on postgres.")
-	}
-
 	userClaims := jwt.MapClaims{
 		"roles": []string{
 			"foo", "bar", "baz",


### PR DESCRIPTION
Related to https://github.com/coder/coder/issues/15109.

Running postgres tests used to create a new postgres docker container every time. I believe the slow down might've been caused by that and was misattributed to postgres performance.

```
coder@main ~/coder ((0e90ac29))> DB=ci gotestsum --packages="./coderd/idpsync" -- -count=1
✓  coderd/idpsync (1.471s)

DONE 91 tests in 4.766s
```