### PR TITLE
feat(scaletest): add runner for notifications delivery

### DIFF
--- a/scaletest/notifications/config.go
+++ b/scaletest/notifications/config.go
@@ -33,8 +33,8 @@ type Config struct {
 	// DialBarrier ensures all runners are connected before notifications are triggered.
 	DialBarrier *sync.WaitGroup `json:"-"`
 
-	// OwnerWatchBarrier is the barrier for owner users. Regular users wait on this to disconnect after owner users complete.
-	OwnerWatchBarrier *sync.WaitGroup `json:"-"`
+	// ReceivingWatchBarrier is the barrier for receiving users. Regular users wait on this to disconnect after receiving users complete.
+	ReceivingWatchBarrier *sync.WaitGroup `json:"-"`
 }
 
 func (c Config) Validate() error {
@@ -51,8 +51,8 @@ func (c Config) Validate() error {
 		return xerrors.New("dial barrier must be set")
 	}
 
-	if c.OwnerWatchBarrier == nil {
-		return xerrors.New("owner_watch_barrier must be set")
+	if c.ReceivingWatchBarrier == nil {
+		return xerrors.New("receiving_watch_barrier must be set")
 	}
 
 	if c.NotificationTimeout <= 0 {

--- a/scaletest/notifications/config.go
+++ b/scaletest/notifications/config.go
@@ -25,6 +25,10 @@ type Config struct {
 	// DialTimeout is how long to wait for websocket connection.
 	DialTimeout time.Duration `json:"dial_timeout"`
 
+	// ExpectedNotifications maps notification template IDs to channels
+	// that receive the trigger time for each notification.
+	ExpectedNotifications map[uuid.UUID]chan time.Time `json:"-"`
+
 	Metrics *Metrics `json:"-"`
 
 	// DialBarrier ensures all runners are connected before notifications are triggered.
@@ -50,6 +54,10 @@ func (c Config) Validate() error {
 
 	if !c.IsOwner && c.OwnerDialBarrier == nil {
 		return xerrors.New("owner_dial_barrier must be set for regular users")
+	}
+
+	if c.IsOwner && len(c.ExpectedNotifications) == 0 {
+		return xerrors.New("expected_notifications must be set for owner users")
 	}
 
 	if c.NotificationTimeout <= 0 {

--- a/scaletest/notifications/config.go
+++ b/scaletest/notifications/config.go
@@ -1,0 +1,61 @@
+package notifications
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/scaletest/createusers"
+)
+
+type Config struct {
+	// User is the configuration for the user to create.
+	User createusers.Config `json:"user"`
+
+	// IsOwner indicates if this user should be assigned Owner role.
+	// If true, the user will receive notifications.
+	IsOwner bool `json:"is_owner"`
+
+	// NotificationTimeout is how long to wait for notifications after triggering.
+	NotificationTimeout time.Duration `json:"notification_timeout"`
+
+	// DialTimeout is how long to wait for websocket connection.
+	DialTimeout time.Duration `json:"dial_timeout"`
+
+	Metrics *Metrics `json:"-"`
+
+	// DialBarrier ensures all runners are connected before notifications are triggered.
+	DialBarrier *sync.WaitGroup `json:"-"`
+}
+
+func (c Config) Validate() error {
+	// The runner always needs an org; ensure we propagate it into the user config.
+	if c.User.OrganizationID == uuid.Nil {
+		return xerrors.New("user organization_id must be set")
+	}
+
+	if err := c.User.Validate(); err != nil {
+		return xerrors.Errorf("user config: %w", err)
+	}
+
+	if c.DialBarrier == nil {
+		return xerrors.New("dial barrier must be set")
+	}
+
+	if c.NotificationTimeout <= 0 {
+		return xerrors.New("notification_timeout must be greater than 0")
+	}
+
+	if c.DialTimeout <= 0 {
+		return xerrors.New("dial_timeout must be greater than 0")
+	}
+
+	if c.Metrics == nil {
+		return xerrors.New("metrics must be set")
+	}
+
+	return nil
+}

--- a/scaletest/notifications/config.go
+++ b/scaletest/notifications/config.go
@@ -15,9 +15,8 @@ type Config struct {
 	// User is the configuration for the user to create.
 	User createusers.Config `json:"user"`
 
-	// IsOwner indicates if this user should be assigned Owner role.
-	// If true, the user will receive notifications.
-	IsOwner bool `json:"is_owner"`
+	// Roles are the roles to assign to the user.
+	Roles []string `json:"roles"`
 
 	// NotificationTimeout is how long to wait for notifications after triggering.
 	NotificationTimeout time.Duration `json:"notification_timeout"`
@@ -34,8 +33,8 @@ type Config struct {
 	// DialBarrier ensures all runners are connected before notifications are triggered.
 	DialBarrier *sync.WaitGroup `json:"-"`
 
-	// OwnerDialBarrier is the barrier for owner users. Regular users wait on this to disconnect after owner users complete.
-	OwnerDialBarrier *sync.WaitGroup `json:"-"`
+	// OwnerWatchBarrier is the barrier for owner users. Regular users wait on this to disconnect after owner users complete.
+	OwnerWatchBarrier *sync.WaitGroup `json:"-"`
 }
 
 func (c Config) Validate() error {
@@ -52,12 +51,8 @@ func (c Config) Validate() error {
 		return xerrors.New("dial barrier must be set")
 	}
 
-	if !c.IsOwner && c.OwnerDialBarrier == nil {
-		return xerrors.New("owner_dial_barrier must be set for regular users")
-	}
-
-	if c.IsOwner && len(c.ExpectedNotifications) == 0 {
-		return xerrors.New("expected_notifications must be set for owner users")
+	if c.OwnerWatchBarrier == nil {
+		return xerrors.New("owner_watch_barrier must be set")
 	}
 
 	if c.NotificationTimeout <= 0 {

--- a/scaletest/notifications/config.go
+++ b/scaletest/notifications/config.go
@@ -29,6 +29,9 @@ type Config struct {
 
 	// DialBarrier ensures all runners are connected before notifications are triggered.
 	DialBarrier *sync.WaitGroup `json:"-"`
+
+	// OwnerDialBarrier is the barrier for owner users. Regular users wait on this to disconnect after owner users complete.
+	OwnerDialBarrier *sync.WaitGroup `json:"-"`
 }
 
 func (c Config) Validate() error {
@@ -43,6 +46,10 @@ func (c Config) Validate() error {
 
 	if c.DialBarrier == nil {
 		return xerrors.New("dial barrier must be set")
+	}
+
+	if !c.IsOwner && c.OwnerDialBarrier == nil {
+		return xerrors.New("owner_dial_barrier must be set for regular users")
 	}
 
 	if c.NotificationTimeout <= 0 {

--- a/scaletest/notifications/metrics.go
+++ b/scaletest/notifications/metrics.go
@@ -21,7 +21,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Namespace: "coderd",
 		Subsystem: "scaletest",
 		Name:      "notification_delivery_latency_seconds",
-		Help:      "Time between test trigger and receipt of notification by client",
+		Help:      "Time between notification-creating action and receipt of notification by client",
 	}, []string{"username", "notification_type"})
 	errors := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "coderd",

--- a/scaletest/notifications/metrics.go
+++ b/scaletest/notifications/metrics.go
@@ -1,0 +1,58 @@
+package notifications
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	notificationLatency *prometheus.HistogramVec
+	notificationErrors  *prometheus.CounterVec
+	missedNotifications *prometheus.CounterVec
+}
+
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+
+	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "coderd",
+		Subsystem: "scaletest",
+		Name:      "notification_delivery_latency_seconds",
+		Help:      "Time between test trigger and receipt of notification by client",
+	}, []string{"username", "notification_type"})
+	errors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "coderd",
+		Subsystem: "scaletest",
+		Name:      "notification_delivery_errors_total",
+		Help:      "Total number of notification delivery errors",
+	}, []string{"username", "action"})
+	missed := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "coderd",
+		Subsystem: "scaletest",
+		Name:      "notification_delivery_missed_total",
+		Help:      "Total number of missed notifications",
+	}, []string{"username"})
+
+	reg.MustRegister(latency, errors, missed)
+
+	return &Metrics{
+		notificationLatency: latency,
+		notificationErrors:  errors,
+		missedNotifications: missed,
+	}
+}
+
+func (m *Metrics) RecordLatency(latency time.Duration, username, notificationType string) {
+	m.notificationLatency.WithLabelValues(username, notificationType).Observe(latency.Seconds())
+}
+
+func (m *Metrics) AddError(username, action string) {
+	m.notificationErrors.WithLabelValues(username, action).Inc()
+}
+
+func (m *Metrics) RecordMissed(username string) {
+	m.missedNotifications.WithLabelValues(username).Inc()
+}

--- a/scaletest/notifications/run.go
+++ b/scaletest/notifications/run.go
@@ -1,0 +1,239 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+
+	"github.com/coder/coder/v2/coderd/notifications"
+	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/createusers"
+	"github.com/coder/coder/v2/scaletest/harness"
+	"github.com/coder/coder/v2/scaletest/loadtestutil"
+	"github.com/coder/websocket"
+)
+
+type Runner struct {
+	client *codersdk.Client
+	cfg    Config
+
+	createUserRunner *createusers.Runner
+
+	userCreatedNotificationLatency time.Duration
+	userDeletedNotificationLatency time.Duration
+}
+
+func NewRunner(client *codersdk.Client, cfg Config) *Runner {
+	return &Runner{
+		client: client,
+		cfg:    cfg,
+	}
+}
+
+var (
+	_ harness.Runnable    = &Runner{}
+	_ harness.Cleanable   = &Runner{}
+	_ harness.Collectable = &Runner{}
+)
+
+func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	reachedBarrier := false
+	defer func() {
+		if !reachedBarrier {
+			r.cfg.DialBarrier.Done()
+		}
+	}()
+
+	logs = loadtestutil.NewSyncWriter(logs)
+	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
+	r.client.SetLogger(logger)
+	r.client.SetLogBodies(true)
+
+	r.createUserRunner = createusers.NewRunner(r.client, r.cfg.User)
+	newUserAndToken, err := r.createUserRunner.RunReturningUser(ctx, id, logs)
+	if err != nil {
+		r.cfg.Metrics.AddError("", "create_user")
+		return xerrors.Errorf("create user: %w", err)
+	}
+	newUser := newUserAndToken.User
+	newUserClient := codersdk.New(r.client.URL,
+		codersdk.WithSessionToken(newUserAndToken.SessionToken),
+		codersdk.WithLogger(logger),
+		codersdk.WithLogBodies())
+
+	logger.Info(ctx, fmt.Sprintf("user %q created", newUser.Username), slog.F("id", newUser.ID.String()))
+
+	if r.cfg.IsOwner {
+		logger.Info(ctx, "assigning Owner role to user")
+
+		_, err := r.client.UpdateUserRoles(ctx, newUser.ID.String(), codersdk.UpdateRoles{
+			Roles: []string{codersdk.RoleOwner},
+		})
+		if err != nil {
+			r.cfg.Metrics.AddError(newUser.Username, "assign_owner_role")
+			return xerrors.Errorf("assign owner role: %w", err)
+		}
+	}
+
+	logger.Info(ctx, "notification runner is ready")
+
+	// We don't need to wait for notifications since we're not an owner
+	if !r.cfg.IsOwner {
+		reachedBarrier = true
+		r.cfg.DialBarrier.Done()
+		return nil
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, r.cfg.DialTimeout)
+	defer cancel()
+
+	logger.Info(ctx, "connecting to notification websocket")
+	conn, err := r.dialNotificationWebsocket(dialCtx, newUserClient, newUser, logger)
+	if err != nil {
+		return xerrors.Errorf("dial notification websocket: %w", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	logger.Info(ctx, "connected to notification websocket")
+
+	reachedBarrier = true
+	r.cfg.DialBarrier.Done()
+	r.cfg.DialBarrier.Wait()
+
+	logger.Info(ctx, fmt.Sprintf("waiting up to %v for notifications...", r.cfg.NotificationTimeout))
+
+	watchCtx, cancel := context.WithTimeout(ctx, r.cfg.NotificationTimeout)
+	defer cancel()
+
+	if err := r.watchNotifications(watchCtx, conn, newUser, logger); err != nil {
+		return xerrors.Errorf("notification watch failed: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Runner) Cleanup(ctx context.Context, id string, logs io.Writer) error {
+	if r.createUserRunner != nil {
+		_, _ = fmt.Fprintln(logs, "Cleaning up user...")
+		if err := r.createUserRunner.Cleanup(ctx, id, logs); err != nil {
+			return xerrors.Errorf("cleanup user: %w", err)
+		}
+	}
+
+	return nil
+}
+
+const (
+	UserCreatedNotificationLatencyMetric = "user_created_notification_latency_seconds"
+	UserDeletedNotificationLatencyMetric = "user_deleted_notification_latency_seconds"
+)
+
+func (r *Runner) GetMetrics() map[string]any {
+	metrics := map[string]any{}
+
+	if r.userCreatedNotificationLatency > 0 {
+		metrics[UserCreatedNotificationLatencyMetric] = r.userCreatedNotificationLatency.Seconds()
+	}
+
+	if r.userDeletedNotificationLatency > 0 {
+		metrics[UserDeletedNotificationLatencyMetric] = r.userDeletedNotificationLatency.Seconds()
+	}
+
+	return metrics
+}
+
+func (r *Runner) dialNotificationWebsocket(ctx context.Context, client *codersdk.Client, user codersdk.User, logger slog.Logger) (*websocket.Conn, error) {
+	u, err := client.URL.Parse("/api/v2/notifications/inbox/watch")
+	if err != nil {
+		logger.Error(ctx, "parse notification URL", slog.Error(err))
+		r.cfg.Metrics.AddError(user.Username, "parse_url")
+		return nil, xerrors.Errorf("parse notification URL: %w", err)
+	}
+
+	conn, resp, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Coder-Session-Token": []string{client.SessionToken()},
+		},
+	})
+	if err != nil {
+		if resp != nil {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusSwitchingProtocols {
+				err = codersdk.ReadBodyAsError(resp)
+			}
+		}
+		logger.Error(ctx, "dial notification websocket", slog.Error(err))
+		r.cfg.Metrics.AddError(user.Username, "dial")
+		return nil, xerrors.Errorf("dial notification websocket: %w", err)
+	}
+
+	return conn, nil
+}
+
+// watchNotifications reads notifications from the websockert and returns error or nil
+// once both expected notifications are received.
+func (r *Runner) watchNotifications(ctx context.Context, conn *websocket.Conn, user codersdk.User, logger slog.Logger) error {
+	notificationStartTime := time.Now()
+	logger.Info(ctx, "waiting for notifications", slog.F("username", user.Username))
+
+	receivedCreated := false
+	receivedDeleted := false
+
+	// Read notifications until we have both expected types
+	for !receivedCreated || !receivedDeleted {
+		notif, err := r.readNotification(ctx, conn)
+		if err != nil {
+			logger.Error(ctx, "read notification", slog.Error(err))
+			r.cfg.Metrics.AddError(user.Username, "read_notification")
+			return xerrors.Errorf("read notification: %w", err)
+		}
+
+		switch notif.Notification.TemplateID {
+		case notifications.TemplateUserAccountCreated:
+			if !receivedCreated {
+				r.userCreatedNotificationLatency = time.Since(notificationStartTime)
+				r.cfg.Metrics.RecordLatency(r.userCreatedNotificationLatency, user.Username, "user_created")
+				receivedCreated = true
+				logger.Info(ctx, "received user created notification")
+			}
+		case notifications.TemplateUserAccountDeleted:
+			if !receivedDeleted {
+				r.userDeletedNotificationLatency = time.Since(notificationStartTime)
+				r.cfg.Metrics.RecordLatency(r.userDeletedNotificationLatency, user.Username, "user_deleted")
+				receivedDeleted = true
+				logger.Info(ctx, "received user deleted notification")
+			}
+		default:
+			logger.Warn(ctx, "received unexpected notification type",
+				slog.F("template_id", notif.Notification.TemplateID),
+				slog.F("title", notif.Notification.Title))
+		}
+	}
+	logger.Info(ctx, "received both notifications successfully")
+	return nil
+}
+
+func (*Runner) readNotification(ctx context.Context, conn *websocket.Conn) (codersdk.GetInboxNotificationResponse, error) {
+	_, message, err := conn.Read(ctx)
+	if err != nil {
+		return codersdk.GetInboxNotificationResponse{}, err
+	}
+
+	var notif codersdk.GetInboxNotificationResponse
+	if err := json.Unmarshal(message, &notif); err != nil {
+		return codersdk.GetInboxNotificationResponse{}, xerrors.Errorf("unmarshal notification: %w", err)
+	}
+
+	return notif, nil
+}

--- a/scaletest/notifications/run.go
+++ b/scaletest/notifications/run.go
@@ -111,7 +111,7 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	r.cfg.DialBarrier.Done()
 	r.cfg.DialBarrier.Wait()
 
-	logger.Info(ctx, fmt.Sprintf("waiting for notifications", slog.F("timeout", r.cfg.NotificationTimeout))
+	logger.Info(ctx, "waiting for notifications", slog.F("timeout", r.cfg.NotificationTimeout))
 
 	watchCtx, cancel := context.WithTimeout(ctx, r.cfg.NotificationTimeout)
 	defer cancel()
@@ -192,7 +192,7 @@ func (r *Runner) watchNotifications(ctx context.Context, conn *websocket.Conn, u
 
 	// Read notifications until we have both expected types
 	for !receivedCreated || !receivedDeleted {
-		notif, err := r.readNotification(ctx, conn)
+		notif, err := readNotification(ctx, conn)
 		if err != nil {
 			logger.Error(ctx, "read notification", slog.Error(err))
 			r.cfg.Metrics.AddError(user.Username, "read_notification")
@@ -224,7 +224,7 @@ func (r *Runner) watchNotifications(ctx context.Context, conn *websocket.Conn, u
 	return nil
 }
 
-readNotification(ctx context.Context, conn *websocket.Conn) (codersdk.GetInboxNotificationResponse, error) {
+func readNotification(ctx context.Context, conn *websocket.Conn) (codersdk.GetInboxNotificationResponse, error) {
 	_, message, err := conn.Read(ctx)
 	if err != nil {
 		return codersdk.GetInboxNotificationResponse{}, err

--- a/scaletest/notifications/run.go
+++ b/scaletest/notifications/run.go
@@ -73,7 +73,7 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 		codersdk.WithLogger(logger),
 		codersdk.WithLogBodies())
 
-	logger.Info(ctx, fmt.Sprintf("user %q created", newUser.Username), slog.F("id", newUser.ID.String()))
+	logger.Info(ctx, "user created", slog.F("username", newUser.Username), slog.F("user_id", newUser.ID.String()))
 
 	if r.cfg.IsOwner {
 		logger.Info(ctx, "assigning Owner role to user")
@@ -111,7 +111,7 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	r.cfg.DialBarrier.Done()
 	r.cfg.DialBarrier.Wait()
 
-	logger.Info(ctx, fmt.Sprintf("waiting up to %v for notifications...", r.cfg.NotificationTimeout))
+	logger.Info(ctx, fmt.Sprintf("waiting for notifications", slog.F("timeout", r.cfg.NotificationTimeout))
 
 	watchCtx, cancel := context.WithTimeout(ctx, r.cfg.NotificationTimeout)
 	defer cancel()
@@ -224,7 +224,7 @@ func (r *Runner) watchNotifications(ctx context.Context, conn *websocket.Conn, u
 	return nil
 }
 
-func (*Runner) readNotification(ctx context.Context, conn *websocket.Conn) (codersdk.GetInboxNotificationResponse, error) {
+readNotification(ctx context.Context, conn *websocket.Conn) (codersdk.GetInboxNotificationResponse, error) {
 	_, message, err := conn.Read(ctx)
 	if err != nil {
 		return codersdk.GetInboxNotificationResponse{}, err

--- a/scaletest/notifications/run_test.go
+++ b/scaletest/notifications/run_test.go
@@ -66,7 +66,6 @@ func TestRun(t *testing.T) {
 	require.NoError(t, err)
 
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerDaemon: true,
 		Database:                 db,
 		Pubsub:                   ps,
 		NotificationsEnqueuer:    enqueuer,

--- a/scaletest/notifications/run_test.go
+++ b/scaletest/notifications/run_test.go
@@ -1,0 +1,172 @@
+package notifications_test
+
+import (
+	"io"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/serpent"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	notificationsLib "github.com/coder/coder/v2/coderd/notifications"
+	"github.com/coder/coder/v2/coderd/notifications/dispatch"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/createusers"
+	"github.com/coder/coder/v2/scaletest/notifications"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := testutil.Logger(t)
+	db, ps := dbtestutil.NewDB(t)
+
+	// Setup notifications manager with inbox handler
+	cfg := defaultNotificationsConfig(database.NotificationMethodSmtp)
+	mgr, err := notificationsLib.NewManager(
+		cfg,
+		db,
+		ps,
+		defaultHelpers(),
+		notificationsLib.NewMetrics(prometheus.NewRegistry()),
+		logger.Named("manager"),
+	)
+	require.NoError(t, err)
+
+	mgr.WithHandlers(map[database.NotificationMethod]notificationsLib.Handler{
+		database.NotificationMethodInbox: dispatch.NewInboxHandler(logger.Named("inbox"), db, ps),
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, mgr.Stop(dbauthz.AsNotifier(ctx)))
+	})
+	mgr.Run(dbauthz.AsNotifier(ctx))
+
+	enqueuer, err := notificationsLib.NewStoreEnqueuer(
+		cfg,
+		db,
+		defaultHelpers(),
+		logger.Named("enqueuer"),
+		quartz.NewReal(),
+	)
+	require.NoError(t, err)
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: true,
+		Database:                 db,
+		Pubsub:                   ps,
+		NotificationsEnqueuer:    enqueuer,
+	})
+	firstUser := coderdtest.CreateFirstUser(t, client)
+
+	const numOwners = 2
+	barrier := new(sync.WaitGroup)
+	barrier.Add(numOwners + 1)
+	metrics := notifications.NewMetrics(prometheus.NewRegistry())
+
+	eg, runCtx := errgroup.WithContext(ctx)
+
+	// Start owner runners who will receive notifications
+	runners := make([]*notifications.Runner, 0, numOwners)
+	for i := range numOwners {
+		runnerCfg := notifications.Config{
+			User: createusers.Config{
+				OrganizationID: firstUser.OrganizationID,
+			},
+			IsOwner:             true,
+			NotificationTimeout: testutil.WaitLong,
+			DialTimeout:         testutil.WaitLong,
+			Metrics:             metrics,
+			DialBarrier:         barrier,
+		}
+		err := runnerCfg.Validate()
+		require.NoError(t, err)
+
+		runner := notifications.NewRunner(client, runnerCfg)
+		runners = append(runners, runner)
+		eg.Go(func() error {
+			return runner.Run(runCtx, "owner-"+strconv.Itoa(i), io.Discard)
+		})
+	}
+
+	// Trigger notifications by creating and deleting a user
+	eg.Go(func() error {
+		barrier.Done()
+		barrier.Wait()
+
+		newUser, err := client.CreateUserWithOrgs(runCtx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "test-user@coder.com",
+			Username:        "test-user",
+			Password:        "SomeSecurePassword!",
+		})
+		if err != nil {
+			return xerrors.Errorf("create test user: %w", err)
+		}
+
+		if err := client.DeleteUser(runCtx, newUser.ID); err != nil {
+			return xerrors.Errorf("delete test user: %w", err)
+		}
+
+		return nil
+	})
+
+	err = eg.Wait()
+	require.NoError(t, err, "runner execution should complete successfully")
+
+	cleanupEg, cleanupCtx := errgroup.WithContext(ctx)
+	for i, runner := range runners {
+		cleanupEg.Go(func() error {
+			return runner.Cleanup(cleanupCtx, strconv.Itoa(i), io.Discard)
+		})
+	}
+	err = cleanupEg.Wait()
+	require.NoError(t, err)
+
+	// Verify that each runner received both notifications and recorded metrics
+	for _, runner := range runners {
+		runnerMetrics := runner.GetMetrics()
+		require.Contains(t, runnerMetrics, notifications.UserCreatedNotificationLatencyMetric)
+		require.Contains(t, runnerMetrics, notifications.UserDeletedNotificationLatencyMetric)
+	}
+}
+
+func defaultNotificationsConfig(method database.NotificationMethod) codersdk.NotificationsConfig {
+	return codersdk.NotificationsConfig{
+		Method:              serpent.String(method),
+		MaxSendAttempts:     5,
+		FetchInterval:       serpent.Duration(time.Millisecond * 100),
+		StoreSyncInterval:   serpent.Duration(time.Millisecond * 200),
+		LeasePeriod:         serpent.Duration(time.Second * 10),
+		DispatchTimeout:     serpent.Duration(time.Second * 5),
+		RetryInterval:       serpent.Duration(time.Millisecond * 50),
+		LeaseCount:          10,
+		StoreSyncBufferSize: 50,
+		Inbox: codersdk.NotificationsInboxConfig{
+			Enabled: serpent.Bool(true),
+		},
+	}
+}
+
+func defaultHelpers() map[string]any {
+	return map[string]any{
+		"base_url":     func() string { return "http://test.com" },
+		"current_year": func() string { return "2024" },
+		"logo_url":     func() string { return "https://coder.com/coder-logo-horizontal.png" },
+		"app_name":     func() string { return "Coder" },
+	}
+}

--- a/scaletest/notifications/run_test.go
+++ b/scaletest/notifications/run_test.go
@@ -188,19 +188,9 @@ func TestRun(t *testing.T) {
 	require.Equal(t, firstUser.UserID, users.Users[0].ID)
 
 	for _, runner := range receivingRunners {
-		runnerMetrics := runner.GetMetrics()[notifications.NotificationDeliveryLatencyMetric]
-		foundCreated := false
-		foundDeleted := false
-		for key := range runnerMetrics.(map[uuid.UUID]time.Duration) {
-			if key == notificationsLib.TemplateUserAccountCreated {
-				foundCreated = true
-			}
-			if key == notificationsLib.TemplateUserAccountDeleted {
-				foundDeleted = true
-			}
-		}
-		require.True(t, foundCreated)
-		require.True(t, foundDeleted)
+		runnerMetrics := runner.GetMetrics()[notifications.NotificationDeliveryLatencyMetric].(map[uuid.UUID]time.Duration)
+		require.Contains(t, runnerMetrics, notificationsLib.TemplateUserAccountCreated)
+		require.Contains(t, runnerMetrics, notificationsLib.TemplateUserAccountDeleted)
 	}
 }
 


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/910

This PR adds a scaletest runner that simulates users receiving notifications through WebSocket connections.

An instance of this notification runner does the following:

1. Creates a user (optionally with specific roles like owner).
2. Connects to /api/v2/notifications/inbox/watch via WebSocket to receive notifications in real-time.
3. Waits for all other concurrently executing runners (per the DialBarrier WaitGroup) to also connect their websockets.
4. For receiving users: Watches the WebSocket for expected notifications and records delivery latency for each notification type.
5. For regular users: Maintains WebSocket connections to simulate concurrent load while receiving users wait for notifications.
6. Waits on the ReceivingWatchBarrier to coordinate between receiving and regular users.
7. Cleans up the created user after the test completes.


Exposes three prometheus metrics:

1. notification_delivery_latency_seconds - HistogramVec. Labels = {username, notification_type}
2. notification_delivery_errors_total - CounterVec. Labels = {username, action}
3. notification_delivery_missed_total - CounterVec. Labels = {username}

The runner measures end-to-end notification latency from when a notification-triggering event occurs (e.g., user creation/deletion) to when the notification is received by a WebSocket client. 
