### PR TITLE
chore(coderd/database): optimize GetRunningPrebuiltWorkspaces

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6243,18 +6243,59 @@ func (q *sqlQuerier) GetPresetsBackoff(ctx context.Context, lookback time.Time) 
 }
 
 const getRunningPrebuiltWorkspaces = `-- name: GetRunningPrebuiltWorkspaces :many
+WITH latest_prebuilds AS (
+	SELECT
+		latest_build.workspace_id,
+		workspaces.name,
+		workspaces.template_id,
+		latest_build.template_version_id,
+		latest_build.template_version_preset_id,
+		latest_build.job_id,
+		workspaces.created_at
+	FROM workspaces
+	JOIN LATERAL (
+		SELECT
+			workspace_builds.id,
+			workspace_builds.workspace_id,
+			workspace_builds.template_version_id,
+			workspace_builds.job_id,
+			workspace_builds.template_version_preset_id,
+			workspace_builds.transition,
+			workspace_builds.created_at,
+			provisioner_jobs.job_status
+		FROM workspace_builds
+		JOIN provisioner_jobs ON provisioner_jobs.id = workspace_builds.job_id
+		WHERE workspace_builds.workspace_id = workspaces.id
+		AND workspace_builds.transition = 'start'::workspace_transition
+		AND provisioner_jobs.job_status = 'succeeded'::provisioner_job_status
+		ORDER BY workspace_builds.build_number DESC
+		LIMIT 1
+	) AS latest_build ON true
+	WHERE workspaces.deleted = false
+	AND workspaces.owner_id = 'c42fdf75-3097-471c-8c33-fb52454d81c0'::UUID
+),
+ready_agents AS (
+	SELECT
+		latest_prebuilds.job_id,
+		BOOL_AND(workspace_agents.lifecycle_state = 'ready'::workspace_agent_lifecycle_state)::boolean AS ready
+	FROM latest_prebuilds
+	JOIN workspace_resources ON workspace_resources.job_id = latest_prebuilds.job_id
+	JOIN workspace_agents ON workspace_agents.resource_id = workspace_resources.id
+	WHERE workspace_agents.deleted = false
+	AND workspace_agents.parent_id IS NULL
+	GROUP BY latest_prebuilds.job_id
+	)
 SELECT
-		p.id,
-		p.name,
-		p.template_id,
-		b.template_version_id,
-		p.current_preset_id AS current_preset_id,
-		p.ready,
-		p.created_at
-FROM workspace_prebuilds p
-		INNER JOIN workspace_latest_builds b ON b.workspace_id = p.id
-WHERE (b.transition = 'start'::workspace_transition
-	AND b.job_status = 'succeeded'::provisioner_job_status)
+	latest_prebuilds.workspace_id AS id,
+	latest_prebuilds.name,
+	latest_prebuilds.template_id,
+	latest_prebuilds.template_version_id,
+	latest_prebuilds.template_version_preset_id AS current_preset_id,
+	COALESCE(ready_agents.ready, false)::boolean AS ready,
+	latest_prebuilds.created_at
+FROM latest_prebuilds
+LEFT JOIN ready_agents ON ready_agents.job_id = latest_prebuilds.job_id
+ORDER BY latest_prebuilds.workspace_id ASC
 `
 
 type GetRunningPrebuiltWorkspacesRow struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6255,14 +6255,10 @@ WITH latest_prebuilds AS (
 	FROM workspaces
 	JOIN LATERAL (
 		SELECT
-			workspace_builds.id,
 			workspace_builds.workspace_id,
 			workspace_builds.template_version_id,
 			workspace_builds.job_id,
-			workspace_builds.template_version_preset_id,
-			workspace_builds.transition,
-			workspace_builds.created_at,
-			provisioner_jobs.job_status
+			workspace_builds.template_version_preset_id
 		FROM workspace_builds
 		JOIN provisioner_jobs ON provisioner_jobs.id = workspace_builds.job_id
 		WHERE workspace_builds.workspace_id = workspaces.id
@@ -6284,7 +6280,7 @@ ready_agents AS (
 	WHERE workspace_agents.deleted = false
 	AND workspace_agents.parent_id IS NULL
 	GROUP BY latest_prebuilds.job_id
-	)
+)
 SELECT
 	latest_prebuilds.workspace_id AS id,
 	latest_prebuilds.name,

--- a/coderd/database/queries/prebuilds.sql
+++ b/coderd/database/queries/prebuilds.sql
@@ -49,18 +49,59 @@ WHERE tvp.desired_instances IS NOT NULL -- Consider only presets that have a pre
 	AND (t.id = sqlc.narg('template_id')::uuid OR sqlc.narg('template_id') IS NULL);
 
 -- name: GetRunningPrebuiltWorkspaces :many
+WITH latest_prebuilds AS (
+	SELECT
+		latest_build.workspace_id,
+		workspaces.name,
+		workspaces.template_id,
+		latest_build.template_version_id,
+		latest_build.template_version_preset_id,
+		latest_build.job_id,
+		workspaces.created_at
+	FROM workspaces
+	JOIN LATERAL (
+		SELECT
+			workspace_builds.id,
+			workspace_builds.workspace_id,
+			workspace_builds.template_version_id,
+			workspace_builds.job_id,
+			workspace_builds.template_version_preset_id,
+			workspace_builds.transition,
+			workspace_builds.created_at,
+			provisioner_jobs.job_status
+		FROM workspace_builds
+		JOIN provisioner_jobs ON provisioner_jobs.id = workspace_builds.job_id
+		WHERE workspace_builds.workspace_id = workspaces.id
+		AND workspace_builds.transition = 'start'::workspace_transition
+		AND provisioner_jobs.job_status = 'succeeded'::provisioner_job_status
+		ORDER BY workspace_builds.build_number DESC
+		LIMIT 1
+	) AS latest_build ON true
+	WHERE workspaces.deleted = false
+	AND workspaces.owner_id = 'c42fdf75-3097-471c-8c33-fb52454d81c0'::UUID
+),
+ready_agents AS (
+	SELECT
+		latest_prebuilds.job_id,
+		BOOL_AND(workspace_agents.lifecycle_state = 'ready'::workspace_agent_lifecycle_state)::boolean AS ready
+	FROM latest_prebuilds
+	JOIN workspace_resources ON workspace_resources.job_id = latest_prebuilds.job_id
+	JOIN workspace_agents ON workspace_agents.resource_id = workspace_resources.id
+	WHERE workspace_agents.deleted = false
+	AND workspace_agents.parent_id IS NULL
+	GROUP BY latest_prebuilds.job_id
+	)
 SELECT
-		p.id,
-		p.name,
-		p.template_id,
-		b.template_version_id,
-		p.current_preset_id AS current_preset_id,
-		p.ready,
-		p.created_at
-FROM workspace_prebuilds p
-		INNER JOIN workspace_latest_builds b ON b.workspace_id = p.id
-WHERE (b.transition = 'start'::workspace_transition
-	AND b.job_status = 'succeeded'::provisioner_job_status);
+	latest_prebuilds.workspace_id AS id,
+	latest_prebuilds.name,
+	latest_prebuilds.template_id,
+	latest_prebuilds.template_version_id,
+	latest_prebuilds.template_version_preset_id AS current_preset_id,
+	COALESCE(ready_agents.ready, false)::boolean AS ready,
+	latest_prebuilds.created_at
+FROM latest_prebuilds
+LEFT JOIN ready_agents ON ready_agents.job_id = latest_prebuilds.job_id
+ORDER BY latest_prebuilds.workspace_id ASC;
 
 -- name: CountInProgressPrebuilds :many
 -- CountInProgressPrebuilds returns the number of in-progress prebuilds, grouped by preset ID and transition.

--- a/coderd/database/queries/prebuilds.sql
+++ b/coderd/database/queries/prebuilds.sql
@@ -61,14 +61,10 @@ WITH latest_prebuilds AS (
 	FROM workspaces
 	JOIN LATERAL (
 		SELECT
-			workspace_builds.id,
 			workspace_builds.workspace_id,
 			workspace_builds.template_version_id,
 			workspace_builds.job_id,
-			workspace_builds.template_version_preset_id,
-			workspace_builds.transition,
-			workspace_builds.created_at,
-			provisioner_jobs.job_status
+			workspace_builds.template_version_preset_id
 		FROM workspace_builds
 		JOIN provisioner_jobs ON provisioner_jobs.id = workspace_builds.job_id
 		WHERE workspace_builds.workspace_id = workspaces.id
@@ -90,7 +86,7 @@ ready_agents AS (
 	WHERE workspace_agents.deleted = false
 	AND workspace_agents.parent_id IS NULL
 	GROUP BY latest_prebuilds.job_id
-	)
+)
 SELECT
 	latest_prebuilds.workspace_id AS id,
 	latest_prebuilds.name,


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/715

After this change, the only use of the `workspace_prebuilds` view is the `ClaimPrebuiltWorkspace` query. A subsequent PR will update the view.

Before: ~44ms https://explain.dalibo.com/plan/76cbe21d1a4c9329#plan

~After: ~3.7ms https://explain.dalibo.com/plan/f61beg93f9306fc0#plan~

After: 7.3ms https://explain.dalibo.com/plan/5abbdf926315677e#plan