### PR TITLE
fix: use only template version ID to create task workspace

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -206,7 +206,7 @@ const TaskFormSection: FC<{
 	);
 };
 
-type CreateTaskMutationFnProps = { prompt: string; template: Template };
+type CreateTaskMutationFnProps = { prompt: string; templateVersionId: string };
 
 type TaskFormProps = {
 	templates: Template[];
@@ -236,8 +236,11 @@ const TaskForm: FC<TaskFormProps> = ({ templates, onSuccess }) => {
 		: true;
 
 	const createTaskMutation = useMutation({
-		mutationFn: async ({ prompt, template }: CreateTaskMutationFnProps) =>
-			data.createTask(prompt, user.id, template.id, template.active_version_id),
+		mutationFn: async ({
+			prompt,
+			templateVersionId,
+		}: CreateTaskMutationFnProps) =>
+			data.createTask(prompt, user.id, templateVersionId),
 		onSuccess: async (task) => {
 			await queryClient.invalidateQueries({
 				queryKey: ["tasks"],
@@ -257,7 +260,7 @@ const TaskForm: FC<TaskFormProps> = ({ templates, onSuccess }) => {
 		try {
 			await createTaskMutation.mutateAsync({
 				prompt,
-				template: selectedTemplate,
+				templateVersionId: selectedTemplate.active_version_id,
 			});
 		} catch (error) {
 			const message = getErrorMessage(error, "Error creating task");
@@ -600,14 +603,12 @@ export const data = {
 	async createTask(
 		prompt: string,
 		userId: string,
-		templateId: string,
 		templateVersionId: string,
 	): Promise<Task> {
 		const presets = await API.getTemplateVersionPresets(templateVersionId);
 		const defaultPreset = presets.find((p) => p.Default);
 		const workspace = await API.createWorkspace(userId, {
 			name: `task-${generateWorkspaceName()}`,
-			template_id: templateId,
 			template_version_id: templateVersionId,
 			template_version_preset_id: defaultPreset?.ID,
 			rich_parameter_values: [


### PR DESCRIPTION
When creating a new task, the following error was getting returned:

**Error:**
```json
{
    "message": "Validation failed.",
    "validations": [
        {
            "field": "template_id",
            "detail": "Validation failed for tag \"excluded_with\" with value: \"42205a38-845c-4186-8475-f002e0936d53\""
        },
        {
            "field": "template_version_id",
            "detail": "Validation failed for tag \"excluded_with\" with value: \"22b1c4b7-432d-4eb5-9341-cd8efacb8f46\""
        }
    ]
}
```

Caused by https://github.com/coder/coder/pull/18623