### PR TITLE
feat: sign coder binaries with the release key using GPG

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1279,6 +1279,7 @@ jobs:
           CODER_SIGN_WINDOWS: "1"
           CODER_WINDOWS_RESOURCES: "1"
           CODER_SIGN_GPG: "1"
+          CODER_GPG_RELEASE_KEY_BASE64: ${{ secrets.GPG_RELEASE_KEY_BASE64 }}
           EV_KEY: ${{ secrets.EV_KEY }}
           EV_KEYSTORE: ${{ secrets.EV_KEYSTORE }}
           EV_TSA_URL: ${{ secrets.EV_TSA_URL }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1278,6 +1278,7 @@ jobs:
           # do (see above).
           CODER_SIGN_WINDOWS: "1"
           CODER_WINDOWS_RESOURCES: "1"
+          CODER_SIGN_GPG: "1"
           EV_KEY: ${{ secrets.EV_KEY }}
           EV_KEYSTORE: ${{ secrets.EV_KEYSTORE }}
           EV_TSA_URL: ${{ secrets.EV_TSA_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -323,6 +323,7 @@ jobs:
         env:
           CODER_SIGN_WINDOWS: "1"
           CODER_SIGN_DARWIN: "1"
+          CODER_SIGN_GPG: "1"
           CODER_WINDOWS_RESOURCES: "1"
           AC_CERTIFICATE_FILE: /tmp/apple_cert.p12
           AC_CERTIFICATE_PASSWORD_FILE: /tmp/apple_cert_password.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -324,6 +324,7 @@ jobs:
           CODER_SIGN_WINDOWS: "1"
           CODER_SIGN_DARWIN: "1"
           CODER_SIGN_GPG: "1"
+          CODER_GPG_RELEASE_KEY_BASE64: ${{ secrets.GPG_RELEASE_KEY_BASE64 }}
           CODER_WINDOWS_RESOURCES: "1"
           AC_CERTIFICATE_FILE: /tmp/apple_cert.p12
           AC_CERTIFICATE_PASSWORD_FILE: /tmp/apple_cert_password.txt

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,10 @@ $(CODER_ALL_BINARIES): go.mod go.sum \
 		fi
 
 		cp "$@" "./site/out/bin/coder-$$os-$$arch$$dot_ext"
+
+		if [[ "$${CODER_SIGN_GPG:-0}" == "1" ]]; then
+			cp "$@.asc" "./site/out/bin/coder-$$os-$$arch$$dot_ext.asc"
+		fi
 	fi
 
 # This task builds Coder Desktop dylibs

--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -41,6 +41,7 @@ slim="${CODER_SLIM_BUILD:-0}"
 agpl="${CODER_BUILD_AGPL:-0}"
 sign_darwin="${CODER_SIGN_DARWIN:-0}"
 sign_windows="${CODER_SIGN_WINDOWS:-0}"
+sign_gpg="${CODER_SIGN_GPG:-0}"
 boringcrypto=${CODER_BUILD_BORINGCRYPTO:-0}
 dylib=0
 windows_resources="${CODER_WINDOWS_RESOURCES:-0}"
@@ -83,6 +84,10 @@ while true; do
 		;;
 	--sign-windows)
 		sign_windows=1
+		shift
+		;;
+	--sign-gpg)
+		sign_gpg=1
 		shift
 		;;
 	--boringcrypto)
@@ -317,6 +322,11 @@ fi
 
 if [[ "$sign_windows" == 1 ]] && [[ "$os" == "windows" ]]; then
 	execrelative ./sign_windows.sh "$output_path" 1>&2
+fi
+
+# Platform agnostic signing
+if [[ "$sign_gpg" == 1 ]]; then
+	execrelative ./sign_with_gpg.sh "$output_path" 1>&2
 fi
 
 echo "$output_path"

--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -20,6 +20,9 @@
 # binary will be signed using ./sign_darwin.sh. Read that file for more details
 # on the requirements.
 #
+# If the --sign-gpg parameter is specified, the output binary will be signed using ./sign_with_gpg.sh.
+# Read that file for more details on the requirements.
+#
 # If the --agpl parameter is specified, builds only the AGPL-licensed code (no
 # Coder enterprise features).
 #

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -129,26 +129,9 @@ if [[ "$dry_run" == 0 ]] && [[ "${CODER_GPG_RELEASE_KEY_BASE64:-}" != "" ]]; the
 	log "--- Signing checksums file"
 	log
 
-	# Import the GPG key.
-	old_gnupg_home="${GNUPGHOME:-}"
-	gnupg_home_temp="$(mktemp -d)"
-	export GNUPGHOME="$gnupg_home_temp"
-	echo "$CODER_GPG_RELEASE_KEY_BASE64" | base64 -d | gpg --import 1>&2
-
-	# Sign the checksums file. This generates a file in the same directory and
-	# with the same name as the checksums file but ending in ".asc".
-	#
-	# We pipe `true` into `gpg` so that it never tries to be interactive (i.e.
-	# ask for a passphrase). The key we import above is not password protected.
-	true | gpg --detach-sign --armor "${temp_dir}/${checksum_file}" 1>&2
-
-	rm -rf "$gnupg_home_temp"
-	unset GNUPGHOME
-	if [[ "$old_gnupg_home" != "" ]]; then
-		export GNUPGHOME="$old_gnupg_home"
-	fi
-
+	execrelative ../sign_with_gpg.sh "${temp_dir}/${checksum_file}"
 	signed_checksum_path="${temp_dir}/${checksum_file}.asc"
+
 	if [[ ! -e "$signed_checksum_path" ]]; then
 		log "Signed checksum file not found: ${signed_checksum_path}"
 		log

--- a/scripts/sign_with_gpg.sh
+++ b/scripts/sign_with_gpg.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# This script signs a given binary using GPG.
+# It expects the binary to be signed as the first argument.
+#
+# Usage: ./sign_with_gpg.sh path/to/binary
+#
+# On success, the input file will be signed using the GPG key.
+#
+# Depends on the GPG utility. Requires the following environment variables to be set:
+#  - $CODER_GPG_RELEASE_KEY_BASE64: The base64 encoded private key to use.
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+requiredenvs CODER_GPG_RELEASE_KEY_BASE64
+
+FILE_TO_SIGN="$1"
+
+if [[ -z "$FILE_TO_SIGN" ]]; then
+	echo "Usage: $0 <file_to_sign>"
+	exit 1
+fi
+
+if [[ ! -f "$FILE_TO_SIGN" ]]; then
+	echo "File not found: $FILE_TO_SIGN"
+	exit 1
+fi
+
+# Import the GPG key.
+old_gnupg_home="${GNUPGHOME:-}"
+gnupg_home_temp="$(mktemp -d)"
+export GNUPGHOME="$gnupg_home_temp"
+
+# Ensure GPG uses the temporary directory
+echo "$CODER_GPG_RELEASE_KEY_BASE64" | base64 -d | gpg --homedir "$gnupg_home_temp" --import 1>&2
+
+# Sign the binary. This generates a file in the same directory and
+# with the same name as the binary but ending in ".asc".
+#
+# We pipe `true` into `gpg` so that it never tries to be interactive (i.e.
+# ask for a passphrase). The key we import above is not password protected.
+true | gpg --homedir "$gnupg_home_temp" --detach-sign --armor "$FILE_TO_SIGN" 1>&2
+
+# Verify the signature and capture the exit status
+gpg --homedir "$gnupg_home_temp" --verify "${FILE_TO_SIGN}.asc" "$FILE_TO_SIGN" 1>&2
+verification_result=$?
+
+# Clean up the temporary GPG home
+rm -rf "$gnupg_home_temp"
+unset GNUPGHOME
+if [[ "$old_gnupg_home" != "" ]]; then
+	export GNUPGHOME="$old_gnupg_home"
+fi
+
+if [[ $verification_result -eq 0 ]]; then
+	echo "${FILE_TO_SIGN}.asc"
+else
+	echo "Signature verification failed!" >&2
+	exit 1
+fi

--- a/scripts/sign_with_gpg.sh
+++ b/scripts/sign_with_gpg.sh
@@ -19,11 +19,11 @@ requiredenvs CODER_GPG_RELEASE_KEY_BASE64
 FILE_TO_SIGN="$1"
 
 if [[ -z "$FILE_TO_SIGN" ]]; then
-	echo "Usage: $0 <file_to_sign>"
+	error "Usage: $0 <file_to_sign>"
 fi
 
 if [[ ! -f "$FILE_TO_SIGN" ]]; then
-	echo "File not found: $FILE_TO_SIGN"
+	error "File not found: $FILE_TO_SIGN"
 fi
 
 # Import the GPG key.
@@ -55,5 +55,5 @@ fi
 if [[ $verification_result -eq 0 ]]; then
 	echo "${FILE_TO_SIGN}.asc"
 else
-	echo "Signature verification failed!" >&2
+	error "Signature verification failed!" >&2
 fi

--- a/scripts/sign_with_gpg.sh
+++ b/scripts/sign_with_gpg.sh
@@ -5,7 +5,7 @@
 #
 # Usage: ./sign_with_gpg.sh path/to/binary
 #
-# On success, the input file will be signed using the GPG key.
+# On success, the input file will be signed using the GPG key and the signature output file will moved to /site/out/bin/ (happens in the Makefile)
 #
 # Depends on the GPG utility. Requires the following environment variables to be set:
 #  - $CODER_GPG_RELEASE_KEY_BASE64: The base64 encoded private key to use.
@@ -20,12 +20,10 @@ FILE_TO_SIGN="$1"
 
 if [[ -z "$FILE_TO_SIGN" ]]; then
 	echo "Usage: $0 <file_to_sign>"
-	exit 1
 fi
 
 if [[ ! -f "$FILE_TO_SIGN" ]]; then
 	echo "File not found: $FILE_TO_SIGN"
-	exit 1
 fi
 
 # Import the GPG key.
@@ -58,5 +56,4 @@ if [[ $verification_result -eq 0 ]]; then
 	echo "${FILE_TO_SIGN}.asc"
 else
 	echo "Signature verification failed!" >&2
-	exit 1
 fi

--- a/scripts/sign_with_gpg.sh
+++ b/scripts/sign_with_gpg.sh
@@ -55,5 +55,5 @@ fi
 if [[ $verification_result -eq 0 ]]; then
 	echo "${FILE_TO_SIGN}.asc"
 else
-	error "Signature verification failed!" >&2
+	error "Signature verification failed!"
 fi


### PR DESCRIPTION
### Description
This PR introduces GPG signing for all Coder *slim-binaries*.
Detached signatures will allow users to verify the integrity and authenticity of the binaries they download.

### Changes
  * `scripts/sign_with_gpg.sh`: New script to sign a given binary
     using GPG. It imports the release key, signs the binary, and
     verifies the signature.
   * `scripts/build_go.sh`: Updated to call `sign_with_gpg.sh` when the
     `CODER_SIGN_GPG` environment variable is set to 1.
   * `.github/workflows/release.yaml`: The` CODER_SIGN_GPG` environment
     variable is now set to 1 during the release build, enabling GPG
     signing for all release binaries.
   * `.github/workflows/ci.yaml`: The `CODER_SIGN_GPG` environment
     variable is now set to 1 during the CI build, enabling GPG
     signing for all CI binaries.
   * `Makefile`: Detached signatures are moved to the `/site/out/bin/ `directory