### PR TITLE
fix(coderd): fix parsing of response format in tasks send

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -675,7 +675,7 @@ func (api *API) taskSend(rw http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		if v, ok := respBody["status"].(string); !ok || v != "ok" {
+		if v, ok := respBody["ok"].(bool); !ok || !v {
 			return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
 				Message: "Task app rejected the message.",
 				Detail:  fmt.Sprintf("Upstream response: %v", respBody),

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -449,7 +449,7 @@ func TestTasks(t *testing.T) {
 					assert.Equal(t, `{"content":"Hello, Agent!","type":"user"}`, string(b), "expected message content")
 
 					w.WriteHeader(http.StatusOK)
-					io.WriteString(w, `{"status": "ok"}`)
+					io.WriteString(w, `{"ok": true}`)
 					return
 				}
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This change fixes the parsing of the wrong response format from agentapi in tasks send.