### PR TITLE
fix: fix race in reconnecting-pty/screen

### DIFF
--- a/agent/reconnectingpty/screen.go
+++ b/agent/reconnectingpty/screen.go
@@ -244,16 +244,11 @@ func (rpty *screenReconnectingPTY) doAttach(ctx context.Context, conn net.Conn, 
 		return nil, nil, err
 	}
 
-	// This context lets us abort the version command if the process dies.
-	versionCtx, versionCancel := context.WithCancel(ctx)
-	defer versionCancel()
-
 	// Pipe pty -> conn and close the connection when the process exits.
 	// We do not need to separately monitor for the process exiting.  When it
 	// exits, our ptty.OutputReader() will return EOF after reading all process
 	// output.
 	go func() {
-		defer versionCancel()
 		defer func() {
 			err := conn.Close()
 			if err != nil {
@@ -300,7 +295,7 @@ func (rpty *screenReconnectingPTY) doAttach(ctx context.Context, conn net.Conn, 
 	// making the version pop up briefly) so use it to wait for the session to
 	// come up.  If we do not wait we could end up spawning multiple sessions with
 	// the same name.
-	err = rpty.sendCommand(versionCtx, "version", nil)
+	err = rpty.sendCommand(ctx, "version", nil)
 	if err != nil {
 		// Log only for debugging since the process might already have closed.
 		closeErr := ptty.Close()


### PR DESCRIPTION
Context: Screen backend used a readiness probe (screen -X version) tied to a cancel coming from the output reader, so an initial short-lived attach (e.g., for connection reporting) could cancel the wait and leave no master session. Subsequent attaches then failed with "Cannot find master process to attach to!" and tests would fail attempting to find the prompt.

Change: decouple the readiness probe from the output reader cancellation; use the attach context directly so the session must reach ready or fail. This prevents the flake where the first quick connect/disconnect prevents actual session creation.

Tested: ran agent package tests locally; Screen subtest is skipped here without `screen`, but the change is isolated to screen backend.

Co-authored-by: sreya <4856196+sreya@users.noreply.github.com>