### PR TITLE
test(codersdk/toolsdk): skip `coder_workspace_bash` tool test on windows

### DIFF
--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -665,6 +665,10 @@ func TestMain(m *testing.M) {
 	var untested []string
 	for _, tool := range toolsdk.All {
 		if tested, ok := testedTools.Load(tool.Name); !ok || !tested.(bool) {
+			// Test is skipped on Windows
+			if runtime.GOOS == "windows" && tool.Name == "coder_workspace_bash" {
+				continue
+			}
 			untested = append(untested, tool.Name)
 		}
 	}


### PR DESCRIPTION
Fixes flakes on the nightly-gauntlet like:
https://github.com/coder/coder/actions/runs/16955654896
since there's no `bash` on windows...
```
=== Failed
=== FAIL: codersdk/toolsdk  (0.00s)
PASS
The following tools were not tested:
 - coder_workspace_bash
Please ensure that all tools are tested using testTool().
If you just added a new tool, please add a test for it.
NOTE: if you just ran an individual test, this is expected.
FAIL	github.com/coder/coder/v2/codersdk/toolsdk	4.185s
```