### PR TITLE
ci: ping blink on slack on ci failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1582,6 +1582,13 @@ jobs:
                   "type": "mrkdwn",
                   "text": "*View failure:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here>"
                 }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<@U08TJ4YNCA3> investigate this CI failure. Check logs, search for existing issues, use git blame to find who last modified failing tests, create issue in coder/internal (not public repo), use title format \"flake: TestName\" for flaky tests, and assign to the person from git blame."
+                }
               }
             ]
           }' ${{ secrets.CI_FAILURE_SLACK_WEBHOOK }}

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -203,6 +203,13 @@ jobs:
                   "type": "mrkdwn",
                   "text": "*View failure:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here>"
                 }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<@U08TJ4YNCA3> investigate this CI failure. Check logs, search for existing issues, use git blame to find who last modified failing tests, create issue in coder/internal (not public repo), use title format \"flake: TestName\" for flaky tests, and assign to the person from git blame."
+                }
               }
             ]
           }' ${{ secrets.CI_FAILURE_SLACK_WEBHOOK }}


### PR DESCRIPTION
im experimenting with getting blink to track flakes for us in coder/internal, it worked when kyle and I pinged it by hand, so let's try this too.