### PR TITLE
chore(helm): make coder pprof endpoint available externally

### DIFF
--- a/helm/coder/templates/_coder.tpl
+++ b/helm/coder/templates/_coder.tpl
@@ -41,6 +41,8 @@ env:
   value: "0.0.0.0:8080"
 - name: CODER_PROMETHEUS_ADDRESS
   value: "0.0.0.0:2112"
+- name: CODER_PPROF_ADDRESS
+  value: "0.0.0.0:6060"
 {{- if .Values.provisionerDaemon.pskSecretName }}
 - name: CODER_PROVISIONER_DAEMON_PSK
   valueFrom:

--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:

--- a/helm/coder/tests/testdata/auto_access_url_1_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/auto_access_url_2_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:

--- a/helm/coder/tests/testdata/auto_access_url_3_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/command_args_coder.golden
+++ b/helm/coder/tests/testdata/command_args_coder.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/command_coder.golden
+++ b/helm/coder/tests/testdata/command_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/custom_resources.golden
+++ b/helm/coder/tests/testdata/custom_resources.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/custom_resources_coder.golden
+++ b/helm/coder/tests/testdata/custom_resources_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/default_values_coder.golden
+++ b/helm/coder/tests/testdata/default_values_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/env_from_coder.golden
+++ b/helm/coder/tests/testdata/env_from_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -162,6 +162,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/extra_templates_coder.golden
+++ b/helm/coder/tests/testdata/extra_templates_coder.golden
@@ -162,6 +162,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -161,6 +161,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/labels_annotations_coder.golden
+++ b/helm/coder/tests/testdata/labels_annotations_coder.golden
@@ -161,6 +161,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/partial_resources.golden
+++ b/helm/coder/tests/testdata/partial_resources.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/partial_resources_coder.golden
+++ b/helm/coder/tests/testdata/partial_resources_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/pod_securitycontext.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/pod_securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -152,6 +152,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/prometheus_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_coder.golden
@@ -152,6 +152,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_PROVISIONER_DAEMON_PSK
           valueFrom:
             secretKeyRef:

--- a/helm/coder/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_PROVISIONER_DAEMON_PSK
           valueFrom:
             secretKeyRef:

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/sa_disabled.golden
+++ b/helm/coder/tests/testdata/sa_disabled.golden
@@ -139,6 +139,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/sa_disabled_coder.golden
+++ b/helm/coder/tests/testdata/sa_disabled_coder.golden
@@ -139,6 +139,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -167,6 +167,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/sa_extra_rules_coder.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules_coder.golden
@@ -167,6 +167,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/securitycontext.golden
+++ b/helm/coder/tests/testdata/securitycontext.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/securitycontext_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/svc_loadbalancer.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/svc_loadbalancer_class.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/svc_nodeport.golden
+++ b/helm/coder/tests/testdata/svc_nodeport.golden
@@ -152,6 +152,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/svc_nodeport_coder.golden
+++ b/helm/coder/tests/testdata/svc_nodeport_coder.golden
@@ -152,6 +152,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -158,6 +158,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: https://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/tls_coder.golden
+++ b/helm/coder/tests/testdata/tls_coder.golden
@@ -158,6 +158,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: https://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/topology.golden
+++ b/helm/coder/tests/testdata/topology.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/topology_coder.golden
+++ b/helm/coder/tests/testdata/topology_coder.golden
@@ -153,6 +153,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/tests/testdata/workspace_proxy_coder.golden
+++ b/helm/coder/tests/testdata/workspace_proxy_coder.golden
@@ -154,6 +154,8 @@ spec:
           value: 0.0.0.0:8080
         - name: CODER_PROMETHEUS_ADDRESS
           value: 0.0.0.0:2112
+        - name: CODER_PPROF_ADDRESS
+          value: 0.0.0.0:6060
         - name: CODER_ACCESS_URL
           value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -12,6 +12,8 @@ coder:
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
   # - CODER_PROMETHEUS_ADDRESS: set to 0.0.0.0:2112 and cannot be changed.
   #   Prometheus must still be enabled by setting CODER_PROMETHEUS_ENABLE.
+  # - CODER_PPROF_ADDRESS: set to 0.0.0.0:6060 and cannot be changed.
+  #   Profiling must still be enabled by setting CODER_PPROF_ENABLE.
   # - KUBE_POD_IP
   # - CODER_DERP_SERVER_RELAY_URL
   #


### PR DESCRIPTION
PProf is still disabled by default