### PR TITLE
chore: specify `packageManager` explicitly to match pinned version in `Dockerfile`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"_comment": "This version doesn't matter, it's just to allow importing from other repos.",
 	"name": "coder",
 	"version": "0.0.0",
-	"packageManager": "pnpm@9.14.4",
+	"packageManager": "pnpm@9.15.1",
 	"scripts": {
 		"format-docs": "markdown-table-formatter $(find docs -name '*.md') *.md",
 		"lint-docs": "markdownlint-cli2 --fix $(find docs -name '*.md') *.md",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"_comment": "This version doesn't matter, it's just to allow importing from other repos.",
 	"name": "coder",
 	"version": "0.0.0",
-	"packageManager": "pnpm@9.15.1",
+	"packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf",
 	"scripts": {
 		"format-docs": "markdown-table-formatter $(find docs -name '*.md') *.md",
 		"lint-docs": "markdownlint-cli2 --fix $(find docs -name '*.md') *.md",

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
 	"repository": "https://github.com/coder/coder",
 	"private": true,
 	"license": "AGPL-3.0",
-	"packageManager": "pnpm@9.15.1",
+	"packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf",
 	"scripts": {
 		"build": "NODE_ENV=production pnpm vite build",
 		"check": "biome check --error-on-warnings .",

--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,7 @@
 	"repository": "https://github.com/coder/coder",
 	"private": true,
 	"license": "AGPL-3.0",
+	"packageManager": "pnpm@9.15.1",
 	"scripts": {
 		"build": "NODE_ENV=production pnpm vite build",
 		"check": "biome check --error-on-warnings .",


### PR DESCRIPTION
_Disclaimer: I have no idea what I'm doing._

[It would _seem_ this is necessary since we use corepack](https://github.com/nodejs/corepack?tab=readme-ov-file#when-authoring-packages) in `dogfood/coder/Dockerfile`.

Without this, I run into:

```bash
$ ./scripts/develop.sh --debug --access-url=
generate
+ pnpm install 
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/home/coder/coder/site".

Expected version: >=9.0.0 <10.0.0
Got: 10.14.0

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
```

Blocked by https://github.com/coder/internal/issues/881 it seems.