### PR TITLE
[WIP] fix: test multiple lifecycle executors flake

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -446,7 +446,6 @@ func WorkspaceBuild(t testing.TB, db database.Store, orig database.WorkspaceBuil
 			UpdatedAt:         takeFirst(orig.UpdatedAt, dbtime.Now()),
 			WorkspaceID:       takeFirst(orig.WorkspaceID, uuid.New()),
 			TemplateVersionID: takeFirst(orig.TemplateVersionID, uuid.New()),
-			BuildNumber:       takeFirst(orig.BuildNumber, 1),
 			Transition:        takeFirst(orig.Transition, database.WorkspaceTransitionStart),
 			InitiatorID:       takeFirst(orig.InitiatorID, uuid.New()),
 			JobID:             jobID,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -19356,7 +19356,9 @@ INSERT INTO
 		template_version_preset_id
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	($1, $2, $3, $4, $5,
+	COALESCE((SELECT MAX("build_number") + 1 FROM workspace_builds WHERE workspace_id = $4), 1),
+	$6, $7, $8, $9, $10, $11, $12, $13)
 `
 
 type InsertWorkspaceBuildParams struct {
@@ -19365,7 +19367,6 @@ type InsertWorkspaceBuildParams struct {
 	UpdatedAt               time.Time           `db:"updated_at" json:"updated_at"`
 	WorkspaceID             uuid.UUID           `db:"workspace_id" json:"workspace_id"`
 	TemplateVersionID       uuid.UUID           `db:"template_version_id" json:"template_version_id"`
-	BuildNumber             int32               `db:"build_number" json:"build_number"`
 	Transition              WorkspaceTransition `db:"transition" json:"transition"`
 	InitiatorID             uuid.UUID           `db:"initiator_id" json:"initiator_id"`
 	JobID                   uuid.UUID           `db:"job_id" json:"job_id"`
@@ -19383,7 +19384,6 @@ func (q *sqlQuerier) InsertWorkspaceBuild(ctx context.Context, arg InsertWorkspa
 		arg.UpdatedAt,
 		arg.WorkspaceID,
 		arg.TemplateVersionID,
-		arg.BuildNumber,
 		arg.Transition,
 		arg.InitiatorID,
 		arg.JobID,

--- a/coderd/database/queries/workspacebuilds.sql
+++ b/coderd/database/queries/workspacebuilds.sql
@@ -110,7 +110,9 @@ INSERT INTO
 		template_version_preset_id
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);
+	($1, $2, $3, $4, $5,
+	COALESCE((SELECT MAX("build_number") + 1 FROM workspace_builds WHERE workspace_id = $4), 1),
+	$6, $7, $8, $9, $10, $11, $12, $13);
 
 -- name: UpdateWorkspaceBuildCostByID :exec
 UPDATE

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -893,7 +893,6 @@ func insertRunning(t *testing.T, db database.Store, u database.User, org databas
 		ID:                uuid.New(),
 		WorkspaceID:       workspace.ID,
 		JobID:             job.ID,
-		BuildNumber:       1,
 		Transition:        database.WorkspaceTransitionStart,
 		Reason:            database.BuildReasonInitiator,
 		TemplateVersionID: templateVersionID,

--- a/coderd/workspacestats/activitybump_test.go
+++ b/coderd/workspacestats/activitybump_test.go
@@ -241,7 +241,6 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 					ID:                buildID,
 					CreatedAt:         dbtime.Now(),
 					UpdatedAt:         dbtime.Now(),
-					BuildNumber:       buildNumber,
 					InitiatorID:       user.ID,
 					Reason:            database.BuildReasonInitiator,
 					WorkspaceID:       ws.ID,

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -432,10 +432,7 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 	if err != nil {
 		return nil, nil, nil, BuildError{http.StatusInternalServerError, "compute template version ID", err}
 	}
-	buildNum, err := b.getBuildNumber()
-	if err != nil {
-		return nil, nil, nil, BuildError{http.StatusInternalServerError, "compute build number", err}
-	}
+
 	state, err := b.getState()
 	if err != nil {
 		return nil, nil, nil, BuildError{http.StatusInternalServerError, "compute build state", err}
@@ -463,7 +460,6 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 			UpdatedAt:         now,
 			WorkspaceID:       b.workspace.ID,
 			TemplateVersionID: templateVersionID,
-			BuildNumber:       buildNum,
 			ProvisionerState:  state,
 			InitiatorID:       b.initiator,
 			Transition:        b.trans,
@@ -714,18 +710,6 @@ func (b *Builder) firstBuild() (bool, error) {
 		return false, err
 	}
 	return false, nil
-}
-
-func (b *Builder) getBuildNumber() (int32, error) {
-	bld, err := b.getLastBuild()
-	if xerrors.Is(err, sql.ErrNoRows) {
-		// first build!
-		return 1, nil
-	}
-	if err != nil {
-		return 0, xerrors.Errorf("get last build to compute build number: %w", err)
-	}
-	return bld.BuildNumber + 1, nil
 }
 
 func (b *Builder) getState() ([]byte, error) {

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -86,7 +86,6 @@ func TestBuilder_NoOptions(t *testing.T) {
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(inactiveVersionID, bld.TemplateVersionID)
 			asrt.Equal(workspaceID, bld.WorkspaceID)
-			asrt.Equal(int32(2), bld.BuildNumber)
 			asrt.Equal("last build state", string(bld.ProvisionerState))
 			asrt.Equal(userID, bld.InitiatorID)
 			asrt.Equal(database.WorkspaceTransitionStart, bld.Transition)
@@ -268,8 +267,6 @@ func TestBuilder_ActiveVersion(t *testing.T) {
 		expectFindMatchingPresetID(uuid.Nil, sql.ErrNoRows),
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(activeVersionID, bld.TemplateVersionID)
-			// no previous build...
-			asrt.Equal(int32(1), bld.BuildNumber)
 			asrt.Len(bld.ProvisionerState, 0)
 		}),
 		expectBuildParameters(func(params database.InsertWorkspaceBuildParametersParams) {
@@ -851,7 +848,6 @@ func TestWorkspaceBuildWithPreset(t *testing.T) {
 		expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 			asrt.Equal(activeVersionID, bld.TemplateVersionID)
 			asrt.Equal(workspaceID, bld.WorkspaceID)
-			asrt.Equal(int32(1), bld.BuildNumber)
 			asrt.Equal(userID, bld.InitiatorID)
 			asrt.Equal(database.WorkspaceTransitionStart, bld.Transition)
 			asrt.Equal(database.BuildReasonInitiator, bld.Reason)
@@ -921,7 +917,6 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 				asrt.Equal(inactiveVersionID, bld.TemplateVersionID)
 				asrt.Equal(workspaceID, bld.WorkspaceID)
-				asrt.Equal(int32(2), bld.BuildNumber)
 				asrt.Empty(string(bld.ProvisionerState))
 				asrt.Equal(userID, bld.InitiatorID)
 				asrt.Equal(database.WorkspaceTransitionDelete, bld.Transition)
@@ -984,7 +979,6 @@ func TestWorkspaceBuildDeleteOrphan(t *testing.T) {
 			expectBuild(func(bld database.InsertWorkspaceBuildParams) {
 				asrt.Equal(inactiveVersionID, bld.TemplateVersionID)
 				asrt.Equal(workspaceID, bld.WorkspaceID)
-				asrt.Equal(int32(2), bld.BuildNumber)
 				asrt.Empty(string(bld.ProvisionerState))
 				asrt.Equal(userID, bld.InitiatorID)
 				asrt.Equal(database.WorkspaceTransitionDelete, bld.Transition)


### PR DESCRIPTION
Work in progress!
fixes https://github.com/coder/internal/issues/455

This PR moves incrementing the workspace build number into the insert workspace build query so the operation is atomic. 
I'm not exactly sure if this is the right fix yet.

Theory: 
You can hit a race condition where the lifecycle executor takes a lock on the workspace, but it's only scoped to prevent multiple lifecycle executors from operating on the workspace at the same time:
`ok, err := tx.TryAcquireLock(e.ctx, database.GenLockID(fmt.Sprintf("lifecycle-executor:%s", wsID)))`
A manual action (like clicking "start workspace" or perhaps an API call in a concurrent build) can compete with a lifecycle executor.

I need to dig into how concurrent builds work to actually verify what's going on here.

Edit: the fix will probably involve moving the build_number field over to a serial type, it seems I just moved the race condition to the database