### PR TITLE
feat: add shared filter to workspaces query

### DIFF
--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -275,6 +275,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 		arg.UsingActive,
 		arg.HasAITask,
 		arg.HasExternalAgent,
+		arg.Shared,
 		arg.RequesterID,
 		arg.Offset,
 		arg.Limit,

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -378,6 +378,13 @@ WHERE
 			latest_build.has_external_agent = sqlc.narg('has_external_agent') :: boolean
 		ELSE true
 	END
+	-- Filter by shared status
+	AND CASE
+		WHEN sqlc.narg('shared') :: boolean IS NOT NULL THEN
+			(workspaces.user_acl != '{}'::jsonb OR workspaces.group_acl != '{}'::jsonb) = sqlc.narg('shared') :: boolean
+		ELSE true
+	END
+
 	-- Authorize Filter clause will be injected below in GetAuthorizedWorkspaces
 	-- @authorize_filter
 ), filtered_workspaces_order AS (

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -225,6 +225,7 @@ func Workspaces(ctx context.Context, db database.Store, query string, page coder
 	filter.HasAITask = parser.NullableBoolean(values, sql.NullBool{}, "has-ai-task")
 	filter.HasExternalAgent = parser.NullableBoolean(values, sql.NullBool{}, "has_external_agent")
 	filter.OrganizationID = parseOrganization(ctx, db, parser, values, "organization")
+	filter.Shared = parser.NullableBoolean(values, sql.NullBool{}, "shared")
 
 	type paramMatch struct {
 		name  string

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -282,6 +282,36 @@ func TestSearchWorkspace(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:  "SharedTrue",
+			Query: "shared:true",
+			Expected: database.GetWorkspacesParams{
+				Shared: sql.NullBool{
+					Bool:  true,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "SharedFalse",
+			Query: "shared:false",
+			Expected: database.GetWorkspacesParams{
+				Shared: sql.NullBool{
+					Bool:  false,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "SharedMissing",
+			Query: "",
+			Expected: database.GetWorkspacesParams{
+				Shared: sql.NullBool{
+					Bool:  false,
+					Valid: false,
+				},
+			},
+		},
 
 		// Failures
 		{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1844,7 +1844,7 @@ func TestWorkspaceFilter(t *testing.T) {
 		})
 
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Shared: true,
+			Shared: ptr.Ref(true),
 		})
 		require.NoError(t, err, "fetch workspaces")
 		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
@@ -1882,7 +1882,7 @@ func TestWorkspaceFilter(t *testing.T) {
 		})
 
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Shared: false,
+			Shared: ptr.Ref(false),
 		})
 		require.NoError(t, err, "fetch workspaces")
 		require.Equal(t, 1, workspaces.Count, "expected only one workspace")

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1812,6 +1812,82 @@ func TestWorkspaceFilter(t *testing.T) {
 			require.ElementsMatch(t, exp, workspaces, "expected workspaces returned")
 		})
 	}
+
+	t.Run("SharedWithUser", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+
+		var (
+			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
+				DeploymentValues: dv,
+			})
+			orgOwner          = coderdtest.CreateFirstUser(t, client)
+			_, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
+			sharedWorkspace   = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			_ = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			_, toShareWithUser = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID)
+			ctx                = testutil.Context(t, testutil.WaitMedium)
+		)
+
+		client.UpdateWorkspaceACL(ctx, sharedWorkspace.ID, codersdk.UpdateWorkspaceACL{
+			UserRoles: map[string]codersdk.WorkspaceRole{
+				toShareWithUser.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+		})
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Shared: true,
+		})
+		require.NoError(t, err, "fetch workspaces")
+		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
+		require.Equal(t, workspaces.Workspaces[0].ID, sharedWorkspace.ID)
+	})
+
+	t.Run("NotSharedWithUser", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+
+		var (
+			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
+				DeploymentValues: dv,
+			})
+			orgOwner          = coderdtest.CreateFirstUser(t, client)
+			_, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
+			sharedWorkspace   = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			notSharedWorkspace = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			_, toShareWithUser = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID)
+			ctx                = testutil.Context(t, testutil.WaitMedium)
+		)
+
+		client.UpdateWorkspaceACL(ctx, sharedWorkspace.ID, codersdk.UpdateWorkspaceACL{
+			UserRoles: map[string]codersdk.WorkspaceRole{
+				toShareWithUser.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+		})
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Shared: false,
+		})
+		require.NoError(t, err, "fetch workspaces")
+		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
+		require.Equal(t, workspaces.Workspaces[0].ID, notSharedWorkspace.ID)
+	})
 }
 
 // TestWorkspaceFilterManual runs some specific setups with basic checks.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -518,6 +518,8 @@ type WorkspaceFilter struct {
 	Limit int `json:"limit,omitempty" typescript:"-"`
 	// FilterQuery supports a raw filter query string
 	FilterQuery string `json:"q,omitempty"`
+	// Shared is a whether the workspace is shared with any users or groups
+	Shared bool `json:"shared" typescript:"-"`
 }
 
 // asRequestOption returns a function that can be used in (*Client).Request.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -516,10 +516,10 @@ type WorkspaceFilter struct {
 	Offset int `json:"offset,omitempty" typescript:"-"`
 	// Limit is a limit on the number of workspaces returned.
 	Limit int `json:"limit,omitempty" typescript:"-"`
+	// Shared is a whether the workspace is shared with any users or groups
+	Shared *bool `json:"shared,omitempty" typescript:"-"`
 	// FilterQuery supports a raw filter query string
 	FilterQuery string `json:"q,omitempty"`
-	// Shared is a whether the workspace is shared with any users or groups
-	Shared bool `json:"shared" typescript:"-"`
 }
 
 // asRequestOption returns a function that can be used in (*Client).Request.
@@ -540,6 +540,9 @@ func (f WorkspaceFilter) asRequestOption() RequestOption {
 		}
 		if f.Status != "" {
 			params = append(params, fmt.Sprintf("status:%q", f.Status))
+		}
+		if f.Shared != nil {
+			params = append(params, fmt.Sprintf("shared:%v", *f.Shared))
 		}
 		if f.FilterQuery != "" {
 			// If custom stuff is added, just add it on here.

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3617,7 +3617,7 @@ func TestWorkspacesFiltering(t *testing.T) {
 		})
 
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Shared: true,
+			Shared: ptr.Ref(true),
 		})
 		require.NoError(t, err, "fetch workspaces")
 		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
@@ -3669,7 +3669,7 @@ func TestWorkspacesFiltering(t *testing.T) {
 		})
 
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Shared: true,
+			Shared: ptr.Ref(true),
 		})
 		require.NoError(t, err, "fetch workspaces")
 		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
@@ -3717,7 +3717,7 @@ func TestWorkspacesFiltering(t *testing.T) {
 		})
 
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Shared: false,
+			Shared: ptr.Ref(false),
 		})
 		require.NoError(t, err, "fetch workspaces")
 		require.Equal(t, 1, workspaces.Count, "expected only one workspace")

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3575,6 +3575,154 @@ func TestWorkspacesFiltering(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("SharedWithGroup", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+
+		var (
+			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+				Options: &coderdtest.Options{
+					DeploymentValues: dv,
+				},
+				LicenseOptions: &coderdenttest.LicenseOptions{
+					Features: license.Features{
+						codersdk.FeatureTemplateRBAC: 1,
+					},
+				},
+			})
+			_, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
+			sharedWorkspace   = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			_ = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			ctx = testutil.Context(t, testutil.WaitMedium)
+		)
+
+		group, err := client.CreateGroup(ctx, orgOwner.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "wibble",
+		})
+		require.NoError(t, err, "create group")
+
+		client.UpdateWorkspaceACL(ctx, sharedWorkspace.ID, codersdk.UpdateWorkspaceACL{
+			GroupRoles: map[string]codersdk.WorkspaceRole{
+				group.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+		})
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Shared: true,
+		})
+		require.NoError(t, err, "fetch workspaces")
+		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
+		require.Equal(t, workspaces.Workspaces[0].ID, sharedWorkspace.ID)
+	})
+
+	t.Run("SharedWithUserAndGroup", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+
+		var (
+			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+				Options: &coderdtest.Options{
+					DeploymentValues: dv,
+				},
+				LicenseOptions: &coderdenttest.LicenseOptions{
+					Features: license.Features{
+						codersdk.FeatureTemplateRBAC: 1,
+					},
+				},
+			})
+			_, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
+			sharedWorkspace   = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			_ = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			_, toShareWithUser = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID)
+			ctx                = testutil.Context(t, testutil.WaitMedium)
+		)
+
+		group, err := client.CreateGroup(ctx, orgOwner.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "wibble",
+		})
+		require.NoError(t, err, "create group")
+
+		client.UpdateWorkspaceACL(ctx, sharedWorkspace.ID, codersdk.UpdateWorkspaceACL{
+			UserRoles: map[string]codersdk.WorkspaceRole{
+				toShareWithUser.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+			GroupRoles: map[string]codersdk.WorkspaceRole{
+				group.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+		})
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Shared: true,
+		})
+		require.NoError(t, err, "fetch workspaces")
+		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
+		require.Equal(t, workspaces.Workspaces[0].ID, sharedWorkspace.ID)
+	})
+
+	t.Run("NotSharedWithGroup", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+
+		var (
+			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+				Options: &coderdtest.Options{
+					DeploymentValues: dv,
+				},
+				LicenseOptions: &coderdenttest.LicenseOptions{
+					Features: license.Features{
+						codersdk.FeatureTemplateRBAC: 1,
+					},
+				},
+			})
+			_, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
+			sharedWorkspace   = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			notSharedWorkspace = dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OwnerID:        workspaceOwner.ID,
+				OrganizationID: orgOwner.OrganizationID,
+			}).Do().Workspace
+			ctx = testutil.Context(t, testutil.WaitMedium)
+		)
+
+		group, err := client.CreateGroup(ctx, orgOwner.OrganizationID, codersdk.CreateGroupRequest{
+			Name: "wibble",
+		})
+		require.NoError(t, err, "create group")
+
+		client.UpdateWorkspaceACL(ctx, sharedWorkspace.ID, codersdk.UpdateWorkspaceACL{
+			GroupRoles: map[string]codersdk.WorkspaceRole{
+				group.ID.String(): codersdk.WorkspaceRoleUse,
+			},
+		})
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Shared: false,
+		})
+		require.NoError(t, err, "fetch workspaces")
+		require.Equal(t, 1, workspaces.Count, "expected only one workspace")
+		require.Equal(t, workspaces.Workspaces[0].ID, notSharedWorkspace.ID)
+	})
 }
 
 // TestWorkspacesWithoutTemplatePerms creates a workspace for a user, then drops


### PR DESCRIPTION
Adds a `shared:<boolean>` search query to the `/workspaces [get]` endpoint

https://github.com/user-attachments/assets/ccf84bd9-c1fd-4085-825b-2e3176a2d488

Closes [coder/internal#972](https://github.com/coder/internal/issues/972)