### PR TITLE
refactor(scaletest): support exposing arbitrary metrics on scaletest runs

### DIFF
--- a/scaletest/harness/results.go
+++ b/scaletest/harness/results.go
@@ -27,16 +27,15 @@ type Results struct {
 
 // RunResult is the result of a single test run.
 type RunResult struct {
-	FullID            string           `json:"full_id"`
-	TestName          string           `json:"test_name"`
-	ID                string           `json:"id"`
-	Logs              string           `json:"logs"`
-	Error             error            `json:"error"`
-	StartedAt         time.Time        `json:"started_at"`
-	Duration          httpapi.Duration `json:"duration"`
-	DurationMS        int64            `json:"duration_ms"`
-	TotalBytesRead    int64            `json:"total_bytes_read"`
-	TotalBytesWritten int64            `json:"total_bytes_written"`
+	FullID     string           `json:"full_id"`
+	TestName   string           `json:"test_name"`
+	ID         string           `json:"id"`
+	Logs       string           `json:"logs"`
+	Error      error            `json:"error"`
+	StartedAt  time.Time        `json:"started_at"`
+	Duration   httpapi.Duration `json:"duration"`
+	DurationMS int64            `json:"duration_ms"`
+	Metrics    map[string]any   `json:"metrics,omitempty"`
 }
 
 // MarshalJSON implements json.Marhshaler for RunResult.
@@ -61,16 +60,15 @@ func (r *TestRun) Result() RunResult {
 	}
 
 	return RunResult{
-		FullID:            r.FullID(),
-		TestName:          r.testName,
-		ID:                r.id,
-		Logs:              r.logs.String(),
-		Error:             r.err,
-		StartedAt:         r.started,
-		Duration:          httpapi.Duration(r.duration),
-		DurationMS:        r.duration.Milliseconds(),
-		TotalBytesRead:    r.bytesRead,
-		TotalBytesWritten: r.bytesWritten,
+		FullID:     r.FullID(),
+		TestName:   r.testName,
+		ID:         r.id,
+		Logs:       r.logs.String(),
+		Error:      r.err,
+		StartedAt:  r.started,
+		Duration:   httpapi.Duration(r.duration),
+		DurationMS: r.duration.Milliseconds(),
+		Metrics:    r.metrics,
 	}
 }
 

--- a/scaletest/harness/results_test.go
+++ b/scaletest/harness/results_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/scaletest/harness"
+	"github.com/coder/coder/v2/scaletest/workspacetraffic"
 )
 
 type testError struct {
@@ -36,40 +37,46 @@ func Test_Results(t *testing.T) {
 		TotalFail: 2,
 		Runs: map[string]harness.RunResult{
 			"test-0/0": {
-				FullID:            "test-0/0",
-				TestName:          "test-0",
-				ID:                "0",
-				Logs:              "test-0/0 log line 1\ntest-0/0 log line 2",
-				Error:             xerrors.New("test-0/0 error"),
-				StartedAt:         now,
-				Duration:          httpapi.Duration(time.Second),
-				DurationMS:        1000,
-				TotalBytesRead:    1024,
-				TotalBytesWritten: 2048,
+				FullID:     "test-0/0",
+				TestName:   "test-0",
+				ID:         "0",
+				Logs:       "test-0/0 log line 1\ntest-0/0 log line 2",
+				Error:      xerrors.New("test-0/0 error"),
+				StartedAt:  now,
+				Duration:   httpapi.Duration(time.Second),
+				DurationMS: 1000,
+				Metrics: map[string]any{
+					workspacetraffic.BytesReadMetric:    1024,
+					workspacetraffic.BytesWrittenMetric: 2048,
+				},
 			},
 			"test-0/1": {
-				FullID:            "test-0/1",
-				TestName:          "test-0",
-				ID:                "1",
-				Logs:              "test-0/1 log line 1\ntest-0/1 log line 2",
-				Error:             nil,
-				StartedAt:         now.Add(333 * time.Millisecond),
-				Duration:          httpapi.Duration(time.Second),
-				DurationMS:        1000,
-				TotalBytesRead:    512,
-				TotalBytesWritten: 1024,
+				FullID:     "test-0/1",
+				TestName:   "test-0",
+				ID:         "1",
+				Logs:       "test-0/1 log line 1\ntest-0/1 log line 2",
+				Error:      nil,
+				StartedAt:  now.Add(333 * time.Millisecond),
+				Duration:   httpapi.Duration(time.Second),
+				DurationMS: 1000,
+				Metrics: map[string]any{
+					workspacetraffic.BytesReadMetric:    512,
+					workspacetraffic.BytesWrittenMetric: 1024,
+				},
 			},
 			"test-0/2": {
-				FullID:            "test-0/2",
-				TestName:          "test-0",
-				ID:                "2",
-				Logs:              "test-0/2 log line 1\ntest-0/2 log line 2",
-				Error:             testError{hidden: xerrors.New("test-0/2 error")},
-				StartedAt:         now.Add(666 * time.Millisecond),
-				Duration:          httpapi.Duration(time.Second),
-				DurationMS:        1000,
-				TotalBytesRead:    2048,
-				TotalBytesWritten: 4096,
+				FullID:     "test-0/2",
+				TestName:   "test-0",
+				ID:         "2",
+				Logs:       "test-0/2 log line 1\ntest-0/2 log line 2",
+				Error:      testError{hidden: xerrors.New("test-0/2 error")},
+				StartedAt:  now.Add(666 * time.Millisecond),
+				Duration:   httpapi.Duration(time.Second),
+				DurationMS: 1000,
+				Metrics: map[string]any{
+					workspacetraffic.BytesReadMetric:    2048,
+					workspacetraffic.BytesWrittenMetric: 4096,
+				},
 			},
 		},
 		Elapsed:   httpapi.Duration(time.Second),
@@ -115,9 +122,11 @@ Test results:
 			"started_at": "2023-10-05T12:03:56.395813665Z",
 			"duration": "1s",
 			"duration_ms": 1000,
-			"total_bytes_read": 1024,
-			"total_bytes_written": 2048,
-			"error": "test-0/0 error:\n    github.com/coder/coder/v2/scaletest/harness_test.Test_Results\n        [working_directory]/results_test.go:43"
+			"metrics": {
+				"bytes_read": 1024,
+				"bytes_written": 2048
+			},
+			"error": "test-0/0 error:\n    github.com/coder/coder/v2/scaletest/harness_test.Test_Results\n        [working_directory]/results_test.go:44"
 		},
 		"test-0/1": {
 			"full_id": "test-0/1",
@@ -127,8 +136,10 @@ Test results:
 			"started_at": "2023-10-05T12:03:56.728813665Z",
 			"duration": "1s",
 			"duration_ms": 1000,
-			"total_bytes_read": 512,
-			"total_bytes_written": 1024,
+			"metrics": {
+				"bytes_read": 512,
+				"bytes_written": 1024
+			},
 			"error": "\u003cnil\u003e"
 		},
 		"test-0/2": {
@@ -139,8 +150,10 @@ Test results:
 			"started_at": "2023-10-05T12:03:57.061813665Z",
 			"duration": "1s",
 			"duration_ms": 1000,
-			"total_bytes_read": 2048,
-			"total_bytes_written": 4096,
+			"metrics": {
+				"bytes_read": 2048,
+				"bytes_written": 4096
+			},
 			"error": "test-0/2 error"
 		}
 	}

--- a/scaletest/workspacetraffic/run.go
+++ b/scaletest/workspacetraffic/run.go
@@ -28,8 +28,9 @@ type Runner struct {
 }
 
 var (
-	_ harness.Runnable  = &Runner{}
-	_ harness.Cleanable = &Runner{}
+	_ harness.Runnable    = &Runner{}
+	_ harness.Cleanable   = &Runner{}
+	_ harness.Collectable = &Runner{}
 )
 
 // func NewRunner(client *codersdk.Client, cfg Config, metrics *Metrics) *Runner {
@@ -210,10 +211,16 @@ func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) (err error) 
 	}
 }
 
-func (r *Runner) GetBytesTransferred() (bytesRead, bytesWritten int64) {
-	bytesRead = r.cfg.ReadMetrics.GetTotalBytes()
-	bytesWritten = r.cfg.WriteMetrics.GetTotalBytes()
-	return bytesRead, bytesWritten
+const (
+	BytesReadMetric    = "bytes_read"
+	BytesWrittenMetric = "bytes_written"
+)
+
+func (r *Runner) GetMetrics() map[string]any {
+	return map[string]any{
+		BytesReadMetric:    r.cfg.ReadMetrics.GetTotalBytes(),
+		BytesWrittenMetric: r.cfg.WriteMetrics.GetTotalBytes(),
+	}
 }
 
 // Cleanup does nothing, successfully.


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/889

The existing implementation for exposing read and written bytes was a little awkward - we're going to be adding a bunch of scaletest runners / load generators that *don't* transfer any bytes. This PR has the scaletest reports expose a map of arbitrary string-keyed metrics instead.

FWIW, the latest iteration of the scaletesting infrastructure doesn't parse these reports right now - they're just logged to stdout, so we're good to break the json schema here.