### PR TITLE
feat: minor prompt redesign

### DIFF
--- a/site/src/pages/TasksPage/TaskPrompt.tsx
+++ b/site/src/pages/TasksPage/TaskPrompt.tsx
@@ -34,11 +34,11 @@ import { ArrowUpIcon, RedoIcon, RotateCcwIcon } from "lucide-react";
 import { AI_PROMPT_PARAMETER_NAME } from "modules/tasks/tasks";
 import { type FC, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import TextareaAutosize from "react-textarea-autosize";
+import TextareaAutosize, {
+	type TextareaAutosizeProps,
+} from "react-textarea-autosize";
 import { cn } from "utils/cn";
 import { docs } from "utils/docs";
-
-const textareaPlaceholder = "Prompt your AI agent to start a task...";
 
 type TaskPromptProps = {
 	templates: Template[] | undefined;
@@ -94,23 +94,14 @@ const TaskPromptLoadingError: FC<{
 
 const TaskPromptSkeleton: FC = () => {
 	return (
-		<div className="border border-border border-solid rounded-lg p-4">
-			<div className="space-y-4">
-				{/* Textarea skeleton */}
-				<TextareaAutosize
-					disabled
-					id="prompt"
-					name="prompt"
-					placeholder={textareaPlaceholder}
-					className={`border-0 resize-none w-full h-full bg-transparent rounded-lg outline-none flex min-h-[60px]
-				text-sm shadow-sm text-content-primary placeholder:text-content-secondary md:text-sm`}
-				/>
+		<div className="border border-border border-solid rounded-3xl p-3 bg-surface-secondary">
+			{/* Textarea skeleton */}
+			<PromptTextarea disabled />
 
-				{/* Bottom controls skeleton */}
-				<div className="flex items-center justify-between pt-2">
-					<Skeleton className="w-[208px] h-8" />
-					<Skeleton className="w-[96px] h-8" />
-				</div>
+			{/* Bottom controls skeleton */}
+			<div className="flex items-center justify-between pt-2">
+				<Skeleton className="w-[208px] h-8 rounded-full" />
+				<Skeleton className="size-8 rounded-full" />
 			</div>
 		</div>
 	);
@@ -240,16 +231,10 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 				>
 					{isPromptReadOnly ? "Prompt defined by preset" : "Prompt"}
 				</label>
-				<TextareaAutosize
+				<PromptTextarea
 					required
-					id="prompt"
-					name="prompt"
 					value={presetAIPrompt || undefined}
 					readOnly={isPromptReadOnly}
-					placeholder={textareaPlaceholder}
-					className={`border-0 px-3 py-2 resize-none w-full h-full bg-transparent rounded-lg
-						outline-none flex min-h-24 text-sm shadow-sm text-content-primary
-						placeholder:text-content-secondary md:text-sm ${isPromptReadOnly ? "opacity-60 cursor-not-allowed" : ""}`}
 				/>
 				<div className="flex items-center justify-between pt-2">
 					<div className="flex items-center gap-1">
@@ -325,7 +310,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 							size="icon"
 							type="submit"
 							disabled={isMissingExternalAuth}
-							className="rounded-full"
+							className="rounded-full disabled:bg-surface-invert-primary disabled:opacity-70"
 						>
 							<Spinner
 								loading={
@@ -382,7 +367,7 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 		return (
 			<div className="flex items-center gap-2" key={auth.id}>
 				<Button
-					variant="outline"
+					className="bg-surface-tertiary hover:bg-surface-quaternary rounded-full text-white"
 					size="sm"
 					disabled={isPollingExternalAuth || auth.authenticated}
 					onClick={() => {
@@ -449,3 +434,17 @@ async function createTaskWithLatestTemplateVersion(
 		template_version_preset_id: presetId,
 	});
 }
+
+const PromptTextarea: FC<TextareaAutosizeProps> = (props) => {
+	return (
+		<TextareaAutosize
+			required
+			id="prompt"
+			name="prompt"
+			placeholder="Prompt your AI agent to start a task..."
+			className={`border-0 px-3 py-2 resize-none w-full h-full bg-transparent rounded-lg
+						outline-none flex min-h-24 text-sm shadow-sm text-content-primary
+						placeholder:text-content-secondary md:text-sm ${props.readOnly ? "opacity-60 cursor-not-allowed" : ""}`}
+		/>
+	);
+};


### PR DESCRIPTION
When I navigate to tasks, the prompt doesn’t feel prominent enough—even though it should be the primary element on the screen. To give it more focus, I made some small design changes. Here are both versions: 

**Before:**
<img width="1624" height="970" alt="Screenshot 2025-09-30 at 12 10 58" src="https://github.com/user-attachments/assets/b5451ad5-4d32-4716-8e0f-e4596e7c92c8" />

**After:**
<img width="1624" height="970" alt="Screenshot 2025-09-30 at 12 10 46" src="https://github.com/user-attachments/assets/f478e327-12c0-4f49-829f-8b094a6b613e" />
