### PR TITLE
test: add unit test to create a workspace for a non-org-member

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1521,7 +1521,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value: &c.DERP.Config.BlockDirect,
 			Group: &deploymentGroupNetworkingDERP,
 			YAML:  "blockDirect", Annotations: serpent.Annotations{}.
-				Mark(annotationExternalProxies, "true"),
+			Mark(annotationExternalProxies, "true"),
 		},
 		{
 			Name:        "DERP Force WebSockets",
@@ -3380,7 +3380,6 @@ var ExperimentsKnown = Experiments{
 	ExperimentWebPush,
 	ExperimentWorkspacePrebuilds,
 	ExperimentAgenticChat,
-	ExperimentAITasks,
 }
 
 // ExperimentsSafe should include all experiments that are safe for


### PR DESCRIPTION
Test fails on `creator.CreateUserWorkspace`
https://github.com/coder/coder/blob/cb49449549c15c32c9bb5eb1caea00a6517d8e2c/enterprise/coderd/workspaces_test.go#L301-L305

> POST http://localhost:46577/api/v2/users/1c098569-dfed-4629-a971-cc7f4613c982/workspaces: unexpected status code 404: Resource not found or you do not have access to this resource


From this check on `ExtractOrganizationMember`

https://github.com/coder/coder/blob/cb49449549c15c32c9bb5eb1caea00a6517d8e2c/coderd/httpmw/organizationparam.go#L180-L188