### PR TITLE
chore: add CodeRabbit config with disabled auto-reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit Configuration
+# This configuration disables automatic reviews entirely
+
+language: "en-US"
+early_access: false
+
+reviews:
+  # Disable automatic reviews for new PRs, but allow incremental reviews
+  auto_review:
+    enabled: false # Disable automatic review of new/updated PRs
+    drafts: false # Don't review draft PRs automatically
+
+  # Other review settings (only apply if manually requested)
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+
+chat:
+  auto_reply: true # Allow automatic chat replies
+
+# Note: With auto_review.enabled: false, CodeRabbit will only perform initial
+# reviews when manually requested, but incremental reviews and chat replies remain enabled
+


### PR DESCRIPTION
# Add CodeRabbit Configuration File with Automatic Reviews Disabled

This PR adds a new `.coderabbit.yaml` configuration file that disables automatic PR reviews while maintaining other CodeRabbit functionality. Key configurations include:

- Disables automatic reviews for new and updated PRs
- Prevents automatic reviews of draft PRs
- Sets review profile to "chill" when reviews are manually requested
- Enables high-level summaries and review status
- Keeps auto-reply functionality for chat interactions
- Maintains incremental review capability

With this configuration, CodeRabbit will only perform initial reviews when manually requested, while still allowing incremental reviews and chat replies.