### PR TITLE
fix(agent/agentcontainers): filter out "is test run" devcontainers

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -571,7 +571,8 @@ func (api *API) processUpdatedContainersLocked(ctx context.Context, updated code
 			slog.F("config_file", configFile),
 		)
 
-		if len(api.containerLabelIncludeFilter) > 0 {
+		// Filter out devcontainer tests, unless explicitly set in include filters.
+		if len(api.containerLabelIncludeFilter) > 0 || container.Labels[DevcontainerIsTestRunLabel] == "true" {
 			var ok bool
 			for label, value := range api.containerLabelIncludeFilter {
 				if v, found := container.Labels[label]; found && v == value {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -800,7 +800,7 @@ func TestAPI(t *testing.T) {
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
-									agentcontainers.DevcontainerIsTestRunLabel: "true",
+									agentcontainers.DevcontainerIsTestRunLabel:   "true",
 								},
 							},
 							{
@@ -845,14 +845,14 @@ func TestAPI(t *testing.T) {
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/runtime1/.devcontainer/devcontainer.json",
 								},
 							},
-														{
+							{
 								ID:           "test-container-1",
 								FriendlyName: "test-container-1",
 								Running:      true,
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
-									agentcontainers.DevcontainerIsTestRunLabel: "true",
+									agentcontainers.DevcontainerIsTestRunLabel:   "true",
 								},
 							},
 						},
@@ -901,14 +901,14 @@ func TestAPI(t *testing.T) {
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/non-running/.devcontainer/devcontainer.json",
 								},
 							},
-														{
+							{
 								ID:           "test-container-1",
 								FriendlyName: "test-container-1",
 								Running:      true,
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
-									agentcontainers.DevcontainerIsTestRunLabel: "true",
+									agentcontainers.DevcontainerIsTestRunLabel:   "true",
 								},
 							},
 						},
@@ -944,14 +944,14 @@ func TestAPI(t *testing.T) {
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/known2/.devcontainer/devcontainer.json",
 								},
 							},
-														{
+							{
 								ID:           "test-container-1",
 								FriendlyName: "test-container-1",
 								Running:      true,
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
-									agentcontainers.DevcontainerIsTestRunLabel: "true",
+									agentcontainers.DevcontainerIsTestRunLabel:   "true",
 								},
 							},
 						},
@@ -1007,14 +1007,14 @@ func TestAPI(t *testing.T) {
 									agentcontainers.DevcontainerConfigFileLabel:  "/var/lib/project3/.devcontainer/devcontainer.json",
 								},
 							},
-														{
+							{
 								ID:           "test-container-1",
 								FriendlyName: "test-container-1",
 								Running:      true,
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
-									agentcontainers.DevcontainerIsTestRunLabel: "true",
+									agentcontainers.DevcontainerIsTestRunLabel:   "true",
 								},
 							},
 						},

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -794,6 +794,16 @@ func TestAPI(t *testing.T) {
 								},
 							},
 							{
+								ID:           "test-container-1",
+								FriendlyName: "test-container-1",
+								Running:      true,
+								Labels: map[string]string{
+									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
+									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
+									agentcontainers.DevcontainerIsTestRunLabel: "true",
+								},
+							},
+							{
 								ID:           "not-a-devcontainer",
 								FriendlyName: "not-a-devcontainer",
 								Running:      true,
@@ -833,6 +843,16 @@ func TestAPI(t *testing.T) {
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/runtime1",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/runtime1/.devcontainer/devcontainer.json",
+								},
+							},
+														{
+								ID:           "test-container-1",
+								FriendlyName: "test-container-1",
+								Running:      true,
+								Labels: map[string]string{
+									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
+									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
+									agentcontainers.DevcontainerIsTestRunLabel: "true",
 								},
 							},
 						},
@@ -881,6 +901,16 @@ func TestAPI(t *testing.T) {
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/non-running/.devcontainer/devcontainer.json",
 								},
 							},
+														{
+								ID:           "test-container-1",
+								FriendlyName: "test-container-1",
+								Running:      true,
+								Labels: map[string]string{
+									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
+									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
+									agentcontainers.DevcontainerIsTestRunLabel: "true",
+								},
+							},
 						},
 					},
 				},
@@ -912,6 +942,16 @@ func TestAPI(t *testing.T) {
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/known2",
 									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/known2/.devcontainer/devcontainer.json",
+								},
+							},
+														{
+								ID:           "test-container-1",
+								FriendlyName: "test-container-1",
+								Running:      true,
+								Labels: map[string]string{
+									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
+									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
+									agentcontainers.DevcontainerIsTestRunLabel: "true",
 								},
 							},
 						},
@@ -965,6 +1005,16 @@ func TestAPI(t *testing.T) {
 								Labels: map[string]string{
 									agentcontainers.DevcontainerLocalFolderLabel: "/var/lib/project3",
 									agentcontainers.DevcontainerConfigFileLabel:  "/var/lib/project3/.devcontainer/devcontainer.json",
+								},
+							},
+														{
+								ID:           "test-container-1",
+								FriendlyName: "test-container-1",
+								Running:      true,
+								Labels: map[string]string{
+									agentcontainers.DevcontainerLocalFolderLabel: "/workspace/test1",
+									agentcontainers.DevcontainerConfigFileLabel:  "/workspace/test1/.devcontainer/devcontainer.json",
+									agentcontainers.DevcontainerIsTestRunLabel: "true",
 								},
 							},
 						},

--- a/agent/agentcontainers/devcontainer.go
+++ b/agent/agentcontainers/devcontainer.go
@@ -18,6 +18,9 @@ const (
 	// DevcontainerConfigFileLabel is the label that contains the path to
 	// the devcontainer.json configuration file.
 	DevcontainerConfigFileLabel = "devcontainer.config_file"
+	// DevcontainerIsTestRunLabel is set if the devcontainer is part of a test
+	// and should be excluded.
+	DevcontainerIsTestRunLabel = "devcontainer.is_test_run"
 	// The default workspace folder inside the devcontainer.
 	DevcontainerDefaultContainerWorkspaceFolder = "/workspaces"
 )


### PR DESCRIPTION
This change filters out `"devcontainer.is_test_run"` devcontainers, a label set by `@devconainters/cli` when running tests.

Related https://github.com/coder/coder/pull/18545

<img width="476" alt="image" src="https://github.com/user-attachments/assets/649ea09f-3fed-4f2e-be1d-75db754cbf77" />
