### PR TITLE
fix(site): only attempt to watch when dev containers enabled

### DIFF
--- a/site/src/modules/resources/useAgentContainers.test.tsx
+++ b/site/src/modules/resources/useAgentContainers.test.tsx
@@ -230,9 +230,7 @@ describe("useAgentContainers", () => {
 				`/api/v2/workspaceagents/${MockWorkspaceAgent.id}/containers`,
 				() => {
 					return HttpResponse.json(
-						{
-							message: "Dev Container feature not enabled.",
-						},
+						{ message: "Dev Container feature not enabled." },
 						{ status: 403 },
 					);
 				},

--- a/site/src/modules/resources/useAgentContainers.test.tsx
+++ b/site/src/modules/resources/useAgentContainers.test.tsx
@@ -4,23 +4,19 @@ import type { WorkspaceAgentListContainersResponse } from "api/typesGenerated";
 import * as GlobalSnackbar from "components/GlobalSnackbar/utils";
 import { http, HttpResponse } from "msw";
 import type { FC, PropsWithChildren } from "react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { act } from "react";
+import { QueryClientProvider } from "react-query";
 import {
 	MockWorkspaceAgent,
 	MockWorkspaceAgentDevcontainer,
 } from "testHelpers/entities";
+import { createTestQueryClient } from "testHelpers/renderHelpers";
 import { server } from "testHelpers/server";
 import type { OneWayWebSocket } from "utils/OneWayWebSocket";
 import { useAgentContainers } from "./useAgentContainers";
 
 const createWrapper = (): FC<PropsWithChildren> => {
-	const queryClient = new QueryClient({
-		defaultOptions: {
-			queries: {
-				retry: false,
-			},
-		},
-	});
+	const queryClient = createTestQueryClient();
 	return ({ children }) => (
 		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 	);
@@ -111,22 +107,29 @@ describe("useAgentContainers", () => {
 			),
 		);
 
-		const { unmount } = renderHook(
+		const { result, unmount } = renderHook(
 			() => useAgentContainers(MockWorkspaceAgent),
 			{
 				wrapper: createWrapper(),
 			},
 		);
 
-		// Simulate message event with parsing error
+		// Wait for initial query to complete
+		await waitFor(() => {
+			expect(result.current).toEqual([MockWorkspaceAgentDevcontainer]);
+		});
+
+		// Now simulate message event with parsing error
 		const messageHandler = mockSocket.addEventListener.mock.calls.find(
 			(call) => call[0] === "message",
 		)?.[1];
 
 		if (messageHandler) {
-			messageHandler({
-				parseError: new Error("Parse error"),
-				parsedMessage: null,
+			act(() => {
+				messageHandler({
+					parseError: new Error("Parse error"),
+					parsedMessage: null,
+				});
 			});
 		}
 
@@ -166,20 +169,27 @@ describe("useAgentContainers", () => {
 			),
 		);
 
-		const { unmount } = renderHook(
+		const { result, unmount } = renderHook(
 			() => useAgentContainers(MockWorkspaceAgent),
 			{
 				wrapper: createWrapper(),
 			},
 		);
 
-		// Simulate error event
+		// Wait for initial query to complete
+		await waitFor(() => {
+			expect(result.current).toEqual([MockWorkspaceAgentDevcontainer]);
+		});
+
+		// Now simulate error event
 		const errorHandler = mockSocket.addEventListener.mock.calls.find(
 			(call) => call[0] === "error",
 		)?.[1];
 
 		if (errorHandler) {
-			errorHandler(new Error("WebSocket error"));
+			act(() => {
+				errorHandler(new Error("WebSocket error"));
+			});
 		}
 
 		await waitFor(() => {
@@ -208,6 +218,40 @@ describe("useAgentContainers", () => {
 
 		expect(watchAgentContainersSpy).not.toHaveBeenCalled();
 		expect(result.current).toBeUndefined();
+
+		watchAgentContainersSpy.mockRestore();
+	});
+
+	it("does not establish WebSocket connection when dev container feature is not enabled", async () => {
+		const watchAgentContainersSpy = jest.spyOn(API, "watchAgentContainers");
+
+		server.use(
+			http.get(
+				`/api/v2/workspaceagents/${MockWorkspaceAgent.id}/containers`,
+				() => {
+					return HttpResponse.json(
+						{
+							message: "Dev Container feature not enabled.",
+						},
+						{ status: 403 },
+					);
+				},
+			),
+		);
+
+		const { result } = renderHook(
+			() => useAgentContainers(MockWorkspaceAgent),
+			{
+				wrapper: createWrapper(),
+			},
+		);
+
+		// Wait for the query to complete and error to be processed
+		await waitFor(() => {
+			expect(result.current).toBeUndefined();
+		});
+
+		expect(watchAgentContainersSpy).not.toHaveBeenCalled();
 
 		watchAgentContainersSpy.mockRestore();
 	});

--- a/site/src/modules/resources/useAgentContainers.ts
+++ b/site/src/modules/resources/useAgentContainers.ts
@@ -4,7 +4,6 @@ import type {
 	WorkspaceAgentDevcontainer,
 	WorkspaceAgentListContainersResponse,
 } from "api/typesGenerated";
-import { AxiosError } from "axios";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { useEffectEvent } from "hooks/hookPolyfills";
 import { useEffect } from "react";

--- a/site/src/modules/resources/useAgentContainers.ts
+++ b/site/src/modules/resources/useAgentContainers.ts
@@ -37,19 +37,13 @@ export function useAgentContainers(
 
 	useEffect(() => {
 		const devcontainerFeatureDisabled =
-			queryError instanceof AxiosError &&
-			queryError.status === 403 &&
-			queryError.response?.data.message ===
-				"Dev Container feature not enabled.";
-
-		// We do not want to attempt to call the `/watch` endpoint
-		// if the agent isn't connected yet as the endpoint will
-		// not be ready to call.
-		if (
-			agent.status !== "connected" ||
 			queryIsLoading ||
-			devcontainerFeatureDisabled
-		) {
+			(queryError instanceof AxiosError &&
+				queryError.status === 403 &&
+				queryError.response?.data.message ===
+					"Dev Container feature not enabled.");
+
+		if (agent.status !== "connected" || devcontainerFeatureDisabled) {
 			return;
 		}
 

--- a/site/src/modules/resources/useAgentContainers.ts
+++ b/site/src/modules/resources/useAgentContainers.ts
@@ -36,14 +36,7 @@ export function useAgentContainers(
 	);
 
 	useEffect(() => {
-		const devcontainerFeatureDisabled =
-			queryIsLoading ||
-			(queryError instanceof AxiosError &&
-				queryError.status === 403 &&
-				queryError.response?.data.message ===
-					"Dev Container feature not enabled.");
-
-		if (agent.status !== "connected" || devcontainerFeatureDisabled) {
+		if (agent.status !== "connected" || queryIsLoading || queryError) {
 			return;
 		}
 


### PR DESCRIPTION
When an agent has explicitly disable the dev container integration, we currently show an ugly error when watching for containers inevitably fails. Instead, we now detect when the initial list fails due to the integration being disabled, and not attempt to begin watching. 