### PR TITLE
fix(coderd/database): optimize provisioner daemon with status query using index

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -2947,6 +2947,10 @@ CREATE INDEX provisioner_job_logs_id_job_id_idx ON provisioner_job_logs USING bt
 
 CREATE INDEX provisioner_jobs_started_at_idx ON provisioner_jobs USING btree (started_at) WHERE (started_at IS NULL);
 
+CREATE INDEX provisioner_jobs_worker_id_organization_id_completed_at_idx ON provisioner_jobs USING btree (worker_id, organization_id, completed_at DESC);
+
+COMMENT ON INDEX provisioner_jobs_worker_id_organization_id_completed_at_idx IS 'Support index for finding the latest completed jobs for a worker (and organization), nulls first so that active jobs have priority; targets: GetProvisionerDaemonsWithStatusByOrganization';
+
 CREATE UNIQUE INDEX provisioner_keys_organization_id_name_idx ON provisioner_keys USING btree (organization_id, lower((name)::text));
 
 CREATE INDEX template_usage_stats_start_time_idx ON template_usage_stats USING btree (start_time DESC);

--- a/coderd/database/migrations/000363_optimize_getprovisionerdaemonswithstatusbyorganization_query.down.sql
+++ b/coderd/database/migrations/000363_optimize_getprovisionerdaemonswithstatusbyorganization_query.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX provisioner_jobs_worker_id_organization_id_completed_at_idx;

--- a/coderd/database/migrations/000363_optimize_getprovisionerdaemonswithstatusbyorganization_query.up.sql
+++ b/coderd/database/migrations/000363_optimize_getprovisionerdaemonswithstatusbyorganization_query.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX provisioner_jobs_worker_id_organization_id_completed_at_idx ON provisioner_jobs (worker_id, organization_id, completed_at DESC NULLS FIRST);
+
+COMMENT ON INDEX provisioner_jobs_worker_id_organization_id_completed_at_idx IS 'Support index for finding the latest completed jobs for a worker (and organization), nulls first so that active jobs have priority; targets: GetProvisionerDaemonsWithStatusByOrganization';


### PR DESCRIPTION
Fixes coder/internal#724

This change adds an index to optimize the `GetProvisionerDaemonsWithStatusByOrganization` query.

On dogfood, this index does not add a lot of weight to the database and reduces execution time.

- Execution time: `18s 838ms` => `107ms`.
- Old plan: https://explain.dalibo.com/plan/eb54e284g5age6a1
- New plan: https://explain.dalibo.com/plan/3fh6defecffhbg49

```
coder=> \di+ provisioner_jobs_worker_id_organization_id_completed_at_idx
List of relations
-[ RECORD 1 ]-+------------------------------------------------------------
Schema        | public
Name          | provisioner_jobs_worker_id_organization_id_completed_at_idx
Type          | index
Owner         | coder
Table         | provisioner_jobs
Persistence   | permanent
Access method | btree
Size          | 4720 kB
Description   |
```