### PR TITLE
feat: add app iframe controls

### DIFF
--- a/site/src/pages/TaskPage/TaskAppIframe.tsx
+++ b/site/src/pages/TaskPage/TaskAppIframe.tsx
@@ -6,16 +6,11 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
-import {
-	EllipsisVertical,
-	ExternalLinkIcon,
-	HouseIcon,
-	RotateCwIcon,
-} from "lucide-react";
-import { openAppInNewWindow } from "modules/apps/apps";
+import { EllipsisVertical, ExternalLinkIcon, HouseIcon } from "lucide-react";
 import { useAppLink } from "modules/apps/useAppLink";
 import type { Task } from "modules/tasks/tasks";
 import { type FC, useRef } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import { cn } from "utils/cn";
 
 type TaskAppIFrameProps = {
@@ -70,20 +65,6 @@ export const TaskAppIFrame: FC<TaskAppIFrameProps> = ({
 					onClick={(e) => {
 						e.preventDefault();
 						if (frameRef.current?.contentWindow) {
-							frameRef.current.contentWindow.location.reload();
-						}
-					}}
-				>
-					<RotateCwIcon />
-					<span className="sr-only">Refresh</span>
-				</Button>
-
-				<Button
-					size="icon"
-					variant="subtle"
-					onClick={(e) => {
-						e.preventDefault();
-						if (frameRef.current?.contentWindow) {
 							frameRef.current.contentWindow.location.href = appHref();
 						}
 					}}
@@ -104,13 +85,11 @@ export const TaskAppIFrame: FC<TaskAppIFrameProps> = ({
 						</Button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end">
-						<DropdownMenuItem
-							onClick={() => {
-								openAppInNewWindow(frameSrc);
-							}}
-						>
-							<ExternalLinkIcon />
-							Open app in new tab
+						<DropdownMenuItem asChild>
+							<RouterLink to={frameSrc} target="_blank">
+								<ExternalLinkIcon />
+								Open app in new tab
+							</RouterLink>
 						</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>

--- a/site/src/pages/TaskPage/TaskApps.tsx
+++ b/site/src/pages/TaskPage/TaskApps.tsx
@@ -57,19 +57,21 @@ export const TaskApps: FC<TaskAppsProps> = ({ task }) => {
 
 	return (
 		<main className="flex-1 flex flex-col">
-			<div className="border-0 border-b border-border border-solid w-full p-1 flex gap-2">
-				{embeddedApps.map((app) => (
-					<TaskAppButton
-						key={app.id}
-						task={task}
-						app={app}
-						active={app.id === activeAppId}
-						onClick={(e) => {
-							e.preventDefault();
-							setActiveAppId(app.id);
-						}}
-					/>
-				))}
+			<div className="w-full flex items-center border-0 border-b border-border border-solid">
+				<div className="p-2 pb-0 flex gap-2 items-center">
+					{embeddedApps.map((app) => (
+						<TaskAppTab
+							key={app.id}
+							task={task}
+							app={app}
+							active={app.id === activeAppId}
+							onClick={(e) => {
+								e.preventDefault();
+								setActiveAppId(app.id);
+							}}
+						/>
+					))}
+				</div>
 
 				{externalApps.length > 0 && (
 					<div className="ml-auto">
@@ -122,19 +124,14 @@ export const TaskApps: FC<TaskAppsProps> = ({ task }) => {
 	);
 };
 
-type TaskAppButtonProps = {
+type TaskAppTabProps = {
 	task: Task;
 	app: WorkspaceApp;
 	active: boolean;
 	onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
-const TaskAppButton: FC<TaskAppButtonProps> = ({
-	task,
-	app,
-	active,
-	onClick,
-}) => {
+const TaskAppTab: FC<TaskAppTabProps> = ({ task, app, active, onClick }) => {
 	const agent = task.workspace.latest_build.resources
 		.flatMap((r) => r.agents)
 		.filter((a) => !!a)
@@ -156,7 +153,11 @@ const TaskAppButton: FC<TaskAppButtonProps> = ({
 			key={app.id}
 			asChild
 			className={cn([
-				{ "text-content-primary": active },
+				"px-3",
+				{
+					"text-content-primary bg-surface-tertiary rounded-sm rounded-b-none":
+						active,
+				},
 				{ "opacity-75 hover:opacity-100": !active },
 			])}
 		>


### PR DESCRIPTION
I was not able to implement back/forward as we have no way of interacting with history in a cross-origin iframe.

The URL input was also a problem because there is no way to know if the cross-origin iframe's URL changes (due to a link inside the iframe for example), so it risks becoming stale.

In the future we can maybe do something where we serve our own HTML that sets up a message channel with the parent to communicate history changes, and then it replaces itself with the real content (similar to weno), or alternatively we munge the original content and inject our message channel code directly into it, although this will only work for apps we ourselves serve, nothing externally hosted will work this way.

fixes #18178