### PR TITLE
feat: add workspace build status to task page

### DIFF
--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, spyOn, within } from "@storybook/test";
+import { API } from "api/api";
 import type {
 	Workspace,
 	WorkspaceApp,
@@ -9,6 +10,7 @@ import {
 	MockFailedWorkspace,
 	MockStartingWorkspace,
 	MockStoppedWorkspace,
+	MockTemplate,
 	MockWorkspace,
 	MockWorkspaceAgent,
 	MockWorkspaceApp,
@@ -52,6 +54,16 @@ export const LoadingError: Story = {
 
 export const WaitingOnBuild: Story = {
 	beforeEach: () => {
+		spyOn(data, "fetchTask").mockResolvedValue({
+			prompt: "Create competitors page",
+			workspace: MockStartingWorkspace,
+		});
+	},
+};
+
+export const WaitingOnBuildWithTemplate: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplate").mockResolvedValue(MockTemplate);
 		spyOn(data, "fetchTask").mockResolvedValue({
 			prompt: "Create competitors page",
 			workspace: MockStartingWorkspace,

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -124,6 +124,7 @@ const TaskPage = () => {
 					<WorkspaceBuildProgress
 						workspace={task.workspace}
 						transitionStats={transition}
+						stack={true}
 					/>
 				</div>
 			</div>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -116,9 +116,6 @@ const TaskPage = () => {
 					<h3 className="m-0 font-medium text-content-primary text-base">
 						Starting your workspace
 					</h3>
-					<span className="text-content-secondary text-sm">
-						This should take a few minutes
-					</span>
 				</div>
 				{lastStage && (
 					<div className="text-content-secondary text-sm">{lastStage}</div>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -109,22 +109,23 @@ const TaskPage = () => {
 		// If no template yet, use an indeterminate progress bar.
 		const transition = (template &&
 			ActiveTransition(template, task.workspace)) || { P50: 0, P95: null };
-		const lastStage = buildLogs?.[buildLogs.length - 1]?.stage;
+		const lastStage =
+			buildLogs?.[buildLogs.length - 1]?.stage || "Waiting for build status";
 		content = (
-			<div className="w-full min-h-80 flex flex-col items-center justify-center gap-2">
-				<div className="flex flex-col items-center">
+			<div className="w-full min-h-80 flex flex-col">
+				<div className="flex flex-col items-center grow justify-center">
 					<h3 className="m-0 font-medium text-content-primary text-base">
 						Starting your workspace
 					</h3>
+					{lastStage && (
+						<div className="text-content-secondary text-sm">{lastStage}</div>
+					)}
 				</div>
-				{lastStage && (
-					<div className="text-content-secondary text-sm">{lastStage}</div>
-				)}
-				<div css={{ minWidth: 315 }}>
+				<div className="w-full">
 					<WorkspaceBuildProgress
 						workspace={task.workspace}
 						transitionStats={transition}
-						stack={true}
+						style="task"
 					/>
 				</div>
 			</div>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -125,7 +125,7 @@ const TaskPage = () => {
 					<WorkspaceBuildProgress
 						workspace={task.workspace}
 						transitionStats={transition}
-						style="task"
+						variant="task"
 					/>
 				</div>
 			</div>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -117,9 +117,7 @@ const TaskPage = () => {
 					<h3 className="m-0 font-medium text-content-primary text-base">
 						Starting your workspace
 					</h3>
-					{lastStage && (
-						<div className="text-content-secondary text-sm">{lastStage}</div>
-					)}
+					<div className="text-content-secondary text-sm">{lastStage}</div>
 				</div>
 				<div className="w-full">
 					<WorkspaceBuildProgress

--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -117,7 +117,7 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	return (
 		<div css={styles.stack}>
 			{style === "task" && (
-				<div className={"mb-1 text-center"}>
+				<div className="mb-1 text-center">
 					<div css={styles.label} data-chromatic="ignore">
 						{progressText}
 					</div>
@@ -144,7 +144,7 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 				}}
 			/>
 			{style !== "task" && (
-				<div className={"flex mt-1 justify-between"}>
+				<div className="flex mt-1 justify-between">
 					<div css={styles.label}>
 						{capitalize(workspace.latest_build.status)} workspace...
 					</div>

--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -62,13 +62,18 @@ const estimateFinish = (
 interface WorkspaceBuildProgressProps {
 	workspace: Workspace;
 	transitionStats: TransitionStats;
-	style?: "workspace" | "task";
+	// variant changes how the progress bar is displayed: with the workspace
+	// variant the workspace transition and time remaining are displayed under the
+	// bar aligned to the left and right respectively.  With the task variant the
+	// workspace transition is not displayed and the time remaining is displayed
+	// centered above the bar, and the bar's border radius is removed.
+	variant?: "workspace" | "task";
 }
 
 export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	workspace,
 	transitionStats,
-	style,
+	variant,
 }) => {
 	const job = workspace.latest_build.job;
 	const [progressValue, setProgressValue] = useState<number | undefined>(0);
@@ -116,7 +121,7 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	}
 	return (
 		<div css={styles.stack}>
-			{style === "task" && (
+			{variant === "task" && (
 				<div className="mb-1 text-center">
 					<div css={styles.label} data-chromatic="ignore">
 						{progressText}
@@ -135,15 +140,17 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 						? "determinate"
 						: "indeterminate"
 				}
-				// If a transition is set, there is a moment on new load where the
-				// bar accelerates to progressValue and then rapidly decelerates, which
-				// is not indicative of true progress.
 				classes={{
+					// If a transition is set, there is a moment on new load where the bar
+					// accelerates to progressValue and then rapidly decelerates, which is
+					// not indicative of true progress.
 					bar: classNames.bar,
-					root: style === "task" ? classNames.root : undefined,
+					// With the "task" variant, the progress bar is fullscreen, so remove
+					// the border radius.
+					root: variant === "task" ? classNames.root : undefined,
 				}}
 			/>
-			{style !== "task" && (
+			{variant !== "task" && (
 				<div className="flex mt-1 justify-between">
 					<div css={styles.label}>
 						{capitalize(workspace.latest_build.status)} workspace...

--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -62,14 +62,13 @@ const estimateFinish = (
 interface WorkspaceBuildProgressProps {
 	workspace: Workspace;
 	transitionStats: TransitionStats;
-	// stack indicates to stack the text vertically, otherwise put it on one line.
-	stack?: boolean;
+	style?: "workspace" | "task";
 }
 
 export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	workspace,
 	transitionStats,
-	stack,
+	style,
 }) => {
 	const job = workspace.latest_build.job;
 	const [progressValue, setProgressValue] = useState<number | undefined>(0);
@@ -117,6 +116,13 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	}
 	return (
 		<div css={styles.stack}>
+			{style === "task" && (
+				<div className={"mb-1 text-center"}>
+					<div css={styles.label} data-chromatic="ignore">
+						{progressText}
+					</div>
+				</div>
+			)}
 			<LinearProgress
 				data-chromatic="ignore"
 				value={progressValue !== undefined ? progressValue : 0}
@@ -132,16 +138,21 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 				// If a transition is set, there is a moment on new load where the
 				// bar accelerates to progressValue and then rapidly decelerates, which
 				// is not indicative of true progress.
-				classes={{ bar: classNames.bar }}
+				classes={{
+					bar: classNames.bar,
+					root: style === "task" ? classNames.root : undefined,
+				}}
 			/>
-			<div className={stack ? "leading-tight mt-1" : "flex mt-1 justify-between"}>
-				<div css={styles.label}>
-					{capitalize(workspace.latest_build.status)} workspace...
+			{style !== "task" && (
+				<div className={"flex mt-1 justify-between"}>
+					<div css={styles.label}>
+						{capitalize(workspace.latest_build.status)} workspace...
+					</div>
+					<div css={styles.label} data-chromatic="ignore">
+						{progressText}
+					</div>
 				</div>
-				<div css={styles.label} data-chromatic="ignore">
-					{progressText}
-				</div>
-			</div>
+			)}
 		</div>
 	);
 };
@@ -149,6 +160,9 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 const classNames = {
 	bar: css`
     transition: none;
+  `,
+	root: css`
+    border-radius: 0;
   `,
 };
 

--- a/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceBuildProgress.tsx
@@ -62,11 +62,14 @@ const estimateFinish = (
 interface WorkspaceBuildProgressProps {
 	workspace: Workspace;
 	transitionStats: TransitionStats;
+	// stack indicates to stack the text vertically, otherwise put it on one line.
+	stack?: boolean;
 }
 
 export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 	workspace,
 	transitionStats,
+	stack,
 }) => {
 	const job = workspace.latest_build.job;
 	const [progressValue, setProgressValue] = useState<number | undefined>(0);
@@ -131,7 +134,7 @@ export const WorkspaceBuildProgress: FC<WorkspaceBuildProgressProps> = ({
 				// is not indicative of true progress.
 				classes={{ bar: classNames.bar }}
 			/>
-			<div css={styles.barHelpers}>
+			<div className={stack ? "leading-tight mt-1" : "flex mt-1 justify-between"}>
 				<div css={styles.label}>
 					{capitalize(workspace.latest_build.status)} workspace...
 				</div>
@@ -153,11 +156,6 @@ const styles = {
 	stack: {
 		paddingLeft: 2,
 		paddingRight: 2,
-	},
-	barHelpers: {
-		display: "flex",
-		justifyContent: "space-between",
-		marginTop: 4,
 	},
 	label: (theme) => ({
 		fontSize: 12,


### PR DESCRIPTION
~I think this might need to be rebased on the latest changes,~ (done) but this adds a progress bar and the most recent build stage.

I only did this for workspaces starting up, but we could do it for when the workspace is shutting down as well.

Although I tried adding a story for the build log, the mock web socket keeps closing in Storybook before it gets any logs, so I had to skip it.  Not sure what is going on there...

https://github.com/user-attachments/assets/972bf0b0-07df-4389-bf91-215042dd509a

Closes #18183 