### PR TITLE
chore: refactor CLI agent auth tests as unit tests

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -179,7 +179,7 @@ func workspaceAgent() *serpent.Command {
 				slog.F("auth", agentAuth.agentAuth),
 				slog.F("version", version),
 			)
-			client, err := agentAuth.CreateClient(ctx)
+			client, err := agentAuth.CreateClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,7 +10,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,10 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/codersdk/workspacesdk"
-	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -62,158 +57,6 @@ func TestWorkspaceAgent(t *testing.T) {
 			}
 			return info.Size() > 0
 		}, testutil.WaitLong, testutil.IntervalMedium)
-	})
-
-	t.Run("Azure", func(t *testing.T) {
-		t.Parallel()
-		instanceID := "instanceidentifier"
-		certificates, metadataClient := coderdtest.NewAzureInstanceIdentity(t, instanceID)
-		db, ps := dbtestutil.NewDB(t,
-			dbtestutil.WithDumpOnFailure(),
-		)
-		client := coderdtest.New(t, &coderdtest.Options{
-			Database:          db,
-			Pubsub:            ps,
-			AzureCertificates: certificates,
-		})
-		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-			OrganizationID: user.OrganizationID,
-			OwnerID:        user.UserID,
-		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
-			agents[0].Auth = &proto.Agent_InstanceId{InstanceId: instanceID}
-			return agents
-		}).Do()
-
-		inv, _ := clitest.New(t, "agent", "--auth", "azure-instance-identity", "--agent-url", client.URL.String())
-		inv = inv.WithContext(
-			//nolint:revive,staticcheck
-			context.WithValue(inv.Context(), "azure-client", metadataClient),
-		)
-
-		ctx := inv.Context()
-		clitest.Start(t, inv)
-		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
-			MatchResources(matchAgentWithVersion).Wait()
-		workspace, err := client.Workspace(ctx, r.Workspace.ID)
-		require.NoError(t, err)
-		resources := workspace.LatestBuild.Resources
-		if assert.NotEmpty(t, workspace.LatestBuild.Resources) && assert.NotEmpty(t, resources[0].Agents) {
-			assert.NotEmpty(t, resources[0].Agents[0].Version)
-		}
-		dialer, err := workspacesdk.New(client).
-			DialAgent(ctx, resources[0].Agents[0].ID, nil)
-		require.NoError(t, err)
-		defer dialer.Close()
-		require.True(t, dialer.AwaitReachable(ctx))
-	})
-
-	t.Run("AWS", func(t *testing.T) {
-		t.Parallel()
-		instanceID := "instanceidentifier"
-		certificates, metadataClient := coderdtest.NewAWSInstanceIdentity(t, instanceID)
-		db, ps := dbtestutil.NewDB(t,
-			dbtestutil.WithDumpOnFailure(),
-		)
-		client := coderdtest.New(t, &coderdtest.Options{
-			Database:        db,
-			Pubsub:          ps,
-			AWSCertificates: certificates,
-		})
-		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-			OrganizationID: user.OrganizationID,
-			OwnerID:        user.UserID,
-		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
-			agents[0].Auth = &proto.Agent_InstanceId{InstanceId: instanceID}
-			return agents
-		}).Do()
-
-		inv, _ := clitest.New(t, "agent", "--auth", "aws-instance-identity", "--agent-url", client.URL.String())
-		inv = inv.WithContext(
-			//nolint:revive,staticcheck
-			context.WithValue(inv.Context(), "aws-client", metadataClient),
-		)
-
-		clitest.Start(t, inv)
-		ctx := inv.Context()
-		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
-			MatchResources(matchAgentWithVersion).
-			Wait()
-		workspace, err := client.Workspace(ctx, r.Workspace.ID)
-		require.NoError(t, err)
-		resources := workspace.LatestBuild.Resources
-		if assert.NotEmpty(t, resources) && assert.NotEmpty(t, resources[0].Agents) {
-			assert.NotEmpty(t, resources[0].Agents[0].Version)
-		}
-		dialer, err := workspacesdk.New(client).
-			DialAgent(ctx, resources[0].Agents[0].ID, nil)
-		require.NoError(t, err)
-		defer dialer.Close()
-		require.True(t, dialer.AwaitReachable(ctx))
-	})
-
-	t.Run("GoogleCloud", func(t *testing.T) {
-		t.Parallel()
-		instanceID := "instanceidentifier"
-		validator, metadataClient := coderdtest.NewGoogleInstanceIdentity(t, instanceID, false)
-		db, ps := dbtestutil.NewDB(t,
-			dbtestutil.WithDumpOnFailure(),
-		)
-		client := coderdtest.New(t, &coderdtest.Options{
-			Database:             db,
-			Pubsub:               ps,
-			GoogleTokenValidator: validator,
-		})
-		owner := coderdtest.CreateFirstUser(t, client)
-		member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-		r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-			OrganizationID: owner.OrganizationID,
-			OwnerID:        memberUser.ID,
-		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
-			agents[0].Auth = &proto.Agent_InstanceId{InstanceId: instanceID}
-			return agents
-		}).Do()
-
-		inv, cfg := clitest.New(t, "agent", "--auth", "google-instance-identity", "--agent-url", client.URL.String())
-		clitest.SetupConfig(t, member, cfg)
-
-		clitest.Start(t,
-			inv.WithContext(
-				//nolint:revive,staticcheck
-				context.WithValue(inv.Context(), "gcp-client", metadataClient),
-			),
-		)
-
-		ctx := inv.Context()
-		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
-			MatchResources(matchAgentWithVersion).
-			Wait()
-		workspace, err := client.Workspace(ctx, r.Workspace.ID)
-		require.NoError(t, err)
-		resources := workspace.LatestBuild.Resources
-		if assert.NotEmpty(t, resources) && assert.NotEmpty(t, resources[0].Agents) {
-			assert.NotEmpty(t, resources[0].Agents[0].Version)
-		}
-		dialer, err := workspacesdk.New(client).DialAgent(ctx, resources[0].Agents[0].ID, nil)
-		require.NoError(t, err)
-		defer dialer.Close()
-		require.True(t, dialer.AwaitReachable(ctx))
-		sshClient, err := dialer.SSHClient(ctx)
-		require.NoError(t, err)
-		defer sshClient.Close()
-		session, err := sshClient.NewSession()
-		require.NoError(t, err)
-		defer session.Close()
-		key := "CODER_AGENT_TOKEN"
-		command := "sh -c 'echo $" + key + "'"
-		if runtime.GOOS == "windows" {
-			command = "cmd.exe /c echo %" + key + "%"
-		}
-		token, err := session.CombinedOutput(command)
-		require.NoError(t, err)
-		_, err = uuid.Parse(strings.TrimSpace(string(token)))
-		require.NoError(t, err)
 	})
 
 	t.Run("PostStartup", func(t *testing.T) {

--- a/cli/exp_mcp.go
+++ b/cli/exp_mcp.go
@@ -149,7 +149,7 @@ func mcpConfigureClaudeCode() *serpent.Command {
 				binPath = testBinaryName
 			}
 			configureClaudeEnv := map[string]string{}
-			agentClient, err := agentAuth.CreateClient(inv.Context())
+			agentClient, err := agentAuth.CreateClient()
 			if err != nil {
 				cliui.Warnf(inv.Stderr, "failed to create agent client: %s", err)
 			} else {
@@ -497,7 +497,7 @@ func (r *RootCmd) mcpServer() *serpent.Command {
 			}
 
 			// Try to create an agent client for status reporting.  Not validated.
-			agentClient, err := agentAuth.CreateClient(inv.Context())
+			agentClient, err := agentAuth.CreateClient()
 			if err == nil {
 				cliui.Infof(inv.Stderr, "Agent URL      : %s", agentClient.SDK.URL.String())
 				srv.agentClient = agentClient

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -68,7 +68,7 @@ fi
 			ctx, stop := inv.SignalNotifyContext(ctx, StopSignals...)
 			defer stop()
 
-			client, err := agentAuth.CreateClient(ctx)
+			client, err := agentAuth.CreateClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/gitaskpass.go
+++ b/cli/gitaskpass.go
@@ -33,7 +33,7 @@ func gitAskpass(agentAuth *AgentAuth) *serpent.Command {
 				return xerrors.Errorf("parse host: %w", err)
 			}
 
-			client, err := agentAuth.CreateClient(ctx)
+			client, err := agentAuth.CreateClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -39,7 +39,7 @@ func gitssh() *serpent.Command {
 				return err
 			}
 
-			client, err := agentAuth.CreateClient(ctx)
+			client, err := agentAuth.CreateClient()
 			if err != nil {
 				return xerrors.Errorf("create agent client: %w", err)
 			}

--- a/codersdk/agentsdk/aws.go
+++ b/codersdk/agentsdk/aws.go
@@ -16,16 +16,16 @@ type AWSInstanceIdentityToken struct {
 	Document  string `json:"document" validate:"required"`
 }
 
-// awsSessionTokenExchanger exchanges AWS instance metadata for a Coder session token.
-// @typescript-ignore awsSessionTokenExchanger
-type awsSessionTokenExchanger struct {
+// AWSSessionTokenExchanger exchanges AWS instance metadata for a Coder session token.
+// @typescript-ignore AWSSessionTokenExchanger
+type AWSSessionTokenExchanger struct {
 	client *codersdk.Client
 }
 
 func WithAWSInstanceIdentity() SessionTokenSetup {
 	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
-		return &instanceIdentitySessionTokenProvider{
-			tokenExchanger: &awsSessionTokenExchanger{client: client},
+		return &InstanceIdentitySessionTokenProvider{
+			TokenExchanger: &AWSSessionTokenExchanger{client: client},
 		}
 	}
 }
@@ -34,7 +34,7 @@ func WithAWSInstanceIdentity() SessionTokenSetup {
 // agent.
 //
 // The requesting instance must be registered as a resource in the latest history for a workspace.
-func (a *awsSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
+func (a *AWSSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://169.254.169.254/latest/api/token", nil)
 	if err != nil {
 		return AuthenticateResponse{}, nil

--- a/codersdk/agentsdk/azure.go
+++ b/codersdk/agentsdk/azure.go
@@ -13,23 +13,23 @@ type AzureInstanceIdentityToken struct {
 	Encoding  string `json:"encoding" validate:"required"`
 }
 
-// azureSessionTokenExchanger exchanges Azure attested metadata for a Coder session token.
-// @typescript-ignore azureSessionTokenExchanger
-type azureSessionTokenExchanger struct {
+// AzureSessionTokenExchanger exchanges Azure attested metadata for a Coder session token.
+// @typescript-ignore AzureSessionTokenExchanger
+type AzureSessionTokenExchanger struct {
 	client *codersdk.Client
 }
 
 func WithAzureInstanceIdentity() SessionTokenSetup {
 	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
-		return &instanceIdentitySessionTokenProvider{
-			tokenExchanger: &azureSessionTokenExchanger{client: client},
+		return &InstanceIdentitySessionTokenProvider{
+			TokenExchanger: &AzureSessionTokenExchanger{client: client},
 		}
 	}
 }
 
 // AuthWorkspaceAzureInstanceIdentity uses the Azure Instance Metadata Service to
 // fetch a signed payload, and exchange it for a session token for a workspace agent.
-func (a *azureSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
+func (a *AzureSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/metadata/attested/document?api-version=2020-09-01", nil)
 	if err != nil {
 		return AuthenticateResponse{}, nil

--- a/codersdk/agentsdk/google.go
+++ b/codersdk/agentsdk/google.go
@@ -16,9 +16,9 @@ type GoogleInstanceIdentityToken struct {
 	JSONWebToken string `json:"json_web_token" validate:"required"`
 }
 
-// googleSessionTokenExchanger exchanges a Google instance JWT document for a Coder session token.
-// @typescript-ignore googleSessionTokenExchanger
-type googleSessionTokenExchanger struct {
+// GoogleSessionTokenExchanger exchanges a Google instance JWT document for a Coder session token.
+// @typescript-ignore GoogleSessionTokenExchanger
+type GoogleSessionTokenExchanger struct {
 	serviceAccount string
 	gcpClient      *metadata.Client
 	client         *codersdk.Client
@@ -26,8 +26,8 @@ type googleSessionTokenExchanger struct {
 
 func WithGoogleInstanceIdentity(serviceAccount string, gcpClient *metadata.Client) SessionTokenSetup {
 	return func(client *codersdk.Client) RefreshableSessionTokenProvider {
-		return &instanceIdentitySessionTokenProvider{
-			tokenExchanger: &googleSessionTokenExchanger{
+		return &InstanceIdentitySessionTokenProvider{
+			TokenExchanger: &GoogleSessionTokenExchanger{
 				client:         client,
 				gcpClient:      gcpClient,
 				serviceAccount: serviceAccount,
@@ -40,7 +40,7 @@ func WithGoogleInstanceIdentity(serviceAccount string, gcpClient *metadata.Clien
 // workspace agent.
 //
 // The requesting instance must be registered as a resource in the latest history for a workspace.
-func (g *googleSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
+func (g *GoogleSessionTokenExchanger) exchange(ctx context.Context) (AuthenticateResponse, error) {
 	if g.serviceAccount == "" {
 		// This is the default name specified by Google.
 		g.serviceAccount = "default"


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/933

Refactors CLI tests that check the `--auth` flag parsing for various public clouds into a unit test that just creates the agent Client and asserts on the type.

Testing that the agent client actually authenticates correctly with these auth types is well covered by Coderd tests, so we don't need to retread that ground here, and the deleted tests were flaky on Windows.