### PR TITLE
chore(cli): re-order CLI create command

### DIFF
--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -87,8 +87,23 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 					return xerrors.Errorf("template name not provided")
 				}
 
-				templateName = templates[0].Name
-				templateVersionID = templates[0].ActiveVersionID
+				if templateVersionName != "" {
+					templateVersion, err := client.TemplateVersionByOrganizationAndName(ctx, organization.ID, templates[0].Name, templateVersionName)
+					if err != nil {
+						return xerrors.Errorf("get template version: %w", err)
+					}
+
+					templateVersionID = templateVersion.ID
+				} else {
+					templateVersionID = templates[0].ActiveVersionID
+				}
+			} else if templateVersionName != "" {
+				templateVersion, err := client.TemplateVersionByOrganizationAndName(ctx, organization.ID, templateName, templateVersionName)
+				if err != nil {
+					return xerrors.Errorf("get template version: %w", err)
+				}
+
+				templateVersionID = templateVersion.ID
 			} else {
 				template, err := client.TemplateByName(ctx, organization.ID, templateName)
 				if err != nil {
@@ -96,15 +111,6 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 				}
 
 				templateVersionID = template.ActiveVersionID
-			}
-
-			if templateVersionName != "" {
-				templateVersion, err := client.TemplateVersionByOrganizationAndName(ctx, organization.ID, templateName, templateVersionName)
-				if err != nil {
-					return xerrors.Errorf("get template version: %w", err)
-				}
-
-				templateVersionID = templateVersion.ID
 			}
 
 			if presetName != PresetNone {

--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -106,7 +107,12 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 				// allow omitting the template. Otherwise we will require
 				// the user to be explicit with their choice of template.
 				if len(templates) > 1 {
-					return xerrors.Errorf("template name not provided")
+					templateNames := make([]string, 0, len(templates))
+					for _, template := range templates {
+						templateNames = append(templateNames, template.Name)
+					}
+
+					return xerrors.Errorf("template name not provided, available templates: %s", strings.Join(templateNames, ", "))
 				}
 
 				if templateVersionName != "" {

--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -87,6 +87,10 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 				taskInput = inv.Args[0]
 			}
 
+			if taskInput == "" {
+				return xerrors.Errorf("a task cannot be started with an empty input")
+			}
+
 			if templateName == "" {
 				templates, err := client.Templates(ctx, codersdk.TemplateFilter{SearchQuery: "has-ai-task:true", OrganizationID: organization.ID})
 				if err != nil {

--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -91,7 +91,8 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 				return xerrors.Errorf("a task cannot be started with an empty input")
 			}
 
-			if templateName == "" {
+			switch {
+			case templateName == "":
 				templates, err := client.Templates(ctx, codersdk.TemplateFilter{SearchQuery: "has-ai-task:true", OrganizationID: organization.ID})
 				if err != nil {
 					return xerrors.Errorf("list templates: %w", err)
@@ -118,14 +119,16 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 				} else {
 					templateVersionID = templates[0].ActiveVersionID
 				}
-			} else if templateVersionName != "" {
+
+			case templateVersionName != "":
 				templateVersion, err := client.TemplateVersionByOrganizationAndName(ctx, organization.ID, templateName, templateVersionName)
 				if err != nil {
 					return xerrors.Errorf("get template version: %w", err)
 				}
 
 				templateVersionID = templateVersion.ID
-			} else {
+
+			default:
 				template, err := client.TemplateByName(ctx, organization.ID, templateName)
 				if err != nil {
 					return xerrors.Errorf("get template: %w", err)

--- a/cli/exp_task_create_test.go
+++ b/cli/exp_task_create_test.go
@@ -267,6 +267,29 @@ func TestTaskCreate(t *testing.T) {
 				}
 			},
 		},
+		{
+			args:        []string{"no template name provided"},
+			expectError: "template name not provided, available templates: wibble, wobble",
+			handler: func(t *testing.T, ctx context.Context) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v2/users/me/organizations":
+						httpapi.Write(ctx, w, http.StatusOK, []codersdk.Organization{
+							{MinimalOrganization: codersdk.MinimalOrganization{
+								ID: organizationID,
+							}},
+						})
+					case "/api/v2/templates":
+						httpapi.Write(ctx, w, http.StatusOK, []codersdk.Template{
+							{Name: "wibble"},
+							{Name: "wobble"},
+						})
+					default:
+						t.Errorf("unexpected path: %s", r.URL.Path)
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/893

Instead of `coder task create <template> --input <input>`, it is now `coder task create <input> --template <template>`.

If there is only one AI task template on the deployment, the `--template` parameter can be omitted.