### PR TITLE
chore: rename docker-compose.yaml to compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   coder:
     # This MUST be stable for our documentation and

--- a/docs/admin/networking/workspace-proxies.md
+++ b/docs/admin/networking/workspace-proxies.md
@@ -178,7 +178,7 @@ regular Coder server.
 #### Docker Compose
 
 Change the provided
-[`docker-compose.yml`](https://github.com/coder/coder/blob/main/docker-compose.yaml)
+[`compose.yml`](https://github.com/coder/coder/blob/main/compose.yaml)
 file to include a custom entrypoint:
 
 ```diff

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -50,14 +50,14 @@ docker run --rm -it \
 ## Install Coder via `docker compose`
 
 Coder's publishes a
-[docker-compose example](https://github.com/coder/coder/blob/main/docker-compose.yaml)
+[docker compose example](https://github.com/coder/coder/blob/main/compose.yaml)
 which includes an PostgreSQL container and volume.
 
 1. Make sure you have [Docker Compose](https://docs.docker.com/compose/install/)
    installed.
 
 1. Download the
-   [`docker-compose.yaml`](https://github.com/coder/coder/blob/main/docker-compose.yaml)
+   [`docker-compose.yaml`](https://github.com/coder/coder/blob/main/compose.yaml)
    file.
 
 1. Update `group_add:` in `docker-compose.yaml` with the `gid` of `docker`

--- a/docs/tutorials/reverse-proxy-caddy.md
+++ b/docs/tutorials/reverse-proxy-caddy.md
@@ -6,12 +6,12 @@ certificates, you'll need a domain name that resolves to your Caddy server.
 
 ## Getting started
 
-### With docker-compose
+### With `docker compose`
 
 1. [Install Docker](https://docs.docker.com/engine/install/) and
    [Docker Compose](https://docs.docker.com/compose/install/)
 
-2. Create a `docker-compose.yaml` file and add the following:
+2. Create a `compose.yaml` file and add the following:
 
    ```yaml
    services:
@@ -212,7 +212,7 @@ Caddy modules.
    - Docker:
      [Build an custom Caddy image](https://github.com/docker-library/docs/tree/master/caddy#adding-custom-caddy-modules)
      with the module for your DNS provider. Be sure to reference the new image
-     in the `docker-compose.yaml`.
+     in the `compose.yaml`.
 
    - Standalone:
      [Download a custom Caddy build](https://caddyserver.com/download) with the


### PR DESCRIPTION
Docker recommends using a `compose.yaml` file.