### PR TITLE
test: fix rbac benchmark to test performance instead of cache

### DIFF
--- a/coderd/rbac/authz_test.go
+++ b/coderd/rbac/authz_test.go
@@ -187,7 +187,7 @@ func BenchmarkRBACAuthorizeGroups(b *testing.B) {
 		uuid.MustParse("0632b012-49e0-4d70-a5b3-f4398f1dcd52"),
 		uuid.MustParse("70dbaa7a-ea9c-4f68-a781-97b08af8461d"),
 	)
-	authorizer := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
+	authorizer := rbac.NewAuthorizer(prometheus.NewRegistry())
 
 	// Same benchmark cases, but this time groups will be used to match.
 	// Some '*' permissions will still match, but using a fake action reduces


### PR DESCRIPTION
The benchmark should be testing the performance of `authorize`, not a cache lookup
