### PR TITLE
fix(dogfood/coder): fix env var for exp mcp configure claude-code

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -810,10 +810,11 @@ resource "coder_env" "claude_task_prompt" {
   value    = data.coder_parameter.ai_prompt.value
 }
 
-resource "coder_env" "anthropic_api_key" {
+# coder exp mcp configure claude-code reads from CLAUDE_API_KEY
+resource "coder_env" "claude_api_key" {
   count    = local.has_ai_prompt ? data.coder_workspace.me.start_count : 0
   agent_id = coder_agent.dev.id
-  name     = "ANTHROPIC_API_KEY"
+  name     = "CLAUDE_API_KEY"
   value    = var.anthropic_api_key
 }
 

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -399,7 +399,7 @@ module "devcontainers-cli" {
 module "claude-code" {
   count               = local.has_ai_prompt ? data.coder_workspace.me.start_count : 0
   source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "~>2.0"
+  version             = "2.0.7"
   agent_id            = coder_agent.dev.id
   folder              = local.repo_dir
   install_claude_code = true


### PR DESCRIPTION
`coder exp mcp configure claude-code` will read the API key for claude-code from the environment variable `CLAUDE_API_KEY`. Claude will also happily read `ANTHROPIC_API_KEY` but will ask you to confirm first, which is problematic in an automated setup.

Also bumps claude-code module.