### PR TITLE
feat(cli): add 'list presets' command and '--preset' flag to 'create' command

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/coder/v2/cli"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -298,7 +300,7 @@ func TestCreate(t *testing.T) {
 	})
 }
 
-func prepareEchoResponses(parameters []*proto.RichParameter) *echo.Responses {
+func prepareEchoResponses(parameters []*proto.RichParameter, presets ...*proto.Preset) *echo.Responses {
 	return &echo.Responses{
 		Parse: echo.ParseComplete,
 		ProvisionPlan: []*proto.Response{
@@ -306,6 +308,7 @@ func prepareEchoResponses(parameters []*proto.RichParameter) *echo.Responses {
 				Type: &proto.Response_Plan{
 					Plan: &proto.PlanComplete{
 						Parameters: parameters,
+						Presets:    presets,
 					},
 				},
 			},
@@ -660,6 +663,581 @@ func TestCreateWithRichParameters(t *testing.T) {
 		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: firstParameterValue})
 		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: secondParameterName, Value: secondParameterValue})
 		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: immutableParameterName, Value: immutableParameterValue})
+	})
+}
+
+func TestCreateWithPreset(t *testing.T) {
+	t.Parallel()
+
+	const (
+		firstParameterName        = "first_parameter"
+		firstParameterDisplayName = "First Parameter"
+		firstParameterDescription = "This is the first parameter"
+		firstParameterValue       = "1"
+
+		firstOptionalParameterName         = "first_optional_parameter"
+		firstOptionParameterDescription    = "This is the first optional parameter"
+		firstOptionalParameterValue        = "1"
+		secondOptionalParameterName        = "second_optional_parameter"
+		secondOptionalParameterDescription = "This is the second optional parameter"
+		secondOptionalParameterValue       = "2"
+
+		thirdParameterName        = "third_parameter"
+		thirdParameterDescription = "This is the third parameter"
+		thirdParameterValue       = "3"
+	)
+
+	echoResponses := func(presets ...*proto.Preset) *echo.Responses {
+		return prepareEchoResponses([]*proto.RichParameter{
+			{
+				Name:         firstParameterName,
+				DisplayName:  firstParameterDisplayName,
+				Description:  firstParameterDescription,
+				Mutable:      true,
+				DefaultValue: firstParameterValue,
+				Options: []*proto.RichParameterOption{
+					{
+						Name:        firstOptionalParameterName,
+						Description: firstOptionParameterDescription,
+						Value:       firstOptionalParameterValue,
+					},
+					{
+						Name:        secondOptionalParameterName,
+						Description: secondOptionalParameterDescription,
+						Value:       secondOptionalParameterValue,
+					},
+				},
+			},
+			{
+				Name:         thirdParameterName,
+				Description:  thirdParameterDescription,
+				DefaultValue: thirdParameterValue,
+				Mutable:      true,
+			},
+		}, presets...)
+	}
+
+	// This test verifies that when a user provides the `--preset` flag,
+	// the CLI correctly uses the parameters defined in the preset.
+	// The workspace is created using those preset parameters.
+	t.Run("PresetFlag", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version where the preset defines values for all required parameters
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command with the specified preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", preset.Name)
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err)
+
+		// Should: display the selected preset as well as its parameters
+		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", thirdParameterName, thirdParameterValue))
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		tvPresets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, tvPresets, 1)
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: create a workspace using the expected template version and the preset-defined parameters
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, tvPresets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that when the user does not provide the `--preset` flag,
+	// the workspace is created without using any preset.
+	t.Run("NoPresetFlag", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses())
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command without a preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y",
+			"--parameter", fmt.Sprintf("%s=%s", firstParameterName, firstOptionalParameterValue),
+			"--parameter", fmt.Sprintf("%s=%s", thirdParameterName, thirdParameterValue))
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err)
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: create a workspace using the expected template version and no preset
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Nil(t, workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: firstOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that the CLI returns an appropriate error
+	// when a user provides a `--preset` value that does not correspond
+	// to any existing preset in the template version.
+	t.Run("FailsWhenPresetDoesNotExist", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version where the preset defines values for all required parameters
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command with a non-existent preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", "invalid-preset")
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+
+		// Should: fail with an error indicating the preset was not found
+		require.Contains(t, err.Error(), "preset \"invalid-preset\" not found")
+	})
+
+	// This test verifies that when the user provides `--preset default`,
+	// the CLI selects the preset marked as the default in the template version.
+	// The workspace should be created using that default preset's parameters.
+	t.Run("PresetFlagDefault", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version with a default preset
+		preset := proto.Preset{
+			Name:    "preset-test",
+			Default: true,
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command with the default preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", cli.DefaultPresetName)
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err)
+
+		// Should: display the default preset as well as its parameters
+		presetName := fmt.Sprintf("Preset '%s' (default) applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", thirdParameterName, thirdParameterValue))
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		tvPresets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, tvPresets, 1)
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: create a workspace using the expected template version and the preset-defined parameters
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, tvPresets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that when the user provides `--preset default`,
+	// but there is no preset marked as default in the template version,
+	// and a preset literally named "default" exists,
+	// the CLI selects the preset named "default" instead.
+	// The workspace should be created using that preset's parameters.
+	t.Run("PresetFlagDefaultName", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version with a preset named "default"
+		preset := proto.Preset{
+			Name: cli.DefaultPresetName,
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command with the preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", preset.Name)
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err)
+
+		// Should: display the preset as well as its parameters
+		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", thirdParameterName, thirdParameterValue))
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		tvPresets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, tvPresets, 1)
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: create a workspace using the expected template version and the preset-defined parameters
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, tvPresets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that when the user provides `--preset default`
+	// but the template version does not define any default preset,
+	// the CLI returns an appropriate error.
+	t.Run("FailsWhenDefaultPresetIsRequestedButNotDefined", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version where the preset defines values for all required parameters
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command with a non-existent default preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", cli.DefaultPresetName)
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+
+		// Should: fail with an error indicating the default preset was not found
+		require.Contains(t, err.Error(), "preset \"default\" not found")
+	})
+
+	// This test verifies that when both a preset and a user-provided
+	// `--parameter` flag define a value for the same parameter,
+	// the preset's value takes precedence over the user's.
+	//
+	// The preset defines one parameter (A), and two `--parameter` flags provide A and B.
+	// The workspace should be created using:
+	// - the value of parameter A from the preset (overriding the parameter flag's value),
+	// - and the value of parameter B from the parameter flag.
+	t.Run("PresetOverridesParameterFlagValues", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template version with a preset that defines one parameter
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: creating a workspace with a preset and passing overlapping and additional parameters via `--parameter`
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y",
+			"--preset", preset.Name,
+			"--parameter", fmt.Sprintf("%s=%s", firstParameterName, firstOptionalParameterValue),
+			"--parameter", fmt.Sprintf("%s=%s", thirdParameterName, thirdParameterValue))
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err)
+
+		// Should: display the selected preset as well as its parameter
+		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		tvPresets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, tvPresets, 1)
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: include both parameters, one from the preset and one from the `--parameter` flag
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, tvPresets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that when both a preset and a user-provided
+	// `--rich-parameter-file` define a value for the same parameter,
+	// the preset's value takes precedence over the one in the file.
+	//
+	// The preset defines one parameter (A), and the parameter file provides two parameters (A and B).
+	// The workspace should be created using:
+	// - the value of parameter A from the preset (overriding the file's value),
+	// - and the value of parameter B from the file.
+	t.Run("PresetOverridesParameterFileValues", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template version with a preset that defines one parameter
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: creating a workspace with the preset and passing the second required parameter via `--rich-parameter-file`
+		workspaceName := "my-workspace"
+		tempDir := t.TempDir()
+		removeTmpDirUntilSuccessAfterTest(t, tempDir)
+		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
+		_, _ = parameterFile.WriteString(
+			firstParameterName + ": " + firstOptionalParameterValue + "\n" +
+				thirdParameterName + ": " + thirdParameterValue)
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y",
+			"--preset", preset.Name,
+			"--rich-parameter-file", parameterFile.Name())
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err)
+
+		// Should: display the selected preset as well as its parameter
+		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		tvPresets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, tvPresets, 1)
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: include both parameters, one from the preset and one from the `--rich-parameter-file` flag
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, tvPresets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that when a preset provides only some parameters,
+	// and the remaining ones are not provided via flags,
+	// the CLI prompts the user for input to fill in the missing parameters.
+	t.Run("PromptsForMissingParametersWhenPresetIsIncomplete", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template and a template version where the preset defines values for all required parameters
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: running the create command with the specified preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "--preset", preset.Name)
+		clitest.SetupConfig(t, member, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t).Attach(inv)
+		go func() {
+			defer close(doneChan)
+			err := inv.Run()
+			assert.NoError(t, err)
+		}()
+
+		// Should: display the selected preset as well as its parameters
+		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+
+		// Should: prompt for the missing parameter
+		pty.ExpectMatch(thirdParameterDescription)
+		pty.WriteLine(thirdParameterValue)
+		pty.ExpectMatch("Confirm create?")
+		pty.WriteLine("yes")
+
+		<-doneChan
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		tvPresets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, tvPresets, 1)
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+
+		// Should: create a workspace using the expected template version and the preset-defined parameters
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, tvPresets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
 	})
 }
 

--- a/cli/parameter.go
+++ b/cli/parameter.go
@@ -100,6 +100,14 @@ func (wpf *workspaceParameterFlags) alwaysPrompt() serpent.Option {
 	}
 }
 
+func presetParameterAsWorkspaceBuildParameters(presetParameters []codersdk.PresetParameter) ([]codersdk.WorkspaceBuildParameter, error) {
+	var params []codersdk.WorkspaceBuildParameter
+	for _, parameter := range presetParameters {
+		params = append(params, codersdk.WorkspaceBuildParameter(parameter))
+	}
+	return params, nil
+}
+
 func asWorkspaceBuildParameters(nameValuePairs []string) ([]codersdk.WorkspaceBuildParameter, error) {
 	var params []codersdk.WorkspaceBuildParameter
 	for _, nameValue := range nameValuePairs {

--- a/cli/templateversionpresets.go
+++ b/cli/templateversionpresets.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) templateVersionPresets() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:     "presets",
+		Short:   "Manage presets of the specified template version",
+		Aliases: []string{"preset"},
+		Long: FormatExamples(
+			Example{
+				Description: "List presets of a specific template version",
+				Command:     "coder templates versions presets list my-template my-template-version",
+			},
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Children: []*serpent.Command{
+			r.templateVersionPresetsList(),
+		},
+	}
+
+	return cmd
+}
+
+func (r *RootCmd) templateVersionPresetsList() *serpent.Command {
+	defaultColumns := []string{
+		"name",
+		"parameters",
+		"default",
+		"prebuilds",
+	}
+	formatter := cliui.NewOutputFormatter(
+		cliui.TableFormat([]templateVersionPresetRow{}, defaultColumns),
+		cliui.JSONFormat(),
+	)
+	client := new(codersdk.Client)
+	orgContext := NewOrganizationContext()
+
+	cmd := &serpent.Command{
+		Use: "list <template> <version>",
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(2),
+			r.InitClient(client),
+		),
+		Short:   "List all the presets of the specified template version",
+		Options: serpent.OptionSet{},
+		Handler: func(inv *serpent.Invocation) error {
+			organization, err := orgContext.Selected(inv, client)
+			if err != nil {
+				return xerrors.Errorf("get current organization: %w", err)
+			}
+
+			template, err := client.TemplateByName(inv.Context(), organization.ID, inv.Args[0])
+			if err != nil {
+				return xerrors.Errorf("get template by name: %w", err)
+			}
+
+			version, err := client.TemplateVersionByName(inv.Context(), template.ID, inv.Args[1])
+			if err != nil {
+				return xerrors.Errorf("get template version by name: %w", err)
+			}
+
+			presets, err := client.TemplateVersionPresets(inv.Context(), version.ID)
+			if err != nil {
+				return xerrors.Errorf("get template versions presets by template version: %w", err)
+			}
+
+			if len(presets) == 0 {
+				return xerrors.Errorf("no presets found for template %q and template-version %q", template.Name, version.Name)
+			}
+
+			rows := templateVersionPresetsToRows(presets...)
+			out, err := formatter.Format(inv.Context(), rows)
+			if err != nil {
+				return xerrors.Errorf("render table: %w", err)
+			}
+
+			_, err = fmt.Fprintln(inv.Stdout, out)
+			return err
+		},
+	}
+
+	orgContext.AttachOptions(cmd)
+	formatter.AttachOptions(&cmd.Options)
+	return cmd
+}
+
+type templateVersionPresetRow struct {
+	// For json format:
+	TemplateVersionPreset codersdk.Preset `table:"-"`
+
+	// For table format:
+	Name       string `json:"-" table:"name,default_sort"`
+	Parameters string `json:"-" table:"parameters"`
+	Default    bool   `json:"-" table:"default"`
+	Prebuilds  string `json:"-" table:"prebuilds"`
+}
+
+func formatPresetParameters(params []codersdk.PresetParameter) string {
+	var paramsStr []string
+	for _, p := range params {
+		paramsStr = append(paramsStr, fmt.Sprintf("%s=%s", p.Name, p.Value))
+	}
+	return strings.Join(paramsStr, ",")
+}
+
+// templateVersionPresetsToRows converts a list of presets to a list of rows
+// for outputting.
+func templateVersionPresetsToRows(presets ...codersdk.Preset) []templateVersionPresetRow {
+	rows := make([]templateVersionPresetRow, len(presets))
+	for i, preset := range presets {
+		prebuilds := "-"
+		if preset.Prebuilds != nil {
+			prebuilds = strconv.Itoa(*preset.Prebuilds)
+		}
+		rows[i] = templateVersionPresetRow{
+			Name:       preset.Name,
+			Parameters: formatPresetParameters(preset.Parameters),
+			Default:    preset.Default,
+			Prebuilds:  prebuilds,
+		}
+	}
+
+	return rows
+}

--- a/cli/templateversionpresets_test.go
+++ b/cli/templateversionpresets_test.go
@@ -1,0 +1,137 @@
+package cli_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk/proto"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/pty/ptytest"
+)
+
+func TestTemplateVersionPresets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ListPresets", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template version that includes presets
+		presets := []*proto.Preset{
+			{
+				Name: "preset-multiple-params",
+				Parameters: []*proto.PresetParameter{
+					{
+						Name:  "k1",
+						Value: "v1",
+					}, {
+						Name:  "k2",
+						Value: "v2",
+					},
+				},
+			},
+			{
+				Name:    "preset-default",
+				Default: true,
+				Parameters: []*proto.PresetParameter{
+					{
+						Name:  "k1",
+						Value: "v2",
+					},
+				},
+				Prebuild: &proto.Prebuild{
+					Instances: 0,
+				},
+			},
+			{
+				Name:       "preset-prebuilds",
+				Parameters: []*proto.PresetParameter{},
+				Prebuild: &proto.Prebuild{
+					Instances: 2,
+				},
+			},
+		}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, templateWithPresets(presets))
+		_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: listing presets for that template and template version
+		inv, root := clitest.New(t, "templates", "versions", "presets", "list", template.Name, version.Name)
+		clitest.SetupConfig(t, member, root)
+
+		pty := ptytest.New(t).Attach(inv)
+		doneChan := make(chan struct{})
+		var runErr error
+		go func() {
+			defer close(doneChan)
+			runErr = inv.Run()
+		}()
+
+		<-doneChan
+		require.NoError(t, runErr)
+
+		// Should: return the presets sorted by name
+		pty.ExpectRegexMatch(`preset-default\s+k1=v2\s+true\s+0`)
+		// The parameter order is not guaranteed in the output, so we match both possible orders
+		pty.ExpectRegexMatch(`preset-multiple-params\s+(k1=v1,k2=v2)|(k2=v2,k1=v1)\s+false\s+-`)
+		pty.ExpectRegexMatch(`preset-prebuilds\s+\s+false\s+2`)
+	})
+
+	t.Run("NoPresets", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+		// Given: a template version without presets
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, templateWithPresets([]*proto.Preset{}))
+		_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// When: listing presets for that template and template version
+		inv, root := clitest.New(t, "templates", "versions", "presets", "list", template.Name, version.Name)
+		clitest.SetupConfig(t, member, root)
+
+		ptytest.New(t).Attach(inv)
+		doneChan := make(chan struct{})
+		var runErr error
+		go func() {
+			defer close(doneChan)
+			runErr = inv.Run()
+		}()
+		<-doneChan
+
+		// Should return an error when no presets are found for the given template and version.
+		require.Error(t, runErr)
+		expectedErr := fmt.Sprintf(
+			"no presets found for template %q and template-version %q",
+			template.Name,
+			version.Name,
+		)
+		require.Contains(t, runErr.Error(), expectedErr)
+	})
+}
+
+func templateWithPresets(presets []*proto.Preset) *echo.Responses {
+	return &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Response{
+			{
+				Type: &proto.Response_Plan{
+					Plan: &proto.PlanComplete{
+						Presets: presets,
+					},
+				},
+			},
+		},
+	}
+}

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -33,6 +33,7 @@ func (r *RootCmd) templateVersions() *serpent.Command {
 			r.archiveTemplateVersion(),
 			r.unarchiveTemplateVersion(),
 			r.templateVersionsPromote(),
+			r.templateVersionPresets(),
 		},
 	}
 

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -26,6 +26,10 @@ OPTIONS:
       --parameter-default string-array, $CODER_RICH_PARAMETER_DEFAULT
           Rich parameter default values in the format "name=value".
 
+      --preset string, $CODER_PRESET_NAME
+          Specify a template version preset name. Use 'default' to apply the
+          default preset defined in the template version, if available.
+
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the
           template. The file should be in YAML format, containing key-value

--- a/cli/testdata/coder_templates_versions_--help.golden
+++ b/cli/testdata/coder_templates_versions_--help.golden
@@ -14,6 +14,7 @@ USAGE:
 SUBCOMMANDS:
     archive      Archive a template version(s).
     list         List all the versions of the specified template
+    presets      Manage presets of the specified template version
     promote      Promote a template version to active.
     unarchive    Unarchive a template version(s).
 

--- a/cli/testdata/coder_templates_versions_presets_--help.golden
+++ b/cli/testdata/coder_templates_versions_presets_--help.golden
@@ -1,0 +1,18 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder templates versions presets
+
+  Manage presets of the specified template version
+
+  Aliases: preset
+
+    - List presets of a specific template version:
+  
+       $ coder templates versions presets list my-template my-template-version
+
+SUBCOMMANDS:
+    list    List all the presets of the specified template version
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_templates_versions_presets_--help_--help.golden
+++ b/cli/testdata/coder_templates_versions_presets_--help_--help.golden
@@ -1,0 +1,18 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder templates versions presets
+
+  Manage presets of the specified template version
+
+  Aliases: preset
+
+    - List presets of a specific template version:
+  
+       $ coder templates versions presets list my-template my-template-version
+
+SUBCOMMANDS:
+    list    List all the presets of the specified template version
+
+———
+Run `coder --help` for a list of global options.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14837,6 +14837,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.PresetParameter"
                     }
+                },
+                "prebuilds": {
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13439,6 +13439,9 @@
 					"items": {
 						"$ref": "#/definitions/codersdk.PresetParameter"
 					}
+				},
+				"prebuilds": {
+					"type": "integer"
 				}
 			}
 		},

--- a/coderd/presets.go
+++ b/coderd/presets.go
@@ -1,6 +1,7 @@
 package coderd
 
 import (
+	"database/sql"
 	"net/http"
 
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -38,12 +39,21 @@ func (api *API) templateVersionPresets(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	getPrebuildInstances := func(desiredInstances sql.NullInt32) *int {
+		if desiredInstances.Valid {
+			value := int(desiredInstances.Int32)
+			return &value
+		}
+		return nil
+	}
+
 	var res []codersdk.Preset
 	for _, preset := range presets {
 		sdkPreset := codersdk.Preset{
-			ID:      preset.ID,
-			Name:    preset.Name,
-			Default: preset.IsDefault,
+			ID:        preset.ID,
+			Name:      preset.Name,
+			Default:   preset.IsDefault,
+			Prebuilds: getPrebuildInstances(preset.DesiredInstances),
 		}
 		for _, presetParam := range presetParams {
 			if presetParam.TemplateVersionPresetID != preset.ID {

--- a/codersdk/presets.go
+++ b/codersdk/presets.go
@@ -15,6 +15,7 @@ type Preset struct {
 	Name       string
 	Parameters []PresetParameter
 	Default    bool
+	Prebuilds  *int
 }
 
 type PresetParameter struct {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1665,6 +1665,16 @@
 							"path": "reference/cli/templates_versions_list.md"
 						},
 						{
+							"title": "templates versions presets",
+							"description": "Manage presets of the specified template version",
+							"path": "reference/cli/templates_versions_presets.md"
+						},
+						{
+							"title": "templates versions presets list",
+							"description": "List all the presets of the specified template version",
+							"path": "reference/cli/templates_versions_presets_list.md"
+						},
+						{
 							"title": "templates versions promote",
 							"description": "Promote a template version to active.",
 							"path": "reference/cli/templates_versions_promote.md"

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5468,7 +5468,8 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
       "name": "string",
       "value": "string"
     }
-  ]
+  ],
+  "prebuilds": 0
 }
 ```
 
@@ -5480,6 +5481,7 @@ Git clone makes use of this by parsing the URL from: 'Username for "https://gith
 | `id`         | string                                                        | false    |              |             |
 | `name`       | string                                                        | false    |              |             |
 | `parameters` | array of [codersdk.PresetParameter](#codersdkpresetparameter) | false    |              |             |
+| `prebuilds`  | integer                                                       | false    |              |             |
 
 ## codersdk.PresetParameter
 

--- a/docs/reference/api/templates.md
+++ b/docs/reference/api/templates.md
@@ -2921,7 +2921,8 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/p
         "name": "string",
         "value": "string"
       }
-    ]
+    ],
+    "prebuilds": 0
   }
 ]
 ```
@@ -2945,6 +2946,7 @@ Status Code **200**
 | `» parameters` | array   | false    |              |             |
 | `»» name`      | string  | false    |              |             |
 | `»» value`     | string  | false    |              |             |
+| `» prebuilds`  | integer | false    |              |             |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/cli/create.md
+++ b/docs/reference/cli/create.md
@@ -37,6 +37,15 @@ Specify a template name.
 
 Specify a template version name.
 
+### --preset
+
+|             |                                 |
+|-------------|---------------------------------|
+| Type        | <code>string</code>             |
+| Environment | <code>$CODER_PRESET_NAME</code> |
+
+Specify a template version preset name. Use 'default' to apply the default preset defined in the template version, if available.
+
 ### --start-at
 
 |             |                                        |

--- a/docs/reference/cli/templates_versions.md
+++ b/docs/reference/cli/templates_versions.md
@@ -23,9 +23,10 @@ coder templates versions
 
 ## Subcommands
 
-| Name                                                        | Purpose                                         |
-|-------------------------------------------------------------|-------------------------------------------------|
-| [<code>list</code>](./templates_versions_list.md)           | List all the versions of the specified template |
-| [<code>archive</code>](./templates_versions_archive.md)     | Archive a template version(s).                  |
-| [<code>unarchive</code>](./templates_versions_unarchive.md) | Unarchive a template version(s).                |
-| [<code>promote</code>](./templates_versions_promote.md)     | Promote a template version to active.           |
+| Name                                                        | Purpose                                          |
+|-------------------------------------------------------------|--------------------------------------------------|
+| [<code>list</code>](./templates_versions_list.md)           | List all the versions of the specified template  |
+| [<code>archive</code>](./templates_versions_archive.md)     | Archive a template version(s).                   |
+| [<code>unarchive</code>](./templates_versions_unarchive.md) | Unarchive a template version(s).                 |
+| [<code>promote</code>](./templates_versions_promote.md)     | Promote a template version to active.            |
+| [<code>presets</code>](./templates_versions_presets.md)     | Manage presets of the specified template version |

--- a/docs/reference/cli/templates_versions_presets.md
+++ b/docs/reference/cli/templates_versions_presets.md
@@ -1,0 +1,28 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+# templates versions presets
+
+Manage presets of the specified template version
+
+Aliases:
+
+* preset
+
+## Usage
+
+```console
+coder templates versions presets
+```
+
+## Description
+
+```console
+  - List presets of a specific template version:
+
+     $ coder templates versions presets list my-template my-template-version
+```
+
+## Subcommands
+
+| Name                                                      | Purpose                                                |
+|-----------------------------------------------------------|--------------------------------------------------------|
+| [<code>list</code>](./templates_versions_presets_list.md) | List all the presets of the specified template version |

--- a/docs/reference/cli/templates_versions_presets_list.md
+++ b/docs/reference/cli/templates_versions_presets_list.md
@@ -1,0 +1,39 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+# templates versions presets list
+
+List all the presets of the specified template version
+
+## Usage
+
+```console
+coder templates versions presets list [flags] <template> <version>
+```
+
+## Options
+
+### -O, --org
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>string</code>              |
+| Environment | <code>$CODER_ORGANIZATION</code> |
+
+Select which organization (uuid or name) to use.
+
+### -c, --column
+
+|         |                                                     |
+|---------|-----------------------------------------------------|
+| Type    | <code>[name\|parameters\|default\|prebuilds]</code> |
+| Default | <code>name,parameters,default,prebuilds</code>      |
+
+Columns to display in table output.
+
+### -o, --output
+
+|         |                          |
+|---------|--------------------------|
+| Type    | <code>table\|json</code> |
+| Default | <code>table</code>       |
+
+Output format.

--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -2,13 +2,27 @@ package cli_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/files"
+	"github.com/coder/coder/v2/coderd/notifications"
+	agplprebuilds "github.com/coder/coder/v2/coderd/prebuilds"
+	"github.com/coder/coder/v2/enterprise/coderd/prebuilds"
+	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk/proto"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -201,4 +215,357 @@ func TestEnterpriseCreate(t *testing.T) {
 		// The error message should indicate the flag to fix the issue.
 		require.ErrorContains(t, err, fmt.Sprintf("--org=%q", "coder"))
 	})
+}
+
+func TestEnterpriseCreateWithPreset(t *testing.T) {
+	t.Parallel()
+
+	const (
+		firstParameterName        = "first_parameter"
+		firstParameterDisplayName = "First Parameter"
+		firstParameterDescription = "This is the first parameter"
+		firstParameterValue       = "1"
+
+		firstOptionalParameterName         = "first_optional_parameter"
+		firstOptionParameterDescription    = "This is the first optional parameter"
+		firstOptionalParameterValue        = "1"
+		secondOptionalParameterName        = "second_optional_parameter"
+		secondOptionalParameterDescription = "This is the second optional parameter"
+		secondOptionalParameterValue       = "2"
+
+		thirdParameterName        = "third_parameter"
+		thirdParameterDescription = "This is the third parameter"
+		thirdParameterValue       = "3"
+	)
+
+	echoResponses := func(presets ...*proto.Preset) *echo.Responses {
+		return prepareEchoResponses([]*proto.RichParameter{
+			{
+				Name:         firstParameterName,
+				DisplayName:  firstParameterDisplayName,
+				Description:  firstParameterDescription,
+				Mutable:      true,
+				DefaultValue: firstParameterValue,
+				Options: []*proto.RichParameterOption{
+					{
+						Name:        firstOptionalParameterName,
+						Description: firstOptionParameterDescription,
+						Value:       firstOptionalParameterValue,
+					},
+					{
+						Name:        secondOptionalParameterName,
+						Description: secondOptionalParameterDescription,
+						Value:       secondOptionalParameterValue,
+					},
+				},
+			},
+			{
+				Name:         thirdParameterName,
+				Description:  thirdParameterDescription,
+				DefaultValue: thirdParameterValue,
+				Mutable:      true,
+			},
+		}, presets...)
+	}
+
+	runReconciliationLoop := func(
+		t *testing.T,
+		ctx context.Context,
+		db database.Store,
+		reconciler *prebuilds.StoreReconciler,
+		presets []codersdk.Preset,
+	) {
+		t.Helper()
+
+		state, err := reconciler.SnapshotState(ctx, db)
+		require.NoError(t, err)
+		ps, err := state.FilterByPreset(presets[0].ID)
+		require.NoError(t, err)
+		require.NotNil(t, ps)
+		actions, err := reconciler.CalculateActions(ctx, *ps)
+		require.NoError(t, err)
+		require.NotNil(t, actions)
+		require.NoError(t, reconciler.ReconcilePreset(ctx, *ps))
+	}
+
+	getRunningPrebuilds := func(
+		t *testing.T,
+		ctx context.Context,
+		db database.Store,
+		prebuildInstances int,
+	) []database.GetRunningPrebuiltWorkspacesRow {
+		t.Helper()
+
+		var runningPrebuilds []database.GetRunningPrebuiltWorkspacesRow
+		testutil.Eventually(ctx, t, func(context.Context) bool {
+			rows, err := db.GetRunningPrebuiltWorkspaces(ctx)
+			if err != nil {
+				return false
+			}
+
+			for _, row := range rows {
+				runningPrebuilds = append(runningPrebuilds, row)
+
+				agents, err := db.GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx, row.ID)
+				if err != nil || len(agents) == 0 {
+					return false
+				}
+
+				for _, agent := range agents {
+					err = db.UpdateWorkspaceAgentLifecycleStateByID(ctx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{
+						ID:             agent.ID,
+						LifecycleState: database.WorkspaceAgentLifecycleStateReady,
+						StartedAt:      sql.NullTime{Time: time.Now().Add(time.Hour), Valid: true},
+						ReadyAt:        sql.NullTime{Time: time.Now().Add(-1 * time.Hour), Valid: true},
+					})
+					if err != nil {
+						return false
+					}
+				}
+			}
+
+			t.Logf("found %d running prebuilds so far, want %d", len(runningPrebuilds), prebuildInstances)
+			return len(runningPrebuilds) == prebuildInstances
+		}, testutil.IntervalSlow, "prebuilds not running")
+
+		return runningPrebuilds
+	}
+
+	// This test verifies that when the selected preset has running prebuilds,
+	// one of those prebuilds is claimed for the user upon workspace creation.
+	t.Run("PresetFlagClaimsPrebuiltWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		// Setup
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+		db, pb := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		client, _, api, owner := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				Database:                 db,
+				Pubsub:                   pb,
+				IncludeProvisionerDaemon: true,
+			},
+		})
+
+		// Setup Prebuild reconciler
+		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
+		reconciler := prebuilds.NewStoreReconciler(
+			db, pb, cache,
+			codersdk.PrebuildsConfig{},
+			testutil.Logger(t),
+			quartz.NewMock(t),
+			prometheus.NewRegistry(),
+			notifications.NewNoopEnqueuer(),
+		)
+		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
+		api.AGPL.PrebuildsClaimer.Store(&claimer)
+
+		// Given: a template and a template version where the preset defines values for all required parameters,
+		// and is configured to have 1 prebuild instance
+		prebuildInstances := int32(1)
+		preset := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: secondOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+			Prebuild: &proto.Prebuild{
+				Instances: prebuildInstances,
+			},
+		}
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&preset))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+		presets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, presets, 1)
+		require.Equal(t, preset.Name, presets[0].Name)
+
+		// Given: Reconciliation loop runs and starts prebuilt workspaces
+		runReconciliationLoop(t, ctx, db, reconciler, presets)
+		runningPrebuilds := getRunningPrebuilds(t, ctx, db, int(prebuildInstances))
+		require.Len(t, runningPrebuilds, int(prebuildInstances))
+		require.Equal(t, presets[0].ID, runningPrebuilds[0].CurrentPresetID.UUID)
+
+		// Given: a running prebuilt workspace, ready to be claimed
+		prebuild := coderdtest.MustWorkspace(t, client, runningPrebuilds[0].ID)
+		require.Equal(t, codersdk.WorkspaceTransitionStart, prebuild.LatestBuild.Transition)
+		require.Equal(t, template.ID, prebuild.TemplateID)
+		require.Equal(t, version.ID, prebuild.TemplateActiveVersionID)
+		require.Equal(t, presets[0].ID, *prebuild.LatestBuild.TemplateVersionPresetID)
+
+		// When: running the create command with the specified preset
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y", "--preset", preset.Name)
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err = inv.Run()
+		require.NoError(t, err)
+
+		// Should: display the selected preset as well as its parameters
+		presetName := fmt.Sprintf("Preset '%s' applied:", preset.Name)
+		pty.ExpectMatch(presetName)
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", firstParameterName, secondOptionalParameterValue))
+		pty.ExpectMatch(fmt.Sprintf("%s: '%s'", thirdParameterName, thirdParameterValue))
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		// Should: create the user's workspace by claiming the existing prebuilt workspace
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+		require.Equal(t, prebuild.ID, workspaces.Workspaces[0].ID)
+
+		// Should: create a workspace using the expected template version and the preset-defined parameters
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Equal(t, presets[0].ID, *workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: secondOptionalParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+
+	// This test verifies that when no preset is selected, no prebuilt workspace
+	// is claimed, and instead a new regular workspace is created.
+	t.Run("NoPresetFlagDoesNotClaimPrebuiltWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		// Setup
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+		db, pb := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		client, _, api, owner := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				Database:                 db,
+				Pubsub:                   pb,
+				IncludeProvisionerDaemon: true,
+			},
+		})
+
+		// Setup Prebuild reconciler
+		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
+		reconciler := prebuilds.NewStoreReconciler(
+			db, pb, cache,
+			codersdk.PrebuildsConfig{},
+			testutil.Logger(t),
+			quartz.NewMock(t),
+			prometheus.NewRegistry(),
+			notifications.NewNoopEnqueuer(),
+		)
+		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
+		api.AGPL.PrebuildsClaimer.Store(&claimer)
+
+		// Given: a template and a template version where the preset defines values for all required parameters,
+		// and is configured to have 1 prebuild instance
+		prebuildInstances := int32(1)
+		presetWithPrebuild := proto.Preset{
+			Name: "preset-test",
+			Parameters: []*proto.PresetParameter{
+				{Name: firstParameterName, Value: firstOptionalParameterValue},
+				{Name: thirdParameterName, Value: thirdParameterValue},
+			},
+			Prebuild: &proto.Prebuild{
+				Instances: prebuildInstances,
+			},
+		}
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses(&presetWithPrebuild))
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+		presets, err := client.TemplateVersionPresets(ctx, version.ID)
+		require.NoError(t, err)
+		require.Len(t, presets, 1)
+
+		// Given: Reconciliation loop runs and starts prebuilt workspaces
+		runReconciliationLoop(t, ctx, db, reconciler, presets)
+		runningPrebuilds := getRunningPrebuilds(t, ctx, db, int(prebuildInstances))
+		require.Len(t, runningPrebuilds, int(prebuildInstances))
+		require.Equal(t, presets[0].ID, runningPrebuilds[0].CurrentPresetID.UUID)
+
+		// Given: a running prebuilt workspace, ready to be claimed
+		prebuild := coderdtest.MustWorkspace(t, client, runningPrebuilds[0].ID)
+		require.Equal(t, codersdk.WorkspaceTransitionStart, prebuild.LatestBuild.Transition)
+		require.Equal(t, template.ID, prebuild.TemplateID)
+		require.Equal(t, version.ID, prebuild.TemplateActiveVersionID)
+		require.Equal(t, presets[0].ID, *prebuild.LatestBuild.TemplateVersionPresetID)
+
+		// When: running the create command without a preset flag
+		workspaceName := "my-workspace"
+		inv, root := clitest.New(t, "create", workspaceName, "--template", template.Name, "-y",
+			"--parameter", fmt.Sprintf("%s=%s", firstParameterName, firstParameterValue),
+			"--parameter", fmt.Sprintf("%s=%s", thirdParameterName, thirdParameterValue))
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err = inv.Run()
+		require.NoError(t, err)
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		// Should: create a new user's workspace without claiming the existing prebuilt workspace
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: workspaceName,
+		})
+		require.NoError(t, err)
+		require.Len(t, workspaces.Workspaces, 1)
+		require.NotEqual(t, prebuild.ID, workspaces.Workspaces[0].ID)
+
+		// Should: create a workspace using the expected template version and the specified parameters
+		workspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, workspaceLatestBuild.TemplateVersionID)
+		require.Nil(t, workspaceLatestBuild.TemplateVersionPresetID)
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, workspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 2)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: firstParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: thirdParameterName, Value: thirdParameterValue})
+	})
+}
+
+func prepareEchoResponses(parameters []*proto.RichParameter, presets ...*proto.Preset) *echo.Responses {
+	return &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Response{
+			{
+				Type: &proto.Response_Plan{
+					Plan: &proto.PlanComplete{
+						Parameters: parameters,
+						Presets:    presets,
+					},
+				},
+			},
+		},
+		ProvisionApply: []*proto.Response{
+			{
+				Type: &proto.Response_Apply{
+					Apply: &proto.ApplyComplete{
+						Resources: []*proto.Resource{
+							{
+								Type: "compute",
+								Name: "main",
+								Agents: []*proto.Agent{
+									{
+										Name:            "smith",
+										OperatingSystem: "linux",
+										Architecture:    "i386",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1962,6 +1962,7 @@ export interface Preset {
 	readonly Name: string;
 	readonly Parameters: readonly PresetParameter[];
 	readonly Default: boolean;
+	readonly Prebuilds: number | null;
 }
 
 // From codersdk/presets.go

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -132,6 +132,7 @@ export const PresetsButNoneSelected: Story = {
 						Value: "preset 1 override",
 					},
 				],
+				Prebuilds: null,
 			},
 			{
 				ID: "preset-2",
@@ -143,6 +144,7 @@ export const PresetsButNoneSelected: Story = {
 						Value: "42",
 					},
 				],
+				Prebuilds: null,
 			},
 		],
 		parameters: [
@@ -256,6 +258,7 @@ export const PresetsWithDefault: Story = {
 						Value: "preset 1 override",
 					},
 				],
+				Prebuilds: null,
 			},
 			{
 				ID: "preset-2",
@@ -267,6 +270,7 @@ export const PresetsWithDefault: Story = {
 						Value: "150189",
 					},
 				],
+				Prebuilds: null,
 			},
 		],
 		parameters: [


### PR DESCRIPTION
## Description 

This PR introduces:

- A new `list presets` command to display presets correspondent to a template and template version.
- A `--preset` flag for the `create` command to allow users to apply a predefined preset to their workspace build.

## Changes

- The `list presets` command queries the available presets associated with a template and version, and outputs them in a readable format.
- The `--preset` flag on the `create` command integrates with the parameter resolution logic and takes precedence over other sources (e.g., CLI/env vars, last build, etc.).
- Added internal logic to ensure that preset parameters override parameters values during resolution.
- Updated tests and added new ones to cover these flows.

## Help commands

* `coder templates versions presets list`

```
> coder templates versions presets list --help

USAGE:
  coder templates versions presets list [flags] <template> <version>

  List all the presets of the specified template version

OPTIONS:
  -O, --org string, $CODER_ORGANIZATION
          Select which organization (uuid or name) to use.

  -c, --column [name|parameters|default|prebuilds] (default: name,parameters,default,prebuilds)
          Columns to display in table output.

  -o, --output table|json (default: table)
          Output format.
```

* `coder create`

```
> coder create --help

USAGE:
  coder create [flags] [workspace]

  Create a workspace

    - Create a workspace for another user (if you have permission):

        $ coder create <username>/<workspace_name>

OPTIONS:
      (...)

      --preset string, $CODER_PRESET_NAME
          Specify a template version preset name. Use 'default' to apply the default preset defined in the template version, if available.

      (...)

  -y, --yes bool
          Bypass prompts.