### PR TITLE
feat: improve workspace upgrade flow when template parameters change 

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -399,6 +399,7 @@ export class ParameterValidationError extends Error {
 		super("Parameters are not valid for new template version");
 	}
 }
+
 export type GetProvisionerJobsParams = {
 	status?: string;
 	limit?: number;
@@ -2199,9 +2200,9 @@ class ApiMethods {
 			default_value: p.default_value?.valid ? p.default_value.value : "",
 			options: p.options
 				? p.options.map((opt) => ({
-						...opt,
-						value: opt.value?.valid ? opt.value.value : "",
-					}))
+					...opt,
+					value: opt.value?.valid ? opt.value.value : "",
+				}))
 				: [],
 		}));
 	};
@@ -2284,6 +2285,8 @@ class ApiMethods {
 					rich_parameter_values: newBuildParameters,
 				});
 			} catch (error) {
+				// If the build failed because of a parameter validation error, then we
+				// throw a special sentinel error that can be caught by the caller.
 				if (
 					isApiError(error) &&
 					error.response.status === 400 &&
@@ -2625,7 +2628,7 @@ class ApiMethods {
 // All methods must be defined with arrow function syntax. See the docstring
 // above the ApiMethods class for a full explanation.
 class ExperimentalApiMethods {
-	constructor(protected readonly axios: AxiosInstance) {}
+	constructor(protected readonly axios: AxiosInstance) { }
 
 	getAITasksPrompts = async (
 		buildIds: TypesGen.WorkspaceBuild["id"][],

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2200,9 +2200,9 @@ class ApiMethods {
 			default_value: p.default_value?.valid ? p.default_value.value : "",
 			options: p.options
 				? p.options.map((opt) => ({
-					...opt,
-					value: opt.value?.valid ? opt.value.value : "",
-				}))
+						...opt,
+						value: opt.value?.valid ? opt.value.value : "",
+					}))
 				: [],
 		}));
 	};
@@ -2628,7 +2628,7 @@ class ApiMethods {
 // All methods must be defined with arrow function syntax. See the docstring
 // above the ApiMethods class for a full explanation.
 class ExperimentalApiMethods {
-	constructor(protected readonly axios: AxiosInstance) { }
+	constructor(protected readonly axios: AxiosInstance) {}
 
 	getAITasksPrompts = async (
 		buildIds: TypesGen.WorkspaceBuild["id"][],

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2278,7 +2278,7 @@ class ApiMethods {
 
 		if (isDynamicParametersEnabled) {
 			try {
-				return this.postWorkspaceBuild(workspace.id, {
+				return await this.postWorkspaceBuild(workspace.id, {
 					transition: "start",
 					template_version_id: activeVersionId,
 					rich_parameter_values: newBuildParameters,

--- a/site/src/modules/workspaces/WorkspaceMoreActions/UpdateBuildParametersDialogExperimental.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/UpdateBuildParametersDialogExperimental.tsx
@@ -1,4 +1,4 @@
-import type { TemplateVersionParameter } from "api/typesGenerated";
+import type { FieldError } from "api/errors";
 import { Button } from "components/Button/Button";
 import {
 	Dialog,
@@ -14,7 +14,7 @@ import { useNavigate } from "react-router-dom";
 type UpdateBuildParametersDialogExperimentalProps = {
 	open: boolean;
 	onClose: () => void;
-	missedParameters: TemplateVersionParameter[];
+	validations: FieldError[];
 	workspaceOwnerName: string;
 	workspaceName: string;
 	templateVersionId: string | undefined;
@@ -23,7 +23,7 @@ type UpdateBuildParametersDialogExperimentalProps = {
 export const UpdateBuildParametersDialogExperimental: FC<
 	UpdateBuildParametersDialogExperimentalProps
 > = ({
-	missedParameters,
+	validations,
 	open,
 	onClose,
 	workspaceOwnerName,
@@ -47,8 +47,8 @@ export const UpdateBuildParametersDialogExperimental: FC<
 					<DialogDescription>
 						This template has{" "}
 						<strong className="text-content-primary">
-							{missedParameters.length} new parameter
-							{missedParameters.length === 1 ? "" : "s"}
+							{validations.length} parameter
+							{validations.length === 1 ? "" : "s"}
 						</strong>{" "}
 						that must be configured to complete the update.
 					</DialogDescription>

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
@@ -1,4 +1,4 @@
-import { MissingBuildParameters } from "api/api";
+import { MissingBuildParameters, ParameterValidationError } from "api/api";
 import { isApiError } from "api/errors";
 import { type ApiError, getErrorMessage } from "api/errors";
 import {
@@ -192,19 +192,19 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 				/>
 			) : (
 				<UpdateBuildParametersDialogExperimental
-					missedParameters={
-						changeVersionMutation.error instanceof MissingBuildParameters
-							? changeVersionMutation.error.parameters
+					validations={
+						changeVersionMutation.error instanceof ParameterValidationError
+							? changeVersionMutation.error.validations
 							: []
 					}
-					open={changeVersionMutation.error instanceof MissingBuildParameters}
+					open={changeVersionMutation.error instanceof ParameterValidationError}
 					onClose={() => {
 						changeVersionMutation.reset();
 					}}
 					workspaceOwnerName={workspace.owner_name}
 					workspaceName={workspace.name}
 					templateVersionId={
-						changeVersionMutation.error instanceof MissingBuildParameters
+						changeVersionMutation.error instanceof ParameterValidationError
 							? changeVersionMutation.error?.versionId
 							: undefined
 					}

--- a/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
@@ -1,4 +1,4 @@
-import { MissingBuildParameters } from "api/api";
+import { MissingBuildParameters, ParameterValidationError } from "api/api";
 import { updateWorkspace } from "api/queries/workspaces";
 import type {
 	TemplateVersion,
@@ -78,7 +78,10 @@ export const useWorkspaceUpdate = ({
 					updateWorkspaceMutation.reset();
 				},
 				onUpdate: (buildParameters: WorkspaceBuildParameter[]) => {
-					if (updateWorkspaceMutation.error instanceof MissingBuildParameters) {
+					if (
+						updateWorkspaceMutation.error instanceof MissingBuildParameters ||
+						updateWorkspaceMutation.error instanceof ParameterValidationError
+					) {
 						confirmUpdate(buildParameters);
 					}
 				},
@@ -155,7 +158,9 @@ const MissingBuildParametersDialog: FC<MissingBuildParametersDialogProps> = ({
 		error instanceof MissingBuildParameters ? error.parameters : [];
 	const versionId =
 		error instanceof MissingBuildParameters ? error.versionId : undefined;
-	const isOpen = error instanceof MissingBuildParameters;
+	const isOpen =
+		error instanceof MissingBuildParameters ||
+		error instanceof ParameterValidationError;
 
 	return workspace.template_use_classic_parameter_flow ? (
 		<UpdateBuildParametersDialog
@@ -165,7 +170,9 @@ const MissingBuildParametersDialog: FC<MissingBuildParametersDialogProps> = ({
 		/>
 	) : (
 		<UpdateBuildParametersDialogExperimental
-			missedParameters={missedParameters}
+			validations={
+				error instanceof ParameterValidationError ? error.validations : []
+			}
 			open={isOpen}
 			onClose={dialogProps.onClose}
 			workspaceOwnerName={workspace.owner_name}

--- a/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
@@ -177,7 +177,9 @@ const MissingBuildParametersDialog: FC<MissingBuildParametersDialogProps> = ({
 			onClose={dialogProps.onClose}
 			workspaceOwnerName={workspace.owner_name}
 			workspaceName={workspace.name}
-			templateVersionId={versionId}
+			templateVersionId={
+				error instanceof ParameterValidationError ? error.versionId : undefined
+			}
 		/>
 	);
 };

--- a/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
@@ -157,7 +157,7 @@ const MissingBuildParametersDialog: FC<MissingBuildParametersDialogProps> = ({
 	const missedParameters =
 		error instanceof MissingBuildParameters ? error.parameters : [];
 	const versionId =
-		error instanceof MissingBuildParameters ? error.versionId : undefined;
+		error instanceof ParameterValidationError ? error.versionId : undefined;
 	const isOpen =
 		error instanceof MissingBuildParameters ||
 		error instanceof ParameterValidationError;
@@ -177,9 +177,7 @@ const MissingBuildParametersDialog: FC<MissingBuildParametersDialogProps> = ({
 			onClose={dialogProps.onClose}
 			workspaceOwnerName={workspace.owner_name}
 			workspaceName={workspace.name}
-			templateVersionId={
-				error instanceof ParameterValidationError ? error.versionId : undefined
-			}
+			templateVersionId={versionId}
 		/>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/18259

Historically, we've had some frontend code to detect conditions which would lead to build failures, and we would require their correction before ever talking to the backend. In a dynamic parameters world there are now _many_ more possible ways this could fail and validating all of that on the frontend would be a lot of duplication and have a lot of room for logic errors.

We have decided to simplify, and delegate all parameter validation to the backend. The only ways which can _authoritatively_ validate parameters is to actually trigger a build or establish an evaluation loop over WebSocket. As such, instead of doing any upfront validation on the frontend, we should just queue up a build and see what happens. This has two primary outcomes...

1. The build is fine, which means we would've queued it up anyway after validation (if we were doing any frontend pre-validation)
2. The build fails and we get back validation errors. We detect this and redirect to the parameters settings page, where an evaluation WebSocket will be established and the user can update things as necessary. When they are done, they'll queue another build from here which should succeed.

Importantly, the build will fail during a validation step that is performed on the backend. It will not actually add a job to the job queue. It does not require the availability of a provisioner. The response time was always very fast when testing locally, and shouldn't be of concern.