### PR TITLE
chore: check version.Err() after version.Next() in ConnectToPostgres

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2360,10 +2360,12 @@ func ConnectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 		return nil, xerrors.Errorf("get postgres version: %w", err)
 	}
 	defer version.Close()
-	if version.Err() != nil {
-		return nil, xerrors.Errorf("version select: %w", version.Err())
-	}
 	if !version.Next() {
+		// it's critical we assign to the err variable, otherwise the defer statement
+		// that runs db.Close() will not execute it
+		if err = version.Err(); err != nil {
+			return nil, xerrors.Errorf("no rows returned for version select: %w", err)
+		}
 		return nil, xerrors.Errorf("no rows returned for version select")
 	}
 	var versionNum int


### PR DESCRIPTION
According to `version.Next`'s docstring:

> Next prepares the next result row for reading with the [Rows.Scan] method. It returns true on success, or false if there is no next result row or an error happened while preparing it. [Rows.Err] should be consulted to distinguish between the two cases.

I locally reproduced the flake reported in https://github.com/coder/internal/issues/672 and this PR should fix it.