### PR TITLE
fix: return empty array if no option multi-selected

### DIFF
--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -349,7 +349,11 @@ func RichMultiSelect(inv *serpent.Invocation, richOptions RichMultiSelectOptions
 	}
 
 	// Check selected option, convert descriptions (line) to values
-	var results []string
+	//
+	// The function must return an initialized empty array, since it is later marshalled
+	// into JSON. Otherwise, `var results []string` would be marshalled to "null".
+	// See: https://github.com/golang/go/issues/27589
+	results := []string{}
 	for _, sel := range selected {
 		custom := true
 		for i, option := range richOptions.Options {

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -350,8 +350,8 @@ func RichMultiSelect(inv *serpent.Invocation, richOptions RichMultiSelectOptions
 
 	// Check selected option, convert descriptions (line) to values
 	//
-	// The function must return an initialized empty array, since it is later marshalled
-	// into JSON. Otherwise, `var results []string` would be marshalled to "null".
+	// The function must return an initialized empty array, since it is later marshaled
+	// into JSON. Otherwise, `var results []string` would be marshaled to "null".
 	// See: https://github.com/golang/go/issues/27589
 	results := []string{}
 	for _, sel := range selected {

--- a/cli/cliui/select_test.go
+++ b/cli/cliui/select_test.go
@@ -112,7 +112,7 @@ func TestRichMultiSelect(t *testing.T) {
 			want:        []string{"aaa", "bbb"},
 		},
 		{
-			name: "Empty",
+			name: "NoOptionSelected",
 			options: []codersdk.TemplateVersionParameterOption{
 				{Name: "AAA", Description: "This is AAA", Value: "aaa"},
 				{Name: "BBB", Description: "This is BBB", Value: "bbb"},

--- a/cli/cliui/select_test.go
+++ b/cli/cliui/select_test.go
@@ -111,6 +111,17 @@ func TestRichMultiSelect(t *testing.T) {
 			allowCustom: true,
 			want:        []string{"aaa", "bbb"},
 		},
+		{
+			name: "Empty",
+			options: []codersdk.TemplateVersionParameterOption{
+				{Name: "AAA", Description: "This is AAA", Value: "aaa"},
+				{Name: "BBB", Description: "This is BBB", Value: "bbb"},
+				{Name: "CCC", Description: "This is CCC", Value: "ccc"},
+			},
+			defaults:    []string{},
+			allowCustom: false,
+			want:        []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/19145

This PR adds a workaround for standard Go behavior: marshal `[]string` to `[]` rather than `null`.