### PR TITLE
fix: avoid duplicating logs on Coder Connect Windows

### DIFF
--- a/cli/vpndaemon_windows.go
+++ b/cli/vpndaemon_windows.go
@@ -63,10 +63,7 @@ func (r *RootCmd) vpnDaemonRun() *serpent.Command {
 			defer pipe.Close()
 
 			logger.Info(ctx, "starting tunnel")
-			tunnel, err := vpn.NewTunnel(ctx, logger, pipe, vpn.NewClient(),
-				vpn.UseOSNetworkingStack(),
-				vpn.UseCustomLogSinks(sinks...),
-			)
+			tunnel, err := vpn.NewTunnel(ctx, logger, pipe, vpn.NewClient(), vpn.UseOSNetworkingStack())
 			if err != nil {
 				return xerrors.Errorf("create new tunnel for client: %w", err)
 			}

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -192,12 +192,6 @@ func UseAsLogger() TunnelOption {
 	}
 }
 
-func UseCustomLogSinks(sinks ...slog.Sink) TunnelOption {
-	return func(t *Tunnel) {
-		t.clientLogger = t.clientLogger.AppendSinks(sinks...)
-	}
-}
-
 func WithClock(clock quartz.Clock) TunnelOption {
 	return func(t *Tunnel) {
 		t.clock = clock


### PR DESCRIPTION
The sinks are already added to the logger above, so they're just getting duplicated