### PR TITLE
feat(coderd): add tasks list and get endpoints

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -192,8 +192,16 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 }
 
 // tasksFromWorkspaces converts a slice of API workspaces into tasks, fetching
-// prompts and mapping status/state.
+// prompts and mapping status/state. This method enforces that only AI task
+// workspaces are given.
 func (api *API) tasksFromWorkspaces(ctx context.Context, apiWorkspaces []codersdk.Workspace) ([]codersdk.Task, error) {
+	// Enforce that only AI task workspaces are given.
+	for _, ws := range apiWorkspaces {
+		if ws.LatestBuild.HasAITask == nil || !*ws.LatestBuild.HasAITask {
+			return nil, fmt.Errorf("workspace %s is not an AI task workspace", ws.ID)
+		}
+	}
+
 	// Fetch prompts for each workspace build and map by build ID.
 	buildIDs := make([]uuid.UUID, 0, len(apiWorkspaces))
 	for _, ws := range apiWorkspaces {

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -374,7 +374,10 @@ func (api *API) taskGet(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspace, err := api.Database.GetWorkspaceByID(ctx, taskID)
+	// For now, taskID = workspaceID, once we have a task data model in
+	// the DB, we can change this lookup.
+	workspaceID := taskID
+	workspace, err := api.Database.GetWorkspaceByID(ctx, workspaceID)
 	if httpapi.Is404Error(err) {
 		httpapi.ResourceNotFound(rw)
 		return

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
 
@@ -198,7 +199,7 @@ func (api *API) tasksFromWorkspaces(ctx context.Context, apiWorkspaces []codersd
 	// Enforce that only AI task workspaces are given.
 	for _, ws := range apiWorkspaces {
 		if ws.LatestBuild.HasAITask == nil || !*ws.LatestBuild.HasAITask {
-			return nil, fmt.Errorf("workspace %s is not an AI task workspace", ws.ID)
+			return nil, xerrors.Errorf("workspace %s is not an AI task workspace", ws.ID)
 		}
 	}
 

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -230,7 +230,7 @@ func (api *API) tasksFromWorkspaces(ctx context.Context, apiWorkspaces []codersd
 			WorkspaceID:    uuid.NullUUID{Valid: true, UUID: ws.ID},
 			CreatedAt:      ws.CreatedAt,
 			UpdatedAt:      ws.UpdatedAt,
-			Prompt:         promptsByBuildID[ws.LatestBuild.ID],
+			InitialPrompt:  promptsByBuildID[ws.LatestBuild.ID],
 			Status:         ws.LatestBuild.Status,
 			CurrentState:   currentState,
 		})

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -199,28 +199,39 @@ type tasksListResponse struct {
 }
 
 func mapTaskStatus(ws codersdk.Workspace) codersdk.TaskStatus {
-	if ws.LatestAppStatus != nil {
-		switch ws.LatestAppStatus.State {
-		case codersdk.WorkspaceAppStatusStateWorking:
-			return codersdk.TaskStatusWorking
-		case codersdk.WorkspaceAppStatusStateIdle:
-			return codersdk.TaskStatusIdle
-		case codersdk.WorkspaceAppStatusStateComplete:
-			return codersdk.TaskStatusCompleted
-		case codersdk.WorkspaceAppStatusStateFailure:
-			return codersdk.TaskStatusFailed
-		}
-	}
-
 	switch ws.LatestBuild.Status {
-	case codersdk.WorkspaceStatusPending, codersdk.WorkspaceStatusStarting, codersdk.WorkspaceStatusRunning:
-		return codersdk.TaskStatusWorking
-	case codersdk.WorkspaceStatusStopping, codersdk.WorkspaceStatusStopped, codersdk.WorkspaceStatusDeleting, codersdk.WorkspaceStatusDeleted:
-		return codersdk.TaskStatusCompleted
+	case codersdk.WorkspaceStatusPending:
+		return codersdk.TaskStatusPending
+
+	case codersdk.WorkspaceStatusStarting:
+		return codersdk.TaskStatusStarting
+
+	case codersdk.WorkspaceStatusRunning:
+		if ws.LatestAppStatus != nil {
+			switch ws.LatestAppStatus.State {
+			case codersdk.WorkspaceAppStatusStateWorking:
+				return codersdk.TaskStatusWorking
+			case codersdk.WorkspaceAppStatusStateIdle:
+				return codersdk.TaskStatusIdle
+			case codersdk.WorkspaceAppStatusStateComplete:
+				return codersdk.TaskStatusCompleted
+			case codersdk.WorkspaceAppStatusStateFailure:
+				return codersdk.TaskStatusFailed
+			}
+		}
+		return codersdk.TaskStatusStarting
+
+	case codersdk.WorkspaceStatusStopping, codersdk.WorkspaceStatusStopped:
+		return codersdk.TaskStatusStopping
+
+	case codersdk.WorkspaceStatusDeleting, codersdk.WorkspaceStatusDeleted:
+		return codersdk.TaskStatusDeleting
+
 	case codersdk.WorkspaceStatusFailed, codersdk.WorkspaceStatusCanceling, codersdk.WorkspaceStatusCanceled:
 		return codersdk.TaskStatusFailed
+
 	default:
-		return codersdk.TaskStatusWorking
+		return codersdk.TaskStatusPending
 	}
 }
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -146,7 +146,7 @@ func TestAITasksPrompts(t *testing.T) {
 func TestTasks(t *testing.T) {
 	t.Parallel()
 
-	createAITemplate := func(t *testing.T, client *coderdtest.Client, user coderdtest.User) codersdk.Template {
+	createAITemplate := func(t *testing.T, client *codersdk.Client, user codersdk.CreateFirstUserResponse) codersdk.Template {
 		t.Helper()
 
 		// Create a template version that supports AI tasks with the AI Prompt parameter.

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -226,7 +226,7 @@ func TestTasks(t *testing.T) {
 			}
 		}
 		require.NotEqual(t, uuid.Nil, got.ID, "expected to find created task in list")
-		assert.Equal(t, wantPrompt, got.Prompt, "task prompt should match the AI Prompt parameter")
+		assert.Equal(t, wantPrompt, got.InitialPrompt, "task prompt should match the AI Prompt parameter")
 		assert.Equal(t, workspace.Name, got.Name, "task name should map from workspace name")
 		assert.Equal(t, workspace.ID, got.WorkspaceID.UUID, "workspace id should match")
 		// Status should be populated via app status or workspace status mapping.
@@ -308,7 +308,7 @@ func TestTasks(t *testing.T) {
 
 		assert.Equal(t, workspace.ID, task.ID, "task ID should match workspace ID")
 		assert.Equal(t, workspace.Name, task.Name, "task name should map from workspace name")
-		assert.Equal(t, wantPrompt, task.Prompt, "task prompt should match the AI Prompt parameter")
+		assert.Equal(t, wantPrompt, task.InitialPrompt, "task prompt should match the AI Prompt parameter")
 		assert.Equal(t, workspace.ID, task.WorkspaceID.UUID, "workspace id should match")
 		assert.NotEmpty(t, task.Status, "task status should not be empty")
 	})

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1011,6 +1011,8 @@ func New(options *Options) *API {
 			r.Route("/{user}", func(r chi.Router) {
 				r.Use(httpmw.ExtractOrganizationMembersParam(options.Database, api.HTTPAuth.Authorize))
 
+				r.Get("/", api.tasksList)
+				r.Get("/{id}", api.taskGet)
 				r.Post("/", api.tasksCreate)
 			})
 		})

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -94,7 +94,7 @@ type Task struct {
 	Name           string          `json:"name"`
 	TemplateID     uuid.UUID       `json:"template_id" format:"uuid"`
 	WorkspaceID    uuid.NullUUID   `json:"workspace_id" format:"uuid"`
-	Prompt         string          `json:"prompt"`
+	InitialPrompt  string          `json:"initial_prompt"`
 	Status         WorkspaceStatus `json:"status" enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
 	CurrentState   *TaskStateEntry `json:"current_state"`
 	CreatedAt      time.Time       `json:"created_at" format:"date-time"`

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -72,21 +72,44 @@ func (c *ExperimentalClient) CreateTask(ctx context.Context, user string, reques
 	return workspace, nil
 }
 
-// TaskStatus represents the high-level lifecycle of a task.
+// TaskState represents the high-level lifecycle of a task.
 //
 // Experimental: This type is experimental and may change in the future.
-type TaskStatus string
+type TaskState string
 
 const (
-	TaskStatusPending   TaskStatus = "pending"
-	TaskStatusStarting  TaskStatus = "starting"
-	TaskStatusStopping  TaskStatus = "stopping"
-	TaskStatusDeleting  TaskStatus = "deleting"
-	TaskStatusWorking   TaskStatus = "working"
-	TaskStatusIdle      TaskStatus = "idle"
-	TaskStatusCompleted TaskStatus = "completed"
-	TaskStatusFailed    TaskStatus = "failed"
+	TaskStateWorking   TaskState = "working"
+	TaskStateIdle      TaskState = "idle"
+	TaskStateCompleted TaskState = "completed"
+	TaskStateFailed    TaskState = "failed"
 )
+
+// Task represents a task.
+//
+// Experimental: This type is experimental and may change in the future.
+type Task struct {
+	ID             uuid.UUID       `json:"id" format:"uuid"`
+	OrganizationID uuid.UUID       `json:"organization_id" format:"uuid"`
+	OwnerID        uuid.UUID       `json:"owner_id" format:"uuid"`
+	Name           string          `json:"name"`
+	TemplateID     uuid.UUID       `json:"template_id" format:"uuid"`
+	WorkspaceID    uuid.NullUUID   `json:"workspace_id" format:"uuid"`
+	Prompt         string          `json:"prompt"`
+	Status         WorkspaceStatus `json:"status" enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
+	CurrentState   *TaskStateEntry `json:"current_state"`
+	CreatedAt      time.Time       `json:"created_at" format:"date-time"`
+	UpdatedAt      time.Time       `json:"updated_at" format:"date-time"`
+}
+
+// TaskStateEntry represents a single entry in the task's state history.
+//
+// Experimental: This type is experimental and may change in the future.
+type TaskStateEntry struct {
+	Timestamp time.Time `json:"timestamp" format:"date-time"`
+	State     TaskState `json:"state" enum:"working,idle,completed,failed"`
+	Message   string    `json:"message"`
+	URI       string    `json:"uri"`
+}
 
 // TasksFilter filters the list of tasks.
 //
@@ -94,22 +117,6 @@ const (
 type TasksFilter struct {
 	// Owner can be a username, UUID, or "me"
 	Owner string `json:"owner,omitempty"`
-}
-
-// Task represents a task.
-//
-// Experimental: This type is experimental and may change in the future.
-type Task struct {
-	ID             uuid.UUID     `json:"id" format:"uuid"`
-	OrganizationID uuid.UUID     `json:"organization_id" format:"uuid"`
-	OwnerID        uuid.UUID     `json:"owner_id" format:"uuid"`
-	Name           string        `json:"name"`
-	TemplateID     uuid.UUID     `json:"template_id" format:"uuid"`
-	WorkspaceID    uuid.NullUUID `json:"workspace_id" format:"uuid"`
-	Prompt         string        `json:"prompt"`
-	Status         TaskStatus    `json:"status" enum:"pending,starting,stopping,deleting,working,idle,completed,failed"`
-	CreatedAt      time.Time     `json:"created_at" format:"date-time"`
-	UpdatedAt      time.Time     `json:"updated_at" format:"date-time"`
 }
 
 // Tasks lists all tasks belonging to the user or specified owner.

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -78,10 +78,12 @@ func (c *ExperimentalClient) CreateTask(ctx context.Context, user string, reques
 type TaskStatus string
 
 const (
-	TaskStatusQueued    TaskStatus = "queued"
+	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusStarting  TaskStatus = "starting"
+	TaskStatusStopping  TaskStatus = "stopping"
+	TaskStatusDeleting  TaskStatus = "deleting"
 	TaskStatusWorking   TaskStatus = "working"
 	TaskStatusIdle      TaskStatus = "idle"
-	TaskStatusPaused    TaskStatus = "paused"
 	TaskStatusCompleted TaskStatus = "completed"
 	TaskStatusFailed    TaskStatus = "failed"
 )
@@ -105,7 +107,7 @@ type Task struct {
 	TemplateID     uuid.UUID     `json:"template_id" format:"uuid"`
 	WorkspaceID    uuid.NullUUID `json:"workspace_id" format:"uuid"`
 	Prompt         string        `json:"prompt"`
-	Status         TaskStatus    `json:"status" enum:"queued,working,idle,paused,completed,failed"`
+	Status         TaskStatus    `json:"status" enum:"pending,starting,stopping,deleting,working,idle,completed,failed"`
 	CreatedAt      time.Time     `json:"created_at" format:"date-time"`
 	UpdatedAt      time.Time     `json:"updated_at" format:"date-time"`
 }

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -98,14 +98,14 @@ type TasksFilter struct {
 //
 // Experimental: This type is experimental and may change in the future.
 type Task struct {
-	ID             uuid.UUID     `json:"id"`
-	OrganizationID uuid.UUID     `json:"organization_id"`
-	OwnerID        uuid.UUID     `json:"owner_id"`
+	ID             uuid.UUID     `json:"id" format:"uuid"`
+	OrganizationID uuid.UUID     `json:"organization_id" format:"uuid"`
+	OwnerID        uuid.UUID     `json:"owner_id" format:"uuid"`
 	Name           string        `json:"name"`
-	TemplateID     uuid.UUID     `json:"template_id"`
-	WorkspaceID    uuid.NullUUID `json:"workspace_id"`
+	TemplateID     uuid.UUID     `json:"template_id" format:"uuid"`
+	WorkspaceID    uuid.NullUUID `json:"workspace_id" format:"uuid"`
 	Prompt         string        `json:"prompt"`
-	Status         TaskStatus    `json:"status"`
+	Status         TaskStatus    `json:"status" enum:"queued,working,idle,paused,completed,failed"`
 	CreatedAt      time.Time     `json:"created_at" format:"date-time"`
 	UpdatedAt      time.Time     `json:"updated_at" format:"date-time"`
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2804,6 +2804,43 @@ export interface TailDERPRegion {
 	readonly Nodes: readonly TailDERPNode[];
 }
 
+// From codersdk/aitasks.go
+export interface Task {
+	readonly id: string;
+	readonly organization_id: string;
+	readonly owner_id: string;
+	readonly name: string;
+	readonly template_id: string;
+	readonly workspace_id: string | null;
+	readonly prompt: string;
+	readonly status: TaskStatus;
+	readonly created_at: string;
+	readonly updated_at: string;
+}
+
+// From codersdk/aitasks.go
+export type TaskStatus =
+	| "completed"
+	| "failed"
+	| "idle"
+	| "paused"
+	| "queued"
+	| "working";
+
+export const TaskStatuses: TaskStatus[] = [
+	"completed",
+	"failed",
+	"idle",
+	"paused",
+	"queued",
+	"working",
+];
+
+// From codersdk/aitasks.go
+export interface TasksFilter {
+	readonly owner?: string;
+}
+
 // From codersdk/deployment.go
 export interface TelemetryConfig {
 	readonly enable: boolean;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2812,31 +2812,28 @@ export interface Task {
 	readonly name: string;
 	readonly template_id: string;
 	readonly workspace_id: string | null;
-	readonly prompt: string;
-	readonly status: TaskStatus;
+	readonly initial_prompt: string;
+	readonly status: WorkspaceStatus;
+	readonly current_state: TaskStateEntry | null;
 	readonly created_at: string;
 	readonly updated_at: string;
 }
 
 // From codersdk/aitasks.go
-export type TaskStatus =
-	| "completed"
-	| "deleting"
-	| "failed"
-	| "idle"
-	| "pending"
-	| "starting"
-	| "stopping"
-	| "working";
+export type TaskState = "completed" | "failed" | "idle" | "working";
 
-export const TaskStatuses: TaskStatus[] = [
+// From codersdk/aitasks.go
+export interface TaskStateEntry {
+	readonly timestamp: string;
+	readonly state: TaskState;
+	readonly message: string;
+	readonly uri: string;
+}
+
+export const TaskStates: TaskState[] = [
 	"completed",
-	"deleting",
 	"failed",
 	"idle",
-	"pending",
-	"starting",
-	"stopping",
 	"working",
 ];
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2821,18 +2821,22 @@ export interface Task {
 // From codersdk/aitasks.go
 export type TaskStatus =
 	| "completed"
+	| "deleting"
 	| "failed"
 	| "idle"
-	| "paused"
-	| "queued"
+	| "pending"
+	| "starting"
+	| "stopping"
 	| "working";
 
 export const TaskStatuses: TaskStatus[] = [
 	"completed",
+	"deleting",
 	"failed",
 	"idle",
-	"paused",
-	"queued",
+	"pending",
+	"starting",
+	"stopping",
 	"working",
 ];
 


### PR DESCRIPTION
Fixes coder/internal#899

Example API response:

```json
{
  "tasks": [
    {
      "id": "a7a27450-ca16-4553-a6c5-9d6f04808569",
      "organization_id": "241e869f-1a61-42c9-ae1e-9d46df874058",
      "owner_id": "9e9b9475-0fc0-47b2-9170-a5b7b9a075ee",
      "name": "task-hardcore-herschel-bd08",
      "template_id": "accab607-bbda-4794-89ac-da3926a8b71c",
      "workspace_id": "a7a27450-ca16-4553-a6c5-9d6f04808569",
      "initial_prompt": "What directory are you in?",
      "status": "running",
      "current_state": {
        "timestamp": "2025-08-22T10:03:27.837842Z",
        "state": "working",
        "message": "Listed root directory contents, working directory reset",
        "uri": ""
      },
      "created_at": "2025-08-22T09:21:39.697094Z",
      "updated_at": "2025-08-22T09:21:39.697094Z"
    },
    {
      "id": "50f92138-f463-4f2b-abad-1816264b065f",
      "organization_id": "241e869f-1a61-42c9-ae1e-9d46df874058",
      "owner_id": "9e9b9475-0fc0-47b2-9170-a5b7b9a075ee",
      "name": "task-musing-dewdney-f058",
      "template_id": "accab607-bbda-4794-89ac-da3926a8b71c",
      "workspace_id": "50f92138-f463-4f2b-abad-1816264b065f",
      "initial_prompt": "What is 1 + 1?",
      "status": "running",
      "current_state": {
        "timestamp": "2025-08-22T09:22:33.810707Z",
        "state": "idle",
        "message": "Completed arithmetic calculation",
        "uri": ""
      },
      "created_at": "2025-08-22T09:18:28.027378Z",
      "updated_at": "2025-08-22T09:18:28.027378Z"
    }
  ],
  "count": 2
}
```

**NOTE:** For now I've opted not to implement task "state" filter. Will require joining workspace apps to the workspaces query which is already complex enough. Regular workspace filters (status = running) will work, though.