### PR TITLE
fix(docs): add missing div to fix formatting

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -46,6 +46,8 @@ package manager to install Coder:
 winget install Coder.Coder
 ```
 
+</div>
+
 ## Hosted/Enterprise Installs
 
 This install guide is meant for **IT Administrators, DevOps, and Platform Teams** deploying Coder for an organization. It covers production-grade, multi-user installs on Kubernetes and other hosted platforms.


### PR DESCRIPTION
This PR adds a missing `div` that wasn't added in https://github.com/coder/coder/pull/20041. The intent is to have two separate install sections, one for Enterprise and the other for local. Basically, getting these two sections!
<img width="815" height="977" alt="image" src="https://github.com/user-attachments/assets/17d95198-a8e1-4fa2-9d0a-7534a959a7e1" />

See a preview at: https://coder.com/docs/@df%2Ffix-fmt/install
