### PR TITLE
feat(dogfood/coder): add devcontainer-cli module

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -343,6 +343,13 @@ module "zed" {
   folder     = local.repo_dir
 }
 
+module "devcontainers-cli" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/modules/devcontainers-cli/coder"
+  version  = ">= 1.0.0"
+  agent_id = coder_agent.dev.id
+}
+
 resource "coder_agent" "dev" {
   arch = "amd64"
   os   = "linux"


### PR DESCRIPTION
This change adds the `devcontainers-cli` module to ensure the command
has been installed.

Its presence will not change how workspaces behave currently without
additional changes to the terraform.

Updates coder/internal#463