### PR TITLE
test: fix flake, TestLabelsAggregation update & collect timing

### DIFF
--- a/coderd/prometheusmetrics/aggregator_test.go
+++ b/coderd/prometheusmetrics/aggregator_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
-	"github.com/coder/coder/v2/coderd/agentmetrics"
-
 	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/coderd/agentmetrics"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics"
 	"github.com/coder/coder/v2/cryptorand"
 	"github.com/coder/coder/v2/testutil"
@@ -592,7 +592,10 @@ func TestLabelsAggregation(t *testing.T) {
 
 			// given
 			registry := prometheus.NewRegistry()
-			metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Hour, tc.aggregateOn) // time.Hour, so metrics won't expire
+
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger = logger.Leveled(slog.LevelDebug)
+			metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(logger, registry, time.Hour, tc.aggregateOn) // time.Hour, so metrics won't expire
 			require.NoError(t, err)
 
 			ctx, cancelFunc := context.WithCancel(context.Background())


### PR DESCRIPTION
If you see the logs, the `collect` happens before the `update metrics`

```
    t.go:106: 2025-08-30 11:43:03.849 [debu]  prometheusmetrics: update metrics
    t.go:106: 2025-08-30 11:43:03.850 [debu]  prometheusmetrics: collect metrics
    t.go:106: 2025-08-30 11:43:03.850 [debu]  prometheusmetrics: update metrics
    aggregator_test.go:201: 
        	Error Trace:	/home/steven/go/src/github.com/coder/coder/coderd/prometheusmetrics/aggregator_test.go:201
        	            				/home/steven/go/src/github.com/coder/coder/coderd/prometheusmetrics/aggregator_test.go:629
        	            				/home/steven/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.linux-amd64/src/runtime/asm_amd64.s:1700
        	Error:      	Not equal: 
        	            	expected: 8
        	            	actual  : 1
        	Test:       	TestLabelsAggregation/single_label_aggregation,_aggregating_to_single_metric
    aggregator_test.go:613: 
        	Error Trace:	/home/steven/go/src/github.com/coder/coder/coderd/prometheusmetrics/aggregator_test.go:613
        	Error:      	Condition never satisfied
        	Test:       	TestLabelsAggregation/single_label_aggregation,_aggregating_to_single_metric
```