### PR TITLE
fix: use httponly flag on coder_signed_app_token cookie

### DIFF
--- a/coderd/workspaceapps/provider.go
+++ b/coderd/workspaceapps/provider.go
@@ -77,10 +77,11 @@ func ResolveRequest(rw http.ResponseWriter, r *http.Request, opts ResolveRequest
 	// For subdomain apps, this applies to the entire subdomain, e.g.
 	//   app--agent--workspace--user.apps.example.com
 	http.SetCookie(rw, opts.CookieCfg.Apply(&http.Cookie{
-		Name:    codersdk.SignedAppTokenCookie,
-		Value:   tokenStr,
-		Path:    appReq.BasePath,
-		Expires: token.Expiry.Time(),
+		Name:     codersdk.SignedAppTokenCookie,
+		Value:    tokenStr,
+		Path:     appReq.BasePath,
+		HttpOnly: true,
+		Expires:  token.Expiry.Time(),
 	}))
 
 	return token, true


### PR DESCRIPTION
This cookie is only used by the server, not by any JS code anywhere.