### PR TITLE
ci: reduce size of ci failure slack notification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1627,23 +1627,6 @@ jobs:
               },
               {
                 "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Workflow:*\n'"${GITHUB_WORKFLOW}"'"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Committer:*\n'"${GITHUB_ACTOR}"'"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Commit:*\n'"${GITHUB_SHA}"'"
-                  }
-                ]
-              },
-              {
-                "type": "section",
                 "text": {
                   "type": "mrkdwn",
                   "text": "*View failure:* <'"${RUN_URL}"'|Click here>"

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -184,23 +184,6 @@ jobs:
               },
               {
                 "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Workflow:*\n'"${GITHUB_WORKFLOW}"'"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Committer:*\n'"${GITHUB_ACTOR}"'"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Commit:*\n'"${GITHUB_SHA}"'"
-                  }
-                ]
-              },
-              {
-                "type": "section",
                 "text": {
                   "type": "mrkdwn",
                   "text": "*View failure:* <'"${RUN_URL}"'|Click here>"


### PR DESCRIPTION
The slack message will now look something like:

> :x: CI Failure in main
>
> View failure: Click here
>
> @.Blink Investigate this CI failure. Before starting, use your workspace to read https://gist.githubusercontent.com/ethanndickson/8dea9f1db3957ac1baf30ae8ce6f1a42/raw/da95920805456580499462a14b9a906d377414c5/blink-flake-instructions.md

(The prompt section is stored in a GHA variable so it can be modified without committing.)

