### PR TITLE
ci: fix shellcheck lint error

### DIFF
--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -143,7 +143,7 @@ jobs:
 
           DB=ci gotestsum \
             --format standard-quiet --packages "./..." \
-            -- -timeout=20m -v -p $NUM_PARALLEL_PACKAGES -parallel=$NUM_PARALLEL_TESTS $TESTCOUNT
+            -- -timeout=20m -v -p "$NUM_PARALLEL_PACKAGES" -parallel="$NUM_PARALLEL_TESTS" "$TESTCOUNT"
 
       - name: Upload Embedded Postgres Cache
         uses: ./.github/actions/embedded-pg-cache/upload


### PR DESCRIPTION
When running `make lint` locally, the GitHub action linter complained about missing double quotes around the `gotestsum` command. This PR adds the double quotes around the `$NUM_PARALLEL_PACKAGES` and `$NUM_PARALLEL_TESTS $TESTCOUNT` variables.

```bash
.github/workflows/nightly-gauntlet.yaml:90:9: shellcheck reported issue in this script: SC2086:info:56:25: Double quote to prevent globbing and word splitting [shellcheck]
   |
90 |         run: |
   |         ^~~~
.github/workflows/nightly-gauntlet.yaml:90:9: shellcheck reported issue in this script: SC2086:info:56:58: Double quote to prevent globbing and word splitting [shellcheck]
   |
90 |         run: |
   |         ^~~~
exit status 1
make: *** [Makefile:607: lint/actions/actionlint] Error 1
```