### PR TITLE
fix: fix storybook when using coder desktop

### DIFF
--- a/site/.storybook/main.ts
+++ b/site/.storybook/main.ts
@@ -23,7 +23,7 @@ export default {
 		config.server = {
 			...config.server,
 			allowedHosts: [".coder", ".dev.coder.com"],
-		}
+		};
 		return config;
 	},
 } satisfies import("@storybook/react-vite").StorybookConfig;

--- a/site/.storybook/main.ts
+++ b/site/.storybook/main.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	stories: ["../src/**/*.stories.tsx"],
 
 	addons: [
@@ -15,4 +15,12 @@ module.exports = {
 		name: "@storybook/react-vite",
 		options: {},
 	},
-};
+
+	async viteFinal(config) {
+		config.server = {
+			...config.server,
+			allowedHosts: [".coder", ".dev.coder.com"],
+		}
+		return config;
+	},
+} satisfies import("@storybook/react-vite").StorybookConfig;

--- a/site/.storybook/main.ts
+++ b/site/.storybook/main.ts
@@ -17,6 +17,9 @@ export default {
 	},
 
 	async viteFinal(config) {
+		// Storybook seems to strip this setting out of our Vite config. We need to
+		// put it back in order to be able to access Storybook with Coder Desktop or
+		// port sharing.
 		config.server = {
 			...config.server,
 			allowedHosts: [".coder", ".dev.coder.com"],


### PR DESCRIPTION
I suggested a change in https://github.com/coder/coder/pull/19341 that I did not expect to be breaking, but that apparently is 🤦‍♀️

Added a comment explaining why this config is necessary so it doesn't get removed accidentally again.