### PR TITLE
fix: use filepath to construct mcp test write path

### DIFF
--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -569,14 +569,17 @@ func TestTools(t *testing.T) {
 		tb, err := toolsdk.NewDeps(client)
 		require.NoError(t, err)
 
+		tmpdir := os.TempDir()
+		filePath := filepath.Join(tmpdir, "write")
+
 		_, err = testTool(t, toolsdk.WorkspaceWriteFile, tb, toolsdk.WorkspaceWriteFileArgs{
 			Workspace: workspace.Name,
-			Path:      "/test/some/path",
+			Path:      filePath,
 			Content:   []byte("content"),
 		})
 		require.NoError(t, err)
 
-		b, err := afero.ReadFile(fs, "/test/some/path")
+		b, err := afero.ReadFile(fs, filePath)
 		require.NoError(t, err)
 		require.Equal(t, []byte("content"), b)
 	})


### PR DESCRIPTION
Hopefully fixes https://github.com/coder/internal/issues/993

```
  file path must be absolute: "/test/some/path"
```

Not sure if this is the right fix though, since I am not sure how this only flakes rather than always failing.  It looks like starting with `/` should not be considered absolute in Windows, but then how did it ever pass at all?

