### PR TITLE
chore: modify parameter dynamic immutability behavior

### DIFF
--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -126,7 +126,7 @@ func ResolveParameters(
 		parameterNames[parameter.Name] = struct{}{}
 
 		if !firstBuild && !parameter.Mutable {
-			originalValue, ok := originalInputValues[parameter.Name]
+			originalValue, ok := previousValuesMap[parameter.Name]
 			// Immutable parameters should not be changed after the first build.
 			// If the value matches the original input value, that is fine.
 			//
@@ -134,7 +134,7 @@ func ResolveParameters(
 			// immutable parameters are allowed. This is an opinionated choice to prevent
 			// workspaces failing to update or delete. Ideally we would block this, as
 			// immutable parameters should only be able to be set at creation time.
-			if ok && parameter.Value.AsString() != originalValue.Value {
+			if ok && parameter.Value.AsString() != originalValue {
 				var src *hcl.Range
 				if parameter.Source != nil {
 					src = &parameter.Source.HCLBlock().TypeRange

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -93,22 +93,6 @@ func ResolveParameters(
 				delete(values, parameter.Name)
 			}
 		}
-
-		// Immutable parameters should also not be allowed to be changed from
-		// the previous build. Remove any values taken from the preset or
-		// new build params. This forces the value to be the same as it was before.
-		//
-		// We do this so the next form render uses the original immutable value.
-		if !firstBuild && !parameter.Mutable {
-			delete(values, parameter.Name)
-			prev, ok := previousValuesMap[parameter.Name]
-			if ok {
-				values[parameter.Name] = parameterValue{
-					Value:  prev,
-					Source: sourcePrevious,
-				}
-			}
-		}
 	}
 
 	// This is the final set of values that will be used. Any errors at this stage
@@ -118,7 +102,7 @@ func ResolveParameters(
 		return nil, parameterValidationError(diags)
 	}
 
-	// parameterNames is going to be used to remove any excess values that were left
+	// parameterNames is going to be used to remove any excess values left
 	// around without a parameter.
 	parameterNames := make(map[string]struct{}, len(output.Parameters))
 	parameterError := parameterValidationError(nil)
@@ -126,11 +110,16 @@ func ResolveParameters(
 		parameterNames[parameter.Name] = struct{}{}
 
 		if !firstBuild && !parameter.Mutable {
+			// previousValuesMap should be used over the first render output
+			// for the previous state of parameters. The previous build
+			// should emit all values, so the previousValuesMap should be
+			// complete with all parameter values (user specified and defaults)
 			originalValue, ok := previousValuesMap[parameter.Name]
+
 			// Immutable parameters should not be changed after the first build.
-			// If the value matches the original input value, that is fine.
+			// If the value matches the previous input value, that is fine.
 			//
-			// If the original value is not set, that means this is a new parameter. New
+			// If the previous value is not set, that means this is a new parameter. New
 			// immutable parameters are allowed. This is an opinionated choice to prevent
 			// workspaces failing to update or delete. Ideally we would block this, as
 			// immutable parameters should only be able to be set at creation time.

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -55,19 +55,11 @@ func ResolveParameters(
 		values[preset.Name] = parameterValue{Source: sourcePreset, Value: preset.Value}
 	}
 
-	// originalValues is going to be used to detect if a user tried to change
-	// an immutable parameter after the first build.
-	originalValues := make(map[string]parameterValue, len(values))
-	for name, value := range values {
-		// Store the original values for later use.
-		originalValues[name] = value
-	}
-
 	// Render the parameters using the values that were supplied to the previous build.
 	//
 	// This is how the form should look to the user on their workspace settings page.
 	// This is the original form truth that our validations should initially be based on.
-	output, diags := renderer.Render(ctx, ownerID, values.ValuesMap())
+	output, diags := renderer.Render(ctx, ownerID, previousValuesMap)
 	if diags.HasErrors() {
 		// Top level diagnostics should break the build. Previous values (and new) should
 		// always be valid. If there is a case where this is not true, then this has to
@@ -124,7 +116,7 @@ func ResolveParameters(
 		parameterNames[parameter.Name] = struct{}{}
 
 		if !firstBuild && !parameter.Mutable {
-			originalValue, ok := originalValues[parameter.Name]
+			originalValue, ok := previousValuesMap[parameter.Name]
 			// Immutable parameters should not be changed after the first build.
 			// If the value matches the original value, that is fine.
 			//
@@ -132,7 +124,7 @@ func ResolveParameters(
 			// immutable parameters are allowed. This is an opinionated choice to prevent
 			// workspaces failing to update or delete. Ideally we would block this, as
 			// immutable parameters should only be able to be set at creation time.
-			if ok && parameter.Value.AsString() != originalValue.Value {
+			if ok && parameter.Value.AsString() != originalValue {
 				var src *hcl.Range
 				if parameter.Source != nil {
 					src = &parameter.Source.HCLBlock().TypeRange

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -67,7 +67,7 @@ func ResolveParameters(
 	//
 	// This is how the form should look to the user on their workspace settings page.
 	// This is the original form truth that our validations should initially be based on.
-	output, diags := renderer.Render(ctx, ownerID, previousValuesMap)
+	output, diags := renderer.Render(ctx, ownerID, values.ValuesMap())
 	if diags.HasErrors() {
 		// Top level diagnostics should break the build. Previous values (and new) should
 		// always be valid. If there is a case where this is not true, then this has to
@@ -81,7 +81,6 @@ func ResolveParameters(
 	//
 	// To enforce these, the user's input values are trimmed based on the
 	// mutability and ephemeral parameters defined in the template version.
-	wasImmutable := make(map[string]struct{})
 	for _, parameter := range output.Parameters {
 		// Ephemeral parameters should not be taken from the previous build.
 		// They must always be explicitly set in every build.
@@ -99,7 +98,6 @@ func ResolveParameters(
 		//
 		// We do this so the next form render uses the original immutable value.
 		if !firstBuild && !parameter.Mutable {
-			wasImmutable[parameter.Name] = struct{}{}
 			delete(values, parameter.Name)
 			prev, ok := previousValuesMap[parameter.Name]
 			if ok {
@@ -125,12 +123,7 @@ func ResolveParameters(
 	for _, parameter := range output.Parameters {
 		parameterNames[parameter.Name] = struct{}{}
 
-		// Immutability is sourced from the current `mutable` argument, and also the
-		// previous parameter's `mutable` argument. This means you cannot flip an
-		// `immutable` parameter to `mutable` in a single build. This is to preserve the
-		// original mutability of the parameter.
-		_, wi := wasImmutable[parameter.Name]
-		if !firstBuild && (!parameter.Mutable || wi) {
+		if !firstBuild && !parameter.Mutable {
 			originalValue, ok := originalValues[parameter.Name]
 			// Immutable parameters should not be changed after the first build.
 			// If the value matches the original value, that is fine.
@@ -144,19 +137,13 @@ func ResolveParameters(
 				if parameter.Source != nil {
 					src = &parameter.Source.HCLBlock().TypeRange
 				}
-				errTitle := "Immutable"
-				// In the strange case someone flips mutability from `true` to `false`.
-				// Change the error title to indicate that this was previously immutable.
-				if wi && parameter.Mutable {
-					errTitle = "Previously immutable"
-				}
 
 				// An immutable parameter was changed, which is not allowed.
 				// Add a failed diagnostic to the output.
 				parameterError.Extend(parameter.Name, hcl.Diagnostics{
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  fmt.Sprintf("%s parameter changed", errTitle),
+						Summary:  "Immutable parameter changed",
 						Detail:   fmt.Sprintf("Parameter %q is not mutable, so it can't be updated after creating a workspace.", parameter.Name),
 						Subject:  src,
 					},

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -97,9 +97,8 @@ func TestResolveParameters(t *testing.T) {
 				Parameters: []previewtypes.Parameter{
 					{
 						ParameterData: immutable,
-						// User changes the value to 'bar'
-						Value:       previewtypes.StringLiteral("bar"),
-						Diagnostics: nil,
+						Value:         previewtypes.StringLiteral("foo"),
+						Diagnostics:   nil,
 					},
 				},
 			}, nil)

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/dynamicparameters"
 	"github.com/coder/coder/v2/coderd/dynamicparameters/rendermock"
+	"github.com/coder/coder/v2/coderd/httpapi/httperror"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/preview"
@@ -55,5 +56,70 @@ func TestResolveParameters(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, map[string]string{"immutable": "foo"}, values)
+	})
+
+	// Tests a parameter going from mutable -> immutable
+	t.Run("BecameImmutable", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		render := rendermock.NewMockRenderer(ctrl)
+
+		mutable := previewtypes.ParameterData{
+			Name:         "immutable",
+			Type:         previewtypes.ParameterTypeString,
+			FormType:     provider.ParameterFormTypeInput,
+			Mutable:      false,
+			DefaultValue: previewtypes.StringLiteral("foo"),
+			Required:     true,
+		}
+		immutable := mutable
+		immutable.Mutable = false
+
+		// A single immutable parameter with no previous value.
+		render.EXPECT().
+			Render(gomock.Any(), gomock.Any(), gomock.Any()).
+			// Return the mutable param first
+			Return(&preview.Output{
+				Parameters: []previewtypes.Parameter{
+					{
+						ParameterData: mutable,
+						Value:         previewtypes.StringLiteral("foo"),
+						Diagnostics:   nil,
+					},
+				},
+			}, nil)
+
+		render.EXPECT().
+			Render(gomock.Any(), gomock.Any(), gomock.Any()).
+			// Then the immutable param
+			Return(&preview.Output{
+				Parameters: []previewtypes.Parameter{
+					{
+						ParameterData: immutable,
+						// User changes the value to 'bar'
+						Value:       previewtypes.StringLiteral("bar"),
+						Diagnostics: nil,
+					},
+				},
+			}, nil)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		_, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
+			[]database.WorkspaceBuildParameter{
+				{Name: "immutable", Value: "foo"}, // Previous value foo
+			},
+			[]codersdk.WorkspaceBuildParameter{
+				{Name: "immutable", Value: "bar"}, // New value
+			},
+			[]database.TemplateVersionPresetParameter{}, // No preset values
+		)
+		require.Error(t, err)
+		resp, ok := httperror.IsResponder(err)
+		require.True(t, ok)
+
+		_, respErr := resp.Response()
+		require.Len(t, respErr.Validations, 1)
+		require.Contains(t, respErr.Validations[0].Error(), "is not mutable")
 	})
 }

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -20,58 +20,6 @@ import (
 func TestResolveParameters(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ChangeImmutable", func(t *testing.T) {
-		t.Parallel()
-
-		ctrl := gomock.NewController(t)
-		render := rendermock.NewMockRenderer(ctrl)
-
-		// The first render takes in the existing values
-		render.EXPECT().
-			Render(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(&preview.Output{
-				Parameters: []previewtypes.Parameter{
-					{
-						ParameterData: previewtypes.ParameterData{
-							Name:         "immutable",
-							Type:         previewtypes.ParameterTypeString,
-							FormType:     provider.ParameterFormTypeInput,
-							Mutable:      false,
-							DefaultValue: previewtypes.StringLiteral("foo"),
-							Required:     true,
-						},
-						Value:       previewtypes.StringLiteral("foo"),
-						Diagnostics: nil,
-					},
-				},
-			}, nil).
-			Return(&preview.Output{
-				Parameters: []previewtypes.Parameter{
-					{
-						ParameterData: previewtypes.ParameterData{
-							Name:         "immutable",
-							Type:         previewtypes.ParameterTypeString,
-							FormType:     provider.ParameterFormTypeInput,
-							Mutable:      false,
-							DefaultValue: previewtypes.StringLiteral("foo"),
-							Required:     true,
-						},
-						Value:       previewtypes.StringLiteral("foo"),
-						Diagnostics: nil,
-					},
-				},
-			}, nil)
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-		values, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
-			[]database.WorkspaceBuildParameter{},        // No previous values
-			[]codersdk.WorkspaceBuildParameter{},        // No new build values
-			[]database.TemplateVersionPresetParameter{}, // No preset values
-		)
-		require.NoError(t, err)
-		require.Equal(t, map[string]string{"immutable": "foo"}, values)
-	})
-
 	t.Run("NewImmutable", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -20,6 +20,58 @@ import (
 func TestResolveParameters(t *testing.T) {
 	t.Parallel()
 
+	t.Run("ChangeImmutable", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		render := rendermock.NewMockRenderer(ctrl)
+
+		// The first render takes in the existing values
+		render.EXPECT().
+			Render(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&preview.Output{
+				Parameters: []previewtypes.Parameter{
+					{
+						ParameterData: previewtypes.ParameterData{
+							Name:         "immutable",
+							Type:         previewtypes.ParameterTypeString,
+							FormType:     provider.ParameterFormTypeInput,
+							Mutable:      false,
+							DefaultValue: previewtypes.StringLiteral("foo"),
+							Required:     true,
+						},
+						Value:       previewtypes.StringLiteral("foo"),
+						Diagnostics: nil,
+					},
+				},
+			}, nil).
+			Return(&preview.Output{
+				Parameters: []previewtypes.Parameter{
+					{
+						ParameterData: previewtypes.ParameterData{
+							Name:         "immutable",
+							Type:         previewtypes.ParameterTypeString,
+							FormType:     provider.ParameterFormTypeInput,
+							Mutable:      false,
+							DefaultValue: previewtypes.StringLiteral("foo"),
+							Required:     true,
+						},
+						Value:       previewtypes.StringLiteral("foo"),
+						Diagnostics: nil,
+					},
+				},
+			}, nil)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		values, err := dynamicparameters.ResolveParameters(ctx, uuid.New(), render, false,
+			[]database.WorkspaceBuildParameter{},        // No previous values
+			[]codersdk.WorkspaceBuildParameter{},        // No new build values
+			[]database.TemplateVersionPresetParameter{}, // No preset values
+		)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"immutable": "foo"}, values)
+	})
+
 	t.Run("NewImmutable", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -97,8 +97,9 @@ func TestResolveParameters(t *testing.T) {
 				Parameters: []previewtypes.Parameter{
 					{
 						ParameterData: immutable,
-						Value:         previewtypes.StringLiteral("foo"),
-						Diagnostics:   nil,
+						//  The user set the value to bar
+						Value:       previewtypes.StringLiteral("bar"),
+						Diagnostics: nil,
 					},
 				},
 			}, nil)

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -69,7 +69,7 @@ func TestResolveParameters(t *testing.T) {
 			Name:         "immutable",
 			Type:         previewtypes.ParameterTypeString,
 			FormType:     provider.ParameterFormTypeInput,
-			Mutable:      false,
+			Mutable:      true,
 			DefaultValue: previewtypes.StringLiteral("foo"),
 			Required:     true,
 		}

--- a/enterprise/coderd/dynamicparameters_test.go
+++ b/enterprise/coderd/dynamicparameters_test.go
@@ -364,7 +364,7 @@ func TestDynamicParameterBuild(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
 			// Start with a new template that has 1 parameter that is immutable
 			immutable, _ := coderdtest.DynamicParameterTemplate(t, templateAdmin, orgID, coderdtest.DynamicParameterTemplateParams{
-				MainTF: string(must(os.ReadFile("testdata/parameters/dynamicimmutable/main.tf"))),
+				MainTF: "# PreviouslyImmutable\n" + string(must(os.ReadFile("testdata/parameters/dynamicimmutable/main.tf"))),
 			})
 
 			// Create the workspace with the immutable parameter
@@ -396,7 +396,7 @@ func TestDynamicParameterBuild(t *testing.T) {
 
 			ctx := testutil.Context(t, testutil.WaitShort)
 			immutable, _ := coderdtest.DynamicParameterTemplate(t, templateAdmin, orgID, coderdtest.DynamicParameterTemplateParams{
-				MainTF: string(must(os.ReadFile("testdata/parameters/dynamicimmutable/main.tf"))),
+				MainTF: "# PreviouslyMutable\n" + string(must(os.ReadFile("testdata/parameters/dynamicimmutable/main.tf"))),
 			})
 
 			// Create the workspace with the mutable parameter

--- a/enterprise/coderd/testdata/parameters/dynamicimmutable/main.tf
+++ b/enterprise/coderd/testdata/parameters/dynamicimmutable/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+data "coder_workspace_owner" "me" {}
+
+data "coder_parameter" "isimmutable" {
+  name   = "isimmutable"
+  type    = "bool"
+  mutable = true
+  default = "true"
+}
+
+data "coder_parameter" "immutable" {
+  name    = "immutable"
+  type    = "string"
+  mutable = data.coder_parameter.isimmutable.value == "false"
+  default = "Hello World"
+}

--- a/enterprise/coderd/testdata/parameters/dynamicimmutable/main.tf
+++ b/enterprise/coderd/testdata/parameters/dynamicimmutable/main.tf
@@ -9,7 +9,7 @@ terraform {
 data "coder_workspace_owner" "me" {}
 
 data "coder_parameter" "isimmutable" {
-  name   = "isimmutable"
+  name    = "isimmutable"
   type    = "bool"
   mutable = true
   default = "true"


### PR DESCRIPTION
Parameter `mutablity` is determined by the current state. So a previously `immutable` parameter can become `mutable`.

Terraform:

```terraform
data "coder_parameter" "isimmutable" {
  name   = "isimmutable"
  type    = "bool"
  mutable = true
  default = "true"
}

data "coder_parameter" "immutable" {
  name    = "immutable"
  type    = "string"
  mutable = data.coder_parameter.isimmutable.value == "false"
  default = "Hello World"
}
```

### Trivial Case:

1. Workspace built with `isimmutable = true` & `immutable = "bar"`
2. Workspace updates `immutable = foo`
   1. Breaks, because you cannot update an immutable value 

### Immutability source from the past

1. Workspace built with `isimmutable = true` & `immutable = "bar"`
2. Workspace updates `immutable = foo` & `isimmutable = false`
   1. This works because at validation time, `mutable = true`

# Why ignore the previous parameter state?

Ignoring previous state is vastly simplier and more intuitive. If the previous parameter `mutability` affected the current build, then questions such as, "What if the last build failed? Do we take the last successful build?", etc.
