### PR TITLE
docs: add code-server/vs code web comparison table

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -252,6 +252,11 @@
 							"path": "./user-guides/workspace-access/web-ides.md"
 						},
 						{
+							"title": "code-server",
+							"description": "Access your workspace with code-server",
+							"path": "./user-guides/workspace-access/code-server.md"
+						},
+						{
 							"title": "Zed",
 							"description": "Access your workspace with Zed",
 							"path": "./user-guides/workspace-access/zed.md"

--- a/docs/user-guides/workspace-access/code-server.md
+++ b/docs/user-guides/workspace-access/code-server.md
@@ -1,0 +1,29 @@
+# code-server
+
+[code-server](https://github.com/coder/code-server) is our supported method of running VS Code in the web browser.
+
+![code-server in a workspace](../../images/code-server-ide.png)
+
+## Differences between code-server and VS Code Web
+
+Some of the key differences between code-server and VS Code Web are:
+
+| Feature                  | code-server                                                                 | VS Code Web                                                       |
+|--------------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------|
+| Authentication           | Optional login form                                                         | No built-in auth                                                  |
+| Built-in proxy           | Includes development proxy (not needed with Coder)                          | No built-in development proxy                                     |
+| Clipboard integration    | Supports piping text from terminal (similar to `xclip`)                     | More limited                                                      |
+| Display languages        | Supports language pack extensions                                           | Limited language support                                          |
+| File operations          | Options to disable downloads and uploads                                    | No built-in restrictions                                          |
+| Health endpoint          | Provides `/healthz` endpoint                                                | Limited health monitoring                                         |
+| Marketplace              | Open VSX by default, configurable via flags/env vars                        | Uses Microsoft marketplace; modify `product.json` to use your own |
+| Path-based routing       | Has fixes for state collisions when used path-based                         | May have issues with path-based routing in certain configurations |
+| Proposed API             | Always enabled for all extensions                                           | Only Microsoft extensions without configuration                   |
+| Proxy integration        | Integrates with Coder's proxy for ports panel                               | Integration is more limited                                       |
+| Sourcemaps               | Loads locally                                                               | Uses CDN                                                          |
+| Telemetry                | Configurable endpoint                                                       | Does not allow a configurable endpoint                            |
+| Terminal access to files | You can use a terminal outside of the integrated one to interact with files | Limited to integrated terminal access                             |
+| User settings            | Stored on remote disk                                                       | Stored in browser                                                 |
+| Web views                | Self-contained                                                              | Uses Microsoft CDN                                                |
+
+For more information about code-server, visit the [code-server FAQ](https://coder.com/docs/code-server/FAQ).

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -78,12 +78,12 @@ Your workspace is now accessible via `ssh coder.<workspace_name>`
 ## Visual Studio Code
 
 You can develop in your Coder workspace remotely with
-[VSCode](https://code.visualstudio.com/download). We support connecting with the
-desktop client and VSCode in the browser with [code-server](#code-server).
+[VS Code](https://code.visualstudio.com/download).
+We support connecting with the desktop client and VS Code in the browser with [code-server](#code-server).
 
 ![Demo](https://github.com/coder/vscode-coder/raw/main/demo.gif?raw=true)
 
-Read more details on [using VSCode in your workspace](./vscode.md).
+Read more details on [using VS Code in your workspace](./vscode.md).
 
 ## Cursor
 
@@ -118,7 +118,8 @@ on connecting your JetBrains IDEs.
 ## code-server
 
 [code-server](https://github.com/coder/code-server) is our supported method of
-running VS Code in the web browser. You can read more in our
+running VS Code in the web browser.
+Learn more about [what makes code-server different from VS Code web](./code-server.md) or visit the
 [documentation for code-server](https://coder.com/docs/code-server/latest).
 
 ![code-server in a workspace](../../images/code-server-ide.png)

--- a/docs/user-guides/workspace-access/vscode.md
+++ b/docs/user-guides/workspace-access/vscode.md
@@ -1,13 +1,15 @@
 # Visual Studio Code
 
 You can develop in your Coder workspace remotely with
-[VSCode](https://code.visualstudio.com/download). We support connecting with the
-desktop client and VSCode in the browser with
+[VS Code](https://code.visualstudio.com/download).
+We support connecting with the desktop client and VS Code in the browser with
 [code-server](https://github.com/coder/code-server).
+Learn more about how VS Code Web and code-server compare in the
+[code-server doc](./code-server.md).
 
-## VSCode Desktop
+## VS Code Desktop
 
-VSCode desktop is a default app for workspaces.
+VS Code desktop is a default app for workspaces.
 
 Click `VS Code Desktop` in the dashboard to one-click enter a workspace. This
 automatically installs the [Coder Remote](https://github.com/coder/vscode-coder)
@@ -21,7 +23,7 @@ extension, authenticates with Coder, and connects to the workspace.
 
 ### Manual Installation
 
-You can install our extension manually in VSCode using the command palette.
+You can install our extension manually in VS Code using the command palette.
 Launch VS Code Quick Open (Ctrl+P), paste the following command, and press
 enter.
 


### PR DESCRIPTION
closes #18815 

adds a doc with comparison table and links to main documentation for code-server

[preview](https://coder.com/docs/@18815-code-server-vs/user-guides/workspace-access/code-server)