### PR TITLE
fix(cli): fix flakes related to context cancellation when establishing pg connections

### DIFF
--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -168,6 +168,12 @@ func StartWithAssert(t *testing.T, inv *serpent.Invocation, assertCallback func(
 		switch {
 		case errors.Is(err, context.Canceled):
 			return
+		case err != nil && strings.Contains(err.Error(), "driver: bad connection"):
+			// When we cancel the context on a query that's being executed within
+			// a transaction, sometimes, instead of a context.Canceled error we get
+			// a "driver: bad connection" error.
+			// https://github.com/lib/pq/issues/1137
+			return
 		default:
 			assert.NoError(t, err)
 		}

--- a/cli/server.go
+++ b/cli/server.go
@@ -2359,6 +2359,10 @@ func ConnectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 	if err != nil {
 		return nil, xerrors.Errorf("get postgres version: %w", err)
 	}
+	defer version.Close()
+	if version.Err() != nil {
+		return nil, xerrors.Errorf("version select: %w", version.Err())
+	}
 	if !version.Next() {
 		return nil, xerrors.Errorf("no rows returned for version select")
 	}
@@ -2367,7 +2371,6 @@ func ConnectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 	if err != nil {
 		return nil, xerrors.Errorf("scan version: %w", err)
 	}
-	_ = version.Close()
 
 	if versionNum < 130000 {
 		return nil, xerrors.Errorf("PostgreSQL version must be v13.0.0 or higher! Got: %d", versionNum)


### PR DESCRIPTION
Since https://github.com/coder/coder/pull/18195 was merged, we started running CLI tests with postgres instead of just dbmem. This surfaced errors related to context cancellation while establishing postgres connections.

This PR should fix https://github.com/coder/internal/issues/672. Related to https://github.com/coder/coder/issues/15109.