### PR TITLE
feat(agent): enable devcontainers by default

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1954,8 +1954,8 @@ func TestAgent_ReconnectingPTYContainer(t *testing.T) {
 
 	// nolint: dogsled
 	conn, _, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
-		o.ExperimentalDevcontainersEnabled = true
-		o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+		o.Devcontainers = true
+		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 			agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 		)
 	})
@@ -2161,9 +2161,9 @@ func TestAgent_DevcontainerAutostart(t *testing.T) {
 
 	//nolint:dogsled
 	_, agentClient, _, _, _ := setupAgent(t, manifest, 0, func(_ *agenttest.Client, o *agent.Options) {
-		o.ExperimentalDevcontainersEnabled = true
-		o.ContainerAPIOptions = append(
-			o.ContainerAPIOptions,
+		o.Devcontainers = true
+		o.DevcontainerAPIOptions = append(
+			o.DevcontainerAPIOptions,
 			// Only match this specific dev container.
 			agentcontainers.WithClock(mClock),
 			agentcontainers.WithContainerLabelIncludeFilter("devcontainer.local_folder", tempWorkspaceFolder),
@@ -2312,8 +2312,8 @@ func TestAgent_DevcontainerRecreate(t *testing.T) {
 
 	//nolint:dogsled
 	conn, client, _, _, _ := setupAgent(t, manifest, 0, func(_ *agenttest.Client, o *agent.Options) {
-		o.ExperimentalDevcontainersEnabled = true
-		o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+		o.Devcontainers = true
+		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 			agentcontainers.WithContainerLabelIncludeFilter("devcontainer.local_folder", workspaceFolder),
 		)
 	})
@@ -2438,8 +2438,7 @@ func TestAgent_DevcontainersDisabledForSubAgent(t *testing.T) {
 
 	// Setup the agent with devcontainers enabled initially.
 	//nolint:dogsled
-	conn, _, _, _, _ := setupAgent(t, manifest, 0, func(_ *agenttest.Client, o *agent.Options) {
-		o.ExperimentalDevcontainersEnabled = true
+	conn, _, _, _, _ := setupAgent(t, manifest, 0, func(*agenttest.Client, *agent.Options) {
 	})
 
 	// Query the containers API endpoint. This should fail because

--- a/agent/api.go
+++ b/agent/api.go
@@ -40,7 +40,7 @@ func (a *agent) apiHandler(aAPI proto.DRPCAgentClient26) (http.Handler, func() e
 		cacheDuration: cacheDuration,
 	}
 
-	if a.experimentalDevcontainersEnabled {
+	if a.devcontainers {
 		containerAPIOpts := []agentcontainers.Option{
 			agentcontainers.WithExecer(a.execer),
 			agentcontainers.WithCommandEnv(a.sshServer.CommandEnv),

--- a/agent/reconnectingpty/server.go
+++ b/agent/reconnectingpty/server.go
@@ -31,8 +31,10 @@ type Server struct {
 	connCount        atomic.Int64
 	reconnectingPTYs sync.Map
 	timeout          time.Duration
-
-	ExperimentalDevcontainersEnabled bool
+	// Experimental: allow connecting to running containers via Docker exec.
+	// Note that this is different from the devcontainers feature, which uses
+	// subagents.
+	ExperimentalContainers bool
 }
 
 // NewServer returns a new ReconnectingPTY server
@@ -187,7 +189,7 @@ func (s *Server) handleConn(ctx context.Context, logger slog.Logger, conn net.Co
 		}()
 
 		var ei usershell.EnvInfoer
-		if s.ExperimentalDevcontainersEnabled && msg.Container != "" {
+		if s.ExperimentalContainers && msg.Container != "" {
 			dei, err := agentcontainers.EnvInfo(ctx, s.commandCreator.Execer, msg.Container, msg.ContainerUser)
 			if err != nil {
 				return xerrors.Errorf("get container env info: %w", err)

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -55,8 +55,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 		blockFileTransfer   bool
 		agentHeaderCommand  string
 		agentHeader         []string
-
-		experimentalDevcontainersEnabled bool
+		devcontainers       bool
 	)
 	cmd := &serpent.Command{
 		Use:   "agent",
@@ -321,7 +320,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 				return xerrors.Errorf("create agent execer: %w", err)
 			}
 
-			if experimentalDevcontainersEnabled {
+			if devcontainers {
 				logger.Info(ctx, "agent devcontainer detection enabled")
 			} else {
 				logger.Info(ctx, "agent devcontainer detection not enabled")
@@ -359,11 +358,11 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 					SSHMaxTimeout:        sshMaxTimeout,
 					Subsystems:           subsystems,
 
-					PrometheusRegistry:               prometheusRegistry,
-					BlockFileTransfer:                blockFileTransfer,
-					Execer:                           execer,
-					ExperimentalDevcontainersEnabled: experimentalDevcontainersEnabled,
-					ContainerAPIOptions: []agentcontainers.Option{
+					PrometheusRegistry: prometheusRegistry,
+					BlockFileTransfer:  blockFileTransfer,
+					Execer:             execer,
+					Devcontainers:      devcontainers,
+					DevcontainerAPIOptions: []agentcontainers.Option{
 						agentcontainers.WithSubAgentURL(r.agentURL.String()),
 					},
 				})
@@ -506,10 +505,10 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 		},
 		{
 			Flag:        "devcontainers-enable",
-			Default:     "false",
+			Default:     "true",
 			Env:         "CODER_AGENT_DEVCONTAINERS_ENABLE",
 			Description: "Allow the agent to automatically detect running devcontainers.",
-			Value:       serpent.BoolOf(&experimentalDevcontainersEnabled),
+			Value:       serpent.BoolOf(&devcontainers),
 		},
 	}
 

--- a/cli/exp_rpty_test.go
+++ b/cli/exp_rpty_test.go
@@ -116,8 +116,8 @@ func TestExpRpty(t *testing.T) {
 		})
 
 		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-			o.ExperimentalDevcontainersEnabled = true
-			o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+			o.Devcontainers = true
+			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 				agentcontainers.WithContainerLabelIncludeFilter(wantLabel, "true"),
 			)
 		})

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -334,8 +334,8 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 	})
 
 	_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-		o.ExperimentalDevcontainersEnabled = true
-		o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+		o.Devcontainers = true
+		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 			agentcontainers.WithContainerCLI(mccli),
 			agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 		)
@@ -509,8 +509,8 @@ func TestOpenVSCodeDevContainer_NoAgentDirectory(t *testing.T) {
 	})
 
 	_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-		o.ExperimentalDevcontainersEnabled = true
-		o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+		o.Devcontainers = true
+		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 			agentcontainers.WithContainerCLI(mccli),
 			agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 		)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2029,8 +2029,8 @@ func TestSSH_Container(t *testing.T) {
 		})
 
 		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-			o.ExperimentalDevcontainersEnabled = true
-			o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+			o.Devcontainers = true
+			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 				agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 			)
 		})
@@ -2069,8 +2069,8 @@ func TestSSH_Container(t *testing.T) {
 			Warnings: nil,
 		}, nil).AnyTimes()
 		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
-			o.ExperimentalDevcontainersEnabled = true
-			o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+			o.Devcontainers = true
+			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 				agentcontainers.WithContainerCLI(mLister),
 				agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 			)

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -33,7 +33,7 @@ OPTIONS:
       --debug-address string, $CODER_AGENT_DEBUG_ADDRESS (default: 127.0.0.1:2113)
           The bind address to serve a debug HTTP server.
 
-      --devcontainers-enable bool, $CODER_AGENT_DEVCONTAINERS_ENABLE (default: false)
+      --devcontainers-enable bool, $CODER_AGENT_DEVCONTAINERS_ENABLE (default: true)
           Allow the agent to automatically detect running devcontainers.
 
       --log-dir string, $CODER_AGENT_LOG_DIR (default: /tmp)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1250,8 +1250,8 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 			return agents
 		}).Do()
 		_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
-			o.ExperimentalDevcontainersEnabled = true
-			o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+			o.Devcontainers = true
+			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 				agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 			)
 		})
@@ -1358,8 +1358,8 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 				}).Do()
 				_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
 					o.Logger = logger.Named("agent")
-					o.ExperimentalDevcontainersEnabled = true
-					o.ContainerAPIOptions = append(o.ContainerAPIOptions,
+					o.Devcontainers = true
+					o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 						agentcontainers.WithContainerCLI(mcl),
 						agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 					)
@@ -1473,9 +1473,9 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 				}).Do()
 				_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
 					o.Logger = logger.Named("agent")
-					o.ExperimentalDevcontainersEnabled = true
-					o.ContainerAPIOptions = append(
-						o.ContainerAPIOptions,
+					o.Devcontainers = true
+					o.DevcontainerAPIOptions = append(
+						o.DevcontainerAPIOptions,
 						agentcontainers.WithContainerCLI(mccli),
 						agentcontainers.WithDevcontainerCLI(mdccli),
 						agentcontainers.WithWatcher(watcher.NewNoop()),


### PR DESCRIPTION
This change makes devcontainers default enabled.

Edit: The code paths that rely on Docker and `@devcontainers/cli` will log errors though, which is probably not ideal for someone who doesn't want devcontainers. I will think about a solution for that (but doesn't really have to be this PR).