### PR TITLE
[DNM & DNR] Find and fix a simple coder bug

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -203,7 +203,23 @@ export const verifyParameters = async (
 			const value = await parameterField.inputValue();
 			expect(value).toEqual(buildParameter.value);
 		} else if (richParameter.type === "list(string)") {
-			throw new Error("not implemented yet"); // FIXME
+			// Expect value to be a JSON-encoded string array
+			let expected: string[] = [];
+			try {
+				expected = JSON.parse(buildParameter.value) as string[];
+			} catch (e) {
+				throw new Error(
+					`invalid list(string) value, expected JSON array: ${buildParameter.value}`,
+				);
+			}
+
+			const listField = await parameterLabel.waitForSelector(
+				`[data-testid='parameter-field-list-of-string']`,
+			);
+			// Chips render the values. Verify that each expected value is present.
+			for (const value of expected) {
+				await expect(listField.getByText(value, { exact: true })).toBeVisible();
+			}
 		} else {
 			// text or number
 			const parameterField = await parameterLabel.waitForSelector(
@@ -920,7 +936,25 @@ const fillParameters = async (
 				.locator(`.MuiRadio-root input[value='${buildParameter.value}']`);
 			await parameterField.click();
 		} else if (richParameter.type === "list(string)") {
-			throw new Error("not implemented yet"); // FIXME
+			// Expect JSON-encoded array. Fill TagInput by typing values separated by comma.
+			let values: string[] = [];
+			try {
+				values = JSON.parse(buildParameter.value) as string[];
+			} catch (e) {
+				throw new Error(
+					`invalid list(string) value, expected JSON array: ${buildParameter.value}`,
+				);
+			}
+
+			const listField = parameterLabel.getByTestId(
+				"parameter-field-list-of-string",
+			);
+			await expect(listField).toBeVisible();
+			const input = listField.locator("input");
+			for (const v of values) {
+				await input.fill(v);
+				await input.press(",");
+			}
 		} else {
 			// text or number
 			const parameterField = parameterLabel


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
This PR addresses a `FIXME` by implementing support for `list(string)` parameter types within the e2e helpers (`site/e2e/helpers.ts`).

This enables robust end-to-end testing for builds that utilize list parameters:
- `verifyParameters` now parses JSON string arrays and asserts that each value's chip is visible.
- `fillParameters` now parses JSON string arrays and simulates typing each value into the `TagInput` followed by a comma.

---
<a href="https://cursor.com/background-agent?bcId=bc-357d1c5c-daf8-4c00-a1b4-0a0a0103a80e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-357d1c5c-daf8-4c00-a1b4-0a0a0103a80e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

