### PR TITLE
fix: set fileSize to full length instead of unread portion

### DIFF
--- a/coderd/files/cache.go
+++ b/coderd/files/cache.go
@@ -35,7 +35,7 @@ func NewFromStore(store database.Store, registerer prometheus.Registerer, authz 
 		return CacheEntryValue{
 			Object: file.RBACObject(),
 			FS:     archivefs.FromTarReader(content),
-			Size:   int64(content.Len()),
+			Size:   int64(len(file.Data)),
 		}, nil
 	}
 


### PR DESCRIPTION
`content.Len()` would return `0` bytes after a file was fully read. Since the buffer `Len` function returns the length of the unread portion.