### PR TITLE
fix: preserve existing template fields in PATCH requests

### DIFF
--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -771,12 +771,34 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 		classicTemplateFlow = *req.UseClassicParameterFlow
 	}
 
+	// Users should not be able to clear the template name in the UI
+	name := req.Name
+	if name == "" {
+		name = template.Name
+	}
+
+	// Preserve existing values for fields not provided in PATCH request
+	displayName := req.DisplayName
+	if displayName == "" {
+		displayName = template.DisplayName
+	}
+
+	description := req.Description
+	if description == "" {
+		description = template.Description
+	}
+
+	icon := req.Icon
+	if icon == "" {
+		icon = template.Icon
+	}
+
 	var updated database.Template
 	err = api.Database.InTx(func(tx database.Store) error {
-		if req.Name == template.Name &&
-			req.Description == template.Description &&
-			req.DisplayName == template.DisplayName &&
-			req.Icon == template.Icon &&
+		if name == template.Name &&
+			description == template.Description &&
+			displayName == template.DisplayName &&
+			icon == template.Icon &&
 			req.AllowUserAutostart == template.AllowUserAutostart &&
 			req.AllowUserAutostop == template.AllowUserAutostop &&
 			req.AllowUserCancelWorkspaceJobs == template.AllowUserCancelWorkspaceJobs &&
@@ -794,12 +816,6 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 			maxPortShareLevel == template.MaxPortSharingLevel &&
 			corsBehavior == template.CorsBehavior {
 			return nil
-		}
-
-		// Users should not be able to clear the template name in the UI
-		name := req.Name
-		if name == "" {
-			name = template.Name
 		}
 
 		groupACL := template.GroupACL
@@ -827,9 +843,9 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 			ID:                           template.ID,
 			UpdatedAt:                    dbtime.Now(),
 			Name:                         name,
-			DisplayName:                  req.DisplayName,
-			Description:                  req.Description,
-			Icon:                         req.Icon,
+			DisplayName:                  displayName,
+			Description:                  description,
+			Icon:                         icon,
 			AllowUserCancelWorkspaceJobs: req.AllowUserCancelWorkspaceJobs,
 			GroupACL:                     groupACL,
 			MaxPortSharingLevel:          maxPortShareLevel,

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -1377,7 +1377,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 		assert.Equal(t, template.DefaultTTLMillis, updated.DefaultTTLMillis)
 	})
 
-	t.Run("RemoveIcon", func(t *testing.T) {
+	t.Run("PreserveIconWhenEmpty", func(t *testing.T) {
 		t.Parallel()
 
 		client := coderdtest.New(t, nil)
@@ -1386,15 +1386,18 @@ func TestPatchTemplateMeta(t *testing.T) {
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
 			ctr.Icon = "/icon/code.png"
 		})
+		// Test that when only updating other fields, the icon is preserved
 		req := codersdk.UpdateTemplateMeta{
-			Icon: "",
+			DefaultTTLMillis: 12 * time.Hour.Milliseconds(),
 		}
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		updated, err := client.UpdateTemplateMeta(ctx, template.ID, req)
 		require.NoError(t, err)
-		assert.Equal(t, updated.Icon, "")
+		// Icon should be preserved when not explicitly provided
+		assert.Equal(t, "/icon/code.png", updated.Icon)
+		assert.Equal(t, req.DefaultTTLMillis, updated.DefaultTTLMillis)
 	})
 
 	t.Run("AutostopRequirement", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes issue #19036 where updating only specific fields (like `default_ttl_ms`) via PATCH request would unintentionally clear other fields (like `icon`, `display_name`, `description`) when they weren't provided in the request.

## Problem

When making a PATCH request to `/api/v2/templates/{template_id}` with only `{"default_ttl_ms": 12345}`, the template's icon field was being cleared because the request struct would have empty strings for fields not provided in the JSON, and these empty strings were being used to update the database.

## Solution

The fix preserves existing values for fields that are not explicitly provided in the request:

- If a field is empty in the request (indicating it wasn't provided), use the existing value from the database
- If a field has a value in the request, use that value to update the database

This follows proper PATCH semantics where only provided fields should be updated.

## Changes

- **`coderd/templates.go`**: Added logic to preserve existing values for `name`, `displayName`, `description`, and `icon` fields when they are empty in the request
- **`coderd/templates_test.go`**: Updated test to verify that fields are preserved when not provided in PATCH requests

## Testing

- ✅ Code compiles successfully
- ✅ Updated existing test to verify the new behavior
- ✅ Manually tested the fix logic

## Breaking Changes

This change modifies the behavior of the template PATCH endpoint. Previously, sending an empty string for a field would clear it. Now, empty strings are treated as "preserve existing value". This is generally the expected behavior for PATCH operations, but it means you can no longer explicitly clear fields by sending empty strings.

## Fixes

Fixes #19036