### PR TITLE
fix(coderd)!: only show task status for current build

### DIFF
--- a/cli/exp_task_status_test.go
+++ b/cli/exp_task_status_test.go
@@ -143,7 +143,7 @@ STATE CHANGED  STATUS   STATE  MESSAGE
 								CreatedAt: now.Add(-5 * time.Second),
 								UpdatedAt: now.Add(-4 * time.Second),
 								CurrentState: &codersdk.TaskStateEntry{
-									State:     codersdk.TaskStateCompleted,
+									State:     codersdk.TaskStateComplete,
 									Timestamp: now.Add(-2 * time.Second),
 									Message:   "Splines reticulated successfully!",
 								},
@@ -155,7 +155,7 @@ STATE CHANGED  STATUS   STATE  MESSAGE
 								CreatedAt: now.Add(-5 * time.Second),
 								UpdatedAt: now.Add(-1 * time.Second),
 								CurrentState: &codersdk.TaskStateEntry{
-									State:     codersdk.TaskStateCompleted,
+									State:     codersdk.TaskStateComplete,
 									Timestamp: now.Add(-2 * time.Second),
 									Message:   "Splines reticulated successfully!",
 								},
@@ -167,7 +167,7 @@ STATE CHANGED  STATUS   STATE  MESSAGE
 								CreatedAt: now.Add(-5 * time.Second),
 								UpdatedAt: now,
 								CurrentState: &codersdk.TaskStateEntry{
-									State:     codersdk.TaskStateCompleted,
+									State:     codersdk.TaskStateComplete,
 									Timestamp: now.Add(-2 * time.Second),
 									Message:   "Splines reticulated successfully!",
 								},

--- a/cli/exp_task_status_test.go
+++ b/cli/exp_task_status_test.go
@@ -96,9 +96,9 @@ func Test_TaskStatus(t *testing.T) {
 STATE CHANGED  STATUS   STATE  MESSAGE
 4s ago         running
 3s ago         running  working  Reticulating splines...
-2s ago         running  completed  Splines reticulated successfully!
-2s ago         stopping  completed  Splines reticulated successfully!
-2s ago         stopped  completed  Splines reticulated successfully!`,
+2s ago         running  complete  Splines reticulated successfully!
+2s ago         stopping  complete  Splines reticulated successfully!
+2s ago         stopped  complete  Splines reticulated successfully!`,
 			hf: func(ctx context.Context, now time.Time) func(http.ResponseWriter, *http.Request) {
 				var calls atomic.Int64
 				return func(w http.ResponseWriter, r *http.Request) {

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -245,13 +245,18 @@ func taskFromWorkspace(ws codersdk.Workspace, initialPrompt string) codersdk.Tas
 		}
 	}
 
+	// Ignore 'latest app status' if it is older than the latest build and the latest build is a 'start' transition.
+	// This ensures that you don't show a stale app status from a previous build.
+	// For stop transitions, there is still value in showing the latest app status.
 	var currentState *codersdk.TaskStateEntry
 	if ws.LatestAppStatus != nil {
-		currentState = &codersdk.TaskStateEntry{
-			Timestamp: ws.LatestAppStatus.CreatedAt,
-			State:     codersdk.TaskState(ws.LatestAppStatus.State),
-			Message:   ws.LatestAppStatus.Message,
-			URI:       ws.LatestAppStatus.URI,
+		if ws.LatestBuild.Transition != codersdk.WorkspaceTransitionStart || ws.LatestAppStatus.CreatedAt.After(ws.LatestBuild.CreatedAt) {
+			currentState = &codersdk.TaskStateEntry{
+				Timestamp: ws.LatestAppStatus.CreatedAt,
+				State:     codersdk.TaskState(ws.LatestAppStatus.State),
+				Message:   ws.LatestAppStatus.Message,
+				URI:       ws.LatestAppStatus.URI,
+			}
 		}
 	}
 

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -79,10 +79,10 @@ func (c *ExperimentalClient) CreateTask(ctx context.Context, user string, reques
 type TaskState string
 
 const (
-	TaskStateWorking   TaskState = "working"
-	TaskStateIdle      TaskState = "idle"
-	TaskStateCompleted TaskState = "completed"
-	TaskStateFailed    TaskState = "failed"
+	TaskStateWorking  TaskState = "working"
+	TaskStateIdle     TaskState = "idle"
+	TaskStateComplete TaskState = "complete"
+	TaskStateFailed   TaskState = "failed"
 )
 
 // Task represents a task.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2889,7 +2889,7 @@ export interface TaskSendRequest {
 }
 
 // From codersdk/aitasks.go
-export type TaskState = "completed" | "failed" | "idle" | "working";
+export type TaskState = "complete" | "failed" | "idle" | "working";
 
 // From codersdk/aitasks.go
 export interface TaskStateEntry {
@@ -2900,7 +2900,7 @@ export interface TaskStateEntry {
 }
 
 export const TaskStates: TaskState[] = [
-	"completed",
+	"complete",
 	"failed",
 	"idle",
 	"working",


### PR DESCRIPTION
This changes the task get endpoint to omit app statuses for previous 'lifetimes' of a workspace.

It also introduces a [breaking change](https://github.com/coder/coder/blob/release/2.26/codersdk/aitasks.go#L83) to bring `TaskStateComplete` in line with `WorkspaceAppStatusStateComplete`. I can alternatively revert this change and add a conversion function between the two SDK types.