### PR TITLE
docs:  update claude code version in docs

### DIFF
--- a/docs/ai-coder/tasks.md
+++ b/docs/ai-coder/tasks.md
@@ -65,31 +65,43 @@ data "coder_parameter" "setup_script" {
 # Other agent modules: https://registry.coder.com/modules?search=agent
 # Or use a custom agent:  
 module "claude-code" {
-  count               = data.coder_workspace.me.start_count
-  source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.2.0"
-  agent_id            = coder_agent.main.id
-  folder              = "/home/coder/projects"
-  install_claude_code = true
-  claude_code_version = "latest"
-  order               = 999
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "3.0.1"
+  agent_id = coder_agent.example.id
+  workdir  = "/home/coder/project"
 
-  # experiment_post_install_script = data.coder_parameter.setup_script.value
+  claude_api_key = var.anthropic_api_key
+  # OR
+  # claude_code_oauth_token = var.anthropic_oauth_token
 
-  # This enables Coder Tasks
-  experiment_report_tasks = true
+  claude_code_version = "1.0.82" # Pin to a specific version
+  agentapi_version    = "v0.6.1"
+
+  ai_prompt = data.coder_parameter.ai_prompt.value
+  model     = "sonnet"
+
+  # Optional: run your pre-flight script
+  # pre_install_script = data.coder_parameter.setup_script.value
+
+  permission_mode = "plan"
+
+  mcp = <<-EOF
+  {
+    "mcpServers": {
+      "my-custom-tool": {
+        "command": "my-tool-server",
+        "args": ["--port", "8080"]
+      }
+    }
+  }
+  EOF
 }
 
+# Rename to `anthropic_oauth_token` if using the Oauth Token
 variable "anthropic_api_key" {
   type        = string
   description = "Generate one at: https://console.anthropic.com/settings/keys"
   sensitive   = true
-}
-
-resource "coder_env" "anthropic_api_key" {
-  agent_id = coder_agent.main.id
-  name     = "CODER_MCP_CLAUDE_API_KEY"
-  value    = var.anthropic_api_key
 }
 ```
 


### PR DESCRIPTION
# Description

This PR updates our documentation's usage of the Claude Code module to v3. I matched what our [docs specify](https://registry.coder.com/modules/coder/claude-code?tab=readme) with the exception that I define a variable for the API Key. See a preview at:
* https://coder.com/docs/@df%2fclaude-code-mod-v3/ai-coder/tasks#option-2-create-or-duplicate-your-own-template
* https://coder.com/docs/@df%2fclaude-code-mod-v3/ai-coder/tasks-core-principles#using-a-registry-module

