### PR TITLE
chore: integrate broker into dbtestutil

### DIFF
--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -263,8 +263,13 @@ func TestTemplatePull_ToDir(t *testing.T) {
 	// nolint: paralleltest // These tests change the current working dir, and is therefore unsuitable for parallelisation.
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
+			// create coderd first, because our postgres cloning code needs to be run from somewhere in the package
+			// hierarchy, before we change directories.
+			client := coderdtest.New(t, &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+			})
 
+			dir := t.TempDir()
 			cwd, err := os.Getwd()
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -282,9 +287,6 @@ func TestTemplatePull_ToDir(t *testing.T) {
 				actualDest = filepath.Join(dir, "actual")
 			}
 
-			client := coderdtest.New(t, &coderdtest.Options{
-				IncludeProvisionerDaemon: true,
-			})
 			owner := coderdtest.CreateFirstUser(t, client)
 			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
 

--- a/coderd/database/dbtestutil/postgres_test.go
+++ b/coderd/database/dbtestutil/postgres_test.go
@@ -3,6 +3,7 @@ package dbtestutil_test
 import (
 	"database/sql"
 	"testing"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -109,4 +110,28 @@ func TestOpen_ValidDBFrom(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Close())
+}
+
+func TestOpen_Panic(t *testing.T) {
+	t.Skip("unskip this to manually test that we don't leak a database into postgres")
+	t.Parallel()
+	if !dbtestutil.WillUsePostgres() {
+		t.Skip("this test requires postgres")
+	}
+
+	_, err := dbtestutil.Open(t)
+	require.NoError(t, err)
+	panic("now check SELECT datname FROM pg_database;")
+}
+
+func TestOpen_Timeout(t *testing.T) {
+	t.Skip("unskip this and set a short timeout to manually test that we don't leak a database into postgres")
+	t.Parallel()
+	if !dbtestutil.WillUsePostgres() {
+		t.Skip("this test requires postgres")
+	}
+
+	_, err := dbtestutil.Open(t)
+	require.NoError(t, err)
+	time.Sleep(11 * time.Minute)
 }


### PR DESCRIPTION
Integrates the test DB Broker into `dbtestutils`​

Replaces in-process generation and cleanup of test databases with the use of the Broker, running in a subprocess.

fixes https://github.com/coder/internal/issues/927