### PR TITLE
chore: preload inter font

### DIFF
--- a/site/.storybook/preview-head.html
+++ b/site/.storybook/preview-head.html
@@ -1,1 +1,5 @@
 <link rel="preload" href="/node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2" as="font" type="font/woff2" crossorigin />
+
+<!-- Web terminal fonts -->
+<link rel="preload" href="/node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+<link rel="preload" href="/node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-600-normal.woff2" as="font" type="font/woff2" crossorigin />

--- a/site/.storybook/preview-head.html
+++ b/site/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link rel="preload" href="/node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
This aims to solve font rendering issues in Storybook like the inconsistent snapshot below.

**Inconsistent snapshot:**
<img width="3022" height="1552" alt="image" src="https://github.com/user-attachments/assets/ad0e1060-89cc-4255-b601-97ed59286080" />


**References:**
- https://www.chromatic.com/docs/troubleshooting-snapshots/#why-are-fonts-in-my-graph-component-rendering-inconsistently
- https://fontsource.org/docs/getting-started/preload