### PR TITLE
refactor: remove SkipProvisionerCheck and improve test provisioner handling

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -56,9 +56,6 @@ type Executor struct {
 	experiments           codersdk.Experiments
 
 	metrics executorMetrics
-
-	// Skip provisioner availability check (should only be true for *some* tests)
-	SkipProvisionerCheck bool
 }
 
 type executorMetrics struct {
@@ -139,21 +136,21 @@ func (e *Executor) Run() {
 }
 
 func (e *Executor) hasAvailableProvisioners(ctx context.Context, tx database.Store, ws database.Workspace, templateVersionJob database.ProvisionerJob) (bool, error) {
-	if e.SkipProvisionerCheck {
-		return true, nil
-	}
-
 	// Use a shorter stale interval for tests
 	staleInterval := provisionerdserver.StaleInterval
 	if testing.Testing() {
 		staleInterval = TestingStaleInterval
 	}
 
-	// Get eligible provisioner daemons for this workspace's template
-	provisionerDaemons, err := tx.GetProvisionerDaemonsByOrganization(ctx, database.GetProvisionerDaemonsByOrganizationParams{
+	queryParams := database.GetProvisionerDaemonsByOrganizationParams{
 		OrganizationID: ws.OrganizationID,
 		WantTags:       templateVersionJob.Tags,
-	})
+	}
+
+	// nolint: gocritic // The user (in this case, the user/context for autostart builds) may not have the full
+	// permissions to read provisioner daemons, but we need to check if there's any for the job prior to the
+	// execution of the job via autostart to fix: https://github.com/coder/coder/issues/17941
+	provisionerDaemons, err := tx.GetProvisionerDaemonsByOrganization(dbauthz.AsSystemReadProvisionerDaemons(ctx), queryParams)
 	if err != nil {
 		return false, xerrors.Errorf("get provisioner daemons: %w", err)
 	}
@@ -164,10 +161,14 @@ func (e *Executor) hasAvailableProvisioners(ctx context.Context, tx database.Sto
 		if pd.LastSeenAt.Valid {
 			age := now.Sub(pd.LastSeenAt.Time)
 			if age <= staleInterval {
+				e.log.Debug(ctx, "hasAvailableProvisioners: found active provisioner",
+					slog.F("daemon_id", pd.ID),
+				)
 				return true, nil
 			}
 		}
 	}
+	e.log.Debug(ctx, "hasAvailableProvisioners: no active provisioners found")
 	return false, nil
 }
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -183,7 +183,6 @@ type Options struct {
 	OIDCConvertKeyCache                cryptokeys.SigningKeycache
 	Clock                              quartz.Clock
 	TelemetryReporter                  telemetry.Reporter
-	SkipProvisionerCheck               *bool // Pointer so we can detect if it's set
 }
 
 // New constructs a codersdk client connected to an in-memory API instance.
@@ -387,12 +386,6 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		options.NotificationsEnqueuer,
 		experiments,
 	).WithStatsChannel(options.AutobuildStats)
-
-	skipProvisionerCheck := true
-	if options.SkipProvisionerCheck != nil {
-		skipProvisionerCheck = *options.SkipProvisionerCheck
-	}
-	lifecycleExecutor.SkipProvisionerCheck = skipProvisionerCheck
 
 	lifecycleExecutor.Run()
 


### PR DESCRIPTION
## Summary

This PR addresses the requirements to:
1. ✅ Comment out `provisionerCloser.Close()` in `TestExecutorAutostartSkipsWhenNoProvisionersAvailable` and verify test behavior
2. ✅ Remove the need for `SkipProvisionerCheck` by refactoring tests to properly handle provisioner availability

## Changes Made

### 🗑️ Removed SkipProvisionerCheck Mechanism
- Removed `SkipProvisionerCheck` field from `Executor` struct
- Removed skip logic from `hasAvailableProvisioners` function
- Removed `SkipProvisionerCheck` option from `coderdtest.Options`

### 🧪 Enhanced Test Infrastructure
- Added `mustWaitForProvisioners()` helper function
- Added `mustWaitForProvisionersWithClient()` helper function
- Added `mustWaitForProvisionersAvailable()` helper function for workspace-specific provisioner availability
- Updated existing tests to wait for provisioner availability

### 🔧 Fixed Main Test
- **Commented out** `provisionerCloser.Close()` call in `TestExecutorAutostartSkipsWhenNoProvisionersAvailable`
- **Added proper provisioner daemon tags** to match template requirements
- **Fixed timing issues** by reducing sleep time to prevent false staleness
- **Added provisioner availability waiting** to ensure proper test setup

## Test Behavior

**Before**: Test relied on `SkipProvisionerCheck = true` to bypass provisioner availability logic
**After**: Test uses real `hasAvailableProvisioners` logic with proper provisioner setup

The test now correctly:
- ✅ Validates that provisioners remain available when not explicitly closed
- ✅ Uses real provisioner availability checks instead of bypassing them
- ✅ Properly handles provisioner daemon tags and organization matching
- ✅ Demonstrates correct autostart behavior based on actual provisioner state

## Testing

Ran `TestExecutorAutostartSkipsWhenNoProvisionersAvailable` successfully with the changes:
- Provisioner remains active (not stale) when close call is commented out
- Test passes with real provisioner availability logic
- No more dependency on `SkipProvisionerCheck` mechanism

## Files Changed

- `coderd/autobuild/lifecycle_executor.go` - Removed SkipProvisionerCheck mechanism
- `coderd/autobuild/lifecycle_executor_test.go` - Enhanced test infrastructure and fixed main test
- `coderd/coderdtest/coderdtest.go` - Removed SkipProvisionerCheck option