### PR TITLE
chore: add Audit Log purge advice

### DIFF
--- a/docs/admin/security/audit-logs.md
+++ b/docs/admin/security/audit-logs.md
@@ -149,6 +149,22 @@ ORDER BY pg_total_relation_size(relid) DESC;
 Should you wish to purge these records, it is safe to do so. This can only be done by running SQL queries
 directly against the `audit_logs` table in the database. We advise users to only purge old records (>1yr).
 
+### Backup/Archive
+
+Consider exporting or archiving these records before deletion:
+
+```sql
+-- Export to CSV
+COPY (SELECT * FROM audit_logs WHERE time < CURRENT_TIMESTAMP - INTERVAL '1 year')
+TO '/path/to/audit_logs_archive.csv' DELIMITER ',' CSV HEADER;
+
+-- Copy to archive table
+CREATE TABLE audit_logs_archive AS
+SELECT * FROM audit_logs WHERE time < CURRENT_TIMESTAMP - INTERVAL '1 year';
+```
+
+### Permanent Deletion
+
 > [!NOTE]
 > For large `audit_logs` tables, consider running the `DELETE` operation during maintenance windows as it may impact
 > database performance. You can also batch the deletions to reduce lock time.

--- a/docs/admin/security/audit-logs.md
+++ b/docs/admin/security/audit-logs.md
@@ -136,11 +136,11 @@ Use the following query to determine the amount of disk space used by the `audit
 
 ```sql
 SELECT
-		relname AS table_name,
-		pg_size_pretty(pg_total_relation_size(relid)) AS total_size,
-		pg_size_pretty(pg_relation_size(relid)) AS table_size,
-		pg_size_pretty(pg_indexes_size(relid)) AS indexes_size,
-		(SELECT COUNT(*) FROM audit_logs) AS total_records
+    relname AS table_name,
+    pg_size_pretty(pg_total_relation_size(relid)) AS total_size,
+    pg_size_pretty(pg_relation_size(relid)) AS table_size,
+    pg_size_pretty(pg_indexes_size(relid)) AS indexes_size,
+    (SELECT COUNT(*) FROM audit_logs) AS total_records
 FROM pg_catalog.pg_statio_user_tables
 WHERE relname = 'audit_logs'
 ORDER BY pg_total_relation_size(relid) DESC;

--- a/docs/admin/security/audit-logs.md
+++ b/docs/admin/security/audit-logs.md
@@ -147,7 +147,8 @@ ORDER BY pg_total_relation_size(relid) DESC;
 ```
 
 Should you wish to purge these records, it is safe to do so. This can only be done by running SQL queries
-directly against the `audit_logs` table in the database. We advise users to only purge old records (>1yr).
+directly against the `audit_logs` table in the database. We advise users to only purge old records (>1yr)
+and in accordance with your compliance requirements.
 
 ### Backup/Archive
 


### PR DESCRIPTION
Audit Log entries can be deleted safely (with appropriate caveats), but we don't specifically call this out in the docs.