### PR TITLE
fix(agent/agentcontainers): fix `TestAPI/IgnoreCustomization` flake

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -2887,7 +2887,7 @@ func TestAPI(t *testing.T) {
 			err = api.RefreshContainers(ctx)
 			require.NoError(t, err)
 
-			return len(fakeSAC.created) > 0
+			return len(fakeSAC.agents) == 1
 		}, testutil.WaitShort, testutil.IntervalFast, "subagent should be created after config change")
 
 		t.Log("Phase 2: Cont, waiting for sub agent to exit")
@@ -2927,8 +2927,8 @@ func TestAPI(t *testing.T) {
 			err = api.RefreshContainers(ctx)
 			require.NoError(t, err)
 
-			return len(fakeSAC.created) > 0
-		}, testutil.WaitShort, testutil.IntervalFast, "subagent should be created after config change")
+			return len(fakeSAC.agents) == 0
+		}, testutil.WaitShort, testutil.IntervalFast, "subagent should be deleted after config change")
 
 		req = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 		rec = httptest.NewRecorder()

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -2883,21 +2883,12 @@ func TestAPI(t *testing.T) {
 			Op:   fsnotify.Write,
 		})
 
-		// Retry RefreshContainers until subagent injection succeeds
-		// This handles the race condition where the watcher loop may not have
-		// finished processing the config change yet
-		var subAgentCreated bool
-		for i := 0; i < 10; i++ {
+		require.Eventuallyf(t, func() bool {
 			err = api.RefreshContainers(ctx)
 			require.NoError(t, err)
 
-			if len(fakeSAC.created) > 0 {
-				subAgentCreated = true
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		require.True(t, subAgentCreated, "subagent should be created after config change")
+			return len(fakeSAC.created) > 0
+		}, testutil.WaitShort, testutil.IntervalFast, "subagent should be created after config change")
 
 		t.Log("Phase 2: Cont, waiting for sub agent to exit")
 		exitSubAgentOnce.Do(func() {
@@ -2932,21 +2923,12 @@ func TestAPI(t *testing.T) {
 			Op:   fsnotify.Write,
 		})
 
-		// Retry RefreshContainers until subagent injection succeeds
-		// This handles the race condition where the watcher loop may not have
-		// finished processing the config change yet
-		subAgentCreated = false
-		for i := 0; i < 10; i++ {
+		require.Eventuallyf(t, func() bool {
 			err = api.RefreshContainers(ctx)
 			require.NoError(t, err)
 
-			if len(fakeSAC.created) > 0 {
-				subAgentCreated = true
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		require.True(t, subAgentCreated, "subagent should be created after config change")
+			return len(fakeSAC.created) > 0
+		}, testutil.WaitShort, testutil.IntervalFast, "subagent should be created after config change")
 
 		req = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 		rec = httptest.NewRecorder()


### PR DESCRIPTION
Fixes a flake spotted here https://github.com/coder/coder/actions/runs/16277283041/job/45959150449

The flake occurred due to a race condition between `RefreshContainers` and the file system watcher. We might want to improve how these tests are written in the future, but for now it appears this change has fixed the flake on my Coder Workspace.

How I ran the test to recreate the issue
```sh
seq 1 128 | xargs -P 64 -I {} sh -c 'echo "Run {}:" &&  go test -run="TestAPI/IgnoreCustomization" -race -count=20 ./agent/agentcontainers'
```