### PR TITLE
chore(agent): add workspace owner env var and log dev container app failures

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1297,6 +1297,7 @@ func (a *agent) updateCommandEnv(current []string) (updated []string, err error)
 		"CODER":                      "true",
 		"CODER_WORKSPACE_NAME":       manifest.WorkspaceName,
 		"CODER_WORKSPACE_AGENT_NAME": manifest.AgentName,
+		"CODER_WORKSPACE_OWNER_NAME": manifest.OwnerName,
 
 		// Specific Coder subcommands require the agent token exposed!
 		"CODER_AGENT_TOKEN": *a.sessionToken.Load(),

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1209,7 +1209,7 @@ func TestAgent_EnvironmentVariableExpansion(t *testing.T) {
 func TestAgent_CoderEnvVars(t *testing.T) {
 	t.Parallel()
 
-	for _, key := range []string{"CODER", "CODER_WORKSPACE_NAME", "CODER_WORKSPACE_AGENT_NAME"} {
+	for _, key := range []string{"CODER", "CODER_WORKSPACE_NAME", "CODER_WORKSPACE_OWNER_NAME", "CODER_WORKSPACE_AGENT_NAME"} {
 		key := key
 		t.Run(key, func(t *testing.T) {
 			t.Parallel()
@@ -3078,6 +3078,9 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 	}
 	if metadata.WorkspaceName == "" {
 		metadata.WorkspaceName = "test-workspace"
+	}
+	if metadata.OwnerName == "" {
+		metadata.OwnerName = "test-user"
 	}
 	if metadata.WorkspaceID == uuid.Nil {
 		metadata.WorkspaceID = uuid.New()

--- a/agent/agentcontainers/subagent.go
+++ b/agent/agentcontainers/subagent.go
@@ -233,6 +233,15 @@ func (a *subAgentAPIClient) Create(ctx context.Context, agent SubAgent) (SubAgen
 	if err != nil {
 		return SubAgent{}, err
 	}
+	for _, appError := range resp.AppCreationErrors {
+		app := apps[appError.Index]
+
+		a.logger.Warn(ctx, "unable to create app",
+			slog.F("app_slug", app.Slug),
+			slog.F("field", appError.GetField()),
+			slog.F("error", appError.GetError()),
+		)
+	}
 
 	agent.Name = resp.Agent.Name
 	agent.ID, err = uuid.FromBytes(resp.Agent.Id)

--- a/agent/agentcontainers/subagent.go
+++ b/agent/agentcontainers/subagent.go
@@ -233,15 +233,6 @@ func (a *subAgentAPIClient) Create(ctx context.Context, agent SubAgent) (SubAgen
 	if err != nil {
 		return SubAgent{}, err
 	}
-	for _, appError := range resp.AppCreationErrors {
-		app := apps[appError.Index]
-
-		a.logger.Warn(ctx, "unable to create app",
-			slog.F("app_slug", app.Slug),
-			slog.F("field", appError.GetField()),
-			slog.F("error", appError.GetError()),
-		)
-	}
 
 	agent.Name = resp.Agent.Name
 	agent.ID, err = uuid.FromBytes(resp.Agent.Id)
@@ -252,6 +243,20 @@ func (a *subAgentAPIClient) Create(ctx context.Context, agent SubAgent) (SubAgen
 	if err != nil {
 		return agent, err
 	}
+
+	for _, appError := range resp.AppCreationErrors {
+		app := apps[appError.Index]
+
+		a.logger.Warn(ctx, "unable to create app",
+			slog.F("agent_name", agent.Name),
+			slog.F("agent_id", agent.ID),
+			slog.F("directory", agent.Directory),
+			slog.F("app_slug", app.Slug),
+			slog.F("field", appError.GetField()),
+			slog.F("error", appError.GetError()),
+		)
+	}
+
 	return agent, nil
 }
 


### PR DESCRIPTION
Listen to feedback that was missed in https://github.com/coder/coder/pull/18346

- Adds `CODER_WORKSPACE_OWNER_NAME` into the agent environment.
- Logs warnings for when dev container app creation fails.