### PR TITLE
fix(enterprise): correct order for external agent init cmd

### DIFF
--- a/enterprise/coderd/workspaceagents.go
+++ b/enterprise/coderd/workspaceagents.go
@@ -86,7 +86,7 @@ func (api *API) workspaceExternalAgentCredentials(rw http.ResponseWriter, r *htt
 	}
 
 	initScriptURL := fmt.Sprintf("%s/api/v2/init-script/%s/%s", api.AccessURL.String(), agent.OperatingSystem, agent.Architecture)
-	command := fmt.Sprintf("CODER_AGENT_TOKEN=%q curl -fsSL %q | sh", agent.AuthToken.String(), initScriptURL)
+	command := fmt.Sprintf("curl -fsSL %q | CODER_AGENT_TOKEN=%q sh", initScriptURL, agent.AuthToken.String())
 	if agent.OperatingSystem == "windows" {
 		command = fmt.Sprintf("$env:CODER_AGENT_TOKEN=%q; iwr -useb %q | iex", agent.AuthToken.String(), initScriptURL)
 	}

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -385,7 +385,7 @@ func TestWorkspaceExternalAgentCredentials(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, r.AgentToken, credentials.AgentToken)
-		expectedCommand := fmt.Sprintf("CODER_AGENT_TOKEN=%q curl -fsSL \"%s/api/v2/init-script/linux/amd64\" | sh", r.AgentToken, client.URL)
+		expectedCommand := fmt.Sprintf("curl -fsSL \"%s/api/v2/init-script/linux/amd64\" | CODER_AGENT_TOKEN=%q sh", client.URL, r.AgentToken)
 		require.Equal(t, expectedCommand, credentials.Command)
 	})
 


### PR DESCRIPTION
### Description

`CODER_AGENT_TOKEN` env variable was incorrectly being passed to the curl command instead of the executed script during agent initialization.

Fixed the command order to ensure `CODER_AGENT_TOKEN` is properly passed to the script execution context rather than the download command.

