### PR TITLE
fix: allow dynamic parameters without requiring org membership

### DIFF
--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -243,24 +243,30 @@ func (r *dynamicRenderer) getWorkspaceOwnerData(ctx context.Context, ownerID uui
 		return nil // already fetched
 	}
 
-	// You only need to be able to read the organization member to get the owner
-	// data. Only the terraform files can therefore leak more information than the
-	// caller should have access to. All this info should be public assuming you can
-	// read the user though.
-	mem, err := database.ExpectOne(r.db.OrganizationMembers(ctx, database.OrganizationMembersParams{
-		OrganizationID: r.data.templateVersion.OrganizationID,
-		UserID:         ownerID,
-		IncludeSystem:  true,
-	}))
+	user, err := r.db.GetUserByID(ctx, ownerID)
 	if err != nil {
-		return err
-	}
+		// If the user failed to read, we also try to read the user from their
+		// organization member. You only need to be able to read the organization member
+		// to get the owner data.
+		//
+		// Only the terraform files can therefore leak more information than the
+		// caller should have access to. All this info should be public assuming you can
+		// read the user though.
+		mem, err := database.ExpectOne(r.db.OrganizationMembers(ctx, database.OrganizationMembersParams{
+			OrganizationID: r.data.templateVersion.OrganizationID,
+			UserID:         ownerID,
+			IncludeSystem:  true,
+		}))
+		if err != nil {
+			return xerrors.Errorf("fetch user: %w", err)
+		}
 
-	// User data is required for the form. Org member is checked above
-	// nolint:gocritic
-	user, err := r.db.GetUserByID(dbauthz.AsProvisionerd(ctx), mem.OrganizationMember.UserID)
-	if err != nil {
-		return xerrors.Errorf("fetch user: %w", err)
+		// Org member fetched, so use the provisioner context to fetch the user.
+		//nolint:gocritic // Has the correct permissions, and matches the provisioning flow.
+		user, err = r.db.GetUserByID(dbauthz.AsProvisionerd(ctx), mem.OrganizationMember.UserID)
+		if err != nil {
+			return xerrors.Errorf("fetch user: %w", err)
+		}
 	}
 
 	// nolint:gocritic // This is kind of the wrong query to use here, but it
@@ -314,10 +320,10 @@ func (r *dynamicRenderer) getWorkspaceOwnerData(ctx context.Context, ownerID uui
 	}
 
 	r.currentOwner = &previewtypes.WorkspaceOwner{
-		ID:           mem.OrganizationMember.UserID.String(),
-		Name:         mem.Username,
-		FullName:     mem.Name,
-		Email:        mem.Email,
+		ID:           user.ID.String(),
+		Name:         user.Username,
+		FullName:     user.Name,
+		Email:        user.Email,
 		LoginType:    string(user.LoginType),
 		RBACRoles:    ownerRoles,
 		SSHPublicKey: key.PublicKey,

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -289,7 +289,7 @@ func TestCreateUserWorkspace(t *testing.T) {
 
 		template, _ := coderdtest.DynamicParameterTemplate(t, admin, first.OrganizationID, coderdtest.DynamicParameterTemplateParams{})
 
-		ctx = testutil.Context(t, testutil.WaitLong*1000) // Reset the context to avoid timeouts.
+		ctx = testutil.Context(t, testutil.WaitLong)
 
 		wrk, err := creator.CreateUserWorkspace(ctx, adminID.ID.String(), codersdk.CreateWorkspaceRequest{
 			TemplateID: template.ID,
@@ -347,11 +347,9 @@ func TestCreateUserWorkspace(t *testing.T) {
 			},
 		)
 
-		version := coderdtest.CreateTemplateVersion(t, creator, first.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, creator, version.ID)
-		template := coderdtest.CreateTemplate(t, creator, first.OrganizationID, version.ID)
+		template, _ := coderdtest.DynamicParameterTemplate(t, creator, first.OrganizationID, coderdtest.DynamicParameterTemplateParams{})
 
-		ctx = testutil.Context(t, testutil.WaitLong*1000) // Reset the context to avoid timeouts.
+		ctx = testutil.Context(t, testutil.WaitLong)
 
 		wrk, err := creator.CreateUserWorkspace(ctx, forUser.ID.String(), codersdk.CreateWorkspaceRequest{
 			TemplateID: template.ID,

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -260,8 +260,9 @@ func TestCreateUserWorkspace(t *testing.T) {
 			},
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{
-					codersdk.FeatureCustomRoles:  1,
-					codersdk.FeatureTemplateRBAC: 1,
+					codersdk.FeatureCustomRoles:           1,
+					codersdk.FeatureTemplateRBAC:          1,
+					codersdk.FeatureMultipleOrganizations: 1,
 				},
 			},
 		})
@@ -278,8 +279,15 @@ func TestCreateUserWorkspace(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// use admin for setting up test
-		admin, adminID := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.RoleTemplateAdmin())
+		secondOrg := coderdenttest.CreateOrganization(t, owner, coderdenttest.CreateOrganizationOptions{})
+
+		// user to make the workspace for, **note** the user is not a member of the first org.
+		// This is strange, but technically valid. The creator can create a workspace for
+		// this user in this org, even though the user cannot access the workspace.
+		_, forUser := coderdtest.CreateAnotherUser(t, owner, secondOrg.ID)
+
+		// Need an admin to make the template
+		admin, _ := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.ScopedRoleOrgTemplateAdmin(first.OrganizationID))
 
 		// try the test action with this user & custom role
 		creator, _ := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.RoleMember(), rbac.RoleIdentifier{
@@ -287,20 +295,18 @@ func TestCreateUserWorkspace(t *testing.T) {
 			OrganizationID: first.OrganizationID,
 		})
 
-		version := coderdtest.CreateTemplateVersion(t, admin, first.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, admin, version.ID)
-		template := coderdtest.CreateTemplate(t, admin, first.OrganizationID, version.ID)
+		template, _ := coderdtest.DynamicParameterTemplate(t, admin, first.OrganizationID, coderdtest.DynamicParameterTemplateParams{})
 
 		ctx = testutil.Context(t, testutil.WaitLong*1000) // Reset the context to avoid timeouts.
 
-		wrk, err := creator.CreateUserWorkspace(ctx, adminID.ID.String(), codersdk.CreateWorkspaceRequest{
+		wrk, err := creator.CreateUserWorkspace(ctx, forUser.ID.String(), codersdk.CreateWorkspaceRequest{
 			TemplateID: template.ID,
 			Name:       "workspace",
 		})
 		require.NoError(t, err)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, admin, wrk.LatestBuild.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, creator, wrk.LatestBuild.ID)
 
-		_, err = creator.WorkspaceByOwnerAndName(ctx, adminID.Username, wrk.Name, codersdk.WorkspaceOptions{
+		_, err = creator.WorkspaceByOwnerAndName(ctx, forUser.Username, wrk.Name, codersdk.WorkspaceOptions{
 			IncludeDeleted: false,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
Test failure on `main`

```
POST http://localhost:36481/api/v2/users/e27d2233-85fb-4c8d-b063-f69da3cbb07c/workspaces: unexpected status code 400: Unable to validate parameters
        	            		Error: Failed to fetch workspace owner; Please check your permissions or the user may not exist.
```