### PR TITLE
chore(scaletest): add deployment name to all metrics

### DIFF
--- a/scaletest/terraform/action/prometheus.tf
+++ b/scaletest/terraform/action/prometheus.tf
@@ -17,6 +17,7 @@ resource "helm_release" "prometheus_chart_primary" {
   name       = local.prometheus_release_name
   namespace  = kubernetes_namespace.coder_primary.metadata.0.name
   values = [templatefile("${path.module}/prometheus_helm_values.tftpl", {
+    deployment_name                       = var.name,
     nodepool                              = google_container_node_pool.node_pool["primary_misc"].name,
     cluster                               = "primary",
     prometheus_remote_write_url           = var.prometheus_remote_write_url,
@@ -104,6 +105,7 @@ resource "helm_release" "prometheus_chart_europe" {
   name       = local.prometheus_release_name
   namespace  = kubernetes_namespace.coder_europe.metadata.0.name
   values = [templatefile("${path.module}/prometheus_helm_values.tftpl", {
+    deployment_name                       = var.name,
     nodepool                              = google_container_node_pool.node_pool["europe_misc"].name,
     cluster                               = "europe",
     prometheus_remote_write_url           = var.prometheus_remote_write_url,
@@ -141,6 +143,7 @@ resource "helm_release" "prometheus_chart_asia" {
   name       = local.prometheus_release_name
   namespace  = kubernetes_namespace.coder_asia.metadata.0.name
   values = [templatefile("${path.module}/prometheus_helm_values.tftpl", {
+    deployment_name                       = var.name,
     nodepool                              = google_container_node_pool.node_pool["asia_misc"].name,
     cluster                               = "asia",
     prometheus_remote_write_url           = var.prometheus_remote_write_url,

--- a/scaletest/terraform/action/prometheus_helm_values.tftpl
+++ b/scaletest/terraform/action/prometheus_helm_values.tftpl
@@ -22,6 +22,7 @@ prometheus:
             values: ["${nodepool}"]
   prometheusSpec:
     externalLabels:
+      deployment_name: "${deployment_name}"
       cluster: "${cluster}"
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
If multiple of `alpha`, `bravo` or `charlie` are running simultaneously, we'll have trouble differentiating the metrics. To fix this, we'll add that name to all metrics. 
<img width="1051" height="113" alt="image" src="https://github.com/user-attachments/assets/618c0105-0668-46ba-af3f-13cce3d5d512" />
