### PR TITLE
fix(vpn): avoid setting session token header twice

### DIFF
--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -354,7 +354,7 @@ func (c *Client) Dial(ctx context.Context, path string, opts *websocket.DialOpti
 	if opts.HTTPHeader == nil {
 		opts.HTTPHeader = http.Header{}
 	}
-	if opts.HTTPHeader.Get("tokenHeader") == "" {
+	if opts.HTTPHeader.Get(tokenHeader) == "" {
 		opts.HTTPHeader.Set(tokenHeader, c.SessionToken())
 	}
 

--- a/vpn/client_test.go
+++ b/vpn/client_test.go
@@ -90,6 +90,8 @@ func TestClient_WorkspaceUpdates(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/api/v2/users/me":
+					values := r.Header.Values(codersdk.SessionTokenHeader)
+					assert.Len(t, values, 1, "expected exactly one session token header value")
 					httpapi.Write(ctx, w, http.StatusOK, codersdk.User{
 						ReducedUser: codersdk.ReducedUser{
 							MinimalUser: codersdk.MinimalUser{
@@ -101,6 +103,8 @@ func TestClient_WorkspaceUpdates(t *testing.T) {
 					user <- struct{}{}
 
 				case "/api/v2/workspaceagents/connection":
+					values := r.Header.Values(codersdk.SessionTokenHeader)
+					assert.Len(t, values, 1, "expected exactly one session token header value")
 					httpapi.Write(ctx, w, http.StatusOK, tc.agentConnectionInfo)
 					connInfo <- struct{}{}
 
@@ -108,6 +112,9 @@ func TestClient_WorkspaceUpdates(t *testing.T) {
 					// need 2.3 for WorkspaceUpdates RPC
 					cVer := r.URL.Query().Get("version")
 					assert.Equal(t, "2.3", cVer)
+
+					values := r.Header.Values(codersdk.SessionTokenHeader)
+					assert.Len(t, values, 1, "expected exactly one session token header value")
 
 					sws, err := websocket.Accept(w, r, nil)
 					if !assert.NoError(t, err) {


### PR DESCRIPTION
`coderd` currently does not handle a session token header value of the form `token1, token2`. However, it does handle multiple instances of the token header by simply taking the first. This is the default behaviour of `http.Header.Get`.

So, setting the token header twice causes issues when Coder is behind a proxy that merges duplicate headers, such as [Apache](https://httpd.apache.org/docs/2.4/mod/mod_headers.html#:~:text=list%20of%20values.-,When%20a%20new%20value%20is%20merged%20onto%20an%20existing%20header,format%20specifiers%20have%20been%20processed).


This PR ensures we don't set it twice by not sharing one slice between the `HTTPClient` and the `websocket.DialerOptions`. It also adds a regression test.