### PR TITLE
chore: stop running postgres-only tests if DB is not set

### DIFF
--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -85,6 +85,10 @@ func TestNestedInTx(t *testing.T) {
 func testSQLDB(t testing.TB) *sql.DB {
 	t.Helper()
 
+	if !dbtestutil.WillUsePostgres() {
+		t.Skip("this test requires postgres")
+	}
+
 	connection, err := dbtestutil.Open(t)
 	require.NoError(t, err)
 

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -81,7 +81,7 @@ func initDefaultConnection(t TBSubset) error {
 	}
 
 	var dbErr error
-	// Retry up to 3 seconds for temporary errors.
+	// Retry up to 10 seconds for temporary errors.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for r := retry.New(10*time.Millisecond, 500*time.Millisecond); r.Wait(ctx); {
@@ -93,7 +93,7 @@ func initDefaultConnection(t TBSubset) error {
 		if !containsAnySubstring(errString, retryableErrSubstrings) {
 			break
 		}
-		t.Logf("failed to connect to postgres, retrying: %s", errString)
+		t.Logf("%s failed to connect to postgres, retrying: %s", time.Now().Format(time.StampMilli), errString)
 	}
 
 	// After the loop dbErr is the last connection error (if any).


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/695

PostgreSQL tests are getting run in a non-postgres CI job because the tests don't get skipped if the `DB=` env is unset. This PR adds a skip for them.

They are flaking in the `test-go-race` CI job. They run fine in the `test-go-race-pg` job, which pre-creates the postgres server, so the flakiness is almost certainly related to spinning up the database server.