### PR TITLE
fix: support oidc group allowlist in oss

### DIFF
--- a/enterprise/coderd/enidpsync/groups.go
+++ b/enterprise/coderd/enidpsync/groups.go
@@ -2,7 +2,6 @@ package enidpsync
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/golang-jwt/jwt/v4"
 
@@ -20,51 +19,12 @@ func (e EnterpriseIDPSync) GroupSyncEntitled() bool {
 // GroupAllowList is implemented here to prevent login by unauthorized users.
 // TODO: GroupAllowList overlaps with the default organization group sync settings.
 func (e EnterpriseIDPSync) ParseGroupClaims(ctx context.Context, mergedClaims jwt.MapClaims) (idpsync.GroupParams, *idpsync.HTTPError) {
-	if !e.GroupSyncEntitled() {
-		return e.AGPLIDPSync.ParseGroupClaims(ctx, mergedClaims)
+	resp, err := e.AGPLIDPSync.ParseGroupClaims(ctx, mergedClaims)
+	if err != nil {
+		return idpsync.GroupParams{}, err
 	}
-
-	if e.GroupField != "" && len(e.GroupAllowList) > 0 {
-		groupsRaw, ok := mergedClaims[e.GroupField]
-		if !ok {
-			return idpsync.GroupParams{}, &idpsync.HTTPError{
-				Code:             http.StatusForbidden,
-				Msg:              "Not a member of an allowed group",
-				Detail:           "You have no groups in your claims!",
-				RenderStaticPage: true,
-			}
-		}
-		parsedGroups, err := idpsync.ParseStringSliceClaim(groupsRaw)
-		if err != nil {
-			return idpsync.GroupParams{}, &idpsync.HTTPError{
-				Code:             http.StatusBadRequest,
-				Msg:              "Failed read groups from claims for allow list check. Ask an administrator for help.",
-				Detail:           err.Error(),
-				RenderStaticPage: true,
-			}
-		}
-
-		inAllowList := false
-	AllowListCheckLoop:
-		for _, group := range parsedGroups {
-			if _, ok := e.GroupAllowList[group]; ok {
-				inAllowList = true
-				break AllowListCheckLoop
-			}
-		}
-
-		if !inAllowList {
-			return idpsync.GroupParams{}, &idpsync.HTTPError{
-				Code:             http.StatusForbidden,
-				Msg:              "Not a member of an allowed group",
-				Detail:           "Ask an administrator to add one of your groups to the allow list.",
-				RenderStaticPage: true,
-			}
-		}
-	}
-
 	return idpsync.GroupParams{
-		SyncEntitled: true,
-		MergedClaims: mergedClaims,
+		SyncEntitled: e.GroupSyncEntitled(),
+		MergedClaims: resp.MergedClaims,
 	}, nil
 }


### PR DESCRIPTION
## Summary

In this pull request we're adding support for OIDC allowed groups in the OSS version as part of work for https://github.com/coder/coder/issues/17027.

### Changes

- Restored support for parsing group allow list in OSS code

### Testing

- Added tests for OSS code
- Tested allowed/prohibited group OIDC flows in premium and OSS