### PR TITLE
chore: override version of DOMPurify

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -204,7 +204,8 @@
 			"@babel/helpers": "7.26.10",
 			"esbuild": "^0.25.0",
 			"form-data": "4.0.4",
-			"prismjs": "1.30.0"
+			"prismjs": "1.30.0",
+			"dompurify": "3.2.6"
 		},
 		"ignoredBuiltDependencies": [
 			"storybook-addon-remix-react-router"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   esbuild: ^0.25.0
   form-data: 4.0.4
   prismjs: 1.30.0
+  dompurify: 3.2.6
 
 importers:
 


### PR DESCRIPTION
The [DOMPurify](https://github.com/cure53/DOMPurify) version used by the latest version of [monaco-editor](https://github.com/microsoft/monaco-editor) contains [at least one known CVE](https://security.snyk.io/package/npm/dompurify/3.1.7)
https://github.com/coder/coder/issues/19445
https://github.com/coder/coder/pull/19446

This PR aims to override the version to resolve security issues:
https://www.npmjs.com/package/dompurify/v/3.2.6
