### PR TITLE
fix!: use devcontainer ID when rebuilding a devcontainer

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -494,8 +494,8 @@ func (api *API) Routes() http.Handler {
 	r.Get("/", api.handleList)
 	// TODO(mafredri): Simplify this route as the previous /devcontainers
 	// /-route was dropped. We can drop the /devcontainers prefix here too.
-	r.Route("/devcontainers", func(r chi.Router) {
-		r.Post("/container/{container}/recreate", api.handleDevcontainerRecreate)
+	r.Route("/devcontainers/{devcontainer}", func(r chi.Router) {
+		r.Post("/recreate", api.handleDevcontainerRecreate)
 	})
 
 	return r
@@ -859,60 +859,34 @@ func (api *API) getContainers() (codersdk.WorkspaceAgentListContainersResponse, 
 // devcontainer by referencing the container.
 func (api *API) handleDevcontainerRecreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	containerID := chi.URLParam(r, "container")
+	devcontainerID := chi.URLParam(r, "devcontainer")
 
-	if containerID == "" {
+	if devcontainerID == "" {
 		httpapi.Write(ctx, w, http.StatusBadRequest, codersdk.Response{
-			Message: "Missing container ID or name",
-			Detail:  "Container ID or name is required to recreate a devcontainer.",
-		})
-		return
-	}
-
-	containers, err := api.getContainers()
-	if err != nil {
-		httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
-			Message: "Could not list containers",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	containerIdx := slices.IndexFunc(containers.Containers, func(c codersdk.WorkspaceAgentContainer) bool { return c.Match(containerID) })
-	if containerIdx == -1 {
-		httpapi.Write(ctx, w, http.StatusNotFound, codersdk.Response{
-			Message: "Container not found",
-			Detail:  "Container ID or name not found in the list of containers.",
-		})
-		return
-	}
-
-	container := containers.Containers[containerIdx]
-	workspaceFolder := container.Labels[DevcontainerLocalFolderLabel]
-	configPath := container.Labels[DevcontainerConfigFileLabel]
-
-	// Workspace folder is required to recreate a container, we don't verify
-	// the config path here because it's optional.
-	if workspaceFolder == "" {
-		httpapi.Write(ctx, w, http.StatusBadRequest, codersdk.Response{
-			Message: "Missing workspace folder label",
-			Detail:  "The container is not a devcontainer, the container must have the workspace folder label to support recreation.",
+			Message: "Missing devcontainer ID",
+			Detail:  "Devcontainer ID is required to recreate a devcontainer.",
 		})
 		return
 	}
 
 	api.mu.Lock()
 
+	var workspaceFolder string
+	for _, dc := range api.knownDevcontainers {
+		if dc.ID.String() == devcontainerID {
+			workspaceFolder = dc.WorkspaceFolder
+			break
+		}
+	}
+
 	dc, ok := api.knownDevcontainers[workspaceFolder]
 	switch {
 	case !ok:
 		api.mu.Unlock()
 
-		// This case should not happen if the container is a valid devcontainer.
-		api.logger.Error(ctx, "devcontainer not found for workspace folder", slog.F("workspace_folder", workspaceFolder))
-		httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
+		httpapi.Write(ctx, w, http.StatusNotFound, codersdk.Response{
 			Message: "Devcontainer not found.",
-			Detail:  fmt.Sprintf("Could not find devcontainer for workspace folder: %q", workspaceFolder),
+			Detail:  fmt.Sprintf("Could not find devcontainer with ID: %q", devcontainerID),
 		})
 		return
 	case dc.Status == codersdk.WorkspaceAgentDevcontainerStatusStarting:
@@ -920,7 +894,7 @@ func (api *API) handleDevcontainerRecreate(w http.ResponseWriter, r *http.Reques
 
 		httpapi.Write(ctx, w, http.StatusConflict, codersdk.Response{
 			Message: "Devcontainer recreation already in progress",
-			Detail:  fmt.Sprintf("Recreation for workspace folder %q is already underway.", dc.WorkspaceFolder),
+			Detail:  fmt.Sprintf("Recreation for devcontainer %q is already underway.", dc.Name),
 		})
 		return
 	}
@@ -931,14 +905,14 @@ func (api *API) handleDevcontainerRecreate(w http.ResponseWriter, r *http.Reques
 	dc.Container = nil
 	api.knownDevcontainers[dc.WorkspaceFolder] = dc
 	go func() {
-		_ = api.CreateDevcontainer(dc.WorkspaceFolder, configPath, WithRemoveExistingContainer())
+		_ = api.CreateDevcontainer(dc.WorkspaceFolder, dc.ConfigPath, WithRemoveExistingContainer())
 	}()
 
 	api.mu.Unlock()
 
 	httpapi.Write(ctx, w, http.StatusAccepted, codersdk.Response{
 		Message: "Devcontainer recreation initiated",
-		Detail:  fmt.Sprintf("Recreation process for workspace folder %q has started.", dc.WorkspaceFolder),
+		Detail:  fmt.Sprintf("Recreation process for devcontainer %q has started.", dc.Name),
 	})
 }
 

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8453,7 +8453,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceagents/{workspaceagent}/containers/devcontainers/container/{container}/recreate": {
+        "/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate": {
             "post": {
                 "security": [
                     {
@@ -8479,8 +8479,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Container ID or name",
-                        "name": "container",
+                        "description": "Devcontainer ID",
+                        "name": "devcontainer",
                         "in": "path",
                         "required": true
                     }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7472,7 +7472,7 @@
 				}
 			}
 		},
-		"/workspaceagents/{workspaceagent}/containers/devcontainers/container/{container}/recreate": {
+		"/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate": {
 			"post": {
 				"security": [
 					{
@@ -7494,8 +7494,8 @@
 					},
 					{
 						"type": "string",
-						"description": "Container ID or name",
-						"name": "container",
+						"description": "Devcontainer ID",
+						"name": "devcontainer",
 						"in": "path",
 						"required": true
 					}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1314,7 +1314,7 @@ func New(options *Options) *API {
 				r.Get("/listening-ports", api.workspaceAgentListeningPorts)
 				r.Get("/connection", api.workspaceAgentConnection)
 				r.Get("/containers", api.workspaceAgentListContainers)
-				r.Post("/containers/devcontainers/container/{container}/recreate", api.workspaceAgentRecreateDevcontainer)
+				r.Post("/containers/devcontainers/{devcontainer}/recreate", api.workspaceAgentRecreateDevcontainer)
 				r.Get("/coordinate", api.workspaceAgentClientCoordinate)
 
 				// PTY is part of workspaceAppServer.

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -905,19 +905,19 @@ func (api *API) workspaceAgentListContainers(rw http.ResponseWriter, r *http.Req
 // @Tags Agents
 // @Produce json
 // @Param workspaceagent path string true "Workspace agent ID" format(uuid)
-// @Param container path string true "Container ID or name"
+// @Param devcontainer path string true "Devcontainer ID"
 // @Success 202 {object} codersdk.Response
-// @Router /workspaceagents/{workspaceagent}/containers/devcontainers/container/{container}/recreate [post]
+// @Router /workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate [post]
 func (api *API) workspaceAgentRecreateDevcontainer(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceAgent := httpmw.WorkspaceAgentParam(r)
 
-	container := chi.URLParam(r, "container")
-	if container == "" {
+	devcontainer := chi.URLParam(r, "devcontainer")
+	if devcontainer == "" {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Container ID or name is required.",
+			Message: "Devcontainer ID is required.",
 			Validations: []codersdk.ValidationError{
-				{Field: "container", Detail: "Container ID or name is required."},
+				{Field: "devcontainer", Detail: "Devcontainer ID is required."},
 			},
 		})
 		return
@@ -961,7 +961,7 @@ func (api *API) workspaceAgentRecreateDevcontainer(rw http.ResponseWriter, r *ht
 	}
 	defer release()
 
-	m, err := agentConn.RecreateDevcontainer(ctx, container)
+	m, err := agentConn.RecreateDevcontainer(ctx, devcontainer)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			httpapi.Write(ctx, rw, http.StatusRequestTimeout, codersdk.Response{

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1396,36 +1396,42 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 		var (
 			workspaceFolder = t.TempDir()
 			configFile      = filepath.Join(workspaceFolder, ".devcontainer", "devcontainer.json")
-			dcLabels        = map[string]string{
-				agentcontainers.DevcontainerLocalFolderLabel: workspaceFolder,
-				agentcontainers.DevcontainerConfigFileLabel:  configFile,
-			}
+			devcontainerID  = uuid.New()
+
+			// Create a container that would be associated with the devcontainer
 			devContainer = codersdk.WorkspaceAgentContainer{
 				ID:           uuid.NewString(),
 				CreatedAt:    dbtime.Now(),
 				FriendlyName: testutil.GetRandomName(t),
 				Image:        "busybox:latest",
-				Labels:       dcLabels,
-				Running:      true,
-				Status:       "running",
+				Labels: map[string]string{
+					agentcontainers.DevcontainerLocalFolderLabel: workspaceFolder,
+					agentcontainers.DevcontainerConfigFileLabel:  configFile,
+				},
+				Running: true,
+				Status:  "running",
 			}
-			plainContainer = codersdk.WorkspaceAgentContainer{
-				ID:           uuid.NewString(),
-				CreatedAt:    dbtime.Now(),
-				FriendlyName: testutil.GetRandomName(t),
-				Image:        "busybox:latest",
-				Labels:       map[string]string{},
-				Running:      true,
-				Status:       "running",
+
+			devcontainer = codersdk.WorkspaceAgentDevcontainer{
+				ID:              devcontainerID,
+				Name:            "test-devcontainer",
+				WorkspaceFolder: workspaceFolder,
+				ConfigPath:      configFile,
+				Status:          codersdk.WorkspaceAgentDevcontainerStatusRunning,
+				Container:       &devContainer,
 			}
 		)
 
 		for _, tc := range []struct {
-			name      string
-			setupMock func(mccli *acmock.MockContainerCLI, mdccli *acmock.MockDevcontainerCLI) (status int)
+			name               string
+			devcontainerID     string
+			setupDevcontainers []codersdk.WorkspaceAgentDevcontainer
+			setupMock          func(mccli *acmock.MockContainerCLI, mdccli *acmock.MockDevcontainerCLI) (status int)
 		}{
 			{
-				name: "Recreate",
+				name:               "Recreate",
+				devcontainerID:     devcontainerID.String(),
+				setupDevcontainers: []codersdk.WorkspaceAgentDevcontainer{devcontainer},
 				setupMock: func(mccli *acmock.MockContainerCLI, mdccli *acmock.MockDevcontainerCLI) int {
 					mccli.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
 						Containers: []codersdk.WorkspaceAgentContainer{devContainer},
@@ -1438,18 +1444,11 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 				},
 			},
 			{
-				name: "Container does not exist",
+				name:               "Devcontainer does not exist",
+				devcontainerID:     uuid.NewString(),
+				setupDevcontainers: nil,
 				setupMock: func(mccli *acmock.MockContainerCLI, mdccli *acmock.MockDevcontainerCLI) int {
 					mccli.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{}, nil).AnyTimes()
-					return http.StatusNotFound
-				},
-			},
-			{
-				name: "Not a devcontainer",
-				setupMock: func(mccli *acmock.MockContainerCLI, mdccli *acmock.MockDevcontainerCLI) int {
-					mccli.EXPECT().List(gomock.Any()).Return(codersdk.WorkspaceAgentListContainersResponse{
-						Containers: []codersdk.WorkspaceAgentContainer{plainContainer},
-					}, nil).AnyTimes()
 					return http.StatusNotFound
 				},
 			},
@@ -1472,16 +1471,21 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 				}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
 					return agents
 				}).Do()
+
+				devcontainerAPIOptions := []agentcontainers.Option{
+					agentcontainers.WithContainerCLI(mccli),
+					agentcontainers.WithDevcontainerCLI(mdccli),
+					agentcontainers.WithWatcher(watcher.NewNoop()),
+				}
+				if tc.setupDevcontainers != nil {
+					devcontainerAPIOptions = append(devcontainerAPIOptions,
+						agentcontainers.WithDevcontainers(tc.setupDevcontainers, nil))
+				}
+
 				_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
 					o.Logger = logger.Named("agent")
 					o.Devcontainers = true
-					o.DevcontainerAPIOptions = append(
-						o.DevcontainerAPIOptions,
-						agentcontainers.WithContainerCLI(mccli),
-						agentcontainers.WithDevcontainerCLI(mdccli),
-						agentcontainers.WithWatcher(watcher.NewNoop()),
-						agentcontainers.WithContainerLabelIncludeFilter(agentcontainers.DevcontainerLocalFolderLabel, workspaceFolder),
-					)
+					o.DevcontainerAPIOptions = devcontainerAPIOptions
 				})
 				resources := coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).Wait()
 				require.Len(t, resources, 1, "expected one resource")
@@ -1490,7 +1494,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 
 				ctx := testutil.Context(t, testutil.WaitLong)
 
-				_, err := client.WorkspaceAgentRecreateDevcontainer(ctx, agentID, devContainer.ID)
+				_, err := client.WorkspaceAgentRecreateDevcontainer(ctx, agentID, tc.devcontainerID)
 				if wantStatus > 0 {
 					cerr, ok := codersdk.AsError(err)
 					require.True(t, ok, "expected error to be a coder error")

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -519,8 +519,8 @@ func (c *Client) WorkspaceAgentListContainers(ctx context.Context, agentID uuid.
 }
 
 // WorkspaceAgentRecreateDevcontainer recreates the devcontainer with the given ID.
-func (c *Client) WorkspaceAgentRecreateDevcontainer(ctx context.Context, agentID uuid.UUID, containerIDOrName string) (Response, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/workspaceagents/%s/containers/devcontainers/container/%s/recreate", agentID, containerIDOrName), nil)
+func (c *Client) WorkspaceAgentRecreateDevcontainer(ctx context.Context, agentID uuid.UUID, devcontainerID string) (Response, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/workspaceagents/%s/containers/devcontainers/%s/recreate", agentID, devcontainerID), nil)
 	if err != nil {
 		return Response{}, err
 	}

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -389,10 +389,10 @@ func (c *AgentConn) ListContainers(ctx context.Context) (codersdk.WorkspaceAgent
 
 // RecreateDevcontainer recreates a devcontainer with the given container.
 // This is a blocking call and will wait for the container to be recreated.
-func (c *AgentConn) RecreateDevcontainer(ctx context.Context, containerIDOrName string) (codersdk.Response, error) {
+func (c *AgentConn) RecreateDevcontainer(ctx context.Context, devcontainerID string) (codersdk.Response, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	res, err := c.apiRequest(ctx, http.MethodPost, "/api/v0/containers/devcontainers/container/"+containerIDOrName+"/recreate", nil)
+	res, err := c.apiRequest(ctx, http.MethodPost, "/api/v0/containers/devcontainers/"+devcontainerID+"/recreate", nil)
 	if err != nil {
 		return codersdk.Response{}, xerrors.Errorf("do request: %w", err)
 	}

--- a/docs/reference/api/agents.md
+++ b/docs/reference/api/agents.md
@@ -859,19 +859,19 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/container/{container}/recreate \
+curl -X POST http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/{workspaceagent}/containers/devcontainers/container/{container}/recreate`
+`POST /workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate`
 
 ### Parameters
 
-| Name             | In   | Type         | Required | Description          |
-|------------------|------|--------------|----------|----------------------|
-| `workspaceagent` | path | string(uuid) | true     | Workspace agent ID   |
-| `container`      | path | string       | true     | Container ID or name |
+| Name             | In   | Type         | Required | Description        |
+|------------------|------|--------------|----------|--------------------|
+| `workspaceagent` | path | string(uuid) | true     | Workspace agent ID |
+| `devcontainer`   | path | string       | true     | Devcontainer ID    |
 
 ### Example responses
 

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -80,7 +80,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 	const rebuildDevcontainerMutation = useMutation({
 		mutationFn: async () => {
 			const response = await fetch(
-				`/api/v2/workspaceagents/${parentAgent.id}/containers/devcontainers/container/${devcontainer.container?.id}/recreate`,
+				`/api/v2/workspaceagents/${parentAgent.id}/containers/devcontainers/${devcontainer.id}/recreate`,
 				{ method: "POST" },
 			);
 			if (!response.ok) {


### PR DESCRIPTION
This PR replaces the use of the **container** ID with the **devcontainer** ID. This is a breaking change. This allows rebuilding a devcontainer when there is no valid container ID.