### PR TITLE
fix: handle nil writer in bash MCP tool

### DIFF
--- a/codersdk/toolsdk/bash.go
+++ b/codersdk/toolsdk/bash.go
@@ -79,13 +79,12 @@ Examples:
 		}
 
 		// Wait for agent to be ready
-		err = cliui.Agent(ctx, nil, workspaceAgent.ID, cliui.AgentOptions{
+		if err := cliui.Agent(ctx, io.Discard, workspaceAgent.ID, cliui.AgentOptions{
 			FetchInterval: 0,
 			Fetch:         deps.coderClient.WorkspaceAgent,
 			FetchLogs:     deps.coderClient.WorkspaceAgentLogsAfter,
 			Wait:          true, // Always wait for startup scripts
-		})
-		if err != nil {
+		}); err != nil {
 			return WorkspaceBashResult{}, xerrors.Errorf("agent not ready: %w", err)
 		}
 

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -6,12 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"runtime/debug"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/aisdk-go"
 
+	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -122,7 +124,14 @@ func WithRecover(h GenericHandlerFunc) GenericHandlerFunc {
 	return func(ctx context.Context, deps Deps, args json.RawMessage) (ret json.RawMessage, err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				err = xerrors.Errorf("tool handler panic: %v", r)
+				if buildinfo.IsDev() {
+					// Capture stack trace in dev builds
+					stack := debug.Stack()
+					err = xerrors.Errorf("tool handler panic: %v\nstack trace:\n%s", r, stack)
+				} else {
+					// Simple error message in production builds
+					err = xerrors.Errorf("tool handler panic: %v", r)
+				}
 			}
 		}()
 		return h(ctx, deps, args)


### PR DESCRIPTION
- Refactors the bash tool to use `io.Discard` instead of nil to avoid panics.

- Enhances panic recovery in `codersdk/toolsdk/toolsdk.go` by adding stack trace information in development builds. When a panic occurs in a tool handler:
   - In development builds: The error includes the full stack trace for easier debugging
   - In production builds: A simpler error message is shown without the stack trace
