### PR TITLE
fix(scripts): unset CODER_URL and CODER_SESSION_TOKEN for development server

### DIFF
--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck disable=SC1091,SC1090
 source "${SCRIPT_DIR}/lib.sh"
 
+# Ensure that these do not interfere with the below.
+unset CODER_SESSION_TOKEN
+unset CODER_URL
+
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
 CODER_AGENT_URL="${CODER_AGENT_URL:-}"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -8,7 +8,8 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck disable=SC1091,SC1090
 source "${SCRIPT_DIR}/lib.sh"
 
-# Ensure that these do not interfere with the below.
+# Ensure that extant environment variables do not override
+# the config dir we use to override auth for dev.coder.com.
 unset CODER_SESSION_TOKEN
 unset CODER_URL
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -21,6 +21,10 @@ password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"
 use_proxy=0
 multi_org=0
 
+# Ensure that these do not interfere with the below.
+unset CODER_SESSION_TOKEN
+unset CODER_URL
+
 args="$(getopt -o "" -l access-url:,use-proxy,agpl,debug,password:,multi-organization -- "$@")"
 eval set -- "$args"
 while true; do

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -21,7 +21,8 @@ password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"
 use_proxy=0
 multi_org=0
 
-# Ensure that these do not interfere with the below.
+# Ensure that extant environment variables do not override
+# the config dir we use to override auth for dev.coder.com.
 unset CODER_SESSION_TOKEN
 unset CODER_URL
 


### PR DESCRIPTION
The coder-login module was recently [updated](https://github.com/coder/registry/pull/389/) to set environment variables instead of running `coder login`.

This unfortunately broke `develop.sh`:

```
Encountered an error running "coder login", see "coder login --help" for more information
error: Trace=[create api key: ]
```

Unsetting these env vars so that they do not interfere.