### PR TITLE
fix(site): resolve circular dependency between WorkspacesPage components

### DIFF
--- a/site/src/modules/workspaces/status.ts
+++ b/site/src/modules/workspaces/status.ts
@@ -1,0 +1,14 @@
+import type { WorkspaceStatus } from "api/typesGenerated";
+
+/**
+ * The set of all workspace statuses that indicate that the state for a
+ * workspace is in the middle of a transition and will eventually reach a more
+ * stable state/status.
+ */
+export const ACTIVE_BUILD_STATUSES: readonly WorkspaceStatus[] = [
+	"canceling",
+	"deleting",
+	"pending",
+	"starting",
+	"stopping",
+];

--- a/site/src/pages/WorkspacesPage/BatchUpdateModalForm.stories.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateModalForm.stories.tsx
@@ -9,8 +9,8 @@ import type {
 import { useQueryClient } from "react-query";
 import { action } from "storybook/internal/actions";
 import { expect, screen, userEvent, within } from "storybook/test";
+import { ACTIVE_BUILD_STATUSES } from "utils/workspace";
 import { BatchUpdateModalForm } from "./BatchUpdateModalForm";
-import { ACTIVE_BUILD_STATUSES } from "./WorkspacesPage";
 
 type Writeable<T> = { -readonly [Key in keyof T]: T[Key] };
 type MutableWorkspace = Writeable<Omit<Workspace, "latest_build">> & {

--- a/site/src/pages/WorkspacesPage/BatchUpdateModalForm.stories.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateModalForm.stories.tsx
@@ -6,10 +6,10 @@ import type {
 	Workspace,
 	WorkspaceBuild,
 } from "api/typesGenerated";
+import { ACTIVE_BUILD_STATUSES } from "modules/workspaces/status";
 import { useQueryClient } from "react-query";
 import { action } from "storybook/internal/actions";
 import { expect, screen, userEvent, within } from "storybook/test";
-import { ACTIVE_BUILD_STATUSES } from "utils/workspace";
 import { BatchUpdateModalForm } from "./BatchUpdateModalForm";
 
 type Writeable<T> = { -readonly [Key in keyof T]: T[Key] };

--- a/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
@@ -15,6 +15,7 @@ import {
 } from "components/Dialog/Dialog";
 import { Spinner } from "components/Spinner/Spinner";
 import { TriangleAlert } from "lucide-react";
+import { ACTIVE_BUILD_STATUSES } from "modules/workspaces/status";
 import {
 	type FC,
 	type ForwardedRef,
@@ -25,7 +26,6 @@ import {
 } from "react";
 import { useQueries } from "react-query";
 import { cn } from "utils/cn";
-import { ACTIVE_BUILD_STATUSES } from "utils/workspace";
 
 export const BatchUpdateModalForm: FC<BatchUpdateModalFormProps> = ({
 	open,

--- a/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
@@ -25,7 +25,7 @@ import {
 } from "react";
 import { useQueries } from "react-query";
 import { cn } from "utils/cn";
-import { ACTIVE_BUILD_STATUSES } from "./WorkspacesPage";
+import { ACTIVE_BUILD_STATUSES } from "utils/workspace";
 
 export const BatchUpdateModalForm: FC<BatchUpdateModalFormProps> = ({
 	open,

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -2,7 +2,6 @@ import { getErrorDetail, getErrorMessage } from "api/errors";
 import { workspacePermissionsByOrganization } from "api/queries/organizations";
 import { templates, templateVersionRoot } from "api/queries/templates";
 import { workspaces } from "api/queries/workspaces";
-import type { WorkspaceStatus } from "api/typesGenerated";
 import { useFilter } from "components/Filter/Filter";
 import { useUserFilterMenu } from "components/Filter/UserFilter";
 import { displayError } from "components/GlobalSnackbar/utils";
@@ -16,24 +15,13 @@ import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "react-query";
 import { useSearchParams } from "react-router";
 import { pageTitle } from "utils/page";
+import { ACTIVE_BUILD_STATUSES } from "utils/workspace";
 import { BatchDeleteConfirmation } from "./BatchDeleteConfirmation";
 import { BatchUpdateModalForm } from "./BatchUpdateModalForm";
 import { useBatchActions } from "./batchActions";
 import { useStatusFilterMenu, useTemplateFilterMenu } from "./filter/menus";
 import { WorkspacesPageView } from "./WorkspacesPageView";
 
-/**
- * The set of all workspace statuses that indicate that the state for a
- * workspace is in the middle of a transition and will eventually reach a more
- * stable state/status.
- */
-export const ACTIVE_BUILD_STATUSES: readonly WorkspaceStatus[] = [
-	"canceling",
-	"deleting",
-	"pending",
-	"starting",
-	"stopping",
-];
 
 // To reduce the number of fetches, we reduce the fetch interval if there are no
 // active workspace builds.

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -10,18 +10,17 @@ import { useEffectEvent } from "hooks/hookPolyfills";
 import { usePagination } from "hooks/usePagination";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import { useOrganizationsFilterMenu } from "modules/tableFiltering/options";
+import { ACTIVE_BUILD_STATUSES } from "modules/workspaces/status";
 import { type FC, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "react-query";
 import { useSearchParams } from "react-router";
 import { pageTitle } from "utils/page";
-import { ACTIVE_BUILD_STATUSES } from "utils/workspace";
 import { BatchDeleteConfirmation } from "./BatchDeleteConfirmation";
 import { BatchUpdateModalForm } from "./BatchUpdateModalForm";
 import { useBatchActions } from "./batchActions";
 import { useStatusFilterMenu, useTemplateFilterMenu } from "./filter/menus";
 import { WorkspacesPageView } from "./WorkspacesPageView";
-
 
 // To reduce the number of fetches, we reduce the fetch interval if there are no
 // active workspace builds.

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -18,6 +18,19 @@ dayjs.extend(duration);
 dayjs.extend(utc);
 dayjs.extend(minMax);
 
+/**
+ * The set of all workspace statuses that indicate that the state for a
+ * workspace is in the middle of a transition and will eventually reach a more
+ * stable state/status.
+ */
+export const ACTIVE_BUILD_STATUSES: readonly TypesGen.WorkspaceStatus[] = [
+	"canceling",
+	"deleting",
+	"pending",
+	"starting",
+	"stopping",
+];
+
 const DisplayWorkspaceBuildStatusLanguage = {
 	succeeded: "Succeeded",
 	pending: "Pending",

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -18,19 +18,6 @@ dayjs.extend(duration);
 dayjs.extend(utc);
 dayjs.extend(minMax);
 
-/**
- * The set of all workspace statuses that indicate that the state for a
- * workspace is in the middle of a transition and will eventually reach a more
- * stable state/status.
- */
-export const ACTIVE_BUILD_STATUSES: readonly TypesGen.WorkspaceStatus[] = [
-	"canceling",
-	"deleting",
-	"pending",
-	"starting",
-	"stopping",
-];
-
 const DisplayWorkspaceBuildStatusLanguage = {
 	succeeded: "Succeeded",
 	pending: "Pending",


### PR DESCRIPTION
Move `ACTIVE_BUILD_STATUSES` constant from `WorkspacesPage.tsx` to a module to break the circular dependency between `WorkspacesPage.tsx` and `BatchUpdateModalForm.tsx`. This resolves the circular dependency lint error and ensures proper code organization.

**Error:**
```
• Circular Dependencies
  1) src/pages/WorkspacesPage/WorkspacesPage.tsx -> src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
```
