### PR TITLE
ci(.github/workflows/traiage.yaml): set default inputs on trigger by label assignment

### DIFF
--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Create and upload archive
         id: create-archive
-        if: ${{ steps.determine-inputs.outputs.cleanup }}
+        if: steps.determine-inputs.outputs.cleanup == 'true'
         env:
           BUCKET_PREFIX: "gs://coder-traiage-outputs/traiage"
           CODER_USERNAME: ${{ steps.get-coder-username.outputs.coder_username }}
@@ -240,7 +240,7 @@ jobs:
 
       - name: Generate a summary of the changes and post a comment on GitHub.
         id: generate-summary
-        if: ${{ steps.determine-inputs.outputs.cleanup }}
+        if: steps.determine-inputs.outputs.cleanup == 'true'
         env:
           ARCHIVE_URL: ${{ steps.create-archive.outputs.archive_url }}
           BUCKET_PREFIX: "gs://coder-traiage-outputs/traiage"
@@ -279,7 +279,7 @@ jobs:
           cat "${SUMMARY_FILE}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup task
-        if: steps.determine-inputs.outputs.cleanup && steps.create-task.outputs.TASK_NAME != '' && steps.create-archive.outputs.archive_url != ''
+        if: steps.determine-inputs.outputs.cleanup == 'true' && steps.create-task.outputs.TASK_NAME != '' && steps.create-archive.outputs.archive_url != ''
         run: |
           echo "Cleaning up task: $TASK_NAME"
           ./scripts/traiage.sh delete || true

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -233,8 +233,8 @@ jobs:
           TASK_NAME: ${{ steps.create-task.outputs.TASK_NAME }}
         run: |
           echo "Waiting for task to complete..."
-          coder exp task status "${CODER_USERNAME}/$TASK_NAME" --watch
-          echo "Creating archive for workspace: $TASK_NAME"
+          coder exp task status "${TASK_NAME}" --watch
+          echo "Creating archive for workspace: ${TASK_NAME}"
           ./scripts/traiage.sh archive
           echo "archive_url=${BUCKET_PREFIX%%/}/$TASK_NAME.tar.gz" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -40,25 +40,53 @@ jobs:
     env:
       CODER_URL: ${{ secrets.TRAIAGE_CODER_URL }}
       CODER_SESSION_TOKEN: ${{ secrets.TRAIAGE_CODER_SESSION_TOKEN }}
-      TEMPLATE_NAME: ${{ inputs.template_name }}
     permissions:
       contents: read
       issues: write
       actions: write
 
     steps:
-      - name: Get GitHub user ID
-        id: github-user-id
+      # This is only required for testing locally using nektos/act, so leaving commented out.
+      # An alternative is to use a larger or custom image.
+      # - name: Install Github CLI
+      #   id: install-gh
+      #   run: |
+      #     (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
+      #     && sudo mkdir -p -m 755 /etc/apt/keyrings \
+      #     && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      #     && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+      #     && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+      #     && sudo mkdir -p -m 755 /etc/apt/sources.list.d \
+      #     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+      #     && sudo apt update \
+      #     && sudo apt install gh -y
+
+      - name: Determine Inputs
+        id: determine-inputs
         if: always()
         env:
           GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_EVENT_ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_USER_ID: ${{ github.event.sender.id }}
           GITHUB_EVENT_USER_LOGIN: ${{ github.event.sender.login }}
+          INPUTS_ISSUE_URL: ${{ inputs.issue_url }}
+          INPUTS_TEMPLATE_NAME: ${{ inputs.template_name || 'traiage' }}
+          INPUTS_TEMPLATE_PRESET: ${{ inputs.template_preset || 'Default'}}
+          INPUTS_PREFIX: ${{ inputs.prefix || 'traiage' }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          echo "Using template name: ${INPUTS_TEMPLATE_NAME}"
+          echo "template_name=${INPUTS_TEMPLATE_NAME}" >> "${GITHUB_OUTPUT}"
+
+          echo "Using template preset: ${INPUTS_TEMPLATE_PRESET}"
+          echo "template_preset=${INPUTS_TEMPLATE_PRESET}" >> "${GITHUB_OUTPUT}"
+
+          echo "Using prefix: ${INPUTS_PREFIX}"
+          echo "prefix=${INPUTS_PREFIX}" >> "${GITHUB_OUTPUT}"
+
           # For workflow_dispatch, use the actor who triggered it
-          # For issues events, use the issue author
+          # For issues events, use the issue author.
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             if ! GITHUB_USER_ID=$(gh api "users/${GITHUB_ACTOR}" --jq '.id'); then
               echo "::error::Failed to get GitHub user ID for actor ${GITHUB_ACTOR}"
@@ -67,12 +95,20 @@ jobs:
             echo "Using workflow_dispatch actor: ${GITHUB_ACTOR} (ID: ${GITHUB_USER_ID})"
             echo "github_user_id=${GITHUB_USER_ID}" >> "${GITHUB_OUTPUT}"
             echo "github_username=${GITHUB_ACTOR}" >> "${GITHUB_OUTPUT}"
+
+            echo "Using issue URL: ${INPUTS_ISSUE_URL}"
+            echo "issue_url=${INPUTS_ISSUE_URL}" >> "${GITHUB_OUTPUT}"
+
             exit 0
           elif [[ "${GITHUB_EVENT_NAME}" == "issues" ]]; then
             GITHUB_USER_ID=${GITHUB_EVENT_USER_ID}
             echo "Using issue author: ${GITHUB_EVENT_USER_LOGIN} (ID: ${GITHUB_USER_ID})"
             echo "github_user_id=${GITHUB_USER_ID}" >> "${GITHUB_OUTPUT}"
             echo "github_username=${GITHUB_EVENT_USER_LOGIN}" >> "${GITHUB_OUTPUT}"
+
+            echo "Using issue URL: ${GITHUB_EVENT_ISSUE_HTML_URL}"
+            echo "issue_url=${GITHUB_EVENT_ISSUE_HTML_URL}" >> "${GITHUB_OUTPUT}"
+
             exit 0
           else
             echo "::error::Unsupported event type: ${GITHUB_EVENT_NAME}"
@@ -83,8 +119,8 @@ jobs:
         env:
           GITHUB_ORG: ${{ github.repository_owner }}
           GH_TOKEN: ${{ github.token }}
-          GITHUB_USERNAME: ${{ steps.github-user-id.outputs.github_username }}
-          GITHUB_USER_ID: ${{ steps.github-user-id.outputs.github_user_id }}
+          GITHUB_USERNAME: ${{ steps.determine-inputs.outputs.github_username }}
+          GITHUB_USER_ID: ${{ steps.determine-inputs.outputs.github_user_id }}
         run: |
           # Check if the actor is a member of the organization
           if ! gh api "orgs/${GITHUB_ORG}/members/${GITHUB_USERNAME}" --silent 2>/dev/null; then
@@ -94,28 +130,10 @@ jobs:
           fi
           echo "::notice::User ${GITHUB_USERNAME} verified as member of ${GITHUB_ORG} organization"
 
-      - name: Determine issue URL
-        id: determine-issue-url
-        env:
-          INPUTS_ISSUE_URL: ${{ inputs.issue_url }}
-          GITHUB_EVENT_ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            echo "issue_url=${INPUTS_ISSUE_URL}" >> "${GITHUB_OUTPUT}"
-            exit 0
-          elif [[ "${GITHUB_EVENT_NAME}" == "issues" ]]; then
-            echo "issue_url=${GITHUB_EVENT_ISSUE_HTML_URL}" >> "${GITHUB_OUTPUT}"
-            exit 0
-          else
-            echo "::error::Unsupported event type: ${GITHUB_EVENT_NAME}"
-            exit 1
-          fi
-
       - name: Extract context key from issue
         id: extract-context
         env:
-          ISSUE_URL: ${{ steps.determine-issue-url.outputs.issue_url }}
+          ISSUE_URL: ${{ steps.determine-inputs.outputs.issue_url }}
           GH_TOKEN: ${{ github.token }}
         run: |
           issue_number="$(gh issue view "${ISSUE_URL}" --json number --jq '.number')"
@@ -146,7 +164,7 @@ jobs:
         env:
           CODER_SESSION_TOKEN: ${{ secrets.TRAIAGE_CODER_SESSION_TOKEN }}
           GH_TOKEN: ${{ github.token }}
-          GITHUB_USER_ID: ${{ steps.github-user-id.outputs.github_user_id }}
+          GITHUB_USER_ID: ${{ steps.determine-inputs.outputs.github_user_id }}
         run: |
           user_json=$(
             coder users list --github-user-id="${GITHUB_USER_ID}" --output=json
@@ -169,11 +187,12 @@ jobs:
           CONTEXT_KEY: ${{ steps.extract-context.outputs.context_key }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          ISSUE_URL: ${{ steps.determine-issue-url.outputs.issue_url }}
-          PREFIX: ${{ inputs.prefix }}
+          ISSUE_URL: ${{ steps.determine-inputs.outputs.issue_url }}
+          PREFIX: ${{ steps.determine-inputs.outputs.prefix }}
           RUN_ID: ${{ github.run_id }}
+          TEMPLATE_NAME: ${{ steps.determine-inputs.outputs.template_name }}
           TEMPLATE_PARAMETERS: ${{ secrets.TRAIAGE_TEMPLATE_PARAMETERS }}
-          TEMPLATE_PRESET: ${{ inputs.template_preset }}
+          TEMPLATE_PRESET: ${{ steps.determine-inputs.outputs.template_preset }}
         run: |
           # Fetch issue description using `gh` CLI
           issue_description=$(gh issue view "${ISSUE_URL}")
@@ -225,7 +244,7 @@ jobs:
           CONTEXT_KEY: ${{ steps.extract-context.outputs.context_key }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          ISSUE_URL: ${{ steps.determine-issue-url.outputs.issue_url }}
+          ISSUE_URL: ${{ steps.determine-inputs.outputs.issue_url }}
           TASK_NAME: ${{ steps.create-task.outputs.TASK_NAME }}
         run: |
           SUMMARY_FILE=$(mktemp)

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -70,7 +70,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_USER_ID: ${{ github.event.sender.id }}
           GITHUB_EVENT_USER_LOGIN: ${{ github.event.sender.login }}
-          INPUTS_CLEANUP: ${{ inputs.cleanup || 'false' }}
+          INPUTS_CLEANUP: ${{ inputs.cleanup || false }}
           INPUTS_ISSUE_URL: ${{ inputs.issue_url }}
           INPUTS_TEMPLATE_NAME: ${{ inputs.template_name || 'traiage' }}
           INPUTS_TEMPLATE_PRESET: ${{ inputs.template_preset || 'Default'}}

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -70,6 +70,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_USER_ID: ${{ github.event.sender.id }}
           GITHUB_EVENT_USER_LOGIN: ${{ github.event.sender.login }}
+          INPUTS_CLEANUP: ${{ inputs.cleanup || 'false' }}
           INPUTS_ISSUE_URL: ${{ inputs.issue_url }}
           INPUTS_TEMPLATE_NAME: ${{ inputs.template_name || 'traiage' }}
           INPUTS_TEMPLATE_PRESET: ${{ inputs.template_preset || 'Default'}}
@@ -84,6 +85,9 @@ jobs:
 
           echo "Using prefix: ${INPUTS_PREFIX}"
           echo "prefix=${INPUTS_PREFIX}" >> "${GITHUB_OUTPUT}"
+
+          echo "Using cleanup: ${INPUTS_CLEANUP}"
+          echo "cleanup=${INPUTS_CLEANUP}" >> "${GITHUB_OUTPUT}"
 
           # For workflow_dispatch, use the actor who triggered it
           # For issues events, use the issue author.
@@ -222,7 +226,7 @@ jobs:
 
       - name: Create and upload archive
         id: create-archive
-        if: inputs.cleanup
+        if: ${{ steps.determine-inputs.outputs.cleanup }}
         env:
           BUCKET_PREFIX: "gs://coder-traiage-outputs/traiage"
           CODER_USERNAME: ${{ steps.get-coder-username.outputs.coder_username }}
@@ -236,7 +240,7 @@ jobs:
 
       - name: Generate a summary of the changes and post a comment on GitHub.
         id: generate-summary
-        if: inputs.cleanup
+        if: ${{ steps.determine-inputs.outputs.cleanup }}
         env:
           ARCHIVE_URL: ${{ steps.create-archive.outputs.archive_url }}
           BUCKET_PREFIX: "gs://coder-traiage-outputs/traiage"
@@ -275,7 +279,7 @@ jobs:
           cat "${SUMMARY_FILE}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup task
-        if: inputs.cleanup && steps.create-task.outputs.TASK_NAME != '' && steps.create-archive.outputs.archive_url != ''
+        if: steps.determine-inputs.outputs.cleanup && steps.create-task.outputs.TASK_NAME != '' && steps.create-archive.outputs.archive_url != ''
         run: |
           echo "Cleaning up task: $TASK_NAME"
           ./scripts/traiage.sh delete || true


### PR DESCRIPTION
When not triggering via `workflow_dispatch`, it looks like the default values are simply empty.
This PR creates an intermediate step to conditionally set defaults based on `github.event_name`. 

I'm also adding a commented-out step for installing `gh` that's required for local testing via `nektos/act`. It's not required in a 'real' runner.