### PR TITLE
[2.25 backport] fix: expire token for prebuilds user when regenerating session token (#19667)

### DIFF
--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -12,6 +12,8 @@ import (
 	"github.com/moby/moby/pkg/namesgenerator"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+
 	"github.com/coder/coder/v2/coderd/apikey"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
@@ -53,6 +55,14 @@ func (api *API) postToken(rw http.ResponseWriter, r *http.Request) {
 
 	var createToken codersdk.CreateTokenRequest
 	if !httpapi.Read(ctx, rw, r, &createToken) {
+		return
+	}
+
+	// TODO(Cian): System users technically just have the 'member' role
+	// and we don't want to disallow all members from creating API keys.
+	if user.IsSystem {
+		api.Logger.Warn(ctx, "disallowed creating api key for system user", slog.F("user_id", user.ID))
+		httpapi.Forbidden(rw)
 		return
 	}
 
@@ -123,6 +133,14 @@ func (api *API) postToken(rw http.ResponseWriter, r *http.Request) {
 func (api *API) postAPIKey(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	user := httpmw.UserParam(r)
+
+	// TODO(Cian): System users technically just have the 'member' role
+	// and we don't want to disallow all members from creating API keys.
+	if user.IsSystem {
+		api.Logger.Warn(ctx, "disallowed creating api key for system user", slog.F("user_id", user.ID))
+		httpapi.Forbidden(rw)
+		return
+	}
 
 	cookie, _, err := api.createAPIKey(ctx, apikey.CreateParams{
 		UserID:          user.ID,

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1725,6 +1725,13 @@ func (q *querier) EnqueueNotificationMessage(ctx context.Context, arg database.E
 	return q.db.EnqueueNotificationMessage(ctx, arg)
 }
 
+func (q *querier) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceApiKey); err != nil {
+		return err
+	}
+	return q.db.ExpirePrebuildsAPIKeys(ctx, now)
+}
+
 func (q *querier) FavoriteWorkspace(ctx context.Context, id uuid.UUID) error {
 	fetch := func(ctx context.Context, id uuid.UUID) (database.Workspace, error) {
 		return q.db.GetWorkspaceByID(ctx, id)
@@ -3623,6 +3630,14 @@ func (q *querier) HasTemplateVersionsWithAITask(ctx context.Context) (bool, erro
 }
 
 func (q *querier) InsertAPIKey(ctx context.Context, arg database.InsertAPIKeyParams) (database.APIKey, error) {
+	// TODO(Cian): ideally this would be encoded in the policy, but system users are just members and we
+	// don't currently have a capability to conditionally deny creating resources by owner ID in a role.
+	// We also need to enrich rbac.Actor with IsSystem so that we can distinguish all system users.
+	// For now, there is only one system user (prebuilds).
+	if act, ok := ActorFromContext(ctx); ok && act.ID == database.PrebuildsSystemUserID.String() {
+		return database.APIKey{}, logNotAuthorizedError(ctx, q.log, NotAuthorizedError{Err: xerrors.Errorf("prebuild user may not create api keys")})
+	}
+
 	return insert(q.log, q.auth,
 		rbac.ResourceApiKey.WithOwner(arg.UserID.String()),
 		q.db.InsertAPIKey)(ctx, arg)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -14,14 +14,17 @@ import (
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/notifications"
@@ -1680,6 +1683,9 @@ func (s *MethodTestSuite) TestUser() {
 	s.Run("DeleteAPIKeysByUserID", s.Subtest(func(db database.Store, check *expects) {
 		u := dbgen.User(s.T(), db, database.User{})
 		check.Args(u.ID).Asserts(rbac.ResourceApiKey.WithOwner(u.ID.String()), policy.ActionDelete).Returns()
+	}))
+	s.Run("ExpirePrebuildsAPIKeys", s.Subtest(func(db database.Store, check *expects) {
+		check.Args(dbtime.Now()).Asserts(rbac.ResourceApiKey, policy.ActionDelete).Returns()
 	}))
 	s.Run("GetQuotaAllowanceForUser", s.Subtest(func(db database.Store, check *expects) {
 		u := dbgen.User(s.T(), db, database.User{})
@@ -5844,4 +5850,19 @@ func (s *MethodTestSuite) TestAuthorizePrebuiltWorkspace() {
 				return nil
 			}).Asserts(w, policy.ActionUpdate, w.AsPrebuild(), policy.ActionUpdate)
 	}))
+}
+
+// Ensures that the prebuilds actor may never insert an api key.
+func TestInsertAPIKey_AsPrebuildsUser(t *testing.T) {
+	t.Parallel()
+	prebuildsSubj := rbac.Subject{
+		ID: database.PrebuildsSystemUserID.String(),
+	}
+	ctx := dbauthz.As(testutil.Context(t, testutil.WaitShort), prebuildsSubj)
+	mDB := dbmock.NewMockStore(gomock.NewController(t))
+	log := slogtest.Make(t, nil)
+	mDB.EXPECT().Wrappers().Times(1).Return([]string{})
+	dbz := dbauthz.New(mDB, nil, log, nil)
+	_, err := dbz.InsertAPIKey(ctx, database.InsertAPIKeyParams{})
+	require.True(t, dbauthz.IsNotAuthorizedError(err))
 }

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -156,7 +156,7 @@ func Template(t testing.TB, db database.Store, seed database.Template) database.
 	return template
 }
 
-func APIKey(t testing.TB, db database.Store, seed database.APIKey) (key database.APIKey, token string) {
+func APIKey(t testing.TB, db database.Store, seed database.APIKey, munge ...func(*database.InsertAPIKeyParams)) (key database.APIKey, token string) {
 	id, _ := cryptorand.String(10)
 	secret, _ := cryptorand.String(22)
 	hashed := sha256.Sum256([]byte(secret))
@@ -172,7 +172,7 @@ func APIKey(t testing.TB, db database.Store, seed database.APIKey) (key database
 		}
 	}
 
-	key, err := db.InsertAPIKey(genCtx, database.InsertAPIKeyParams{
+	params := database.InsertAPIKeyParams{
 		ID: takeFirst(seed.ID, id),
 		// 0 defaults to 86400 at the db layer
 		LifetimeSeconds: takeFirst(seed.LifetimeSeconds, 0),
@@ -186,7 +186,11 @@ func APIKey(t testing.TB, db database.Store, seed database.APIKey) (key database
 		LoginType:       takeFirst(seed.LoginType, database.LoginTypePassword),
 		Scope:           takeFirst(seed.Scope, database.APIKeyScopeAll),
 		TokenName:       takeFirst(seed.TokenName),
-	})
+	}
+	for _, fn := range munge {
+		fn(&params)
+	}
+	key, err := db.InsertAPIKey(genCtx, params)
 	require.NoError(t, err, "insert api key")
 	return key, fmt.Sprintf("%s-%s", key.ID, secret)
 }

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -509,6 +509,13 @@ func (m queryMetricsStore) EnqueueNotificationMessage(ctx context.Context, arg d
 	return r0
 }
 
+func (m queryMetricsStore) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error {
+	start := time.Now()
+	r0 := m.s.ExpirePrebuildsAPIKeys(ctx, now)
+	m.queryLatencies.WithLabelValues("ExpirePrebuildsAPIKeys").Observe(time.Since(start).Seconds())
+	return r0
+}
+
 func (m queryMetricsStore) FavoriteWorkspace(ctx context.Context, arg uuid.UUID) error {
 	start := time.Now()
 	r0 := m.s.FavoriteWorkspace(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -933,6 +933,20 @@ func (mr *MockStoreMockRecorder) EnqueueNotificationMessage(ctx, arg any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueNotificationMessage", reflect.TypeOf((*MockStore)(nil).EnqueueNotificationMessage), ctx, arg)
 }
 
+// ExpirePrebuildsAPIKeys mocks base method.
+func (m *MockStore) ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExpirePrebuildsAPIKeys", ctx, now)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExpirePrebuildsAPIKeys indicates an expected call of ExpirePrebuildsAPIKeys.
+func (mr *MockStoreMockRecorder) ExpirePrebuildsAPIKeys(ctx, now any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpirePrebuildsAPIKeys", reflect.TypeOf((*MockStore)(nil).ExpirePrebuildsAPIKeys), ctx, now)
+}
+
 // FavoriteWorkspace mocks base method.
 func (m *MockStore) FavoriteWorkspace(ctx context.Context, id uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -67,6 +67,9 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, clk quartz.
 			if err := tx.DeleteOldNotificationMessages(ctx); err != nil {
 				return xerrors.Errorf("failed to delete old notification messages: %w", err)
 			}
+			if err := tx.ExpirePrebuildsAPIKeys(ctx, dbtime.Time(start)); err != nil {
+				return xerrors.Errorf("failed to expire prebuilds user api keys: %w", err)
+			}
 
 			deleteOldAuditLogConnectionEventsBefore := start.Add(-maxAuditLogConnectionEventAge)
 			if err := tx.DeleteOldAuditLogConnectionEvents(ctx, database.DeleteOldAuditLogConnectionEventsParams{

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionersdk"
@@ -634,4 +635,69 @@ func TestDeleteOldAuditLogConnectionEventsLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, logs, 0)
+}
+
+func TestExpireOldAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	// Given: a number of workspaces and API keys owned by a regular user and the prebuilds system user.
+	var (
+		ctx    = testutil.Context(t, testutil.WaitShort)
+		now    = dbtime.Now()
+		db, _  = dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		org    = dbgen.Organization(t, db, database.Organization{})
+		user   = dbgen.User(t, db, database.User{})
+		tpl    = dbgen.Template(t, db, database.Template{OrganizationID: org.ID, CreatedBy: user.ID})
+		userWs = dbgen.Workspace(t, db, database.WorkspaceTable{
+			OwnerID:    user.ID,
+			TemplateID: tpl.ID,
+		})
+		prebuildsWs = dbgen.Workspace(t, db, database.WorkspaceTable{
+			OwnerID:    database.PrebuildsSystemUserID,
+			TemplateID: tpl.ID,
+		})
+		createAPIKey = func(userID uuid.UUID, name string) database.APIKey {
+			k, _ := dbgen.APIKey(t, db, database.APIKey{UserID: userID, TokenName: name, ExpiresAt: now.Add(time.Hour)}, func(iap *database.InsertAPIKeyParams) {
+				iap.TokenName = name
+			})
+			return k
+		}
+		assertKeyActive = func(kid string) {
+			k, err := db.GetAPIKeyByID(ctx, kid)
+			require.NoError(t, err)
+			assert.True(t, k.ExpiresAt.After(now))
+		}
+		assertKeyExpired = func(kid string) {
+			k, err := db.GetAPIKeyByID(ctx, kid)
+			require.NoError(t, err)
+			assert.True(t, k.ExpiresAt.Equal(now))
+		}
+		unnamedUserAPIKey         = createAPIKey(user.ID, "")
+		unnamedPrebuildsAPIKey    = createAPIKey(database.PrebuildsSystemUserID, "")
+		namedUserAPIKey           = createAPIKey(user.ID, "my-token")
+		namedPrebuildsAPIKey      = createAPIKey(database.PrebuildsSystemUserID, "also-my-token")
+		userWorkspaceAPIKey1      = createAPIKey(user.ID, provisionerdserver.WorkspaceSessionTokenName(user.ID, userWs.ID))
+		userWorkspaceAPIKey2      = createAPIKey(user.ID, provisionerdserver.WorkspaceSessionTokenName(user.ID, prebuildsWs.ID))
+		prebuildsWorkspaceAPIKey1 = createAPIKey(database.PrebuildsSystemUserID, provisionerdserver.WorkspaceSessionTokenName(database.PrebuildsSystemUserID, prebuildsWs.ID))
+		prebuildsWorkspaceAPIKey2 = createAPIKey(database.PrebuildsSystemUserID, provisionerdserver.WorkspaceSessionTokenName(database.PrebuildsSystemUserID, userWs.ID))
+	)
+
+	// When: we call ExpirePrebuildsAPIKeys
+	err := db.ExpirePrebuildsAPIKeys(ctx, now)
+	// Then: no errors is reported.
+	require.NoError(t, err)
+
+	// We do not touch user API keys.
+	assertKeyActive(unnamedUserAPIKey.ID)
+	assertKeyActive(namedUserAPIKey.ID)
+	assertKeyActive(userWorkspaceAPIKey1.ID)
+	assertKeyActive(userWorkspaceAPIKey2.ID)
+	// Unnamed prebuilds API keys get expired.
+	assertKeyExpired(unnamedPrebuildsAPIKey.ID)
+	// API keys for workspaces still owned by prebuilds user remain active until claimed.
+	assertKeyActive(prebuildsWorkspaceAPIKey1.ID)
+	// API keys for workspaces no longer owned by prebuilds user get expired.
+	assertKeyExpired(prebuildsWorkspaceAPIKey2.ID)
+	// Out of an abundance of caution, we do not expire explicitly named prebuilds API keys.
+	assertKeyActive(namedPrebuildsAPIKey.ID)
 }

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -128,6 +128,11 @@ type sqlcQuerier interface {
 	// of the test-only in-memory database. Do not use this in new code.
 	DisableForeignKeysAndTriggers(ctx context.Context) error
 	EnqueueNotificationMessage(ctx context.Context, arg EnqueueNotificationMessageParams) error
+	// Firstly, collect api_keys owned by the prebuilds user that correlate
+	// to workspaces no longer owned by the prebuilds user.
+	// Next, collect api_keys that belong to the prebuilds user but have no token name.
+	// These were most likely created via 'coder login' as the prebuilds user.
+	ExpirePrebuildsAPIKeys(ctx context.Context, now time.Time) error
 	FavoriteWorkspace(ctx context.Context, id uuid.UUID) error
 	FetchMemoryResourceMonitorsByAgentID(ctx context.Context, agentID uuid.UUID) (WorkspaceAgentMemoryResourceMonitor, error)
 	FetchMemoryResourceMonitorsUpdatedAfter(ctx context.Context, updatedAt time.Time) ([]WorkspaceAgentMemoryResourceMonitor, error)

--- a/coderd/database/queries/apikeys.sql
+++ b/coderd/database/queries/apikeys.sql
@@ -83,3 +83,37 @@ DELETE FROM
 	api_keys
 WHERE
 	user_id = $1;
+
+-- name: ExpirePrebuildsAPIKeys :exec
+-- Firstly, collect api_keys owned by the prebuilds user that correlate
+-- to workspaces no longer owned by the prebuilds user.
+WITH unexpired_prebuilds_workspace_session_tokens AS (
+	SELECT id, SUBSTRING(token_name FROM 38 FOR 36)::uuid AS workspace_id
+	FROM api_keys
+	WHERE user_id = 'c42fdf75-3097-471c-8c33-fb52454d81c0'::uuid
+	AND expires_at > @now::timestamptz
+	AND token_name SIMILAR TO 'c42fdf75-3097-471c-8c33-fb52454d81c0_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}_session_token'
+),
+stale_prebuilds_workspace_session_tokens AS (
+	SELECT upwst.id
+	FROM unexpired_prebuilds_workspace_session_tokens upwst
+	LEFT JOIN workspaces w
+	ON w.id = upwst.workspace_id
+	WHERE w.owner_id <> 'c42fdf75-3097-471c-8c33-fb52454d81c0'::uuid
+),
+-- Next, collect api_keys that belong to the prebuilds user but have no token name.
+-- These were most likely created via 'coder login' as the prebuilds user.
+unnamed_prebuilds_api_keys AS (
+	SELECT id
+	FROM api_keys
+	WHERE user_id = 'c42fdf75-3097-471c-8c33-fb52454d81c0'::uuid
+	AND token_name = ''
+	AND expires_at > @now::timestamptz
+)
+UPDATE api_keys
+SET expires_at = @now::timestamptz
+WHERE id IN (
+	SELECT id FROM stale_prebuilds_workspace_session_tokens
+	UNION
+	SELECT id FROM unnamed_prebuilds_api_keys
+);

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2711,15 +2711,23 @@ func InsertWorkspaceResource(ctx context.Context, db database.Store, jobID uuid.
 	return nil
 }
 
-func workspaceSessionTokenName(workspace database.Workspace) string {
-	return fmt.Sprintf("%s_%s_session_token", workspace.OwnerID, workspace.ID)
+func WorkspaceSessionTokenName(ownerID, workspaceID uuid.UUID) string {
+	return fmt.Sprintf("%s_%s_session_token", ownerID, workspaceID)
 }
 
 func (s *server) regenerateSessionToken(ctx context.Context, user database.User, workspace database.Workspace) (string, error) {
+	// NOTE(Cian): Once a workspace is claimed, there's no reason for the session token to be valid any longer.
+	// Not generating any session token at all for a system user may unintentionally break existing templates,
+	// which we want to avoid. If there's no session token for the workspace belonging to the prebuilds user,
+	// then there's nothing for us to worry about here.
+	// TODO(Cian): Update this to handle _all_ system users. At the time of writing, only one system user exists.
+	if err := deleteSessionTokenForUserAndWorkspace(ctx, s.Database, database.PrebuildsSystemUserID, workspace.ID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		s.Logger.Error(ctx, "failed to delete prebuilds session token", slog.Error(err), slog.F("workspace_id", workspace.ID))
+	}
 	newkey, sessionToken, err := apikey.Generate(apikey.CreateParams{
 		UserID:          user.ID,
 		LoginType:       user.LoginType,
-		TokenName:       workspaceSessionTokenName(workspace),
+		TokenName:       WorkspaceSessionTokenName(workspace.OwnerID, workspace.ID),
 		DefaultLifetime: s.DeploymentValues.Sessions.DefaultTokenDuration.Value(),
 		LifetimeSeconds: int64(s.DeploymentValues.Sessions.MaximumTokenDuration.Value().Seconds()),
 	})
@@ -2747,10 +2755,14 @@ func (s *server) regenerateSessionToken(ctx context.Context, user database.User,
 }
 
 func deleteSessionToken(ctx context.Context, db database.Store, workspace database.Workspace) error {
+	return deleteSessionTokenForUserAndWorkspace(ctx, db, workspace.OwnerID, workspace.ID)
+}
+
+func deleteSessionTokenForUserAndWorkspace(ctx context.Context, db database.Store, userID, workspaceID uuid.UUID) error {
 	err := db.InTx(func(tx database.Store) error {
 		key, err := tx.GetAPIKeyByName(ctx, database.GetAPIKeyByNameParams{
-			UserID:    workspace.OwnerID,
-			TokenName: workspaceSessionTokenName(workspace),
+			UserID:    userID,
+			TokenName: WorkspaceSessionTokenName(userID, workspaceID),
 		})
 		if err == nil {
 			err = tx.DeleteAPIKeyByID(ctx, key.ID)

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -3576,6 +3576,70 @@ func TestNotifications(t *testing.T) {
 	})
 }
 
+func TestServer_ExpirePrebuildsSessionToken(t *testing.T) {
+	t.Parallel()
+
+	// Given: a prebuilt workspace where an API key was previously created for the prebuilds user.
+	var (
+		ctx             = testutil.Context(t, testutil.WaitShort)
+		srv, db, ps, pd = setup(t, false, nil)
+		user            = dbgen.User(t, db, database.User{})
+		template        = dbgen.Template(t, db, database.Template{
+			OrganizationID: pd.OrganizationID,
+			CreatedBy:      user.ID,
+		})
+		version = dbgen.TemplateVersion(t, db, database.TemplateVersion{
+			TemplateID:     uuid.NullUUID{UUID: template.ID, Valid: true},
+			OrganizationID: pd.OrganizationID,
+			CreatedBy:      user.ID,
+		})
+		workspace = dbgen.Workspace(t, db, database.WorkspaceTable{
+			OrganizationID: pd.OrganizationID,
+			TemplateID:     template.ID,
+			OwnerID:        database.PrebuildsSystemUserID,
+		})
+		workspaceBuildID = uuid.New()
+		buildJob         = dbgen.ProvisionerJob(t, db, ps, database.ProvisionerJob{
+			OrganizationID: pd.OrganizationID,
+			FileID:         dbgen.File(t, db, database.File{CreatedBy: user.ID}).ID,
+			Type:           database.ProvisionerJobTypeWorkspaceBuild,
+			Input: must(json.Marshal(provisionerdserver.WorkspaceProvisionJob{
+				WorkspaceBuildID: workspaceBuildID,
+			})),
+			InitiatorID: database.PrebuildsSystemUserID,
+			Tags:        pd.Tags,
+		})
+		_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+			ID:                workspaceBuildID,
+			WorkspaceID:       workspace.ID,
+			TemplateVersionID: version.ID,
+			JobID:             buildJob.ID,
+			Transition:        database.WorkspaceTransitionStart,
+			InitiatorID:       database.PrebuildsSystemUserID,
+		})
+		existingKey, _ = dbgen.APIKey(t, db, database.APIKey{
+			UserID:    database.PrebuildsSystemUserID,
+			TokenName: provisionerdserver.WorkspaceSessionTokenName(database.PrebuildsSystemUserID, workspace.ID),
+		})
+	)
+
+	// When: the prebuild claim job is acquired
+	fs := newFakeStream(ctx)
+	err := srv.AcquireJobWithCancel(fs)
+	require.NoError(t, err)
+	job, err := fs.waitForJob()
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	workspaceBuildJob := job.Type.(*proto.AcquiredJob_WorkspaceBuild_).WorkspaceBuild
+	require.NotNil(t, workspaceBuildJob.Metadata)
+
+	// Assert test invariant: we acquired the expected build job
+	require.Equal(t, workspaceBuildID.String(), workspaceBuildJob.WorkspaceBuildId)
+	// Then: The session token should be deleted
+	_, err = db.GetAPIKeyByID(ctx, existingKey.ID)
+	require.ErrorIs(t, err, sql.ErrNoRows, "api key for prebuilds user should be deleted")
+}
+
 type overrides struct {
 	ctx                         context.Context
 	deploymentValues            *codersdk.DeploymentValues


### PR DESCRIPTION

* provisionerdserver: Expires prebuild user token for workspace, if it exists, when regenerating session token.
* dbauthz: disallow prebuilds user from creating api keys
* dbpurge: added functionality to expire stale api keys owned by the prebuilds user

(cherry picked from commit 06cbb2890f453cd522bb2158a6549afa3419c276)
