### PR TITLE
docs: re-add missing Templates and Modules entries to manifest.json

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -48,6 +48,18 @@
 							"icon_path": "./images/icons/document.svg"
 						},
 						{
+							"title": "Modules",
+							"description": "Learn how to contribute modules to Coder",
+							"path": "./about/contributing/modules.md",
+							"icon_path": "./images/icons/gear.svg"
+						},
+						{
+							"title": "Templates",
+							"description": "Learn how to contribute templates to Coder",
+							"path": "./about/contributing/templates.md",
+							"icon_path": "./images/icons/picture.svg"
+						},
+						{
 							"title": "Backend",
 							"description": "Our guide for backend development",
 							"path": "./about/contributing/backend.md",


### PR DESCRIPTION
- Restores Templates and Modules entries accidentally removed in commit 9edceef0bff9455e5c7d17658cd3a9cd3d24bc2f
- Fixes 404 errors for /docs/about/contributing/templates and /docs/about/contributing/modules
- Both markdown files exist and are ready to be linked