### PR TITLE
fix(coderd): filter out non-task workspaces in api.tasksList

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
 
@@ -196,13 +195,6 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 // prompts and mapping status/state. This method enforces that only AI task
 // workspaces are given.
 func (api *API) tasksFromWorkspaces(ctx context.Context, apiWorkspaces []codersdk.Workspace) ([]codersdk.Task, error) {
-	// Enforce that only AI task workspaces are given.
-	for _, ws := range apiWorkspaces {
-		if ws.LatestBuild.HasAITask == nil || !*ws.LatestBuild.HasAITask {
-			return nil, xerrors.Errorf("workspace %s is not an AI task workspace", ws.ID)
-		}
-	}
-
 	// Fetch prompts for each workspace build and map by build ID.
 	buildIDs := make([]uuid.UUID, 0, len(apiWorkspaces))
 	for _, ws := range apiWorkspaces {


### PR DESCRIPTION
Quick fix for following issue in CLI:
```
$ go run ./cmd/coder exp task list
Encountered an error running "coder exp task list", see "coder exp task list --help" for more information
error: Trace=[list tasks: ]
Internal error fetching task prompts and states.
workspace 14d548f4-aaad-40dd-833b-6ffe9c9d31bc is not an AI task workspace
exit status 1
```

This occurs in a short time window directly after creating a new task.

I took a stab at writing a test for this, but ran out of time. I'm not entirely sure what causes non-AI-task workspaces to be returned in the query but I suspect it's when a workspace build is pending or running.