### PR TITLE
refactor: reduce the default workspace name for a task

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -489,7 +489,7 @@ export const data = {
 		templateId: string,
 	): Promise<Task> {
 		const workspace = await API.createWorkspace(userId, {
-			name: `ai-task-${new Date().getTime()}`,
+			name: `task-${new Date().getTime()}`,
 			template_id: templateId,
 			rich_parameter_values: [
 				{ name: AI_PROMPT_PARAMETER_NAME, value: prompt },


### PR DESCRIPTION
Subdomains should have 63 max characters, so we don't want to have a long default workspace name that could overflow this limit. With that in mind, I'm reducing 3 characters from the default name.

PS: I've been facing issues with that already. Eg:
```
claude-code-web--dev--ai-task-1748889021126--brunoquaresma--apps.sao-paulo.fly.dev.coder.com
```