### PR TITLE
feat(agent/agentcontainers): support displayApps from devcontainer config

### DIFF
--- a/agent/agentcontainers/acmock/acmock.go
+++ b/agent/agentcontainers/acmock/acmock.go
@@ -149,6 +149,26 @@ func (mr *MockDevcontainerCLIMockRecorder) Exec(ctx, workspaceFolder, configPath
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockDevcontainerCLI)(nil).Exec), varargs...)
 }
 
+// ReadConfig mocks base method.
+func (m *MockDevcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, configPath string, opts ...agentcontainers.DevcontainerCLIReadConfigOptions) (agentcontainers.DevcontainerConfig, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, workspaceFolder, configPath}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadConfig", varargs...)
+	ret0, _ := ret[0].(agentcontainers.DevcontainerConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadConfig indicates an expected call of ReadConfig.
+func (mr *MockDevcontainerCLIMockRecorder) ReadConfig(ctx, workspaceFolder, configPath any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, workspaceFolder, configPath}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadConfig", reflect.TypeOf((*MockDevcontainerCLI)(nil).ReadConfig), varargs...)
+}
+
 // Up mocks base method.
 func (m *MockDevcontainerCLI) Up(ctx context.Context, workspaceFolder, configPath string, opts ...agentcontainers.DevcontainerCLIUpOptions) (string, error) {
 	m.ctrl.T.Helper()

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1099,6 +1099,17 @@ func (api *API) injectSubAgentIntoContainerLocked(ctx context.Context, dc coders
 		directory = DevcontainerDefaultContainerWorkspaceFolder
 	}
 
+	var displayApps []codersdk.DisplayApp
+
+	if config, err := api.dccli.ReadConfig(ctx, dc.WorkspaceFolder, dc.ConfigPath); err != nil {
+		api.logger.Error(ctx, "unable to read devcontainer config", slog.Error(err))
+	} else {
+		coderCustomization := config.Configuration.Customizations.Coder
+		if coderCustomization != nil {
+			displayApps = coderCustomization.DisplayApps
+		}
+	}
+
 	// The preparation of the subagent is done, now we can create the
 	// subagent record in the database to receive the auth token.
 	createdAgent, err := api.subAgentClient.Create(ctx, SubAgent{
@@ -1106,6 +1117,7 @@ func (api *API) injectSubAgentIntoContainerLocked(ctx context.Context, dc coders
 		Directory:       directory,
 		OperatingSystem: "linux", // Assuming Linux for dev containers.
 		Architecture:    arch,
+		DisplayApps:     displayApps,
 	})
 	if err != nil {
 		return xerrors.Errorf("create agent: %w", err)

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1104,7 +1104,7 @@ func (api *API) injectSubAgentIntoContainerLocked(ctx context.Context, dc coders
 	if config, err := api.dccli.ReadConfig(ctx, dc.WorkspaceFolder, dc.ConfigPath); err != nil {
 		api.logger.Error(ctx, "unable to read devcontainer config", slog.Error(err))
 	} else {
-		coderCustomization := config.Configuration.Customizations.Coder
+		coderCustomization := config.MergedConfiguration.Customizations.Coder
 		if coderCustomization != nil {
 			displayApps = coderCustomization.DisplayApps
 		}

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1487,7 +1487,7 @@ func TestAPI(t *testing.T) {
 					fSAC   = &fakeSubAgentClient{createErrC: make(chan error, 1)}
 					fDCCLI = &fakeDevcontainerCLI{
 						readConfig: agentcontainers.DevcontainerConfig{
-							Configuration: agentcontainers.DevcontainerConfiguration{
+							MergedConfiguration: agentcontainers.DevcontainerConfiguration{
 								Customizations: agentcontainers.DevcontainerCustomizations{
 									Coder: tt.customization,
 								},

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -253,10 +253,10 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 				logFile:         "read-config-with-coder-customization.log",
 				workspaceFolder: "/test/workspace",
 				configPath:      "",
-				wantArgs:        "read-configuration --workspace-folder /test/workspace",
+				wantArgs:        "read-configuration --include-merged-configuration --workspace-folder /test/workspace",
 				wantError:       false,
 				wantConfig: agentcontainers.DevcontainerConfig{
-					Configuration: agentcontainers.DevcontainerConfiguration{
+					MergedConfiguration: agentcontainers.DevcontainerConfiguration{
 						Customizations: agentcontainers.DevcontainerCustomizations{
 							Coder: &agentcontainers.CoderCustomization{
 								DisplayApps: []codersdk.DisplayApp{
@@ -273,10 +273,10 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 				logFile:         "read-config-without-coder-customization.log",
 				workspaceFolder: "/test/workspace",
 				configPath:      "/test/config.json",
-				wantArgs:        "read-configuration --workspace-folder /test/workspace --config /test/config.json",
+				wantArgs:        "read-configuration --include-merged-configuration --workspace-folder /test/workspace --config /test/config.json",
 				wantError:       false,
 				wantConfig: agentcontainers.DevcontainerConfig{
-					Configuration: agentcontainers.DevcontainerConfiguration{
+					MergedConfiguration: agentcontainers.DevcontainerConfiguration{
 						Customizations: agentcontainers.DevcontainerCustomizations{
 							Coder: nil,
 						},
@@ -288,7 +288,7 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 				logFile:         "read-config-error-not-found.log",
 				workspaceFolder: "/nonexistent/workspace",
 				configPath:      "",
-				wantArgs:        "read-configuration --workspace-folder /nonexistent/workspace",
+				wantArgs:        "read-configuration --include-merged-configuration --workspace-folder /nonexistent/workspace",
 				wantError:       true,
 				wantConfig:      agentcontainers.DevcontainerConfig{},
 			},

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -22,6 +22,7 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -233,6 +234,91 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ReadConfig", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name            string
+			logFile         string
+			workspaceFolder string
+			configPath      string
+			opts            []agentcontainers.DevcontainerCLIReadConfigOptions
+			wantArgs        string
+			wantError       bool
+			wantConfig      agentcontainers.DevcontainerConfig
+		}{
+			{
+				name:            "WithCoderCustomization",
+				logFile:         "read-config-with-coder-customization.log",
+				workspaceFolder: "/test/workspace",
+				configPath:      "",
+				wantArgs:        "read-configuration --workspace-folder /test/workspace",
+				wantError:       false,
+				wantConfig: agentcontainers.DevcontainerConfig{
+					Configuration: agentcontainers.DevcontainerConfiguration{
+						Customizations: agentcontainers.DevcontainerCustomizations{
+							Coder: &agentcontainers.CoderCustomization{
+								DisplayApps: []codersdk.DisplayApp{
+									codersdk.DisplayAppVSCodeDesktop,
+									codersdk.DisplayAppWebTerminal,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				name:            "WithoutCoderCustomization",
+				logFile:         "read-config-without-coder-customization.log",
+				workspaceFolder: "/test/workspace",
+				configPath:      "/test/config.json",
+				wantArgs:        "read-configuration --workspace-folder /test/workspace --config /test/config.json",
+				wantError:       false,
+				wantConfig: agentcontainers.DevcontainerConfig{
+					Configuration: agentcontainers.DevcontainerConfiguration{
+						Customizations: agentcontainers.DevcontainerCustomizations{
+							Coder: nil,
+						},
+					},
+				},
+			},
+			{
+				name:            "FileNotFound",
+				logFile:         "read-config-error-not-found.log",
+				workspaceFolder: "/nonexistent/workspace",
+				configPath:      "",
+				wantArgs:        "read-configuration --workspace-folder /nonexistent/workspace",
+				wantError:       true,
+				wantConfig:      agentcontainers.DevcontainerConfig{},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx := testutil.Context(t, testutil.WaitMedium)
+
+				testExecer := &testDevcontainerExecer{
+					testExePath: testExePath,
+					wantArgs:    tt.wantArgs,
+					wantError:   tt.wantError,
+					logFile:     filepath.Join("testdata", "devcontainercli", "readconfig", tt.logFile),
+				}
+
+				dccli := agentcontainers.NewDevcontainerCLI(logger, testExecer)
+				config, err := dccli.ReadConfig(ctx, tt.workspaceFolder, tt.configPath, tt.opts...)
+				if tt.wantError {
+					assert.Error(t, err, "want error")
+					assert.Equal(t, agentcontainers.DevcontainerConfig{}, config, "expected empty config on error")
+				} else {
+					assert.NoError(t, err, "want no error")
+					assert.Equal(t, tt.wantConfig, config, "expected config to match")
+				}
+			})
+		}
+	})
 }
 
 // TestDevcontainerCLI_WithOutput tests that WithUpOutput and WithExecOutput capture CLI
@@ -313,6 +399,39 @@ func TestDevcontainerCLI_WithOutput(t *testing.T) {
 
 		assert.NotEmpty(t, outBuf.String(), "stdout buffer should not be empty for exec with log file")
 		assert.Empty(t, errBuf.String(), "stderr buffer should be empty")
+	})
+
+	t.Run("ReadConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// Buffers to capture stdout and stderr.
+		outBuf := &bytes.Buffer{}
+		errBuf := &bytes.Buffer{}
+
+		// Simulate CLI execution with a read-config-success.log file.
+		wantArgs := "read-configuration --workspace-folder /test/workspace --config /test/config.json"
+		testExecer := &testDevcontainerExecer{
+			testExePath: testExePath,
+			wantArgs:    wantArgs,
+			wantError:   false,
+			logFile:     filepath.Join("testdata", "devcontainercli", "readconfig", "read-config-success.log"),
+		}
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		dccli := agentcontainers.NewDevcontainerCLI(logger, testExecer)
+
+		// Call ReadConfig with WithReadConfigOutput to capture CLI logs.
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		config, err := dccli.ReadConfig(ctx, "/test/workspace", "/test/config.json", agentcontainers.WithReadConfigOutput(outBuf, errBuf))
+		require.NoError(t, err, "ReadConfig should succeed")
+		require.NotEmpty(t, config.Configuration.Customizations, "expected non-empty customizations")
+
+		// Read expected log content.
+		expLog, err := os.ReadFile(filepath.Join("testdata", "devcontainercli", "readconfig", "read-config-success.log"))
+		require.NoError(t, err, "reading expected log file")
+
+		// Verify stdout buffer contains the CLI logs and stderr is empty.
+		assert.Equal(t, string(expLog), outBuf.String(), "stdout buffer should match CLI logs")
+		assert.Empty(t, errBuf.String(), "stderr buffer should be empty on success")
 	})
 }
 

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -400,39 +400,6 @@ func TestDevcontainerCLI_WithOutput(t *testing.T) {
 		assert.NotEmpty(t, outBuf.String(), "stdout buffer should not be empty for exec with log file")
 		assert.Empty(t, errBuf.String(), "stderr buffer should be empty")
 	})
-
-	t.Run("ReadConfig", func(t *testing.T) {
-		t.Parallel()
-
-		// Buffers to capture stdout and stderr.
-		outBuf := &bytes.Buffer{}
-		errBuf := &bytes.Buffer{}
-
-		// Simulate CLI execution with a read-config-success.log file.
-		wantArgs := "read-configuration --workspace-folder /test/workspace --config /test/config.json"
-		testExecer := &testDevcontainerExecer{
-			testExePath: testExePath,
-			wantArgs:    wantArgs,
-			wantError:   false,
-			logFile:     filepath.Join("testdata", "devcontainercli", "readconfig", "read-config-success.log"),
-		}
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-		dccli := agentcontainers.NewDevcontainerCLI(logger, testExecer)
-
-		// Call ReadConfig with WithReadConfigOutput to capture CLI logs.
-		ctx := testutil.Context(t, testutil.WaitMedium)
-		config, err := dccli.ReadConfig(ctx, "/test/workspace", "/test/config.json", agentcontainers.WithReadConfigOutput(outBuf, errBuf))
-		require.NoError(t, err, "ReadConfig should succeed")
-		require.NotEmpty(t, config.Configuration.Customizations, "expected non-empty customizations")
-
-		// Read expected log content.
-		expLog, err := os.ReadFile(filepath.Join("testdata", "devcontainercli", "readconfig", "read-config-success.log"))
-		require.NoError(t, err, "reading expected log file")
-
-		// Verify stdout buffer contains the CLI logs and stderr is empty.
-		assert.Equal(t, string(expLog), outBuf.String(), "stdout buffer should match CLI logs")
-		assert.Empty(t, errBuf.String(), "stderr buffer should be empty on success")
-	})
 }
 
 // testDevcontainerExecer implements the agentexec.Execer interface for testing.

--- a/agent/agentcontainers/subagent_test.go
+++ b/agent/agentcontainers/subagent_test.go
@@ -3,16 +3,16 @@ package agentcontainers_test
 import (
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agenttest"
-	"github.com/coder/coder/v2/agent/proto"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/testutil"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
@@ -75,7 +75,7 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 
 				ctx := testutil.Context(t, testutil.WaitShort)
 				logger := testutil.Logger(t)
-				statsCh := make(chan *proto.Stats)
+				statsCh := make(chan *agentproto.Stats)
 
 				agentAPI := agenttest.NewClient(t, logger, uuid.New(), agentsdk.Manifest{}, statsCh, tailnet.NewCoordinator(logger))
 
@@ -102,5 +102,4 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 			})
 		}
 	})
-
 }

--- a/agent/agentcontainers/subagent_test.go
+++ b/agent/agentcontainers/subagent_test.go
@@ -1,0 +1,106 @@
+package agentcontainers_test
+
+import (
+	"testing"
+
+	"github.com/coder/coder/v2/agent/agentcontainers"
+	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/agent/proto"
+	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/tailnet"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CreateWithDisplayApps", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name         string
+			displayApps  []codersdk.DisplayApp
+			expectedApps []agentproto.CreateSubAgentRequest_DisplayApp
+		}{
+			{
+				name:        "single display app",
+				displayApps: []codersdk.DisplayApp{codersdk.DisplayAppVSCodeDesktop},
+				expectedApps: []agentproto.CreateSubAgentRequest_DisplayApp{
+					agentproto.CreateSubAgentRequest_VSCODE,
+				},
+			},
+			{
+				name: "multiple display apps",
+				displayApps: []codersdk.DisplayApp{
+					codersdk.DisplayAppVSCodeDesktop,
+					codersdk.DisplayAppSSH,
+					codersdk.DisplayAppPortForward,
+				},
+				expectedApps: []agentproto.CreateSubAgentRequest_DisplayApp{
+					agentproto.CreateSubAgentRequest_VSCODE,
+					agentproto.CreateSubAgentRequest_SSH_HELPER,
+					agentproto.CreateSubAgentRequest_PORT_FORWARDING_HELPER,
+				},
+			},
+			{
+				name: "all display apps",
+				displayApps: []codersdk.DisplayApp{
+					codersdk.DisplayAppPortForward,
+					codersdk.DisplayAppSSH,
+					codersdk.DisplayAppVSCodeDesktop,
+					codersdk.DisplayAppVSCodeInsiders,
+					codersdk.DisplayAppWebTerminal,
+				},
+				expectedApps: []agentproto.CreateSubAgentRequest_DisplayApp{
+					agentproto.CreateSubAgentRequest_PORT_FORWARDING_HELPER,
+					agentproto.CreateSubAgentRequest_SSH_HELPER,
+					agentproto.CreateSubAgentRequest_VSCODE,
+					agentproto.CreateSubAgentRequest_VSCODE_INSIDERS,
+					agentproto.CreateSubAgentRequest_WEB_TERMINAL,
+				},
+			},
+			{
+				name:        "no display apps",
+				displayApps: []codersdk.DisplayApp{},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx := testutil.Context(t, testutil.WaitShort)
+				logger := testutil.Logger(t)
+				statsCh := make(chan *proto.Stats)
+
+				agentAPI := agenttest.NewClient(t, logger, uuid.New(), agentsdk.Manifest{}, statsCh, tailnet.NewCoordinator(logger))
+
+				agentClient, _, err := agentAPI.ConnectRPC26(ctx)
+				require.NoError(t, err)
+
+				subAgentClient := agentcontainers.NewSubAgentClientFromAPI(logger, agentClient)
+
+				// When: We create a sub agent with display apps.
+				subAgent, err := subAgentClient.Create(ctx, agentcontainers.SubAgent{
+					Name:            "sub-agent-" + tt.name,
+					Directory:       "/workspaces/coder",
+					Architecture:    "amd64",
+					OperatingSystem: "linux",
+					DisplayApps:     tt.displayApps,
+				})
+				require.NoError(t, err)
+
+				displayApps, err := agentAPI.GetSubAgentDisplayApps(subAgent.ID)
+				require.NoError(t, err)
+
+				// Then: We expect the apps to be created.
+				require.Equal(t, tt.expectedApps, displayApps)
+			})
+		}
+	})
+
+}

--- a/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-error-not-found.log
+++ b/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-error-not-found.log
@@ -1,0 +1,2 @@
+{"type":"text","level":3,"timestamp":1749557935646,"text":"@devcontainers/cli 0.75.0. Node.js v20.16.0. linux 6.8.0-60-generic x64."}
+{"type":"text","level":2,"timestamp":1749557935646,"text":"Error: Dev container config (/home/coder/.devcontainer/devcontainer.json) not found.\n    at v7 (/usr/local/nvm/versions/node/v20.16.0/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:668:6918)\n    at async /usr/local/nvm/versions/node/v20.16.0/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:484:1188"}

--- a/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-with-coder-customization.log
+++ b/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-with-coder-customization.log
@@ -1,0 +1,8 @@
+{"type":"text","level":3,"timestamp":1749557820014,"text":"@devcontainers/cli 0.75.0. Node.js v20.16.0. linux 6.8.0-60-generic x64."}
+{"type":"start","level":2,"timestamp":1749557820014,"text":"Run: git rev-parse --show-cdup"}
+{"type":"stop","level":2,"timestamp":1749557820023,"text":"Run: git rev-parse --show-cdup","startTimestamp":1749557820014}
+{"type":"start","level":2,"timestamp":1749557820023,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder --filter label=devcontainer.config_file=/home/coder/coder/.devcontainer/devcontainer.json"}
+{"type":"stop","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder --filter label=devcontainer.config_file=/home/coder/coder/.devcontainer/devcontainer.json","startTimestamp":1749557820023}
+{"type":"start","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder"}
+{"type":"stop","level":2,"timestamp":1749557820054,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder","startTimestamp":1749557820039}
+{"configuration":{"customizations":{"com.coder":{"displayApps":["vscode", "web_terminal"]}}}}

--- a/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-with-coder-customization.log
+++ b/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-with-coder-customization.log
@@ -5,4 +5,4 @@
 {"type":"stop","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder --filter label=devcontainer.config_file=/home/coder/coder/.devcontainer/devcontainer.json","startTimestamp":1749557820023}
 {"type":"start","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder"}
 {"type":"stop","level":2,"timestamp":1749557820054,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder","startTimestamp":1749557820039}
-{"configuration":{"customizations":{"com.coder":{"displayApps":["vscode", "web_terminal"]}}}}
+{"mergedConfiguration":{"customizations":{"coder":{"displayApps":["vscode", "web_terminal"]}}}}

--- a/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-without-coder-customization.log
+++ b/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-without-coder-customization.log
@@ -1,0 +1,8 @@
+{"type":"text","level":3,"timestamp":1749557820014,"text":"@devcontainers/cli 0.75.0. Node.js v20.16.0. linux 6.8.0-60-generic x64."}
+{"type":"start","level":2,"timestamp":1749557820014,"text":"Run: git rev-parse --show-cdup"}
+{"type":"stop","level":2,"timestamp":1749557820023,"text":"Run: git rev-parse --show-cdup","startTimestamp":1749557820014}
+{"type":"start","level":2,"timestamp":1749557820023,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder --filter label=devcontainer.config_file=/home/coder/coder/.devcontainer/devcontainer.json"}
+{"type":"stop","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder --filter label=devcontainer.config_file=/home/coder/coder/.devcontainer/devcontainer.json","startTimestamp":1749557820023}
+{"type":"start","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder"}
+{"type":"stop","level":2,"timestamp":1749557820054,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder","startTimestamp":1749557820039}
+{"configuration":{"customizations":{}}}

--- a/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-without-coder-customization.log
+++ b/agent/agentcontainers/testdata/devcontainercli/readconfig/read-config-without-coder-customization.log
@@ -5,4 +5,4 @@
 {"type":"stop","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder --filter label=devcontainer.config_file=/home/coder/coder/.devcontainer/devcontainer.json","startTimestamp":1749557820023}
 {"type":"start","level":2,"timestamp":1749557820039,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder"}
 {"type":"stop","level":2,"timestamp":1749557820054,"text":"Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/coder/coder","startTimestamp":1749557820039}
-{"configuration":{"customizations":{}}}
+{"mergedConfiguration":{"customizations":{}}}


### PR DESCRIPTION
This updates the agent injection routine to read the dev container's configuration so we can add display apps to the sub agent.

## Example

```
{
        "name": "Sample Dev Container",
        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
        "customizations": {
                "com.coder": {
                        "displayApps": ["vscode", "web_terminal"]
                }
        }
}
```

With this `devcontainer.json`, the agent that is created for this dev container will have the `vscode` and `web_terminal` display apps.