### PR TITLE
fix: use client preferred URL for the default DERP

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -98,7 +98,7 @@ type Client interface {
 	ConnectRPC26(ctx context.Context) (
 		proto.DRPCAgentClient26, tailnetproto.DRPCTailnetClient26, error,
 	)
-	RewriteDERPMap(derpMap *tailcfg.DERPMap)
+	tailnet.DERPMapRewriter
 }
 
 type Agent interface {

--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -98,7 +98,7 @@ func NewServerTailnet(
 	controller := tailnet.NewController(logger, dialer)
 	// it's important to set the DERPRegionDialer above _before_ we set the DERP map so that if
 	// there is an embedded relay, we use the local in-memory dialer.
-	controller.DERPCtrl = tailnet.NewBasicDERPController(logger, conn)
+	controller.DERPCtrl = tailnet.NewBasicDERPController(logger, nil, conn)
 	coordCtrl := NewMultiAgentController(serverCtx, logger, tracer, conn)
 	controller.CoordCtrl = coordCtrl
 	// TODO: support controller.TelemetryCtrl

--- a/codersdk/agentsdk/agentsdk_test.go
+++ b/codersdk/agentsdk/agentsdk_test.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -119,4 +121,32 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		require.Nil(t, sentEvent)
 		require.ErrorIs(t, receiveErr, context.Canceled)
 	})
+}
+
+func TestRewriteDERPMap(t *testing.T) {
+	t.Parallel()
+	// This test ensures that RewriteDERPMap mutates built-in DERPs with the
+	// client access URL.
+	dm := &tailcfg.DERPMap{
+		Regions: map[int]*tailcfg.DERPRegion{
+			1: {
+				EmbeddedRelay: true,
+				RegionID:      1,
+				Nodes: []*tailcfg.DERPNode{{
+					HostName: "bananas.org",
+					DERPPort: 1,
+				}},
+			},
+		},
+	}
+	parsed, err := url.Parse("https://coconuts.org:44558")
+	require.NoError(t, err)
+	client := agentsdk.New(parsed)
+	client.RewriteDERPMap(dm)
+	region := dm.Regions[1]
+	require.True(t, region.EmbeddedRelay)
+	require.Len(t, region.Nodes, 1)
+	node := region.Nodes[0]
+	require.Equal(t, "coconuts.org", node.HostName)
+	require.Equal(t, 44558, node.DERPPort)
 }

--- a/codersdk/workspacesdk/workspacesdk_test.go
+++ b/codersdk/workspacesdk/workspacesdk_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/testutil"
@@ -43,7 +42,7 @@ func TestWorkspaceRewriteDERPMap(t *testing.T) {
 	}
 	parsed, err := url.Parse("https://coconuts.org:44558")
 	require.NoError(t, err)
-	client := agentsdk.New(parsed)
+	client := workspacesdk.New(codersdk.New(parsed))
 	client.RewriteDERPMap(dm)
 	region := dm.Regions[1]
 	require.True(t, region.EmbeddedRelay)

--- a/tailnet/derp.go
+++ b/tailnet/derp.go
@@ -5,10 +5,15 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
 	"tailscale.com/derp"
+	"tailscale.com/tailcfg"
+
+	"cdr.dev/slog"
 
 	"github.com/coder/websocket"
 )
@@ -69,4 +74,55 @@ func WithWebsocketSupport(s *derp.Server, base http.Handler) (http.Handler, func
 			waitGroup.Wait()
 			mu.Unlock()
 		}
+}
+
+type DERPMapRewriter interface {
+	RewriteDERPMap(derpMap *tailcfg.DERPMap)
+}
+
+// RewriteDERPMapDefaultRelay rewrites the DERP map to use the given access URL
+// as the "embedded relay" access URL. The passed derp map is modified in place.
+//
+// This is used by clients and agents to rewrite the default DERP relay to use
+// their preferred access URL. Both of these clients can use a different access
+// URL than the deployment has configured (with `--access-url`), so we need to
+// accommodate that and respect the locally configured access URL.
+//
+// Note: passed context is only used for logging.
+func RewriteDERPMapDefaultRelay(ctx context.Context, logger slog.Logger, derpMap *tailcfg.DERPMap, accessURL *url.URL) {
+	if derpMap == nil {
+		return
+	}
+
+	accessPort := 80
+	if accessURL.Scheme == "https" {
+		accessPort = 443
+	}
+	if accessURL.Port() != "" {
+		parsedAccessPort, err := strconv.Atoi(accessURL.Port())
+		if err != nil {
+			// This should never happen because URL.Port() returns the empty string
+			// if the port is not valid.
+			logger.Critical(ctx, "failed to parse URL port, using default port",
+				slog.F("port", accessURL.Port()),
+				slog.F("access_url", accessURL))
+		} else {
+			accessPort = parsedAccessPort
+		}
+	}
+
+	for _, region := range derpMap.Regions {
+		if !region.EmbeddedRelay {
+			continue
+		}
+
+		for _, node := range region.Nodes {
+			if node.STUNOnly {
+				continue
+			}
+			node.HostName = accessURL.Hostname()
+			node.DERPPort = accessPort
+			node.ForceHTTP = accessURL.Scheme == "http"
+		}
+	}
 }

--- a/vpn/client.go
+++ b/vpn/client.go
@@ -78,6 +78,19 @@ type Options struct {
 	UpdateHandler    tailnet.UpdatesHandler
 }
 
+type derpMapRewriter struct {
+	logger    slog.Logger
+	serverURL *url.URL
+}
+
+var _ tailnet.DERPMapRewriter = &derpMapRewriter{}
+
+// RewriteDERPMap implements tailnet.DERPMapRewriter. See
+// tailnet.RewriteDERPMapDefaultRelay for more details on why this is necessary.
+func (d *derpMapRewriter) RewriteDERPMap(derpMap *tailcfg.DERPMap) {
+	tailnet.RewriteDERPMapDefaultRelay(context.Background(), d.logger, derpMap, d.serverURL)
+}
+
 func (*client) NewConn(initCtx context.Context, serverURL *url.URL, token string, options *Options) (vpnC Conn, err error) {
 	if options == nil {
 		options = &Options{}
@@ -135,6 +148,12 @@ func (*client) NewConn(initCtx context.Context, serverURL *url.URL, token string
 		WorkspaceOwnerId: tailnet.UUIDToByteSlice(me.ID),
 	}))
 
+	derpMapRewriter := &derpMapRewriter{
+		logger:    options.Logger,
+		serverURL: serverURL,
+	}
+	derpMapRewriter.RewriteDERPMap(connInfo.DERPMap)
+
 	clonedHeaders := headers.Clone()
 	ip := tailnet.CoderServicePrefix.RandomAddr()
 	conn, err := tailnet.NewConn(&tailnet.Options{
@@ -164,7 +183,7 @@ func (*client) NewConn(initCtx context.Context, serverURL *url.URL, token string
 	coordCtrl := tailnet.NewTunnelSrcCoordController(options.Logger, conn)
 	controller.ResumeTokenCtrl = tailnet.NewBasicResumeTokenController(options.Logger, clk)
 	controller.CoordCtrl = coordCtrl
-	controller.DERPCtrl = tailnet.NewBasicDERPController(options.Logger, conn)
+	controller.DERPCtrl = tailnet.NewBasicDERPController(options.Logger, derpMapRewriter, conn)
 	updatesCtrl := tailnet.NewTunnelAllWorkspaceUpdatesController(
 		options.Logger,
 		coordCtrl,

--- a/vpn/client_test.go
+++ b/vpn/client_test.go
@@ -43,14 +43,19 @@ func TestClient_WorkspaceUpdates(t *testing.T) {
 		hostnames           []string
 	}{
 		{
-			name:                "empty",
-			agentConnectionInfo: workspacesdk.AgentConnectionInfo{},
-			hostnames:           []string{"wrk.coder.", "agnt.wrk.me.coder.", "agnt.wrk.rootbeer.coder."},
+			name: "empty",
+			agentConnectionInfo: workspacesdk.AgentConnectionInfo{
+				DERPMap: &tailcfg.DERPMap{},
+			},
+			hostnames: []string{"wrk.coder.", "agnt.wrk.me.coder.", "agnt.wrk.rootbeer.coder."},
 		},
 		{
-			name:                "suffix",
-			agentConnectionInfo: workspacesdk.AgentConnectionInfo{HostnameSuffix: "float"},
-			hostnames:           []string{"wrk.float.", "agnt.wrk.me.float.", "agnt.wrk.rootbeer.float."},
+			name: "suffix",
+			agentConnectionInfo: workspacesdk.AgentConnectionInfo{
+				HostnameSuffix: "float",
+				DERPMap:        &tailcfg.DERPMap{},
+			},
+			hostnames: []string{"wrk.float.", "agnt.wrk.me.float.", "agnt.wrk.rootbeer.float."},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
The agentsdk currently does a remap of the DERP map to change the EmbeddedRelay node's URL to match the agent's access URL.

This PR makes changes to the `workspacesdk` (used by clients like the CLI) and `vpn` (used by Coder Desktop) to match this behavior.

This enables us the ability to try Coder clients in dogfood over a VPN without changing the global access URL.