### PR TITLE
test: increase timeout in TestRun (scaletest/workspaceupdates)

### DIFF
--- a/scaletest/workspaceupdates/run_test.go
+++ b/scaletest/workspaceupdates/run_test.go
@@ -24,7 +24,7 @@ import (
 func TestRun(t *testing.T) {
 	t.Parallel()
 
-	ctx := testutil.Context(t, testutil.WaitMedium)
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 	client := coderdtest.New(t, &coderdtest.Options{
 		IncludeProvisionerDaemon: true,


### PR DESCRIPTION
fixes https://github.com/coder/internal/issues/1050

Extends the timeout on the affected test. It uses a postgres database, and so 15s timeout isn't enough to not flake with our test infra these days.