### PR TITLE
chore: update docs to mention debug logging config explicitly

### DIFF
--- a/docs/admin/monitoring/logs.md
+++ b/docs/admin/monitoring/logs.md
@@ -17,7 +17,7 @@ machine/VM.
   options.
 - To only display certain types of logs, use
   the[`CODER_LOG_FILTER`](../../reference/cli/server.md#-l---log-filter) server
-  config.
+  config. Using `.*` will result in the `DEBUG` log level being used.
 
 Events such as server errors, audit logs, user activities, and SSO & OpenID
 Connect logs are all captured in the `coderd` logs.


### PR DESCRIPTION
From https://coder.com/docs/admin/monitoring/logs#coderd-logs

It wasn't overly clear what was needed to get debug logs, this PR adds a mention explaining it.