### PR TITLE
chore: fix api param name

### DIFF
--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -66,20 +66,18 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 				return xerrors.Errorf("current organization: %w", err)
 			}
 
-			var initiatorID *uuid.UUID
-
 			if initiator != "" {
 				user, err := client.User(ctx, initiator)
 				if err != nil {
 					return xerrors.Errorf("initiator not found: %s", initiator)
 				}
-				initiatorID = &user.ID
+				initiator = user.ID.String()
 			}
 
 			jobs, err := client.OrganizationProvisionerJobs(ctx, org.ID, &codersdk.OrganizationProvisionerJobsOptions{
-				Status:      slice.StringEnums[codersdk.ProvisionerJobStatus](status),
-				Limit:       int(limit),
-				InitiatorID: initiatorID,
+				Status:    slice.StringEnums[codersdk.ProvisionerJobStatus](status),
+				Limit:     int(limit),
+				Initiator: initiator,
 			})
 			if err != nil {
 				return xerrors.Errorf("list provisioner jobs: %w", err)

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -111,7 +111,7 @@ func (api *API) handleAuthAndFetchProvisionerJobs(rw http.ResponseWriter, r *htt
 		ids = p.UUIDs(qp, nil, "ids")
 	}
 	tags := p.JSONStringMap(qp, database.StringMap{}, "tags")
-	initiatorID := p.UUID(qp, uuid.Nil, "initiator_id")
+	initiatorID := p.UUID(qp, uuid.Nil, "initiator")
 	p.ErrorExcessParams(qp)
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -173,7 +173,7 @@ func TestProvisionerJobs(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitMedium)
 
 			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: &member.ID,
+				Initiator: member.ID.String(),
 			})
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(jobs), 1)
@@ -186,8 +186,8 @@ func TestProvisionerJobs(t *testing.T) {
 
 			// Test filtering by initiator ID combined with status filter
 			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: &owner.UserID,
-				Status:      []codersdk.ProvisionerJobStatus{codersdk.ProvisionerJobSucceeded},
+				Initiator: owner.UserID.String(),
+				Status:    []codersdk.ProvisionerJobStatus{codersdk.ProvisionerJobSucceeded},
 			})
 			require.NoError(t, err)
 
@@ -204,8 +204,8 @@ func TestProvisionerJobs(t *testing.T) {
 
 			// Test filtering by initiator ID with limit
 			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: &owner.UserID,
-				Limit:       1,
+				Initiator: owner.UserID.String(),
+				Limit:     1,
 			})
 			require.NoError(t, err)
 			require.Len(t, jobs, 1)
@@ -220,8 +220,8 @@ func TestProvisionerJobs(t *testing.T) {
 
 			// Test filtering by initiator ID combined with tags
 			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: &member.ID,
-				Tags:        map[string]string{"initiatorTest": "true"},
+				Initiator: member.ID.String(),
+				Tags:      map[string]string{"initiatorTest": "true"},
 			})
 			require.NoError(t, err)
 			require.Len(t, jobs, 1)
@@ -238,7 +238,7 @@ func TestProvisionerJobs(t *testing.T) {
 			// Test with non-existent initiator ID
 			nonExistentID := uuid.New()
 			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: &nonExistentID,
+				Initiator: nonExistentID.String(),
 			})
 			require.NoError(t, err)
 			require.Len(t, jobs, 0)
@@ -250,7 +250,7 @@ func TestProvisionerJobs(t *testing.T) {
 
 			// Test with nil initiator ID (should return all jobs)
 			jobs, err := templateAdminClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: nil,
+				Initiator: "",
 			})
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(jobs), 50) // Should return all jobs (up to default limit)
@@ -282,7 +282,7 @@ func TestProvisionerJobs(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitMedium)
 			// Member should not be able to access jobs even with initiator filter
 			jobs, err := memberClient.OrganizationProvisionerJobs(ctx, owner.OrganizationID, &codersdk.OrganizationProvisionerJobsOptions{
-				InitiatorID: &member.ID,
+				Initiator: member.ID.String(),
 			})
 			require.Error(t, err)
 			require.Len(t, jobs, 0)

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -397,11 +397,11 @@ func (c *Client) OrganizationProvisionerDaemons(ctx context.Context, organizatio
 }
 
 type OrganizationProvisionerJobsOptions struct {
-	Limit       int
-	IDs         []uuid.UUID
-	Status      []ProvisionerJobStatus
-	Tags        map[string]string
-	InitiatorID *uuid.UUID
+	Limit     int
+	IDs       []uuid.UUID
+	Status    []ProvisionerJobStatus
+	Tags      map[string]string
+	Initiator string
 }
 
 func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID uuid.UUID, opts *OrganizationProvisionerJobsOptions) ([]ProvisionerJob, error) {
@@ -423,8 +423,8 @@ func (c *Client) OrganizationProvisionerJobs(ctx context.Context, organizationID
 			}
 			qp.Add("tags", string(tagsRaw))
 		}
-		if opts.InitiatorID != nil {
-			qp.Add("initiator_id", opts.InitiatorID.String())
+		if opts.Initiator != "" {
+			qp.Add("initiator", opts.Initiator)
 		}
 	}
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2060,7 +2060,7 @@ export interface OrganizationProvisionerJobsOptions {
 	readonly IDs: readonly string[];
 	readonly Status: readonly ProvisionerJobStatus[];
 	readonly Tags: Record<string, string>;
-	readonly InitiatorID: string | null;
+	readonly Initiator: string;
 }
 
 // From codersdk/idpsync.go


### PR DESCRIPTION
In https://github.com/coder/coder/pull/20137, we added a new flag to `coder provisioner jobs list`, namely `--initiator`.

To make some follow-up worth it, I need to rename an API param used in the process before it becomes part of our released and tagged API.

Instead of only accepting UUIDs, we accept an arbitrary string.
We still validate it as a UUID now, but we will expand its validation to allow any string and then resolve that string the same way that we resolve the user parameter elsewhere in the API. 