### PR TITLE
fix!: use client ip when creating connection logs for workspace proxied app accesses

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -891,7 +891,7 @@ CREATE TABLE connection_logs (
     workspace_name text NOT NULL,
     agent_name text NOT NULL,
     type connection_type NOT NULL,
-    ip inet NOT NULL,
+    ip inet,
     code integer,
     user_agent text,
     user_id uuid,

--- a/coderd/database/migrations/000369_nullable_conn_log_ip.down.sql
+++ b/coderd/database/migrations/000369_nullable_conn_log_ip.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE connection_logs ALTER COLUMN ip SET NOT NULL;

--- a/coderd/database/migrations/000369_nullable_conn_log_ip.up.sql
+++ b/coderd/database/migrations/000369_nullable_conn_log_ip.up.sql
@@ -1,0 +1,3 @@
+-- We can't guarantee that an IP will always be available, and omitting an IP
+-- is preferable to not creating a connection log at all.
+ALTER TABLE connection_logs ALTER COLUMN ip DROP NOT NULL;

--- a/codersdk/connectionlog.go
+++ b/codersdk/connectionlog.go
@@ -20,7 +20,7 @@ type ConnectionLog struct {
 	WorkspaceID            uuid.UUID           `json:"workspace_id" format:"uuid"`
 	WorkspaceName          string              `json:"workspace_name"`
 	AgentName              string              `json:"agent_name"`
-	IP                     netip.Addr          `json:"ip"`
+	IP                     *netip.Addr         `json:"ip,omitempty"`
 	Type                   ConnectionType      `json:"type"`
 
 	// WebInfo is only set when `type` is one of:

--- a/enterprise/coderd/connectionlog.go
+++ b/enterprise/coderd/connectionlog.go
@@ -93,7 +93,13 @@ func convertConnectionLogs(dblogs []database.GetConnectionLogsOffsetRow) []coder
 }
 
 func convertConnectionLog(dblog database.GetConnectionLogsOffsetRow) codersdk.ConnectionLog {
-	ip, _ := netip.AddrFromSlice(dblog.ConnectionLog.Ip.IPNet.IP)
+	var ip *netip.Addr
+	if dblog.ConnectionLog.Ip.Valid {
+		parsedIP, ok := netip.AddrFromSlice(dblog.ConnectionLog.Ip.IPNet.IP)
+		if ok {
+			ip = &parsedIP
+		}
+	}
 
 	var user *codersdk.User
 	if dblog.ConnectionLog.UserID.Valid {

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -490,6 +490,7 @@ func (api *API) workspaceProxyIssueSignedAppToken(rw http.ResponseWriter, r *htt
 		return
 	}
 	userReq.Header.Set(codersdk.SessionTokenHeader, req.SessionToken)
+	userReq.RemoteAddr = r.Header.Get(wsproxysdk.CoderWorkspaceProxyRealIPHeader)
 
 	// Exchange the token.
 	token, tokenStr, ok := api.AGPL.WorkspaceAppsProvider.Issue(ctx, rw, userReq, req)

--- a/enterprise/wsproxy/tokenprovider.go
+++ b/enterprise/wsproxy/tokenprovider.go
@@ -39,7 +39,7 @@ func (p *TokenProvider) Issue(ctx context.Context, rw http.ResponseWriter, r *ht
 	}
 	issueReq.AppRequest = appReq
 
-	resp, ok := p.Client.IssueSignedAppTokenHTML(ctx, rw, issueReq)
+	resp, ok := p.Client.IssueSignedAppTokenHTML(ctx, rw, issueReq, r.RemoteAddr)
 	if !ok {
 		return nil, "", false
 	}

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -21,6 +21,12 @@ import (
 	"github.com/coder/websocket"
 )
 
+const (
+	// CoderWorkspaceProxyAuthTokenHeader is the header that contains the
+	// resolved real IP address of the client that made the request to the proxy.
+	CoderWorkspaceProxyRealIPHeader = "Coder-Workspace-Proxy-Real-IP"
+)
+
 // Client is a HTTP client for a subset of Coder API routes that external
 // proxies need.
 type Client struct {
@@ -84,10 +90,11 @@ type IssueSignedAppTokenResponse struct {
 // IssueSignedAppToken issues a new signed app token for the provided app
 // request. The error page will be returned as JSON. For use in external
 // proxies, use IssueSignedAppTokenHTML instead.
-func (c *Client) IssueSignedAppToken(ctx context.Context, req workspaceapps.IssueTokenRequest) (IssueSignedAppTokenResponse, error) {
+func (c *Client) IssueSignedAppToken(ctx context.Context, req workspaceapps.IssueTokenRequest, clientIP string) (IssueSignedAppTokenResponse, error) {
 	resp, err := c.RequestIgnoreRedirects(ctx, http.MethodPost, "/api/v2/workspaceproxies/me/issue-signed-app-token", req, func(r *http.Request) {
 		// This forces any HTML error pages to be returned as JSON instead.
 		r.Header.Set("Accept", "application/json")
+		r.Header.Set(CoderWorkspaceProxyRealIPHeader, clientIP)
 	})
 	if err != nil {
 		return IssueSignedAppTokenResponse{}, xerrors.Errorf("make request: %w", err)
@@ -105,7 +112,7 @@ func (c *Client) IssueSignedAppToken(ctx context.Context, req workspaceapps.Issu
 // IssueSignedAppTokenHTML issues a new signed app token for the provided app
 // request. The error page will be returned as HTML in most cases, and will be
 // written directly to the provided http.ResponseWriter.
-func (c *Client) IssueSignedAppTokenHTML(ctx context.Context, rw http.ResponseWriter, req workspaceapps.IssueTokenRequest) (IssueSignedAppTokenResponse, bool) {
+func (c *Client) IssueSignedAppTokenHTML(ctx context.Context, rw http.ResponseWriter, req workspaceapps.IssueTokenRequest, clientIP string) (IssueSignedAppTokenResponse, bool) {
 	writeError := func(rw http.ResponseWriter, err error) {
 		res := codersdk.Response{
 			Message: "Internal server error",
@@ -117,6 +124,7 @@ func (c *Client) IssueSignedAppTokenHTML(ctx context.Context, rw http.ResponseWr
 
 	resp, err := c.RequestIgnoreRedirects(ctx, http.MethodPost, "/api/v2/workspaceproxies/me/issue-signed-app-token", req, func(r *http.Request) {
 		r.Header.Set("Accept", "text/html")
+		r.Header.Set(CoderWorkspaceProxyRealIPHeader, clientIP)
 	})
 	if err != nil {
 		writeError(rw, xerrors.Errorf("perform issue signed app token request: %w", err))

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
@@ -22,6 +22,8 @@ import (
 func Test_IssueSignedAppTokenHTML(t *testing.T) {
 	t.Parallel()
 
+	fakeClientIP := "127.0.0.1"
+
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
@@ -68,7 +70,7 @@ func Test_IssueSignedAppTokenHTML(t *testing.T) {
 		tokenRes, ok := client.IssueSignedAppTokenHTML(ctx, rw, workspaceapps.IssueTokenRequest{
 			AppRequest:   expectedAppReq,
 			SessionToken: expectedSessionToken,
-		})
+		}, fakeClientIP)
 		if !assert.True(t, ok) {
 			t.Log("issue request failed when it should've succeeded")
 			t.Log("response dump:")
@@ -118,7 +120,7 @@ func Test_IssueSignedAppTokenHTML(t *testing.T) {
 		tokenRes, ok := client.IssueSignedAppTokenHTML(ctx, rw, workspaceapps.IssueTokenRequest{
 			AppRequest:   workspaceapps.Request{},
 			SessionToken: "user-session-token",
-		})
+		}, fakeClientIP)
 		require.False(t, ok)
 		require.Empty(t, tokenRes)
 		require.True(t, rw.WasWritten())

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -351,7 +351,7 @@ export interface ConnectionLog {
 	readonly workspace_id: string;
 	readonly workspace_name: string;
 	readonly agent_name: string;
-	readonly ip: string;
+	readonly ip?: string;
 	readonly type: ConnectionType;
 	readonly web_info?: ConnectionLogWebInfo;
 	readonly ssh_info?: ConnectionLogSSHInfo;


### PR DESCRIPTION
Breaking API Change for changelog: 
> The presence of the `ip` field on `codersdk.ConnectionLog` cannot be guaranteed, and so the field has been made optional. It may be omitted on API responses.

When running a scaletest, I noticed logs of the form:
```
2025-09-12 06:34:10.924 [erro]  coderd.workspaceapps: upsert connection log failed  trace=0xa17580  span=0xa17620  workspace_id=81b937d7-5777-4df5-b5cb-80241f30326f  agent_id=78b2ff6d-b4a6-4a4e-88a7-283e05455a88  app_id=00000000-0000-0000-0000-000000000000  user_id=00000000-0000-0000-0000-000000000000  user_agent=""  app_slug_or_port=terminal  status_code=404  request_id=67f03cf8-9523-444a-97bc-90de080a54c8 ...
    error= 1 error occurred:
           	* pq: null value in column "ip" of relation "connection_logs" violates not-null constraint
```

to ensure logs are never omitted from the connection log due to a missing IP again (i.e. I'm not sure if we can always rely on a valid, parseable, IP from `(http.Request).RemoteAddr`), I've removed the `NOT NULL` constraint on `ip` on `connection_logs`, and made `ip` on the API response optional.


The specific cause for these null IPs was the `/workspaceproxies/me/issue-signed-app-token [post]` endpoint constructing it's own `http.Request` without a `RemoteAddr` set, and then passing that to the token issuer. 

To solve this, we'll have workspace proxies send the real IP of the client when calling `/workspaceproxies/me/issue-signed-app-token [post]` via the header `Coder-Workspace-Proxy-Real-IP`.