### PR TITLE
fix(agent/agentcontainers): respect ignore files

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -21,11 +21,13 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/agent/agentcontainers/ignore"
 	"github.com/coder/coder/v2/agent/agentcontainers/watcher"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/usershell"
@@ -469,13 +471,33 @@ func (api *API) discoverDevcontainerProjects() error {
 }
 
 func (api *API) discoverDevcontainersInProject(projectPath string) error {
+	patterns, err := ignore.ReadPatterns(api.fs, projectPath)
+	if err != nil {
+		return fmt.Errorf("read git ignore patterns: %w", err)
+	}
+
+	matcher := gitignore.NewMatcher(patterns)
+
 	devcontainerConfigPaths := []string{
 		"/.devcontainer/devcontainer.json",
 		"/.devcontainer.json",
 	}
 
 	return afero.Walk(api.fs, projectPath, func(path string, info fs.FileInfo, _ error) error {
+		pathParts := ignore.FilePathToParts(path)
+
+		// We know that a directory entry cannot be a `devcontainer.json` file, so we
+		// always skip processing directories. If the directory happens to be ignored
+		// by git then we'll make sure to ignore all of the children of that directory.
 		if info.IsDir() {
+			if matcher.Match(pathParts, true) {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if matcher.Match(pathParts, false) {
 			return nil
 		}
 

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -473,7 +473,7 @@ func (api *API) discoverDevcontainerProjects() error {
 func (api *API) discoverDevcontainersInProject(projectPath string) error {
 	patterns, err := ignore.ReadPatterns(api.fs, projectPath)
 	if err != nil {
-		return fmt.Errorf("read git ignore patterns: %w", err)
+		return xerrors.Errorf("read git ignore patterns: %w", err)
 	}
 
 	matcher := gitignore.NewMatcher(patterns)

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -472,6 +472,9 @@ func (api *API) discoverDevcontainerProjects() error {
 
 func (api *API) discoverDevcontainersInProject(projectPath string) error {
 	globalPatterns, err := ignore.LoadGlobalPatterns(api.fs)
+	if err != nil {
+		return xerrors.Errorf("read global git ignore patterns: %w", err)
+	}
 
 	patterns, err := ignore.ReadPatterns(api.fs, projectPath)
 	if err != nil {

--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -471,12 +471,14 @@ func (api *API) discoverDevcontainerProjects() error {
 }
 
 func (api *API) discoverDevcontainersInProject(projectPath string) error {
+	globalPatterns, err := ignore.LoadGlobalPatterns(api.fs)
+
 	patterns, err := ignore.ReadPatterns(api.fs, projectPath)
 	if err != nil {
 		return xerrors.Errorf("read git ignore patterns: %w", err)
 	}
 
-	matcher := gitignore.NewMatcher(patterns)
+	matcher := gitignore.NewMatcher(append(globalPatterns, patterns...))
 
 	devcontainerConfigPaths := []string{
 		"/.devcontainer/devcontainer.json",

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3345,6 +3345,46 @@ func TestDevcontainerDiscovery(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "RespectGitIgnore",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":              "",
+				"/home/coder/coder/.gitignore":             "y/",
+				"/home/coder/coder/.devcontainer.json":     "",
+				"/home/coder/coder/x/y/.devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
+		{
+			name:     "RespectNestedGitIgnore",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":              "",
+				"/home/coder/coder/.devcontainer.json":     "",
+				"/home/coder/coder/y/.devcontainer.json":   "",
+				"/home/coder/coder/x/.gitignore":           "y/",
+				"/home/coder/coder/x/y/.devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+				{
+					WorkspaceFolder: "/home/coder/coder/y",
+					ConfigPath:      "/home/coder/coder/y/.devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
 	}
 
 	initFS := func(t *testing.T, files map[string]string) afero.Fs {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3428,6 +3428,34 @@ func TestDevcontainerDiscovery(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "IgnoreNonsenseDevcontainerNames",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/.git/HEAD": "",
+
+				"/home/coder/.devcontainer/devcontainer.json.bak": "",
+				"/home/coder/.devcontainer/devcontainer.json.old": "",
+				"/home/coder/.devcontainer/devcontainer.json~":    "",
+				"/home/coder/.devcontainer/notdevcontainer.json":  "",
+				"/home/coder/.devcontainer/devcontainer.json.swp": "",
+
+				"/home/coder/foo/.devcontainer.json.bak": "",
+				"/home/coder/foo/.devcontainer.json.old": "",
+				"/home/coder/foo/.devcontainer.json~":    "",
+				"/home/coder/foo/.notdevcontainer.json":  "",
+				"/home/coder/foo/.devcontainer.json.swp": "",
+
+				"/home/coder/bar/.devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/bar",
+					ConfigPath:      "/home/coder/bar/.devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
 	}
 
 	initFS := func(t *testing.T, files map[string]string) afero.Fs {

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3385,6 +3385,23 @@ func TestDevcontainerDiscovery(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "RespectGitInfoExclude",
+			agentDir: "/home/coder",
+			fs: map[string]string{
+				"/home/coder/coder/.git/HEAD":              "",
+				"/home/coder/coder/.git/info/exclude":      "y/",
+				"/home/coder/coder/.devcontainer.json":     "",
+				"/home/coder/coder/x/y/.devcontainer.json": "",
+			},
+			expected: []codersdk.WorkspaceAgentDevcontainer{
+				{
+					WorkspaceFolder: "/home/coder/coder",
+					ConfigPath:      "/home/coder/coder/.devcontainer.json",
+					Status:          codersdk.WorkspaceAgentDevcontainerStatusStopped,
+				},
+			},
+		},
 	}
 
 	initFS := func(t *testing.T, files map[string]string) afero.Fs {

--- a/agent/agentcontainers/ignore/dir.go
+++ b/agent/agentcontainers/ignore/dir.go
@@ -15,7 +15,7 @@ func FilePathToParts(path string) []string {
 	components := []string{}
 
 	if path == "" {
-		return []string{}
+		return components
 	}
 
 	for segment := range strings.SplitSeq(filepath.Clean(path), string(filepath.Separator)) {

--- a/agent/agentcontainers/ignore/dir.go
+++ b/agent/agentcontainers/ignore/dir.go
@@ -1,0 +1,68 @@
+package ignore
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+	"github.com/spf13/afero"
+)
+
+func FilePathToParts(path string) []string {
+	components := []string{}
+
+	if path == "" {
+		return []string{}
+	}
+
+	for segment := range strings.SplitSeq(filepath.Clean(path), "/") {
+		if segment != "" {
+			components = append(components, segment)
+		}
+	}
+
+	return components
+}
+
+func readIgnoreFile(fs afero.Fs, path string) ([]gitignore.Pattern, error) {
+	var ps []gitignore.Pattern
+
+	data, err := afero.ReadFile(fs, filepath.Join(path, ".gitignore"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	for s := range strings.SplitSeq(string(data), "\n") {
+		if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
+			ps = append(ps, gitignore.ParsePattern(s, FilePathToParts(path)))
+		}
+	}
+
+	return ps, nil
+}
+
+func ReadPatterns(fileSystem afero.Fs, path string) ([]gitignore.Pattern, error) {
+	ps, _ := readIgnoreFile(fileSystem, path)
+
+	if err := afero.Walk(fileSystem, path, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() {
+			return nil
+		}
+
+		subPs, err := readIgnoreFile(fileSystem, path)
+		if err != nil {
+			return err
+		}
+
+		ps = append(ps, subPs...)
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return ps, nil
+}

--- a/agent/agentcontainers/ignore/dir.go
+++ b/agent/agentcontainers/ignore/dir.go
@@ -27,10 +27,10 @@ func FilePathToParts(path string) []string {
 	return components
 }
 
-func readIgnoreFile(fs afero.Fs, path string) ([]gitignore.Pattern, error) {
+func readIgnoreFile(fileSystem afero.Fs, path string) ([]gitignore.Pattern, error) {
 	var ps []gitignore.Pattern
 
-	data, err := afero.ReadFile(fs, filepath.Join(path, ".gitignore"))
+	data, err := afero.ReadFile(fileSystem, filepath.Join(path, ".gitignore"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func readIgnoreFile(fs afero.Fs, path string) ([]gitignore.Pattern, error) {
 func ReadPatterns(fileSystem afero.Fs, path string) ([]gitignore.Pattern, error) {
 	ps, _ := readIgnoreFile(fileSystem, path)
 
-	if err := afero.Walk(fileSystem, path, func(path string, info fs.FileInfo, err error) error {
+	if err := afero.Walk(fileSystem, path, func(path string, info fs.FileInfo, _ error) error {
 		if !info.IsDir() {
 			return nil
 		}

--- a/agent/agentcontainers/ignore/dir.go
+++ b/agent/agentcontainers/ignore/dir.go
@@ -18,7 +18,7 @@ func FilePathToParts(path string) []string {
 		return []string{}
 	}
 
-	for segment := range strings.SplitSeq(filepath.Clean(path), "/") {
+	for segment := range strings.SplitSeq(filepath.Clean(path), string(filepath.Separator)) {
 		if segment != "" {
 			components = append(components, segment)
 		}

--- a/agent/agentcontainers/ignore/dir.go
+++ b/agent/agentcontainers/ignore/dir.go
@@ -9,11 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"cdr.dev/slog"
 	"github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/spf13/afero"
 	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
 )
 
 const (

--- a/agent/agentcontainers/ignore/dir.go
+++ b/agent/agentcontainers/ignore/dir.go
@@ -45,7 +45,7 @@ func readIgnoreFile(fileSystem afero.Fs, path string) ([]gitignore.Pattern, erro
 }
 
 func ReadPatterns(fileSystem afero.Fs, path string) ([]gitignore.Pattern, error) {
-	ps, _ := readIgnoreFile(fileSystem, path)
+	var ps []gitignore.Pattern
 
 	if err := afero.Walk(fileSystem, path, func(path string, info fs.FileInfo, _ error) error {
 		if !info.IsDir() {

--- a/agent/agentcontainers/ignore/dir_test.go
+++ b/agent/agentcontainers/ignore/dir_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coder/coder/v2/agent/agentcontainers/ignore"
 	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/agentcontainers/ignore"
 )
 
 func TestFilePathToParts(t *testing.T) {

--- a/agent/agentcontainers/ignore/dir_test.go
+++ b/agent/agentcontainers/ignore/dir_test.go
@@ -1,0 +1,46 @@
+package ignore_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coder/coder/v2/agent/agentcontainers/ignore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilePathToParts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     string
+		expected []string
+	}{
+		{"/foo/bar/baz", []string{"foo", "bar", "baz"}},
+		{"foo/bar/baz", []string{"foo", "bar", "baz"}},
+		{"/foo", []string{"foo"}},
+		{"foo", []string{"foo"}},
+		{"/", []string{}},
+		{"", []string{}},
+		{"./foo/bar", []string{"foo", "bar"}},
+		{"../foo/bar", []string{"..", "foo", "bar"}},
+		{"/foo//bar///baz", []string{"foo", "bar", "baz"}},
+		{"foo/bar/", []string{"foo", "bar"}},
+		{"/foo/bar/", []string{"foo", "bar"}},
+		{"foo/../bar", []string{"bar"}},
+		{"./foo/../bar", []string{"bar"}},
+		{"/foo/../bar", []string{"bar"}},
+		{"foo/./bar", []string{"foo", "bar"}},
+		{"/foo/./bar", []string{"foo", "bar"}},
+		{"a/b/c/d/e", []string{"a", "b", "c", "d", "e"}},
+		{"/a/b/c/d/e", []string{"a", "b", "c", "d", "e"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("`%s`", tt.path), func(t *testing.T) {
+			t.Parallel()
+
+			parts := ignore.FilePathToParts(tt.path)
+			require.Equal(t, tt.expected, parts)
+		})
+	}
+}

--- a/agent/agentcontainers/ignore/dir_test.go
+++ b/agent/agentcontainers/ignore/dir_test.go
@@ -16,24 +16,15 @@ func TestFilePathToParts(t *testing.T) {
 		path     string
 		expected []string
 	}{
-		{"/foo/bar/baz", []string{"foo", "bar", "baz"}},
-		{"foo/bar/baz", []string{"foo", "bar", "baz"}},
-		{"/foo", []string{"foo"}},
-		{"foo", []string{"foo"}},
-		{"/", []string{}},
 		{"", []string{}},
+		{"/", []string{}},
+		{"foo", []string{"foo"}},
+		{"/foo", []string{"foo"}},
 		{"./foo/bar", []string{"foo", "bar"}},
 		{"../foo/bar", []string{"..", "foo", "bar"}},
-		{"/foo//bar///baz", []string{"foo", "bar", "baz"}},
-		{"foo/bar/", []string{"foo", "bar"}},
-		{"/foo/bar/", []string{"foo", "bar"}},
+		{"foo/bar/baz", []string{"foo", "bar", "baz"}},
+		{"/foo/bar/baz", []string{"foo", "bar", "baz"}},
 		{"foo/../bar", []string{"bar"}},
-		{"./foo/../bar", []string{"bar"}},
-		{"/foo/../bar", []string{"bar"}},
-		{"foo/./bar", []string{"foo", "bar"}},
-		{"/foo/./bar", []string{"foo", "bar"}},
-		{"a/b/c/d/e", []string{"a", "b", "c", "d", "e"}},
-		{"/a/b/c/d/e", []string{"a", "b", "c", "d", "e"}},
 	}
 
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -484,6 +484,7 @@ require (
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/preview v1.0.3-0.20250714153828-a737d4750448
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/go-git/go-git/v5 v5.16.2
 	github.com/mark3labs/mcp-go v0.34.0
 )
 
@@ -514,7 +515,6 @@ require (
 	github.com/esiqveland/notify v0.13.3 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-git/go-git/v5 v5.16.2 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/go-getter v1.7.8 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/fergusstrange/embedded-postgres v1.31.0
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/gen2brain/beeep v0.11.1
-	github.com/gliderlabs/ssh v0.3.4
+	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/httprate v0.15.0
@@ -512,10 +512,14 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/esiqveland/notify v0.13.3 // indirect
+	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
+	github.com/go-git/go-billy/v5 v5.6.2 // indirect
+	github.com/go-git/go-git/v5 v5.16.2 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/go-getter v1.7.8 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/jackmordaunt/icns/v3 v3.0.1 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
@@ -535,5 +539,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	google.golang.org/genai v1.12.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1102,6 +1102,8 @@ github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UN
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git/v5 v5.16.0 h1:k3kuOEpkc0DeY7xlL6NaaNg39xdgQbtH5mwCafHO9AQ=
 github.com/go-git/go-git/v5 v5.16.0/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-git/go-git/v5 v5.16.2 h1:fT6ZIOjE5iEnkzKyxTHK1W4HGAsPhqEqiSAssSO77hM=
+github.com/go-git/go-git/v5 v5.16.2/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/go.sum
+++ b/go.sum
@@ -1100,8 +1100,6 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
-github.com/go-git/go-git/v5 v5.16.0 h1:k3kuOEpkc0DeY7xlL6NaaNg39xdgQbtH5mwCafHO9AQ=
-github.com/go-git/go-git/v5 v5.16.0/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/go-git/go-git/v5 v5.16.2 h1:fT6ZIOjE5iEnkzKyxTHK1W4HGAsPhqEqiSAssSO77hM=
 github.com/go-git/go-git/v5 v5.16.2/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/19011

We now use [go-git](https://pkg.go.dev/github.com/go-git/go-git/v5@v5.16.2/plumbing/format/gitignore)'s `gitignore` plumbing implementation to parse the `.gitignore` files and match against the patterns generated. We use this to ignore any ignored files in the git repository.

Unfortunately I've had to slightly re-implement some of the interface exposed by `go-git` because they use `billy.Filesystem` instead of `afero.Fs`.