### PR TITLE
fix: fix jetbrains toolbox connection tracking

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -46,6 +46,7 @@ const (
 	// MagicProcessCmdlineJetBrains is a string in a process's command line that
 	// uniquely identifies it as JetBrains software.
 	MagicProcessCmdlineJetBrains = "idea.vendor.name=JetBrains"
+	MagicProcessCmdlineToolbox   = "com.jetbrains.toolbox"
 
 	// BlockedFileTransferErrorCode indicates that SSH server restricted the raw command from performing
 	// the file transfer.

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -47,6 +47,7 @@ const (
 	// uniquely identifies it as JetBrains software.
 	MagicProcessCmdlineJetBrains = "idea.vendor.name=JetBrains"
 	MagicProcessCmdlineToolbox   = "com.jetbrains.toolbox"
+	MagicProcessCmdlineGateway   = "remote-dev-server"
 
 	// BlockedFileTransferErrorCode indicates that SSH server restricted the raw command from performing
 	// the file transfer.

--- a/agent/agentssh/jetbrainstrack.go
+++ b/agent/agentssh/jetbrainstrack.go
@@ -53,8 +53,7 @@ func NewJetbrainsChannelWatcher(ctx ssh.Context, logger slog.Logger, reportConne
 
 	// If this is not JetBrains, then we do not need to do anything special.  We
 	// attempt to match on something that appears unique to JetBrains software.
-	isJetbrains := strings.Contains(strings.ToLower(cmdline), strings.ToLower(MagicProcessCmdlineJetBrains)) || strings.Contains(strings.ToLower(cmdline), strings.ToLower(MagicProcessCmdlineToolbox))
-	if !isJetbrains {
+	if !isJetbrainsProcess(cmdline) {
 		return newChannel
 	}
 
@@ -104,4 +103,19 @@ type ChannelOnClose struct {
 func (c *ChannelOnClose) Close() error {
 	c.once.Do(c.done)
 	return c.Channel.Close()
+}
+
+func isJetbrainsProcess(cmdline string) bool {
+	opts := []string{
+		MagicProcessCmdlineJetBrains,
+		MagicProcessCmdlineToolbox,
+		MagicProcessCmdlineGateway,
+	}
+
+	for _, opt := range opts {
+		if strings.Contains(strings.ToLower(cmdline), strings.ToLower(opt)) {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/agentssh/jetbrainstrack.go
+++ b/agent/agentssh/jetbrainstrack.go
@@ -53,7 +53,8 @@ func NewJetbrainsChannelWatcher(ctx ssh.Context, logger slog.Logger, reportConne
 
 	// If this is not JetBrains, then we do not need to do anything special.  We
 	// attempt to match on something that appears unique to JetBrains software.
-	if !strings.Contains(strings.ToLower(cmdline), strings.ToLower(MagicProcessCmdlineJetBrains)) {
+	isJetbrains := strings.Contains(strings.ToLower(cmdline), strings.ToLower(MagicProcessCmdlineJetBrains)) || strings.Contains(strings.ToLower(cmdline), strings.ToLower(MagicProcessCmdlineToolbox))
+	if !isJetbrains {
 		return newChannel
 	}
 


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/18350

Here's the process name I used to decide what to detect:
```
/home/coder/.cache/JetBrains/Toolbox-CLI-dist/jbr-21.0.3-linux-x64-b509.11-1/bin/java -ea -Dfile.encoding=UTF8 -Xss384k -XX:+UnlockExperimentalVMOptions -XX:+CreateCoredumpOnCrash -XX:+UseStringDeduplication -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:MinMetaspaceFreeRatio=10 -XX:MaxMetaspaceFreeRatio=10 -XX:+UseSerialGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=10 -XX:-ShrinkHeapInSteps -Xmx120m -Djna.debug_load.jna=true -Djna.nosys=true -Djna.noclasspath=true -Djna.nounpack=true -Djna.boot.library.path=/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/linux-x86-64:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/linux-aarch64:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/darwin-x86-64:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/darwin-aarch64 -classpath /home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/cli-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/agent-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/rpc-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/core-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/remote-development-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/remote-development-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/enterprise-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jbclient-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/gateway-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/rpc-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/cli-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/agent-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/accounts-enterprise-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/accounts-jba-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/accounts-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/disk-usage-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/dot-desktop-files-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tools-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/file-associations-windows-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/intellij-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/registration-windows-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/project-fleet-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/fleet-core-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/package-extractors-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/project-visualstudio-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/resharper-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/shell-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/shortcuts-windows-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/ui-theme-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/project-intellij-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/project-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/gateway-remote-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/feed-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tbe-test-access-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/settings-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/interop-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/ipc-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/network-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/station-comms-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/file-associations-windows-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/intellij-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/shell-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/gateway-error-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/fus-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/environment-descriptor-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/project-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/licensing-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/agent-network-mappers-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/settings-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/agent-network-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/accounts-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/enterprise-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/disk-usage-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/fleet-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/resharper-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/shortcuts-windows-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tools-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/network-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/environment-descriptor-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/package-extractor-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/common-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/i18n-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/protocolhandler-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/agent-network-api-utils-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/feed-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/interop-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tinylog-api-kotlin-2.6.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/openssh-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/okhttp-tls-4.12.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/logging-interceptor-4.12.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/okhttp-4.12.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/station-comms-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/station-comms-common-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/serialization-kotlin-85.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/keychain-4.4.3.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tbe-config-machine-2024.5.0.1988.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-krpc-serialization-json-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-serialization-json-jvm-1.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/gateway-internal-plugin-api-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/plugin-api-remote-dev-1.4.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/plugin-api-ui-1.4.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/platform-image-1.4.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-krpc-client-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-krpc-server-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-krpc-core-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-core-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-krpc-serialization-core-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-serialization-core-jvm-1.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-serialization-json-okio-jvm-1.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/okio-jvm-3.9.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/logging-bootstrap-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/install-commands-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/plugin-api-localization-1.4.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/plugin-api-core-1.4.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-krpc-logging-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-rpc-utils-jvm-0.8.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-coroutines-core-jvm-1.10.2.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-coroutines-slf4j-1.10.2.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/koin-core-jvm-3.5.2.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlinx-datetime-jvm-0.6.2.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/platform-resource-1.4.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/scheme-85.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/ap-validation-85.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/model-85.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/id-generation-85.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlin-stdlib-jdk8-1.9.22.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlin-reflect-2.2.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlin-stdlib-jdk7-1.9.22.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlin-logging-jvm-7.0.7.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/kotlin-stdlib-2.2.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tinylog-impl-2.6.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/picocli-4.7.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jvm-native-trusted-roots-1.1.7.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jna-platform-5.17.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/annotations-26.0.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jna-5.17.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/slf4j-tinylog-2.6.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/statusnotifier-2.8.1.52155.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/dbus-java-transport-native-unixsocket-4.0.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/dbus-java-core-4.0.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/proxy-vole-11b8f6af4a.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/slf4j-api-2.0.16.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jbr-api-1.2.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/nanohttpd-2.3.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/commons-compress-1.26.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/delight-rhino-sandbox-0.0.12.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/org.eclipse.xtend.lib-2.17.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/org.eclipse.xtend.lib.macro-2.17.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/org.eclipse.xtext.xbase.lib-2.17.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/guava-33.1.0-jre.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/caffeine-3.1.8.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-codec-http-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-handler-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-codec-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-codec-compression-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-codec-protobuf-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-codec-marshalling-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-codec-base-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-transport-native-unix-common-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-transport-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-buffer-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/xz-1.9.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/bcpkix-jdk18on-1.80.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/bcutil-jdk18on-1.80.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/bcprov-jdk18on-1.80.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/tinylog-api-2.6.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/commons-codec-1.16.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/commons-io-2.15.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/commons-lang3-3.14.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/failureaccess-1.0.2.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jsr305-3.0.2.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/checker-qual-3.42.0.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/error_prone_annotations-2.26.1.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/ini4j-0.5.4.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-resolver-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/netty-common-4.2.0.Alpha5.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jackson-core-2.18.3.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jackson-annotations-2.18.3.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/jackson-databind-2.18.3.jar:/home/coder/.cache/JetBrains/Toolbox-CLI-dist/tbcli-2.8.1.52155/lib/rhino-1.7.13.jar com.jetbrains.toolbox.MainKt --structured-logging agent
```

I attempted the route of relying on just the session env vars, in hopes that this issue was fixed in Toolbox and the process name matching was no longer need, but it was not a fruitful endeavor and it seems to be using the same connection logic as it did in gateway, just with new binary and flag names.  