### PR TITLE
chore: add image styles for kiro.svg

### DIFF
--- a/site/src/theme/externalImages.ts
+++ b/site/src/theme/externalImages.ts
@@ -154,6 +154,7 @@ export const defaultParametersForBuiltinIcons = new Map<string, string>([
 	["/icon/image.svg", "monochrome"],
 	["/icon/jupyter.svg", "blackWithColor"],
 	["/icon/kasmvnc.svg", "whiteWithColor"],
+	["/icon/kiro.svg", "whiteWithColor"],
 	["/icon/memory.svg", "monochrome"],
 	["/icon/rust.svg", "monochrome"],
 	["/icon/terminal.svg", "monochrome"],


### PR DESCRIPTION
The `whiteWithColor` style gives this image a more appropriate treatment on light themes:

<img width="78" height="75" alt="Screenshot 2025-07-15 at 1 54 33 PM" src="https://github.com/user-attachments/assets/0ac1bb50-d9d1-4a2e-a4ec-e7ba756589ad" />
<img width="78" height="75" alt="Screenshot 2025-07-15 at 1 54 38 PM" src="https://github.com/user-attachments/assets/2a4f442e-df42-485f-a213-8ab08f30ef6f" />
