### PR TITLE
ci: bump xcode version to 16.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -340,6 +340,11 @@ jobs:
       - name: Disable Spotlight Indexing
         if: runner.os == 'macOS'
         run: |
+          enabled=$(sudo mdutil -a -s | grep "Indexing enabled" | wc -l)
+          if [ $enabled -eq 0 ]; then
+            echo "Spotlight indexing is already disabled"
+            exit 0
+          fi
           sudo mdutil -a -i off
           sudo mdutil -X /
           sudo launchctl bootout system /System/Library/LaunchDaemons/com.apple.metadata.mds.plist

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -964,7 +964,7 @@ jobs:
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: "16.0.0"
+          xcode-version: "16.1.0"
 
       - name: Setup Go
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
Looks like 16.0.0 is no longer available

```
Available versions:
┌─────────┬──────────┬─────────────┬─────────────┬────────┬──────────────────────────────────┐
│ (index) │ version  │ buildNumber │ releaseType │ stable │ path                             │
├─────────┼──────────┼─────────────┼─────────────┼────────┼──────────────────────────────────┤
│ 0       │ '16.4.0' │ '16F6'      │ 'GM'        │ true   │ '/Applications/Xcode_16.4.app'   │
│ 1       │ '16.3.0' │ '16E140'    │ 'GM'        │ true   │ '/Applications/Xcode_16.3.app'   │
│ 2       │ '16.2.0' │ '16C5032a'  │ 'GM'        │ true   │ '/Applications/Xcode_16.2.app'   │
│ 3       │ '16.1.0' │ '16B40'     │ 'GM'        │ true   │ '/Applications/Xcode_16.1.app'   │
│ 4       │ '15.4.0' │ '15F31d'    │ 'GM'        │ true   │ '/Applications/Xcode_15.4.app'   │
│ 5       │ '15.3.0' │ '15E204a'   │ 'GM'        │ true   │ '/Applications/Xcode_15.3.app'   │
│ 6       │ '15.2.0' │ '15C500b'   │ 'GM'        │ true   │ '/Applications/Xcode_15.2.app'   │
│ 7       │ '15.1.0' │ '15C65'     │ 'GM'        │ true   │ '/Applications/Xcode_15.1.app'   │
│ 8       │ '15.0.1' │ '15A507'    │ 'GM'        │ true   │ '/Applications/Xcode_15.0.1.app' │
└─────────┴──────────┴─────────────┴─────────────┴────────┴──────────────────────────────────┘
```

Bumping in `ci.yaml` so we can test before bumping in `release.yaml`