### PR TITLE
fix(enterprise): update external agent instructions in cli

### DIFF
--- a/enterprise/cli/externalworkspaces.go
+++ b/enterprise/cli/externalworkspaces.go
@@ -243,15 +243,14 @@ func fetchExternalAgents(inv *serpent.Invocation, client *codersdk.Client, works
 // formatExternalAgent formats the instructions for an external agent.
 func formatExternalAgent(workspaceName string, externalAgents []externalAgent) string {
 	var output strings.Builder
-	_, _ = output.WriteString(fmt.Sprintf("\nPlease run the following commands to attach external agent to the workspace %s:\n\n", cliui.Keyword(workspaceName)))
+	_, _ = output.WriteString(fmt.Sprintf("\nPlease run the following command to attach external agent to the workspace %s:\n\n", cliui.Keyword(workspaceName)))
 
 	for i, agent := range externalAgents {
 		if len(externalAgents) > 1 {
 			_, _ = output.WriteString(fmt.Sprintf("For agent %s:\n", cliui.Keyword(agent.AgentName)))
 		}
 
-		_, _ = output.WriteString(fmt.Sprintf("%s\n", pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("export CODER_AGENT_TOKEN=%s", agent.AuthToken))))
-		_, _ = output.WriteString(fmt.Sprintf("%s\n", pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("curl -fsSL %s | sh", agent.InitScript))))
+		_, _ = output.WriteString(fmt.Sprintf("%s\n", pretty.Sprint(cliui.DefaultStyles.Code, agent.InitScript)))
 
 		if i < len(externalAgents)-1 {
 			_, _ = output.WriteString("\n")

--- a/enterprise/cli/externalworkspaces_test.go
+++ b/enterprise/cli/externalworkspaces_test.go
@@ -162,11 +162,10 @@ func TestExternalWorkspaces(t *testing.T) {
 		pty.WriteLine("yes")
 
 		// Expect the external agent instructions
-		pty.ExpectMatch("Please run the following commands to attach external agent")
-		pty.ExpectMatch("export CODER_AGENT_TOKEN=")
-		pty.ExpectMatch("curl -fsSL")
+		pty.ExpectMatch("Please run the following command to attach external agent")
+		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 
-		<-doneChan
+		testutil.TryReceive(context.Background(), t, doneChan)
 
 		// Verify the workspace was created
 		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-external-workspace", codersdk.WorkspaceOptions{})
@@ -392,11 +391,10 @@ func TestExternalWorkspaces(t *testing.T) {
 			assert.NoError(t, errC)
 			close(done)
 		}()
-		pty.ExpectMatch("Please run the following commands to attach external agent to the workspace")
-		pty.ExpectMatch("export CODER_AGENT_TOKEN=")
-		pty.ExpectMatch("curl -fsSL")
+		pty.ExpectMatch("Please run the following command to attach external agent to the workspace")
+		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 		cancelFunc()
-		<-done
+		testutil.TryReceive(context.Background(), t, done)
 	})
 
 	t.Run("AgentInstructionsJSON", func(t *testing.T) {
@@ -545,11 +543,10 @@ func TestExternalWorkspaces(t *testing.T) {
 		pty.ExpectMatch("external-agent (linux, amd64)")
 
 		// Expect the external agent instructions
-		pty.ExpectMatch("Please run the following commands to attach external agent")
-		pty.ExpectMatch("export CODER_AGENT_TOKEN=")
-		pty.ExpectMatch("curl -fsSL")
+		pty.ExpectMatch("Please run the following command to attach external agent")
+		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 
-		<-doneChan
+		testutil.TryReceive(context.Background(), t, doneChan)
 
 		// Verify the workspace was created
 		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-external-workspace", codersdk.WorkspaceOptions{})

--- a/enterprise/cli/externalworkspaces_test.go
+++ b/enterprise/cli/externalworkspaces_test.go
@@ -165,7 +165,8 @@ func TestExternalWorkspaces(t *testing.T) {
 		pty.ExpectMatch("Please run the following command to attach external agent")
 		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 
-		testutil.TryReceive(context.Background(), t, doneChan)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		testutil.TryReceive(ctx, t, doneChan)
 
 		// Verify the workspace was created
 		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-external-workspace", codersdk.WorkspaceOptions{})
@@ -394,7 +395,9 @@ func TestExternalWorkspaces(t *testing.T) {
 		pty.ExpectMatch("Please run the following command to attach external agent to the workspace")
 		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 		cancelFunc()
-		testutil.TryReceive(context.Background(), t, done)
+
+		ctx = testutil.Context(t, testutil.WaitLong)
+		testutil.TryReceive(ctx, t, done)
 	})
 
 	t.Run("AgentInstructionsJSON", func(t *testing.T) {
@@ -546,7 +549,8 @@ func TestExternalWorkspaces(t *testing.T) {
 		pty.ExpectMatch("Please run the following command to attach external agent")
 		pty.ExpectRegexMatch("curl -fsSL .* | CODER_AGENT_TOKEN=.* sh")
 
-		testutil.TryReceive(context.Background(), t, doneChan)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		testutil.TryReceive(ctx, t, doneChan)
 
 		// Verify the workspace was created
 		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-external-workspace", codersdk.WorkspaceOptions{})


### PR DESCRIPTION
### Description

The command for agent instructions was incorrectly displayed in the CLI.