### PR TITLE
fix: use new http transport for webhook handler

### DIFF
--- a/coderd/notifications/dispatch/webhook_test.go
+++ b/coderd/notifications/dispatch/webhook_test.go
@@ -131,7 +131,7 @@ func TestWebhook(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					tc.serverFn(msgID, w, r)
 				}))
-				defer server.Close()
+				t.Cleanup(server.Close)
 
 				endpoint, err = url.Parse(server.URL)
 				require.NoError(t, err)


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/919

I believe that `Error "request failed: Post \"http://127.0.0.1:46685\": net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called" does not contain "non-2xx response (500)"` indicates that the client is closing what it considers to be an idle connection while another goroutine is using it. This is likely caused by another test (running concurrently) shutting down its http server while this test was still running, and both shared a reference to the global `http.DefaultTransport`. `http.Transport` maintains a connection pool.

Now we'll be cloning `http.DefaultTransport` whenever a new webhook handler gets created, ensuring that it maintains its own conn pool.

I've added some defensiveness for the type inference, but it's highly unlikely that will change; in which case let's just revert to previous behaviour and log. I considered copying the panic pattern from [`tailnet.go`](https://github.com/coder/coder/blob/main/coderd/tailnet.go#L40-L49), but since this webhook feature is optional, I think it's better to choose a slightly racy implementation than crash the server.