### PR TITLE
docs: oauth2-provider fixes

### DIFF
--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -1,7 +1,6 @@
 # OAuth2 Provider (Experimental)
 
-> ⚠️ **Experimental Feature**
->
+> [!WARNING]
 > The OAuth2 provider functionality is currently **experimental and unstable**. This feature:
 >
 > - Is subject to breaking changes without notice
@@ -232,8 +231,6 @@ This implementation follows established OAuth2 standards including [RFC 6749](ht
 - Check [External Authentication](../external-auth/index.md) for configuring Coder as an OAuth2 client
 - See [Security Best Practices](../security/index.md) for deployment security guidance
 
----
+## Feedback
 
-> 📝 **Feedback**
->
-> This is an experimental feature under active development. Please report issues and feedback through [GitHub Issues](https://github.com/coder/coder/issues) with the `oauth2` label.
+This is an experimental feature under active development. Please report issues and feedback through [GitHub Issues](https://github.com/coder/coder/issues) with the `oauth2` label.

--- a/docs/ai-coder/mcp-server.md
+++ b/docs/ai-coder/mcp-server.md
@@ -55,4 +55,4 @@ https://coder.example.com/api/experimental/mcp/http
 > [!NOTE]
 > At this time, the remote MCP server is not compatible with web-based ChatGPT.
 
-Users can authenticate applications to use the remote MCP server with OAuth2. An authenticated application can perform any action on the user's behalf. Fine-grained permissions are in development.
+Users can authenticate applications to use the remote MCP server with [OAuth2](../admin/integrations/oauth2-provider.md). An authenticated application can perform any action on the user's behalf. Fine-grained permissions are in development.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -718,6 +718,11 @@
 							"title": "Hashicorp Vault",
 							"description": "Integrate Coder with Hashicorp Vault",
 							"path": "./admin/integrations/vault.md"
+						},
+						{
+							"title": "OAuth2 Provider",
+							"description": "Use Coder as an OAuth2 provider",
+							"path": "./admin/integrations/oauth2-provider.md"
 						}
 					]
 				},


### PR DESCRIPTION
Adds the oauth2-provider doc page to the manifest so it's rendered in the docs, fixes formatting in the oauth2-provider doc, and links to it from the MCP doc.

To see the formatting issues, visit https://coder.com/docs/@4bcf44a/admin/integrations/oauth2-provider. To see the doc after the fixes, visit https://coder.com/docs/@f05969a/admin/integrations/oauth2-provider.