### PR TITLE
fix: increase timeout for watch workspace agent devcontainers test

### DIFF
--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1579,12 +1579,12 @@ func TestWatchWorkspaceAgentDevcontainers(t *testing.T) {
 		t.Parallel()
 
 		var (
-			ctx    = testutil.Context(t, testutil.WaitLong)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			ctx               = testutil.Context(t, testutil.WaitLong)
+			logger            = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 			mClock            = quartz.NewMock(t)
 			updaterTickerTrap = mClock.Trap().TickerFunc("updaterLoop")
-			mCtrl  = gomock.NewController(t)
-			mCCLI  = acmock.NewMockContainerCLI(mCtrl)
+			mCtrl             = gomock.NewController(t)
+			mCCLI             = acmock.NewMockContainerCLI(mCtrl)
 
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{Logger: &logger})
 			user       = coderdtest.CreateFirstUser(t, client)


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/907

When running in a CI environment, the process of setting up the agent + coderd + creating the websocket connection can sometimes take up to 10 seconds, by which time we timeout. To resolve this we up the timeout from `WaitShort` to `WaitLong`.