### PR TITLE
fix(coderd): add audit log on creating a new session key

### DIFF
--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -2,6 +2,7 @@ package coderd_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -303,21 +304,32 @@ func TestSessionExpiry(t *testing.T) {
 
 func TestAPIKey_OK(t *testing.T) {
 	t.Parallel()
+
+	// Given: a deployment with auditing enabled
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 	auditor := audit.NewMock()
 	client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
 	owner := coderdtest.CreateFirstUser(t, client)
-
 	auditor.ResetLogs()
+
+	// When: an API key is created
 	res, err := client.CreateAPIKey(ctx, codersdk.Me)
 	require.NoError(t, err)
 	require.Greater(t, len(res.Key), 2)
-	require.True(t, auditor.Contains(t, database.AuditLog{
-		UserID:       owner.UserID,
-		Action:       database.AuditActionCreate,
-		ResourceType: database.ResourceTypeApiKey,
-	}))
+
+	// Then: an audit log is generated
+	als := auditor.AuditLogs()
+	require.Len(t, als, 1)
+	al := als[0]
+	assert.Equal(t, owner.UserID, al.UserID)
+	assert.Equal(t, database.AuditActionCreate, al.Action)
+	assert.Equal(t, database.ResourceTypeApiKey, al.ResourceType)
+
+	// Then: the diff MUST NOT contain the generated key.
+	raw, err := json.Marshal(al)
+	require.NoError(t, err)
+	require.NotContains(t, res.Key, string(raw))
 }
 
 func TestAPIKey_Deleted(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/19671
(re-?)Adds an audit log entry when an API key is created via `coder login`.

NOTE: This does _not_ backfill audit logs.

<img width="1354" height="207" alt="Screenshot 2025-09-02 at 14 16 24" src="https://github.com/user-attachments/assets/921e85c1-eced-4a19-9d37-8f84f4af1e73" />

