### PR TITLE
docs: add next steps to coder desktop guide

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -286,7 +286,7 @@
 					"icon_path": "./images/icons/computer-code.svg",
 					"children": [
 						{
-							"title": "Coder Desktop connect and sync",
+							"title": "Coder Desktop Connect and Sync",
 							"description": "Use Coder Desktop to manage your workspace code and files locally",
 							"path": "./user-guides/desktop/desktop-connect-sync.md"
 						}

--- a/docs/user-guides/desktop/index.md
+++ b/docs/user-guides/desktop/index.md
@@ -44,8 +44,8 @@ brew install --cask coder/coder/coder-desktop
 #### Manual Installation
 
 1. Download the latest release from [coder-desktop-macos releases](https://github.com/coder/coder-desktop-macos/releases)
-1. Drag `Coder Desktop.app` to your Applications folder
-1. Open from Applications directory
+1. Run `Coder-Desktop.pkg` and follow the prompts to install
+1. `Coder Desktop.app` will be installed to your Applications folder
 
 </div>
 
@@ -129,12 +129,6 @@ Open `http://your-workspace.coder:PORT` in your browser, replacing `PORT` with t
 - Check system permissions for network extensions
 - Ensure only one copy of Coder Desktop is installed
 
-### Known Limitations
-
-#### Secure Browser Context
-
-Some web applications require HTTPS for certain features. While Coder Connect uses encrypted WireGuard tunnels, browsers may show security warnings for HTTP connections to `.coder` hostnames.
-
 ### Getting Help
 
 If you encounter issues not covered here:
@@ -162,3 +156,7 @@ If you encounter issues not covered here:
 4. **Remove configuration** (optional): Delete `%APPDATA%\Coder Desktop`
 
 </div>
+
+## Next Steps
+
+- [Using Coder Connect and File Sync](./desktop-connect-sync.md)


### PR DESCRIPTION
I ended up on the Coder Desktop docs page and thought half of it had disappeared, though it was actually tucked away behind a second page. This PR adds a next steps section to the first page that links there, as it seems very easy to miss right now.