### PR TITLE
chore(provisionersdk): ignore io.EOF in Session.requestReader

### DIFF
--- a/provisionersdk/session.go
+++ b/provisionersdk/session.go
@@ -100,7 +100,11 @@ func (s *Session) requestReader(done <-chan struct{}) <-chan *proto.Request {
 		for {
 			req, err := s.stream.Recv()
 			if err != nil {
-				s.Logger.Info(s.Context(), "recv done on Session", slog.Error(err))
+				if !xerrors.Is(err, io.EOF) {
+					s.Logger.Warn(s.Context(), "recv done on Session", slog.Error(err))
+				} else {
+					s.Logger.Info(s.Context(), "recv done on Session")
+				}
 				return
 			}
 			select {


### PR DESCRIPTION
My understanding is that `io.EOF` is eventually expected, so logging it as an error may be confusing. For other errors we should definitely WARN.

```
[info]  provisionerd-ip-172-31-12-44-14: recv done on Session  session_id=22b9ef8a-9cd6-4188-98e0-573a50d724cc  error=EOF
```