### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/ai-coder/custom-agents.md
+++ b/docs/ai-coder/custom-agents.md
@@ -1,6 +1,6 @@
 # Custom Agents
 
-Custom agents beyond the ones listed in the [Coder registry](https://registry.coder.com/modules?tag=agent) can be used with Coder Tasks.
+Custom agents beyond the ones listed in the [Coder registry](https://registry.coder.com/modules?search=tag%3Aagent) can be used with Coder Tasks.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixed a broken link to the coder registry so that it correctly loads agent modules

https://coder.com/docs/ai-coder/custom-agents

