### PR TITLE
feat(agent/agentcontainers): add feature options as envs

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -2152,8 +2152,8 @@ func TestAPI(t *testing.T) {
 			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
 			assert.Contains(t, envs, "CODER_URL=test-subagent-url")
 			// First call should not have feature envs.
-			assert.NotContains(t, envs, "FEATURE_CODE_SERVER_PORT=9090")
-			assert.NotContains(t, envs, "FEATURE_DOCKER_IN_DOCKER_MOBY=false")
+			assert.NotContains(t, envs, "FEATURE_CODE_SERVER_OPTION_PORT=9090")
+			assert.NotContains(t, envs, "FEATURE_DOCKER_IN_DOCKER_OPTION_MOBY=false")
 			return nil
 		})
 
@@ -2163,8 +2163,8 @@ func TestAPI(t *testing.T) {
 			assert.Contains(t, envs, "CODER_WORKSPACE_OWNER_NAME=test-user")
 			assert.Contains(t, envs, "CODER_URL=test-subagent-url")
 			// Second call should have feature envs from the first config read.
-			assert.Contains(t, envs, "FEATURE_CODE_SERVER_PORT=9090")
-			assert.Contains(t, envs, "FEATURE_DOCKER_IN_DOCKER_MOBY=false")
+			assert.Contains(t, envs, "FEATURE_CODE_SERVER_OPTION_PORT=9090")
+			assert.Contains(t, envs, "FEATURE_DOCKER_IN_DOCKER_OPTION_MOBY=false")
 			return nil
 		})
 

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -40,7 +40,7 @@ type DevcontainerFeatures map[string]any
 
 // OptionsAsEnvs converts the DevcontainerFeatures into a list of
 // environment variables that can be used to set feature options.
-// The format is FEATURE_<FEATURE_NAME>_<OPTION_NAME>=<value>.
+// The format is FEATURE_<FEATURE_NAME>_OPTION_<OPTION_NAME>=<value>.
 // For example, if the feature is:
 //
 //		"ghcr.io/coder/devcontainer-features/code-server:1": {
@@ -49,7 +49,7 @@ type DevcontainerFeatures map[string]any
 //
 // It will produce:
 //
-//	FEATURE_CODE_SERVER_PORT=9090
+//	FEATURE_CODE_SERVER_OPTION_PORT=9090
 //
 // Note that the feature name is derived from the last part of the key,
 // so "ghcr.io/coder/devcontainer-features/code-server:1" becomes
@@ -71,7 +71,7 @@ func (f DevcontainerFeatures) OptionsAsEnvs() []string {
 		k = strings.ReplaceAll(k, "-", "_")
 		for k2, v2 := range vv {
 			k2 = strings.ReplaceAll(k2, "-", "_")
-			env = append(env, fmt.Sprintf("FEATURE_%s_%s=%s", strings.ToUpper(k), strings.ToUpper(k2), fmt.Sprintf("%v", v2)))
+			env = append(env, fmt.Sprintf("FEATURE_%s_OPTION_%s=%s", strings.ToUpper(k), strings.ToUpper(k2), fmt.Sprintf("%v", v2)))
 		}
 	}
 	slices.Sort(env)

--- a/agent/agentcontainers/devcontainercli.go
+++ b/agent/agentcontainers/devcontainercli.go
@@ -38,6 +38,23 @@ type DevcontainerMergedCustomizations struct {
 
 type DevcontainerFeatures map[string]any
 
+// OptionsAsEnvs converts the DevcontainerFeatures into a list of
+// environment variables that can be used to set feature options.
+// The format is FEATURE_<FEATURE_NAME>_<OPTION_NAME>=<value>.
+// For example, if the feature is:
+//
+//		"ghcr.io/coder/devcontainer-features/code-server:1": {
+//	   "port": 9090,
+//	 }
+//
+// It will produce:
+//
+//	FEATURE_CODE_SERVER_PORT=9090
+//
+// Note that the feature name is derived from the last part of the key,
+// so "ghcr.io/coder/devcontainer-features/code-server:1" becomes
+// "CODE_SERVER". The version part (e.g. ":1") is removed, and dashes in
+// the feature and option names are replaced with underscores.
 func (f DevcontainerFeatures) OptionsAsEnvs() []string {
 	var env []string
 	for k, v := range f {
@@ -45,9 +62,9 @@ func (f DevcontainerFeatures) OptionsAsEnvs() []string {
 		if !ok {
 			continue
 		}
-		// Take the last part of the key as the feature name.
+		// Take the last part of the key as the feature name/path.
 		k = k[strings.LastIndex(k, "/")+1:]
-		// Removing trailing : and anything following it
+		// Remove ":" and anything following it.
 		if idx := strings.Index(k, ":"); idx != -1 {
 			k = k[:idx]
 		}

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -672,7 +672,7 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 				},
 			},
 			want: []string{
-				"FEATURE_CODE_SERVER_PORT=9090",
+				"FEATURE_CODE_SERVER_OPTION_PORT=9090",
 			},
 		},
 		{
@@ -683,7 +683,7 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 				},
 			},
 			want: []string{
-				"FEATURE_DOCKER_IN_DOCKER_MOBY=false",
+				"FEATURE_DOCKER_IN_DOCKER_OPTION_MOBY=false",
 			},
 		},
 		{
@@ -699,10 +699,10 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 				},
 			},
 			want: []string{
-				"FEATURE_CODE_SERVER_PASSWORD=secret",
-				"FEATURE_CODE_SERVER_PORT=9090",
-				"FEATURE_DOCKER_IN_DOCKER_DOCKER_DASH_COMPOSE_VERSION=v2",
-				"FEATURE_DOCKER_IN_DOCKER_MOBY=false",
+				"FEATURE_CODE_SERVER_OPTION_PASSWORD=secret",
+				"FEATURE_CODE_SERVER_OPTION_PORT=9090",
+				"FEATURE_DOCKER_IN_DOCKER_OPTION_DOCKER_DASH_COMPOSE_VERSION=v2",
+				"FEATURE_DOCKER_IN_DOCKER_OPTION_MOBY=false",
 			},
 		},
 		{
@@ -714,15 +714,15 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 				"./invalid-feature": "not-a-map",
 			},
 			want: []string{
-				"FEATURE_CODE_SERVER_PORT=9090",
+				"FEATURE_CODE_SERVER_OPTION_PORT=9090",
 			},
 		},
 		{
 			name:     "real config example",
 			features: realConfig.MergedConfiguration.Features,
 			want: []string{
-				"FEATURE_CODE_SERVER_PORT=9090",
-				"FEATURE_DOCKER_IN_DOCKER_MOBY=false",
+				"FEATURE_CODE_SERVER_OPTION_PORT=9090",
+				"FEATURE_DOCKER_IN_DOCKER_OPTION_MOBY=false",
 			},
 		},
 		{

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
@@ -681,10 +682,10 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 				},
 			},
 			want: []string{
-				"FEATURE_CODE_SERVER_PORT=9090",
 				"FEATURE_CODE_SERVER_PASSWORD=secret",
-				"FEATURE_DOCKER_IN_DOCKER_MOBY=false",
+				"FEATURE_CODE_SERVER_PORT=9090",
 				"FEATURE_DOCKER_IN_DOCKER_DOCKER_DASH_COMPOSE_VERSION=v2",
+				"FEATURE_DOCKER_IN_DOCKER_MOBY=false",
 			},
 		},
 		{
@@ -717,7 +718,7 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 		{
 			name:     "empty features",
 			features: agentcontainers.DevcontainerFeatures{},
-			want:     []string{},
+			want:     nil,
 		},
 	}
 
@@ -726,11 +727,8 @@ func TestDevcontainerFeatures_OptionsAsEnvs(t *testing.T) {
 			t.Parallel()
 
 			got := tt.features.OptionsAsEnvs()
-
-			require.Len(t, got, len(tt.want), "number of environment variables should match")
-
-			for _, expected := range tt.want {
-				assert.Contains(t, got, expected, "expected environment variable not found")
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				require.Failf(t, "OptionsAsEnvs() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Since `devcontainer-feature.json` does not support referencing options anywhere outside the feature installation, especially within the JSON itself, this change implements a work-around by defining environment variables based on the feature options that we can use in our features.

This allows us to define a dynamic URL for e.g. the `code-server` feature.