### PR TITLE
chore: move all images to new GCP project

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -719,7 +719,7 @@ jobs:
       # c.f. discussion on https://github.com/coder/coder/pull/15106
       - name: Run Tests
         env:
-          POSTGRES_VERSION: "16"
+          POSTGRES_VERSION: "17"
         run: |
           make test-postgres-docker
           DB=ci gotestsum --junitfile="gotests.xml" --packages="./..." --rerun-fails=2 --rerun-fails-abort-on-data-race -- -race -parallel 4 -p 4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -582,7 +582,7 @@ jobs:
   # NOTE: this could instead be defined as a matrix strategy, but we want to
   # only block merging if tests on postgres 13 fail. Using a matrix strategy
   # here makes the check in the above `required` job rather complicated.
-  test-go-pg-16:
+  test-go-pg-17:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     needs:
       - changes
@@ -613,11 +613,11 @@ jobs:
         id: download-cache
         uses: ./.github/actions/test-cache/download
         with:
-          key-prefix: test-go-pg-16-${{ runner.os }}-${{ runner.arch }}
+          key-prefix: test-go-pg-17-${{ runner.os }}-${{ runner.arch }}
 
       - name: Test with PostgreSQL Database
         env:
-          POSTGRES_VERSION: "16"
+          POSTGRES_VERSION: "17"
           TS_DEBUG_DISCO: "true"
           TEST_RETRIES: 2
         run: |

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -298,7 +298,7 @@ func PGDumpSchemaOnly(dbURL string) ([]byte, error) {
 			"run",
 			"--rm",
 			"--network=host",
-			fmt.Sprintf("%s:%d", containerImage, minimumPostgreSQLVersion),
+			fmt.Sprintf("%s:%d", postgresImage, minimumPostgreSQLVersion),
 		}, cmdArgs...)
 	}
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //#nosec

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -298,7 +298,7 @@ func PGDumpSchemaOnly(dbURL string) ([]byte, error) {
 			"run",
 			"--rm",
 			"--network=host",
-			fmt.Sprintf("gcr.io/coder-dev-1/postgres:%d", minimumPostgreSQLVersion),
+			fmt.Sprintf("%s:%d", containerImage, minimumPostgreSQLVersion),
 		}, cmdArgs...)
 	}
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //#nosec

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -26,6 +26,8 @@ import (
 	"github.com/coder/retry"
 )
 
+const containerImage = "us-docker.pkg.dev/coder-v2-images-public/public/postgres"
+
 type ConnectionParams struct {
 	Username string
 	Password string
@@ -379,8 +381,8 @@ func openContainer(t TBSubset, opts DBContainerOptions) (container, func(), erro
 			return container{}, nil, xerrors.Errorf("create tempdir: %w", err)
 		}
 		runOptions := dockertest.RunOptions{
-			Repository: "gcr.io/coder-dev-1/postgres",
-			Tag:        "13",
+			Repository: containerImage,
+			Tag:        strconv.Itoa(minimumPostgreSQLVersion),
 			Env: []string{
 				"POSTGRES_PASSWORD=postgres",
 				"POSTGRES_USER=postgres",

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coder/retry"
 )
 
-const containerImage = "us-docker.pkg.dev/coder-v2-images-public/public/postgres"
+const postgresImage = "us-docker.pkg.dev/coder-v2-images-public/public/postgres"
 
 type ConnectionParams struct {
 	Username string
@@ -381,7 +381,7 @@ func openContainer(t TBSubset, opts DBContainerOptions) (container, func(), erro
 			return container{}, nil, xerrors.Errorf("create tempdir: %w", err)
 		}
 		runOptions := dockertest.RunOptions{
-			Repository: containerImage,
+			Repository: postgresImage,
 			Tag:        strconv.Itoa(minimumPostgreSQLVersion),
 			Env: []string{
 				"POSTGRES_PASSWORD=postgres",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
   database:
     # Minimum supported version is 13.
     # More versions here: https://hub.docker.com/_/postgres
-    image: "postgres:16"
+    image: "postgres:17"
     ports:
       - "5432:5432"
     environment:

--- a/docs/tutorials/reverse-proxy-caddy.md
+++ b/docs/tutorials/reverse-proxy-caddy.md
@@ -39,7 +39,7 @@ certificates, you'll need a domain name that resolves to your Caddy server.
            condition: service_healthy
 
    database:
-       image: "postgres:16"
+       image: "postgres:17"
        ports:
            - "5432:5432"
        environment:

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -87,7 +87,7 @@ RUN apt-get update && \
 	rm -rf /tmp/go/src
 
 # alpine:3.18
-FROM gcr.io/coder-dev-1/alpine@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70 AS proto
+FROM us-docker.pkg.dev/coder-v2-images-public/public/alpine@sha256:fd032399cd767f310a1d1274e81cab9f0fd8a49b3589eba2c3420228cd45b6a7 AS proto
 WORKDIR /tmp
 RUN apk add curl unzip
 RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip && \

--- a/scaletest/templates/scaletest-runner/Dockerfile
+++ b/scaletest/templates/scaletest-runner/Dockerfile
@@ -1,6 +1,6 @@
 # This image is used to run scaletest jobs and, although it is inside
 # the template directory, it is built separately and pushed to
-# gcr.io/coder-dev-1/scaletest-runner:latest.
+# us-docker.pkg.dev/coder-v2-images-public/public/scaletest-runner:latest.
 #
 # Future improvements will include versioning and including the version
 # in the template push.

--- a/scaletest/templates/scaletest-runner/main.tf
+++ b/scaletest/templates/scaletest-runner/main.tf
@@ -822,7 +822,7 @@ resource "kubernetes_pod" "main" {
 
     container {
       name              = "dev"
-      image             = "gcr.io/coder-dev-1/scaletest-runner:latest"
+      image             = "us-docker.pkg.dev/coder-v2-images-public/public/scaletest-runner:latest"
       image_pull_policy = "Always"
       command           = ["sh", "-c", coder_agent.main.init_script]
       security_context {

--- a/site/src/pages/ChatPage/ChatToolInvocation.stories.tsx
+++ b/site/src/pages/ChatPage/ChatToolInvocation.stories.tsx
@@ -408,7 +408,7 @@ RUN apt-get update && \
 	rm -rf /tmp/go/src
 
 # alpine:3.18
-FROM gcr.io/coder-dev-1/alpine@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70 AS proto
+FROM us-docker.pkg.dev/coder-v2-images-public/public/alpine@sha256:fd032399cd767f310a1d1274e81cab9f0fd8a49b3589eba2c3420228cd45b6a7 AS proto
 WORKDIR /tmp
 RUN apk add curl unzip
 RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip && \


### PR DESCRIPTION
The alpine image I repulled from `alpine:3.18` but the digest changed, I guess because it had it's packages updated or something.