### PR TITLE
chore: add unknown usage event type error

### DIFF
--- a/enterprise/coderd/usage/publisher.go
+++ b/enterprise/coderd/usage/publisher.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
@@ -396,6 +397,7 @@ func (p *tallymanPublisher) sendPublishRequest(ctx context.Context, deploymentID
 	if err != nil {
 		return usagetypes.TallymanV1IngestResponse{}, err
 	}
+	r.Header.Set("User-Agent", "coderd/"+buildinfo.Version())
 	r.Header.Set(usagetypes.TallymanCoderLicenseKeyHeader, licenseJwt)
 	r.Header.Set(usagetypes.TallymanCoderDeploymentIDHeader, deploymentID.String())
 


### PR DESCRIPTION
- Adds `usagetypes.UnknownEventTypeError` type, which is returned by `ParseEventWithType`
- Changes `ParseEvent` to not be a generic function since it doesn't really need it
- Adds `User-Agent` to tallyman requests