### PR TITLE
fix: suppress license expiry warning if a new license covers the gap

### DIFF
--- a/enterprise/coderd/license/license_internal_test.go
+++ b/enterprise/coderd/license/license_internal_test.go
@@ -1,0 +1,140 @@
+package license
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNextLicenseValidityPeriod(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name string
+
+			licensePeriods  [][2]time.Time
+			expectedPeriods [][2]time.Time
+		}{
+			{
+				name:            "None",
+				licensePeriods:  [][2]time.Time{},
+				expectedPeriods: [][2]time.Time{},
+			},
+			{
+				name: "One",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			{
+				name: "TwoOverlapping",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			{
+				name: "TwoNonOverlapping",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			{
+				name: "ThreeOverlapping",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			{
+				name: "ThreeNonOverlapping",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			{
+				name: "PeriodContainsAnotherPeriod",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC)},
+					{time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: [][2]time.Time{
+					{time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			{
+				name: "EndBeforeStart",
+				licensePeriods: [][2]time.Time{
+					{time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+				},
+				expectedPeriods: nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				// Test with all possible permutations of the periods to ensure
+				// consistency regardless of the order.
+				ps := permutations(tc.licensePeriods)
+				for _, p := range ps {
+					t.Logf("permutation: %v", p)
+					period := &licenseValidityPeriod{}
+					for _, times := range p {
+						t.Logf("applying %v", times)
+						period.Apply(times[0], times[1])
+					}
+					assert.Equal(t, tc.expectedPeriods, period.merged(), "merged")
+				}
+			})
+		}
+	})
+}
+
+func permutations[T any](arr []T) [][]T {
+	var res [][]T
+	var helper func([]T, int)
+	helper = func(a []T, i int) {
+		if i == len(a)-1 {
+			// make a copy before appending
+			tmp := make([]T, len(a))
+			copy(tmp, a)
+			res = append(res, tmp)
+			return
+		}
+		for j := i; j < len(a); j++ {
+			a[i], a[j] = a[j], a[i]
+			helper(a, i+1)
+			a[i], a[j] = a[j], a[i] // backtrack
+		}
+	}
+	helper(arr, 0)
+	return res
+}

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -180,6 +180,109 @@ func TestEntitlements(t *testing.T) {
 		)
 	})
 
+	t.Run("Expiration warning suppressed if new license covers gap", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		// Insert the expiring license
+		graceDate := dbtime.Now().AddDate(0, 0, 1)
+		db.InsertLicense(context.Background(), database.InsertLicenseParams{
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureUserLimit: 100,
+					codersdk.FeatureAuditLog:  1,
+				},
+
+				FeatureSet: codersdk.FeatureSetPremium,
+				GraceAt:    graceDate,
+				ExpiresAt:  dbtime.Now().AddDate(0, 0, 5),
+			}),
+			Exp: time.Now().AddDate(0, 0, 5),
+		})
+		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.False(t, entitlements.Trial)
+		require.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[codersdk.FeatureAuditLog].Entitlement)
+		require.Len(t, entitlements.Warnings, 1)
+		require.Contains(t, entitlements.Warnings, "Your license expires in 1 day.")
+
+		// Insert the new, not-yet-valid license that starts before the expiring
+		// license expires.
+		db.InsertLicense(context.Background(), database.InsertLicenseParams{
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureUserLimit: 100,
+					codersdk.FeatureAuditLog:  1,
+				},
+
+				FeatureSet: codersdk.FeatureSetPremium,
+				NotBefore:  graceDate.Add(-time.Hour), // contiguous, and also in the future
+				GraceAt:    dbtime.Now().AddDate(1, 0, 0),
+				ExpiresAt:  dbtime.Now().AddDate(1, 0, 5),
+			}),
+			Exp: dbtime.Now().AddDate(1, 0, 5),
+		})
+		entitlements, err = license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.False(t, entitlements.Trial)
+		require.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[codersdk.FeatureAuditLog].Entitlement)
+		require.Len(t, entitlements.Warnings, 0) // suppressed
+	})
+
+	t.Run("Expiration warning not suppressed if new license has gap", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		// Insert the expiring license
+		graceDate := dbtime.Now().AddDate(0, 0, 1)
+		db.InsertLicense(context.Background(), database.InsertLicenseParams{
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureUserLimit: 100,
+					codersdk.FeatureAuditLog:  1,
+				},
+
+				FeatureSet: codersdk.FeatureSetPremium,
+				GraceAt:    graceDate,
+				ExpiresAt:  dbtime.Now().AddDate(0, 0, 5),
+			}),
+			Exp: time.Now().AddDate(0, 0, 5),
+		})
+		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.False(t, entitlements.Trial)
+		require.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[codersdk.FeatureAuditLog].Entitlement)
+		require.Len(t, entitlements.Warnings, 1)
+		require.Contains(t, entitlements.Warnings, "Your license expires in 1 day.")
+
+		// Insert the new, not-yet-valid license that starts before the expiring
+		// license expires.
+		db.InsertLicense(context.Background(), database.InsertLicenseParams{
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureUserLimit: 100,
+					codersdk.FeatureAuditLog:  1,
+				},
+
+				FeatureSet: codersdk.FeatureSetPremium,
+				NotBefore:  graceDate.Add(time.Minute), // gap of 1 second!
+				GraceAt:    dbtime.Now().AddDate(1, 0, 0),
+				ExpiresAt:  dbtime.Now().AddDate(1, 0, 5),
+			}),
+			Exp: dbtime.Now().AddDate(1, 0, 5),
+		})
+		entitlements, err = license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.False(t, entitlements.Trial)
+		require.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[codersdk.FeatureAuditLog].Entitlement)
+		require.Len(t, entitlements.Warnings, 1)
+		require.Contains(t, entitlements.Warnings, "Your license expires in 1 day.")
+	})
+
 	t.Run("Expiration warning for trials", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)


### PR DESCRIPTION
Previously, if you had a new license that would start before the current one fully expired, you would get a warning. Now, the license validity periods are merged together, and a warning is only generated based on the end of the current contiguous period of license coverage.

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

Closes #19498 