### PR TITLE
test: add increasing integer to GetRandomNameHyphenated

### DIFF
--- a/testutil/names.go
+++ b/testutil/names.go
@@ -30,7 +30,7 @@ func GetRandomName(t testing.TB) string {
 // an underscore.
 func GetRandomNameHyphenated(t testing.TB) string {
 	t.Helper()
-	name := namesgenerator.GetRandomName(0)
+	name := GetRandomName(t)
 	return strings.ReplaceAll(name, "_", "-")
 }
 


### PR DESCRIPTION
Fixes flakes like the following:
```
workspaces_test.go:4938: 
	Error Trace:	/home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:1279
											/home/runner/work/coder/coder/coderd/workspaces_test.go:4938
											/home/runner/work/coder/coder/coderd/workspaces_test.go:5044
	Error:      	Received unexpected error:
								POST http://127.0.0.1:42597/api/v2/users/me/workspaces: unexpected status code 409: Workspace "romantic-mcclintock" already exists.
									name: This value is already in use and should be unique.
	Test:       	TestWorkspaceCreateWithImplicitPreset/SinglePresetWithParameters
```
https://github.com/coder/coder/actions/runs/17142665868/job/48633017007?pr=19464
 
 Which are caused by insufficient randomness when creating multiple workspaces with random names. Two words is not enough to avoid flakes. We have a `testutil.GetRandomName` function that appends a monotonically increasing integer, but this alternative function that uses hyphens doesn't add that integer. This PR fixes that by just `testutil.GetRandomName`