### PR TITLE
fix: update bitnami to use legacy image

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -46,6 +46,7 @@ on the internet that explain sensible configurations for this chart. Example:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install postgresql bitnami/postgresql \
     --namespace coder \
+    --set image.repository=bitnamilegacy/postgresql
     --set auth.username=coder \
     --set auth.password=coder \
     --set auth.database=coder \

--- a/docs/install/kubernetes/kubernetes-azure-app-gateway.md
+++ b/docs/install/kubernetes/kubernetes-azure-app-gateway.md
@@ -109,6 +109,7 @@ The steps here follow the Microsoft tutorial for a Coder deployment.
    ```shell
    helm repo add bitnami https://charts.bitnami.com/bitnami
    helm install coder-db bitnami/postgresql \
+   --set image.repository=bitnamilegacy/postgresql
    --namespace coder \
    --set auth.username=coder \
    --set auth.password=coder \

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -55,6 +55,7 @@ For proof-of-concept deployments, you can use Bitnami Helm chart to install Post
 ```console
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install coder-db bitnami/postgresql \
+    --set image.repository=bitnamilegacy/postgresql
     --namespace coder \
     --set auth.username=coder \
     --set auth.password=coder \


### PR DESCRIPTION
If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

This PR updates our install docs to use the Bitnami legacy postgres image. Bitnami is [deprecating the image](https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon). 

[Longer term updates](https://codercom.slack.com/archives/C06V069CL3T/p1758293230885509?thread_ts=1758224664.297189&cid=C06V069CL3T) to come later. 