### PR TITLE
chore(cli): reduce clutter from `exp tasks list` command

### DIFF
--- a/cli/exp_task_list.go
+++ b/cli/exp_task_list.go
@@ -36,13 +36,13 @@ func (r *RootCmd) taskList() *serpent.Command {
 		statusFilter string
 		all          bool
 		user         string
+		quiet        bool
 
 		client    = new(codersdk.Client)
 		formatter = cliui.NewOutputFormatter(
 			cliui.TableFormat(
 				[]taskListRow{},
 				[]string{
-					"id",
 					"name",
 					"status",
 					"state",
@@ -98,6 +98,14 @@ func (r *RootCmd) taskList() *serpent.Command {
 				Default:     "",
 				Value:       serpent.StringOf(&user),
 			},
+			{
+				Name:          "quiet",
+				Description:   "Only display task IDs.",
+				Flag:          "quiet",
+				FlagShorthand: "q",
+				Default:       "false",
+				Value:         serpent.BoolOf(&quiet),
+			},
 		},
 		Handler: func(inv *serpent.Invocation) error {
 			ctx := inv.Context()
@@ -114,6 +122,14 @@ func (r *RootCmd) taskList() *serpent.Command {
 			})
 			if err != nil {
 				return xerrors.Errorf("list tasks: %w", err)
+			}
+
+			if quiet {
+				for _, task := range tasks {
+					_, _ = fmt.Fprintln(inv.Stdout, task.ID.String())
+				}
+
+				return nil
 			}
 
 			// If no rows and not JSON, show a friendly message.


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/19623

- Stop showing the long ID of each task by default.
- Add new `--quiet` flag to _only_ show IDs.

```sh
coder@danielle ~/coder > ./scripts/coder-dev.sh exp task list --quiet
df0eef9d-899a-4755-ba38-dc8990b567c7
ff4d95a8-ab0d-4185-85b0-78db0c75d67d

coder@danielle ~/coder > ./scripts/coder-dev.sh exp task list
NAME                STATUS   STATE  STATE CHANGED  MESSAGE
blush-platypus-16   stopped  idle   74h29m5s ago
task-stoic-tu-4067  stopped  idle   93h25m25s ago  Ready for next task
```