### PR TITLE
chore(agent/agentcontainers): disable project autostart by default

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -289,7 +289,7 @@ func WithProjectDiscovery(projectDiscovery bool) Option {
 	}
 }
 
-// WithProjectDiscovery sets if the API should attempt to autostart
+// WithDiscoveryAutostart sets if the API should attempt to autostart
 // projects that have been discovered
 func WithDiscoveryAutostart(discoveryAutostart bool) Option {
 	return func(api *API) {

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -40,23 +40,24 @@ import (
 
 func (r *RootCmd) workspaceAgent() *serpent.Command {
 	var (
-		auth                         string
-		logDir                       string
-		scriptDataDir                string
-		pprofAddress                 string
-		noReap                       bool
-		sshMaxTimeout                time.Duration
-		tailnetListenPort            int64
-		prometheusAddress            string
-		debugAddress                 string
-		slogHumanPath                string
-		slogJSONPath                 string
-		slogStackdriverPath          string
-		blockFileTransfer            bool
-		agentHeaderCommand           string
-		agentHeader                  []string
-		devcontainers                bool
-		devcontainerProjectDiscovery bool
+		auth                           string
+		logDir                         string
+		scriptDataDir                  string
+		pprofAddress                   string
+		noReap                         bool
+		sshMaxTimeout                  time.Duration
+		tailnetListenPort              int64
+		prometheusAddress              string
+		debugAddress                   string
+		slogHumanPath                  string
+		slogJSONPath                   string
+		slogStackdriverPath            string
+		blockFileTransfer              bool
+		agentHeaderCommand             string
+		agentHeader                    []string
+		devcontainers                  bool
+		devcontainerProjectDiscovery   bool
+		devcontainerDiscoveryAutostart bool
 	)
 	cmd := &serpent.Command{
 		Use:   "agent",
@@ -366,6 +367,7 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 					DevcontainerAPIOptions: []agentcontainers.Option{
 						agentcontainers.WithSubAgentURL(r.agentURL.String()),
 						agentcontainers.WithProjectDiscovery(devcontainerProjectDiscovery),
+						agentcontainers.WithDiscoveryAutostart(devcontainerDiscoveryAutostart),
 					},
 				})
 
@@ -518,6 +520,13 @@ func (r *RootCmd) workspaceAgent() *serpent.Command {
 			Env:         "CODER_AGENT_DEVCONTAINERS_PROJECT_DISCOVERY_ENABLE",
 			Description: "Allow the agent to search the filesystem for devcontainer projects.",
 			Value:       serpent.BoolOf(&devcontainerProjectDiscovery),
+		},
+		{
+			Flag:        "devcontainers-discovery-autostart-enable",
+			Default:     "false",
+			Env:         "CODER_AGENT_DEVCONTAINERS_DISCOVERY_AUTOSTART_ENABLE",
+			Description: "Allow the agent to autostart devcontainer projects it discovers based on their configuration.",
+			Value:       serpent.BoolOf(&devcontainerDiscoveryAutostart),
 		},
 	}
 

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -33,6 +33,10 @@ OPTIONS:
       --debug-address string, $CODER_AGENT_DEBUG_ADDRESS (default: 127.0.0.1:2113)
           The bind address to serve a debug HTTP server.
 
+      --devcontainers-discovery-autostart-enable bool, $CODER_AGENT_DEVCONTAINERS_DISCOVERY_AUTOSTART_ENABLE (default: false)
+          Allow the agent to autostart devcontainer projects it discovers based
+          on their configuration.
+
       --devcontainers-enable bool, $CODER_AGENT_DEVCONTAINERS_ENABLE (default: true)
           Allow the agent to automatically detect running devcontainers.
 


### PR DESCRIPTION
We disable the logic that allows autostarting discovered devcontainers by default. We want this behavior to be opt-in rather than opt-out.