### PR TITLE
docs: add link for Coder Desktop docs on workspace page

### DIFF
--- a/site/src/modules/resources/SSHButton/SSHButton.tsx
+++ b/site/src/modules/resources/SSHButton/SSHButton.tsx
@@ -73,6 +73,9 @@ export const AgentSSHButton: FC<AgentSSHButtonProps> = ({
 					>
 						Connect via JetBrains IDEs
 					</HelpTooltipLink>
+					<HelpTooltipLink href={docs("/user-guides/desktop")}>
+						Connect via Coder Desktop
+					</HelpTooltipLink>
 					<HelpTooltipLink href={docs("/user-guides/workspace-access#ssh")}>
 						SSH configuration
 					</HelpTooltipLink>


### PR DESCRIPTION
<img width="392" alt="image" src="https://github.com/user-attachments/assets/125ddb5b-453f-4735-b224-c0ed8bccd7d8" />
Links to Coder Desktop docs.