### PR TITLE
test: fix test flake in TestDynamicParametersWithTerraformValues

### DIFF
--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -276,7 +276,7 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 				EnableDynamicParameters: ptr.Ref(true),
 			})
 			require.NoError(t, err)
-			coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, wrk.LatestBuild.ID)
+			coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, bld.ID)
 
 			latestParams, err := setup.client.WorkspaceBuildParameters(ctx, bld.ID)
 			require.NoError(t, err)


### PR DESCRIPTION
Wrong build ID was being used for the await.

Closes https://github.com/coder/internal/issues/687