### PR TITLE
fix(coderd): fix panics by always checking for non-nil request logger

### DIFF
--- a/coderd/inboxnotifications.go
+++ b/coderd/inboxnotifications.go
@@ -221,7 +221,9 @@ func (api *API) watchInboxNotifications(rw http.ResponseWriter, r *http.Request)
 	defer encoder.Close(websocket.StatusNormalClosure)
 
 	// Log the request immediately instead of after it completes.
-	loggermw.RequestLoggerFromContext(ctx).WriteLog(ctx, http.StatusAccepted)
+	if rl := loggermw.RequestLoggerFromContext(ctx); rl != nil {
+		rl.WriteLog(ctx, http.StatusAccepted)
+	}
 
 	for {
 		select {

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -557,7 +557,9 @@ func (f *logFollower) follow() {
 	}
 
 	// Log the request immediately instead of after it completes.
-	loggermw.RequestLoggerFromContext(f.ctx).WriteLog(f.ctx, http.StatusAccepted)
+	if rl := loggermw.RequestLoggerFromContext(f.ctx); rl != nil {
+		rl.WriteLog(f.ctx, http.StatusAccepted)
+	}
 
 	// no need to wait if the job is done
 	if f.complete {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -578,7 +578,9 @@ func (api *API) workspaceAgentLogs(rw http.ResponseWriter, r *http.Request) {
 	defer t.Stop()
 
 	// Log the request immediately instead of after it completes.
-	loggermw.RequestLoggerFromContext(ctx).WriteLog(ctx, http.StatusAccepted)
+	if rl := loggermw.RequestLoggerFromContext(ctx); rl != nil {
+		rl.WriteLog(ctx, http.StatusAccepted)
+	}
 
 	go func() {
 		defer func() {
@@ -1047,7 +1049,9 @@ func (api *API) derpMapUpdates(rw http.ResponseWriter, r *http.Request) {
 	defer encoder.Close(websocket.StatusGoingAway)
 
 	// Log the request immediately instead of after it completes.
-	loggermw.RequestLoggerFromContext(ctx).WriteLog(ctx, http.StatusAccepted)
+	if rl := loggermw.RequestLoggerFromContext(ctx); rl != nil {
+		rl.WriteLog(ctx, http.StatusAccepted)
+	}
 
 	go func(ctx context.Context) {
 		// TODO(mafredri): Is this too frequent? Use separate ping disconnect timeout?
@@ -1501,7 +1505,9 @@ func (api *API) watchWorkspaceAgentMetadata(
 	defer sendTicker.Stop()
 
 	// Log the request immediately instead of after it completes.
-	loggermw.RequestLoggerFromContext(ctx).WriteLog(ctx, http.StatusAccepted)
+	if rl := loggermw.RequestLoggerFromContext(ctx); rl != nil {
+		rl.WriteLog(ctx, http.StatusAccepted)
+	}
 
 	// Send initial metadata.
 	sendMetadata()

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -384,7 +384,9 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 	})
 
 	// Log the request immediately instead of after it completes.
-	loggermw.RequestLoggerFromContext(ctx).WriteLog(ctx, http.StatusAccepted)
+	if rl := loggermw.RequestLoggerFromContext(ctx); rl != nil {
+		rl.WriteLog(ctx, http.StatusAccepted)
+	}
 
 	err = server.Serve(ctx, session)
 	srvCancel()


### PR DESCRIPTION
These panics can happen during tests (racy), saw that some places protect the request logger via non-nil check so fixed all instances.

(Discussion: This seems like a dangerous tool, perhaps a noop type would be better than `nil` to cover our bases, but I did not make that decision here.)
