### PR TITLE
fix: fix flaky test in WorkspacePage.test.tsx

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -340,10 +340,9 @@ describe("WorkspacePage", () => {
 
 		// After trying to update, a new dialog asking for missed parameters should
 		// be displayed and filled
-		const dialog = await screen.findByRole(
-			"dialog",
-			{ name: /workspace parameters/i }
-		);
+		const dialog = await screen.findByRole("dialog", {
+			name: /workspace parameters/i,
+		});
 		const firstParameterInput = within(dialog).getByLabelText(
 			MockTemplateVersionParameter1.name,
 			{ exact: false },

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -340,10 +340,10 @@ describe("WorkspacePage", () => {
 
 		// After trying to update, a new dialog asking for missed parameters should
 		// be displayed and filled
-		const dialog = await screen.findByRole("dialog", {
-			name: /workspace parameters/i,
-			timeout: 5000,
-		});
+		const dialog = await screen.findByRole(
+			"dialog",
+			{ name: /workspace parameters/i }
+		);
 		const firstParameterInput = within(dialog).getByLabelText(
 			MockTemplateVersionParameter1.name,
 			{ exact: false },

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -309,7 +309,7 @@ describe("WorkspacePage", () => {
 	// Started flaking after upgrading react-router. Tests the old parameters path
 	// and isn't worth spending more time to fix since this code will be removed
 	// in a few releases when dynamic parameters takes over the world.
-	it.skip("updates the parameters when they are missing during update", async () => {
+	it("updates the parameters when they are missing during update", async () => {
 		// Mocks
 		jest
 			.spyOn(API, "getWorkspaceByOwnerAndName")
@@ -340,7 +340,10 @@ describe("WorkspacePage", () => {
 
 		// After trying to update, a new dialog asking for missed parameters should
 		// be displayed and filled
-		const dialog = await waitFor(() => screen.findByTestId("dialog"));
+		const dialog = await screen.findByRole("dialog", {
+			name: /workspace parameters/i,
+			timeout: 5000,
+		});
 		const firstParameterInput = within(dialog).getByLabelText(
 			MockTemplateVersionParameter1.name,
 			{ exact: false },


### PR DESCRIPTION
re-enabled the skipped test and tested locally. Passed 100 out of 100 times locally.

resolves coder/internal#883
