### PR TITLE
chore(agent/agentcontainers): skip part of test if on `darwin`

### DIFF
--- a/agent/agentcontainers/watcher/watcher_test.go
+++ b/agent/agentcontainers/watcher/watcher_test.go
@@ -95,7 +95,7 @@ func TestFSNotifyWatcher(t *testing.T) {
 	// This test flake could be indicative of an issue that may present itself
 	// in a running environment. Fortunately, we only use this (as of 2025-07-29)
 	// for our dev container integration. We do not expect the host workspace
-	// (where this is used), to ever be ran on macOS, as containers are a linux
+	// (where this is used), to ever be run on macOS, as containers are a linux
 	// paradigm.
 	if runtime.GOOS != "darwin" {
 		err = os.WriteFile(testFile+".atomic", []byte(`{"test": "atomic"}`), 0o600)

--- a/agent/agentcontainers/watcher/watcher_test.go
+++ b/agent/agentcontainers/watcher/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -88,24 +89,34 @@ func TestFSNotifyWatcher(t *testing.T) {
 		break
 	}
 
-	err = os.WriteFile(testFile+".atomic", []byte(`{"test": "atomic"}`), 0o600)
-	require.NoError(t, err, "write new atomic test file failed")
+	// TODO(DanielleMaywood):
+	// Unfortunately it appears this atomic-rename phase of the test is flakey on macOS.
+	//
+	// This test flake could be indicative of an issue that may present itself
+	// in a running environment. Fortunately, we only use this (as of 2025-07-29)
+	// for our dev container integration. We do not expect the host workspace
+	// (where this is used), to ever be ran on macOS, as containers are a linux
+	// paradigm.
+	if runtime.GOOS != "darwin" {
+		err = os.WriteFile(testFile+".atomic", []byte(`{"test": "atomic"}`), 0o600)
+		require.NoError(t, err, "write new atomic test file failed")
 
-	err = os.Rename(testFile+".atomic", testFile)
-	require.NoError(t, err, "rename atomic test file failed")
+		err = os.Rename(testFile+".atomic", testFile)
+		require.NoError(t, err, "rename atomic test file failed")
 
-	// Verify that we receive the event we want.
-	for {
-		event, err := wut.Next(ctx)
-		require.NoError(t, err, "next event failed")
-		require.NotNil(t, event, "want non-nil event")
-		if !event.Has(fsnotify.Create) {
-			t.Logf("Ignoring event: %s", event)
-			continue
+		// Verify that we receive the event we want.
+		for {
+			event, err := wut.Next(ctx)
+			require.NoError(t, err, "next event failed")
+			require.NotNil(t, event, "want non-nil event")
+			if !event.Has(fsnotify.Create) {
+				t.Logf("Ignoring event: %s", event)
+				continue
+			}
+			require.Truef(t, event.Has(fsnotify.Create), "want create event: %s", event.String())
+			require.Equal(t, event.Name, testFile, "want event for test file")
+			break
 		}
-		require.Truef(t, event.Has(fsnotify.Create), "want create event: %s", event.String())
-		require.Equal(t, event.Name, testFile, "want event for test file")
-		break
 	}
 
 	// Test removing the file from the watcher.


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/765

I've been unable to figure out how to fix this (unfortunately my macOS file system knowledge is lacking). Given that this test is causing a lot of flakes at the moment, I think it is best to skip this part of the test on macOS for now.