### PR TITLE
feat(cli): support `--wait` command for task creation

### DIFF
--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -204,9 +204,18 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 			}
 
 			var (
-				eg      errgroup.Group
+				eg   errgroup.Group
+				done = make(chan struct{})
+
+				// When a task has just been created, it will not yet
+				// have an agent associated with it. We have to wait
+				// until the provisioner has picked the job up and
+				// made it sufficiently far.
+				//
+				// As we want to stream the agent logs, we need to
+				// have a way of knowing when an agent has become
+				// available.
 				agentID = make(chan uuid.UUID)
-				done    = make(chan struct{})
 			)
 
 			eg.Go(func() error {

--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -290,7 +290,7 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 
 						case agentLogChunk := <-agentLogs:
 							for _, agentLog := range agentLogChunk {
-								fmt.Fprintln(inv.Stdout, agentLog.Output)
+								fmt.Fprintln(inv.Stderr, agentLog.Output)
 							}
 						}
 					}

--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -77,7 +77,7 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 			},
 			{
 				Name:        "wait-interval",
-				Flag:        "wait-interval",
+				Flag:        "test.wait-interval",
 				Description: "Interval to poll the task for status updates. Only used in tests.",
 				Hidden:      true,
 				Value:       serpent.DurationOf(&waitInterval),

--- a/cli/exp_task_create_test.go
+++ b/cli/exp_task_create_test.go
@@ -439,7 +439,7 @@ func TestTaskCreate(t *testing.T) {
 				ctx    = testutil.Context(t, testutil.WaitShort)
 				srv    = httptest.NewServer(tt.handler(t, ctx))
 				client = codersdk.New(testutil.MustURL(t, srv.URL))
-				args   = []string{"exp", "task", "create", "--wait-interval", testutil.IntervalFast.String()}
+				args   = []string{"exp", "task", "create", "--test.wait-interval", testutil.IntervalFast.String()}
 				sb     strings.Builder
 				err    error
 			)


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/956

Adds a `--wait` flag to the `task create` command to allow waiting until the task reaches an idle or completed state. Whilst waiting it will also stream agent logs.