### PR TITLE
feat: ensure OAuth2 refresh tokens outlive access tokens

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -350,6 +350,11 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				return xerrors.Errorf("access-url must include a scheme (e.g. 'http://' or 'https://)")
 			}
 
+			// Cross-field configuration validation after initial parsing.
+			if err := vals.Validate(); err != nil {
+				return err
+			}
+
 			// Disable rate limits if the `--dangerous-disable-rate-limits` flag
 			// was specified.
 			loginRateLimit := 60

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -25,6 +25,10 @@ OPTIONS:
           systemd. This directory is NOT safe to be configured as a shared
           directory across coderd/provisionerd replicas.
 
+      --default-oauth-refresh-lifetime duration, $CODER_DEFAULT_OAUTH_REFRESH_LIFETIME (default: 720h0m0s)
+          The default lifetime duration for OAuth2 refresh tokens. This controls
+          how long refresh tokens remain valid after issuance or rotation.
+
       --default-token-lifetime duration, $CODER_DEFAULT_TOKEN_LIFETIME (default: 168h0m0s)
           The default lifetime duration for API tokens. This value is used when
           creating a token without specifying a duration, such as when

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -454,6 +454,10 @@ updateCheck: false
 # IDE plugin.
 # (default: 168h0m0s, type: duration)
 defaultTokenLifetime: 168h0m0s
+# The default lifetime duration for OAuth2 refresh tokens. This controls how long
+# refresh tokens remain valid after issuance or rotation.
+# (default: 720h0m0s, type: duration)
+defaultOAuthRefreshLifetime: 720h0m0s
 # Expose the swagger endpoint via /swagger.
 # (default: <unset>, type: bool)
 enableSwagger: false

--- a/cli/vpndaemon_darwin.go
+++ b/cli/vpndaemon_darwin.go
@@ -10,7 +10,7 @@ import (
 	"github.com/coder/serpent"
 )
 
-func (r *RootCmd) vpnDaemonRun() *serpent.Command {
+func (*RootCmd) vpnDaemonRun() *serpent.Command {
 	var (
 		rpcReadFD  int64
 		rpcWriteFD int64

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16397,6 +16397,10 @@ const docTemplate = `{
                 },
                 "max_token_lifetime": {
                     "type": "integer"
+                },
+                "refresh_default_duration": {
+                    "description": "RefreshDefaultDuration is the default lifetime for OAuth2 refresh tokens.\nThis should generally be longer than access token lifetimes to allow\nrefreshing after access token expiry.",
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14920,6 +14920,10 @@
 				},
 				"max_token_lifetime": {
 					"type": "integer"
+				},
+				"refresh_default_duration": {
+					"description": "RefreshDefaultDuration is the default lifetime for OAuth2 refresh tokens.\nThis should generally be longer than access token lifetimes to allow\nrefreshing after access token expiry.",
+					"type": "integer"
 				}
 			}
 		},

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -442,7 +442,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "default_token_lifetime": 0,
       "disable_expiry_refresh": true,
       "max_admin_token_lifetime": 0,
-      "max_token_lifetime": 0
+      "max_token_lifetime": 0,
+      "refresh_default_duration": 0
     },
     "ssh_keygen_algorithm": "string",
     "strict_transport_security": 0,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2466,7 +2466,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "default_token_lifetime": 0,
       "disable_expiry_refresh": true,
       "max_admin_token_lifetime": 0,
-      "max_token_lifetime": 0
+      "max_token_lifetime": 0,
+      "refresh_default_duration": 0
     },
     "ssh_keygen_algorithm": "string",
     "strict_transport_security": 0,
@@ -2953,7 +2954,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "default_token_lifetime": 0,
     "disable_expiry_refresh": true,
     "max_admin_token_lifetime": 0,
-    "max_token_lifetime": 0
+    "max_token_lifetime": 0,
+    "refresh_default_duration": 0
   },
   "ssh_keygen_algorithm": "string",
   "strict_transport_security": 0,
@@ -6867,19 +6869,21 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   "default_token_lifetime": 0,
   "disable_expiry_refresh": true,
   "max_admin_token_lifetime": 0,
-  "max_token_lifetime": 0
+  "max_token_lifetime": 0,
+  "refresh_default_duration": 0
 }
 ```
 
 ### Properties
 
-| Name                       | Type    | Required | Restrictions | Description                                                                                                                                                                        |
-|----------------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `default_duration`         | integer | false    |              | Default duration is only for browser, workspace app and oauth sessions.                                                                                                            |
-| `default_token_lifetime`   | integer | false    |              |                                                                                                                                                                                    |
-| `disable_expiry_refresh`   | boolean | false    |              | Disable expiry refresh will disable automatically refreshing api keys when they are used from the api. This means the api key lifetime at creation is the lifetime of the api key. |
-| `max_admin_token_lifetime` | integer | false    |              |                                                                                                                                                                                    |
-| `max_token_lifetime`       | integer | false    |              |                                                                                                                                                                                    |
+| Name                       | Type    | Required | Restrictions | Description                                                                                                                                                                            |
+|----------------------------|---------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `default_duration`         | integer | false    |              | Default duration is only for browser, workspace app and oauth sessions.                                                                                                                |
+| `default_token_lifetime`   | integer | false    |              |                                                                                                                                                                                        |
+| `disable_expiry_refresh`   | boolean | false    |              | Disable expiry refresh will disable automatically refreshing api keys when they are used from the api. This means the api key lifetime at creation is the lifetime of the api key.     |
+| `max_admin_token_lifetime` | integer | false    |              |                                                                                                                                                                                        |
+| `max_token_lifetime`       | integer | false    |              |                                                                                                                                                                                        |
+| `refresh_default_duration` | integer | false    |              | Refresh default duration is the default lifetime for OAuth2 refresh tokens. This should generally be longer than access token lifetimes to allow refreshing after access token expiry. |
 
 ## codersdk.SlimRole
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -932,6 +932,17 @@ The maximum lifetime duration administrators can specify when creating an API to
 
 The default lifetime duration for API tokens. This value is used when creating a token without specifying a duration, such as when authenticating the CLI or an IDE plugin.
 
+### --default-oauth-refresh-lifetime
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>duration</code>                              |
+| Environment | <code>$CODER_DEFAULT_OAUTH_REFRESH_LIFETIME</code> |
+| YAML        | <code>defaultOAuthRefreshLifetime</code>           |
+| Default     | <code>720h0m0s</code>                              |
+
+The default lifetime duration for OAuth2 refresh tokens. This controls how long refresh tokens remain valid after issuance or rotation.
+
 ### --swagger-enable
 
 |             |                                    |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -26,6 +26,10 @@ OPTIONS:
           systemd. This directory is NOT safe to be configured as a shared
           directory across coderd/provisionerd replicas.
 
+      --default-oauth-refresh-lifetime duration, $CODER_DEFAULT_OAUTH_REFRESH_LIFETIME (default: 720h0m0s)
+          The default lifetime duration for OAuth2 refresh tokens. This controls
+          how long refresh tokens remain valid after issuance or rotation.
+
       --default-token-lifetime duration, $CODER_DEFAULT_TOKEN_LIFETIME (default: 168h0m0s)
           The default lifetime duration for API tokens. This value is used when
           creating a token without specifying a duration, such as when

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2741,6 +2741,7 @@ export interface SessionCountDeploymentStats {
 export interface SessionLifetime {
 	readonly disable_expiry_refresh?: boolean;
 	readonly default_duration: number;
+	readonly refresh_default_duration?: number;
 	readonly default_token_lifetime?: number;
 	readonly max_token_lifetime?: number;
 	readonly max_admin_token_lifetime?: number;


### PR DESCRIPTION
# Implement OAuth2 Refresh Token Expiry Configuration

This PR adds a dedicated configuration option for OAuth2 refresh token lifetimes, allowing refresh tokens to outlive their associated access tokens. This is important for OAuth2 flows where refresh tokens should remain valid after access tokens expire.

Key changes:
- Added `RefreshDefaultDuration` to `SessionLifetime` struct to control refresh token expiry
- Modified token generation to use this new setting when creating refresh tokens
- Added a test to verify refresh tokens outlive access tokens
- Set default refresh token lifetime to 30 days

The PR ensures that refresh tokens can have a longer lifetime than access tokens, which is a standard OAuth2 pattern that allows clients to obtain new access tokens without requiring user re-authentication.