### PR TITLE
chore: remove site/ CODEOWNERS entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,3 @@ vpn/version.go @spikecurtis @johnstcn
 # This caching code is particularly tricky, and one must be very careful when
 # altering it.
 coderd/files/ @aslilac
-
-
-site/ @aslilac


### PR DESCRIPTION
Since site/src/api/typesGenerated.ts gets updated by pretty much any functionality change to codersdk, this seems to result in me getting tagged as a reviewer in pretty much every PR all the time. Really unfortunate. Even worse, Github does not support negative patterns, or really any syntax except "here's a path fragment, tag me on anything that matches". Bummer.