### PR TITLE
feat(cli): add formatting options to coder whoami

### DIFF
--- a/cli/testdata/coder_whoami_--help.golden
+++ b/cli/testdata/coder_whoami_--help.golden
@@ -1,9 +1,16 @@
 coder v0.0.0-devel
 
 USAGE:
-  coder whoami
+  coder whoami [flags]
 
   Fetch authenticated user info for Coder deployment
+
+OPTIONS:
+  -c, --column [URL|Username] (default: url,username)
+          Columns to display in table output.
+
+  -o, --output text|json|table (default: text)
+          Output format.
 
 ———
 Run `coder --help` for a list of global options.

--- a/docs/reference/cli/whoami.md
+++ b/docs/reference/cli/whoami.md
@@ -6,5 +6,25 @@ Fetch authenticated user info for Coder deployment
 ## Usage
 
 ```console
-coder whoami
+coder whoami [flags]
 ```
+
+## Options
+
+### -c, --column
+
+|         |                              |
+|---------|------------------------------|
+| Type    | <code>[URL\|Username]</code> |
+| Default | <code>url,username</code>    |
+
+Columns to display in table output.
+
+### -o, --output
+
+|         |                                |
+|---------|--------------------------------|
+| Type    | <code>text\|json\|table</code> |
+| Default | <code>text</code>              |
+
+Output format.


### PR DESCRIPTION
This addresses a long-standing gripe of mine: to get your logged in username you would have to do
```bash
coder whoami | awk '{print $9}'
```

This allows you to do:

```
coder whoami -o json | jq -r '.username'
```

or

```
coder whoami -f table -c username
```