### PR TITLE
fix(coderd/agentapi): make sub agent slugs more unique

### DIFF
--- a/coderd/agentapi/subagent_test.go
+++ b/coderd/agentapi/subagent_test.go
@@ -216,7 +216,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:                 "code-server",
+						Slug:                 "d2b537b8-code-server",
 						DisplayName:          "VS Code",
 						Icon:                 "/icon/code.svg",
 						Command:              sql.NullString{},
@@ -234,7 +234,7 @@ func TestSubAgentAPI(t *testing.T) {
 						DisplayGroup:         sql.NullString{},
 					},
 					{
-						Slug:         "vim",
+						Slug:         "9c813024-vim",
 						DisplayName:  "Vim",
 						Icon:         "/icon/vim.svg",
 						Command:      sql.NullString{Valid: true, String: "vim"},
@@ -377,7 +377,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "valid-app",
+						Slug:         "7f9e8fef-valid-app",
 						DisplayName:  "Valid App",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
@@ -410,19 +410,19 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "authenticated-app",
+						Slug:         "51f592de-authenticated-app",
 						SharingLevel: database.AppSharingLevelAuthenticated,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
 					},
 					{
-						Slug:         "owner-app",
+						Slug:         "cad4f019-owner-app",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
 					},
 					{
-						Slug:         "public-app",
+						Slug:         "9e367a4c-public-app",
 						SharingLevel: database.AppSharingLevelPublic,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
@@ -443,13 +443,13 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "tab-app",
+						Slug:         "6cb5ae2b-tab-app",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInTab,
 					},
 					{
-						Slug:         "window-app",
+						Slug:         "11675927-window-app",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
@@ -479,7 +479,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:                 "full-app",
+						Slug:                 "1067629f-full-app",
 						Command:              sql.NullString{Valid: true, String: "echo hello"},
 						DisplayName:          "Full Featured App",
 						External:             true,
@@ -507,7 +507,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:                 "no-health-app",
+						Slug:                 "3290f004-no-health-app",
 						Health:               database.WorkspaceAppHealthDisabled,
 						SharingLevel:         database.AppSharingLevelOwner,
 						OpenIn:               database.WorkspaceAppOpenInSlimWindow,
@@ -531,7 +531,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "duplicate-app",
+						Slug:         "6977f2fe-duplicate-app",
 						DisplayName:  "First App",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
@@ -568,14 +568,14 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "duplicate-app",
+						Slug:         "6977f2fe-duplicate-app",
 						DisplayName:  "First Duplicate",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
 					},
 					{
-						Slug:         "valid-app",
+						Slug:         "7f9e8fef-valid-app",
 						DisplayName:  "Valid App",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
@@ -754,7 +754,7 @@ func TestSubAgentAPI(t *testing.T) {
 			apps, err := db.GetWorkspaceAppsByAgentID(dbauthz.AsSystemRestricted(ctx), agentID) //nolint:gocritic // this is a test.
 			require.NoError(t, err)
 			require.Len(t, apps, 1)
-			require.Equal(t, "duplicate-slug", apps[0].Slug)
+			require.Equal(t, "b219bd99-duplicate-slug", apps[0].Slug)
 			require.Equal(t, "First Duplicate", apps[0].DisplayName)
 		})
 	})
@@ -1128,7 +1128,7 @@ func TestSubAgentAPI(t *testing.T) {
 		apps, err := api.Database.GetWorkspaceAppsByAgentID(dbauthz.AsSystemRestricted(ctx), agentID) //nolint:gocritic // this is a test.
 		require.NoError(t, err)
 		require.Len(t, apps, 1)
-		require.Equal(t, "custom-app", apps[0].Slug)
+		require.Equal(t, "9cc545fe-custom-app", apps[0].Slug)
 		require.Equal(t, "Custom App", apps[0].DisplayName)
 	})
 

--- a/coderd/agentapi/subagent_test.go
+++ b/coderd/agentapi/subagent_test.go
@@ -216,7 +216,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:                 "d2b537b8-code-server",
+						Slug:                 "fdqf0lpd-code-server",
 						DisplayName:          "VS Code",
 						Icon:                 "/icon/code.svg",
 						Command:              sql.NullString{},
@@ -234,7 +234,7 @@ func TestSubAgentAPI(t *testing.T) {
 						DisplayGroup:         sql.NullString{},
 					},
 					{
-						Slug:         "9c813024-vim",
+						Slug:         "547knu0f-vim",
 						DisplayName:  "Vim",
 						Icon:         "/icon/vim.svg",
 						Command:      sql.NullString{Valid: true, String: "vim"},
@@ -377,7 +377,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "7f9e8fef-valid-app",
+						Slug:         "511ctirn-valid-app",
 						DisplayName:  "Valid App",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
@@ -410,19 +410,19 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "51f592de-authenticated-app",
+						Slug:         "atpt261l-authenticated-app",
 						SharingLevel: database.AppSharingLevelAuthenticated,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
 					},
 					{
-						Slug:         "cad4f019-owner-app",
+						Slug:         "eh5gp1he-owner-app",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
 					},
 					{
-						Slug:         "9e367a4c-public-app",
+						Slug:         "oopjevf1-public-app",
 						SharingLevel: database.AppSharingLevelPublic,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
@@ -443,13 +443,13 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "6cb5ae2b-tab-app",
+						Slug:         "ci9500rm-tab-app",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInTab,
 					},
 					{
-						Slug:         "11675927-window-app",
+						Slug:         "p17s76re-window-app",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
@@ -479,7 +479,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:                 "1067629f-full-app",
+						Slug:                 "0ccdbg39-full-app",
 						Command:              sql.NullString{Valid: true, String: "echo hello"},
 						DisplayName:          "Full Featured App",
 						External:             true,
@@ -507,7 +507,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:                 "3290f004-no-health-app",
+						Slug:                 "nphrhbh6-no-health-app",
 						Health:               database.WorkspaceAppHealthDisabled,
 						SharingLevel:         database.AppSharingLevelOwner,
 						OpenIn:               database.WorkspaceAppOpenInSlimWindow,
@@ -531,7 +531,7 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "6977f2fe-duplicate-app",
+						Slug:         "uiklfckv-duplicate-app",
 						DisplayName:  "First App",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
@@ -568,14 +568,14 @@ func TestSubAgentAPI(t *testing.T) {
 				},
 				expectApps: []database.WorkspaceApp{
 					{
-						Slug:         "6977f2fe-duplicate-app",
+						Slug:         "uiklfckv-duplicate-app",
 						DisplayName:  "First Duplicate",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
 						OpenIn:       database.WorkspaceAppOpenInSlimWindow,
 					},
 					{
-						Slug:         "7f9e8fef-valid-app",
+						Slug:         "511ctirn-valid-app",
 						DisplayName:  "Valid App",
 						SharingLevel: database.AppSharingLevelOwner,
 						Health:       database.WorkspaceAppHealthDisabled,
@@ -754,7 +754,7 @@ func TestSubAgentAPI(t *testing.T) {
 			apps, err := db.GetWorkspaceAppsByAgentID(dbauthz.AsSystemRestricted(ctx), agentID) //nolint:gocritic // this is a test.
 			require.NoError(t, err)
 			require.Len(t, apps, 1)
-			require.Equal(t, "b219bd99-duplicate-slug", apps[0].Slug)
+			require.Equal(t, "k5jd7a99-duplicate-slug", apps[0].Slug)
 			require.Equal(t, "First Duplicate", apps[0].DisplayName)
 		})
 	})
@@ -1128,7 +1128,7 @@ func TestSubAgentAPI(t *testing.T) {
 		apps, err := api.Database.GetWorkspaceAppsByAgentID(dbauthz.AsSystemRestricted(ctx), agentID) //nolint:gocritic // this is a test.
 		require.NoError(t, err)
 		require.Len(t, apps, 1)
-		require.Equal(t, "9cc545fe-custom-app", apps[0].Slug)
+		require.Equal(t, "v4qhkq17-custom-app", apps[0].Slug)
 		require.Equal(t, "Custom App", apps[0].DisplayName)
 	})
 


### PR DESCRIPTION
The incorrect assumption that slugs were unique per-agent was made when the subagent API was implemented. Whilst this PR doesn't completely enforce that, we instead compute a stable hash to prefix the slug that should provide a reasonable level of probability that the slug will be unique.