### PR TITLE
refactor(scaletest): generate user and workspace names if omitted

### DIFF
--- a/scaletest/createworkspaces/config.go
+++ b/scaletest/createworkspaces/config.go
@@ -13,9 +13,9 @@ import (
 type UserConfig struct {
 	// OrganizationID is the ID of the organization to add the user to.
 	OrganizationID uuid.UUID `json:"organization_id"`
-	// Username is the username of the new user.
+	// Username is the username of the new user. Generated if empty.
 	Username string `json:"username"`
-	// Email is the email of the new user.
+	// Email is the email of the new user. Generated if empty.
 	Email string `json:"email"`
 	// SessionToken is the session token of an already existing user. If set, no
 	// user will be created.
@@ -25,14 +25,6 @@ type UserConfig struct {
 func (c UserConfig) Validate() error {
 	if c.OrganizationID == uuid.Nil {
 		return xerrors.New("organization_id must not be a nil UUID")
-	}
-	if c.SessionToken == "" {
-		if c.Username == "" {
-			return xerrors.New("username must be set")
-		}
-		if c.Email == "" {
-			return xerrors.New("email must be set")
-		}
 	}
 
 	return nil

--- a/scaletest/createworkspaces/config.go
+++ b/scaletest/createworkspaces/config.go
@@ -26,6 +26,14 @@ func (c UserConfig) Validate() error {
 	if c.OrganizationID == uuid.Nil {
 		return xerrors.New("organization_id must not be a nil UUID")
 	}
+	if c.SessionToken != "" {
+		if c.Username != "" {
+			return xerrors.New("username must be empty when session_token is set")
+		}
+		if c.Email != "" {
+			return xerrors.New("email must be empty when session_token is set")
+		}
+	}
 
 	return nil
 }

--- a/scaletest/createworkspaces/config_test.go
+++ b/scaletest/createworkspaces/config_test.go
@@ -15,6 +15,75 @@ import (
 	"github.com/coder/coder/v2/scaletest/workspacebuild"
 )
 
+func Test_UserConfig(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+
+	cases := []struct {
+		name        string
+		config      createworkspaces.UserConfig
+		errContains string
+	}{
+		{
+			name: "OK",
+			config: createworkspaces.UserConfig{
+				OrganizationID: id,
+				Username:       "test",
+				Email:          "test@test.coder.com",
+			},
+		},
+		{
+			name: "NoOrganizationID",
+			config: createworkspaces.UserConfig{
+				OrganizationID: uuid.Nil,
+				Username:       "test",
+				Email:          "test@test.coder.com",
+			},
+			errContains: "organization_id must not be a nil UUID",
+		},
+		{
+			name: "OKSessionToken",
+			config: createworkspaces.UserConfig{
+				OrganizationID: id,
+				SessionToken:   "sometoken",
+			},
+		},
+		{
+			name: "WithSessionTokenAndUsername",
+			config: createworkspaces.UserConfig{
+				OrganizationID: id,
+				Username:       "test",
+				SessionToken:   "sometoken",
+			},
+			errContains: "username must be empty when session_token is set",
+		},
+		{
+			name: "WithSessionTokenAndEmail",
+			config: createworkspaces.UserConfig{
+				OrganizationID: id,
+				Email:          "test@test.coder.com",
+				SessionToken:   "sometoken",
+			},
+			errContains: "email must be empty when session_token is set",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := c.config.Validate()
+			if c.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_Config(t *testing.T) {
 	t.Parallel()
 

--- a/scaletest/createworkspaces/config_test.go
+++ b/scaletest/createworkspaces/config_test.go
@@ -15,68 +15,6 @@ import (
 	"github.com/coder/coder/v2/scaletest/workspacebuild"
 )
 
-func Test_UserConfig(t *testing.T) {
-	t.Parallel()
-
-	id := uuid.New()
-
-	cases := []struct {
-		name        string
-		config      createworkspaces.UserConfig
-		errContains string
-	}{
-		{
-			name: "OK",
-			config: createworkspaces.UserConfig{
-				OrganizationID: id,
-				Username:       "test",
-				Email:          "test@test.coder.com",
-			},
-		},
-		{
-			name: "NoOrganizationID",
-			config: createworkspaces.UserConfig{
-				OrganizationID: uuid.Nil,
-				Username:       "test",
-				Email:          "test@test.coder.com",
-			},
-			errContains: "organization_id must not be a nil UUID",
-		},
-		{
-			name: "NoUsername",
-			config: createworkspaces.UserConfig{
-				OrganizationID: id,
-				Username:       "",
-				Email:          "test@test.coder.com",
-			},
-			errContains: "username must be set",
-		},
-		{
-			name: "NoEmail",
-			config: createworkspaces.UserConfig{
-				OrganizationID: id,
-				Username:       "test",
-				Email:          "",
-			},
-			errContains: "email must be set",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := c.config.Validate()
-			if c.errContains != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), c.errContains)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func Test_Config(t *testing.T) {
 	t.Parallel()
 

--- a/scaletest/loadtestutil/names.go
+++ b/scaletest/loadtestutil/names.go
@@ -1,0 +1,55 @@
+package loadtestutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coder/coder/v2/cryptorand"
+)
+
+const (
+	// Prefix for all scaletest resources (users and workspaces)
+	ScaleTestPrefix = "scaletest"
+
+	// Email domain for scaletest users
+	EmailDomain = "@scaletest.local"
+
+	DefaultRandLength = 8
+)
+
+// GenerateUserIdentifier generates a username and email for scale testing.
+// The username follows the pattern: scaletest-<random>-<id>
+// The email follows the pattern: <random>-<id>@scaletest.local
+func GenerateUserIdentifier(id string) (username, email string, err error) {
+	randStr, err := cryptorand.String(DefaultRandLength)
+	if err != nil {
+		return "", "", err
+	}
+
+	username = fmt.Sprintf("%s-%s-%s", ScaleTestPrefix, randStr, id)
+	email = fmt.Sprintf("%s-%s%s", randStr, id, EmailDomain)
+	return username, email, nil
+}
+
+// GenerateWorkspaceName generates a workspace name for scale testing.
+// The workspace name follows the pattern: scaletest-<random>-<id>
+func GenerateWorkspaceName(id string) (name string, err error) {
+	randStr, err := cryptorand.String(DefaultRandLength)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s-%s-%s", ScaleTestPrefix, randStr, id), nil
+}
+
+// IsScaleTestUser checks if a username indicates it was created for scale testing.
+func IsScaleTestUser(username, email string) bool {
+	return strings.HasPrefix(username, ScaleTestPrefix+"-") ||
+		strings.HasSuffix(email, EmailDomain)
+}
+
+// IsScaleTestWorkspace checks if a workspace name indicates it was created for scale testing.
+func IsScaleTestWorkspace(workspaceName, ownerName string) bool {
+	return strings.HasPrefix(workspaceName, ScaleTestPrefix+"-") ||
+		strings.HasPrefix(ownerName, ScaleTestPrefix+"-")
+}

--- a/scaletest/workspacebuild/run.go
+++ b/scaletest/workspacebuild/run.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/cryptorand"
 	"github.com/coder/coder/v2/scaletest/harness"
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
 )
@@ -40,7 +39,7 @@ func NewRunner(client *codersdk.Client, cfg Config) *Runner {
 }
 
 // Run implements Runnable.
-func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) error {
+func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -51,11 +50,11 @@ func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) error {
 
 	req := r.cfg.Request
 	if req.Name == "" {
-		randName, err := cryptorand.HexString(8)
+		randName, err := loadtestutil.GenerateWorkspaceName(id)
 		if err != nil {
 			return xerrors.Errorf("generate random name for workspace: %w", err)
 		}
-		req.Name = "test-" + randName
+		req.Name = randName
 	}
 
 	workspace, err := r.client.CreateWorkspace(ctx, r.cfg.OrganizationID, r.cfg.UserID, req)


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/985.

Some scaletest runners would autogenerate names if they weren't supplied on the config, while others required a name be supplied, and a name was autogenerated in the CLI command handler. This PR unifies the runners to make names and emails optional on each config, and generate them in the scaletest runner if omitted. 

The create user runner in the PR above in the stack will do this too.