### PR TITLE
fix(site): update `useClipboard` to work better with effect logic

### DIFF
--- a/site/src/components/CopyButton/CopyButton.tsx
+++ b/site/src/components/CopyButton/CopyButton.tsx
@@ -19,9 +19,7 @@ export const CopyButton: FC<CopyButtonProps> = ({
 	label,
 	...buttonProps
 }) => {
-	const { showCopiedSuccess, copyToClipboard } = useClipboard({
-		textToCopy: text,
-	});
+	const { showCopiedSuccess, copyToClipboard } = useClipboard();
 
 	return (
 		<TooltipProvider>
@@ -30,7 +28,7 @@ export const CopyButton: FC<CopyButtonProps> = ({
 					<Button
 						size="icon"
 						variant="subtle"
-						onClick={copyToClipboard}
+						onClick={() => copyToClipboard(text)}
 						{...buttonProps}
 					>
 						{showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}

--- a/site/src/components/CopyableValue/CopyableValue.tsx
+++ b/site/src/components/CopyableValue/CopyableValue.tsx
@@ -16,10 +16,10 @@ export const CopyableValue: FC<CopyableValueProps> = ({
 	children,
 	...attrs
 }) => {
-	const { showCopiedSuccess, copyToClipboard } = useClipboard({
-		textToCopy: value,
+	const { showCopiedSuccess, copyToClipboard } = useClipboard();
+	const clickableProps = useClickable<HTMLSpanElement>(() => {
+		copyToClipboard(value);
 	});
-	const clickableProps = useClickable<HTMLSpanElement>(copyToClipboard);
 
 	return (
 		<Tooltip

--- a/site/src/hooks/useClickable.ts
+++ b/site/src/hooks/useClickable.ts
@@ -4,6 +4,7 @@ import {
 	type RefObject,
 	useRef,
 } from "react";
+import { useEffectEvent } from "./hookPolyfills";
 
 // Literally any object (ideally an HTMLElement) that has a .click method
 type ClickableElement = {
@@ -43,10 +44,11 @@ export const useClickable = <
 	role?: TRole,
 ): UseClickableResult<TElement, TRole> => {
 	const ref = useRef<TElement>(null);
+	const stableOnClick = useEffectEvent(onClick);
 
 	return {
 		ref,
-		onClick,
+		onClick: stableOnClick,
 		tabIndex: 0,
 		role: (role ?? "button") as TRole,
 

--- a/site/src/hooks/useClipboard.test.tsx
+++ b/site/src/hooks/useClipboard.test.tsx
@@ -287,6 +287,22 @@ describe.each(secureContextValues)("useClipboard - secure: %j", (isSecure) => {
 		setSimulateFailure(true);
 		await act(() => result.current.copyToClipboard("dummy-text-2"));
 		expect(result.current.copyToClipboard).toBe(initialCopy);
+
+		/**
+		 * Trigger a successful clipboard interaction
+		 *
+		 * @todo For some reason, using the assertClipboardUpdateLifecycle
+		 * helper triggers Jest errors with it thinking that values are being
+		 * accessed after teardown, even though the problem doesn't exist for
+		 * any other test case.
+		 *
+		 * It's not a huge deal, because we only need to inspect React after the
+		 * interaction, instead of the full DOM, but for correctness, it would
+		 * be nice if we could get this issue figured out.
+		 */
+		setSimulateFailure(false);
+		await act(() => result.current.copyToClipboard("dummy-text-2"));
+		expect(result.current.copyToClipboard).toBe(initialCopy);
 	});
 
 	it("Always uses the most up-to-date onError prop", async () => {

--- a/site/src/hooks/useClipboard.test.tsx
+++ b/site/src/hooks/useClipboard.test.tsx
@@ -275,7 +275,7 @@ describe.each(secureContextValues)("useClipboard - secure: %j", (isSecure) => {
 		expect(result.current.error).toBeUndefined();
 	});
 
-	// This check is really important to ensure that it's easy to plop this
+	// This test case is really important to ensure that it's easy to plop this
 	// inside of useEffect calls without having to think about dependencies too
 	// much
 	it("Ensures that the copyToClipboard function always maintains a stable reference across all re-renders", async () => {

--- a/site/src/hooks/useClipboard.ts
+++ b/site/src/hooks/useClipboard.ts
@@ -1,8 +1,3 @@
-/**
- * Modified version of the useClipboard hook from Coder core.
- * @see {@link https://github.com/coder/coder/blob/main/site/src/hooks/useClipboard.ts}
- */
-
 import { displayError } from "components/GlobalSnackbar/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useEffectEvent } from "./hookPolyfills";

--- a/site/src/hooks/useClipboard.ts
+++ b/site/src/hooks/useClipboard.ts
@@ -2,6 +2,8 @@
  * Modified version of the useClipboard hook from Coder core.
  * @see {@link https://github.com/coder/coder/blob/main/site/src/hooks/useClipboard.ts}
  */
+
+import { displayError } from "components/GlobalSnackbar/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useEffectEvent } from "./hookPolyfills";
 
@@ -40,7 +42,7 @@ export type UseClipboardResult = Readonly<{
 }>;
 
 export const useClipboard = (input?: UseClipboardInput): UseClipboardResult => {
-	const { onError: errorCallback, clearErrorOnSuccess = true } = input ?? {};
+	const { onError = displayError, clearErrorOnSuccess = true } = input ?? {};
 
 	const [showCopiedSuccess, setShowCopiedSuccess] = useState(false);
 	const [error, setError] = useState<Error>();
@@ -53,9 +55,7 @@ export const useClipboard = (input?: UseClipboardInput): UseClipboardResult => {
 		return clearTimeoutOnUnmount;
 	}, []);
 
-	const stableOnError = useEffectEvent(() => {
-		errorCallback?.(COPY_FAILED_MESSAGE);
-	});
+	const stableOnError = useEffectEvent(() => onError(COPY_FAILED_MESSAGE));
 	const handleSuccessfulCopy = useEffectEvent(() => {
 		setShowCopiedSuccess(true);
 		if (clearErrorOnSuccess) {

--- a/site/src/hooks/useClipboard.ts
+++ b/site/src/hooks/useClipboard.ts
@@ -1,22 +1,21 @@
-import { displayError } from "components/GlobalSnackbar/utils";
-import { useEffect, useRef, useState } from "react";
+/**
+ * Modified version of the useClipboard hook from Coder core.
+ * @see {@link https://github.com/coder/coder/blob/main/site/src/hooks/useClipboard.ts}
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffectEvent } from "./hookPolyfills";
 
 const CLIPBOARD_TIMEOUT_MS = 1_000;
 export const COPY_FAILED_MESSAGE = "Failed to copy text to clipboard";
 export const HTTP_FALLBACK_DATA_ID = "http-fallback";
 
 export type UseClipboardInput = Readonly<{
-	textToCopy: string;
-
-	/**
-	 * Optional callback to call when an error happens. If not specified, the hook
-	 * will dispatch an error message to the GlobalSnackbar
-	 */
 	onError?: (errorMessage: string) => void;
+	clearErrorOnSuccess?: boolean;
 }>;
 
 export type UseClipboardResult = Readonly<{
-	copyToClipboard: () => Promise<void>;
+	copyToClipboard: (textToCopy: string) => Promise<void>;
 	error: Error | undefined;
 
 	/**
@@ -40,47 +39,58 @@ export type UseClipboardResult = Readonly<{
 	showCopiedSuccess: boolean;
 }>;
 
-export const useClipboard = (input: UseClipboardInput): UseClipboardResult => {
-	const { textToCopy, onError: errorCallback } = input;
+export const useClipboard = (input?: UseClipboardInput): UseClipboardResult => {
+	const { onError: errorCallback, clearErrorOnSuccess = true } = input ?? {};
+
 	const [showCopiedSuccess, setShowCopiedSuccess] = useState(false);
 	const [error, setError] = useState<Error>();
 	const timeoutIdRef = useRef<number | undefined>(undefined);
 
 	useEffect(() => {
-		const clearIdOnUnmount = () => window.clearTimeout(timeoutIdRef.current);
-		return clearIdOnUnmount;
+		const clearTimeoutOnUnmount = () => {
+			window.clearTimeout(timeoutIdRef.current);
+		};
+		return clearTimeoutOnUnmount;
 	}, []);
 
-	const handleSuccessfulCopy = () => {
+	const stableOnError = useEffectEvent(() => {
+		errorCallback?.(COPY_FAILED_MESSAGE);
+	});
+	const handleSuccessfulCopy = useEffectEvent(() => {
 		setShowCopiedSuccess(true);
+		if (clearErrorOnSuccess) {
+			setError(undefined);
+		}
+
 		timeoutIdRef.current = window.setTimeout(() => {
 			setShowCopiedSuccess(false);
 		}, CLIPBOARD_TIMEOUT_MS);
-	};
+	});
 
-	const copyToClipboard = async () => {
-		try {
-			await window.navigator.clipboard.writeText(textToCopy);
-			handleSuccessfulCopy();
-		} catch (err) {
-			const fallbackCopySuccessful = simulateClipboardWrite(textToCopy);
-			if (fallbackCopySuccessful) {
+	const copyToClipboard = useCallback(
+		async (textToCopy: string) => {
+			try {
+				await window.navigator.clipboard.writeText(textToCopy);
 				handleSuccessfulCopy();
-				return;
+			} catch (err) {
+				const fallbackCopySuccessful = simulateClipboardWrite(textToCopy);
+				if (fallbackCopySuccessful) {
+					handleSuccessfulCopy();
+					return;
+				}
+
+				const wrappedErr = new Error(COPY_FAILED_MESSAGE);
+				if (err instanceof Error) {
+					wrappedErr.stack = err.stack;
+				}
+
+				console.error(wrappedErr);
+				setError(wrappedErr);
+				stableOnError();
 			}
-
-			const wrappedErr = new Error(COPY_FAILED_MESSAGE);
-			if (err instanceof Error) {
-				wrappedErr.stack = err.stack;
-			}
-
-			console.error(wrappedErr);
-			setError(wrappedErr);
-
-			const notifyUser = errorCallback ?? displayError;
-			notifyUser(COPY_FAILED_MESSAGE);
-		}
-	};
+		},
+		[stableOnError, handleSuccessfulCopy],
+	);
 
 	return { showCopiedSuccess, error, copyToClipboard };
 };

--- a/site/src/pages/CliAuthPage/CliAuthPageView.tsx
+++ b/site/src/pages/CliAuthPage/CliAuthPageView.tsx
@@ -12,10 +12,7 @@ interface CliAuthPageViewProps {
 }
 
 export const CliAuthPageView: FC<CliAuthPageViewProps> = ({ sessionToken }) => {
-	const clipboard = useClipboard({
-		textToCopy: sessionToken ?? "",
-	});
-
+	const clipboardState = useClipboard();
 	return (
 		<SignInLayout>
 			<Welcome>Session token</Welcome>
@@ -30,16 +27,20 @@ export const CliAuthPageView: FC<CliAuthPageViewProps> = ({ sessionToken }) => {
 					className="w-full"
 					size="lg"
 					disabled={!sessionToken}
-					onClick={clipboard.copyToClipboard}
+					onClick={() => {
+						if (sessionToken) {
+							clipboardState.copyToClipboard(sessionToken);
+						}
+					}}
 				>
-					{clipboard.showCopiedSuccess ? (
+					{clipboardState.showCopiedSuccess ? (
 						<CheckIcon />
 					) : (
 						<Spinner loading={!sessionToken}>
 							<CopyIcon />
 						</Spinner>
 					)}
-					{clipboard.showCopiedSuccess
+					{clipboardState.showCopiedSuccess
 						? "Session token copied!"
 						: "Copy session token"}
 				</Button>

--- a/site/src/pages/TaskPage/TaskTopbar.tsx
+++ b/site/src/pages/TaskPage/TaskTopbar.tsx
@@ -81,14 +81,11 @@ export const TaskTopbar: FC<TaskTopbarProps> = ({ task }) => {
 type CopyPromptButtonProps = { prompt: string };
 
 const CopyPromptButton: FC<CopyPromptButtonProps> = ({ prompt }) => {
-	const { copyToClipboard, showCopiedSuccess } = useClipboard({
-		textToCopy: prompt,
-	});
-
+	const { copyToClipboard, showCopiedSuccess } = useClipboard();
 	return (
 		<Button
 			disabled={showCopiedSuccess}
-			onClick={copyToClipboard}
+			onClick={() => copyToClipboard(prompt)}
 			size="sm"
 			variant="subtle"
 			className="p-0 min-w-0"

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage.tsx
@@ -74,13 +74,7 @@ export const TemplateEmbedPageView: FC<TemplateEmbedPageViewProps> = ({
 	templateParameters,
 }) => {
 	const [buttonValues, setButtonValues] = useState<ButtonValues | undefined>();
-	const clipboard = useClipboard({
-		textToCopy: getClipboardCopyContent(
-			template.name,
-			template.organization_name,
-			buttonValues,
-		),
-	});
+	const clipboard = useClipboard();
 
 	// template parameters is async so we need to initialize the values after it
 	// is loaded
@@ -237,8 +231,15 @@ export const TemplateEmbedPageView: FC<TemplateEmbedPageViewProps> = ({
 						>
 							<Button
 								className="rounded-full"
-								onClick={clipboard.copyToClipboard}
 								disabled={clipboard.showCopiedSuccess}
+								onClick={() => {
+									const textToCopy = getClipboardCopyContent(
+										template.name,
+										template.organization_name,
+										buttonValues,
+									);
+									clipboard.copyToClipboard(textToCopy);
+								}}
 							>
 								{clipboard.showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}
 								Copy button code

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -289,14 +289,7 @@ interface ButtonPreviewProps {
 }
 
 const ButtonPreview: FC<ButtonPreviewProps> = ({ template, buttonValues }) => {
-	const clipboard = useClipboard({
-		textToCopy: getClipboardCopyContent(
-			template.name,
-			template.organization_name,
-			buttonValues,
-		),
-	});
-
+	const clipboard = useClipboard();
 	return (
 		<div
 			className="sticky top-10 flex gap-16 h-96 flex-1 flex-col items-center justify-center
@@ -305,8 +298,15 @@ const ButtonPreview: FC<ButtonPreviewProps> = ({ template, buttonValues }) => {
 			<img src="/open-in-coder.svg" alt="Open in Coder button" />
 			<Button
 				variant="default"
-				onClick={clipboard.copyToClipboard}
 				disabled={clipboard.showCopiedSuccess}
+				onClick={() => {
+					const textToCopy = getClipboardCopyContent(
+						template.name,
+						template.organization_name,
+						buttonValues,
+					);
+					clipboard.copyToClipboard(textToCopy);
+				}}
 			>
 				{clipboard.showCopiedSuccess ? <CheckOutlined /> : <FileCopyOutlined />}{" "}
 				Copy button code


### PR DESCRIPTION
No issue to track – spurred by https://github.com/coder/coder/pull/20129

Basically, the `useClipboard` hook worked just fine up until now because we could always derive the clipboard text from within a render. There was never a case before where we would need to derive the text from outside React, and then sync it with both React and the browser. This PR updates the API to make that use case much more ergonomic and avoid risks of infinite renders

## Changes made
- Updated `useClipboard` API to require passing the text in via the `copyToClipboard` function, rather than requiring that the text gets specified in render logic
- Ensured that the `copyToClipboard` function always stays stable across all React lifecycles
- Updated all existing uses to use the new function signatures
- Updated all tests and added new cases