### PR TITLE
refactor: remove unused enterprise prebuilds id.go

### DIFF
--- a/enterprise/coderd/prebuilds/id.go
+++ b/enterprise/coderd/prebuilds/id.go
@@ -1,1 +1,0 @@
-package prebuilds


### PR DESCRIPTION
## Description

Remove unused `enterprise/coderd/prebuilds/id.go` file.
Note: PR https://github.com/coder/coder/pull/18333 moved `SystemUserID` constant from `coderd/prebuilds/id.go` to the database package `PrebuildsSystemUserID` to resolve an import cycle: https://github.com/coder/coder/blob/main/coderd/database/constants.go