### PR TITLE
feat: add separate max token lifetime for administrators

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -332,6 +332,10 @@ NETWORKING / HTTP OPTIONS:
           The maximum lifetime duration users can specify when creating an API
           token.
 
+      --max-admin-token-lifetime duration, $CODER_MAX_ADMIN_TOKEN_LIFETIME (default: 168h0m0s)
+          The maximum lifetime duration administrators can specify when creating
+          an API token.
+
       --proxy-health-interval duration, $CODER_PROXY_HEALTH_INTERVAL (default: 1m0s)
           The interval in which coderd should be checking the status of
           workspace proxies.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -25,6 +25,10 @@ networking:
     # The maximum lifetime duration users can specify when creating an API token.
     # (default: 876600h0m0s, type: duration)
     maxTokenLifetime: 876600h0m0s
+    # The maximum lifetime duration administrators can specify when creating an API
+    # token.
+    # (default: 168h0m0s, type: duration)
+    maxAdminTokenLifetime: 168h0m0s
     # The token expiry duration for browser sessions. Sessions may last longer if they
     # are actively making requests, but this functionality can be disabled via
     # --disable-session-expiry-refresh.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15705,6 +15705,9 @@ const docTemplate = `{
                     "description": "DisableExpiryRefresh will disable automatically refreshing api\nkeys when they are used from the api. This means the api key lifetime at\ncreation is the lifetime of the api key.",
                     "type": "boolean"
                 },
+                "max_admin_token_lifetime": {
+                    "type": "integer"
+                },
                 "max_token_lifetime": {
                     "type": "integer"
                 }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14283,6 +14283,9 @@
 					"description": "DisableExpiryRefresh will disable automatically refreshing api\nkeys when they are used from the api. This means the api key lifetime at\ncreation is the lifetime of the api key.",
 					"type": "boolean"
 				},
+				"max_admin_token_lifetime": {
+					"type": "integer"
+				},
 				"max_token_lifetime": {
 					"type": "integer"
 				}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -468,6 +468,8 @@ type SessionLifetime struct {
 	DefaultTokenDuration serpent.Duration `json:"default_token_lifetime,omitempty" typescript:",notnull"`
 
 	MaximumTokenDuration serpent.Duration `json:"max_token_lifetime,omitempty" typescript:",notnull"`
+
+	MaximumAdminTokenDuration serpent.Duration `json:"max_admin_token_lifetime,omitempty" typescript:",notnull"`
 }
 
 type DERP struct {
@@ -2338,6 +2340,17 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.Sessions.MaximumTokenDuration,
 			Group:       &deploymentGroupNetworkingHTTP,
 			YAML:        "maxTokenLifetime",
+			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
+		},
+		{
+			Name:        "Maximum Admin Token Lifetime",
+			Description: "The maximum lifetime duration administrators can specify when creating an API token.",
+			Flag:        "max-admin-token-lifetime",
+			Env:         "CODER_MAX_ADMIN_TOKEN_LIFETIME",
+			Default:     (7 * 24 * time.Hour).String(),
+			Value:       &c.Sessions.MaximumAdminTokenDuration,
+			Group:       &deploymentGroupNetworkingHTTP,
+			YAML:        "maxAdminTokenLifetime",
 			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
 		},
 		{

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -454,6 +454,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "default_duration": 0,
       "default_token_lifetime": 0,
       "disable_expiry_refresh": true,
+      "max_admin_token_lifetime": 0,
       "max_token_lifetime": 0
     },
     "ssh_keygen_algorithm": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2625,6 +2625,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "default_duration": 0,
       "default_token_lifetime": 0,
       "disable_expiry_refresh": true,
+      "max_admin_token_lifetime": 0,
       "max_token_lifetime": 0
     },
     "ssh_keygen_algorithm": "string",
@@ -3124,6 +3125,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "default_duration": 0,
     "default_token_lifetime": 0,
     "disable_expiry_refresh": true,
+    "max_admin_token_lifetime": 0,
     "max_token_lifetime": 0
   },
   "ssh_keygen_algorithm": "string",
@@ -6767,18 +6769,20 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
   "default_duration": 0,
   "default_token_lifetime": 0,
   "disable_expiry_refresh": true,
+  "max_admin_token_lifetime": 0,
   "max_token_lifetime": 0
 }
 ```
 
 ### Properties
 
-| Name                     | Type    | Required | Restrictions | Description                                                                                                                                                                        |
-|--------------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `default_duration`       | integer | false    |              | Default duration is only for browser, workspace app and oauth sessions.                                                                                                            |
-| `default_token_lifetime` | integer | false    |              |                                                                                                                                                                                    |
-| `disable_expiry_refresh` | boolean | false    |              | Disable expiry refresh will disable automatically refreshing api keys when they are used from the api. This means the api key lifetime at creation is the lifetime of the api key. |
-| `max_token_lifetime`     | integer | false    |              |                                                                                                                                                                                    |
+| Name                       | Type    | Required | Restrictions | Description                                                                                                                                                                        |
+|----------------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `default_duration`         | integer | false    |              | Default duration is only for browser, workspace app and oauth sessions.                                                                                                            |
+| `default_token_lifetime`   | integer | false    |              |                                                                                                                                                                                    |
+| `disable_expiry_refresh`   | boolean | false    |              | Disable expiry refresh will disable automatically refreshing api keys when they are used from the api. This means the api key lifetime at creation is the lifetime of the api key. |
+| `max_admin_token_lifetime` | integer | false    |              |                                                                                                                                                                                    |
+| `max_token_lifetime`       | integer | false    |              |                                                                                                                                                                                    |
 
 ## codersdk.SlimRole
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -910,6 +910,17 @@ Periodically check for new releases of Coder and inform the owner. The check is 
 
 The maximum lifetime duration users can specify when creating an API token.
 
+### --max-admin-token-lifetime
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>duration</code>                              |
+| Environment | <code>$CODER_MAX_ADMIN_TOKEN_LIFETIME</code>       |
+| YAML        | <code>networking.http.maxAdminTokenLifetime</code> |
+| Default     | <code>168h0m0s</code>                              |
+
+The maximum lifetime duration administrators can specify when creating an API token.
+
 ### --default-token-lifetime
 
 |             |                                            |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -333,6 +333,10 @@ NETWORKING / HTTP OPTIONS:
           The maximum lifetime duration users can specify when creating an API
           token.
 
+      --max-admin-token-lifetime duration, $CODER_MAX_ADMIN_TOKEN_LIFETIME (default: 168h0m0s)
+          The maximum lifetime duration administrators can specify when creating
+          an API token.
+
       --proxy-health-interval duration, $CODER_PROXY_HEALTH_INTERVAL (default: 1m0s)
           The interval in which coderd should be checking the status of
           workspace proxies.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2519,6 +2519,7 @@ export interface SessionLifetime {
 	readonly default_duration: number;
 	readonly default_token_lifetime?: number;
 	readonly max_token_lifetime?: number;
+	readonly max_admin_token_lifetime?: number;
 }
 
 // From codersdk/client.go


### PR DESCRIPTION
# Add separate token lifetime limits for administrators

This PR introduces a new configuration option `--max-admin-token-lifetime` that allows administrators to create API tokens with longer lifetimes than regular users. By default, administrators can create tokens with a lifetime of up to 7 days (168 hours), while the existing `--max-token-lifetime` setting continues to apply to regular users.

The implementation:
- Adds a new `MaximumAdminTokenDuration` field to the session configuration
- Modifies the token validation logic to check the user's role and apply the appropriate lifetime limit
- Updates the token configuration endpoint to return the correct maximum lifetime based on the user's role
- Adds tests to verify that administrators can create tokens with longer and shorter lifetimes
- Updates documentation and help text to reflect the new option

This change allows organizations to grant administrators extended token lifetimes while maintaining tighter security controls for regular users.

Fixes #17395
