### PR TITLE
fix: avoid error when AI usage is zero

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.stories.tsx
@@ -26,6 +26,23 @@ type Story = StoryObj<typeof ManagedAgentsConsumption>;
 
 export const Default: Story = {};
 
+export const ZeroUsage: Story = {
+	args: {
+		managedAgentFeature: {
+			enabled: true,
+			actual: 0,
+			soft_limit: 60000,
+			limit: 120000,
+			usage_period: {
+				start: "February 27, 2025",
+				end: "February 27, 2026",
+				issued_at: "February 27, 2025",
+			},
+			entitlement: "entitled",
+		},
+	},
+};
+
 export const NearLimit: Story = {
 	args: {
 		managedAgentFeature: {

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -38,17 +38,17 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 		);
 	}
 
-	const usage = managedAgentFeature.actual ?? 0;
-	const included = managedAgentFeature.soft_limit ?? 0;
-	const limit = managedAgentFeature.limit ?? 0;
+	const usage = managedAgentFeature.actual;
+	const included = managedAgentFeature.soft_limit;
+	const limit = managedAgentFeature.limit;
 	const startDate = managedAgentFeature.usage_period?.start;
 	const endDate = managedAgentFeature.usage_period?.end;
 
-	if (usage < 0) {
+	if (usage === undefined || usage < 0) {
 		return <ErrorAlert error="Invalid usage data" />;
 	}
 
-	if (included < 0 || limit < 0) {
+	if (included === undefined || included < 0 || limit === undefined || limit < 0) {
 		return <ErrorAlert error="Invalid license usage limits" />;
 	}
 

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -48,7 +48,12 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 		return <ErrorAlert error="Invalid usage data" />;
 	}
 
-	if (included === undefined || included < 0 || limit === undefined || limit < 0) {
+	if (
+		included === undefined ||
+		included < 0 ||
+		limit === undefined ||
+		limit < 0
+	) {
 		return <ErrorAlert error="Invalid license usage limits" />;
 	}
 

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -38,12 +38,9 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 		);
 	}
 
-	const valueOrZero = (value: number | undefined | null) =>
-		value === undefined || value === null ? 0 : value;
-
-	const usage = valueOrZero(managedAgentFeature.actual);
-	const included = valueOrZero(managedAgentFeature.soft_limit);
-	const limit = valueOrZero(managedAgentFeature.limit);
+	const usage = managedAgentFeature.actual ?? 0;
+	const included = managedAgentFeature.soft_limit ?? 0;
+	const limit = managedAgentFeature.limit ?? 0;
 	const startDate = managedAgentFeature.usage_period?.start;
 	const endDate = managedAgentFeature.usage_period?.end;
 

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/ManagedAgentsConsumption.tsx
@@ -38,17 +38,20 @@ export const ManagedAgentsConsumption: FC<ManagedAgentsConsumptionProps> = ({
 		);
 	}
 
-	const usage = managedAgentFeature.actual;
-	const included = managedAgentFeature.soft_limit;
-	const limit = managedAgentFeature.limit;
+	const valueOrZero = (value: number | undefined | null) =>
+		value === undefined || value === null ? 0 : value;
+
+	const usage = valueOrZero(managedAgentFeature.actual);
+	const included = valueOrZero(managedAgentFeature.soft_limit);
+	const limit = valueOrZero(managedAgentFeature.limit);
 	const startDate = managedAgentFeature.usage_period?.start;
 	const endDate = managedAgentFeature.usage_period?.end;
 
-	if (!usage || usage < 0) {
+	if (usage < 0) {
 		return <ErrorAlert error="Invalid usage data" />;
 	}
 
-	if (!included || included < 0 || !limit || limit < 0) {
+	if (included < 0 || limit < 0) {
 		return <ErrorAlert error="Invalid license usage limits" />;
 	}
 


### PR DESCRIPTION
Fixes a bug that prevents the managed AI agent usage from showing in the licenses page of the dashboard when the usage is zero. Adds a story with this case as well.

`!usage` is true when `usage == 0`.

<img width="1554" height="840" alt="image" src="https://github.com/user-attachments/assets/a7cf9c39-f3a7-43cb-8f90-74592e98908c" />
