### PR TITLE
chore: avoid DNS lookups for DERP in tests

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -471,7 +471,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 
 	serverURL, err := url.Parse(srv.URL)
 	require.NoError(t, err)
-	serverURL.Host = fmt.Sprintf("localhost:%d", tcpAddr.Port)
+	serverURL.Host = fmt.Sprintf("127.0.0.1:%d", tcpAddr.Port)
 
 	derpPort, err := strconv.Atoi(serverURL.Port())
 	require.NoError(t, err)

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -105,7 +105,7 @@ func NewWithAPI(t *testing.T, options *Options) (
 		AuditLogging:               options.AuditLogging,
 		BrowserOnly:                options.BrowserOnly,
 		SCIMAPIKey:                 options.SCIMAPIKey,
-		DERPServerRelayAddress:     oop.AccessURL.String(),
+		DERPServerRelayAddress:     serverURL.String(),
 		DERPServerRegionID:         oop.BaseDERPMap.RegionIDs()[0],
 		ReplicaSyncUpdateInterval:  options.ReplicaSyncUpdateInterval,
 		ReplicaErrorGracePeriod:    options.ReplicaErrorGracePeriod,

--- a/enterprise/coderd/coderdenttest/proxytest.go
+++ b/enterprise/coderd/coderdenttest/proxytest.go
@@ -109,7 +109,7 @@ func NewWorkspaceProxyReplica(t *testing.T, coderdAPI *coderd.API, owner *coders
 	serverURL, err := url.Parse(srv.URL)
 	require.NoError(t, err)
 
-	serverURL.Host = fmt.Sprintf("localhost:%d", tcpAddr.Port)
+	serverURL.Host = fmt.Sprintf("127.0.0.1:%d", tcpAddr.Port)
 
 	accessURL := options.ProxyURL
 	if accessURL == nil {

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -94,14 +94,8 @@ func TestDERPOnly(t *testing.T) {
 func TestDERP(t *testing.T) {
 	t.Parallel()
 
-	deploymentValues := coderdtest.DeploymentValues(t)
-	deploymentValues.Experiments = []string{
-		"*",
-	}
-
 	client, closer, api, user := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{
-			DeploymentValues:         deploymentValues,
 			AppHostname:              "*.primary.test.coder.com",
 			IncludeProvisionerDaemon: true,
 			RealIPConfig: &httpmw.RealIPConfig{
@@ -146,7 +140,7 @@ func TestDERP(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Wait for both running proxies to become healthy.
+	// Wait for all three running proxies to become healthy.
 	require.Eventually(t, func() bool {
 		err := api.ProxyHealth.ForceUpdate(ctx)
 		if !assert.NoError(t, err) {
@@ -207,7 +201,7 @@ resourceLoop:
 		require.NoError(t, err)
 
 		// There should be three DERP regions in the map: the primary, and each
-		// of the two running proxies. Also the STUN-only regions.
+		// of the two DERP-enabled running proxies. Also the STUN-only regions.
 		require.NotNil(t, connInfo.DERPMap)
 		require.Len(t, connInfo.DERPMap.Regions, 3+len(api.DeploymentValues.DERP.Server.STUNAddresses.Value()))
 
@@ -290,7 +284,7 @@ resourceLoop:
 
 			t.Run(r.RegionName, func(t *testing.T) {
 				t.Parallel()
-				ctx := testutil.Context(t, testutil.WaitShort)
+				ctx := testutil.Context(t, testutil.WaitLong)
 
 				derpMap := &tailcfg.DERPMap{
 					Regions: map[int]*tailcfg.DERPRegion{


### PR DESCRIPTION
enterprise/wsproxy TestDERP/ConnectDERP/best-proxy

```
connect to derp: derphttp.Client.Connect connect to http://localhost:43565/derp: context deadline exceeded: dial of localhost: dial tcp: lookup localhost: i/o timeout
```

The test was failing due to an i/o timeout trying to resolve `localhost` to `127.0.0.1`, presumably due to high load on the runner. Since these are just hardcoded strings in our tests, it's easy to change them to `127.0.0.1` and avoid the additional lookups.

Also bumps the timeout for the test in question to `WaitLong`.

Closes https://github.com/coder/internal/issues/886