### PR TITLE
perf(enterprise): remove expensive GetWorkspaces query from entitlements

### DIFF
--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -844,9 +844,6 @@ func TestEntitlements(t *testing.T) {
 			})).
 			Return(int64(175), nil)
 		mDB.EXPECT().
-			GetWorkspaces(gomock.Any(), gomock.Any()).
-			Return([]database.GetWorkspacesRow{}, nil)
-		mDB.EXPECT().
 			GetTemplatesWithFilter(gomock.Any(), gomock.Any()).
 			Return([]database.Template{}, nil)
 

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -1237,19 +1237,6 @@ func TestLicenseEntitlements(t *testing.T) {
 			},
 		},
 		{
-			Name: "ExternalWorkspace",
-			Licenses: []*coderdenttest.LicenseOptions{
-				enterpriseLicense().UserLimit(100),
-			},
-			Arguments: license.FeatureArguments{
-				ExternalWorkspaceCount: 1,
-			},
-			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
-				assert.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[codersdk.FeatureWorkspaceExternalAgent].Entitlement)
-				assert.True(t, entitlements.Features[codersdk.FeatureWorkspaceExternalAgent].Enabled)
-			},
-		},
-		{
 			Name: "ExternalTemplate",
 			Licenses: []*coderdenttest.LicenseOptions{
 				enterpriseLicense().UserLimit(100),


### PR DESCRIPTION
Closes: https://github.com/coder/internal/issues/964

This PR addresses the significant database load issue where the `GetWorkspaces` query was causing performance problems in the license entitlements code.

