### PR TITLE
feat(site): add emoji picker to /icons route

### DIFF
--- a/site/src/pages/IconsPage/IconsPage.tsx
+++ b/site/src/pages/IconsPage/IconsPage.tsx
@@ -1,20 +1,34 @@
-import { useTheme } from "@emotion/react";
+import { css, Global, useTheme } from "@emotion/react";
 import IconButton from "@mui/material/IconButton";
 import InputAdornment from "@mui/material/InputAdornment";
 import Link from "@mui/material/Link";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
+import { Button } from "components/Button/Button";
 import { CopyableValue } from "components/CopyableValue/CopyableValue";
 import { EmptyState } from "components/EmptyState/EmptyState";
+import { Loader } from "components/Loader/Loader";
 import { Margins } from "components/Margins/Margins";
 import {
 	PageHeader,
 	PageHeaderSubtitle,
 	PageHeaderTitle,
 } from "components/PageHeader/PageHeader";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "components/Popover/Popover";
 import { Stack } from "components/Stack/Stack";
-import { SearchIcon, XIcon } from "lucide-react";
-import { type FC, type ReactNode, useMemo, useState } from "react";
+import { ChevronDownIcon, SearchIcon, XIcon } from "lucide-react";
+import {
+	type FC,
+	lazy,
+	type ReactNode,
+	Suspense,
+	useMemo,
+	useState,
+} from "react";
 import {
 	defaultParametersForBuiltinIcons,
 	parseImageParameters,
@@ -32,9 +46,17 @@ const fuzzyFinder = new uFuzzy({
 	intraDel: 1,
 });
 
+// See: https://github.com/missive/emoji-mart/issues/51#issuecomment-287353222
+const urlFromUnifiedCode = (unified: string) =>
+	`/emojis/${unified.replace(/-fe0f$/, "")}.png`;
+
+const EmojiPicker = lazy(() => import("components/IconField/EmojiPicker"));
+
 const IconsPage: FC = () => {
 	const theme = useTheme();
 	const [searchInputText, setSearchInputText] = useState("");
+	const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
+	const [selectedEmojiUrl, setSelectedEmojiUrl] = useState("");
 	const searchText = searchInputText.trim();
 
 	const searchedIcons = useMemo(() => {
@@ -76,27 +98,64 @@ const IconsPage: FC = () => {
 			<Margins>
 				<PageHeader
 					actions={
-						<Tooltip
-							placement="bottom-end"
-							title={
-								<p
-									css={{
-										padding: 8,
-										fontSize: 13,
-										lineHeight: 1.5,
-									}}
+						<div className="flex items-center gap-4">
+							<Tooltip
+								placement="bottom-end"
+								title={
+									<p
+										css={{
+											padding: 8,
+											fontSize: 13,
+											lineHeight: 1.5,
+										}}
+									>
+										You can suggest a new icon by submitting a Pull Request to
+										our public GitHub repository. Just keep in mind that it
+										should be relevant to many Coder users, and redistributable
+										under a permissive license.
+									</p>
+								}
+							>
+								<Link href="https://github.com/coder/coder/tree/main/site/static/icon">
+									Suggest an icon
+								</Link>
+							</Tooltip>
+
+							<Global
+								styles={css`
+									em-emoji-picker {
+										--rgb-background: ${theme.palette.background.paper};
+										--rgb-input: ${theme.palette.primary.main};
+										--rgb-color: ${theme.palette.text.primary};
+									}
+								`}
+							/>
+							<Popover open={emojiPickerOpen} onOpenChange={setEmojiPickerOpen}>
+								<PopoverTrigger asChild>
+									<Button variant="outline" size="lg" className="flex-shrink-0">
+										Emoji Picker
+										<ChevronDownIcon />
+									</Button>
+								</PopoverTrigger>
+								<PopoverContent
+									id="emoji"
+									side="bottom"
+									align="end"
+									className="w-min"
 								>
-									You can suggest a new icon by submitting a Pull Request to our
-									public GitHub repository. Just keep in mind that it should be
-									relevant to many Coder users, and redistributable under a
-									permissive license.
-								</p>
-							}
-						>
-							<Link href="https://github.com/coder/coder/tree/main/site/static/icon">
-								Suggest an icon
-							</Link>
-						</Tooltip>
+									<Suspense fallback={<Loader />}>
+										<EmojiPicker
+											onEmojiSelect={(emoji) => {
+												const value =
+													emoji.src ?? urlFromUnifiedCode(emoji.unified);
+												setSelectedEmojiUrl(value);
+												setEmojiPickerOpen(false);
+											}}
+										/>
+									</Suspense>
+								</PopoverContent>
+							</Popover>
+						</div>
 					}
 				>
 					<PageHeaderTitle>Icons</PageHeaderTitle>
@@ -104,6 +163,63 @@ const IconsPage: FC = () => {
 						All of the icons included with Coder
 					</PageHeaderSubtitle>
 				</PageHeader>
+
+				{selectedEmojiUrl && (
+					<div
+						css={{
+							marginTop: 16,
+							marginBottom: 16,
+							padding: 16,
+							backgroundColor: theme.palette.background.paper,
+							borderRadius: 8,
+							border: `1px solid ${theme.palette.divider}`,
+						}}
+					>
+						<Stack direction="row" alignItems="center" spacing={2}>
+							<img
+								src={selectedEmojiUrl}
+								alt="Selected emoji"
+								css={{
+									width: 40,
+									height: 40,
+									objectFit: "contain",
+								}}
+							/>
+							<div css={{ flex: 1 }}>
+								<div
+									css={{
+										fontSize: 12,
+										color: theme.palette.text.secondary,
+										marginBottom: 4,
+									}}
+								>
+									Selected Emoji URL
+								</div>
+								<CopyableValue value={selectedEmojiUrl}>
+									<code
+										css={{
+											fontSize: 14,
+											color: theme.palette.text.primary,
+											backgroundColor: theme.palette.background.default,
+											padding: "4px 8px",
+											borderRadius: 4,
+											display: "inline-block",
+										}}
+									>
+										{selectedEmojiUrl}
+									</code>
+								</CopyableValue>
+							</div>
+							<IconButton
+								size="small"
+								onClick={() => setSelectedEmojiUrl("")}
+								css={{ color: theme.palette.text.secondary }}
+							>
+								<XIcon className="size-icon-xs" />
+							</IconButton>
+						</Stack>
+					</div>
+				)}
 				<TextField
 					size="small"
 					InputProps={{

--- a/site/src/pages/IconsPage/IconsPage.tsx
+++ b/site/src/pages/IconsPage/IconsPage.tsx
@@ -101,20 +101,7 @@ const IconsPage: FC = () => {
 						<div className="flex items-center gap-4">
 							<Tooltip
 								placement="bottom-end"
-								title={
-									<p
-										css={{
-											padding: 8,
-											fontSize: 13,
-											lineHeight: 1.5,
-										}}
-									>
-										You can suggest a new icon by submitting a Pull Request to
-										our public GitHub repository. Just keep in mind that it
-										should be relevant to many Coder users, and redistributable
-										under a permissive license.
-									</p>
-								}
+								title="Submit a PR to suggest a new icon"
 							>
 								<Link href="https://github.com/coder/coder/tree/main/site/static/icon">
 									Suggest an icon


### PR DESCRIPTION
## Summary

Adds an emoji picker to the `/icons` route, allowing users to browse and select emojis with their URLs displayed in a copyable format.

## Changes

- Added "Emoji Picker" button to the Icons page header
- When an emoji is selected, displays a card showing:
  - Preview of the selected emoji/icon
  - The full URL in a copyable code block
  - Close button to dismiss the card
- Reuses the existing `EmojiPicker` component from `IconField` for consistency

## Screenshots

### Before
Users could only see emojis by visiting template settings page.

### After
Users can now access the emoji picker directly from the `/icons` page and see the URL for any selected emoji.

## Testing

- ✅ TypeScript checks pass
- ✅ Biome linting passes
- ✅ Code formatting applied

## Related Issue

Fixes #11752

🤖 Generated with [Claude Code](https://claude.com/claude-code)