### PR TITLE
chore: upgrade to pnpm 10

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -257,7 +257,7 @@ RUN source $NVM_DIR/nvm.sh && \
 ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN corepack enable && \
 	corepack prepare npm@10.8.1 --activate && \
-	corepack prepare pnpm@9.15.1 --activate
+	corepack prepare pnpm@10.14.0 --activate
 
 RUN pnpx playwright@1.47.0 install --with-deps chromium
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
         formatter = pkgs.nixfmt-rfc-style;
 
         nodejs = pkgs.nodejs_20;
-        pnpm = pkgs.pnpm_9.override {
+        pnpm = pkgs.pnpm_10.override {
           inherit nodejs; # Ensure it points to the above nodejs version
         };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"_comment": "This version doesn't matter, it's just to allow importing from other repos.",
 	"name": "coder",
 	"version": "0.0.0",
-	"packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf",
+	"packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
 	"scripts": {
 		"format-docs": "markdown-table-formatter $(find docs -name '*.md') *.md",
 		"lint-docs": "markdownlint-cli2 --fix $(find docs -name '*.md') *.md",

--- a/site/package.json
+++ b/site/package.json
@@ -186,11 +186,7 @@
 		"vite-plugin-checker": "0.9.3",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": [
-		"chrome 110",
-		"firefox 111",
-		"safari 16.0"
-	],
+	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"
@@ -207,8 +203,6 @@
 			"form-data": "4.0.4",
 			"prismjs": "1.30.0"
 		},
-		"ignoredBuiltDependencies": [
-			"storybook-addon-remix-react-router"
-		]
+		"ignoredBuiltDependencies": ["storybook-addon-remix-react-router"]
 	}
 }

--- a/site/package.json
+++ b/site/package.json
@@ -192,7 +192,7 @@
 		"semver": "7.6.2"
 	},
 	"engines": {
-		"pnpm": ">=9.0.0 <10.0.0",
+		"pnpm": ">=10.0.0 <11.0.0",
 		"node": ">=18.0.0 <21.0.0"
 	},
 	"pnpm": {
@@ -202,6 +202,7 @@
 			"esbuild": "^0.25.0",
 			"form-data": "4.0.4",
 			"prismjs": "1.30.0"
-		}
+		},
+		"ignoredBuiltDependencies": ["storybook-addon-remix-react-router"]
 	}
 }

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
 	"repository": "https://github.com/coder/coder",
 	"private": true,
 	"license": "AGPL-3.0",
-	"packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf",
+	"packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
 	"scripts": {
 		"build": "NODE_ENV=production pnpm vite build",
 		"check": "biome check --error-on-warnings .",
@@ -186,7 +186,11 @@
 		"vite-plugin-checker": "0.9.3",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
+	"browserslist": [
+		"chrome 110",
+		"firefox 111",
+		"safari 16.0"
+	],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"
@@ -203,6 +207,8 @@
 			"form-data": "4.0.4",
 			"prismjs": "1.30.0"
 		},
-		"ignoredBuiltDependencies": ["storybook-addon-remix-react-router"]
+		"ignoredBuiltDependencies": [
+			"storybook-addon-remix-react-router"
+		]
 	}
 }


### PR DESCRIPTION
pnpm 9 yells pretty loudly about being out of date. also, pnpm 10 no longer runs untrusted `postinstall`/`prepare` scripts by default, which, _finally_.