### PR TITLE
chore(dogfood): update filebrowser module to version 1.1.1

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -315,7 +315,7 @@ module "jetbrains" {
 module "filebrowser" {
   count      = data.coder_workspace.me.start_count
   source     = "dev.registry.coder.com/coder/filebrowser/coder"
-  version    = "1.0.31"
+  version    = "1.1.1"
   agent_id   = coder_agent.dev.id
   agent_name = "dev"
 }


### PR DESCRIPTION
Workspaces with `Write Coder on Coder` template are failing with an error in the agent related to File Browser:
```
2025/07/08 14:00:29 Using database: /home/coder/filebrowser.db  
2025/07/08 14:00:29 password is too short, minimum length is 12
```
Updating filebrowser module version to 1.1.1: https://github.com/coder/registry/pull/173