### PR TITLE
fix(coderd/database/db2sdk): add agent parent ID

### DIFF
--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -378,6 +378,7 @@ func WorkspaceAgent(derpMap *tailcfg.DERPMap, coordinator tailnet.Coordinator,
 
 	workspaceAgent := codersdk.WorkspaceAgent{
 		ID:                       dbAgent.ID,
+		ParentID:                 dbAgent.ParentID,
 		CreatedAt:                dbAgent.CreatedAt,
 		UpdatedAt:                dbAgent.UpdatedAt,
 		ResourceID:               dbAgent.ResourceID,


### PR DESCRIPTION
The parent ID was missing, causing sub agents to show up in the UI. This change fixes db2sdk to include it.
