### PR TITLE
fix: scroll item list into view when opening `MultiSelectCombobox`

### DIFF
--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -216,6 +216,7 @@ export const MultiSelectCombobox = forwardRef<
 		const [onScrollbar, setOnScrollbar] = useState(false);
 		const [isLoading, setIsLoading] = useState(false);
 		const dropdownRef = useRef<HTMLDivElement>(null);
+		const listRef = useRef<HTMLDivElement>(null);
 
 		const [selected, setSelected] = useState<Option[]>(
 			arrayDefaultOptions ?? [],
@@ -363,6 +364,15 @@ export const MultiSelectCombobox = forwardRef<
 
 			void exec();
 		}, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus, onSearch]);
+
+		// Scroll dropdown into view on open
+		useEffect(() => {
+			if (!open || !listRef.current) {
+				return;
+			}
+
+			listRef.current.scrollIntoView({ behavior: "smooth" });
+		}, [open]);
 
 		const CreatableItem = () => {
 			if (!creatable) {
@@ -603,7 +613,7 @@ export const MultiSelectCombobox = forwardRef<
 						</div>
 					</div>
 				</div>
-				<div className="relative">
+				<div className="relative" ref={listRef}>
 					{open && (
 						<CommandList
 							className={`absolute top-1 z-10 w-full rounded-md


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/18785

https://github.com/user-attachments/assets/5bdf9734-9605-4d45-a708-ccd2c63db0b6

This plus some recent box fixes seems like enough to really improve the situation when one of these is lower down on the page