### PR TITLE
feat: improve RBAC resource ID matching and structured allowlist targets

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11910,6 +11910,9 @@ const docTemplate = `{
         "codersdk.APIAllowListTarget": {
             "type": "object",
             "properties": {
+                "display_name": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10600,6 +10600,9 @@
 		"codersdk.APIAllowListTarget": {
 			"type": "object",
 			"properties": {
+				"display_name": {
+					"type": "string"
+				},
 				"id": {
 					"type": "string"
 				},

--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -214,7 +214,10 @@ func (api *API) apiKeyByID(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertAPIKey(key))
+	sdkKey := convertAPIKey(key)
+	api.populateAllowListDisplayNames(ctx, sdkKey.AllowList)
+
+	httpapi.Write(ctx, rw, http.StatusOK, sdkKey)
 }
 
 // @Summary Get API key by token name
@@ -249,7 +252,10 @@ func (api *API) apiKeyByName(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertAPIKey(token))
+	sdkKey := convertAPIKey(token)
+	api.populateAllowListDisplayNames(ctx, sdkKey.AllowList)
+
+	httpapi.Write(ctx, rw, http.StatusOK, sdkKey)
 }
 
 // @Summary Update token API key

--- a/coderd/apikey_resolve_internal_test.go
+++ b/coderd/apikey_resolve_internal_test.go
@@ -1,0 +1,78 @@
+package coderd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestConvertAPIKeyAllowListDisplayName(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	db := dbmock.NewMockStore(ctrl)
+	templateID := uuid.New()
+
+	db.EXPECT().
+		GetTemplateByID(gomock.Any(), templateID).
+		Return(database.Template{
+			ID:          templateID,
+			Name:        "infra-template",
+			DisplayName: "Infra Template",
+		}, nil).
+		Times(1)
+
+	key := database.APIKey{
+		ID:              "key-1",
+		UserID:          uuid.New(),
+		LastUsed:        time.Now(),
+		ExpiresAt:       time.Now().Add(time.Hour),
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+		LoginType:       database.LoginTypeToken,
+		LifetimeSeconds: int64(time.Hour.Seconds()),
+		TokenName:       "cli",
+		Scopes:          database.APIKeyScopes{database.ApiKeyScopeCoderAll},
+		AllowList: database.AllowList{
+			{Type: string(codersdk.ResourceTemplate), ID: templateID.String()},
+		},
+	}
+
+	result := convertAPIKey(key)
+
+	require.Len(t, result.AllowList, 1)
+	require.Equal(t, codersdk.ResourceTemplate, result.AllowList[0].Type)
+	require.Equal(t, templateID.String(), result.AllowList[0].ID)
+	require.Equal(t, "Infra Template", result.AllowList[0].DisplayName)
+}
+
+func TestConvertAPIKeyAllowListDisplayNameWildcard(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	key := database.APIKey{
+		ID: "key-2",
+		AllowList: database.AllowList{
+			{Type: string(codersdk.ResourceWildcard), ID: policy.WildcardSymbol},
+		},
+	}
+
+	result := convertAPIKey(key)
+
+	require.Len(t, result.AllowList, 1)
+	require.Equal(t, codersdk.ResourceWildcard, result.AllowList[0].Type)
+	require.Equal(t, "*", result.AllowList[0].ID)
+	require.Empty(t, result.AllowList[0].DisplayName)
+}

--- a/coderd/apikey_scopes_validation_test.go
+++ b/coderd/apikey_scopes_validation_test.go
@@ -93,9 +93,10 @@ func TestTokenCreation_AllowListValidation(t *testing.T) {
 	// Invalid resource type should be rejected.
 	_, err := client.CreateToken(ctx, codersdk.Me, codersdk.CreateTokenRequest{
 		Scopes: []codersdk.APIKeyScope{codersdk.APIKeyScopeWorkspaceRead},
-		AllowList: []codersdk.APIAllowListTarget{
-			{Type: codersdk.RBACResource("unknown"), ID: uuid.New().String()},
-		},
+		AllowList: []codersdk.APIAllowListTarget{{
+			Type: codersdk.RBACResource("unknown"),
+			ID:   uuid.New().String(),
+		}},
 	})
 	require.Error(t, err)
 

--- a/coderd/rbac/regosql/compile_test.go
+++ b/coderd/rbac/regosql/compile_test.go
@@ -218,6 +218,14 @@ func TestRegoQueries(t *testing.T) {
 			VariableConverter: regosql.WorkspaceConverter(),
 		},
 		{
+			Name: "WorkspaceIDMatcher",
+			Queries: []string{
+				`input.object.id = "a8d0f8ce-6a01-4d0d-ab1d-1d546958feae"`,
+			},
+			ExpectedSQL:       p("workspaces.id :: text = 'a8d0f8ce-6a01-4d0d-ab1d-1d546958feae'"),
+			VariableConverter: regosql.WorkspaceConverter(),
+		},
+		{
 			Name: "NoACLConfig",
 			Queries: []string{
 				`input.object.org_owner != "";
@@ -260,6 +268,14 @@ neq(input.object.owner, "");
 				p("t.organization_id :: text = ANY(ARRAY ['3bf82434-e40b-44ae-b3d8-d0115bba9bad','5630fda3-26ab-462c-9014-a88a62d7a415','c304877a-bc0d-4e9b-9623-a38eae412929'])") + " AND " +
 				p("false") + " AND " +
 				p("false")),
+			VariableConverter: regosql.TemplateConverter(),
+		},
+		{
+			Name: "TemplateIDMatcher",
+			Queries: []string{
+				`input.object.id = "a829cb9d-7c5b-4c3b-bf78-053827a56e58"`,
+			},
+			ExpectedSQL:       p("t.id :: text = 'a829cb9d-7c5b-4c3b-bf78-053827a56e58'"),
 			VariableConverter: regosql.TemplateConverter(),
 		},
 		{

--- a/coderd/rbac/regosql/configs.go
+++ b/coderd/rbac/regosql/configs.go
@@ -24,7 +24,7 @@ func userACLMatcher(m sqltypes.VariableMatcher) ACLMappingVar {
 
 func TemplateConverter() *sqltypes.VariableConverter {
 	matcher := sqltypes.NewVariableConverter().RegisterMatcher(
-		resourceIDMatcher(),
+		sqltypes.StringVarMatcher("t.id :: text", []string{"input", "object", "id"}),
 		sqltypes.StringVarMatcher("t.organization_id :: text", []string{"input", "object", "org_owner"}),
 		// Templates have no user owner, only owner by an organization.
 		sqltypes.AlwaysFalse(userOwnerMatcher()),
@@ -38,7 +38,7 @@ func TemplateConverter() *sqltypes.VariableConverter {
 
 func WorkspaceConverter() *sqltypes.VariableConverter {
 	matcher := sqltypes.NewVariableConverter().RegisterMatcher(
-		resourceIDMatcher(),
+		sqltypes.StringVarMatcher("workspaces.id :: text", []string{"input", "object", "id"}),
 		sqltypes.StringVarMatcher("workspaces.organization_id :: text", []string{"input", "object", "org_owner"}),
 		userOwnerMatcher(),
 	)

--- a/codersdk/allowlist.go
+++ b/codersdk/allowlist.go
@@ -10,12 +10,16 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
-// APIAllowListTarget represents a single allow-list entry using the canonical
-// string form "<resource_type>:<id>". The wildcard symbol "*" is treated as a
-// permissive match for either side.
+// APIAllowListTarget represents a single allow-list entry. The canonical string
+// form is "<resource_type>:<id>" with "*" acting as a wildcard for either
+// component. Structured JSON callers should use the object form
+// `{ "type": "workspace", "id": "<uuid>" }`. Optionally, servers may attach a
+// DisplayName to provide a human-friendly label; clients must ignore the field
+// when submitting data.
 type APIAllowListTarget struct {
-	Type RBACResource `json:"type"`
-	ID   string       `json:"id"`
+	Type        RBACResource `json:"type"`
+	ID          string       `json:"id"`
+	DisplayName string       `json:"display_name,omitempty"`
 }
 
 func AllowAllTarget() APIAllowListTarget {
@@ -30,51 +34,92 @@ func AllowResourceTarget(r RBACResource, id uuid.UUID) APIAllowListTarget {
 	return APIAllowListTarget{Type: r, ID: id.String()}
 }
 
-// String returns the canonical string representation "<type>:<id>" with "*" wildcards.
+// String returns the canonical string representation "<type>:<id>" with wildcards preserved.
 func (t APIAllowListTarget) String() string {
 	return string(t.Type) + ":" + t.ID
 }
 
-// MarshalJSON encodes as a JSON string: "<type>:<id>".
-func (t APIAllowListTarget) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.String())
+// UnmarshalJSON accepts either the structured object representation
+// `{ "type": "workspace", "id": "<uuid>" }` or the legacy string form "workspace:<uuid>".
+func (t *APIAllowListTarget) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return xerrors.New("empty allow_list entry")
+	}
+
+	// Attempt to decode the structured object form first.
+	var obj struct {
+		Type        string `json:"type"`
+		ID          string `json:"id"`
+		DisplayName string `json:"display_name"`
+	}
+	if err := json.Unmarshal(b, &obj); err == nil {
+		if obj.Type != "" || obj.ID != "" {
+			if obj.Type == "" || obj.ID == "" {
+				return xerrors.New("allow_list entry must include both type and id")
+			}
+			if err := t.setValues(obj.Type, obj.ID); err != nil {
+				return err
+			}
+			// Ignore object.DisplayName on input to keep backend validation strict.
+			return nil
+		}
+	}
+
+	var legacy string
+	if err := json.Unmarshal(b, &legacy); err != nil {
+		return xerrors.New("invalid allow_list entry: expected object with type/id or string")
+	}
+	parts := strings.SplitN(strings.TrimSpace(legacy), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return xerrors.Errorf("invalid allow_list entry %q: want <type>:<id>", legacy)
+	}
+	return t.setValues(parts[0], parts[1])
 }
 
-// UnmarshalJSON decodes from a JSON string: "<type>:<id>".
-func (t *APIAllowListTarget) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-	parts := strings.SplitN(strings.TrimSpace(s), ":", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return xerrors.Errorf("invalid allow_list entry %q: want <type>:<id>", s)
+func (t *APIAllowListTarget) setValues(rawType, rawID string) error {
+	rawType = strings.TrimSpace(rawType)
+	rawID = strings.TrimSpace(rawID)
+
+	if rawType == "" || rawID == "" {
+		return xerrors.New("allow_list entry must include non-empty type and id")
 	}
 
-	resource, id := RBACResource(parts[0]), parts[1]
-
-	// Type
-	if resource != ResourceWildcard {
-		if _, ok := policy.RBACPermissions[string(resource)]; !ok {
-			return xerrors.Errorf("unknown resource type %q", resource)
+	if rawType == policy.WildcardSymbol {
+		t.Type = ResourceWildcard
+	} else {
+		if _, ok := policy.RBACPermissions[rawType]; !ok {
+			return xerrors.Errorf("unknown resource type %q", rawType)
 		}
+		t.Type = RBACResource(rawType)
 	}
-	t.Type = resource
 
-	// ID
-	if id != policy.WildcardSymbol {
-		if _, err := uuid.Parse(id); err != nil {
-			return xerrors.Errorf("invalid %s ID (must be UUID): %q", resource, id)
-		}
+	if rawID == policy.WildcardSymbol {
+		t.ID = policy.WildcardSymbol
+		return nil
 	}
-	t.ID = id
+
+	if _, err := uuid.Parse(rawID); err != nil {
+		return xerrors.Errorf("invalid %s ID (must be UUID): %q", rawType, rawID)
+	}
+	t.ID = rawID
 	return nil
 }
 
-// Implement encoding.TextMarshaler/Unmarshaler for broader compatibility
+// MarshalJSON ensures encoding/json uses the structured representation instead
+// of the legacy colon-delimited string form.
+func (t APIAllowListTarget) MarshalJSON() ([]byte, error) {
+	type alias APIAllowListTarget
+	return json.Marshal(alias(t))
+}
 
+// Implement encoding.TextMarshaler/Unmarshaler for broader compatibility.
 func (t APIAllowListTarget) MarshalText() ([]byte, error) { return []byte(t.String()), nil }
 
 func (t *APIAllowListTarget) UnmarshalText(b []byte) error {
-	return t.UnmarshalJSON([]byte("\"" + string(b) + "\""))
+	strTarget := strings.TrimSpace(string(b))
+	parts := strings.SplitN(strTarget, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return xerrors.Errorf("invalid allow_list entry %q: want <type>:<id>", strTarget)
+	}
+	return t.setValues(parts[0], parts[1])
 }

--- a/codersdk/allowlist_test.go
+++ b/codersdk/allowlist_test.go
@@ -17,7 +17,7 @@ func TestAPIAllowListTarget_JSONRoundTrip(t *testing.T) {
 	all := codersdk.AllowAllTarget()
 	b, err := json.Marshal(all)
 	require.NoError(t, err)
-	require.JSONEq(t, `"*:*"`, string(b))
+	require.JSONEq(t, `{"type":"*","id":"*"}`, string(b))
 	var rt codersdk.APIAllowListTarget
 	require.NoError(t, json.Unmarshal(b, &rt))
 	require.Equal(t, codersdk.ResourceWildcard, rt.Type)
@@ -26,7 +26,7 @@ func TestAPIAllowListTarget_JSONRoundTrip(t *testing.T) {
 	ty := codersdk.AllowTypeTarget(codersdk.ResourceWorkspace)
 	b, err = json.Marshal(ty)
 	require.NoError(t, err)
-	require.JSONEq(t, `"workspace:*"`, string(b))
+	require.JSONEq(t, `{"type":"workspace","id":"*"}`, string(b))
 	require.NoError(t, json.Unmarshal(b, &rt))
 	require.Equal(t, codersdk.ResourceWorkspace, rt.Type)
 	require.Equal(t, policy.WildcardSymbol, rt.ID)
@@ -35,6 +35,24 @@ func TestAPIAllowListTarget_JSONRoundTrip(t *testing.T) {
 	res := codersdk.AllowResourceTarget(codersdk.ResourceTemplate, id)
 	b, err = json.Marshal(res)
 	require.NoError(t, err)
-	exp := `"template:` + id.String() + `"`
+	exp := `{"type":"template","id":"` + id.String() + `"}`
 	require.JSONEq(t, exp, string(b))
+}
+
+func TestAPIAllowListTarget_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	var target codersdk.APIAllowListTarget
+	require.NoError(t, target.UnmarshalText([]byte("workspace:123e4567-e89b-12d3-a456-426614174000")))
+	require.Equal(t, codersdk.ResourceWorkspace, target.Type)
+	require.Equal(t, "123e4567-e89b-12d3-a456-426614174000", target.ID)
+}
+
+func TestAPIAllowListTarget_UnmarshalObject(t *testing.T) {
+	t.Parallel()
+
+	var target codersdk.APIAllowListTarget
+	require.NoError(t, json.Unmarshal([]byte(`{"type":"workspace","id":"*"}`), &target))
+	require.Equal(t, codersdk.ResourceWorkspace, target.Type)
+	require.Equal(t, policy.WildcardSymbol, target.ID)
 }

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -670,6 +670,7 @@
 
 ```json
 {
+  "display_name": "string",
   "id": "string",
   "type": "*"
 }
@@ -677,10 +678,11 @@
 
 ### Properties
 
-| Name   | Type                                           | Required | Restrictions | Description |
-|--------|------------------------------------------------|----------|--------------|-------------|
-| `id`   | string                                         | false    |              |             |
-| `type` | [codersdk.RBACResource](#codersdkrbacresource) | false    |              |             |
+| Name           | Type                                           | Required | Restrictions | Description |
+|----------------|------------------------------------------------|----------|--------------|-------------|
+| `display_name` | string                                         | false    |              |             |
+| `id`           | string                                         | false    |              |             |
+| `type`         | [codersdk.RBACResource](#codersdkrbacresource) | false    |              |             |
 
 ## codersdk.APIKey
 
@@ -688,6 +690,7 @@
 {
   "allow_list": [
     {
+      "display_name": "string",
       "id": "string",
       "type": "*"
     }
@@ -2237,6 +2240,7 @@ This is required on creation to enable a user-flow of validating a template work
 {
   "allow_list": [
     {
+      "display_name": "string",
       "id": "string",
       "type": "*"
     }
@@ -9160,6 +9164,7 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 {
   "allow_list": [
     {
+      "display_name": "string",
       "id": "string",
       "type": "*"
     }

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -759,6 +759,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/tokens \
   {
     "allow_list": [
       {
+        "display_name": "string",
         "id": "string",
         "type": "*"
       }
@@ -794,6 +795,7 @@ Status Code **200**
 |----------------------|----------------------------------------------------------|----------|--------------|---------------------------------|
 | `[array item]`       | array                                                    | false    |              |                                 |
 | `» allow_list`       | array                                                    | false    |              |                                 |
+| `»» display_name`    | string                                                   | false    |              |                                 |
 | `»» id`              | string                                                   | false    |              |                                 |
 | `»» type`            | [codersdk.RBACResource](schemas.md#codersdkrbacresource) | false    |              |                                 |
 | `» created_at`       | string(date-time)                                        | true     |              |                                 |
@@ -883,6 +885,7 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/keys/tokens \
 {
   "allow_list": [
     {
+      "display_name": "string",
       "id": "string",
       "type": "*"
     }
@@ -949,6 +952,85 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/tokens/{keyname} \
 {
   "allow_list": [
     {
+      "display_name": "string",
+      "id": "string",
+      "type": "*"
+    }
+  ],
+  "created_at": "2019-08-24T14:15:22Z",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "last_used": "2019-08-24T14:15:22Z",
+  "lifetime_seconds": 0,
+  "login_type": "password",
+  "scope": "all",
+  "scopes": [
+    "all"
+  ],
+  "token_name": "string",
+  "updated_at": "2019-08-24T14:15:22Z",
+  "user_id": "a169451c-8525-4352-b8ca-070dd449a1a5"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                       |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.APIKey](schemas.md#codersdkapikey) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update token API key
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PATCH http://coder-server:8080/api/v2/users/{user}/keys/tokens/{keyname} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PATCH /users/{user}/keys/tokens/{keyname}`
+
+> Body parameter
+
+```json
+{
+  "allow_list": [
+    {
+      "display_name": "string",
+      "id": "string",
+      "type": "*"
+    }
+  ],
+  "lifetime": 0,
+  "scope": "all",
+  "scopes": [
+    "all"
+  ]
+}
+```
+
+### Parameters
+
+| Name      | In   | Type                                                                 | Required | Description          |
+|-----------|------|----------------------------------------------------------------------|----------|----------------------|
+| `user`    | path | string                                                               | true     | User ID, name, or me |
+| `keyname` | path | string(string)                                                       | true     | Key Name             |
+| `body`    | body | [codersdk.UpdateTokenRequest](schemas.md#codersdkupdatetokenrequest) | true     | Update token request |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "allow_list": [
+    {
+      "display_name": "string",
       "id": "string",
       "type": "*"
     }
@@ -1081,6 +1163,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/{keyid} \
 {
   "allow_list": [
     {
+      "display_name": "string",
       "id": "string",
       "type": "*"
     }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -123,6 +123,7 @@ export interface AITasksPromptsResponse {
 export interface APIAllowListTarget {
 	readonly type: RBACResource;
 	readonly id: string;
+	readonly display_name?: string;
 }
 
 // From codersdk/apikey.go


### PR DESCRIPTION
# Structured JSON Representation for Allow List Targets

This PR changes the JSON representation of `APIAllowListTarget` from a string format (`"type:id"`) to a structured object format (`{"type": "...", "id": "..."}`). The change maintains backward compatibility by preserving the string format for text marshaling/unmarshaling, which is used by CLI flag parsing and database helpers.

Key changes:
- Updated `APIAllowListTarget` to use JSON struct tags
- Implemented separate JSON and Text marshaling/unmarshaling logic
- Added JSON marshaling/unmarshaling to the `wildcard.Value` type
- Fixed SQL variable matchers for workspace and template IDs
- Added test cases for both string and object formats

This change improves the API's consistency and makes it easier to work with allow list targets in the frontend.