### PR TITLE
chore(coderd/database): optimize AuditLogs queries

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1301,6 +1301,22 @@ func (q *querier) CleanTailnetTunnels(ctx context.Context) error {
 	return q.db.CleanTailnetTunnels(ctx)
 }
 
+func (q *querier) CountAuditLogs(ctx context.Context, arg database.CountAuditLogsParams) (int64, error) {
+	// Shortcut if the user is an owner. The SQL filter is noticeable,
+	// and this is an easy win for owners. Which is the common case.
+	err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAuditLog)
+	if err == nil {
+		return q.db.CountAuditLogs(ctx, arg)
+	}
+
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceAuditLog.Type)
+	if err != nil {
+		return 0, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
+	}
+
+	return q.db.CountAuthorizedAuditLogs(ctx, arg, prep)
+}
+
 func (q *querier) CountInProgressPrebuilds(ctx context.Context) ([]database.CountInProgressPrebuildsRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceWorkspace.All()); err != nil {
 		return nil, err
@@ -5255,4 +5271,8 @@ func (q *querier) GetAuthorizedUsers(ctx context.Context, arg database.GetUsersP
 
 func (q *querier) GetAuthorizedAuditLogsOffset(ctx context.Context, arg database.GetAuditLogsOffsetParams, _ rbac.PreparedAuthorized) ([]database.GetAuditLogsOffsetRow, error) {
 	return q.GetAuditLogsOffset(ctx, arg)
+}
+
+func (q *querier) CountAuthorizedAuditLogs(ctx context.Context, arg database.CountAuditLogsParams, _ rbac.PreparedAuthorized) (int64, error) {
+	return q.CountAuditLogs(ctx, arg)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -327,6 +327,16 @@ func (s *MethodTestSuite) TestAuditLogs() {
 			LimitOpt: 10,
 		}, emptyPreparedAuthorized{}).Asserts(rbac.ResourceAuditLog, policy.ActionRead)
 	}))
+	s.Run("CountAuditLogs", s.Subtest(func(db database.Store, check *expects) {
+		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})
+		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})
+		check.Args(database.CountAuditLogsParams{}).Asserts(rbac.ResourceAuditLog, policy.ActionRead).WithNotAuthorized("nil")
+	}))
+	s.Run("CountAuthorizedAuditLogs", s.Subtest(func(db database.Store, check *expects) {
+		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})
+		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})
+		check.Args(database.CountAuditLogsParams{}, emptyPreparedAuthorized{}).Asserts(rbac.ResourceAuditLog, policy.ActionRead)
+	}))
 }
 
 func (s *MethodTestSuite) TestFile() {

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -271,7 +271,7 @@ func (s *MethodTestSuite) NotAuthorizedErrorTest(ctx context.Context, az *coderd
 
 		// This is unfortunate, but if we are using `Filter` the error returned will be nil. So filter out
 		// any case where the error is nil and the response is an empty slice.
-		if err != nil || !hasEmptySliceResponse(resp) {
+		if err != nil || !hasEmptyResponse(resp) {
 			// Expect the default error
 			if testCase.notAuthorizedExpect == "" {
 				s.ErrorContainsf(err, "unauthorized", "error string should have a good message")
@@ -297,7 +297,7 @@ func (s *MethodTestSuite) NotAuthorizedErrorTest(ctx context.Context, az *coderd
 
 		// This is unfortunate, but if we are using `Filter` the error returned will be nil. So filter out
 		// any case where the error is nil and the response is an empty slice.
-		if err != nil || !hasEmptySliceResponse(resp) {
+		if err != nil || !hasEmptyResponse(resp) {
 			if testCase.cancelledCtxExpect == "" {
 				s.Errorf(err, "method should an error with cancellation")
 				s.ErrorIsf(err, context.Canceled, "error should match context.Canceled")
@@ -308,10 +308,17 @@ func (s *MethodTestSuite) NotAuthorizedErrorTest(ctx context.Context, az *coderd
 	})
 }
 
-func hasEmptySliceResponse(values []reflect.Value) bool {
+func hasEmptyResponse(values []reflect.Value) bool {
 	for _, r := range values {
 		if r.Kind() == reflect.Slice || r.Kind() == reflect.Array {
 			if r.Len() == 0 {
+				return true
+			}
+		}
+
+		// Special case for int64, as it's the return type for count query.
+		if r.Kind() == reflect.Int64 {
+			if r.Int() == 0 {
 				return true
 			}
 		}

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -296,7 +296,7 @@ func (s *MethodTestSuite) NotAuthorizedErrorTest(ctx context.Context, az *coderd
 		resp, err := callMethod(ctx)
 
 		// This is unfortunate, but if we are using `Filter` the error returned will be nil. So filter out
-		// any case where the error is nil and the response is an empty slice.
+		// any case where the error is nil and the response is an empty slice or int64(0).
 		if err != nil || !hasEmptyResponse(resp) {
 			if testCase.cancelledCtxExpect == "" {
 				s.Errorf(err, "method should an error with cancellation")

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -186,6 +186,13 @@ func (m queryMetricsStore) CleanTailnetTunnels(ctx context.Context) error {
 	return r0
 }
 
+func (m queryMetricsStore) CountAuditLogs(ctx context.Context, arg database.CountAuditLogsParams) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.CountAuditLogs(ctx, arg)
+	m.queryLatencies.WithLabelValues("CountAuditLogs").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) CountInProgressPrebuilds(ctx context.Context) ([]database.CountInProgressPrebuildsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.CountInProgressPrebuilds(ctx)
@@ -3319,5 +3326,12 @@ func (m queryMetricsStore) GetAuthorizedAuditLogsOffset(ctx context.Context, arg
 	start := time.Now()
 	r0, r1 := m.s.GetAuthorizedAuditLogsOffset(ctx, arg, prepared)
 	m.queryLatencies.WithLabelValues("GetAuthorizedAuditLogsOffset").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
+func (m queryMetricsStore) CountAuthorizedAuditLogs(ctx context.Context, arg database.CountAuditLogsParams, prepared rbac.PreparedAuthorized) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.CountAuthorizedAuditLogs(ctx, arg, prepared)
+	m.queryLatencies.WithLabelValues("CountAuthorizedAuditLogs").Observe(time.Since(start).Seconds())
 	return r0, r1
 }

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -247,6 +247,36 @@ func (mr *MockStoreMockRecorder) CleanTailnetTunnels(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanTailnetTunnels", reflect.TypeOf((*MockStore)(nil).CleanTailnetTunnels), ctx)
 }
 
+// CountAuditLogs mocks base method.
+func (m *MockStore) CountAuditLogs(ctx context.Context, arg database.CountAuditLogsParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAuditLogs", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAuditLogs indicates an expected call of CountAuditLogs.
+func (mr *MockStoreMockRecorder) CountAuditLogs(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAuditLogs", reflect.TypeOf((*MockStore)(nil).CountAuditLogs), ctx, arg)
+}
+
+// CountAuthorizedAuditLogs mocks base method.
+func (m *MockStore) CountAuthorizedAuditLogs(ctx context.Context, arg database.CountAuditLogsParams, prepared rbac.PreparedAuthorized) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAuthorizedAuditLogs", ctx, arg, prepared)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAuthorizedAuditLogs indicates an expected call of CountAuthorizedAuditLogs.
+func (mr *MockStoreMockRecorder) CountAuthorizedAuditLogs(ctx, arg, prepared any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAuthorizedAuditLogs", reflect.TypeOf((*MockStore)(nil).CountAuthorizedAuditLogs), ctx, arg, prepared)
+}
+
 // CountInProgressPrebuilds mocks base method.
 func (m *MockStore) CountInProgressPrebuilds(ctx context.Context) ([]database.CountInProgressPrebuildsRow, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -598,7 +598,9 @@ func (q *sqlQuerier) CountAuthorizedAuditLogs(ctx context.Context, arg CountAudi
 	defer rows.Close()
 	var count int64
 	for rows.Next() {
-		count++
+		if err := rows.Scan(&count); err != nil {
+			return 0, err
+		}
 	}
 	if err := rows.Close(); err != nil {
 		return 0, err

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -478,6 +478,7 @@ func (q *sqlQuerier) GetAuthorizedUsers(ctx context.Context, arg GetUsersParams,
 
 type auditLogQuerier interface {
 	GetAuthorizedAuditLogsOffset(ctx context.Context, arg GetAuditLogsOffsetParams, prepared rbac.PreparedAuthorized) ([]GetAuditLogsOffsetRow, error)
+	CountAuthorizedAuditLogs(ctx context.Context, arg CountAuditLogsParams, prepared rbac.PreparedAuthorized) (int64, error)
 }
 
 func (q *sqlQuerier) GetAuthorizedAuditLogsOffset(ctx context.Context, arg GetAuditLogsOffsetParams, prepared rbac.PreparedAuthorized) ([]GetAuditLogsOffsetRow, error) {
@@ -548,7 +549,6 @@ func (q *sqlQuerier) GetAuthorizedAuditLogsOffset(ctx context.Context, arg GetAu
 			&i.OrganizationName,
 			&i.OrganizationDisplayName,
 			&i.OrganizationIcon,
-			&i.Count,
 		); err != nil {
 			return nil, err
 		}
@@ -561,6 +561,52 @@ func (q *sqlQuerier) GetAuthorizedAuditLogsOffset(ctx context.Context, arg GetAu
 		return nil, err
 	}
 	return items, nil
+}
+
+func (q *sqlQuerier) CountAuthorizedAuditLogs(ctx context.Context, arg CountAuditLogsParams, prepared rbac.PreparedAuthorized) (int64, error) {
+	authorizedFilter, err := prepared.CompileToSQL(ctx, regosql.ConvertConfig{
+		VariableConverter: regosql.AuditLogConverter(),
+	})
+	if err != nil {
+		return 0, xerrors.Errorf("compile authorized filter: %w", err)
+	}
+
+	filtered, err := insertAuthorizedFilter(countAuditLogs, fmt.Sprintf(" AND %s", authorizedFilter))
+	if err != nil {
+		return 0, xerrors.Errorf("insert authorized filter: %w", err)
+	}
+
+	query := fmt.Sprintf("-- name: CountAuthorizedAuditLogs :one\n%s", filtered)
+
+	rows, err := q.db.QueryContext(ctx, query,
+		arg.ResourceType,
+		arg.ResourceID,
+		arg.OrganizationID,
+		arg.ResourceTarget,
+		arg.Action,
+		arg.UserID,
+		arg.Username,
+		arg.Email,
+		arg.DateFrom,
+		arg.DateTo,
+		arg.BuildReason,
+		arg.RequestID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var count int64
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func insertAuthorizedFilter(query string, replaceWith string) (string, error) {

--- a/coderd/database/modelqueries_internal_test.go
+++ b/coderd/database/modelqueries_internal_test.go
@@ -1,9 +1,12 @@
 package database
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/testutil"
@@ -53,4 +56,42 @@ func TestWorkspaceTableConvert(t *testing.T) {
 	require.Equal(t, workspace.WorkspaceTable(), subset,
 		"'workspace.WorkspaceTable()' is not missing at least 1 field when converting to 'WorkspaceTable'. "+
 			"To resolve this, go to the 'func (w Workspace) WorkspaceTable()' and ensure all fields are converted.")
+}
+
+// TestAuditLogsQueryConsistency ensures that GetAuditLogsOffset and CountAuditLogs
+// have identical WHERE clauses to prevent filtering inconsistencies.
+// This test is a guard rail to prevent developer oversight mistakes.
+func TestAuditLogsQueryConsistency(t *testing.T) {
+	t.Parallel()
+
+	getWhereClause := extractWhereClause(getAuditLogsOffset)
+	require.NotEmpty(t, getWhereClause, "failed to extract WHERE clause from GetAuditLogsOffset")
+
+	countWhereClause := extractWhereClause(countAuditLogs)
+	require.NotEmpty(t, countWhereClause, "failed to extract WHERE clause from CountAuditLogs")
+
+	// Compare the WHERE clauses
+	if diff := cmp.Diff(getWhereClause, countWhereClause); diff != "" {
+		t.Errorf("GetAuditLogsOffset and CountAuditLogs WHERE clauses must be identical to ensure consistent filtering.\nDiff:\n%s", diff)
+	}
+}
+
+// extractWhereClause extracts the WHERE clause from a SQL query string
+func extractWhereClause(query string) string {
+	// Find WHERE and get everything after it
+	wherePattern := regexp.MustCompile(`(?is)WHERE\s+(.*)`)
+	whereMatches := wherePattern.FindStringSubmatch(query)
+	if len(whereMatches) < 2 {
+		return ""
+	}
+
+	whereClause := whereMatches[1]
+
+	// Remove ORDER BY, LIMIT, OFFSET clauses from the end
+	whereClause = regexp.MustCompile(`(?is)\s+(ORDER BY|LIMIT|OFFSET).*$`).ReplaceAllString(whereClause, "")
+
+	// Remove SQL comments
+	whereClause = regexp.MustCompile(`(?m)--.*$`).ReplaceAllString(whereClause, "")
+
+	return strings.TrimSpace(whereClause)
 }

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -64,6 +64,7 @@ type sqlcQuerier interface {
 	CleanTailnetCoordinators(ctx context.Context) error
 	CleanTailnetLostPeers(ctx context.Context) error
 	CleanTailnetTunnels(ctx context.Context) error
+	CountAuditLogs(ctx context.Context, arg CountAuditLogsParams) (int64, error)
 	// CountInProgressPrebuilds returns the number of in-progress prebuilds, grouped by preset ID and transition.
 	// Prebuild considered in-progress if it's in the "starting", "stopping", or "deleting" state.
 	CountInProgressPrebuilds(ctx context.Context) ([]CountInProgressPrebuildsRow, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -2042,9 +2042,9 @@ func TestAuthorizedAuditLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Then: All logs for both organizations are returned and count matches
-		expectedLogs := append(orgAuditLogs[first], orgAuditLogs[second]...)
-		expectedCount := int64(len(expectedLogs))
-		require.Equal(t, expectedCount, count, "count should match sum of both organizations")
+		expectedLogs := append([]uuid.UUID{}, orgAuditLogs[first]...)
+		expectedLogs = append(expectedLogs, orgAuditLogs[second]...)
+		require.Equal(t, int64(len(expectedLogs)), count, "count should match sum of both organizations")
 		require.ElementsMatch(t, expectedLogs, auditOnlyIDs(logs), "logs from both organizations should be returned")
 	})
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -524,7 +524,7 @@ END
     -- Filter by build_reason
 AND CASE
 	    WHEN $11::text != '' THEN
-            COALESCE(wb_build.reason::text, wb_workspace.reason::text)  = $11
+            COALESCE(wb_build.reason::text, wb_workspace.reason::text) = $11
         ELSE true
 END
 	-- Filter request_id

--- a/coderd/database/queries/auditlogs.sql
+++ b/coderd/database/queries/auditlogs.sql
@@ -2,237 +2,238 @@
 -- ID.
 -- name: GetAuditLogsOffset :many
 SELECT sqlc.embed(audit_logs),
-	   -- sqlc.embed(users) would be nice but it does not seem to play well with
-	   -- left joins.
-	   users.username                           AS user_username,
-	   users.name                               AS user_name,
-	   users.email                              AS user_email,
-	   users.created_at                         AS user_created_at,
-	   users.updated_at                         AS user_updated_at,
-	   users.last_seen_at                       AS user_last_seen_at,
-	   users.status                             AS user_status,
-	   users.login_type                         AS user_login_type,
-	   users.rbac_roles                         AS user_roles,
-	   users.avatar_url                         AS user_avatar_url,
-	   users.deleted                            AS user_deleted,
-	   users.quiet_hours_schedule               AS user_quiet_hours_schedule,
-	   COALESCE(organizations.name, '')         AS organization_name,
-	   COALESCE(organizations.display_name, '') AS organization_display_name,
-	   COALESCE(organizations.icon, '')         AS organization_icon
+	-- sqlc.embed(users) would be nice but it does not seem to play well with
+	-- left joins.
+	users.username AS user_username,
+	users.name AS user_name,
+	users.email AS user_email,
+	users.created_at AS user_created_at,
+	users.updated_at AS user_updated_at,
+	users.last_seen_at AS user_last_seen_at,
+	users.status AS user_status,
+	users.login_type AS user_login_type,
+	users.rbac_roles AS user_roles,
+	users.avatar_url AS user_avatar_url,
+	users.deleted AS user_deleted,
+	users.quiet_hours_schedule AS user_quiet_hours_schedule,
+	COALESCE(organizations.name, '') AS organization_name,
+	COALESCE(organizations.display_name, '') AS organization_display_name,
+	COALESCE(organizations.icon, '') AS organization_icon
 FROM audit_logs
-		 LEFT JOIN users ON audit_logs.user_id = users.id
-		 LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
+	LEFT JOIN users ON audit_logs.user_id = users.id
+	LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
 	-- First join on workspaces to get the initial workspace create
 	-- to workspace build 1 id. This is because the first create is
 	-- is a different audit log than subsequent starts.
-		 LEFT JOIN workspaces ON
-	audit_logs.resource_type = 'workspace' AND
-	audit_logs.resource_id = workspaces.id
+	LEFT JOIN workspaces ON audit_logs.resource_type = 'workspace'
+	AND audit_logs.resource_id = workspaces.id
 	-- Get the reason from the build if the resource type
 	-- is a workspace_build
-		 LEFT JOIN workspace_builds wb_build ON
-	audit_logs.resource_type = 'workspace_build' AND
-	audit_logs.resource_id = wb_build.id
+	LEFT JOIN workspace_builds wb_build ON audit_logs.resource_type = 'workspace_build'
+	AND audit_logs.resource_id = wb_build.id
 	-- Get the reason from the build #1 if this is the first
 	-- workspace create.
-		 LEFT JOIN workspace_builds wb_workspace ON
-	audit_logs.resource_type = 'workspace' AND
-	audit_logs.action = 'create' AND
-	workspaces.id = wb_workspace.workspace_id AND
-	wb_workspace.build_number = 1
+	LEFT JOIN workspace_builds wb_workspace ON audit_logs.resource_type = 'workspace'
+	AND audit_logs.action = 'create'
+	AND workspaces.id = wb_workspace.workspace_id
+	AND wb_workspace.build_number = 1
 WHERE
-  -- Filter resource_type
+	-- Filter resource_type
 	CASE
-		WHEN @resource_type :: text != '' THEN resource_type = @resource_type :: resource_type
+		WHEN @resource_type::text != '' THEN resource_type = @resource_type::resource_type
 		ELSE true
-		END
-  -- Filter resource_id
-  AND CASE
-		  WHEN @resource_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN resource_id = @resource_id
-		  ELSE true
 	END
-  -- Filter organization_id
-  AND CASE
-		  WHEN @organization_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.organization_id = @organization_id
-		  ELSE true
+	-- Filter resource_id
+	AND CASE
+		WHEN @resource_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN resource_id = @resource_id
+		ELSE true
 	END
-  -- Filter by resource_target
-  AND CASE
-		  WHEN @resource_target :: text != '' THEN resource_target = @resource_target
-		  ELSE true
+	-- Filter organization_id
+	AND CASE
+		WHEN @organization_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.organization_id = @organization_id
+		ELSE true
 	END
-  -- Filter action
-  AND CASE
-		  WHEN @action :: text != '' THEN
-	action = @action :: audit_action
-	ELSE true
-END
+	-- Filter by resource_target
+	AND CASE
+		WHEN @resource_target::text != '' THEN resource_target = @resource_target
+		ELSE true
+	END
+	-- Filter action
+	AND CASE
+		WHEN @action::text != '' THEN action = @action::audit_action
+		ELSE true
+	END
 	-- Filter by user_id
-AND CASE
-		WHEN @user_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			user_id = @user_id
+	AND CASE
+		WHEN @user_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN user_id = @user_id
 		ELSE true
-END
+	END
 	-- Filter by username
-AND CASE
-		WHEN @username :: text != '' THEN
-			user_id = (SELECT id FROM users WHERE lower(username) = lower(@username) AND deleted = false)
+	AND CASE
+		WHEN @username::text != '' THEN user_id = (
+			SELECT id
+			FROM users
+			WHERE lower(username) = lower(@username)
+				AND deleted = false
+		)
 		ELSE true
-END
+	END
 	-- Filter by user_email
-AND CASE
-		WHEN @email :: text != '' THEN
-			users.email = @email
+	AND CASE
+		WHEN @email::text != '' THEN users.email = @email
 		ELSE true
-END
+	END
 	-- Filter by date_from
-AND CASE
-		WHEN @date_from :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
-			"time" >= @date_from
+	AND CASE
+		WHEN @date_from::timestamp with time zone != '0001-01-01 00:00:00Z' THEN "time" >= @date_from
 		ELSE true
-END
+	END
 	-- Filter by date_to
-AND CASE
-		WHEN @date_to :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
-			"time" <= @date_to
+	AND CASE
+		WHEN @date_to::timestamp with time zone != '0001-01-01 00:00:00Z' THEN "time" <= @date_to
 		ELSE true
-END
-    -- Filter by build_reason
-AND CASE
-	    WHEN @build_reason::text != '' THEN
-            COALESCE(wb_build.reason::text, wb_workspace.reason::text) = @build_reason
-        ELSE true
-END
+	END
+	-- Filter by build_reason
+	AND CASE
+		WHEN @build_reason::text != '' THEN COALESCE(wb_build.reason::text, wb_workspace.reason::text) = @build_reason
+		ELSE true
+	END
 	-- Filter request_id
-AND CASE
-		WHEN @request_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			audit_logs.request_id = @request_id
+	AND CASE
+		WHEN @request_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.request_id = @request_id
 		ELSE true
-END
-
+	END
 	-- Authorize Filter clause will be injected below in GetAuthorizedAuditLogsOffset
 	-- @authorize_filter
-ORDER BY
-    "time" DESC
-LIMIT
-	-- a limit of 0 means "no limit". The audit log table is unbounded
+ORDER BY "time" DESC
+LIMIT -- a limit of 0 means "no limit". The audit log table is unbounded
 	-- in size, and is expected to be quite large. Implement a default
 	-- limit of 100 to prevent accidental excessively large queries.
-	COALESCE(NULLIF(@limit_opt :: int, 0), 100)
-OFFSET
-    @offset_opt;
+	COALESCE(NULLIF(@limit_opt::int, 0), 100) OFFSET @offset_opt;
 
 -- name: InsertAuditLog :one
-INSERT INTO audit_logs (id,
-						"time",
-						user_id,
-						organization_id,
-						ip,
-						user_agent,
-						resource_type,
-						resource_id,
-						resource_target,
-						action,
-						diff,
-						status_code,
-						additional_fields,
-						request_id,
-						resource_icon)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING *;
+INSERT INTO audit_logs (
+		id,
+		"time",
+		user_id,
+		organization_id,
+		ip,
+		user_agent,
+		resource_type,
+		resource_id,
+		resource_target,
+		action,
+		diff,
+		status_code,
+		additional_fields,
+		request_id,
+		resource_icon
+	)
+VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		$10,
+		$11,
+		$12,
+		$13,
+		$14,
+		$15
+	)
+RETURNING *;
 
 -- name: CountAuditLogs :one
 SELECT COUNT(*)
 FROM audit_logs
-		 LEFT JOIN users ON audit_logs.user_id = users.id
-		 LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
+	LEFT JOIN users ON audit_logs.user_id = users.id
+	LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
 	-- First join on workspaces to get the initial workspace create
 	-- to workspace build 1 id. This is because the first create is
 	-- is a different audit log than subsequent starts.
-		 LEFT JOIN workspaces ON
-	audit_logs.resource_type = 'workspace' AND
-	audit_logs.resource_id = workspaces.id
+	LEFT JOIN workspaces ON audit_logs.resource_type = 'workspace'
+	AND audit_logs.resource_id = workspaces.id
 	-- Get the reason from the build if the resource type
 	-- is a workspace_build
-		 LEFT JOIN workspace_builds wb_build ON
-	audit_logs.resource_type = 'workspace_build' AND
-	audit_logs.resource_id = wb_build.id
+	LEFT JOIN workspace_builds wb_build ON audit_logs.resource_type = 'workspace_build'
+	AND audit_logs.resource_id = wb_build.id
 	-- Get the reason from the build #1 if this is the first
 	-- workspace create.
-		 LEFT JOIN workspace_builds wb_workspace ON
-	audit_logs.resource_type = 'workspace' AND
-	audit_logs.action = 'create' AND
-	workspaces.id = wb_workspace.workspace_id AND
-	wb_workspace.build_number = 1
+	LEFT JOIN workspace_builds wb_workspace ON audit_logs.resource_type = 'workspace'
+	AND audit_logs.action = 'create'
+	AND workspaces.id = wb_workspace.workspace_id
+	AND wb_workspace.build_number = 1
 WHERE
-  -- Filter resource_type
+	-- Filter resource_type
 	CASE
-		WHEN @resource_type :: text != '' THEN resource_type = @resource_type :: resource_type
+		WHEN @resource_type::text != '' THEN resource_type = @resource_type::resource_type
 		ELSE true
-		END
-  -- Filter resource_id
-  AND CASE
-		  WHEN @resource_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN resource_id = @resource_id
-		  ELSE true
 	END
-  -- Filter organization_id
-  AND CASE
-		  WHEN @organization_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.organization_id = @organization_id
-		  ELSE true
+	-- Filter resource_id
+	AND CASE
+		WHEN @resource_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN resource_id = @resource_id
+		ELSE true
 	END
-  -- Filter by resource_target
-  AND CASE
-		  WHEN @resource_target :: text != '' THEN resource_target = @resource_target
-		  ELSE true
+	-- Filter organization_id
+	AND CASE
+		WHEN @organization_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.organization_id = @organization_id
+		ELSE true
 	END
-  -- Filter action
-  AND CASE
-		  WHEN @action :: text != '' THEN
-	action = @action :: audit_action
-	ELSE true
-END
+	-- Filter by resource_target
+	AND CASE
+		WHEN @resource_target::text != '' THEN resource_target = @resource_target
+		ELSE true
+	END
+	-- Filter action
+	AND CASE
+		WHEN @action::text != '' THEN action = @action::audit_action
+		ELSE true
+	END
 	-- Filter by user_id
-AND CASE
-		WHEN @user_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			user_id = @user_id
+	AND CASE
+		WHEN @user_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN user_id = @user_id
 		ELSE true
-END
+	END
 	-- Filter by username
-AND CASE
-		WHEN @username :: text != '' THEN
-			user_id = (SELECT id FROM users WHERE lower(username) = lower(@username) AND deleted = false)
+	AND CASE
+		WHEN @username::text != '' THEN user_id = (
+			SELECT id
+			FROM users
+			WHERE lower(username) = lower(@username)
+				AND deleted = false
+		)
 		ELSE true
-END
+	END
 	-- Filter by user_email
-AND CASE
-		WHEN @email :: text != '' THEN
-			users.email = @email
+	AND CASE
+		WHEN @email::text != '' THEN users.email = @email
 		ELSE true
-END
+	END
 	-- Filter by date_from
-AND CASE
-		WHEN @date_from :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
-			"time" >= @date_from
+	AND CASE
+		WHEN @date_from::timestamp with time zone != '0001-01-01 00:00:00Z' THEN "time" >= @date_from
 		ELSE true
-END
+	END
 	-- Filter by date_to
-AND CASE
-		WHEN @date_to :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
-			"time" <= @date_to
+	AND CASE
+		WHEN @date_to::timestamp with time zone != '0001-01-01 00:00:00Z' THEN "time" <= @date_to
 		ELSE true
-END
-    -- Filter by build_reason
-AND CASE
-	    WHEN @build_reason::text != '' THEN
-            COALESCE(wb_build.reason::text, wb_workspace.reason::text) = @build_reason
-        ELSE true
-END
+	END
+	-- Filter by build_reason
+	AND CASE
+		WHEN @build_reason::text != '' THEN COALESCE(wb_build.reason::text, wb_workspace.reason::text) = @build_reason
+		ELSE true
+	END
 	-- Filter request_id
-AND CASE
-		WHEN @request_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			audit_logs.request_id = @request_id
+	AND CASE
+		WHEN @request_id::uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.request_id = @request_id
 		ELSE true
-END
-
+	END
 	-- Authorize Filter clause will be injected below in CountAuthorizedAuditLogs
 	-- @authorize_filter
 ;

--- a/coderd/database/queries/auditlogs.sql
+++ b/coderd/database/queries/auditlogs.sql
@@ -1,127 +1,114 @@
 -- GetAuditLogsBefore retrieves `row_limit` number of audit logs before the provided
 -- ID.
 -- name: GetAuditLogsOffset :many
-SELECT
-    sqlc.embed(audit_logs),
-    -- sqlc.embed(users) would be nice but it does not seem to play well with
-    -- left joins.
-    users.username AS user_username,
-    users.name AS user_name,
-    users.email AS user_email,
-    users.created_at AS user_created_at,
-    users.updated_at AS user_updated_at,
-    users.last_seen_at AS user_last_seen_at,
-    users.status AS user_status,
-    users.login_type AS user_login_type,
-    users.rbac_roles AS user_roles,
-    users.avatar_url AS user_avatar_url,
-    users.deleted AS user_deleted,
-    users.quiet_hours_schedule AS user_quiet_hours_schedule,
-    COALESCE(organizations.name, '') AS organization_name,
-    COALESCE(organizations.display_name, '') AS organization_display_name,
-    COALESCE(organizations.icon, '') AS organization_icon,
-    COUNT(audit_logs.*) OVER () AS count
-FROM
-    audit_logs
-    LEFT JOIN users ON audit_logs.user_id = users.id
-    LEFT JOIN
-        -- First join on workspaces to get the initial workspace create
-        -- to workspace build 1 id. This is because the first create is
-        -- is a different audit log than subsequent starts.
-        workspaces ON
-		    audit_logs.resource_type = 'workspace' AND
-			audit_logs.resource_id = workspaces.id
-    LEFT JOIN
-	    workspace_builds ON
-            -- Get the reason from the build if the resource type
-            -- is a workspace_build
-            (
-			    audit_logs.resource_type = 'workspace_build'
-                AND audit_logs.resource_id = workspace_builds.id
-			)
-            OR
-            -- Get the reason from the build #1 if this is the first
-            -- workspace create.
-            (
-				audit_logs.resource_type = 'workspace' AND
-				audit_logs.action = 'create' AND
-				workspaces.id = workspace_builds.workspace_id AND
-				workspace_builds.build_number = 1
-			)
-		LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
+SELECT sqlc.embed(audit_logs),
+	   -- sqlc.embed(users) would be nice but it does not seem to play well with
+	   -- left joins.
+	   users.username                           AS user_username,
+	   users.name                               AS user_name,
+	   users.email                              AS user_email,
+	   users.created_at                         AS user_created_at,
+	   users.updated_at                         AS user_updated_at,
+	   users.last_seen_at                       AS user_last_seen_at,
+	   users.status                             AS user_status,
+	   users.login_type                         AS user_login_type,
+	   users.rbac_roles                         AS user_roles,
+	   users.avatar_url                         AS user_avatar_url,
+	   users.deleted                            AS user_deleted,
+	   users.quiet_hours_schedule               AS user_quiet_hours_schedule,
+	   COALESCE(organizations.name, '')         AS organization_name,
+	   COALESCE(organizations.display_name, '') AS organization_display_name,
+	   COALESCE(organizations.icon, '')         AS organization_icon
+FROM audit_logs
+		 LEFT JOIN users ON audit_logs.user_id = users.id
+		 LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
+	-- First join on workspaces to get the initial workspace create
+	-- to workspace build 1 id. This is because the first create is
+	-- is a different audit log than subsequent starts.
+		 LEFT JOIN workspaces ON
+	audit_logs.resource_type = 'workspace' AND
+	audit_logs.resource_id = workspaces.id
+	-- Get the reason from the build if the resource type
+	-- is a workspace_build
+		 LEFT JOIN workspace_builds wb_build ON
+	audit_logs.resource_type = 'workspace_build' AND
+	audit_logs.resource_id = wb_build.id
+	-- Get the reason from the build #1 if this is the first
+	-- workspace create.
+		 LEFT JOIN workspace_builds wb_workspace ON
+	audit_logs.resource_type = 'workspace' AND
+	audit_logs.action = 'create' AND
+	workspaces.id = wb_workspace.workspace_id AND
+	wb_workspace.build_number = 1
 WHERE
-    -- Filter resource_type
+  -- Filter resource_type
 	CASE
-		WHEN @resource_type :: text != '' THEN
-			resource_type = @resource_type :: resource_type
+		WHEN @resource_type :: text != '' THEN resource_type = @resource_type :: resource_type
 		ELSE true
+		END
+  -- Filter resource_id
+  AND CASE
+		  WHEN @resource_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN resource_id = @resource_id
+		  ELSE true
 	END
-	-- Filter resource_id
-	AND CASE
-		WHEN @resource_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			resource_id = @resource_id
-		ELSE true
+  -- Filter organization_id
+  AND CASE
+		  WHEN @organization_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.organization_id = @organization_id
+		  ELSE true
 	END
-  	-- Filter organization_id
-  	AND CASE
-		WHEN @organization_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			audit_logs.organization_id = @organization_id
-		ELSE true
+  -- Filter by resource_target
+  AND CASE
+		  WHEN @resource_target :: text != '' THEN resource_target = @resource_target
+		  ELSE true
 	END
-	-- Filter by resource_target
-	AND CASE
-		WHEN @resource_target :: text != '' THEN
-			resource_target = @resource_target
-		ELSE true
-	END
-	-- Filter action
-	AND CASE
-		WHEN @action :: text != '' THEN
-			action = @action :: audit_action
-		ELSE true
-	END
+  -- Filter action
+  AND CASE
+		  WHEN @action :: text != '' THEN
+	action = @action :: audit_action
+	ELSE true
+END
 	-- Filter by user_id
-	AND CASE
+AND CASE
 		WHEN @user_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
 			user_id = @user_id
 		ELSE true
-	END
+END
 	-- Filter by username
-	AND CASE
+AND CASE
 		WHEN @username :: text != '' THEN
 			user_id = (SELECT id FROM users WHERE lower(username) = lower(@username) AND deleted = false)
 		ELSE true
-	END
+END
 	-- Filter by user_email
-	AND CASE
+AND CASE
 		WHEN @email :: text != '' THEN
 			users.email = @email
 		ELSE true
-	END
+END
 	-- Filter by date_from
-	AND CASE
+AND CASE
 		WHEN @date_from :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
 			"time" >= @date_from
 		ELSE true
-	END
+END
 	-- Filter by date_to
-	AND CASE
+AND CASE
 		WHEN @date_to :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
 			"time" <= @date_to
 		ELSE true
-	END
+END
     -- Filter by build_reason
-    AND CASE
+AND CASE
 	    WHEN @build_reason::text != '' THEN
-            workspace_builds.reason::text = @build_reason
+            COALESCE(wb_build.reason::text, wb_workspace.reason::text) = @build_reason
         ELSE true
-    END
+END
 	-- Filter request_id
-	AND CASE
+AND CASE
 		WHEN @request_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
 			audit_logs.request_id = @request_id
 		ELSE true
-	END
+END
 
 	-- Authorize Filter clause will be injected below in GetAuthorizedAuditLogsOffset
 	-- @authorize_filter
@@ -136,23 +123,116 @@ OFFSET
     @offset_opt;
 
 -- name: InsertAuditLog :one
-INSERT INTO
-	audit_logs (
-        id,
-        "time",
-        user_id,
-        organization_id,
-        ip,
-        user_agent,
-        resource_type,
-        resource_id,
-        resource_target,
-        action,
-        diff,
-        status_code,
-        additional_fields,
-        request_id,
-        resource_icon
-    )
-VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING *;
+INSERT INTO audit_logs (id,
+						"time",
+						user_id,
+						organization_id,
+						ip,
+						user_agent,
+						resource_type,
+						resource_id,
+						resource_target,
+						action,
+						diff,
+						status_code,
+						additional_fields,
+						request_id,
+						resource_icon)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING *;
+
+-- name: CountAuditLogs :one
+SELECT COUNT(*)
+FROM audit_logs
+		 LEFT JOIN users ON audit_logs.user_id = users.id
+		 LEFT JOIN organizations ON audit_logs.organization_id = organizations.id
+	-- First join on workspaces to get the initial workspace create
+	-- to workspace build 1 id. This is because the first create is
+	-- is a different audit log than subsequent starts.
+		 LEFT JOIN workspaces ON
+	audit_logs.resource_type = 'workspace' AND
+	audit_logs.resource_id = workspaces.id
+	-- Get the reason from the build if the resource type
+	-- is a workspace_build
+		 LEFT JOIN workspace_builds wb_build ON
+	audit_logs.resource_type = 'workspace_build' AND
+	audit_logs.resource_id = wb_build.id
+	-- Get the reason from the build #1 if this is the first
+	-- workspace create.
+		 LEFT JOIN workspace_builds wb_workspace ON
+	audit_logs.resource_type = 'workspace' AND
+	audit_logs.action = 'create' AND
+	workspaces.id = wb_workspace.workspace_id AND
+	wb_workspace.build_number = 1
+WHERE
+  -- Filter resource_type
+	CASE
+		WHEN @resource_type :: text != '' THEN resource_type = @resource_type :: resource_type
+		ELSE true
+		END
+  -- Filter resource_id
+  AND CASE
+		  WHEN @resource_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN resource_id = @resource_id
+		  ELSE true
+	END
+  -- Filter organization_id
+  AND CASE
+		  WHEN @organization_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN audit_logs.organization_id = @organization_id
+		  ELSE true
+	END
+  -- Filter by resource_target
+  AND CASE
+		  WHEN @resource_target :: text != '' THEN resource_target = @resource_target
+		  ELSE true
+	END
+  -- Filter action
+  AND CASE
+		  WHEN @action :: text != '' THEN
+	action = @action :: audit_action
+	ELSE true
+END
+	-- Filter by user_id
+AND CASE
+		WHEN @user_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			user_id = @user_id
+		ELSE true
+END
+	-- Filter by username
+AND CASE
+		WHEN @username :: text != '' THEN
+			user_id = (SELECT id FROM users WHERE lower(username) = lower(@username) AND deleted = false)
+		ELSE true
+END
+	-- Filter by user_email
+AND CASE
+		WHEN @email :: text != '' THEN
+			users.email = @email
+		ELSE true
+END
+	-- Filter by date_from
+AND CASE
+		WHEN @date_from :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
+			"time" >= @date_from
+		ELSE true
+END
+	-- Filter by date_to
+AND CASE
+		WHEN @date_to :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
+			"time" <= @date_to
+		ELSE true
+END
+    -- Filter by build_reason
+AND CASE
+	    WHEN @build_reason::text != '' THEN
+            COALESCE(wb_build.reason::text, wb_workspace.reason::text)  = @build_reason
+        ELSE true
+END
+	-- Filter request_id
+AND CASE
+		WHEN @request_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			audit_logs.request_id = @request_id
+		ELSE true
+END
+
+	-- Authorize Filter clause will be injected below in CountAuthorizedAuditLogs
+	-- @authorize_filter
+;

--- a/coderd/database/queries/auditlogs.sql
+++ b/coderd/database/queries/auditlogs.sql
@@ -223,7 +223,7 @@ END
     -- Filter by build_reason
 AND CASE
 	    WHEN @build_reason::text != '' THEN
-            COALESCE(wb_build.reason::text, wb_workspace.reason::text)  = @build_reason
+            COALESCE(wb_build.reason::text, wb_workspace.reason::text) = @build_reason
         ELSE true
 END
 	-- Filter request_id

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -34,7 +34,8 @@ import (
 //   - action: string (enum)
 //   - build_reason: string (enum)
 func AuditLogs(ctx context.Context, db database.Store, query string) (database.GetAuditLogsOffsetParams,
-	database.CountAuditLogsParams, []codersdk.ValidationError) {
+	database.CountAuditLogsParams, []codersdk.ValidationError,
+) {
 	// Always lowercase for all searches.
 	query = strings.ToLower(query)
 	values, errors := searchTerms(query, func(term string, values url.Values) error {

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -42,6 +42,7 @@ func AuditLogs(ctx context.Context, db database.Store, query string) (database.G
 		return nil
 	})
 	if len(errors) > 0 {
+		// nolint:exhaustruct // We don't need to initialize these structs because we return an error.
 		return database.GetAuditLogsOffsetParams{}, database.CountAuditLogsParams{}, errors
 	}
 
@@ -65,6 +66,7 @@ func AuditLogs(ctx context.Context, db database.Store, query string) (database.G
 	}
 
 	// Prepare the count filter, which uses the same parameters as the GetAuditLogsOffsetParams.
+	// nolint:exhaustruct // UserID is not obtained from the query parameters.
 	countFilter := database.CountAuditLogsParams{
 		RequestID:      filter.RequestID,
 		ResourceID:     filter.ResourceID,

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -343,6 +343,7 @@ func TestSearchAudit(t *testing.T) {
 		Name                  string
 		Query                 string
 		Expected              database.GetAuditLogsOffsetParams
+		ExpectedCountParams   database.CountAuditLogsParams
 		ExpectedErrorContains string
 	}{
 		{
@@ -372,6 +373,9 @@ func TestSearchAudit(t *testing.T) {
 			Expected: database.GetAuditLogsOffsetParams{
 				ResourceTarget: "foo",
 			},
+			ExpectedCountParams: database.CountAuditLogsParams{
+				ResourceTarget: "foo",
+			},
 		},
 		{
 			Name:                  "RequestID",
@@ -386,7 +390,7 @@ func TestSearchAudit(t *testing.T) {
 			// Do not use a real database, this is only used for an
 			// organization lookup.
 			db := dbmem.New()
-			values, errs := searchquery.AuditLogs(context.Background(), db, c.Query)
+			values, countValues, errs := searchquery.AuditLogs(context.Background(), db, c.Query)
 			if c.ExpectedErrorContains != "" {
 				require.True(t, len(errs) > 0, "expect some errors")
 				var s strings.Builder
@@ -397,6 +401,7 @@ func TestSearchAudit(t *testing.T) {
 			} else {
 				require.Len(t, errs, 0, "expected no error")
 				require.Equal(t, c.Expected, values, "expected values")
+				require.Equal(t, c.ExpectedCountParams, countValues, "expected count values")
 			}
 		})
 	}


### PR DESCRIPTION
Closes #17689

This PR optimizes the audit logs query performance by extracting the count operation into a separate query and replacing the OR-based workspace_builds with conditional joins.

## Query changes
* Extracted count query to separate one
* Replaced single `workspace_builds` join with OR conditions with separate conditional joins
* Added conditional joins
    * `wb_build` for workspace_build audit logs (which is a direct lookup)
    * `wb_workspace` for workspace create audit logs (via workspace)

Optimized AuditLogsOffset query:
https://explain.dalibo.com/plan/4g1hbedg4a564bg8

New CountAuditLogs query:
https://explain.dalibo.com/plan/ga2fbcecb9efbce3

