### PR TITLE
fix: don't show prebuild workspaces as tasks

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2704,12 +2704,14 @@ class ExperimentalApiMethods {
 
 		const workspaces = await API.getWorkspaces({
 			q: queryExpressions.join(" "),
-		});
+		}).then((res) =>
+			res.workspaces.filter((workspace) => !workspace.is_prebuild),
+		);
 		const prompts = await API.experimental.getAITasksPrompts(
-			workspaces.workspaces.map((workspace) => workspace.latest_build.id),
+			workspaces.map((workspace) => workspace.latest_build.id),
 		);
 
-		return workspaces.workspaces.map((workspace) => ({
+		return workspaces.map((workspace) => ({
 			workspace,
 			prompt: prompts.prompts[workspace.latest_build.id],
 		}));

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2702,10 +2702,12 @@ class ExperimentalApiMethods {
 			queryExpressions.push(`owner:${filter.username}`);
 		}
 
-		const workspaces = await API.getWorkspaces({
+		const res = await API.getWorkspaces({
 			q: queryExpressions.join(" "),
-		}).then((res) =>
-			res.workspaces.filter((workspace) => !workspace.is_prebuild),
+		});
+		// Exclude prebuild workspaces as they are not user-facing.
+		const workspaces = res.workspaces.filter(
+			(workspace) => !workspace.is_prebuild,
 		);
 		const prompts = await API.experimental.getAITasksPrompts(
 			workspaces.map((workspace) => workspace.latest_build.id),


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/19570

**Before:**

<img width="2776" height="1274" alt="image" src="https://github.com/user-attachments/assets/bd260dbf-0868-4e4a-9997-b2fd3c99f33c" />

**After:**

<img width="1624" height="970" alt="Screenshot 2025-08-27 at 09 11 31" src="https://github.com/user-attachments/assets/c85489d8-031c-4cbe-8298-6fee04e30b1f" />

**Things to notice:**
- There is a task without a prompt at the end, it should not happen anymore
- There is no test for this because we mock the API function and the fix was inside of it. It is a temp solution, the API should be ready to be used by the FE soon



