### PR TITLE
chore: sort AI tasks by starting/running then created date

### DIFF
--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -380,11 +380,21 @@ WHERE
 	ORDER BY
 		-- To ensure that 'favorite' workspaces show up first in the list only for their owner.
 		CASE WHEN owner_id = @requester_id AND favorite THEN 0 ELSE 1 END ASC,
-		(latest_build_completed_at IS NOT NULL AND
-			latest_build_canceled_at IS NULL AND
-			latest_build_error IS NULL AND
-			latest_build_transition = 'start'::workspace_transition) DESC,
+		-- For AI tasks, put anything running or starting first.  Otherwise put
+		-- running only first.
+		CASE WHEN sqlc.narg('has_ai_task') :: boolean = true THEN
+			(latest_build_canceled_at IS NULL AND
+				latest_build_error IS NULL AND
+				latest_build_transition = 'start'::workspace_transition)
+		ELSE
+			(latest_build_completed_at IS NOT NULL AND
+				latest_build_canceled_at IS NULL AND
+				latest_build_error IS NULL AND
+				latest_build_transition = 'start'::workspace_transition)
+		END DESC,
 		LOWER(owner_username) ASC,
+		-- AI tasks are additionally sorted by creation date before the name.
+		CASE WHEN sqlc.narg('has_ai_task') :: boolean = true THEN created_at END DESC,
 		LOWER(name) ASC
 	LIMIT
 		CASE


### PR DESCRIPTION
This tweaks the workspace ordering for AI task workspaces by putting starting and running workspaces together then sorting them by created date (as opposed to the default ordering which is to put running workspaces first then sort by name).

An alternative would be to add new query params rather than switching on the `has_ai_task` query param.