### PR TITLE
fix(agent/agentcontainers): reduce need to recreate sub agents

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -671,9 +671,9 @@ func (api *API) getContainers() (codersdk.WorkspaceAgentListContainersResponse, 
 	if len(api.knownDevcontainers) > 0 {
 		devcontainers = make([]codersdk.WorkspaceAgentDevcontainer, 0, len(api.knownDevcontainers))
 		for _, dc := range api.knownDevcontainers {
-			// Include the agent if it's been created (we're iterating over
+			// Include the agent if it's running (we're iterating over
 			// copies, so mutating is fine).
-			if proc := api.injectedSubAgentProcs[dc.WorkspaceFolder]; proc.agent.ID != uuid.Nil && dc.Container != nil && proc.containerID == dc.Container.ID {
+			if proc := api.injectedSubAgentProcs[dc.WorkspaceFolder]; proc.agent.ID != uuid.Nil {
 				dc.Agent = &codersdk.WorkspaceAgentDevcontainerAgent{
 					ID:        proc.agent.ID,
 					Name:      proc.agent.Name,

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -992,7 +992,7 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 			logger.Debug(ctx, "container ID changed, injecting subagent into new container",
 				slog.F("old_container_id", proc.containerID),
 			)
-			maybeRecreateSubAgent = true
+			maybeRecreateSubAgent = proc.agent.ID != uuid.Nil
 		}
 
 		// Container ID changed or the subagent process is not running,
@@ -1157,7 +1157,7 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 		subAgentConfig.DisplayApps = displayApps
 	}
 
-	deleteSubAgent := maybeRecreateSubAgent && !proc.agent.EqualConfig(subAgentConfig)
+	deleteSubAgent := proc.agent.ID != uuid.Nil && maybeRecreateSubAgent && !proc.agent.EqualConfig(subAgentConfig)
 	if deleteSubAgent {
 		logger.Debug(ctx, "deleting existing subagent for recreation", slog.F("agent_id", proc.agent.ID))
 		client := *api.subAgentClient.Load()

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1347,7 +1347,11 @@ func TestAPI(t *testing.T) {
 			}
 			return errTestTermination
 		})
-		testutil.RequireReceive(ctx, t, terminated)
+		select {
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for agent termination")
+		case <-terminated:
+		}
 
 		t.Log("Waiting for agent reinjection...")
 
@@ -1371,7 +1375,11 @@ func TestAPI(t *testing.T) {
 				assert.Fail(t, `want "agent" command argument`)
 			}
 			close(agentStarted)
-			<-continueTerminate
+			select {
+			case <-ctx.Done():
+				t.Error("timeout waiting for agent continueTerminate")
+			case <-continueTerminate:
+			}
 			return errTestTermination
 		})
 
@@ -1429,7 +1437,11 @@ func TestAPI(t *testing.T) {
 
 		// Terminate the running agent.
 		close(continueTerminate)
-		testutil.RequireReceive(ctx, t, terminated)
+		select {
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for agent termination")
+		case <-terminated:
+		}
 
 		// Simulate the agent deletion (this happens because the
 		// devcontainer configuration changed).

--- a/agent/agentcontainers/subagent.go
+++ b/agent/agentcontainers/subagent.go
@@ -2,6 +2,7 @@ package agentcontainers
 
 import (
 	"context"
+	"slices"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -21,6 +22,26 @@ type SubAgent struct {
 	Architecture    string
 	OperatingSystem string
 	DisplayApps     []codersdk.DisplayApp
+}
+
+// CloneConfig makes a copy of SubAgent without ID and AuthToken. The
+// name is inherited from the devcontainer.
+func (s SubAgent) CloneConfig(dc codersdk.WorkspaceAgentDevcontainer) SubAgent {
+	return SubAgent{
+		Name:            dc.Name,
+		Directory:       s.Directory,
+		Architecture:    s.Architecture,
+		OperatingSystem: s.OperatingSystem,
+		DisplayApps:     slices.Clone(s.DisplayApps),
+	}
+}
+
+func (s SubAgent) EqualConfig(other SubAgent) bool {
+	return s.Name == other.Name &&
+		s.Directory == other.Directory &&
+		s.Architecture == other.Architecture &&
+		s.OperatingSystem == other.OperatingSystem &&
+		slices.Equal(s.DisplayApps, other.DisplayApps)
 }
 
 // SubAgentClient is an interface for managing sub agents and allows

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -116,7 +116,6 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							if (dc.id === devcontainer.id) {
 								return {
 									...dc,
-									agent: null,
 									container: null,
 									status: "starting",
 								};


### PR DESCRIPTION
Unless significant agent fields change, like directory, name, or apps, we no longer re-create the subagent. This reduces DB load and decreases the chance of hitting edge cases from deletion (although this will be addressed later).

Updates #18332
