### PR TITLE
feat: improve AppLink error message for coder:// URLs

### DIFF
--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -66,7 +66,7 @@ export const useAppLink = (
 					);
 				} else if (isCoderApp) {
 					displayError(
-						`To use ${label} you need Coder Desktop to be installed first.`,
+						`To use ${label} you need to have Coder Desktop installed`,
 					);
 				} else {
 					displayError(`${label} must be installed first.`);

--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -57,8 +57,7 @@ export const useAppLink = (
 						app.url.startsWith("jetbrains:"));
 
 				// Check if this is a coder:// URL
-				const isCoderApp =
-					app.url && app.url.startsWith("coder://");
+				const isCoderApp = app.url?.startsWith("coder://");
 
 				if (isJetBrainsApp) {
 					displayError(

--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -56,9 +56,17 @@ export const useAppLink = (
 					(app.url.startsWith("jetbrains-gateway:") ||
 						app.url.startsWith("jetbrains:"));
 
+				// Check if this is a coder:// URL
+				const isCoderApp =
+					app.url && app.url.startsWith("coder://");
+
 				if (isJetBrainsApp) {
 					displayError(
 						`To use ${label}, you need to have JetBrains Toolbox installed.`,
+					);
+				} else if (isCoderApp) {
+					displayError(
+						`To use ${label} you need Coder Desktop to be installed first.`,
 					);
 				} else {
 					displayError(`${label} must be installed first.`);

--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -57,7 +57,7 @@ export const useAppLink = (
 						app.url.startsWith("jetbrains:"));
 
 				// Check if this is a coder:// URL
-				const isCoderApp = app.url?.startsWith("coder://");
+				const isCoderApp = app.url?.startsWith("coder:");
 
 				if (isJetBrainsApp) {
 					displayError(


### PR DESCRIPTION
Add a specific error message for `coder://` URLs that instructs users to install Coder Desktop first. This follows the same pattern as the existing JetBrains error handling.

Follows #18294