### PR TITLE
fix(coderd): ensure agent WebSocket conn is cleaned up

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -883,10 +883,10 @@ func (api *API) watchWorkspaceAgentContainers(rw http.ResponseWriter, r *http.Re
 	// close frames.
 	_ = conn.CloseRead(context.Background())
 
-	go httpapi.HeartbeatClose(ctx, logger, cancel, conn)
-
 	ctx, wsNetConn := codersdk.WebsocketNetConn(ctx, conn, websocket.MessageText)
 	defer wsNetConn.Close()
+
+	go httpapi.HeartbeatClose(ctx, logger, cancel, conn)
 
 	encoder := json.NewEncoder(wsNetConn)
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -815,12 +815,10 @@ func (api *API) workspaceAgentListeningPorts(rw http.ResponseWriter, r *http.Req
 // @Router /workspaceagents/{workspaceagent}/containers/watch [get]
 func (api *API) watchWorkspaceAgentContainers(rw http.ResponseWriter, r *http.Request) {
 	var (
+		ctx            = r.Context()
 		workspaceAgent = httpmw.WorkspaceAgentParam(r)
 		logger         = api.Logger.Named("agent_container_watcher").With(slog.F("agent_id", workspaceAgent.ID))
 	)
-
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
 
 	// If the agent is unreachable, the request will hang. Assume that if we
 	// don't get a response after 30s that the agent is unreachable.
@@ -878,6 +876,9 @@ func (api *API) watchWorkspaceAgentContainers(rw http.ResponseWriter, r *http.Re
 		})
 		return
 	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
 
 	// Here we close the websocket for reading, so that the websocket library will handle pings and
 	// close frames.


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/19449

This PR fixes an unfortunate bug in the watch workspace agent containers endpoint.

The `/containers/watch` endpoint works a little like this:

```mermaid
sequenceDiagram
  Client->>coderd: `GET /containers/watch`
  coderd->>Agent: `GET /containers/watch`
  Agent->>coderd: `ACCEPT`
  Agent<<->>coderd: WebSocket Connection
  coderd->>Client: `ACCEPT`
  coderd<<->>Client: WebSocket Connection
```

Unfortunately, when the connection between the Client and coderd was closed, the connection between coderd and the Agent was kept alive. Leaving this WebSocket connection alive meant that every 15 seconds a Heartbeat ping was sent between coderd and the agent. As this heartbeat traffic happened over the tailnet, the agent recorded this network traffic as workspace activity, which resulted in coderd bumping the lifetime of the workspace every minute.

The changes introduced in this PR ensure that when the heartbeat between the Client and coderd stop, it cancels a context which causes a cleanup for the WebSocket between coderd and the Agent.