### PR TITLE
fix: handle paths with spaces in Match exec clause of SSH config

### DIFF
--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -200,7 +200,7 @@ func Test_sshConfigMatchExecEscape(t *testing.T) {
 	}{
 		{"no spaces", "simple", false, false},
 		{"spaces", "path with spaces", false, false},
-		{"quotes", "path with \"quotes\"", false, true},
+		{"quotes", "path with \"quotes\"", true, true},
 		{"backslashes", "path with\\backslashes", false, false},
 		{"tabs", "path with \ttabs", false, true},
 		{"newline fails", "path with \nnewline", true, true},

--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -171,7 +171,7 @@ func Test_sshConfigExecEscape(t *testing.T) {
 			err = os.WriteFile(bin, contents, 0o755) //nolint:gosec
 			require.NoError(t, err)
 
-			escaped, err := sshConfigExecEscape(bin, false)
+			escaped, err := sshConfigProxyCommandEscape(bin, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -236,7 +236,7 @@ func Test_sshConfigExecEscapeSeparatorForce(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			found, err := sshConfigExecEscape(tt.path, tt.forceUnix)
+			found, err := sshConfigProxyCommandEscape(tt.path, tt.forceUnix)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/cli/configssh_other.go
+++ b/cli/configssh_other.go
@@ -26,9 +26,10 @@ func sshConfigMatchExecEscape(path string) (string, error) {
 		return "", xerrors.Errorf("path must not contain quotes: %q", path)
 	}
 
-	// OpenSSH passes the match exec string directly to the user's shell. sh, bash and zsh accept spaces and tabs
-	// simply escaped by a `\`. It's hard to predict exactly what more exotic shells might do, but this should work for
-	// macOS and most Linux distros in their default configuration.
+	// OpenSSH passes the match exec string directly to the user's shell. sh, bash and zsh accept spaces, tabs and
+	// backslashes simply escaped by a `\`. It's hard to predict exactly what more exotic shells might do, but this
+	// should work for macOS and most Linux distros in their default configuration.
+	path = strings.ReplaceAll(path, `\`, `\\`) // must be first, since later replacements add backslashes.
 	path = strings.ReplaceAll(path, " ", "\\ ")
 	path = strings.ReplaceAll(path, "\t", "\\\t")
 	return path, nil

--- a/cli/configssh_other.go
+++ b/cli/configssh_other.go
@@ -2,4 +2,34 @@
 
 package cli
 
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
 var hideForceUnixSlashes = true
+
+// sshConfigMatchExecEscape prepares the path for use in `Match exec` statement.
+//
+// OpenSSH parses the Match line with a very simple tokenizer that accepts "-enclosed strings for the exec command, and
+// has no supported escape sequences for ". This means we cannot include " within the command to execute.
+func sshConfigMatchExecEscape(path string) (string, error) {
+	// This is unlikely to ever happen, but newlines are allowed on
+	// certain filesystems, but cannot be used inside ssh config.
+	if strings.ContainsAny(path, "\n") {
+		return "", xerrors.Errorf("invalid path: %s", path)
+	}
+	// Quotes are allowed in path names on unix-like file systems, but OpenSSH's parsing of `Match exec` doesn't allow
+	// them.
+	if strings.Contains(path, `"`) {
+		return "", xerrors.Errorf("path must not contain quotes: %q", path)
+	}
+
+	// OpenSSH passes the match exec string directly to the user's shell. sh, bash and zsh accept spaces and tabs
+	// simply escaped by a `\`. It's hard to predict exactly what more exotic shells might do, but this should work for
+	// macOS and most Linux distros in their default configuration.
+	path = strings.ReplaceAll(path, " ", "\\ ")
+	path = strings.ReplaceAll(path, "\t", "\\\t")
+	return path, nil
+}

--- a/cli/configssh_windows.go
+++ b/cli/configssh_windows.go
@@ -2,5 +2,59 @@
 
 package cli
 
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
 // Must be a var for unit tests to conform behavior
 var hideForceUnixSlashes = false
+
+// sshConfigMatchExecEscape prepares the path for use in `Match exec` statement.
+//
+// OpenSSH parses the Match line with a very simple tokenizer that accepts "-enclosed strings for the exec command, and
+// has no supported escape sequences for ". This means we cannot include " within the command to execute.
+//
+// To make matters worse, on Windows, OpenSSH passes the string directly to cmd.exe for execution, and as far as I can
+// tell, the only supported way to call a path that has spaces in it is to surround it with ".
+//
+// So, we can't actually include " directly, but here is a horrible workaround:
+//
+// "for /f %%a in ('powershell.exe -Command [char]34') do @cmd.exe /c %%aC:\Program Files\Coder\bin\coder.exe%%a connect exists %h"
+//
+// The key insight here is to store the character " in a variable (%a in this case, but the % itself needs to be
+// escaped, so it becomes %%a), and then use that variable to construct the double-quoted path:
+//
+// %%aC:\Program Files\Coder\bin\coder.exe%%a.
+//
+// How do we generate a single " character without actually using that character? I couldn't find any command in cmd.exe
+// to do it, but powershell.exe can convert ASCII to characters like this: `[char]34` (where 34 is the code point for ").
+//
+// Other notes:
+//   - @ in `@cmd.exe` suppresses echoing it, so you don't get this command printed
+//   - without another invocation of cmd.exe (e.g. `do @cmd.exe /c %%aC:\Program Files\Coder\bin\coder.exe%%a`) then
+//     the double-quote gets interpreted as part of the path and you get: '"C:\Program' is not recognized. Constructing
+//     the string and then passing it to another instance of cmd.exe does this trick here.
+//   - OpenSSH passes the `Match exec` command to cmd.exe regardless of whether the user has a unix-like shell like
+//     git bash, so we don't have a `forceUnixPath` option like for the ProxyCommand which does respect the user's
+//     configured shell.
+func sshConfigMatchExecEscape(path string) (string, error) {
+	// This is unlikely to ever happen, but newlines are allowed on
+	// certain filesystems, but cannot be used inside ssh config.
+	if strings.ContainsAny(path, "\n") {
+		return "", xerrors.Errorf("invalid path: %s", path)
+	}
+	// Windows does not allow double-quotes in paths. If we get one it is an error.
+	if strings.Contains(path, `"`) {
+		return "", xerrors.Errorf("path must not contain quotes: %q", path)
+	}
+	// A space or a tab requires quoting, but tabs must not be escaped
+	// (\t) since OpenSSH interprets it as a literal \t, not a tab.
+	if strings.ContainsAny(path, " \t") {
+		// c.f. function comment for how this works.
+		path = fmt.Sprintf("for /f %%%%a in ('powershell.exe -Command [char]34') do @cmd.exe /c %%%%a%s%%%%a", path) //nolint:gocritic // We don't want %q here.
+	}
+	return path, nil
+}


### PR DESCRIPTION
fixes #18199 

Corrects handling of paths with spaces in the `Match !exec` clause we use to determine whether Coder Connect is running. This is handled differently than the ProxyCommand, so we have a different escape routine, which also varies by OS.

On Windows, we resort to a pretty gnarly hack, but it does work and I feel the only other option would be to reduce functionality such that we could not detect the Coder Connect state.