### PR TITLE
docs: add AWS Q Developer to list of agents

### DIFF
--- a/docs/ai-coder/ide-agents.md
+++ b/docs/ai-coder/ide-agents.md
@@ -21,6 +21,20 @@ Running coding agents in Coder workspaces provides several advantages over runni
 
 Follow the Coder Documentation for [Connecting to Workspaces](../user-guides/workspace-access/index.md) to connect to your Coder Workspaces with your favorite IDEs.
 
+## Types of Coding Agents
+
+Coder supports a wide range of coding agents that can be integrated into your development workflow:
+
+### IDE-Integrated Agents
+
+- **Cursor** - AI-first code editor with built-in pair programming
+- **GitHub Copilot** - AI pair programmer that suggests code completions
+- **Windsurf** - AI-powered development environment
+- **RooCode** - Intelligent code assistant
+- **Sourcegraph Cody** - AI coding assistant with codebase context
+- **Zed** - High-performance collaborative code editor
+- **AWS Q Developer** - AI-powered assistant for AWS and general software development. Learn more about our [AWS Q Developer module](https://registry.coder.com/modules?tag=amazon-q) for easy integration.
+
 ## Pre-Configuring Extensions &amp; Plugins
 
 Read our [VS Code module documentation](https://registry.coder.com/modules/coder/vscode-web) for examples on how to pre-install plugins like GitHub Copilot, RooCode, Sourcegraph Cody, and more in Coder workspaces.


### PR DESCRIPTION
## Summary
- Added AWS Q Developer to the list of coding agents in the documentation
- Included link to the AWS Q Developer module on the Coder registry
- Created a new "Types of Coding Agents" section to organize the agent list

## Related Issue
Closes #18113

## Test Plan
Documentation change only - reviewed for accuracy and formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>