### PR TITLE
chore: standardize indent size for golang files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,10 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
+[*.go]
+indent_style = tab
+indent_size = 4
+
 [*.proto]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Go has an opinion on use of tabs over spaces, but has no opinion on the size of the tab.
