### PR TITLE
chore: fix incorrect ordering of OS options in docs

### DIFF
--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -74,17 +74,17 @@ performing the following step or copying the directory to another location.
 
 <div class="tabs">
 
-## macOS
-
-```shell
-rm -rf ~/Library/Application\ Support/coderv2
-```
-
 ## Linux
 
 ```shell
 rm -rf ~/.config/coderv2
 rm -rf ~/.cache/coder
+```
+
+## macOS
+
+```shell
+rm -rf ~/Library/Application\ Support/coderv2
 ```
 
 ## Windows


### PR DESCRIPTION
On https://coder.com/docs/install/uninstall at present we order the top OS listing as "Linux | macOS | Windows", while in the `Coder settings, cache, and the optional built-in PostgreSQL database` paragraph towards the bottom of the page we change to using "macOS | Linux | Windows" for some reason. This PR moves Linux to be listed first instead of macOS in the bottom paragraph to match the ordering of the top section.