### PR TITLE
chore: fix biome error when running make lint

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -6,10 +6,7 @@
 		"defaultBranch": "main"
 	},
 	"files": {
-		"includes": [
-			"**",
-			"!**/pnpm-lock.yaml"
-		],
+		"includes": ["**", "!**/pnpm-lock.yaml"],
 		"ignoreUnknown": true
 	},
 	"linter": {
@@ -69,11 +66,7 @@
 				"noConsole": {
 					"level": "error",
 					"options": {
-						"allow": [
-							"error",
-							"info",
-							"warn"
-						]
+						"allow": ["error", "info", "warn"]
 					}
 				}
 			},
@@ -82,5 +75,5 @@
 			}
 		}
 	},
-	"$schema": "https://biomejs.dev/schemas/2.2.0/schema.json"
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
 }

--- a/site/biome.jsonc
+++ b/site/biome.jsonc
@@ -3,5 +3,5 @@
 	"files": {
 		"includes": ["!e2e/**/*Generated.ts"]
 	},
-	"$schema": "./node_modules/@biomejs/biome/biome.schema.json"
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
 }

--- a/site/biome.jsonc
+++ b/site/biome.jsonc
@@ -3,5 +3,5 @@
 	"files": {
 		"includes": ["!e2e/**/*Generated.ts"]
 	},
-	"$schema": "https://biomejs.dev/schemas/2.2.0/schema.json"
+	"$schema": "https://biomejs.dev/schemas/2.2.4/schema.json"
 }

--- a/site/biome.jsonc
+++ b/site/biome.jsonc
@@ -3,5 +3,5 @@
 	"files": {
 		"includes": ["!e2e/**/*Generated.ts"]
 	},
-	"$schema": "https://biomejs.dev/schemas/2.2.4/schema.json"
+	"$schema": "./node_modules/@biomejs/biome/biome.schema.json"
 }


### PR DESCRIPTION
Fixes a Biome lint error when running `make lint`.

```
> biome check --error-on-warnings --fix .

biome.jsonc:6:13 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ The configuration schema version does not match the CLI version 2.2.4
  
    4 │                 "includes": ["!e2e/**/*Generated.ts"]
    5 │         },
  > 6 │         "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json"
      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    7 │ }
    8 │ 
  
  ℹ   Expected:                     2.2.4
      Found:                        2.2.0
  
  
  ℹ Run the command biome migrate to migrate the configuration file.
  

Checked 1165 files in 796ms. No fixes applied.
```