### PR TITLE
chore: revert "feat: include latest build id in task responses"

### DIFF
--- a/cli/exp_task_status_test.go
+++ b/cli/exp_task_status_test.go
@@ -193,7 +193,6 @@ STATE CHANGED  STATUS   HEALTHY  STATE  MESSAGE
   "workspace_agent_id": null,
   "workspace_agent_lifecycle": null,
   "workspace_agent_health": null,
-  "latest_build_id": null,
   "initial_prompt": "",
   "status": "running",
   "current_state": {

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -272,7 +272,6 @@ func taskFromWorkspace(ws codersdk.Workspace, initialPrompt string) codersdk.Tas
 		WorkspaceAgentID:        taskAgentID,
 		WorkspaceAgentLifecycle: taskAgentLifecycle,
 		WorkspaceAgentHealth:    taskAgentHealth,
-		LatestBuildID:           uuid.NullUUID{Valid: true, UUID: ws.LatestBuild.ID},
 		CreatedAt:               ws.CreatedAt,
 		UpdatedAt:               ws.UpdatedAt,
 		InitialPrompt:           initialPrompt,

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -270,7 +270,6 @@ func TestTasks(t *testing.T) {
 		assert.Equal(t, wantPrompt, got.InitialPrompt, "task prompt should match the AI Prompt parameter")
 		assert.Equal(t, workspace.Name, got.Name, "task name should map from workspace name")
 		assert.Equal(t, workspace.ID, got.WorkspaceID.UUID, "workspace id should match")
-		assert.Equal(t, workspace.LatestBuild.ID, got.LatestBuildID.UUID, "latest build id should match")
 		// Status should be populated via app status or workspace status mapping.
 		assert.NotEmpty(t, got.Status, "task status should not be empty")
 	})
@@ -321,7 +320,6 @@ func TestTasks(t *testing.T) {
 		assert.Equal(t, workspace.Name, task.Name, "task name should map from workspace name")
 		assert.Equal(t, wantPrompt, task.InitialPrompt, "task prompt should match the AI Prompt parameter")
 		assert.Equal(t, workspace.ID, task.WorkspaceID.UUID, "workspace id should match")
-		assert.Equal(t, workspace.LatestBuild.ID, task.LatestBuildID.UUID, "latest build id should match")
 		assert.NotEmpty(t, task.Status, "task status should not be empty")
 
 		// Stop the workspace

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -119,7 +119,6 @@ type Task struct {
 	WorkspaceAgentID        uuid.NullUUID            `json:"workspace_agent_id" format:"uuid" table:"workspace agent id"`
 	WorkspaceAgentLifecycle *WorkspaceAgentLifecycle `json:"workspace_agent_lifecycle" table:"workspace agent lifecycle"`
 	WorkspaceAgentHealth    *WorkspaceAgentHealth    `json:"workspace_agent_health" table:"workspace agent health"`
-	LatestBuildID           uuid.NullUUID            `json:"latest_build_id" format:"uuid" table:"latest build id"`
 	InitialPrompt           string                   `json:"initial_prompt" table:"initial prompt"`
 	Status                  WorkspaceStatus          `json:"status" enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted" table:"status"`
 	CurrentState            *TaskStateEntry          `json:"current_state" table:"cs,recursive_inline"`

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3330,7 +3330,6 @@ export interface Task {
 	readonly workspace_agent_id: string | null;
 	readonly workspace_agent_lifecycle: WorkspaceAgentLifecycle | null;
 	readonly workspace_agent_health: WorkspaceAgentHealth | null;
-	readonly latest_build_id: string | null;
 	readonly initial_prompt: string;
 	readonly status: WorkspaceStatus;
 	readonly current_state: TaskStateEntry | null;

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -5031,7 +5031,6 @@ export const MockTask: TypesGen.Task = {
 	workspace_agent_id: MockWorkspaceAgent.id,
 	workspace_agent_lifecycle: MockWorkspaceAgent.lifecycle_state,
 	workspace_agent_health: MockWorkspaceAgent.health,
-	latest_build_id: MockWorkspace.latest_build.id,
 	initial_prompt: "Perform some task",
 	status: "running",
 	current_state: {


### PR DESCRIPTION
Reverts coder/coder#20181

I realized we don’t need this in the task response. When loading a task, we already need much more workspace information, so it makes more sense to fetch the workspace data separately instead of trying to embed all its details into the response.

I think we can keep the task response clean and focused on the essential information needed to list tasks. For more specific details, we can fetch the related resources as needed. So, I’m reverting this PR.