### PR TITLE
feat: add user filter to templates page to filter by template author

### DIFF
--- a/site/src/components/Filter/UserFilter.tsx
+++ b/site/src/components/Filter/UserFilter.tsx
@@ -85,9 +85,10 @@ export type UserFilterMenu = ReturnType<typeof useUserFilterMenu>;
 interface UserMenuProps {
 	menu: UserFilterMenu;
 	placeholder?: string;
+	width?: number;
 }
 
-export const UserMenu: FC<UserMenuProps> = ({ menu, placeholder }) => {
+export const UserMenu: FC<UserMenuProps> = ({ menu, width, placeholder }) => {
 	return (
 		<SelectFilter
 			label="Select user"
@@ -104,7 +105,7 @@ export const UserMenu: FC<UserMenuProps> = ({ menu, placeholder }) => {
 					onChange={menu.setQuery}
 				/>
 			}
-			width={DEFAULT_USER_FILTER_WIDTH}
+			width={width}
 		/>
 	);
 };

--- a/site/src/components/Filter/UserFilter.tsx
+++ b/site/src/components/Filter/UserFilter.tsx
@@ -9,6 +9,8 @@ import { useAuthenticated } from "hooks";
 import type { FC } from "react";
 import { type UseFilterMenuOptions, useFilterMenu } from "./menu";
 
+export const DEFAULT_USER_FILTER_WIDTH = 175;
+
 export const useUserFilterMenu = ({
 	value,
 	onChange,
@@ -83,10 +85,9 @@ export type UserFilterMenu = ReturnType<typeof useUserFilterMenu>;
 interface UserMenuProps {
 	menu: UserFilterMenu;
 	placeholder?: string;
-	width?: number;
 }
 
-export const UserMenu: FC<UserMenuProps> = ({ menu, width, placeholder }) => {
+export const UserMenu: FC<UserMenuProps> = ({ menu, placeholder }) => {
 	return (
 		<SelectFilter
 			label="Select user"
@@ -103,7 +104,7 @@ export const UserMenu: FC<UserMenuProps> = ({ menu, width, placeholder }) => {
 					onChange={menu.setQuery}
 				/>
 			}
-			width={width}
+			width={DEFAULT_USER_FILTER_WIDTH}
 		/>
 	);
 };

--- a/site/src/pages/AuditPage/AuditFilter.tsx
+++ b/site/src/pages/AuditPage/AuditFilter.tsx
@@ -51,6 +51,7 @@ interface AuditFilterProps {
 }
 
 export const AuditFilter: FC<AuditFilterProps> = ({ filter, error, menus }) => {
+	const width = menus.organization ? DEFAULT_USER_FILTER_WIDTH : undefined;
 	return (
 		<Filter
 			learnMoreLink={docs("/admin/security/audit-logs#filtering-logs")}
@@ -61,14 +62,14 @@ export const AuditFilter: FC<AuditFilterProps> = ({ filter, error, menus }) => {
 			options={
 				<>
 					<ResourceTypeMenu
-						width={DEFAULT_USER_FILTER_WIDTH}
+						width={width}
 						menu={menus.resourceType}
 					/>
-					<ActionMenu width={DEFAULT_USER_FILTER_WIDTH} menu={menus.action} />
+					<ActionMenu width={width} menu={menus.action} />
 					<UserMenu menu={menus.user} />
 					{menus.organization && (
 						<OrganizationsMenu
-							width={DEFAULT_USER_FILTER_WIDTH}
+							width={width}
 							menu={menus.organization}
 						/>
 					)}

--- a/site/src/pages/AuditPage/AuditFilter.tsx
+++ b/site/src/pages/AuditPage/AuditFilter.tsx
@@ -8,7 +8,11 @@ import {
 	SelectFilter,
 	type SelectFilterOption,
 } from "components/Filter/SelectFilter";
-import { type UserFilterMenu, UserMenu } from "components/Filter/UserFilter";
+import {
+	DEFAULT_USER_FILTER_WIDTH,
+	type UserFilterMenu,
+	UserMenu,
+} from "components/Filter/UserFilter";
 import capitalize from "lodash/capitalize";
 import {
 	type OrganizationsFilterMenu,
@@ -47,8 +51,6 @@ interface AuditFilterProps {
 }
 
 export const AuditFilter: FC<AuditFilterProps> = ({ filter, error, menus }) => {
-	const width = menus.organization ? 175 : undefined;
-
 	return (
 		<Filter
 			learnMoreLink={docs("/admin/security/audit-logs#filtering-logs")}
@@ -58,11 +60,17 @@ export const AuditFilter: FC<AuditFilterProps> = ({ filter, error, menus }) => {
 			error={error}
 			options={
 				<>
-					<ResourceTypeMenu width={width} menu={menus.resourceType} />
-					<ActionMenu width={width} menu={menus.action} />
-					<UserMenu width={width} menu={menus.user} />
+					<ResourceTypeMenu
+						width={DEFAULT_USER_FILTER_WIDTH}
+						menu={menus.resourceType}
+					/>
+					<ActionMenu width={DEFAULT_USER_FILTER_WIDTH} menu={menus.action} />
+					<UserMenu menu={menus.user} />
 					{menus.organization && (
-						<OrganizationsMenu width={width} menu={menus.organization} />
+						<OrganizationsMenu
+							width={DEFAULT_USER_FILTER_WIDTH}
+							menu={menus.organization}
+						/>
 					)}
 				</>
 			}

--- a/site/src/pages/AuditPage/AuditFilter.tsx
+++ b/site/src/pages/AuditPage/AuditFilter.tsx
@@ -61,17 +61,11 @@ export const AuditFilter: FC<AuditFilterProps> = ({ filter, error, menus }) => {
 			error={error}
 			options={
 				<>
-					<ResourceTypeMenu
-						width={width}
-						menu={menus.resourceType}
-					/>
+					<ResourceTypeMenu width={width} menu={menus.resourceType} />
 					<ActionMenu width={width} menu={menus.action} />
 					<UserMenu menu={menus.user} />
 					{menus.organization && (
-						<OrganizationsMenu
-							width={width}
-							menu={menus.organization}
-						/>
+						<OrganizationsMenu width={width} menu={menus.organization} />
 					)}
 				</>
 			}

--- a/site/src/pages/AuditPage/AuditFilter.tsx
+++ b/site/src/pages/AuditPage/AuditFilter.tsx
@@ -63,7 +63,7 @@ export const AuditFilter: FC<AuditFilterProps> = ({ filter, error, menus }) => {
 				<>
 					<ResourceTypeMenu width={width} menu={menus.resourceType} />
 					<ActionMenu width={width} menu={menus.action} />
-					<UserMenu menu={menus.user} />
+					<UserMenu width={width} menu={menus.user} />
 					{menus.organization && (
 						<OrganizationsMenu width={width} menu={menus.organization} />
 					)}

--- a/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
@@ -58,7 +58,7 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 			error={error}
 			options={
 				<>
-					<UserMenu placeholder="All owners" menu={menus.user} />
+					<UserMenu placeholder="All owners" menu={menus.user} width={width} />
 					<StatusMenu menu={menus.status} width={width} />
 					<TypeMenu menu={menus.type} width={width} />
 					{menus.organization && (

--- a/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
@@ -8,7 +8,11 @@ import {
 	SelectFilter,
 	type SelectFilterOption,
 } from "components/Filter/SelectFilter";
-import { type UserFilterMenu, UserMenu } from "components/Filter/UserFilter";
+import {
+	DEFAULT_USER_FILTER_WIDTH,
+	type UserFilterMenu,
+	UserMenu,
+} from "components/Filter/UserFilter";
 import capitalize from "lodash/capitalize";
 import {
 	type OrganizationsFilterMenu,
@@ -42,8 +46,6 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 	error,
 	menus,
 }) => {
-	const width = menus.organization ? 175 : undefined;
-
 	return (
 		<Filter
 			learnMoreLink={docs(
@@ -55,11 +57,14 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 			error={error}
 			options={
 				<>
-					<UserMenu placeholder="All owners" menu={menus.user} width={width} />
-					<StatusMenu menu={menus.status} width={width} />
-					<TypeMenu menu={menus.type} width={width} />
+					<UserMenu placeholder="All owners" menu={menus.user} />
+					<StatusMenu menu={menus.status} width={DEFAULT_USER_FILTER_WIDTH} />
+					<TypeMenu menu={menus.type} width={DEFAULT_USER_FILTER_WIDTH} />
 					{menus.organization && (
-						<OrganizationsMenu menu={menus.organization} width={width} />
+						<OrganizationsMenu
+							menu={menus.organization}
+							width={DEFAULT_USER_FILTER_WIDTH}
+						/>
 					)}
 				</>
 			}

--- a/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
@@ -46,6 +46,7 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 	error,
 	menus,
 }) => {
+	const width = menus.organization ? DEFAULT_USER_FILTER_WIDTH : undefined;
 	return (
 		<Filter
 			learnMoreLink={docs(
@@ -58,12 +59,12 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 			options={
 				<>
 					<UserMenu placeholder="All owners" menu={menus.user} />
-					<StatusMenu menu={menus.status} width={DEFAULT_USER_FILTER_WIDTH} />
-					<TypeMenu menu={menus.type} width={DEFAULT_USER_FILTER_WIDTH} />
+					<StatusMenu menu={menus.status} width={width} />
+					<TypeMenu menu={menus.type} width={width} />
 					{menus.organization && (
 						<OrganizationsMenu
 							menu={menus.organization}
-							width={DEFAULT_USER_FILTER_WIDTH}
+							width={width}
 						/>
 					)}
 				</>

--- a/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
@@ -62,10 +62,7 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 					<StatusMenu menu={menus.status} width={width} />
 					<TypeMenu menu={menus.type} width={width} />
 					{menus.organization && (
-						<OrganizationsMenu
-							menu={menus.organization}
-							width={width}
-						/>
+						<OrganizationsMenu menu={menus.organization} width={width} />
 					)}
 				</>
 			}

--- a/site/src/pages/TemplatesPage/TemplatesFilter.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.tsx
@@ -1,23 +1,37 @@
 import { API } from "api/api";
 import type { Organization } from "api/typesGenerated";
 import { Avatar } from "components/Avatar/Avatar";
-import { Filter, MenuSkeleton, type useFilter } from "components/Filter/Filter";
+import {
+	Filter,
+	MenuSkeleton,
+	type UseFilterResult,
+} from "components/Filter/Filter";
 import { useFilterMenu } from "components/Filter/menu";
 import {
 	SelectFilter,
 	type SelectFilterOption,
 } from "components/Filter/SelectFilter";
 import type { FC } from "react";
+import {
+	type UserFilterMenu,
+	UserMenu,
+} from "../../components/Filter/UserFilter";
+import { useDashboard } from "../../modules/dashboard/useDashboard";
 
 interface TemplatesFilterProps {
-	filter: ReturnType<typeof useFilter>;
+	filter: UseFilterResult;
 	error?: unknown;
+
+	userMenu?: UserFilterMenu;
 }
 
 export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 	filter,
 	error,
+	userMenu,
 }) => {
+	const { showOrganizations } = useDashboard();
+	const width = showOrganizations ? 175 : undefined;
 	const organizationMenu = useFilterMenu({
 		onChange: (option) =>
 			filter.update({ ...filter.values, organization: option?.value }),
@@ -50,15 +64,23 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 			filter={filter}
 			error={error}
 			options={
-				<SelectFilter
-					placeholder="All organizations"
-					label="Select an organization"
-					options={organizationMenu.searchOptions}
-					selectedOption={organizationMenu.selectedOption ?? undefined}
-					onSelect={organizationMenu.selectOption}
-				/>
+				<>
+					{userMenu && <UserMenu width={width} menu={userMenu} />}
+					<SelectFilter
+						placeholder="All organizations"
+						label="Select an organization"
+						options={organizationMenu.searchOptions}
+						selectedOption={organizationMenu.selectedOption ?? undefined}
+						onSelect={organizationMenu.selectOption}
+					/>
+				</>
 			}
-			optionsSkeleton={<MenuSkeleton />}
+			optionsSkeleton={
+				<>
+					{userMenu && <MenuSkeleton />}
+					<MenuSkeleton />
+				</>
+			}
 		/>
 	);
 };

--- a/site/src/pages/TemplatesPage/TemplatesFilter.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.tsx
@@ -16,7 +16,6 @@ import {
 	type UserFilterMenu,
 	UserMenu,
 } from "../../components/Filter/UserFilter";
-import { useDashboard } from "../../modules/dashboard/useDashboard";
 
 interface TemplatesFilterProps {
 	filter: UseFilterResult;
@@ -30,8 +29,6 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 	error,
 	userMenu,
 }) => {
-	const { showOrganizations } = useDashboard();
-	const width = showOrganizations ? 175 : undefined;
 	const organizationMenu = useFilterMenu({
 		onChange: (option) =>
 			filter.update({ ...filter.values, organization: option?.value }),
@@ -65,7 +62,7 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 			error={error}
 			options={
 				<>
-					{userMenu && <UserMenu width={width} menu={userMenu} />}
+					{userMenu && <UserMenu menu={userMenu} />}
 					<SelectFilter
 						placeholder="All organizations"
 						label="Select an organization"

--- a/site/src/pages/TemplatesPage/TemplatesFilter.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.tsx
@@ -11,8 +11,10 @@ import {
 	SelectFilter,
 	type SelectFilterOption,
 } from "components/Filter/SelectFilter";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import {
+	DEFAULT_USER_FILTER_WIDTH,
 	type UserFilterMenu,
 	UserMenu,
 } from "../../components/Filter/UserFilter";
@@ -29,6 +31,8 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 	error,
 	userMenu,
 }) => {
+	const { showOrganizations } = useDashboard();
+	const width = showOrganizations ? DEFAULT_USER_FILTER_WIDTH : undefined;
 	const organizationMenu = useFilterMenu({
 		onChange: (option) =>
 			filter.update({ ...filter.values, organization: option?.value }),
@@ -62,7 +66,7 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 			error={error}
 			options={
 				<>
-					{userMenu && <UserMenu menu={userMenu} />}
+					{userMenu && <UserMenu width={width} menu={userMenu} />}
 					<SelectFilter
 						placeholder="All organizations"
 						label="Select an organization"

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -1,6 +1,7 @@
 import { workspacePermissionsByOrganization } from "api/queries/organizations";
 import { templateExamples, templates } from "api/queries/templates";
 import { useFilter } from "components/Filter/Filter";
+import { useUserFilterMenu } from "components/Filter/UserFilter";
 import { useAuthenticated } from "hooks";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
@@ -15,14 +16,13 @@ const TemplatesPage: FC = () => {
 	const { showOrganizations } = useDashboard();
 
 	const [searchParams, setSearchParams] = useSearchParams();
-	const filter = useFilter({
-		fallbackFilter: "deprecated:false",
+	const filterState = useTemplatesFilter({
 		searchParams,
 		onSearchParamsChange: setSearchParams,
-		onUpdate: () => {}, // reset pagination
+		onFilterChange: () => {},
 	});
 
-	const templatesQuery = useQuery(templates({ q: filter.query }));
+	const templatesQuery = useQuery(templates({ q: filterState.filter.query }));
 	const examplesQuery = useQuery({
 		...templateExamples(),
 		enabled: permissions.createTemplates,
@@ -47,7 +47,7 @@ const TemplatesPage: FC = () => {
 			</Helmet>
 			<TemplatesPageView
 				error={error}
-				filter={filter}
+				filterState={filterState}
 				showOrganizations={showOrganizations}
 				canCreateTemplates={permissions.createTemplates}
 				examples={examplesQuery.data}
@@ -59,3 +59,45 @@ const TemplatesPage: FC = () => {
 };
 
 export default TemplatesPage;
+
+export type TemplateFilterState = {
+	filter: ReturnType<typeof useFilter>;
+	menus: {
+		user?: ReturnType<typeof useUserFilterMenu>;
+	};
+};
+
+type UseTemplatesFilterOptions = {
+	searchParams: URLSearchParams;
+	onSearchParamsChange: (params: URLSearchParams) => void;
+	onFilterChange: () => void;
+};
+
+const useTemplatesFilter = ({
+	searchParams,
+	onSearchParamsChange,
+	onFilterChange,
+}: UseTemplatesFilterOptions): TemplateFilterState => {
+	const filter = useFilter({
+		fallbackFilter: "deprecated:false",
+		searchParams,
+		onSearchParamsChange,
+		onUpdate: onFilterChange,
+	});
+
+	const { permissions } = useAuthenticated();
+	const canFilterByUser = permissions.viewAllUsers;
+	const userMenu = useUserFilterMenu({
+		value: filter.values.author,
+		onChange: (option) =>
+			filter.update({ ...filter.values, author: option?.value }),
+		enabled: canFilterByUser,
+	});
+
+	return {
+		filter,
+		menus: {
+			user: canFilterByUser ? userMenu : undefined,
+		},
+	};
+};

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -19,7 +19,6 @@ const TemplatesPage: FC = () => {
 	const filterState = useTemplatesFilter({
 		searchParams,
 		onSearchParamsChange: setSearchParams,
-		onFilterChange: () => {},
 	});
 
 	const templatesQuery = useQuery(templates({ q: filterState.filter.query }));
@@ -70,19 +69,16 @@ export type TemplateFilterState = {
 type UseTemplatesFilterOptions = {
 	searchParams: URLSearchParams;
 	onSearchParamsChange: (params: URLSearchParams) => void;
-	onFilterChange: () => void;
 };
 
 const useTemplatesFilter = ({
 	searchParams,
 	onSearchParamsChange,
-	onFilterChange,
 }: UseTemplatesFilterOptions): TemplateFilterState => {
 	const filter = useFilter({
 		fallbackFilter: "deprecated:false",
 		searchParams,
 		onSearchParamsChange,
-		onUpdate: onFilterChange,
 	});
 
 	const { permissions } = useAuthenticated();

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -1,6 +1,6 @@
 import { workspacePermissionsByOrganization } from "api/queries/organizations";
 import { templateExamples, templates } from "api/queries/templates";
-import { useFilter } from "components/Filter/Filter";
+import { type UseFilterResult, useFilter } from "components/Filter/Filter";
 import { useUserFilterMenu } from "components/Filter/UserFilter";
 import { useAuthenticated } from "hooks";
 import { useDashboard } from "modules/dashboard/useDashboard";
@@ -60,7 +60,7 @@ const TemplatesPage: FC = () => {
 export default TemplatesPage;
 
 export type TemplateFilterState = {
-	filter: ReturnType<typeof useFilter>;
+	filter: UseFilterResult;
 	menus: {
 		user?: ReturnType<typeof useUserFilterMenu>;
 	};

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -115,12 +115,15 @@ export const WithFilteredAllTemplates: Story = {
 	args: {
 		...WithTemplates.args,
 		templates: [],
-		...getDefaultFilterProps({
-			query: "deprecated:false searchnotfound",
-			menus: {},
-			values: {},
-			used: true,
-		}),
+		filterState: {
+			filter: {
+				...defaultFilterProps.filter,
+				query: "deprecated:false searchnotfound",
+				values: {},
+				used: true,
+			},
+			menus: defaultFilterProps.menus,
+		},
 	},
 };
 

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -3,12 +3,27 @@ import {
 	MockTemplate,
 	MockTemplateExample,
 	MockTemplateExample2,
+	MockUserOwner,
 	mockApiError,
 } from "testHelpers/entities";
 import { withDashboardProvider } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { getDefaultFilterProps } from "components/Filter/storyHelpers";
+import {
+	getDefaultFilterProps,
+	MockMenu,
+} from "components/Filter/storyHelpers";
+import type { TemplateFilterState } from "./TemplatesPage";
 import { TemplatesPageView } from "./TemplatesPageView";
+
+const defaultFilterProps = getDefaultFilterProps<TemplateFilterState>({
+	query: "deprecated:false",
+	menus: {
+		organizations: MockMenu,
+	},
+	values: {
+		author: MockUserOwner.username,
+	},
+});
 
 const meta: Meta<typeof TemplatesPageView> = {
 	title: "pages/TemplatesPage",
@@ -16,11 +31,7 @@ const meta: Meta<typeof TemplatesPageView> = {
 	parameters: { chromatic: chromaticWithTablet },
 	component: TemplatesPageView,
 	args: {
-		...getDefaultFilterProps({
-			query: "deprecated:false",
-			menus: {},
-			values: {},
-		}),
+		filterState: defaultFilterProps,
 	},
 };
 
@@ -110,6 +121,23 @@ export const WithFilteredAllTemplates: Story = {
 			values: {},
 			used: true,
 		}),
+	},
+};
+
+export const WithUserDropdown: Story = {
+	args: {
+		...WithTemplates.args,
+		filterState: {
+			...defaultFilterProps,
+			menus: {
+				user: MockMenu,
+			},
+			filter: {
+				...defaultFilterProps.filter,
+				query: "author:me",
+				values: { author: "me" },
+			},
+		},
 	},
 };
 

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -9,7 +9,6 @@ import { AvatarData } from "components/Avatar/AvatarData";
 import { AvatarDataSkeleton } from "components/Avatar/AvatarDataSkeleton";
 import { DeprecatedBadge } from "components/Badges/Badges";
 import { Button } from "components/Button/Button";
-import type { useFilter } from "components/Filter/Filter";
 import {
 	HelpTooltip,
 	HelpTooltipContent,

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -52,6 +52,7 @@ import {
 } from "utils/templates";
 import { EmptyTemplates } from "./EmptyTemplates";
 import { TemplatesFilter } from "./TemplatesFilter";
+import type { TemplateFilterState } from "./TemplatesPage";
 
 const Language = {
 	developerCount: (activeCount: number): string => {
@@ -184,7 +185,7 @@ const TemplateRow: FC<TemplateRowProps> = ({
 
 interface TemplatesPageViewProps {
 	error?: unknown;
-	filter: ReturnType<typeof useFilter>;
+	filterState: TemplateFilterState;
 	showOrganizations: boolean;
 	canCreateTemplates: boolean;
 	examples: TemplateExample[] | undefined;
@@ -194,7 +195,7 @@ interface TemplatesPageViewProps {
 
 export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 	error,
-	filter,
+	filterState,
 	showOrganizations,
 	canCreateTemplates,
 	examples,
@@ -229,7 +230,11 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 				</PageHeaderSubtitle>
 			</PageHeader>
 
-			<TemplatesFilter filter={filter} error={error} />
+			<TemplatesFilter
+				filter={filterState.filter}
+				error={error}
+				userMenu={filterState.menus.user}
+			/>
 			{/* Validation errors are shown on the filter, other errors are an alert box. */}
 			{hasError(error) && !isApiValidationError(error) && (
 				<ErrorAlert error={error} />
@@ -256,7 +261,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 						<EmptyTemplates
 							canCreateTemplates={canCreateTemplates}
 							examples={examples ?? []}
-							isUsingFilter={filter.used}
+							isUsingFilter={filterState.filter.used}
 						/>
 					) : (
 						templates?.map((template) => (

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -3,7 +3,11 @@ import {
 	MenuSkeleton,
 	type UseFilterResult,
 } from "components/Filter/Filter";
-import { type UserFilterMenu, UserMenu } from "components/Filter/UserFilter";
+import {
+	DEFAULT_USER_FILTER_WIDTH,
+	type UserFilterMenu,
+	UserMenu,
+} from "components/Filter/UserFilter";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import {
 	type OrganizationsFilterMenu,
@@ -96,7 +100,6 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 	organizationsMenu,
 }) => {
 	const { entitlements, showOrganizations } = useDashboard();
-	const width = showOrganizations ? 175 : undefined;
 	const presets = entitlements.features.advanced_template_scheduling.enabled
 		? PRESETS_WITH_DORMANT
 		: PRESET_FILTERS;
@@ -114,11 +117,14 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 			)}
 			options={
 				<>
-					{userMenu && <UserMenu width={width} menu={userMenu} />}
-					<TemplateMenu width={width} menu={templateMenu} />
-					<StatusMenu width={width} menu={statusMenu} />
+					{userMenu && <UserMenu menu={userMenu} />}
+					<TemplateMenu width={DEFAULT_USER_FILTER_WIDTH} menu={templateMenu} />
+					<StatusMenu width={DEFAULT_USER_FILTER_WIDTH} menu={statusMenu} />
 					{organizationsActive && (
-						<OrganizationsMenu width={width} menu={organizationsMenu} />
+						<OrganizationsMenu
+							width={DEFAULT_USER_FILTER_WIDTH}
+							menu={organizationsMenu}
+						/>
 					)}
 				</>
 			}

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -100,6 +100,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 	organizationsMenu,
 }) => {
 	const { entitlements, showOrganizations } = useDashboard();
+	const width = showOrganizations ? DEFAULT_USER_FILTER_WIDTH : undefined;
 	const presets = entitlements.features.advanced_template_scheduling.enabled
 		? PRESETS_WITH_DORMANT
 		: PRESET_FILTERS;
@@ -118,11 +119,11 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 			options={
 				<>
 					{userMenu && <UserMenu menu={userMenu} />}
-					<TemplateMenu width={DEFAULT_USER_FILTER_WIDTH} menu={templateMenu} />
-					<StatusMenu width={DEFAULT_USER_FILTER_WIDTH} menu={statusMenu} />
+					<TemplateMenu width={width} menu={templateMenu} />
+					<StatusMenu width={width} menu={statusMenu} />
 					{organizationsActive && (
 						<OrganizationsMenu
-							width={DEFAULT_USER_FILTER_WIDTH}
+							width={width}
 							menu={organizationsMenu}
 						/>
 					)}

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -118,7 +118,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 			)}
 			options={
 				<>
-					{userMenu && <UserMenu menu={userMenu} />}
+					{userMenu && <UserMenu width={width} menu={userMenu} />}
 					<TemplateMenu width={width} menu={templateMenu} />
 					<StatusMenu width={width} menu={statusMenu} />
 					{organizationsActive && (

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.tsx
@@ -122,10 +122,7 @@ export const WorkspacesFilter: FC<WorkspaceFilterProps> = ({
 					<TemplateMenu width={width} menu={templateMenu} />
 					<StatusMenu width={width} menu={statusMenu} />
 					{organizationsActive && (
-						<OrganizationsMenu
-							width={width}
-							menu={organizationsMenu}
-						/>
+						<OrganizationsMenu width={width} menu={organizationsMenu} />
 					)}
 				</>
 			}


### PR DESCRIPTION
## Summary

In this pull request we're adding a user selector dropdown to the templates page that allows an admin to select a user. The selected user will be used in the `author:<username>` filter to filter the templates list by a template author.

Closes: https://github.com/coder/coder/issues/19547

### Changes

Admin View - Can view all users

<img width="1622" height="489" alt="Screenshot 2025-08-26 at 5 24 07 PM" src="https://github.com/user-attachments/assets/f2ace51e-5834-4bed-bd4f-14c6800816f0" />

Admin View - Using the user filter

https://github.com/user-attachments/assets/b4570cca-6dff-45c1-89ab-844f126bdc0f

User view - Cannot view all users

<img width="1617" height="455" alt="Screenshot 2025-08-26 at 5 25 38 PM" src="https://github.com/user-attachments/assets/f8680acb-d463-4a22-826e-053f0e7dbe21" />

### Testing

- Added storybook test for viewing the templates page with a user dropdown
