### PR TITLE
fix: support path parameters in OAuth2 metadata endpoints

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -948,9 +948,13 @@ func New(options *Options) *API {
 	}
 
 	// OAuth2 metadata endpoint for RFC 8414 discovery
-	r.Get("/.well-known/oauth-authorization-server", api.oauth2AuthorizationServerMetadata())
+	r.Route("/.well-known/oauth-authorization-server", func(r chi.Router) {
+		r.Get("/*", api.oauth2AuthorizationServerMetadata())
+	})
 	// OAuth2 protected resource metadata endpoint for RFC 9728 discovery
-	r.Get("/.well-known/oauth-protected-resource", api.oauth2ProtectedResourceMetadata())
+	r.Route("/.well-known/oauth-protected-resource", func(r chi.Router) {
+		r.Get("/*", api.oauth2ProtectedResourceMetadata())
+	})
 
 	// OAuth2 linking routes do not make sense under the /api/v2 path.  These are
 	// for an external application to use Coder as an OAuth2 provider, not for


### PR DESCRIPTION
Update OAuth2 metadata endpoint routes to support path suffixes

This PR updates the OAuth2 metadata endpoint routes to include a wildcard character (*) at the end of the paths. This change allows the endpoints to match requests with path suffixes, making our OAuth2 discovery implementation more flexible and compliant with the relevant RFCs.

The updated routes are:
- `/.well-known/oauth-authorization-server*` for RFC 8414 discovery
- `/.well-known/oauth-protected-resource*` for RFC 9728 discovery