### PR TITLE
feat(agent/agentcontainers): support apps for dev container agents

### DIFF
--- a/agent/agentcontainers/acmock/acmock.go
+++ b/agent/agentcontainers/acmock/acmock.go
@@ -150,9 +150,9 @@ func (mr *MockDevcontainerCLIMockRecorder) Exec(ctx, workspaceFolder, configPath
 }
 
 // ReadConfig mocks base method.
-func (m *MockDevcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, configPath string, opts ...agentcontainers.DevcontainerCLIReadConfigOptions) (agentcontainers.DevcontainerConfig, error) {
+func (m *MockDevcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, configPath string, env []string, opts ...agentcontainers.DevcontainerCLIReadConfigOptions) (agentcontainers.DevcontainerConfig, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, workspaceFolder, configPath}
+	varargs := []any{ctx, workspaceFolder, configPath, env}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -163,9 +163,9 @@ func (m *MockDevcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, c
 }
 
 // ReadConfig indicates an expected call of ReadConfig.
-func (mr *MockDevcontainerCLIMockRecorder) ReadConfig(ctx, workspaceFolder, configPath any, opts ...any) *gomock.Call {
+func (mr *MockDevcontainerCLIMockRecorder) ReadConfig(ctx, workspaceFolder, configPath, env any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, workspaceFolder, configPath}, opts...)
+	varargs := append([]any{ctx, workspaceFolder, configPath, env}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadConfig", reflect.TypeOf((*MockDevcontainerCLI)(nil).ReadConfig), varargs...)
 }
 

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1146,12 +1146,14 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 
 		var apps []SubAgentApp
 
-		if config, err := api.dccli.ReadConfig(ctx, dc.WorkspaceFolder, dc.ConfigPath, []string{
-			fmt.Sprintf("CODER_AGENT_NAME=%s", dc.Name),
-			fmt.Sprintf("CODER_USER_NAME=%s", api.userName),
-			fmt.Sprintf("CODER_WORKSPACE_NAME=%s", api.workspaceName),
-			fmt.Sprintf("CODER_DEPLOYMENT_URL=%s", api.subAgentURL),
-		}); err != nil {
+		if config, err := api.dccli.ReadConfig(ctx, dc.WorkspaceFolder, dc.ConfigPath,
+			[]string{
+				fmt.Sprintf("CODER_WORKSPACE_AGENT_NAME=%s", dc.Name),
+				fmt.Sprintf("CODER_WORKSPACE_OWNER_NAME=%s", api.userName),
+				fmt.Sprintf("CODER_WORKSPACE_NAME=%s", api.workspaceName),
+				fmt.Sprintf("CODER_DEPLOYMENT_URL=%s", api.subAgentURL),
+			},
+		); err != nil {
 			api.logger.Error(ctx, "unable to read devcontainer config", slog.Error(err))
 		} else {
 			coderCustomization := config.MergedConfiguration.Customizations.Coder

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1183,6 +1183,7 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 		slices.Sort(displayApps)
 
 		subAgentConfig.DisplayApps = displayApps
+		subAgentConfig.Apps = apps
 	}
 
 	deleteSubAgent := proc.agent.ID != uuid.Nil && maybeRecreateSubAgent && !proc.agent.EqualConfig(subAgentConfig)

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1151,7 +1151,7 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 				fmt.Sprintf("CODER_WORKSPACE_AGENT_NAME=%s", dc.Name),
 				fmt.Sprintf("CODER_WORKSPACE_OWNER_NAME=%s", api.userName),
 				fmt.Sprintf("CODER_WORKSPACE_NAME=%s", api.workspaceName),
-				fmt.Sprintf("CODER_DEPLOYMENT_URL=%s", api.subAgentURL),
+				fmt.Sprintf("CODER_URL=%s", api.subAgentURL),
 			},
 		); err != nil {
 			api.logger.Error(ctx, "unable to read devcontainer config", slog.Error(err))

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -64,7 +64,7 @@ type API struct {
 	subAgentURL                 string
 	subAgentEnv                 []string
 
-	userName      string
+	ownerName     string
 	workspaceName string
 
 	mu                      sync.RWMutex
@@ -156,17 +156,12 @@ func WithSubAgentEnv(env ...string) Option {
 	}
 }
 
-// WithWorkspaceName sets the workspace name for the sub-agent.
-func WithWorkspaceName(name string) Option {
+// WithManifestInfo sets the owner name, and workspace name
+// for the sub-agent.
+func WithManifestInfo(owner, workspace string) Option {
 	return func(api *API) {
-		api.workspaceName = name
-	}
-}
-
-// WithUserName sets the user name for the sub-agent.
-func WithUserName(name string) Option {
-	return func(api *API) {
-		api.userName = name
+		api.ownerName = owner
+		api.workspaceName = workspace
 	}
 }
 
@@ -1149,7 +1144,7 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 		if config, err := api.dccli.ReadConfig(ctx, dc.WorkspaceFolder, dc.ConfigPath,
 			[]string{
 				fmt.Sprintf("CODER_WORKSPACE_AGENT_NAME=%s", dc.Name),
-				fmt.Sprintf("CODER_WORKSPACE_OWNER_NAME=%s", api.userName),
+				fmt.Sprintf("CODER_WORKSPACE_OWNER_NAME=%s", api.ownerName),
 				fmt.Sprintf("CODER_WORKSPACE_NAME=%s", api.workspaceName),
 				fmt.Sprintf("CODER_URL=%s", api.subAgentURL),
 			},

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -163,7 +163,7 @@ func WithWorkspaceName(name string) Option {
 	}
 }
 
-// WithUserName sets the workspace name for the sub-agent.
+// WithUserName sets the user name for the sub-agent.
 func WithUserName(name string) Option {
 	return func(api *API) {
 		api.userName = name

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1294,8 +1294,7 @@ func TestAPI(t *testing.T) {
 			agentcontainers.WithSubAgentClient(fakeSAC),
 			agentcontainers.WithSubAgentURL("test-subagent-url"),
 			agentcontainers.WithDevcontainerCLI(fakeDCCLI),
-			agentcontainers.WithUserName("test-user"),
-			agentcontainers.WithWorkspaceName("test-workspace"),
+			agentcontainers.WithManifestInfo("test-user", "test-workspace"),
 		)
 		apiClose := func() {
 			closeOnce.Do(func() {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1322,7 +1322,7 @@ func TestAPI(t *testing.T) {
 			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
 			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
-			assert.Contains(t, envs, "CODER_DEPLOYMENT_URL=test-subagent-url")
+			assert.Contains(t, envs, "CODER_URL=test-subagent-url")
 			return nil
 		})
 
@@ -1469,7 +1469,7 @@ func TestAPI(t *testing.T) {
 			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
 			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
-			assert.Contains(t, envs, "CODER_DEPLOYMENT_URL=test-subagent-url")
+			assert.Contains(t, envs, "CODER_URL=test-subagent-url")
 			return nil
 		})
 

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentcontainers/acmock"
 	"github.com/coder/coder/v2/agent/agentcontainers/watcher"
-	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
@@ -1629,31 +1628,31 @@ func TestAPI(t *testing.T) {
 						Apps: []agentcontainers.SubAgentApp{
 							{
 								Slug:        "web-app",
-								DisplayName: ptr.Ref("Web Application"),
-								URL:         ptr.Ref("http://localhost:8080"),
-								OpenIn:      ptr.Ref(codersdk.WorkspaceAppOpenInTab),
-								Share:       ptr.Ref(codersdk.WorkspaceAppSharingLevelOwner),
-								Icon:        ptr.Ref("/icons/web.svg"),
-								Order:       ptr.Ref(int32(1)),
+								DisplayName: "Web Application",
+								URL:         "http://localhost:8080",
+								OpenIn:      codersdk.WorkspaceAppOpenInTab,
+								Share:       codersdk.WorkspaceAppSharingLevelOwner,
+								Icon:        "/icons/web.svg",
+								Order:       int32(1),
 							},
 							{
 								Slug:        "api-server",
-								DisplayName: ptr.Ref("API Server"),
-								URL:         ptr.Ref("http://localhost:3000"),
-								OpenIn:      ptr.Ref(codersdk.WorkspaceAppOpenInSlimWindow),
-								Share:       ptr.Ref(codersdk.WorkspaceAppSharingLevelAuthenticated),
-								Icon:        ptr.Ref("/icons/api.svg"),
-								Order:       ptr.Ref(int32(2)),
-								Hidden:      ptr.Ref(true),
+								DisplayName: "API Server",
+								URL:         "http://localhost:3000",
+								OpenIn:      codersdk.WorkspaceAppOpenInSlimWindow,
+								Share:       codersdk.WorkspaceAppSharingLevelAuthenticated,
+								Icon:        "/icons/api.svg",
+								Order:       int32(2),
+								Hidden:      true,
 							},
 							{
 								Slug:        "docs",
-								DisplayName: ptr.Ref("Documentation"),
-								URL:         ptr.Ref("http://localhost:4000"),
-								OpenIn:      ptr.Ref(codersdk.WorkspaceAppOpenInTab),
-								Share:       ptr.Ref(codersdk.WorkspaceAppSharingLevelPublic),
-								Icon:        ptr.Ref("/icons/book.svg"),
-								Order:       ptr.Ref(int32(3)),
+								DisplayName: "Documentation",
+								URL:         "http://localhost:4000",
+								OpenIn:      codersdk.WorkspaceAppOpenInTab,
+								Share:       codersdk.WorkspaceAppSharingLevelPublic,
+								Icon:        "/icons/book.svg",
+								Order:       int32(3),
 							},
 						},
 					},
@@ -1663,31 +1662,31 @@ func TestAPI(t *testing.T) {
 
 					// Verify first app
 					assert.Equal(t, "web-app", subAgent.Apps[0].Slug)
-					assert.Equal(t, "Web Application", *subAgent.Apps[0].DisplayName)
-					assert.Equal(t, "http://localhost:8080", *subAgent.Apps[0].URL)
-					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, *subAgent.Apps[0].OpenIn)
-					assert.Equal(t, codersdk.WorkspaceAppSharingLevelOwner, *subAgent.Apps[0].Share)
-					assert.Equal(t, "/icons/web.svg", *subAgent.Apps[0].Icon)
-					assert.Equal(t, int32(1), *subAgent.Apps[0].Order)
+					assert.Equal(t, "Web Application", subAgent.Apps[0].DisplayName)
+					assert.Equal(t, "http://localhost:8080", subAgent.Apps[0].URL)
+					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, subAgent.Apps[0].OpenIn)
+					assert.Equal(t, codersdk.WorkspaceAppSharingLevelOwner, subAgent.Apps[0].Share)
+					assert.Equal(t, "/icons/web.svg", subAgent.Apps[0].Icon)
+					assert.Equal(t, int32(1), subAgent.Apps[0].Order)
 
 					// Verify second app
 					assert.Equal(t, "api-server", subAgent.Apps[1].Slug)
-					assert.Equal(t, "API Server", *subAgent.Apps[1].DisplayName)
-					assert.Equal(t, "http://localhost:3000", *subAgent.Apps[1].URL)
-					assert.Equal(t, codersdk.WorkspaceAppOpenInSlimWindow, *subAgent.Apps[1].OpenIn)
-					assert.Equal(t, codersdk.WorkspaceAppSharingLevelAuthenticated, *subAgent.Apps[1].Share)
-					assert.Equal(t, "/icons/api.svg", *subAgent.Apps[1].Icon)
-					assert.Equal(t, int32(2), *subAgent.Apps[1].Order)
-					assert.Equal(t, true, *subAgent.Apps[1].Hidden)
+					assert.Equal(t, "API Server", subAgent.Apps[1].DisplayName)
+					assert.Equal(t, "http://localhost:3000", subAgent.Apps[1].URL)
+					assert.Equal(t, codersdk.WorkspaceAppOpenInSlimWindow, subAgent.Apps[1].OpenIn)
+					assert.Equal(t, codersdk.WorkspaceAppSharingLevelAuthenticated, subAgent.Apps[1].Share)
+					assert.Equal(t, "/icons/api.svg", subAgent.Apps[1].Icon)
+					assert.Equal(t, int32(2), subAgent.Apps[1].Order)
+					assert.Equal(t, true, subAgent.Apps[1].Hidden)
 
 					// Verify third app
 					assert.Equal(t, "docs", subAgent.Apps[2].Slug)
-					assert.Equal(t, "Documentation", *subAgent.Apps[2].DisplayName)
-					assert.Equal(t, "http://localhost:4000", *subAgent.Apps[2].URL)
-					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, *subAgent.Apps[2].OpenIn)
-					assert.Equal(t, codersdk.WorkspaceAppSharingLevelPublic, *subAgent.Apps[2].Share)
-					assert.Equal(t, "/icons/book.svg", *subAgent.Apps[2].Icon)
-					assert.Equal(t, int32(3), *subAgent.Apps[2].Order)
+					assert.Equal(t, "Documentation", subAgent.Apps[2].DisplayName)
+					assert.Equal(t, "http://localhost:4000", subAgent.Apps[2].URL)
+					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, subAgent.Apps[2].OpenIn)
+					assert.Equal(t, codersdk.WorkspaceAppSharingLevelPublic, subAgent.Apps[2].Share)
+					assert.Equal(t, "/icons/book.svg", subAgent.Apps[2].Icon)
+					assert.Equal(t, int32(3), subAgent.Apps[2].Order)
 				},
 			},
 		}

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1319,9 +1319,9 @@ func TestAPI(t *testing.T) {
 			return nil
 		}) // Exec pwd.
 		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) (agentcontainers.DevcontainerConfig, error) {
-			assert.Contains(t, envs, "CODER_AGENT_NAME=test-container")
+			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
-			assert.Contains(t, envs, "CODER_USER_NAME=test-user")
+			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
 			assert.Contains(t, envs, "CODER_DEPLOYMENT_URL=test-subagent-url")
 			return agentcontainers.DevcontainerConfig{}, nil
 		})
@@ -1466,9 +1466,9 @@ func TestAPI(t *testing.T) {
 			return nil
 		}) // Exec pwd.
 		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) (agentcontainers.DevcontainerConfig, error) {
-			assert.Contains(t, envs, "CODER_AGENT_NAME=test-container")
+			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
-			assert.Contains(t, envs, "CODER_USER_NAME=test-user")
+			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
 			assert.Contains(t, envs, "CODER_DEPLOYMENT_URL=test-subagent-url")
 			return agentcontainers.DevcontainerConfig{}, nil
 		})
@@ -1631,8 +1631,8 @@ func TestAPI(t *testing.T) {
 								Slug:        "web-app",
 								DisplayName: ptr.Ref("Web Application"),
 								URL:         ptr.Ref("http://localhost:8080"),
-								OpenIn:      codersdk.WorkspaceAppOpenInTab,
-								Share:       codersdk.WorkspaceAppSharingLevelOwner,
+								OpenIn:      ptr.Ref(codersdk.WorkspaceAppOpenInTab),
+								Share:       ptr.Ref(codersdk.WorkspaceAppSharingLevelOwner),
 								Icon:        ptr.Ref("/icons/web.svg"),
 								Order:       ptr.Ref(int32(1)),
 							},
@@ -1640,8 +1640,8 @@ func TestAPI(t *testing.T) {
 								Slug:        "api-server",
 								DisplayName: ptr.Ref("API Server"),
 								URL:         ptr.Ref("http://localhost:3000"),
-								OpenIn:      codersdk.WorkspaceAppOpenInSlimWindow,
-								Share:       codersdk.WorkspaceAppSharingLevelAuthenticated,
+								OpenIn:      ptr.Ref(codersdk.WorkspaceAppOpenInSlimWindow),
+								Share:       ptr.Ref(codersdk.WorkspaceAppSharingLevelAuthenticated),
 								Icon:        ptr.Ref("/icons/api.svg"),
 								Order:       ptr.Ref(int32(2)),
 								Hidden:      ptr.Ref(true),
@@ -1650,8 +1650,8 @@ func TestAPI(t *testing.T) {
 								Slug:        "docs",
 								DisplayName: ptr.Ref("Documentation"),
 								URL:         ptr.Ref("http://localhost:4000"),
-								OpenIn:      codersdk.WorkspaceAppOpenInTab,
-								Share:       codersdk.WorkspaceAppSharingLevelPublic,
+								OpenIn:      ptr.Ref(codersdk.WorkspaceAppOpenInTab),
+								Share:       ptr.Ref(codersdk.WorkspaceAppSharingLevelPublic),
 								Icon:        ptr.Ref("/icons/book.svg"),
 								Order:       ptr.Ref(int32(3)),
 							},
@@ -1665,8 +1665,8 @@ func TestAPI(t *testing.T) {
 					assert.Equal(t, "web-app", subAgent.Apps[0].Slug)
 					assert.Equal(t, "Web Application", *subAgent.Apps[0].DisplayName)
 					assert.Equal(t, "http://localhost:8080", *subAgent.Apps[0].URL)
-					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, subAgent.Apps[0].OpenIn)
-					assert.Equal(t, codersdk.WorkspaceAppSharingLevelOwner, subAgent.Apps[0].Share)
+					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, *subAgent.Apps[0].OpenIn)
+					assert.Equal(t, codersdk.WorkspaceAppSharingLevelOwner, *subAgent.Apps[0].Share)
 					assert.Equal(t, "/icons/web.svg", *subAgent.Apps[0].Icon)
 					assert.Equal(t, int32(1), *subAgent.Apps[0].Order)
 
@@ -1674,8 +1674,8 @@ func TestAPI(t *testing.T) {
 					assert.Equal(t, "api-server", subAgent.Apps[1].Slug)
 					assert.Equal(t, "API Server", *subAgent.Apps[1].DisplayName)
 					assert.Equal(t, "http://localhost:3000", *subAgent.Apps[1].URL)
-					assert.Equal(t, codersdk.WorkspaceAppOpenInSlimWindow, subAgent.Apps[1].OpenIn)
-					assert.Equal(t, codersdk.WorkspaceAppSharingLevelAuthenticated, subAgent.Apps[1].Share)
+					assert.Equal(t, codersdk.WorkspaceAppOpenInSlimWindow, *subAgent.Apps[1].OpenIn)
+					assert.Equal(t, codersdk.WorkspaceAppSharingLevelAuthenticated, *subAgent.Apps[1].Share)
 					assert.Equal(t, "/icons/api.svg", *subAgent.Apps[1].Icon)
 					assert.Equal(t, int32(2), *subAgent.Apps[1].Order)
 					assert.Equal(t, true, *subAgent.Apps[1].Hidden)
@@ -1684,8 +1684,8 @@ func TestAPI(t *testing.T) {
 					assert.Equal(t, "docs", subAgent.Apps[2].Slug)
 					assert.Equal(t, "Documentation", *subAgent.Apps[2].DisplayName)
 					assert.Equal(t, "http://localhost:4000", *subAgent.Apps[2].URL)
-					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, subAgent.Apps[2].OpenIn)
-					assert.Equal(t, codersdk.WorkspaceAppSharingLevelPublic, subAgent.Apps[2].Share)
+					assert.Equal(t, codersdk.WorkspaceAppOpenInTab, *subAgent.Apps[2].OpenIn)
+					assert.Equal(t, codersdk.WorkspaceAppSharingLevelPublic, *subAgent.Apps[2].Share)
 					assert.Equal(t, "/icons/book.svg", *subAgent.Apps[2].Icon)
 					assert.Equal(t, int32(3), *subAgent.Apps[2].Order)
 				},

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1718,7 +1718,7 @@ func TestAPI(t *testing.T) {
 				afterCreate: func(t *testing.T, subAgent agentcontainers.SubAgent) {
 					require.Len(t, subAgent.Apps, 3)
 
-					// As the original "foo-app" gets overriden by the later "foo-app",
+					// As the original "foo-app" gets overridden by the later "foo-app",
 					// we expect "bar-app" to be first in the order.
 					assert.Equal(t, "bar-app", subAgent.Apps[0].Slug)
 					assert.Equal(t, "foo-app", subAgent.Apps[1].Slug)

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -265,7 +265,7 @@ func (d *devcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, confi
 	}
 
 	c := d.execer.CommandContext(ctx, "devcontainer", args...)
-	c.Env = append(c.Env, os.Environ()...)
+	c.Env = append(c.Env, "PATH="+os.Getenv("PATH"))
 	c.Env = append(c.Env, env...)
 
 	var stdoutBuf bytes.Buffer

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
 
 	"golang.org/x/xerrors"
 
@@ -264,7 +265,7 @@ func (d *devcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, confi
 	}
 
 	c := d.execer.CommandContext(ctx, "devcontainer", args...)
-	// c.Env = append(c.Env, env...)
+	c.Env = append(os.Environ(), env...)
 
 	var stdoutBuf bytes.Buffer
 	stdoutWriters := []io.Writer{&stdoutBuf, &devcontainerCLILogWriter{ctx: ctx, logger: logger.With(slog.F("stdout", true))}}

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -265,7 +265,8 @@ func (d *devcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, confi
 	}
 
 	c := d.execer.CommandContext(ctx, "devcontainer", args...)
-	c.Env = append(os.Environ(), env...)
+	c.Env = append(c.Env, os.Environ()...)
+	c.Env = append(c.Env, env...)
 
 	var stdoutBuf bytes.Buffer
 	stdoutWriters := []io.Writer{&stdoutBuf, &devcontainerCLILogWriter{ctx: ctx, logger: logger.With(slog.F("stdout", true))}}

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -264,7 +264,7 @@ func (d *devcontainerCLI) ReadConfig(ctx context.Context, workspaceFolder, confi
 	}
 
 	c := d.execer.CommandContext(ctx, "devcontainer", args...)
-	c.Env = append(c.Env, env...)
+	// c.Env = append(c.Env, env...)
 
 	var stdoutBuf bytes.Buffer
 	stdoutWriters := []io.Writer{&stdoutBuf, &devcontainerCLILogWriter{ctx: ctx, logger: logger.With(slog.F("stdout", true))}}

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -316,7 +316,7 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 				}
 
 				dccli := agentcontainers.NewDevcontainerCLI(logger, testExecer)
-				config, err := dccli.ReadConfig(ctx, tt.workspaceFolder, tt.configPath, tt.opts...)
+				config, err := dccli.ReadConfig(ctx, tt.workspaceFolder, tt.configPath, []string{}, tt.opts...)
 				if tt.wantError {
 					assert.Error(t, err, "want error")
 					assert.Equal(t, agentcontainers.DevcontainerConfig{}, config, "expected empty config on error")

--- a/agent/agentcontainers/subagent.go
+++ b/agent/agentcontainers/subagent.go
@@ -34,6 +34,7 @@ func (s SubAgent) CloneConfig(dc codersdk.WorkspaceAgentDevcontainer) SubAgent {
 		Architecture:    s.Architecture,
 		OperatingSystem: s.OperatingSystem,
 		DisplayApps:     slices.Clone(s.DisplayApps),
+		Apps:            slices.Clone(s.Apps),
 	}
 }
 

--- a/agent/agentcontainers/subagent.go
+++ b/agent/agentcontainers/subagent.go
@@ -181,6 +181,8 @@ func (a *subAgentAPIClient) Create(ctx context.Context, agent SubAgent) (SubAgen
 				share = agentproto.CreateSubAgentRequest_App_OWNER.Enum()
 			case codersdk.WorkspaceAppSharingLevelPublic:
 				share = agentproto.CreateSubAgentRequest_App_PUBLIC.Enum()
+			case codersdk.WorkspaceAppSharingLevelOrganization:
+				share = agentproto.CreateSubAgentRequest_App_ORGANIZATION.Enum()
 			default:
 				return SubAgent{}, xerrors.Errorf("unexpected codersdk.WorkspaceAppSharingLevel: %#v", app.Share)
 			}

--- a/agent/agentcontainers/subagent.go
+++ b/agent/agentcontainers/subagent.go
@@ -47,19 +47,19 @@ func (s SubAgent) EqualConfig(other SubAgent) bool {
 }
 
 type SubAgentApp struct {
-	Slug        string                            `json:"slug"`
-	Command     *string                           `json:"command"`
-	DisplayName *string                           `json:"displayName"`
-	External    *bool                             `json:"external"`
-	Group       *string                           `json:"group"`
-	HealthCheck *SubAgentHealthCheck              `json:"healthCheck"`
-	Hidden      *bool                             `json:"hidden"`
-	Icon        *string                           `json:"icon"`
-	OpenIn      codersdk.WorkspaceAppOpenIn       `json:"openIn"`
-	Order       *int32                            `json:"order"`
-	Share       codersdk.WorkspaceAppSharingLevel `json:"share"`
-	Subdomain   *bool                             `json:"subdomain"`
-	URL         *string                           `json:"url"`
+	Slug        string                             `json:"slug"`
+	Command     *string                            `json:"command"`
+	DisplayName *string                            `json:"displayName"`
+	External    *bool                              `json:"external"`
+	Group       *string                            `json:"group"`
+	HealthCheck *SubAgentHealthCheck               `json:"healthCheck"`
+	Hidden      *bool                              `json:"hidden"`
+	Icon        *string                            `json:"icon"`
+	OpenIn      *codersdk.WorkspaceAppOpenIn       `json:"openIn"`
+	Order       *int32                             `json:"order"`
+	Share       *codersdk.WorkspaceAppSharingLevel `json:"share"`
+	Subdomain   *bool                              `json:"subdomain"`
+	URL         *string                            `json:"url"`
 }
 
 type SubAgentHealthCheck struct {
@@ -161,25 +161,29 @@ func (a *subAgentAPIClient) Create(ctx context.Context, agent SubAgent) (SubAgen
 		}
 
 		var openIn *agentproto.CreateSubAgentRequest_App_OpenIn
-		switch app.OpenIn {
-		case codersdk.WorkspaceAppOpenInSlimWindow:
-			openIn = agentproto.CreateSubAgentRequest_App_SLIM_WINDOW.Enum()
-		case codersdk.WorkspaceAppOpenInTab:
-			openIn = agentproto.CreateSubAgentRequest_App_TAB.Enum()
-		default:
-			return SubAgent{}, xerrors.Errorf("unexpected codersdk.WorkspaceAppOpenIn: %#v", app.OpenIn)
+		if app.OpenIn != nil {
+			switch *app.OpenIn {
+			case codersdk.WorkspaceAppOpenInSlimWindow:
+				openIn = agentproto.CreateSubAgentRequest_App_SLIM_WINDOW.Enum()
+			case codersdk.WorkspaceAppOpenInTab:
+				openIn = agentproto.CreateSubAgentRequest_App_TAB.Enum()
+			default:
+				return SubAgent{}, xerrors.Errorf("unexpected codersdk.WorkspaceAppOpenIn: %#v", app.OpenIn)
+			}
 		}
 
 		var share *agentproto.CreateSubAgentRequest_App_SharingLevel
-		switch app.Share {
-		case codersdk.WorkspaceAppSharingLevelAuthenticated:
-			share = agentproto.CreateSubAgentRequest_App_AUTHENTICATED.Enum()
-		case codersdk.WorkspaceAppSharingLevelOwner:
-			share = agentproto.CreateSubAgentRequest_App_OWNER.Enum()
-		case codersdk.WorkspaceAppSharingLevelPublic:
-			share = agentproto.CreateSubAgentRequest_App_PUBLIC.Enum()
-		default:
-			return SubAgent{}, xerrors.Errorf("unexpected codersdk.WorkspaceAppSharingLevel: %#v", app.Share)
+		if app.Share != nil {
+			switch *app.Share {
+			case codersdk.WorkspaceAppSharingLevelAuthenticated:
+				share = agentproto.CreateSubAgentRequest_App_AUTHENTICATED.Enum()
+			case codersdk.WorkspaceAppSharingLevelOwner:
+				share = agentproto.CreateSubAgentRequest_App_OWNER.Enum()
+			case codersdk.WorkspaceAppSharingLevelPublic:
+				share = agentproto.CreateSubAgentRequest_App_PUBLIC.Enum()
+			default:
+				return SubAgent{}, xerrors.Errorf("unexpected codersdk.WorkspaceAppSharingLevel: %#v", app.Share)
+			}
 		}
 
 		apps = append(apps, &agentproto.CreateSubAgentRequest_App{

--- a/agent/agentcontainers/subagent_test.go
+++ b/agent/agentcontainers/subagent_test.go
@@ -131,22 +131,22 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 				apps: []agentcontainers.SubAgentApp{
 					{
 						Slug:        "jupyter",
-						Command:     ptr.Ref("jupyter lab --port=8888"),
-						DisplayName: ptr.Ref("Jupyter Lab"),
-						External:    ptr.Ref(false),
-						Group:       ptr.Ref("Development"),
-						HealthCheck: &agentcontainers.SubAgentHealthCheck{
+						Command:     "jupyter lab --port=8888",
+						DisplayName: "Jupyter Lab",
+						External:    false,
+						Group:       "Development",
+						HealthCheck: agentcontainers.SubAgentHealthCheck{
 							Interval:  30,
 							Threshold: 3,
 							URL:       "http://localhost:8888/api",
 						},
-						Hidden:    ptr.Ref(false),
-						Icon:      ptr.Ref("/icon/jupyter.svg"),
-						OpenIn:    ptr.Ref(codersdk.WorkspaceAppOpenInTab),
-						Order:     ptr.Ref(int32(1)),
-						Share:     ptr.Ref(codersdk.WorkspaceAppSharingLevelAuthenticated),
-						Subdomain: ptr.Ref(true),
-						URL:       ptr.Ref("http://localhost:8888"),
+						Hidden:    false,
+						Icon:      "/icon/jupyter.svg",
+						OpenIn:    codersdk.WorkspaceAppOpenInTab,
+						Order:     int32(1),
+						Share:     codersdk.WorkspaceAppSharingLevelAuthenticated,
+						Subdomain: true,
+						URL:       "http://localhost:8888",
 					},
 				},
 				expectedApps: []*agentproto.CreateSubAgentRequest_App{
@@ -176,19 +176,19 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 				apps: []agentcontainers.SubAgentApp{
 					{
 						Slug:  "owner-app",
-						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelOwner),
+						Share: codersdk.WorkspaceAppSharingLevelOwner,
 					},
 					{
 						Slug:  "authenticated-app",
-						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelAuthenticated),
+						Share: codersdk.WorkspaceAppSharingLevelAuthenticated,
 					},
 					{
 						Slug:  "public-app",
-						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelPublic),
+						Share: codersdk.WorkspaceAppSharingLevelPublic,
 					},
 					{
 						Slug:  "organization-app",
-						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelOrganization),
+						Share: codersdk.WorkspaceAppSharingLevelOrganization,
 					},
 				},
 				expectedApps: []*agentproto.CreateSubAgentRequest_App{
@@ -215,7 +215,7 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 				apps: []agentcontainers.SubAgentApp{
 					{
 						Slug: "health-app",
-						HealthCheck: &agentcontainers.SubAgentHealthCheck{
+						HealthCheck: agentcontainers.SubAgentHealthCheck{
 							Interval:  60,
 							Threshold: 5,
 							URL:       "http://localhost:3000/health",
@@ -271,12 +271,12 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 					assert.Equal(t, expectedApp.Slug, actualApp.Slug)
 					assert.Equal(t, expectedApp.Command, actualApp.Command)
 					assert.Equal(t, expectedApp.DisplayName, actualApp.DisplayName)
-					assert.Equal(t, expectedApp.External, actualApp.External)
+					assert.Equal(t, ptr.NilToEmpty(expectedApp.External), ptr.NilToEmpty(actualApp.External))
 					assert.Equal(t, expectedApp.Group, actualApp.Group)
-					assert.Equal(t, expectedApp.Hidden, actualApp.Hidden)
+					assert.Equal(t, ptr.NilToEmpty(expectedApp.Hidden), ptr.NilToEmpty(actualApp.Hidden))
 					assert.Equal(t, expectedApp.Icon, actualApp.Icon)
-					assert.Equal(t, expectedApp.Order, actualApp.Order)
-					assert.Equal(t, expectedApp.Subdomain, actualApp.Subdomain)
+					assert.Equal(t, ptr.NilToEmpty(expectedApp.Order), ptr.NilToEmpty(actualApp.Order))
+					assert.Equal(t, ptr.NilToEmpty(expectedApp.Subdomain), ptr.NilToEmpty(actualApp.Subdomain))
 					assert.Equal(t, expectedApp.Url, actualApp.Url)
 
 					if expectedApp.OpenIn != nil {

--- a/agent/agentcontainers/subagent_test.go
+++ b/agent/agentcontainers/subagent_test.go
@@ -186,6 +186,10 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 						Slug:  "public-app",
 						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelPublic),
 					},
+					{
+						Slug:  "organization-app",
+						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelOrganization),
+					},
 				},
 				expectedApps: []*agentproto.CreateSubAgentRequest_App{
 					{
@@ -199,6 +203,10 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 					{
 						Slug:  "public-app",
 						Share: agentproto.CreateSubAgentRequest_App_PUBLIC.Enum(),
+					},
+					{
+						Slug:  "organization-app",
+						Share: agentproto.CreateSubAgentRequest_App_ORGANIZATION.Enum(),
 					},
 				},
 			},

--- a/agent/agentcontainers/subagent_test.go
+++ b/agent/agentcontainers/subagent_test.go
@@ -114,24 +114,20 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 			expectedApps []*agentproto.CreateSubAgentRequest_App
 		}{
 			{
-				name: "single app with minimal fields",
+				name: "SlugOnly",
 				apps: []agentcontainers.SubAgentApp{
 					{
-						Slug:   "code-server",
-						OpenIn: codersdk.WorkspaceAppOpenInSlimWindow,
-						Share:  codersdk.WorkspaceAppSharingLevelOwner,
+						Slug: "code-server",
 					},
 				},
 				expectedApps: []*agentproto.CreateSubAgentRequest_App{
 					{
-						Slug:   "code-server",
-						OpenIn: agentproto.CreateSubAgentRequest_App_SLIM_WINDOW.Enum(),
-						Share:  agentproto.CreateSubAgentRequest_App_OWNER.Enum(),
+						Slug: "code-server",
 					},
 				},
 			},
 			{
-				name: "single app with all fields",
+				name: "AllFields",
 				apps: []agentcontainers.SubAgentApp{
 					{
 						Slug:        "jupyter",
@@ -146,9 +142,9 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 						},
 						Hidden:    ptr.Ref(false),
 						Icon:      ptr.Ref("/icon/jupyter.svg"),
-						OpenIn:    codersdk.WorkspaceAppOpenInTab,
+						OpenIn:    ptr.Ref(codersdk.WorkspaceAppOpenInTab),
 						Order:     ptr.Ref(int32(1)),
-						Share:     codersdk.WorkspaceAppSharingLevelAuthenticated,
+						Share:     ptr.Ref(codersdk.WorkspaceAppSharingLevelAuthenticated),
 						Subdomain: ptr.Ref(true),
 						URL:       ptr.Ref("http://localhost:8888"),
 					},
@@ -176,44 +172,38 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 				},
 			},
 			{
-				name: "multiple apps with different sharing levels",
+				name: "AllSharingLevels",
 				apps: []agentcontainers.SubAgentApp{
 					{
-						Slug:   "owner-app",
-						OpenIn: codersdk.WorkspaceAppOpenInSlimWindow,
-						Share:  codersdk.WorkspaceAppSharingLevelOwner,
+						Slug:  "owner-app",
+						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelOwner),
 					},
 					{
-						Slug:   "authenticated-app",
-						OpenIn: codersdk.WorkspaceAppOpenInTab,
-						Share:  codersdk.WorkspaceAppSharingLevelAuthenticated,
+						Slug:  "authenticated-app",
+						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelAuthenticated),
 					},
 					{
-						Slug:   "public-app",
-						OpenIn: codersdk.WorkspaceAppOpenInSlimWindow,
-						Share:  codersdk.WorkspaceAppSharingLevelPublic,
+						Slug:  "public-app",
+						Share: ptr.Ref(codersdk.WorkspaceAppSharingLevelPublic),
 					},
 				},
 				expectedApps: []*agentproto.CreateSubAgentRequest_App{
 					{
-						Slug:   "owner-app",
-						OpenIn: agentproto.CreateSubAgentRequest_App_SLIM_WINDOW.Enum(),
-						Share:  agentproto.CreateSubAgentRequest_App_OWNER.Enum(),
+						Slug:  "owner-app",
+						Share: agentproto.CreateSubAgentRequest_App_OWNER.Enum(),
 					},
 					{
-						Slug:   "authenticated-app",
-						OpenIn: agentproto.CreateSubAgentRequest_App_TAB.Enum(),
-						Share:  agentproto.CreateSubAgentRequest_App_AUTHENTICATED.Enum(),
+						Slug:  "authenticated-app",
+						Share: agentproto.CreateSubAgentRequest_App_AUTHENTICATED.Enum(),
 					},
 					{
-						Slug:   "public-app",
-						OpenIn: agentproto.CreateSubAgentRequest_App_SLIM_WINDOW.Enum(),
-						Share:  agentproto.CreateSubAgentRequest_App_PUBLIC.Enum(),
+						Slug:  "public-app",
+						Share: agentproto.CreateSubAgentRequest_App_PUBLIC.Enum(),
 					},
 				},
 			},
 			{
-				name: "app with health check",
+				name: "WithHealthCheck",
 				apps: []agentcontainers.SubAgentApp{
 					{
 						Slug: "health-app",
@@ -222,8 +212,6 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 							Threshold: 5,
 							URL:       "http://localhost:3000/health",
 						},
-						OpenIn: codersdk.WorkspaceAppOpenInSlimWindow,
-						Share:  codersdk.WorkspaceAppSharingLevelOwner,
 					},
 				},
 				expectedApps: []*agentproto.CreateSubAgentRequest_App{
@@ -234,31 +222,8 @@ func TestSubAgentClient_CreateWithDisplayApps(t *testing.T) {
 							Threshold: 5,
 							Url:       "http://localhost:3000/health",
 						},
-						OpenIn: agentproto.CreateSubAgentRequest_App_SLIM_WINDOW.Enum(),
-						Share:  agentproto.CreateSubAgentRequest_App_OWNER.Enum(),
 					},
 				},
-			},
-			{
-				name: "app without health check",
-				apps: []agentcontainers.SubAgentApp{
-					{
-						Slug:   "no-health-app",
-						OpenIn: codersdk.WorkspaceAppOpenInTab,
-						Share:  codersdk.WorkspaceAppSharingLevelOwner,
-					},
-				},
-				expectedApps: []*agentproto.CreateSubAgentRequest_App{
-					{
-						Slug:   "no-health-app",
-						OpenIn: agentproto.CreateSubAgentRequest_App_TAB.Enum(),
-						Share:  agentproto.CreateSubAgentRequest_App_OWNER.Enum(),
-					},
-				},
-			},
-			{
-				name: "no apps",
-				apps: []agentcontainers.SubAgentApp{},
 			},
 		}
 

--- a/agent/api.go
+++ b/agent/api.go
@@ -49,7 +49,7 @@ func (a *agent) apiHandler(aAPI proto.DRPCAgentClient26) (http.Handler, func() e
 			agentcontainers.WithSubAgentClient(agentcontainers.NewSubAgentClientFromAPI(a.logger, aAPI)),
 		}
 		manifest := a.manifest.Load()
-		if manifest != nil && len(manifest.Devcontainers) > 0 {
+		if manifest != nil {
 			containerAPIOpts = append(containerAPIOpts,
 				agentcontainers.WithUserName(manifest.OwnerName),
 				agentcontainers.WithWorkspaceName(manifest.WorkspaceName),

--- a/agent/api.go
+++ b/agent/api.go
@@ -50,10 +50,17 @@ func (a *agent) apiHandler(aAPI proto.DRPCAgentClient26) (http.Handler, func() e
 		}
 		manifest := a.manifest.Load()
 		if manifest != nil && len(manifest.Devcontainers) > 0 {
-			containerAPIOpts = append(
-				containerAPIOpts,
-				agentcontainers.WithDevcontainers(manifest.Devcontainers, manifest.Scripts),
+			containerAPIOpts = append(containerAPIOpts,
+				agentcontainers.WithUserName(manifest.OwnerName),
+				agentcontainers.WithWorkspaceName(manifest.WorkspaceName),
 			)
+
+			if len(manifest.Devcontainers) > 0 {
+				containerAPIOpts = append(
+					containerAPIOpts,
+					agentcontainers.WithDevcontainers(manifest.Devcontainers, manifest.Scripts),
+				)
+			}
 		}
 
 		// Append after to allow the agent options to override the default options.

--- a/agent/api.go
+++ b/agent/api.go
@@ -51,8 +51,7 @@ func (a *agent) apiHandler(aAPI proto.DRPCAgentClient26) (http.Handler, func() e
 		manifest := a.manifest.Load()
 		if manifest != nil {
 			containerAPIOpts = append(containerAPIOpts,
-				agentcontainers.WithUserName(manifest.OwnerName),
-				agentcontainers.WithWorkspaceName(manifest.WorkspaceName),
+				agentcontainers.WithManifestInfo(manifest.OwnerName, manifest.WorkspaceName),
 			)
 
 			if len(manifest.Devcontainers) > 0 {

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -99,8 +99,6 @@ export const Workspace: FC<WorkspaceProps> = ({
 	const shouldShowProvisionerAlert =
 		workspacePending && !haveBuildLogs && !provisionersHealthy && !isRestarting;
 
-	console.log(selectedResource?.agents);
-
 	return (
 		<div
 			css={{

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -99,6 +99,8 @@ export const Workspace: FC<WorkspaceProps> = ({
 	const shouldShowProvisionerAlert =
 		workspacePending && !haveBuildLogs && !provisionersHealthy && !isRestarting;
 
+	console.log(selectedResource?.agents);
+
 	return (
 		<div
 			css={{


### PR DESCRIPTION
Add apps to the sub agent based on the dev container customization.

```
{
  "name": "Development Container",
  "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
  "customizations": {
    "coder": {
      "apps": [
        {
          "slug": "web-app",
          "displayName": "Web Application",
          "url": "http://localhost:8080/${localEnv:CODER_USER_NAME}/${localEnv:CODER_WORKSPACE_NAME}/${localEnv:CODER_AGENT_NAME}",
          "openIn": "tab",
          "share": "owner",
          "icon": "${localEnv:CODER_URL}/icons/web.svg",
          "order": 1,
          "group": "Web Editors"
        }
      ]
    }
  }
}
```

The implementation also provides the following env variables for use in the devcontainer json

- `CODER_WORKSPACE_AGENT_NAME`
- `CODER_WORKSPACE_USER_NAME`
- `CODER_WORKSPACE_NAME`
- `CODER_URL`