### PR TITLE
fix: update link to CLI server experiments documentation

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/OverviewPageView.tsx
@@ -63,7 +63,7 @@ export const OverviewPageView: FC<OverviewPageViewProps> = ({
 						It is recommended that you remove these experiments from your
 						configuration as they have no effect. See{" "}
 						<Link
-							href="https://coder.com/docs/cli/server#--experiments"
+							href="https://coder.com/docs/reference/cli/server#--experiments"
 							target="_blank"
 							rel="noreferrer"
 						>


### PR DESCRIPTION
This pull request makes a minor update to an external documentation link in the `OverviewPageView` component. The change ensures that users are directed to the correct reference section for CLI server experiments.

* Updated the `href` attribute in the documentation link to point to `https://coder.com/docs/reference/cli/server#--experiments` instead of the previous URL, improving the accuracy of the reference for users.