### PR TITLE
feat: add OAuth2 provider functionality as an experiment

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12550,12 +12550,14 @@ const docTemplate = `{
                 "auto-fill-parameters",
                 "notifications",
                 "workspace-usage",
-                "web-push"
+                "web-push",
+                "oauth2"
             ],
             "x-enum-comments": {
                 "ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
                 "ExperimentExample": "This isn't used for anything.",
                 "ExperimentNotifications": "Sends notifications via SMTP and webhooks following certain events.",
+                "ExperimentOAuth2": "Enables OAuth2 provider functionality.",
                 "ExperimentWebPush": "Enables web push notifications through the browser.",
                 "ExperimentWorkspaceUsage": "Enables the new workspace usage tracking."
             },
@@ -12564,7 +12566,8 @@ const docTemplate = `{
                 "ExperimentAutoFillParameters",
                 "ExperimentNotifications",
                 "ExperimentWorkspaceUsage",
-                "ExperimentWebPush"
+                "ExperimentWebPush",
+                "ExperimentOAuth2"
             ]
         },
         "codersdk.ExternalAuth": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -11231,12 +11231,14 @@
 				"auto-fill-parameters",
 				"notifications",
 				"workspace-usage",
-				"web-push"
+				"web-push",
+				"oauth2"
 			],
 			"x-enum-comments": {
 				"ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
 				"ExperimentExample": "This isn't used for anything.",
 				"ExperimentNotifications": "Sends notifications via SMTP and webhooks following certain events.",
+				"ExperimentOAuth2": "Enables OAuth2 provider functionality.",
 				"ExperimentWebPush": "Enables web push notifications through the browser.",
 				"ExperimentWorkspaceUsage": "Enables the new workspace usage tracking."
 			},
@@ -11245,7 +11247,8 @@
 				"ExperimentAutoFillParameters",
 				"ExperimentNotifications",
 				"ExperimentWorkspaceUsage",
-				"ExperimentWebPush"
+				"ExperimentWebPush",
+				"ExperimentOAuth2"
 			]
 		},
 		"codersdk.ExternalAuth": {

--- a/coderd/oauth2.go
+++ b/coderd/oauth2.go
@@ -37,11 +37,11 @@ const (
 	displaySecretLength = 6  // Length of visible part in UI (last 6 characters)
 )
 
-func (*API) oAuth2ProviderMiddleware(next http.Handler) http.Handler {
+func (api *API) oAuth2ProviderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if !buildinfo.IsDev() {
+		if !api.Experiments.Enabled(codersdk.ExperimentOAuth2) && !buildinfo.IsDev() {
 			httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-				Message: "OAuth2 provider is under development.",
+				Message: "OAuth2 provider functionality requires enabling the 'oauth2' experiment.",
 			})
 			return
 		}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3341,6 +3341,7 @@ const (
 	ExperimentNotifications      Experiment = "notifications"        // Sends notifications via SMTP and webhooks following certain events.
 	ExperimentWorkspaceUsage     Experiment = "workspace-usage"      // Enables the new workspace usage tracking.
 	ExperimentWebPush            Experiment = "web-push"             // Enables web push notifications through the browser.
+	ExperimentOAuth2             Experiment = "oauth2"               // Enables OAuth2 provider functionality.
 )
 
 // ExperimentsKnown should include all experiments defined above.
@@ -3350,6 +3351,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentNotifications,
 	ExperimentWorkspaceUsage,
 	ExperimentWebPush,
+	ExperimentOAuth2,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3039,6 +3039,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `notifications`        |
 | `workspace-usage`      |
 | `web-push`             |
+| `oauth2`               |
 
 ## codersdk.ExternalAuth
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -795,6 +795,7 @@ export type Experiment =
 	| "auto-fill-parameters"
 	| "example"
 	| "notifications"
+	| "oauth2"
 	| "web-push"
 	| "workspace-usage";
 
@@ -802,6 +803,7 @@ export const Experiments: Experiment[] = [
 	"auto-fill-parameters",
 	"example",
 	"notifications",
+	"oauth2",
 	"web-push",
 	"workspace-usage",
 ];


### PR DESCRIPTION
# Add OAuth2 Provider Functionality as an Experiment

This PR adds a new experiment flag `oauth2` that enables OAuth2 provider functionality in Coder. When enabled, this experiment allows Coder to act as an OAuth2 provider.

The changes include:
- Added the new `ExperimentOAuth2` constant with appropriate documentation
- Updated the OAuth2 provider middleware to check for the experiment flag
- Modified the error message to indicate that the OAuth2 provider requires enabling the experiment
- Added the new experiment to the known experiments list in the SDK

Previously, OAuth2 provider functionality was only available in development mode. With this change, it can be enabled in production environments by activating the experiment.