### PR TITLE
test: wait for completion before asserting in TestAgentConnectionMonitor_BuildOutdated

### DIFF
--- a/coderd/workspaceagentsrpc_internal_test.go
+++ b/coderd/workspaceagentsrpc_internal_test.go
@@ -215,14 +215,20 @@ func TestAgentConnectionMonitor_BuildOutdated(t *testing.T) {
 		AnyTimes().
 		Return(database.WorkspaceBuild{ID: uuid.New()}, nil)
 
-	go uut.monitor(ctx)
+	done := make(chan struct{})
+	go func() {
+		uut.monitor(ctx)
+		close(done)
+	}()
 	fConn.requireEventuallyClosed(t, websocket.StatusGoingAway, "build is outdated")
 	fUpdater.requireEventuallySomeUpdates(t, build.WorkspaceID)
+	_ = testutil.TryReceive(ctx, t, done) // ensure monitor() exits before mDB assertions are checked.
 }
 
 func TestAgentConnectionMonitor_SendPings(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+	testCtx := testutil.Context(t, testutil.WaitShort)
+	ctx, cancel := context.WithCancel(testCtx)
 	t.Cleanup(cancel)
 	fConn := &fakePingerCloser{}
 	uut := &agentConnectionMonitor{
@@ -236,7 +242,7 @@ func TestAgentConnectionMonitor_SendPings(t *testing.T) {
 	}()
 	fConn.requireEventuallyHasPing(t)
 	cancel()
-	<-done
+	_ = testutil.TryReceive(testCtx, t, done)
 	lastPing := uut.lastPing.Load()
 	require.NotNil(t, lastPing)
 }


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

follow on to #19836 
fixes https://github.com/coder/internal/issues/970

Same issue, different (adjacent) test.