### PR TITLE
ci: make `changes` required

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -919,6 +919,7 @@ jobs:
   required:
     runs-on: ubuntu-latest
     needs:
+      - changes
       - fmt
       - lint
       - gen
@@ -942,6 +943,7 @@ jobs:
       - name: Ensure required checks
         run: | # zizmor: ignore[template-injection] We're just reading needs.x.result here, no risk of injection
           echo "Checking required checks"
+          echo "- changes: ${{ needs.changes.result }}"
           echo "- fmt: ${{ needs.fmt.result }}"
           echo "- lint: ${{ needs.lint.result }}"
           echo "- gen: ${{ needs.gen.result }}"


### PR DESCRIPTION
Earlier today, a dependabot PR was merged despite CI not having been run. https://github.com/coder/coder/pull/20068

This was because the `changes` job failed due to a github ratelimit, which caused all the tests to be skipped, which caused `required` to pass as it passes if tests are skipped.

<img width="725" height="872" alt="image" src="https://github.com/user-attachments/assets/3a13d19b-819a-48df-ad8c-e9ff903a0496" />

This PR makes `changes` required so this can't happen again (assuming we keep around the dependabot automerge around, it might).