### PR TITLE
fix: use system context for managed agent count query

### DIFF
--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -961,7 +961,8 @@ func (api *API) CheckBuildUsage(ctx context.Context, store database.Store, templ
 
 	// This check is intentionally not committed to the database. It's fine if
 	// it's not 100% accurate or allows for minor breaches due to build races.
-	managedAgentCount, err := store.GetManagedAgentCount(ctx, database.GetManagedAgentCountParams{
+	// nolint:gocritic // Requires permission to read all workspaces to read managed agent count.
+	managedAgentCount, err := store.GetManagedAgentCount(agpldbauthz.AsSystemRestricted(ctx), database.GetManagedAgentCountParams{
 		StartTime: managedAgentLimit.UsagePeriod.Start,
 		EndTime:   managedAgentLimit.UsagePeriod.End,
 	})

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -99,7 +99,8 @@ func Entitlements(
 		ReplicaCount:      replicaCount,
 		ExternalAuthCount: externalAuthCount,
 		ManagedAgentCountFn: func(ctx context.Context, startTime time.Time, endTime time.Time) (int64, error) {
-			return db.GetManagedAgentCount(ctx, database.GetManagedAgentCountParams{
+			// nolint:gocritic // Requires permission to read all workspaces to read managed agent count.
+			return db.GetManagedAgentCount(dbauthz.AsSystemRestricted(ctx), database.GetManagedAgentCountParams{
 				StartTime: startTime,
 				EndTime:   endTime,
 			})


### PR DESCRIPTION
Fixes the banner on dogfood

<img width="970" height="44" alt="image" src="https://github.com/user-attachments/assets/cce2117d-43d1-40d7-ab53-0dd7489ada57" />
