### PR TITLE
fix(cli): scope context per subtest to fix flake test in prebuilt workspace delete

### DIFF
--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -233,9 +233,6 @@ func TestDelete(t *testing.T) {
 			t.Skip("this test requires postgres")
 		}
 
-		clock := quartz.NewMock(t)
-		ctx := testutil.Context(t, testutil.WaitSuperLong)
-
 		// Setup
 		db, pb := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
 		client, _ := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
@@ -300,6 +297,9 @@ func TestDelete(t *testing.T) {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
+
+				clock := quartz.NewMock(t)
+				ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 				// Create one prebuilt workspace (owned by system user) and one normal workspace (owned by a user)
 				// Each workspace is persisted in the DB along with associated workspace jobs and builds.


### PR DESCRIPTION
## Description

This PR fixes a flaky test in `TestDelete/Prebuilt_workspace_delete_permissions`: https://github.com/coder/internal/issues/764

Previously, all subtests used the same context created at the top level. Since the subtests run in parallel, they could run for too long and cause the shared context to expire. This sometimes led to context deadline exceeded errors, especially during the `testutil.Eventually` check for running prebuilt workspaces.

The fix is to create a fresh context per subtest, ensuring they are isolated and not prematurely cancelled due to other subtests' durations.