### PR TITLE
docs: use CODER_LOG_FILTER instead of CODER_VERBOSE

### DIFF
--- a/docs/admin/monitoring/notifications/index.md
+++ b/docs/admin/monitoring/notifications/index.md
@@ -282,7 +282,7 @@ troubleshoot:
 1. Review the logs. Search for the term `notifications` for diagnostic information.
 
    - If you do not see any relevant logs, set
-    `CODER_VERBOSE=true` or `--verbose` to output debug logs.
+    `CODER_LOG_FILTER=".*notifications.*"` to filter for notification-related logs.
 1. If you are on version 2.15.x, notifications must be enabled using the
     `notifications`
     [experiment](../../../install/releases/feature-stages.md#early-access-features).

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -419,7 +419,6 @@ If you are running into issues with a sync:
 1. To reduce noise, you can filter for only logs related to group/role sync:
 
    ```sh
-   CODER_VERBOSE=true
    CODER_LOG_FILTER=".*userauth.*|.*groups returned.*"
    ```
 

--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -203,7 +203,7 @@ Visit the Coder UI to confirm these changes:
 ### Group allowlist
 
 You can limit which groups from your identity provider can log in to Coder with
-[CODER_OIDC_ALLOWED_GROUPS](https://coder.com/docs/cli/server#--oidc-allowed-groups).
+[CODER_OIDC_ALLOWED_GROUPS](../../reference/cli/server.md#--oidc-allowed-groups).
 Users who are not in a matching group will see the following error:
 
 <Image height="412px" src="../../images/admin/group-allowlist.png" alt="Unauthorized group error" align="center" />

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -27,7 +27,7 @@ claims from the ID token and the claims obtained from hitting the upstream
 provider's `userinfo` endpoint, and use the resulting data as a basis for
 creating a new user or looking up an existing user.
 
-To troubleshoot claims, set `CODER_VERBOSE=true` and follow the logs while
+To troubleshoot claims, set `CODER_LOG_FILTER=".*got oidc claims.*"` and follow the logs while
 signing in via OIDC as a new user. Coder will log the claim fields returned by
 the upstream identity provider in a message containing the string
 `got oidc claims`, as well as the user info returned.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -252,6 +252,11 @@
 							"path": "./user-guides/workspace-access/web-ides.md"
 						},
 						{
+							"title": "code-server",
+							"description": "Access your workspace with code-server",
+							"path": "./user-guides/workspace-access/code-server.md"
+						},
+						{
 							"title": "Zed",
 							"description": "Access your workspace with Zed",
 							"path": "./user-guides/workspace-access/zed.md"

--- a/docs/user-guides/workspace-access/code-server.md
+++ b/docs/user-guides/workspace-access/code-server.md
@@ -1,0 +1,29 @@
+# code-server
+
+[code-server](https://github.com/coder/code-server) is our supported method of running VS Code in the web browser.
+
+![code-server in a workspace](../../images/code-server-ide.png)
+
+## Differences between code-server and VS Code Web
+
+Some of the key differences between code-server and VS Code Web are:
+
+| Feature                  | code-server                                                                 | VS Code Web                                                       |
+|--------------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------|
+| Authentication           | Optional login form                                                         | No built-in auth                                                  |
+| Built-in proxy           | Includes development proxy (not needed with Coder)                          | No built-in development proxy                                     |
+| Clipboard integration    | Supports piping text from terminal (similar to `xclip`)                     | More limited                                                      |
+| Display languages        | Supports language pack extensions                                           | Limited language support                                          |
+| File operations          | Options to disable downloads and uploads                                    | No built-in restrictions                                          |
+| Health endpoint          | Provides `/healthz` endpoint                                                | Limited health monitoring                                         |
+| Marketplace              | Open VSX by default, configurable via flags/env vars                        | Uses Microsoft marketplace; modify `product.json` to use your own |
+| Path-based routing       | Has fixes for state collisions when used path-based                         | May have issues with path-based routing in certain configurations |
+| Proposed API             | Always enabled for all extensions                                           | Only Microsoft extensions without configuration                   |
+| Proxy integration        | Integrates with Coder's proxy for ports panel                               | Integration is more limited                                       |
+| Sourcemaps               | Loads locally                                                               | Uses CDN                                                          |
+| Telemetry                | Configurable endpoint                                                       | Does not allow a configurable endpoint                            |
+| Terminal access to files | You can use a terminal outside of the integrated one to interact with files | Limited to integrated terminal access                             |
+| User settings            | Stored on remote disk                                                       | Stored in browser                                                 |
+| Web views                | Self-contained                                                              | Uses Microsoft CDN                                                |
+
+For more information about code-server, visit the [code-server FAQ](https://coder.com/docs/code-server/FAQ).

--- a/docs/user-guides/workspace-access/index.md
+++ b/docs/user-guides/workspace-access/index.md
@@ -78,12 +78,12 @@ Your workspace is now accessible via `ssh coder.<workspace_name>`
 ## Visual Studio Code
 
 You can develop in your Coder workspace remotely with
-[VSCode](https://code.visualstudio.com/download). We support connecting with the
-desktop client and VSCode in the browser with [code-server](#code-server).
+[VS Code](https://code.visualstudio.com/download).
+We support connecting with the desktop client and VS Code in the browser with [code-server](#code-server).
 
 ![Demo](https://github.com/coder/vscode-coder/raw/main/demo.gif?raw=true)
 
-Read more details on [using VSCode in your workspace](./vscode.md).
+Read more details on [using VS Code in your workspace](./vscode.md).
 
 ## Cursor
 
@@ -118,7 +118,8 @@ on connecting your JetBrains IDEs.
 ## code-server
 
 [code-server](https://github.com/coder/code-server) is our supported method of
-running VS Code in the web browser. You can read more in our
+running VS Code in the web browser.
+Learn more about [what makes code-server different from VS Code web](./code-server.md) or visit the
 [documentation for code-server](https://coder.com/docs/code-server/latest).
 
 ![code-server in a workspace](../../images/code-server-ide.png)


### PR DESCRIPTION
closes #18833

replace suggestions to use the now-deprecated `CODER_VERBOSE` with more specific `CODER_LOG_FILTER`

thanks @UnicornyRainbow!