### PR TITLE
fix(agent): delay containerAPI init to ensure startup scripts run before

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1158,20 +1158,8 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				}
 			}
 
-			var (
-				scripts             = manifest.Scripts
-				scriptRunnerOpts    []agentscripts.InitOption
-				devcontainerScripts map[uuid.UUID]codersdk.WorkspaceAgentScript
-			)
-			if a.devcontainers {
-				a.containerAPI.Init(
-					agentcontainers.WithManifestInfo(manifest.OwnerName, manifest.WorkspaceName, manifest.AgentName),
-					agentcontainers.WithDevcontainers(manifest.Devcontainers, scripts),
-					agentcontainers.WithSubAgentClient(agentcontainers.NewSubAgentClientFromAPI(a.logger, aAPI)),
-				)
-
-				scripts, devcontainerScripts = agentcontainers.ExtractDevcontainerScripts(manifest.Devcontainers, scripts)
-			}
+			var scriptRunnerOpts []agentscripts.InitOption
+			scripts, devcontainerScripts := agentcontainers.ExtractDevcontainerScripts(manifest.Devcontainers, manifest.Scripts)
 			err = a.scriptRunner.Init(scripts, aAPI.ScriptCompleted, scriptRunnerOpts...)
 			if err != nil {
 				return xerrors.Errorf("init script runner: %w", err)
@@ -1190,9 +1178,17 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				// autostarted devcontainer will be included in this time.
 				err := a.scriptRunner.Execute(a.gracefulCtx, agentscripts.ExecuteStartScripts)
 
-				for _, dc := range manifest.Devcontainers {
-					cErr := a.createDevcontainer(ctx, aAPI, dc, devcontainerScripts[dc.ID])
-					err = errors.Join(err, cErr)
+				if a.containerAPI != nil {
+					a.containerAPI.Init(
+						agentcontainers.WithManifestInfo(manifest.OwnerName, manifest.WorkspaceName, manifest.AgentName),
+						agentcontainers.WithDevcontainers(manifest.Devcontainers, scripts),
+						agentcontainers.WithSubAgentClient(agentcontainers.NewSubAgentClientFromAPI(a.logger, aAPI)),
+					)
+
+					for _, dc := range manifest.Devcontainers {
+						cErr := a.createDevcontainer(ctx, aAPI, dc, devcontainerScripts[dc.ID])
+						err = errors.Join(err, cErr)
+					}
 				}
 
 				dur := time.Since(start).Seconds()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1158,8 +1158,14 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				}
 			}
 
-			var scriptRunnerOpts []agentscripts.InitOption
-			scripts, devcontainerScripts := agentcontainers.ExtractDevcontainerScripts(manifest.Devcontainers, manifest.Scripts)
+			var (
+				scripts             = manifest.Scripts
+				scriptRunnerOpts    []agentscripts.InitOption
+				devcontainerScripts map[uuid.UUID]codersdk.WorkspaceAgentScript
+			)
+			if a.containerAPI != nil {
+				scripts, devcontainerScripts = agentcontainers.ExtractDevcontainerScripts(manifest.Devcontainers, scripts)
+			}
 			err = a.scriptRunner.Init(scripts, aAPI.ScriptCompleted, scriptRunnerOpts...)
 			if err != nil {
 				return xerrors.Errorf("init script runner: %w", err)

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -530,7 +530,6 @@ func (api *API) updateContainers(ctx context.Context) error {
 		// will clear up on the next update.
 		if !errors.Is(err, context.Canceled) {
 			api.mu.Lock()
-			api.containers = codersdk.WorkspaceAgentListContainersResponse{}
 			api.containersErr = err
 			api.mu.Unlock()
 		}
@@ -947,7 +946,7 @@ func (api *API) CreateDevcontainer(workspaceFolder, configPath string, opts ...D
 			slog.F("devcontainer_id", dc.ID),
 			slog.F("devcontainer_name", dc.Name),
 			slog.F("workspace_folder", dc.WorkspaceFolder),
-			slog.F("config_path", configPath),
+			slog.F("config_path", dc.ConfigPath),
 		)
 	)
 

--- a/agent/api.go
+++ b/agent/api.go
@@ -36,7 +36,7 @@ func (a *agent) apiHandler() http.Handler {
 		cacheDuration: cacheDuration,
 	}
 
-	if a.devcontainers {
+	if a.containerAPI != nil {
 		r.Mount("/api/v0/containers", a.containerAPI.Routes())
 	} else {
 		r.HandleFunc("/api/v0/containers", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
We want to delay containerAPI initialization so that tools can be installed by startup scripts and avoid uneccessary errors during startup.