### PR TITLE
chore: change format of key from uuid to string to fix swagger issue

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7383,7 +7383,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "format": "uuid",
+                        "format": "string",
                         "description": "Key ID",
                         "name": "keyid",
                         "in": "path",
@@ -7420,7 +7420,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "format": "uuid",
+                        "format": "string",
                         "description": "Key ID",
                         "name": "keyid",
                         "in": "path",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6516,7 +6516,7 @@
 					},
 					{
 						"type": "string",
-						"format": "uuid",
+						"format": "string",
 						"description": "Key ID",
 						"name": "keyid",
 						"in": "path",
@@ -6551,7 +6551,7 @@
 					},
 					{
 						"type": "string",
-						"format": "uuid",
+						"format": "string",
 						"description": "Key ID",
 						"name": "keyid",
 						"in": "path",

--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -151,7 +151,7 @@ func (api *API) postAPIKey(rw http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Tags Users
 // @Param user path string true "User ID, name, or me"
-// @Param keyid path string true "Key ID" format(uuid)
+// @Param keyid path string true "Key ID" format(string)
 // @Success 200 {object} codersdk.APIKey
 // @Router /users/{user}/keys/{keyid} [get]
 func (api *API) apiKeyByID(rw http.ResponseWriter, r *http.Request) {
@@ -292,7 +292,7 @@ func (api *API) tokens(rw http.ResponseWriter, r *http.Request) {
 // @Security CoderSessionToken
 // @Tags Users
 // @Param user path string true "User ID, name, or me"
-// @Param keyid path string true "Key ID" format(uuid)
+// @Param keyid path string true "Key ID" format(string)
 // @Success 204
 // @Router /users/{user}/keys/{keyid} [delete]
 func (api *API) deleteAPIKey(rw http.ResponseWriter, r *http.Request) {

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -919,10 +919,10 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/{keyid} \
 
 ### Parameters
 
-| Name    | In   | Type         | Required | Description          |
-|---------|------|--------------|----------|----------------------|
-| `user`  | path | string       | true     | User ID, name, or me |
-| `keyid` | path | string(uuid) | true     | Key ID               |
+| Name    | In   | Type           | Required | Description          |
+|---------|------|----------------|----------|----------------------|
+| `user`  | path | string         | true     | User ID, name, or me |
+| `keyid` | path | string(string) | true     | Key ID               |
 
 ### Example responses
 
@@ -965,10 +965,10 @@ curl -X DELETE http://coder-server:8080/api/v2/users/{user}/keys/{keyid} \
 
 ### Parameters
 
-| Name    | In   | Type         | Required | Description          |
-|---------|------|--------------|----------|----------------------|
-| `user`  | path | string       | true     | User ID, name, or me |
-| `keyid` | path | string(uuid) | true     | Key ID               |
+| Name    | In   | Type           | Required | Description          |
+|---------|------|----------------|----------|----------------------|
+| `user`  | path | string         | true     | User ID, name, or me |
+| `keyid` | path | string(string) | true     | Key ID               |
 
 ### Responses
 


### PR DESCRIPTION
ref: https://codercom.slack.com/archives/C014JH42DBJ/p1755192759211289

this change allows api keys to be deleted via swagger