### PR TITLE
chore: use large modules in dogfood template

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -11,6 +11,16 @@ terraform {
   }
 }
 
+// This module is a terraform no-op. It contains 5mb worth of files to test
+// Coder's behavior dealing with larger modules. This is included to test
+// protobuf message size limits and the performance of module loading.
+//
+// In reality, modules might have accidental bloat from non-terraform files such
+// as images & documentation.
+module "large-5mb-module" {
+  source        = "git::https://github.com/Emyrk/large-module.git"
+}
+
 locals {
   // These are cluster service addresses mapped to Tailscale nodes. Ask Dean or
   // Kyle for help.

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -18,7 +18,7 @@ terraform {
 // In reality, modules might have accidental bloat from non-terraform files such
 // as images & documentation.
 module "large-5mb-module" {
-  source        = "git::https://github.com/Emyrk/large-module.git"
+  source = "git::https://github.com/Emyrk/large-module.git"
 }
 
 locals {


### PR DESCRIPTION
Large modules can potentially break or slow down template behaviors. Our primary dogfood template should experience this if it becomes an issue.

Just trying to catch things in dogfood before we experience them in the wild.

**Note**: On `main` today, you would never know this used to be a problem. I see no difference, and want to keep it that way.