### PR TITLE
chore: log error when checking if codersdk.Err

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1589,7 +1589,7 @@ func (nopcloser) Close() error { return nil }
 // SDKError coerces err into an SDK error.
 func SDKError(t testing.TB, err error) *codersdk.Error {
 	var cerr *codersdk.Error
-	require.True(t, errors.As(err, &cerr))
+	require.True(t, errors.As(err, &cerr), "should be SDK error, got %w", err)
 	return cerr
 }
 


### PR DESCRIPTION
Trying to figure out this flake: https://github.com/coder/internal/issues/982

It fails at this line but I am unable to reproduce locally, so I am hoping logging what the error is will help.
