### PR TITLE
ci: add `check-build` job to require `make build` to pass on prs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -916,6 +916,7 @@ jobs:
       - test-e2e
       - offlinedocs
       - sqlc-vet
+      - check-build
     # Allow this job to run even if the needed jobs fail, are skipped or
     # cancelled.
     if: always()
@@ -936,6 +937,7 @@ jobs:
           echo "- test-js: ${{ needs.test-js.result }}"
           echo "- test-e2e: ${{ needs.test-e2e.result }}"
           echo "- offlinedocs: ${{ needs.offlinedocs.result }}"
+          echo "- check-build: ${{ needs.check-build.result }}"
           echo
 
           # We allow skipped jobs to pass, but not failed or cancelled jobs.
@@ -1025,6 +1027,44 @@ jobs:
       - name: Delete Apple Developer certificate and API key
         if: ${{ github.repository_owner == 'coder' && github.ref == 'refs/heads/main' }}
         run: rm -f /tmp/{apple_cert.p12,apple_cert_password.txt,apple_apikey.p8}
+
+  check-build:
+    # This job runs make build to verify compilation on PRs
+    needs: changes
+    if: needs.changes.outputs.go == 'true' && github.ref != 'refs/heads/main'
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install go-winres
+        run: go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1
+
+      - name: Install zstd
+        run: sudo apt-get install -y zstd
+
+      - name: Build
+        run: |
+          set -euxo pipefail
+          go mod download
+          make gen/mark-fresh
+          make build
 
   build:
     # This builds and publishes ghcr.io/coder/coder-preview:main for each commit
@@ -1541,7 +1581,6 @@ jobs:
 
   notify-slack-on-failure:
     needs:
-      - build
       - required
     runs-on: ubuntu-latest
     if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1029,7 +1029,9 @@ jobs:
         run: rm -f /tmp/{apple_cert.p12,apple_cert_password.txt,apple_apikey.p8}
 
   check-build:
-    # This job runs make build to verify compilation on PRs
+    # This job runs make build to verify compilation on PRs.
+    # The build doesn't get signed, and is not suitable for usage, unlike the
+    # `build` job that runs on main.
     needs: changes
     if: needs.changes.outputs.go == 'true' && github.ref != 'refs/heads/main'
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1541,6 +1541,7 @@ jobs:
 
   notify-slack-on-failure:
     needs:
+      - build
       - required
     runs-on: ubuntu-latest
     if: failure() && github.ref == 'refs/heads/main'

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2564,7 +2564,7 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 		},
 		{
 			name:          "invalid schedule",
-			schedule:      ptr.Ref("asdfa asdf asdf "),
+			schedule:      ptr.Ref("asdf asdf asdf "),
 			expectedError: `validate weekly schedule: expected schedule to consist of 5 fields with an optional CRON_TZ=<timezone> prefix`,
 		},
 		{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2564,7 +2564,7 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 		},
 		{
 			name:          "invalid schedule",
-			schedule:      ptr.Ref("asdf asdf asdf "),
+			schedule:      ptr.Ref("asdfa asdf asdf "),
 			expectedError: `validate weekly schedule: expected schedule to consist of 5 fields with an optional CRON_TZ=<timezone> prefix`,
 		},
 		{


### PR DESCRIPTION
We've had `build` fail on main one or two times, and it's easily preventable by just running `make build` on PRs.

I didn't add `build` to required as it's already pretty complex, and we'd be making it more complex by skipping half of it when not on coder/coder main.