### PR TITLE
ci: add `paralleltestctx` to `lint/go`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -576,6 +576,7 @@ lint/go:
 	./scripts/check_codersdk_imports.sh
 	linter_ver=$(shell egrep -o 'GOLANGCI_LINT_VERSION=\S+' dogfood/coder/Dockerfile | cut -d '=' -f 2)
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v$$linter_ver run
+	go run github.com/coder/paralleltestctx/cmd/paralleltestctx@v0.0.1 -custom-funcs="testutil.Context" ./...
 .PHONY: lint/go
 
 lint/examples:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -456,8 +456,6 @@ func TestAgent_GitSSH(t *testing.T) {
 
 func TestAgent_SessionTTYShell(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-	t.Cleanup(cancel)
 	if runtime.GOOS == "windows" {
 		// This might be our implementation, or ConPTY itself.
 		// It's difficult to find extensive tests for it, so
@@ -468,6 +466,7 @@ func TestAgent_SessionTTYShell(t *testing.T) {
 	for _, port := range sshPorts {
 		t.Run(fmt.Sprintf("(%d)", port), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
 
 			session := setupSSHSessionOnPort(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{}, nil, port)
 			command := "sh"

--- a/agent/agentcontainers/containers_dockercli_test.go
+++ b/agent/agentcontainers/containers_dockercli_test.go
@@ -55,11 +55,11 @@ func TestIntegrationDockerCLI(t *testing.T) {
 	}, testutil.WaitShort, testutil.IntervalSlow, "Container did not start in time")
 
 	dcli := agentcontainers.NewDockerCLI(agentexec.DefaultExecer)
-	ctx := testutil.Context(t, testutil.WaitMedium) // Longer timeout for multiple subtests
 	containerName := strings.TrimPrefix(ct.Container.Name, "/")
 
 	t.Run("DetectArchitecture", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		arch, err := dcli.DetectArchitecture(ctx, containerName)
 		require.NoError(t, err, "DetectArchitecture failed")
@@ -71,6 +71,7 @@ func TestIntegrationDockerCLI(t *testing.T) {
 
 	t.Run("Copy", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		want := "Help, I'm trapped!"
 		tempFile := filepath.Join(t.TempDir(), "test-file.txt")
@@ -90,6 +91,7 @@ func TestIntegrationDockerCLI(t *testing.T) {
 
 	t.Run("ExecAs", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		// Test ExecAs without specifying user (should use container's default).
 		want := "root"

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -403,7 +403,6 @@ func TestTelemetryItem(t *testing.T) {
 
 func TestPrebuiltWorkspacesTelemetry(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitMedium)
 	db, _ := dbtestutil.NewDB(t)
 
 	cases := []struct {
@@ -435,6 +434,7 @@ func TestPrebuiltWorkspacesTelemetry(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
 
 			deployment, snapshot := collectSnapshot(ctx, t, db, func(opts telemetry.Options) telemetry.Options {
 				opts.Database = tc.storeFn(db)

--- a/coderd/workspaceapps/db_test.go
+++ b/coderd/workspaceapps/db_test.go
@@ -255,6 +255,7 @@ func Test_ResolveRequest(t *testing.T) {
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
 				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitShort)
 
 				// Try resolving a request for each app as the owner, without a
 				// token, then use the token to resolve each app.
@@ -589,6 +590,7 @@ func Test_ResolveRequest(t *testing.T) {
 
 	t.Run("TokenDoesNotMatchRequest", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		badToken := workspaceapps.SignedToken{
 			Request: (workspaceapps.Request{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1800,6 +1800,7 @@ func TestWorkspaceFilter(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
 			workspaces, err := client.Workspaces(ctx, c.Filter)
 			require.NoError(t, err, "fetch workspaces")
 

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -222,6 +222,7 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitShort)
 
 			user := quietUser
 			if c.noQuietHours {

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -290,6 +290,7 @@ resourceLoop:
 
 			t.Run(r.RegionName, func(t *testing.T) {
 				t.Parallel()
+				ctx := testutil.Context(t, testutil.WaitShort)
 
 				derpMap := &tailcfg.DERPMap{
 					Regions: map[int]*tailcfg.DERPRegion{


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/884

We're adding this as a `go run` in `lint/go` for now, since adding it to golangci-lint ourselves involves recompiling golangci-lint and then running that new binary. I'll look into proposing it being added to the public golangci-lint linters.

Doesn't appear to cause the lint ci job to take any longer, which is nice.

This first pass of the linter picked up 10 issues! :tada: 