### PR TITLE
chore(scaletest): add barrier synchronization primitive

### DIFF
--- a/scaletest/harness/barrier.go
+++ b/scaletest/harness/barrier.go
@@ -1,0 +1,35 @@
+package harness
+
+import (
+	"sync/atomic"
+)
+
+type Barrier struct {
+	count atomic.Int64
+	done  chan struct{}
+}
+
+// NewBarrier creates a new barrier that will block until `size` calls to Wait
+// or `Cancel` have been made. It's the caller's responsibility to ensure this
+// eventually happens.
+func NewBarrier(size int) *Barrier {
+	b := &Barrier{
+		done: make(chan struct{}),
+	}
+	b.count.Store(int64(size))
+	return b
+}
+
+// Wait blocks until the barrier count reaches zero.
+func (b *Barrier) Wait() {
+	b.Cancel()
+	<-b.done
+}
+
+// Cancel decrements the barrier count, unblocking other Wait calls if it
+// reaches zero.
+func (b *Barrier) Cancel() {
+	if b.count.Add(-1) == 0 {
+		close(b.done)
+	}
+}

--- a/scaletest/harness/barrier_test.go
+++ b/scaletest/harness/barrier_test.go
@@ -1,0 +1,75 @@
+package harness_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/coder/coder/v2/scaletest/harness"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestBarrier_MultipleRunners(t *testing.T) {
+	t.Parallel()
+	const numRunners = 3
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	barrier := harness.NewBarrier(numRunners)
+
+	var wg sync.WaitGroup
+	wg.Add(numRunners)
+
+	done := make(chan struct{})
+
+	for range numRunners {
+		go func() {
+			defer wg.Done()
+			barrier.Wait()
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-ctx.Done():
+		t.Fatal("barrier should have released all runners")
+	}
+}
+
+func TestBarrier_Cancel(t *testing.T) {
+	t.Parallel()
+	const numRunners = 3
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	barrier := harness.NewBarrier(numRunners)
+
+	var wg sync.WaitGroup
+	wg.Add(numRunners - 1)
+
+	done := make(chan struct{})
+
+	for range numRunners - 1 {
+		go func() {
+			defer wg.Done()
+			barrier.Wait()
+		}()
+	}
+
+	barrier.Cancel()
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-ctx.Done():
+		t.Fatal("barrier should have released after cancel")
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/889.

To fairly compare the latency of Coder Connect workspace updates, we require that all clients be listening for workspace updates before we begin creating workspaces, and thus workspace updates.

To support this, this PR adds a barrier synchronization primitive. Only once `Wait` or `Cancel` has been called `size` times will a goroutine calling `Wait` be unblocked.

The `Cancel` function exists to handle the case where an instance of a Coder Connect runner exits early, if user creation fails. This single failure should not cause all the other goroutines to block indefinitely.