### PR TITLE
fix: handle null response from the template presets endpoint

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1237,7 +1237,7 @@ class ApiMethods {
 
 	getTemplateVersionPresets = async (
 		templateVersionId: string,
-	): Promise<TypesGen.Preset[]> => {
+	): Promise<TypesGen.Preset[] | null> => {
 		const response = await this.axios.get<TypesGen.Preset[]>(
 			`/api/v2/templateversions/${templateVersionId}/presets`,
 		);

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -610,7 +610,7 @@ export const data = {
 		templateVersionId: string,
 	): Promise<Task> {
 		const presets = await API.getTemplateVersionPresets(templateVersionId);
-		const defaultPreset = presets.find((p) => p.Default);
+		const defaultPreset = presets?.find((p) => p.Default);
 		const workspace = await API.createWorkspace(userId, {
 			name: `task-${generateWorkspaceName()}`,
 			template_version_id: templateVersionId,


### PR DESCRIPTION
The template presets endpoint returns a null response when a template version does not define any presets.