### PR TITLE
fix: fix flashing error dialog in the create workspace page

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspaceExperimentRouter.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspaceExperimentRouter.tsx
@@ -44,11 +44,11 @@ const CreateWorkspaceExperimentRouter: FC = () => {
 	});
 
 	if (dynamicParametersEnabled) {
-		if (optOutQuery.isLoading) {
-			return <Loader />;
-		}
 		if (optOutQuery.isError) {
 			return <ErrorAlert error={optOutQuery.error} />;
+		}
+		if (!optOutQuery.data) {
+			return <Loader />;
 		}
 
 		const toggleOptedOut = () => {
@@ -64,7 +64,7 @@ const CreateWorkspaceExperimentRouter: FC = () => {
 		};
 		return (
 			<ExperimentalFormContext.Provider value={{ toggleOptedOut }}>
-				{optOutQuery.data?.optedOut ? (
+				{optOutQuery.data.optedOut ? (
 					<CreateWorkspacePage />
 				) : (
 					<CreateWorkspacePageExperimental />

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspaceExperimentRouter.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspaceExperimentRouter.tsx
@@ -47,7 +47,7 @@ const CreateWorkspaceExperimentRouter: FC = () => {
 		if (optOutQuery.isLoading) {
 			return <Loader />;
 		}
-		if (!optOutQuery.data) {
+		if (optOutQuery.isError) {
 			return <ErrorAlert error={optOutQuery.error} />;
 		}
 
@@ -64,7 +64,7 @@ const CreateWorkspaceExperimentRouter: FC = () => {
 		};
 		return (
 			<ExperimentalFormContext.Provider value={{ toggleOptedOut }}>
-				{optOutQuery.data.optedOut ? (
+				{optOutQuery.data?.optedOut ? (
 					<CreateWorkspacePage />
 				) : (
 					<CreateWorkspacePageExperimental />


### PR DESCRIPTION
This PR which updated react-query to 5.77.0 introduced an issue on the create workspace page where the error dialog would be briefly displayed while the page is loading. https://github.com/coder/coder/pull/18039

The issue is that there is a moment when `optOutQuery.isLoading` is false and `optOutQuery.data` is undefined causing the ErrorAlert to display.
