### PR TITLE
fix: fix TestAcquireJob_LongPoll flake

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -321,7 +321,7 @@ func (s *server) AcquireJob(ctx context.Context, _ *proto.Empty) (*proto.Acquire
 	acqCtx, acqCancel := context.WithTimeout(ctx, s.acquireJobLongPollDur)
 	defer acqCancel()
 	job, err := s.Acquirer.AcquireJob(acqCtx, s.OrganizationID, s.ID, s.Provisioners, s.Tags)
-	if xerrors.Is(err, context.DeadlineExceeded) {
+	if database.IsQueryCanceledError(err) {
 		s.Logger.Debug(ctx, "successful cancel")
 		return &proto.AcquiredJob{}, nil
 	}


### PR DESCRIPTION
~I'll be honest I'm not even really sure the point of this test but it was failing due to~ The intention appears to be to have the context expire due to the poll override as opposed to the context provided to `AcquireJob`

```
2025-06-16T15:01:54.0863251Z         	Error:      	Received unexpected error:
2025-06-16T15:01:54.0863554Z         	            	acquire job:
2025-06-16T15:01:54.0864230Z         	            	    github.com/coder/coder/v2/coderd/provisionerdserver.(*server).AcquireJob
2025-06-16T15:01:54.0865173Z         	            	        /home/runner/work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:329
2025-06-16T15:01:54.0865683Z         	            	  - failed to acquire job:
2025-06-16T15:01:54.0866374Z         	            	    github.com/coder/coder/v2/coderd/provisionerdserver.(*Acquirer).AcquireJob
2025-06-16T15:01:54.0867262Z         	            	        /home/runner/work/coder/coder/coderd/provisionerdserver/acquirer.go:148
2025-06-16T15:01:54.0867819Z         	            	  - pq: canceling statement due to user request
```

fixes https://github.com/coder/internal/issues/714