### PR TITLE
chore: ignore `.git` directories in terraform modules

### DIFF
--- a/provisioner/terraform/modules.go
+++ b/provisioner/terraform/modules.go
@@ -104,9 +104,9 @@ func GetModulesArchive(root fs.FS) ([]byte, error) {
 				return nil
 			}
 
+			// .git directories are not needed in the archive and only cause
+			// hash differences for identical modules.
 			if fileMode.IsDir() && d.Name() == ".git" {
-				// .git directories are not needed in the archive and only cause
-				// hash differences for identical modules.
 				return fs.SkipDir
 			}
 

--- a/provisioner/terraform/modules.go
+++ b/provisioner/terraform/modules.go
@@ -103,6 +103,13 @@ func GetModulesArchive(root fs.FS) ([]byte, error) {
 			if !fileMode.IsRegular() && !fileMode.IsDir() {
 				return nil
 			}
+
+			if fileMode.IsDir() && d.Name() == ".git" {
+				// .git directories are not needed in the archive and only cause
+				// hash differences for identical modules.
+				return fs.SkipDir
+			}
+
 			fileInfo, err := d.Info()
 			if err != nil {
 				return xerrors.Errorf("failed to archive module file %q: %w", filePath, err)


### PR DESCRIPTION
.git directories were causing identical modules to have different hashes. This adds unecessary bloat to the database, and the .git directory is not needed for dynamic params