### PR TITLE
docs: update Tailscale DERP fleet usage phrasing

### DIFF
--- a/docs/admin/networking/index.md
+++ b/docs/admin/networking/index.md
@@ -123,8 +123,7 @@ but this can be disabled or changed for
 By default, your Coder server also runs a built-in DERP relay which can be used
 for both public and [Air-gapped deployments](../../install/airgap.md).
 
-Tailscale maintains a global fleet of DERP relays intended for their product, and has agreed to allow Coder to access and use them. 
-[their global DERP relays](https://tailscale.com/kb/1118/custom-derp-servers/#what-are-derp-servers).
+However, Tailscale maintains a global fleet of [DERP relays](https://tailscale.com/kb/1118/custom-derp-servers/#what-are-derp-servers) intended for their product, and has allowed Coder to access and use them.
 You can launch `coder server` with Tailscale's DERPs like so:
 
 ```bash

--- a/docs/admin/networking/index.md
+++ b/docs/admin/networking/index.md
@@ -123,8 +123,7 @@ but this can be disabled or changed for
 By default, your Coder server also runs a built-in DERP relay which can be used
 for both public and [Air-gapped deployments](../../install/airgap.md).
 
-However, our Wireguard integration through Tailscale has graciously allowed us
-to use
+However, Tailscale has graciously allowed us to use
 [their global DERP relays](https://tailscale.com/kb/1118/custom-derp-servers/#what-are-derp-servers).
 You can launch `coder server` with Tailscale's DERPs like so:
 

--- a/docs/admin/networking/index.md
+++ b/docs/admin/networking/index.md
@@ -123,7 +123,7 @@ but this can be disabled or changed for
 By default, your Coder server also runs a built-in DERP relay which can be used
 for both public and [Air-gapped deployments](../../install/airgap.md).
 
-However, Tailscale has graciously allowed us to use
+Tailscale maintains a global fleet of DERP relays intended for their product, and has agreed to allow Coder to access and use them. 
 [their global DERP relays](https://tailscale.com/kb/1118/custom-derp-servers/#what-are-derp-servers).
 You can launch `coder server` with Tailscale's DERPs like so:
 


### PR DESCRIPTION
I noticed that our docs mention the possibility of using the Tailscale-managed DERP server fleet. https://github.com/coder/coder/pull/15901 changed the phrasing from  

> However, Tailscale has graciously allowed us to use  

to  

> However, our Wireguard integration through Tailscale has graciously allowed us to use  

This change alters the original meaning of the sentence. AFAIK, the original meant that we contacted Tailscale directly and asked if it would be ok for our customers to use the Tailscale-managed DERP server fleet, and Tailscale graciously agreed. The new phrasing conveys something different. This PR reverts the phrasing to the original.