### PR TITLE
feat: add support for exp immortal streams command and ssh --stdio variant

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -817,11 +817,9 @@ func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_T
 	if host, _, err := net.SplitHostPort(ip); err == nil {
 		// Best effort.
 		ip = host
-	} else if !strings.Contains(ip, ":") {
-		// net.Pipe and other in-memory transports may not include a port. Use the
-		// provided value without logging an error so tests using these transports
-		// do not fail due to expected placeholder addresses like "pipe".
-	} else {
+	} else if strings.Contains(ip, ":") {
+		// The address includes a colon but could not be split into host:port.
+		// Log the error; otherwise, tolerate placeholders like "pipe" which lack ports.
 		a.logger.Error(a.hardCtx, "split host and port for connection report failed", slog.F("ip", ip), slog.Error(err))
 	}
 

--- a/cli/immortal_backed_pipe_conn.go
+++ b/cli/immortal_backed_pipe_conn.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"github.com/coder/coder/v2/agent/immortalstreams/backedpipe"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/websocket"
+)
+
+// immortalBackedConn adapts a BackedPipe to net.Conn for client-side immortal streams.
+type immortalBackedConn struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	pipe   *backedpipe.BackedPipe
+	logger slog.Logger
+}
+
+// clientStreamReconnector dials the agent websocket and exchanges sequence numbers.
+type clientStreamReconnector struct {
+	agentConn workspacesdk.AgentConn
+	client    *codersdk.Client
+	agentID   uuid.UUID
+	streamID  uuid.UUID
+	logger    slog.Logger
+
+	// precomputed strategy
+	wsURL      string
+	httpClient *http.Client
+}
+
+// newClientStreamReconnector decides once whether to use Coder Connect or agentConn
+// and constructs the static WebSocket URL and HTTP client accordingly.
+func newClientStreamReconnector(ctx context.Context, agentConn workspacesdk.AgentConn, client *codersdk.Client, agentID uuid.UUID, streamID uuid.UUID, logger slog.Logger, coderConnectHost string) *clientStreamReconnector {
+	wsClient := workspacesdk.New(client)
+
+	// Defaults: use tailnet via agentConn
+	apiAddr := fmt.Sprintf("127.0.0.1:%d", workspacesdk.AgentHTTPAPIServerPort)
+	wsURL := fmt.Sprintf("ws://%s/api/v0/immortal-stream/%s", apiAddr, streamID)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(dialCtx context.Context, network, addr string) (net.Conn, error) {
+				logger.Info(context.Background(), "immortal: dialing network connection", slog.F("strategy", "agent_conn"), slog.F("network", network), slog.F("addr", addr))
+				conn, err := agentConn.DialContext(dialCtx, network, addr)
+				if err != nil {
+					logger.Error(context.Background(), "immortal: dial attempt failed", slog.F("strategy", "agent_conn"), slog.Error(err))
+					return nil, err
+				}
+				logger.Info(context.Background(), "immortal: dial connected", slog.F("strategy", "agent_conn"))
+				return conn, nil
+			},
+		},
+	}
+
+	// Fetch connection info first, then check Coder Connect using the correct suffix
+	if connInfo, err := wsClient.AgentConnectionInfoGeneric(ctx); err == nil {
+		logger.Info(ctx, "immortal: fetched agent connection info", slog.F("hostname_suffix", connInfo.HostnameSuffix))
+		if ok, err := wsClient.IsCoderConnectRunning(ctx, workspacesdk.CoderConnectQueryOptions{HostnameSuffix: connInfo.HostnameSuffix}); err == nil && ok {
+			logger.Info(ctx, "immortal: coder connect is running", slog.F("hostname_suffix", connInfo.HostnameSuffix))
+			wsURL = fmt.Sprintf("ws://%s:%d/api/v0/immortal-stream/%s", coderConnectHost, workspacesdk.AgentHTTPAPIServerPort, streamID)
+
+			// Use the shared Coder Connect dialer (overridable in tests) instead of a raw net.Dialer
+			dialer := testOrDefaultDialer(ctx)
+			httpClient = &http.Client{
+				Transport: &http.Transport{
+					DialContext: func(dialCtx context.Context, network, addr string) (net.Conn, error) {
+						logger.Info(context.Background(), "immortal: dialing network connection", slog.F("strategy", "coder_connect"), slog.F("network", network), slog.F("addr", addr))
+						conn, err := dialer.DialContext(dialCtx, network, addr)
+						if err != nil {
+							logger.Error(context.Background(), "immortal: dial attempt failed", slog.F("strategy", "coder_connect"), slog.Error(err))
+							return nil, err
+						}
+						logger.Info(context.Background(), "immortal: dial connected", slog.F("strategy", "coder_connect"))
+						return conn, nil
+					},
+				},
+			}
+			logger.Info(ctx, "immortal reconnector strategy selected", slog.F("strategy", "coder_connect"), slog.F("url", wsURL))
+		} else {
+			if err != nil {
+				logger.Info(ctx, "immortal: coder connect check errored", slog.F("hostname_suffix", connInfo.HostnameSuffix), slog.Error(err))
+			} else {
+				logger.Info(ctx, "immortal: coder connect not running", slog.F("hostname_suffix", connInfo.HostnameSuffix))
+			}
+		}
+	} else {
+		logger.Info(ctx, "immortal: failed to fetch agent connection info", slog.Error(err))
+		logger.Info(ctx, "immortal reconnector strategy selected", slog.F("strategy", "agent_conn"), slog.F("url", wsURL))
+	}
+
+	return &clientStreamReconnector{
+		agentConn:  agentConn,
+		client:     client,
+		agentID:    agentID,
+		streamID:   streamID,
+		logger:     logger,
+		wsURL:      wsURL,
+		httpClient: httpClient,
+	}
+}
+
+func (r *clientStreamReconnector) Reconnect(ctx context.Context, readerSeqNum uint64) (io.ReadWriteCloser, uint64, error) {
+	// Prepare dial options using the precomputed HTTP client.
+	dialOptions := &websocket.DialOptions{
+		HTTPClient: r.httpClient,
+		HTTPHeader: http.Header{
+			codersdk.HeaderImmortalStreamSequenceNum: []string{strconv.FormatUint(readerSeqNum, 10)},
+		},
+		// Negotiate the immortal stream subprotocol with the agent.
+		Subprotocols:    []string{codersdk.HeaderUpgradeImmortalStream},
+		CompressionMode: websocket.CompressionDisabled,
+	}
+
+	// Per-attempt timeout: keep reconnect attempts snappy
+	dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	r.logger.Debug(ctx, "immortal reconnect dialing", slog.F("url", r.wsURL), slog.F("reader_seq", readerSeqNum))
+	ws, resp, err := websocket.Dial(dialCtx, r.wsURL, dialOptions)
+	if err != nil {
+		var status string
+		var hdr http.Header
+		var bodyStr string
+		if resp != nil {
+			status = resp.Status
+			hdr = resp.Header.Clone()
+			if resp.Body != nil {
+				b, _ := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
+				bodyStr = string(b)
+			}
+		}
+		r.logger.Error(ctx, "immortal reconnect dial failed", slog.Error(err), slog.F("url", r.wsURL), slog.F("status", status), slog.F("headers", hdr), slog.F("body", bodyStr))
+		return nil, 0, xerrors.Errorf("failed to WebSocket dial: %w", err)
+	}
+
+	// Get remote reader sequence number from response header
+	var remoteReaderSeq uint64
+	if resp != nil && resp.Header != nil {
+		seqStr := resp.Header.Get(codersdk.HeaderImmortalStreamSequenceNum)
+		if seqStr != "" {
+			if seq, parseErr := strconv.ParseUint(seqStr, 10, 64); parseErr == nil {
+				remoteReaderSeq = seq
+			}
+		}
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}
+	r.logger.Debug(ctx, "immortal reconnect upgraded", slog.F("url", r.wsURL), slog.F("remote_reader_seq", remoteReaderSeq))
+
+	// Convert to net.Conn for binary transport
+	nc := websocket.NetConn(ctx, ws, websocket.MessageBinary)
+	r.logger.Debug(ctx, "immortal reconnect returning stream")
+
+	// Return the connection and remote reader sequence for writer replay.
+	return nc, remoteReaderSeq, nil
+}
+
+func (c *immortalBackedConn) Read(p []byte) (int, error)  { return c.pipe.Read(p) }
+func (c *immortalBackedConn) Write(p []byte) (int, error) { return c.pipe.Write(p) }
+func (c *immortalBackedConn) Close() error {
+	c.cancel()
+	return c.pipe.Close()
+}
+
+// The following implement net.Conn; they are best-effort/no-op where not applicable.
+func (*immortalBackedConn) LocalAddr() net.Addr                { return nil }
+func (*immortalBackedConn) RemoteAddr() net.Addr               { return nil }
+func (*immortalBackedConn) SetDeadline(t time.Time) error      { _ = t; return nil }
+func (*immortalBackedConn) SetReadDeadline(t time.Time) error  { _ = t; return nil }
+func (*immortalBackedConn) SetWriteDeadline(t time.Time) error { _ = t; return nil }
+
+// startSupervisor keeps attempting reconnection while disconnected.
+func (c *immortalBackedConn) startSupervisor() {
+	go func() {
+		for {
+			select {
+			case <-c.ctx.Done():
+				return
+			default:
+			}
+
+			// Attempt reconnect if not connected
+			if !c.pipe.Connected() {
+				if err := c.pipe.ForceReconnect(); err != nil {
+					c.logger.Error(context.Background(), "backedpipe reconnect attempt failed", slog.Error(err))
+				}
+			}
+
+			select {
+			case <-time.After(5 * time.Second):
+			case <-c.ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/cli/immortal_backed_pipe_conn.go
+++ b/cli/immortal_backed_pipe_conn.go
@@ -127,7 +127,7 @@ func (r *clientStreamReconnector) Reconnect(ctx context.Context, readerSeqNum ui
 	dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	r.logger.Debug(ctx, "immortal reconnect dialing", slog.F("url", r.wsURL), slog.F("reader_seq", readerSeqNum))
+	r.logger.Info(ctx, "immortal: attempting reconnect", slog.F("url", r.wsURL), slog.F("reader_seq", readerSeqNum))
 	ws, resp, err := websocket.Dial(dialCtx, r.wsURL, dialOptions)
 	if err != nil {
 		var status string
@@ -159,7 +159,7 @@ func (r *clientStreamReconnector) Reconnect(ctx context.Context, readerSeqNum ui
 			_ = resp.Body.Close()
 		}
 	}
-	r.logger.Debug(ctx, "immortal reconnect upgraded", slog.F("url", r.wsURL), slog.F("remote_reader_seq", remoteReaderSeq))
+	r.logger.Info(ctx, "immortal: reconnect established", slog.F("url", r.wsURL), slog.F("remote_reader_seq", remoteReaderSeq))
 
 	// Convert to net.Conn for binary transport
 	nc := websocket.NetConn(ctx, ws, websocket.MessageBinary)
@@ -195,6 +195,7 @@ func (c *immortalBackedConn) startSupervisor() {
 
 			// Attempt reconnect if not connected
 			if !c.pipe.Connected() {
+				c.logger.Info(context.Background(), "immortal: supervisor forcing reconnect")
 				if err := c.pipe.ForceReconnect(); err != nil {
 					c.logger.Error(context.Background(), "backedpipe reconnect attempt failed", slog.Error(err))
 				}

--- a/cli/immortalstreams.go
+++ b/cli/immortalstreams.go
@@ -108,6 +108,10 @@ func DialImmortalOrFallback(
 	reconnector := newClientStreamReconnector(ctx, agentConn, client, agentID, stream.ID, logger, ops.CoderConnectHost)
 	logger.Info(ctx, "immortal: created reconnector")
 	pipe := backedpipe.NewBackedPipe(ctx, reconnector)
+	// Ensure a 404 on upgrade terminates the pipe immediately.
+	reconnector.onPermanentFailure = func() {
+		_ = pipe.Close()
+	}
 	logger.Info(ctx, "immortal: connecting backed pipe")
 	if err := pipe.Connect(); err != nil {
 		_ = streamClient.deleteStream(ctx, stream.ID)

--- a/cli/immortalstreams.go
+++ b/cli/immortalstreams.go
@@ -1,0 +1,287 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"github.com/coder/coder/v2/agent/immortalstreams/backedpipe"
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/serpent"
+)
+
+// immortalStreamClient provides methods to interact with immortal streams API
+// This uses the main codersdk.Client to make server-proxied requests to agents
+type immortalStreamClient struct {
+	client  *codersdk.Client
+	agentID uuid.UUID
+	logger  slog.Logger
+}
+
+// newImmortalStreamClient creates a new client for immortal streams
+func newImmortalStreamClient(client *codersdk.Client, agentID uuid.UUID, logger slog.Logger) *immortalStreamClient {
+	return &immortalStreamClient{
+		client:  client,
+		agentID: agentID,
+		logger:  logger,
+	}
+}
+
+// ImmortalDialOptions control dialing behavior for immortal streams.
+type ImmortalDialOptions struct {
+	Enabled  bool
+	Fallback bool
+	// TargetPort is the agent TCP port to connect to when using an immortal stream (e.g., 1 for SSH).
+	TargetPort uint16
+	// CoderConnectHost, if set, is the hostname to use when Coder Connect is running (e.g. agent.workspace.owner.suffix).
+	CoderConnectHost string
+}
+
+// ImmortalConnResult describes the connection and (if used) associated immortal stream resources.
+type ImmortalConnResult struct {
+	Conn         net.Conn
+	StreamClient *immortalStreamClient
+	StreamID     *uuid.UUID
+	UsedImmortal bool
+}
+
+// DialImmortalOrFallback creates an immortal stream and connects to it, or falls back
+// to a provided dialer if disabled or creation fails and fallback is allowed.
+func DialImmortalOrFallback(
+	ctx context.Context,
+	agentConn workspacesdk.AgentConn,
+	client *codersdk.Client,
+	agentID uuid.UUID,
+	logger slog.Logger,
+	ops ImmortalDialOptions,
+	fallbackDial func(context.Context) (net.Conn, error),
+) (ImmortalConnResult, error) {
+	if !ops.Enabled {
+		c, err := fallbackDial(ctx)
+		if err != nil {
+			return ImmortalConnResult{}, err
+		}
+		return ImmortalConnResult{Conn: c, UsedImmortal: false}, nil
+	}
+
+	streamClient := newImmortalStreamClient(client, agentID, logger)
+	stream, err := streamClient.createStream(ctx, ops.TargetPort)
+	if err != nil {
+		logger.Error(ctx, "failed to create immortal stream", slog.Error(err), slog.F("agent_id", agentID), slog.F("target_port", ops.TargetPort), slog.F("immortal_fallback_enabled", ops.Fallback))
+		// Allow fallback for common infra/transient errors in addition to explicit limits.
+		lower := strings.ToLower(err.Error())
+		// Be lenient on message formatting/casing from server
+		tooManyErr := strings.Contains(lower, "too many immortal stream")
+		connRefused := strings.Contains(err.Error(), "The connection was refused") || strings.Contains(lower, "connection refused")
+		timeoutErr := strings.Contains(lower, "context deadline exceeded") || strings.Contains(lower, "timeout")
+		unreachableErr := strings.Contains(lower, "not reachable")
+		shouldFallback := ops.Fallback && (tooManyErr || connRefused || timeoutErr || unreachableErr)
+		if !shouldFallback {
+			return ImmortalConnResult{}, xerrors.Errorf("create immortal stream: %w", err)
+		}
+		switch {
+		case tooManyErr:
+			logger.Warn(ctx, "too many immortal streams, falling back to regular connection", slog.F("max_streams", "32"), slog.F("target_port", ops.TargetPort))
+		case connRefused:
+			logger.Warn(ctx, "service not available, falling back to regular connection", slog.F("reason", "connection_refused"), slog.F("target_port", ops.TargetPort))
+		case timeoutErr:
+			logger.Warn(ctx, "agent HTTP API timed out, falling back to regular connection", slog.F("reason", "context_deadline_exceeded"), slog.F("target_port", ops.TargetPort))
+		case unreachableErr:
+			logger.Warn(ctx, "agent unreachable for immortal stream, falling back to regular connection", slog.F("target_port", ops.TargetPort))
+		}
+		c, derr := fallbackDial(ctx)
+		if derr != nil {
+			return ImmortalConnResult{}, xerrors.Errorf("fallback dial: %w", derr)
+		}
+		return ImmortalConnResult{Conn: c, UsedImmortal: false}, nil
+	}
+
+	// connect to the stream using the agent tailnet connection
+	logger.Info(ctx, "immortal: creating reconnector", slog.F("agent_id", agentID), slog.F("stream_id", stream.ID))
+	reconnector := newClientStreamReconnector(ctx, agentConn, client, agentID, stream.ID, logger, ops.CoderConnectHost)
+	logger.Info(ctx, "immortal: created reconnector")
+	pipe := backedpipe.NewBackedPipe(ctx, reconnector)
+	logger.Info(ctx, "immortal: connecting backed pipe")
+	if err := pipe.Connect(); err != nil {
+		_ = streamClient.deleteStream(ctx, stream.ID)
+		return ImmortalConnResult{}, xerrors.Errorf("connect to immortal stream: %w", err)
+	}
+	logger.Info(ctx, "immortal: backed pipe connected")
+
+	conn := &immortalBackedConn{ctx: ctx, cancel: func() {}, pipe: pipe, logger: logger}
+	conn.startSupervisor()
+
+	streamID := stream.ID
+	return ImmortalConnResult{
+		Conn:         conn,
+		StreamClient: streamClient,
+		StreamID:     &streamID,
+		UsedImmortal: true,
+	}, nil
+}
+
+// createStream creates a new immortal stream
+func (c *immortalStreamClient) createStream(ctx context.Context, port uint16) (*codersdk.ImmortalStream, error) {
+	stream, err := c.client.WorkspaceAgentCreateImmortalStream(ctx, c.agentID, codersdk.CreateImmortalStreamRequest{
+		TCPPort: port,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &stream, nil
+}
+
+// listStreams lists all immortal streams
+func (c *immortalStreamClient) listStreams(ctx context.Context) ([]codersdk.ImmortalStream, error) {
+	return c.client.WorkspaceAgentImmortalStreams(ctx, c.agentID)
+}
+
+// deleteStream deletes an immortal stream
+func (c *immortalStreamClient) deleteStream(ctx context.Context, streamID uuid.UUID) error {
+	return c.client.WorkspaceAgentDeleteImmortalStream(ctx, c.agentID, streamID)
+}
+
+// CLI Commands
+
+func (r *RootCmd) immortalStreamCmd() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "immortal-stream",
+		Short: "Manage immortal streams in workspaces",
+		Long:  "Immortal streams provide persistent TCP connections to workspace services that automatically reconnect when interrupted.",
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Children: []*serpent.Command{
+			r.immortalStreamListCmd(),
+			r.immortalStreamDeleteCmd(),
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) immortalStreamListCmd() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "list <workspace-name>",
+		Short: "List active immortal streams in a workspace",
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(1),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			workspaceName := inv.Args[0]
+
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+
+			workspace, workspaceAgent, _, err := GetWorkspaceAndAgent(ctx, inv, client, false, workspaceName)
+			if err != nil {
+				return err
+			}
+
+			if workspace.LatestBuild.Transition != codersdk.WorkspaceTransitionStart {
+				return xerrors.New("workspace must be running to list immortal streams")
+			}
+
+			// Create immortal stream client
+			// Note: We don't need to dial the agent for management operations
+			// as these go through the server's proxy endpoints
+			streamClient := newImmortalStreamClient(client, workspaceAgent.ID, inv.Logger)
+			streams, err := streamClient.listStreams(ctx)
+			if err != nil {
+				return xerrors.Errorf("list immortal streams: %w", err)
+			}
+
+			if len(streams) == 0 {
+				cliui.Info(inv.Stderr, "No active immortal streams found.")
+				return nil
+			}
+
+			// Display the streams in a table
+			displayImmortalStreams(inv, streams)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) immortalStreamDeleteCmd() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "delete <workspace-name> <immortal-stream-name>",
+		Short: "Delete an active immortal stream",
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(2),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			workspaceName := inv.Args[0]
+			streamName := inv.Args[1]
+
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+
+			workspace, workspaceAgent, _, err := GetWorkspaceAndAgent(ctx, inv, client, false, workspaceName)
+			if err != nil {
+				return err
+			}
+
+			if workspace.LatestBuild.Transition != codersdk.WorkspaceTransitionStart {
+				return xerrors.New("workspace must be running to delete immortal streams")
+			}
+
+			// Create immortal stream client
+			streamClient := newImmortalStreamClient(client, workspaceAgent.ID, inv.Logger)
+			streams, err := streamClient.listStreams(ctx)
+			if err != nil {
+				return xerrors.Errorf("list immortal streams: %w", err)
+			}
+
+			var targetStream *codersdk.ImmortalStream
+			for _, stream := range streams {
+				if stream.Name == streamName {
+					targetStream = &stream
+					break
+				}
+			}
+
+			if targetStream == nil {
+				return xerrors.Errorf("immortal stream %q not found", streamName)
+			}
+
+			// Delete the stream
+			err = streamClient.deleteStream(ctx, targetStream.ID)
+			if err != nil {
+				return xerrors.Errorf("delete immortal stream: %w", err)
+			}
+
+			cliui.Info(inv.Stderr, fmt.Sprintf("Deleted immortal stream %q (ID: %s)", streamName, targetStream.ID))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func displayImmortalStreams(inv *serpent.Invocation, streams []codersdk.ImmortalStream) {
+	_, _ = fmt.Fprintf(inv.Stderr, "Active Immortal Streams:\n\n")
+	_, _ = fmt.Fprintf(inv.Stderr, "%-20s %-6s %-20s %-20s\n", "NAME", "PORT", "CREATED", "LAST CONNECTED")
+	_, _ = fmt.Fprintf(inv.Stderr, "%-20s %-6s %-20s %-20s\n", "----", "----", "-------", "--------------")
+
+	for _, stream := range streams {
+		createdTime := stream.CreatedAt.Format("2006-01-02 15:04:05")
+		lastConnTime := stream.LastConnectionAt.Format("2006-01-02 15:04:05")
+
+		_, _ = fmt.Fprintf(inv.Stderr, "%-20s %-6d %-20s %-20s\n",
+			stream.Name, stream.TCPPort, createdTime, lastConnTime)
+	}
+	_, _ = fmt.Fprintf(inv.Stderr, "\n")
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -145,6 +145,7 @@ func (r *RootCmd) AGPLExperimental() []*serpent.Command {
 		r.promptExample(),
 		r.rptyCommand(),
 		r.tasksCommand(),
+		r.immortalStreamCmd(),
 	}
 }
 

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -8,10 +8,10 @@ USAGE:
   This command does not have full parity with the standard SSH command. For
   users who need the full functionality of SSH, create an ssh configuration with
   `coder config-ssh`.
-  
+
     - Use `--` to separate and pass flags directly to the command executed via
   SSH.:
-  
+
        $ coder ssh <workspace> -- ls -la
 
 OPTIONS:
@@ -40,6 +40,13 @@ OPTIONS:
       --identity-agent string, $CODER_SSH_IDENTITY_AGENT
           Specifies which identity agent to use (overrides $SSH_AUTH_SOCK),
           forward agent must also be enabled.
+
+      --immortal bool, $CODER_SSH_IMMORTAL
+          Use an Immortal Stream for SSH in stdio mode.
+
+      --immortal-fallback bool, $CODER_SSH_IMMORTAL_FALLBACK (default: false)
+          If enabled, fall back to regular TCP when Immortal Stream creation
+          fails.
 
   -l, --log-dir string, $CODER_SSH_LOG_DIR
           Specify the directory containing SSH diagnostic log files.

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -8,10 +8,10 @@ USAGE:
   This command does not have full parity with the standard SSH command. For
   users who need the full functionality of SSH, create an ssh configuration with
   `coder config-ssh`.
-
+  
     - Use `--` to separate and pass flags directly to the command executed via
   SSH.:
-
+  
        $ coder ssh <workspace> -- ls -la
 
 OPTIONS:

--- a/docs/reference/cli/ssh.md
+++ b/docs/reference/cli/ssh.md
@@ -30,6 +30,25 @@ This command does not have full parity with the standard SSH command. For users 
 
 Specifies whether to emit SSH output over stdin/stdout.
 
+### --immortal
+
+|             |                                  |
+|-------------|----------------------------------|
+| Type        | <code>bool</code>                |
+| Environment | <code>$CODER_SSH_IMMORTAL</code> |
+
+Use an Immortal Stream for SSH in stdio mode.
+
+### --immortal-fallback
+
+|             |                                           |
+|-------------|-------------------------------------------|
+| Type        | <code>bool</code>                         |
+| Environment | <code>$CODER_SSH_IMMORTAL_FALLBACK</code> |
+| Default     | <code>false</code>                        |
+
+If enabled, fall back to regular TCP when Immortal Stream creation fails.
+
 ### --ssh-host-prefix
 
 |             |                                         |


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/19979

Added support for immortal streams to maintain persistent TCP connections to workspace services that automatically reconnect when interrupted.

### What changed?

- Implemented a new immortal streams feature that provides persistent TCP connections to workspace services
- Created CLI commands for managing immortal streams (`coder exp immortal-stream list/delete`)
- Added support for using immortal streams with SSH stdio command
- Implemented server-side API endpoints for creating, listing, and deleting immortal streams
- Added fallback mechanism to regular connections when immortal streams are unavailable

### How to test?

1. Use the experimental CLI commands to manage immortal streams:
   ```
   coder exp immortal-stream list <workspace-name>
   coder exp immortal-stream delete <workspace-name> <stream-name>
   ```

2. Test SSH with immortal streams:
   ```
   coder ssh --stdio --immortal <workspace-name>
   ```

3. Verify automatic reconnection by temporarily disrupting the network connection

### Why make this change?

Immortal streams provide a more resilient connection mechanism for workspace services, automatically reconnecting when network interruptions occur. This improves the user experience by maintaining persistent connections to SSH and port-forwarded services, reducing the need for manual reconnection and preventing session loss during temporary network issues.