### PR TITLE
feat: use cloud secret for DNS token in scaletest TF

### DIFF
--- a/scaletest/terraform/action/cf_dns.tf
+++ b/scaletest/terraform/action/cf_dns.tf
@@ -1,6 +1,10 @@
+data "cloudflare_zone" "domain" {
+  name = var.cloudflare_domain
+}
+
 resource "cloudflare_record" "coder" {
   for_each = local.deployments
-  zone_id  = var.cloudflare_zone_id
+  zone_id  = data.cloudflare_zone.domain.zone_id
   name     = each.value.subdomain
   content  = google_compute_address.coder[each.key].address
   type     = "A"

--- a/scaletest/terraform/action/main.tf
+++ b/scaletest/terraform/action/main.tf
@@ -46,8 +46,13 @@ terraform {
 provider "google" {
 }
 
+data "google_secret_manager_secret_version_access" "cloudflare_api_token_dns" {
+  secret  = "cloudflare-api-token-dns"
+  project = var.project_id
+}
+
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  api_token = coalesce(var.cloudflare_api_token, data.google_secret_manager_secret_version_access.cloudflare_api_token_dns.secret_data)
 }
 
 provider "kubernetes" {

--- a/scaletest/terraform/action/vars.tf
+++ b/scaletest/terraform/action/vars.tf
@@ -13,6 +13,7 @@ variable "scenario" {
 // GCP
 variable "project_id" {
   description = "The project in which to provision resources"
+  default     = "coder-scaletest"
 }
 
 variable "k8s_version" {
@@ -24,19 +25,14 @@ variable "k8s_version" {
 variable "cloudflare_api_token" {
   description = "Cloudflare API token."
   sensitive   = true
-}
-
-variable "cloudflare_email" {
-  description = "Cloudflare email address."
-  sensitive   = true
+  # only override if you want to change the cloudflare_domain; pulls the token for scaletest.dev from Google Secrets
+  # Manager if null.
+  default = null
 }
 
 variable "cloudflare_domain" {
   description = "Cloudflare coder domain."
-}
-
-variable "cloudflare_zone_id" {
-  description = "Cloudflare zone ID."
+  default     = "scaletest.dev"
 }
 
 // Coder


### PR DESCRIPTION
**Note(ethanndickson):** Though this is marked as a feat, I don't think there's any point calling it out in the changelog. It's a scaletesting infrastructure change only, and we're moving that to a private repo.

Removes the requirement to obtain a Cloudflare DNS token from our scaletest/terraform/action builds. Instead, by default, we pull the token from Google Secrets Manager and use the `scaletest.dev` DNS domain.

Removes cloudflare_email as this was unneeded.  
  
Removes the cloudflare_zone_id and instead pulls it from a data source via the Cloudflare API.  
  
closes https://github.com/coder/internal/issues/839