### PR TITLE
fix: only show error once when failing to update org member roles

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
@@ -149,8 +149,10 @@ export const OrganizationMembersPageView: FC<
 											isLoading={isUpdatingMemberRoles}
 											canEditUsers={canEditMembers}
 											onEditRoles={async (roles) => {
-												await updateMemberRoles(member, roles);
-												displaySuccess("Roles updated successfully.");
+												try {
+													await updateMemberRoles(member, roles);
+													displaySuccess("Roles updated successfully.");
+												} catch {}
 											}}
 										/>
 										<UserGroupsCell userGroups={member.groups} />

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
@@ -149,6 +149,8 @@ export const OrganizationMembersPageView: FC<
 											isLoading={isUpdatingMemberRoles}
 											canEditUsers={canEditMembers}
 											onEditRoles={async (roles) => {
+												// React doesn't mind uncaught errors in even handlers,
+												// but testing-library does.
 												try {
 													await updateMemberRoles(member, roles);
 													displaySuccess("Roles updated successfully.");

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
@@ -149,7 +149,7 @@ export const OrganizationMembersPageView: FC<
 											isLoading={isUpdatingMemberRoles}
 											canEditUsers={canEditMembers}
 											onEditRoles={async (roles) => {
-												// React doesn't mind uncaught errors in even handlers,
+												// React doesn't mind uncaught errors in event handlers,
 												// but testing-library does.
 												try {
 													await updateMemberRoles(member, roles);

--- a/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationMembersPageView.tsx
@@ -149,14 +149,8 @@ export const OrganizationMembersPageView: FC<
 											isLoading={isUpdatingMemberRoles}
 											canEditUsers={canEditMembers}
 											onEditRoles={async (roles) => {
-												try {
-													await updateMemberRoles(member, roles);
-													displaySuccess("Roles updated successfully.");
-												} catch (error) {
-													displayError(
-														getErrorMessage(error, "Failed to update roles."),
-													);
-												}
+												await updateMemberRoles(member, roles);
+												displaySuccess("Roles updated successfully.");
 											}}
 										/>
 										<UserGroupsCell userGroups={member.groups} />


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

Closes https://github.com/coder/internal/issues/1030

the flake stems from the fact that we're showing both a toast with the error, and it's being displayed persistently with `ErrorAlert`. sometimes the assert would happen before the toast rendered, allowing the test to pass.

as recently discussed, showing toasts for errors is not a best practice, especially when showing the error persistently with `ErrorAlert` is a good possibility. we're already doing that, so the toast is redundant.