### PR TITLE
test: avoid sharing deployment values between subtests

### DIFF
--- a/cli/sharing_test.go
+++ b/cli/sharing_test.go
@@ -21,15 +21,14 @@ import (
 func TestSharingShare(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("ShareWithUsers_Simple", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			orgOwner                             = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
@@ -69,7 +68,9 @@ func TestSharingShare(t *testing.T) {
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			orgOwner = coderdtest.CreateFirstUser(t, client)
 
@@ -124,7 +125,9 @@ func TestSharingShare(t *testing.T) {
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			orgOwner                             = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
@@ -171,15 +174,14 @@ func TestSharingShare(t *testing.T) {
 func TestSharingStatus(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("ListSharedUsers", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			orgOwner                             = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
@@ -220,15 +222,14 @@ func TestSharingStatus(t *testing.T) {
 func TestSharingRemove(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("RemoveSharedUser_Simple", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			orgOwner                             = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))
@@ -287,7 +288,9 @@ func TestSharingRemove(t *testing.T) {
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			orgOwner                             = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, orgOwner.OrganizationID, rbac.ScopedRoleOrgAuditor(orgOwner.OrganizationID))

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -4917,15 +4917,14 @@ func TestUpdateWorkspaceACL(t *testing.T) {
 func TestDeleteWorkspaceACL(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("WorkspaceOwnerCanDelete", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			admin                                = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
@@ -4958,7 +4957,9 @@ func TestDeleteWorkspaceACL(t *testing.T) {
 
 		var (
 			client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
-				DeploymentValues: dv,
+				DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+					dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+				}),
 			})
 			admin                                = coderdtest.CreateFirstUser(t, client)
 			workspaceOwnerClient, workspaceOwner = coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)

--- a/enterprise/cli/sharing_test.go
+++ b/enterprise/cli/sharing_test.go
@@ -26,16 +26,15 @@ import (
 func TestSharingShare(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("ShareWithGroups_Simple", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{
@@ -86,7 +85,9 @@ func TestSharingShare(t *testing.T) {
 		var (
 			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{
@@ -140,7 +141,9 @@ func TestSharingShare(t *testing.T) {
 			var (
 				client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 					Options: &coderdtest.Options{
-						DeploymentValues: dv,
+						DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+							dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+						}),
 					},
 					LicenseOptions: &coderdenttest.LicenseOptions{
 						Features: license.Features{
@@ -190,16 +193,15 @@ func TestSharingShare(t *testing.T) {
 func TestSharingStatus(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("ListSharedUsers", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{
@@ -248,16 +250,15 @@ func TestSharingStatus(t *testing.T) {
 func TestSharingRemove(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("RemoveSharedGroup_Single", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{
@@ -328,7 +329,9 @@ func TestSharingRemove(t *testing.T) {
 		var (
 			client, db, orgOwner = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -4106,16 +4106,15 @@ func TestUpdateWorkspaceACL(t *testing.T) {
 func TestDeleteWorkspaceACL(t *testing.T) {
 	t.Parallel()
 
-	dv := coderdtest.DeploymentValues(t)
-	dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
-
 	t.Run("WorkspaceOwnerCanDelete_Groups", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			client, db, admin = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{
@@ -4157,7 +4156,9 @@ func TestDeleteWorkspaceACL(t *testing.T) {
 		var (
 			client, db, admin = coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 				Options: &coderdtest.Options{
-					DeploymentValues: dv,
+					DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+						dv.Experiments = []string{string(codersdk.ExperimentWorkspaceSharing)}
+					}),
 				},
 				LicenseOptions: &coderdenttest.LicenseOptions{
 					Features: license.Features{


### PR DESCRIPTION
Blink didn't figure out a CI failure on main was caused by a data race; fixing it.


I've also updated the [blink prompt](https://gist.githubusercontent.com/ethanndickson/8dea9f1db3957ac1baf30ae8ce6f1a42/raw/060aea7fabb82bef0029a17dad9a5daee7940760/blink-flake-instructions.md).

https://github.com/coder/coder/actions/runs/17737809615
```
WARNING: DATA RACE
Write at 0x00c021670198 by goroutine 19760:
  github.com/coder/coder/v2/coderd/coderdtest.NewOptions()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:497 +0x4739
  github.com/coder/coder/v2/coderd/webpush.New()
      /home/runner/work/coder/coder/coderd/webpush/webpush.go:56 +0x139
  github.com/coder/coder/v2/coderd/coderdtest.NewOptions()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:299 +0x1472
  github.com/coder/coder/v2/coderd/coderdtest.NewOptions()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:293 +0x12f9
  github.com/coder/coder/v2/coderd/coderdtest.NewWithAPI()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:620 +0xd9
  github.com/coder/coder/v2/coderd/coderdtest.NewWithDatabase()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:200 +0x124
  github.com/coder/coder/v2/cli_test.TestSharingShare.func1()
      /home/runner/work/coder/coder/cli/sharing_test.go:31 +0x53
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1851 +0x44

Previous read at 0x00c021670198 by goroutine 19763:
  github.com/coder/coder/v2/coderd/coderdtest.NewOptions()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:490 +0x42c8
  github.com/coder/coder/v2/coderd/webpush.New()
      /home/runner/work/coder/coder/coderd/webpush/webpush.go:56 +0x139
  github.com/coder/coder/v2/coderd/coderdtest.NewOptions()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:299 +0x1472
  github.com/coder/coder/v2/coderd/coderdtest.NewOptions()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:293 +0x12f9
  github.com/coder/coder/v2/coderd/coderdtest.NewWithAPI()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:620 +0xd9
  github.com/coder/coder/v2/coderd/coderdtest.NewWithDatabase()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:200 +0x124
  github.com/coder/coder/v2/cli_test.TestSharingShare.func3()
      /home/runner/work/coder/coder/cli/sharing_test.go:126 +0x53
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1851 +0x44

Goroutine 19760 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1851 +0x8f2
  github.com/coder/coder/v2/cli_test.TestSharingShare()
      /home/runner/work/coder/coder/cli/sharing_test.go:27 +0x165
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1851 +0x44

Goroutine 19763 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1851 +0x8f2
  github.com/coder/coder/v2/cli_test.TestSharingShare()
      /home/runner/work/coder/coder/cli/sharing_test.go:122 +0x255
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.6/x64/src/testing/testing.go:1851 +0x44
```