### PR TITLE
fix(site): update vs code dev container button URLs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 				{
 					"slug": "cursor",
 					"displayName": "Cursor Desktop",
-					"url": "cursor://coder.coder-remote/openDevContainer?owner=${localEnv:CODER_WORKSPACE_OWNER_NAME}&workspace=${localEnv:CODER_WORKSPACE_NAME}&agent=${localEnv:CODER_WORKSPACE_PARENT_AGENT_NAME}&url=${localEnv:CODER_URL}&token=$SESSION_TOKEN&devContainerName=${localEnv:CONTAINER_ID}&devContainerFolder=${containerWorkspaceFolder}",
+					"url": "cursor://coder.coder-remote/openDevContainer?owner=${localEnv:CODER_WORKSPACE_OWNER_NAME}&workspace=${localEnv:CODER_WORKSPACE_NAME}&agent=${localEnv:CODER_WORKSPACE_PARENT_AGENT_NAME}&url=${localEnv:CODER_URL}&token=$SESSION_TOKEN&devContainerName=${localEnv:CONTAINER_ID}&devContainerFolder=${containerWorkspaceFolder}&localWorkspaceFolder=${localWorkspaceFolder}",
 					"external": true,
 					"icon": "/icon/cursor.svg",
 					"order": 1
@@ -32,7 +32,7 @@
 				{
 					"slug": "windsurf",
 					"displayName": "Windsurf Editor",
-					"url": "windsurf://coder.coder-remote/openDevContainer?owner=${localEnv:CODER_WORKSPACE_OWNER_NAME}&workspace=${localEnv:CODER_WORKSPACE_NAME}&agent=${localEnv:CODER_WORKSPACE_PARENT_AGENT_NAME}&url=${localEnv:CODER_URL}&token=$SESSION_TOKEN&devContainerName=${localEnv:CONTAINER_ID}&devContainerFolder=${containerWorkspaceFolder}",
+					"url": "windsurf://coder.coder-remote/openDevContainer?owner=${localEnv:CODER_WORKSPACE_OWNER_NAME}&workspace=${localEnv:CODER_WORKSPACE_NAME}&agent=${localEnv:CODER_WORKSPACE_PARENT_AGENT_NAME}&url=${localEnv:CODER_URL}&token=$SESSION_TOKEN&devContainerName=${localEnv:CONTAINER_ID}&devContainerFolder=${containerWorkspaceFolder}&localWorkspaceFolder=${localWorkspaceFolder}",
 					"external": true,
 					"icon": "/icon/windsurf.svg",
 					"order": 4

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -307,6 +307,8 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 										workspaceName={workspace.name}
 										devContainerName={devcontainer.container.name}
 										devContainerFolder={subAgent?.directory ?? ""}
+										localWorkspaceFolder={devcontainer.workspace_folder}
+										localConfigFile={devcontainer.config_path || ""}
 										displayApps={displayApps} // TODO(mafredri): We could use subAgent display apps here but we currently set none.
 										agentName={parentAgent.name}
 									/>
@@ -331,7 +333,9 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 
 							{wildcardHostname !== "" &&
 								devcontainer.container?.ports.map((port) => {
-									const portLabel = `${port.port}/${port.network.toUpperCase()}`;
+									const portLabel = `${
+										port.port
+									}/${port.network.toUpperCase()}`;
 									const hasHostBind =
 										port.host_port !== undefined && port.host_ip !== undefined;
 									const helperText = hasHostBind

--- a/site/src/modules/resources/VSCodeDevContainerButton/VSCodeDevContainerButton.stories.tsx
+++ b/site/src/modules/resources/VSCodeDevContainerButton/VSCodeDevContainerButton.stories.tsx
@@ -17,6 +17,8 @@ export const Default: Story = {
 		agentName: MockWorkspaceAgent.name,
 		devContainerName: "musing_ride",
 		devContainerFolder: "/workspace/coder",
+		localWorkspaceFolder: "/home/coder/coder",
+		localConfigFile: "/home/coder/coder/.devcontainer/devcontainer.json",
 		displayApps: [
 			"vscode",
 			"vscode_insiders",
@@ -34,6 +36,8 @@ export const VSCodeOnly: Story = {
 		agentName: MockWorkspaceAgent.name,
 		devContainerName: "nifty_borg",
 		devContainerFolder: "/workspace/coder",
+		localWorkspaceFolder: "/home/coder/coder",
+		localConfigFile: "/home/coder/coder/.devcontainer/devcontainer.json",
 		displayApps: [
 			"vscode",
 			"port_forwarding_helper",
@@ -50,6 +54,8 @@ export const InsidersOnly: Story = {
 		agentName: MockWorkspaceAgent.name,
 		devContainerName: "amazing_swartz",
 		devContainerFolder: "/workspace/coder",
+		localWorkspaceFolder: "/home/coder/coder",
+		localConfigFile: "/home/coder/coder/.devcontainer/devcontainer.json",
 		displayApps: [
 			"vscode_insiders",
 			"port_forwarding_helper",

--- a/site/src/modules/resources/VSCodeDevContainerButton/VSCodeDevContainerButton.tsx
+++ b/site/src/modules/resources/VSCodeDevContainerButton/VSCodeDevContainerButton.tsx
@@ -15,6 +15,8 @@ interface VSCodeDevContainerButtonProps {
 	agentName?: string;
 	devContainerName: string;
 	devContainerFolder: string;
+	localWorkspaceFolder: string;
+	localConfigFile: string;
 	displayApps: readonly DisplayApp[];
 }
 
@@ -112,6 +114,8 @@ const VSCodeButton: FC<VSCodeDevContainerButtonProps> = ({
 	agentName,
 	devContainerName,
 	devContainerFolder,
+	localWorkspaceFolder,
+	localConfigFile,
 }) => {
 	const [loading, setLoading] = useState(false);
 
@@ -129,6 +133,8 @@ const VSCodeButton: FC<VSCodeDevContainerButtonProps> = ({
 							token: key,
 							devContainerName,
 							devContainerFolder,
+							localWorkspaceFolder,
+							localConfigFile,
 						});
 						if (agentName) {
 							query.set("agent", agentName);
@@ -156,6 +162,8 @@ const VSCodeInsidersButton: FC<VSCodeDevContainerButtonProps> = ({
 	agentName,
 	devContainerName,
 	devContainerFolder,
+	localWorkspaceFolder,
+	localConfigFile,
 }) => {
 	const [loading, setLoading] = useState(false);
 
@@ -173,6 +181,8 @@ const VSCodeInsidersButton: FC<VSCodeDevContainerButtonProps> = ({
 							token: key,
 							devContainerName,
 							devContainerFolder,
+							localWorkspaceFolder,
+							localConfigFile,
 						});
 						if (agentName) {
 							query.set("agent", agentName);


### PR DESCRIPTION
This updates the Dev Container VS Code button to include `localWorkspaceFolder` and `localConfigFile` that will be added in coder/vscode-coder#544.

This change is backwards compatible as the new arguments will be ignored.

Refs coder/vscode-coder#544
Refs #16426