### PR TITLE
fix: use the correct key for tasks tab visibility in embedded metadata

### DIFF
--- a/site/src/hooks/useEmbeddedMetadata.test.ts
+++ b/site/src/hooks/useEmbeddedMetadata.test.ts
@@ -42,7 +42,7 @@ const mockDataForTags = {
 	user: MockUserOwner,
 	userAppearance: MockUserAppearanceSettings,
 	regions: MockRegions,
-	tasksTabVisible: MockTasksTabVisible,
+	"tasks-tab-visible": MockTasksTabVisible,
 } as const satisfies Record<MetadataKey, MetadataValue>;
 
 const emptyMetadata: RuntimeHtmlMetadata = {
@@ -74,7 +74,7 @@ const emptyMetadata: RuntimeHtmlMetadata = {
 		available: false,
 		value: undefined,
 	},
-	tasksTabVisible: {
+	"tasks-tab-visible": {
 		available: false,
 		value: undefined,
 	},
@@ -109,7 +109,7 @@ const populatedMetadata: RuntimeHtmlMetadata = {
 		available: true,
 		value: MockUserAppearanceSettings,
 	},
-	tasksTabVisible: {
+	"tasks-tab-visible": {
 		available: true,
 		value: MockTasksTabVisible,
 	},

--- a/site/src/hooks/useEmbeddedMetadata.ts
+++ b/site/src/hooks/useEmbeddedMetadata.ts
@@ -30,7 +30,7 @@ type AvailableMetadata = Readonly<{
 	entitlements: Entitlements;
 	regions: readonly Region[];
 	"build-info": BuildInfoResponse;
-	tasksTabVisible: boolean;
+	"tasks-tab-visible": boolean;
 }>;
 
 export type MetadataKey = keyof AvailableMetadata;
@@ -92,7 +92,7 @@ export class MetadataManager implements MetadataManagerApi {
 			experiments: this.registerValue<Experiment[]>("experiments"),
 			"build-info": this.registerValue<BuildInfoResponse>("build-info"),
 			regions: this.registerRegionValue(),
-			tasksTabVisible: this.registerValue<boolean>("tasksTabVisible"),
+			"tasks-tab-visible": this.registerValue<boolean>("tasks-tab-visible"),
 		};
 	}
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -175,7 +175,7 @@ const NavItems: FC<NavItemsProps> = ({ className }) => {
 					Chat
 				</NavLink>
 			)}
-			{metadata.tasksTabVisible.value && (
+			{metadata["tasks-tab-visible"].value && (
 				<NavLink
 					className={({ isActive }) => {
 						return cn(linkStyles.default, isActive ? linkStyles.active : "");


### PR DESCRIPTION
The backend (introduced in https://github.com/coder/coder/pull/18401) actually puts the value under the `tasks-tab-visible` key instead of the `tasksTabVisible`: 