### PR TITLE
fix: show popup on successful template build

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -21,7 +21,7 @@ import {
 	TopbarDivider,
 	TopbarIconButton,
 } from "components/FullPageLayout/Topbar";
-import { displayError } from "components/GlobalSnackbar/utils";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
 import { Loader } from "components/Loader/Loader";
 import { TriangleAlertIcon } from "lucide-react";
 import { ChevronLeftIcon } from "lucide-react";
@@ -178,6 +178,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 			templateVersion.job.status === "succeeded"
 		) {
 			setDirty(false);
+			displaySuccess(`Template version "${previousVersion.current.name}" built successfully.`);
 		}
 		previousVersion.current = templateVersion;
 	}, [templateVersion]);

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
@@ -104,6 +104,7 @@ const buildTemplateVersion = async (
 	});
 	await user.click(buildButton);
 	await within(topbar).findByText("Success");
+	await screen.findByText(`Template version "${templateVersion.name}" built successfully.`);
 };
 
 test("Use custom name, message and set it as active when publishing", async () => {


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/18364

This PR modifies the Template Editor to display a notification when the template build is successful. The previous AI trial is [here](https://github.com/coder/coder/pull/18369).

<img width="564" height="673" alt="Screenshot 2025-09-02 at 14 35 53" src="https://github.com/user-attachments/assets/7a2fb896-b37c-4608-9291-0ef026abb9f8" />
