### PR TITLE
feat(cli): add more information to `coder whoami`

### DIFF
--- a/cli/testdata/coder_whoami_--help.golden
+++ b/cli/testdata/coder_whoami_--help.golden
@@ -6,7 +6,7 @@ USAGE:
   Fetch authenticated user info for Coder deployment
 
 OPTIONS:
-  -c, --column [URL|Username] (default: url,username)
+  -c, --column [URL|Username|ID|Orgs|Roles] (default: url,username,id)
           Columns to display in table output.
 
   -o, --output text|json|table (default: text)

--- a/docs/reference/cli/whoami.md
+++ b/docs/reference/cli/whoami.md
@@ -13,10 +13,10 @@ coder whoami [flags]
 
 ### -c, --column
 
-|         |                              |
-|---------|------------------------------|
-| Type    | <code>[URL\|Username]</code> |
-| Default | <code>url,username</code>    |
+|         |                                               |
+|---------|-----------------------------------------------|
+| Type    | <code>[URL\|Username\|ID\|Orgs\|Roles]</code> |
+| Default | <code>url,username,id</code>                  |
 
 Columns to display in table output.
 


### PR DESCRIPTION
Builds upon https://github.com/coder/coder/pull/19970

I got kinda carried away when I saw the extra stuff we could add in here, so I went ahead and added it:

* User ID
* Organization IDs
* Roles

This technically duplicates functionality from `coder users show` but I figure folks may find it useful.