### PR TITLE
fix(docs): add missing GFM alert directives to blockquotes

### DIFF
--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -96,6 +96,7 @@ Use the following `make` commands and scripts in development:
 
    This should return an empty list of workspaces. If you encounter an error, review the output from the [develop.sh](https://github.com/coder/coder/blob/main/scripts/develop.sh) script for issues.
 
+   > [!NOTE]
    > `coder-dev.sh` is a helper script that behaves like the regular coder CLI, but uses the binary built from your local source and shares the same configuration directory set up by `develop.sh`. This ensures your local changes are reflected when testing.
    >
    > The default user is `admin@coder.com` and the default password is `SomeSecurePassword!`

--- a/docs/support/support-bundle.md
+++ b/docs/support/support-bundle.md
@@ -73,6 +73,7 @@ A brief overview of all files contained in the bundle is provided below:
    prompt. The support bundle will be generated in the current directory with
    the filename `coder-support-$TIMESTAMP.zip`.
 
+   > [!NOTE]
    > While support bundles can be generated without a running workspace, it is
    > recommended to specify one to maximize troubleshooting information.
 

--- a/docs/user-guides/workspace-access/jetbrains/gateway.md
+++ b/docs/user-guides/workspace-access/jetbrains/gateway.md
@@ -10,6 +10,7 @@ manually configured SSH connection.
 
 ### How to use the plugin
 
+> [!NOTE]
 > If you experience problems, please
 > [create a GitHub issue](https://github.com/coder/coder/issues) or share in
 > [our Discord channel](https://discord.gg/coder).


### PR DESCRIPTION
I just added support for rendering GFM alerts inside of numbered lists in coder.com (see https://github.com/coder/coder.com/pull/328), and noticed that these plain blockquotes should probably be alerts.

This should cover all the missing alerts. I found them by searching for the regex `^\s*>\s` within docs/**/*.md

Is `[!NOTE]` the correct type for these? Or do we want to use tip/important/etc?

- @mtojek CONTRIBUTING.md
- @johnstcn support-bundle.md
- @matifali gateway.md