### PR TITLE
feat: add status watcher to MCP server

### DIFF
--- a/cli/cliutil/queue.go
+++ b/cli/cliutil/queue.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // Queue is a FIFO queue with a fixed size.  If the size is exceeded, the first
@@ -14,6 +16,7 @@ type Queue[T any] struct {
 	mu     sync.Mutex
 	size   int
 	closed bool
+	pred   func(x T) (T, bool)
 }
 
 // NewQueue creates a queue with the given size.
@@ -23,6 +26,13 @@ func NewQueue[T any](size int) *Queue[T] {
 		size:  size,
 	}
 	q.cond = sync.NewCond(&q.mu)
+	return q
+}
+
+// WithPredicate adds the given predicate function, which can control what is
+// pushed to the queue.
+func (q *Queue[T]) WithPredicate(pred func(x T) (T, bool)) *Queue[T] {
+	q.pred = pred
 	return q
 }
 
@@ -41,6 +51,15 @@ func (q *Queue[T]) Push(x T) error {
 	if q.closed {
 		return xerrors.New("queue has been closed")
 	}
+	// Potentially mutate or skip the push using the predicate.
+	if q.pred != nil {
+		var ok bool
+		x, ok = q.pred(x)
+		if !ok {
+			return nil
+		}
+	}
+	// Remove the first item from the queue if it has gotten too big.
 	if len(q.items) >= q.size {
 		q.items = q.items[1:]
 	}
@@ -69,4 +88,73 @@ func (q *Queue[T]) Len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	return len(q.items)
+}
+
+type reportTask struct {
+	link         string
+	messageID    int64
+	selfReported bool
+	state        codersdk.WorkspaceAppStatusState
+	summary      string
+}
+
+// statusQueue is a Queue that:
+// 1. Only pushes items that are not duplicates.
+// 2. Preserves the existing message and URI when one a message is not provided.
+// 3. Ignores "working" updates from the status watcher.
+type StatusQueue struct {
+	Queue[reportTask]
+	// lastMessageID is the ID of the last *user* message that we saw.  A user
+	// message only happens when interacting via the API (as opposed to
+	// interacting with the terminal directly).
+	lastMessageID int64
+}
+
+func (q *StatusQueue) Push(report reportTask) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return xerrors.New("queue has been closed")
+	}
+	var lastReport reportTask
+	if len(q.items) > 0 {
+		lastReport = q.items[len(q.items)-1]
+	}
+	// Use "working" status if this is a new user message.  If this is not a new
+	// user message, and the status is "working" and not self-reported (meaning it
+	// came from the screen watcher), then it means one of two things:
+	// 1. The LLM is still working, in which case our last status will already
+	//    have been "working", so there is nothing to do.
+	// 2. The user has interacted with the terminal directly.  For now, we are
+	//    ignoring these updates.  This risks missing cases where the user
+	//    manually submits a new prompt and the LLM becomes active and does not
+	//    update itself, but it avoids spamming useless status updates as the user
+	//    is typing, so the tradeoff is worth it.  In the future, if we can
+	//    reliably distinguish between user and LLM activity, we can change this.
+	if report.messageID > q.lastMessageID {
+		report.state = codersdk.WorkspaceAppStatusStateWorking
+	} else if report.state == codersdk.WorkspaceAppStatusStateWorking && !report.selfReported {
+		q.mu.Unlock()
+		return nil
+	}
+	// Preserve previous message and URI if there was no message.
+	if report.summary == "" {
+		report.summary = lastReport.summary
+		if report.link == "" {
+			report.link = lastReport.link
+		}
+	}
+	// Avoid queueing duplicate updates.
+	if report.state == lastReport.state &&
+		report.link == lastReport.link &&
+		report.summary == lastReport.summary {
+		return nil
+	}
+	// Drop the first item if the queue has gotten too big.
+	if len(q.items) >= q.size {
+		q.items = q.items[1:]
+	}
+	q.items = append(q.items, report)
+	q.cond.Broadcast()
+	return nil
 }

--- a/cli/cliutil/queue.go
+++ b/cli/cliutil/queue.go
@@ -1,0 +1,72 @@
+package cliutil
+
+import (
+	"sync"
+
+	"golang.org/x/xerrors"
+)
+
+// Queue is a FIFO queue with a fixed size.  If the size is exceeded, the first
+// item is dropped.
+type Queue[T any] struct {
+	cond   *sync.Cond
+	items  []T
+	mu     sync.Mutex
+	size   int
+	closed bool
+}
+
+// NewQueue creates a queue with the given size.
+func NewQueue[T any](size int) *Queue[T] {
+	q := &Queue[T]{
+		items: make([]T, 0, size),
+		size:  size,
+	}
+	q.cond = sync.NewCond(&q.mu)
+	return q
+}
+
+// Close aborts any pending pops and makes future pushes error.
+func (q *Queue[T]) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	q.cond.Broadcast()
+}
+
+// Push adds an item to the queue.  If closed, returns an error.
+func (q *Queue[T]) Push(x T) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return xerrors.New("queue has been closed")
+	}
+	if len(q.items) >= q.size {
+		q.items = q.items[1:]
+	}
+	q.items = append(q.items, x)
+	q.cond.Broadcast()
+	return nil
+}
+
+// Pop removes and returns the first item from the queue, waiting until there is
+// something to pop if necessary.  If closed, returns false.
+func (q *Queue[T]) Pop() (T, bool) {
+	var head T
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.items) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if q.closed {
+		return head, false
+	}
+	head, q.items = q.items[0], q.items[1:]
+	return head, true
+}
+
+func (q *Queue[T]) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.items)
+}

--- a/cli/cliutil/queue_test.go
+++ b/cli/cliutil/queue_test.go
@@ -1,0 +1,85 @@
+package cliutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/cliutil"
+)
+
+func TestQueue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DropsFirst", func(t *testing.T) {
+		t.Parallel()
+
+		q := cliutil.NewQueue[int](10)
+		require.Equal(t, 0, q.Len())
+
+		for i := 0; i < 20; i++ {
+			err := q.Push(i)
+			require.NoError(t, err)
+			if i < 10 {
+				require.Equal(t, i+1, q.Len())
+			} else {
+				require.Equal(t, 10, q.Len())
+			}
+		}
+
+		val, ok := q.Pop()
+		require.True(t, ok)
+		require.Equal(t, 10, val)
+		require.Equal(t, 9, q.Len())
+	})
+
+	t.Run("Pop", func(t *testing.T) {
+		t.Parallel()
+
+		q := cliutil.NewQueue[int](10)
+		for i := 0; i < 5; i++ {
+			err := q.Push(i)
+			require.NoError(t, err)
+		}
+
+		// No blocking, should pop immediately.
+		for i := 0; i < 5; i++ {
+			val, ok := q.Pop()
+			require.True(t, ok)
+			require.Equal(t, i, val)
+		}
+
+		// Pop should block until the next push.
+		go func() {
+			err := q.Push(55)
+			assert.NoError(t, err)
+		}()
+
+		item, ok := q.Pop()
+		require.True(t, ok)
+		require.Equal(t, 55, item)
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		t.Parallel()
+
+		q := cliutil.NewQueue[int](10)
+
+		done := make(chan bool)
+		go func() {
+			_, ok := q.Pop()
+			done <- ok
+		}()
+
+		q.Close()
+
+		require.False(t, <-done)
+
+		_, ok := q.Pop()
+		require.False(t, ok)
+
+		err := q.Push(10)
+		require.Error(t, err)
+	})
+}

--- a/cli/cliutil/queue_test.go
+++ b/cli/cliutil/queue_test.go
@@ -82,4 +82,29 @@ func TestQueue(t *testing.T) {
 		err := q.Push(10)
 		require.Error(t, err)
 	})
+
+	t.Run("WithPredicate", func(t *testing.T) {
+		t.Parallel()
+
+		q := cliutil.NewQueue[int](10)
+		q.WithPredicate(func(n int) (int, bool) {
+			if n == 2 {
+				return n, false
+			}
+			return n + 1, true
+		})
+
+		for i := 0; i < 5; i++ {
+			err := q.Push(i)
+			require.NoError(t, err)
+		}
+
+		got := []int{}
+		for i := 0; i < 4; i++ {
+			val, ok := q.Pop()
+			require.True(t, ok)
+			got = append(got, val)
+		}
+		require.Equal(t, []int{1, 2, 4, 5}, got)
+	})
 }

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -547,12 +547,12 @@ func (s *mcpServer) startReporter(ctx context.Context, inv *serpent.Invocation) 
 				State:   state,
 			}
 
-			// Preserve previous message and URI.
+			// Preserve previous message and URI if there was no message.
 			if payload.Message == "" {
 				payload.Message = lastPayload.Message
-			}
-			if payload.URI == "" {
-				payload.URI = lastPayload.URI
+				if payload.URI == "" {
+					payload.URI = lastPayload.URI
+				}
 			}
 
 			// Avoid sending duplicate updates.

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -581,7 +581,9 @@ func (s *mcpServer) startReporter(ctx context.Context, inv *serpent.Invocation) 
 				cliui.Warnf(inv.Stderr, "Failed to report task status: %s", err)
 			}
 
-			lastPayload = payload
+			if err == nil {
+				lastPayload = payload
+			}
 		}
 	}()
 }

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -380,7 +380,7 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 		Handler: func(inv *serpent.Invocation) error {
 			srv := &mcpServer{
 				appStatusSlug: appStatusSlug,
-				queue:         cliutil.NewQueue[reportTask](10),
+				queue:         cliutil.NewQueue[reportTask](100),
 			}
 
 			// Display client URL separately from authentication status.

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -653,8 +653,6 @@ func (s *mcpServer) startServer(ctx context.Context, inv *serpent.Invocation, in
 	// Add tool dependencies.
 	toolOpts := []func(*toolsdk.Deps){
 		toolsdk.WithTaskReporter(func(args toolsdk.ReportTaskArgs) error {
-			// TODO: Is it OK to just push and return or should we wait for it to
-			// actually get disatched to return any request errors?
 			return s.queue.Push(reportTask{
 				link:         args.Link,
 				selfReported: true,

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -190,9 +190,9 @@ func (r *RootCmd) mcpConfigureClaudeCode() *serpent.Command {
 			// Determine if we should include the reportTaskPrompt
 			var reportTaskPrompt string
 			if agentClient != nil && appStatusSlug != "" {
-				// Only include the report task prompt if both agent token and app
-				// status slug are defined. Otherwise, reporting a task will fail
-				// and confuse the agent (and by extension, the user).
+				// Only include the report task prompt if both the agent client and app
+				// status slug are defined. Otherwise, reporting a task will fail and
+				// confuse the agent (and by extension, the user).
 				reportTaskPrompt = defaultReportTaskPrompt
 			}
 

--- a/cli/exp_mcp_test.go
+++ b/cli/exp_mcp_test.go
@@ -365,7 +365,8 @@ test-system-prompt
 							"env": {
 								"CODER_AGENT_URL": "%s",
 								"CODER_AGENT_TOKEN": "test-agent-token",
-								"CODER_MCP_APP_STATUS_SLUG": "some-app-name"
+								"CODER_MCP_APP_STATUS_SLUG": "some-app-name",
+								"CODER_MCP_LLM_AGENT_URL": "http://localhost:3284"
 							}
 						}
 					}
@@ -390,6 +391,7 @@ test-system-prompt
 			"--claude-test-binary-name=pathtothecoderbinary",
 			"--agent-url", client.URL.String(),
 			"--agent-token", "test-agent-token",
+			"--llm-agent-url", "http://localhost:3284",
 		)
 		clitest.SetupConfig(t, client, root)
 

--- a/cli/exp_mcp_test.go
+++ b/cli/exp_mcp_test.go
@@ -905,6 +905,10 @@ func TestExpMcpReporter(t *testing.T) {
 					URI:     "https://dev.coder.com",
 				},
 			},
+			// A completed update at this point from the watcher should be discarded.
+			{
+				event: makeStatusEvent(agentapi.StatusStable),
+			},
 			// Terminal becomes active again according to the screen watcher, but no
 			// new user message.  This could be the LLM being active again, but it
 			// could also be the user messing around.  We will prefer not updating the

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -75,7 +75,7 @@ fi
 				return xerrors.Errorf("agent token not found")
 			}
 
-			client, err := r.createAgentClient()
+			client, err := r.tryCreateAgentClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/gitaskpass.go
+++ b/cli/gitaskpass.go
@@ -33,7 +33,7 @@ func (r *RootCmd) gitAskpass() *serpent.Command {
 				return xerrors.Errorf("parse host: %w", err)
 			}
 
-			client, err := r.createAgentClient()
+			client, err := r.tryCreateAgentClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -38,7 +38,7 @@ func (r *RootCmd) gitssh() *serpent.Command {
 				return err
 			}
 
-			client, err := r.createAgentClient()
+			client, err := r.tryCreateAgentClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/codersdk/agentsdk"
 )
 
 func NewDeps(client *codersdk.Client, opts ...func(*Deps)) (Deps, error) {
@@ -27,23 +26,16 @@ func NewDeps(client *codersdk.Client, opts ...func(*Deps)) (Deps, error) {
 	return d, nil
 }
 
-func WithAgentClient(client *agentsdk.Client) func(*Deps) {
-	return func(d *Deps) {
-		d.agentClient = client
-	}
-}
-
-func WithAppStatusSlug(slug string) func(*Deps) {
-	return func(d *Deps) {
-		d.appStatusSlug = slug
-	}
-}
-
 // Deps provides access to tool dependencies.
 type Deps struct {
-	coderClient   *codersdk.Client
-	agentClient   *agentsdk.Client
-	appStatusSlug string
+	coderClient *codersdk.Client
+	report      func(ReportTaskArgs) error
+}
+
+func WithTaskReporter(fn func(ReportTaskArgs) error) func(*Deps) {
+	return func(d *Deps) {
+		d.report = fn
+	}
 }
 
 // HandlerFunc is a typed function that handles a tool call.
@@ -225,22 +217,12 @@ ONLY report a "complete" or "failure" state if you have FULLY completed the task
 		},
 	},
 	UserClientOptional: true,
-	Handler: func(ctx context.Context, deps Deps, args ReportTaskArgs) (codersdk.Response, error) {
-		if deps.agentClient == nil {
-			return codersdk.Response{}, xerrors.New("tool unavailable as CODER_AGENT_TOKEN or CODER_AGENT_TOKEN_FILE not set")
-		}
-		if deps.appStatusSlug == "" {
-			return codersdk.Response{}, xerrors.New("tool unavailable as CODER_MCP_APP_STATUS_SLUG is not set")
-		}
+	Handler: func(_ context.Context, deps Deps, args ReportTaskArgs) (codersdk.Response, error) {
 		if len(args.Summary) > 160 {
 			return codersdk.Response{}, xerrors.New("summary must be less than 160 characters")
 		}
-		if err := deps.agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
-			AppSlug: deps.appStatusSlug,
-			Message: args.Summary,
-			URI:     args.Link,
-			State:   codersdk.WorkspaceAppStatusState(args.State),
-		}); err != nil {
+		err := deps.report(args)
+		if err != nil {
 			return codersdk.Response{}, err
 		}
 		return codersdk.Response{

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -72,7 +72,14 @@ func TestTools(t *testing.T) {
 	})
 
 	t.Run("ReportTask", func(t *testing.T) {
-		tb, err := toolsdk.NewDeps(memberClient, toolsdk.WithAgentClient(agentClient), toolsdk.WithAppStatusSlug("some-agent-app"))
+		tb, err := toolsdk.NewDeps(memberClient, toolsdk.WithTaskReporter(func(args toolsdk.ReportTaskArgs) error {
+			return agentClient.PatchAppStatus(setupCtx, agentsdk.PatchAppStatus{
+				AppSlug: "some-agent-app",
+				Message: args.Summary,
+				URI:     args.Link,
+				State:   codersdk.WorkspaceAppStatusState(args.State),
+			})
+		}))
 		require.NoError(t, err)
 		_, err = testTool(t, toolsdk.ReportTask, tb, toolsdk.ReportTaskArgs{
 			Summary: "test summary",

--- a/go.mod
+++ b/go.mod
@@ -481,6 +481,7 @@ require (
 
 require (
 	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
+	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
 	github.com/coder/preview v0.0.2-0.20250611164554-2e5caa65a54a
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/kylecarbs/aisdk-go v0.0.8
@@ -521,6 +522,7 @@ require (
 	github.com/samber/lo v1.50.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tmaxmax/go-sse v0.10.0 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -893,6 +893,8 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f h1:C5bqEmzEPLsHm9Mv73lSE9e9bKV23aB1vxOsmZrkl3k=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
+github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
+github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwuWwPHPYoCZ/KLAjHv5g4h2MS4f2/MTI=
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.0.0 h1:MjiS7qQ1IobuSSgDnxcCSyBPESs44hExnh2TEqMcGnA=
@@ -1806,6 +1808,8 @@ github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8O
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=
 github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
+github.com/tmaxmax/go-sse v0.10.0 h1:j9F93WB4Hxt8wUf6oGffMm4dutALvUPoDDxfuDQOSqA=
+github.com/tmaxmax/go-sse v0.10.0/go.mod h1:u/2kZQR1tyngo1lKaNCj1mJmhXGZWS1Zs5yiSOD+Eg8=
 github.com/u-root/gobusybox/src v0.0.0-20240225013946-a274a8d5d83a h1:eg5FkNoQp76ZsswyGZ+TjYqA/rhKefxK8BW7XOlQsxo=
 github.com/u-root/gobusybox/src v0.0.0-20240225013946-a274a8d5d83a/go.mod h1:e/8TmrdreH0sZOw2DFKBaUV7bvDWRq6SeM9PzkuVM68=
 github.com/u-root/u-root v0.14.0 h1:Ka4T10EEML7dQ5XDvO9c3MBN8z4nuSnGjcd1jmU2ivg=


### PR DESCRIPTION
This is meant to complement the existing task reporter since the LLM does not call it reliably.

I also did some refactoring to use the common agent flags/env vars, those changes are in separate commits.

For #18163, but will need to update the modules to make use of it.