### PR TITLE
chore: update the slim binaries upload from the build directory to the GCS bucket

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -641,20 +641,21 @@ jobs:
 
           version="$(./scripts/version.sh)"
 
-          binaries=(
-              "coder-darwin-amd64"
-              "coder-darwin-arm64"
-              "coder-linux-amd64"
-              "coder-linux-arm64"
-              "coder-linux-armv7"
-              "coder-windows-amd64.exe"
-              "coder-windows-arm64.exe"
-          )
+          # Source array of slim binaries
+          declare -A binaries
+          binaries["coder-darwin-amd64"]="coder-slim_${version}_darwin_amd64"
+          binaries["coder-darwin-arm64"]="coder-slim_${version}_darwin_arm64"
+          binaries["coder-linux-amd64"]="coder-slim_${version}_linux_amd64"
+          binaries["coder-linux-arm64"]="coder-slim_${version}_linux_arm64"
+          binaries["coder-linux-armv7"]="coder-slim_${version}_linux_armv7"
+          binaries["coder-windows-amd64.exe"]="coder-slim_${version}_windows_amd64.exe"
+          binaries["coder-windows-arm64.exe"]="coder-slim_${version}_windows_arm64.exe"
 
-          for binary in "${binaries[@]}"; do
-            detached_signature="${binary}.asc"
-            gcloud storage cp "./site/out/bin/${binary}" "gs://releases.coder.com/coder-cli/${version}/${binary}"
-            gcloud storage cp "./site/out/bin/${detached_signature}" "gs://releases.coder.com/coder-cli/${version}/${detached_signature}"
+          for cli_name in "${!binaries[@]}"; do
+            slim_binary="${binaries[$cli_name]}"
+            detached_signature="${slim_binary}.asc"
+            gcloud storage cp "./build/${slim_binary}" "gs://releases.coder.com/coder-cli/${version}/${cli_name}"
+            gcloud storage cp "./build/${detached_signature}" "gs://releases.coder.com/coder-cli/${version}/${cli_name}.asc"
           done
 
       - name: Publish release


### PR DESCRIPTION
Updated the upload script to copy the slim binaries from the ./build directory to the GCS bucket (instead of the ./site/out/bin directory)

