### PR TITLE
feat(coderd): add ability to search org members by user_id, is_system, github_user_id

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1691,6 +1691,7 @@ func (q *querier) DeleteOrganizationMember(ctx context.Context, arg database.Del
 			OrganizationID: arg.OrganizationID,
 			UserID:         arg.UserID,
 			IncludeSystem:  false,
+			GithubUserID:   0,
 		}))
 		if err != nil {
 			return database.OrganizationMember{}, err
@@ -4694,6 +4695,7 @@ func (q *querier) UpdateMemberRoles(ctx context.Context, arg database.UpdateMemb
 		OrganizationID: arg.OrgID,
 		UserID:         arg.UserID,
 		IncludeSystem:  false,
+		GithubUserID:   0,
 	}))
 	if err != nil {
 		return database.OrganizationMember{}, err

--- a/coderd/database/queries/organizationmembers.sql
+++ b/coderd/database/queries/organizationmembers.sql
@@ -28,7 +28,13 @@ WHERE
 		  WHEN @include_system::bool THEN TRUE
 		  ELSE
 			  is_system = false
-	END;
+	END
+  -- Filter by github user ID. Note that this requires a join on the users table.
+  AND CASE
+    WHEN @github_user_id :: bigint != 0 THEN
+      users.github_com_user_id = @github_user_id
+    ELSE true
+  END;
 
 -- name: InsertOrganizationMember :one
 INSERT INTO

--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -300,6 +300,7 @@ func WorkspaceOwner(ctx context.Context, db database.Store, org uuid.UUID, owner
 			OrganizationID: org,
 			UserID:         ownerID,
 			IncludeSystem:  true,
+			GithubUserID:   0,
 		}))
 		if err != nil {
 			return nil, xerrors.Errorf("fetch user: %w", err)

--- a/coderd/httpmw/organizationparam.go
+++ b/coderd/httpmw/organizationparam.go
@@ -181,6 +181,7 @@ func ExtractOrganizationMember(ctx context.Context, auth func(r *http.Request, a
 		OrganizationID: orgID,
 		UserID:         user.ID,
 		IncludeSystem:  true,
+		GithubUserID:   0,
 	})
 	if httpapi.Is404Error(err) {
 		httpapi.ResourceNotFound(rw)

--- a/coderd/idpsync/role.go
+++ b/coderd/idpsync/role.go
@@ -93,6 +93,7 @@ func (s AGPLIDPSync) SyncRoles(ctx context.Context, db database.Store, user data
 			OrganizationID: uuid.Nil,
 			UserID:         user.ID,
 			IncludeSystem:  false,
+			GithubUserID:   0,
 		})
 		if err != nil {
 			return xerrors.Errorf("get organizations by user id: %w", err)

--- a/coderd/members.go
+++ b/coderd/members.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"cdr.dev/slog"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
@@ -166,9 +165,9 @@ func (api *API) listMembers(rw http.ResponseWriter, r *http.Request) {
 			Message:     "Invalid organization member search query.",
 			Validations: errors,
 		})
+		return
 	}
 
-	api.Logger.Debug(ctx, "list organization members", slog.F("params", params))
 	members, err := api.Database.OrganizationMembers(ctx, params)
 	if httpapi.Is404Error(err) {
 		httpapi.ResourceNotFound(rw)

--- a/coderd/members_test.go
+++ b/coderd/members_test.go
@@ -1,14 +1,16 @@
 package coderd_test
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -52,19 +54,64 @@ func TestDeleteMember(t *testing.T) {
 func TestListMembers(t *testing.T) {
 	t.Parallel()
 
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	owner := coderdtest.CreateFirstUser(t, client)
+	_, orgMember := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	_, orgAdmin := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	anotherOrg := dbgen.Organization(t, db, database.Organization{})
+	anotherUser := dbgen.User(t, db, database.User{
+		GithubComUserID: sql.NullInt64{Valid: true, Int64: 12345},
+	})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		OrganizationID: anotherOrg.ID,
+		UserID:         anotherUser.ID,
+	})
+
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
-		owner := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, owner)
-
-		client, user := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.ScopedRoleOrgAdmin(first.OrganizationID))
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		members, err := client.OrganizationMembers(ctx, first.OrganizationID)
+		members, err := client.OrganizationMembers(ctx, owner.OrganizationID)
 		require.NoError(t, err)
-		require.Len(t, members, 2)
+		require.Len(t, members, 3)
 		require.ElementsMatch(t,
-			[]uuid.UUID{first.UserID, user.ID},
+			[]uuid.UUID{owner.UserID, orgMember.ID, orgAdmin.ID},
+			db2sdk.List(members, onlyIDs))
+	})
+
+	t.Run("UserID", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		members, err := client.OrganizationMembers(ctx, owner.OrganizationID, codersdk.OrganizationMembersQueryOptionUserID(orgMember.ID))
+		require.NoError(t, err)
+		require.Len(t, members, 1)
+		require.ElementsMatch(t,
+			[]uuid.UUID{orgMember.ID},
+			db2sdk.List(members, onlyIDs))
+	})
+
+	t.Run("IncludeSystem", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		members, err := client.OrganizationMembers(ctx, owner.OrganizationID, codersdk.OrganizationMembersQueryOptionIncludeSystem())
+		require.NoError(t, err)
+		require.Len(t, members, 4)
+		require.ElementsMatch(t,
+			[]uuid.UUID{owner.UserID, orgMember.ID, orgAdmin.ID, database.PrebuildsSystemUserID},
+			db2sdk.List(members, onlyIDs))
+	})
+
+	t.Run("GithubUserID", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		members, err := client.OrganizationMembers(ctx, anotherOrg.ID, codersdk.OrganizationMembersQueryOptionGithubUserID(anotherUser.GithubComUserID.Int64))
+		require.NoError(t, err)
+		require.Len(t, members, 1)
+		require.ElementsMatch(t,
+			[]uuid.UUID{anotherUser.ID},
 			db2sdk.List(members, onlyIDs))
 	})
 }

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -177,7 +177,19 @@ func Members(query string, organizationID uuid.UUID) (database.OrganizationMembe
 			OrganizationID: organizationID,
 		}, nil
 	}
-	values, errors := searchTerms(query, nil)
+	values, errors := searchTerms(query, func(term string, values url.Values) error {
+		switch term {
+		case "user_id":
+			values.Set("user_id", "")
+		case "github_user_id":
+			values.Set("github_user_id", "")
+		case "include_system":
+			values.Set("include_system", "")
+		default:
+			return fmt.Errorf("invalid search term: %s", term)
+		}
+		return nil
+	})
 	if len(errors) > 0 {
 		return database.OrganizationMembersParams{}, errors
 	}

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -175,6 +175,9 @@ func Members(query string, organizationID uuid.UUID) (database.OrganizationMembe
 	if query == "" {
 		return database.OrganizationMembersParams{
 			OrganizationID: organizationID,
+			UserID:         uuid.Nil,
+			IncludeSystem:  false,
+			GithubUserID:   0,
 		}, nil
 	}
 	values, errors := searchTerms(query, func(term string, values url.Values) error {
@@ -186,12 +189,17 @@ func Members(query string, organizationID uuid.UUID) (database.OrganizationMembe
 		case "include_system":
 			values.Set("include_system", "")
 		default:
-			return fmt.Errorf("invalid search term: %s", term)
+			return xerrors.Errorf("invalid search term: %s", term)
 		}
 		return nil
 	})
 	if len(errors) > 0 {
-		return database.OrganizationMembersParams{}, errors
+		return database.OrganizationMembersParams{
+			OrganizationID: organizationID,
+			UserID:         uuid.Nil,
+			IncludeSystem:  false,
+			GithubUserID:   0,
+		}, errors
 	}
 
 	parser := httpapi.NewQueryParamParser()

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1236,6 +1236,7 @@ func (api *API) userRoles(rw http.ResponseWriter, r *http.Request) {
 		UserID:         user.ID,
 		OrganizationID: uuid.Nil,
 		IncludeSystem:  false,
+		GithubUserID:   0,
 	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -554,9 +555,65 @@ func (c *Client) DeleteOrganizationMember(ctx context.Context, organizationID uu
 	return nil
 }
 
+type OrganizationMembersQuery struct {
+	UserID        uuid.UUID
+	IncludeSystem bool
+	GithubUserID  int64
+}
+
+func (omq OrganizationMembersQuery) AsRequestOption() RequestOption {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		var sb strings.Builder
+		if omq.UserID != uuid.Nil {
+			_, _ = sb.WriteString("user_id:")
+			_, _ = sb.WriteString(omq.UserID.String())
+			_, _ = sb.WriteString(" ")
+		}
+		if omq.IncludeSystem {
+			_, _ = sb.WriteString("include_system:true")
+		}
+		if omq.GithubUserID != 0 {
+			_, _ = sb.WriteString("github_user_id:")
+			_, _ = sb.WriteString(strconv.FormatInt(omq.GithubUserID, 10))
+			_, _ = sb.WriteString(" ")
+		}
+		qs := strings.TrimSpace(sb.String())
+		if len(qs) == 0 {
+			return
+		}
+		q.Set("q", qs)
+		r.URL.RawQuery = q.Encode()
+	}
+}
+
+type OrganizationMembersQueryOption func(*OrganizationMembersQuery)
+
+func OrganizationMembersQueryOptionUserID(userID uuid.UUID) OrganizationMembersQueryOption {
+	return func(query *OrganizationMembersQuery) {
+		query.UserID = userID
+	}
+}
+
+func OrganizationMembersQueryOptionIncludeSystem() OrganizationMembersQueryOption {
+	return func(query *OrganizationMembersQuery) {
+		query.IncludeSystem = true
+	}
+}
+
+func OrganizationMembersQueryOptionGithubUserID(githubUserID int64) OrganizationMembersQueryOption {
+	return func(query *OrganizationMembersQuery) {
+		query.GithubUserID = githubUserID
+	}
+}
+
 // OrganizationMembers lists all members in an organization
-func (c *Client) OrganizationMembers(ctx context.Context, organizationID uuid.UUID) ([]OrganizationMemberWithUserData, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/members/", organizationID), nil)
+func (c *Client) OrganizationMembers(ctx context.Context, organizationID uuid.UUID, opts ...OrganizationMembersQueryOption) ([]OrganizationMemberWithUserData, error) {
+	var query OrganizationMembersQuery
+	for _, opt := range opts {
+		opt(&query)
+	}
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/members/", organizationID), nil, query.AsRequestOption())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -181,6 +181,7 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 			OrganizationID: group.OrganizationID,
 			UserID:         uuid.MustParse(id),
 			IncludeSystem:  false,
+			GithubUserID:   0,
 		}))
 		if errors.Is(err, sql.ErrNoRows) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2037,6 +2037,13 @@ export interface OrganizationMemberWithUserData extends OrganizationMember {
 	readonly global_roles: readonly SlimRole[];
 }
 
+// From codersdk/users.go
+export interface OrganizationMembersQuery {
+	readonly UserID: string;
+	readonly IncludeSystem: boolean;
+	readonly GithubUserID: number;
+}
+
 // From codersdk/organizations.go
 export interface OrganizationProvisionerDaemonsOptions {
 	readonly Limit: number;


### PR DESCRIPTION
Adds the ability to search org members by query.
Supported fields: `user_id`, `is_system`, `github_user_id`.