### PR TITLE
feat: add RFC 9728 OAuth2 resource metadata support

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -790,6 +790,7 @@ func New(options *Options) *API {
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
 		Logger:                        options.Logger,
+		AccessURL:                     options.AccessURL,
 	})
 	// Same as above but it redirects to the login page.
 	apiKeyMiddlewareRedirect := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -801,6 +802,7 @@ func New(options *Options) *API {
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
 		Logger:                        options.Logger,
+		AccessURL:                     options.AccessURL,
 	})
 	// Same as the first but it's optional.
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -812,6 +814,7 @@ func New(options *Options) *API {
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
 		Logger:                        options.Logger,
+		AccessURL:                     options.AccessURL,
 	})
 
 	workspaceAgentInfo := httpmw.ExtractWorkspaceAgentAndLatestBuild(httpmw.ExtractWorkspaceAgentAndLatestBuildConfig{

--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/go-chi/cors"
 
@@ -28,13 +29,15 @@ const (
 func Cors(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
 	if len(origins) == 0 {
 		// The default behavior is '*', so putting the empty string defaults to
-		// the secure behavior of blocking CORs requests.
+		// the secure behavior of blocking CORS requests.
 		origins = []string{""}
 	}
 	if allowAll {
 		origins = []string{"*"}
 	}
-	return cors.Handler(cors.Options{
+
+	// Standard CORS for most endpoints
+	standardCors := cors.Handler(cors.Options{
 		AllowedOrigins: origins,
 		// We only need GET for latency requests
 		AllowedMethods: []string{http.MethodOptions, http.MethodGet},
@@ -42,6 +45,50 @@ func Cors(allowAll bool, origins ...string) func(next http.Handler) http.Handler
 		// Do not send any cookies
 		AllowCredentials: false,
 	})
+
+	// Permissive CORS for OAuth2 and MCP endpoints
+	permissiveCors := cors.Handler(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodDelete,
+			http.MethodOptions,
+		},
+		AllowedHeaders: []string{
+			"Content-Type",
+			"Accept",
+			"Authorization",
+			"x-api-key",
+			"Mcp-Session-Id",
+			"MCP-Protocol-Version",
+			"Last-Event-ID",
+		},
+		ExposedHeaders: []string{
+			"Content-Type",
+			"Authorization",
+			"x-api-key",
+			"Mcp-Session-Id",
+			"MCP-Protocol-Version",
+		},
+		MaxAge:           86400, // 24 hours in seconds
+		AllowCredentials: false,
+	})
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Use permissive CORS for OAuth2, MCP, and well-known endpoints
+			if strings.HasPrefix(r.URL.Path, "/oauth2/") ||
+				strings.HasPrefix(r.URL.Path, "/api/experimental/mcp/") ||
+				strings.HasPrefix(r.URL.Path, "/.well-known/oauth-") {
+				permissiveCors(next).ServeHTTP(w, r)
+				return
+			}
+
+			// Use standard CORS for all other endpoints
+			standardCors(next).ServeHTTP(w, r)
+		})
+	}
 }
 
 func WorkspaceAppCors(regex *regexp.Regexp, app appurl.ApplicationURL) func(next http.Handler) http.Handler {

--- a/coderd/httpmw/csp_test.go
+++ b/coderd/httpmw/csp_test.go
@@ -34,7 +34,7 @@ func TestCSP(t *testing.T) {
 
 	expected := []string{
 		"frame-src 'self' *.test.com *.coder.com *.coder2.com",
-		"media-src 'self' media.com media2.com",
+		"media-src 'self' " + strings.Join(expectedMedia, " "),
 		strings.Join([]string{
 			"connect-src", "'self'",
 			// Added from host header.

--- a/coderd/httpmw/httpmw_internal_test.go
+++ b/coderd/httpmw/httpmw_internal_test.go
@@ -258,7 +258,7 @@ func TestExtractExpectedAudience(t *testing.T) {
 			}
 			req.Host = tc.host
 
-			result := extractExpectedAudience(req)
+			result := extractExpectedAudience(nil, req)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/coderd/oauth2provider/authorize.go
+++ b/coderd/oauth2provider/authorize.go
@@ -33,7 +33,7 @@ func extractAuthorizeParams(r *http.Request, callbackURL *url.URL) (authorizePar
 	p := httpapi.NewQueryParamParser()
 	vals := r.URL.Query()
 
-	p.RequiredNotEmpty("state", "response_type", "client_id")
+	p.RequiredNotEmpty("response_type", "client_id")
 
 	params := authorizeParams{
 		clientID:            p.String(vals, "", "client_id"),
@@ -154,7 +154,9 @@ func ProcessAuthorize(db database.Store, accessURL *url.URL) http.HandlerFunc {
 
 		newQuery := params.redirectURL.Query()
 		newQuery.Add("code", code.Formatted)
-		newQuery.Add("state", params.state)
+		if params.state != "" {
+			newQuery.Add("state", params.state)
+		}
 		params.redirectURL.RawQuery = newQuery.Encode()
 
 		http.Redirect(rw, r, params.redirectURL.String(), http.StatusTemporaryRedirect)


### PR DESCRIPTION
# Enhanced OAuth2 and MCP Compliance for API Authentication

This PR improves OAuth2 and MCP (Microsoft Cloud for Sovereignty) compliance by:

1. Adding RFC 9728 compliant `WWW-Authenticate` headers with resource metadata URLs
2. Passing the configured `AccessURL` to API key middleware for proper audience validation
3. Creating specialized CORS handling for OAuth2 and MCP endpoints with appropriate headers
4. Making the `state` parameter optional in OAuth2 authorization requests

These changes ensure proper OAuth2 token audience validation against the configured access URL and improve interoperability with OAuth2 clients by providing better error responses and metadata discovery.