### PR TITLE
test: precompile the db cleaner on make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1020,16 +1020,19 @@ endif
 
 TEST_PACKAGES ?= ./...
 
-test:
+warm-go-cache-db-cleaner:
 	# ensure Go's build cache for the cleanercmd is fresh so that tests don't have to build from scratch. This
 	# could take some time and counts against the test's timeout, which can lead to flakes.
 	# c.f. https://github.com/coder/internal/issues/1026
 	mkdir -p build
 	$(GIT_FLAGS) go build -o ./build/cleaner github.com/coder/coder/v2/coderd/database/dbtestutil/cleanercmd
+.PHONY: warm-go-cache-db-cleaner
+
+test: warm-go-cache-db-cleaner
 	$(GIT_FLAGS) gotestsum --format standard-quiet $(GOTESTSUM_RETRY_FLAGS) --packages="$(TEST_PACKAGES)" -- $(GOTEST_FLAGS)
 .PHONY: test
 
-test-cli:
+test-cli: warm-go-cache-db-cleaner
 	$(MAKE) test TEST_PACKAGES="./cli..."
 .PHONY: test-cli
 

--- a/Makefile
+++ b/Makefile
@@ -1021,6 +1021,11 @@ endif
 TEST_PACKAGES ?= ./...
 
 test:
+	# ensure Go's build cache for the cleanercmd is fresh so that tests don't have to build from scratch. This
+	# could take some time and counts against the test's timeout, which can lead to flakes.
+	# c.f. https://github.com/coder/internal/issues/1026
+	mkdir -p build
+	$(GIT_FLAGS) go build -o ./build/cleaner github.com/coder/coder/v2/coderd/database/dbtestutil/cleanercmd
 	$(GIT_FLAGS) gotestsum --format standard-quiet $(GOTESTSUM_RETRY_FLAGS) --packages="$(TEST_PACKAGES)" -- $(GOTEST_FLAGS)
 .PHONY: test
 


### PR DESCRIPTION
We're seeing some timeouts from starting the db cleaner, e.g. https://github.com/coder/internal/issues/1026

My suspicion is that in CI the go build cache might not be warm, and so it can take a while to compile and run the dbcleaner subprocess.

This fix builds the cleaner once prior to starting a test run via `make test` to ensure we have a warm cache.