### PR TITLE
fix: add heartbeat to keep dynamic params websocket open

### DIFF
--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -139,6 +139,8 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 		})
 		return
 	}
+	go httpapi.Heartbeat(ctx, conn)
+
 	stream := wsjson.NewStream[codersdk.DynamicParametersRequest, codersdk.DynamicParametersResponse](
 		conn,
 		websocket.MessageText,


### PR DESCRIPTION
## Summary

In this pull request we're adding a heartbeat to the `handleParameterWebsocket` function to ensure that the connection stays open until the 30 min timeout has been reached.

Closes: https://github.com/coder/coder/issues/19805

### Testing

- Reproduced the problem mentioned in the issue (websocket connection closes after ~10 minutes of inactivity on the create workspace page)

<img width="1870" height="357" alt="Screenshot 2025-09-26 at 15 58 51" src="https://github.com/user-attachments/assets/a9e2e89e-87c5-4afa-9644-afe246a15f79" />

- Confirmed that adding the heartbeat kept the connection open until the 30 min timeout was reached

<img width="1636" height="387" alt="Screenshot 2025-09-29 at 15 51 43" src="https://github.com/user-attachments/assets/0a8c5cda-29a6-493d-a6c0-4a2629da8838" />
