### PR TITLE
fix: use system context for querying workspaces when deleting users (#19211)

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -542,7 +542,10 @@ func (api *API) deleteUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspaces, err := api.Database.GetWorkspaces(ctx, database.GetWorkspacesParams{
+	// This query is ONLY done to get the workspace count, so we use a system
+	// context to return ALL workspaces. Not just workspaces the user can view.
+	// nolint:gocritic
+	workspaces, err := api.Database.GetWorkspaces(dbauthz.AsSystemRestricted(ctx), database.GetWorkspacesParams{
 		OwnerID: user.ID,
 	})
 	if err != nil {


### PR DESCRIPTION
Backport of #19211 to our ESR, v2.24, since this is a kind of bad (albeit rare) bug and very easy to fix.

### Original PR

Closes #19209.

This fixes a bug where a user who has workspaces could be deleted, if the user doing the deleting couldn't view the workspace.

In `templates.go`, we do this to make sure we count ALL workspaces for a template before we try and delete that template: https://github.com/coder/coder/blob/dc598856e3be0926573dbbe2ec680e95a139093a/coderd/templates.go#L81-L99

However, we weren't doing the same when attempting to delete users, leading to the linked issue. We can solve the issue the same way as we do for templates.