### PR TITLE
fix: adjust workspace claims to be initiated by users

### DIFF
--- a/coderd/prebuilds/api.go
+++ b/coderd/prebuilds/api.go
@@ -66,5 +66,4 @@ type Claimer interface {
 		nextStartAt sql.NullTime,
 		ttl sql.NullInt64,
 	) (*uuid.UUID, error)
-	Initiator() uuid.UUID
 }

--- a/coderd/prebuilds/noop.go
+++ b/coderd/prebuilds/noop.go
@@ -35,8 +35,4 @@ func (NoopClaimer) Claim(context.Context, time.Time, uuid.UUID, string, uuid.UUI
 	return nil, ErrAGPLDoesNotSupportPrebuiltWorkspaces
 }
 
-func (NoopClaimer) Initiator() uuid.UUID {
-	return uuid.Nil
-}
-
 var DefaultClaimer Claimer = NoopClaimer{}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -719,7 +719,6 @@ func createWorkspace(
 		} else {
 			// Prebuild found!
 			workspaceID = claimedWorkspace.ID
-			initiatorID = prebuildsClaimer.Initiator()
 		}
 
 		// We have to refetch the workspace for the joined in fields.

--- a/enterprise/coderd/prebuilds/claim.go
+++ b/enterprise/coderd/prebuilds/claim.go
@@ -55,8 +55,4 @@ func (c EnterpriseClaimer) Claim(
 	return &result.ID, nil
 }
 
-func (EnterpriseClaimer) Initiator() uuid.UUID {
-	return database.PrebuildsSystemUserID
-}
-
 var _ prebuilds.Claimer = &EnterpriseClaimer{}


### PR DESCRIPTION
The prebuilds user never initiates a workspace claim autonomously. A claim can only happen when a user attempts to create a workspace. When listing prebuild provisioner jobs, it would not make sense to see jobs related to users who are creating workspaces and have gotten a prebuilt workspace. When cleaning up an overwhelmed provisioner queue, we should not delete claims as they have humans waiting for them and are not part of the thundering herd. 

Therefore, this PR ensures that provisioner jobs that claim workspaces are considered to be initiated by the user, not the prebuilds system.