### PR TITLE
docs: bitnami/postgresql primary prefix for persistence.size config key

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -49,7 +49,7 @@ helm install coder-db bitnami/postgresql \
     --set auth.username=coder \
     --set auth.password=coder \
     --set auth.database=coder \
-    --set persistence.size=10Gi
+    --set primary.persistence.size=10Gi
 ```
 
 The cluster-internal DB URL for the above database is:


### PR DESCRIPTION
The `bitnami/postgresql`chart doesn't have a value with key `persistence.size`. The correct value key which control the size of the PVC is `primary.persistence.size`.

See:
- https://github.com/bitnami/charts/blob/postgresql/16.7.12/bitnami/postgresql/values.yaml
- The JSON schema, [`values.schema.json`](https://github.com/bitnami/charts/blob/postgresql/16.7.12/bitnami/postgresql/values.schema.json) of the [`values.yaml`](https://github.com/bitnami/charts/blob/postgresql/16.7.12/bitnami/postgresql/values.yaml) included in the chart is out of sync. https://github.com/bitnami/readme-generator-for-helm/issues/142