### PR TITLE
chore(site): set `server.allowedHosts` in storybook config to `.coder`

### DIFF
--- a/site/.storybook/main.js
+++ b/site/.storybook/main.js
@@ -35,6 +35,7 @@ module.exports = {
 				}),
 			);
 		}
+		config.server.allowedHosts = [".coder"];
 		return config;
 	},
 };

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -116,7 +116,7 @@ export default defineConfig({
 				secure: process.env.NODE_ENV === "production",
 			},
 		},
-		allowedHosts: true,
+		allowedHosts: [".coder"],
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
This lets you browse storybook using a Coder Desktop hostname (i.e. `workspace.coder:6006`). The default configuration (including `localhost`) will still work.