### PR TITLE
WIP: fix: add registry declaration to dependabot yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,10 @@
 version: 2
+
+registries:
+  coder-registry:
+    type: terraform-registry
+    url: https://registry.coder.com
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -122,3 +128,5 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    registries:
+        - coder-registry


### PR DESCRIPTION
This PR updates the dependabot configuration to work with coder's registry (assuming I get it working)
Edit: The issue was in dependabot: https://github.com/dependabot/dependabot-core/pull/12610