### PR TITLE
fix(agent/agentcontainers): remove shellquote in favor of %q

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -2040,7 +2040,7 @@ func TestAPI(t *testing.T) {
 		// Verify commands were executed through the custom shell and environment.
 		require.NotEmpty(t, fakeExec.commands, "commands should be executed")
 
-		// Want: /bin/custom-shell -c "docker ps --all --quiet --no-trunc"
+		// Want: /bin/custom-shell -c '"docker" "ps" "--all" "--quiet" "--no-trunc"'
 		require.Equal(t, testShell, fakeExec.commands[0][0], "custom shell should be used")
 		if runtime.GOOS == "windows" {
 			require.Equal(t, "/c", fakeExec.commands[0][1], "shell should be called with /c on Windows")
@@ -2049,6 +2049,7 @@ func TestAPI(t *testing.T) {
 		}
 		require.Len(t, fakeExec.commands[0], 3, "command should have 3 arguments")
 		require.GreaterOrEqual(t, strings.Count(fakeExec.commands[0][2], " "), 2, "command/script should have multiple arguments")
+		require.True(t, strings.HasPrefix(fakeExec.commands[0][2], `"docker" "ps"`), "command should start with \"docker\" \"ps\"")
 
 		// Verify the environment was set on the command.
 		lastCmd := fakeExec.getLastCommand()

--- a/agent/agentcontainers/execer.go
+++ b/agent/agentcontainers/execer.go
@@ -2,10 +2,10 @@ package agentcontainers
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"runtime"
-
-	"github.com/kballard/go-shellquote"
+	"strings"
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/agent/agentexec"
@@ -56,7 +56,10 @@ func (e *commandEnvExecer) prepare(ctx context.Context, inName string, inArgs ..
 		caller = "/c"
 	}
 	name = shell
-	args = []string{caller, shellquote.Join(append([]string{inName}, inArgs...)...)}
+	for _, arg := range append([]string{inName}, inArgs...) {
+		args = append(args, fmt.Sprintf("%q", arg))
+	}
+	args = []string{caller, strings.Join(args, " ")}
 	return name, args, dir, env
 }
 


### PR DESCRIPTION
Shellquote modified `{{.Name}}` to `\{\{.Name}}` breaking Fish, by
switching to quoting each arg individually we should have a more
portable (across shells) implementation.
