### PR TITLE
fix(site): hide "Show parent apps" when no running or starting devcontainers

### DIFF
--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -286,11 +286,17 @@ export const GroupApp: Story = {
 };
 
 export const Devcontainer: Story = {
-	beforeEach: () => {
-		spyOn(API, "getAgentContainers").mockResolvedValue({
-			devcontainers: [M.MockWorkspaceAgentDevcontainer],
-			containers: [M.MockWorkspaceAgentContainer],
-		});
+	parameters: {
+		queries: [
+			{
+				key: ["agents", M.MockWorkspaceAgent.id, "containers"],
+				data: {
+					devcontainers: [M.MockWorkspaceAgentDevcontainer],
+					containers: [M.MockWorkspaceAgentContainer],
+				},
+			},
+		],
+		webSocket: [],
 	},
 };
 
@@ -300,17 +306,23 @@ export const FoundDevcontainer: Story = {
 			...M.MockWorkspaceAgentReady,
 		},
 	},
-	beforeEach: () => {
-		spyOn(API, "getAgentContainers").mockResolvedValue({
-			devcontainers: [
-				{
-					...M.MockWorkspaceAgentDevcontainer,
-					status: "stopped",
-					container: undefined,
-					agent: undefined,
+	parameters: {
+		queries: [
+			{
+				key: ["agents", M.MockWorkspaceAgentReady.id, "containers"],
+				data: {
+					devcontainers: [
+						{
+							...M.MockWorkspaceAgentDevcontainer,
+							status: "stopped",
+							container: undefined,
+							agent: undefined,
+						},
+					],
+					containers: [],
 				},
-			],
-			containers: [],
-		});
+			},
+		],
+		webSocket: [],
 	},
 };

--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -293,3 +293,24 @@ export const Devcontainer: Story = {
 		});
 	},
 };
+
+export const FoundDevcontainer: Story = {
+	args: {
+		agent: {
+			...M.MockWorkspaceAgentReady,
+		},
+	},
+	beforeEach: () => {
+		spyOn(API, "getAgentContainers").mockResolvedValue({
+			devcontainers: [
+				{
+					...M.MockWorkspaceAgentDevcontainer,
+					status: "stopped",
+					container: undefined,
+					agent: undefined,
+				},
+			],
+			containers: [],
+		});
+	},
+};

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -137,17 +137,16 @@ export const AgentRow: FC<AgentRowProps> = ({
 	// This is used to show the parent apps of the devcontainer.
 	const [showParentApps, setShowParentApps] = useState(false);
 
-	let shouldDisplayAppsSection = shouldDisplayAgentApps;
-	if (
-		devcontainers &&
-		devcontainers.find(
-			// We only want to hide the parent apps by default when there are dev
-			// containers that are either starting or running. If they are all in
-			// the stopped state, it doesn't make sense to hide the parent apps.
+	const anyRunningOrStartingDevcontainers =
+		devcontainers?.find(
 			(dc) => dc.status === "running" || dc.status === "starting",
-		) !== undefined &&
-		!showParentApps
-	) {
+		) !== undefined;
+
+	// We only want to hide the parent apps by default when there are dev
+	// containers that are either starting or running. If they are all in
+	// the stopped state, it doesn't make sense to hide the parent apps.
+	let shouldDisplayAppsSection = shouldDisplayAgentApps;
+	if (devcontainers && anyRunningOrStartingDevcontainers && !showParentApps) {
 		shouldDisplayAppsSection = false;
 	}
 
@@ -187,7 +186,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 				</div>
 
 				<div className="flex items-center gap-2">
-					{devcontainers && devcontainers.length > 0 && (
+					{anyRunningOrStartingDevcontainers && (
 						<Button
 							variant="outline"
 							size="sm"

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -146,7 +146,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 	// containers that are either starting or running. If they are all in
 	// the stopped state, it doesn't make sense to hide the parent apps.
 	let shouldDisplayAppsSection = shouldDisplayAgentApps;
-	if (devcontainers && anyRunningOrStartingDevcontainers && !showParentApps) {
+	if (anyRunningOrStartingDevcontainers && !showParentApps) {
 		shouldDisplayAppsSection = false;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/19199

We now hide the "Show parent apps" button when there are no running or starting devcontainers.
