### PR TITLE
fix!: do not create provisioner job for orphan delete

### DIFF
--- a/cli/cliui/provisionerjob.go
+++ b/cli/cliui/provisionerjob.go
@@ -19,6 +19,9 @@ import (
 )
 
 func WorkspaceBuild(ctx context.Context, writer io.Writer, client *codersdk.Client, build uuid.UUID) error {
+	if build == uuid.Nil {
+		return nil
+	}
 	return ProvisionerJob(ctx, writer, ProvisionerJobOptions{
 		Fetch: func() (codersdk.ProvisionerJob, error) {
 			build, err := client.WorkspaceBuild(ctx, build)

--- a/cli/cliutil/provisionerwarn.go
+++ b/cli/cliutil/provisionerwarn.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -26,10 +28,13 @@ Details:
 
 // WarnMatchedProvisioners warns the user if there are no provisioners that
 // match the requested tags for a given provisioner job.
-// If the job is not pending, it is ignored.
+// If the job is not pending or its ID is nil, it is ignored.
 func WarnMatchedProvisioners(w io.Writer, mp *codersdk.MatchedProvisioners, job codersdk.ProvisionerJob) {
 	if mp == nil {
 		// Nothing in the response, nothing to do here!
+		return
+	}
+	if job.ID == uuid.Nil {
 		return
 	}
 	if job.Status != codersdk.ProvisionerJobPending {

--- a/cli/cliutil/provisionerwarn_test.go
+++ b/cli/cliutil/provisionerwarn_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/cliutil"
@@ -20,12 +21,19 @@ func TestWarnMatchedProvisioners(t *testing.T) {
 		expect string
 	}{
 		{
+			name:   "empty",
+			mp:     nil,
+			job:    codersdk.ProvisionerJob{},
+			expect: "",
+		},
+		{
 			name: "no_match",
 			mp: &codersdk.MatchedProvisioners{
 				Count:     0,
 				Available: 0,
 			},
 			job: codersdk.ProvisionerJob{
+				ID:     uuid.New(),
 				Status: codersdk.ProvisionerJobPending,
 			},
 			expect: `there are no provisioners that accept the required tags`,
@@ -37,6 +45,7 @@ func TestWarnMatchedProvisioners(t *testing.T) {
 				Available: 0,
 			},
 			job: codersdk.ProvisionerJob{
+				ID:     uuid.New(),
 				Status: codersdk.ProvisionerJobPending,
 			},
 			expect: `Provisioners that accept the required tags have not responded for longer than expected`,
@@ -48,6 +57,7 @@ func TestWarnMatchedProvisioners(t *testing.T) {
 				Available: 1,
 			},
 			job: codersdk.ProvisionerJob{
+				ID:     uuid.New(),
 				Status: codersdk.ProvisionerJobPending,
 			},
 		},
@@ -55,6 +65,7 @@ func TestWarnMatchedProvisioners(t *testing.T) {
 			name: "not_pending",
 			mp:   &codersdk.MatchedProvisioners{},
 			job: codersdk.ProvisionerJob{
+				ID:     uuid.New(),
 				Status: codersdk.ProvisionerJobRunning,
 			},
 		},

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,30 +50,42 @@ func TestDelete(t *testing.T) {
 
 	t.Run("Orphan", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		client, closer := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
-		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
-		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
-		inv, root := clitest.New(t, "delete", workspace.Name, "-y", "--orphan")
+		templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+		version := coderdtest.CreateTemplateVersion(t, templateAdmin, owner.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, templateAdmin, version.ID)
+		template := coderdtest.CreateTemplate(t, templateAdmin, owner.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, templateAdmin, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, templateAdmin, workspace.LatestBuild.ID)
 
-		//nolint:gocritic // Deleting orphaned workspaces requires an admin.
-		clitest.SetupConfig(t, client, root)
+		// Ensure the provisioner daemon is closed before running the test.
+		// This is to validate that the orphan deletion does not require
+		// a provisioner job.
+		require.NoError(t, closer.Close())
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		inv, root := clitest.New(t, "delete", workspace.Name, "-y", "--orphan")
+		clitest.SetupConfig(t, templateAdmin, root)
+
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t).Attach(inv)
 		inv.Stderr = pty.Output()
 		go func() {
 			defer close(doneChan)
-			err := inv.Run()
+			err := inv.WithContext(ctx).Run()
 			// When running with the race detector on, we sometimes get an EOF.
 			if err != nil {
 				assert.ErrorIs(t, err, io.EOF)
 			}
 		}()
 		pty.ExpectMatch("has been deleted")
-		<-doneChan
+		testutil.TryReceive(ctx, t, doneChan)
+
+		_, err := client.Workspace(ctx, workspace.ID)
+		require.Error(t, err)
+		cerr := coderdtest.SDKError(t, err)
+		require.Equal(t, http.StatusGone, cerr.StatusCode())
 	})
 
 	// Super orphaned, as the workspace doesn't even have a user.

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1235,6 +1235,12 @@ class ApiMethods {
 			data,
 		);
 
+		if (response.status === 204) {
+			if (data.transition === "delete" && data.orphan) {
+				return {} as TypesGen.WorkspaceBuild;
+			}
+		}
+
 		return response.data;
 	};
 


### PR DESCRIPTION
Fixes #18080

NOTE: calling this out as a breaking change so that it is highly visible in the changelog.

This modifies wsbuilder to no longer create a workspace build when orphan is set.
As a consequence of this, `POST /api/v2/workspaces/{id}/builds` will return a 204 No Content when a workspace is successfully deleted with the `--orphan` option.