### PR TITLE
feat: add has-ai-task filters to the /workspaces and /templates endpoints

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9653,7 +9653,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Search query in the format ` + "`" + `key:value` + "`" + `. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before.",
+                        "description": "Search query in the format ` + "`" + `key:value` + "`" + `. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task.",
                         "name": "q",
                         "in": "query"
                     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8538,7 +8538,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"description": "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before.",
+						"description": "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task.",
 						"name": "q",
 						"in": "query"
 					},

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1389,6 +1389,17 @@ func isDeprecated(template database.Template) bool {
 	return template.Deprecated != ""
 }
 
+func (q *FakeQuerier) getWorkspaceBuildParametersNoLock(workspaceBuildID uuid.UUID) ([]database.WorkspaceBuildParameter, error) {
+	params := make([]database.WorkspaceBuildParameter, 0)
+	for _, param := range q.workspaceBuildParameters {
+		if param.WorkspaceBuildID != workspaceBuildID {
+			continue
+		}
+		params = append(params, param)
+	}
+	return params, nil
+}
+
 func (*FakeQuerier) AcquireLock(_ context.Context, _ int64) error {
 	return xerrors.New("AcquireLock must only be called within a transaction")
 }
@@ -7898,14 +7909,7 @@ func (q *FakeQuerier) GetWorkspaceBuildParameters(_ context.Context, workspaceBu
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
-	params := make([]database.WorkspaceBuildParameter, 0)
-	for _, param := range q.workspaceBuildParameters {
-		if param.WorkspaceBuildID != workspaceBuildID {
-			continue
-		}
-		params = append(params, param)
-	}
-	return params, nil
+	return q.getWorkspaceBuildParametersNoLock(workspaceBuildID)
 }
 
 func (q *FakeQuerier) GetWorkspaceBuildStatsByTemplates(ctx context.Context, since time.Time) ([]database.GetWorkspaceBuildStatsByTemplatesRow, error) {
@@ -13233,6 +13237,18 @@ func (q *FakeQuerier) GetAuthorizedTemplates(ctx context.Context, arg database.G
 				continue
 			}
 		}
+
+		if arg.HasAITask.Valid {
+			tv, err := q.getTemplateVersionByIDNoLock(ctx, template.ActiveVersionID)
+			if err != nil {
+				return nil, xerrors.Errorf("get template version: %w", err)
+			}
+			tvHasAITask := tv.HasAITask.Valid && tv.HasAITask.Bool
+			if tvHasAITask != arg.HasAITask.Bool {
+				continue
+			}
+		}
+
 		templates = append(templates, template)
 	}
 	if len(templates) > 0 {
@@ -13558,6 +13574,43 @@ func (q *FakeQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg database.
 				}
 			}
 			if !match {
+				continue
+			}
+		}
+
+		if arg.HasAITask.Valid {
+			hasAITask, err := func() (bool, error) {
+				build, err := q.getLatestWorkspaceBuildByWorkspaceIDNoLock(ctx, workspace.ID)
+				if err != nil {
+					return false, xerrors.Errorf("get latest build: %w", err)
+				}
+				if build.HasAITask.Valid {
+					return build.HasAITask.Bool, nil
+				}
+				// If the build has a nil AI task, check if the job is in progress
+				// and if it has a non-empty AI Prompt parameter
+				job, err := q.getProvisionerJobByIDNoLock(ctx, build.JobID)
+				if err != nil {
+					return false, xerrors.Errorf("get provisioner job: %w", err)
+				}
+				if job.CompletedAt.Valid {
+					return false, nil
+				}
+				parameters, err := q.getWorkspaceBuildParametersNoLock(build.ID)
+				if err != nil {
+					return false, xerrors.Errorf("get workspace build parameters: %w", err)
+				}
+				for _, param := range parameters {
+					if param.Name == "AI Prompt" && param.Value != "" {
+						return true, nil
+					}
+				}
+				return false, nil
+			}()
+			if err != nil {
+				return nil, xerrors.Errorf("get hasAITask: %w", err)
+			}
+			if hasAITask != arg.HasAITask.Bool {
 				continue
 			}
 		}

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -80,6 +80,7 @@ func (q *sqlQuerier) GetAuthorizedTemplates(ctx context.Context, arg GetTemplate
 		arg.FuzzyName,
 		pq.Array(arg.IDs),
 		arg.Deprecated,
+		arg.HasAITask,
 	)
 	if err != nil {
 		return nil, err
@@ -264,6 +265,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 		arg.LastUsedBefore,
 		arg.LastUsedAfter,
 		arg.UsingActive,
+		arg.HasAITask,
 		arg.RequesterID,
 		arg.Offset,
 		arg.Limit,
@@ -311,6 +313,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 			&i.LatestBuildError,
 			&i.LatestBuildTransition,
 			&i.LatestBuildStatus,
+			&i.LatestBuildHasAITask,
 			&i.Count,
 		); err != nil {
 			return nil, err

--- a/coderd/database/queries/templates.sql
+++ b/coderd/database/queries/templates.sql
@@ -10,34 +10,36 @@ LIMIT
 
 -- name: GetTemplatesWithFilter :many
 SELECT
-	*
+	t.*
 FROM
-	template_with_names AS templates
+	template_with_names AS t
+LEFT JOIN
+	template_versions tv ON t.active_version_id = tv.id
 WHERE
 	-- Optionally include deleted templates
-	templates.deleted = @deleted
+	t.deleted = @deleted
 	-- Filter by organization_id
 	AND CASE
 		WHEN @organization_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			organization_id = @organization_id
+			t.organization_id = @organization_id
 		ELSE true
 	END
 	-- Filter by exact name
 	AND CASE
 		WHEN @exact_name :: text != '' THEN
-			LOWER("name") = LOWER(@exact_name)
+			LOWER(t.name) = LOWER(@exact_name)
 		ELSE true
 	END
 	-- Filter by name, matching on substring
 	AND CASE
 		WHEN @fuzzy_name :: text != '' THEN
-			lower(name) ILIKE '%' || lower(@fuzzy_name) || '%'
+			lower(t.name) ILIKE '%' || lower(@fuzzy_name) || '%'
 		ELSE true
 	END
 	-- Filter by ids
 	AND CASE
 		WHEN array_length(@ids :: uuid[], 1) > 0 THEN
-			id = ANY(@ids)
+			t.id = ANY(@ids)
 		ELSE true
 	END
 	-- Filter by deprecated
@@ -45,15 +47,21 @@ WHERE
 		WHEN sqlc.narg('deprecated') :: boolean IS NOT NULL THEN
 			CASE
 				WHEN sqlc.narg('deprecated') :: boolean THEN
-					deprecated != ''
+					t.deprecated != ''
 				ELSE
-					deprecated = ''
+					t.deprecated = ''
 			END
+		ELSE true
+	END
+	-- Filter by has_ai_task in latest version
+	AND CASE
+		WHEN sqlc.narg('has_ai_task') :: boolean IS NOT NULL THEN
+			tv.has_ai_task = sqlc.narg('has_ai_task') :: boolean
 		ELSE true
 	END
   -- Authorize Filter clause will be injected below in GetAuthorizedTemplates
   -- @authorize_filter
-ORDER BY (name, id) ASC
+ORDER BY (t.name, t.id) ASC
 ;
 
 -- name: GetTemplateByOrganizationAndName :one

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -149,6 +149,7 @@ sql:
           stale_interval_ms: StaleIntervalMS
           has_ai_task: HasAITask
           ai_tasks_sidebar_app_id: AITasksSidebarAppID
+          latest_build_has_ai_task: LatestBuildHasAITask
 rules:
   - name: do-not-use-public-schema-in-queries
     message: "do not use public schema in queries"

--- a/coderd/rbac/regosql/compile_test.go
+++ b/coderd/rbac/regosql/compile_test.go
@@ -236,8 +236,8 @@ internal.member_2(input.object.org_owner, {"3bf82434-e40b-44ae-b3d8-d0115bba9bad
 neq(input.object.owner, "");
 "806dd721-775f-4c85-9ce3-63fbbd975954" = input.object.owner`,
 			},
-			ExpectedSQL: p(p("organization_id :: text != ''") + " AND " +
-				p("organization_id :: text = ANY(ARRAY ['3bf82434-e40b-44ae-b3d8-d0115bba9bad','5630fda3-26ab-462c-9014-a88a62d7a415','c304877a-bc0d-4e9b-9623-a38eae412929'])") + " AND " +
+			ExpectedSQL: p(p("t.organization_id :: text != ''") + " AND " +
+				p("t.organization_id :: text = ANY(ARRAY ['3bf82434-e40b-44ae-b3d8-d0115bba9bad','5630fda3-26ab-462c-9014-a88a62d7a415','c304877a-bc0d-4e9b-9623-a38eae412929'])") + " AND " +
 				p("false") + " AND " +
 				p("false")),
 			VariableConverter: regosql.TemplateConverter(),

--- a/coderd/rbac/regosql/configs.go
+++ b/coderd/rbac/regosql/configs.go
@@ -25,7 +25,7 @@ func userACLMatcher(m sqltypes.VariableMatcher) sqltypes.VariableMatcher {
 func TemplateConverter() *sqltypes.VariableConverter {
 	matcher := sqltypes.NewVariableConverter().RegisterMatcher(
 		resourceIDMatcher(),
-		organizationOwnerMatcher(),
+		sqltypes.StringVarMatcher("t.organization_id :: text", []string{"input", "object", "org_owner"}),
 		// Templates have no user owner, only owner by an organization.
 		sqltypes.AlwaysFalse(userOwnerMatcher()),
 	)

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -146,6 +146,7 @@ func Workspaces(ctx context.Context, db database.Store, query string, page coder
 		// which will return all workspaces.
 		Valid: values.Has("outdated"),
 	}
+	filter.HasAITask = parser.NullableBoolean(values, sql.NullBool{}, "has-ai-task")
 	filter.OrganizationID = parseOrganization(ctx, db, parser, values, "organization")
 
 	type paramMatch struct {
@@ -206,6 +207,7 @@ func Templates(ctx context.Context, db database.Store, query string) (database.G
 		IDs:            parser.UUIDs(values, []uuid.UUID{}, "ids"),
 		Deprecated:     parser.NullableBoolean(values, sql.NullBool{}, "deprecated"),
 		OrganizationID: parseOrganization(ctx, db, parser, values, "organization"),
+		HasAITask:      parser.NullableBoolean(values, sql.NullBool{}, "has-ai-task"),
 	}
 
 	parser.ErrorExcessParams(values)

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -222,6 +222,36 @@ func TestSearchWorkspace(t *testing.T) {
 				OrganizationID: uuid.MustParse("08eb6715-02f8-45c5-b86d-03786fcfbb4e"),
 			},
 		},
+		{
+			Name:  "HasAITaskTrue",
+			Query: "has-ai-task:true",
+			Expected: database.GetWorkspacesParams{
+				HasAITask: sql.NullBool{
+					Bool:  true,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "HasAITaskFalse",
+			Query: "has-ai-task:false",
+			Expected: database.GetWorkspacesParams{
+				HasAITask: sql.NullBool{
+					Bool:  false,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "HasAITaskMissing",
+			Query: "",
+			Expected: database.GetWorkspacesParams{
+				HasAITask: sql.NullBool{
+					Bool:  false,
+					Valid: false,
+				},
+			},
+		},
 
 		// Failures
 		{
@@ -557,6 +587,36 @@ func TestSearchTemplates(t *testing.T) {
 			Query: "foobar",
 			Expected: database.GetTemplatesWithFilterParams{
 				FuzzyName: "foobar",
+			},
+		},
+		{
+			Name:  "HasAITaskTrue",
+			Query: "has-ai-task:true",
+			Expected: database.GetTemplatesWithFilterParams{
+				HasAITask: sql.NullBool{
+					Bool:  true,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "HasAITaskFalse",
+			Query: "has-ai-task:false",
+			Expected: database.GetTemplatesWithFilterParams{
+				HasAITask: sql.NullBool{
+					Bool:  false,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "HasAITaskMissing",
+			Query: "",
+			Expected: database.GetTemplatesWithFilterParams{
+				HasAITask: sql.NullBool{
+					Bool:  false,
+					Valid: false,
+				},
 			},
 		},
 	}

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -2,6 +2,7 @@ package coderd_test
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/notifications"
@@ -1808,4 +1810,67 @@ func TestTemplateNotifications(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestTemplateFilterHasAITask(t *testing.T) {
+	t.Parallel()
+
+	db, pubsub := dbtestutil.NewDB(t)
+	client := coderdtest.New(t, &coderdtest.Options{
+		Database:                 db,
+		Pubsub:                   pubsub,
+		IncludeProvisionerDaemon: true,
+	})
+	user := coderdtest.CreateFirstUser(t, client)
+
+	jobWithAITask := dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
+		OrganizationID: user.OrganizationID,
+		InitiatorID:    user.UserID,
+		Tags:           database.StringMap{},
+		Type:           database.ProvisionerJobTypeTemplateVersionImport,
+	})
+	jobWithoutAITask := dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
+		OrganizationID: user.OrganizationID,
+		InitiatorID:    user.UserID,
+		Tags:           database.StringMap{},
+		Type:           database.ProvisionerJobTypeTemplateVersionImport,
+	})
+	versionWithAITask := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+		OrganizationID: user.OrganizationID,
+		CreatedBy:      user.UserID,
+		HasAITask:      sql.NullBool{Bool: true, Valid: true},
+		JobID:          jobWithAITask.ID,
+	})
+	versionWithoutAITask := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+		OrganizationID: user.OrganizationID,
+		CreatedBy:      user.UserID,
+		HasAITask:      sql.NullBool{Bool: false, Valid: true},
+		JobID:          jobWithoutAITask.ID,
+	})
+	templateWithAITask := coderdtest.CreateTemplate(t, client, user.OrganizationID, versionWithAITask.ID)
+	templateWithoutAITask := coderdtest.CreateTemplate(t, client, user.OrganizationID, versionWithoutAITask.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	// Test filtering
+	templates, err := client.Templates(ctx, codersdk.TemplateFilter{
+		SearchQuery: "has-ai-task:true",
+	})
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, templateWithAITask.ID, templates[0].ID)
+
+	templates, err = client.Templates(ctx, codersdk.TemplateFilter{
+		SearchQuery: "has-ai-task:false",
+	})
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, templateWithoutAITask.ID, templates[0].ID)
+
+	templates, err = client.Templates(ctx, codersdk.TemplateFilter{})
+	require.NoError(t, err)
+	require.Len(t, templates, 2)
+	require.Contains(t, templates, templateWithAITask)
+	require.Contains(t, templates, templateWithoutAITask)
 }

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -136,7 +136,7 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Workspaces
-// @Param q query string false "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before."
+// @Param q query string false "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task."
 // @Param limit query int false "Page limit"
 // @Param offset query int false "Page offset"
 // @Success 200 {object} codersdk.WorkspacesResponse

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -920,11 +920,11 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
 
 ### Parameters
 
-| Name     | In    | Type    | Required | Description                                                                                                                                       |
-|----------|-------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `q`      | query | string  | false    | Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before. |
-| `limit`  | query | integer | false    | Page limit                                                                                                                                        |
-| `offset` | query | integer | false    | Page offset                                                                                                                                       |
+| Name     | In    | Type    | Required | Description                                                                                                                                                    |
+|----------|-------|---------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `q`      | query | string  | false    | Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task. |
+| `limit`  | query | integer | false    | Page limit                                                                                                                                                     |
+| `offset` | query | integer | false    | Page offset                                                                                                                                                    |
 
 ### Example responses
 


### PR DESCRIPTION
This PR allows filtering templates and workspaces with the `has-ai-task` filter as described in the [Coder Tasks RFC](https://www.notion.so/coderhq/Coder-Tasks-207d579be5928053ab68c8d9a4b59eaa?source=copy_link#20ad579be59280e6a000eb0646d3c2df).