### PR TITLE
feat: log non-sensitive query param fields in the httpmw logger

### DIFF
--- a/coderd/httpmw/loggermw/logger.go
+++ b/coderd/httpmw/loggermw/logger.go
@@ -18,8 +18,10 @@ import (
 	"github.com/coder/coder/v2/coderd/tracing"
 )
 
-var safeParams = []string{"page", "limit", "offset"}
-var countParams = []string{"ids", "template_ids"}
+var (
+	safeParams  = []string{"page", "limit", "offset"}
+	countParams = []string{"ids", "template_ids"}
+)
 
 func safeQueryParams(params url.Values) []slog.Field {
 	if len(params) == 0 {

--- a/coderd/httpmw/loggermw/logger_internal_test.go
+++ b/coderd/httpmw/loggermw/logger_internal_test.go
@@ -304,20 +304,24 @@ func TestSafeQueryParams(t *testing.T) {
 		{
 			name: "safe parameters",
 			params: url.Values{
-				"page":   []string{"1"},
-				"limit":  []string{"10"},
-				"filter": []string{"active"},
-				"sort":   []string{"name"},
+				"page":         []string{"1"},
+				"limit":        []string{"10"},
+				"filter":       []string{"active"},
+				"sort":         []string{"name"},
+				"offset":       []string{"2"},
+				"ids":          []string{"some-id,another-id", "second-param"},
+				"template_ids": []string{"some-id,another-id", "second-param"},
 			},
 			expected: map[string]interface{}{
-				"query_page":   "1",
-				"query_limit":  "10",
-				"query_filter": "active",
-				"query_sort":   "name",
+				"query_page":               "1",
+				"query_limit":              "10",
+				"query_offset":             "2",
+				"query_ids_count":          "3",
+				"query_template_ids_count": "3",
 			},
 		},
 		{
-			name: "sensitive parameters",
+			name: "unknown/sensitive parameters",
 			params: url.Values{
 				"token":                             []string{"secret-token"},
 				"api_key":                           []string{"secret-key"},
@@ -336,8 +340,7 @@ func TestSafeQueryParams(t *testing.T) {
 				"filter": []string{"active"},
 			},
 			expected: map[string]interface{}{
-				"query_page":   "1",
-				"query_filter": "active",
+				"query_page": "1",
 			},
 		},
 	}


### PR DESCRIPTION
Blink helped here but it's suggestion was to have a set map of sensitive fields based on predefined constants in various files, such as the api token string names. The map lookup would be faster than `strings.Contains` but would be more likely to lead to edge cases where new sensitive fields/slightly different formatting of a field leads to something sensitive being logged.

We could change back to the map of sensitive field names, or alternatively we could define a map/slice of field names we know we do want to log, such as the params for pagination and overall limits. Personally I would prefer this approach just so we don't need to go in and add new values for each new field we want to log (when we notice it's not present), but it's not a hill I would die on.