### PR TITLE
fix: pin Nix version to 2.28.4 to avoid JSON type error

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -35,7 +35,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Nix
-        uses: nixbuild/nix-quick-install-action@889f3180bb5f064ee9e3201428d04ae9e41d54ad # v31
+        uses: nixbuild/nix-quick-install-action@63ca48f939ee3b8d835f4126562537df0fee5b91 # v32
+        with:
+          # Pinning to 2.28 here, as Nix gets a "error: [json.exception.type_error.302] type must be array, but is string"
+          # on version 2.29 and above.
+          nix_version: "2.28.4"
 
       - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
         with:


### PR DESCRIPTION
Pin Nix version to 2.28.4 in dogfood workflow

Pins the Nix version in the dogfood workflow to 2.28.4 to avoid a JSON type error that occurs with Nix 2.29 and above.

Change-Id: Ie024d5070dbe5901952fc52463c6602363ef8886
Signed-off-by: Thomas Kosiewski [tk@coder.com](mailto:tk@coder.com)