### PR TITLE
fix: do not block form control rendering for dynamic parameters on parsing error

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -387,11 +387,9 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			const parsedValues = parseStringArrayValue(value ?? "");
 
 			if (parsedValues.error) {
-				return (
-					<p className="text-sm text-content-destructive">
-						{parsedValues.error}
-					</p>
-				);
+				// Diagnostics on parameter already handle this case, do not duplicate error message
+				// Reset user's values to an empty array. This would overwrite any default values
+				parsedValues.values = [];
 			}
 
 			// Map parameter options to MultiSelectCombobox options format
@@ -440,11 +438,9 @@ const ParameterField: FC<ParameterFieldProps> = ({
 			const parsedValues = parseStringArrayValue(value ?? "");
 
 			if (parsedValues.error) {
-				return (
-					<p className="text-sm text-content-destructive">
-						{parsedValues.error}
-					</p>
-				);
+				// Diagnostics on parameter already handle this case, do not duplicate error message
+				// Reset user's values to an empty array. This would overwrite any default values
+				parsedValues.values = [];
 			}
 
 			return (


### PR DESCRIPTION
Defer to backend diagnostics when the values cannot be parsed and allow the form control to render so the user can select a different option.