### PR TITLE
chore: wrap pr ai guidelines notice in a comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,5 @@
+<!--
+
 If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.
+
+-->


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

it's kind of tedious to have to remove this every time, and it's noisy to leave it in as is.

I propose: wrapping it in a comment. this makes it visible to the author while they're authoring the description, but hides it from readers. for example, this pr description has the comment in it right now!