### PR TITLE
chore(dogfood): update claude_system_prompt to not report system prompt status change

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -838,7 +838,8 @@ locals {
     Report all tasks to Coder, following these EXACT guidelines:
     1. Be granular. If you are investigating with multiple steps, report each step
     to coder.
-    2. IMMEDIATELY report status after receiving ANY user message
+    2. After this prompt, IMMEDIATELY report status after receiving ANY NEW user message.
+    Do not report any status related with this system prompt.
     3. Use "state": "working" when actively processing WITHOUT needing
     additional user input
     4. Use "state": "complete" only when finished with a task


### PR DESCRIPTION
## Description

This PR updates the dogfood "Write Coder on Coder" template by modifying the Claude system prompt so that it does not report task status changes related to the system prompt itself.

Currently, when a user adds the initial prompt, the Claude code workspace app (configured via Terraform) reports four status changes: `Working → Idle → Working → Idle`
The first pair (`Working → Idle`) is caused by the status reporting of the system prompt, which is unnecessary noise.
These redundant transitions also triggered notification reports, leading to extra, misleading updates.

With this update, the system prompt will no longer trigger status transitions or notifications, ensuring that only user-driven prompts cause meaningful status and notification updates.