### PR TITLE
chore: reduce execution time of TestProvisionerJobs

### DIFF
--- a/cli/provisionerjobs_test.go
+++ b/cli/provisionerjobs_test.go
@@ -36,7 +36,9 @@ func TestProvisionerJobs(t *testing.T) {
 	templateAdminClient, templateAdmin := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.ScopedRoleOrgTemplateAdmin(owner.OrganizationID))
 	memberClient, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 
-	// Create minimal template setup without provisioner overhead
+	// These CLI tests are related to provisioner job CRUD operations and as such
+	// do not require the overhead of starting a provisioner. Other provisioner job
+	// functionalities (acquisition etc.) are tested elsewhere.
 	template := dbgen.Template(t, db, database.Template{
 		OrganizationID:               owner.OrganizationID,
 		CreatedBy:                    owner.UserID,
@@ -51,7 +53,7 @@ func TestProvisionerJobs(t *testing.T) {
 	t.Run("Cancel", func(t *testing.T) {
 		t.Parallel()
 
-		// Set up test helpers - simplified to avoid provisioner daemon overhead.
+		// Test helper to create a provisioner job of a given type with a given input.
 		prepareJob := func(t *testing.T, jobType database.ProvisionerJobType, input json.RawMessage) database.ProvisionerJob {
 			t.Helper()
 			return dbgen.ProvisionerJob(t, db, coderdAPI.Pubsub, database.ProvisionerJob{
@@ -63,6 +65,7 @@ func TestProvisionerJobs(t *testing.T) {
 			})
 		}
 
+		// Test helper to create a workspace build job with a predefined input.
 		prepareWorkspaceBuildJob := func(t *testing.T) database.ProvisionerJob {
 			t.Helper()
 			wbID := uuid.New()
@@ -84,6 +87,7 @@ func TestProvisionerJobs(t *testing.T) {
 			return job
 		}
 
+		// Test helper to create a template version import job with a predefined input.
 		prepareTemplateVersionImportJob := func(t *testing.T) database.ProvisionerJob {
 			t.Helper()
 			tvID := uuid.New()
@@ -100,6 +104,7 @@ func TestProvisionerJobs(t *testing.T) {
 			return job
 		}
 
+		// Test helper to create a template version import dry run job with a predefined input.
 		prepareTemplateVersionImportJobDryRun := func(t *testing.T) database.ProvisionerJob {
 			t.Helper()
 			tvID := uuid.New()

--- a/cli/provisionerjobs_test.go
+++ b/cli/provisionerjobs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -58,6 +59,7 @@ func TestProvisionerJobs(t *testing.T) {
 				Input:       input,
 				Type:        jobType,
 				StartedAt:   sql.NullTime{Time: coderdAPI.Clock.Now().Add(-time.Minute), Valid: true},
+				Tags:        database.StringMap{provisionersdk.TagOwner: "", provisionersdk.TagScope: provisionersdk.ScopeOrganization, "foo": uuid.NewString()},
 			})
 		}
 

--- a/cli/provisionerjobs_test.go
+++ b/cli/provisionerjobs_test.go
@@ -68,59 +68,62 @@ func TestProvisionerJobs(t *testing.T) {
 		// Test helper to create a workspace build job with a predefined input.
 		prepareWorkspaceBuildJob := func(t *testing.T) database.ProvisionerJob {
 			t.Helper()
-			wbID := uuid.New()
-			input, _ := json.Marshal(map[string]string{"workspace_build_id": wbID.String()})
-			job := prepareJob(t, database.ProvisionerJobTypeWorkspaceBuild, input)
-
-			w := dbgen.Workspace(t, db, database.WorkspaceTable{
-				OrganizationID: owner.OrganizationID,
-				OwnerID:        member.ID,
-				TemplateID:     template.ID,
-			})
-			_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-				ID:                wbID,
-				InitiatorID:       member.ID,
-				WorkspaceID:       w.ID,
-				TemplateVersionID: version.ID,
-				JobID:             job.ID,
-			})
+			var (
+				wbID     = uuid.New()
+				input, _ = json.Marshal(map[string]string{"workspace_build_id": wbID.String()})
+				job      = prepareJob(t, database.ProvisionerJobTypeWorkspaceBuild, input)
+				w        = dbgen.Workspace(t, db, database.WorkspaceTable{
+					OrganizationID: owner.OrganizationID,
+					OwnerID:        member.ID,
+					TemplateID:     template.ID,
+				})
+				_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+					ID:                wbID,
+					InitiatorID:       member.ID,
+					WorkspaceID:       w.ID,
+					TemplateVersionID: version.ID,
+					JobID:             job.ID,
+				})
+			)
 			return job
 		}
 
 		// Test helper to create a template version import job with a predefined input.
 		prepareTemplateVersionImportJob := func(t *testing.T) database.ProvisionerJob {
 			t.Helper()
-			tvID := uuid.New()
-			input, _ := json.Marshal(map[string]string{"template_version_id": tvID.String()})
-			job := prepareJob(t, database.ProvisionerJobTypeTemplateVersionImport, input)
-
-			_ = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-				OrganizationID: owner.OrganizationID,
-				CreatedBy:      templateAdmin.ID,
-				ID:             tvID,
-				TemplateID:     uuid.NullUUID{UUID: template.ID, Valid: true},
-				JobID:          job.ID,
-			})
+			var (
+				tvID     = uuid.New()
+				input, _ = json.Marshal(map[string]string{"template_version_id": tvID.String()})
+				job      = prepareJob(t, database.ProvisionerJobTypeTemplateVersionImport, input)
+				_        = dbgen.TemplateVersion(t, db, database.TemplateVersion{
+					OrganizationID: owner.OrganizationID,
+					CreatedBy:      templateAdmin.ID,
+					ID:             tvID,
+					TemplateID:     uuid.NullUUID{UUID: template.ID, Valid: true},
+					JobID:          job.ID,
+				})
+			)
 			return job
 		}
 
 		// Test helper to create a template version import dry run job with a predefined input.
 		prepareTemplateVersionImportJobDryRun := func(t *testing.T) database.ProvisionerJob {
 			t.Helper()
-			tvID := uuid.New()
-			input, _ := json.Marshal(map[string]interface{}{
-				"template_version_id": tvID.String(),
-				"dry_run":             true,
-			})
-			job := prepareJob(t, database.ProvisionerJobTypeTemplateVersionDryRun, input)
-
-			_ = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-				OrganizationID: owner.OrganizationID,
-				CreatedBy:      templateAdmin.ID,
-				ID:             tvID,
-				TemplateID:     uuid.NullUUID{UUID: template.ID, Valid: true},
-				JobID:          job.ID,
-			})
+			var (
+				tvID     = uuid.New()
+				input, _ = json.Marshal(map[string]interface{}{
+					"template_version_id": tvID.String(),
+					"dry_run":             true,
+				})
+				job = prepareJob(t, database.ProvisionerJobTypeTemplateVersionDryRun, input)
+				_   = dbgen.TemplateVersion(t, db, database.TemplateVersion{
+					OrganizationID: owner.OrganizationID,
+					CreatedBy:      templateAdmin.ID,
+					ID:             tvID,
+					TemplateID:     uuid.NullUUID{UUID: template.ID, Valid: true},
+					JobID:          job.ID,
+				})
+			)
 			return job
 		}
 


### PR DESCRIPTION
Note: this commit was partially authored by AI.

  - Replaces coderdtest.CreateTemplate/TemplateVersion() with direct dbgen calls. We do not need a fully functional template for these tests.
  - Removes provisioner daemon creation/cleanup. We do not need a running provisioner daemon here; this functionality is tested elsewhere.
  - Simplifies provisioner job creation test helpers.

This reduces the test runtime by over 50%:

Old:
```
time go test -count=100 ./cli -test.run=TestProvisionerJobs
ok      github.com/coder/coder/v2/cli   50.149s
```

New:
```
time go test -count=100 ./cli -test.run=TestProvisionerJobs
ok      github.com/coder/coder/v2/cli   21.898
```