### PR TITLE
fix(cli): allow specifying empty provisioner tag set with --provisioner-tag="-"

### DIFF
--- a/cli/testdata/coder_templates_push_--help.golden
+++ b/cli/testdata/coder_templates_push_--help.golden
@@ -33,7 +33,10 @@ OPTIONS:
           generated if not provided.
 
       --provisioner-tag string-array
-          Specify a set of tags to target provisioner daemons.
+          Specify a set of tags to target provisioner daemons. If you do not
+          specify any tags, the tags from the active template version will be
+          reused, if available. To remove existing tags, use
+          --provisioner-tag="-".
 
       --var string-array
           Alias of --variable.

--- a/docs/reference/cli/templates_push.md
+++ b/docs/reference/cli/templates_push.md
@@ -41,7 +41,7 @@ Alias of --variable.
 |------|---------------------------|
 | Type | <code>string-array</code> |
 
-Specify a set of tags to target provisioner daemons.
+Specify a set of tags to target provisioner daemons. If you do not specify any tags, the tags from the active template version will be reused, if available. To remove existing tags, use --provisioner-tag="-".
 
 ### --name
 


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/17818

Note: due to limitations in `cobra/serpent` I ended up having to use `-` to signify absence of provisioner tags. This value is not a valid key-value pair and thus not a valid tag.
