### PR TITLE
feat(agent/agentcontainers): implement ignore customization for devcontainers

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -2234,7 +2234,7 @@ func TestAPI(t *testing.T) {
 
 		assert.Empty(t, response.Devcontainers, "devcontainer should be filtered out when ignore=true again")
 		assert.Len(t, response.Containers, 1, "regular container should still be listed")
-		assert.Len(t, fakeSAC.deleted, 1, "sub agent should be deleted when ignore=true")
+		require.Len(t, fakeSAC.deleted, 1, "sub agent should be deleted when ignore=true")
 		assert.Equal(t, createdAgentID, fakeSAC.deleted[0], "the same sub agent that was created should be deleted")
 	})
 }

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -44,6 +44,7 @@ type CoderCustomization struct {
 	DisplayApps map[codersdk.DisplayApp]bool `json:"displayApps,omitempty"`
 	Apps        []SubAgentApp                `json:"apps,omitempty"`
 	Name        string                       `json:"name,omitempty"`
+	Ignore      bool                         `json:"ignore,omitempty"`
 }
 
 type DevcontainerWorkspace struct {

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1432,6 +1432,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 					}, nil).AnyTimes()
 					// DetectArchitecture always returns "<none>" for this test to disable agent injection.
 					mccli.EXPECT().DetectArchitecture(gomock.Any(), devContainer.ID).Return("<none>", nil).AnyTimes()
+					mdccli.EXPECT().ReadConfig(gomock.Any(), workspaceFolder, configFile, gomock.Any()).Return(agentcontainers.DevcontainerConfig{}, nil).Times(1)
 					mdccli.EXPECT().Up(gomock.Any(), workspaceFolder, configFile, gomock.Any()).Return("someid", nil).Times(1)
 					return 0
 				},


### PR DESCRIPTION
This turned out to be a bit more tricky than I had anticipated. In my mind we must treat the ignore field differently than we have treated `devcontainer.json` before.

Previously, in rough terms, the `devcontainer.json` is "manifested" once for a container, and re-evaluated upon detecting a new container (recreation).

But if a user has a container running and wants to start ignoring it, it would be confusing if they had to "recreate" the devcontainer for it to disappear.

Fixes coder/internal#737
