### PR TITLE
fix: revert playwright update and update dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -80,6 +80,9 @@ updates:
       mui:
         patterns:
           - "@mui*"
+      radix:
+        patterns:
+          - "@radix-ui/*"
       react:
         patterns:
           - "react"
@@ -104,6 +107,7 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      - dependency-name: "@playwright/test"
     open-pull-requests-limit: 15
 
   - package-ecosystem: "terraform"

--- a/site/package.json
+++ b/site/package.json
@@ -126,7 +126,7 @@
 		"@biomejs/biome": "2.2.0",
 		"@chromatic-com/storybook": "4.1.0",
 		"@octokit/types": "12.3.0",
-		"@playwright/test": "1.55.1",
+		"@playwright/test": "1.50.1",
 		"@storybook/addon-docs": "9.1.2",
 		"@storybook/addon-links": "9.1.2",
 		"@storybook/addon-themes": "9.1.2",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -288,8 +288,8 @@ importers:
         specifier: 12.3.0
         version: 12.3.0
       '@playwright/test':
-        specifier: 1.55.1
-        version: 1.55.1
+        specifier: 1.50.1
+        version: 1.50.1
       '@storybook/addon-docs':
         specifier: 9.1.2
         version: 9.1.2(@types/react@19.1.17)(storybook@9.1.2(@testing-library/dom@10.4.0)(msw@2.4.8(typescript@5.6.3))(prettier@3.4.1)(vite@7.1.7(@types/node@20.17.16)(jiti@2.6.1)(yaml@2.7.0)))
@@ -1625,8 +1625,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.55.1':
-    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==, tarball: https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz}
+  '@playwright/test@1.50.1':
+    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==, tarball: https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5459,13 +5459,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==, tarball: https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz}
     engines: {node: '>=8'}
 
-  playwright-core@1.55.1:
-    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==, tarball: https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz}
+  playwright-core@1.50.1:
+    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==, tarball: https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.55.1:
-    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==, tarball: https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz}
+  playwright@1.50.1:
+    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==, tarball: https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7915,9 +7915,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.55.1':
+  '@playwright/test@1.50.1':
     dependencies:
-      playwright: 1.55.1
+      playwright: 1.50.1
 
   '@popperjs/core@2.11.8': {}
 
@@ -12322,11 +12322,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.55.1: {}
+  playwright-core@1.50.1: {}
 
-  playwright@1.55.1:
+  playwright@1.50.1:
     dependencies:
-      playwright-core: 1.55.1
+      playwright-core: 1.50.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

- Revert the Playwright update, because we need to use the version from nixpkgs/stable
- Make sure dependabot doesn't try to update it again
- Make sure that Radix updates are batches, rather than bludgeoning us with dozens of PRs