### PR TITLE
chore: refactor instance identity to be a SessionTokenProvider

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2952,9 +2952,12 @@ func TestAgent_Reconnect(t *testing.T) {
 	defer closer.Close()
 
 	call1 := testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
+	require.Equal(t, client.GetNumRefreshTokenCalls(), 1)
 	close(call1.Resps) // hang up
 	// expect reconnect
 	testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
+	// Check that the agent refreshes the token when it reconnects.
+	require.Equal(t, client.GetNumRefreshTokenCalls(), 2)
 	closer.Close()
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -22,7 +22,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2926,11 +2925,11 @@ func TestAgent_Speedtest(t *testing.T) {
 
 func TestAgent_Reconnect(t *testing.T) {
 	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
 	logger := testutil.Logger(t)
 	// After the agent is disconnected from a coordinator, it's supposed
 	// to reconnect!
-	coordinator := tailnet.NewCoordinator(logger)
-	defer coordinator.Close()
+	fCoordinator := tailnettest.NewFakeCoordinator()
 
 	agentID := uuid.New()
 	statsCh := make(chan *proto.Stats, 50)
@@ -2942,27 +2941,21 @@ func TestAgent_Reconnect(t *testing.T) {
 			DERPMap: derpMap,
 		},
 		statsCh,
-		coordinator,
+		fCoordinator,
 	)
 	defer client.Close()
-	initialized := atomic.Int32{}
+
 	closer := agent.New(agent.Options{
-		ExchangeToken: func(ctx context.Context) (string, error) {
-			initialized.Add(1)
-			return "", nil
-		},
 		Client: client,
 		Logger: logger.Named("agent"),
 	})
 	defer closer.Close()
 
-	require.Eventually(t, func() bool {
-		return coordinator.Node(agentID) != nil
-	}, testutil.WaitShort, testutil.IntervalFast)
-	client.LastWorkspaceAgent()
-	require.Eventually(t, func() bool {
-		return initialized.Load() == 2
-	}, testutil.WaitShort, testutil.IntervalFast)
+	call1 := testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
+	close(call1.Resps) // hang up
+	// expect reconnect
+	testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
+	closer.Close()
 }
 
 func TestAgent_WriteVSCodeConfigs(t *testing.T) {
@@ -2984,9 +2977,6 @@ func TestAgent_WriteVSCodeConfigs(t *testing.T) {
 	defer client.Close()
 	filesystem := afero.NewMemMapFs()
 	closer := agent.New(agent.Options{
-		ExchangeToken: func(ctx context.Context) (string, error) {
-			return "", nil
-		},
 		Client:     client,
 		Logger:     logger.Named("agent"),
 		Filesystem: filesystem,
@@ -3015,9 +3005,6 @@ func TestAgent_DebugServer(t *testing.T) {
 	conn, _, _, _, agnt := setupAgent(t, agentsdk.Manifest{
 		DERPMap: derpMap,
 	}, 0, func(c *agenttest.Client, o *agent.Options) {
-		o.ExchangeToken = func(context.Context) (string, error) {
-			return "token", nil
-		}
 		o.LogDir = logDir
 	})
 

--- a/agent/agenttest/agent.go
+++ b/agent/agenttest/agent.go
@@ -30,7 +30,7 @@ func New(t testing.TB, coderURL *url.URL, agentToken string, opts ...func(*agent
 	}
 
 	if o.Client == nil {
-		agentClient := agentsdk.New(coderURL, agentsdk.UsingFixedToken(agentToken))
+		agentClient := agentsdk.New(coderURL, agentsdk.WithFixedToken(agentToken))
 		agentClient.SDK.SetLogger(log)
 		o.Client = agentClient
 	}

--- a/agent/agenttest/agent.go
+++ b/agent/agenttest/agent.go
@@ -1,7 +1,6 @@
 package agenttest
 
 import (
-	"context"
 	"net/url"
 	"testing"
 
@@ -31,16 +30,9 @@ func New(t testing.TB, coderURL *url.URL, agentToken string, opts ...func(*agent
 	}
 
 	if o.Client == nil {
-		agentClient := agentsdk.New(coderURL)
-		agentClient.SetSessionToken(agentToken)
+		agentClient := agentsdk.New(coderURL, agentsdk.UsingFixedToken(agentToken))
 		agentClient.SDK.SetLogger(log)
 		o.Client = agentClient
-	}
-
-	if o.ExchangeToken == nil {
-		o.ExchangeToken = func(_ context.Context) (string, error) {
-			return agentToken, nil
-		}
 	}
 
 	if o.LogDir == "" {

--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -3,6 +3,7 @@ package agenttest
 import (
 	"context"
 	"io"
+	"net/http"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,7 @@ import (
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/websocket"
 )
 
 const statsInterval = 500 * time.Millisecond
@@ -90,6 +92,20 @@ type Client struct {
 	logs           []agentsdk.Log
 	derpMapUpdates chan *tailcfg.DERPMap
 	derpMapOnce    sync.Once
+}
+
+func (*Client) AsRequestOption() codersdk.RequestOption {
+	return func(_ *http.Request) {}
+}
+
+func (*Client) SetDialOption(*websocket.DialOptions) {}
+
+func (*Client) GetSessionToken() string {
+	return "agenttest-token"
+}
+
+func (*Client) RefreshToken(context.Context) error {
+	return nil
 }
 
 func (*Client) RewriteDERPMap(*tailcfg.DERPMap) {}

--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -88,10 +88,11 @@ type Client struct {
 	fakeAgentAPI       *FakeAgentAPI
 	LastWorkspaceAgent func()
 
-	mu             sync.Mutex // Protects following.
-	logs           []agentsdk.Log
-	derpMapUpdates chan *tailcfg.DERPMap
-	derpMapOnce    sync.Once
+	mu                sync.Mutex // Protects following.
+	logs              []agentsdk.Log
+	derpMapUpdates    chan *tailcfg.DERPMap
+	derpMapOnce       sync.Once
+	refreshTokenCalls int
 }
 
 func (*Client) AsRequestOption() codersdk.RequestOption {
@@ -104,8 +105,17 @@ func (*Client) GetSessionToken() string {
 	return "agenttest-token"
 }
 
-func (*Client) RefreshToken(context.Context) error {
+func (c *Client) RefreshToken(context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refreshTokenCalls++
 	return nil
+}
+
+func (c *Client) GetNumRefreshTokenCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.refreshTokenCalls
 }
 
 func (*Client) RewriteDERPMap(*tailcfg.DERPMap) {}

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -57,7 +57,7 @@ func workspaceAgent() *serpent.Command {
 		devcontainerProjectDiscovery   bool
 		devcontainerDiscoveryAutostart bool
 	)
-	agentAuth := NewAgentAuth()
+	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
 		Use:   "agent",
 		Short: `Starts the Coder workspace agent.`,
@@ -191,7 +191,7 @@ func workspaceAgent() *serpent.Command {
 			client.SDK.HTTPClient.Timeout = 30 * time.Second
 			// Attach header transport so we process --agent-header and
 			// --agent-header-command flags
-			headerTransport, err := headerTransport(ctx, agentAuth.agentURL, agentHeader, agentHeaderCommand)
+			headerTransport, err := headerTransport(ctx, &agentAuth.agentURL, agentHeader, agentHeaderCommand)
 			if err != nil {
 				return xerrors.Errorf("configure header transport: %w", err)
 			}

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -148,7 +148,7 @@ func (r *RootCmd) mcpConfigureClaudeCode() *serpent.Command {
 				binPath = testBinaryName
 			}
 			configureClaudeEnv := map[string]string{}
-			agentClient, err := r.createAgentClient()
+			agentClient, err := r.createAgentClient(inv.Context())
 			if err != nil {
 				cliui.Warnf(inv.Stderr, "failed to create agent client: %s", err)
 			} else {
@@ -494,7 +494,7 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 			}
 
 			// Try to create an agent client for status reporting.  Not validated.
-			agentClient, err := r.createAgentClient()
+			agentClient, err := r.createAgentClient(inv.Context())
 			if err == nil {
 				cliui.Infof(inv.Stderr, "Agent URL      : %s", agentClient.SDK.URL.String())
 				srv.agentClient = agentClient

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -131,7 +131,7 @@ func mcpConfigureClaudeCode() *serpent.Command {
 
 		deprecatedCoderMCPClaudeAPIKey string
 	)
-	agentAuth := NewAgentAuth()
+	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
 		Use:   "claude-code <project-directory>",
 		Short: "Configure the Claude Code server. You will need to run this command for each project you want to use. Specify the project directory as the first argument.",
@@ -405,7 +405,7 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 		appStatusSlug string
 		aiAgentAPIURL url.URL
 	)
-	agentAuth := NewAgentAuth()
+	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
 		Use: "server",
 		Handler: func(inv *serpent.Invocation) error {

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -56,7 +56,7 @@ func (r *RootCmd) mcpConfigure() *serpent.Command {
 		},
 		Children: []*serpent.Command{
 			r.mcpConfigureClaudeDesktop(),
-			r.mcpConfigureClaudeCode(),
+			mcpConfigureClaudeCode(),
 			r.mcpConfigureCursor(),
 		},
 	}
@@ -117,7 +117,7 @@ func (*RootCmd) mcpConfigureClaudeDesktop() *serpent.Command {
 	return cmd
 }
 
-func (r *RootCmd) mcpConfigureClaudeCode() *serpent.Command {
+func mcpConfigureClaudeCode() *serpent.Command {
 	var (
 		claudeAPIKey     string
 		claudeConfigPath string
@@ -131,6 +131,7 @@ func (r *RootCmd) mcpConfigureClaudeCode() *serpent.Command {
 
 		deprecatedCoderMCPClaudeAPIKey string
 	)
+	agentAuth := NewAgentAuth()
 	cmd := &serpent.Command{
 		Use:   "claude-code <project-directory>",
 		Short: "Configure the Claude Code server. You will need to run this command for each project you want to use. Specify the project directory as the first argument.",
@@ -148,7 +149,7 @@ func (r *RootCmd) mcpConfigureClaudeCode() *serpent.Command {
 				binPath = testBinaryName
 			}
 			configureClaudeEnv := map[string]string{}
-			agentClient, err := r.createAgentClient(inv.Context())
+			agentClient, err := agentAuth.CreateClient(inv.Context())
 			if err != nil {
 				cliui.Warnf(inv.Stderr, "failed to create agent client: %s", err)
 			} else {
@@ -292,6 +293,7 @@ func (r *RootCmd) mcpConfigureClaudeCode() *serpent.Command {
 			},
 		},
 	}
+	agentAuth.AttachOptions(cmd, false)
 	return cmd
 }
 
@@ -403,7 +405,8 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 		appStatusSlug string
 		aiAgentAPIURL url.URL
 	)
-	return &serpent.Command{
+	agentAuth := NewAgentAuth()
+	cmd := &serpent.Command{
 		Use: "server",
 		Handler: func(inv *serpent.Invocation) error {
 			var lastReport taskReport
@@ -494,7 +497,7 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 			}
 
 			// Try to create an agent client for status reporting.  Not validated.
-			agentClient, err := r.createAgentClient(inv.Context())
+			agentClient, err := agentAuth.CreateClient(inv.Context())
 			if err == nil {
 				cliui.Infof(inv.Stderr, "Agent URL      : %s", agentClient.SDK.URL.String())
 				srv.agentClient = agentClient
@@ -579,6 +582,8 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 			},
 		},
 	}
+	agentAuth.AttachOptions(cmd, false)
+	return cmd
 }
 
 func (s *mcpServer) startReporter(ctx context.Context, inv *serpent.Invocation) {

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -2,19 +2,16 @@ package cli
 
 import (
 	"encoding/json"
-	"fmt"
-
-	"golang.org/x/xerrors"
 
 	"github.com/tidwall/gjson"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
-	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 )
 
-func (r *RootCmd) externalAuth() *serpent.Command {
+func externalAuth() *serpent.Command {
 	return &serpent.Command{
 		Use:   "external-auth",
 		Short: "Manage external authentication",
@@ -23,14 +20,15 @@ func (r *RootCmd) externalAuth() *serpent.Command {
 			return i.Command.HelpHandler(i)
 		},
 		Children: []*serpent.Command{
-			r.externalAuthAccessToken(),
+			externalAuthAccessToken(),
 		},
 	}
 }
 
-func (r *RootCmd) externalAuthAccessToken() *serpent.Command {
+func externalAuthAccessToken() *serpent.Command {
 	var extra string
-	return &serpent.Command{
+	agentAuth := NewAgentAuth()
+	cmd := &serpent.Command{
 		Use:   "access-token <provider>",
 		Short: "Print auth for an external provider",
 		Long: "Print an access-token for an external auth provider. " +
@@ -70,12 +68,7 @@ fi
 			ctx, stop := inv.SignalNotifyContext(ctx, StopSignals...)
 			defer stop()
 
-			if r.agentToken == "" {
-				_, _ = fmt.Fprint(inv.Stderr, pretty.Sprintf(headLineStyle(), "No agent token found, this command must be run from inside a running workspace.\n"))
-				return xerrors.Errorf("agent token not found")
-			}
-
-			client, err := r.createAgentClient(ctx)
+			client, err := agentAuth.CreateClient(ctx)
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}
@@ -115,4 +108,6 @@ fi
 			return nil
 		},
 	}
+	agentAuth.AttachOptions(cmd, false)
+	return cmd
 }

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -75,7 +75,7 @@ fi
 				return xerrors.Errorf("agent token not found")
 			}
 
-			client, err := r.tryCreateAgentClient()
+			client, err := r.createAgentClient(ctx)
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -27,7 +27,7 @@ func externalAuth() *serpent.Command {
 
 func externalAuthAccessToken() *serpent.Command {
 	var extra string
-	agentAuth := NewAgentAuth()
+	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
 		Use:   "access-token <provider>",
 		Short: "Print auth for an external provider",

--- a/cli/gitaskpass.go
+++ b/cli/gitaskpass.go
@@ -33,7 +33,7 @@ func (r *RootCmd) gitAskpass() *serpent.Command {
 				return xerrors.Errorf("parse host: %w", err)
 			}
 
-			client, err := r.tryCreateAgentClient()
+			client, err := r.createAgentClient(ctx)
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/gitaskpass.go
+++ b/cli/gitaskpass.go
@@ -18,8 +18,8 @@ import (
 
 // gitAskpass is used by the Coder agent to automatically authenticate
 // with Git providers based on a hostname.
-func (r *RootCmd) gitAskpass() *serpent.Command {
-	return &serpent.Command{
+func gitAskpass(agentAuth *AgentAuth) *serpent.Command {
+	cmd := &serpent.Command{
 		Use:    "gitaskpass",
 		Hidden: true,
 		Handler: func(inv *serpent.Invocation) error {
@@ -33,7 +33,7 @@ func (r *RootCmd) gitAskpass() *serpent.Command {
 				return xerrors.Errorf("parse host: %w", err)
 			}
 
-			client, err := r.createAgentClient(ctx)
+			client, err := agentAuth.CreateClient(ctx)
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}
@@ -90,4 +90,6 @@ func (r *RootCmd) gitAskpass() *serpent.Command {
 			return nil
 		},
 	}
+	agentAuth.AttachOptions(cmd, false)
+	return cmd
 }

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -38,7 +38,7 @@ func (r *RootCmd) gitssh() *serpent.Command {
 				return err
 			}
 
-			client, err := r.tryCreateAgentClient()
+			client, err := r.createAgentClient(ctx)
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -19,7 +19,7 @@ import (
 )
 
 func gitssh() *serpent.Command {
-	agentAuth := NewAgentAuth()
+	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
 		Use:    "gitssh",
 		Hidden: true,

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -18,7 +18,8 @@ import (
 	"github.com/coder/serpent"
 )
 
-func (r *RootCmd) gitssh() *serpent.Command {
+func gitssh() *serpent.Command {
+	agentAuth := NewAgentAuth()
 	cmd := &serpent.Command{
 		Use:    "gitssh",
 		Hidden: true,
@@ -38,7 +39,7 @@ func (r *RootCmd) gitssh() *serpent.Command {
 				return err
 			}
 
-			client, err := r.createAgentClient(ctx)
+			client, err := agentAuth.CreateClient(ctx)
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}
@@ -108,7 +109,7 @@ func (r *RootCmd) gitssh() *serpent.Command {
 			return nil
 		},
 	}
-
+	agentAuth.AttachOptions(cmd, false)
 	return cmd
 }
 

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -54,8 +54,7 @@ func prepareTestGitSSH(ctx context.Context, t *testing.T) (*agentsdk.Client, str
 	}).WithAgent().Do()
 
 	// start workspace agent
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 	_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
 		o.Client = agentClient
 	})

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -54,7 +54,7 @@ func prepareTestGitSSH(ctx context.Context, t *testing.T) (*agentsdk.Client, str
 	}).WithAgent().Do()
 
 	// start workspace agent
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 	_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
 		o.Client = agentClient
 	})

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -24,9 +24,6 @@ OPTIONS:
           requests. The command must output each header as `key=value` on its
           own line.
 
-      --auth string, $CODER_AGENT_AUTH (default: token)
-          Specify the authentication type to use for the agent.
-
       --block-file-transfer bool, $CODER_AGENT_BLOCK_FILE_TRANSFER (default: false)
           Block file transfer using known applications: nc,rsync,scp,sftp.
 

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -6,6 +6,18 @@ USAGE:
   Starts the Coder workspace agent.
 
 OPTIONS:
+      --auth string, $CODER_AGENT_AUTH (default: token)
+          Specify the authentication type to use for the agent.
+
+      --agent-token string, $CODER_AGENT_TOKEN
+          An agent authentication token.
+
+      --agent-token-file string, $CODER_AGENT_TOKEN_FILE
+          A file containing an agent authentication token.
+
+      --agent-url url, $CODER_AGENT_URL
+          URL for an agent to access your deployment.
+
       --log-human string, $CODER_AGENT_LOGGING_HUMAN (default: /dev/stderr)
           Output human-readable logs to a given file.
 

--- a/cli/testdata/coder_external-auth_access-token_--help.golden
+++ b/cli/testdata/coder_external-auth_access-token_--help.golden
@@ -25,6 +25,18 @@ USAGE:
        $ coder external-auth access-token slack --extra "authed_user.id"
 
 OPTIONS:
+      --auth string, $CODER_AGENT_AUTH (default: token)
+          Specify the authentication type to use for the agent.
+
+      --agent-token string, $CODER_AGENT_TOKEN
+          An agent authentication token.
+
+      --agent-token-file string, $CODER_AGENT_TOKEN_FILE
+          A file containing an agent authentication token.
+
+      --agent-url url, $CODER_AGENT_URL
+          URL for an agent to access your deployment.
+
       --extra string
           Extract a field from the "extra" properties of the OAuth token.
 

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -432,8 +432,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(authToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 		_, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com",
 		})
@@ -464,8 +463,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(authToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 		token, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com/asd/asd",
 		})
@@ -565,8 +563,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(authToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 		resp := coderdtest.RequestExternalAuthCallback(t, "github", client)
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
@@ -627,8 +624,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(authToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 		token, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com/asd/asd",
@@ -674,8 +670,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(authToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 		token, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com/asd/asd",
@@ -740,8 +735,7 @@ func TestExternalAuthCallback(t *testing.T) {
 				workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 				coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-				agentClient := agentsdk.New(client.URL)
-				agentClient.SetSessionToken(authToken)
+				agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 				token, err := agentClient.ExternalAuth(t.Context(), agentsdk.ExternalAuthRequest{
 					Match: "github.com/asd/asd",

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -432,7 +432,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 		_, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com",
 		})
@@ -463,7 +463,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 		token, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com/asd/asd",
 		})
@@ -563,7 +563,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 		resp := coderdtest.RequestExternalAuthCallback(t, "github", client)
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
@@ -624,7 +624,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 		token, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com/asd/asd",
@@ -670,7 +670,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 		token, err := agentClient.ExternalAuth(context.Background(), agentsdk.ExternalAuthRequest{
 			Match: "github.com/asd/asd",
@@ -735,7 +735,7 @@ func TestExternalAuthCallback(t *testing.T) {
 				workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 				coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-				agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+				agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 				token, err := agentClient.ExternalAuth(t.Context(), agentsdk.ExternalAuthRequest{
 					Match: "github.com/asd/asd",

--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -118,7 +118,7 @@ func TestAgentGitSSHKey(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, project.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
@@ -156,7 +156,7 @@ func TestAgentGitSSHKey_APIKeyScopes(t *testing.T) {
 			workspace := coderdtest.CreateWorkspace(t, client, project.ID)
 			coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-			agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+			agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()

--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -118,8 +118,7 @@ func TestAgentGitSSHKey(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, project.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(authToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
@@ -157,8 +156,7 @@ func TestAgentGitSSHKey_APIKeyScopes(t *testing.T) {
 			workspace := coderdtest.CreateWorkspace(t, client, project.ID)
 			coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-			agentClient := agentsdk.New(client.URL)
-			agentClient.SetSessionToken(authToken)
+			agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 			defer cancel()

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -585,7 +585,7 @@ func TestTemplateInsights_Golden(t *testing.T) {
 						continue
 					}
 					authToken := uuid.New()
-					agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken.String()))
+					agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken.String()))
 					workspace.agentClient = agentClient
 
 					var apps []*proto.App
@@ -1493,7 +1493,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 						continue
 					}
 					authToken := uuid.New()
-					agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken.String()))
+					agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken.String()))
 					workspace.agentClient = agentClient
 
 					var apps []*proto.App

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -585,8 +585,7 @@ func TestTemplateInsights_Golden(t *testing.T) {
 						continue
 					}
 					authToken := uuid.New()
-					agentClient := agentsdk.New(client.URL)
-					agentClient.SetSessionToken(authToken.String())
+					agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken.String()))
 					workspace.agentClient = agentClient
 
 					var apps []*proto.App
@@ -1494,8 +1493,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 						continue
 					}
 					authToken := uuid.New()
-					agentClient := agentsdk.New(client.URL)
-					agentClient.SetSessionToken(authToken.String())
+					agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken.String()))
 					workspace.agentClient = agentClient
 
 					var apps []*proto.App

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -90,7 +90,7 @@ func TestCollectInsights(t *testing.T) {
 	// Start an agent so that we can generate stats.
 	var agentClients []agentproto.DRPCAgentClient
 	for i, agent := range []database.WorkspaceAgent{agent1, agent2} {
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(agent.AuthToken.String()))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(agent.AuthToken.String()))
 		agentClient.SDK.SetLogger(logger.Leveled(slog.LevelDebug).Named(fmt.Sprintf("agent%d", i+1)))
 		conn, err := agentClient.ConnectRPC(context.Background())
 		require.NoError(t, err)

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -90,8 +90,7 @@ func TestCollectInsights(t *testing.T) {
 	// Start an agent so that we can generate stats.
 	var agentClients []agentproto.DRPCAgentClient
 	for i, agent := range []database.WorkspaceAgent{agent1, agent2} {
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(agent.AuthToken.String())
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(agent.AuthToken.String()))
 		agentClient.SDK.SetLogger(logger.Leveled(slog.LevelDebug).Named(fmt.Sprintf("agent%d", i+1)))
 		conn, err := agentClient.ConnectRPC(context.Background())
 		require.NoError(t, err)

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -875,8 +875,7 @@ func prepareWorkspaceAndAgent(ctx context.Context, t *testing.T, client *codersd
 	})
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-	ac := agentsdk.New(client.URL)
-	ac.SetSessionToken(authToken)
+	ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 	conn, err := ac.ConnectRPC(ctx)
 	require.NoError(t, err)
 	agentAPI := agentproto.NewDRPCAgentClient(conn)

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -875,7 +875,7 @@ func prepareWorkspaceAndAgent(ctx context.Context, t *testing.T, client *codersd
 	})
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-	ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+	ac := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 	conn, err := ac.ConnectRPC(ctx)
 	require.NoError(t, err)
 	agentAPI := agentproto.NewDRPCAgentClient(conn)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -228,7 +228,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 		err := agentClient.PatchLogs(ctx, agentsdk.PatchLogs{
 			Logs: []agentsdk.Log{
 				{
@@ -268,7 +268,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 		err := agentClient.PatchLogs(ctx, agentsdk.PatchLogs{
 			Logs: []agentsdk.Log{
 				{
@@ -312,7 +312,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		updates, err := client.WatchWorkspace(ctx, r.Workspace.ID)
 		require.NoError(t, err)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 		err = agentClient.PatchLogs(ctx, agentsdk.PatchLogs{
 			Logs: []agentsdk.Log{{
 				CreatedAt: dbtime.Now(),
@@ -357,7 +357,7 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 		return a
 	}).Do()
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -538,7 +538,7 @@ func TestWorkspaceAgentConnectRPC(t *testing.T) {
 		require.NoError(t, err)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, stopBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 		_, err = agentClient.ConnectRPC(ctx)
 		require.Error(t, err)
@@ -563,7 +563,7 @@ func TestWorkspaceAgentConnectRPC(t *testing.T) {
 		)
 		require.NoError(t, err)
 		// Then: the agent token should no longer be valid
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken((wsb.AgentToken)))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken((wsb.AgentToken)))
 		_, err = agentClient.ConnectRPC(ctx)
 		require.Error(t, err)
 		var sdkErr *codersdk.Error
@@ -884,7 +884,7 @@ func TestWorkspaceAgentTailnetDirectDisabled(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	// Verify that the manifest has DisableDirectConnections set to true.
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 	rpc, err := agentClient.ConnectRPC(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -1735,7 +1735,7 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 	conn, err := agentClient.ConnectRPC(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -1810,7 +1810,7 @@ func TestWorkspaceAgentPostLogSource(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 		req := agentsdk.PostLogSourceRequest{
 			ID:          uuid.New(),
@@ -1858,7 +1858,7 @@ func TestWorkspaceAgent_LifecycleState(t *testing.T) {
 			}
 		}
 
-		ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		ac := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 		conn, err := ac.ConnectRPC(ctx)
 		require.NoError(t, err)
 		defer func() {
@@ -1955,7 +1955,7 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 		}
 	}
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	conn, err := agentClient.ConnectRPC(ctx)
@@ -2218,7 +2218,7 @@ func TestWorkspaceAgent_Metadata_CatchMemoryLeak(t *testing.T) {
 		}
 	}
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	conn, err := agentClient.ConnectRPC(ctx)
@@ -2323,7 +2323,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
@@ -2369,7 +2369,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
@@ -2533,7 +2533,7 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 			return agents
 		}).Do()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 		// We need to include an invalid oauth token that is not expired.
 		dbgen.ExternalAuthLink(t, db, database.ExternalAuthLink{
@@ -3013,7 +3013,7 @@ func TestReinit(t *testing.T) {
 	pubsubSpy.Unlock()
 
 	agentCtx := testutil.Context(t, testutil.WaitShort)
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
 	agentReinitializedCh := make(chan *agentsdk.ReinitializationEvent)
 	go func() {

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -228,8 +228,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 		err := agentClient.PatchLogs(ctx, agentsdk.PatchLogs{
 			Logs: []agentsdk.Log{
 				{
@@ -269,8 +268,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 		err := agentClient.PatchLogs(ctx, agentsdk.PatchLogs{
 			Logs: []agentsdk.Log{
 				{
@@ -314,8 +312,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		updates, err := client.WatchWorkspace(ctx, r.Workspace.ID)
 		require.NoError(t, err)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 		err = agentClient.PatchLogs(ctx, agentsdk.PatchLogs{
 			Logs: []agentsdk.Log{{
 				CreatedAt: dbtime.Now(),
@@ -360,8 +357,7 @@ func TestWorkspaceAgentAppStatus(t *testing.T) {
 		return a
 	}).Do()
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -542,8 +538,7 @@ func TestWorkspaceAgentConnectRPC(t *testing.T) {
 		require.NoError(t, err)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, stopBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(authToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 		_, err = agentClient.ConnectRPC(ctx)
 		require.Error(t, err)
@@ -568,8 +563,7 @@ func TestWorkspaceAgentConnectRPC(t *testing.T) {
 		)
 		require.NoError(t, err)
 		// Then: the agent token should no longer be valid
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(wsb.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken((wsb.AgentToken)))
 		_, err = agentClient.ConnectRPC(ctx)
 		require.Error(t, err)
 		var sdkErr *codersdk.Error
@@ -890,8 +884,7 @@ func TestWorkspaceAgentTailnetDirectDisabled(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	// Verify that the manifest has DisableDirectConnections set to true.
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 	rpc, err := agentClient.ConnectRPC(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -1742,8 +1735,7 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 	conn, err := agentClient.ConnectRPC(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -1818,8 +1810,7 @@ func TestWorkspaceAgentPostLogSource(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 		req := agentsdk.PostLogSourceRequest{
 			ID:          uuid.New(),
@@ -1867,8 +1858,7 @@ func TestWorkspaceAgent_LifecycleState(t *testing.T) {
 			}
 		}
 
-		ac := agentsdk.New(client.URL)
-		ac.SetSessionToken(r.AgentToken)
+		ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 		conn, err := ac.ConnectRPC(ctx)
 		require.NoError(t, err)
 		defer func() {
@@ -1965,8 +1955,7 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 		}
 	}
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	conn, err := agentClient.ConnectRPC(ctx)
@@ -2229,8 +2218,7 @@ func TestWorkspaceAgent_Metadata_CatchMemoryLeak(t *testing.T) {
 		}
 	}
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	conn, err := agentClient.ConnectRPC(ctx)
@@ -2335,8 +2323,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
@@ -2382,8 +2369,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
@@ -2547,8 +2533,7 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 			return agents
 		}).Do()
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 		// We need to include an invalid oauth token that is not expired.
 		dbgen.ExternalAuthLink(t, db, database.ExternalAuthLink{
@@ -3028,8 +3013,7 @@ func TestReinit(t *testing.T) {
 	pubsubSpy.Unlock()
 
 	agentCtx := testutil.Context(t, testutil.WaitShort)
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 
 	agentReinitializedCh := make(chan *agentsdk.ReinitializationEvent)
 	go func() {

--- a/coderd/workspaceagentsrpc_test.go
+++ b/coderd/workspaceagentsrpc_test.go
@@ -68,7 +68,7 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 				},
 			).Do()
 
-			ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+			ac := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 			conn, err := ac.ConnectRPC(context.Background())
 			require.NoError(t, err)
 			defer func() {
@@ -154,7 +154,7 @@ func TestAgentAPI_LargeManifest(t *testing.T) {
 				agents[0].ApiKeyScope = string(tc.apiKeyScope)
 				return agents
 			}).Do()
-			ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+			ac := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 			conn, err := ac.ConnectRPC(ctx)
 			defer func() {
 				_ = conn.Close()

--- a/coderd/workspaceagentsrpc_test.go
+++ b/coderd/workspaceagentsrpc_test.go
@@ -68,8 +68,7 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 				},
 			).Do()
 
-			ac := agentsdk.New(client.URL)
-			ac.SetSessionToken(r.AgentToken)
+			ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 			conn, err := ac.ConnectRPC(context.Background())
 			require.NoError(t, err)
 			defer func() {
@@ -155,8 +154,7 @@ func TestAgentAPI_LargeManifest(t *testing.T) {
 				agents[0].ApiKeyScope = string(tc.apiKeyScope)
 				return agents
 			}).Do()
-			ac := agentsdk.New(client.URL)
-			ac.SetSessionToken(r.AgentToken)
+			ac := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 			conn, err := ac.ConnectRPC(ctx)
 			defer func() {
 				_ = conn.Close()

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -482,7 +482,7 @@ func createWorkspaceWithApps(t *testing.T, client *codersdk.Client, orgID uuid.U
 		require.Equal(t, appURL.String(), app.SubdomainName)
 	}
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 	// TODO (@dean): currently, the primary app host is used when generating
 	// the port URL we tell the agent to use. We don't have any plans to change

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -482,8 +482,7 @@ func createWorkspaceWithApps(t *testing.T, client *codersdk.Client, orgID uuid.U
 		require.Equal(t, appURL.String(), app.SubdomainName)
 	}
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(authToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 	// TODO (@dean): currently, the primary app host is used when generating
 	// the port URL we tell the agent to use. We don't have any plans to change

--- a/coderd/workspaceresourceauth_test.go
+++ b/coderd/workspaceresourceauth_test.go
@@ -51,11 +51,9 @@ func TestPostWorkspaceAuthAzureInstanceIdentity(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	client.HTTPClient = metadataClient
-	agentClient := &agentsdk.Client{
-		SDK: client,
-	}
-	_, err := agentClient.AuthAzureInstanceIdentity(ctx)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingAzureInstanceIdentity())
+	agentClient.SDK.HTTPClient = metadataClient
+	err := agentClient.RefreshToken(ctx)
 	require.NoError(t, err)
 }
 
@@ -97,11 +95,9 @@ func TestPostWorkspaceAuthAWSInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		client.HTTPClient = metadataClient
-		agentClient := &agentsdk.Client{
-			SDK: client,
-		}
-		_, err := agentClient.AuthAWSInstanceIdentity(ctx)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingAWSInstanceIdentity())
+		agentClient.SDK.HTTPClient = metadataClient
+		err := agentClient.RefreshToken(ctx)
 		require.NoError(t, err)
 	})
 }
@@ -119,10 +115,8 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := &agentsdk.Client{
-			SDK: client,
-		}
-		_, err := agentClient.AuthGoogleInstanceIdentity(ctx, "", metadata)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingGoogleInstanceIdentity("", metadata))
+		err := agentClient.RefreshToken(ctx)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
@@ -139,10 +133,8 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := &agentsdk.Client{
-			SDK: client,
-		}
-		_, err := agentClient.AuthGoogleInstanceIdentity(ctx, "", metadata)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingGoogleInstanceIdentity("", metadata))
+		err := agentClient.RefreshToken(ctx)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
@@ -184,10 +176,8 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := &agentsdk.Client{
-			SDK: client,
-		}
-		_, err := agentClient.AuthGoogleInstanceIdentity(ctx, "", metadata)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingGoogleInstanceIdentity("", metadata))
+		err := agentClient.RefreshToken(ctx)
 		require.NoError(t, err)
 	})
 }

--- a/coderd/workspaceresourceauth_test.go
+++ b/coderd/workspaceresourceauth_test.go
@@ -51,7 +51,7 @@ func TestPostWorkspaceAuthAzureInstanceIdentity(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingAzureInstanceIdentity())
+	agentClient := agentsdk.New(client.URL, agentsdk.WithAzureInstanceIdentity())
 	agentClient.SDK.HTTPClient = metadataClient
 	err := agentClient.RefreshToken(ctx)
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestPostWorkspaceAuthAWSInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingAWSInstanceIdentity())
+		agentClient := agentsdk.New(client.URL, agentsdk.WithAWSInstanceIdentity())
 		agentClient.SDK.HTTPClient = metadataClient
 		err := agentClient.RefreshToken(ctx)
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingGoogleInstanceIdentity("", metadata))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithGoogleInstanceIdentity("", metadata))
 		err := agentClient.RefreshToken(ctx)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
@@ -133,7 +133,7 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingGoogleInstanceIdentity("", metadata))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithGoogleInstanceIdentity("", metadata))
 		err := agentClient.RefreshToken(ctx)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
@@ -176,7 +176,7 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingGoogleInstanceIdentity("", metadata))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithGoogleInstanceIdentity("", metadata))
 		err := agentClient.RefreshToken(ctx)
 		require.NoError(t, err)
 	})

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -414,7 +414,7 @@ func (FixedSessionTokenProvider) RefreshToken(_ context.Context) error {
 	return nil
 }
 
-func UsingFixedToken(token string) SessionTokenSetup {
+func WithFixedToken(token string) SessionTokenSetup {
 	return func(_ *codersdk.Client) RefreshableSessionTokenProvider {
 		return FixedSessionTokenProvider{FixedSessionTokenProvider: codersdk.FixedSessionTokenProvider{SessionToken: token}}
 	}

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"sync"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
 	"github.com/google/uuid"
 	"github.com/hashicorp/yamux"
 	"golang.org/x/xerrors"
@@ -37,22 +37,29 @@ import (
 // log-source. This should be removed in the future.
 var ExternalLogSourceID = uuid.MustParse("3b579bf4-1ed8-4b99-87a8-e9a1e3410410")
 
-// New returns a client that is used to interact with the
-// Coder API from a workspace agent.
-func New(serverURL *url.URL) *Client {
+// SessionTokenSetup is a function that creates the token provider while setting up the workspace agent. We do it this
+// way because cloud instance identity (AWS, Azure, Google, etc.) requires interacting with coderd to exchange tokens.
+// This means that the token providers need a codersdk.Client. However, the SessionTokenProvider is itself used by
+// the client to authenticate requests. Thus, the dependency is bidirectional. Functions of this type are used in
+// New() to ensure that things are set up correctly so there is only one instance of the codersdk.Client created.
+// @typescript-ignore SessionTokenSetup
+type SessionTokenSetup func(client *codersdk.Client) RefreshableSessionTokenProvider
+
+func New(serverURL *url.URL, setup SessionTokenSetup) *Client {
+	c := codersdk.New(serverURL)
+	provider := setup(c)
+	c.SessionTokenProvider = provider
 	return &Client{
-		SDK: codersdk.New(serverURL),
+		SDK:                             c,
+		RefreshableSessionTokenProvider: provider,
 	}
 }
 
 // Client wraps `codersdk.Client` with specific functions
 // scoped to a workspace agent.
 type Client struct {
+	RefreshableSessionTokenProvider
 	SDK *codersdk.Client
-}
-
-func (c *Client) SetSessionToken(token string) {
-	c.SDK.SetSessionToken(token)
 }
 
 type GitSSHKey struct {
@@ -326,146 +333,91 @@ type AuthenticateResponse struct {
 	SessionToken string `json:"session_token"`
 }
 
-type GoogleInstanceIdentityToken struct {
-	JSONWebToken string `json:"json_web_token" validate:"required"`
+// RefreshableSessionTokenProvider is a SessionTokenProvider that can be refreshed, for example, via token exchange.
+// @typescript-ignore RefreshableSessionTokenProvider
+type RefreshableSessionTokenProvider interface {
+	codersdk.SessionTokenProvider
+	RefreshToken(ctx context.Context) error
 }
 
-// AuthWorkspaceGoogleInstanceIdentity uses the Google Compute Engine Metadata API to
-// fetch a signed JWT, and exchange it for a session token for a workspace agent.
-//
-// The requesting instance must be registered as a resource in the latest history for a workspace.
-func (c *Client) AuthGoogleInstanceIdentity(ctx context.Context, serviceAccount string, gcpClient *metadata.Client) (AuthenticateResponse, error) {
-	if serviceAccount == "" {
-		// This is the default name specified by Google.
-		serviceAccount = "default"
-	}
-	if gcpClient == nil {
-		gcpClient = metadata.NewClient(c.SDK.HTTPClient)
-	}
-	// "format=full" is required, otherwise the responding payload will be missing "instance_id".
-	jwt, err := gcpClient.Get(fmt.Sprintf("instance/service-accounts/%s/identity?audience=coder&format=full", serviceAccount))
-	if err != nil {
-		return AuthenticateResponse{}, xerrors.Errorf("get metadata identity: %w", err)
-	}
-	res, err := c.SDK.Request(ctx, http.MethodPost, "/api/v2/workspaceagents/google-instance-identity", GoogleInstanceIdentityToken{
-		JSONWebToken: jwt,
-	})
-	if err != nil {
-		return AuthenticateResponse{}, err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
-	}
-	var resp AuthenticateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
+// instanceIdentitySessionTokenProvider implements RefreshableSessionTokenProvider via token exchange for a cloud
+// compute instance identity.
+// @typescript-ignore instanceIdentitySessionTokenProvider
+type instanceIdentitySessionTokenProvider struct {
+	tokenExchanger tokenExchanger
+	logger         slog.Logger
+
+	// cache so we don't request each time
+	mu           sync.Mutex
+	sessionToken string
 }
 
-type AWSInstanceIdentityToken struct {
-	Signature string `json:"signature" validate:"required"`
-	Document  string `json:"document" validate:"required"`
+// tokenExchanger obtains a session token by exchanging a cloud instance identity credential for a Coder session token.
+// @typescript-ignore tokenExchanger
+type tokenExchanger interface {
+	exchange(ctx context.Context) (AuthenticateResponse, error)
 }
 
-// AuthWorkspaceAWSInstanceIdentity uses the Amazon Metadata API to
-// fetch a signed payload, and exchange it for a session token for a workspace agent.
-//
-// The requesting instance must be registered as a resource in the latest history for a workspace.
-func (c *Client) AuthAWSInstanceIdentity(ctx context.Context) (AuthenticateResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://169.254.169.254/latest/api/token", nil)
-	if err != nil {
-		return AuthenticateResponse{}, nil
+func (i *instanceIdentitySessionTokenProvider) AsRequestOption() codersdk.RequestOption {
+	t := i.GetSessionToken()
+	return func(req *http.Request) {
+		req.Header.Set(codersdk.SessionTokenHeader, t)
 	}
-	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "21600")
-	res, err := c.SDK.HTTPClient.Do(req)
-	if err != nil {
-		return AuthenticateResponse{}, err
-	}
-	defer res.Body.Close()
-	token, err := io.ReadAll(res.Body)
-	if err != nil {
-		return AuthenticateResponse{}, xerrors.Errorf("read token: %w", err)
-	}
-
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/dynamic/instance-identity/signature", nil)
-	if err != nil {
-		return AuthenticateResponse{}, nil
-	}
-	req.Header.Set("X-aws-ec2-metadata-token", string(token))
-	res, err = c.SDK.HTTPClient.Do(req)
-	if err != nil {
-		return AuthenticateResponse{}, err
-	}
-	defer res.Body.Close()
-	signature, err := io.ReadAll(res.Body)
-	if err != nil {
-		return AuthenticateResponse{}, xerrors.Errorf("read token: %w", err)
-	}
-
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/dynamic/instance-identity/document", nil)
-	if err != nil {
-		return AuthenticateResponse{}, nil
-	}
-	req.Header.Set("X-aws-ec2-metadata-token", string(token))
-	res, err = c.SDK.HTTPClient.Do(req)
-	if err != nil {
-		return AuthenticateResponse{}, err
-	}
-	defer res.Body.Close()
-	document, err := io.ReadAll(res.Body)
-	if err != nil {
-		return AuthenticateResponse{}, xerrors.Errorf("read token: %w", err)
-	}
-
-	res, err = c.SDK.Request(ctx, http.MethodPost, "/api/v2/workspaceagents/aws-instance-identity", AWSInstanceIdentityToken{
-		Signature: string(signature),
-		Document:  string(document),
-	})
-	if err != nil {
-		return AuthenticateResponse{}, err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
-	}
-	var resp AuthenticateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-type AzureInstanceIdentityToken struct {
-	Signature string `json:"signature" validate:"required"`
-	Encoding  string `json:"encoding" validate:"required"`
+func (i *instanceIdentitySessionTokenProvider) SetDialOption(opts *websocket.DialOptions) {
+	t := i.GetSessionToken()
+	if opts.HTTPHeader == nil {
+		opts.HTTPHeader = http.Header{}
+	}
+	if opts.HTTPHeader.Get(codersdk.SessionTokenHeader) == "" {
+		opts.HTTPHeader.Set(codersdk.SessionTokenHeader, t)
+	}
 }
 
-// AuthWorkspaceAzureInstanceIdentity uses the Azure Instance Metadata Service to
-// fetch a signed payload, and exchange it for a session token for a workspace agent.
-func (c *Client) AuthAzureInstanceIdentity(ctx context.Context) (AuthenticateResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/metadata/attested/document?api-version=2020-09-01", nil)
-	if err != nil {
-		return AuthenticateResponse{}, nil
+func (i *instanceIdentitySessionTokenProvider) GetSessionToken() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.sessionToken != "" {
+		return i.sessionToken
 	}
-	req.Header.Set("Metadata", "true")
-	res, err := c.SDK.HTTPClient.Do(req)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	resp, err := i.tokenExchanger.exchange(ctx)
 	if err != nil {
-		return AuthenticateResponse{}, err
+		i.logger.Error(ctx, "failed to exchange session token: %v", err)
+		return ""
 	}
-	defer res.Body.Close()
+	i.sessionToken = resp.SessionToken
+	return i.sessionToken
+}
 
-	var token AzureInstanceIdentityToken
-	err = json.NewDecoder(res.Body).Decode(&token)
+func (i *instanceIdentitySessionTokenProvider) RefreshToken(ctx context.Context) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	resp, err := i.tokenExchanger.exchange(ctx)
 	if err != nil {
-		return AuthenticateResponse{}, err
+		return err
 	}
+	i.sessionToken = resp.SessionToken
+	return nil
+}
 
-	res, err = c.SDK.Request(ctx, http.MethodPost, "/api/v2/workspaceagents/azure-instance-identity", token)
-	if err != nil {
-		return AuthenticateResponse{}, err
+// FixedSessionTokenProvider wraps the codersdk variant to add a no-op RefreshToken method to satisfy the
+// RefreshableSessionTokenProvider interface.
+// @typescript-ignore FixedSessionTokenProvider
+type FixedSessionTokenProvider struct {
+	codersdk.FixedSessionTokenProvider
+}
+
+func (FixedSessionTokenProvider) RefreshToken(_ context.Context) error {
+	return nil
+}
+
+func UsingFixedToken(token string) SessionTokenSetup {
+	return func(_ *codersdk.Client) RefreshableSessionTokenProvider {
+		return FixedSessionTokenProvider{FixedSessionTokenProvider: codersdk.FixedSessionTokenProvider{SessionToken: token}}
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
-	}
-	var resp AuthenticateResponse
-	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
 // Stats records the Agent's network connection statistics for use in

--- a/codersdk/agentsdk/agentsdk_test.go
+++ b/codersdk/agentsdk/agentsdk_test.go
@@ -141,7 +141,7 @@ func TestRewriteDERPMap(t *testing.T) {
 	}
 	parsed, err := url.Parse("https://coconuts.org:44558")
 	require.NoError(t, err)
-	client := agentsdk.New(parsed, agentsdk.UsingFixedToken("unused"))
+	client := agentsdk.New(parsed, agentsdk.WithFixedToken("unused"))
 	client.RewriteDERPMap(dm)
 	region := dm.Regions[1]
 	require.True(t, region.EmbeddedRelay)

--- a/codersdk/agentsdk/agentsdk_test.go
+++ b/codersdk/agentsdk/agentsdk_test.go
@@ -141,7 +141,7 @@ func TestRewriteDERPMap(t *testing.T) {
 	}
 	parsed, err := url.Parse("https://coconuts.org:44558")
 	require.NoError(t, err)
-	client := agentsdk.New(parsed)
+	client := agentsdk.New(parsed, agentsdk.UsingFixedToken("unused"))
 	client.RewriteDERPMap(dm)
 	region := dm.Regions[1]
 	require.True(t, region.EmbeddedRelay)

--- a/codersdk/agentsdk/aws.go
+++ b/codersdk/agentsdk/aws.go
@@ -22,7 +22,7 @@ type awsSessionTokenExchanger struct {
 	client *codersdk.Client
 }
 
-func UsingAWSInstanceIdentity() SessionTokenSetup {
+func WithAWSInstanceIdentity() SessionTokenSetup {
 	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
 		return &instanceIdentitySessionTokenProvider{
 			tokenExchanger: &awsSessionTokenExchanger{client: client},

--- a/codersdk/agentsdk/aws.go
+++ b/codersdk/agentsdk/aws.go
@@ -1,0 +1,97 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type AWSInstanceIdentityToken struct {
+	Signature string `json:"signature" validate:"required"`
+	Document  string `json:"document" validate:"required"`
+}
+
+// awsSessionTokenExchanger exchanges AWS instance metadata for a Coder session token.
+// @typescript-ignore awsSessionTokenExchanger
+type awsSessionTokenExchanger struct {
+	client *codersdk.Client
+}
+
+func UsingAWSInstanceIdentity() SessionTokenSetup {
+	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
+		return &instanceIdentitySessionTokenProvider{
+			tokenExchanger: &awsSessionTokenExchanger{client: client},
+		}
+	}
+}
+
+// exchange uses the Amazon Metadata API to fetch a signed payload, and exchange it for a session token for a workspace
+// agent.
+//
+// The requesting instance must be registered as a resource in the latest history for a workspace.
+func (a *awsSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://169.254.169.254/latest/api/token", nil)
+	if err != nil {
+		return AuthenticateResponse{}, nil
+	}
+	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "21600")
+	res, err := a.client.HTTPClient.Do(req)
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+	token, err := io.ReadAll(res.Body)
+	if err != nil {
+		return AuthenticateResponse{}, xerrors.Errorf("read token: %w", err)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/dynamic/instance-identity/signature", nil)
+	if err != nil {
+		return AuthenticateResponse{}, nil
+	}
+	req.Header.Set("X-aws-ec2-metadata-token", string(token))
+	res, err = a.client.HTTPClient.Do(req)
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+	signature, err := io.ReadAll(res.Body)
+	if err != nil {
+		return AuthenticateResponse{}, xerrors.Errorf("read token: %w", err)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/dynamic/instance-identity/document", nil)
+	if err != nil {
+		return AuthenticateResponse{}, nil
+	}
+	req.Header.Set("X-aws-ec2-metadata-token", string(token))
+	res, err = a.client.HTTPClient.Do(req)
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+	document, err := io.ReadAll(res.Body)
+	if err != nil {
+		return AuthenticateResponse{}, xerrors.Errorf("read token: %w", err)
+	}
+
+	// request without the token to avoid re-entering this function
+	res, err = a.client.RequestNoSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/aws-instance-identity", AWSInstanceIdentityToken{
+		Signature: string(signature),
+		Document:  string(document),
+	})
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
+	}
+	var resp AuthenticateResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}

--- a/codersdk/agentsdk/aws.go
+++ b/codersdk/agentsdk/aws.go
@@ -81,7 +81,7 @@ func (a *awsSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateRe
 	}
 
 	// request without the token to avoid re-entering this function
-	res, err = a.client.RequestNoSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/aws-instance-identity", AWSInstanceIdentityToken{
+	res, err = a.client.RequestWithoutSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/aws-instance-identity", AWSInstanceIdentityToken{
 		Signature: string(signature),
 		Document:  string(document),
 	})

--- a/codersdk/agentsdk/azure.go
+++ b/codersdk/agentsdk/azure.go
@@ -19,7 +19,7 @@ type azureSessionTokenExchanger struct {
 	client *codersdk.Client
 }
 
-func UsingAzureInstanceIdentity() SessionTokenSetup {
+func WithAzureInstanceIdentity() SessionTokenSetup {
 	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
 		return &instanceIdentitySessionTokenProvider{
 			tokenExchanger: &azureSessionTokenExchanger{client: client},

--- a/codersdk/agentsdk/azure.go
+++ b/codersdk/agentsdk/azure.go
@@ -47,7 +47,7 @@ func (a *azureSessionTokenExchanger) exchange(ctx context.Context) (Authenticate
 		return AuthenticateResponse{}, err
 	}
 
-	res, err = a.client.RequestNoSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/azure-instance-identity", token)
+	res, err = a.client.RequestWithoutSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/azure-instance-identity", token)
 	if err != nil {
 		return AuthenticateResponse{}, err
 	}

--- a/codersdk/agentsdk/azure.go
+++ b/codersdk/agentsdk/azure.go
@@ -1,0 +1,60 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type AzureInstanceIdentityToken struct {
+	Signature string `json:"signature" validate:"required"`
+	Encoding  string `json:"encoding" validate:"required"`
+}
+
+// azureSessionTokenExchanger exchanges Azure attested metadata for a Coder session token.
+// @typescript-ignore azureSessionTokenExchanger
+type azureSessionTokenExchanger struct {
+	client *codersdk.Client
+}
+
+func UsingAzureInstanceIdentity() SessionTokenSetup {
+	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
+		return &instanceIdentitySessionTokenProvider{
+			tokenExchanger: &azureSessionTokenExchanger{client: client},
+		}
+	}
+}
+
+// AuthWorkspaceAzureInstanceIdentity uses the Azure Instance Metadata Service to
+// fetch a signed payload, and exchange it for a session token for a workspace agent.
+func (a *azureSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/metadata/attested/document?api-version=2020-09-01", nil)
+	if err != nil {
+		return AuthenticateResponse{}, nil
+	}
+	req.Header.Set("Metadata", "true")
+	res, err := a.client.HTTPClient.Do(req)
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+
+	var token AzureInstanceIdentityToken
+	err = json.NewDecoder(res.Body).Decode(&token)
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+
+	res, err = a.client.RequestNoSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/azure-instance-identity", token)
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
+	}
+	var resp AuthenticateResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}

--- a/codersdk/agentsdk/google.go
+++ b/codersdk/agentsdk/google.go
@@ -56,7 +56,7 @@ func (g *googleSessionTokenExchanger) exchange(ctx context.Context) (Authenticat
 		return AuthenticateResponse{}, xerrors.Errorf("get metadata identity: %w", err)
 	}
 	// request without the token to avoid re-entering this function
-	res, err := g.client.RequestNoSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/google-instance-identity", GoogleInstanceIdentityToken{
+	res, err := g.client.RequestWithoutSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/google-instance-identity", GoogleInstanceIdentityToken{
 		JSONWebToken: jwt,
 	})
 	if err != nil {

--- a/codersdk/agentsdk/google.go
+++ b/codersdk/agentsdk/google.go
@@ -1,0 +1,71 @@
+package agentsdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"cloud.google.com/go/compute/metadata"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type GoogleInstanceIdentityToken struct {
+	JSONWebToken string `json:"json_web_token" validate:"required"`
+}
+
+// googleSessionTokenExchanger exchanges a Google instance JWT document for a Coder session token.
+// @typescript-ignore googleSessionTokenExchanger
+type googleSessionTokenExchanger struct {
+	serviceAccount string
+	gcpClient      *metadata.Client
+	client         *codersdk.Client
+}
+
+func UsingGoogleInstanceIdentity(serviceAccount string, gcpClient *metadata.Client) SessionTokenSetup {
+	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
+		return &instanceIdentitySessionTokenProvider{
+			tokenExchanger: &googleSessionTokenExchanger{
+				client:         client,
+				gcpClient:      gcpClient,
+				serviceAccount: serviceAccount,
+			},
+		}
+	}
+}
+
+// exchange uses the Google Compute Engine Metadata API to fetch a signed JWT, and exchange it for a session token for a
+// workspace agent.
+//
+// The requesting instance must be registered as a resource in the latest history for a workspace.
+func (g *googleSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
+	if g.serviceAccount == "" {
+		// This is the default name specified by Google.
+		g.serviceAccount = "default"
+	}
+	gcpClient := metadata.NewClient(g.client.HTTPClient)
+	if g.gcpClient != nil {
+		gcpClient = g.gcpClient
+	}
+
+	// "format=full" is required, otherwise the responding payload will be missing "instance_id".
+	jwt, err := gcpClient.Get(fmt.Sprintf("instance/service-accounts/%s/identity?audience=coder&format=full", g.serviceAccount))
+	if err != nil {
+		return AuthenticateResponse{}, xerrors.Errorf("get metadata identity: %w", err)
+	}
+	// request without the token to avoid re-entering this function
+	res, err := g.client.RequestNoSessionToken(ctx, http.MethodPost, "/api/v2/workspaceagents/google-instance-identity", GoogleInstanceIdentityToken{
+		JSONWebToken: jwt,
+	})
+	if err != nil {
+		return AuthenticateResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AuthenticateResponse{}, codersdk.ReadBodyAsError(res)
+	}
+	var resp AuthenticateResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}

--- a/codersdk/agentsdk/google.go
+++ b/codersdk/agentsdk/google.go
@@ -24,7 +24,7 @@ type googleSessionTokenExchanger struct {
 	client         *codersdk.Client
 }
 
-func UsingGoogleInstanceIdentity(serviceAccount string, gcpClient *metadata.Client) SessionTokenSetup {
+func WithGoogleInstanceIdentity(serviceAccount string, gcpClient *metadata.Client) SessionTokenSetup {
 	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
 		return &instanceIdentitySessionTokenProvider{
 			tokenExchanger: &googleSessionTokenExchanger{

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -75,8 +75,7 @@ func TestTools(t *testing.T) {
 	}).Do()
 
 	// Given: a client configured with the agent token.
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(r.AgentToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 	// Get the agent ID from the API. Overriding it in dbfake doesn't work.
 	ws, err := client.Workspace(setupCtx, r.Workspace.ID)
 	require.NoError(t, err)

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -75,7 +75,7 @@ func TestTools(t *testing.T) {
 	}).Do()
 
 	// Given: a client configured with the agent token.
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 	// Get the agent ID from the API. Overriding it in dbfake doesn't work.
 	ws, err := client.Workspace(setupCtx, r.Workspace.ID)
 	require.NoError(t, err)

--- a/docs/reference/cli/external-auth_access-token.md
+++ b/docs/reference/cli/external-auth_access-token.md
@@ -40,3 +40,40 @@ fi
 | Type | <code>string</code> |
 
 Extract a field from the "extra" properties of the OAuth token.
+
+### --agent-token
+
+|             |                                 |
+|-------------|---------------------------------|
+| Type        | <code>string</code>             |
+| Environment | <code>$CODER_AGENT_TOKEN</code> |
+
+An agent authentication token.
+
+### --agent-token-file
+
+|             |                                      |
+|-------------|--------------------------------------|
+| Type        | <code>string</code>                  |
+| Environment | <code>$CODER_AGENT_TOKEN_FILE</code> |
+
+A file containing an agent authentication token.
+
+### --agent-url
+
+|             |                               |
+|-------------|-------------------------------|
+| Type        | <code>url</code>              |
+| Environment | <code>$CODER_AGENT_URL</code> |
+
+URL for an agent to access your deployment.
+
+### --auth
+
+|             |                                |
+|-------------|--------------------------------|
+| Type        | <code>string</code>            |
+| Environment | <code>$CODER_AGENT_AUTH</code> |
+| Default     | <code>token</code>             |
+
+Specify the authentication type to use for the agent.

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -153,13 +153,13 @@ func TestAnnouncementBanners(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 		banners := requireGetAnnouncementBanners(ctx, t, agentClient)
 		require.Equal(t, cfg.AnnouncementBanners, banners)
 
 		// Create an AGPL Coderd against the same database
 		agplClient := coderdtest.New(t, &coderdtest.Options{Database: store, Pubsub: ps})
-		agplAgentClient := agentsdk.New(agplClient.URL, agentsdk.UsingFixedToken(r.AgentToken))
+		agplAgentClient := agentsdk.New(agplClient.URL, agentsdk.WithFixedToken(r.AgentToken))
 		banners = requireGetAnnouncementBanners(ctx, t, agplAgentClient)
 		require.Equal(t, []codersdk.BannerConfig{}, banners)
 

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -153,15 +153,13 @@ func TestAnnouncementBanners(t *testing.T) {
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(r.AgentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(r.AgentToken))
 		banners := requireGetAnnouncementBanners(ctx, t, agentClient)
 		require.Equal(t, cfg.AnnouncementBanners, banners)
 
 		// Create an AGPL Coderd against the same database
 		agplClient := coderdtest.New(t, &coderdtest.Options{Database: store, Pubsub: ps})
-		agplAgentClient := agentsdk.New(agplClient.URL)
-		agplAgentClient.SetSessionToken(r.AgentToken)
+		agplAgentClient := agentsdk.New(agplClient.URL, agentsdk.UsingFixedToken(r.AgentToken))
 		banners = requireGetAnnouncementBanners(ctx, t, agplAgentClient)
 		require.Equal(t, []codersdk.BannerConfig{}, banners)
 

--- a/enterprise/coderd/gitsshkey_test.go
+++ b/enterprise/coderd/gitsshkey_test.go
@@ -69,8 +69,7 @@ func TestAgentGitSSHKeyCustomRoles(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, project.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-	agentClient := agentsdk.New(client.URL)
-	agentClient.SetSessionToken(authToken)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()

--- a/enterprise/coderd/gitsshkey_test.go
+++ b/enterprise/coderd/gitsshkey_test.go
@@ -69,7 +69,7 @@ func TestAgentGitSSHKeyCustomRoles(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, project.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -319,7 +319,7 @@ func setupWorkspaceAgent(t *testing.T, client *codersdk.Client, user codersdk.Cr
 	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
-	agentClient := agentsdk.New(client.URL)
+	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 	agentClient.SDK.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -328,7 +328,6 @@ func setupWorkspaceAgent(t *testing.T, client *codersdk.Client, user codersdk.Cr
 			},
 		},
 	}
-	agentClient.SetSessionToken(authToken)
 	agnt := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: testutil.Logger(t).Named("agent"),

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -319,7 +319,7 @@ func setupWorkspaceAgent(t *testing.T, client *codersdk.Client, user codersdk.Cr
 	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
-	agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 	agentClient.SDK.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -561,7 +561,7 @@ func goEventuallyStartFakeAgent(ctx context.Context, t *testing.T, client *coder
 
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(agentToken))
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(agentToken))
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
 			Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -561,8 +561,7 @@ func goEventuallyStartFakeAgent(ctx context.Context, t *testing.T, client *coder
 
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		agentClient := agentsdk.New(client.URL)
-		agentClient.SetSessionToken(agentToken)
+		agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(agentToken))
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
 			Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).

--- a/scaletest/workspacebuild/run_test.go
+++ b/scaletest/workspacebuild/run_test.go
@@ -134,7 +134,7 @@ func Test_Runner(t *testing.T) {
 			for i, authToken := range []string{authToken1, authToken2, authToken3} {
 				i := i + 1
 
-				agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
+				agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 				agentCloser := agent.New(agent.Options{
 					Client: agentClient,
 					Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).

--- a/scaletest/workspacebuild/run_test.go
+++ b/scaletest/workspacebuild/run_test.go
@@ -134,8 +134,7 @@ func Test_Runner(t *testing.T) {
 			for i, authToken := range []string{authToken1, authToken2, authToken3} {
 				i := i + 1
 
-				agentClient := agentsdk.New(client.URL)
-				agentClient.SetSessionToken(authToken)
+				agentClient := agentsdk.New(client.URL, agentsdk.UsingFixedToken(authToken))
 				agentCloser := agent.New(agent.Options{
 					Client: agentClient,
 					Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).


### PR DESCRIPTION
Refactors Agent instance identity to be a SessionTokenProvider.

Refactors the CLI to create Agent clients via a centralized function, rather than add-hoc via individual command handlers and their flags.

This allows commands besides `coder agent`, but which still use the agent identity, to support instance identity authentication.

Fixes #19111 by unifying all API requests to go thru the SessionTokenProvider for auth credentials.