### PR TITLE
refactor!: rename prompt field to input for task creation

### DIFF
--- a/cli/exp_task_create.go
+++ b/cli/exp_task_create.go
@@ -181,7 +181,7 @@ func (r *RootCmd) taskCreate() *serpent.Command {
 				Name:                    taskName,
 				TemplateVersionID:       templateVersionID,
 				TemplateVersionPresetID: templateVersionPresetID,
-				Prompt:                  taskInput,
+				Input:                   taskInput,
 			})
 			if err != nil {
 				return xerrors.Errorf("create task: %w", err)

--- a/cli/exp_task_create_test.go
+++ b/cli/exp_task_create_test.go
@@ -75,7 +75,7 @@ func TestTaskCreate(t *testing.T) {
 					return
 				}
 
-				assert.Equal(t, prompt, req.Prompt, "prompt mismatch")
+				assert.Equal(t, prompt, req.Input, "prompt mismatch")
 				assert.Equal(t, templateVersionID, req.TemplateVersionID, "template version mismatch")
 
 				if presetName == "" {

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -136,7 +136,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 		if anthropicAPIKey := taskname.GetAnthropicAPIKeyFromEnv(); anthropicAPIKey != "" {
 			anthropicModel := taskname.GetAnthropicModelFromEnv()
 
-			generatedName, err := taskname.Generate(ctx, req.Prompt, taskname.WithAPIKey(anthropicAPIKey), taskname.WithModel(anthropicModel))
+			generatedName, err := taskname.Generate(ctx, req.Input, taskname.WithAPIKey(anthropicAPIKey), taskname.WithModel(anthropicModel))
 			if err != nil {
 				api.Logger.Error(ctx, "unable to generate task name", slog.Error(err))
 			} else {
@@ -150,7 +150,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 		TemplateVersionID:       req.TemplateVersionID,
 		TemplateVersionPresetID: req.TemplateVersionPresetID,
 		RichParameterValues: []codersdk.WorkspaceBuildParameter{
-			{Name: codersdk.AITaskPromptParameterName, Value: req.Prompt},
+			{Name: codersdk.AITaskPromptParameterName, Value: req.Input},
 		},
 	}
 
@@ -216,7 +216,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task := taskFromWorkspace(w, req.Prompt)
+	task := taskFromWorkspace(w, req.Input)
 	httpapi.Write(ctx, rw, http.StatusCreated, task)
 }
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -349,7 +349,7 @@ func TestTasks(t *testing.T) {
 			exp := codersdk.NewExperimentalClient(client)
 			task, err := exp.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 				TemplateVersionID: template.ActiveVersionID,
-				Prompt:            "delete me",
+				Input:             "delete me",
 			})
 			require.NoError(t, err)
 			ws, err := client.Workspace(ctx, task.ID)
@@ -429,7 +429,7 @@ func TestTasks(t *testing.T) {
 			exp := codersdk.NewExperimentalClient(client)
 			task, err := exp.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 				TemplateVersionID: template.ActiveVersionID,
-				Prompt:            "delete me not",
+				Input:             "delete me not",
 			})
 			require.NoError(t, err)
 			ws, err := client.Workspace(ctx, task.ID)
@@ -802,7 +802,7 @@ func TestTasksCreate(t *testing.T) {
 		// When: We attempt to create a Task.
 		task, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 			TemplateVersionID: template.ActiveVersionID,
-			Prompt:            taskPrompt,
+			Input:             taskPrompt,
 		})
 		require.NoError(t, err)
 		require.True(t, task.WorkspaceID.Valid)
@@ -875,7 +875,7 @@ func TestTasksCreate(t *testing.T) {
 				// When: We attempt to create a Task.
 				task, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 					TemplateVersionID: template.ActiveVersionID,
-					Prompt:            "Some prompt",
+					Input:             "Some prompt",
 					Name:              tt.taskName,
 				})
 				if tt.expectError == "" {
@@ -919,7 +919,7 @@ func TestTasksCreate(t *testing.T) {
 		// When: We attempt to create a Task.
 		_, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 			TemplateVersionID: template.ActiveVersionID,
-			Prompt:            taskPrompt,
+			Input:             taskPrompt,
 		})
 
 		// Then: We expect it to fail.
@@ -951,7 +951,7 @@ func TestTasksCreate(t *testing.T) {
 		// When: We attempt to create a Task with an invalid template version ID.
 		_, err := expClient.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
 			TemplateVersionID: uuid.New(),
-			Prompt:            taskPrompt,
+			Input:             taskPrompt,
 		})
 
 		// Then: We expect it to fail.

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -63,7 +63,7 @@ func (c *ExperimentalClient) AITaskPrompts(ctx context.Context, buildIDs []uuid.
 type CreateTaskRequest struct {
 	TemplateVersionID       uuid.UUID `json:"template_version_id" format:"uuid"`
 	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty" format:"uuid"`
-	Prompt                  string    `json:"prompt"`
+	Input                   string    `json:"input"`
 	Name                    string    `json:"name,omitempty"`
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -574,7 +574,7 @@ export interface CreateProvisionerKeyResponse {
 export interface CreateTaskRequest {
 	readonly template_version_id: string;
 	readonly template_version_preset_id?: string;
-	readonly prompt: string;
+	readonly input: string;
 	readonly name?: string;
 }
 

--- a/site/src/pages/TasksPage/TaskPrompt.tsx
+++ b/site/src/pages/TasksPage/TaskPrompt.tsx
@@ -434,14 +434,14 @@ function sortByDefault(a: Preset, b: Preset) {
 // and user action. Since handling this in the FE cannot guarantee correctness,
 // we should move the logic to the BE after the experimental phase.
 async function createTaskWithLatestTemplateVersion(
-	prompt: string,
+	input: string,
 	userId: string,
 	templateId: string,
 	presetId: string | undefined,
 ): Promise<Task> {
 	const template = await API.getTemplate(templateId);
 	return API.experimental.createTask(userId, {
-		prompt,
+		input,
 		template_version_id: template.active_version_id,
 		template_version_preset_id: presetId,
 	});

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -271,7 +271,7 @@ export const CreateTaskSuccessfully: Story = {
 			expect(API.experimental.createTask).toHaveBeenCalledWith(
 				MockUserOwner.id,
 				{
-					prompt: MockNewTaskData.prompt,
+					input: MockNewTaskData.prompt,
 					template_version_id: `${MockTemplate.active_version_id}-latest`,
 					template_version_preset_id: undefined,
 				},


### PR DESCRIPTION
Renames the `prompt` field to `input` for task creation. This matches the naming used in the CLI and elsewhere.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
