### PR TITLE
fix: avoid displaying 'everyone' group for idp group sync

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
@@ -12,7 +12,6 @@ import {
 	HelpTooltipTitle,
 	HelpTooltipTrigger,
 } from "components/HelpTooltip/HelpTooltip";
-import { isEveryoneGroup } from "utils/groups";
 import { Input } from "components/Input/Input";
 import { Label } from "components/Label/Label";
 import { Link } from "components/Link/Link";
@@ -33,6 +32,7 @@ import { useFormik } from "formik";
 import { Plus, Trash, TriangleAlert } from "lucide-react";
 import { type FC, type KeyboardEventHandler, useId, useState } from "react";
 import { docs } from "utils/docs";
+import { isEveryoneGroup } from "utils/groups";
 import { isUUID } from "utils/uuid";
 import * as Yup from "yup";
 import { ExportPolicyButton } from "./ExportPolicyButton";

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpGroupSyncForm.tsx
@@ -12,6 +12,7 @@ import {
 	HelpTooltipTitle,
 	HelpTooltipTrigger,
 } from "components/HelpTooltip/HelpTooltip";
+import { isEveryoneGroup } from "utils/groups";
 import { Input } from "components/Input/Input";
 import { Label } from "components/Label/Label";
 import { Link } from "components/Link/Link";
@@ -259,15 +260,17 @@ export const IdpGroupSyncForm: FC<IdpGroupSyncFormProps> = ({
 							className="min-w-60 max-w-3xl"
 							value={coderGroups}
 							onChange={setCoderGroups}
-							options={groups.map((group) => ({
-								label: group.display_name || group.name,
-								value: group.id,
-							}))}
+							options={groups
+								.filter((group) => !isEveryoneGroup(group))
+								.map((group) => ({
+									label: group.display_name || group.name,
+									value: group.id,
+								}))}
 							hidePlaceholderWhenSelected
 							placeholder="Select group"
 							emptyIndicator={
 								<p className="text-center text-md text-content-primary">
-									All groups selected
+									No more groups to select
 								</p>
 							}
 						/>


### PR DESCRIPTION
fixes coder/coder#16987

Fix implemented through the coder tasks UI using Coder with Claude Code.

Prompt:
fix this issue, https://github.com/coder/coder/issues/16987
