### PR TITLE
chore: work around timing issue in TestReplicas/ErrorWithoutLicense

### DIFF
--- a/enterprise/coderd/replicas_test.go
+++ b/enterprise/coderd/replicas_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -24,6 +25,7 @@ func TestReplicas(t *testing.T) {
 	}
 	t.Run("ErrorWithoutLicense", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
 		// This will error because replicas are expected to instantly report
 		// errors when the license is not present.
 		db, pubsub := dbtestutil.NewDB(t)
@@ -46,14 +48,19 @@ func TestReplicas(t *testing.T) {
 			ReplicaErrorGracePeriod: time.Nanosecond,
 		})
 		secondClient.SetSessionToken(firstClient.SessionToken())
-		ents, err := secondClient.Entitlements(context.Background())
-		require.NoError(t, err)
-		require.Len(t, ents.Errors, 1)
+
+		testutil.Eventually(ctx, t, func(ctx context.Context) (done bool) {
+			ents, err := secondClient.Entitlements(ctx)
+			return assert.NoError(t, err, "unexpected error from secondClient.Entitlements") &&
+				len(ents.Errors) == 1
+		}, testutil.IntervalFast)
 		_ = secondAPI.Close()
 
-		ents, err = firstClient.Entitlements(context.Background())
-		require.NoError(t, err)
-		require.Len(t, ents.Warnings, 0)
+		testutil.Eventually(ctx, t, func(ctx context.Context) (done bool) {
+			ents, err := firstClient.Entitlements(ctx)
+			return assert.NoError(t, err, "unexpected error from firstClient.Entitlements") &&
+				len(ents.Warnings) == 0
+		}, testutil.IntervalFast)
 	})
 	t.Run("DoesNotErrorBeforeGrace", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/268

Wraps the assertions in a `testutil.Eventually` so that hopefully any transient timing issues resolve themselves. If this does not resolve the issue, we may need to plumb through some kind of `chan struct{}` into `api.Entitlements.Update()`