### PR TITLE
fix(enterprise/coderd): skip org membership check for prebuilds user on group patch

### DIFF
--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/prebuilds"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -175,7 +174,7 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 		// Skip membership checks for the prebuilds user. There is a valid use case
 		// for adding the prebuilds user to a single group: in order to set a quota
 		// allowance specifically for prebuilds.
-		if id == prebuilds.SystemUserID.String() {
+		if id == database.PrebuildsSystemUserID.String() {
 			continue
 		}
 		_, err := database.ExpectOne(api.Database.OrganizationMembers(ctx, database.OrganizationMembersParams{

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/prebuilds"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -170,6 +171,12 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 				Message: fmt.Sprintf("ID %q must be a valid user UUID.", id),
 			})
 			return
+		}
+		// Skip membership checks for the prebuilds user. There is a valid use case
+		// for adding the prebuilds user to a single group: in order to set a quota
+		// allowance specifically for prebuilds.
+		if id == prebuilds.SystemUserID.String() {
+			continue
 		}
 		_, err := database.ExpectOne(api.Database.OrganizationMembers(ctx, database.OrganizationMembersParams{
 			OrganizationID: group.OrganizationID,

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -484,7 +484,7 @@ func TestPatchGroup(t *testing.T) {
 
 		group, err = userAdminClient.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
 			Name:     "prebuilds",
-			AddUsers: []string{prebuilds.SystemUserID.String()},
+			AddUsers: []string{database.PrebuildsSystemUserID.String()},
 		})
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
Currently, the prebuilds documentation states:

```
### Managing resource quotas

Prebuilt workspaces can be used in conjunction with [resource quotas](../../users/quotas.md).
Because unclaimed prebuilt workspaces are owned by the `prebuilds` user, you can:

1. Configure quotas for any group that includes this user.
1. Set appropriate limits to balance prebuilt workspace availability with resource constraints.

If a quota is exceeded, the prebuilt workspace will fail provisioning the same way other workspaces do.
```

If you need to have a separate quota for prebuilds as opposed to regular users, you are required to create a separate group, as quotas are applied to groups.

Currently it is not possible to create a separate 'prebuilds' group with only the prebuilds user to add a quota. This PR skips the org membership check specifically for the prebuilds user when patching a group.

![image](https://github.com/user-attachments/assets/2ff566bb-97bd-4c73-917a-903ea54dd7a6)
