### PR TITLE
fix: change enqueue error to debug log level

### DIFF
--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -693,8 +693,9 @@ func (m *mapper) run() {
 			m.logger.Debug(m.ctx, "skipping nil node update")
 			continue
 		}
-		if err := m.c.Enqueue(update); err != nil && !xerrors.Is(err, context.Canceled) {
-			m.logger.Error(m.ctx, "failed to enqueue node update", slog.Error(err))
+		if err := m.c.Enqueue(update); err != nil {
+			// lots of reasons this could happen, most usually, the peer has disconnected.
+			m.logger.Debug(m.ctx, "failed to enqueue node update", slog.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
fixes https://github.com/coder/internal/issues/958

Logging was being done at error level, but most likely any errors are from simple races between an update triggered around the same time as a client disconnecting. Debug is fine for these.