### PR TITLE
docs: update port forwarding docs to include Coder Desktop

### DIFF
--- a/docs/user-guides/workspace-access/port-forwarding.md
+++ b/docs/user-guides/workspace-access/port-forwarding.md
@@ -6,25 +6,17 @@ Port forwarding lets developers securely access processes on their Coder
 workspace from a local machine. A common use case is testing web applications in
 a browser.
 
-There are multiple ways to forward ports in Coder:
-
-- [Coder Desktop](../desktop/index.md)
-- The `coder port-forward` command
-- Dashboard
-- SSH
-
-The performance of these methods generally follows in the following order.
-
-1. Coder Desktop: as it uses a VPN tunnel to your workspace and provides access to all running ports.
-1. The `coder port-forward` command.
-1. The Dashboard, which proxies traffic through the Coder control plane versus
-   peer-to-pee,r which is possible with the Coder CLI and Coder Desktop.
-1. `ssh`, which does double encryption of traffic with both Wireguard and SSH.
+| Method                                                          | Details                                                                                                                     |
+|:----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| [Coder Desktop](../desktop/index.md)                            | Uses a VPN tunnel to your workspace and provides access to all running ports.                                               |
+| [`coder port-forward` command](#the-coder-port-forward-command) | Can be used to forward TCP or UDP ports from the remote workspace so they can be accessed locally.                          |
+| [Dashboard](#dashboard)                                         | Proxies traffic through the Coder control plane versus peer-to-peer which is possible with the Coder CLI and Coder Desktop. |
+| [SSH](#ssh)                                                     | Double-encrypts traffic with both Wireguard and SSH.                                                                        |
 
 ## Coder Desktop
 
 [Coder Desktop](../desktop/index.md) provides seamless access to your remote workspaces, eliminating the need to install a CLI or manually configure port forwarding.
-Just install and access all your ports at `<workspace-name>.coder:PORT`.
+Access all your ports at `<workspace-name>.coder:PORT`.
 
 ## The `coder port-forward` command
 

--- a/docs/user-guides/workspace-access/port-forwarding.md
+++ b/docs/user-guides/workspace-access/port-forwarding.md
@@ -10,7 +10,7 @@ There are multiple ways to forward ports in Coder:
 
 | Method                                                          | Details                                                                                                                                                                 |
 |:----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Coder Desktop](../desktop/index.md)                            | Uses a VPN tunnel to your workspaces and provides access to all running ports. Supports peer-to-peer connections for the best performance.                              |
+| [Coder Desktop](#coder-desktop)                                 | Uses a VPN tunnel to your workspaces and provides access to all running ports. Supports peer-to-peer connections for the best performance.                              |
 | [`coder port-forward` command](#the-coder-port-forward-command) | Can be used to forward specific TCP or UDP ports from the remote workspace so they can be accessed locally. Supports peer-to-peer connections for the best performance. |
 | [Dashboard](#dashboard)                                         | Proxies traffic through the Coder control plane.                                                                                                                        |
 | [SSH](#ssh)                                                     | Forwards ports over an SSH connection.                                                                                                                                  |

--- a/docs/user-guides/workspace-access/port-forwarding.md
+++ b/docs/user-guides/workspace-access/port-forwarding.md
@@ -6,6 +6,8 @@ Port forwarding lets developers securely access processes on their Coder
 workspace from a local machine. A common use case is testing web applications in
 a browser.
 
+There are multiple ways to forward ports in Coder:
+
 | Method                                                          | Details                                                                                                                     |
 |:----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | [Coder Desktop](../desktop/index.md)                            | Uses a VPN tunnel to your workspace and provides access to all running ports.                                               |

--- a/docs/user-guides/workspace-access/port-forwarding.md
+++ b/docs/user-guides/workspace-access/port-forwarding.md
@@ -8,12 +8,12 @@ a browser.
 
 There are multiple ways to forward ports in Coder:
 
-| Method                                                          | Details                                                                                                                     |
-|:----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| [Coder Desktop](../desktop/index.md)                            | Uses a VPN tunnel to your workspace and provides access to all running ports.                                               |
-| [`coder port-forward` command](#the-coder-port-forward-command) | Can be used to forward TCP or UDP ports from the remote workspace so they can be accessed locally.                          |
-| [Dashboard](#dashboard)                                         | Proxies traffic through the Coder control plane versus peer-to-peer which is possible with the Coder CLI and Coder Desktop. |
-| [SSH](#ssh)                                                     | Forwards ports over an SSH connection.                                                                                      |
+| Method                                                          | Details                                                                                                                                                                 |
+|:----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Coder Desktop](../desktop/index.md)                            | Uses a VPN tunnel to your workspaces and provides access to all running ports. Supports peer-to-peer connections for the best performance.                              |
+| [`coder port-forward` command](#the-coder-port-forward-command) | Can be used to forward specific TCP or UDP ports from the remote workspace so they can be accessed locally. Supports peer-to-peer connections for the best performance. |
+| [Dashboard](#dashboard)                                         | Proxies traffic through the Coder control plane.                                                                                                                        |
+| [SSH](#ssh)                                                     | Forwards ports over an SSH connection.                                                                                                                                  |
 
 ## Coder Desktop
 

--- a/docs/user-guides/workspace-access/port-forwarding.md
+++ b/docs/user-guides/workspace-access/port-forwarding.md
@@ -13,7 +13,7 @@ There are multiple ways to forward ports in Coder:
 | [Coder Desktop](../desktop/index.md)                            | Uses a VPN tunnel to your workspace and provides access to all running ports.                                               |
 | [`coder port-forward` command](#the-coder-port-forward-command) | Can be used to forward TCP or UDP ports from the remote workspace so they can be accessed locally.                          |
 | [Dashboard](#dashboard)                                         | Proxies traffic through the Coder control plane versus peer-to-peer which is possible with the Coder CLI and Coder Desktop. |
-| [SSH](#ssh)                                                     | Double-encrypts traffic with both Wireguard and SSH.                                                                        |
+| [SSH](#ssh)                                                     | Forwards ports over an SSH connection.                                                                                      |
 
 ## Coder Desktop
 

--- a/docs/user-guides/workspace-access/port-forwarding.md
+++ b/docs/user-guides/workspace-access/port-forwarding.md
@@ -6,17 +6,25 @@ Port forwarding lets developers securely access processes on their Coder
 workspace from a local machine. A common use case is testing web applications in
 a browser.
 
-There are three ways to forward ports in Coder:
+There are multiple ways to forward ports in Coder:
 
+- [Coder Desktop](../desktop/index.md)
 - The `coder port-forward` command
 - Dashboard
 - SSH
 
-The `coder port-forward` command is generally more performant than:
+The performance of these methods generally follows in the following order.
 
-1. The Dashboard which proxies traffic through the Coder control plane versus
-   peer-to-peer which is possible with the Coder CLI
-1. `sshd` which does double encryption of traffic with both Wireguard and SSH
+1. Coder Desktop: as it uses a VPN tunnel to your workspace and provides access to all running ports.
+1. The `coder port-forward` command.
+1. The Dashboard, which proxies traffic through the Coder control plane versus
+   peer-to-pee,r which is possible with the Coder CLI and Coder Desktop.
+1. `ssh`, which does double encryption of traffic with both Wireguard and SSH.
+
+## Coder Desktop
+
+[Coder Desktop](../desktop/index.md) provides seamless access to your remote workspaces, eliminating the need to install a CLI or manually configure port forwarding.
+Just install and access all your ports at `<workspace-name>.coder:PORT`.
 
 ## The `coder port-forward` command
 
@@ -62,7 +70,7 @@ where each segment of hostnames must not exceed 63 characters. If your app
 name, agent name, workspace name and username exceed 63 characters in the
 hostname, port forwarding via the dashboard will not work.
 
-### From an coder_app resource
+### From a coder_app resource
 
 One way to port forward is to configure a `coder_app` resource in the
 workspace's template. This approach shows a visual application icon in the


### PR DESCRIPTION
Noticed that Coder Desktop was missing from port-forwarding docs which is kind of a big feature for Coder Connect.

[preview](https://coder.com/docs/@atif%2Fdesktop-ports/user-guides/workspace-access/port-forwarding)