### PR TITLE
chore: add enterprise feature for aibridge

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -90,6 +90,7 @@ const (
 	// enterprise/coderd/license/license.go for the license format.
 	FeatureManagedAgentLimit      FeatureName = "managed_agent_limit"
 	FeatureWorkspaceExternalAgent FeatureName = "workspace_external_agent"
+	FeatureAIBridge               FeatureName = "aibridge"
 )
 
 var (
@@ -117,6 +118,7 @@ var (
 		FeatureWorkspacePrebuilds,
 		FeatureManagedAgentLimit,
 		FeatureWorkspaceExternalAgent,
+		FeatureAIBridge,
 	}
 
 	// FeatureNamesMap is a map of all feature names for quick lookups.
@@ -136,6 +138,8 @@ func (n FeatureName) Humanize() string {
 		return "Template RBAC"
 	case FeatureSCIM:
 		return "SCIM"
+	case FeatureAIBridge:
+		return "AI Bridge"
 	default:
 		return strings.Title(strings.ReplaceAll(string(n), "_", " "))
 	}

--- a/enterprise/cli/exp_aibridge_test.go
+++ b/enterprise/cli/exp_aibridge_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -30,6 +31,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		memberClient, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
@@ -76,6 +82,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		memberClient, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
@@ -157,6 +168,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		memberClient, member := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)

--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -148,8 +148,12 @@ func (r *RootCmd) Server(_ func()) *serpent.Command {
 
 		experiments := agplcoderd.ReadExperiments(options.Logger, options.DeploymentValues.Experiments.Value())
 
-		var aibridgeDaemon *aibridged.Server
 		// In-memory aibridge daemon.
+		// TODO(@deansheather): the lifecycle of the aibridged server is
+		// probably better managed by the enterprise API type itself. Managing
+		// it in the API type means we can avoid starting it up when the license
+		// is not entitled to the feature.
+		var aibridgeDaemon *aibridged.Server
 		if options.DeploymentValues.AI.BridgeConfig.Enabled {
 			if experiments.Enabled(codersdk.ExperimentAIBridge) {
 				aibridgeDaemon, err = newAIBridgeDaemon(api)

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -1,6 +1,7 @@
 package coderd_test
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -15,11 +16,36 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
 )
 
 func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Parallel()
+
+	t.Run("RequiresLicenseFeature", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentAIBridge)}
+		client, _ := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				// No aibridge feature
+				Features: license.Features{},
+			},
+		})
+		experimentalClient := codersdk.NewExperimentalClient(client)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		_, err := experimentalClient.AIBridgeListInterceptions(ctx, codersdk.AIBridgeListInterceptionsFilter{})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+		require.Equal(t, "AI Bridge is a Premium feature. Contact sales!", sdkErr.Message)
+	})
 
 	t.Run("EmptyDB", func(t *testing.T) {
 		t.Parallel()
@@ -28,6 +54,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		experimentalClient := codersdk.NewExperimentalClient(client)
@@ -44,6 +75,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, db, _ := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		experimentalClient := codersdk.NewExperimentalClient(client)
@@ -125,6 +161,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, db, _ := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		experimentalClient := codersdk.NewExperimentalClient(client)
@@ -210,6 +251,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
 			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
+			},
 		})
 		adminExperimentalClient := codersdk.NewExperimentalClient(adminClient)
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -248,6 +294,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		experimentalClient := codersdk.NewExperimentalClient(client)
@@ -406,6 +457,11 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAIBridge: 1,
+				},
 			},
 		})
 		experimentalClient := codersdk.NewExperimentalClient(client)

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -229,6 +229,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 	api.AGPL.ExperimentalHandler.Group(func(r chi.Router) {
 		r.Route("/aibridge", func(r chi.Router) {
 			r.Use(
+				api.RequireFeatureMW(codersdk.FeatureAIBridge),
 				httpmw.RequireExperimentWithDevBypass(api.AGPL.Experiments, codersdk.ExperimentAIBridge),
 			)
 			r.Group(func(r chi.Router) {
@@ -770,6 +771,7 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 				codersdk.FeatureUserRoleManagement:         true,
 				codersdk.FeatureAccessControl:              true,
 				codersdk.FeatureControlSharedPorts:         true,
+				codersdk.FeatureAIBridge:                   true,
 			})
 		if err != nil {
 			return codersdk.Entitlements{}, err

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -890,6 +890,7 @@ func TestLicenseEntitlements(t *testing.T) {
 		codersdk.FeatureAccessControl:              true,
 		codersdk.FeatureControlSharedPorts:         true,
 		codersdk.FeatureWorkspaceExternalAgent:     true,
+		codersdk.FeatureAIBridge:                   true,
 	}
 
 	legacyLicense := func() *coderdenttest.LicenseOptions {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1222,6 +1222,7 @@ export interface Feature {
 
 // From codersdk/deployment.go
 export type FeatureName =
+	| "aibridge"
 	| "access_control"
 	| "advanced_template_scheduling"
 	| "appearance"
@@ -1246,6 +1247,7 @@ export type FeatureName =
 	| "workspace_proxy";
 
 export const FeatureNames: FeatureName[] = [
+	"aibridge",
 	"access_control",
 	"advanced_template_scheduling",
 	"appearance",


### PR DESCRIPTION
Adds enterprise feature "aibridge" and gates the aibridge CRUD and LLM API endpoints behind it.