### PR TITLE
fix: show error message for incompatible parameters

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -596,11 +596,18 @@ export const CreateWorkspacePageViewExperimental: FC<
 									const currentParameterValueIndex =
 										form.values.rich_parameter_values?.findIndex(
 											(p) => p.name === parameter.name,
-										) ?? -1;
+										);
 									const parameterFieldIndex =
-										currentParameterValueIndex !== -1
+										currentParameterValueIndex !== undefined
 											? currentParameterValueIndex
 											: index;
+									// Get the form value by parameter name to ensure correct value mapping
+									const formValue =
+										currentParameterValueIndex !== undefined
+											? form.values?.rich_parameter_values?.[
+													currentParameterValueIndex
+												]?.value || ""
+											: "";
 									const parameterField = `rich_parameter_values.${parameterFieldIndex}`;
 									const isPresetParameter = presetParameterNames.includes(
 										parameter.name,
@@ -621,14 +628,6 @@ export const CreateWorkspacePageViewExperimental: FC<
 									) {
 										return null;
 									}
-
-									// Get the form value by parameter name to ensure correct value mapping
-									const formValue =
-										currentParameterValueIndex !== -1
-											? form.values?.rich_parameter_values?.[
-													currentParameterValueIndex
-												]?.value || ""
-											: "";
 
 									return (
 										<DynamicParameter


### PR DESCRIPTION
resolves coder/preview#148

If there are any immutable params with diagnostics on the workspace parameters page, display this error dialog.

<img width="838" alt="Screenshot 2025-06-13 at 18 06 36" src="https://github.com/user-attachments/assets/47a9ad04-7969-4567-a5fc-39301c5f830c" />
