### PR TITLE
chore: refactor cli and coderd to use ClientOptions

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1004,9 +1004,10 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *serpent.Command {
 						return xerrors.Errorf("parse workspace proxy URL: %w", err)
 					}
 
-					webClient = codersdk.New(u)
-					webClient.HTTPClient = client.HTTPClient
-					webClient.SetSessionToken(client.SessionToken())
+					webClient = codersdk.New(u,
+						codersdk.WithHTTPClient(client.HTTPClient),
+						codersdk.WithSessionToken(client.SessionToken()),
+					)
 
 					appConfig, err = createWorkspaceAppConfig(webClient, appHost.Host, app, ws, agent)
 					if err != nil {
@@ -1240,8 +1241,9 @@ func (r *RootCmd) scaletestDashboard() *serpent.Command {
 					return xerrors.Errorf("create token for user: %w", err)
 				}
 
-				userClient := codersdk.New(client.URL)
-				userClient.SetSessionToken(userTokResp.Key)
+				userClient := codersdk.New(client.URL,
+					codersdk.WithSessionToken(userTokResp.Key),
+				)
 
 				config := dashboard.Config{
 					Interval: interval,

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -845,8 +845,7 @@ func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationI
 		require.NoError(t, err)
 	}
 
-	other := codersdk.New(client.URL)
-	other.SetSessionToken(sessionToken)
+	other := codersdk.New(client.URL, codersdk.WithSessionToken(sessionToken))
 	t.Cleanup(func() {
 		other.HTTPClient.CloseIdleConnections()
 	})

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -1467,8 +1467,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 				TokenName: "no-password-user-token",
 			})
 			require.NoError(t, err)
-			userClient := codersdk.New(client.URL)
-			userClient.SetSessionToken(token.Key)
+			userClient := codersdk.New(client.URL, codersdk.WithSessionToken(token.Key))
 
 			coderUser, err := userClient.User(context.Background(), user.id.String())
 			require.NoError(t, err)

--- a/coderd/mcp_http.go
+++ b/coderd/mcp_http.go
@@ -32,10 +32,9 @@ func (api *API) mcpHTTPHandler() http.Handler {
 			})
 			return
 		}
-		authenticatedClient := codersdk.New(api.AccessURL)
 		// Extract the original session token from the request
-		authenticatedClient.SetSessionToken(httpmw.APITokenFromRequest(r))
-
+		authenticatedClient := codersdk.New(api.AccessURL,
+			codersdk.WithSessionToken(httpmw.APITokenFromRequest(r)))
 		toolset := MCPToolset(r.URL.Query().Get("toolset"))
 		// Default to standard toolset if no toolset is specified.
 		if toolset == "" {

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -137,8 +137,7 @@ type Details struct {
 //
 // The client is authenticated as the first user by default.
 func (d *Details) AppClient(t *testing.T) *codersdk.Client {
-	client := codersdk.New(d.PathAppBaseURL)
-	client.SetSessionToken(d.SDKClient.SessionToken())
+	client := codersdk.New(d.PathAppBaseURL, codersdk.WithSessionToken(d.SDKClient.SessionToken()))
 	forceURLTransport(t, client)
 	client.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 		return http.ErrUseLastResponse


### PR DESCRIPTION
Refactors CLI and coderd to use the ClientBuilder pattern rather than directly instantiating the Client.
