### PR TITLE
feat: allow the provisioner jobs list command to filter by initiator

### DIFF
--- a/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -14,6 +14,9 @@ OPTIONS:
   -c, --column [id|created at|started at|completed at|canceled at|error|error code|status|worker id|worker name|file id|tags|queue position|queue size|organization id|template version id|workspace build id|type|available workers|template version name|template id|template name|template display name|template icon|workspace id|workspace name|logs overflowed|organization|queue] (default: created at,id,type,template display name,status,queue,tags)
           Columns to display in table output.
 
+      --initiator string, $CODER_PROVISIONER_JOB_LIST_INITIATOR
+          Filter by initiator (user ID or username).
+
   -l, --limit int, $CODER_PROVISIONER_JOB_LIST_LIMIT (default: 50)
           Limit the number of jobs returned.
 

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3744,6 +3744,13 @@ const docTemplate = `{
                         "description": "Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'})",
                         "name": "tags",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Filter results by initiator ID",
+                        "name": "initiator_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3299,6 +3299,13 @@
 						"description": "Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'})",
 						"name": "tags",
 						"in": "query"
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Filter results by initiator ID",
+						"name": "initiator_id",
+						"in": "query"
 					}
 				],
 				"responses": {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2484,10 +2484,12 @@ func (s *MethodTestSuite) TestExtraMethods() {
 
 		ds, err := db.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisioner(context.Background(), database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
 			OrganizationID: org.ID,
+			InitiatorID:    uuid.Nil,
 		})
 		s.NoError(err, "get provisioner jobs by org")
 		check.Args(database.GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams{
 			OrganizationID: org.ID,
+			InitiatorID:    uuid.Nil,
 		}).Asserts(j1, policy.ActionRead, j2, policy.ActionRead).Returns(ds)
 	}))
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -9822,6 +9822,7 @@ WHERE
 	AND (COALESCE(array_length($2::uuid[], 1), 0) = 0 OR pj.id = ANY($2::uuid[]))
 	AND (COALESCE(array_length($3::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY($3::provisioner_job_status[]))
 	AND ($4::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, $4::tagset))
+	AND ($5::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = $5::uuid)
 GROUP BY
 	pj.id,
 	qp.queue_position,
@@ -9837,7 +9838,7 @@ GROUP BY
 ORDER BY
 	pj.created_at DESC
 LIMIT
-	$5::int
+	$6::int
 `
 
 type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerParams struct {
@@ -9845,6 +9846,7 @@ type GetProvisionerJobsByOrganizationAndStatusWithQueuePositionAndProvisionerPar
 	IDs            []uuid.UUID            `db:"ids" json:"ids"`
 	Status         []ProvisionerJobStatus `db:"status" json:"status"`
 	Tags           StringMap              `db:"tags" json:"tags"`
+	InitiatorID    uuid.UUID              `db:"initiator_id" json:"initiator_id"`
 	Limit          sql.NullInt32          `db:"limit" json:"limit"`
 }
 
@@ -9869,6 +9871,7 @@ func (q *sqlQuerier) GetProvisionerJobsByOrganizationAndStatusWithQueuePositionA
 		pq.Array(arg.IDs),
 		pq.Array(arg.Status),
 		arg.Tags,
+		arg.InitiatorID,
 		arg.Limit,
 	)
 	if err != nil {

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -224,6 +224,7 @@ WHERE
 	AND (COALESCE(array_length(@ids::uuid[], 1), 0) = 0 OR pj.id = ANY(@ids::uuid[]))
 	AND (COALESCE(array_length(@status::provisioner_job_status[], 1), 0) = 0 OR pj.job_status = ANY(@status::provisioner_job_status[]))
 	AND (@tags::tagset = 'null'::tagset OR provisioner_tagset_contains(pj.tags::tagset, @tags::tagset))
+	AND (@initiator_id::uuid = '00000000-0000-0000-0000-000000000000'::uuid OR pj.initiator_id = @initiator_id::uuid)
 GROUP BY
 	pj.id,
 	qp.queue_position,

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -76,6 +76,7 @@ func (api *API) provisionerJob(rw http.ResponseWriter, r *http.Request) {
 // @Param ids query []string false "Filter results by job IDs" format(uuid)
 // @Param status query codersdk.ProvisionerJobStatus false "Filter results by status" enums(pending,running,succeeded,canceling,canceled,failed)
 // @Param tags query object false "Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'})"
+// @Param initiator_id query string false "Filter results by initiator ID" format(uuid)
 // @Success 200 {array} codersdk.ProvisionerJob
 // @Router /organizations/{organization}/provisionerjobs [get]
 func (api *API) provisionerJobs(rw http.ResponseWriter, r *http.Request) {
@@ -110,6 +111,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 		ids = p.UUIDs(qp, nil, "ids")
 	}
 	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
+	initiatorID := p.UUID(qp, uuid.Nil, "initiator_id")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -125,6 +127,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 		Limit:          sql.NullInt32{Int32: limit, Valid: limit > 0},
 		IDs:            ids,
 		Tags:           tags,
+		InitiatorID:    initiatorID,
 	})
 	if err != nil {
 		if httpapi.Is404Error(err) {

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -397,10 +397,11 @@ func (c *Client) OrganizationProvisionerDaemons(ctx context.Context, organizatio
 }
 
 type OrganizationProvisionerJobsOptions struct {
-	Limit  int
-	IDs    []uuid.UUID
-	Status []ProvisionerJobStatus
-	Tags   map[string]string
+	Limit       int
+	IDs         []uuid.UUID
+	Status      []ProvisionerJobStatus
+	Tags        map[string]string
+	InitiatorID *uuid.UUID
 }
 
 func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID uuid.UUID, opts *OrganizationProvisionerJobsOptions) ([]ProvisionerJob, error) {
@@ -421,6 +422,9 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 				return nil, xerrors.Errorf("marshal tags: %w", err)
 			}
 			qp.Add("tags", string(tagsRaw))
+		}
+		if opts.InitiatorID != nil {
+			qp.Add("initiator_id", opts.InitiatorID.String())
 		}
 	}
 

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -366,6 +366,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 | `ids`          | query | array(uuid)  | false    | Filter results by job IDs                                                          |
 | `status`       | query | string       | false    | Filter results by status                                                           |
 | `tags`         | query | object       | false    | Provisioner tags to filter by (JSON of the form {'tag1':'value1','tag2':'value2'}) |
+| `initiator_id` | query | string(uuid) | false    | Filter results by initiator ID                                                     |
 
 #### Enumerated Values
 

--- a/docs/reference/cli/provisioner_jobs_list.md
+++ b/docs/reference/cli/provisioner_jobs_list.md
@@ -34,6 +34,15 @@ Filter by job status.
 
 Limit the number of jobs returned.
 
+### --initiator
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>string</code>                                |
+| Environment | <code>$CODER_PROVISIONER_JOB_LIST_INITIATOR</code> |
+
+Filter by initiator (user ID or username).
+
 ### -O, --org
 
 |             |                                  |

--- a/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
+++ b/enterprise/cli/testdata/coder_provisioner_jobs_list_--help.golden
@@ -14,6 +14,9 @@ OPTIONS:
   -c, --column [id|created at|started at|completed at|canceled at|error|error code|status|worker id|worker name|file id|tags|queue position|queue size|organization id|template version id|workspace build id|type|available workers|template version name|template id|template name|template display name|template icon|workspace id|workspace name|logs overflowed|organization|queue] (default: created at,id,type,template display name,status,queue,tags)
           Columns to display in table output.
 
+      --initiator string, $CODER_PROVISIONER_JOB_LIST_INITIATOR
+          Filter by initiator (user ID or username).
+
   -l, --limit int, $CODER_PROVISIONER_JOB_LIST_LIMIT (default: 50)
           Limit the number of jobs returned.
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2039,6 +2039,7 @@ export interface OrganizationProvisionerJobsOptions {
 	readonly IDs: readonly string[];
 	readonly Status: readonly ProvisionerJobStatus[];
 	readonly Tags: Record<string, string>;
+	readonly InitiatorID: string | null;
 }
 
 // From codersdk/idpsync.go


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/934

This PR provides a mechanism to filter provisioner jobs according to who initiated the job.
This will be used to find pending prebuild jobs when prebuilds have overwhelmed the provisioner job queue. They can then be canceled. 

The cli flags differ somewhat from what was specified in the issue.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
