### PR TITLE
feat(site): add support for external agents in the UI and extend CodeExample

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2022,6 +2022,16 @@ class ApiMethods {
 		return response.data;
 	};
 
+	getWorkspaceAgentCredentials = async (
+		workspaceID: string,
+		agentName: string,
+	): Promise<TypesGen.ExternalAgentCredentials> => {
+		const response = await this.axios.get(
+			`/api/v2/workspaces/${workspaceID}/external-agent/${agentName}/credentials`,
+		);
+		return response.data;
+	};
+
 	upsertWorkspaceAgentSharedPort = async (
 		workspaceID: string,
 		req: TypesGen.UpsertWorkspaceAgentPortShareRequest,

--- a/site/src/api/queries/workspaces.ts
+++ b/site/src/api/queries/workspaces.ts
@@ -430,3 +430,13 @@ export const updateWorkspaceACL = (workspaceId: string) => {
 		},
 	};
 };
+
+export const workspaceAgentCredentials = (
+	workspaceId: string,
+	agentName: string,
+) => {
+	return {
+		queryKey: ["workspaces", workspaceId, "agents", agentName, "credentials"],
+		queryFn: () => API.getWorkspaceAgentCredentials(workspaceId, agentName),
+	};
+};

--- a/site/src/components/CodeExample/CodeExample.stories.tsx
+++ b/site/src/components/CodeExample/CodeExample.stories.tsx
@@ -31,3 +31,12 @@ export const LongCode: Story = {
 		code: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICnKzATuWwmmt5+CKTPuRGN0R1PBemA+6/SStpLiyX+L",
 	},
 };
+
+export const Redact: Story = {
+	args: {
+		secret: false,
+		redactPattern: /CODER_AGENT_TOKEN="([^"]+)"/g,
+		redactReplacement: `CODER_AGENT_TOKEN="********"`,
+		showRevealButton: true,
+	},
+};

--- a/site/src/modules/resources/AgentExternal.stories.tsx
+++ b/site/src/modules/resources/AgentExternal.stories.tsx
@@ -1,14 +1,13 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
 import { chromatic } from "testHelpers/chromatic";
 import { MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
 import { withDashboardProvider } from "testHelpers/storybook";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { AgentExternal } from "./AgentExternal";
 
 const meta: Meta<typeof AgentExternal> = {
 	title: "modules/resources/AgentExternal",
 	component: AgentExternal,
 	args: {
-		isExternalAgent: true,
 		agent: {
 			...MockWorkspaceAgent,
 			status: "connecting",
@@ -61,7 +60,6 @@ export const DifferentOS: Story = {
 
 export const NotExternalAgent: Story = {
 	args: {
-		isExternalAgent: false,
 		agent: {
 			...MockWorkspaceAgent,
 			status: "connecting",

--- a/site/src/modules/resources/AgentExternal.stories.tsx
+++ b/site/src/modules/resources/AgentExternal.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { chromatic } from "testHelpers/chromatic";
+import { MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
+import { withDashboardProvider } from "testHelpers/storybook";
+import { AgentExternal } from "./AgentExternal";
+
+const meta: Meta<typeof AgentExternal> = {
+	title: "modules/resources/AgentExternal",
+	component: AgentExternal,
+	args: {
+		isExternalAgent: true,
+		agent: {
+			...MockWorkspaceAgent,
+			status: "connecting",
+			operating_system: "linux",
+			architecture: "amd64",
+		},
+		workspace: MockWorkspace,
+	},
+	decorators: [withDashboardProvider],
+	parameters: {
+		chromatic,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof AgentExternal>;
+
+export const Connecting: Story = {
+	args: {
+		agent: {
+			...MockWorkspaceAgent,
+			status: "connecting",
+			operating_system: "linux",
+			architecture: "amd64",
+		},
+	},
+};
+
+export const Timeout: Story = {
+	args: {
+		agent: {
+			...MockWorkspaceAgent,
+			status: "timeout",
+			operating_system: "linux",
+			architecture: "amd64",
+		},
+	},
+};
+
+export const DifferentOS: Story = {
+	args: {
+		agent: {
+			...MockWorkspaceAgent,
+			status: "connecting",
+			operating_system: "darwin",
+			architecture: "arm64",
+		},
+	},
+};
+
+export const NotExternalAgent: Story = {
+	args: {
+		isExternalAgent: false,
+		agent: {
+			...MockWorkspaceAgent,
+			status: "connecting",
+			operating_system: "linux",
+			architecture: "amd64",
+		},
+	},
+};

--- a/site/src/modules/resources/AgentExternal.stories.tsx
+++ b/site/src/modules/resources/AgentExternal.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { chromatic } from "testHelpers/chromatic";
 import { MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
 import { withDashboardProvider } from "testHelpers/storybook";

--- a/site/src/modules/resources/AgentExternal.tsx
+++ b/site/src/modules/resources/AgentExternal.tsx
@@ -28,12 +28,16 @@ export const AgentExternal: FC<AgentExternalProps> = ({
 			isExternalAgent &&
 			(agent.status === "timeout" || agent.status === "connecting")
 		) {
-			API.getWorkspaceAgentCredentials(workspace.id, agent.name).then((res) => {
-				setExternalAgentToken(res.agent_token);
-				setCommand(res.command);
-			}).catch((err) => {
-				displayError(getErrorMessage(err, "Failed to get external agent credentials"));
-			});
+			API.getWorkspaceAgentCredentials(workspace.id, agent.name)
+				.then((res) => {
+					setExternalAgentToken(res.agent_token);
+					setCommand(res.command);
+				})
+				.catch((err) => {
+					displayError(
+						getErrorMessage(err, "Failed to get external agent credentials"),
+					);
+				});
 		}
 	}, [isExternalAgent, agent.status, workspace.id, agent.name]);
 

--- a/site/src/modules/resources/AgentExternal.tsx
+++ b/site/src/modules/resources/AgentExternal.tsx
@@ -1,0 +1,51 @@
+import { API } from "api/api";
+import type { Workspace, WorkspaceAgent } from "api/typesGenerated";
+import isChromatic from "chromatic/isChromatic";
+import { CodeExample } from "components/CodeExample/CodeExample";
+import { type FC, useEffect, useState } from "react";
+
+interface AgentExternalProps {
+	isExternalAgent: boolean;
+	agent: WorkspaceAgent;
+	workspace: Workspace;
+}
+
+export const AgentExternal: FC<AgentExternalProps> = ({
+	isExternalAgent,
+	agent,
+	workspace,
+}) => {
+	const [externalAgentToken, setExternalAgentToken] = useState<string | null>(
+		null,
+	);
+	const [command, setCommand] = useState<string | null>(null);
+
+	const origin = isChromatic() ? "https://example.com" : window.location.origin;
+	useEffect(() => {
+		if (
+			isExternalAgent &&
+			(agent.status === "timeout" || agent.status === "connecting")
+		) {
+			API.getWorkspaceAgentCredentials(workspace.id, agent.name).then((res) => {
+				setExternalAgentToken(res.agent_token);
+				setCommand(res.command);
+			});
+		}
+	}, [isExternalAgent, agent.status, workspace.id, agent.name]);
+
+	return (
+		<section className="text-base text-muted-foreground pb-2 leading-relaxed">
+			<p>
+				Please run the following command to attach an agent to the{" "}
+				{workspace.name} workspace:
+			</p>
+			<CodeExample
+				code={command ?? ""}
+				secret={false}
+				redactPattern={/CODER_AGENT_TOKEN="([^"]+)"/g}
+				redactReplacement={`CODER_AGENT_TOKEN="********"`}
+				showRevealButton={true}
+			/>
+		</section>
+	);
+};

--- a/site/src/modules/resources/AgentExternal.tsx
+++ b/site/src/modules/resources/AgentExternal.tsx
@@ -7,20 +7,11 @@ import type { FC } from "react";
 import { useQuery } from "react-query";
 
 interface AgentExternalProps {
-	isExternalAgent: boolean;
 	agent: WorkspaceAgent;
 	workspace: Workspace;
 }
 
-export const AgentExternal: FC<AgentExternalProps> = ({
-	isExternalAgent,
-	agent,
-	workspace,
-}) => {
-	if (!isExternalAgent) {
-		return null;
-	}
-
+export const AgentExternal: FC<AgentExternalProps> = ({ agent, workspace }) => {
 	const {
 		data: credentials,
 		error,

--- a/site/src/modules/resources/AgentExternal.tsx
+++ b/site/src/modules/resources/AgentExternal.tsx
@@ -1,7 +1,9 @@
 import { API } from "api/api";
+import { getErrorMessage } from "api/errors";
 import type { Workspace, WorkspaceAgent } from "api/typesGenerated";
 import isChromatic from "chromatic/isChromatic";
 import { CodeExample } from "components/CodeExample/CodeExample";
+import { displayError } from "components/GlobalSnackbar/utils";
 import { type FC, useEffect, useState } from "react";
 
 interface AgentExternalProps {
@@ -29,6 +31,8 @@ export const AgentExternal: FC<AgentExternalProps> = ({
 			API.getWorkspaceAgentCredentials(workspace.id, agent.name).then((res) => {
 				setExternalAgentToken(res.agent_token);
 				setCommand(res.command);
+			}).catch((err) => {
+				displayError(getErrorMessage(err, "Failed to get external agent credentials"));
 			});
 		}
 	}, [isExternalAgent, agent.status, workspace.id, agent.name]);

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -298,11 +298,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 				{isExternalAgent &&
 					(agent.status === "timeout" || agent.status === "connecting") &&
 					workspace_external_agent && (
-						<AgentExternal
-							isExternalAgent={isExternalAgent}
-							agent={agent}
-							workspace={workspace}
-						/>
+						<AgentExternal agent={agent} workspace={workspace} />
 					)}
 
 				<AgentMetadata initialMetadata={initialMetadata} agent={agent} />

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -27,6 +27,7 @@ import AutoSizer from "react-virtualized-auto-sizer";
 import type { FixedSizeList as List, ListOnScrollProps } from "react-window";
 import { AgentApps, organizeAgentApps } from "./AgentApps/AgentApps";
 import { AgentDevcontainerCard } from "./AgentDevcontainerCard";
+import { AgentExternal } from "./AgentExternal";
 import { AgentLatency } from "./AgentLatency";
 import { AGENT_LOG_LINE_HEIGHT } from "./AgentLogs/AgentLogLine";
 import { AgentLogs } from "./AgentLogs/AgentLogs";
@@ -62,9 +63,10 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const appSections = organizeAgentApps(agent.apps);
 	const hasAppsToDisplay =
 		!browser_only || appSections.some((it) => it.apps.length > 0);
+	const isExternalAgent = workspace.latest_build.has_external_agent;
 	const shouldDisplayAgentApps =
 		(agent.status === "connected" && hasAppsToDisplay) ||
-		agent.status === "connecting";
+		(agent.status === "connecting" && !isExternalAgent);
 	const hasVSCodeApp =
 		agent.display_apps.includes("vscode") ||
 		agent.display_apps.includes("vscode_insiders");
@@ -258,7 +260,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 					</section>
 				)}
 
-				{agent.status === "connecting" && (
+				{agent.status === "connecting" && !isExternalAgent && (
 					<section css={styles.apps}>
 						<Skeleton
 							width={80}
@@ -292,6 +294,15 @@ export const AgentRow: FC<AgentRowProps> = ({
 						})}
 					</section>
 				)}
+
+				{isExternalAgent &&
+					(agent.status === "timeout" || agent.status === "connecting") && (
+						<AgentExternal
+							isExternalAgent={isExternalAgent}
+							agent={agent}
+							workspace={workspace}
+						/>
+					)}
 
 				<AgentMetadata initialMetadata={initialMetadata} agent={agent} />
 			</div>

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -59,7 +59,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 	onUpdateAgent,
 	initialMetadata,
 }) => {
-	const { browser_only } = useFeatureVisibility();
+	const { browser_only, workspace_external_agent } = useFeatureVisibility();
 	const appSections = organizeAgentApps(agent.apps);
 	const hasAppsToDisplay =
 		!browser_only || appSections.some((it) => it.apps.length > 0);
@@ -296,7 +296,8 @@ export const AgentRow: FC<AgentRowProps> = ({
 				)}
 
 				{isExternalAgent &&
-					(agent.status === "timeout" || agent.status === "connecting") && (
+					(agent.status === "timeout" || agent.status === "connecting") &&
+					workspace_external_agent && (
 						<AgentExternal
 							isExternalAgent={isExternalAgent}
 							agent={agent}

--- a/site/src/modules/workspaces/actions.ts
+++ b/site/src/modules/workspaces/actions.ts
@@ -63,6 +63,14 @@ export const abilitiesByWorkspaceStatus = (
 		};
 	}
 
+	if (workspace.latest_build.has_external_agent) {
+		return {
+			actions: [],
+			canCancel: false,
+			canAcceptJobs: true,
+		};
+	}
+
 	const status = workspace.latest_build.status;
 
 	switch (status) {


### PR DESCRIPTION
This pull request introduces support for external workspace management, allowing users to register and manage workspaces that are provisioned and managed outside of the Coder.

* Added a new component AgentExternal which shows instructions for connecting external agents.
* Added redacted fields to CodeExample so you can now hide specific parts of the code instead of the full line
* Hides workspace actions if workspace is using external agent.

<img width="1719" height="646" alt="image" src="https://github.com/user-attachments/assets/45b7bfae-7006-461f-a96d-e61f97084819" />
