### PR TITLE
feat: claim prebuilds based on workspace parameters instead of preset id

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1810,6 +1810,14 @@ func (q *querier) FetchVolumesResourceMonitorsUpdatedAfter(ctx context.Context, 
 	return q.db.FetchVolumesResourceMonitorsUpdatedAfter(ctx, updatedAt)
 }
 
+func (q *querier) FindMatchingPresetID(ctx context.Context, arg database.FindMatchingPresetIDParams) (uuid.UUID, error) {
+	_, err := q.GetTemplateVersionByID(ctx, arg.TemplateVersionID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return q.db.FindMatchingPresetID(ctx, arg)
+}
+
 func (q *querier) GetAPIKeyByID(ctx context.Context, id string) (database.APIKey, error) {
 	return fetch(q.log, q.auth, q.db.GetAPIKeyByID)(ctx, id)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4975,28 +4975,6 @@ func (s *MethodTestSuite) TestPrebuilds() {
 			ParameterValues:   []string{"test"},
 		}).Asserts(tv.RBACObject(t1), policy.ActionRead).Returns(uuid.Nil)
 	}))
-	// s.Run("FindMatchingPresetID", s.Subtest(func(db database.Store, check *expects) {
-	// 	org := dbgen.Organization(s.T(), db, database.Organization{})
-	// 	user := dbgen.User(s.T(), db, database.User{})
-	// 	templateVersion := dbgen.TemplateVersion(s.T(), db, database.TemplateVersion{
-	// 		OrganizationID: org.ID,
-	// 		CreatedBy:      user.ID,
-	// 	})
-	// 	template := dbgen.Template(s.T(), db, database.Template{
-	// 		OrganizationID:  org.ID,
-	// 		CreatedBy:       user.ID,
-	// 		ActiveVersionID: templateVersion.ID,
-	// 	})
-	// 	db.UpdateTemplateActiveVersionByID(context.Background(), database.UpdateTemplateActiveVersionByIDParams{
-	// 		ID:              template.ID,
-	// 		ActiveVersionID: templateVersion.ID,
-	// 	})
-	// 	check.Args(database.FindMatchingPresetIDParams{
-	// 		TemplateVersionID: templateVersion.ID,
-	// 		ParameterNames:    []string{"test"},
-	// 		ParameterValues:   []string{"test"},
-	// 	}).Asserts(templateVersion.RBACObject(template), policy.ActionRead)
-	// }))
 	s.Run("GetPrebuildMetrics", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args().
 			Asserts(rbac.ResourceWorkspace.All(), policy.ActionRead)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4959,6 +4959,13 @@ func (s *MethodTestSuite) TestPrebuilds() {
 			template, policy.ActionUse,
 		).Errors(sql.ErrNoRows)
 	}))
+	s.Run("FindMatchingPresetID", s.Subtest(func(db database.Store, check *expects) {
+		check.Args(database.FindMatchingPresetIDParams{
+			TemplateVersionID: uuid.New(),
+			ParameterNames:    []string{"test"},
+			ParameterValues:   []string{"test"},
+		}).Asserts(rbac.ResourceTemplate, policy.ActionRead)
+	}))
 	s.Run("GetPrebuildMetrics", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args().
 			Asserts(rbac.ResourceWorkspace.All(), policy.ActionRead)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4959,13 +4959,44 @@ func (s *MethodTestSuite) TestPrebuilds() {
 			template, policy.ActionUse,
 		).Errors(sql.ErrNoRows)
 	}))
-	s.Run("FindMatchingPresetID", s.Subtest(func(db database.Store, check *expects) {
-		check.Args(database.FindMatchingPresetIDParams{
-			TemplateVersionID: uuid.New(),
+	s.Run("FindMatchingPresetID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		t1 := testutil.Fake(s.T(), faker, database.Template{})
+		tv := testutil.Fake(s.T(), faker, database.TemplateVersion{TemplateID: uuid.NullUUID{UUID: t1.ID, Valid: true}})
+		dbm.EXPECT().FindMatchingPresetID(gomock.Any(), database.FindMatchingPresetIDParams{
+			TemplateVersionID: tv.ID,
 			ParameterNames:    []string{"test"},
 			ParameterValues:   []string{"test"},
-		}).Asserts(rbac.ResourceTemplate, policy.ActionRead)
+		}).Return(uuid.Nil, nil).AnyTimes()
+		dbm.EXPECT().GetTemplateVersionByID(gomock.Any(), tv.ID).Return(tv, nil).AnyTimes()
+		dbm.EXPECT().GetTemplateByID(gomock.Any(), t1.ID).Return(t1, nil).AnyTimes()
+		check.Args(database.FindMatchingPresetIDParams{
+			TemplateVersionID: tv.ID,
+			ParameterNames:    []string{"test"},
+			ParameterValues:   []string{"test"},
+		}).Asserts(tv.RBACObject(t1), policy.ActionRead).Returns(uuid.Nil)
 	}))
+	// s.Run("FindMatchingPresetID", s.Subtest(func(db database.Store, check *expects) {
+	// 	org := dbgen.Organization(s.T(), db, database.Organization{})
+	// 	user := dbgen.User(s.T(), db, database.User{})
+	// 	templateVersion := dbgen.TemplateVersion(s.T(), db, database.TemplateVersion{
+	// 		OrganizationID: org.ID,
+	// 		CreatedBy:      user.ID,
+	// 	})
+	// 	template := dbgen.Template(s.T(), db, database.Template{
+	// 		OrganizationID:  org.ID,
+	// 		CreatedBy:       user.ID,
+	// 		ActiveVersionID: templateVersion.ID,
+	// 	})
+	// 	db.UpdateTemplateActiveVersionByID(context.Background(), database.UpdateTemplateActiveVersionByIDParams{
+	// 		ID:              template.ID,
+	// 		ActiveVersionID: templateVersion.ID,
+	// 	})
+	// 	check.Args(database.FindMatchingPresetIDParams{
+	// 		TemplateVersionID: templateVersion.ID,
+	// 		ParameterNames:    []string{"test"},
+	// 		ParameterValues:   []string{"test"},
+	// 	}).Asserts(templateVersion.RBACObject(template), policy.ActionRead)
+	// }))
 	s.Run("GetPrebuildMetrics", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args().
 			Asserts(rbac.ResourceWorkspace.All(), policy.ActionRead)

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -565,6 +565,13 @@ func (m queryMetricsStore) FetchVolumesResourceMonitorsUpdatedAfter(ctx context.
 	return r0, r1
 }
 
+func (m queryMetricsStore) FindMatchingPresetID(ctx context.Context, arg database.FindMatchingPresetIDParams) (uuid.UUID, error) {
+	start := time.Now()
+	r0, r1 := m.s.FindMatchingPresetID(ctx, arg)
+	m.queryLatencies.WithLabelValues("FindMatchingPresetID").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetAPIKeyByID(ctx context.Context, id string) (database.APIKey, error) {
 	start := time.Now()
 	apiKey, err := m.s.GetAPIKeyByID(ctx, id)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1051,6 +1051,21 @@ func (mr *MockStoreMockRecorder) FetchVolumesResourceMonitorsUpdatedAfter(ctx, u
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchVolumesResourceMonitorsUpdatedAfter", reflect.TypeOf((*MockStore)(nil).FetchVolumesResourceMonitorsUpdatedAfter), ctx, updatedAt)
 }
 
+// FindMatchingPresetID mocks base method.
+func (m *MockStore) FindMatchingPresetID(ctx context.Context, arg database.FindMatchingPresetIDParams) (uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindMatchingPresetID", ctx, arg)
+	ret0, _ := ret[0].(uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindMatchingPresetID indicates an expected call of FindMatchingPresetID.
+func (mr *MockStoreMockRecorder) FindMatchingPresetID(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMatchingPresetID", reflect.TypeOf((*MockStore)(nil).FindMatchingPresetID), ctx, arg)
+}
+
 // GetAPIKeyByID mocks base method.
 func (m *MockStore) GetAPIKeyByID(ctx context.Context, id string) (database.APIKey, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -40,14 +40,6 @@ func (p ConnectionParams) DSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", p.Username, p.Password, p.Host, p.Port, p.DBName)
 }
 
-// WillLogDSN returns true if the DSN should be shown during testing.
-// Set the CODER_TEST_LOG_PG_DSN environment variable to show the DSN.
-// This provides an ergonomic way to connect to test databases during
-// debugging without the need to spin up postgres manually.
-func WillLogDSN() bool {
-	return os.Getenv("CODER_TEST_LOG_PG_DSN") != ""
-}
-
 // These variables are global because all tests share them.
 var (
 	connectionParamsInitOnce       sync.Once

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -40,6 +40,10 @@ func (p ConnectionParams) DSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", p.Username, p.Password, p.Host, p.Port, p.DBName)
 }
 
+func WillLogDSN() bool {
+	return os.Getenv("CODER_TEST_LOG_PG_DSN") != ""
+}
+
 // These variables are global because all tests share them.
 var (
 	connectionParamsInitOnce       sync.Once

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -40,6 +40,10 @@ func (p ConnectionParams) DSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", p.Username, p.Password, p.Host, p.Port, p.DBName)
 }
 
+// WillLogDSN returns true if the DSN should be shown during testing.
+// Set the CODER_TEST_LOG_PG_DSN environment variable to show the DSN.
+// This provides an ergonomic way to connect to test databases during
+// debugging without the need to spin up postgres manually.
 func WillLogDSN() bool {
 	return os.Getenv("CODER_TEST_LOG_PG_DSN") != ""
 }

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -137,6 +137,11 @@ type sqlcQuerier interface {
 	FetchNewMessageMetadata(ctx context.Context, arg FetchNewMessageMetadataParams) (FetchNewMessageMetadataRow, error)
 	FetchVolumesResourceMonitorsByAgentID(ctx context.Context, agentID uuid.UUID) ([]WorkspaceAgentVolumeResourceMonitor, error)
 	FetchVolumesResourceMonitorsUpdatedAfter(ctx context.Context, updatedAt time.Time) ([]WorkspaceAgentVolumeResourceMonitor, error)
+	// FindMatchingPresetID finds a preset ID that is the largest exact subset of the provided parameters.
+	// It returns the preset ID if a match is found, or NULL if no match is found.
+	// The query finds presets where all preset parameters are present in the provided parameters,
+	// and returns the preset with the most parameters (largest subset).
+	FindMatchingPresetID(ctx context.Context, arg FindMatchingPresetIDParams) (uuid.UUID, error)
 	GetAPIKeyByID(ctx context.Context, id string) (APIKey, error)
 	// there is no unique constraint on empty token names
 	GetAPIKeyByName(ctx context.Context, arg GetAPIKeyByNameParams) (APIKey, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -7252,6 +7252,46 @@ func (q *sqlQuerier) CountInProgressPrebuilds(ctx context.Context) ([]CountInPro
 	return items, nil
 }
 
+const findMatchingPresetID = `-- name: FindMatchingPresetID :one
+WITH provided_params AS (
+	SELECT unnest($1::text[]) AS name,
+		   unnest($2::text[]) AS value
+),
+preset_matches AS (
+	SELECT
+		tvp.id AS template_version_preset_id,
+		COALESCE(COUNT(tvpp.name), 0) AS total_preset_params,
+		COALESCE(COUNT(pp.name), 0) AS matching_params
+	FROM template_version_presets tvp
+	LEFT JOIN template_version_preset_parameters tvpp ON tvpp.template_version_preset_id = tvp.id
+	LEFT JOIN provided_params pp ON pp.name = tvpp.name AND pp.value = tvpp.value
+	WHERE tvp.template_version_id = $3
+	GROUP BY tvp.id
+)
+SELECT pm.template_version_preset_id
+FROM preset_matches pm
+WHERE pm.total_preset_params = pm.matching_params  -- All preset parameters must match
+ORDER BY pm.total_preset_params DESC               -- Return the preset with the most parameters
+LIMIT 1
+`
+
+type FindMatchingPresetIDParams struct {
+	ParameterNames    []string  `db:"parameter_names" json:"parameter_names"`
+	ParameterValues   []string  `db:"parameter_values" json:"parameter_values"`
+	TemplateVersionID uuid.UUID `db:"template_version_id" json:"template_version_id"`
+}
+
+// FindMatchingPresetID finds a preset ID that is the largest exact subset of the provided parameters.
+// It returns the preset ID if a match is found, or NULL if no match is found.
+// The query finds presets where all preset parameters are present in the provided parameters,
+// and returns the preset with the most parameters (largest subset).
+func (q *sqlQuerier) FindMatchingPresetID(ctx context.Context, arg FindMatchingPresetIDParams) (uuid.UUID, error) {
+	row := q.db.QueryRowContext(ctx, findMatchingPresetID, pq.Array(arg.ParameterNames), pq.Array(arg.ParameterValues), arg.TemplateVersionID)
+	var template_version_preset_id uuid.UUID
+	err := row.Scan(&template_version_preset_id)
+	return template_version_preset_id, err
+}
+
 const getPrebuildMetrics = `-- name: GetPrebuildMetrics :many
 SELECT
 	t.name as template_name,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -7254,8 +7254,9 @@ func (q *sqlQuerier) CountInProgressPrebuilds(ctx context.Context) ([]CountInPro
 
 const findMatchingPresetID = `-- name: FindMatchingPresetID :one
 WITH provided_params AS (
-	SELECT unnest($1::text[]) AS name,
-		   unnest($2::text[]) AS value
+	SELECT
+		unnest($1::text[]) AS name,
+		unnest($2::text[]) AS value
 ),
 preset_matches AS (
 	SELECT

--- a/coderd/database/queries/prebuilds.sql
+++ b/coderd/database/queries/prebuilds.sql
@@ -252,8 +252,9 @@ ORDER BY t.name, tvp.name, o.name;
 -- The query finds presets where all preset parameters are present in the provided parameters,
 -- and returns the preset with the most parameters (largest subset).
 WITH provided_params AS (
-	SELECT unnest(@parameter_names::text[]) AS name,
-		   unnest(@parameter_values::text[]) AS value
+	SELECT
+		unnest(@parameter_names::text[]) AS name,
+		unnest(@parameter_values::text[]) AS value
 ),
 preset_matches AS (
 	SELECT

--- a/coderd/database/queries/prebuilds.sql
+++ b/coderd/database/queries/prebuilds.sql
@@ -245,3 +245,29 @@ INNER JOIN organizations o ON o.id = w.organization_id
 WHERE NOT t.deleted AND wpb.build_number = 1
 GROUP BY t.name, tvp.name, o.name
 ORDER BY t.name, tvp.name, o.name;
+
+-- name: FindMatchingPresetID :one
+-- FindMatchingPresetID finds a preset ID that is the largest exact subset of the provided parameters.
+-- It returns the preset ID if a match is found, or NULL if no match is found.
+-- The query finds presets where all preset parameters are present in the provided parameters,
+-- and returns the preset with the most parameters (largest subset).
+WITH provided_params AS (
+	SELECT unnest(@parameter_names::text[]) AS name,
+		   unnest(@parameter_values::text[]) AS value
+),
+preset_matches AS (
+	SELECT
+		tvp.id AS template_version_preset_id,
+		COALESCE(COUNT(tvpp.name), 0) AS total_preset_params,
+		COALESCE(COUNT(pp.name), 0) AS matching_params
+	FROM template_version_presets tvp
+	LEFT JOIN template_version_preset_parameters tvpp ON tvpp.template_version_preset_id = tvp.id
+	LEFT JOIN provided_params pp ON pp.name = tvpp.name AND pp.value = tvpp.value
+	WHERE tvp.template_version_id = @template_version_id
+	GROUP BY tvp.id
+)
+SELECT pm.template_version_preset_id
+FROM preset_matches pm
+WHERE pm.total_preset_params = pm.matching_params  -- All preset parameters must match
+ORDER BY pm.total_preset_params DESC               -- Return the preset with the most parameters
+LIMIT 1;

--- a/coderd/prebuilds/parameters.go
+++ b/coderd/prebuilds/parameters.go
@@ -1,0 +1,42 @@
+package prebuilds
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// FindMatchingPresetID finds a preset ID that matches the provided parameters.
+// It returns the preset ID if a match is found, or uuid.Nil if no match is found.
+// The function performs a bidirectional comparison to ensure all parameters match exactly.
+func FindMatchingPresetID(
+	ctx context.Context,
+	store database.Store,
+	templateVersionID uuid.UUID,
+	parameterNames []string,
+	parameterValues []string,
+) (uuid.UUID, error) {
+	if len(parameterNames) != len(parameterValues) {
+		return uuid.Nil, xerrors.New("parameter names and values must have the same length")
+	}
+
+	result, err := store.FindMatchingPresetID(ctx, database.FindMatchingPresetIDParams{
+		TemplateVersionID: templateVersionID,
+		ParameterNames:    parameterNames,
+		ParameterValues:   parameterValues,
+	})
+	if err != nil {
+		// Handle the case where no matching preset is found (no rows returned)
+		if errors.Is(err, sql.ErrNoRows) {
+			return uuid.Nil, nil
+		}
+		return uuid.Nil, xerrors.Errorf("find matching preset ID: %w", err)
+	}
+
+	return result, nil
+}

--- a/coderd/prebuilds/parameters_test.go
+++ b/coderd/prebuilds/parameters_test.go
@@ -1,0 +1,198 @@
+package prebuilds_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/prebuilds"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestFindMatchingPresetID(t *testing.T) {
+	t.Parallel()
+
+	presetIDs := []uuid.UUID{
+		uuid.New(),
+		uuid.New(),
+	}
+	// Give each preset a meaningful name in alphabetical order
+	presetNames := map[uuid.UUID]string{
+		presetIDs[0]: "development",
+		presetIDs[1]: "production",
+	}
+	tests := []struct {
+		name             string
+		parameterNames   []string
+		parameterValues  []string
+		presetParameters []database.TemplateVersionPresetParameter
+		expectedPresetID uuid.UUID
+		expectError      bool
+		errorContains    string
+	}{
+		{
+			name:            "exact match",
+			parameterNames:  []string{"region", "instance_type"},
+			parameterValues: []string{"us-west-2", "t3.medium"},
+			presetParameters: []database.TemplateVersionPresetParameter{
+				{TemplateVersionPresetID: presetIDs[0], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[0], Name: "instance_type", Value: "t3.medium"},
+				// antagonist:
+				{TemplateVersionPresetID: presetIDs[1], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "instance_type", Value: "t3.large"},
+			},
+			expectedPresetID: presetIDs[0],
+			expectError:      false,
+		},
+		{
+			name:            "no match - different values",
+			parameterNames:  []string{"region", "instance_type"},
+			parameterValues: []string{"us-east-1", "t3.medium"},
+			presetParameters: []database.TemplateVersionPresetParameter{
+				{TemplateVersionPresetID: presetIDs[0], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[0], Name: "instance_type", Value: "t3.medium"},
+				// antagonist:
+				{TemplateVersionPresetID: presetIDs[1], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "instance_type", Value: "t3.large"},
+			},
+			expectedPresetID: uuid.Nil,
+			expectError:      false,
+		},
+		{
+			name:            "no match - fewer provided parameters",
+			parameterNames:  []string{"region"},
+			parameterValues: []string{"us-west-2"},
+			presetParameters: []database.TemplateVersionPresetParameter{
+				{TemplateVersionPresetID: presetIDs[0], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[0], Name: "instance_type", Value: "t3.medium"},
+				// antagonist:
+				{TemplateVersionPresetID: presetIDs[1], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "instance_type", Value: "t3.large"},
+			},
+			expectedPresetID: uuid.Nil,
+			expectError:      false,
+		},
+		{
+			name:            "subset match - extra provided parameter",
+			parameterNames:  []string{"region", "instance_type", "extra_param"},
+			parameterValues: []string{"us-west-2", "t3.medium", "extra_value"},
+			presetParameters: []database.TemplateVersionPresetParameter{
+				{TemplateVersionPresetID: presetIDs[0], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[0], Name: "instance_type", Value: "t3.medium"},
+				// antagonist:
+				{TemplateVersionPresetID: presetIDs[1], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "instance_type", Value: "t3.large"},
+			},
+			expectedPresetID: presetIDs[0], // Should match because all preset parameters are present
+			expectError:      false,
+		},
+		{
+			name:             "mismatched parameter names vs values",
+			parameterNames:   []string{"region", "instance_type"},
+			parameterValues:  []string{"us-west-2"},
+			presetParameters: []database.TemplateVersionPresetParameter{},
+			expectedPresetID: uuid.Nil,
+			expectError:      true,
+			errorContains:    "parameter names and values must have the same length",
+		},
+		{
+			name:            "multiple presets - match first",
+			parameterNames:  []string{"region", "instance_type"},
+			parameterValues: []string{"us-west-2", "t3.medium"},
+			presetParameters: []database.TemplateVersionPresetParameter{
+				{TemplateVersionPresetID: presetIDs[0], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[0], Name: "instance_type", Value: "t3.medium"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "region", Value: "us-east-1"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "instance_type", Value: "t3.large"},
+			},
+			expectedPresetID: presetIDs[0],
+			expectError:      false,
+		},
+		{
+			name:            "largest subset match",
+			parameterNames:  []string{"region", "instance_type", "storage_size"},
+			parameterValues: []string{"us-west-2", "t3.medium", "100gb"},
+			presetParameters: []database.TemplateVersionPresetParameter{
+				{TemplateVersionPresetID: presetIDs[0], Name: "region", Value: "us-west-2"},
+				{TemplateVersionPresetID: presetIDs[0], Name: "instance_type", Value: "t3.medium"},
+				{TemplateVersionPresetID: presetIDs[1], Name: "region", Value: "us-west-2"},
+			},
+			expectedPresetID: presetIDs[0], // Should match the larger subset (2 params vs 1 param)
+			expectError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+			db, _ := dbtestutil.NewDB(t)
+			org := dbgen.Organization(t, db, database.Organization{})
+			user := dbgen.User(t, db, database.User{})
+			templateVersion := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+				OrganizationID: org.ID,
+				CreatedBy:      user.ID,
+				JobID:          uuid.New(),
+			})
+
+			// Group parameters by preset ID and create presets
+			presetMap := make(map[uuid.UUID][]database.TemplateVersionPresetParameter)
+			for _, param := range tt.presetParameters {
+				presetMap[param.TemplateVersionPresetID] = append(presetMap[param.TemplateVersionPresetID], param)
+			}
+
+			// Create presets and insert their parameters
+			for presetID, params := range presetMap {
+				// Create the preset
+				_, err := db.InsertPreset(ctx, database.InsertPresetParams{
+					ID:                presetID,
+					TemplateVersionID: templateVersion.ID,
+					Name:              presetNames[presetID],
+					CreatedAt:         dbtestutil.NowInDefaultTimezone(),
+				})
+				require.NoError(t, err)
+
+				// Insert parameters for this preset
+				names := make([]string, len(params))
+				values := make([]string, len(params))
+				for i, param := range params {
+					names[i] = param.Name
+					values[i] = param.Value
+				}
+
+				_, err = db.InsertPresetParameters(ctx, database.InsertPresetParametersParams{
+					TemplateVersionPresetID: presetID,
+					Names:                   names,
+					Values:                  values,
+				})
+				require.NoError(t, err)
+			}
+
+			result, err := prebuilds.FindMatchingPresetID(
+				ctx,
+				db,
+				templateVersion.ID,
+				tt.parameterNames,
+				tt.parameterValues,
+			)
+
+			// Assert results
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedPresetID, result)
+			}
+		})
+	}
+}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -638,14 +638,36 @@ func createWorkspace(
 		// Use injected Clock to allow time mocking in tests
 		now := api.Clock.Now()
 
-		// If a template preset was chosen, try claim a prebuilt workspace.
-		if req.TemplateVersionPresetID != uuid.Nil {
+		templateVersionPresetID := req.TemplateVersionPresetID
+
+		// If no preset was chosen, look for a matching preset by parameter values.
+		if templateVersionPresetID == uuid.Nil {
+			parameterNames := make([]string, len(req.RichParameterValues))
+			parameterValues := make([]string, len(req.RichParameterValues))
+			for i, parameter := range req.RichParameterValues {
+				parameterNames[i] = parameter.Name
+				parameterValues[i] = parameter.Value
+			}
+			var err error
+			templateVersionID := req.TemplateVersionID
+			if templateVersionID == uuid.Nil {
+				templateVersionID = template.ActiveVersionID
+			}
+			templateVersionPresetID, err = prebuilds.FindMatchingPresetID(ctx, db, templateVersionID, parameterNames, parameterValues)
+			if err != nil {
+				return xerrors.Errorf("find matching preset: %w", err)
+			}
+		}
+
+		// Try to claim a prebuilt workspace.
+		if templateVersionPresetID != uuid.Nil {
 			// Try and claim an eligible prebuild, if available.
 			// On successful claim, initialize all lifecycle fields from template and workspace-level config
 			// so the newly claimed workspace is properly managed by the lifecycle executor.
 			claimedWorkspace, err = claimPrebuild(
-				ctx, prebuildsClaimer, db, api.Logger, now, req, owner,
-				dbAutostartSchedule, nextStartAt, dbTTL)
+				ctx, prebuildsClaimer, db, api.Logger, now, req.Name, owner,
+				templateVersionPresetID, dbAutostartSchedule, nextStartAt, dbTTL)
+
 			// If claiming fails with an expected error (no claimable prebuilds or AGPL does not support prebuilds),
 			// we fall back to creating a new workspace. Otherwise, propagate the unexpected error.
 			if err != nil {
@@ -654,7 +676,7 @@ func createWorkspace(
 				fields := []any{
 					slog.Error(err),
 					slog.F("workspace_name", req.Name),
-					slog.F("template_version_preset_id", req.TemplateVersionPresetID),
+					slog.F("template_version_preset_id", templateVersionPresetID),
 				}
 
 				if !isExpectedError {
@@ -718,8 +740,8 @@ func createWorkspace(
 		if req.TemplateVersionID != uuid.Nil {
 			builder = builder.VersionID(req.TemplateVersionID)
 		}
-		if req.TemplateVersionPresetID != uuid.Nil {
-			builder = builder.TemplateVersionPresetID(req.TemplateVersionPresetID)
+		if templateVersionPresetID != uuid.Nil {
+			builder = builder.TemplateVersionPresetID(templateVersionPresetID)
 		}
 		if claimedWorkspace != nil {
 			builder = builder.MarkPrebuiltWorkspaceClaim()
@@ -884,8 +906,9 @@ func claimPrebuild(
 	db database.Store,
 	logger slog.Logger,
 	now time.Time,
-	req codersdk.CreateWorkspaceRequest,
+	name string,
 	owner workspaceOwner,
+	templateVersionPresetID uuid.UUID
 	autostartSchedule sql.NullString,
 	nextStartAt sql.NullTime,
 	ttl sql.NullInt64,

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -908,12 +908,12 @@ func claimPrebuild(
 	now time.Time,
 	name string,
 	owner workspaceOwner,
-	templateVersionPresetID uuid.UUID
+	templateVersionPresetID uuid.UUID,
 	autostartSchedule sql.NullString,
 	nextStartAt sql.NullTime,
 	ttl sql.NullInt64,
 ) (*database.Workspace, error) {
-	claimedID, err := claimer.Claim(ctx, now, owner.ID, req.Name, req.TemplateVersionPresetID, autostartSchedule, nextStartAt, ttl)
+	claimedID, err := claimer.Claim(ctx, now, owner.ID, name, templateVersionPresetID, autostartSchedule, nextStartAt, ttl)
 	if err != nil {
 		// TODO: enhance this by clarifying whether this *specific* prebuild failed or whether there are none to claim.
 		return nil, xerrors.Errorf("claim prebuild: %w", err)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -667,7 +667,6 @@ func createWorkspace(
 			claimedWorkspace, err = claimPrebuild(
 				ctx, prebuildsClaimer, db, api.Logger, now, req.Name, owner,
 				templateVersionPresetID, dbAutostartSchedule, nextStartAt, dbTTL)
-
 			// If claiming fails with an expected error (no claimable prebuilds or AGPL does not support prebuilds),
 			// we fall back to creating a new workspace. Otherwise, propagate the unexpected error.
 			if err != nil {

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -82,6 +82,7 @@ func TestBuilder_NoOptions(t *testing.T) {
 		}),
 
 		withInTx,
+		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(inactiveVersionID, bld.TemplateVersionID)
 			asrt.Equal(workspaceID, bld.WorkspaceID)
@@ -132,6 +133,7 @@ func TestBuilder_Initiator(t *testing.T) {
 			asrt.Equal(otherUserID, job.InitiatorID)
 		}),
 		withInTx,
+		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(otherUserID, bld.InitiatorID)
 		}),
@@ -180,6 +182,7 @@ func TestBuilder_Baggage(t *testing.T) {
 			asrt.Contains(string(job.TraceMetadata.RawMessage), "ip=127.0.0.1")
 		}),
 		withInTx,
+		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 		}),
 		expectBuildParameters(func(params database.InsertWorkspaceBuildParametersParams) {
@@ -219,6 +222,7 @@ func TestBuilder_Reason(t *testing.T) {
 		expectProvisionerJob(func(_ database.InsertProvisionerJobParams) {
 		}),
 		withInTx,
+		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(database.BuildReasonAutostart, bld.Reason)
 		}),
@@ -261,6 +265,7 @@ func TestBuilder_ActiveVersion(t *testing.T) {
 		}),
 
 		withInTx,
+		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(activeVersionID, bld.TemplateVersionID)
 			// no previous build...
@@ -386,10 +391,8 @@ func TestWorkspaceBuildWithTags(t *testing.T) {
 		expectBuildParameters(func(_ database.InsertWorkspaceBuildParametersParams) {
 		}),
 		withBuild,
+		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 	)
-	mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
-		Times(1).
-		Return(uuid.Nil, sql.ErrNoRows)
 	fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 	ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -473,10 +476,8 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 				}
 			}),
 			withBuild,
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		)
-		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -525,10 +526,8 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 				}
 			}),
 			withBuild,
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		)
-		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -670,10 +669,8 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 				}
 			}),
 			withBuild,
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		)
-		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -725,6 +722,7 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			withProvisionerDaemons([]database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow{}),
 
 			// Outputs
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 			expectProvisionerJob(func(job database.InsertProvisionerJobParams) {}),
 			withInTx,
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {}),
@@ -738,9 +736,6 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			}),
 			withBuild,
 		)
-		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -790,6 +785,7 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			withProvisionerDaemons([]database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow{}),
 
 			// Outputs
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 			expectProvisionerJob(func(job database.InsertProvisionerJobParams) {}),
 			withInTx,
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {}),
@@ -921,6 +917,7 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 			}),
 
 			withInTx,
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 				asrt.Equal(inactiveVersionID, bld.TemplateVersionID)
 				asrt.Equal(workspaceID, bld.WorkspaceID)
@@ -983,6 +980,7 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 			}),
 
 			withInTx,
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 				asrt.Equal(inactiveVersionID, bld.TemplateVersionID)
 				asrt.Equal(workspaceID, bld.WorkspaceID)
@@ -1056,6 +1054,7 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 			// Outputs
 			expectProvisionerJob(func(job database.InsertProvisionerJobParams) {}),
 			withInTx,
+			expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {}),
 			withBuild,
 			expectBuildParameters(func(params database.InsertWorkspaceBuildParametersParams) {}),
@@ -1497,6 +1496,14 @@ func expectBuildParameters(
 func withProvisionerDaemons(provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow) func(mTx *dbmock.MockStore) {
 	return func(mTx *dbmock.MockStore) {
 		mTx.EXPECT().GetEligibleProvisionerDaemonsByProvisionerJobIDs(gomock.Any(), gomock.Any()).Return(provisionerDaemons, nil)
+	}
+}
+
+func expectFindMatchingPresetID(id uuid.UUID, err error) func(mTx *dbmock.MockStore) {
+	return func(mTx *dbmock.MockStore) {
+		mTx.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
+			Times(1).
+			Return(id, err)
 	}
 }
 

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -387,6 +387,9 @@ func TestWorkspaceBuildWithTags(t *testing.T) {
 		}),
 		withBuild,
 	)
+	mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(uuid.Nil, sql.ErrNoRows)
 	fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 	ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -471,6 +474,9 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			}),
 			withBuild,
 		)
+		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
+			Times(1).
+			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -520,6 +526,9 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			}),
 			withBuild,
 		)
+		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
+			Times(1).
+			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -662,6 +671,9 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			}),
 			withBuild,
 		)
+		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
+			Times(1).
+			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}
@@ -726,6 +738,9 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			}),
 			withBuild,
 		)
+		mDB.EXPECT().FindMatchingPresetID(gomock.Any(), gomock.Any()).
+			Times(1).
+			Return(uuid.Nil, sql.ErrNoRows)
 		fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 
 		ws := database.Workspace{ID: workspaceID, TemplateID: templateID, OwnerID: userID}

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -29,6 +29,7 @@ Prebuilt workspaces are tightly integrated with [workspace presets](./parameters
 1. The preset must define all required parameters needed to build the workspace.
 1. The preset parameters define the base configuration and are immutable once a prebuilt workspace is provisioned.
 1. Parameters that are not defined in the preset can still be customized by users when they claim a workspace.
+1. If a user does not select a preset but provides parameters that match one or more presets, Coder will automatically select the most specific matching preset and assign a prebuilt workspace if one is available.
 
 ## Prerequisites
 
@@ -290,16 +291,6 @@ Once a prebuilt workspace has been claimed, and if its template uses `ignore_cha
 does not reconnect after a template update. This shortcoming is described in [this issue](https://github.com/coder/coder/issues/17840)
 and will be addressed before the next release (v2.23). In the interim, a simple workaround is to restart the workspace
 when it is in this problematic state.
-
-### Current limitations
-
-The prebuilt workspaces feature has these current limitations:
-
-- **Organizations**
-
-  Prebuilt workspaces can only be used with the default organization.
-
-  [View issue](https://github.com/coder/internal/issues/364)
 
 ### Monitoring and observability
 


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/18356.

This change finds and selects a matching preset if one was not chosen during workspace creation. This solidifies the relationship between presets and parameters.

When a workspace is created without in explicitly chosen preset, it will now still be eligible to claim a prebuilt workspace if one is available.