### PR TITLE
chore: add managed ai usage consumption to license view

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -191,11 +191,7 @@
 		"vite-plugin-checker": "0.9.3",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": [
-		"chrome 110",
-		"firefox 111",
-		"safari 16.0"
-	],
+	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/package.json
+++ b/site/package.json
@@ -191,7 +191,11 @@
 		"vite-plugin-checker": "0.9.3",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
+	"browserslist": [
+		"chrome 110",
+		"firefox 111",
+		"safari 16.0"
+	],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
@@ -85,7 +85,9 @@ const LicensesSettingsPage: FC = () => {
 				isRemovingLicense={isRemovingLicense}
 				removeLicense={(licenseId: number) => removeLicenseApi(licenseId)}
 				activeUsers={userStatusCount?.active}
-				managedAgentFeature={entitlementsQuery.data?.features.managed_agent_limit}
+				managedAgentFeature={
+					entitlementsQuery.data?.features.managed_agent_limit
+				}
 				refreshEntitlements={async () => {
 					try {
 						await refreshEntitlementsMutation.mutateAsync();

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
@@ -85,7 +85,7 @@ const LicensesSettingsPage: FC = () => {
 				isRemovingLicense={isRemovingLicense}
 				removeLicense={(licenseId: number) => removeLicenseApi(licenseId)}
 				activeUsers={userStatusCount?.active}
-				entitlements={entitlementsQuery.data}
+				managedAgentFeature={entitlementsQuery.data?.features.managed_agent_limit}
 				refreshEntitlements={async () => {
 					try {
 						await refreshEntitlementsMutation.mutateAsync();

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPage.tsx
@@ -85,6 +85,7 @@ const LicensesSettingsPage: FC = () => {
 				isRemovingLicense={isRemovingLicense}
 				removeLicense={(licenseId: number) => removeLicenseApi(licenseId)}
 				activeUsers={userStatusCount?.active}
+				entitlements={entitlementsQuery.data}
 				refreshEntitlements={async () => {
 					try {
 						await refreshEntitlementsMutation.mutateAsync();

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -51,9 +51,6 @@ const LicensesSettingsPageView: FC<Props> = ({
 }) => {
 	const theme = useTheme();
 	const { width, height } = useWindowSize();
-	const managedAgentLimitStarts = managedAgentFeature?.usage_period?.start;
-	const managedAgentLimitExpires = managedAgentFeature?.usage_period?.end;
-	const managedAgentFeatureEnabled = managedAgentFeature?.enabled;
 
 	return (
 		<>
@@ -158,15 +155,8 @@ const LicensesSettingsPageView: FC<Props> = ({
 					/>
 				)}
 
-				{licenses && licenses.length > 0 && managedAgentFeature && (
-					<ManagedAgentsConsumption
-						usage={managedAgentFeature.actual || 0}
-						included={managedAgentFeature.soft_limit || 0}
-						limit={managedAgentFeature.limit || 0}
-						startDate={managedAgentLimitStarts || ""}
-						endDate={managedAgentLimitExpires || ""}
-						enabled={managedAgentFeatureEnabled}
-					/>
+				{licenses && licenses.length > 0 && (
+					<ManagedAgentsConsumption managedAgentFeature={managedAgentFeature} />
 				)}
 			</div>
 		</>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -4,7 +4,7 @@ import MuiLink from "@mui/material/Link";
 import Skeleton from "@mui/material/Skeleton";
 import Tooltip from "@mui/material/Tooltip";
 import type { GetLicensesResponse } from "api/api";
-import type { UserStatusChangeCount } from "api/typesGenerated";
+import type { Entitlements, UserStatusChangeCount } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
 	SettingsHeader,
@@ -20,6 +20,7 @@ import Confetti from "react-confetti";
 import { Link } from "react-router-dom";
 import { LicenseCard } from "./LicenseCard";
 import { LicenseSeatConsumptionChart } from "./LicenseSeatConsumptionChart";
+import { ManagedAgentsConsumption } from "./ManagedAgentsConsumption";
 
 type Props = {
 	showConfetti: boolean;
@@ -32,6 +33,7 @@ type Props = {
 	removeLicense: (licenseId: number) => void;
 	refreshEntitlements: () => void;
 	activeUsers: UserStatusChangeCount[] | undefined;
+	entitlements?: Entitlements;
 };
 
 const LicensesSettingsPageView: FC<Props> = ({
@@ -45,9 +47,14 @@ const LicensesSettingsPageView: FC<Props> = ({
 	removeLicense,
 	refreshEntitlements,
 	activeUsers,
+	entitlements,
 }) => {
 	const theme = useTheme();
 	const { width, height } = useWindowSize();
+	const managedAgentFeature = entitlements?.features?.managed_agent_limit;
+	const managedAgentLimitStarts = entitlements?.features?.managed_agent_limit?.usage_period?.start;
+	const managedAgentLimitExpires = entitlements?.features?.managed_agent_limit?.usage_period?.end;
+	const managedAgentFeatureEnabled = entitlements?.features?.managed_agent_limit?.enabled;
 
 	return (
 		<>
@@ -149,6 +156,17 @@ const LicensesSettingsPageView: FC<Props> = ({
 							users: i.count,
 							limit: 80,
 						}))}
+					/>
+				)}
+
+				{licenses && licenses.length > 0 && managedAgentFeature && (
+					<ManagedAgentsConsumption
+						usage={managedAgentFeature.actual || 0}
+						included={managedAgentFeature.soft_limit || 0}
+						limit={managedAgentFeature.limit || 0}
+						startDate={managedAgentLimitStarts || ""}
+						endDate={managedAgentLimitExpires || ""}
+						enabled={managedAgentFeatureEnabled}
 					/>
 				)}
 			</div>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -4,7 +4,7 @@ import MuiLink from "@mui/material/Link";
 import Skeleton from "@mui/material/Skeleton";
 import Tooltip from "@mui/material/Tooltip";
 import type { GetLicensesResponse } from "api/api";
-import type { Entitlements, Feature, UserStatusChangeCount } from "api/typesGenerated";
+import type { Feature, UserStatusChangeCount } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
 	SettingsHeader,

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -4,7 +4,7 @@ import MuiLink from "@mui/material/Link";
 import Skeleton from "@mui/material/Skeleton";
 import Tooltip from "@mui/material/Tooltip";
 import type { GetLicensesResponse } from "api/api";
-import type { Entitlements, UserStatusChangeCount } from "api/typesGenerated";
+import type { Entitlements, Feature, UserStatusChangeCount } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
 	SettingsHeader,
@@ -33,7 +33,7 @@ type Props = {
 	removeLicense: (licenseId: number) => void;
 	refreshEntitlements: () => void;
 	activeUsers: UserStatusChangeCount[] | undefined;
-	entitlements?: Entitlements;
+	managedAgentFeature?: Feature;
 };
 
 const LicensesSettingsPageView: FC<Props> = ({
@@ -47,14 +47,13 @@ const LicensesSettingsPageView: FC<Props> = ({
 	removeLicense,
 	refreshEntitlements,
 	activeUsers,
-	entitlements,
+	managedAgentFeature,
 }) => {
 	const theme = useTheme();
 	const { width, height } = useWindowSize();
-	const managedAgentFeature = entitlements?.features?.managed_agent_limit;
-	const managedAgentLimitStarts = entitlements?.features?.managed_agent_limit?.usage_period?.start;
-	const managedAgentLimitExpires = entitlements?.features?.managed_agent_limit?.usage_period?.end;
-	const managedAgentFeatureEnabled = entitlements?.features?.managed_agent_limit?.enabled;
+	const managedAgentLimitStarts = managedAgentFeature?.usage_period?.start;
+	const managedAgentLimitExpires = managedAgentFeature?.usage_period?.end;
+	const managedAgentFeatureEnabled = managedAgentFeature?.enabled;
 
 	return (
 		<>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -24,13 +24,70 @@ const meta: Meta<typeof ManagedAgentsConsumption> = {
 export default meta;
 type Story = StoryObj<typeof ManagedAgentsConsumption>;
 
-export const Default: Story = {};
+export const Default: Story = {
+	name: "Normal Usage (42% of limit)",
+};
 
-export const NearLimit: Story = {
+export const Warning: Story = {
+	name: "Warning (80-99% of limit)",
 	args: {
 		managedAgentFeature: {
 			enabled: true,
-			actual: 115000,
+			actual: 96000, // 80% of limit - should show orange
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const NearLimit: Story = {
+	name: "Near Limit (95% of limit)",
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 114000, // 95% of limit - should show orange
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const AtLimit: Story = {
+	name: "At Limit (100% of limit)",
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 120000, // 100% of limit - should show red
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const OverLimit: Story = {
+	name: "Over Limit (120% of limit)",
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 144000, // 120% of limit - should show red
 			soft_limit: 60000,
 			limit: 120000,
 			usage_period: {
@@ -44,10 +101,11 @@ export const NearLimit: Story = {
 };
 
 export const OverIncluded: Story = {
+	name: "Over Included (67% of limit)",
 	args: {
 		managedAgentFeature: {
 			enabled: true,
-			actual: 80000,
+			actual: 80000, // Over included but under 80% of total limit - should still be green
 			soft_limit: 60000,
 			limit: 120000,
 			usage_period: {
@@ -61,6 +119,7 @@ export const OverIncluded: Story = {
 };
 
 export const LowUsage: Story = {
+	name: "Low Usage (21% of limit)",
 	args: {
 		managedAgentFeature: {
 			enabled: true,

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -24,70 +24,13 @@ const meta: Meta<typeof ManagedAgentsConsumption> = {
 export default meta;
 type Story = StoryObj<typeof ManagedAgentsConsumption>;
 
-export const Default: Story = {
-	name: "Normal Usage (42% of limit)",
-};
-
-export const Warning: Story = {
-	name: "Warning (80-99% of limit)",
-	args: {
-		managedAgentFeature: {
-			enabled: true,
-			actual: 96000, // 80% of limit - should show orange
-			soft_limit: 60000,
-			limit: 120000,
-			usage_period: {
-				start: "February 27, 2025",
-				end: "February 27, 2026",
-				issued_at: "February 27, 2025",
-			},
-			entitlement: "entitled",
-		},
-	},
-};
+export const Default: Story = {};
 
 export const NearLimit: Story = {
-	name: "Near Limit (95% of limit)",
 	args: {
 		managedAgentFeature: {
 			enabled: true,
-			actual: 114000, // 95% of limit - should show orange
-			soft_limit: 60000,
-			limit: 120000,
-			usage_period: {
-				start: "February 27, 2025",
-				end: "February 27, 2026",
-				issued_at: "February 27, 2025",
-			},
-			entitlement: "entitled",
-		},
-	},
-};
-
-export const AtLimit: Story = {
-	name: "At Limit (100% of limit)",
-	args: {
-		managedAgentFeature: {
-			enabled: true,
-			actual: 120000, // 100% of limit - should show red
-			soft_limit: 60000,
-			limit: 120000,
-			usage_period: {
-				start: "February 27, 2025",
-				end: "February 27, 2026",
-				issued_at: "February 27, 2025",
-			},
-			entitlement: "entitled",
-		},
-	},
-};
-
-export const OverLimit: Story = {
-	name: "Over Limit (120% of limit)",
-	args: {
-		managedAgentFeature: {
-			enabled: true,
-			actual: 144000, // 120% of limit - should show red
+			actual: 115000,
 			soft_limit: 60000,
 			limit: 120000,
 			usage_period: {
@@ -101,11 +44,10 @@ export const OverLimit: Story = {
 };
 
 export const OverIncluded: Story = {
-	name: "Over Included (67% of limit)",
 	args: {
 		managedAgentFeature: {
 			enabled: true,
-			actual: 80000, // Over included but under 80% of total limit - should still be green
+			actual: 80000,
 			soft_limit: 60000,
 			limit: 120000,
 			usage_period: {
@@ -119,7 +61,6 @@ export const OverIncluded: Story = {
 };
 
 export const LowUsage: Story = {
-	name: "Low Usage (21% of limit)",
 	args: {
 		managedAgentFeature: {
 			enabled: true,

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ManagedAgentsConsumption } from "./ManagedAgentsConsumption";
+
+const meta: Meta<typeof ManagedAgentsConsumption> = {
+  title:
+    "pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption",
+  component: ManagedAgentsConsumption,
+  args: {
+    usage: 50000,
+    included: 60000,
+    limit: 120000,
+    startDate: "February 27, 2025",
+    endDate: "February 27, 2026",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ManagedAgentsConsumption>;
+
+export const Default: Story = {};
+
+export const NearLimit: Story = {
+  args: {
+    usage: 115000,
+    included: 60000,
+    limit: 120000,
+  },
+};
+
+export const OverIncluded: Story = {
+  args: {
+    usage: 80000,
+    included: 60000,
+    limit: 120000,
+  },
+};
+
+export const LowUsage: Story = {
+  args: {
+    usage: 25000,
+    included: 60000,
+    limit: 120000,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    usage: NaN,
+    included: NaN,
+    limit: NaN,
+  },
+};

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -2,16 +2,16 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ManagedAgentsConsumption } from "./ManagedAgentsConsumption";
 
 const meta: Meta<typeof ManagedAgentsConsumption> = {
-  title:
-    "pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption",
-  component: ManagedAgentsConsumption,
-  args: {
-    usage: 50000,
-    included: 60000,
-    limit: 120000,
-    startDate: "February 27, 2025",
-    endDate: "February 27, 2026",
-  },
+	title:
+		"pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption",
+	component: ManagedAgentsConsumption,
+	args: {
+		usage: 50000,
+		included: 60000,
+		limit: 120000,
+		startDate: "February 27, 2025",
+		endDate: "February 27, 2026",
+	},
 };
 
 export default meta;
@@ -20,33 +20,33 @@ type Story = StoryObj<typeof ManagedAgentsConsumption>;
 export const Default: Story = {};
 
 export const NearLimit: Story = {
-  args: {
-    usage: 115000,
-    included: 60000,
-    limit: 120000,
-  },
+	args: {
+		usage: 115000,
+		included: 60000,
+		limit: 120000,
+	},
 };
 
 export const OverIncluded: Story = {
-  args: {
-    usage: 80000,
-    included: 60000,
-    limit: 120000,
-  },
+	args: {
+		usage: 80000,
+		included: 60000,
+		limit: 120000,
+	},
 };
 
 export const LowUsage: Story = {
-  args: {
-    usage: 25000,
-    included: 60000,
-    limit: 120000,
-  },
+	args: {
+		usage: 25000,
+		included: 60000,
+		limit: 120000,
+	},
 };
 
 export const Disabled: Story = {
-  args: {
-    usage: NaN,
-    included: NaN,
-    limit: NaN,
-  },
+	args: {
+		usage: Number.NaN,
+		included: Number.NaN,
+		limit: Number.NaN,
+	},
 };

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -6,11 +6,18 @@ const meta: Meta<typeof ManagedAgentsConsumption> = {
 		"pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption",
 	component: ManagedAgentsConsumption,
 	args: {
-		usage: 50000,
-		included: 60000,
-		limit: 120000,
-		startDate: "February 27, 2025",
-		endDate: "February 27, 2026",
+		managedAgentFeature: {
+			enabled: true,
+			actual: 50000,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
 	},
 };
 
@@ -21,41 +28,169 @@ export const Default: Story = {};
 
 export const NearLimit: Story = {
 	args: {
-		usage: 115000,
-		included: 60000,
-		limit: 120000,
+		managedAgentFeature: {
+			enabled: true,
+			actual: 115000,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
 	},
 };
 
 export const OverIncluded: Story = {
 	args: {
-		usage: 80000,
-		included: 60000,
-		limit: 120000,
+		managedAgentFeature: {
+			enabled: true,
+			actual: 80000,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
 	},
 };
 
 export const LowUsage: Story = {
 	args: {
-		usage: 25000,
-		included: 60000,
-		limit: 120000,
+		managedAgentFeature: {
+			enabled: true,
+			actual: 25000,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
 	},
 };
 
 export const IncludedAtLimit: Story = {
 	args: {
-		usage: 25000,
-		included: 30500,
-		limit: 30500,
+		managedAgentFeature: {
+			enabled: true,
+			actual: 25000,
+			soft_limit: 30500,
+			limit: 30500,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
 	},
 };
 
 export const Disabled: Story = {
 	args: {
-		enabled: false,
-		usage: Number.NaN,
-		included: Number.NaN,
-		limit: Number.NaN,
+		managedAgentFeature: {
+			enabled: false,
+			actual: undefined,
+			soft_limit: undefined,
+			limit: undefined,
+			usage_period: undefined,
+			entitlement: "not_entitled",
+		},
+	},
+};
+
+export const NoFeature: Story = {
+	args: {
+		managedAgentFeature: undefined,
+	},
+};
+
+// Error States for Validation
+export const ErrorMissingData: Story = {
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: undefined,
+			soft_limit: undefined,
+			limit: undefined,
+			usage_period: undefined,
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const ErrorNegativeValues: Story = {
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: -100,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const ErrorSoftLimitExceedsLimit: Story = {
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 50000,
+			soft_limit: 150000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const ErrorInvalidDates: Story = {
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 50000,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "invalid-date",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
+export const ErrorEndBeforeStart: Story = {
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 50000,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2026",
+				end: "February 27, 2025",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
 	},
 };

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -43,8 +43,17 @@ export const LowUsage: Story = {
 	},
 };
 
+export const IncludedAtLimit: Story = {
+	args: {
+		usage: 25000,
+		included: 30500,
+		limit: 30500,
+	},
+};
+
 export const Disabled: Story = {
 	args: {
+		enabled: false,
 		usage: Number.NaN,
 		included: Number.NaN,
 		limit: Number.NaN,

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -31,11 +31,7 @@ const validateFeature = (feature?: Feature): string | null => {
 			return "Managed agent feature is enabled but missing required usage data (actual, soft_limit, or limit).";
 		}
 
-		if (
-			feature.actual < 0 ||
-			feature.soft_limit < 0 ||
-			feature.limit < 0
-		) {
+		if (feature.actual < 0 || feature.soft_limit < 0 || feature.limit < 0) {
 			return "Managed agent feature contains invalid negative values for usage metrics.";
 		}
 
@@ -76,14 +72,11 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 			<div className="min-h-60 flex items-center justify-center rounded-lg border border-solid p-12">
 				<Stack alignItems="center" spacing={1}>
 					<Stack alignItems="center" spacing={0.5}>
-						<span className="text-base">
-							Managed AI Agents Disabled
-						</span>
+						<span className="text-base">Managed AI Agents Disabled</span>
 						<span className="text-content-secondary text-center max-w-[464px] mt-2">
 							Managed AI agents are not included in your current license.
-							Contact{" "}
-							<MuiLink href="mailto:sales@coder.com">sales</MuiLink> to upgrade
-							your license and unlock this feature.
+							Contact <MuiLink href="mailto:sales@coder.com">sales</MuiLink> to
+							upgrade your license and unlock this feature.
 						</span>
 					</Stack>
 				</Stack>
@@ -171,7 +164,8 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 								>
 									<div className="w-full border-b-1 border-t-1 border-dashed border-content-disabled" />
 								</div>
-								Total limit after which further AI workspace builds will be blocked.
+								Total limit after which further AI workspace builds will be
+								blocked.
 							</li>
 						</ul>
 					</CollapsibleContent>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -9,8 +9,9 @@ import {
 } from "components/Collapsible/Collapsible";
 import { Stack } from "components/Stack/Stack";
 import dayjs from "dayjs";
-import { ChevronRightIcon } from "lucide-react";
+import { ChevronRightIcon, Link } from "lucide-react";
 import type { FC } from "react";
+import { docs } from "utils/docs";
 
 interface ManagedAgentsConsumptionProps {
 	managedAgentFeature?: Feature;
@@ -100,7 +101,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 				<Collapsible>
 					<header className="flex flex-col gap-2 items-start">
 						<h3 className="text-md m-0 font-medium">
-							Managed agents consumption
+							Managed AI Agents Usage
 						</h3>
 
 						<CollapsibleTrigger asChild>
@@ -112,7 +113,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
                 `}
 							>
 								<ChevronRightIcon />
-								How we calculate managed agents consumption
+								Learn more
 							</Button>
 						</CollapsibleTrigger>
 					</header>
@@ -125,8 +126,13 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
             `}
 					>
 						<p>
-							Managed agents are counted based on the amount of successfully
-							started workspaces with an AI agent.
+							<MuiLink
+								href={docs("/ai-coder/tasks")}
+								target="_blank"
+								rel="noreferrer">
+								Coder Tasks
+							</MuiLink>{" "} and upcoming managed AI features are included in Coder Premium
+							licenses during beta. Usage limits and pricing subject to change.
 						</p>
 						<ul>
 							<li className="flex items-center gap-2">

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -9,7 +9,7 @@ import {
 } from "components/Collapsible/Collapsible";
 import { Stack } from "components/Stack/Stack";
 import dayjs from "dayjs";
-import { ChevronRightIcon, Link } from "lucide-react";
+import { ChevronRightIcon } from "lucide-react";
 import type { FC } from "react";
 import { docs } from "utils/docs";
 
@@ -100,9 +100,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 			<div className="p-4">
 				<Collapsible>
 					<header className="flex flex-col gap-2 items-start">
-						<h3 className="text-md m-0 font-medium">
-							Managed AI Agents Usage
-						</h3>
+						<h3 className="text-md m-0 font-medium">Managed AI Agents Usage</h3>
 
 						<CollapsibleTrigger asChild>
 							<Button
@@ -129,9 +127,11 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 							<MuiLink
 								href={docs("/ai-coder/tasks")}
 								target="_blank"
-								rel="noreferrer">
+								rel="noreferrer"
+							>
 								Coder Tasks
-							</MuiLink>{" "} and upcoming managed AI features are included in Coder Premium
+							</MuiLink>{" "}
+							and upcoming managed AI features are included in Coder Premium
 							licenses during beta. Usage limits and pricing subject to change.
 						</p>
 						<ul>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -1,187 +1,188 @@
+import type { Interpolation, Theme } from "@emotion/react";
+import MuiLink from "@mui/material/Link";
 import { Button } from "components/Button/Button";
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
 } from "components/Collapsible/Collapsible";
-import { Link } from "components/Link/Link";
 import { Stack } from "components/Stack/Stack";
+import dayjs from "dayjs";
 import { ChevronRightIcon } from "lucide-react";
 import type { FC } from "react";
-import { Link as RouterLink } from "react-router-dom";
-import { docs } from "utils/docs";
-import MuiLink from "@mui/material/Link";
-import { type Interpolation, type Theme } from "@emotion/react";
-import dayjs from "dayjs";
 
 interface ManagedAgentsConsumptionProps {
-  usage: number;
-  included: number;
-  limit: number;
-  startDate: string;
-  endDate: string;
-  enabled?: boolean;
+	usage: number;
+	included: number;
+	limit: number;
+	startDate: string;
+	endDate: string;
+	enabled?: boolean;
 }
 
 export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
-  usage,
-  included,
-  limit,
-  startDate,
-  endDate,
-  enabled = true,
+	usage,
+	included,
+	limit,
+	startDate,
+	endDate,
+	enabled = true,
 }) => {
+	if (!enabled) {
+		return (
+			<div css={styles.disabledRoot}>
+				<Stack alignItems="center" spacing={1}>
+					<Stack alignItems="center" spacing={0.5}>
+						<span css={styles.disabledTitle}>
+							Managed AI Agent Feature Disabled
+						</span>
+						<span css={styles.disabledDescription}>
+							The managed AI agent feature is not included in your current
+							license. Contact{" "}
+							<MuiLink href="mailto:sales@coder.com">sales</MuiLink> to upgrade
+							your license and unlock this feature.
+						</span>
+					</Stack>
+				</Stack>
+			</div>
+		);
+	}
 
-  if (!enabled) {
-    return (
-      <div css={styles.disabledRoot}>
-        <Stack alignItems="center" spacing={1}>
-          <Stack alignItems="center" spacing={0.5}>
-            <span css={styles.disabledTitle}>
-              Managed AI Agent Feature Disabled
-            </span>
-            <span css={styles.disabledDescription}>
-              The managed AI agent feature is not included in your current license.
-              Contact{" "}
-              <MuiLink href="mailto:sales@coder.com">sales</MuiLink> to
-              upgrade your license and unlock this feature.
-            </span>
-          </Stack>
-        </Stack>
-      </div>
-    );
-  }
+	const usagePercentage = Math.min((usage / limit) * 100, 100);
+	const includedPercentage = Math.min((included / limit) * 100, 100);
+	const remainingPercentage = Math.max(100 - includedPercentage, 0);
 
-  const usagePercentage = Math.min((usage / limit) * 100, 100);
-  const includedPercentage = Math.min((included / limit) * 100, 100);
-  const remainingPercentage = Math.max(100 - includedPercentage, 0);
+	return (
+		<section className="border border-solid rounded">
+			<div className="p-4">
+				<Collapsible>
+					<header className="flex flex-col gap-2 items-start">
+						<h3 className="text-md m-0 font-medium">
+							Managed agents consumption
+						</h3>
 
-  return (
-    <section className="border border-solid rounded">
-      <div className="p-4">
-        <Collapsible>
-          <header className="flex flex-col gap-2 items-start">
-            <h3 className="text-md m-0 font-medium">
-              Managed agents consumption
-            </h3>
-
-            <CollapsibleTrigger asChild>
-              <Button
-                className={`
+						<CollapsibleTrigger asChild>
+							<Button
+								className={`
                   h-auto p-0 border-0 bg-transparent font-medium text-content-secondary
                   hover:bg-transparent hover:text-content-primary
                   [&[data-state=open]_svg]:rotate-90
                 `}
-              >
-                <ChevronRightIcon />
-                How we calculate managed agent consumption
-              </Button>
-            </CollapsibleTrigger>
-          </header>
+							>
+								<ChevronRightIcon />
+								How we calculate managed agent consumption
+							</Button>
+						</CollapsibleTrigger>
+					</header>
 
-          <CollapsibleContent
-            className={`
+					<CollapsibleContent
+						className={`
               pt-2 pl-7 pr-5 space-y-4 font-medium max-w-[720px]
               text-sm text-content-secondary
               [&_p]:m-0 [&_ul]:m-0 [&_ul]:p-0 [&_ul]:list-none
             `}
-          >
-            <p>
-              Managed agents are counted based on the amount of started workspaces with an AI agent.
-            </p>
-            <ul>
-              <li className="flex items-center gap-2">
-                <div
-                  className="rounded-[2px] bg-highlight-green size-3 inline-block"
-                  aria-label="Legend for current usage in the chart"
-                />
-                Amount of started workspaces with an AI agent.
-              </li>
-              <li className="flex items-center gap-2">
-                <div
-                  className="rounded-[2px] bg-content-disabled size-3 inline-block"
-                  aria-label="Legend for included allowance in the chart"
-                />
-                Included allowance from your current license plan.
-              </li>
-              <li className="flex items-center gap-2">
-                <div
-                  className="size-3 inline-flex items-center justify-center"
-                  aria-label="Legend for total limit in the chart"
-                >
-                  <div className="w-full border-b-1 border-t-1 border-dashed border-content-disabled" />
-                </div>
-                Total limit after which the feature will be disabled.
-              </li>
-            </ul>
-          </CollapsibleContent>
-        </Collapsible>
-      </div>
+					>
+						<p>
+							Managed agents are counted based on the amount of started
+							workspaces with an AI agent.
+						</p>
+						<ul>
+							<li className="flex items-center gap-2">
+								<div
+									className="rounded-[2px] bg-highlight-green size-3 inline-block"
+									aria-label="Legend for current usage in the chart"
+								/>
+								Amount of started workspaces with an AI agent.
+							</li>
+							<li className="flex items-center gap-2">
+								<div
+									className="rounded-[2px] bg-content-disabled size-3 inline-block"
+									aria-label="Legend for included allowance in the chart"
+								/>
+								Included allowance from your current license plan.
+							</li>
+							<li className="flex items-center gap-2">
+								<div
+									className="size-3 inline-flex items-center justify-center"
+									aria-label="Legend for total limit in the chart"
+								>
+									<div className="w-full border-b-1 border-t-1 border-dashed border-content-disabled" />
+								</div>
+								Total limit after which the feature will be disabled.
+							</li>
+						</ul>
+					</CollapsibleContent>
+				</Collapsible>
+			</div>
 
-      <div className="p-6 border-0 border-t border-solid">
-        <div className="flex justify-between text-sm text-content-secondary mb-4">
-          <span>{startDate ? dayjs(startDate).format("MMMM D, YYYY") : ""}</span>
-          <span>{endDate ? dayjs(endDate).format("MMMM D, YYYY") : ""}</span>
-        </div>
+			<div className="p-6 border-0 border-t border-solid">
+				<div className="flex justify-between text-sm text-content-secondary mb-4">
+					<span>
+						{startDate ? dayjs(startDate).format("MMMM D, YYYY") : ""}
+					</span>
+					<span>{endDate ? dayjs(endDate).format("MMMM D, YYYY") : ""}</span>
+				</div>
 
-        <div className="relative h-6 bg-surface-secondary rounded overflow-hidden">
-          <div
-            className="absolute top-0 left-0 h-full bg-highlight-green transition-all duration-300"
-            style={{ width: `${usagePercentage}%` }}
-          />
+				<div className="relative h-6 bg-surface-secondary rounded overflow-hidden">
+					<div
+						className="absolute top-0 left-0 h-full bg-highlight-green transition-all duration-300"
+						style={{ width: `${usagePercentage}%` }}
+					/>
 
-          <div
-            className="absolute top-0 h-full bg-content-disabled opacity-30"
-            style={{
-              left: `${includedPercentage}%`,
-              width: `${remainingPercentage}%`,
-            }}
-          />
-        </div>
+					<div
+						className="absolute top-0 h-full bg-content-disabled opacity-30"
+						style={{
+							left: `${includedPercentage}%`,
+							width: `${remainingPercentage}%`,
+						}}
+					/>
+				</div>
 
-        <div className="relative flex justify-between mt-4 text-sm">
-          <div className="flex flex-col items-start">
-            <span className="text-content-secondary">Actual:</span>
-            <span className="font-medium">{usage.toLocaleString()}</span>
-          </div>
+				<div className="relative flex justify-between mt-4 text-sm">
+					<div className="flex flex-col items-start">
+						<span className="text-content-secondary">Actual:</span>
+						<span className="font-medium">{usage.toLocaleString()}</span>
+					</div>
 
-          <div
-            className="absolute flex flex-col items-center transform -translate-x-1/2"
-            style={{ left: `${Math.max(Math.min(includedPercentage, 90), 10)}%` }}
-          >
-            <span className="text-content-secondary">Included:</span>
-            <span className="font-medium">{included.toLocaleString()}</span>
-          </div>
+					<div
+						className="absolute flex flex-col items-center transform -translate-x-1/2"
+						style={{
+							left: `${Math.max(Math.min(includedPercentage, 90), 10)}%`,
+						}}
+					>
+						<span className="text-content-secondary">Included:</span>
+						<span className="font-medium">{included.toLocaleString()}</span>
+					</div>
 
-          <div className="flex flex-col items-end">
-            <span className="text-content-secondary">Limit:</span>
-            <span className="font-medium">{limit.toLocaleString()}</span>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+					<div className="flex flex-col items-end">
+						<span className="text-content-secondary">Limit:</span>
+						<span className="font-medium">{limit.toLocaleString()}</span>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 const styles = {
-  disabledTitle: {
-    fontSize: 16,
-  },
+	disabledTitle: {
+		fontSize: 16,
+	},
 
-  disabledRoot: (theme) => ({
-    minHeight: 240,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 8,
-    border: `1px solid ${theme.palette.divider}`,
-    padding: 48,
-  }),
+	disabledRoot: (theme) => ({
+		minHeight: 240,
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		borderRadius: 8,
+		border: `1px solid ${theme.palette.divider}`,
+		padding: 48,
+	}),
 
-  disabledDescription: (theme) => ({
-    color: theme.palette.text.secondary,
-    textAlign: "center",
-    maxWidth: 464,
-    marginTop: 8,
-  }),
+	disabledDescription: (theme) => ({
+		color: theme.palette.text.secondary,
+		textAlign: "center",
+		maxWidth: 464,
+		marginTop: 8,
+	}),
 } satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -94,20 +94,6 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 	const includedPercentage = Math.min((included / limit) * 100, 100);
 	const remainingPercentage = Math.max(100 - includedPercentage, 0);
 
-	// Determine usage bar color based on percentage
-	const getUsageColor = () => {
-		const actualUsagePercent = (usage / limit) * 100;
-		if (actualUsagePercent >= 100) {
-			return "bg-highlight-red"; // Critical: at or over limit
-		}
-		if (actualUsagePercent >= 80) {
-			return "bg-surface-orange"; // Warning: approaching limit
-		}
-		return "bg-highlight-green"; // Normal: safe usage
-	};
-
-	const usageBarColor = getUsageColor();
-
 	return (
 		<section className="border border-solid rounded">
 			<div className="p-4">
@@ -145,7 +131,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 						<ul>
 							<li className="flex items-center gap-2">
 								<div
-									className={`rounded-[2px] ${usageBarColor} size-3 inline-block`}
+									className="rounded-[2px] bg-highlight-green size-3 inline-block"
 									aria-label="Legend for current usage in the chart"
 								/>
 								Amount of started workspaces with an AI agent.
@@ -182,7 +168,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 
 				<div className="relative h-6 bg-surface-secondary rounded overflow-hidden">
 					<div
-						className={`absolute top-0 left-0 h-full ${usageBarColor} transition-all duration-300`}
+						className="absolute top-0 left-0 h-full bg-highlight-green transition-all duration-300"
 						style={{ width: `${usagePercentage}%` }}
 					/>
 

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -1,0 +1,210 @@
+import { Button } from "components/Button/Button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "components/Collapsible/Collapsible";
+import { Link } from "components/Link/Link";
+import { Stack } from "components/Stack/Stack";
+import { ChevronRightIcon } from "lucide-react";
+import type { FC } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { docs } from "utils/docs";
+import MuiLink from "@mui/material/Link";
+import { type Interpolation, type Theme } from "@emotion/react";
+import dayjs from "dayjs";
+
+interface ManagedAgentsConsumptionProps {
+  usage: number;
+  included: number;
+  limit: number;
+  startDate: string;
+  endDate: string;
+  enabled?: boolean;
+}
+
+export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
+  usage,
+  included,
+  limit,
+  startDate,
+  endDate,
+  enabled = true,
+}) => {
+  // If feature is disabled, show disabled state
+  if (!enabled) {
+    return (
+      <div css={styles.disabledRoot}>
+        <Stack alignItems="center" spacing={1}>
+          <Stack alignItems="center" spacing={0.5}>
+            <span css={styles.disabledTitle}>
+              Managed AI Agent Feature Disabled
+            </span>
+            <span css={styles.disabledDescription}>
+              The managed AI agent feature is not included in your current license.
+              Contact{" "}
+              <MuiLink href="mailto:sales@coder.com">sales</MuiLink> to
+              upgrade your license and unlock this feature.
+            </span>
+          </Stack>
+        </Stack>
+      </div>
+    );
+  }
+
+  // Calculate percentages for the progress bar
+  const usagePercentage = Math.min((usage / limit) * 100, 100);
+  const includedPercentage = Math.min((included / limit) * 100, 100);
+  const remainingPercentage = Math.max(100 - includedPercentage, 0);
+
+  return (
+    <section className="border border-solid rounded">
+      <div className="p-4">
+        <Collapsible>
+          <header className="flex flex-col gap-2 items-start">
+            <h3 className="text-md m-0 font-medium">
+              Managed agents consumption
+            </h3>
+
+            <CollapsibleTrigger asChild>
+              <Button
+                className={`
+                  h-auto p-0 border-0 bg-transparent font-medium text-content-secondary
+                  hover:bg-transparent hover:text-content-primary
+                  [&[data-state=open]_svg]:rotate-90
+                `}
+              >
+                <ChevronRightIcon />
+                How we calculate managed agent consumption
+              </Button>
+            </CollapsibleTrigger>
+          </header>
+
+          <CollapsibleContent
+            className={`
+              pt-2 pl-7 pr-5 space-y-4 font-medium max-w-[720px]
+              text-sm text-content-secondary
+              [&_p]:m-0 [&_ul]:m-0 [&_ul]:p-0 [&_ul]:list-none
+            `}
+          >
+            <p>
+              Managed agents are counted based on active agent connections during the billing period.
+              Each unique agent that connects to your deployment consumes one managed agent seat.
+            </p>
+            <ul>
+              <li className="flex items-center gap-2">
+                <div
+                  className="rounded-[2px] bg-highlight-green size-3 inline-block"
+                  aria-label="Legend for current usage in the chart"
+                />
+                Current usage represents active managed agents during this period.
+              </li>
+              <li className="flex items-center gap-2">
+                <div
+                  className="rounded-[2px] bg-content-disabled size-3 inline-block"
+                  aria-label="Legend for included allowance in the chart"
+                />
+                Included allowance from your current license plan.
+              </li>
+              <li className="flex items-center gap-2">
+                <div
+                  className="size-3 inline-flex items-center justify-center"
+                  aria-label="Legend for total limit in the chart"
+                >
+                  <div className="w-full border-b-1 border-t-1 border-dashed border-content-disabled" />
+                </div>
+                Total limit including any additional purchased capacity.
+              </li>
+            </ul>
+            <div>
+              You might also check:
+              <ul>
+                <li>
+                  <Link asChild>
+                    <RouterLink to="/deployment/overview">
+                      Deployment overview
+                    </RouterLink>
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href={docs("/admin/managed-agents")}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    More details on managed agents
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+
+      <div className="p-6 border-0 border-t border-solid">
+        {/* Date range */}
+        <div className="flex justify-between text-sm text-content-secondary mb-4">
+          <span>{startDate ? dayjs(startDate).format("MMMM D, YYYY") : ""}</span>
+          <span>{endDate ? dayjs(endDate).format("MMMM D, YYYY") : ""}</span>
+        </div>
+
+        {/* Progress bar container */}
+        <div className="relative h-6 bg-surface-secondary rounded overflow-hidden">
+          {/* Usage bar (green) */}
+          <div
+            className="absolute top-0 left-0 h-full bg-highlight-green transition-all duration-300"
+            style={{ width: `${usagePercentage}%` }}
+          />
+
+          {/* Included allowance background (darker) */}
+          <div
+            className="absolute top-0 h-full bg-content-disabled opacity-30"
+            style={{
+              left: `${includedPercentage}%`,
+              width: `${remainingPercentage}%`,
+            }}
+          />
+        </div>
+
+        {/* Labels */}
+        <div className="flex justify-between mt-4 text-sm">
+          <div className="flex flex-col items-start">
+            <span className="text-content-secondary">Usage:</span>
+            <span className="font-medium">{usage.toLocaleString()}</span>
+          </div>
+          <div className="flex flex-col items-center">
+            <span className="text-content-secondary">Included:</span>
+            <span className="font-medium">{included.toLocaleString()}</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span className="text-content-secondary">Limit:</span>
+            <span className="font-medium">{limit.toLocaleString()}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const styles = {
+  disabledTitle: {
+    fontSize: 16,
+  },
+
+  disabledRoot: (theme) => ({
+    minHeight: 240,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 8,
+    border: `1px solid ${theme.palette.divider}`,
+    padding: 48,
+  }),
+
+  disabledDescription: (theme) => ({
+    color: theme.palette.text.secondary,
+    textAlign: "center",
+    maxWidth: 464,
+    marginTop: 8,
+  }),
+} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -1,4 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
 import MuiLink from "@mui/material/Link";
 import type { Feature } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
@@ -74,13 +73,13 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 	// If no feature is provided or it's disabled, show disabled state
 	if (!managedAgentFeature?.enabled) {
 		return (
-			<div css={styles.disabledRoot}>
+			<div className="min-h-60 flex items-center justify-center rounded-lg border border-solid p-12">
 				<Stack alignItems="center" spacing={1}>
 					<Stack alignItems="center" spacing={0.5}>
-						<span css={styles.disabledTitle}>
+						<span className="text-base">
 							Managed AI Agents Disabled
 						</span>
-						<span css={styles.disabledDescription}>
+						<span className="text-content-secondary text-center max-w-[464px] mt-2">
 							Managed AI agents are not included in your current license.
 							Contact{" "}
 							<MuiLink href="mailto:sales@coder.com">sales</MuiLink> to upgrade
@@ -101,6 +100,20 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 	const usagePercentage = Math.min((usage / limit) * 100, 100);
 	const includedPercentage = Math.min((included / limit) * 100, 100);
 	const remainingPercentage = Math.max(100 - includedPercentage, 0);
+
+	// Determine usage bar color based on percentage
+	const getUsageColor = () => {
+		const actualUsagePercent = (usage / limit) * 100;
+		if (actualUsagePercent >= 100) {
+			return "bg-highlight-red"; // Critical: at or over limit
+		}
+		if (actualUsagePercent >= 80) {
+			return "bg-surface-orange"; // Warning: approaching limit
+		}
+		return "bg-highlight-green"; // Normal: safe usage
+	};
+
+	const usageBarColor = getUsageColor();
 
 	return (
 		<section className="border border-solid rounded">
@@ -139,7 +152,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 						<ul>
 							<li className="flex items-center gap-2">
 								<div
-									className="rounded-[2px] bg-highlight-green size-3 inline-block"
+									className={`rounded-[2px] ${usageBarColor} size-3 inline-block`}
 									aria-label="Legend for current usage in the chart"
 								/>
 								Amount of started workspaces with an AI agent.
@@ -175,7 +188,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 
 				<div className="relative h-6 bg-surface-secondary rounded overflow-hidden">
 					<div
-						className="absolute top-0 left-0 h-full bg-highlight-green transition-all duration-300"
+						className={`absolute top-0 left-0 h-full ${usageBarColor} transition-all duration-300`}
 						style={{ width: `${usagePercentage}%` }}
 					/>
 
@@ -230,26 +243,3 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 		</section>
 	);
 };
-
-const styles = {
-	disabledTitle: {
-		fontSize: 16,
-	},
-
-	disabledRoot: (theme) => ({
-		minHeight: 240,
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "center",
-		borderRadius: 8,
-		border: `1px solid ${theme.palette.divider}`,
-		padding: 48,
-	}),
-
-	disabledDescription: (theme) => ({
-		color: theme.palette.text.secondary,
-		textAlign: "center",
-		maxWidth: 464,
-		marginTop: 8,
-	}),
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -31,7 +31,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
   endDate,
   enabled = true,
 }) => {
-  // If feature is disabled, show disabled state
+
   if (!enabled) {
     return (
       <div css={styles.disabledRoot}>
@@ -52,7 +52,6 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
     );
   }
 
-  // Calculate percentages for the progress bar
   const usagePercentage = Math.min((usage / limit) * 100, 100);
   const includedPercentage = Math.min((included / limit) * 100, 100);
   const remainingPercentage = Math.max(100 - includedPercentage, 0);
@@ -88,8 +87,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
             `}
           >
             <p>
-              Managed agents are counted based on active agent connections during the billing period.
-              Each unique agent that connects to your deployment consumes one managed agent seat.
+              Managed agents are counted based on the amount of started workspaces with an AI agent.
             </p>
             <ul>
               <li className="flex items-center gap-2">
@@ -97,7 +95,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
                   className="rounded-[2px] bg-highlight-green size-3 inline-block"
                   aria-label="Legend for current usage in the chart"
                 />
-                Current usage represents active managed agents during this period.
+                Amount of started workspaces with an AI agent.
               </li>
               <li className="flex items-center gap-2">
                 <div
@@ -113,50 +111,25 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
                 >
                   <div className="w-full border-b-1 border-t-1 border-dashed border-content-disabled" />
                 </div>
-                Total limit including any additional purchased capacity.
+                Total limit after which the feature will be disabled.
               </li>
             </ul>
-            <div>
-              You might also check:
-              <ul>
-                <li>
-                  <Link asChild>
-                    <RouterLink to="/deployment/overview">
-                      Deployment overview
-                    </RouterLink>
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href={docs("/admin/managed-agents")}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    More details on managed agents
-                  </Link>
-                </li>
-              </ul>
-            </div>
           </CollapsibleContent>
         </Collapsible>
       </div>
 
       <div className="p-6 border-0 border-t border-solid">
-        {/* Date range */}
         <div className="flex justify-between text-sm text-content-secondary mb-4">
           <span>{startDate ? dayjs(startDate).format("MMMM D, YYYY") : ""}</span>
           <span>{endDate ? dayjs(endDate).format("MMMM D, YYYY") : ""}</span>
         </div>
 
-        {/* Progress bar container */}
         <div className="relative h-6 bg-surface-secondary rounded overflow-hidden">
-          {/* Usage bar (green) */}
           <div
             className="absolute top-0 left-0 h-full bg-highlight-green transition-all duration-300"
             style={{ width: `${usagePercentage}%` }}
           />
 
-          {/* Included allowance background (darker) */}
           <div
             className="absolute top-0 h-full bg-content-disabled opacity-30"
             style={{
@@ -166,16 +139,20 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
           />
         </div>
 
-        {/* Labels */}
-        <div className="flex justify-between mt-4 text-sm">
+        <div className="relative flex justify-between mt-4 text-sm">
           <div className="flex flex-col items-start">
-            <span className="text-content-secondary">Usage:</span>
+            <span className="text-content-secondary">Actual:</span>
             <span className="font-medium">{usage.toLocaleString()}</span>
           </div>
-          <div className="flex flex-col items-center">
+
+          <div
+            className="absolute flex flex-col items-center transform -translate-x-1/2"
+            style={{ left: `${Math.max(Math.min(includedPercentage, 90), 10)}%` }}
+          >
             <span className="text-content-secondary">Included:</span>
             <span className="font-medium">{included.toLocaleString()}</span>
           </div>
+
           <div className="flex flex-col items-end">
             <span className="text-content-secondary">Limit:</span>
             <span className="font-medium">{limit.toLocaleString()}</span>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -34,11 +34,11 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 				<Stack alignItems="center" spacing={1}>
 					<Stack alignItems="center" spacing={0.5}>
 						<span css={styles.disabledTitle}>
-							Managed AI Agent Feature Disabled
+							Managed AI Agents Disabled
 						</span>
 						<span css={styles.disabledDescription}>
-							The managed AI agent feature is not included in your current
-							license. Contact{" "}
+							Managed AI agents are not included in your current license.
+							Contact{" "}
 							<MuiLink href="mailto:sales@coder.com">sales</MuiLink> to upgrade
 							your license and unlock this feature.
 						</span>
@@ -70,7 +70,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
                 `}
 							>
 								<ChevronRightIcon />
-								How we calculate managed agent consumption
+								How we calculate managed agents consumption
 							</Button>
 						</CollapsibleTrigger>
 					</header>
@@ -83,8 +83,8 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
             `}
 					>
 						<p>
-							Managed agents are counted based on the amount of started
-							workspaces with an AI agent.
+							Managed agents are counted based on the amount of successfully
+							started workspaces with an AI agent.
 						</p>
 						<ul>
 							<li className="flex items-center gap-2">
@@ -108,7 +108,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 								>
 									<div className="w-full border-b-1 border-t-1 border-dashed border-content-disabled" />
 								</div>
-								Total limit after which the feature will be disabled.
+								Total limit after which further AI workspace builds will be blocked.
 							</li>
 						</ul>
 					</CollapsibleContent>
@@ -138,7 +138,7 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 					/>
 				</div>
 
-				<div className="relative flex justify-between mt-4 text-sm">
+				<div className="relative hidden lg:flex justify-between mt-4 text-sm">
 					<div className="flex flex-col items-start">
 						<span className="text-content-secondary">Actual:</span>
 						<span className="font-medium">{usage.toLocaleString()}</span>
@@ -157,6 +157,23 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 					<div className="flex flex-col items-end">
 						<span className="text-content-secondary">Limit:</span>
 						<span className="font-medium">{limit.toLocaleString()}</span>
+					</div>
+				</div>
+
+				<div className="flex lg:hidden flex-col gap-3 mt-4 text-sm">
+					<div className="flex justify-between">
+						<div className="flex flex-col items-start">
+							<span className="text-content-secondary">Actual:</span>
+							<span className="font-medium">{usage.toLocaleString()}</span>
+						</div>
+						<div className="flex flex-col items-center">
+							<span className="text-content-secondary">Included:</span>
+							<span className="font-medium">{included.toLocaleString()}</span>
+						</div>
+						<div className="flex flex-col items-end">
+							<span className="text-content-secondary">Limit:</span>
+							<span className="font-medium">{limit.toLocaleString()}</span>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Customers with licenses not supporting managed AI agents will receive the following information:
<img width="597" height="261" alt="image" src="https://github.com/user-attachments/assets/b794a9f2-bca8-494e-a8d1-cc6e6bc43bfe" />

Customers with active licenes for managed AI agents will see:
<img width="604" height="293" alt="image" src="https://github.com/user-attachments/assets/7ce8931c-05c6-4e64-a5a1-2e9364e99de2" />

Closes https://github.com/coder/internal/issues/813
