### PR TITLE
ci: add workflow for agentic issue triage

### DIFF
--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -15,12 +15,19 @@ on:
       prefix:
         description: 'Prefix for workspace name'
         required: false
-        default: 'triage'
+        default: 'traiage'
         type: string
-
+      persistence_mode:
+        description: 'Persistence mode (push or archive)'
+        required: false
+        type: choice
+        options:
+          - push
+          - archive
+        default: 'archive'
 
 jobs:
-  triage:
+  traiage:
     name: Triage GitHub Issue with Claude Code
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -114,12 +121,16 @@ jobs:
 
       - name: Commit and push changes
         id: commit-push
+        if: ${{ inputs.persistence_mode == 'push' }}
         run: |
           echo "Committing and pushing changes in workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh commit-push
 
       - name: Create and upload archive
         id: create-archive
+        if: ${{ inputs.persistence_mode == 'archive' }}
+          env:
+            GCS_BUCKET: ${{ secrets.TRAIAGE_DEST_GCS_BUCKET }}
         run: |
           echo "Creating archive for workspace: $WORKSPACE_NAME"
           archive_url=$(./scripts/traiage.sh archive)
@@ -133,7 +144,7 @@ jobs:
           ARCHIVE_URL: ${{ steps.create-archive.outputs.archive_url }}
         run: |
           {
-            echo "## AI Triage Results";
+            echo "## TrAIage Results";
             echo "- **Issue URL:** ${ISSUE_URL}";
             echo "- **Context Key:** ${CONTEXT_KEY}";
             echo "- **Workspace:** ${WORKSPACE_NAME}";

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -70,9 +70,10 @@ jobs:
           mkdir -p "${HOME}/.local/bin"
           curl -fsSL --compressed "$CODER_URL/bin/coder-linux-${ARCH}" -o "${HOME}/.local/bin/coder"
           chmod +x "${HOME}/.local/bin/coder"
+          export PATH="$HOME/.local/bin:$PATH"
+          coder version
+          coder whoami
           echo "$HOME/.local/bin" >> "${GITHUB_PATH}"
-          "$HOME"/.local/bin/coder version
-          "$HOME"/.local/bin/coder whoami
 
       - name: Create Coder workspace
         id: create-workspace
@@ -101,15 +102,17 @@ jobs:
 
           # Write a prompt to PROMPT_FILE
           cat > "${PROMPT_FILE}" <<EOF
-            Analyze the below GitHub issue description, understand the root cause, and make appropriate changes to resolve the issue.
+          Analyze the below GitHub issue description, understand the root cause, and make appropriate changes to resolve the issue.
 
-            ISSUE URL: ${ISSUE_URL}
-            ISSUE DESCRIPTION BELOW:
+          ISSUE URL: ${ISSUE_URL}
+          ISSUE DESCRIPTION BELOW:
 
-            ${issue_description}
+          ${issue_description}
           EOF
 
           echo "WORKSPACE_NAME: ${WORKSPACE_NAME}"
+          # This command will run the prompt inside the workspace
+          # and exit once the agent has completed the task.
           PROMPT=$(cat $PROMPT_FILE) ./scripts/traiage.sh prompt
 
       - name: Commit and push changes

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      CODER_URL: ${{ secrets.CODER_URL }}
-      CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
+      CODER_URL: ${{ secrets.TRAIAGE_CODER_URL }}
+      CODER_SESSION_TOKEN: ${{ secrets.TRAIAGE_CODER_SESSION_TOKEN }}
       TEMPLATE_NAME: ${{ inputs.template_name }}
     permissions:
       contents: read
@@ -52,7 +52,7 @@ jobs:
         run: |
           sudo apt-get update -y && \
           sudo apt-get install -y gh && \
-          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+          gh auth login --with-token <<< "${{ secrets.TRAIAGE_GITHUB_TOKEN }}"
 
       - name: Extract context key from issue
         id: extract-context
@@ -67,7 +67,7 @@ jobs:
       - name: Download and install Coder binary
         shell: bash
         env:
-          CODER_URL: ${{ secrets.CODER_URL }}
+          CODER_URL: ${{ secrets.TRAIAGE_CODER_URL }}
         run: |
           if [ "${{ runner.arch }}" == "ARM64" ]; then
             ARCH="arm64"
@@ -129,8 +129,8 @@ jobs:
       - name: Create and upload archive
         id: create-archive
         if: ${{ inputs.persistence_mode == 'archive' }}
-          env:
-            GCS_BUCKET: ${{ secrets.TRAIAGE_DEST_GCS_BUCKET }}
+        env:
+          GCS_BUCKET: ${{ secrets.TRAIAGE_DEST_GCS_BUCKET }}
         run: |
           echo "Creating archive for workspace: $WORKSPACE_NAME"
           archive_url=$(./scripts/traiage.sh archive)

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -1,0 +1,109 @@
+name: AI Triage Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_url:
+        description: 'GitHub Issue URL to process'
+        required: true
+        type: string
+      context_key:
+        description: 'Unique context key (defaults to issue number)'
+        required: false
+        type: string
+      template_name:
+        description: 'Coder template to use for workspace'
+        required: false
+        default: 'ai-workspace'
+        type: string
+
+env:
+  CODER_URL: ${{ secrets.CODER_URL }}
+  CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
+  TEMPLATE_NAME: ${{ inputs.template_name }}
+
+jobs:
+  triage:
+    name: AI Triage Processing
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Coder CLI
+        uses: coder/setup-coder@latest
+
+      - name: Extract context key from issue URL
+        id: extract-context
+        run: |
+          if [[ -n "${{ inputs.context_key }}" ]]; then
+            echo "context_key=${{ inputs.context_key }}" >> $GITHUB_OUTPUT
+          else
+            # Extract issue number from URL (e.g., https://github.com/owner/repo/issues/123 -> 123)
+            issue_number=$(echo "${{ inputs.issue_url }}" | grep -oE '/issues/([0-9]+)' | grep -oE '[0-9]+')
+            echo "context_key=issue_${issue_number}" >> $GITHUB_OUTPUT
+          fi
+
+          # Generate unique workspace name
+          timestamp=$(date +%s)
+          workspace_name="triage-$(echo "${{ inputs.context_key || 'auto' }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g')-${timestamp}"
+          echo "workspace_name=${workspace_name}" >> $GITHUB_OUTPUT
+
+      - name: Create Coder workspace
+        id: create-workspace
+        env:
+          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
+        run: |
+          echo "Creating workspace: $WORKSPACE_NAME"
+          ./scripts/traiage.sh create
+          echo "workspace_created=true" >> $GITHUB_OUTPUT
+
+      - name: Prepare AI prompt
+        id: prepare-prompt
+        run: |
+          # Extract issue content and prepare prompt
+          issue_url="${{ inputs.issue_url }}"
+          context_key="${{ steps.extract-context.outputs.context_key }}"
+
+          # Create a prompt that includes the issue URL and context
+          prompt="Process GitHub issue: ${issue_url}. Context key: ${context_key}. Please analyze the issue, understand the requirements, and create appropriate solutions."
+
+          # Escape the prompt for shell usage
+          escaped_prompt=$(printf '%s\n' "$prompt" | sed 's/[\[\](){}.*^$+?|\\]/\\&/g')
+          echo "prompt=${escaped_prompt}" >> $GITHUB_OUTPUT
+
+      - name: Execute AI processing
+        id: ai-process
+        env:
+          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
+          PROMPT: ${{ steps.prepare-prompt.outputs.prompt }}
+        run: |
+          echo "Sending prompt to AI agent in workspace: $WORKSPACE_NAME"
+          ./scripts/traiage.sh prompt
+
+      - name: Create and upload archive
+        id: create-archive
+        env:
+          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
+        run: |
+          echo "Creating archive for workspace: $WORKSPACE_NAME"
+          archive_url=$(./scripts/traiage.sh archive)
+          echo "archive_url=${archive_url}" >> $GITHUB_OUTPUT
+
+      - name: Report results
+        run: |
+          echo "## AI Triage Results" >> $GITHUB_STEP_SUMMARY
+          echo "- **Issue URL:** ${{ inputs.issue_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Context Key:** ${{ steps.extract-context.outputs.context_key }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Workspace:** ${{ steps.extract-context.outputs.workspace_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Archive URL:** ${{ steps.create-archive.outputs.archive_url }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Cleanup workspace
+        if: always() && steps.create-workspace.outputs.workspace_created == 'true'
+        env:
+          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
+        run: |
+          echo "Cleaning up workspace: $WORKSPACE_NAME"
+          ./scripts/traiage.sh delete || true

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -47,13 +47,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # NOTE: Only required for local testing via nektos/act
-      - name: Install gh CLI
-        run: |
-          sudo apt-get update -y && \
-          sudo apt-get install -y gh && \
-          gh auth login --with-token <<< "${{ secrets.TRAIAGE_GITHUB_TOKEN }}"
-
       - name: Extract context key from issue
         id: extract-context
         env:
@@ -130,11 +123,11 @@ jobs:
         id: create-archive
         if: ${{ inputs.persistence_mode == 'archive' }}
         env:
-          GCS_BUCKET: ${{ secrets.TRAIAGE_DEST_GCS_BUCKET }}
+          DESTINATION_PREFIX: ${{ secrets.TRAIAGE_DESTINATION_PREFIX }}
         run: |
           echo "Creating archive for workspace: $WORKSPACE_NAME"
-          archive_url=$(./scripts/traiage.sh archive)
-          echo "archive_url=${archive_url}" >> "${GITHUB_OUTPUT}"
+          ./scripts/traiage.sh archive
+          echo "archive_url=${DESTINATION_PREFIX%%/}/$WORKSPACE_NAME.tar.gz" >> "${GITHUB_OUTPUT}"
 
       - name: Report results
         env:
@@ -152,7 +145,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup workspace
-        if: always() && steps.create-workspace.outputs.workspace_name != ''
+        if: steps.create-workspace.outputs.workspace_name != '' && (inputs.persistence_mode == 'archive' && steps.create-archive.outputs.archive_url != '')
         run: |
           echo "Cleaning up workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh delete || true

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -81,6 +81,7 @@ jobs:
           PREFIX: ${{ inputs.prefix }}
           CONTEXT_KEY: ${{ steps.extract-context.outputs.context_key }}
           RUN_ID: ${{ github.run_id }}
+          TEMPLATE_PARAMETERS: ${{ secrets.TRAIAGE_TEMPLATE_PARAMETERS }}
         run: |
           export WORKSPACE_NAME="${PREFIX}-${CONTEXT_KEY}-${RUN_ID}"
           echo "Creating workspace: $WORKSPACE_NAME"

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -28,10 +28,17 @@ jobs:
       CODER_URL: ${{ secrets.CODER_URL }}
       CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
       TEMPLATE_NAME: ${{ inputs.template_name }}
+    permissions:
+      contents: read
+      issues: write
+      actions: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       # NOTE: Only required for local testing via nektos/act
       - name: Install gh CLI
@@ -42,11 +49,13 @@ jobs:
 
       - name: Extract context key from issue
         id: extract-context
+        env:
+          ISSUE_URL: ${{ inputs.issue_url }}
         run: |
-          issue_number=$(gh issue view "${{ inputs.issue_url }}" --json number --jq '.number')
+          issue_number="$(gh issue view "${ISSUE_URL}" --json number --jq '.number')"
           context_key="gh-${issue_number}"
-          echo "context_key=${context_key}" >> $GITHUB_OUTPUT
-          echo "CONTEXT_KEY=${context_key}" >> $GITHUB_ENV
+          echo "context_key=${context_key}" >> "${GITHUB_OUTPUT}"
+          echo "CONTEXT_KEY=${context_key}" >> "${GITHUB_ENV}"
 
       - name: Download and install Coder binary
         shell: bash
@@ -58,41 +67,43 @@ jobs:
           else
             ARCH="amd64"
           fi
-          mkdir -p "$HOME"/.local/bin
-          curl -fsSL --compressed "$CODER_URL"/bin/coder-linux-${ARCH} -o "$HOME"/.local/bin/coder
-          chmod +x "$HOME"/.local/bin/coder
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          mkdir -p "${HOME}/.local/bin"
+          curl -fsSL --compressed "$CODER_URL/bin/coder-linux-${ARCH}" -o "${HOME}/.local/bin/coder"
+          chmod +x "${HOME}/.local/bin/coder"
+          echo "$HOME/.local/bin" >> "${GITHUB_PATH}"
           "$HOME"/.local/bin/coder version
           "$HOME"/.local/bin/coder whoami
 
       - name: Create Coder workspace
         id: create-workspace
+        env:
+          PREFIX: ${{ inputs.prefix }}
+          CONTEXT_KEY: ${{ steps.extract-context.outputs.context_key }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          export WORKSPACE_NAME="${{ inputs.prefix }}-${{ steps.extract-context.outputs.context_key }}-${{ github.run_id }}"
+          export WORKSPACE_NAME="${PREFIX}-${CONTEXT_KEY}-${RUN_ID}"
           echo "Creating workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh create
-          echo "workspace_created=true" >> $GITHUB_OUTPUT
-          echo "workspace_name=$WORKSPACE_NAME" >> $GITHUB_OUTPUT
-          echo "WORKSPACE_NAME=${WORKSPACE_NAME}" >> $GITHUB_ENV
+          echo "workspace_name=$WORKSPACE_NAME" >> "${GITHUB_OUTPUT}"
+          echo "WORKSPACE_NAME=${WORKSPACE_NAME}" >> "${GITHUB_ENV}"
 
       - name: Send prompt to AI agent inside workspace
         id: prepare-prompt
+        env:
+          WORKSPACE_NAME: ${{ steps.create-workspace.outputs.workspace_name }}
+          ISSUE_URL: ${{ inputs.issue_url }}
         run: |
           PROMPT_FILE=/tmp/prompt.txt
-          trap 'rm -f ${PROMPT_FILE}' EXIT
-
-          # Extract issue content and prepare prompt
-          issue_url="${{ inputs.issue_url }}"
-          context_key="${{ steps.extract-context.outputs.context_key }}"
+          trap 'rm -f "${PROMPT_FILE}"' EXIT
 
           # Fetch issue description using `gh` CLI
-          issue_description=$(gh issue view "$issue_url")
+          issue_description=$(gh issue view "${ISSUE_URL}")
 
           # Write a prompt to PROMPT_FILE
           cat > "${PROMPT_FILE}" <<EOF
             Analyze the below GitHub issue description, understand the root cause, and make appropriate changes to resolve the issue.
 
-            ISSUE URL: ${issue_url}
+            ISSUE URL: ${ISSUE_URL}
             ISSUE DESCRIPTION BELOW:
 
             ${issue_description}
@@ -107,23 +118,30 @@ jobs:
           echo "Committing and pushing changes in workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh commit-push
 
-      # - name: Create and upload archive
-        # id: create-archive
-        # run: |
-          # echo "Creating archive for workspace: $WORKSPACE_NAME"
-          # archive_url=$(./scripts/traiage.sh archive)
-          # echo "archive_url=${archive_url}" >> $GITHUB_OUTPUT
+      - name: Create and upload archive
+        id: create-archive
+        run: |
+          echo "Creating archive for workspace: $WORKSPACE_NAME"
+          archive_url=$(./scripts/traiage.sh archive)
+          echo "archive_url=${archive_url}" >> "${GITHUB_OUTPUT}"
 
       - name: Report results
+        env:
+          ISSUE_URL: ${{ inputs.issue_url }}
+          CONTEXT_KEY: ${{ steps.extract-context.outputs.context_key }}
+          WORKSPACE_NAME: ${{ steps.create-workspace.outputs.workspace_name }}
+          ARCHIVE_URL: ${{ steps.create-archive.outputs.archive_url }}
         run: |
-          echo "## AI Triage Results" >> $GITHUB_STEP_SUMMARY
-          echo "- **Issue URL:** ${{ inputs.issue_url }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Context Key:** ${{ steps.extract-context.outputs.context_key }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Workspace:** ${{ steps.create-workspace.outputs.workspace_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Archive URL:** ${{ steps.create-archive.outputs.archive_url }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## AI Triage Results";
+            echo "- **Issue URL:** ${ISSUE_URL}";
+            echo "- **Context Key:** ${CONTEXT_KEY}";
+            echo "- **Workspace:** ${WORKSPACE_NAME}";
+            echo "- **Archive URL:** ${ARCHIVE_URL}"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup workspace
-        if: always() && steps.create-workspace.outputs.workspace_created == 'true'
+        if: always() && steps.create-workspace.outputs.workspace_name != ''
         run: |
           echo "Cleaning up workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh delete || true

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -7,14 +7,15 @@ on:
         description: 'GitHub Issue URL to process'
         required: true
         type: string
-      context_key:
-        description: 'Unique context key (defaults to issue number)'
-        required: true
-        type: string
       template_name:
         description: 'Coder template to use for workspace'
         required: true
         default: 'ai-workspace'
+        type: string
+      prefix:
+        description: 'Prefix for workspace name'
+        required: false
+        default: 'triage'
         type: string
 
 
@@ -33,11 +34,19 @@ jobs:
         uses: actions/checkout@v4
 
       # NOTE: Only required for local testing via nektos/act
-      # - name: Install gh CLI
-        # run: |
-          # sudo apt-get update -y && \
-          # sudo apt-get install -y gh && \
-          # gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+      - name: Install gh CLI
+        run: |
+          sudo apt-get update -y && \
+          sudo apt-get install -y gh && \
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Extract context key from issue
+        id: extract-context
+        run: |
+          issue_number=$(gh issue view "${{ inputs.issue_url }}" --json number --jq '.number')
+          context_key="gh-${issue_number}"
+          echo "context_key=${context_key}" >> $GITHUB_OUTPUT
+          echo "CONTEXT_KEY=${context_key}" >> $GITHUB_ENV
 
       - name: Download and install Coder binary
         shell: bash
@@ -59,7 +68,7 @@ jobs:
       - name: Create Coder workspace
         id: create-workspace
         run: |
-          export WORKSPACE_NAME="gh-issue-${{ inputs.context_key }}-${{ github.run_id }}"
+          export WORKSPACE_NAME="${{ inputs.prefix }}-${{ steps.extract-context.outputs.context_key }}-${{ github.run_id }}"
           echo "Creating workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh create
           echo "workspace_created=true" >> $GITHUB_OUTPUT
@@ -92,19 +101,25 @@ jobs:
           echo "WORKSPACE_NAME: ${WORKSPACE_NAME}"
           PROMPT=$(cat $PROMPT_FILE) ./scripts/traiage.sh prompt
 
-      - name: Create and upload archive
-        id: create-archive
+      - name: Commit and push changes
+        id: commit-push
         run: |
-          echo "Creating archive for workspace: $WORKSPACE_NAME"
-          archive_url=$(./scripts/traiage.sh archive)
-          echo "archive_url=${archive_url}" >> $GITHUB_OUTPUT
+          echo "Committing and pushing changes in workspace: $WORKSPACE_NAME"
+          ./scripts/traiage.sh commit-push
+
+      # - name: Create and upload archive
+        # id: create-archive
+        # run: |
+          # echo "Creating archive for workspace: $WORKSPACE_NAME"
+          # archive_url=$(./scripts/traiage.sh archive)
+          # echo "archive_url=${archive_url}" >> $GITHUB_OUTPUT
 
       - name: Report results
         run: |
           echo "## AI Triage Results" >> $GITHUB_STEP_SUMMARY
           echo "- **Issue URL:** ${{ inputs.issue_url }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Context Key:** ${{ steps.extract-context.outputs.context_key }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Workspace:** ${{ steps.extract-context.outputs.workspace_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Workspace:** ${{ steps.create-workspace.outputs.workspace_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Archive URL:** ${{ steps.create-archive.outputs.archive_url }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Cleanup workspace

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -9,84 +9,91 @@ on:
         type: string
       context_key:
         description: 'Unique context key (defaults to issue number)'
-        required: false
+        required: true
         type: string
       template_name:
         description: 'Coder template to use for workspace'
-        required: false
+        required: true
         default: 'ai-workspace'
         type: string
 
-env:
-  CODER_URL: ${{ secrets.CODER_URL }}
-  CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
-  TEMPLATE_NAME: ${{ inputs.template_name }}
 
 jobs:
   triage:
-    name: AI Triage Processing
+    name: Triage GitHub Issue with Claude Code
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CODER_URL: ${{ secrets.CODER_URL }}
+      CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
+      TEMPLATE_NAME: ${{ inputs.template_name }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Coder CLI
-        uses: coder/setup-coder@latest
+      # NOTE: Only required for local testing via nektos/act
+      # - name: Install gh CLI
+        # run: |
+          # sudo apt-get update -y && \
+          # sudo apt-get install -y gh && \
+          # gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Extract context key from issue URL
-        id: extract-context
+      - name: Download and install Coder binary
+        shell: bash
+        env:
+          CODER_URL: ${{ secrets.CODER_URL }}
         run: |
-          if [[ -n "${{ inputs.context_key }}" ]]; then
-            echo "context_key=${{ inputs.context_key }}" >> $GITHUB_OUTPUT
+          if [ "${{ runner.arch }}" == "ARM64" ]; then
+            ARCH="arm64"
           else
-            # Extract issue number from URL (e.g., https://github.com/owner/repo/issues/123 -> 123)
-            issue_number=$(echo "${{ inputs.issue_url }}" | grep -oE '/issues/([0-9]+)' | grep -oE '[0-9]+')
-            echo "context_key=issue_${issue_number}" >> $GITHUB_OUTPUT
+            ARCH="amd64"
           fi
-
-          # Generate unique workspace name
-          timestamp=$(date +%s)
-          workspace_name="triage-$(echo "${{ inputs.context_key || 'auto' }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g')-${timestamp}"
-          echo "workspace_name=${workspace_name}" >> $GITHUB_OUTPUT
+          mkdir -p "$HOME"/.local/bin
+          curl -fsSL --compressed "$CODER_URL"/bin/coder-linux-${ARCH} -o "$HOME"/.local/bin/coder
+          chmod +x "$HOME"/.local/bin/coder
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          "$HOME"/.local/bin/coder version
+          "$HOME"/.local/bin/coder whoami
 
       - name: Create Coder workspace
         id: create-workspace
-        env:
-          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
         run: |
+          export WORKSPACE_NAME="gh-issue-${{ inputs.context_key }}-${{ github.run_id }}"
           echo "Creating workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh create
           echo "workspace_created=true" >> $GITHUB_OUTPUT
+          echo "workspace_name=$WORKSPACE_NAME" >> $GITHUB_OUTPUT
+          echo "WORKSPACE_NAME=${WORKSPACE_NAME}" >> $GITHUB_ENV
 
-      - name: Prepare AI prompt
+      - name: Send prompt to AI agent inside workspace
         id: prepare-prompt
         run: |
+          PROMPT_FILE=/tmp/prompt.txt
+          trap 'rm -f ${PROMPT_FILE}' EXIT
+
           # Extract issue content and prepare prompt
           issue_url="${{ inputs.issue_url }}"
           context_key="${{ steps.extract-context.outputs.context_key }}"
 
-          # Create a prompt that includes the issue URL and context
-          prompt="Process GitHub issue: ${issue_url}. Context key: ${context_key}. Please analyze the issue, understand the requirements, and create appropriate solutions."
+          # Fetch issue description using `gh` CLI
+          issue_description=$(gh issue view "$issue_url")
 
-          # Escape the prompt for shell usage
-          escaped_prompt=$(printf '%s\n' "$prompt" | sed 's/[\[\](){}.*^$+?|\\]/\\&/g')
-          echo "prompt=${escaped_prompt}" >> $GITHUB_OUTPUT
+          # Write a prompt to PROMPT_FILE
+          cat > "${PROMPT_FILE}" <<EOF
+            Analyze the below GitHub issue description, understand the root cause, and make appropriate changes to resolve the issue.
 
-      - name: Execute AI processing
-        id: ai-process
-        env:
-          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
-          PROMPT: ${{ steps.prepare-prompt.outputs.prompt }}
-        run: |
-          echo "Sending prompt to AI agent in workspace: $WORKSPACE_NAME"
-          ./scripts/traiage.sh prompt
+            ISSUE URL: ${issue_url}
+            ISSUE DESCRIPTION BELOW:
+
+            ${issue_description}
+          EOF
+
+          echo "WORKSPACE_NAME: ${WORKSPACE_NAME}"
+          PROMPT=$(cat $PROMPT_FILE) ./scripts/traiage.sh prompt
 
       - name: Create and upload archive
         id: create-archive
-        env:
-          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
         run: |
           echo "Creating archive for workspace: $WORKSPACE_NAME"
           archive_url=$(./scripts/traiage.sh archive)
@@ -102,8 +109,6 @@ jobs:
 
       - name: Cleanup workspace
         if: always() && steps.create-workspace.outputs.workspace_created == 'true'
-        env:
-          WORKSPACE_NAME: ${{ steps.extract-context.outputs.workspace_name }}
         run: |
           echo "Cleaning up workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh delete || true

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -156,7 +156,6 @@ archive() {
 
 	cat >"${TEMPDIR}/archive.sh" <<-EOF
 		#!/usr/bin/env bash
-		set -x
 		set -euo pipefail
 		/tmp/coder-script-data/bin/coder-archive-create
 		ARCHIVE_NAME=\$(cd && find . -maxdepth 1 -type f -name "*.tar.gz" -print0 | xargs -0 -n 1 basename)

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -19,13 +19,14 @@ usage() {
 }
 
 create() {
-	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME TEMPLATE_NAME
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME TEMPLATE_NAME TEMPLATE_PARAMETERS
 	"${CODER_BIN}" \
 		--url "${CODER_URL}" \
 		--token "${CODER_SESSION_TOKEN}" \
 		create \
 		--template "${TEMPLATE_NAME}" \
 		--stop-after 30m \
+		--parameter "${TEMPLATE_PARAMETERS}" \
 		--yes \
 		"${WORKSPACE_NAME}"
 	exit 0

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -63,7 +63,7 @@ prompt_ssh() {
 	ssh_config
 
 	# Write prompt to a file in the workspace
-	cat <<<"${PROMPT}" > "${TEMPDIR}/prompt.txt"
+	cat <<<"${PROMPT}" >"${TEMPDIR}/prompt.txt"
 	scp \
 		-F "${OPENSSH_CONFIG_FILE}" \
 		"${TEMPDIR}/prompt.txt" \
@@ -167,7 +167,7 @@ commit_push() {
 	ssh_config
 
 	# For multiple commands, upload a script and run it.
-	cat > "${TEMPDIR}/commit_push.sh" <<- EOF
+	cat >"${TEMPDIR}/commit_push.sh" <<-EOF
 		#!/usr/bin/env bash
 		set -euo pipefail
 		if [[ \$(git branch --show-current) != "${WORKSPACE_NAME}" ]]; then

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -152,13 +152,16 @@ wait() {
 
 archive() {
 	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
-
-	ssh_config
 	exit 0
+
+	#shellcheck disable=SC2086
+	ssh_config
+	#shellcheck disable=SC2086
 	"${CODER_BIN}" \
 		--url "${CODER_URL}" \
 		--token "${CODER_SESSION_TOKEN}" \
 		ssh "${WORKSPACE_NAME}" -- /bin/bash -lc "coder-create-archive"
+	#shellcheck disable=SC2086
 	exit 0
 }
 

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -47,6 +47,7 @@ prompt_ssh() {
 		--token "${CODER_SESSION_TOKEN}" \
 		--ssh-config-file="${OPENSSH_CONFIG_FILE}" \
 		--yes
+	trap 'rm -f /tmp/coder-ssh.config' EXIT
 
 	# Write prompt to a file in the workspace
 	ssh \

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -139,6 +139,8 @@ wait() {
 
 archive() {
 	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
+	echo "Not implemented yet!"
+	exit 0
 	"${CODER_BIN}" \
 		--url "${CODER_URL}" \
 		--token "${CODER_SESSION_TOKEN}" \

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -62,7 +62,7 @@ prompt_ssh() {
 		-F /tmp/coder-ssh.config \
 		"${WORKSPACE_NAME}.coder" \
 		-- \
-		"cat /tmp/prompt.txt | \"\${HOME}\"/.local/bin/claude --print --verbose --output-format=stream-json"
+		"cat /tmp/prompt.txt | \"\${HOME}\"/.local/bin/claude --dangerously-skip-permissions --print --verbose --output-format=stream-json"
 	exit 0
 }
 

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -144,23 +144,24 @@ archive() {
 
 	# We want the heredoc to be expanded locally and not remotely.
 	# shellcheck disable=SC2087
-	ARCHIVE_DEST=$(ssh -F "${OPENSSH_CONFIG_FILE}" \
-		"${WORKSPACE_NAME}.coder" \
-		bash <<-EOF
-			#!/usr/bin/env bash
-			set -euo pipefail
-			ARCHIVE_PATH=\$(coder-archive-create)
-			ARCHIVE_NAME=\$(basename "\${ARCHIVE_PATH}")
-			ARCHIVE_DEST="${DESTINATION_PREFIX%%/}/\${ARCHIVE_NAME}"
-			if [[ ! -f "\${ARCHIVE_PATH}" ]]; then
-				echo "FATAL: Archive not found at expected path: \${ARCHIVE_PATH}"
-				exit 1
-			fi
-			gcloud storage cp "\${ARCHIVE_PATH}" "\${ARCHIVE_DEST}"
-			echo "\${ARCHIVE_DEST}"
-			exit 0
-		EOF
-		)
+	ARCHIVE_DEST=$(
+		ssh -F "${OPENSSH_CONFIG_FILE}" \
+			"${WORKSPACE_NAME}.coder" \
+			bash <<-EOF
+				#!/usr/bin/env bash
+				set -euo pipefail
+				ARCHIVE_PATH=\$(coder-archive-create)
+				ARCHIVE_NAME=\$(basename "\${ARCHIVE_PATH}")
+				ARCHIVE_DEST="${DESTINATION_PREFIX%%/}/\${ARCHIVE_NAME}"
+				if [[ ! -f "\${ARCHIVE_PATH}" ]]; then
+					echo "FATAL: Archive not found at expected path: \${ARCHIVE_PATH}"
+					exit 1
+				fi
+				gcloud storage cp "\${ARCHIVE_PATH}" "\${ARCHIVE_DEST}"
+				echo "\${ARCHIVE_DEST}"
+				exit 0
+			EOF
+	)
 
 	echo "${ARCHIVE_DEST}"
 
@@ -171,7 +172,7 @@ commit_push() {
 	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
 	ssh_config
 
-  # We want the heredoc to be expanded locally and not remotely.
+	# We want the heredoc to be expanded locally and not remotely.
 	# shellcheck disable=SC2087
 	ssh \
 		-F "${OPENSSH_CONFIG_FILE}" \

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -52,7 +52,7 @@ prompt_ssh() {
 	# Write prompt to a file in the workspace
 	ssh \
 		-F /tmp/coder-ssh.config \
-	"${WORKSPACE_NAME}.coder" \
+		"${WORKSPACE_NAME}.coder" \
 		-- \
 		"cat > /tmp/prompt.txt" <<<"${PROMPT}"
 
@@ -63,7 +63,7 @@ prompt_ssh() {
 		"${WORKSPACE_NAME}.coder" \
 		-- \
 		"cat /tmp/prompt.txt | \"\${HOME}\"/.local/bin/claude --print --verbose --output-format=stream-json"
-		exit 0
+	exit 0
 }
 
 prompt_agentapi() {
@@ -94,12 +94,12 @@ prompt_agentapi() {
 		--show-error \
 		--silent \
 		"${CODER_URL}/@${username}/${WORKSPACE_NAME}/apps/${AGENTAPI_SLUG}/message" | jq -r '.ok')
-		if [[ "${response}" != "true" ]]; then
-			echo "Failed to send prompt"
-			exit 1
-		fi
+	if [[ "${response}" != "true" ]]; then
+		echo "Failed to send prompt"
+		exit 1
+	fi
 
-		wait
+	wait
 }
 
 wait() {
@@ -119,15 +119,15 @@ wait() {
 
 	for attempt in {1..600}; do
 		response=$(curl \
-		--data-raw "${payload}" \
-		--fail \
-		--header "Content-Type: application/json" \
-		--header "Coder-Session-Token: ${CODER_SESSION_TOKEN}" \
-		--location \
-		--request GET \
-		--show-error \
-		--silent \
-		"${CODER_URL}/@${username}/${WORKSPACE_NAME}/apps/agentapi/status" | jq -r '.status')
+			--data-raw "${payload}" \
+			--fail \
+			--header "Content-Type: application/json" \
+			--header "Coder-Session-Token: ${CODER_SESSION_TOKEN}" \
+			--location \
+			--request GET \
+			--show-error \
+			--silent \
+			"${CODER_URL}/@${username}/${WORKSPACE_NAME}/apps/agentapi/status" | jq -r '.status')
 		if [[ "${response}" == "stable" ]]; then
 			echo "AgentAPI stable"
 			break

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+# shellcheck source=scripts/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+CODER_BIN=${CODER_BIN:-"$(which coder)"}
+
+[[ -n ${VERBOSE:-} ]] && set -x
+set -euo pipefail
+
+usage() {
+	echo "Usage: $0 <options>"
+	exit 1
+}
+
+create() {
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME TEMPLATE_NAME
+	"${CODER_BIN}" \
+		--url "${CODER_URL}" \
+		--token "${CODER_SESSION_TOKEN}" \
+		create \
+		--template "${TEMPLATE_NAME}" \
+		--yes \
+		"${WORKSPACE_NAME}"
+
+	exit 0
+}
+
+prompt() {
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME PROMPT
+	"${CODER_BIN}" \
+		--url "${CODER_URL}" \
+		--token "${CODER_SESSION_TOKEN}" \
+		ssh "${WORKSPACE_NAME}" -- /bin/bash -lc "echo -n '${PROMPT}' | ~/.local/bin/claude --print --verbose --output-format=stream-json -"
+}
+
+delete() {
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
+	"${CODER_BIN}" \
+		--url "${CODER_URL}" \
+		--token "${CODER_SESSION_TOKEN}" \
+		delete \
+		"${WORKSPACE_NAME}" \
+		--yes
+
+	exit 0
+}
+
+main() {
+	dependencies coder
+
+	if [[ $# -eq 0 ]]; then
+		usage
+	fi
+
+	case "$1" in
+		create)
+			create
+			;;
+		prompt)
+			prompt
+			;;
+		delete)
+			delete
+			;;
+		*)
+			echo "Unknown option: $1"
+			usage
+			;;
+	esac
+}
+
+main "$@"

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -21,6 +21,7 @@ create() {
 		--token "${CODER_SESSION_TOKEN}" \
 		create \
 		--template "${TEMPLATE_NAME}" \
+		--stop-after 30m \
 		--yes \
 		"${WORKSPACE_NAME}"
 	exit 0
@@ -63,22 +64,22 @@ main() {
 	fi
 
 	case "$1" in
-		create)
-			create
-			;;
-		prompt)
-			prompt
-			;;
-		archive)
-			archive
-			;;
-		delete)
-			delete
-			;;
-		*)
-			echo "Unknown option: $1"
-			usage
-			;;
+	create)
+		create
+		;;
+	prompt)
+		prompt
+		;;
+	archive)
+		archive
+		;;
+	delete)
+		delete
+		;;
+	*)
+		echo "Unknown option: $1"
+		usage
+		;;
 	esac
 }
 

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -23,7 +23,6 @@ create() {
 		--template "${TEMPLATE_NAME}" \
 		--yes \
 		"${WORKSPACE_NAME}"
-
 	exit 0
 }
 
@@ -33,6 +32,16 @@ prompt() {
 		--url "${CODER_URL}" \
 		--token "${CODER_SESSION_TOKEN}" \
 		ssh "${WORKSPACE_NAME}" -- /bin/bash -lc "echo -n '${PROMPT}' | ~/.local/bin/claude --print --verbose --output-format=stream-json -"
+	exit 0
+}
+
+archive() {
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
+	"${CODER_BIN}" \
+		--url "${CODER_URL}" \
+		--token "${CODER_SESSION_TOKEN}" \
+		ssh "${WORKSPACE_NAME}" -- /bin/bash -lc "coder-create-archive"
+	exit 0
 }
 
 delete() {
@@ -43,7 +52,6 @@ delete() {
 		delete \
 		"${WORKSPACE_NAME}" \
 		--yes
-
 	exit 0
 }
 
@@ -60,6 +68,9 @@ main() {
 			;;
 		prompt)
 			prompt
+			;;
+		archive)
+			archive
 			;;
 		delete)
 			delete


### PR DESCRIPTION
Adds a GH workflow to start a workspace with a pre-determined template, perform a first pass over a given GitHub issue, and persist the changes in a GCS bucket for later refining. Tested locally with `nektos/act`.

Note: "traiage" is not a typo.