### PR TITLE
docs: add warning about prebuilds incompatibility with certain features

### DIFF
--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -1,5 +1,14 @@
 # Prebuilt workspaces
 
+> [!WARNING] Prebuilds Compatibility Limitations
+> Prebuilt workspaces are currently not compatible with configurations that have Workspace schedule (autostart/autostop), or Dormancy enabled.
+> If these features are configured, prebuilt workspaces may fail to run correctly.
+>
+> In addition, prebuilds currently do not work reliably with [DevContainers feature](../managing-templates/devcontainers/index.md).
+> If your project relies on DevContainer configuration, we recommend disabling prebuilds or carefully testing behavior before enabling them in production.
+>
+> We’re actively working to improve compatibility, but for now, please avoid using prebuilds with these features to ensure stability and expected behavior.
+
 Prebuilt workspaces allow template administrators to improve the developer experience by reducing workspace
 creation time with an automatically maintained pool of ready-to-use workspaces for specific parameter presets.
 

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -1,6 +1,7 @@
 # Prebuilt workspaces
 
-> [!WARNING] Prebuilds Compatibility Limitations
+> [!WARNING]
+> Prebuilds Compatibility Limitations:
 > Prebuilt workspaces are currently not compatible with configurations that have Workspace schedule (autostart/autostop), or Dormancy enabled.
 > If these features are configured, prebuilt workspaces may fail to run correctly.
 >


### PR DESCRIPTION
## Description

This PR adds a warning to the prebuilds documentation about incompatibility with Workspace schedule (autostart/autostop), dormancy, and DevContainers. These configurations can interfere with prebuild behavior and should be avoided for now.

Preview:
![Screenshot 2025-07-01 at 12 58 02](https://github.com/user-attachments/assets/e1a837de-b66c-4414-bd0b-471474b43b84)
