### PR TITLE
chore: reorder prebuilt workspace authorization logic

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -169,10 +169,10 @@ func (q *querier) authorizePrebuiltWorkspace(ctx context.Context, action policy.
 		if prebuiltErr = q.authorizeContext(ctx, action, workspace.AsPrebuild()); prebuiltErr == nil {
 			return nil
 		}
-		return xerrors.Errorf("authorize context as prebuild: %w", errors.Join(workspaceErr, prebuiltErr))
+		return xerrors.Errorf("authorize context failed for workspace (%v) and prebuilt (%w)", workspaceErr, prebuiltErr)
 	}
 
-	return xerrors.Errorf("authorize context: %w", errors.Join(workspaceErr))
+	return xerrors.Errorf("authorize context: %w", workspaceErr)
 }
 
 type authContextKey struct{}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -169,7 +169,7 @@ func (q *querier) authorizePrebuiltWorkspace(ctx context.Context, action policy.
 		if prebuiltErr = q.authorizeContext(ctx, action, workspace.AsPrebuild()); prebuiltErr == nil {
 			return nil
 		}
-		return xerrors.Errorf("authorize context: %w", errors.Join(workspaceErr, prebuiltErr))
+		return xerrors.Errorf("authorize context as prebuild: %w", errors.Join(workspaceErr, prebuiltErr))
 	}
 
 	return xerrors.Errorf("authorize context: %w", errors.Join(workspaceErr))

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -5590,7 +5590,17 @@ func (s *MethodTestSuite) TestAuthorizePrebuiltWorkspace() {
 			Reason:            database.BuildReasonInitiator,
 			TemplateVersionID: tv.ID,
 			JobID:             pj.ID,
-		}).Asserts(w.AsPrebuild(), policy.ActionDelete)
+		}).
+			// Simulate a fallback authorization flow:
+			// - First, the default workspace authorization fails (simulated by returning an error).
+			// - Then, authorization is retried using the prebuilt workspace object, which succeeds.
+			// The test asserts that both authorization attempts occur in the correct order.
+			WithSuccessAuthorizer(func(ctx context.Context, subject rbac.Subject, action policy.Action, obj rbac.Object) error {
+				if obj.Type == rbac.ResourceWorkspace.Type {
+					return xerrors.Errorf("not authorized for workspace type")
+				}
+				return nil
+			}).Asserts(w, policy.ActionDelete, w.AsPrebuild(), policy.ActionDelete)
 	}))
 	s.Run("PrebuildUpdate/InsertWorkspaceBuildParameters", s.Subtest(func(db database.Store, check *expects) {
 		u := dbgen.User(s.T(), db, database.User{})
@@ -5619,6 +5629,16 @@ func (s *MethodTestSuite) TestAuthorizePrebuiltWorkspace() {
 		})
 		check.Args(database.InsertWorkspaceBuildParametersParams{
 			WorkspaceBuildID: wb.ID,
-		}).Asserts(w.AsPrebuild(), policy.ActionUpdate)
+		}).
+			// Simulate a fallback authorization flow:
+			// - First, the default workspace authorization fails (simulated by returning an error).
+			// - Then, authorization is retried using the prebuilt workspace object, which succeeds.
+			// The test asserts that both authorization attempts occur in the correct order.
+			WithSuccessAuthorizer(func(ctx context.Context, subject rbac.Subject, action policy.Action, obj rbac.Object) error {
+				if obj.Type == rbac.ResourceWorkspace.Type {
+					return xerrors.Errorf("not authorized for workspace type")
+				}
+				return nil
+			}).Asserts(w, policy.ActionUpdate, w.AsPrebuild(), policy.ActionUpdate)
 	}))
 }

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -199,6 +199,13 @@ func (gm GroupMember) RBACObject() rbac.Object {
 	return rbac.ResourceGroupMember.WithID(gm.UserID).InOrg(gm.OrganizationID).WithOwner(gm.UserID.String())
 }
 
+// PrebuiltWorkspaceResource defines the interface for types that can be identified as prebuilt workspaces
+// and converted to their corresponding prebuilt workspace RBAC object.
+type PrebuiltWorkspaceResource interface {
+	IsPrebuild() bool
+	AsPrebuild() rbac.Object
+}
+
 // WorkspaceTable converts a Workspace to it's reduced version.
 // A more generalized solution is to use json marshaling to
 // consistently keep these two structs in sync.

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -396,10 +396,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 				}
 				// Special handling for prebuilt workspace deletion
 				if action == policy.ActionDelete {
-					if workspaceObj, ok := object.(interface {
-						IsPrebuild() bool
-						AsPrebuild() rbac.Object
-					}); ok && workspaceObj.IsPrebuild() {
+					if workspaceObj, ok := object.(database.PrebuiltWorkspaceResource); ok && workspaceObj.IsPrebuild() {
 						return api.Authorize(r, action, workspaceObj.AsPrebuild())
 					}
 				}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -397,8 +397,11 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 					return true
 				}
 				// Special handling for prebuilt workspace deletion
-				if object.RBACObject().Type == rbac.ResourceWorkspace.Type && action == policy.ActionDelete {
-					if workspaceObj, ok := object.(database.Workspace); ok && workspaceObj.IsPrebuild() {
+				if action == policy.ActionDelete {
+					if workspaceObj, ok := object.(interface {
+						IsPrebuild() bool
+						AsPrebuild() rbac.Object
+					}); ok && workspaceObj.IsPrebuild() {
 						return api.Authorize(r, action, workspaceObj.AsPrebuild())
 					}
 				}

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -963,14 +963,12 @@ func (b *Builder) authorize(authFunc func(action policy.Action, object rbac.Obje
 		return BuildError{http.StatusBadRequest, msg, xerrors.New(msg)}
 	}
 
+	// Try default workspace authorization first
+	authorized := authFunc(action, b.workspace)
+
 	// Special handling for prebuilt workspace deletion
-	authorized := false
-	if action == policy.ActionDelete && b.workspace.IsPrebuild() && authFunc(action, b.workspace.AsPrebuild()) {
-		authorized = true
-	}
-	// Fallback to default authorization
-	if !authorized && authFunc(action, b.workspace) {
-		authorized = true
+	if !authorized && action == policy.ActionDelete && b.workspace.IsPrebuild() {
+		authorized = authFunc(action, b.workspace.AsPrebuild())
 	}
 
 	if !authorized {


### PR DESCRIPTION
## Description

Follow-up from PR https://github.com/coder/coder/pull/18333
Related with: https://github.com/coder/coder/pull/18333#discussion_r2159300881

This changes the authorization logic to first try the normal workspace authorization check, and only if the resource is a prebuilt workspace, fall back to the prebuilt workspace authorization check. Since prebuilt workspaces are a subset of workspaces, the normal workspace check is more likely to succeed. This is a small optimization to reduce unnecessary prebuilt authorization calls.