### PR TITLE
fix: nudge SSH traffic to ensure non-zero Rx/Tx bytes in stats tests

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -149,6 +149,17 @@ func TestAgent_Stats_SSH(t *testing.T) {
 			err = session.Shell()
 			require.NoError(t, err)
 
+			// Nudge traffic so Rx/Tx bytes are non-zero in the same stats window.
+			// Without writing anything, the shell may idle and stats samples can
+			// report session_count_ssh without non-zero byte counts, which makes
+			// the combined predicate below flaky.
+			// Related: https://github.com/coder/internal/issues/505
+			if runtime.GOOS == "windows" {
+				_, _ = io.WriteString(stdin, "echo test\r\n")
+			} else {
+				_, _ = io.WriteString(stdin, "echo test\n")
+			}
+
 			var s *proto.Stats
 			require.Eventuallyf(t, func() bool {
 				var ok bool


### PR DESCRIPTION
This PR fixes a flaky test in `TestAgent_Stats_SSH` by ensuring that Rx/Tx bytes are non-zero in the same stats window. The test now writes a simple command to the SSH session to generate traffic, preventing the shell from idling which could cause stats samples to report session counts without non-zero byte counts.

The fix handles platform differences by using the appropriate line ending for Windows vs other operating systems.

Fixes: https://github.com/coder/internal/issues/505