### PR TITLE
fix: display sample `coder create` command after template push

### DIFF
--- a/cli/cliui/template.go
+++ b/cli/cliui/template.go
@@ -1,0 +1,27 @@
+package cliui
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/coder/pretty"
+)
+
+// WriteTemplateCreateHint writes a standardized banner and example command for creating
+// a workspace from a newly created template.
+//
+// We accept the current time as a parameter instead of calling time.Now() internally so
+// that callers (and tests) can provide a fixed time value, making output deterministic
+// and easy to assert in golden tests.
+func WriteTemplateCreateHint(w io.Writer, templateName, organizationName string, t time.Time) {
+	_, _ = fmt.Fprintln(w, "\n"+Wrap(
+		"The "+Keyword(templateName)+" template has been created at "+Timestamp(t)+"! "+
+			"Developers can provision a workspace with this template using:")+"\n")
+
+	_, _ = fmt.Fprintln(w, "  "+pretty.Sprint(
+		DefaultStyles.Code,
+		fmt.Sprintf("coder create --template=%q --org=%q [workspace name]", templateName, organizationName),
+	))
+	_, _ = fmt.Fprintln(w)
+}

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -8,7 +8,6 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 
 	"github.com/coder/coder/v2/cli/cliui"
@@ -160,19 +159,12 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 				RequireActiveVersion:           requireActiveVersion,
 			}
 
-			template, err := client.CreateTemplate(inv.Context(), organization.ID, createReq)
+			_, err = client.CreateTemplate(inv.Context(), organization.ID, createReq)
 			if err != nil {
 				return err
 			}
 
-			_, _ = fmt.Fprintln(inv.Stdout, "\n"+pretty.Sprint(cliui.DefaultStyles.Wrap,
-				"The "+pretty.Sprint(
-					cliui.DefaultStyles.Keyword, templateName)+" template has been created at "+
-					pretty.Sprint(cliui.DefaultStyles.DateTimeStamp, time.Now().Format(time.Stamp))+"! "+
-					"Developers can provision a workspace with this template using:")+"\n")
-
-			_, _ = fmt.Fprintln(inv.Stdout, "  "+pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("coder create --template=%q --org=%q [workspace name]", templateName, template.OrganizationName)))
-			_, _ = fmt.Fprintln(inv.Stdout)
+			cliui.WriteTemplateCreateHint(inv.Stdout, templateName, organization.Name, time.Now())
 
 			return nil
 		},

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -192,6 +192,9 @@ func (r *RootCmd) templatePush() *serpent.Command {
 					inv.Stdout, "\n"+cliui.Wrap(
 						"The "+cliui.Keyword(name)+" template has been created at "+cliui.Timestamp(time.Now())+"! "+
 							"Developers can provision a workspace with this template using:")+"\n")
+				// Print example command to create a workspace from this template.
+				_, _ = fmt.Fprintln(inv.Stdout, "  "+pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("coder create --template=%q --org=%q [workspace name]", name, organization.Name)))
+				_, _ = fmt.Fprintln(inv.Stdout)
 			} else if activate {
 				err = client.UpdateActiveTemplateVersion(inv.Context(), template.ID, codersdk.UpdateActiveTemplateVersion{
 					ID: job.ID,

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -188,13 +188,7 @@ func (r *RootCmd) templatePush() *serpent.Command {
 					return err
 				}
 
-				_, _ = fmt.Fprintln(
-					inv.Stdout, "\n"+cliui.Wrap(
-						"The "+cliui.Keyword(name)+" template has been created at "+cliui.Timestamp(time.Now())+"! "+
-							"Developers can provision a workspace with this template using:")+"\n")
-				// Print example command to create a workspace from this template.
-				_, _ = fmt.Fprintln(inv.Stdout, "  "+pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("coder create --template=%q --org=%q [workspace name]", name, organization.Name)))
-				_, _ = fmt.Fprintln(inv.Stdout)
+				cliui.WriteTemplateCreateHint(inv.Stdout, name, organization.Name, time.Now())
 			} else if activate {
 				err = client.UpdateActiveTemplateVersion(inv.Context(), template.ID, codersdk.UpdateActiveTemplateVersion{
 					ID: job.ID,


### PR DESCRIPTION
- Fix `coder templates push` to print the example `coder create` command after creating a new template
- Factor shared output into `cliui.WriteTemplateCreateHint` and use in both `templates push` and deprecated `template create`
- Accept time as a parameter to make output deterministic in tests

Tested: ran `go fmt` and built CLI packages (`go build ./cli/...`).