### PR TITLE
fix: use memmap file system for TestServer_X11

### DIFF
--- a/agent/agentssh/x11_test.go
+++ b/agent/agentssh/x11_test.go
@@ -34,7 +34,7 @@ func TestServer_X11(t *testing.T) {
 
 	ctx := context.Background()
 	logger := testutil.Logger(t)
-	fs := afero.NewOsFs()
+	fs := afero.NewMemMapFs()
 	s, err := agentssh.NewServer(ctx, logger, prometheus.NewRegistry(), fs, agentexec.DefaultExecer, &agentssh.Config{})
 	require.NoError(t, err)
 	defer s.Close()


### PR DESCRIPTION
Changes the TestServer_X11 test to use a memmapped file system, so we don't pollute the XAuthority file of the person running the test.