### PR TITLE
fix: ensure template gallery cards take up full container width

### DIFF
--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.stories.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta<typeof TemplateExampleCard> = {
 	component: TemplateExampleCard,
 	args: {
 		example: MockTemplateExample,
+		className: "w-80",
 	},
 };
 

--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
@@ -6,6 +6,7 @@ import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { Pill } from "components/Pill/Pill";
 import type { FC, HTMLAttributes } from "react";
 import { Link as RouterLink } from "react-router";
+import { cn } from "utils/cn";
 
 type TemplateExampleCardProps = HTMLAttributes<HTMLDivElement> & {
 	example: TemplateExample;
@@ -15,22 +16,41 @@ type TemplateExampleCardProps = HTMLAttributes<HTMLDivElement> & {
 export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 	example,
 	activeTag,
+	className,
 	...divProps
 }) => {
 	return (
-		<div css={styles.card} {...divProps}>
-			<div css={styles.header}>
-				<div css={styles.icon}>
+		<div
+			{...divProps}
+			className={cn(
+				"w-80 p-6 rounded-md text-left text-inherit flex flex-col border border-border border-solid hover:border-border-hover transition-colors duration-200",
+				className,
+			)}
+		>
+			<div className="flex items-center justify-between gap-4 pb-6">
+				<div className="shrink-0 pt-1 size-8">
 					<ExternalImage
 						src={example.icon}
-						css={{ width: "100%", height: "100%", objectFit: "contain" }}
+						className="size-full object-contain"
 					/>
 				</div>
 
-				<div css={styles.tags}>
+				<div className="flex flex-wrap gap-1.5 justify-end">
 					{example.tags.map((tag) => (
 						<RouterLink key={tag} to={`/starter-templates?tag=${tag}`}>
-							<Pill css={[styles.tag, activeTag === tag && styles.activeTag]}>
+							<Pill
+								className={cn(
+									"border border-solid border-border no-underline cursor-pointer hover:border-border-hover transition-colors duration-200",
+									tag === activeTag && "",
+								)}
+								css={
+									activeTag === tag &&
+									((theme) => ({
+										borderColor: theme.roles.active.outline,
+										backgroundColor: theme.roles.active.background,
+									}))
+								}
+							>
 								{tag}
 							</Pill>
 						</RouterLink>
@@ -39,19 +59,17 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 			</div>
 
 			<div>
-				<h4 css={{ fontSize: 14, fontWeight: 600, margin: 0, marginBottom: 4 }}>
-					{example.name}
-				</h4>
-				<span css={styles.description}>
+				<h4 className="text-sm font-semibold mb-1">{example.name}</h4>
+				<div className="text-sm text-content-secondary leading-normal">
 					{example.description}{" "}
 					<Link
 						component={RouterLink}
 						to={`/starter-templates/${example.id}`}
-						css={{ display: "inline-block", fontSize: 13, marginTop: 4 }}
+						className="inline-block text-sm mt-1"
 					>
 						Read more
 					</Link>
-				</span>
+				</div>
 			</div>
 
 			<div css={styles.useButtonContainer}>
@@ -66,59 +84,6 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 };
 
 const styles = {
-	card: (theme) => ({
-		width: "320px",
-		padding: 24,
-		borderRadius: 6,
-		border: `1px solid ${theme.palette.divider}`,
-		textAlign: "left",
-		color: "inherit",
-		display: "flex",
-		flexDirection: "column",
-	}),
-
-	header: {
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "space-between",
-		marginBottom: 24,
-	},
-
-	icon: {
-		flexShrink: 0,
-		paddingTop: 4,
-		width: 32,
-		height: 32,
-	},
-
-	tags: {
-		display: "flex",
-		flexWrap: "wrap",
-		gap: 8,
-		justifyContent: "end",
-	},
-
-	tag: (theme) => ({
-		borderColor: theme.palette.divider,
-		textDecoration: "none",
-		cursor: "pointer",
-		"&: hover": {
-			borderColor: theme.palette.primary.main,
-		},
-	}),
-
-	activeTag: (theme) => ({
-		borderColor: theme.roles.active.outline,
-		backgroundColor: theme.roles.active.background,
-	}),
-
-	description: (theme) => ({
-		fontSize: 13,
-		color: theme.palette.text.secondary,
-		lineHeight: "1.6",
-		display: "block",
-	}),
-
 	useButtonContainer: {
 		display: "flex",
 		gap: 12,

--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
@@ -1,4 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
 import Link from "@mui/material/Link";
 import type { TemplateExample } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
@@ -38,19 +37,7 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 				<div className="flex flex-wrap gap-1.5 justify-end">
 					{example.tags.map((tag) => (
 						<RouterLink key={tag} to={`/starter-templates?tag=${tag}`}>
-							<Pill
-								className={cn(
-									"border border-solid border-border no-underline cursor-pointer hover:border-border-hover transition-colors duration-200",
-									tag === activeTag && "",
-								)}
-								css={
-									activeTag === tag &&
-									((theme) => ({
-										borderColor: theme.roles.active.outline,
-										backgroundColor: theme.roles.active.background,
-									}))
-								}
-							>
+							<Pill className="border border-solid border-border no-underline cursor-pointer hover:border-border-hover transition-colors duration-200">
 								{tag}
 							</Pill>
 						</RouterLink>
@@ -72,7 +59,7 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 				</div>
 			</div>
 
-			<div css={styles.useButtonContainer}>
+			<div className="flex flex-col gap-3 pt-6 mt-auto items-center">
 				<Button asChild className="w-full">
 					<RouterLink to={`/templates/new?exampleId=${example.id}`}>
 						Use template
@@ -82,14 +69,3 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 		</div>
 	);
 };
-
-const styles = {
-	useButtonContainer: {
-		display: "flex",
-		gap: 12,
-		flexDirection: "column",
-		paddingTop: 24,
-		marginTop: "auto",
-		alignItems: "center",
-	},
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
@@ -22,7 +22,7 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 		<div
 			{...divProps}
 			className={cn(
-				"w-80 p-6 rounded-md text-left text-inherit flex flex-col border border-border border-solid hover:border-border-hover transition-colors duration-200",
+				"w-full p-6 rounded-md text-left text-inherit flex flex-col border border-border border-solid hover:border-border-hover transition-colors duration-200",
 				className,
 			)}
 		>

--- a/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
@@ -36,6 +36,7 @@ export const CreateTemplateGalleryPageView: FC<
 						>
 							Browse the Coder Registry
 							<ExternalLinkIcon className="size-icon-sm ml-1" />
+							<span className="sr-only"> (link opens in new tab)</span>
 						</a>
 					</Button>
 				}

--- a/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
@@ -1,4 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
 import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import CardContent from "@mui/material/CardContent";
@@ -45,45 +44,33 @@ export const CreateTemplateGalleryPageView: FC<
 			</PageHeader>
 			<Stack spacing={8}>
 				<Stack direction="row" spacing={4}>
-					<div css={{ width: 202 }}>
-						<h2 css={styles.sectionTitle}>
+					<div className="w-[202px]">
+						<h2 className="text-base font-normal m-0 text-content-primary">
 							Choose a starting point for your new template
 						</h2>
 					</div>
-					<div
-						css={{
-							display: "flex",
-							flexWrap: "wrap",
-							gap: 32,
-							height: "max-content",
-						}}
-					>
+					<div className="flex flex-row flex-wrap gap-8 h-max">
 						<Card variant="outlined" css={{ width: 320, borderRadius: 6 }}>
 							<CardActionArea
 								component={RouterLink}
 								to="/templates/new"
-								sx={{ height: 115, padding: 1 }}
+								className="h-[115px] p-2"
 							>
 								<CardContent>
-									<Stack
-										direction="row"
-										spacing={3}
-										css={{ alignItems: "center" }}
-									>
-										<div css={styles.icon}>
+									<Stack direction="row" spacing={3} className="items-center">
+										<div className="shrink-0 size-8">
 											<ExternalImage
 												src="/emojis/1f4e1.png"
-												css={{
-													width: "100%",
-													height: "100%",
-												}}
+												className="size-full"
 											/>
 										</div>
 										<div>
-											<h4 css={styles.cardTitle}>Upload Template</h4>
-											<span css={styles.cardDescription}>
+											<h4 className="text-content-secondary text-sm font-semibold m-0 mb-1">
+												Upload Template
+											</h4>
+											<p className="text-sm text-content-secondary m-0 leading-relaxed">
 												Get started by uploading an existing template
-											</span>
+											</p>
 										</div>
 									</Stack>
 								</CardContent>
@@ -101,39 +88,3 @@ export const CreateTemplateGalleryPageView: FC<
 		</Margins>
 	);
 };
-
-const styles = {
-	sectionTitle: (theme) => ({
-		color: theme.palette.text.primary,
-		fontSize: 16,
-		fontWeight: 400,
-		margin: 0,
-	}),
-
-	cardTitle: (theme) => ({
-		color: theme.palette.text.secondary,
-		fontSize: 14,
-		fontWeight: 600,
-		margin: 0,
-		marginBottom: 4,
-	}),
-
-	cardDescription: (theme) => ({
-		fontSize: 13,
-		color: theme.palette.text.secondary,
-		lineHeight: "1.6",
-		display: "block",
-	}),
-
-	icon: {
-		flexShrink: 0,
-		width: 32,
-		height: 32,
-	},
-
-	menuItemIcon: (theme) => ({
-		color: theme.palette.text.secondary,
-		width: 20,
-		height: 20,
-	}),
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
@@ -1,7 +1,6 @@
 import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import CardContent from "@mui/material/CardContent";
-import Stack from "@mui/material/Stack";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Button } from "components/Button/Button";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
@@ -12,7 +11,10 @@ import { ExternalLinkIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link as RouterLink } from "react-router";
 import type { StarterTemplatesByTag } from "utils/starterTemplates";
-import { StarterTemplates } from "./StarterTemplates";
+import {
+	StarterTemplates,
+	StarterTemplatesGridContainer,
+} from "./StarterTemplates";
 
 interface CreateTemplateGalleryPageViewProps {
 	starterTemplatesByTag?: StarterTemplatesByTag;
@@ -42,22 +44,23 @@ export const CreateTemplateGalleryPageView: FC<
 			>
 				<PageHeaderTitle>Create a Template</PageHeaderTitle>
 			</PageHeader>
-			<Stack spacing={8}>
-				<Stack direction="row" spacing={4}>
-					<div className="w-[202px]">
+			<div className="flex flex-col gap-16">
+				<div className="flex flex-row gap-8">
+					<div className="basis-[202px] shrink-0">
 						<h2 className="text-base font-normal m-0 text-content-primary">
 							Choose a starting point for your new template
 						</h2>
 					</div>
-					<div className="flex flex-row flex-wrap gap-8 h-max">
-						<Card variant="outlined" className="w-80 rounded-md">
+
+					<StarterTemplatesGridContainer>
+						<Card className="rounded-md border-border border-solid">
 							<CardActionArea
 								component={RouterLink}
 								to="/templates/new"
 								className="h-[115px] p-2"
 							>
 								<CardContent>
-									<Stack direction="row" spacing={3} className="items-center">
+									<div className="flex flex-row gap-6 items-center">
 										<div className="shrink-0 size-8">
 											<ExternalImage
 												src="/emojis/1f4e1.png"
@@ -72,19 +75,19 @@ export const CreateTemplateGalleryPageView: FC<
 												Get started by uploading an existing template
 											</p>
 										</div>
-									</Stack>
+									</div>
 								</CardContent>
 							</CardActionArea>
 						</Card>
-					</div>
-				</Stack>
+					</StarterTemplatesGridContainer>
+				</div>
 
 				{Boolean(error) && <ErrorAlert error={error} />}
 
 				{Boolean(!starterTemplatesByTag) && <Loader />}
 
 				<StarterTemplates starterTemplatesByTag={starterTemplatesByTag} />
-			</Stack>
+			</div>
 		</Margins>
 	);
 };

--- a/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
@@ -50,7 +50,7 @@ export const CreateTemplateGalleryPageView: FC<
 						</h2>
 					</div>
 					<div className="flex flex-row flex-wrap gap-8 h-max">
-						<Card variant="outlined" css={{ width: 320, borderRadius: 6 }}>
+						<Card variant="outlined" className="w-80 rounded-md">
 							<CardActionArea
 								component={RouterLink}
 								to="/templates/new"

--- a/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
@@ -2,7 +2,7 @@ import type { Interpolation, Theme } from "@emotion/react";
 import type { TemplateExample } from "api/typesGenerated";
 import { Stack } from "components/Stack/Stack";
 import { TemplateExampleCard } from "modules/templates/TemplateExampleCard/TemplateExampleCard";
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { Link, useSearchParams } from "react-router";
 import type { StarterTemplatesByTag } from "utils/starterTemplates";
 
@@ -35,6 +35,20 @@ const sortVisibleTemplates = (templates: TemplateExample[]) => {
 		}
 		return a.name.localeCompare(b.name);
 	});
+};
+
+type StarterTemplatesGridContainerProps = Readonly<{
+	children?: ReactNode;
+}>;
+
+export const StarterTemplatesGridContainer: FC<
+	StarterTemplatesGridContainerProps
+> = ({ children }) => {
+	return (
+		<div className="grid grid-cols-1 gap-6 h-max w-full xs:grid-cols-2 lg:grid-cols-3">
+			{children}
+		</div>
+	);
 };
 
 interface StarterTemplatesProps {
@@ -71,7 +85,7 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 				</Stack>
 			)}
 
-			<div className="grid grid-cols-1 gap-6 h-max w-full xs:grid-cols-2 lg:grid-cols-3">
+			<StarterTemplatesGridContainer>
 				{visibleTemplates?.map((example) => (
 					<TemplateExampleCard
 						className="bg-surface-secondary w-full"
@@ -80,7 +94,7 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 						activeTag={activeTag}
 					/>
 				))}
-			</div>
+			</StarterTemplatesGridContainer>
 		</Stack>
 	);
 };

--- a/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
@@ -71,19 +71,10 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 				</Stack>
 			)}
 
-			<div
-				css={{
-					display: "flex",
-					flexWrap: "wrap",
-					gap: 32,
-					height: "max-content",
-				}}
-			>
+			<div className="grid grid-cols-1 gap-6 h-max w-full xs:grid-cols-2 lg:grid-cols-3">
 				{visibleTemplates?.map((example) => (
 					<TemplateExampleCard
-						css={(theme) => ({
-							backgroundColor: theme.palette.background.paper,
-						})}
+						className="bg-surface-secondary w-full"
 						example={example}
 						key={example.id}
 						activeTag={activeTag}

--- a/site/src/pages/TemplatesPage/EmptyTemplates.tsx
+++ b/site/src/pages/TemplatesPage/EmptyTemplates.tsx
@@ -74,7 +74,11 @@ export const EmptyTemplates: FC<EmptyTemplatesProps> = ({
 					<Stack alignItems="center" spacing={4}>
 						<div className="flex flex-wrap justify-center gap-4">
 							{featuredExamples.map((example) => (
-								<TemplateExampleCard example={example} key={example.id} />
+								<TemplateExampleCard
+									className="w-80"
+									example={example}
+									key={example.id}
+								/>
 							))}
 						</div>
 


### PR DESCRIPTION
No issue to link – noticed this problem with Dogfood when I was doing other stuff

## Changes made
- Updated layout for `CreateTemplateGalleryPageView` to make sure all columns expand to full width of container
- Updated card styling to use newer surface and border colors
- Removed as much Emotion and MUI code as possible (without going overboard)

## Screenshots

### Before
<img width="1403" height="585" alt="image" src="https://github.com/user-attachments/assets/d35f250c-4bc3-4f27-8da9-c66393dc9476" />


### After
<img width="1403" height="585" alt="image" src="https://github.com/user-attachments/assets/66b7ba97-f126-4b7c-bd24-ed5bb3c4ae41" />
