### PR TITLE
chore: add `which-release` script

### DIFF
--- a/scripts/which-release.sh
+++ b/scripts/which-release.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+COMMIT=$1
+if [[ -z "${COMMIT}" ]]; then
+  echo "Usage: $0 <commit-ref>"
+  echo ""
+  echo -n "Example: $0 "
+  echo $'$(gh pr view <pr-num> --json mergeCommit | jq \'.mergeCommit.oid\' -r)'
+  exit 2
+fi
+
+REMOTE=$(git remote -v | grep coder/coder | awk '{print $1}' | head -n1)
+if [[ -z "${REMOTE}" ]]; then
+  echo "Could not find remote for coder/coder"
+  exit 1
+fi
+
+echo "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
+
+RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release/" | sed "s|${REMOTE}/||")
+if [[ -z "${RELEASES}" ]]; then
+  echo "Commit was not found in any release branch"
+else
+  echo "Commit was found in the following release branches:"
+  echo "${RELEASES}"
+fi

--- a/scripts/which-release.sh
+++ b/scripts/which-release.sh
@@ -2,25 +2,25 @@
 
 COMMIT=$1
 if [[ -z "${COMMIT}" ]]; then
-  echo "Usage: $0 <commit-ref>"
-  echo ""
-  echo -n "Example: $0 "
-  echo $'$(gh pr view <pr-num> --json mergeCommit | jq \'.mergeCommit.oid\' -r)'
-  exit 2
+	echo "Usage: $0 <commit-ref>"
+	echo ""
+	echo -n "Example: $0 "
+	echo $'$(gh pr view <pr-num> --json mergeCommit | jq \'.mergeCommit.oid\' -r)'
+	exit 2
 fi
 
 REMOTE=$(git remote -v | grep coder/coder | awk '{print $1}' | head -n1)
 if [[ -z "${REMOTE}" ]]; then
-  echo "Could not find remote for coder/coder"
-  exit 1
+	echo "Could not find remote for coder/coder"
+	exit 1
 fi
 
 echo "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
 
 RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release/" | sed "s|${REMOTE}/||")
 if [[ -z "${RELEASES}" ]]; then
-  echo "Commit was not found in any release branch"
+	echo "Commit was not found in any release branch"
 else
-  echo "Commit was found in the following release branches:"
-  echo "${RELEASES}"
+	echo "Commit was found in the following release branches:"
+	echo "${RELEASES}"
 fi

--- a/scripts/which-release.sh
+++ b/scripts/which-release.sh
@@ -1,26 +1,30 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 COMMIT=$1
 if [[ -z "${COMMIT}" ]]; then
-	echo "Usage: $0 <commit-ref>"
-	echo ""
-	echo -n "Example: $0 "
-	echo $'$(gh pr view <pr-num> --json mergeCommit | jq \'.mergeCommit.oid\' -r)'
+	log "Usage: $0 <commit-ref>"
+	log ""
+	log -n "Example: $0 "
+	log $'$(gh pr view <pr-num> --json mergeCommit | jq \'.mergeCommit.oid\' -r)'
 	exit 2
 fi
 
 REMOTE=$(git remote -v | grep coder/coder | awk '{print $1}' | head -n1)
 if [[ -z "${REMOTE}" ]]; then
-	echo "Could not find remote for coder/coder"
-	exit 1
+	error "Could not find remote for coder/coder"
 fi
 
-echo "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
+log "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
 
-RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release/" | sed "s|${REMOTE}/||")
+RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release/" | sed "s|${REMOTE}/||" || true)
 if [[ -z "${RELEASES}" ]]; then
-	echo "Commit was not found in any release branch"
+	log "Commit was not found in any release branch"
 else
-	echo "Commit was found in the following release branches:"
-	echo "${RELEASES}"
+	log "Commit was found in the following release branches:"
+	log "${RELEASES}"
 fi


### PR DESCRIPTION
This will help us determine what's made it into releases easily.

Example:

```bash
$ ./scripts/which-release.sh $(gh pr view 12535 --json mergeCommit | jq '.mergeCommit.oid' -r)
It is recommended that you run `git fetch -ap origin` to ensure you get a correct result.
Commit was found in the following release branches:
  release/2.10
  release/2.11
  release/2.12
  release/2.13
  release/2.14
  release/2.15
  release/2.16
  release/2.17
  release/2.18
  release/2.19
  release/2.20
  release/2.21
  release/2.22
  release/2.22-patch
  release/2.23
  release/2.24
```