### PR TITLE
docs: hotfix mainline version number in docs/install/releases to 2.24.2

### DIFF
--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -10,7 +10,7 @@ deployment.
 ## Release channels
 
 We support two release channels:
-[mainline](https://github.com/coder/coder/releases/tag/v2.20.0) for the bleeding
+[mainline](https://github.com/coder/coder/releases/tag/v2.24.2) for the bleeding
 edge version of Coder and
 [stable](https://github.com/coder/coder/releases/latest) for those with lower
 tolerance for fault. We field our mainline releases publicly for one month


### PR DESCRIPTION
hotfix

[preview](https://coder.com/docs/@2-24-mainline/install/releases)