### PR TITLE
ci: set valid xcode version in release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: "16.0.0"
+          xcode-version: "16.1.0"
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -655,7 +655,7 @@ jobs:
             detached_signature="${binary}.asc"
             gcloud storage cp "./site/out/bin/${binary}" "gs://releases.coder.com/coder-cli/${version}/${binary}"
             gcloud storage cp "./site/out/bin/${detached_signature}" "gs://releases.coder.com/coder-cli/${version}/${detached_signature}"
-          done  
+          done
 
       - name: Publish release
         run: |


### PR DESCRIPTION
16.0.0 was yanked from the macOS runners, so this will likely need cherry picking into the upcoming release branch.

We've already checked everything builds fine on #19125.

In a few releases we'll stop building the dylib and also therefore remove xcode as a dependency on coder/coder altogether.