### PR TITLE
chore(dogfood): update workspace lifecycle ignore_changes with env and entrypoint

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -742,6 +742,8 @@ resource "docker_container" "workspace" {
       name,
       hostname,
       labels,
+      env,
+      image
     ]
   }
   count = data.coder_workspace.me.start_count

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -743,7 +743,7 @@ resource "docker_container" "workspace" {
       hostname,
       labels,
       env,
-      image
+      entrypoint
     ]
   }
   count = data.coder_workspace.me.start_count


### PR DESCRIPTION
Update the dogfood "Write Coder on Coder" template to ignore env and entrypoint changes in workspace's lifecycle block according to https://coder.com/docs/admin/templates/extending-templates/prebuilt-workspaces#template-configuration-best-practices

Related to internal thread: https://codercom.slack.com/archives/C07GRNNRW03/p1756295446304449
Related to Prebuilt claim notifications
<img width="1320" height="980" alt="Screenshot 2025-08-27 at 13 55 21" src="https://github.com/user-attachments/assets/b475d057-76c8-4e9d-8e6d-559b292aafe1" />
