### PR TITLE
chore: add git-config module to dogfood template

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -359,6 +359,13 @@ module "dotfiles" {
   agent_id = coder_agent.dev.id
 }
 
+module "git-config" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/coder/git-config/coder"
+  version  = "1.0.31"
+  agent_id = coder_agent.dev.id
+}
+
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "dev.registry.coder.com/coder/git-clone/coder"


### PR DESCRIPTION
As a developer, I want to be immediately able to run `git commit` in a fresh workspace.