### PR TITLE
feat(agent/agentcontainers): support agent name in customization

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1177,12 +1177,10 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 			}
 
 			// NOTE(DanielleMaywood):
-			// We only want to take an agent name specified in the very last customization layer.
+			// We only want to take an agent name specified in the root customization layer.
 			// This restricts the ability for a feature to specify the agent name. We may revisit
 			// this in the future, but for now we want to restrict this behavior.
-			if len(coderCustomization) > 0 {
-				name := coderCustomization[len(coderCustomization)-1].Name
-
+			if name := config.Configuration.Customizations.Coder.Name; name != "" {
 				// We only want to pick this name if it is a valid name.
 				if provisioner.AgentNameRegex.Match([]byte(name)) {
 					possibleAgentName = name

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1776,6 +1776,17 @@ func TestAPI(t *testing.T) {
 					require.NotEmpty(t, subAgent.Name)
 				},
 			},
+			{
+				name: "InvalidNameIsIgnored",
+				customization: []agentcontainers.CoderCustomization{
+					{
+						Name: "This--Is_An_Invalid--Name",
+					},
+				},
+				afterCreate: func(t *testing.T, subAgent agentcontainers.SubAgent) {
+					require.NotEqual(t, "This--Is_An_Invalid--Name", subAgent.Name)
+				},
+			},
 		}
 
 		for _, tt := range tests {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1765,6 +1765,17 @@ func TestAPI(t *testing.T) {
 					require.NotEqual(t, "custom-name", subAgent.Name)
 				},
 			},
+			{
+				name: "EmptyNameIsIgnored",
+				customization: []agentcontainers.CoderCustomization{
+					{
+						Name: "",
+					},
+				},
+				afterCreate: func(t *testing.T, subAgent agentcontainers.SubAgent) {
+					require.NotEmpty(t, subAgent.Name)
+				},
+			},
 		}
 
 		for _, tt := range tests {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1739,6 +1739,32 @@ func TestAPI(t *testing.T) {
 					assert.Equal(t, int32(2), subAgent.Apps[1].Order)
 				},
 			},
+			{
+				name: "Name",
+				customization: []agentcontainers.CoderCustomization{
+					{
+						Name: "not-this-name",
+					},
+					{
+						Name: "custom-name",
+					},
+				},
+				afterCreate: func(t *testing.T, subAgent agentcontainers.SubAgent) {
+					require.Equal(t, "custom-name", subAgent.Name)
+				},
+			},
+			{
+				name: "NameIsOnlyUsedWhenInLastLayer",
+				customization: []agentcontainers.CoderCustomization{
+					{
+						Name: "custom-name",
+					},
+					{},
+				},
+				afterCreate: func(t *testing.T, subAgent agentcontainers.SubAgent) {
+					require.NotEqual(t, "custom-name", subAgent.Name)
+				},
+			},
 		}
 
 		for _, tt := range tests {
@@ -1825,7 +1851,6 @@ func TestAPI(t *testing.T) {
 
 				// Then: We expected it to succeed
 				require.Len(t, fSAC.created, 1)
-				assert.Equal(t, testContainer.FriendlyName, fSAC.created[0].Name)
 
 				if tt.afterCreate != nil {
 					tt.afterCreate(t, fSAC.created[0])

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -20,7 +20,16 @@ import (
 // Unfortunately we cannot make use of `dcspec` as the output doesn't appear to
 // match.
 type DevcontainerConfig struct {
-	MergedConfiguration DevcontainerConfiguration `json:"mergedConfiguration"`
+	MergedConfiguration DevcontainerMergedConfiguration `json:"mergedConfiguration"`
+	Configuration       DevcontainerConfiguration       `json:"configuration"`
+}
+
+type DevcontainerMergedConfiguration struct {
+	Customizations DevcontainerMergedCustomizations `json:"customizations,omitempty"`
+}
+
+type DevcontainerMergedCustomizations struct {
+	Coder []CoderCustomization `json:"coder,omitempty"`
 }
 
 type DevcontainerConfiguration struct {
@@ -28,7 +37,7 @@ type DevcontainerConfiguration struct {
 }
 
 type DevcontainerCustomizations struct {
-	Coder []CoderCustomization `json:"coder,omitempty"`
+	Coder CoderCustomization `json:"coder,omitempty"`
 }
 
 type CoderCustomization struct {

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -34,6 +34,7 @@ type DevcontainerCustomizations struct {
 type CoderCustomization struct {
 	DisplayApps map[codersdk.DisplayApp]bool `json:"displayApps,omitempty"`
 	Apps        []SubAgentApp                `json:"apps,omitempty"`
+	Name        string                       `json:"name,omitempty"`
 }
 
 // DevcontainerCLI is an interface for the devcontainer CLI.

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -256,8 +256,8 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 				wantArgs:        "read-configuration --include-merged-configuration --workspace-folder /test/workspace",
 				wantError:       false,
 				wantConfig: agentcontainers.DevcontainerConfig{
-					MergedConfiguration: agentcontainers.DevcontainerConfiguration{
-						Customizations: agentcontainers.DevcontainerCustomizations{
+					MergedConfiguration: agentcontainers.DevcontainerMergedConfiguration{
+						Customizations: agentcontainers.DevcontainerMergedCustomizations{
 							Coder: []agentcontainers.CoderCustomization{
 								{
 									DisplayApps: map[codersdk.DisplayApp]bool{
@@ -284,8 +284,8 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 				wantArgs:        "read-configuration --include-merged-configuration --workspace-folder /test/workspace --config /test/config.json",
 				wantError:       false,
 				wantConfig: agentcontainers.DevcontainerConfig{
-					MergedConfiguration: agentcontainers.DevcontainerConfiguration{
-						Customizations: agentcontainers.DevcontainerCustomizations{
+					MergedConfiguration: agentcontainers.DevcontainerMergedConfiguration{
+						Customizations: agentcontainers.DevcontainerMergedCustomizations{
 							Coder: nil,
 						},
 					},


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/732

This PR supports specifying a name that will be used for the devcontainer agent in the customizations section of the devcontainer.json configuration file. 

A follow up PR will introduce a fallback that names agents based on the folder name before falling back to the container name.