### PR TITLE
fix: handle task sidebar app health check disabled correctly

### DIFF
--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -113,7 +113,7 @@ export const TerminatedBuildWithStatus: Story = {
 	},
 };
 
-export const SidebarAppDisabled: Story = {
+export const SidebarAppHealthDisabled: Story = {
 	beforeEach: () => {
 		spyOn(data, "fetchTask").mockResolvedValue({
 			prompt: "Create competitors page",

--- a/site/src/pages/TaskPage/TaskSidebar.tsx
+++ b/site/src/pages/TaskPage/TaskSidebar.tsx
@@ -54,8 +54,10 @@ const getSidebarApp = (task: Task): [WorkspaceApp | null, SidebarAppStatus] => {
 		// indefinitely if there's a genuine issue, but this is preferable to false error alerts.
 		return [null, "loading"];
 	}
+	// "disabled" means that the health check is disabled, so we assume
+	// that the app is healthy
 	if (sidebarApp.health === "disabled") {
-		return [sidebarApp, "error"];
+		return [sidebarApp, "healthy"];
 	}
 	if (sidebarApp.health === "healthy") {
 		return [sidebarApp, "healthy"];


### PR DESCRIPTION
Previously, by mistake, the task sidebar would not display workspace apps that don't have a health check configured.