### PR TITLE
feat: add coder_workspace_read_file MCP tool

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -60,6 +60,7 @@ func (a *agent) apiHandler() http.Handler {
 	r.Get("/api/v0/listening-ports", lp.handler)
 	r.Get("/api/v0/netcheck", a.HandleNetcheck)
 	r.Post("/api/v0/list-directory", a.HandleLS)
+	r.Get("/api/v0/read-file", a.HandleReadFile)
 	r.Get("/debug/logs", a.HandleHTTPDebugLogs)
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)

--- a/agent/files.go
+++ b/agent/files.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func (a *agent) HandleReadFile(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	query := r.URL.Query()
+	parser := httpapi.NewQueryParamParser().RequiredNotEmpty("path")
+	path := parser.String(query, "", "path")
+	offset := parser.PositiveInt64(query, 0, "offset")
+	limit := parser.PositiveInt64(query, 0, "limit")
+	parser.ErrorExcessParams(query)
+	if len(parser.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: parser.Errors,
+		})
+		return
+	}
+
+	status, err := a.streamFile(ctx, rw, path, offset, limit)
+	if err != nil {
+		httpapi.Write(ctx, rw, status, codersdk.Response{
+			Message: err.Error(),
+		})
+		return
+	}
+}
+
+func (a *agent) streamFile(ctx context.Context, rw http.ResponseWriter, path string, offset, limit int64) (int, error) {
+	if !filepath.IsAbs(path) {
+		return http.StatusBadRequest, xerrors.Errorf("file path must be absolute: %q", path)
+	}
+
+	f, err := a.filesystem.Open(path)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			status = http.StatusNotFound
+		case errors.Is(err, os.ErrPermission):
+			status = http.StatusForbidden
+		}
+		return status, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	if stat.IsDir() {
+		return http.StatusBadRequest, xerrors.Errorf("open %s: not a file", path)
+	}
+
+	size := stat.Size()
+	if limit == 0 {
+		limit = size
+	}
+	bytesRemaining := max(size-offset, 0)
+	bytesToRead := min(bytesRemaining, limit)
+
+	// Relying on just the file name for the mime type for now.
+	mimeType := mime.TypeByExtension(filepath.Ext(path))
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	rw.Header().Set("Content-Type", mimeType)
+	rw.Header().Set("Content-Length", strconv.FormatInt(bytesToRead, 10))
+	rw.WriteHeader(http.StatusOK)
+
+	reader := io.NewSectionReader(f, offset, bytesToRead)
+	_, err = io.Copy(rw, reader)
+	if err != nil && !errors.Is(err, io.EOF) && ctx.Err() == nil {
+		a.logger.Error(ctx, "workspace agent read file", slog.Error(err))
+	}
+
+	return 0, nil
+}

--- a/agent/files_test.go
+++ b/agent/files_test.go
@@ -1,0 +1,208 @@
+package agent_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent"
+	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+type testFs struct {
+	afero.Fs
+	// intercept can return an error for testing when a call fails.
+	intercept func(call, file string) error
+}
+
+func newTestFs(base afero.Fs, intercept func(call, file string) error) *testFs {
+	return &testFs{
+		Fs:        base,
+		intercept: intercept,
+	}
+}
+
+func (fs *testFs) Open(name string) (afero.File, error) {
+	if err := fs.intercept("open", name); err != nil {
+		return nil, err
+	}
+	return fs.Fs.Open(name)
+}
+
+func TestReadFile(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	noPermsFilePath := filepath.Join(tmpdir, "no-perms")
+	//nolint:dogsled
+	conn, _, _, fs, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, opts *agent.Options) {
+		opts.Filesystem = newTestFs(opts.Filesystem, func(call, file string) error {
+			if file == noPermsFilePath {
+				return os.ErrPermission
+			}
+			return nil
+		})
+	})
+
+	dirPath := filepath.Join(tmpdir, "a-directory")
+	err := fs.MkdirAll(dirPath, 0o755)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(tmpdir, "file")
+	err = afero.WriteFile(fs, filePath, []byte("content"), 0o644)
+	require.NoError(t, err)
+
+	imagePath := filepath.Join(tmpdir, "file.png")
+	err = afero.WriteFile(fs, imagePath, []byte("not really an image"), 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		path     string
+		limit    int64
+		offset   int64
+		bytes    []byte
+		mimeType string
+		errCode  int
+		error    string
+	}{
+		{
+			name:    "NoPath",
+			path:    "",
+			errCode: http.StatusBadRequest,
+			error:   "\"path\" is required",
+		},
+		{
+			name:    "RelativePath",
+			path:    "./relative",
+			errCode: http.StatusBadRequest,
+			error:   "file path must be absolute",
+		},
+		{
+			name:    "RelativePath",
+			path:    "also-relative",
+			errCode: http.StatusBadRequest,
+			error:   "file path must be absolute",
+		},
+		{
+			name:    "NegativeLimit",
+			path:    filePath,
+			limit:   -10,
+			errCode: http.StatusBadRequest,
+			error:   "value is negative",
+		},
+		{
+			name:    "NegativeOffset",
+			path:    filePath,
+			offset:  -10,
+			errCode: http.StatusBadRequest,
+			error:   "value is negative",
+		},
+		{
+			name:    "NonExistent",
+			path:    filepath.Join(tmpdir, "does-not-exist"),
+			errCode: http.StatusNotFound,
+			error:   "file does not exist",
+		},
+		{
+			name:    "IsDir",
+			path:    dirPath,
+			errCode: http.StatusBadRequest,
+			error:   "not a file",
+		},
+		{
+			name:    "NoPermissions",
+			path:    noPermsFilePath,
+			errCode: http.StatusForbidden,
+			error:   "permission denied",
+		},
+		{
+			name:  "Defaults",
+			path:  filePath,
+			bytes: []byte("content"),
+		},
+		{
+			name:  "Limit1",
+			path:  filePath,
+			limit: 1,
+			bytes: []byte("c"),
+		},
+		{
+			name:   "Offset1",
+			path:   filePath,
+			offset: 1,
+			bytes:  []byte("ontent"),
+		},
+		{
+			name:   "Limit1Offset2",
+			path:   filePath,
+			limit:  1,
+			offset: 2,
+			bytes:  []byte("n"),
+		},
+		{
+			name:   "Limit7Offset0",
+			path:   filePath,
+			limit:  7,
+			offset: 0,
+			bytes:  []byte("content"),
+		},
+		{
+			name:  "Limit100",
+			path:  filePath,
+			limit: 100,
+			bytes: []byte("content"),
+		},
+		{
+			name:   "Offset7",
+			path:   filePath,
+			offset: 7,
+			bytes:  []byte{},
+		},
+		{
+			name:   "Offset100",
+			path:   filePath,
+			offset: 100,
+			bytes:  []byte{},
+		},
+		{
+			name:     "MimeTypePng",
+			path:     imagePath,
+			bytes:    []byte("not really an image"),
+			mimeType: "image/png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+			defer cancel()
+
+			b, mimeType, err := conn.ReadFile(ctx, tt.path, tt.offset, tt.limit)
+			if tt.errCode != 0 {
+				require.Error(t, err)
+				cerr := coderdtest.SDKError(t, err)
+				require.Contains(t, cerr.Error(), tt.error)
+				require.Equal(t, tt.errCode, cerr.StatusCode())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.bytes, b)
+				expectedMimeType := tt.mimeType
+				if expectedMimeType == "" {
+					expectedMimeType = "application/octet-stream"
+				}
+				require.Equal(t, expectedMimeType, mimeType)
+			}
+		})
+	}
+}

--- a/coderd/httpapi/queryparams.go
+++ b/coderd/httpapi/queryparams.go
@@ -120,6 +120,27 @@ func (p *QueryParamParser) PositiveInt32(vals url.Values, def int32, queryParam 
 	return v
 }
 
+// PositiveInt64 function checks if the given value is 64-bit and positive.
+func (p *QueryParamParser) PositiveInt64(vals url.Values, def int64, queryParam string) int64 {
+	v, err := parseQueryParam(p, vals, func(v string) (int64, error) {
+		intValue, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		if intValue < 0 {
+			return 0, xerrors.Errorf("value is negative")
+		}
+		return intValue, nil
+	}, def, queryParam)
+	if err != nil {
+		p.Errors = append(p.Errors, codersdk.ValidationError{
+			Field:  queryParam,
+			Detail: fmt.Sprintf("Query param %q must be a valid 64-bit positive integer: %s", queryParam, err.Error()),
+		})
+	}
+	return v
+}
+
 // NullableBoolean will return a null sql value if no input is provided.
 // SQLc still uses sql.NullBool rather than the generic type. So converting from
 // the generic type is required.

--- a/codersdk/toolsdk/bash_test.go
+++ b/codersdk/toolsdk/bash_test.go
@@ -99,63 +99,6 @@ func TestWorkspaceBash(t *testing.T) {
 	})
 }
 
-func TestNormalizeWorkspaceInput(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on Windows: Workspace MCP bash tools rely on a Unix-like shell (bash) and POSIX/SSH semantics. Use Linux/macOS or WSL for these tests.")
-	}
-
-	testCases := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "SimpleWorkspace",
-			input:    "workspace",
-			expected: "workspace",
-		},
-		{
-			name:     "WorkspaceWithAgent",
-			input:    "workspace.agent",
-			expected: "workspace.agent",
-		},
-		{
-			name:     "OwnerAndWorkspace",
-			input:    "owner/workspace",
-			expected: "owner/workspace",
-		},
-		{
-			name:     "OwnerDashWorkspace",
-			input:    "owner--workspace",
-			expected: "owner/workspace",
-		},
-		{
-			name:     "OwnerWorkspaceAgent",
-			input:    "owner/workspace.agent",
-			expected: "owner/workspace.agent",
-		},
-		{
-			name:     "OwnerDashWorkspaceAgent",
-			input:    "owner--workspace.agent",
-			expected: "owner/workspace.agent",
-		},
-		{
-			name:     "CoderConnectFormat",
-			input:    "agent.workspace.owner", // Special Coder Connect reverse format
-			expected: "owner/workspace.agent",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			result := toolsdk.NormalizeWorkspaceInput(tc.input)
-			require.Equal(t, tc.expected, result, "Input %q should normalize to %q but got %q", tc.input, tc.expected, result)
-		})
-	}
-}
-
 func TestAllToolsIncludesBash(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -748,3 +748,57 @@ func TestReportTaskWithReporter(t *testing.T) {
 	// Verify response
 	require.Equal(t, "Thanks for reporting!", result.Message)
 }
+
+func TestNormalizeWorkspaceInput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "SimpleWorkspace",
+			input:    "workspace",
+			expected: "workspace",
+		},
+		{
+			name:     "WorkspaceWithAgent",
+			input:    "workspace.agent",
+			expected: "workspace.agent",
+		},
+		{
+			name:     "OwnerAndWorkspace",
+			input:    "owner/workspace",
+			expected: "owner/workspace",
+		},
+		{
+			name:     "OwnerDashWorkspace",
+			input:    "owner--workspace",
+			expected: "owner/workspace",
+		},
+		{
+			name:     "OwnerWorkspaceAgent",
+			input:    "owner/workspace.agent",
+			expected: "owner/workspace.agent",
+		},
+		{
+			name:     "OwnerDashWorkspaceAgent",
+			input:    "owner--workspace.agent",
+			expected: "owner/workspace.agent",
+		},
+		{
+			name:     "CoderConnectFormat",
+			input:    "agent.workspace.owner", // Special Coder Connect reverse format
+			expected: "owner/workspace.agent",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := toolsdk.NormalizeWorkspaceInput(tc.input)
+			require.Equal(t, tc.expected, result, "Input %q should normalize to %q but got %q", tc.input, tc.expected, result)
+		})
+	}
+}

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -60,7 +60,7 @@ type AgentConn interface {
 	PrometheusMetrics(ctx context.Context) ([]byte, error)
 	ReconnectingPTY(ctx context.Context, id uuid.UUID, height uint16, width uint16, command string, initOpts ...AgentReconnectingPTYInitOption) (net.Conn, error)
 	RecreateDevcontainer(ctx context.Context, devcontainerID string) (codersdk.Response, error)
-	ReadFile(ctx context.Context, path string, offset, limit int64) ([]byte, string, error)
+	ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error)
 	SSH(ctx context.Context) (*gonet.TCPConn, error)
 	SSHClient(ctx context.Context) (*ssh.Client, error)
 	SSHClientOnPort(ctx context.Context, port uint16) (*ssh.Client, error)
@@ -477,35 +477,20 @@ func (c *agentConn) RecreateDevcontainer(ctx context.Context, devcontainerID str
 	return m, nil
 }
 
-const maxFileLimit = 1 << 20 // 1MiB
-
-// ReadFile reads from a file from the workspace, returning the file's
-// (potentially partial) bytes and the mime type.
-func (c *agentConn) ReadFile(ctx context.Context, path string, offset, limit int64) ([]byte, string, error) {
+// ReadFile reads from a file from the workspace, returning a file reader and
+// the mime type.
+func (c *agentConn) ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	// Ideally we could stream this all the way back, but it looks like the MCP
-	// interfaces only allow returning full responses which means the whole thing
-	// has to be read into memory.  So, add a maximum to compensate.
-	if limit == 0 {
-		limit = maxFileLimit
-	} else if limit > maxFileLimit {
-		return nil, "", xerrors.Errorf("limit must be %d or less, got %d", maxFileLimit, limit)
-	}
-
+	//nolint:bodyclose // we want to return the body so the caller can stream.
 	res, err := c.apiRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v0/read-file?path=%s&offset=%d&limit=%d", path, offset, limit), nil)
 	if err != nil {
 		return nil, "", xerrors.Errorf("do request: %w", err)
 	}
-	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
+		// codersdk.ReadBodyAsError will close the body.
 		return nil, "", codersdk.ReadBodyAsError(res)
-	}
-
-	bs, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, "", xerrors.Errorf("read response body: %w", err)
 	}
 
 	mimeType := res.Header.Get("Content-Type")
@@ -513,7 +498,7 @@ func (c *agentConn) ReadFile(ctx context.Context, path string, offset, limit int
 		mimeType = "application/octet-stream"
 	}
 
-	return bs, mimeType, nil
+	return res.Body, mimeType, nil
 }
 
 // apiRequest makes a request to the workspace agent's HTTP API server.

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -232,6 +232,22 @@ func (mr *MockAgentConnMockRecorder) PrometheusMetrics(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrometheusMetrics", reflect.TypeOf((*MockAgentConn)(nil).PrometheusMetrics), ctx)
 }
 
+// ReadFile mocks base method.
+func (m *MockAgentConn) ReadFile(ctx context.Context, path string, offset, limit int64) ([]byte, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadFile", ctx, path, offset, limit)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReadFile indicates an expected call of ReadFile.
+func (mr *MockAgentConnMockRecorder) ReadFile(ctx, path, offset, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockAgentConn)(nil).ReadFile), ctx, path, offset, limit)
+}
+
 // ReconnectingPTY mocks base method.
 func (m *MockAgentConn) ReconnectingPTY(ctx context.Context, id uuid.UUID, height, width uint16, command string, initOpts ...workspacesdk.AgentReconnectingPTYInitOption) (net.Conn, error) {
 	m.ctrl.T.Helper()

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -233,10 +233,10 @@ func (mr *MockAgentConnMockRecorder) PrometheusMetrics(ctx any) *gomock.Call {
 }
 
 // ReadFile mocks base method.
-func (m *MockAgentConn) ReadFile(ctx context.Context, path string, offset, limit int64) ([]byte, string, error) {
+func (m *MockAgentConn) ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadFile", ctx, path, offset, limit)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2


### PR DESCRIPTION
Follows similarly to the bash tool (and some code to connect to an agent was extracted from it).

There are two main parts: a new agent endpoint, and then a new MCP tool that consumes that endpoint.