### PR TITLE
chore(.vscode): disable autoDetectColorScheme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,6 @@
 	"typos.config": ".github/workflows/typos.toml",
 	"[markdown]": {
 		"editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
-	}
+	},
+	"window.autoDetectColorScheme": false
 }


### PR DESCRIPTION
I like to have a separate color scheme for my remote VSCode instance so I can easily distinguish local versus remote.