### PR TITLE
refactor(scaletest): add runner for creating users

### DIFF
--- a/scaletest/createusers/config.go
+++ b/scaletest/createusers/config.go
@@ -1,0 +1,23 @@
+package createusers
+
+import (
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+)
+
+type Config struct {
+	// OrganizationID is the ID of the organization to add the user to.
+	OrganizationID uuid.UUID `json:"organization_id"`
+	// Username is the username of the new user. Generated if empty.
+	Username string `json:"username"`
+	// Email is the email of the new user. Generated if empty.
+	Email string `json:"email"`
+}
+
+func (c Config) Validate() error {
+	if c.OrganizationID == uuid.Nil {
+		return xerrors.New("organization_id must not be a nil UUID")
+	}
+
+	return nil
+}

--- a/scaletest/createusers/run.go
+++ b/scaletest/createusers/run.go
@@ -1,0 +1,119 @@
+package createusers
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+
+	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/cryptorand"
+	"github.com/coder/coder/v2/scaletest/harness"
+	"github.com/coder/coder/v2/scaletest/loadtestutil"
+)
+
+type Runner struct {
+	client *codersdk.Client
+	cfg    Config
+
+	userID       uuid.UUID
+	sessionToken string
+	user         codersdk.User
+}
+
+var (
+	_ harness.Runnable  = &Runner{}
+	_ harness.Cleanable = &Runner{}
+)
+
+func NewRunner(client *codersdk.Client, cfg Config) *Runner {
+	return &Runner{
+		client: client,
+		cfg:    cfg,
+	}
+}
+
+func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	logs = loadtestutil.NewSyncWriter(logs)
+	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
+	r.client.SetLogger(logger)
+	r.client.SetLogBodies(true)
+
+	if r.cfg.Username == "" || r.cfg.Email == "" {
+		genUsername, genEmail, err := loadtestutil.GenerateUserIdentifier(id)
+		if err != nil {
+			return xerrors.Errorf("generate user identifier: %w", err)
+		}
+		if r.cfg.Username == "" {
+			r.cfg.Username = genUsername
+		}
+		if r.cfg.Email == "" {
+			r.cfg.Email = genEmail
+		}
+	}
+
+	_, _ = fmt.Fprintln(logs, "Generating user password...")
+	password, err := cryptorand.String(16)
+	if err != nil {
+		return xerrors.Errorf("generate random password for user: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(logs, "Creating user:")
+	user, err := r.client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+		OrganizationIDs: []uuid.UUID{r.cfg.OrganizationID},
+		Username:        r.cfg.Username,
+		Email:           r.cfg.Email,
+		Password:        password,
+	})
+	if err != nil {
+		return xerrors.Errorf("create user: %w", err)
+	}
+	r.userID = user.ID
+	r.user = user
+
+	_, _ = fmt.Fprintln(logs, "\nLogging in as new user...")
+	client := codersdk.New(r.client.URL)
+	loginRes, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+		Email:    r.cfg.Email,
+		Password: password,
+	})
+	if err != nil {
+		return xerrors.Errorf("login as new user: %w", err)
+	}
+	r.sessionToken = loginRes.SessionToken
+
+	_, _ = fmt.Fprintf(logs, "\tOrg ID:   %s\n", r.cfg.OrganizationID.String())
+	_, _ = fmt.Fprintf(logs, "\tUsername: %s\n", user.Username)
+	_, _ = fmt.Fprintf(logs, "\tEmail:    %s\n", user.Email)
+	_, _ = fmt.Fprintf(logs, "\tPassword: ****************\n")
+
+	return nil
+}
+
+func (r *Runner) Cleanup(ctx context.Context, _ string, logs io.Writer) error {
+	if r.userID != uuid.Nil {
+		err := r.client.DeleteUser(ctx, r.userID)
+		if err != nil {
+			_, _ = fmt.Fprintf(logs, "failed to delete user %q: %v\n", r.userID.String(), err)
+			return xerrors.Errorf("delete user: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *Runner) SessionToken() string {
+	return r.sessionToken
+}
+
+func (r *Runner) User() codersdk.User {
+	return r.user
+}

--- a/scaletest/createusers/run.go
+++ b/scaletest/createusers/run.go
@@ -21,8 +21,7 @@ type Runner struct {
 	client *codersdk.Client
 	cfg    Config
 
-	sessionToken string
-	user         codersdk.User
+	user codersdk.User
 }
 
 type User struct {
@@ -86,14 +85,13 @@ func (r *Runner) RunReturningUser(ctx context.Context, id string, logs io.Writer
 	if err != nil {
 		return User{}, xerrors.Errorf("login as new user: %w", err)
 	}
-	r.sessionToken = loginRes.SessionToken
 
 	_, _ = fmt.Fprintf(logs, "\tOrg ID:   %s\n", r.cfg.OrganizationID.String())
 	_, _ = fmt.Fprintf(logs, "\tUsername: %s\n", user.Username)
 	_, _ = fmt.Fprintf(logs, "\tEmail:    %s\n", user.Email)
 	_, _ = fmt.Fprintf(logs, "\tPassword: ****************\n")
 
-	return User{User: user, SessionToken: r.sessionToken}, nil
+	return User{User: user, SessionToken: loginRes.SessionToken}, nil
 }
 
 func (r *Runner) Cleanup(ctx context.Context, _ string, logs io.Writer) error {

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -73,12 +73,11 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 			return xerrors.Errorf("validate create user config: %w", err)
 		}
 		r.createUserRunner = createusers.NewRunner(r.client, createUserConfig)
-		err = r.createUserRunner.Run(ctx, id, logs)
+		user, err = r.createUserRunner.RunReturningUser(ctx, id, logs)
 		if err != nil {
 			return xerrors.Errorf("create user: %w", err)
 		}
 
-		user = r.createUserRunner.User()
 		client = codersdk.New(r.client.URL)
 		client.SetSessionToken(r.createUserRunner.SessionToken())
 	}

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/cryptorand"
 	"github.com/coder/coder/v2/scaletest/agentconn"
+	"github.com/coder/coder/v2/scaletest/createusers"
 	"github.com/coder/coder/v2/scaletest/harness"
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
 	"github.com/coder/coder/v2/scaletest/reconnectingpty"
@@ -26,7 +26,7 @@ type Runner struct {
 	client *codersdk.Client
 	cfg    Config
 
-	userID               uuid.UUID
+	createUserRunner     *createusers.Runner
 	workspacebuildRunner *workspacebuild.Runner
 }
 
@@ -64,41 +64,24 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 			return xerrors.Errorf("generate random password for user: %w", err)
 		}
 	} else {
-		_, _ = fmt.Fprintln(logs, "Generating user password...")
-		password, err := cryptorand.String(16)
-		if err != nil {
-			return xerrors.Errorf("generate random password for user: %w", err)
+		createUserConfig := createusers.Config{
+			OrganizationID: r.cfg.User.OrganizationID,
+			Username:       r.cfg.User.Username,
+			Email:          r.cfg.User.Email,
 		}
-
-		_, _ = fmt.Fprintln(logs, "Creating user:")
-
-		user, err = r.client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{r.cfg.User.OrganizationID},
-			Username:        r.cfg.User.Username,
-			Email:           r.cfg.User.Email,
-			Password:        password,
-		})
+		if err := createUserConfig.Validate(); err != nil {
+			return xerrors.Errorf("validate create user config: %w", err)
+		}
+		r.createUserRunner = createusers.NewRunner(r.client, createUserConfig)
+		err = r.createUserRunner.Run(ctx, id, logs)
 		if err != nil {
 			return xerrors.Errorf("create user: %w", err)
 		}
-		r.userID = user.ID
 
-		_, _ = fmt.Fprintln(logs, "\nLogging in as new user...")
+		user = r.createUserRunner.User()
 		client = codersdk.New(r.client.URL)
-		loginRes, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
-			Email:    r.cfg.User.Email,
-			Password: password,
-		})
-		if err != nil {
-			return xerrors.Errorf("login as new user: %w", err)
-		}
-		client.SetSessionToken(loginRes.SessionToken)
+		client.SetSessionToken(r.createUserRunner.SessionToken())
 	}
-
-	_, _ = fmt.Fprintf(logs, "\tOrg ID:   %s\n", r.cfg.User.OrganizationID.String())
-	_, _ = fmt.Fprintf(logs, "\tUsername: %s\n", user.Username)
-	_, _ = fmt.Fprintf(logs, "\tEmail:    %s\n", user.Email)
-	_, _ = fmt.Fprintf(logs, "\tPassword: ****************\n")
 
 	_, _ = fmt.Fprintln(logs, "\nCreating workspace...")
 	workspaceBuildConfig := r.cfg.Workspace
@@ -189,11 +172,10 @@ func (r *Runner) Cleanup(ctx context.Context, id string, logs io.Writer) error {
 		}
 	}
 
-	if r.userID != uuid.Nil {
-		err := r.client.DeleteUser(ctx, r.userID)
+	if r.createUserRunner != nil {
+		err := r.createUserRunner.Cleanup(ctx, id, logs)
 		if err != nil {
-			_, _ = fmt.Fprintf(logs, "failed to delete user %q: %v\n", r.userID.String(), err)
-			return xerrors.Errorf("delete user: %w", err)
+			return xerrors.Errorf("cleanup user: %w", err)
 		}
 	}
 

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -73,13 +73,13 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 			return xerrors.Errorf("validate create user config: %w", err)
 		}
 		r.createUserRunner = createusers.NewRunner(r.client, createUserConfig)
-		user, err = r.createUserRunner.RunReturningUser(ctx, id, logs)
+		newUser, err := r.createUserRunner.RunReturningUser(ctx, id, logs)
 		if err != nil {
 			return xerrors.Errorf("create user: %w", err)
 		}
-
+		user = newUser.User
 		client = codersdk.New(r.client.URL)
-		client.SetSessionToken(r.createUserRunner.SessionToken())
+		client.SetSessionToken(newUser.SessionToken)
 	}
 
 	_, _ = fmt.Fprintln(logs, "\nCreating workspace...")


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/985

Simple refactor of the user creation logic into it's own test runner. This lets us create users independently of workspaces, for use in a bunch of load generators, including the Coder Connect load generator.

This PR creates the new runner, and has the existing `createworkspaces` runner use it.