### PR TITLE
feat: configurable cache cleanup via env (CODER_PROVISIONER_CACHE_*)

### DIFF
--- a/docs/tutorials/best-practices/speed-up-templates.md
+++ b/docs/tutorials/best-practices/speed-up-templates.md
@@ -167,7 +167,7 @@ Ensure that this directory is set to a location on disk which will persist acros
 
 Provisioner cache cleanup can be controlled at runtime via environment variables (on both built-in and external provisioners):
 
-- `CODER_TERRAFORM_PLUGIN_CLEANUP` (default `true`): enable or disable cleanup.
-- `CODER_TERRAFORM_PLUGIN_RETENTION` (default `720h`): age threshold for considering a provider plugin stale, parsed with Go's `time.ParseDuration` (example: `720h` ~30 days).
+- `CODER_PROVISIONER_CACHE_CLEANUP` (default `true`): enable or disable cleanup.
+- `CODER_PROVISIONER_CACHE_RETENTION` (default `720h`): age threshold for considering a cached provider stale, parsed with Go's `time.ParseDuration` (example: `720h` ~30 days).
 
 If unset, cleanup runs with a default 30-day retention.

--- a/docs/tutorials/best-practices/speed-up-templates.md
+++ b/docs/tutorials/best-practices/speed-up-templates.md
@@ -159,10 +159,15 @@ provider versions.
 
 ### Cache directory
 
-Coder will instruct Terraform to cache its downloaded providers in the
-configured [`CODER_CACHE_DIRECTORY`](../../reference/cli/server.md#--cache-dir)
-directory.
+Coder will instruct Terraform to cache its downloaded providers in the configured [`CODER_CACHE_DIRECTORY`](../../reference/cli/server.md#--cache-dir) directory.
 
-Ensure that this directory is set to a location on disk which will persist
-across restarts of Coder or
-[external provisioners](../../admin/provisioners/index.md), if you're using them.
+Ensure that this directory is set to a location on disk which will persist across restarts of Coder or [external provisioners](../../admin/provisioners/index.md), if you're using them.
+
+#### Cache cleanup configuration
+
+Provisioner cache cleanup can be controlled at runtime via environment variables (on both built-in and external provisioners):
+
+- `CODER_TERRAFORM_PLUGIN_CLEANUP` (default `true`): enable or disable cleanup.
+- `CODER_TERRAFORM_PLUGIN_RETENTION` (default `720h`): age threshold for considering a provider plugin stale, parsed with Go's `time.ParseDuration` (example: `720h` ~30 days).
+
+If unset, cleanup runs with a default 30-day retention.

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -3,7 +3,10 @@ package terraform
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -86,6 +89,17 @@ func systemBinary(ctx context.Context) (*systemBinaryDetails, error) {
 
 // Serve starts a dRPC server on the provided transport speaking Terraform provisioner.
 func Serve(ctx context.Context, options *ServeOptions) error {
+	// Optional environment overrides for plugin cache cleanup behavior.
+	if v, ok := os.LookupEnv("CODER_TERRAFORM_PLUGIN_CLEANUP"); ok {
+		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
+			terraformPluginCleanupEnabled = b
+		}
+	}
+	if v, ok := os.LookupEnv("CODER_TERRAFORM_PLUGIN_RETENTION"); ok {
+		if d, err := time.ParseDuration(strings.TrimSpace(v)); err == nil {
+			staleTerraformPluginRetention = d
+		}
+	}
 	if options.BinaryPath == "" {
 		binaryDetails, err := systemBinary(ctx)
 		if err != nil {

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -90,12 +90,12 @@ func systemBinary(ctx context.Context) (*systemBinaryDetails, error) {
 // Serve starts a dRPC server on the provided transport speaking Terraform provisioner.
 func Serve(ctx context.Context, options *ServeOptions) error {
 	// Optional environment overrides for plugin cache cleanup behavior.
-	if v, ok := os.LookupEnv("CODER_TERRAFORM_PLUGIN_CLEANUP"); ok {
+	if v, ok := os.LookupEnv("CODER_PROVISIONER_CACHE_CLEANUP"); ok {
 		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
 			terraformPluginCleanupEnabled = b
 		}
 	}
-	if v, ok := os.LookupEnv("CODER_TERRAFORM_PLUGIN_RETENTION"); ok {
+	if v, ok := os.LookupEnv("CODER_PROVISIONER_CACHE_RETENTION"); ok {
 		if d, err := time.ParseDuration(strings.TrimSpace(v)); err == nil {
 			staleTerraformPluginRetention = d
 		}


### PR DESCRIPTION
This change makes Terraform plugin cache cleanup user-configurable with minimal surface area:

- Replace hard-coded 30d retention with a configurable variable
- Read environment in provisioner Serve():
  - CODER_PROVISIONER_CACHE_CLEANUP (default true)
  - CODER_PROVISIONER_CACHE_RETENTION (e.g. 720h)
- Guard the cleanup call in Plan() with the toggle
- Update docs (best practices) to describe the new env vars

Behavior:
- Defaults remain unchanged (cleanup enabled; ~30d retention)
- Works for both built-in and external provisioners (env read in Serve)

Notes:
- Tests in provisioner/terraform require a Terraform binary; build succeeds locally. Happy to add CI setup or adjust tests if needed.
