### PR TITLE
fix: adjust the kubectl exec example

### DIFF
--- a/docs/admin/users/index.md
+++ b/docs/admin/users/index.md
@@ -173,7 +173,7 @@ coder reset-password <username>
 ### Resetting a password on Kubernetes
 
 ```shell
-kubectl exec -it deployment/coder /bin/bash -n coder
+kubectl exec -it deployment/coder -n coder -- /bin/bash
 
 coder reset-password <username>
 ```


### PR DESCRIPTION
Current example fails since kubectl version 1.31:
```sh
$ kubectl exec -it deployment/coder /bin/bash -n coder
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
```

The legacy syntax was removed in:
https://github.com/kubernetes/kubernetes/pull/125437