### PR TITLE
refactor(scaletest): make workspacebuild return the built workspace

### DIFF
--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -87,23 +87,13 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	workspaceBuildConfig.OrganizationID = r.cfg.User.OrganizationID
 	workspaceBuildConfig.UserID = user.ID.String()
 	r.workspacebuildRunner = workspacebuild.NewRunner(client, workspaceBuildConfig)
-	err = r.workspacebuildRunner.Run(ctx, id, logs)
+	workspace, err := r.workspacebuildRunner.RunReturningWorkspace(ctx, id, logs)
 	if err != nil {
 		return xerrors.Errorf("create workspace: %w", err)
 	}
 
 	if r.cfg.Workspace.NoWaitForAgents {
 		return nil
-	}
-
-	// Get the workspace.
-	workspaceID, err := r.workspacebuildRunner.WorkspaceID()
-	if err != nil {
-		return xerrors.Errorf("get workspace ID: %w", err)
-	}
-	workspace, err := client.Workspace(ctx, workspaceID)
-	if err != nil {
-		return xerrors.Errorf("get workspace %q: %w", workspaceID.String(), err)
 	}
 
 	// Find the first agent.
@@ -116,7 +106,7 @@ resourceLoop:
 		}
 	}
 	if agent.ID == uuid.Nil {
-		return xerrors.Errorf("no agents found for workspace %q", workspaceID.String())
+		return xerrors.Errorf("no agents found for workspace %q", workspace.ID.String())
 	}
 
 	eg, egCtx := errgroup.WithContext(ctx)

--- a/scaletest/workspacebuild/run_test.go
+++ b/scaletest/workspacebuild/run_test.go
@@ -158,7 +158,7 @@ func Test_Runner(t *testing.T) {
 		})
 
 		logs := bytes.NewBuffer(nil)
-		err := runner.Run(ctx, "1", logs)
+		_, err := runner.RunReturningWorkspace(ctx, "1", logs)
 		logsStr := logs.String()
 		t.Log("Runner logs:\n\n" + logsStr)
 		require.NoError(t, err)
@@ -224,7 +224,7 @@ func Test_Runner(t *testing.T) {
 		})
 
 		logs := bytes.NewBuffer(nil)
-		err := runner.Run(ctx, "1", logs)
+		_, err := runner.RunReturningWorkspace(ctx, "1", logs)
 		logsStr := logs.String()
 		t.Log("Runner logs:\n\n" + logsStr)
 		require.Error(t, err)
@@ -271,7 +271,7 @@ func Test_Runner(t *testing.T) {
 		})
 
 		logs := bytes.NewBuffer(nil)
-		err := runner.Run(ctx, "1", logs)
+		_, err := runner.RunReturningWorkspace(ctx, "1", logs)
 		logsStr := logs.String()
 		t.Log("Runner logs:\n\n" + logsStr)
 		require.Error(t, err)

--- a/scaletest/workspaceupdates/run.go
+++ b/scaletest/workspaceupdates/run.go
@@ -126,7 +126,7 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 		r.workspaces[workspaceName] = &workspace{
 			buildStartTime: time.Now(),
 		}
-		err = runner.Run(ctx, fmt.Sprintf("%s-%d", id, i), logs)
+		_, err = runner.RunReturningWorkspace(ctx, fmt.Sprintf("%s-%d", id, i), logs)
 		if err != nil {
 			return xerrors.Errorf("create workspace %d: %w", i, err)
 		}


### PR DESCRIPTION
Similar idea as in #19811, this runner doesn't need to conform to `Runnable`, so we have it return the workspace from the `RunReturningWorkspace` function, instead of the more fragile `Run`, followed by a `.WorkspaceID()`.