### PR TITLE
feat: scope allow_list to include `resource_type`

### DIFF
--- a/coderd/rbac/README.md
+++ b/coderd/rbac/README.md
@@ -169,7 +169,7 @@ This command answers the question: “Is the user allowed?”
 ### Partial Evaluation
 
 ```bash
-opa eval --partial --format=pretty 'data.authz.allow' -d policy.rego --unknowns input.object.owner --unknowns input.object.org_owner --unknowns input.object.acl_user_list --unknowns input.object.acl_group_list -i input.json
+opa eval --partial --format=pretty 'data.authz.allow' -d policy.rego --unknowns input.object.id --unknowns input.object.owner --unknowns input.object.org_owner --unknowns input.object.acl_user_list --unknowns input.object.acl_group_list -i input.json
 ```
 
 This command performs a partial evaluation of the policy, specifying a set of unknown input parameters.

--- a/coderd/rbac/astvalue.go
+++ b/coderd/rbac/astvalue.go
@@ -182,9 +182,25 @@ func (s Scope) regoValue() ast.Value {
 	if !ok {
 		panic("developer error: role is not an object")
 	}
+
+	terms := make([]*ast.Term, len(s.AllowIDList))
+	for i, v := range s.AllowIDList {
+		terms[i] = ast.NewTerm(ast.NewObject(
+			[2]*ast.Term{
+				ast.StringTerm("type"),
+				ast.StringTerm(v.Type),
+			},
+			[2]*ast.Term{
+				ast.StringTerm("id"),
+				ast.StringTerm(v.ID),
+			},
+		),
+		)
+	}
+
 	r.Insert(
 		ast.StringTerm("allow_list"),
-		ast.NewTerm(regoSliceString(s.AllowIDList...)),
+		ast.NewTerm(ast.NewArray(terms...)),
 	)
 	return r
 }

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -929,7 +929,7 @@ func TestAuthorizeScope(t *testing.T) {
 				Org:  map[string][]Permission{},
 				User: []Permission{},
 			},
-			AllowIDList: []string{workspaceID.String()},
+			AllowIDList: []AllowListElement{{Type: ResourceWorkspace.Type, ID: workspaceID.String()}},
 		},
 	}
 
@@ -1019,7 +1019,9 @@ func TestAuthorizeScope(t *testing.T) {
 				User: []Permission{},
 			},
 			// Empty string allow_list is allowed for actions like 'create'
-			AllowIDList: []string{""},
+			AllowIDList: []AllowListElement{{
+				Type: ResourceWorkspace.Type, ID: "",
+			}},
 		},
 	}
 
@@ -1145,7 +1147,7 @@ func TestAuthorizeScope(t *testing.T) {
 					ResourceUser.Type: {policy.ActionRead},
 				}),
 			},
-			AllowIDList: []string{policy.WildcardSymbol},
+			AllowIDList: []AllowListElement{AllowListAll()},
 		},
 	}
 

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -1166,6 +1166,8 @@ func TestAuthorizeScope(t *testing.T) {
 }
 
 func TestScopeAllowList(t *testing.T) {
+	t.Parallel()
+
 	defOrg := uuid.New()
 
 	// Some IDs to use

--- a/coderd/rbac/input.json
+++ b/coderd/rbac/input.json
@@ -43,7 +43,7 @@
 			"allow_list": [
 				{
 					"type": "workspace",
-					"id": "9046b041-58ed-47a3-9c3a-de302577875a"
+					"id": "*"
 				}]
 		}
 	}

--- a/coderd/rbac/input.json
+++ b/coderd/rbac/input.json
@@ -1,5 +1,5 @@
 {
-	"action": "never-match-action",
+	"action": "read",
 	"object": {
 		"id": "9046b041-58ed-47a3-9c3a-de302577875a",
 		"owner": "00000000-0000-0000-0000-000000000000",
@@ -42,8 +42,8 @@
 			"user": [],
 			"allow_list": [
 				{
-					"type": "*",
-					"id": "*"
+					"type": "workspace",
+					"id": "9046b041-58ed-47a3-9c3a-de302577875a"
 				}]
 		}
 	}

--- a/coderd/rbac/input.json
+++ b/coderd/rbac/input.json
@@ -40,7 +40,11 @@
 			],
 			"org": {},
 			"user": [],
-			"allow_list": ["*"]
+			"allow_list": [
+				{
+					"type": "*",
+					"id": "*"
+				}]
 		}
 	}
 }

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -249,7 +249,8 @@ user_allow(roles) := num if {
 # Scope allow_list is a list of resource IDs explicitly allowed by the scope.
 # If the list is '*', then all resources are allowed.
 scope_allow_list if {
-	"*" in input.subject.scope.allow_list
+	some x
+	input.subject.scope.allow_list[x] == {"type": "*", "id": "*"}
 }
 
 scope_allow_list if {

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -249,8 +249,12 @@ user_allow(roles) := num if {
 # Scope allow_list is a list of resource IDs explicitly allowed by the scope.
 # If the list is '*', then all resources are allowed.
 scope_allow_list if {
-	some x
-	input.subject.scope.allow_list[x] == {"type": "*", "id": "*"}
+	input.subject.scope.allow_list[_] == {"type": "*", "id": "*"}
+}
+
+scope_allow_list if {
+  # shortcut to not need the comphrehension below if the type is '*'
+	input.subject.scope.allow_list[_] == {"type": input.object.type, "id": "*"}
 }
 
 scope_allow_list if {
@@ -258,6 +262,7 @@ scope_allow_list if {
 	# object.id. This line is included to prevent partial compilations from
 	# ever needing to include the object.id.
 	not {"type": "*", "id": "*"} in input.subject.scope.allow_list
+	not {"type": input.object.type, "id": "*"} in input.subject.scope.allow_list
 	allowed_ids := {allowed_id |
   		# Iterate over all allow list elements
   		ele := input.subject.scope.allow_list[_]

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -257,8 +257,15 @@ scope_allow_list if {
 	# If the wildcard is listed in the allow_list, we do not care about the
 	# object.id. This line is included to prevent partial compilations from
 	# ever needing to include the object.id.
-	not "*" in input.subject.scope.allow_list
-	input.object.id in input.subject.scope.allow_list
+	not {"type": "*", "id": "*"} in input.subject.scope.allow_list
+	allowed_ids := {allowed_id |
+  		# Iterate over all allow list elements
+  		ele := input.subject.scope.allow_list[_]
+  		ele.type in [input.object.type, "*"]
+      allowed_id := ele.id
+  }
+  # this feels weird
+  input.object.id in allowed_ids
 }
 
 # -------------------

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -246,30 +246,38 @@ user_allow(roles) := num if {
 	num := number(allow)
 }
 
-# Scope allow_list is a list of resource IDs explicitly allowed by the scope.
-# If the list is '*', then all resources are allowed.
+# Scope allow_list is a list of resource (Type, ID) tuples explicitly allowed by the scope.
+# If the list contains `(*,*)`, then all resources are allowed.
 scope_allow_list if {
 	input.subject.scope.allow_list[_] == {"type": "*", "id": "*"}
 }
 
+# This is a shortcut if the allow_list contains (type, *), then allow all IDs of that type.
 scope_allow_list if {
-  # shortcut to not need the comphrehension below if the type is '*'
 	input.subject.scope.allow_list[_] == {"type": input.object.type, "id": "*"}
 }
 
+# A comprehension that iterates over the allow_list and checks if the
+# (object.type, object.id) is in the allowed ids.
 scope_allow_list if {
 	# If the wildcard is listed in the allow_list, we do not care about the
 	# object.id. This line is included to prevent partial compilations from
 	# ever needing to include the object.id.
 	not {"type": "*", "id": "*"} in input.subject.scope.allow_list
+	# This is equivalent to the above line, as `type` is known at partial query time.
 	not {"type": input.object.type, "id": "*"} in input.subject.scope.allow_list
+
+	# allows_ids is the set of all ids allowed for the given object.type
 	allowed_ids := {allowed_id |
   		# Iterate over all allow list elements
   		ele := input.subject.scope.allow_list[_]
   		ele.type in [input.object.type, "*"]
       allowed_id := ele.id
   }
-  # this feels weird
+
+  # Return if the object.id is in the allowed ids
+  # This rule is evaluated at the end so the partial query can use the object.id
+  # against this precomputed set of allowed ids.
   input.object.id in allowed_ids
 }
 

--- a/coderd/rbac/scopes.go
+++ b/coderd/rbac/scopes.go
@@ -48,11 +48,11 @@ func WorkspaceAgentScope(params WorkspaceAgentScopeParams) Scope {
 		// This prevents the agent from being able to access any other resource.
 		// Include the list of IDs of anything that is required for the
 		// agent to function.
-		AllowIDList: []string{
-			params.WorkspaceID.String(),
-			params.TemplateID.String(),
-			params.VersionID.String(),
-			params.OwnerID.String(),
+		AllowIDList: []AllowListElement{
+			{Type: ResourceWorkspace.Type, ID: params.WorkspaceID.String()},
+			{Type: ResourceTemplate.Type, ID: params.TemplateID.String()},
+			{Type: ResourceTemplate.Type, ID: params.VersionID.String()},
+			{Type: ResourceUser.Type, ID: params.OwnerID.String()},
 		},
 	}
 }
@@ -77,7 +77,7 @@ var builtinScopes = map[ScopeName]Scope{
 			Org:  map[string][]Permission{},
 			User: []Permission{},
 		},
-		AllowIDList: []string{policy.WildcardSymbol},
+		AllowIDList: []AllowListElement{AllowListAll()},
 	},
 
 	ScopeApplicationConnect: {
@@ -90,7 +90,7 @@ var builtinScopes = map[ScopeName]Scope{
 			Org:  map[string][]Permission{},
 			User: []Permission{},
 		},
-		AllowIDList: []string{policy.WildcardSymbol},
+		AllowIDList: []AllowListElement{AllowListAll()},
 	},
 
 	ScopeNoUserData: {
@@ -101,7 +101,7 @@ var builtinScopes = map[ScopeName]Scope{
 			Org:         map[string][]Permission{},
 			User:        []Permission{},
 		},
-		AllowIDList: []string{policy.WildcardSymbol},
+		AllowIDList: []AllowListElement{AllowListAll()},
 	},
 }
 
@@ -129,7 +129,16 @@ func (name ScopeName) Name() RoleIdentifier {
 // AllowIDList. Eg: 'AllowIDList: []string{WildcardSymbol}'
 type Scope struct {
 	Role
-	AllowIDList []string `json:"allow_list"`
+	AllowIDList []AllowListElement `json:"allow_list"`
+}
+
+type AllowListElement struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+func AllowListAll() AllowListElement {
+	return AllowListElement{ID: policy.WildcardSymbol, Type: policy.WildcardSymbol}
 }
 
 func (s Scope) Expand() (Scope, error) {

--- a/coderd/rbac/scopes.go
+++ b/coderd/rbac/scopes.go
@@ -45,9 +45,10 @@ func WorkspaceAgentScope(params WorkspaceAgentScopeParams) Scope {
 		// incase we change the behavior of the allowlist. The allowlist is new
 		// and evolving.
 		Role: scope.Role,
-		// This prevents the agent from being able to access any other resource.
-		// Include the list of IDs of anything that is required for the
-		// agent to function.
+
+		// Limit the agent to only be able to access the singular workspace and
+		// the template/version it was created from. Add additional resources here
+		// as needed, but do not add more workspace or template resource ids.
 		AllowIDList: []AllowListElement{
 			{Type: ResourceWorkspace.Type, ID: params.WorkspaceID.String()},
 			{Type: ResourceTemplate.Type, ID: params.TemplateID.String()},
@@ -133,6 +134,7 @@ type Scope struct {
 }
 
 type AllowListElement struct {
+	// ID must be a string to allow for the wildcard symbol.
 	ID   string `json:"id"`
 	Type string `json:"type"`
 }


### PR DESCRIPTION
This feature allows the `allow_list` in the scopes to specify the `type` of a resource as well. So this is now possible:

```golang
allowList = [
  // Only access to this specific workspace
  {"type":"workspace", "id":"<uuid>"},
  // But all templates
  {"type":"template", "id":"*"},
]
```

This was added in support of custom scopes, primarily for AI agents. There is a need to add a scope that restricts an API key to accessing a specific workspace. With this, we can exhaustively enumerate the other resources required for functionality.

Example:

```

allowList = [
  // Only access to this specific workspace
  {"type":"workspace", "id":"<uuid>"},
  // Leave the rest of the permissions
  {"type":"template", "id":"*"},
  {"type":"user", "id":"*"},
  {"type":"organization", "id":"*"}, 
  {"type":"group", "id":"*"},
  // ... etc 
]
```

This is unfortunate that the list has to be exhaustive. 