### PR TITLE
fix(cli): calculate coder ping max correctly

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -53,7 +53,7 @@ func (s *pingSummary) addResult(r *ipnstate.PingResult) {
 	if s.Min == nil || r.LatencySeconds < s.Min.Seconds() {
 		s.Min = ptr.Ref(time.Duration(r.LatencySeconds * float64(time.Second)))
 	}
-	if s.Max == nil || r.LatencySeconds > s.Min.Seconds() {
+	if s.Max == nil || r.LatencySeconds > s.Max.Seconds() {
 		s.Max = ptr.Ref(time.Duration(r.LatencySeconds * float64(time.Second)))
 	}
 	s.latencySum += r.LatencySeconds

--- a/cli/ping_internal_test.go
+++ b/cli/ping_internal_test.go
@@ -21,11 +21,11 @@ func TestBuildSummary(t *testing.T) {
 			},
 			{
 				Err:            "",
-				LatencySeconds: 0.2,
+				LatencySeconds: 0.3,
 			},
 			{
 				Err:            "",
-				LatencySeconds: 0.3,
+				LatencySeconds: 0.2,
 			},
 			{
 				Err:            "ping error",


### PR DESCRIPTION
Embarassing mistake I made months ago 😦 

*Doesn't effect schmoder, since we don't parse that max, it calculates it itself