### PR TITLE
fix: prevent unruly stacking contexts from breaking scrolling

### DIFF
--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -706,3 +706,5 @@ export const MultiSelectCombobox = forwardRef<
 		);
 	},
 );
+
+MultiSelectCombobox.displayName = "MultiSelectCombobox";

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -26,7 +26,7 @@ export const DashboardLayout: FC = () => {
 			<div className="flex flex-col h-screen justify-between">
 				<Navbar />
 
-				<div className="flex flex-col flex-1 min-h-0 overflow-y-auto">
+				<div className="relative flex flex-col flex-1 min-h-0 overflow-y-auto">
 					<Suspense fallback={<Loader />}>
 						<Outlet />
 					</Suspense>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -340,7 +340,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 	});
 
 	return (
-		<div className="flex flex-col flex-1 min-h-0 pb-12">
+		<>
 			<div className="sticky top-5 ml-10">
 				<button
 					onClick={onCancel}
@@ -351,7 +351,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 					Go back
 				</button>
 			</div>
-			<div className="flex flex-col flex-1 min-h-0 gap-6 max-w-screen-md mx-auto">
+			<div className="flex flex-col gap-6 max-w-screen-md mx-auto">
 				<header className="flex flex-col items-start gap-3 mt-10">
 					<div className="flex items-center gap-2 justify-between w-full">
 						<span className="flex items-center gap-2">
@@ -412,7 +412,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 				<form
 					onSubmit={form.handleSubmit}
 					aria-label="Create workspace form"
-					className="relative flex flex-col flex-1 min-h-0 overflow-y-auto gap-10 w-full border border-border-default border-solid rounded-lg p-6"
+					className="flex flex-col gap-10 w-full border border-border-default border-solid rounded-lg p-6"
 				>
 					{Boolean(error) && <ErrorAlert error={error} />}
 
@@ -683,6 +683,6 @@ export const CreateWorkspacePageViewExperimental: FC<
 					</div>
 				</form>
 			</div>
-		</div>
+		</>
 	);
 };


### PR DESCRIPTION
Reverts #19705, and introduces a different fix which should still be sufficient.

Basically, scrolling was weird on some pages because of stacking contexts. The initial fix was to reset the stacking context pretty far into the tree on a specific page, but this broke some other things. The more general fix is to reset the stacking context much higher up in the tree in a general container.