### PR TITLE
chore: cleanup unused Client in server command

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -974,23 +974,10 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}
 			}
 
-			client := codersdk.New(localURL)
-			if localURL.Scheme == "https" && IsLocalhost(localURL.Hostname()) {
-				// The certificate will likely be self-signed or for a different
-				// hostname, so we need to skip verification.
-				client.HTTPClient.Transport = &http.Transport{
-					TLSClientConfig: &tls.Config{
-						//nolint:gosec
-						InsecureSkipVerify: true,
-					},
-				}
-			}
-			defer client.HTTPClient.CloseIdleConnections()
-
 			// This is helpful for tests, but can be silently ignored.
 			// Coder may be ran as users that don't have permission to write in the homedir,
 			// such as via the systemd service.
-			err = config.URL().Write(client.URL.String())
+			err = config.URL().Write(localURL.String())
 			if err != nil && flag.Lookup("test.v") != nil {
 				return xerrors.Errorf("write config url: %w", err)
 			}


### PR DESCRIPTION
As part of converting production code to use the new ClientBuilder, I noticed some dead code that creates a client with a URL for the only purpose of later accessing the URL. This PR removes the cruft.
