### PR TITLE
fix: fix TestAcquireJobWithCancel_Cancel flake

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -368,7 +368,7 @@ func (s *server) AcquireJobWithCancel(stream proto.DRPCProvisionerDaemon_Acquire
 		je = <-jec
 	case je = <-jec:
 	}
-	if xerrors.Is(je.err, context.Canceled) {
+	if database.IsQueryCanceledError(je.err) {
 		s.Logger.Debug(streamCtx, "successful cancel")
 		err := stream.Send(&proto.AcquiredJob{})
 		if err != nil {


### PR DESCRIPTION
The test was failing because it was checking for context.Canceled using xerrors.Is, but postgres returns a different error ("pq: canceling statement due to user request") when a query is cancelled. This change uses database.IsQueryCanceledError which properly handles both context.Canceled and postgres-specific cancellation errors.

fixes https://github.com/coder/internal/issues/702