### PR TITLE
fix: pin pg_dump version when generating schema for 2.24

### DIFF
--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -254,26 +253,31 @@ func PGDump(dbURL string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
-const minimumPostgreSQLVersion = 13
+const (
+	minimumPostgreSQLVersion = 13
+	postgresImageSha         = "sha256:467e7f2fb97b2f29d616e0be1d02218a7bbdfb94eb3cda7461fd80165edfd1f7"
+)
 
 // PGDumpSchemaOnly is for use by gen/dump only.
 // It runs pg_dump against dbURL and sets a consistent timezone and encoding.
 func PGDumpSchemaOnly(dbURL string) ([]byte, error) {
 	hasPGDump := false
-	if _, err := exec.LookPath("pg_dump"); err == nil {
-		out, err := exec.Command("pg_dump", "--version").Output()
-		if err == nil {
-			// Parse output:
-			// pg_dump (PostgreSQL) 14.5 (Ubuntu 14.5-0ubuntu0.22.04.1)
-			parts := strings.Split(string(out), " ")
-			if len(parts) > 2 {
-				version, err := strconv.Atoi(strings.Split(parts[2], ".")[0])
-				if err == nil && version >= minimumPostgreSQLVersion {
-					hasPGDump = true
-				}
-			}
-		}
-	}
+	// TODO: Temporarily pin pg_dump to the docker image until
+	// https://github.com/sqlc-dev/sqlc/issues/4065 is resolved.
+	// if _, err := exec.LookPath("pg_dump"); err == nil {
+	// 	out, err := exec.Command("pg_dump", "--version").Output()
+	// 	if err == nil {
+	// 		// Parse output:
+	// 		// pg_dump (PostgreSQL) 14.5 (Ubuntu 14.5-0ubuntu0.22.04.1)
+	// 		parts := strings.Split(string(out), " ")
+	// 		if len(parts) > 2 {
+	// 			version, err := strconv.Atoi(strings.Split(parts[2], ".")[0])
+	// 			if err == nil && version >= minimumPostgreSQLVersion {
+	// 				hasPGDump = true
+	// 			}
+	// 		}
+	// 	}
+	// }
 
 	cmdArgs := []string{
 		"pg_dump",
@@ -298,7 +302,7 @@ func PGDumpSchemaOnly(dbURL string) ([]byte, error) {
 			"run",
 			"--rm",
 			"--network=host",
-			fmt.Sprintf("%s:%d", postgresImage, minimumPostgreSQLVersion),
+			fmt.Sprintf("%s:%d@%s", postgresImage, minimumPostgreSQLVersion, postgresImageSha),
 		}, cmdArgs...)
 	}
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //#nosec


### PR DESCRIPTION
Cherry-pick for release v2.24.4.
https://github.com/coder/coder/pull/19696