### PR TITLE
fix: fix flakes in TestWorkspaceAutobuild due to incorrect tick time

### DIFF
--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1277,7 +1277,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 
 		// We should see the workspace get stopped now.
 		tickTime2 := ws.LastUsedAt.Add(inactiveTTL * 2)
-		coderdtest.UpdateProvisionerLastSeenAt(t, db, p.ID, tickTime)
+		coderdtest.UpdateProvisionerLastSeenAt(t, db, p.ID, tickTime2)
 		tickCh <- tickTime2
 		stats = <-statsCh
 		require.Len(t, stats.Errors, 0)


### PR DESCRIPTION
cc @deansheather we missed these in the previous PR, we find `tickTime2` and pass it to the `tickCh`, but we were incorrectly passing `tickTime` to `UpdateProvisionerLastSeenAt` in some places