### PR TITLE
fix: add bottom padding back

### DIFF
--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -26,7 +26,7 @@ export const DashboardLayout: FC = () => {
 			<div className="flex flex-col min-h-full">
 				<Navbar />
 
-				<div className="flex flex-col flex-1">
+				<div className="flex flex-col flex-1 pb-12">
 					<Suspense fallback={<Loader />}>
 						<Outlet />
 					</Suspense>


### PR DESCRIPTION
This PR removed the bottom padding from the dashboard layout causing to bottom areas of some workspaces and templates page to appear too close to the footer. https://github.com/coder/coder/pull/17981

For now, this fix adds back the bottom padding until a more comprehensive fix can be done for workspace and templates pages.


<img width="1164" alt="Screenshot 2025-06-20 at 18 00 55" src="https://github.com/user-attachments/assets/fa1d703b-aa9d-4835-a3f9-16cdf21efa2c" />
<img width="1005" alt="Screenshot 2025-06-20 at 18 01 12" src="https://github.com/user-attachments/assets/d247948b-8286-41f8-be9f-404f5d28fc73" />
<img width="732" alt="Screenshot 2025-06-20 at 18 02 31" src="https://github.com/user-attachments/assets/aa361491-5316-4468-bc47-59a63a3328ec" />
