### PR TITLE
feat(agent/agentcontainers): auto detect dev containers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -339,7 +339,6 @@ func (a *agent) init() {
 	containerAPIOpts := []agentcontainers.Option{
 		agentcontainers.WithExecer(a.execer),
 		agentcontainers.WithCommandEnv(a.sshServer.CommandEnv),
-		agentcontainers.WithProjectDiscovery(true),
 		agentcontainers.WithScriptLogger(func(logSourceID uuid.UUID) agentcontainers.ScriptLogger {
 			return a.logSender.GetScriptLogger(logSourceID)
 		}),

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1168,7 +1168,7 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				// return existing devcontainers but actual container detection
 				// and creation will be deferred.
 				a.containerAPI.Init(
-					agentcontainers.WithManifestInfo(manifest.OwnerName, manifest.WorkspaceName, manifest.AgentName),
+					agentcontainers.WithManifestInfo(manifest.OwnerName, manifest.WorkspaceName, manifest.AgentName, manifest.Directory),
 					agentcontainers.WithDevcontainers(manifest.Devcontainers, manifest.Scripts),
 					agentcontainers.WithSubAgentClient(agentcontainers.NewSubAgentClientFromAPI(a.logger, aAPI)),
 				)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -339,6 +339,7 @@ func (a *agent) init() {
 	containerAPIOpts := []agentcontainers.Option{
 		agentcontainers.WithExecer(a.execer),
 		agentcontainers.WithCommandEnv(a.sshServer.CommandEnv),
+		agentcontainers.WithProjectDiscovery(true),
 		agentcontainers.WithScriptLogger(func(logSourceID uuid.UUID) agentcontainers.ScriptLogger {
 			return a.logSender.GetScriptLogger(logSourceID)
 		}),

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -419,6 +419,10 @@ func (api *API) discover() {
 	if err := api.discoverDevcontainerProjects(); err != nil {
 		api.logger.Error(api.ctx, "discovering dev container projects", slog.Error(err))
 	}
+
+	if err := api.RefreshContainers(api.ctx); err != nil {
+		api.logger.Error(api.ctx, "refreshing containers after discovery", slog.Error(err))
+	}
 }
 
 func (api *API) discoverDevcontainerProjects() error {

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -426,7 +426,7 @@ func (api *API) discover() {
 }
 
 func (api *API) discoverDevcontainerProjects() error {
-	isGitProject, err := afero.DirExists(api.fs, filepath.Join(api.agentDirectory, "/.git"))
+	isGitProject, err := afero.DirExists(api.fs, filepath.Join(api.agentDirectory, ".git"))
 	if err != nil {
 		return xerrors.Errorf(".git dir exists: %w", err)
 	}

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -398,7 +398,7 @@ func (api *API) Start() {
 		return
 	}
 
-	if api.projectDiscovery {
+	if api.projectDiscovery && api.agentDirectory != "" {
 		api.discoverDone = make(chan struct{})
 
 		go api.discover()

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -267,9 +267,9 @@ func WithWatcher(w watcher.Watcher) Option {
 }
 
 // WithFileSystem sets the file system used for discovering projects.
-func WithFileSystem(fs afero.Fs) Option {
+func WithFileSystem(fileSystem afero.Fs) Option {
 	return func(api *API) {
-		api.fs = fs
+		api.fs = fileSystem
 	}
 }
 
@@ -449,7 +449,11 @@ func (api *API) discoverDevcontainersInProject(projectPath string) error {
 		"/.devcontainer.json",
 	}
 
-	return afero.Walk(api.fs, projectPath, func(path string, info fs.FileInfo, err error) error {
+	return afero.Walk(api.fs, projectPath, func(path string, info fs.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+
 		for _, relativeConfigPath := range devcontainerConfigPaths {
 			if !strings.HasSuffix(path, relativeConfigPath) {
 				continue

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -3188,4 +3189,235 @@ func TestWithDevcontainersNameGeneration(t *testing.T) {
 	assert.NotEqual(t, "another-name", response.Devcontainers[0].Name, "second devcontainer should not keep original name")
 	assert.Equal(t, "bar-project", response.Devcontainers[0].Name, "second devcontainer should has a collision and uses the folder name with a prefix")
 	assert.Equal(t, "baz-project", response.Devcontainers[1].Name, "third devcontainer should use the folder name with a prefix since it collides with the first two")
+}
+
+func TestDevcontainerDiscovery(t *testing.T) {
+	t.Parallel()
+
+	// We discover dev container projects by searching
+	// for git repositories at the agent's directory,
+	// and then recursively walking through these git
+	// repositories to find any `.devcontainer/devcontainer.json`
+	// files. These tests are to validate that behavior.
+
+	tests := []struct {
+		name     string
+		agentDir string
+		fs       map[string]string
+		expected []codersdk.WorkspaceAgentDevcontainer
+	}{
+		{
+			name:     "GitProjectInRootDir/SingleProject",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                       "",
+				"/home/coder/.devcontainer/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "GitProjectInRootDir/MultipleProjects",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD":                            "",
+				"/home/coder/.devcontainer/devcontainer.json":      "",
+				"/home/coder/site/.devcontainer/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder",
+					ConfigPath:      "/home/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/site",
+					ConfigPath:      "/home/coder/site/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "GitProjectInChildDir/SingleProject",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":                       "",
+				"/home/coder/coder/.devcontainer/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "GitProjectInChildDir/MultipleProjects",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":                            "",
+				"/home/coder/coder/.devcontainer/devcontainer.json":      "",
+				"/home/coder/coder/site/.devcontainer/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/coder/site",
+					ConfigPath:      "/home/coder/coder/site/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "GitProjectInMultipleChildDirs/SingleProjectEach",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":                            "",
+				"/home/coder/coder/.devcontainer/devcontainer.json":      "",
+				"/home/coder/envbuilder/.git/HEAD":                       "",
+				"/home/coder/envbuilder/.devcontainer/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/envbuilder",
+					ConfigPath:      "/home/coder/envbuilder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "GitProjectInMultipleChildDirs/MultipleProjectEach",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":                              "",
+				"/home/coder/coder/.devcontainer/devcontainer.json":        "",
+				"/home/coder/coder/site/.devcontainer/devcontainer.json":   "",
+				"/home/coder/envbuilder/.git/HEAD":                         "",
+				"/home/coder/envbuilder/.devcontainer/devcontainer.json":   "",
+				"/home/coder/envbuilder/x/.devcontainer/devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/coder/site",
+					ConfigPath:      "/home/coder/coder/site/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/envbuilder",
+					ConfigPath:      "/home/coder/envbuilder/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/envbuilder/x",
+					ConfigPath:      "/home/coder/envbuilder/x/.devcontainer/devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+	}
+
+	initFS := func(t *testing.T, files map[string]string) afero.Fs {
+		t.Helper()
+
+		fs := afero.NewMemMapFs()
+		for name, content := range files {
+			err := afero.WriteFile(fs, name, []byte(content+"\n"), 0o600)
+			require.NoError(t, err)
+		}
+		return fs
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				ctx        = testutil.Context(t, testutil.WaitShort)
+				logger     = testutil.Logger(t)
+				mClock     = quartz.NewMock(t)
+				tickerTrap = mClock.Trap().TickerFunc("updaterLoop")
+
+				r = chi.NewRouter()
+			)
+
+			api := agentcontainers.NewAPI(logger,
+				agentcontainers.WithClock(mClock),
+				agentcontainers.WithWatcher(watcher.NewNoop()),
+				agentcontainers.WithFileSystem(initFS(t, tt.fs)),
+				agentcontainers.WithManifestInfo("owner", "workspace", "parent-agent", tt.agentDir),
+				agentcontainers.WithContainerCLI(&fakeContainerCLI{}),
+				agentcontainers.WithDevcontainerCLI(&fakeDevcontainerCLI{}),
+			)
+			api.Start()
+			defer api.Close()
+			r.Mount("/", api.Routes())
+
+			tickerTrap.MustWait(ctx).MustRelease(ctx)
+			tickerTrap.Close()
+
+			// Wait until all projects have been discovered
+			require.Eventuallyf(t, func() bool {
+				req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+				rec := httptest.NewRecorder()
+				r.ServeHTTP(rec, req)
+
+				got := codersdk.WorkspaceAgentListContainersResponse{}
+				err := json.NewDecoder(rec.Body).Decode(&got)
+				require.NoError(t, err)
+
+				return len(got.Devcontainers) == len(tt.expected)
+			}, testutil.WaitShort, testutil.IntervalFast, "dev containers never found")
+
+			// Now projects have been discovered, we'll allow the updater loop
+			// to set the appropriate status for these containers.
+			_, aw := mClock.AdvanceNext()
+			aw.MustWait(ctx)
+
+			// Now we'll fetch the list of dev containers
+			req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			got := codersdk.WorkspaceAgentListContainersResponse{}
+			err := json.NewDecoder(rec.Body).Decode(&got)
+			require.NoError(t, err)
+
+			// We will set the IDs of each dev container to uuid.Nil to simplify
+			// this check.
+			for idx := range got.Devcontainers {
+				got.Devcontainers[idx].ID = uuid.Nil
+			}
+
+			// Sort the expected dev containers and got dev containers by their workspace folder.
+			// This helps ensure a deterministic test.
+			slices.SortFunc(tt.expected, func(a, b codersdk.WorkspaceAgentDevcontainer) int {
+				return strings.Compare(a.WorkspaceFolder, b.WorkspaceFolder)
+			})
+			slices.SortFunc(got.Devcontainers, func(a, b codersdk.WorkspaceAgentDevcontainer) int {
+				return strings.Compare(a.WorkspaceFolder, b.WorkspaceFolder)
+			})
+
+			require.Equal(t, tt.expected, got.Devcontainers)
+		})
+	}
 }

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3425,4 +3425,29 @@ func TestDevcontainerDiscovery(t *testing.T) {
 			require.Equal(t, tt.expected, got.Devcontainers)
 		})
 	}
+
+	t.Run("NoErrorWhenAgentDirAbsent", func(t *testing.T) {
+		t.Parallel()
+
+		logger := testutil.Logger(t)
+
+		// Given: We have an empty agent directory
+		agentDir := ""
+
+		api := agentcontainers.NewAPI(logger,
+			agentcontainers.WithWatcher(watcher.NewNoop()),
+			agentcontainers.WithManifestInfo("owner", "workspace", "parent-agent", agentDir),
+			agentcontainers.WithContainerCLI(&fakeContainerCLI{}),
+			agentcontainers.WithDevcontainerCLI(&fakeDevcontainerCLI{}),
+			agentcontainers.WithProjectDiscovery(true),
+		)
+
+		// When: We start and close the API
+		api.Start()
+		api.Close()
+
+		// Then: We expect there to have been no errors.
+		// This is implicitly handled by `testutil.Logger` failing when it
+		// detects an error has been logged.
+	})
 }

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1678,7 +1678,7 @@ func TestAPI(t *testing.T) {
 			agentcontainers.WithSubAgentClient(fakeSAC),
 			agentcontainers.WithSubAgentURL("test-subagent-url"),
 			agentcontainers.WithDevcontainerCLI(fakeDCCLI),
-			agentcontainers.WithManifestInfo("test-user", "test-workspace", "test-parent-agent"),
+			agentcontainers.WithManifestInfo("test-user", "test-workspace", "test-parent-agent", "/parent-agent"),
 		)
 		api.Start()
 		apiClose := func() {
@@ -2662,7 +2662,7 @@ func TestAPI(t *testing.T) {
 			agentcontainers.WithSubAgentClient(fSAC),
 			agentcontainers.WithSubAgentURL("test-subagent-url"),
 			agentcontainers.WithWatcher(watcher.NewNoop()),
-			agentcontainers.WithManifestInfo("test-user", "test-workspace", "test-parent-agent"),
+			agentcontainers.WithManifestInfo("test-user", "test-workspace", "test-parent-agent", "/parent-agent"),
 		)
 		api.Start()
 		defer api.Close()

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3367,6 +3367,7 @@ func TestDevcontainerDiscovery(t *testing.T) {
 				agentcontainers.WithManifestInfo("owner", "workspace", "parent-agent", tt.agentDir),
 				agentcontainers.WithContainerCLI(&fakeContainerCLI{}),
 				agentcontainers.WithDevcontainerCLI(&fakeDevcontainerCLI{}),
+				agentcontainers.WithProjectDiscovery(true),
 			)
 			api.Start()
 			defer api.Close()

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3194,6 +3194,10 @@ func TestWithDevcontainersNameGeneration(t *testing.T) {
 func TestDevcontainerDiscovery(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("Dev Container tests are not supported on Windows")
+	}
+
 	// We discover dev container projects by searching
 	// for git repositories at the agent's directory,
 	// and then recursively walking through these git

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -40,22 +40,23 @@ import (
 
 func (r *RootCmd) workspaceAgent() *serpent.Command {
 	var (
-		auth                string
-		logDir              string
-		scriptDataDir       string
-		pprofAddress        string
-		noReap              bool
-		sshMaxTimeout       time.Duration
-		tailnetListenPort   int64
-		prometheusAddress   string
-		debugAddress        string
-		slogHumanPath       string
-		slogJSONPath        string
-		slogStackdriverPath string
-		blockFileTransfer   bool
-		agentHeaderCommand  string
-		agentHeader         []string
-		devcontainers       bool
+		auth                         string
+		logDir                       string
+		scriptDataDir                string
+		pprofAddress                 string
+		noReap                       bool
+		sshMaxTimeout                time.Duration
+		tailnetListenPort            int64
+		prometheusAddress            string
+		debugAddress                 string
+		slogHumanPath                string
+		slogJSONPath                 string
+		slogStackdriverPath          string
+		blockFileTransfer            bool
+		agentHeaderCommand           string
+		agentHeader                  []string
+		devcontainers                bool
+		devcontainerProjectDiscovery bool
 	)
 	cmd := &serpent.Command{
 		Use:   "agent",
@@ -364,6 +365,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 					Devcontainers:      devcontainers,
 					DevcontainerAPIOptions: []agentcontainers.Option{
 						agentcontainers.WithSubAgentURL(r.agentURL.String()),
+						agentcontainers.WithProjectDiscovery(devcontainerProjectDiscovery),
 					},
 				})
 
@@ -509,6 +511,13 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 			Env:         "CODER_AGENT_DEVCONTAINERS_ENABLE",
 			Description: "Allow the agent to automatically detect running devcontainers.",
 			Value:       serpent.BoolOf(&devcontainers),
+		},
+		{
+			Flag:        "devcontainers-project-discovery-enable",
+			Default:     "true",
+			Env:         "CODER_AGENT_DEVCONTAINERS_PROJECT_DISCOVERY_ENABLE",
+			Description: "Allow the agent to search the filesystem for devcontainer projects.",
+			Value:       serpent.BoolOf(&devcontainerProjectDiscovery),
 		},
 	}
 

--- a/cli/exp_rpty_test.go
+++ b/cli/exp_rpty_test.go
@@ -118,6 +118,7 @@ func TestExpRpty(t *testing.T) {
 		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
 			o.Devcontainers = true
 			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
+				agentcontainers.WithProjectDiscovery(false),
 				agentcontainers.WithContainerLabelIncludeFilter(wantLabel, "true"),
 			)
 		})

--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -406,6 +406,7 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 	_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
 		o.Devcontainers = true
 		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
+			agentcontainers.WithProjectDiscovery(false),
 			agentcontainers.WithContainerCLI(fCCLI),
 			agentcontainers.WithDevcontainerCLI(fDCCLI),
 			agentcontainers.WithWatcher(watcher.NewNoop()),

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2031,6 +2031,7 @@ func TestSSH_Container(t *testing.T) {
 		_ = agenttest.New(t, client.URL, agentToken, func(o *agent.Options) {
 			o.Devcontainers = true
 			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
+				agentcontainers.WithProjectDiscovery(false),
 				agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 			)
 		})
@@ -2072,6 +2073,7 @@ func TestSSH_Container(t *testing.T) {
 			o.Devcontainers = true
 			o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
 				agentcontainers.WithContainerCLI(mLister),
+				agentcontainers.WithProjectDiscovery(false),
 				agentcontainers.WithContainerLabelIncludeFilter("this.label.does.not.exist.ignore.devcontainers", "true"),
 			)
 		})

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -36,6 +36,9 @@ OPTIONS:
       --devcontainers-enable bool, $CODER_AGENT_DEVCONTAINERS_ENABLE (default: true)
           Allow the agent to automatically detect running devcontainers.
 
+      --devcontainers-project-discovery-enable bool, $CODER_AGENT_DEVCONTAINERS_PROJECT_DISCOVERY_ENABLE (default: true)
+          Allow the agent to search the filesystem for devcontainer projects.
+
       --log-dir string, $CODER_AGENT_LOG_DIR (default: /tmp)
           Specify the location for the agent log files.
 

--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -91,6 +91,17 @@ export const Recreating: Story = {
 	},
 };
 
+export const NoContainerOrSubAgent: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			container: undefined,
+			agent: undefined,
+		},
+		subAgents: [],
+	},
+};
+
 export const NoSubAgent: Story = {
 	args: {
 		devcontainer: {

--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -102,6 +102,18 @@ export const NoContainerOrSubAgent: Story = {
 	},
 };
 
+export const NoContainerOrAgentOrName: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			container: undefined,
+			agent: undefined,
+			name: "",
+		},
+		subAgents: [],
+	},
+};
+
 export const NoSubAgent: Story = {
 	args: {
 		devcontainer: {

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -254,7 +254,8 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 						disabled={devcontainer.status === "starting"}
 					>
 						<Spinner loading={devcontainer.status === "starting"} />
-						{devcontainer.container === undefined ? <>Start</> : <>Rebuild</>}
+
+						{devcontainer.container === undefined ? "Start" : "Rebuild"}
 					</Button>
 
 					{showDevcontainerControls && displayApps.includes("ssh_helper") && (

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -181,8 +181,6 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 
 	const appsClasses = "flex flex-wrap gap-4 empty:hidden md:justify-start";
 
-	console.log(devcontainer);
-
 	return (
 		<Stack
 			key={devcontainer.id}

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -181,6 +181,8 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 
 	const appsClasses = "flex flex-wrap gap-4 empty:hidden md:justify-start";
 
+	console.log(devcontainer);
+
 	return (
 		<Stack
 			key={devcontainer.id}
@@ -218,7 +220,8 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							text-sm font-semibold text-content-primary
 							md:overflow-visible"
 						>
-							{subAgent?.name ?? devcontainer.name}
+							{subAgent?.name ??
+								(devcontainer.name || devcontainer.config_path)}
 							{devcontainer.container && (
 								<span className="text-content-tertiary">
 									{" "}
@@ -253,7 +256,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 						disabled={devcontainer.status === "starting"}
 					>
 						<Spinner loading={devcontainer.status === "starting"} />
-						Rebuild
+						{devcontainer.container === undefined ? <>Start</> : <>Rebuild</>}
 					</Button>
 
 					{showDevcontainerControls && displayApps.includes("ssh_helper") && (

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -137,7 +137,16 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const [showParentApps, setShowParentApps] = useState(false);
 
 	let shouldDisplayAppsSection = shouldDisplayAgentApps;
-	if (devcontainers && devcontainers.length > 0 && !showParentApps) {
+	if (
+		devcontainers &&
+		devcontainers.find(
+			// We only want to hide the parent apps by default when there are dev
+			// containers that are either starting or running. If they are all in
+			// the stopped state, it doesn't make sense to hide the parent apps.
+			(dc) => dc.status === "running" || dc.status === "starting",
+		) !== undefined &&
+		!showParentApps
+	) {
 		shouldDisplayAppsSection = false;
 	}
 


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/711

This PR implements a project discovery mechanism that searches for any dev container projects and makes them visible in the UI so that they can be started. To make the wording on the site more clear, "Rebuild" has been changed to "Start" when there is no container associated with a known dev container configuration. I've also made it so that site will show the dev container config path when there is no other name available.

### Design decisions

Just want to ensure my explanation for a few design decisions are noted down:
- We only search for dev container configurations inside git repositories
- We only search for these git repositories if they're at the top level or a direct child of the agent directory.

This limited approach is to reduce the amount of files we ultimately walk when trying to find these projects. It makes sense to limit it to only the agent directory, although I'm open to expanding how deep we search.

### Follow up work

To close the linked issue, we should make it possible to auto start these found projects if their `customization.coder` stanza has `"autostart": true`. I felt that change was separate enough that it should be in a different PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic discovery of devcontainer projects within agent directories, enabling the system to detect and display devcontainers without manual configuration.
  * Added a new command-line option to enable or disable devcontainer project discovery in the agent.

* **Bug Fixes**
  * Improved handling of UI display logic for devcontainer names and rebuild/start button labels.
  * Refined visibility conditions for parent apps based on the running status of devcontainers.

* **Tests**
  * Added and updated tests to verify devcontainer discovery and related behaviors.
  * Enhanced test scenarios for cases with and without project discovery enabled.

* **Documentation**
  * Added new Storybook stories to illustrate different devcontainer card scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->