### PR TITLE
fix: increase timeout for watch workspace agent devcontainers test

### DIFF
--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1579,7 +1579,7 @@ func TestWatchWorkspaceAgentDevcontainers(t *testing.T) {
 		t.Parallel()
 
 		var (
-			ctx               = testutil.Context(t, testutil.WaitLong)
+			ctx               = testutil.Context(t, testutil.WaitSuperLong)
 			logger            = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 			mClock            = quartz.NewMock(t)
 			updaterTickerTrap = mClock.Trap().TickerFunc("updaterLoop")


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/907

The test can take around 10s when it is the only one running, so in a constrained environment like CI it makes sense that it still hits the 25 second timeout. For now we up the limit to 60 seconds until the test is rewritten to greatly reduce the time taken.