### PR TITLE
test: ensure the return value of MockAuditor.Contains is checked

### DIFF
--- a/coderd/agentapi/audit_test.go
+++ b/coderd/agentapi/audit_test.go
@@ -135,7 +135,7 @@ func TestAuditReport(t *testing.T) {
 				},
 			})
 
-			mAudit.Contains(t, database.AuditLog{
+			require.True(t, mAudit.Contains(t, database.AuditLog{
 				Time:           dbtime.Time(tt.time).In(time.UTC),
 				Action:         agentProtoConnectionActionToAudit(t, *tt.action),
 				OrganizationID: workspace.OrganizationID,
@@ -146,7 +146,7 @@ func TestAuditReport(t *testing.T) {
 				ResourceTarget: agent.Name,
 				Ip:             pqtype.Inet{Valid: true, IPNet: net.IPNet{IP: net.ParseIP(tt.ip), Mask: net.CIDRMask(32, 32)}},
 				StatusCode:     tt.status,
-			})
+			}))
 
 			// Check some additional fields.
 			var m map[string]any

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1577,10 +1577,10 @@ func TestUserOIDC(t *testing.T) {
 		})
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		auditor.Contains(t, database.AuditLog{
+		require.True(t, auditor.Contains(t, database.AuditLog{
 			ResourceType:     database.ResourceTypeUser,
 			AdditionalFields: json.RawMessage(`{"automatic_actor":"coder","automatic_subsystem":"dormancy"}`),
-		})
+		}))
 		me, err := client.User(ctx, "me")
 		require.NoError(t, err)
 


### PR DESCRIPTION
It unfortunately doesn't seem possible, even with a custom ruleguard rule, to mark a function as requiring it's return value be used, it looks like you have to go all in on a linter that rejects *any* unused return values.