### PR TITLE
chore: remove turbosnap plugin

### DIFF
--- a/site/.storybook/main.js
+++ b/site/.storybook/main.js
@@ -1,5 +1,3 @@
-import turbosnap from "vite-plugin-turbosnap";
-
 module.exports = {
 	stories: ["../src/**/*.stories.tsx"],
 
@@ -18,15 +16,7 @@ module.exports = {
 		options: {},
 	},
 
-	async viteFinal(config, { configType }) {
-		config.plugins = config.plugins || [];
-		if (configType === "PRODUCTION") {
-			config.plugins.push(
-				turbosnap({
-					rootDir: config.root || "",
-				}),
-			);
-		}
+	async viteFinal(config) {
 		config.server.allowedHosts = [".coder"];
 		return config;
 	},

--- a/site/.storybook/main.js
+++ b/site/.storybook/main.js
@@ -15,9 +15,4 @@ module.exports = {
 		name: "@storybook/react-vite",
 		options: {},
 	},
-
-	async viteFinal(config) {
-		config.server.allowedHosts = [".coder"];
-		return config;
-	},
 };

--- a/site/package.json
+++ b/site/package.json
@@ -185,11 +185,7 @@
 		"vite": "6.3.5",
 		"vite-plugin-checker": "0.9.3"
 	},
-	"browserslist": [
-		"chrome 110",
-		"firefox 111",
-		"safari 16.0"
-	],
+	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/package.json
+++ b/site/package.json
@@ -183,10 +183,13 @@
 		"ts-proto": "1.164.0",
 		"typescript": "5.6.3",
 		"vite": "6.3.5",
-		"vite-plugin-checker": "0.9.3",
-		"vite-plugin-turbosnap": "1.0.3"
+		"vite-plugin-checker": "0.9.3"
 	},
-	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
+	"browserslist": [
+		"chrome 110",
+		"firefox 111",
+		"safari 16.0"
+	],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -459,9 +459,6 @@ importers:
       vite-plugin-checker:
         specifier: 0.9.3
         version: 0.9.3(@biomejs/biome@1.9.4)(eslint@8.52.0)(optionator@0.9.3)(typescript@5.6.3)(vite@6.3.5(@types/node@20.17.16)(jiti@2.4.2)(yaml@2.7.0))
-      vite-plugin-turbosnap:
-        specifier: 1.0.3
-        version: 1.0.3
 
 packages:
 
@@ -6083,9 +6080,6 @@ packages:
         optional: true
       vue-tsc:
         optional: true
-
-  vite-plugin-turbosnap@1.0.3:
-    resolution: {integrity: sha512-p4D8CFVhZS412SyQX125qxyzOgIFouwOcvjZWk6bQbNPR1wtaEzFT6jZxAjf1dejlGqa6fqHcuCvQea6EWUkUA==, tarball: https://registry.npmjs.org/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.3.tgz}
 
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==, tarball: https://registry.npmjs.org/vite/-/vite-6.3.5.tgz}
@@ -12765,8 +12759,6 @@ snapshots:
       eslint: 8.52.0
       optionator: 0.9.3
       typescript: 5.6.3
-
-  vite-plugin-turbosnap@1.0.3: {}
 
   vite@6.3.5(@types/node@20.17.16)(jiti@2.4.2)(yaml@2.7.0):
     dependencies:


### PR DESCRIPTION
Turbosnap plugin is included by default in Storybook 8, so we can remove it from our configuration.

> Found 'rollup-plugin-turbosnap' which is now included by default in Storybook 8.
Removing from your plugins list. Ensure you pass `--stats-json` to generate stats.

> For more information, see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#turbosnap-vite-plugin-is-no-longer-needed