### PR TITLE
feat: add legacy API key scope compatibility

### DIFF
--- a/coderd/apikey_legacy_test.go
+++ b/coderd/apikey_legacy_test.go
@@ -1,0 +1,60 @@
+package coderd_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestLegacyTokenCompatibility(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exposes legacy scope defaults", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := coderdtest.NewWithDatabase(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+		legacyKey, _ := coderdtest.LegacyToken(t, db, first.UserID)
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitShort)
+		defer cancel()
+
+		keys, err := client.Tokens(ctx, codersdk.Me, codersdk.TokensFilter{})
+		require.NoErrorf(t, err, "tokens request failed: %v", err)
+		require.Len(t, keys, 1)
+
+		key := keys[0]
+		require.Equal(t, legacyKey.TokenName, key.TokenName)
+		require.Equal(t, codersdk.APIKeyScopeAll, key.Scope)
+		require.Contains(t, key.Scopes, codersdk.APIKeyScopeCoderAll)
+		require.Len(t, key.AllowList, 1)
+		require.Equal(t, "*:*", key.AllowList[0].String())
+	})
+
+	t.Run("update via legacy scope field", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := coderdtest.NewWithDatabase(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+		legacyKey, _ := coderdtest.LegacyToken(t, db, first.UserID)
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitShort)
+		defer cancel()
+
+		_, err := client.UpdateToken(ctx, codersdk.Me, legacyKey.TokenName, codersdk.UpdateTokenRequest{
+			Scope: ptr.Ref(codersdk.APIKeyScopeApplicationConnect),
+		})
+		require.NoErrorf(t, err, "update token failed: %v", err)
+
+		refreshed, err := client.APIKeyByName(ctx, codersdk.Me, legacyKey.TokenName)
+		require.NoErrorf(t, err, "fetch token failed: %v", err)
+		require.Equal(t, codersdk.APIKeyScopeApplicationConnect, refreshed.Scope)
+		require.Contains(t, refreshed.Scopes, codersdk.APIKeyScopeCoderApplicationConnect)
+	})
+}

--- a/coderd/coderdtest/legacy_tokens.go
+++ b/coderd/coderdtest/legacy_tokens.go
@@ -1,0 +1,31 @@
+package coderdtest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+)
+
+// LegacyToken inserts an API key fixture whose database row mimics the
+// pre-scopes migration shape where scopes/allow_list columns were empty. The
+// returned API key behaves like a legacy token that should expand to coder:all.
+func LegacyToken(t testing.TB, db database.Store, userID uuid.UUID) (database.APIKey, string) {
+	t.Helper()
+
+	tokenName := fmt.Sprintf("legacy-token-%s", uuid.NewString()[:8])
+
+	key, secret := dbgen.APIKey(t, db, database.APIKey{
+		UserID:    userID,
+		TokenName: tokenName,
+		LoginType: database.LoginTypeToken,
+	}, func(params *database.InsertAPIKeyParams) {
+		params.Scopes = database.APIKeyScopes{}
+		params.AllowList = database.AllowList{}
+	})
+
+	return key, secret
+}

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1584,6 +1584,12 @@ func convertAPIKey(k database.APIKey) codersdk.APIKey {
 	// "application_connect". Continue to return those for clients even
 	// though the database stores canonical values (e.g. "coder:all")
 	// and may include low-level scopes.
+	if len(k.Scopes) == 0 {
+		k.Scopes = database.APIKeyScopes{database.ApiKeyScopeCoderAll}
+	}
+	if len(k.AllowList) == 0 {
+		k.AllowList = database.AllowList{rbac.AllowListAll()}
+	}
 	var legacyScope codersdk.APIKeyScope
 	if k.Scopes.Has(database.ApiKeyScopeCoderApplicationConnect) {
 		legacyScope = codersdk.APIKeyScopeApplicationConnect


### PR DESCRIPTION
# Add legacy API key compatibility

This PR adds support for legacy API keys that were created before the scopes migration. It ensures that API keys with empty scopes and allow lists are properly expanded to have full access permissions, maintaining backward compatibility.

Key changes:
- Added a test helper `LegacyToken` to create API keys that mimic pre-migration database structure
- Implemented automatic expansion of empty scopes to `coder:all` in the API key conversion logic
- Added tests to verify that legacy tokens work correctly with the new scopes system
- Ensured legacy tokens can be updated using the legacy scope field

This maintains compatibility with older API keys while preserving the new scopes functionality.