### PR TITLE
refactor: untangle workspace creation from http logic

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -193,6 +193,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 	w, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, createReq, r)
 	if err != nil {
 		httperror.WriteResponseError(ctx, rw, err)
+		return
 	}
 
 	httpapi.Write(ctx, rw, http.StatusCreated, w)

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -190,10 +190,12 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 	})
 
 	defer commitAudit()
-	_, err = createWorkspace(ctx, aReq, apiKey.UserID, api, owner, createReq, r)
+	w, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, createReq, r)
 	if err != nil {
 		httperror.WriteResponseError(ctx, rw, err)
 	}
+
+	httpapi.Write(ctx, rw, http.StatusCreated, w)
 }
 
 // tasksFromWorkspaces converts a slice of API workspaces into tasks, fetching

--- a/coderd/httpapi/httperror/responserror.go
+++ b/coderd/httpapi/httperror/responserror.go
@@ -1,8 +1,12 @@
 package httperror
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
 
+	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -17,3 +21,50 @@ func IsResponder(err error) (Responder, bool) {
 	}
 	return nil, false
 }
+
+func NewResponseError(status int, resp codersdk.Response) error {
+	return &responseError{
+		status:   status,
+		response: resp,
+	}
+}
+
+func WriteResponseError(ctx context.Context, rw http.ResponseWriter, err error) {
+	if responseErr, ok := IsResponder(err); ok {
+		code, resp := responseErr.Response()
+
+		httpapi.Write(ctx, rw, code, resp)
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+		Message: "Internal server error",
+		Detail:  err.Error(),
+	})
+}
+
+type responseError struct {
+	status   int
+	response codersdk.Response
+}
+
+var (
+	_ error     = (*responseError)(nil)
+	_ Responder = (*responseError)(nil)
+)
+
+func (e *responseError) Error() string {
+	return fmt.Sprintf("%s: %s", e.response.Message, e.response.Detail)
+}
+
+func (e *responseError) Status() int {
+	return e.status
+}
+
+func (e *responseError) Response() (int, codersdk.Response) {
+	return e.status, e.response
+}
+
+var (
+	ErrResourceNotFound = NewResponseError(http.StatusNotFound, httpapi.ResourceNotFoundResponse)
+)

--- a/coderd/httpapi/httperror/responserror.go
+++ b/coderd/httpapi/httperror/responserror.go
@@ -65,6 +65,4 @@ func (e *responseError) Response() (int, codersdk.Response) {
 	return e.status, e.response
 }
 
-var (
-	ErrResourceNotFound = NewResponseError(http.StatusNotFound, httpapi.ResourceNotFoundResponse)
-)
+var ErrResourceNotFound = NewResponseError(http.StatusNotFound, httpapi.ResourceNotFoundResponse)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -388,10 +388,12 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		AvatarURL: member.AvatarURL,
 	}
 
-	_, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, req, r)
+	w, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, req, r)
 	if err != nil {
 		httperror.WriteResponseError(ctx, rw, err)
 	}
+
+	httpapi.Write(ctx, rw, http.StatusCreated, w)
 }
 
 // Create a new workspace for the currently authenticated user.
@@ -481,10 +483,13 @@ func (api *API) postUserWorkspaces(rw http.ResponseWriter, r *http.Request) {
 
 	defer commitAudit()
 
-	_, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, req, r)
+	w, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, req, r)
 	if err != nil {
 		httperror.WriteResponseError(ctx, rw, err)
+		return
 	}
+
+	httpapi.Write(ctx, rw, http.StatusCreated, w)
 }
 
 type workspaceOwner struct {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -391,6 +391,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 	w, err := createWorkspace(ctx, aReq, apiKey.UserID, api, owner, req, r)
 	if err != nil {
 		httperror.WriteResponseError(ctx, rw, err)
+		return
 	}
 
 	httpapi.Write(ctx, rw, http.StatusCreated, w)


### PR DESCRIPTION
Coder Tasks requires us to create a workspace, but we want to be able to return a `codersdk.Task` instead of a `codersdk.Workspace`. This requires untangling `createWorkspace` from directly writing to `http.ResponseWriter`.