### PR TITLE
ci: make blink ci failure prompt a gha variable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1614,6 +1614,7 @@ jobs:
     steps:
       - name: Send Slack notification
         run: |
+          ESCAPED_PROMPT=$(printf "%s" "<@U08TJ4YNCA3> $BLINK_CI_FAILURE_PROMPT" | jq -Rsa .)
           curl -X POST -H 'Content-type: application/json' \
           --data '{
             "blocks": [
@@ -1653,7 +1654,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "<@U08TJ4YNCA3> investigate this CI failure. Check logs, search for existing issues, use git blame to find who last modified failing tests, create issue in coder/internal (not public repo), use title format \"flake: TestName\" for flaky tests, and assign to the person from git blame."
+                  "text": '"$ESCAPED_PROMPT"'
                 }
               }
             ]
@@ -1661,3 +1662,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.CI_FAILURE_SLACK_WEBHOOK }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BLINK_CI_FAILURE_PROMPT: ${{ vars.BLINK_CI_FAILURE_PROMPT }}

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -170,6 +170,7 @@ jobs:
     steps:
       - name: Send Slack notification
         run: |
+          ESCAPED_PROMPT=$(printf "%s" "<@U08TJ4YNCA3> $BLINK_CI_FAILURE_PROMPT" | jq -Rsa .)
           curl -X POST -H 'Content-type: application/json' \
           --data '{
             "blocks": [
@@ -209,7 +210,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "<@U08TJ4YNCA3> investigate this CI failure. Check logs, search for existing issues, use git blame to find who last modified failing tests, create issue in coder/internal (not public repo), use title format \"flake: TestName\" for flaky tests, and assign to the person from git blame."
+                  "text": '"$ESCAPED_PROMPT"'
                 }
               }
             ]
@@ -217,3 +218,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.CI_FAILURE_SLACK_WEBHOOK }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BLINK_CI_FAILURE_PROMPT: ${{ vars.BLINK_CI_FAILURE_PROMPT }}


### PR DESCRIPTION
Got sick of seeing blink create duplicates, so I'm updating the prompt. To make it configurable without committing I'm making it a variable, here's what I've got:

> Investigate this CI failure. Check logs, and figure out what went wrong. Search for existing issues in coder/internal. If an issue for the CI failure does not exist already, create one ONLY in coder/internal. Do NOT create duplicate issues. Use title format \"flake: TestName\" for flaky tests, and assign them to the person from git blame.
If multiple tests fail with the reason `unknown`, the test process exited unexpectedly, perhaps due to a panic.

Once blink supports per-slack-channel contexts, i'll probably just set the variable to the empty string and use that instead.

