### PR TITLE
docs: remove github avatars

### DIFF
--- a/docs/admin/integrations/island.md
+++ b/docs/admin/integrations/island.md
@@ -3,7 +3,6 @@
 <div>
   <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Eric Paulsen</span>
-    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 April 24, 2024

--- a/docs/admin/integrations/jfrog-xray.md
+++ b/docs/admin/integrations/jfrog-xray.md
@@ -3,8 +3,6 @@
 <div>
   <a href="https://github.com/matifali" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Muhammad Atif Ali</span>
-    <img src="https://github.com/matifali.png" alt="matifali" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
-
   </a>
 </div>
 March 17, 2024

--- a/docs/admin/integrations/vault.md
+++ b/docs/admin/integrations/vault.md
@@ -3,8 +3,6 @@
 <div>
   <a href="https://github.com/matifali" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Muhammad Atif Ali</span>
-    <img src="https://github.com/matifali.png" alt="matifali" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
-
   </a>
 </div>
 August 05, 2024

--- a/docs/tutorials/azure-federation.md
+++ b/docs/tutorials/azure-federation.md
@@ -3,7 +3,6 @@
 <div>
   <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Eric Paulsen</span>
-    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 January 26, 2024

--- a/docs/tutorials/cloning-git-repositories.md
+++ b/docs/tutorials/cloning-git-repositories.md
@@ -4,7 +4,6 @@
   <span style="vertical-align:middle;">Author: </span>
   <a href="https://github.com/BrunoQuaresma" style="text-decoration: none; color: inherit; margin-bottom: 0px;">
     <span style="vertical-align:middle;">Bruno Quaresma</span>
-    <img src="https://avatars.githubusercontent.com/u/3165839?v=4" alt="Bruno Quaresma" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 August 06, 2024

--- a/docs/tutorials/configuring-okta.md
+++ b/docs/tutorials/configuring-okta.md
@@ -4,7 +4,6 @@
   <span style="vertical-align:middle;">Author: </span>
   <a href="https://github.com/Emyrk" style="text-decoration: none; color: inherit; margin-bottom: 0px;">
     <span style="vertical-align:middle;">Steven Masley</span>
-    <img src="https://avatars.githubusercontent.com/u/5446298?v=4" alt="Steven Masley" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 December 13, 2023

--- a/docs/tutorials/example-guide.md
+++ b/docs/tutorials/example-guide.md
@@ -3,7 +3,6 @@
 <div>
   <a href="https://github.com/coder" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Your Name</span>
-    <img src="https://github.com/coder.png" alt="Coder" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 December 13, 2023

--- a/docs/tutorials/gcp-to-aws.md
+++ b/docs/tutorials/gcp-to-aws.md
@@ -3,7 +3,6 @@
 <div>
   <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Eric Paulsen</span>
-    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 January 4, 2024

--- a/docs/tutorials/image-pull-secret.md
+++ b/docs/tutorials/image-pull-secret.md
@@ -3,7 +3,6 @@
 <div>
   <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Eric Paulsen</span>
-    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 January 12, 2024

--- a/docs/tutorials/postgres-ssl.md
+++ b/docs/tutorials/postgres-ssl.md
@@ -3,7 +3,6 @@
 <div>
   <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Eric Paulsen</span>
-    <img src="https://github.com/ericpaulsen.png" alt="ericpaulsen" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 February 24, 2024

--- a/docs/tutorials/testing-templates.md
+++ b/docs/tutorials/testing-templates.md
@@ -3,8 +3,6 @@
 <div>
   <a href="https://github.com/matifali" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Muhammad Atif Ali</span>
-    <img src="https://github.com/matifali.png" alt="matifali" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
-
   </a>
 </div>
 November 15, 2024


### PR DESCRIPTION
the site is making the pictures big, so I'm just removing them in this PR and then maybe we can investigate it some other time

- [live site](https://coder.com/docs/admin/integrations/island)
- [preview](https://coder.com/docs/@remove-github-avatars/admin/integrations/island)

cc @aqandrew 

#bring-back-the-hotfix-label