### PR TITLE
fix: add accidentally removed registry contribution docs pages

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -48,6 +48,18 @@
 							"icon_path": "./images/icons/document.svg"
 						},
 						{
+							"title": "Modules",
+							"description": "Learn how to contribute modules to Coder",
+							"path": "./about/contributing/modules.md",
+							"icon_path": "./images/icons/gear.svg"
+						},
+						{
+							"title": "Templates",
+							"description": "Learn how to contribute templates to Coder",
+							"path": "./about/contributing/templates.md",
+							"icon_path": "./images/icons/picture.svg"
+						},
+						{
 							"title": "Backend",
 							"description": "Our guide for backend development",
 							"path": "./about/contributing/backend.md",


### PR DESCRIPTION
This was accidentally removed in https://github.com/coder/coder/commit/9edceef0bff9455e5c7d17658cd3a9cd3d24bc2f#diff-0cbcfff19a4479219e722863d8f59891658d042d3fac32fe9d9a75d650ce0524