### PR TITLE
fix(agent/agentcontainers): ensure agent name env var is correct

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1177,7 +1177,10 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 					subAgentConfig.Name = name
 					configOutdated = true
 				} else {
-					logger.Warn(ctx, "invalid name in devcontainer customization, ignoring", slog.F("name", name))
+					logger.Warn(ctx, "invalid name in devcontainer customization, ignoring",
+						slog.F("name", name),
+						slog.F("regex", provisioner.AgentNameRegex.String()),
+					)
 				}
 			}
 

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1160,7 +1160,7 @@ func (api *API) maybeInjectSubAgentIntoContainerLocked(ctx context.Context, dc c
 				if provisioner.AgentNameRegex.Match([]byte(name)) {
 					subAgentConfig.Name = name
 				} else {
-					logger.Warn(ctx, "invalid agent name in devcontainer customization, ignoring", slog.F("name", name))
+					logger.Warn(ctx, "invalid name in devcontainer customization, ignoring", slog.F("name", name))
 				}
 			}
 		}

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1896,6 +1896,10 @@ func TestAPI(t *testing.T) {
 	t.Run("CreateReadsConfigTwice", func(t *testing.T) {
 		t.Parallel()
 
+		if runtime.GOOS == "windows" {
+			t.Skip("Dev Container tests are not supported on Windows (this test uses mocks but fails due to Windows paths)")
+		}
+
 		var (
 			ctx    = testutil.Context(t, testutil.WaitMedium)
 			logger = testutil.Logger(t)

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1263,7 +1263,7 @@ func TestAPI(t *testing.T) {
 			}
 			fakeDCCLI = &fakeDevcontainerCLI{
 				execErrC:       make(chan func(cmd string, args ...string) error, 1),
-				readConfigErrC: make(chan func(envs []string) error, 1),
+				readConfigErrC: make(chan func(envs []string) error, 2),
 			}
 
 			testContainer = codersdk.WorkspaceAgentContainer{
@@ -1325,6 +1325,10 @@ func TestAPI(t *testing.T) {
 			assert.Empty(t, args)
 			return nil
 		}) // Exec pwd.
+		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
+			assert.Empty(t, envs)
+			return nil
+		}) // We run 'ReadConfig' twice, once to get the agent name, second to read the rest.
 		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
 			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
@@ -1472,6 +1476,10 @@ func TestAPI(t *testing.T) {
 			assert.Empty(t, args)
 			return nil
 		}) // Exec pwd.
+		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
+			assert.Empty(t, envs)
+			return nil
+		}) // We run 'ReadConfig' twice, once to get the agent name, second to read the rest.
 		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
 			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
@@ -1883,6 +1891,107 @@ func TestAPI(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("CreateReadsConfigTwice", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctx    = testutil.Context(t, testutil.WaitMedium)
+			logger = testutil.Logger(t)
+			mClock = quartz.NewMock(t)
+			mCCLI  = acmock.NewMockContainerCLI(gomock.NewController(t))
+			fSAC   = &fakeSubAgentClient{
+				logger:     logger.Named("fakeSubAgentClient"),
+				createErrC: make(chan error, 1),
+			}
+			fDCCLI = &fakeDevcontainerCLI{
+				readConfig: agentcontainers.DevcontainerConfig{
+					Configuration: agentcontainers.DevcontainerConfiguration{
+						Customizations: agentcontainers.DevcontainerCustomizations{
+							Coder: agentcontainers.CoderCustomization{
+								// We want to specify a custom name for this agent.
+								Name: "custom-name",
+							},
+						},
+					},
+				},
+				readConfigErrC: make(chan func(envs []string) error, 2),
+				execErrC:       make(chan func(cmd string, args ...string) error, 1),
+			}
+
+			testContainer = codersdk.WorkspaceAgentContainer{
+				ID:           "test-container-id",
+				FriendlyName: "test-container",
+				Image:        "test-image",
+				Running:      true,
+				CreatedAt:    time.Now(),
+				Labels: map[string]string{
+					agentcontainers.DevcontainerLocalFolderLabel: "/workspaces",
+					agentcontainers.DevcontainerConfigFileLabel:  "/workspace/.devcontainer/devcontainer.json",
+				},
+			}
+		)
+
+		coderBin, err := os.Executable()
+		require.NoError(t, err)
+
+		// Mock the `List` function to always return out test container.
+		mCCLI.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
+			Containers: []codersdk.WorkspaceAgentContainer{testContainer},
+		}, nil).AnyTimes()
+
+		// Mock the steps used for injecting the coder agent.
+		gomock.InOrder(
+			mCCLI.EXPECT().DetectArchitecture(gomock.Any(), testContainer.ID).Return(runtime.GOARCH, nil),
+			mCCLI.EXPECT().ExecAs(gomock.Any(), testContainer.ID, "root", "mkdir", "-p", "/.coder-agent").Return(nil, nil),
+			mCCLI.EXPECT().Copy(gomock.Any(), testContainer.ID, coderBin, "/.coder-agent/coder").Return(nil),
+			mCCLI.EXPECT().ExecAs(gomock.Any(), testContainer.ID, "root", "chmod", "0755", "/.coder-agent", "/.coder-agent/coder").Return(nil, nil),
+		)
+
+		mClock.Set(time.Now()).MustWait(ctx)
+		tickerTrap := mClock.Trap().TickerFunc("updaterLoop")
+
+		api := agentcontainers.NewAPI(logger,
+			agentcontainers.WithClock(mClock),
+			agentcontainers.WithContainerCLI(mCCLI),
+			agentcontainers.WithDevcontainerCLI(fDCCLI),
+			agentcontainers.WithSubAgentClient(fSAC),
+			agentcontainers.WithSubAgentURL("test-subagent-url"),
+			agentcontainers.WithWatcher(watcher.NewNoop()),
+		)
+		defer api.Close()
+
+		// Close before api.Close() defer to avoid deadlock after test.
+		defer close(fSAC.createErrC)
+		defer close(fDCCLI.execErrC)
+		defer close(fDCCLI.readConfigErrC)
+
+		// Given: We allow agent creation and injection to succeed.
+		testutil.RequireSend(ctx, t, fSAC.createErrC, nil)
+		testutil.RequireSend(ctx, t, fDCCLI.execErrC, func(cmd string, args ...string) error {
+			assert.Equal(t, "pwd", cmd)
+			assert.Empty(t, args)
+			return nil
+		})
+		testutil.RequireSend(ctx, t, fDCCLI.readConfigErrC, func(env []string) error {
+			// We expect no env args to be passed into the first read.
+			assert.Empty(t, env)
+			return nil
+		})
+		testutil.RequireSend(ctx, t, fDCCLI.readConfigErrC, func(env []string) error {
+			// We expect the agent name passed here to have been read from the config.
+			assert.Contains(t, env, "CODER_WORKSPACE_AGENT_NAME=custom-name")
+			assert.NotContains(t, env, "CODER_WORKSPACE_AGENT_NAME=test-container")
+			return nil
+		})
+
+		// Wait until the ticker has been registered.
+		tickerTrap.MustWait(ctx).MustRelease(ctx)
+		tickerTrap.Close()
+
+		// Then: We expected it to succeed
+		require.Len(t, fSAC.created, 1)
 	})
 }
 

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1263,7 +1263,7 @@ func TestAPI(t *testing.T) {
 			}
 			fakeDCCLI = &fakeDevcontainerCLI{
 				execErrC:       make(chan func(cmd string, args ...string) error, 1),
-				readConfigErrC: make(chan func(envs []string) error, 2),
+				readConfigErrC: make(chan func(envs []string) error, 1),
 			}
 
 			testContainer = codersdk.WorkspaceAgentContainer{

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1326,10 +1326,6 @@ func TestAPI(t *testing.T) {
 			return nil
 		}) // Exec pwd.
 		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
-			assert.Empty(t, envs)
-			return nil
-		}) // We run 'ReadConfig' twice, once to get the agent name, second to read the rest.
-		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
 			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
 			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
@@ -1476,10 +1472,6 @@ func TestAPI(t *testing.T) {
 			assert.Empty(t, args)
 			return nil
 		}) // Exec pwd.
-		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
-			assert.Empty(t, envs)
-			return nil
-		}) // We run 'ReadConfig' twice, once to get the agent name, second to read the rest.
 		testutil.RequireSend(ctx, t, fakeDCCLI.readConfigErrC, func(envs []string) error {
 			assert.Contains(t, envs, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			assert.Contains(t, envs, "CODER_WORKSPACE_NAME=test-workspace")
@@ -1979,12 +1971,12 @@ func TestAPI(t *testing.T) {
 			return nil
 		})
 		testutil.RequireSend(ctx, t, fDCCLI.readConfigErrC, func(env []string) error {
-			// We expect no env args to be passed into the first read.
-			assert.Empty(t, env)
+			// We expect the wrong workspace agent name passed in first.
+			assert.Contains(t, env, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			return nil
 		})
 		testutil.RequireSend(ctx, t, fDCCLI.readConfigErrC, func(env []string) error {
-			// We expect the agent name passed here to have been read from the config.
+			// We then expect the agent name passed here to have been read from the config.
 			assert.Contains(t, env, "CODER_WORKSPACE_AGENT_NAME=custom-name")
 			assert.NotContains(t, env, "CODER_WORKSPACE_AGENT_NAME=test-container")
 			return nil


### PR DESCRIPTION
Previously, `CODER_WORKSPACE_AGENT_NAME` would always be passed as the dev container name.

This is invalid for the following scenarios:
- The dev container is specified in terraform
- The dev container has a name customization

This change now runs `ReadConfig` twice. The first read is to extract a name (if present), from the `devcontainer.json`. The second read will then use the name we have stored for the dev container (so this could be either the customization, terraform resource name, or container name).