### PR TITLE
refactor(site): migrate ActiveUserChart from emotion to tailwind styling

### DIFF
--- a/site/src/components/ActiveUserChart/ActiveUserChart.tsx
+++ b/site/src/components/ActiveUserChart/ActiveUserChart.tsx
@@ -113,7 +113,7 @@ type ActiveUsersTitleProps = {
 
 export const ActiveUsersTitle: FC<ActiveUsersTitleProps> = ({ interval }) => {
 	return (
-		<div css={{ display: "flex", alignItems: "center", gap: 8 }}>
+		<div className="flex items-center gap-2">
 			{interval === "day" ? "Daily" : "Weekly"} Active Users
 			<HelpTooltip>
 				<HelpTooltipTrigger size="small" />


### PR DESCRIPTION
## Summary
- Replaced emotion `css` prop with equivalent Tailwind classes in `ActiveUsersTitle` component
- Migrated inline styling `{ display: "flex", alignItems: "center", gap: 8 }` to Tailwind classes `flex items-center gap-2`
- Part of the ongoing migration from emotion styling to Tailwind

## Test plan
- Visual verification that the component appears the same with flexbox layout and proper spacing

🤖 Generated with [Claude Code](https://claude.ai/code)