### PR TITLE
chore: fix broken link in docs

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -117,7 +117,7 @@ coder:
 ```
 
 You can view our
-[Helm README](https://github.com/coder/coder/blob/main/helm#readme) for
+[Helm README](https://github.com/coder/coder/blob/main/helm/coder#readme) for
 details on the values that are available, or you can view the
 [values.yaml](https://github.com/coder/coder/blob/main/helm/coder/values.yaml)
 file directly.


### PR DESCRIPTION
Fixes the "Helm README" link on https://coder.com/docs/install/kubernetes so it goes to the right path.

Side note: I don't see any content in https://coder.com/docs/about/contributing/documentation about to whom such a PR should be assigned, if any. Edward was suggested and I see you've worked on other PR's with the `docs` label, so going with that.