### PR TITLE
docs: update Claude's guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,5 +103,4 @@ Read [cursor rules](.cursorrules).
 
 The frontend is contained in the site folder.
 
-For building Frontend refer to [this document](docs/contributing/frontend.md)
 For building Frontend refer to [this document](docs/about/contributing/frontend.md)


### PR DESCRIPTION
## PR Summary
Commit 5df70a613d12584e135e9aa0a184b2279848bfb1 added by mistake the the following old line to `CLAUDE.md`:
```
For building Frontend refer to [this document](docs/contributing/frontend.md)
```
This PR removes it.