### PR TITLE
fix: allow dynamic parameters to consider the prebuilds user an owner

### DIFF
--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -253,7 +253,7 @@ func (r *dynamicRenderer) getWorkspaceOwnerData(ctx context.Context, ownerID uui
 	mem, err := database.ExpectOne(r.db.OrganizationMembers(ctx, database.OrganizationMembersParams{
 		OrganizationID: r.data.templateVersion.OrganizationID,
 		UserID:         ownerID,
-		IncludeSystem:  false,
+		IncludeSystem:  true,
 	}))
 	if err != nil {
 		return err


### PR DESCRIPTION
This Pull request allows dynamic parameters to list system users in its search for workspace owners. This is necessary to allow prebuilds to reconcile prebuilt workspaces and to delete them.