### PR TITLE
fix(dogfood/coder): run go clean cache at workspace shutdown

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -496,6 +496,10 @@ resource "coder_agent" "dev" {
     #!/usr/bin/env bash
     set -eux -o pipefail
 
+    # Clean up the Go build cache to prevent the home volume from
+    # accumulating waste and growing too large.
+    go clean -cache
+
     # Clean up the unused resources to keep storage usage low.
     #
     # WARNING! This will remove:


### PR DESCRIPTION
The Go build cache has a tendency to accumulate and waste space (typically in the realm of 10-70 GB). This change automatically cleans up the cache on shutdown to prevent accumulation.