### PR TITLE
test: fix TestCache_DeploymentStats flake

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -459,7 +459,7 @@ func New(options *Options) *API {
 	metricsCache := metricscache.New(
 		options.Database,
 		options.Logger.Named("metrics_cache"),
-		options.Clock,
+		quartz.NewReal(),
 		metricscache.Intervals{
 			TemplateBuildTimes: options.MetricsCacheRefreshInterval,
 			DeploymentStats:    options.AgentStatsRefreshInterval,

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -35,9 +35,9 @@ type Cache struct {
 	templateAverageBuildTime atomic.Pointer[map[uuid.UUID]database.GetTemplateAverageBuildTimeRow]
 	deploymentStatsResponse  atomic.Pointer[codersdk.DeploymentStats]
 
-	cancel     func()
-	tickersMu  sync.Mutex
-	tickers    []quartz.Waiter
+	cancel    func()
+	tickersMu sync.Mutex
+	tickers   []quartz.Waiter
 
 	// usage is a experiment flag to enable new workspace usage tracking behavior and will be
 	// removed when the experiment is complete.
@@ -206,7 +206,7 @@ func (c *Cache) Close() error {
 	c.tickersMu.Lock()
 	tickers := slices.Clone(c.tickers)
 	c.tickersMu.Unlock()
-	
+
 	for _, tkr := range tickers {
 		_ = tkr.Wait()
 	}

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -61,7 +61,6 @@ func TestCache_TemplateWorkspaceOwners(t *testing.T) {
 
 	cache, db := newMetricsCache(t, log, clock, metricscache.Intervals{
 		TemplateBuildTimes: time.Minute,
-		DeploymentStats:    time.Minute,
 	}, false)
 
 	org := dbgen.Organization(t, db, database.Organization{})
@@ -77,10 +76,7 @@ func TestCache_TemplateWorkspaceOwners(t *testing.T) {
 	trapTickerFunc.MustWait(ctx).MustRelease(ctx)
 	trapTickerFunc.MustWait(ctx).MustRelease(ctx)
 
-	_, wait := clock.AdvanceNext()
-	wait.MustWait(ctx)
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
+	clock.Advance(time.Minute).MustWait(ctx)
 
 	count, ok := cache.TemplateWorkspaceOwners(template.ID)
 	require.True(t, ok, "TemplateWorkspaceOwners should be populated")
@@ -92,10 +88,7 @@ func TestCache_TemplateWorkspaceOwners(t *testing.T) {
 		OwnerID:        user1.ID,
 	})
 
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
+	clock.Advance(time.Minute).MustWait(ctx)
 
 	count, _ = cache.TemplateWorkspaceOwners(template.ID)
 	require.Equal(t, 1, count, "should have 1 owner after adding workspace")
@@ -106,10 +99,7 @@ func TestCache_TemplateWorkspaceOwners(t *testing.T) {
 		OwnerID:        user2.ID,
 	})
 
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
+	clock.Advance(time.Minute).MustWait(ctx)
 
 	count, _ = cache.TemplateWorkspaceOwners(template.ID)
 	require.Equal(t, 2, count, "should have 2 owners after adding second workspace")
@@ -126,10 +116,7 @@ func TestCache_TemplateWorkspaceOwners(t *testing.T) {
 		Deleted: true,
 	})
 
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
+	clock.Advance(time.Minute).MustWait(ctx)
 
 	count, _ = cache.TemplateWorkspaceOwners(template.ID)
 	require.Equal(t, 1, count, "should have 1 owner after deleting workspace")
@@ -233,7 +220,6 @@ func TestCache_BuildTime(t *testing.T) {
 			defer trapTickerFunc.Close()
 			cache, db := newMetricsCache(t, log, clock, metricscache.Intervals{
 				TemplateBuildTimes: time.Minute,
-				DeploymentStats:    time.Minute,
 			}, false)
 
 			org := dbgen.Organization(t, db, database.Organization{})
@@ -282,10 +268,7 @@ func TestCache_BuildTime(t *testing.T) {
 			trapTickerFunc.MustWait(ctx).MustRelease(ctx)
 			trapTickerFunc.MustWait(ctx).MustRelease(ctx)
 
-			_, wait := clock.AdvanceNext()
-			wait.MustWait(ctx)
-			_, wait = clock.AdvanceNext()
-			wait.MustWait(ctx)
+			clock.Advance(time.Minute).MustWait(ctx)
 
 			if tt.want.loads {
 				wantTransition := codersdk.WorkspaceTransition(tt.args.transition)
@@ -322,8 +305,7 @@ func TestCache_DeploymentStats(t *testing.T) {
 	defer tickerTrap.Close()
 
 	cache, db := newMetricsCache(t, log, clock, metricscache.Intervals{
-		TemplateBuildTimes: time.Minute,
-		DeploymentStats:    time.Minute,
+		DeploymentStats: time.Minute,
 	}, false)
 
 	err := db.InsertWorkspaceAgentStats(context.Background(), database.InsertWorkspaceAgentStatsParams{
@@ -353,10 +335,7 @@ func TestCache_DeploymentStats(t *testing.T) {
 	tickerTrap.MustWait(ctx).MustRelease(ctx)
 	tickerTrap.MustWait(ctx).MustRelease(ctx)
 
-	_, wait := clock.AdvanceNext()
-	wait.MustWait(ctx)
-	_, wait = clock.AdvanceNext()
-	wait.MustWait(ctx)
+	clock.Advance(time.Minute).MustWait(ctx)
 
 	stat, ok := cache.DeploymentStats()
 	require.True(t, ok, "cache should be populated after refresh")


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/961
Likely the same deal as in #19599, the body of `require.Eventually` now fires immediately, when it used to fire after 250ms (the interval). Presumably, the deployment stats become ready before the vs code session count gets incremented. This was never an issue with the 250ms delay, as this flake has only cropped up after the testify version bump.

We'll fix the issue by making it possible to wait for a full metrics cache refresh, i.e. removing `require.Eventually` in this test altogether.