### PR TITLE
refactor: create tasks in coderd instead of frontend

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -99,7 +99,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 	if !hasAITask {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf(`Template does not have required parameter "%s"`, codersdk.AITaskPromptParameterName),
+			Message: fmt.Sprintf(`Template does not have required parameter %q`, codersdk.AITaskPromptParameterName),
 		})
 		return
 	}

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -99,7 +99,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 	if !hasAITask {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: `Template does not have required parameter "` + codersdk.AITaskPromptParameterName + `"`,
+			Message: fmt.Sprintf(`Template does not have required parameter "%s"`, codersdk.AITaskPromptParameterName),
 		})
 		return
 	}

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -70,28 +70,16 @@ func (api *API) aiTasksPrompts(rw http.ResponseWriter, r *http.Request) {
 
 // This endpoint is experimental and not guaranteed to be stable, so we're not
 // generating public-facing documentation for it.
-func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
+func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx     = r.Context()
 		apiKey  = httpmw.APIKey(r)
 		auditor = api.Auditor.Load()
+		member  = httpmw.OrganizationMemberParam(r)
 	)
 
 	var req codersdk.CreateAITasksRequest
 	if !httpapi.Read(ctx, rw, r, &req) {
-		return
-	}
-
-	user, err := api.Database.GetUserByID(ctx, apiKey.UserID)
-	if httpapi.Is404Error(err) {
-		httpapi.ResourceNotFound(rw)
-		return
-	}
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching user.",
-			Detail:  err.Error(),
-		})
 		return
 	}
 
@@ -125,9 +113,9 @@ func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	owner := workspaceOwner{
-		ID:        user.ID,
-		Username:  user.Username,
-		AvatarURL: user.AvatarURL,
+		ID:        member.UserID,
+		Username:  member.Username,
+		AvatarURL: member.AvatarURL,
 	}
 
 	aReq, commitAudit := audit.InitRequest[database.WorkspaceTable](rw, &audit.RequestParams{

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -95,7 +95,7 @@ func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hasAIPrompt, err := api.Database.GetTemplateVersionHasAIPrompt(ctx, req.TemplateVersionID)
+	hasAITask, err := api.Database.GetTemplateVersionHasAITask(ctx, req.TemplateVersionID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || rbac.IsUnauthorizedError(err) {
 			httpapi.ResourceNotFound(rw)
@@ -103,12 +103,12 @@ func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching if template version has ai prompt.",
+			Message: "Internal error fetching whether the template version has an AI task.",
 			Detail:  err.Error(),
 		})
 		return
 	}
-	if !hasAIPrompt {
+	if !hasAITask {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: `Template does not have required parameter "` + codersdk.AITaskPromptParameterName + `"`,
 		})

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -92,6 +92,21 @@ func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	hasAIPrompt, err := api.Database.GetTemplateVersionHasAIPrompt(ctx, req.TemplateVersionID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching if template version has ai prompt.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if !hasAIPrompt {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: `Template does not have required parameter "AI Prompt"`,
+		})
+		return
+	}
+
 	createReq := codersdk.CreateWorkspaceRequest{
 		Name:                    req.Name,
 		TemplateVersionID:       req.TemplateVersionID,

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -110,7 +110,7 @@ func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
 	}
 	if !hasAIPrompt {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: `Template does not have required parameter "AI Prompt"`,
+			Message: `Template does not have required parameter "` + codersdk.AITaskPromptParameterName + `"`,
 		})
 		return
 	}
@@ -120,7 +120,7 @@ func (api *API) aiTasksCreate(rw http.ResponseWriter, r *http.Request) {
 		TemplateVersionID:       req.TemplateVersionID,
 		TemplateVersionPresetID: req.TemplateVersionPresetID,
 		RichParameterValues: []codersdk.WorkspaceBuildParameter{
-			{Name: "AI Prompt", Value: req.Prompt},
+			{Name: codersdk.AITaskPromptParameterName, Value: req.Prompt},
 		},
 	}
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -154,6 +154,8 @@ func TestAITasksCreate(t *testing.T) {
 	}
 
 	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx = testutil.Context(t, testutil.WaitShort)
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -142,7 +142,7 @@ func TestAITasksPrompts(t *testing.T) {
 	})
 }
 
-func TestAITasksCreate(t *testing.T) {
+func TestTaskCreate(t *testing.T) {
 	t.Parallel()
 
 	t.Run("OK", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestAITasksCreate(t *testing.T) {
 		expClient := codersdk.NewExperimentalClient(client)
 
 		// When: We attempt to create a Task.
-		workspace, err := expClient.AITasksCreate(ctx, codersdk.CreateAITasksRequest{
+		workspace, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 			Name:              taskName,
 			TemplateVersionID: template.ActiveVersionID,
 			Prompt:            taskPrompt,
@@ -216,7 +216,7 @@ func TestAITasksCreate(t *testing.T) {
 		expClient := codersdk.NewExperimentalClient(client)
 
 		// When: We attempt to create a Task.
-		_, err := expClient.AITasksCreate(ctx, codersdk.CreateAITasksRequest{
+		_, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 			Name:              taskName,
 			TemplateVersionID: template.ActiveVersionID,
 			Prompt:            taskPrompt,
@@ -250,7 +250,7 @@ func TestAITasksCreate(t *testing.T) {
 		expClient := codersdk.NewExperimentalClient(client)
 
 		// When: We attempt to create a Task with an invalid template version ID.
-		_, err := expClient.AITasksCreate(ctx, codersdk.CreateAITasksRequest{
+		_, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 			Name:              taskName,
 			TemplateVersionID: uuid.New(),
 			Prompt:            taskPrompt,

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -145,16 +145,6 @@ func TestAITasksPrompts(t *testing.T) {
 func TestAITasksCreate(t *testing.T) {
 	t.Parallel()
 
-	makeEchoResponses := func(parameters []*proto.RichParameter) *echo.Responses {
-		return &echo.Responses{
-			Parse:          echo.ParseComplete,
-			ProvisionApply: echo.ApplyComplete,
-			ProvisionPlan: []*proto.Response{
-				{Type: &proto.Response_Plan{Plan: &proto.PlanComplete{Parameters: parameters}}},
-			},
-		}
-	}
-
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
@@ -169,9 +159,16 @@ func TestAITasksCreate(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 
 		// Given: A template with an "AI Prompt" parameter
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, makeEchoResponses([]*proto.RichParameter{
-			{Name: "AI Prompt", Type: "string"},
-		}))
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionApply: echo.ApplyComplete,
+			ProvisionPlan: []*proto.Response{
+				{Type: &proto.Response_Plan{Plan: &proto.PlanComplete{
+					Parameters: []*proto.RichParameter{{Name: "AI Prompt", Type: "string"}},
+					HasAiTasks: true,
+				}}},
+			},
+		})
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -191,7 +191,7 @@ func TestAITasksCreate(t *testing.T) {
 		parameters, err := client.WorkspaceBuildParameters(ctx, workspace.LatestBuild.ID)
 		require.NoError(t, err)
 		require.Len(t, parameters, 1)
-		assert.Equal(t, "AI Prompt", parameters[0].Name)
+		assert.Equal(t, codersdk.AITaskPromptParameterName, parameters[0].Name)
 		assert.Equal(t, taskPrompt, parameters[0].Value)
 	})
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -199,6 +199,8 @@ func TestAITasksCreate(t *testing.T) {
 	})
 
 	t.Run("FailsOnNonTaskTemplate", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx = testutil.Context(t, testutil.WaitShort)
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -230,6 +230,8 @@ func TestAITasksCreate(t *testing.T) {
 	})
 
 	t.Run("FailsOnInvalidTemplate", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx = testutil.Context(t, testutil.WaitShort)
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -994,7 +994,8 @@ func New(options *Options) *API {
 		r.Use(apiKeyMiddleware)
 		r.Route("/aitasks", func(r chi.Router) {
 			r.Get("/prompts", api.aiTasksPrompts)
-			r.Post("/", api.aiTasksCreate)
+
+			r.With(apiRateLimiter).Post("/", api.aiTasksCreate)
 		})
 		r.Route("/mcp", func(r chi.Router) {
 			r.Use(

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -994,8 +994,11 @@ func New(options *Options) *API {
 		r.Use(apiKeyMiddleware)
 		r.Route("/aitasks", func(r chi.Router) {
 			r.Get("/prompts", api.aiTasksPrompts)
+		})
+		r.Route("/tasks", func(r chi.Router) {
+			r.Use(apiRateLimiter)
 
-			r.With(apiRateLimiter).Post("/", api.aiTasksCreate)
+			r.Post("/{user}", api.tasksCreate)
 		})
 		r.Route("/mcp", func(r chi.Router) {
 			r.Use(

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -994,6 +994,7 @@ func New(options *Options) *API {
 		r.Use(apiKeyMiddleware)
 		r.Route("/aitasks", func(r chi.Router) {
 			r.Get("/prompts", api.aiTasksPrompts)
+			r.Post("/", api.aiTasksCreate)
 		})
 		r.Route("/mcp", func(r chi.Router) {
 			r.Use(

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -998,7 +998,11 @@ func New(options *Options) *API {
 		r.Route("/tasks", func(r chi.Router) {
 			r.Use(apiRateLimiter)
 
-			r.Post("/{user}", api.tasksCreate)
+			r.Route("/{user}", func(r chi.Router) {
+				r.Use(httpmw.ExtractOrganizationMembersParam(options.Database, api.HTTPAuth.Authorize))
+
+				r.Post("/", api.tasksCreate)
+			})
 		})
 		r.Route("/mcp", func(r chi.Router) {
 			r.Use(

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2874,6 +2874,17 @@ func (q *querier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, arg
 	return tv, nil
 }
 
+func (q *querier) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+	// If we can successfully call `GetTemplateVersionByID`, then
+	// we know the actor has sufficient permissions to know if the
+	// template has an AI Prompt.
+	if _, err := q.GetTemplateVersionByID(ctx, id); err != nil {
+		return false, err
+	}
+
+	return q.db.GetTemplateVersionHasAIPrompt(ctx, id)
+}
+
 func (q *querier) GetTemplateVersionParameters(ctx context.Context, templateVersionID uuid.UUID) ([]database.TemplateVersionParameter, error) {
 	// An actor can read template version parameters if they can read the related template.
 	tv, err := q.db.GetTemplateVersionByID(ctx, templateVersionID)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2874,15 +2874,15 @@ func (q *querier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, arg
 	return tv, nil
 }
 
-func (q *querier) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+func (q *querier) GetTemplateVersionHasAITask(ctx context.Context, id uuid.UUID) (bool, error) {
 	// If we can successfully call `GetTemplateVersionByID`, then
 	// we know the actor has sufficient permissions to know if the
-	// template has an AI Prompt.
+	// template has an AI task.
 	if _, err := q.GetTemplateVersionByID(ctx, id); err != nil {
 		return false, err
 	}
 
-	return q.db.GetTemplateVersionHasAIPrompt(ctx, id)
+	return q.db.GetTemplateVersionHasAITask(ctx, id)
 }
 
 func (q *querier) GetTemplateVersionParameters(ctx context.Context, templateVersionID uuid.UUID) ([]database.TemplateVersionParameter, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1443,7 +1443,7 @@ func (s *MethodTestSuite) TestTemplate() {
 		})
 		check.Args(now.Add(-time.Hour)).Asserts(rbac.ResourceTemplate.All(), policy.ActionRead)
 	}))
-	s.Run("GetTemplateVersionHasAIPrompt", s.Subtest(func(db database.Store, check *expects) {
+	s.Run("GetTemplateVersionHasAITask", s.Subtest(func(db database.Store, check *expects) {
 		o := dbgen.Organization(s.T(), db, database.Organization{})
 		u := dbgen.User(s.T(), db, database.User{})
 		t := dbgen.Template(s.T(), db, database.Template{

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1443,6 +1443,20 @@ func (s *MethodTestSuite) TestTemplate() {
 		})
 		check.Args(now.Add(-time.Hour)).Asserts(rbac.ResourceTemplate.All(), policy.ActionRead)
 	}))
+	s.Run("GetTemplateVersionHasAIPrompt", s.Subtest(func(db database.Store, check *expects) {
+		o := dbgen.Organization(s.T(), db, database.Organization{})
+		u := dbgen.User(s.T(), db, database.User{})
+		t := dbgen.Template(s.T(), db, database.Template{
+			OrganizationID: o.ID,
+			CreatedBy:      u.ID,
+		})
+		tv := dbgen.TemplateVersion(s.T(), db, database.TemplateVersion{
+			OrganizationID: o.ID,
+			TemplateID:     uuid.NullUUID{UUID: t.ID, Valid: true},
+			CreatedBy:      u.ID,
+		})
+		check.Args(tv.ID).Asserts(t, policy.ActionRead)
+	}))
 	s.Run("GetTemplatesWithFilter", s.Subtest(func(db database.Store, check *expects) {
 		o := dbgen.Organization(s.T(), db, database.Organization{})
 		u := dbgen.User(s.T(), db, database.User{})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1538,10 +1538,10 @@ func (m queryMetricsStore) GetTemplateVersionByTemplateIDAndName(ctx context.Con
 	return version, err
 }
 
-func (m queryMetricsStore) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+func (m queryMetricsStore) GetTemplateVersionHasAITask(ctx context.Context, id uuid.UUID) (bool, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetTemplateVersionHasAIPrompt(ctx, id)
-	m.queryLatencies.WithLabelValues("GetTemplateVersionHasAIPrompt").Observe(time.Since(start).Seconds())
+	r0, r1 := m.s.GetTemplateVersionHasAITask(ctx, id)
+	m.queryLatencies.WithLabelValues("GetTemplateVersionHasAITask").Observe(time.Since(start).Seconds())
 	return r0, r1
 }
 

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1538,6 +1538,13 @@ func (m queryMetricsStore) GetTemplateVersionByTemplateIDAndName(ctx context.Con
 	return version, err
 }
 
+func (m queryMetricsStore) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetTemplateVersionHasAIPrompt(ctx, id)
+	m.queryLatencies.WithLabelValues("GetTemplateVersionHasAIPrompt").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetTemplateVersionParameters(ctx context.Context, templateVersionID uuid.UUID) ([]database.TemplateVersionParameter, error) {
 	start := time.Now()
 	parameters, err := m.s.GetTemplateVersionParameters(ctx, templateVersionID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3271,6 +3271,21 @@ func (mr *MockStoreMockRecorder) GetTemplateVersionByTemplateIDAndName(ctx, arg 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateVersionByTemplateIDAndName", reflect.TypeOf((*MockStore)(nil).GetTemplateVersionByTemplateIDAndName), ctx, arg)
 }
 
+// GetTemplateVersionHasAIPrompt mocks base method.
+func (m *MockStore) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplateVersionHasAIPrompt", ctx, id)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplateVersionHasAIPrompt indicates an expected call of GetTemplateVersionHasAIPrompt.
+func (mr *MockStoreMockRecorder) GetTemplateVersionHasAIPrompt(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateVersionHasAIPrompt", reflect.TypeOf((*MockStore)(nil).GetTemplateVersionHasAIPrompt), ctx, id)
+}
+
 // GetTemplateVersionParameters mocks base method.
 func (m *MockStore) GetTemplateVersionParameters(ctx context.Context, templateVersionID uuid.UUID) ([]database.TemplateVersionParameter, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3271,19 +3271,19 @@ func (mr *MockStoreMockRecorder) GetTemplateVersionByTemplateIDAndName(ctx, arg 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateVersionByTemplateIDAndName", reflect.TypeOf((*MockStore)(nil).GetTemplateVersionByTemplateIDAndName), ctx, arg)
 }
 
-// GetTemplateVersionHasAIPrompt mocks base method.
-func (m *MockStore) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+// GetTemplateVersionHasAITask mocks base method.
+func (m *MockStore) GetTemplateVersionHasAITask(ctx context.Context, id uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplateVersionHasAIPrompt", ctx, id)
+	ret := m.ctrl.Call(m, "GetTemplateVersionHasAITask", ctx, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTemplateVersionHasAIPrompt indicates an expected call of GetTemplateVersionHasAIPrompt.
-func (mr *MockStoreMockRecorder) GetTemplateVersionHasAIPrompt(ctx, id any) *gomock.Call {
+// GetTemplateVersionHasAITask indicates an expected call of GetTemplateVersionHasAITask.
+func (mr *MockStoreMockRecorder) GetTemplateVersionHasAITask(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateVersionHasAIPrompt", reflect.TypeOf((*MockStore)(nil).GetTemplateVersionHasAIPrompt), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateVersionHasAITask", reflect.TypeOf((*MockStore)(nil).GetTemplateVersionHasAITask), ctx, id)
 }
 
 // GetTemplateVersionParameters mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -355,7 +355,7 @@ type sqlcQuerier interface {
 	GetTemplateVersionByID(ctx context.Context, id uuid.UUID) (TemplateVersion, error)
 	GetTemplateVersionByJobID(ctx context.Context, jobID uuid.UUID) (TemplateVersion, error)
 	GetTemplateVersionByTemplateIDAndName(ctx context.Context, arg GetTemplateVersionByTemplateIDAndNameParams) (TemplateVersion, error)
-	GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error)
+	GetTemplateVersionHasAITask(ctx context.Context, id uuid.UUID) (bool, error)
 	GetTemplateVersionParameters(ctx context.Context, templateVersionID uuid.UUID) ([]TemplateVersionParameter, error)
 	GetTemplateVersionTerraformValues(ctx context.Context, templateVersionID uuid.UUID) (TemplateVersionTerraformValue, error)
 	GetTemplateVersionVariables(ctx context.Context, templateVersionID uuid.UUID) ([]TemplateVersionVariable, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -355,6 +355,7 @@ type sqlcQuerier interface {
 	GetTemplateVersionByID(ctx context.Context, id uuid.UUID) (TemplateVersion, error)
 	GetTemplateVersionByJobID(ctx context.Context, jobID uuid.UUID) (TemplateVersion, error)
 	GetTemplateVersionByTemplateIDAndName(ctx context.Context, arg GetTemplateVersionByTemplateIDAndNameParams) (TemplateVersion, error)
+	GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error)
 	GetTemplateVersionParameters(ctx context.Context, templateVersionID uuid.UUID) ([]TemplateVersionParameter, error)
 	GetTemplateVersionTerraformValues(ctx context.Context, templateVersionID uuid.UUID) (TemplateVersionTerraformValue, error)
 	GetTemplateVersionVariables(ctx context.Context, templateVersionID uuid.UUID) ([]TemplateVersionVariable, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -12870,6 +12870,21 @@ func (q *sqlQuerier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, 
 	return i, err
 }
 
+const getTemplateVersionHasAIPrompt = `-- name: GetTemplateVersionHasAIPrompt :one
+SELECT EXISTS (
+	SELECT 1
+	FROM template_versions
+	WHERE id = $1 AND has_ai_task = TRUE
+)
+`
+
+func (q *sqlQuerier) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
+	row := q.db.QueryRowContext(ctx, getTemplateVersionHasAIPrompt, id)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const getTemplateVersionsByIDs = `-- name: GetTemplateVersionsByIDs :many
 SELECT
 	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by, external_auth_providers, message, archived, source_example_id, has_ai_task, created_by_avatar_url, created_by_username, created_by_name

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -12870,7 +12870,7 @@ func (q *sqlQuerier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, 
 	return i, err
 }
 
-const getTemplateVersionHasAIPrompt = `-- name: GetTemplateVersionHasAIPrompt :one
+const getTemplateVersionHasAITask = `-- name: GetTemplateVersionHasAITask :one
 SELECT EXISTS (
 	SELECT 1
 	FROM template_versions
@@ -12878,8 +12878,8 @@ SELECT EXISTS (
 )
 `
 
-func (q *sqlQuerier) GetTemplateVersionHasAIPrompt(ctx context.Context, id uuid.UUID) (bool, error) {
-	row := q.db.QueryRowContext(ctx, getTemplateVersionHasAIPrompt, id)
+func (q *sqlQuerier) GetTemplateVersionHasAITask(ctx context.Context, id uuid.UUID) (bool, error) {
+	row := q.db.QueryRowContext(ctx, getTemplateVersionHasAITask, id)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err

--- a/coderd/database/queries/templateversions.sql
+++ b/coderd/database/queries/templateversions.sql
@@ -234,3 +234,10 @@ FROM
 WHERE
 	template_versions.id IN (archived_versions.id)
 RETURNING template_versions.id;
+
+-- name: GetTemplateVersionHasAIPrompt :one
+SELECT EXISTS (
+	SELECT 1
+	FROM template_versions
+	WHERE id = $1 AND has_ai_task = TRUE
+);

--- a/coderd/database/queries/templateversions.sql
+++ b/coderd/database/queries/templateversions.sql
@@ -235,7 +235,7 @@ WHERE
 	template_versions.id IN (archived_versions.id)
 RETURNING template_versions.id;
 
--- name: GetTemplateVersionHasAIPrompt :one
+-- name: GetTemplateVersionHasAITask :one
 SELECT EXISTS (
 	SELECT 1
 	FROM template_versions

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -44,3 +44,29 @@ func (c *ExperimentalClient) AITaskPrompts(ctx context.Context, buildIDs []uuid.
 	var prompts AITasksPromptsResponse
 	return prompts, json.NewDecoder(res.Body).Decode(&prompts)
 }
+
+type CreateAITasksRequest struct {
+	Name                    string    `json:"name"`
+	TemplateVersionID       uuid.UUID `json:"template_version_id"`
+	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty"`
+	Prompt                  string    `json:"prompt"`
+}
+
+func (c *ExperimentalClient) AITasksCreate(ctx context.Context, request CreateAITasksRequest) (Workspace, error) {
+	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/aitasks/", request)
+	if err != nil {
+		return Workspace{}, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusCreated {
+		return Workspace{}, ReadBodyAsError(res)
+	}
+
+	var workspace Workspace
+	if err := json.NewDecoder(res.Body).Decode(&workspace); err != nil {
+		return Workspace{}, err
+	}
+
+	return workspace, nil
+}

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -3,6 +3,7 @@ package codersdk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -45,15 +46,15 @@ func (c *ExperimentalClient) AITaskPrompts(ctx context.Context, buildIDs []uuid.
 	return prompts, json.NewDecoder(res.Body).Decode(&prompts)
 }
 
-type CreateAITasksRequest struct {
+type CreateTaskRequest struct {
 	Name                    string    `json:"name"`
 	TemplateVersionID       uuid.UUID `json:"template_version_id" format:"uuid"`
 	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty" format:"uuid"`
 	Prompt                  string    `json:"prompt"`
 }
 
-func (c *ExperimentalClient) AITasksCreate(ctx context.Context, request CreateAITasksRequest) (Workspace, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/aitasks", request)
+func (c *ExperimentalClient) CreateTask(ctx context.Context, user string, request CreateTaskRequest) (Workspace, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/tasks/%s", user), request)
 	if err != nil {
 		return Workspace{}, err
 	}

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -53,7 +53,7 @@ type CreateAITasksRequest struct {
 }
 
 func (c *ExperimentalClient) AITasksCreate(ctx context.Context, request CreateAITasksRequest) (Workspace, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/aitasks/", request)
+	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/aitasks", request)
 	if err != nil {
 		return Workspace{}, err
 	}

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -47,8 +47,8 @@ func (c *ExperimentalClient) AITaskPrompts(ctx context.Context, buildIDs []uuid.
 
 type CreateAITasksRequest struct {
 	Name                    string    `json:"name"`
-	TemplateVersionID       uuid.UUID `json:"template_version_id"`
-	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty"`
+	TemplateVersionID       uuid.UUID `json:"template_version_id" format:"uuid"`
+	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty" format:"uuid"`
 	Prompt                  string    `json:"prompt"`
 }
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2665,6 +2665,17 @@ class ExperimentalApiMethods {
 
 		return response.data;
 	};
+
+	createAITask = async (
+		req: TypesGen.CreateAITasksRequest,
+	): Promise<TypesGen.Workspace> => {
+		const response = await this.axios.post<TypesGen.Workspace>(
+			"/api/experimental/aitasks",
+			req,
+		);
+
+		return response.data;
+	};
 }
 
 // This is a hard coded CSRF token/cookie pair for local development. In prod,

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2666,11 +2666,12 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
-	createAITask = async (
-		req: TypesGen.CreateAITasksRequest,
+	createTask = async (
+		user: string,
+		req: TypesGen.CreateTaskRequest,
 	): Promise<TypesGen.Workspace> => {
 		const response = await this.axios.post<TypesGen.Workspace>(
-			"/api/experimental/aitasks",
+			`/api/experimental/tasks/${user}`,
 			req,
 		);
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -422,6 +422,14 @@ export interface ConvertLoginRequest {
 	readonly password: string;
 }
 
+// From codersdk/aitasks.go
+export interface CreateAITasksRequest {
+	readonly name: string;
+	readonly template_version_id: string;
+	readonly template_version_preset_id?: string;
+	readonly prompt: string;
+}
+
 // From codersdk/users.go
 export interface CreateFirstUserRequest {
 	readonly email: string;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -422,14 +422,6 @@ export interface ConvertLoginRequest {
 	readonly password: string;
 }
 
-// From codersdk/aitasks.go
-export interface CreateAITasksRequest {
-	readonly name: string;
-	readonly template_version_id: string;
-	readonly template_version_preset_id?: string;
-	readonly prompt: string;
-}
-
 // From codersdk/users.go
 export interface CreateFirstUserRequest {
 	readonly email: string;
@@ -482,6 +474,14 @@ export interface CreateProvisionerKeyRequest {
 // From codersdk/provisionerdaemons.go
 export interface CreateProvisionerKeyResponse {
 	readonly key: string;
+}
+
+// From codersdk/aitasks.go
+export interface CreateTaskRequest {
+	readonly name: string;
+	readonly template_version_id: string;
+	readonly template_version_preset_id?: string;
+	readonly prompt: string;
 }
 
 // From codersdk/organizations.go

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -232,7 +232,6 @@ type TaskFormProps = {
 };
 
 const TaskForm: FC<TaskFormProps> = ({ templates, onSuccess }) => {
-	const { user } = useAuthenticated();
 	const queryClient = useQueryClient();
 	const [selectedTemplateId, setSelectedTemplateId] = useState<string>(
 		templates[0].id,
@@ -293,7 +292,7 @@ const TaskForm: FC<TaskFormProps> = ({ templates, onSuccess }) => {
 			templateVersionId,
 			presetId,
 		}: CreateTaskMutationFnProps) =>
-			data.createTask(prompt, user.id, templateVersionId, presetId),
+			data.createTask(prompt, templateVersionId, presetId),
 		onSuccess: async (task) => {
 			await queryClient.invalidateQueries({
 				queryKey: ["tasks"],
@@ -727,7 +726,6 @@ export const data = {
 
 	async createTask(
 		prompt: string,
-		userId: string,
 		templateVersionId: string,
 		presetId: string | null = null,
 	): Promise<Task> {
@@ -741,13 +739,11 @@ export const data = {
 			}
 		}
 
-		const workspace = await API.createWorkspace(userId, {
+		const workspace = await API.experimental.createAITask({
 			name: `task-${generateWorkspaceName()}`,
 			template_version_id: templateVersionId,
 			template_version_preset_id: preset_id || undefined,
-			rich_parameter_values: [
-				{ name: AI_PROMPT_PARAMETER_NAME, value: prompt },
-			],
+			prompt,
 		});
 
 		return {

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -232,6 +232,7 @@ type TaskFormProps = {
 };
 
 const TaskForm: FC<TaskFormProps> = ({ templates, onSuccess }) => {
+	const { user } = useAuthenticated();
 	const queryClient = useQueryClient();
 	const [selectedTemplateId, setSelectedTemplateId] = useState<string>(
 		templates[0].id,
@@ -292,7 +293,7 @@ const TaskForm: FC<TaskFormProps> = ({ templates, onSuccess }) => {
 			templateVersionId,
 			presetId,
 		}: CreateTaskMutationFnProps) =>
-			data.createTask(prompt, templateVersionId, presetId),
+			data.createTask(prompt, user.id, templateVersionId, presetId),
 		onSuccess: async (task) => {
 			await queryClient.invalidateQueries({
 				queryKey: ["tasks"],
@@ -726,6 +727,7 @@ export const data = {
 
 	async createTask(
 		prompt: string,
+		userId: string,
 		templateVersionId: string,
 		presetId: string | null = null,
 	): Promise<Task> {
@@ -739,7 +741,7 @@ export const data = {
 			}
 		}
 
-		const workspace = await API.experimental.createAITask({
+		const workspace = await API.experimental.createTask(userId, {
 			name: `task-${generateWorkspaceName()}`,
 			template_version_id: templateVersionId,
 			template_version_preset_id: preset_id || undefined,


### PR DESCRIPTION
Instead of creating tasks with a specialised call to `CreateWorkspace` on the frontend, we instead lift this to the backend and allow the frontend to simply call `CreateAITask`.