### PR TITLE
fix(site): fix render crash when no embedded apps are defined for task

### DIFF
--- a/site/src/pages/TaskPage/TaskApps.stories.tsx
+++ b/site/src/pages/TaskPage/TaskApps.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { WorkspaceApp } from "api/typesGenerated";
+import {
+	MockTasks,
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+} from "testHelpers/entities";
+import { withProxyProvider } from "testHelpers/storybook";
+import { TaskApps } from "./TaskApps";
+
+const meta: Meta<typeof TaskApps> = {
+	title: "pages/TaskPage/TaskApps",
+	component: TaskApps,
+	decorators: [withProxyProvider()],
+	parameters: {
+		layout: "fullscreen",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof TaskApps>;
+
+const mockAgentNoApps = {
+	...MockWorkspaceAgent,
+	apps: [],
+};
+
+const mockExternalApp: WorkspaceApp = {
+	...MockWorkspaceApp,
+	external: true,
+};
+
+const mockEmbeddedApp: WorkspaceApp = {
+	...MockWorkspaceApp,
+	external: false,
+};
+
+const taskWithNoApps = {
+	...MockTasks[0],
+	workspace: {
+		...MockWorkspace,
+		latest_build: {
+			...MockWorkspace.latest_build,
+			resources: [
+				{
+					...MockWorkspace.latest_build.resources[0],
+					agents: [mockAgentNoApps],
+				},
+			],
+		},
+	},
+};
+
+export const NoEmbeddedApps: Story = {
+	args: {
+		task: taskWithNoApps,
+	},
+};
+
+export const WithExternalAppsOnly: Story = {
+	args: {
+		task: {
+			...MockTasks[0],
+			workspace: {
+				...MockWorkspace,
+				latest_build: {
+					...MockWorkspace.latest_build,
+					resources: [
+						{
+							...MockWorkspace.latest_build.resources[0],
+							agents: [
+								{
+									...MockWorkspaceAgent,
+									apps: [mockExternalApp],
+								},
+							],
+						},
+					],
+				},
+			},
+		},
+	},
+};
+
+export const WithEmbeddedApps: Story = {
+	args: {
+		task: {
+			...MockTasks[0],
+			workspace: {
+				...MockWorkspace,
+				latest_build: {
+					...MockWorkspace.latest_build,
+					resources: [
+						{
+							...MockWorkspace.latest_build.resources[0],
+							agents: [
+								{
+									...MockWorkspaceAgent,
+									apps: [mockEmbeddedApp],
+								},
+							],
+						},
+					],
+				},
+			},
+		},
+	},
+};
+
+export const WithMixedApps: Story = {
+	args: {
+		task: {
+			...MockTasks[0],
+			workspace: {
+				...MockWorkspace,
+				latest_build: {
+					...MockWorkspace.latest_build,
+					resources: [
+						{
+							...MockWorkspace.latest_build.resources[0],
+							agents: [
+								{
+									...MockWorkspaceAgent,
+									apps: [mockEmbeddedApp, mockExternalApp],
+								},
+							],
+						},
+					],
+				},
+			},
+		},
+	},
+};


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/19101

We now gracefully handle the scenario when there are no embedded apps defined for a task.

I've added a storybook file specifically for the `TaskApps` component. I'm aware we already have some stories for `TaskApps` in the `TaskPage.stories.tsx` so I'm happy to move these stories over to that if it makes more sense.

<img width="2560" height="1417" alt="Screenshot 2025-08-07 at 10 31 55" src="https://github.com/user-attachments/assets/5ebcd7a7-712d-4692-a8c9-2898b7864791" />
