### PR TITLE
test: add an ergonomic way to access the test database for debugging

### DIFF
--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -40,6 +40,10 @@ func (p ConnectionParams) DSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", p.Username, p.Password, p.Host, p.Port, p.DBName)
 }
 
+func WillLogDSN() bool {
+	return os.Getenv("CODER_TEST_LOG_PG_DSN") != ""
+}
+
 // These variables are global because all tests share them.
 var (
 	connectionParamsInitOnce       sync.Once
@@ -227,6 +231,12 @@ func Open(t TBSubset, opts ...OpenOption) (string, error) {
 		Port:     port,
 		DBName:   dbName,
 	}.DSN()
+
+	// Optionally log the DSN to help connect to the test database.
+	if WillLogDSN() {
+		t.Logf("Postgres test DSN: %s", dsn)
+		_, _ = fmt.Fprintln(os.Stderr, "Postgres test DSN:", dsn)
+	}
 	return dsn, nil
 }
 

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -152,9 +152,7 @@ func WithDBFrom(dbFrom string) OpenOption {
 }
 
 // WithLogDSN sets whether the DSN should be logged during testing.
-// Set the CODER_TEST_LOG_PG_DSN environment variable to show the DSN.
-// This provides an ergonomic way to connect to test databases during
-// debugging without the need to spin up postgres manually.
+// This provides an ergonomic way to connect to test databases during debugging.
 func WithLogDSN(logDSN bool) OpenOption {
 	return func(o *OpenOptions) {
 		o.LogDSN = logDSN

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -162,6 +162,7 @@ func WithLogDSN(logDSN bool) OpenOption {
 // TBSubset is a subset of the testing.TB interface.
 // It allows to use dbtestutil.Open outside of tests.
 type TBSubset interface {
+	Name() string
 	Cleanup(func())
 	Helper()
 	Logf(format string, args ...any)
@@ -239,7 +240,7 @@ func Open(t TBSubset, opts ...OpenOption) (string, error) {
 
 	// Optionally log the DSN to help connect to the test database.
 	if openOptions.LogDSN {
-		_, _ = fmt.Fprintf(os.Stderr, "Connect to this test database using: psql '%s'\n", dsn)
+		_, _ = fmt.Fprintf(os.Stderr, "Connect to the database for %s using: psql '%s'\n", t.Name(), dsn)
 	}
 	return dsn, nil
 }

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -40,6 +40,10 @@ func (p ConnectionParams) DSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", p.Username, p.Password, p.Host, p.Port, p.DBName)
 }
 
+// WillLogDSN returns true if the DSN should be shown during testing.
+// Set the CODER_TEST_LOG_PG_DSN environment variable to show the DSN.
+// This provides an ergonomic way to connect to test databases during
+// debugging without the need to spin up postgres manually.
 func WillLogDSN() bool {
 	return os.Getenv("CODER_TEST_LOG_PG_DSN") != ""
 }

--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -19,6 +19,10 @@ type mockTB struct {
 	cleanup []func()
 }
 
+func (*mockTB) Name() string {
+	return "mockTB"
+}
+
 func (t *mockTB) Cleanup(f func()) {
 	t.cleanup = append(t.cleanup, f)
 }


### PR DESCRIPTION
Accessing the database during debugging currently requires either spinning up a separate PostgreSQL instance or inspecting memory to retrieve the DSN—both of which add unnecessary friction. While the test suite already provisions a database by default, connecting to it for manual inspection or debugging is not straightforward.

This change introduces a clearer and more accessible way to surface the DSN during debugging sessions, allowing developers to connect to the test database directly without relying on external infrastructure or ad hoc methods.

Expected Usage:
1. Debug using dlv or the IDE.
2. Step through line by line and determine that a query isn't doing what you'd expect
3. No further insight to be gained at the Go level
4. The next place to test is to connect directly to the database while it is in the exact state that the test has produced just before running the query
5. Rerun the test with this option enabled and your breakpoint set right before the questionable query runs
6. Connect to the database and inspect or troubleshoot as you need to
