### PR TITLE
fix: complete job and mark workspace as deleted when no provisioners are available

### DIFF
--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,28 +52,35 @@ func TestDelete(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
-		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
-		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
-		inv, root := clitest.New(t, "delete", workspace.Name, "-y", "--orphan")
+		templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+		version := coderdtest.CreateTemplateVersion(t, templateAdmin, owner.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, templateAdmin, version.ID)
+		template := coderdtest.CreateTemplate(t, templateAdmin, owner.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, templateAdmin, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, templateAdmin, workspace.LatestBuild.ID)
 
-		//nolint:gocritic // Deleting orphaned workspaces requires an admin.
-		clitest.SetupConfig(t, client, root)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		inv, root := clitest.New(t, "delete", workspace.Name, "-y", "--orphan")
+		clitest.SetupConfig(t, templateAdmin, root)
+
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t).Attach(inv)
 		inv.Stderr = pty.Output()
 		go func() {
 			defer close(doneChan)
-			err := inv.Run()
+			err := inv.WithContext(ctx).Run()
 			// When running with the race detector on, we sometimes get an EOF.
 			if err != nil {
 				assert.ErrorIs(t, err, io.EOF)
 			}
 		}()
 		pty.ExpectMatch("has been deleted")
-		<-doneChan
+		testutil.TryReceive(ctx, t, doneChan)
+
+		_, err := client.Workspace(ctx, workspace.ID)
+		require.Error(t, err)
+		cerr := coderdtest.SDKError(t, err)
+		require.Equal(t, http.StatusGone, cerr.StatusCode())
 	})
 
 	// Super orphaned, as the workspace doesn't even have a user.

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -4464,7 +4464,7 @@ func (q *FakeQuerier) GetProvisionerDaemons(_ context.Context) ([]database.Provi
 	defer q.mutex.RUnlock()
 
 	if len(q.provisionerDaemons) == 0 {
-		return nil, sql.ErrNoRows
+		return []database.ProvisionerDaemon{}, nil
 	}
 	// copy the data so that the caller can't manipulate any data inside dbmem
 	// after returning

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -4464,6 +4464,7 @@ func (q *FakeQuerier) GetProvisionerDaemons(_ context.Context) ([]database.Provi
 	defer q.mutex.RUnlock()
 
 	if len(q.provisionerDaemons) == 0 {
+		// Returning err=nil here for consistency with real querier
 		return []database.ProvisionerDaemon{}, nil
 	}
 	// copy the data so that the caller can't manipulate any data inside dbmem

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -424,10 +424,10 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var qpr database.GetProvisionerJobsByIDsWithQueuePositionRow
+	var queuePos database.GetProvisionerJobsByIDsWithQueuePositionRow
 	if provisionerJob != nil {
-		qpr.ProvisionerJob = *provisionerJob
-		qpr.QueuePosition = 0
+		queuePos.ProvisionerJob = *provisionerJob
+		queuePos.QueuePosition = 0
 		if err := provisionerjobs.PostJob(api.Pubsub, *provisionerJob); err != nil {
 			// Client probably doesn't care about this error, so just log it.
 			api.Logger.Error(ctx, "failed to post provisioner job to pubsub", slog.Error(err))
@@ -468,7 +468,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	apiBuild, err := api.convertWorkspaceBuild(
 		*workspaceBuild,
 		workspace,
-		qpr,
+		queuePos,
 		[]database.WorkspaceResource{},
 		[]database.WorkspaceResourceMetadatum{},
 		[]database.WorkspaceAgent{},

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -436,6 +436,11 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		// We may need to complete the audit if wsbuilder determined that
 		// no provisioner could handle an orphan-delete job and completed it.
 		if createBuild.Orphan && createBuild.Transition == codersdk.WorkspaceTransitionDelete && provisionerJob.CompletedAt.Valid {
+			api.Logger.Warn(ctx, "orphan delete handled by wsbuilder due to no eligible provisioners",
+				slog.F("workspace_id", workspace.ID),
+				slog.F("workspace_build_id", workspaceBuild.ID),
+				slog.F("provisioner_job_id", provisionerJob.ID),
+			)
 			buildResourceInfo := audit.AdditionalFields{
 				WorkspaceName:  workspace.Name,
 				BuildNumber:    strconv.Itoa(int(workspaceBuild.BuildNumber)),

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -423,7 +423,10 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var qpr database.GetProvisionerJobsByIDsWithQueuePositionRow
 	if provisionerJob != nil {
+		qpr.ProvisionerJob = *provisionerJob
+		qpr.QueuePosition = 0
 		if err := provisionerjobs.PostJob(api.Pubsub, *provisionerJob); err != nil {
 			// Client probably doesn't care about this error, so just log it.
 			api.Logger.Error(ctx, "failed to post provisioner job to pubsub", slog.Error(err))
@@ -433,10 +436,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	apiBuild, err := api.convertWorkspaceBuild(
 		*workspaceBuild,
 		workspace,
-		database.GetProvisionerJobsByIDsWithQueuePositionRow{
-			ProvisionerJob: *provisionerJob,
-			QueuePosition:  0,
-		},
+		qpr,
 		[]database.WorkspaceResource{},
 		[]database.WorkspaceResourceMetadatum{},
 		[]database.WorkspaceAgent{},

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -500,7 +500,9 @@ func TestWorkspaceBuildsProvisionerState(t *testing.T) {
 				Orphan:            true,
 			})
 			require.NoError(t, err)
-			coderdtest.AwaitWorkspaceBuildJobCompleted(t, templateAdmin, build.ID)
+			require.Equal(t, codersdk.WorkspaceTransitionDelete, build.Transition)
+			require.Equal(t, codersdk.ProvisionerJobFailed, build.Job.Status)
+			require.Contains(t, build.Job.Error, "No provisioners were available to handle the request")
 
 			ws, err := client.Workspace(ctx, r.Workspace.ID)
 			require.Empty(t, ws)

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -528,8 +528,8 @@ func TestWorkspaceBuildsProvisionerState(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, codersdk.WorkspaceTransitionDelete, build.Transition)
-			require.Equal(t, codersdk.ProvisionerJobFailed, build.Job.Status)
-			require.Contains(t, build.Job.Error, "No provisioners were available to handle the request")
+			require.Equal(t, codersdk.ProvisionerJobSucceeded, build.Job.Status)
+			require.Empty(t, build.Job.Error)
 
 			ws, err := client.Workspace(ctx, r.Workspace.ID)
 			require.Empty(t, ws)

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -493,8 +493,6 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 				return BuildError{http.StatusInternalServerError, "mark orphan-delete provisioner job as completed", err}
 			}
 
-			// TODO: audit baggage?
-
 			// Re-fetch the completed provisioner job.
 			if pj, err := store.GetProvisionerJobByID(b.ctx, provisionerJob.ID); err == nil {
 				provisionerJob = pj

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -464,6 +464,35 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 			return BuildError{http.StatusInternalServerError, "get workspace build", err}
 		}
 
+		// If the requestor is trying to orphan-delete a workspace and there are no
+		// provisioners available, we should complete the build and mark the
+		// workspace as deleted ourselves.
+		// Orphan-deleting a workspace sends an empty state to Terraform, which means
+		// it won't actually delete anything.
+		// There are cases where tagged provisioner daemons have been decommissioned
+		// without deleting the relevant workspaces, and without any provisioners
+		// available these workspaces cannot be deleted.
+		if b.state.orphan && len(provisionerDaemons) == 0 {
+			// nolint: gocritic // At this moment, we are pretending to be provisionerd.
+			if err := store.UpdateProvisionerJobWithCompleteWithStartedAtByID(dbauthz.AsProvisionerd(b.ctx), database.UpdateProvisionerJobWithCompleteWithStartedAtByIDParams{
+				CompletedAt: sql.NullTime{Valid: true, Time: now},
+				Error:       sql.NullString{Valid: true, String: "No provisioners were available to handle the orphan-delete request. The workspace was marked as deleted, but no resources were destroyed."},
+				ErrorCode:   sql.NullString{Valid: false},
+				ID:          provisionerJob.ID,
+				StartedAt:   sql.NullTime{Valid: true, Time: now},
+				UpdatedAt:   now,
+			}); err != nil {
+				return BuildError{http.StatusInternalServerError, "mark orphan-delete provisioner job as completed", err}
+			}
+
+			if err := store.UpdateWorkspaceDeletedByID(b.ctx, database.UpdateWorkspaceDeletedByIDParams{
+				ID:      b.workspace.ID,
+				Deleted: true,
+			}); err != nil {
+				return BuildError{http.StatusInternalServerError, "mark workspace as deleted", err}
+			}
+		}
+
 		return nil
 	}, nil)
 	if err != nil {

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -492,7 +492,13 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 			}); err != nil {
 				return BuildError{http.StatusInternalServerError, "mark orphan-delete provisioner job as completed", err}
 			}
+
 			// TODO: audit baggage?
+
+			// Re-fetch the completed provisioner job.
+			if pj, err := store.GetProvisionerJobByID(b.ctx, provisionerJob.ID); err == nil {
+				provisionerJob = pj
+			}
 
 			if err := store.UpdateWorkspaceDeletedByID(b.ctx, database.UpdateWorkspaceDeletedByIDParams{
 				ID:      b.workspace.ID,

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -842,7 +842,7 @@ func TestWorkspaceBuildWithPreset(t *testing.T) {
 func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Provisioners", func(t *testing.T) {
+	t.Run("WithActiveProvisioners", func(t *testing.T) {
 		t.Parallel()
 		req := require.New(t)
 		asrt := assert.New(t)
@@ -904,7 +904,7 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 		req.NoError(err)
 	})
 
-	t.Run("NoProvisioners", func(t *testing.T) {
+	t.Run("NoActiveProvisioners", func(t *testing.T) {
 		t.Parallel()
 		req := require.New(t)
 		asrt := assert.New(t)
@@ -959,7 +959,7 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 			// Because no provisioners were available and the request was to delete --orphan
 			expectUpdateProvisionerJobWithCompleteWithStartedAtByID(func(params database.UpdateProvisionerJobWithCompleteWithStartedAtByIDParams) {
 				asrt.Equal(jobID, params.ID)
-				asrt.Contains(params.Error.String, "No provisioners were available")
+				asrt.False(params.Error.Valid)
 				asrt.True(params.CompletedAt.Valid)
 				asrt.True(params.StartedAt.Valid)
 			}),

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -967,6 +967,9 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 				asrt.Equal(workspaceID, params.ID)
 				asrt.True(params.Deleted)
 			}),
+			expectGetProvisionerJobByID(func(job database.ProvisionerJob) {
+				asrt.Equal(jobID, job.ID)
+			}),
 		)
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -1271,6 +1274,22 @@ func expectUpdateWorkspaceDeletedByID(assertions func(params database.UpdateWork
 				func(ctx context.Context, params database.UpdateWorkspaceDeletedByIDParams) error {
 					assertions(params)
 					return nil
+				},
+			)
+	}
+}
+
+// expectGetProvisionerJobByID asserts a call to GetProvisionerJobByID
+// and runs the provided assertions against it.
+func expectGetProvisionerJobByID(assertions func(job database.ProvisionerJob)) func(mTx *dbmock.MockStore) {
+	return func(mTx *dbmock.MockStore) {
+		mTx.EXPECT().GetProvisionerJobByID(gomock.Any(), gomock.Any()).
+			Times(1).
+			DoAndReturn(
+				func(ctx context.Context, id uuid.UUID) (database.ProvisionerJob, error) {
+					job := database.ProvisionerJob{ID: id}
+					assertions(job)
+					return job, nil
 				},
 			)
 	}

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -861,8 +861,10 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 			withRichParameters(nil),
 			withWorkspaceTags(inactiveVersionID, nil),
 			withProvisionerDaemons([]database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow{{
-				JobID:             inactiveJobID,
-				ProvisionerDaemon: database.ProvisionerDaemon{},
+				JobID: inactiveJobID,
+				ProvisionerDaemon: database.ProvisionerDaemon{
+					LastSeenAt: sql.NullTime{Valid: true, Time: dbtime.Now()},
+				},
 			}}),
 
 			// Outputs

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -43,6 +43,17 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 	const hasError = !deletionConfirmed && userConfirmationText.length > 0;
 	const displayErrorMessage = hasError && !isFocused;
 	const inputColor = hasError ? "error" : "primary";
+	// Orphaning is sort of a "last resort" that should really only
+	// be used under the following circumstances:
+	// a) Terraform is failing to apply while deleting, which
+	//    usually means that builds are failing as well.
+	// b) No provisioner is available to delete the workspace, which will
+	//    cause the job to remain in the "pending" state indefinitely.
+	//    The assumption here is that and admin will cancel the job.
+	const canOrphan =
+		canDeleteFailedWorkspace &&
+		(workspace.latest_build.status === "failed" ||
+			workspace.latest_build.status === "canceled");
 
 	return (
 		<ConfirmDialog
@@ -97,49 +108,41 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 								"data-testid": "delete-dialog-name-confirmation",
 							}}
 						/>
-						{
-							// Orphaning is sort of a "last resort" that should really only
-							// be used if Terraform is failing to apply while deleting, which
-							// usually means that builds are failing as well.
-							canDeleteFailedWorkspace &&
-								workspace.latest_build.status === "failed" && (
-									<div css={styles.orphanContainer}>
-										<div css={{ flexDirection: "column" }}>
-											<Checkbox
-												id="orphan_resources"
-												size="small"
-												color="warning"
-												onChange={() => {
-													setOrphanWorkspace(!orphanWorkspace);
-												}}
-												className="option"
-												name="orphan_resources"
-												checked={orphanWorkspace}
-												data-testid="orphan-checkbox"
-											/>
-										</div>
-										<div css={{ flexDirection: "column" }}>
-											<p className="info">Orphan Resources</p>
-											<span
-												css={{ fontSize: 12, marginTop: 4, display: "block" }}
-											>
-												As a Template Admin, you may skip resource cleanup to
-												delete a failed workspace. Resources such as volumes and
-												virtual machines will not be destroyed.&nbsp;
-												<Link
-													href={docs(
-														"/user-guides/workspace-management#workspace-resources",
-													)}
-													target="_blank"
-													rel="noreferrer"
-												>
-													Learn more...
-												</Link>
-											</span>
-										</div>
-									</div>
-								)
-						}
+						{canOrphan && (
+							<div css={styles.orphanContainer}>
+								<div css={{ flexDirection: "column" }}>
+									<Checkbox
+										id="orphan_resources"
+										size="small"
+										color="warning"
+										onChange={() => {
+											setOrphanWorkspace(!orphanWorkspace);
+										}}
+										className="option"
+										name="orphan_resources"
+										checked={orphanWorkspace}
+										data-testid="orphan-checkbox"
+									/>
+								</div>
+								<div css={{ flexDirection: "column" }}>
+									<p className="info">Orphan Resources</p>
+									<span css={{ fontSize: 12, marginTop: 4, display: "block" }}>
+										As a Template Admin, you may skip resource cleanup to delete
+										a failed workspace. Resources such as volumes and virtual
+										machines will not be destroyed.&nbsp;
+										<Link
+											href={docs(
+												"/user-guides/workspace-management#workspace-resources",
+											)}
+											target="_blank"
+											rel="noreferrer"
+										>
+											Learn more...
+										</Link>
+									</span>
+								</div>
+							</div>
+						)}
 					</form>
 				</>
 			}

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -49,7 +49,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 	//    usually means that builds are failing as well.
 	// b) No provisioner is available to delete the workspace, which will
 	//    cause the job to remain in the "pending" state indefinitely.
-	//    The assumption here is that and admin will cancel the job.
+	//    The assumption here is that an admin will cancel the job.
 	const canOrphan =
 		canDeleteFailedWorkspace &&
 		(workspace.latest_build.status === "failed" ||

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -49,7 +49,8 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 	//    usually means that builds are failing as well.
 	// b) No provisioner is available to delete the workspace, which will
 	//    cause the job to remain in the "pending" state indefinitely.
-	//    The assumption here is that an admin will cancel the job.
+	//    The assumption here is that an admin will cancel the job, in which
+	//    case we want to allow them to perform an orphan-delete.
 	const canOrphan =
 		canDeleteFailedWorkspace &&
 		(workspace.latest_build.status === "failed" ||


### PR DESCRIPTION
Alternate fix for https://github.com/coder/coder/issues/18080

Modifies wsbuilder to complete the provisioner job and mark the workspace as deleted if it is clear that no provisioner will be able to pick up the delete build.

This has a significant advantage of not deviating too much from the current semantics of `POST /api/v2/workspacebuilds`. https://github.com/coder/coder/pull/18460 ends up returning a 204 on orphan delete due to no build being created.

Downside is that we have to duplicate some responsibilities of provisionerdserver in wsbuilder. 

There is a slight gotcha to this approach though: if you stop a provisioner and then immediately try to orphan-delete, the job will still be created because of the provisioner heartbeat interval. However you can cancel it and try again.
