### PR TITLE
docs: list tasks CLI docs in manifest.json

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -917,7 +917,7 @@
 				},
 				{
 					"title": "Tasks CLI",
-					"description": "Coder CLI for managing tasks programatically",
+					"description": "Coder CLI for managing tasks programmatically",
 					"path": "./ai-coder/cli.md",
 					"icon_path": "./images/icons/api.svg",
 					"state": ["beta"]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -914,6 +914,13 @@
 					"path": "./ai-coder/ai-bridge.md",
 					"icon_path": "./images/icons/api.svg",
 					"state": ["premium", "early access"]
+				},
+				{
+					"title": "Tasks CLI",
+					"description": "Coder CLI for managing tasks programatically",
+					"path": "./ai-coder/cli.md",
+					"icon_path": "./images/icons/api.svg",
+					"state": ["beta"]
 				}
 			]
 		},


### PR DESCRIPTION
## Description

We added docs for the Tasks CLI in https://github.com/coder/coder/pull/20019/files. I forgot to mention the manifest.json entry though, so this PR is adding that entry. 

See a preview here: https://coder.com/docs/@df%2fshow-cli-docs/ai-coder/cli