### PR TITLE
ci: fix AI triage (a.k.a. 'traiage') workflow

### DIFF
--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -51,6 +51,7 @@ jobs:
         id: extract-context
         env:
           ISSUE_URL: ${{ inputs.issue_url }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           issue_number="$(gh issue view "${ISSUE_URL}" --json number --jq '.number')"
           context_key="gh-${issue_number}"
@@ -94,6 +95,7 @@ jobs:
         env:
           WORKSPACE_NAME: ${{ steps.create-workspace.outputs.workspace_name }}
           ISSUE_URL: ${{ inputs.issue_url }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           PROMPT_FILE=/tmp/prompt.txt
           trap 'rm -f "${PROMPT_FILE}"' EXIT

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -125,6 +125,7 @@ jobs:
           CONTEXT_KEY: ${{ steps.extract-context.outputs.context_key }}
           WORKSPACE_NAME: ${{ steps.create-workspace.outputs.workspace_name }}
           ARCHIVE_URL: ${{ steps.create-archive.outputs.archive_url }}
+          BUCKET_PREFIX: "gs://coder-traiage-outputs/traiage"
         run: |
           {
             echo "## TrAIage Results";
@@ -136,7 +137,7 @@ jobs:
             echo "To fetch the output to your own workspace:";
             echo '';
             echo '```bash';
-            echo "WORKSPACE_NAME=${WORKSPACE_NAME} ./scripts/traiage.sh resume";
+            echo "BUCKET_PREFIX=${BUCKET_PREFIX} WORKSPACE_NAME=${WORKSPACE_NAME} ./scripts/traiage.sh resume";
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -113,11 +113,11 @@ jobs:
       - name: Create and upload archive
         id: create-archive
         env:
-          DESTINATION_PREFIX: ${{ secrets.TRAIAGE_DESTINATION_PREFIX }}
+          BUCKET_PREFIX: "gs://coder-traiage-outputs/traiage"
         run: |
           echo "Creating archive for workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh archive
-          echo "archive_url=${DESTINATION_PREFIX%%/}/$WORKSPACE_NAME.tar.gz" >> "${GITHUB_OUTPUT}"
+          echo "archive_url=${BUCKET_PREFIX%%/}/$WORKSPACE_NAME.tar.gz" >> "${GITHUB_OUTPUT}"
 
       - name: Report results
         env:

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -17,14 +17,6 @@ on:
         required: false
         default: 'traiage'
         type: string
-      persistence_mode:
-        description: 'Persistence mode (push or archive)'
-        required: false
-        type: choice
-        options:
-          - push
-          - archive
-        default: 'archive'
 
 jobs:
   traiage:
@@ -118,16 +110,8 @@ jobs:
           # and exit once the agent has completed the task.
           PROMPT=$(cat $PROMPT_FILE) ./scripts/traiage.sh prompt
 
-      - name: Commit and push changes
-        id: commit-push
-        if: ${{ inputs.persistence_mode == 'push' }}
-        run: |
-          echo "Committing and pushing changes in workspace: $WORKSPACE_NAME"
-          ./scripts/traiage.sh commit-push
-
       - name: Create and upload archive
         id: create-archive
-        if: ${{ inputs.persistence_mode == 'archive' }}
         env:
           DESTINATION_PREFIX: ${{ secrets.TRAIAGE_DESTINATION_PREFIX }}
         run: |
@@ -151,7 +135,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup workspace
-        if: steps.create-workspace.outputs.workspace_name != '' && (inputs.persistence_mode == 'archive' && steps.create-archive.outputs.archive_url != '')
+        if: steps.create-workspace.outputs.workspace_name != '' && steps.create-archive.outputs.archive_url != ''
         run: |
           echo "Cleaning up workspace: $WORKSPACE_NAME"
           ./scripts/traiage.sh delete || true

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -131,7 +131,13 @@ jobs:
             echo "- **Issue URL:** ${ISSUE_URL}";
             echo "- **Context Key:** ${CONTEXT_KEY}";
             echo "- **Workspace:** ${WORKSPACE_NAME}";
-            echo "- **Archive URL:** ${ARCHIVE_URL}"
+            echo "- **Archive URL:** ${ARCHIVE_URL}";
+
+            echo "To fetch the output to your own workspace:";
+            echo '';
+            echo '```bash';
+            echo "WORKSPACE_NAME=${WORKSPACE_NAME} ./scripts/traiage.sh resume";
+            echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup workspace

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -10,7 +10,7 @@ on:
       template_name:
         description: 'Coder template to use for workspace'
         required: true
-        default: 'ai-workspace'
+        default: 'traiage'
         type: string
       prefix:
         description: 'Prefix for workspace name'

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -140,7 +140,7 @@ wait_agentapi_stable() {
 }
 
 archive() {
-	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME DESTINATION_PREFIX
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME BUCKET_PREFIX
 	ssh_config
 
 	# We want the heredoc to be expanded locally and not remotely.
@@ -153,7 +153,7 @@ archive() {
 				set -euo pipefail
 				ARCHIVE_PATH=\$(coder-archive-create)
 				ARCHIVE_NAME=\$(basename "\${ARCHIVE_PATH}")
-				ARCHIVE_DEST="${DESTINATION_PREFIX%%/}/\${ARCHIVE_NAME}"
+				ARCHIVE_DEST="${BUCKET_PREFIX%%/}/\${ARCHIVE_NAME}"
 				if [[ ! -f "\${ARCHIVE_PATH}" ]]; then
 					echo "FATAL: Archive not found at expected path: \${ARCHIVE_PATH}"
 					exit 1
@@ -216,13 +216,13 @@ delete() {
 }
 
 resume() {
-	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME BUCKET_PREFIX
 
 	# Note: WORKSPACE_NAME here is really the 'context key'.
 	# Files are uploaded to the GCS bucket under this key.
 	# This just happens to be the same as the workspace name.
 
-	src="gs://coder-traiage-outputs/traiage/${WORKSPACE_NAME}.tar.gz"
+	src="${BUCKET_PREFIX%%/}/${WORKSPACE_NAME}.tar.gz"
 	dest="${TEMPDIR}/${WORKSPACE_NAME}.tar.gz"
 	gcloud storage cp "${src}" "${dest}"
 	if [[ ! -f "${dest}" ]]; then

--- a/scripts/traiage.sh
+++ b/scripts/traiage.sh
@@ -216,13 +216,13 @@ delete() {
 }
 
 resume() {
-	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME DESTINATION_PREFIX
+	requiredenvs CODER_URL CODER_SESSION_TOKEN WORKSPACE_NAME
 
 	# Note: WORKSPACE_NAME here is really the 'context key'.
 	# Files are uploaded to the GCS bucket under this key.
 	# This just happens to be the same as the workspace name.
 
-	src="${DESTINATION_PREFIX%%/}/${WORKSPACE_NAME}.tar.gz"
+	src="gs://coder-traiage-outputs/traiage/${WORKSPACE_NAME}.tar.gz"
 	dest="${TEMPDIR}/${WORKSPACE_NAME}.tar.gz"
 	gcloud storage cp "${src}" "${dest}"
 	if [[ ! -f "${dest}" ]]; then


### PR DESCRIPTION
- Updates default template name
- Set `GITHUB_TOKEN` env
- Implement simple `traiage.sh resume` script to download output artifact