### PR TITLE
chore: support the has_ai_task column in template version and workspace insert queries

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -369,6 +369,7 @@ func WorkspaceBuild(t testing.TB, db database.Store, orig database.WorkspaceBuil
 				UUID:  uuid.UUID{},
 				Valid: false,
 			}),
+			HasAITask: orig.HasAITask,
 		})
 		if err != nil {
 			return err
@@ -943,6 +944,7 @@ func TemplateVersion(t testing.TB, db database.Store, orig database.TemplateVers
 			JobID:           takeFirst(orig.JobID, uuid.New()),
 			CreatedBy:       takeFirst(orig.CreatedBy, uuid.New()),
 			SourceExampleID: takeFirst(orig.SourceExampleID, sql.NullString{}),
+			HasAITask:       orig.HasAITask,
 		})
 		if err != nil {
 			return err

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -9382,6 +9382,7 @@ func (q *FakeQuerier) InsertTemplateVersion(_ context.Context, arg database.Inse
 		JobID:           arg.JobID,
 		CreatedBy:       arg.CreatedBy,
 		SourceExampleID: arg.SourceExampleID,
+		HasAITask:       arg.HasAITask,
 	}
 	q.templateVersions = append(q.templateVersions, version)
 	return nil
@@ -10061,6 +10062,7 @@ func (q *FakeQuerier) InsertWorkspaceBuild(_ context.Context, arg database.Inser
 		MaxDeadline:             arg.MaxDeadline,
 		Reason:                  arg.Reason,
 		TemplateVersionPresetID: arg.TemplateVersionPresetID,
+		HasAITask:               arg.HasAITask,
 	}
 	q.workspaceBuilds = append(q.workspaceBuilds, workspaceBuild)
 	return nil

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -11809,10 +11809,11 @@ INSERT INTO
 		readme,
 		job_id,
 		created_by,
-		source_example_id
+		source_example_id,
+		has_ai_task
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 `
 
 type InsertTemplateVersionParams struct {
@@ -11827,6 +11828,7 @@ type InsertTemplateVersionParams struct {
 	JobID           uuid.UUID      `db:"job_id" json:"job_id"`
 	CreatedBy       uuid.UUID      `db:"created_by" json:"created_by"`
 	SourceExampleID sql.NullString `db:"source_example_id" json:"source_example_id"`
+	HasAITask       bool           `db:"has_ai_task" json:"has_ai_task"`
 }
 
 func (q *sqlQuerier) InsertTemplateVersion(ctx context.Context, arg InsertTemplateVersionParams) error {
@@ -11842,6 +11844,7 @@ func (q *sqlQuerier) InsertTemplateVersion(ctx context.Context, arg InsertTempla
 		arg.JobID,
 		arg.CreatedBy,
 		arg.SourceExampleID,
+		arg.HasAITask,
 	)
 	return err
 }
@@ -17521,10 +17524,11 @@ INSERT INTO
 		deadline,
 		max_deadline,
 		reason,
-		template_version_preset_id
+		template_version_preset_id,
+		has_ai_task
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 `
 
 type InsertWorkspaceBuildParams struct {
@@ -17542,6 +17546,7 @@ type InsertWorkspaceBuildParams struct {
 	MaxDeadline             time.Time           `db:"max_deadline" json:"max_deadline"`
 	Reason                  BuildReason         `db:"reason" json:"reason"`
 	TemplateVersionPresetID uuid.NullUUID       `db:"template_version_preset_id" json:"template_version_preset_id"`
+	HasAITask               bool                `db:"has_ai_task" json:"has_ai_task"`
 }
 
 func (q *sqlQuerier) InsertWorkspaceBuild(ctx context.Context, arg InsertWorkspaceBuildParams) error {
@@ -17560,6 +17565,7 @@ func (q *sqlQuerier) InsertWorkspaceBuild(ctx context.Context, arg InsertWorkspa
 		arg.MaxDeadline,
 		arg.Reason,
 		arg.TemplateVersionPresetID,
+		arg.HasAITask,
 	)
 	return err
 }

--- a/coderd/database/queries/templateversions.sql
+++ b/coderd/database/queries/templateversions.sql
@@ -88,10 +88,11 @@ INSERT INTO
 		readme,
 		job_id,
 		created_by,
-		source_example_id
+		source_example_id,
+		has_ai_task
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
 
 -- name: UpdateTemplateVersionByID :exec
 UPDATE

--- a/coderd/database/queries/workspacebuilds.sql
+++ b/coderd/database/queries/workspacebuilds.sql
@@ -121,10 +121,11 @@ INSERT INTO
 		deadline,
 		max_deadline,
 		reason,
-		template_version_preset_id
+		template_version_preset_id,
+		has_ai_task
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);
 
 -- name: UpdateWorkspaceBuildCostByID :exec
 UPDATE

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1730,6 +1730,9 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 				String: req.ExampleID,
 				Valid:  req.ExampleID != "",
 			},
+			// appease the exhaustruct linter
+			// TODO: set this to whether the template version defines a `coder_ai_task` tf resource
+			HasAITask: false,
 		})
 		if err != nil {
 			if database.IsUniqueViolation(err, database.UniqueTemplateVersionsTemplateIDNameKey) {

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -425,6 +425,9 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 				UUID:  b.templateVersionPresetID,
 				Valid: b.templateVersionPresetID != uuid.Nil,
 			},
+			// appease the exhaustruct linter
+			// TODO: set this to whether the build included a `coder_ai_task` tf resource
+			HasAITask: false,
 		})
 		if err != nil {
 			code := http.StatusInternalServerError


### PR DESCRIPTION
https://github.com/coder/coder/pull/18359 added the `has_ai_task` columns on the `workspace_builds` and `template_versions` tables.