### PR TITLE
perf(coderd/database): optimize GetAPIKeysLastUsedAfter

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -2861,6 +2861,10 @@ ALTER TABLE ONLY workspace_resources
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_pkey PRIMARY KEY (id);
 
+CREATE INDEX api_keys_last_used_idx ON api_keys USING btree (last_used DESC);
+
+COMMENT ON INDEX api_keys_last_used_idx IS 'Index for optimizing api_keys queries filtering by last_used';
+
 CREATE INDEX idx_agent_stats_created_at ON workspace_agent_stats USING btree (created_at);
 
 CREATE INDEX idx_agent_stats_user_id ON workspace_agent_stats USING btree (user_id);

--- a/coderd/database/migrations/000365_add_index_for_getapikeyslastusedafter.down.sql
+++ b/coderd/database/migrations/000365_add_index_for_getapikeyslastusedafter.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX api_keys_last_used_idx;

--- a/coderd/database/migrations/000365_add_index_for_getapikeyslastusedafter.up.sql
+++ b/coderd/database/migrations/000365_add_index_for_getapikeyslastusedafter.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX api_keys_last_used_idx ON api_keys (last_used DESC);
+COMMENT ON INDEX api_keys_last_used_idx IS 'Index for optimizing api_keys queries filtering by last_used';


### PR DESCRIPTION
A drive-by DB optimization as I happened to notice it in Google Cloud Console.

- Execution time for test time range: `170ms` -> `3.3ms`
- Before: https://explain.dalibo.com/plan/f7c6hd51d144che2
- After: https://explain.dalibo.com/plan/aaf292723gca3f89

Stats for 24h, seemed significant enough to warrant the change (second row, highlighted):

<img width="927" height="221" alt="image" src="https://github.com/user-attachments/assets/e3f32e5f-ae97-4b6a-9e89-8a9f6abd4e37" />

https://console.cloud.google.com/sql/instances/dogfood-v2/insights;database=coder;start=2025-09-07T08:34:12.939Z;end=2025-09-08T08:34:12.939Z;trace=888deb8b5cc5ec79ab431eb62ac68f66;span=21fc95e3e2bd4505;query_hash=16544386190558458463;sort_by=TOTAL_EXEC_TIME?inv=1&invt=Ab0giQ&project=coder-dogfood-v2
