### PR TITLE
fix: reduce load on DB from entitlements check by introducing count queries

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2081,6 +2081,22 @@ func (q *querier) GetExternalAuthLinksByUserID(ctx context.Context, userID uuid.
 	return fetchWithPostFilter(q.auth, policy.ActionReadPersonal, q.db.GetExternalAuthLinksByUserID)(ctx, userID)
 }
 
+func (q *querier) GetExternalTemplateCount(ctx context.Context) (int64, error) {
+	// This is a system-level count query for license entitlements
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
+		return 0, err
+	}
+	return q.db.GetExternalTemplateCount(ctx)
+}
+
+func (q *querier) GetExternalWorkspaceCount(ctx context.Context) (int64, error) {
+	// This is a system-level count query for license entitlements
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
+		return 0, err
+	}
+	return q.db.GetExternalWorkspaceCount(ctx)
+}
+
 func (q *querier) GetFailedWorkspaceBuildsByTemplateID(ctx context.Context, arg database.GetFailedWorkspaceBuildsByTemplateIDParams) ([]database.GetFailedWorkspaceBuildsByTemplateIDRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2695,6 +2695,15 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		dbm.EXPECT().GetActiveUserCount(gomock.Any(), false).Return(int64(0), nil).AnyTimes()
 		check.Args(false).Asserts(rbac.ResourceSystem, policy.ActionRead).Returns(int64(0))
 	}))
+	s.Run("GetExternalWorkspaceCount", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetExternalWorkspaceCount(gomock.Any()).Return(int64(0), nil).AnyTimes()
+		check.Args().Asserts(rbac.ResourceSystem, policy.ActionRead).Returns(int64(0))
+	}))
+
+	s.Run("GetExternalTemplateCount", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetExternalTemplateCount(gomock.Any()).Return(int64(0), nil).AnyTimes()
+		check.Args().Asserts(rbac.ResourceSystem, policy.ActionRead).Returns(int64(0))
+	}))
 	s.Run("GetAuthorizationUserRoles", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		u := testutil.Fake(s.T(), faker, database.User{})
 		dbm.EXPECT().GetAuthorizationUserRoles(gomock.Any(), u.ID).Return(database.GetAuthorizationUserRolesRow{}, nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -817,6 +817,20 @@ func (m queryMetricsStore) GetExternalAuthLinksByUserID(ctx context.Context, use
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetExternalTemplateCount(ctx context.Context) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetExternalTemplateCount(ctx)
+	m.queryLatencies.WithLabelValues("GetExternalTemplateCount").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetExternalWorkspaceCount(ctx context.Context) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetExternalWorkspaceCount(ctx)
+	m.queryLatencies.WithLabelValues("GetExternalWorkspaceCount").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetFailedWorkspaceBuildsByTemplateID(ctx context.Context, arg database.GetFailedWorkspaceBuildsByTemplateIDParams) ([]database.GetFailedWorkspaceBuildsByTemplateIDRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetFailedWorkspaceBuildsByTemplateID(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1695,6 +1695,36 @@ func (mr *MockStoreMockRecorder) GetExternalAuthLinksByUserID(ctx, userID any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalAuthLinksByUserID", reflect.TypeOf((*MockStore)(nil).GetExternalAuthLinksByUserID), ctx, userID)
 }
 
+// GetExternalTemplateCount mocks base method.
+func (m *MockStore) GetExternalTemplateCount(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExternalTemplateCount", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExternalTemplateCount indicates an expected call of GetExternalTemplateCount.
+func (mr *MockStoreMockRecorder) GetExternalTemplateCount(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalTemplateCount", reflect.TypeOf((*MockStore)(nil).GetExternalTemplateCount), ctx)
+}
+
+// GetExternalWorkspaceCount mocks base method.
+func (m *MockStore) GetExternalWorkspaceCount(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExternalWorkspaceCount", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExternalWorkspaceCount indicates an expected call of GetExternalWorkspaceCount.
+func (mr *MockStoreMockRecorder) GetExternalWorkspaceCount(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalWorkspaceCount", reflect.TypeOf((*MockStore)(nil).GetExternalWorkspaceCount), ctx)
+}
+
 // GetFailedWorkspaceBuildsByTemplateID mocks base method.
 func (m *MockStore) GetFailedWorkspaceBuildsByTemplateID(ctx context.Context, arg database.GetFailedWorkspaceBuildsByTemplateIDParams) ([]database.GetFailedWorkspaceBuildsByTemplateIDRow, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -187,6 +187,8 @@ type sqlcQuerier interface {
 	GetEligibleProvisionerDaemonsByProvisionerJobIDs(ctx context.Context, provisionerJobIds []uuid.UUID) ([]GetEligibleProvisionerDaemonsByProvisionerJobIDsRow, error)
 	GetExternalAuthLink(ctx context.Context, arg GetExternalAuthLinkParams) (ExternalAuthLink, error)
 	GetExternalAuthLinksByUserID(ctx context.Context, userID uuid.UUID) ([]ExternalAuthLink, error)
+	GetExternalTemplateCount(ctx context.Context) (int64, error)
+	GetExternalWorkspaceCount(ctx context.Context) (int64, error)
 	GetFailedWorkspaceBuildsByTemplateID(ctx context.Context, arg GetFailedWorkspaceBuildsByTemplateIDParams) ([]GetFailedWorkspaceBuildsByTemplateIDRow, error)
 	GetFileByHashAndCreator(ctx context.Context, arg GetFileByHashAndCreatorParams) (File, error)
 	GetFileByID(ctx context.Context, id uuid.UUID) (File, error)

--- a/coderd/database/queries/templates.sql
+++ b/coderd/database/queries/templates.sql
@@ -95,6 +95,13 @@ WHERE
 LIMIT
 	1;
 
+-- name: GetExternalTemplateCount :one
+SELECT COUNT(*)
+FROM template_with_names AS t
+LEFT JOIN template_versions tv ON t.active_version_id = tv.id
+WHERE t.deleted = false
+  AND tv.has_external_agent = true;
+
 -- name: GetTemplates :many
 SELECT * FROM template_with_names AS templates
 ORDER BY (name, id) ASC

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -97,6 +97,25 @@ WHERE
 			)
 	);
 
+-- name: GetExternalWorkspaceCount :one
+SELECT COUNT(*)
+FROM workspaces_expanded as workspaces
+WHERE workspaces.deleted = false
+  AND EXISTS (
+    SELECT 1
+    FROM workspace_builds wb
+    JOIN provisioner_jobs pj ON pj.id = wb.job_id
+    WHERE wb.workspace_id = workspaces.id
+      AND wb.has_external_agent = true
+      AND wb.id = (
+        SELECT wb2.id
+        FROM workspace_builds wb2
+        WHERE wb2.workspace_id = workspaces.id
+        ORDER BY wb2.build_number DESC
+        LIMIT 1
+      )
+  );
+
 -- name: GetWorkspaces :many
 WITH
 -- build_params is used to filter by build parameters if present.


### PR DESCRIPTION
These new queries ONLY count the # of relevant workspaces or templates in the database for this entitlements functionality, as opposed to querying all rows and doing complex joins for data that is ultimately irrelevant for this code path.

see https://github.com/coder/internal/issues/964#issue-3381210101
