### PR TITLE
fix(dogfood/coder): allow mutable ai_prompt parameter

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -254,7 +254,7 @@ data "coder_parameter" "ai_prompt" {
   name        = "AI Prompt"
   default     = ""
   description = "Prompt for Claude Code"
-  mutable     = true // You may wish to change the prompt, so mutability here is desirable.
+  mutable     = true // Workaround for issue with claiming a prebuild from a preset that does not include this parameter.
 }
 
 provider "docker" {

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -254,7 +254,7 @@ data "coder_parameter" "ai_prompt" {
   name        = "AI Prompt"
   default     = ""
   description = "Prompt for Claude Code"
-  mutable     = true // MUST be mutable, otherwise claiming a prebuild may fail.
+  mutable     = true // You may wish to change the prompt, so mutability here is desirable.
 }
 
 provider "docker" {

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -254,7 +254,7 @@ data "coder_parameter" "ai_prompt" {
   name        = "AI Prompt"
   default     = ""
   description = "Prompt for Claude Code"
-  mutable     = false
+  mutable     = true // MUST be mutable, otherwise claiming a prebuild may fail.
 }
 
 provider "docker" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The AI Prompt setting is now editable after initial setup, allowing on-the-fly adjustments from the interface.
  * Updates to this setting no longer require recreating environments or configurations.

* **Bug Fixes**
  * Improved handling when applying presets or prebuilt configurations that previously prevented editing the AI Prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->