### PR TITLE
fix: correct hasAITaskResources logic for child modules

### DIFF
--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -178,7 +178,9 @@ func hasAITaskResources(graph *gographviz.Graph) bool {
 		// Check if this node is a coder_ai_task resource
 		if label, exists := node.Attrs["label"]; exists {
 			labelValue := strings.Trim(label, `"`)
-			if strings.HasPrefix(labelValue, "coder_ai_task.") {
+			// The first condition is for the case where the resource is in the root module.
+			// The second condition is for the case where the resource is in a child module.
+			if strings.HasPrefix(labelValue, "coder_ai_task.") || strings.Contains(labelValue, ".coder_ai_task.") {
 				return true
 			}
 		}


### PR DESCRIPTION
As far as I can tell, a resource label in the terraform graph is its address.
Resource addresses are prefixed with module paths if they are in child modules. https://developer.hashicorp.com/terraform/internals/json-format#plan-representation

Here's a partial output of `terraform graph -type=plan` on a Coder template that defines a `coder_ai_task` inside a module that confirms this:

```
digraph {
        compound = "true"
        newrank = "true"
        subgraph "root" {
                "[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
                "[root] coder_app.preview (expand)" [label = "coder_app.preview", shape = "box"]
                "[root] coder_metadata.container_info (expand)" [label = "coder_metadata.container_info", shape = "box"]
                "[root] coder_metadata.home_volume (expand)" [label = "coder_metadata.home_volume", shape = "box"]
                "[root] docker_volume.home_volume (expand)" [label = "docker_volume.home_volume", shape = "box"]
                ...
                "[root] module.claude-code.coder_ai_task.claude_code (expand)" [label = "module.claude-code.coder_ai_task.claude_code", shape = "box"]
                "[root] module.claude-code.coder_app.claude_code (expand)" [label = "module.claude-code.coder_app.claude_code", shape = "box"]
                "[root] module.claude-code.coder_app.claude_code_web (expand)" [label = "module.claude-code.coder_app.claude_code_web", shape = "box"]
                ...
        }
}
```

follow up to https://github.com/coder/coder/pull/18449, related to https://github.com/coder/coder/issues/18453