### PR TITLE
ci: bump xcode version to 16.1.0 (#19125)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -964,7 +964,7 @@ jobs:
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: "16.0.0"
+          xcode-version: "16.1.0"
 
       - name: Setup Go
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
(cherry picked from commit 0d7cc5c1569a5e3f1fe9463c1fbe60b0e7d61d2e)

required for CI to pass with new runner version