### PR TITLE
fix: fix nil pointer dereference in ReportTask

### DIFF
--- a/coderd/mcp/mcp.go
+++ b/coderd/mcp/mcp.go
@@ -79,11 +79,15 @@ func (s *Server) RegisterTools(client *codersdk.Client) error {
 		return xerrors.Errorf("failed to initialize tool dependencies: %w", err)
 	}
 
-	// Register all available tools
+	// Register all available tools, but exclude tools that require dependencies not available in the
+	// remote MCP context
 	for _, tool := range toolsdk.All {
+		if tool.Name == toolsdk.ToolNameReportTask {
+			continue
+		}
+
 		s.mcpServer.AddTools(mcpFromSDK(tool, toolDeps))
 	}
-
 	return nil
 }
 

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -253,6 +253,10 @@ ONLY report an "idle" or "failure" state if you have FULLY completed the task.
 		if len(args.Summary) > 160 {
 			return codersdk.Response{}, xerrors.New("summary must be less than 160 characters")
 		}
+		// Check if task reporting is available to prevent nil pointer dereference
+		if deps.report == nil {
+			return codersdk.Response{}, xerrors.New("task reporting not available. Please ensure a task reporter is configured.")
+		}
 		err := deps.report(args)
 		if err != nil {
 			return codersdk.Response{}, err


### PR DESCRIPTION
This pull request addresses a bug related to a nil pointer dereference in the task reporting functionality.

### Bug Fixes and Error Handling:

* Updated `RegisterTools` in `mcp.go` to skip registering the `ReportTask` tool in the remote MCP context when a task reporter is not configured, preventing potential nil pointer dereference panics.
* Added a check in `toolsdk.go` to ensure task reporting dependencies are available before invoking the reporter, returning an appropriate error if not.

### Test Coverage:

* Added `TestReportTaskNilPointerDeref` in `toolsdk_test.go` to verify that the system does not panic when task reporting dependencies are missing and instead returns a clear error message.
* Added `TestReportTaskWithReporter` in `toolsdk_test.go` to validate correct behavior when a task reporter is configured, ensuring the handler processes the request as expected.