### PR TITLE
[2.26 backport] perf(enterprise): remove expensive GetWorkspaces query from entitlements (#19747)

### DIFF
--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -844,9 +844,6 @@ func TestEntitlements(t *testing.T) {
 			})).
 			Return(int64(175), nil)
 		mDB.EXPECT().
-			GetWorkspaces(gomock.Any(), gomock.Any()).
-			Return([]database.GetWorkspacesRow{}, nil)
-		mDB.EXPECT().
 			GetTemplatesWithFilter(gomock.Any(), gomock.Any()).
 			Return([]database.Template{}, nil)
 
@@ -1234,19 +1231,6 @@ func TestLicenseEntitlements(t *testing.T) {
 				assert.Equal(t, int64(100), *feature.SoftLimit)
 				assert.Equal(t, int64(200), *feature.Limit)
 				assert.Equal(t, int64(200), *feature.Actual)
-			},
-		},
-		{
-			Name: "ExternalWorkspace",
-			Licenses: []*coderdenttest.LicenseOptions{
-				enterpriseLicense().UserLimit(100),
-			},
-			Arguments: license.FeatureArguments{
-				ExternalWorkspaceCount: 1,
-			},
-			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
-				assert.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[codersdk.FeatureWorkspaceExternalAgent].Entitlement)
-				assert.True(t, entitlements.Features[codersdk.FeatureWorkspaceExternalAgent].Enabled)
 			},
 		},
 		{


### PR DESCRIPTION
This PR addresses the significant database load issue where the GetWorkspaces query was causing performance problems in the license entitlements code.

cherry picked from commit 3074547