### PR TITLE
chore: fix typo in clientNetcheckSummary for support bundle command

### DIFF
--- a/cli/support.go
+++ b/cli/support.go
@@ -251,7 +251,7 @@ func summarizeBundle(inv *serpent.Invocation, bun *support.Bundle) {
 
 	clientNetcheckSummary := bun.Network.Netcheck.Summarize("Client netcheck:", docsURL)
 	if len(clientNetcheckSummary) > 0 {
-		cliui.Warn(inv.Stdout, "Networking issues detected:", deployHealthSummary...)
+		cliui.Warn(inv.Stdout, "Networking issues detected:", clientNetcheckSummary...)
 	}
 }
 


### PR DESCRIPTION
(cherry picked from commit 33708413b847550b6d1c51e5044414eeffe9c481)

bringing in https://github.com/coder/coder/pull/19441 to the 2.24 release branch to fix a bug in the `support bundle` command.