### PR TITLE
feat: add publishing of helm charts to ghcr registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -693,6 +693,8 @@ jobs:
           gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/provisioner_helm_${version}.tgz gs://helm.coder.com/v2
           gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/index.yaml gs://helm.coder.com/v2
           gsutil -h "Cache-Control:no-cache,max-age=0" cp helm/artifacthub-repo.yml gs://helm.coder.com/v2
+          helm push build/coder_helm_${version}.tgz oci://ghcr.io/coder/chart
+          helm push build/provisioner_helm_${version}.tgz oci://ghcr.io/coder/chart
 
       - name: Upload artifacts to actions (if dry-run)
         if: ${{ inputs.dry_run }}

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -127,25 +127,52 @@ We support two release channels: mainline and stable - read the
 
 - **Mainline** Coder release:
 
-  <!-- autoversion(mainline): "--version [version]" -->
+  - **Chart Registry**
 
-  ```shell
-  helm install coder coder-v2/coder \
-      --namespace coder \
-      --values values.yaml \
-      --version 2.23.1
-  ```
+    <!-- autoversion(mainline): "--version [version]" -->
+
+    ```shell
+    helm install coder coder-v2/coder \
+        --namespace coder \
+        --values values.yaml \
+        --version 2.23.1
+    ```
+  
+  - **OCI Registry**
+
+    <!-- autoversion(mainline): "--version [version]" -->
+
+    ```shell
+    helm install coder oci://ghcr.io/coder/chart/coder \
+        --namespace coder \
+        --values values.yaml \
+        --version 2.23.1
+    ```
+
 
 - **Stable** Coder release:
 
-  <!-- autoversion(stable): "--version [version]" -->
+  - **Chart Registry**
 
-  ```shell
-  helm install coder coder-v2/coder \
-      --namespace coder \
-      --values values.yaml \
-      --version 2.22.1
-  ```
+    <!-- autoversion(stable): "--version [version]" -->
+
+    ```shell
+    helm install coder coder-v2/coder \
+        --namespace coder \
+        --values values.yaml \
+        --version 2.22.1
+    ```
+  
+  - **OCI Registry**
+
+    <!-- autoversion(stable): "--version [version]" -->
+
+    ```shell
+    helm install coder oci://ghcr.io/coder/chart/coder \
+        --namespace coder \
+        --values values.yaml \
+        --version 2.22.1
+    ```
 
 You can watch Coder start up by running `kubectl get pods -n coder`. Once Coder
 has started, the `coder-*` pods should enter the `Running` state.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -149,7 +149,6 @@ We support two release channels: mainline and stable - read the
         --version 2.23.1
     ```
 
-
 - **Stable** Coder release:
 
   - **Chart Registry**


### PR DESCRIPTION
With Helm v3.8.0, the OCI support became [GA](https://helm.sh/docs/topics/registries), which is an excellent chance to start publishing Helm charts to OCI-compliant registries. Quay / Dockerhub / GHCR supports OCI artifacts and a lot of projects have been using them to publish their helm charts as OCI artifacts.

It brings an opportunity to sign Helm charts stored as OCI Artifacts with [cosign](https://github.com/sigstore/cosign) to provide their integrity and use GitOps tooling such as Flux to reconcile them as they were stored as OCI artifacts. Flux can reconcile OCI Artifacts and verify their integrity before reconciling them.
