### PR TITLE
perf: don't call GetUserByID unnecessarily for Agents metrics loops

### DIFF
--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -41,11 +41,12 @@ func TestUpdateStates(t *testing.T) {
 			Name: "tpl",
 		}
 		workspace = database.Workspace{
-			ID:           uuid.New(),
-			OwnerID:      user.ID,
-			TemplateID:   template.ID,
-			Name:         "xyz",
-			TemplateName: template.Name,
+			ID:            uuid.New(),
+			OwnerID:       user.ID,
+			OwnerUsername: user.Username,
+			TemplateID:    template.ID,
+			Name:          "xyz",
+			TemplateName:  template.Name,
 		}
 		agent = database.WorkspaceAgent{
 			ID:   uuid.New(),
@@ -137,9 +138,6 @@ func TestUpdateStates(t *testing.T) {
 
 		// Workspace gets fetched.
 		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
-
-		// User gets fetched to hit the UpdateAgentMetricsFn.
-		dbM.EXPECT().GetUserByID(gomock.Any(), user.ID).Return(user, nil)
 
 		// We expect an activity bump because ConnectionCount > 0.
 		dbM.EXPECT().ActivityBumpWorkspace(gomock.Any(), database.ActivityBumpWorkspaceParams{
@@ -380,9 +378,6 @@ func TestUpdateStates(t *testing.T) {
 			LastUsedAt: now.UTC(),
 		}).Return(nil)
 
-		// User gets fetched to hit the UpdateAgentMetricsFn.
-		dbM.EXPECT().GetUserByID(gomock.Any(), user.ID).Return(user, nil)
-
 		resp, err := api.UpdateStats(context.Background(), req)
 		require.NoError(t, err)
 		require.Equal(t, &agentproto.UpdateStatsResponse{
@@ -497,9 +492,6 @@ func TestUpdateStates(t *testing.T) {
 			IDs:        []uuid.UUID{workspace.ID},
 			LastUsedAt: now,
 		}).Return(nil)
-
-		// User gets fetched to hit the UpdateAgentMetricsFn.
-		dbM.EXPECT().GetUserByID(gomock.Any(), user.ID).Return(user, nil)
 
 		// Ensure that pubsub notifications are sent.
 		notifyDescription := make(chan struct{})

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -330,7 +330,7 @@ func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Regis
 
 				username := workspace.OwnerUsername
 				// This should never be possible, but we'll guard against it just in case.
-				// 1. The owner_id field on the workspaces table is a reference to IDs in the users table and has a `NUT NULL` constraint
+				// 1. The owner_id field on the workspaces table is a reference to IDs in the users table and has a `NOT NULL` constraint
 				// 2. At user creation time our httpmw package enforces non-empty usernames
 				// 3. The workspaces_expanded view has an inner join on workspaces.owner_id = visible_users.id, and if the owner
 				// is valid in the users table (which visible_users is a view of) then they will have a username set

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -328,42 +328,24 @@ func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Regis
 					templateVersionName = "unknown"
 				}
 
-				username := workspace.OwnerUsername
-				// This should never be possible, but we'll guard against it just in case.
-				// 1. The owner_id field on the workspaces table is a reference to IDs in the users table and has a `NOT NULL` constraint
-				// 2. At user creation time our httpmw package enforces non-empty usernames
-				// 3. The workspaces_expanded view has an inner join on workspaces.owner_id = visible_users.id, and if the owner
-				// is valid in the users table (which visible_users is a view of) then they will have a username set
-				if username == "" {
-					logger.Warn(ctx, "in prometheusmetrics.Agents the username on workspace was empty string, this should not be possible",
-						slog.F("workspace_id", workspace.ID),
-						slog.F("template_id", workspace.TemplateID))
-					// Fallback to GetUserByID if OwnerUsername is empty (e.g., in tests)
-					user, err := db.GetUserByID(ctx, workspace.OwnerID)
-					if err != nil {
-						logger.Error(ctx, "can't get user from the database", slog.F("user_id", workspace.OwnerID), slog.Error(err))
-						agentsGauge.WithLabelValues(VectorOperationAdd, 0, user.Username, workspace.Name, templateName, templateVersionName)
-						continue
-					}
-					username = user.Username
-				}
+				// username :=
 
 				agents, err := db.GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx, workspace.ID)
 				if err != nil {
 					logger.Error(ctx, "can't get workspace agents", slog.F("workspace_id", workspace.ID), slog.Error(err))
-					agentsGauge.WithLabelValues(VectorOperationAdd, 0, username, workspace.Name, templateName, templateVersionName)
+					agentsGauge.WithLabelValues(VectorOperationAdd, 0, workspace.OwnerUsername, workspace.Name, templateName, templateVersionName)
 					continue
 				}
 
 				if len(agents) == 0 {
 					logger.Debug(ctx, "workspace agents are unavailable", slog.F("workspace_id", workspace.ID))
-					agentsGauge.WithLabelValues(VectorOperationAdd, 0, username, workspace.Name, templateName, templateVersionName)
+					agentsGauge.WithLabelValues(VectorOperationAdd, 0, workspace.OwnerUsername, workspace.Name, templateName, templateVersionName)
 					continue
 				}
 
 				for _, agent := range agents {
 					// Collect information about agents
-					agentsGauge.WithLabelValues(VectorOperationAdd, 1, username, workspace.Name, templateName, templateVersionName)
+					agentsGauge.WithLabelValues(VectorOperationAdd, 1, workspace.OwnerUsername, workspace.Name, templateName, templateVersionName)
 
 					connectionStatus := agent.Status(agentInactiveDisconnectTimeout)
 					node := (*coordinator.Load()).Node(agent.ID)
@@ -373,7 +355,7 @@ func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Regis
 						tailnetNode = node.ID.String()
 					}
 
-					agentsConnectionsGauge.WithLabelValues(VectorOperationSet, 1, agent.Name, username, workspace.Name, string(connectionStatus.Status), string(agent.LifecycleState), tailnetNode)
+					agentsConnectionsGauge.WithLabelValues(VectorOperationSet, 1, agent.Name, workspace.OwnerUsername, workspace.Name, string(connectionStatus.Status), string(agent.LifecycleState), tailnetNode)
 
 					if node == nil {
 						logger.Debug(ctx, "can't read in-memory node for agent", slog.F("agent_id", agent.ID))
@@ -398,7 +380,7 @@ func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Regis
 								}
 							}
 
-							agentsConnectionLatenciesGauge.WithLabelValues(VectorOperationSet, latency, agent.Name, username, workspace.Name, region.RegionName, fmt.Sprintf("%v", node.PreferredDERP == regionID))
+							agentsConnectionLatenciesGauge.WithLabelValues(VectorOperationSet, latency, agent.Name, workspace.OwnerUsername, workspace.Name, region.RegionName, fmt.Sprintf("%v", node.PreferredDERP == regionID))
 						}
 					}
 
@@ -410,7 +392,7 @@ func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Regis
 					}
 
 					for _, app := range apps {
-						agentsAppsGauge.WithLabelValues(VectorOperationAdd, 1, agent.Name, username, workspace.Name, app.DisplayName, string(app.Health))
+						agentsAppsGauge.WithLabelValues(VectorOperationAdd, 1, agent.Name, workspace.OwnerUsername, workspace.Name, app.DisplayName, string(app.Health))
 					}
 				}
 			}

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -128,7 +128,7 @@ func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspac
 	if r.opts.UpdateAgentMetricsFn != nil {
 		username := workspace.OwnerUsername
 		// This should never be possible, but we'll guard against it just in case.
-		// 1. The owner_id field on the workspaces table is a reference to IDs in the users table and has a `NUT NULL` constraint
+		// 1. The owner_id field on the workspaces table is a reference to IDs in the users table and has a `NOT NULL` constraint
 		// 2. At user creation time our httpmw package enforces non-empty usernames
 		// 3. The workspaces_expanded view has an inner join on workspaces.owner_id = visible_users.id, and if the owner
 		// is valid in the users table (which visible_users is a view of) then they will have a username set

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -126,13 +126,26 @@ func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspac
 
 	// update prometheus metrics
 	if r.opts.UpdateAgentMetricsFn != nil {
-		user, err := r.opts.Database.GetUserByID(ctx, workspace.OwnerID)
-		if err != nil {
-			return xerrors.Errorf("get user: %w", err)
+		username := workspace.OwnerUsername
+		// This should never be possible, but we'll guard against it just in case.
+		// 1. The owner_id field on the workspaces table is a reference to IDs in the users table and has a `NUT NULL` constraint
+		// 2. At user creation time our httpmw package enforces non-empty usernames
+		// 3. The workspaces_expanded view has an inner join on workspaces.owner_id = visible_users.id, and if the owner
+		// is valid in the users table (which visible_users is a view of) then they will have a username set
+		if username == "" {
+			r.opts.Logger.Warn(ctx, "in ReportAgentStats the username on workspace was empty string, this should not be possible",
+				slog.F("workspace_id", workspace.ID),
+				slog.F("template_id", workspace.TemplateID))
+			// Fallback to GetUserByID if OwnerUsername is empty (e.g., in tests)
+			user, err := r.opts.Database.GetUserByID(ctx, workspace.OwnerID)
+			if err != nil {
+				return xerrors.Errorf("get user: %w", err)
+			}
+			username = user.Username
 		}
 
 		r.opts.UpdateAgentMetricsFn(ctx, prometheusmetrics.AgentMetricLabels{
-			Username:      user.Username,
+			Username:      username,
 			WorkspaceName: workspace.Name,
 			AgentName:     workspaceAgent.Name,
 			TemplateName:  templateName,


### PR DESCRIPTION
At the moment, the loop which retrieves and updates the values of the agents metrics excessively calls `GetUserByID` (a DB query). First it retrieves a list of all workspaces, filtering out inactive agents (not entirely clear to me whether this is non-running workspaces, or just dead agents), and then iterates over those workspaces to get the rest of the relevant data for the metrics. The next call is `GetUserByID` for `workspace.OwnerID` 

This should at least partially resolve https://github.com/coder/internal/issues/726 ~~by caching seen User `uuid.UUID` in a map for each iteration of the loop.~~

UPDATE: we now have a constraint for the `username` field in the `users` table which allows us to safely access the username field from the workspaces_expanded view. See https://github.com/coder/coder/pull/19453

~~UPDATE: It looks like, in theory, the calls here for `GetUserByID` should not even be necessary as we already have a `database.Workspace` object which also already has the owner ID and Username.~~

~~I left comments in both spots as to why the username should never be empty on the workspace again, but I'll reiterate here:~~
~~1. The `owner_id` field on the `workspaces` table is a FK reference to IDs in the `users` table and has a `NOT NULL` constraint, so the owner fields of a workspace will always be populated~~
~~2. While the users table technically only has a constraint that the username has to be `NOT NULL` (meaning empty string is valid), at user creation time our httpmw package enforces non-empty usernames (for example it calls `codersdk.NameValid` which enforces that the name is at least 1 character and fits the `UsernameValidRegex`)~~
~~3. The `workspaces_expanded` view has an inner join on `workspaces.owner_id = visible_users.id`, and if the owner is valid in the `users` table (which `visible_users` is a view of) then they will have a username set~~