### PR TITLE
provisionerd start: ignore env org/tags when using --psk/--key; warn instead

### DIFF
--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -126,8 +126,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			if preSharedKey != "" && len(rawTags) > 0 {
 				for _, opt := range inv.Command.Options {
 					if opt.Env == "CODER_PROVISIONERD_TAGS" {
-						switch opt.ValueSource {
-						case serpent.ValueSourceEnv:
+						if opt.ValueSource == serpent.ValueSourceEnv {
 							cliui.Warn(inv.Stderr, "CODER_PROVISIONERD_TAGS is set but will be ignored when using --psk.")
 							rawTags = nil
 						}

--- a/enterprise/cli/provisionerdaemonstart_test.go
+++ b/enterprise/cli/provisionerdaemonstart_test.go
@@ -144,6 +144,7 @@ func TestProvisionerDaemon_EnvTagsIgnoredWithKey(t *testing.T) {
 			},
 		},
 	})
+	//nolint:gocritic // ignore This client is operating as the owner user, which has unrestricted permissions
 	res, err := client.CreateProvisionerKey(ctx, user.OrganizationID, codersdk.CreateProvisionerKeyRequest{
 		Name: "env-tags-ignored",
 	})


### PR DESCRIPTION
Problem
- Users with CODER_ORGANIZATION and/or CODER_PROVISIONERD_TAGS set in their shell could not start an org-wide provisioner with --psk/--key because the CLI treated these as conflicts and errored.

Change
- When authenticating with --psk or --key:
  - If CODER_ORGANIZATION is set via environment, ignore it and emit a clear warning.
  - If CODER_PROVISIONERD_TAGS is set via environment, ignore it and emit a clear warning.
  - If either is provided explicitly via flags, continue to error to avoid ambiguity.
- Added tests to cover the new behavior (warnings and successful start).

Notes
- go fmt applied to all changes.
- Could not run the new tests locally due to Docker not being available in this environment; CI should validate them.

Co-authored-by: angrycub <464492+angrycub@users.noreply.github.com>
