### PR TITLE
chore: remove per request dynamic parameters opt in and rely on template

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12043,10 +12043,6 @@ const docTemplate = `{
                 "dry_run": {
                     "type": "boolean"
                 },
-                "enable_dynamic_parameters": {
-                    "description": "EnableDynamicParameters skips some of the static parameter checking.\nIt will default to whatever the template has marked as the default experience.\nRequires the \"dynamic-experiment\" to be used.",
-                    "type": "boolean"
-                },
                 "log_level": {
                     "description": "Log level changes the default logging verbosity of a provider (\"info\" if empty).",
                     "enum": [
@@ -12127,9 +12123,6 @@ const docTemplate = `{
                 },
                 "autostart_schedule": {
                     "type": "string"
-                },
-                "enable_dynamic_parameters": {
-                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10753,10 +10753,6 @@
 				"dry_run": {
 					"type": "boolean"
 				},
-				"enable_dynamic_parameters": {
-					"description": "EnableDynamicParameters skips some of the static parameter checking.\nIt will default to whatever the template has marked as the default experience.\nRequires the \"dynamic-experiment\" to be used.",
-					"type": "boolean"
-				},
 				"log_level": {
 					"description": "Log level changes the default logging verbosity of a provider (\"info\" if empty).",
 					"enum": ["debug"],
@@ -10827,9 +10823,6 @@
 				},
 				"autostart_schedule": {
 					"type": "string"
-				},
-				"enable_dynamic_parameters": {
-					"type": "boolean"
 				},
 				"name": {
 					"type": "string"

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/rbac"
-	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
 	"github.com/coder/coder/v2/provisioner/echo"
@@ -260,7 +259,6 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 					Value: "eu",
 				},
 			}
-			request.EnableDynamicParameters = true
 		})
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, wrk.LatestBuild.ID)
 
@@ -285,7 +283,6 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 				RichParameterValues: []codersdk.WorkspaceBuildParameter{
 					{Name: "region", Value: regionVal},
 				},
-				EnableDynamicParameters: ptr.Ref(true),
 			})
 			require.NoError(t, err)
 			coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, bld.ID)

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -385,10 +385,6 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 			builder = builder.State(createBuild.ProvisionerState)
 		}
 
-		if createBuild.EnableDynamicParameters != nil {
-			builder = builder.DynamicParameters(*createBuild.EnableDynamicParameters)
-		}
-
 		workspaceBuild, provisionerJob, provisionerDaemons, err = builder.Build(
 			ctx,
 			tx,

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -717,10 +717,6 @@ func createWorkspace(
 			builder = builder.MarkPrebuiltWorkspaceClaim()
 		}
 
-		if req.EnableDynamicParameters {
-			builder = builder.DynamicParameters(req.EnableDynamicParameters)
-		}
-
 		workspaceBuild, provisionerJob, provisionerDaemons, err = builder.Build(
 			ctx,
 			db,

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -57,12 +57,10 @@ type Builder struct {
 	deploymentValues *codersdk.DeploymentValues
 	experiments      codersdk.Experiments
 
-	richParameterValues []codersdk.WorkspaceBuildParameter
-	// dynamicParametersEnabled is non-nil if set externally
-	dynamicParametersEnabled *bool
-	initiator                uuid.UUID
-	reason                   database.BuildReason
-	templateVersionPresetID  uuid.UUID
+	richParameterValues     []codersdk.WorkspaceBuildParameter
+	initiator               uuid.UUID
+	reason                  database.BuildReason
+	templateVersionPresetID uuid.UUID
 
 	// used during build, makes function arguments less verbose
 	ctx       context.Context
@@ -201,12 +199,6 @@ func (b Builder) MarkPrebuild() Builder {
 func (b Builder) MarkPrebuiltWorkspaceClaim() Builder {
 	// nolint: revive
 	b.prebuiltWorkspaceBuildStage = sdkproto.PrebuiltWorkspaceBuildStage_CLAIM
-	return b
-}
-
-func (b Builder) DynamicParameters(using bool) Builder {
-	// nolint: revive
-	b.dynamicParametersEnabled = ptr.Ref(using)
 	return b
 }
 
@@ -1211,10 +1203,6 @@ func (b *Builder) checkRunningBuild() error {
 }
 
 func (b *Builder) usingDynamicParameters() bool {
-	if b.dynamicParametersEnabled != nil {
-		return *b.dynamicParametersEnabled
-	}
-
 	tpl, err := b.getTemplate()
 	if err != nil {
 		return false // Let another part of the code get this error

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -227,7 +227,6 @@ type CreateWorkspaceRequest struct {
 	RichParameterValues     []WorkspaceBuildParameter `json:"rich_parameter_values,omitempty"`
 	AutomaticUpdates        AutomaticUpdates          `json:"automatic_updates,omitempty"`
 	TemplateVersionPresetID uuid.UUID                 `json:"template_version_preset_id,omitempty" format:"uuid"`
-	EnableDynamicParameters bool                      `json:"enable_dynamic_parameters,omitempty"`
 }
 
 func (c *Client) OrganizationByName(ctx context.Context, name string) (Organization, error) {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -110,10 +110,6 @@ type CreateWorkspaceBuildRequest struct {
 	LogLevel ProvisionerLogLevel `json:"log_level,omitempty" validate:"omitempty,oneof=debug"`
 	// TemplateVersionPresetID is the ID of the template version preset to use for the build.
 	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty" format:"uuid"`
-	// EnableDynamicParameters skips some of the static parameter checking.
-	// It will default to whatever the template has marked as the default experience.
-	// Requires the "dynamic-experiment" to be used.
-	EnableDynamicParameters *bool `json:"enable_dynamic_parameters,omitempty"`
 }
 
 type WorkspaceOptions struct {

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -1752,7 +1752,6 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 ```json
 {
   "dry_run": true,
-  "enable_dynamic_parameters": true,
   "log_level": "debug",
   "orphan": true,
   "rich_parameter_values": [

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1917,7 +1917,6 @@ This is required on creation to enable a user-flow of validating a template work
 ```json
 {
   "dry_run": true,
-  "enable_dynamic_parameters": true,
   "log_level": "debug",
   "orphan": true,
   "rich_parameter_values": [
@@ -1940,7 +1939,6 @@ This is required on creation to enable a user-flow of validating a template work
 | Name                         | Type                                                                          | Required | Restrictions | Description                                                                                                                                                                                                   |
 |------------------------------|-------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `dry_run`                    | boolean                                                                       | false    |              |                                                                                                                                                                                                               |
-| `enable_dynamic_parameters`  | boolean                                                                       | false    |              | Enable dynamic parameters skips some of the static parameter checking. It will default to whatever the template has marked as the default experience. Requires the "dynamic-experiment" to be used.           |
 | `log_level`                  | [codersdk.ProvisionerLogLevel](#codersdkprovisionerloglevel)                  | false    |              | Log level changes the default logging verbosity of a provider ("info" if empty).                                                                                                                              |
 | `orphan`                     | boolean                                                                       | false    |              | Orphan may be set for the Destroy transition.                                                                                                                                                                 |
 | `rich_parameter_values`      | array of [codersdk.WorkspaceBuildParameter](#codersdkworkspacebuildparameter) | false    |              | Rich parameter values are optional. It will write params to the 'workspace' scope. This will overwrite any existing parameters with the same name. This will not delete old params not included in this list. |
@@ -1982,7 +1980,6 @@ This is required on creation to enable a user-flow of validating a template work
 {
   "automatic_updates": "always",
   "autostart_schedule": "string",
-  "enable_dynamic_parameters": true,
   "name": "string",
   "rich_parameter_values": [
     {
@@ -2005,7 +2002,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 |------------------------------|-------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------|
 | `automatic_updates`          | [codersdk.AutomaticUpdates](#codersdkautomaticupdates)                        | false    |              |                                                                                                         |
 | `autostart_schedule`         | string                                                                        | false    |              |                                                                                                         |
-| `enable_dynamic_parameters`  | boolean                                                                       | false    |              |                                                                                                         |
 | `name`                       | string                                                                        | true     |              |                                                                                                         |
 | `rich_parameter_values`      | array of [codersdk.WorkspaceBuildParameter](#codersdkworkspacebuildparameter) | false    |              | Rich parameter values allows for additional parameters to be provided during the initial provision.     |
 | `template_id`                | string                                                                        | false    |              | Template ID specifies which template should be used for creating the workspace.                         |

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -25,7 +25,6 @@ of the template will be used.
 {
   "automatic_updates": "always",
   "autostart_schedule": "string",
-  "enable_dynamic_parameters": true,
   "name": "string",
   "rich_parameter_values": [
     {
@@ -624,7 +623,6 @@ of the template will be used.
 {
   "automatic_updates": "always",
   "autostart_schedule": "string",
-  "enable_dynamic_parameters": true,
   "name": "string",
   "rich_parameter_values": [
     {

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1759,7 +1759,6 @@ func TestWorkspaceTemplateParamsChange(t *testing.T) {
 				Value: "7",
 			},
 		},
-		EnableDynamicParameters: true,
 	})
 
 	// Then: the build should succeed. The updated value of param_min should be

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -490,7 +490,6 @@ export interface CreateWorkspaceBuildRequest {
 	readonly rich_parameter_values?: readonly WorkspaceBuildParameter[];
 	readonly log_level?: ProvisionerLogLevel;
 	readonly template_version_preset_id?: string;
-	readonly enable_dynamic_parameters?: boolean;
 }
 
 // From codersdk/workspaceproxy.go
@@ -510,7 +509,6 @@ export interface CreateWorkspaceRequest {
 	readonly rich_parameter_values?: readonly WorkspaceBuildParameter[];
 	readonly automatic_updates?: AutomaticUpdates;
 	readonly template_version_preset_id?: string;
-	readonly enable_dynamic_parameters?: boolean;
 }
 
 // From codersdk/deployment.go

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageExperimental.tsx
@@ -326,7 +326,6 @@ const CreateWorkspacePageExperimental: FC = () => {
 
 						const workspace = await createWorkspaceMutation.mutateAsync({
 							...workspaceRequest,
-							enable_dynamic_parameters: true,
 							userId: owner.id,
 						});
 						onCreateWorkspace(workspace);


### PR DESCRIPTION
When in experimental this was used as an escape hatch. Removed to be
consistent with the template author's intentions

Backwards compatible, removing an experimental api field that is no longer used.