### PR TITLE
fix: add bottom padding to workspace page

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -98,7 +98,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	const pageNumberIsInvalid = page !== 1 && workspaces?.length === 0;
 
 	return (
-		<Margins>
+		<Margins className="pb-12">
 			<PageHeader
 				actions={
 					<WorkspacesButton


### PR DESCRIPTION
Before:
<img width="2874" height="142" alt="CleanShot 2025-08-29 at 11 58 56@2x" src="https://github.com/user-attachments/assets/4e270397-d0d5-40b7-aac4-f00b7f842fda" />


After:

<img width="3104" height="228" alt="CleanShot 2025-08-29 at 11 59 14@2x" src="https://github.com/user-attachments/assets/106ccaf1-2615-4354-8b1d-3e68fc73b218" />

