### PR TITLE
fix(.devcontainer): remove double slash from zed path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,14 +13,10 @@
 		"./filebrowser": {}
 	},
 	// SYS_PTRACE to enable go debugging
-	"runArgs": [
-		"--cap-add=SYS_PTRACE"
-	],
+	"runArgs": ["--cap-add=SYS_PTRACE"],
 	"customizations": {
 		"vscode": {
-			"extensions": [
-				"biomejs.biome"
-			]
+			"extensions": ["biomejs.biome"]
 		},
 		"coder": {
 			"apps": [
@@ -43,7 +39,7 @@
 				{
 					"slug": "zed",
 					"displayName": "Zed Editor",
-					"url": "zed://ssh/${localEnv:CODER_WORKSPACE_AGENT_NAME}.${localEnv:CODER_WORKSPACE_NAME}.${localEnv:CODER_WORKSPACE_OWNER_NAME}.coder/${containerWorkspaceFolder}",
+					"url": "zed://ssh/${localEnv:CODER_WORKSPACE_AGENT_NAME}.${localEnv:CODER_WORKSPACE_NAME}.${localEnv:CODER_WORKSPACE_OWNER_NAME}.coder${containerWorkspaceFolder}",
 					"external": true,
 					"icon": "/icon/zed.svg",
 					"order": 5


### PR DESCRIPTION
<img width="348" alt="image" src="https://github.com/user-attachments/assets/85ed0f25-ae72-42b8-82d4-b2f2bfce02a3" />
