### PR TITLE
fix: redirect to login with clear message on OIDC session expiry

### DIFF
--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -149,3 +149,20 @@ export class DetailedError extends Error {
 		super(message);
 	}
 }
+
+export const isOIDCSessionExpired = (error: unknown): boolean => {
+	if (!isApiError(error)) {
+		return false;
+	}
+	
+	const message = error.response.data.message?.toLowerCase() ?? "";
+	const detail = error.response.data.detail?.toLowerCase() ?? "";
+	
+	// Check for 401 status and specific OIDC session expiry message patterns
+	return (
+		error.response.status === 401 &&
+		(message.includes("oidc session expired") ||
+		 message.includes("invalid oidc token") ||
+		 detail.includes("oidc session"))
+	);
+};

--- a/site/src/pages/LoginPage/LoginMessage.tsx
+++ b/site/src/pages/LoginPage/LoginMessage.tsx
@@ -1,0 +1,35 @@
+import { Alert } from "components/Alert/Alert";
+import { type FC } from "react";
+import { useLocation } from "react-router-dom";
+
+export const LoginMessage: FC = () => {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const message = params.get("message");
+  const isHtml = params.get("html") === "true";
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <Alert severity="info">
+      {isHtml ? (
+        <span
+          dangerouslySetInnerHTML={{ __html: decodeURIComponent(message) }}
+          css={{
+            "& .link": {
+              color: "inherit",
+              textDecoration: "underline",
+              "&:hover": {
+                textDecoration: "none",
+              },
+            },
+          }}
+        />
+      ) : (
+        message
+      )}
+    </Alert>
+  );
+}; 

--- a/site/src/pages/LoginPage/LoginPageView.tsx
+++ b/site/src/pages/LoginPage/LoginPageView.tsx
@@ -7,6 +7,7 @@ import { type FC, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { SignInForm } from "./SignInForm";
 import { TermsOfServiceLink } from "./TermsOfServiceLink";
+import { LoginMessage } from "./LoginMessage";
 
 interface LoginPageViewProps {
 	authMethods: AuthMethods | undefined;
@@ -53,14 +54,17 @@ export const LoginPageView: FC<LoginPageViewProps> = ({
 						</Button>
 					</>
 				) : (
-					<SignInForm
-						authMethods={authMethods}
-						redirectTo={redirectTo}
-						isSigningIn={isSigningIn}
-						error={error}
-						message={message}
-						onSubmit={onSignIn}
-					/>
+					<>
+						<LoginMessage />
+						<SignInForm
+							authMethods={authMethods}
+							redirectTo={redirectTo}
+							isSigningIn={isSigningIn}
+							error={error}
+							message={message}
+							onSubmit={onSignIn}
+						/>
+					</>
 				)}
 				<footer css={styles.footer}>
 					<div>


### PR DESCRIPTION
## Description
This PR fixes issue #18201  by implementing proper handling of OIDC session expiry:

- Added `isOIDCSessionExpired` function to detect OIDC session expiry cases
- Added automatic redirect to login page when OIDC session expires
- Created new `LoginMessage` component to support HTML-formatted messages
- Added clear error message with documentation link to help users understand and resolve the issue

## Changes
- `site/src/api/errors.ts`: Added OIDC session expiry detection
- `site/src/contexts/auth/AuthProvider.tsx`: Added redirect handling
- `site/src/pages/LoginPage/LoginPageView.tsx`: Updated to use new message component
- `site/src/pages/LoginPage/LoginMessage.tsx`: New component for HTML message support
