### PR TITLE
ci: conditionally disable spotlight indexing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -340,6 +340,11 @@ jobs:
       - name: Disable Spotlight Indexing
         if: runner.os == 'macOS'
         run: |
+          enabled=$(sudo mdutil -a -s | grep "Indexing enabled" | wc -l)
+          if [ $enabled -eq 0 ]; then
+            echo "Spotlight indexing is already disabled"
+            exit 0
+          fi
           sudo mdutil -a -i off
           sudo mdutil -X /
           sudo launchctl bootout system /System/Library/LaunchDaemons/com.apple.metadata.mds.plist


### PR DESCRIPTION
Work around for following issue:
```
Run sudo mdutil -a -i off
  sudo mdutil -a -i off
  sudo mdutil -X /
  sudo launchctl bootout system /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
  shell: /bin/bash -e {0}
4 files/directories removed
Boot-out failed: 5: Input/output error
```

This can happen if spotlight has already been disabled.