### PR TITLE
fix: fix validation error during workspace creation without preset

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -207,10 +207,10 @@ export const PresetNoneSelected: Story = {
 		onSubmit: (request, owner) => {
 			// Assert that template_version_preset_id is not present in the request
 			console.assert(
-				!('template_version_preset_id' in request),
-				'template_version_preset_id should not be present when "None" is selected'
+				!("template_version_preset_id" in request),
+				'template_version_preset_id should not be present when "None" is selected',
 			);
-			action('onSubmit')(request, owner);
+			action("onSubmit")(request, owner);
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -225,13 +225,17 @@ export const PresetNoneSelected: Story = {
 		await userEvent.click(canvas.getByText("None"));
 
 		// Fill in required fields and submit to test the API call
-		await userEvent.type(canvas.getByLabelText("Workspace Name"), "test-workspace");
+		await userEvent.type(
+			canvas.getByLabelText("Workspace Name"),
+			"test-workspace",
+		);
 		await userEvent.click(canvas.getByText("Create workspace"));
 	},
 	parameters: {
 		docs: {
 			description: {
-				story: "This story tests that when 'None' preset is selected, the template_version_preset_id field is not included in the form submission. The story first selects a preset to set the field value, then selects 'None' to unset it, and finally submits the form to verify the API call behavior.",
+				story:
+					"This story tests that when 'None' preset is selected, the template_version_preset_id field is not included in the form submission. The story first selects a preset to set the field value, then selects 'None' to unset it, and finally submits the form to verify the API call behavior.",
 			},
 		},
 	},

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -201,6 +201,42 @@ export const PresetReselected: Story = {
 	},
 };
 
+export const PresetNoneSelected: Story = {
+	args: {
+		...PresetsButNoneSelected.args,
+		onSubmit: (request, owner) => {
+			// Assert that template_version_preset_id is not present in the request
+			console.assert(
+				!('template_version_preset_id' in request),
+				'template_version_preset_id should not be present when "None" is selected'
+			);
+			action('onSubmit')(request, owner);
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// First select a preset to set the field value
+		await userEvent.click(canvas.getByLabelText("Preset"));
+		await userEvent.click(canvas.getByText("Preset 1"));
+
+		// Then select "None" to unset the field value
+		await userEvent.click(canvas.getByLabelText("Preset"));
+		await userEvent.click(canvas.getByText("None"));
+
+		// Fill in required fields and submit to test the API call
+		await userEvent.type(canvas.getByLabelText("Workspace Name"), "test-workspace");
+		await userEvent.click(canvas.getByText("Create workspace"));
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: "This story tests that when 'None' preset is selected, the template_version_preset_id field is not included in the form submission. The story first selects a preset to set the field value, then selects 'None' to unset it, and finally submits the form to verify the API call behavior.",
+			},
+		},
+	},
+};
+
 export const ExternalAuth: Story = {
 	args: {
 		externalAuth: [

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -369,7 +369,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 													setSelectedPresetIndex(index);
 													form.setFieldValue(
 														"template_version_preset_id",
-														option?.value,
+														index === 0 ? undefined : option?.value,
 													);
 												}}
 												placeholder="Select a preset"

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -369,7 +369,8 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 													setSelectedPresetIndex(index);
 													form.setFieldValue(
 														"template_version_preset_id",
-														index === 0 ? undefined : option?.value,
+														// Empty string is equivalent to using None
+														option?.value === "" ? undefined : option?.value,
 													);
 												}}
 												placeholder="Select a preset"

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -563,6 +563,10 @@ export const CreateWorkspacePageViewExperimental: FC<
 														return;
 													}
 													setSelectedPresetIndex(index);
+													form.setFieldValue(
+														"template_version_preset_id",
+														index === 0 ? undefined : option,
+													);
 												}}
 											>
 												<SelectTrigger>


### PR DESCRIPTION
closes https://github.com/coder/coder/issues/18430.

Selecting a preset, and then selecting the "None" preset used to set the preset ID to an empty string instead of `undefined`. This sent `""` to the backend, which expects a valid UUID.