### PR TITLE
chore: populate connectionlog count using a separate query

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1353,13 +1353,24 @@ func (q *querier) CountAuditLogs(ctx context.Context, arg database.CountAuditLog
 	if err == nil {
 		return q.db.CountAuditLogs(ctx, arg)
 	}
-
 	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceAuditLog.Type)
 	if err != nil {
 		return 0, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
 	}
-
 	return q.db.CountAuthorizedAuditLogs(ctx, arg, prep)
+}
+
+func (q *querier) CountConnectionLogs(ctx context.Context, arg database.CountConnectionLogsParams) (int64, error) {
+	// Just like the actual query, shortcut if the user is an owner.
+	err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceConnectionLog)
+	if err == nil {
+		return q.db.CountConnectionLogs(ctx, arg)
+	}
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceConnectionLog.Type)
+	if err != nil {
+		return 0, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
+	}
+	return q.db.CountAuthorizedConnectionLogs(ctx, arg, prep)
 }
 
 func (q *querier) CountInProgressPrebuilds(ctx context.Context) ([]database.CountInProgressPrebuildsRow, error) {
@@ -5391,4 +5402,8 @@ func (q *querier) CountAuthorizedAuditLogs(ctx context.Context, arg database.Cou
 
 func (q *querier) GetAuthorizedConnectionLogsOffset(ctx context.Context, arg database.GetConnectionLogsOffsetParams, _ rbac.PreparedAuthorized) ([]database.GetConnectionLogsOffsetRow, error) {
 	return q.GetConnectionLogsOffset(ctx, arg)
+}
+
+func (q *querier) CountAuthorizedConnectionLogs(ctx context.Context, arg database.CountConnectionLogsParams, _ rbac.PreparedAuthorized) (int64, error) {
+	return q.CountConnectionLogs(ctx, arg)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -406,6 +406,42 @@ func (s *MethodTestSuite) TestConnectionLogs() {
 			LimitOpt: 10,
 		}, emptyPreparedAuthorized{}).Asserts(rbac.ResourceConnectionLog, policy.ActionRead)
 	}))
+	s.Run("CountConnectionLogs", s.Subtest(func(db database.Store, check *expects) {
+		ws := createWorkspace(s.T(), db)
+		_ = dbgen.ConnectionLog(s.T(), db, database.UpsertConnectionLogParams{
+			Type:             database.ConnectionTypeSsh,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+		})
+		_ = dbgen.ConnectionLog(s.T(), db, database.UpsertConnectionLogParams{
+			Type:             database.ConnectionTypeSsh,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+		})
+		check.Args(database.CountConnectionLogsParams{}).Asserts(
+			rbac.ResourceConnectionLog, policy.ActionRead,
+		).WithNotAuthorized("nil")
+	}))
+	s.Run("CountAuthorizedConnectionLogs", s.Subtest(func(db database.Store, check *expects) {
+		ws := createWorkspace(s.T(), db)
+		_ = dbgen.ConnectionLog(s.T(), db, database.UpsertConnectionLogParams{
+			Type:             database.ConnectionTypeSsh,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+		})
+		_ = dbgen.ConnectionLog(s.T(), db, database.UpsertConnectionLogParams{
+			Type:             database.ConnectionTypeSsh,
+			WorkspaceID:      ws.ID,
+			OrganizationID:   ws.OrganizationID,
+			WorkspaceOwnerID: ws.OwnerID,
+		})
+		check.Args(database.CountConnectionLogsParams{}, emptyPreparedAuthorized{}).Asserts(
+			rbac.ResourceConnectionLog, policy.ActionRead,
+		)
+	}))
 }
 
 func (s *MethodTestSuite) TestFile() {

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -318,7 +318,7 @@ func hasEmptyResponse(values []reflect.Value) bool {
 			}
 		}
 
-		// Special case for int64, as it's the return type for count query.
+		// Special case for int64, as it's the return type for count queries.
 		if r.Kind() == reflect.Int64 {
 			if r.Int() == 0 {
 				return true

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -194,6 +194,13 @@ func (m queryMetricsStore) CountAuditLogs(ctx context.Context, arg database.Coun
 	return r0, r1
 }
 
+func (m queryMetricsStore) CountConnectionLogs(ctx context.Context, arg database.CountConnectionLogsParams) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.CountConnectionLogs(ctx, arg)
+	m.queryLatencies.WithLabelValues("CountConnectionLogs").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) CountInProgressPrebuilds(ctx context.Context) ([]database.CountInProgressPrebuildsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.CountInProgressPrebuilds(ctx)
@@ -3411,5 +3418,12 @@ func (m queryMetricsStore) GetAuthorizedConnectionLogsOffset(ctx context.Context
 	start := time.Now()
 	r0, r1 := m.s.GetAuthorizedConnectionLogsOffset(ctx, arg, prepared)
 	m.queryLatencies.WithLabelValues("GetAuthorizedConnectionLogsOffset").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
+func (m queryMetricsStore) CountAuthorizedConnectionLogs(ctx context.Context, arg database.CountConnectionLogsParams, prepared rbac.PreparedAuthorized) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.CountAuthorizedConnectionLogs(ctx, arg, prepared)
+	m.queryLatencies.WithLabelValues("CountAuthorizedConnectionLogs").Observe(time.Since(start).Seconds())
 	return r0, r1
 }

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -278,6 +278,36 @@ func (mr *MockStoreMockRecorder) CountAuthorizedAuditLogs(ctx, arg, prepared any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAuthorizedAuditLogs", reflect.TypeOf((*MockStore)(nil).CountAuthorizedAuditLogs), ctx, arg, prepared)
 }
 
+// CountAuthorizedConnectionLogs mocks base method.
+func (m *MockStore) CountAuthorizedConnectionLogs(ctx context.Context, arg database.CountConnectionLogsParams, prepared rbac.PreparedAuthorized) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAuthorizedConnectionLogs", ctx, arg, prepared)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAuthorizedConnectionLogs indicates an expected call of CountAuthorizedConnectionLogs.
+func (mr *MockStoreMockRecorder) CountAuthorizedConnectionLogs(ctx, arg, prepared any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAuthorizedConnectionLogs", reflect.TypeOf((*MockStore)(nil).CountAuthorizedConnectionLogs), ctx, arg, prepared)
+}
+
+// CountConnectionLogs mocks base method.
+func (m *MockStore) CountConnectionLogs(ctx context.Context, arg database.CountConnectionLogsParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountConnectionLogs", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountConnectionLogs indicates an expected call of CountConnectionLogs.
+func (mr *MockStoreMockRecorder) CountConnectionLogs(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountConnectionLogs", reflect.TypeOf((*MockStore)(nil).CountConnectionLogs), ctx, arg)
+}
+
 // CountInProgressPrebuilds mocks base method.
 func (m *MockStore) CountInProgressPrebuilds(ctx context.Context) ([]database.CountInProgressPrebuildsRow, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/modelqueries_internal_test.go
+++ b/coderd/database/modelqueries_internal_test.go
@@ -76,6 +76,19 @@ func TestAuditLogsQueryConsistency(t *testing.T) {
 	}
 }
 
+// Same as TestAuditLogsQueryConsistency, but for connection logs.
+func TestConnectionLogsQueryConsistency(t *testing.T) {
+	t.Parallel()
+
+	getWhereClause := extractWhereClause(getConnectionLogsOffset)
+	require.NotEmpty(t, getWhereClause, "getConnectionLogsOffset query should have a WHERE clause")
+
+	countWhereClause := extractWhereClause(countConnectionLogs)
+	require.NotEmpty(t, countWhereClause, "countConnectionLogs query should have a WHERE clause")
+
+	require.Equal(t, getWhereClause, countWhereClause, "getConnectionLogsOffset and countConnectionLogs queries should have the same WHERE clause")
+}
+
 // extractWhereClause extracts the WHERE clause from a SQL query string
 func extractWhereClause(query string) string {
 	// Find WHERE and get everything after it

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -66,6 +66,7 @@ type sqlcQuerier interface {
 	CleanTailnetLostPeers(ctx context.Context) error
 	CleanTailnetTunnels(ctx context.Context) error
 	CountAuditLogs(ctx context.Context, arg CountAuditLogsParams) (int64, error)
+	CountConnectionLogs(ctx context.Context, arg CountConnectionLogsParams) (int64, error)
 	// CountInProgressPrebuilds returns the number of in-progress prebuilds, grouped by preset ID and transition.
 	// Prebuild considered in-progress if it's in the "starting", "stopping", or "deleting" state.
 	CountInProgressPrebuilds(ctx context.Context) ([]CountInProgressPrebuildsRow, error)

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -435,7 +435,7 @@ func TestSearchConnectionLogs(t *testing.T) {
 			`connected_before:"2023-01-16T12:00:00+12:00" workspace_id:%s connection_id:%s status:ongoing`,
 			workspaceID.String(), connectionID.String())
 
-		values, errs := searchquery.ConnectionLogs(context.Background(), db, query, database.APIKey{})
+		values, _, errs := searchquery.ConnectionLogs(context.Background(), db, query, database.APIKey{})
 		require.Len(t, errs, 0)
 
 		expected := database.GetConnectionLogsOffsetParams{
@@ -462,7 +462,7 @@ func TestSearchConnectionLogs(t *testing.T) {
 		db, _ := dbtestutil.NewDB(t)
 
 		query := `username:me workspace_owner:me`
-		values, errs := searchquery.ConnectionLogs(context.Background(), db, query, database.APIKey{UserID: userID})
+		values, _, errs := searchquery.ConnectionLogs(context.Background(), db, query, database.APIKey{UserID: userID})
 		require.Len(t, errs, 0)
 
 		expected := database.GetConnectionLogsOffsetParams{

--- a/enterprise/coderd/connectionlog_test.go
+++ b/enterprise/coderd/connectionlog_test.go
@@ -65,6 +65,7 @@ func TestConnectionLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logs.ConnectionLogs, 1)
+		require.EqualValues(t, 1, logs.Count)
 		require.Equal(t, codersdk.ConnectionTypeSSH, logs.ConnectionLogs[0].Type)
 	})
 
@@ -84,7 +85,7 @@ func TestConnectionLogs(t *testing.T) {
 
 		logs, err := client.ConnectionLogs(ctx, codersdk.ConnectionLogsRequest{})
 		require.NoError(t, err)
-
+		require.EqualValues(t, 0, logs.Count)
 		require.Len(t, logs.ConnectionLogs, 0)
 	})
 
@@ -133,6 +134,7 @@ func TestConnectionLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logs.ConnectionLogs, 1)
+		require.EqualValues(t, 1, logs.Count)
 		require.Equal(t, ws.OrganizationID, logs.ConnectionLogs[0].Organization.ID)
 	})
 
@@ -169,6 +171,7 @@ func TestConnectionLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logs.ConnectionLogs, 1)
+		require.EqualValues(t, 1, logs.Count)
 		require.NotNil(t, logs.ConnectionLogs[0].WebInfo)
 		require.Equal(t, clog.SlugOrPort.String, logs.ConnectionLogs[0].WebInfo.SlugOrPort)
 		require.Equal(t, clog.UserAgent.String, logs.ConnectionLogs[0].WebInfo.UserAgent)
@@ -241,6 +244,7 @@ func TestConnectionLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logs.ConnectionLogs, 1)
+		require.EqualValues(t, 1, logs.Count)
 		require.NotNil(t, logs.ConnectionLogs[0].SSHInfo)
 		require.Nil(t, logs.ConnectionLogs[0].WebInfo)
 		require.Equal(t, codersdk.ConnectionTypeSSH, logs.ConnectionLogs[0].Type)


### PR DESCRIPTION
This is the third PR for moving connection events out of the audit log.

This PR populates `count` on `ConnectionLogResponse` using a separate query, to preemptively mitigate the issue described in #17689. It's structurally identical to a portion of https://github.com/coder/coder/pull/18600, but for the connection log instead of the audit log.
       
Future PRs:
- Implement a table in the Web UI for viewing connection logs.
- Write a query to delete old events from the audit log, call it from dbpurge.
- Write documentation for the endpoint / feature
