### PR TITLE
chore: improve dynamic parameter validation errors

### DIFF
--- a/coderd/httpapi/httperror/doc.go
+++ b/coderd/httpapi/httperror/doc.go
@@ -1,0 +1,4 @@
+// Package httperror handles formatting and writing some sentinel errors returned
+// within coder to the API.
+// This package exists outside httpapi to avoid some cyclic dependencies
+package httperror

--- a/coderd/httpapi/httperror/wsbuild.go
+++ b/coderd/httpapi/httperror/wsbuild.go
@@ -1,0 +1,82 @@
+package httperror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/coder/coder/v2/coderd/dynamicparameters"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/wsbuilder"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func WriteWorkspaceBuildError(ctx context.Context, rw http.ResponseWriter, err error) {
+	var buildErr wsbuilder.BuildError
+	if errors.As(err, &buildErr) {
+		if httpapi.IsUnauthorizedError(err) {
+			buildErr.Status = http.StatusForbidden
+		}
+
+		httpapi.Write(ctx, rw, buildErr.Status, codersdk.Response{
+			Message: buildErr.Message,
+			Detail:  buildErr.Error(),
+		})
+		return
+	}
+
+	var parameterErr *dynamicparameters.ResolverError
+	if errors.As(err, &parameterErr) {
+		resp := codersdk.Response{
+			Message:     "Unable to validate parameters",
+			Validations: nil,
+		}
+
+		for name, diag := range parameterErr.Parameter {
+			resp.Validations = append(resp.Validations, codersdk.ValidationError{
+				Field:  name,
+				Detail: DiagnosticsErrorString(diag),
+			})
+		}
+
+		if parameterErr.Diagnostics.HasErrors() {
+			resp.Detail = DiagnosticsErrorString(parameterErr.Diagnostics)
+		}
+
+		httpapi.Write(ctx, rw, http.StatusBadRequest, resp)
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+		Message: "Internal error creating workspace build.",
+		Detail:  err.Error(),
+	})
+}
+
+func DiagnosticError(d *hcl.Diagnostic) string {
+	return fmt.Sprintf("%s; %s", d.Summary, d.Detail)
+}
+
+func DiagnosticsErrorString(d hcl.Diagnostics) string {
+	count := len(d)
+	switch {
+	case count == 0:
+		return "no diagnostics"
+	case count == 1:
+		return DiagnosticError(d[0])
+	default:
+		for _, d := range d {
+			// Render the first error diag.
+			// If there are warnings, do not priority them over errors.
+			if d.Severity == hcl.DiagError {
+				return fmt.Sprintf("%s, and %d other diagnostic(s)", DiagnosticError(d), count-1)
+			}
+		}
+
+		// All warnings? ok...
+		return fmt.Sprintf("%s, and %d other diagnostic(s)", DiagnosticError(d[0]), count-1)
+	}
+}

--- a/coderd/httpapi/httperror/wsbuild.go
+++ b/coderd/httpapi/httperror/wsbuild.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 
@@ -35,7 +36,15 @@ func WriteWorkspaceBuildError(ctx context.Context, rw http.ResponseWriter, err e
 			Validations: nil,
 		}
 
-		for name, diag := range parameterErr.Parameter {
+		// Sort the parameter names so that the order is consistent.
+		sortedNames := make([]string, 0, len(parameterErr.Parameter))
+		for name := range parameterErr.Parameter {
+			sortedNames = append(sortedNames, name)
+		}
+		sort.Strings(sortedNames)
+
+		for _, name := range sortedNames {
+			diag := parameterErr.Parameter[name]
 			resp.Validations = append(resp.Validations, codersdk.ValidationError{
 				Field:  name,
 				Detail: DiagnosticsErrorString(diag),

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/provisionerjobs"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpapi/httperror"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/prebuilds"
@@ -732,21 +733,11 @@ func createWorkspace(
 		)
 		return err
 	}, nil)
-	var bldErr wsbuilder.BuildError
-	if xerrors.As(err, &bldErr) {
-		httpapi.Write(ctx, rw, bldErr.Status, codersdk.Response{
-			Message: bldErr.Message,
-			Detail:  bldErr.Error(),
-		})
-		return
-	}
 	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error creating workspace.",
-			Detail:  err.Error(),
-		})
+		httperror.WriteWorkspaceBuildError(ctx, rw, err)
 		return
 	}
+
 	err = provisionerjobs.PostJob(api.Pubsub, *provisionerJob)
 	if err != nil {
 		// Client probably doesn't care about this error, so just log it.

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -760,20 +760,12 @@ func (b *Builder) getDynamicParameters() (names, values []string, err error) {
 		return nil, nil, BuildError{http.StatusInternalServerError, "failed to check if first build", err}
 	}
 
-	buildValues, diagnostics := dynamicparameters.ResolveParameters(b.ctx, b.workspace.OwnerID, render, firstBuild,
+	buildValues, err := dynamicparameters.ResolveParameters(b.ctx, b.workspace.OwnerID, render, firstBuild,
 		lastBuildParameters,
 		b.richParameterValues,
 		presetParameterValues)
-
-	if diagnostics.HasErrors() {
-		// TODO: Improve the error response. The response should include the validations for each failed
-		//  parameter. The response should also indicate it's a validation error or a more general form failure.
-		//  For now, any error is sufficient.
-		return nil, nil, BuildError{
-			Status:  http.StatusBadRequest,
-			Message: fmt.Sprintf("%d errors occurred while resolving parameters", len(diagnostics)),
-			Wrapped: diagnostics,
-		}
+	if err != nil {
+		return nil, nil, xerrors.Errorf("resolve parameters: %w", err)
 	}
 
 	names = make([]string, 0, len(buildValues))

--- a/coderd/wsbuilder/wsbuilderror/builderror.go
+++ b/coderd/wsbuilder/wsbuilderror/builderror.go
@@ -1,0 +1,1 @@
+package wsbuilderror

--- a/coderd/wsbuilder/wsbuilderror/builderror.go
+++ b/coderd/wsbuilder/wsbuilderror/builderror.go
@@ -1,1 +1,0 @@
-package wsbuilderror


### PR DESCRIPTION
# What this does

The current `BuildError` response from `wsbuilder` does not support rich errors from validation. Changed this to use the `Validations` block of codersdk responses to return all errors for invalid parameters.

-----

Example http response

```json
{
    "message": "Unable to validate parameters",
    "validations": [
        {
            "field": "big_number",
            "detail": "Invalid parameter value according to 'validation' block; Number must be between 500 and 1000"
        },
        {
            "field": "colors",
            "detail": "Values must be a valid option; Value \"[\\\"potatoe\\\"]\" is not a valid option, values \"potatoe\" are missing from the options"
        },
        {
            "field": "intro",
            "detail": "Invalid parameter value according to 'validation' block; All messages must start with 'Hello' (value \"Goodbye!\" does not match \"^Hello\")"
        }
    ]
}
```

Cli error

![Screenshot From 2025-06-23 10-17-26](https://github.com/user-attachments/assets/18be1b85-a0f1-4678-bd53-cad95a71505b)

