### PR TITLE
chore(dogfood): move regions to a separate module

### DIFF
--- a/dogfood/coder/modules/dogfood-regions/main.tf
+++ b/dogfood/coder/modules/dogfood-regions/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "~> 2.9"
+    }
+  }
+}
+
+// These are cluster service addresses mapped to Tailscale nodes. Ask Dean or
+// Kyle for help.
+output "docker_host" { 
+  value = {
+    ""              = "tcp://dogfood-ts-cdr-dev.tailscale.svc.cluster.local:2375"
+    "us-pittsburgh" = "tcp://dogfood-ts-cdr-dev.tailscale.svc.cluster.local:2375"
+    // For legacy reasons, this host is labelled `eu-helsinki` but it's
+    // actually in Germany now.
+    "eu-helsinki" = "tcp://katerose-fsn-cdr-dev.tailscale.svc.cluster.local:2375"
+    "ap-sydney"   = "tcp://wolfgang-syd-cdr-dev.tailscale.svc.cluster.local:2375"
+    "sa-saopaulo" = "tcp://oberstein-sao-cdr-dev.tailscale.svc.cluster.local:2375"
+    "za-cpt"      = "tcp://schonkopf-cpt-cdr-dev.tailscale.svc.cluster.local:2375"
+  }
+}


### PR DESCRIPTION
When we got rid of Helsinki, it broke a bunch of templates that were hardcoding the Docker host.

I feel like this would be good to have to avoid automatic bricking if we ever change anything.

There were other ways to do this, e.g actually incorporate the parameters in the module, and the user group detection, but i didn't think that was really necessary, let me know what you think.