### PR TITLE
fix(dogfood/coder): use agent name for zed app

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -336,10 +336,11 @@ module "windsurf" {
 }
 
 module "zed" {
-  count    = data.coder_workspace.me.start_count
-  source   = "./zed"
-  agent_id = coder_agent.dev.id
-  folder   = local.repo_dir
+  count      = data.coder_workspace.me.start_count
+  source     = "./zed"
+  agent_id   = coder_agent.dev.id
+  agent_name = "dev"
+  folder     = local.repo_dir
 }
 
 resource "coder_agent" "dev" {

--- a/dogfood/coder/zed/main.tf
+++ b/dogfood/coder/zed/main.tf
@@ -12,11 +12,22 @@ variable "agent_id" {
   type = string
 }
 
+variable "agent_name" {
+  type    = string
+  default = ""
+}
+
 variable "folder" {
   type = string
 }
 
 data "coder_workspace" "me" {}
+
+locals {
+  workspace_name = lower(data.coder_workspace.me.name)
+  agent_name     = lower(var.agent_name)
+  hostname       = var.agent_name != "" ? "${local.agent_name}.${local.workspace_name}.me.coder" : "${local.workspace_name}.coder"
+}
 
 resource "coder_app" "zed" {
   agent_id     = var.agent_id
@@ -24,5 +35,5 @@ resource "coder_app" "zed" {
   slug         = "zed"
   icon         = "/icon/zed.svg"
   external     = true
-  url          = "zed://ssh/${lower(data.coder_workspace.me.name)}.coder/${var.folder}"
+  url          = "zed://ssh/${local.hostname}/${var.folder}"
 }


### PR DESCRIPTION
Previously our Zed app did not use the agent name as part of the
hostname being accessed and would break in multi-agent environments.
This change fixes it.
