### PR TITLE
chore: add `depguard`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,21 @@
 # Over time we should try tightening some of these.
 
 linters-settings:
+  depguard:
+    rules:
+      experimental:
+        list-mode: lax
+        deny:
+          - pkg: "github.com/coder/coder/v2/x"
+            desc: "experimental packages must have a reason for being imported"
+          - pkg: "github.com/coder/coder/v2/cli/x"
+            desc: "experimental packages must have a reason for being imported"
+          - pkg: "github.com/coder/coder/v2/coderd/x"
+            desc: "experimental packages must have a reason for being imported"
+          - pkg: "github.com/coder/coder/v2/codersdk/x"
+            desc: "experimental packages must have a reason for being imported"
+          - pkg: "github.com/coder/coder/v2/enterprise/x"
+            desc: "experimental packages must have a reason for being imported"
   dupl:
     # goal: 100
     threshold: 412
@@ -217,6 +232,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - depguard
     - dogsled
     - errcheck
     - errname


### PR DESCRIPTION
[depguard](https://github.com/OpenPeeDeeP/depguard) allows us to cause linting failures when certain packages are imported.

Unfortunately it only provided prefix matching, so we can't support searches like `github.com/coder/coder/v2/*/x` which would be ideal. In the interim, I've added 5 likely top-level packages under which experimental packages may be created.

This is implementing the recommendation proposed in the [Experimental Feature Framework](https://www.notion.so/coderhq/Experimental-Feature-Framework-223d579be5928051b865d4e9572c8d23?source=copy_link#223d579be5928046b37cc91b00b27f19).

Note: ruleguard can't do pattern matching in imports either; depguard seems better suited to the job.

_Excerpt:_

> We will introduce  `x` parent packages at appropriate levels that encapsulate business logic pertaining to an experimental feature (e.g. `coderd/x/secrets` or `enterprise/x/wssharing` ). This has the nice side effect of encouraging more use of packages to encapsulate logic specific to a particular function/feature instead of bloating `coderd`.
> - Any “glue code” that must be included to enable the use of an experiment in a production route must be accompanied with a `//nolint:depguard // Reason.`) tag. Failure to do so should result in a linting error.

---

Example:

```
$ go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run agent/agent_test.go  
agent/agent_test.go:63:2: import 'github.com/coder/coder/v2/x/blah' is not allowed from list 'experimental': experimental packages must have a reason for being imported (depguard)
        "github.com/coder/coder/v2/x/blah"
        ^
exit status 1
```