### PR TITLE
fix(cli/templatepush): only implicitly read from stdin if the directory flag is unset

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -309,8 +309,9 @@ func (pf *templateUploadFlags) stdin(inv *serpent.Invocation) (out bool) {
 			inv.Logger.Info(inv.Context(), "uploading tar read from stdin")
 		}
 	}()
-	// We let the directory override our isTTY check
-	return pf.directory == "-" || (!isTTYIn(inv) && pf.directory == ".")
+	// We read a tar from stdin if the directory is "-" or if we're not in a
+	// TTY and the directory flag is unset.
+	return pf.directory == "-" || (!isTTYIn(inv) && !inv.ParsedFlags().Lookup("directory").Changed)
 }
 
 func (pf *templateUploadFlags) upload(inv *serpent.Invocation, client *codersdk.Client) (*codersdk.UploadResponse, error) {

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -339,6 +339,7 @@ func TestTemplatePush(t *testing.T) {
 		inv, root := clitest.New(t, "templates", "push",
 			"--test.provisioner", string(database.ProvisionerTypeEcho),
 			"--test.workdir", source,
+			"--force-tty",
 		)
 		clitest.SetupConfig(t, templateAdmin, root)
 		pty := ptytest.New(t).Attach(inv)
@@ -1074,6 +1075,45 @@ func TestTemplatePush(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, templateName, template.Name)
 			require.NotEqual(t, uuid.Nil, template.ActiveVersionID)
+		})
+
+		t.Run("NoStdinWithCurrentDirectory", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+			version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+			_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+
+			template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+			source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+				Parse:          echo.ParseComplete,
+				ProvisionApply: echo.ApplyComplete,
+			})
+
+			inv, root := clitest.New(t, "templates", "push", template.Name,
+				"--directory", ".",
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--test.workdir", source,
+				"--name", "example",
+				"--yes")
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			inv.Stdin = strings.NewReader("invalid tar content that would cause failure")
+
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+			defer cancel()
+
+			err := inv.WithContext(ctx).Run()
+			require.NoError(t, err, "Should succeed without reading from stdin")
+
+			templateVersions, err := client.TemplateVersionsByTemplate(ctx, codersdk.TemplateVersionsByTemplateRequest{
+				TemplateID: template.ID,
+			})
+			require.NoError(t, err)
+			require.Len(t, templateVersions, 2)
+			require.Equal(t, "example", templateVersions[1].Name)
 		})
 	})
 }


### PR DESCRIPTION
In trying to address confusion with the `-`  (for stdin) directory flag last year, I had `template push` read from stdin if stdin was not a TTY. However, I made the mistake of checking if the directory flag was set or not by comparing it to the default value. This meant in something like GitHub Actions, where you don't have a TTY for stdin, it was impossible to read from the current working directory. The fix is just to check if the flag was explicitly set, using pflags.

If users encounter this bug, and this fix is unavailable in their version of Coder, they can workaround it by setting `-d "$(pwd)"` 