### PR TITLE
fix(site): use correct order of agent/workspace in AgentSSHButton

### DIFF
--- a/site/src/modules/resources/SSHButton/SSHButton.tsx
+++ b/site/src/modules/resources/SSHButton/SSHButton.tsx
@@ -56,7 +56,7 @@ export const AgentSSHButton: FC<AgentSSHButtonProps> = ({
 						/>
 						<SSHStep
 							helpText="Connect to the agent:"
-							codeExample={`ssh ${workspaceName}.${agentName}.${workspaceOwnerUsername}.${sshSuffix}`}
+							codeExample={`ssh ${agentName}.${workspaceName}.${workspaceOwnerUsername}.${sshSuffix}`}
 						/>
 					</Stack>
 				</ol>


### PR DESCRIPTION
Noticed while I was working on dev container sub agents that the agent and workspace were swapped for suffix-based names.