### PR TITLE
chore(agent/agentcontainers): test current prebuilds integration

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2464,6 +2464,8 @@ func TestAgent_DevcontainersDisabledForSubAgent(t *testing.T) {
 // You can run it manually as follows:
 //
 // CODER_TEST_USE_DOCKER=1 go test -count=1 ./agent -run TestAgent_DevcontainerPrebuildClaim
+//
+//nolint:paralleltest // This test sets an environment variable.
 func TestAgent_DevcontainerPrebuildClaim(t *testing.T) {
 	if os.Getenv("CODER_TEST_USE_DOCKER") != "1" {
 		t.Skip("Set CODER_TEST_USE_DOCKER=1 to run this test")
@@ -2523,6 +2525,7 @@ func TestAgent_DevcontainerPrebuildClaim(t *testing.T) {
 	}
 
 	// When: We create an agent with devcontainers enabled.
+	//nolint:dogsled
 	conn, client, _, _, _ := setupAgent(t, manifest, 0, func(_ *agenttest.Client, o *agent.Options) {
 		o.Devcontainers = true
 		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,
@@ -2597,6 +2600,7 @@ func TestAgent_DevcontainerPrebuildClaim(t *testing.T) {
 	}
 
 	// When: We create an agent with devcontainers enabled.
+	//nolint:dogsled
 	conn, client, _, _, _ = setupAgent(t, manifest, 0, func(_ *agenttest.Client, o *agent.Options) {
 		o.Devcontainers = true
 		o.DevcontainerAPIOptions = append(o.DevcontainerAPIOptions,

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3822,6 +3822,10 @@ func TestDevcontainerDiscovery(t *testing.T) {
 func TestDevcontainerPrebuildSupport(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("Dev Container tests are not supported on Windows")
+	}
+
 	var (
 		ctx        = testutil.Context(t, testutil.WaitShort)
 		logger     = testutil.Logger(t)
@@ -3839,6 +3843,7 @@ func TestDevcontainerPrebuildSupport(t *testing.T) {
 			WorkspaceFolder: "/home/coder/coder",
 			ConfigPath:      "/home/coder/coder/.devcontainer/devcontainer.json",
 		}
+
 		testContainer = newFakeContainer("test-container-id", testDC.ConfigPath, testDC.WorkspaceFolder)
 
 		prebuildOwner     = "prebuilds"

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -3905,9 +3905,9 @@ func TestDevcontainerPrebuildSupport(t *testing.T) {
 			MergedConfiguration: agentcontainers.DevcontainerMergedConfiguration{
 				Customizations: agentcontainers.DevcontainerMergedCustomizations{
 					Coder: []agentcontainers.CoderCustomization{
-						agentcontainers.CoderCustomization{
+						{
 							Apps: []agentcontainers.SubAgentApp{
-								agentcontainers.SubAgentApp{
+								{
 									Slug: "zed",
 									URL:  prebuildAppURL,
 								},
@@ -3929,10 +3929,8 @@ func TestDevcontainerPrebuildSupport(t *testing.T) {
 			testDC.WorkspaceFolder, testDC.ConfigPath,
 			"/.coder-agent/coder", []string{"agent"}, gomock.Any(), gomock.Any(),
 		).Do(func(ctx context.Context, _, _, _ string, _ []string, _ ...agentcontainers.DevcontainerCLIExecOptions) error {
-			select {
-			case <-ctx.Done():
-				return nil
-			}
+			<-ctx.Done()
+			return nil
 		}),
 	)
 
@@ -4018,9 +4016,9 @@ func TestDevcontainerPrebuildSupport(t *testing.T) {
 			MergedConfiguration: agentcontainers.DevcontainerMergedConfiguration{
 				Customizations: agentcontainers.DevcontainerMergedCustomizations{
 					Coder: []agentcontainers.CoderCustomization{
-						agentcontainers.CoderCustomization{
+						{
 							Apps: []agentcontainers.SubAgentApp{
-								agentcontainers.SubAgentApp{
+								{
 									Slug: "zed",
 									URL:  userAppURL,
 								},
@@ -4042,10 +4040,8 @@ func TestDevcontainerPrebuildSupport(t *testing.T) {
 			testDC.WorkspaceFolder, testDC.ConfigPath,
 			"/.coder-agent/coder", []string{"agent"}, gomock.Any(), gomock.Any(),
 		).Do(func(ctx context.Context, _, _, _ string, _ []string, _ ...agentcontainers.DevcontainerCLIExecOptions) error {
-			select {
-			case <-ctx.Done():
-				return nil
-			}
+			<-ctx.Done()
+			return nil
 		}),
 	)
 


### PR DESCRIPTION
As it turns out, prebuilds + devcontainers appear to already work together. This PR has created a test that simulates a prebuild claim happening to `agentcontainers.API`, to see how we handle it.