### PR TITLE
fix: fix flake due to two time.Now() calls

### DIFF
--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -353,7 +353,7 @@ func TestScheduleOverride(t *testing.T) {
 			ownerClient, _, _, ws := setupTestSchedule(t, sched)
 			now := time.Now()
 			// To avoid the likelihood of time-related flakes, only matching up to the hour.
-			expectedDeadline := time.Now().In(loc).Add(10 * time.Hour).Format("2006-01-02T15:")
+			expectedDeadline := now.In(loc).Add(10 * time.Hour).Format("2006-01-02T15:")
 
 			// When: we override the stop schedule
 			inv, root := clitest.New(t,


### PR DESCRIPTION
fixes https://github.com/coder/internal/issues/559

This test is looking to see that after calling `coder schedule extend <workspace> 10h`, the scheduled stop time of the workspace is updated appropriately (or at least that the information printed to the terminal indicates that).

By using two `time.Now()` calls for the current time and the expected time, there was the possibility that the second call just barely crossed over the hour mark. This is shown in the error message when the test would flake: `wanted "2025-04-07T22:"; got "           2025-04-07T23:00:00+05:30  \r\n"` (the 00:00 letting us know we just barely crossed the hour).

Using the same time object to construct the expected time should fix the issue.