### PR TITLE
chore: bump coder/aibridge to v0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -478,7 +478,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.12.0
 	github.com/brianvoe/gofakeit/v7 v7.7.1
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v0.1.2
+	github.com/coder/aibridge v0.1.3
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/preview v1.0.4
 	github.com/dgraph-io/ristretto/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,8 @@ github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v0.1.2 h1:LOG02lecwZSpL3fwbfXKvYzZXnf7s+RxcVY/GInR8OU=
-github.com/coder/aibridge v0.1.2/go.mod h1:GWc0Owtlzz5iMHosDm6FhbO+SoG5W+VeOKyP9p9g9ZM=
+github.com/coder/aibridge v0.1.3 h1:7A9RQaHQUjtse47ShF3kBj2hMmT1R7BEFgiyByr8Vvc=
+github.com/coder/aibridge v0.1.3/go.mod h1:GWc0Owtlzz5iMHosDm6FhbO+SoG5W+VeOKyP9p9g9ZM=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwuWwPHPYoCZ/KLAjHv5g4h2MS4f2/MTI=


### PR DESCRIPTION
Various fixes:

https://github.com/coder/aibridge/pull/10
https://github.com/coder/aibridge/pull/12
https://github.com/coder/aibridge/pull/13
https://github.com/coder/aibridge/pull/14