### PR TITLE
feat(cli): add mock SMTP server for testing scaletest notifications

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -42,7 +42,6 @@ import (
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
 	"github.com/coder/coder/v2/scaletest/notifications"
 	"github.com/coder/coder/v2/scaletest/reconnectingpty"
-	"github.com/coder/coder/v2/scaletest/smtpmock"
 	"github.com/coder/coder/v2/scaletest/workspacebuild"
 	"github.com/coder/coder/v2/scaletest/workspacetraffic"
 	"github.com/coder/coder/v2/scaletest/workspaceupdates"
@@ -2173,101 +2172,6 @@ func (r *RootCmd) scaletestNotifications() *serpent.Command {
 	cleanupStrategy.attach(&cmd.Options)
 	output.attach(&cmd.Options)
 	prometheusFlags.attach(&cmd.Options)
-	return cmd
-}
-
-func (*RootCmd) scaletestSMTP() *serpent.Command {
-	var (
-		hostAddress  string
-		smtpPort     int64
-		apiPort      int64
-		purgeAtCount int64
-	)
-	cmd := &serpent.Command{
-		Use:   "smtp",
-		Short: "Start a mock SMTP server for testing",
-		Long: `Start a mock SMTP server with an HTTP API server that can be used to purge
-messages and get messages by email.`,
-		Handler: func(inv *serpent.Invocation) error {
-			ctx := inv.Context()
-			notifyCtx, stop := signal.NotifyContext(ctx, StopSignals...)
-			defer stop()
-			ctx = notifyCtx
-
-			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelInfo)
-			srv := smtpmock.New(smtpmock.Config{
-				HostAddress: hostAddress,
-				SMTPPort:    int(smtpPort),
-				APIPort:     int(apiPort),
-				Logger:      logger,
-			})
-
-			if err := srv.Start(ctx); err != nil {
-				return xerrors.Errorf("start mock SMTP server: %w", err)
-			}
-			defer func() {
-				_ = srv.Stop()
-			}()
-
-			_, _ = fmt.Fprintf(inv.Stdout, "Mock SMTP server started on %s\n", srv.SMTPAddress())
-			_, _ = fmt.Fprintf(inv.Stdout, "HTTP API server started on %s\n", srv.APIAddress())
-			if purgeAtCount > 0 {
-				_, _ = fmt.Fprintf(inv.Stdout, "  Auto-purge when message count reaches %d\n", purgeAtCount)
-			}
-
-			ticker := time.NewTicker(10 * time.Second)
-			defer ticker.Stop()
-
-			for {
-				select {
-				case <-ctx.Done():
-					_, _ = fmt.Fprintf(inv.Stdout, "\nTotal messages received since last purge: %d\n", srv.MessageCount())
-					return nil
-				case <-ticker.C:
-					count := srv.MessageCount()
-					if count > 0 {
-						_, _ = fmt.Fprintf(inv.Stdout, "Messages received: %d\n", count)
-					}
-
-					if purgeAtCount > 0 && int64(count) >= purgeAtCount {
-						_, _ = fmt.Fprintf(inv.Stdout, "Message count (%d) reached threshold (%d). Purging...\n", count, purgeAtCount)
-						srv.Purge()
-						continue
-					}
-				}
-			}
-		},
-	}
-
-	cmd.Options = []serpent.Option{
-		{
-			Flag:        "host-address",
-			Env:         "CODER_SCALETEST_SMTP_HOST",
-			Default:     "localhost",
-			Description: "Host to bind the mock SMTP and API servers.",
-			Value:       serpent.StringOf(&hostAddress),
-		},
-		{
-			Flag:        "smtp-port",
-			Env:         "CODER_SCALETEST_SMTP_PORT",
-			Description: "Port for the mock SMTP server. Uses a random port if not specified.",
-			Value:       serpent.Int64Of(&smtpPort),
-		},
-		{
-			Flag:        "api-port",
-			Env:         "CODER_SCALETEST_SMTP_API_PORT",
-			Description: "Port for the HTTP API server. Uses a random port if not specified.",
-			Value:       serpent.Int64Of(&apiPort),
-		},
-		{
-			Flag:        "purge-at-count",
-			Env:         "CODER_SCALETEST_SMTP_PURGE_AT_COUNT",
-			Default:     "100000",
-			Description: "Maximum number of messages to keep before auto-purging. Set to 0 to disable.",
-			Value:       serpent.Int64Of(&purgeAtCount),
-		},
-	}
-
 	return cmd
 }
 

--- a/cli/exp_scaletest_smtp.go
+++ b/cli/exp_scaletest_smtp.go
@@ -1,0 +1,111 @@
+//go:build !slim
+
+package cli
+
+import (
+	"fmt"
+	"os/signal"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+	"github.com/coder/coder/v2/scaletest/smtpmock"
+	"github.com/coder/serpent"
+)
+
+func (*RootCmd) scaletestSMTP() *serpent.Command {
+	var (
+		hostAddress  string
+		smtpPort     int64
+		apiPort      int64
+		purgeAtCount int64
+	)
+	cmd := &serpent.Command{
+		Use:   "smtp",
+		Short: "Start a mock SMTP server for testing",
+		Long: `Start a mock SMTP server with an HTTP API server that can be used to purge
+messages and get messages by email.`,
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			notifyCtx, stop := signal.NotifyContext(ctx, StopSignals...)
+			defer stop()
+			ctx = notifyCtx
+
+			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelInfo)
+			srv := smtpmock.New(smtpmock.Config{
+				HostAddress: hostAddress,
+				SMTPPort:    int(smtpPort),
+				APIPort:     int(apiPort),
+				Logger:      logger,
+			})
+
+			if err := srv.Start(ctx); err != nil {
+				return xerrors.Errorf("start mock SMTP server: %w", err)
+			}
+			defer func() {
+				_ = srv.Stop()
+			}()
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Mock SMTP server started on %s\n", srv.SMTPAddress())
+			_, _ = fmt.Fprintf(inv.Stdout, "HTTP API server started on %s\n", srv.APIAddress())
+			if purgeAtCount > 0 {
+				_, _ = fmt.Fprintf(inv.Stdout, "  Auto-purge when message count reaches %d\n", purgeAtCount)
+			}
+
+			ticker := time.NewTicker(10 * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					_, _ = fmt.Fprintf(inv.Stdout, "\nTotal messages received since last purge: %d\n", srv.MessageCount())
+					return nil
+				case <-ticker.C:
+					count := srv.MessageCount()
+					if count > 0 {
+						_, _ = fmt.Fprintf(inv.Stdout, "Messages received: %d\n", count)
+					}
+
+					if purgeAtCount > 0 && int64(count) >= purgeAtCount {
+						_, _ = fmt.Fprintf(inv.Stdout, "Message count (%d) reached threshold (%d). Purging...\n", count, purgeAtCount)
+						srv.Purge()
+						continue
+					}
+				}
+			}
+		},
+	}
+
+	cmd.Options = []serpent.Option{
+		{
+			Flag:        "host-address",
+			Env:         "CODER_SCALETEST_SMTP_HOST_ADDRESS",
+			Default:     "localhost",
+			Description: "Host address to bind the mock SMTP and API servers.",
+			Value:       serpent.StringOf(&hostAddress),
+		},
+		{
+			Flag:        "smtp-port",
+			Env:         "CODER_SCALETEST_SMTP_PORT",
+			Description: "Port for the mock SMTP server. Uses a random port if not specified.",
+			Value:       serpent.Int64Of(&smtpPort),
+		},
+		{
+			Flag:        "api-port",
+			Env:         "CODER_SCALETEST_SMTP_API_PORT",
+			Description: "Port for the HTTP API server. Uses a random port if not specified.",
+			Value:       serpent.Int64Of(&apiPort),
+		},
+		{
+			Flag:        "purge-at-count",
+			Env:         "CODER_SCALETEST_SMTP_PURGE_AT_COUNT",
+			Default:     "100000",
+			Description: "Maximum number of messages to keep before auto-purging. Set to 0 to disable.",
+			Value:       serpent.Int64Of(&purgeAtCount),
+		},
+	}
+
+	return cmd
+}

--- a/cli/exp_scaletest_smtp.go
+++ b/cli/exp_scaletest_smtp.go
@@ -34,14 +34,15 @@ messages and get messages by email.`,
 			ctx = notifyCtx
 
 			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelInfo)
-			srv := smtpmock.New(smtpmock.Config{
+			config := smtpmock.Config{
 				HostAddress: hostAddress,
 				SMTPPort:    int(smtpPort),
 				APIPort:     int(apiPort),
 				Logger:      logger,
-			})
+			}
+			srv := new(smtpmock.Server)
 
-			if err := srv.Start(ctx); err != nil {
+			if err := srv.Start(ctx, config); err != nil {
 				return xerrors.Errorf("start mock SMTP server: %w", err)
 			}
 			defer func() {

--- a/scaletest/smtpmock/server.go
+++ b/scaletest/smtpmock/server.go
@@ -235,9 +235,7 @@ func parseEmailSummary(message string) (EmailSummary, error) {
 
 	// Extract notification ID from decoded email content
 	// Notification ID is present in the email footer like this
-	// <p><a href=3D"http://127.0.0.1:3000/settings/notifications?disabled=3D
-	// =3D4e19c0ac-94e1-4532-9515-d1801aa283b2" style=3D"color: #2563eb; text-deco=
-	// ration: none;">Stop receiving emails like this</a></p>
+	// <p><a href="http://127.0.0.1:3000/settings/notifications?disabled=4e19c0ac-94e1-4532-9515-d1801aa283b2" style="color: #2563eb; text-decoration: none;">Stop receiving emails like this</a></p>
 	if matches := notificationTemplateIDRegex.FindStringSubmatch(contentStr); len(matches) > 1 {
 		summary.NotificationTemplateID, err = uuid.Parse(matches[1])
 		if err != nil {

--- a/scaletest/smtpmock/server.go
+++ b/scaletest/smtpmock/server.go
@@ -50,16 +50,12 @@ type EmailSummary struct {
 
 var notificationTemplateIDRegex = regexp.MustCompile(`notifications\?disabled=([a-f0-9-]+)`)
 
-func New(cfg Config) *Server {
-	return &Server{
-		hostAddress: cfg.HostAddress,
-		smtpPort:    cfg.SMTPPort,
-		apiPort:     cfg.APIPort,
-		logger:      cfg.Logger,
-	}
-}
+func (s *Server) Start(ctx context.Context, cfg Config) error {
+	s.hostAddress = cfg.HostAddress
+	s.smtpPort = cfg.SMTPPort
+	s.apiPort = cfg.APIPort
+	s.logger = cfg.Logger
 
-func (s *Server) Start(ctx context.Context) error {
 	s.smtpServer = smtpmocklib.New(smtpmocklib.ConfigurationAttr{
 		LogToStdout:       false,
 		LogServerActivity: true,

--- a/scaletest/smtpmock/server.go
+++ b/scaletest/smtpmock/server.go
@@ -141,7 +141,10 @@ func (s *Server) startAPIServer(ctx context.Context) error {
 
 	tcpAddr, valid := listener.Addr().(*net.TCPAddr)
 	if !valid {
-		listener.Close()
+		err := listener.Close()
+		if err != nil {
+			s.logger.Error(ctx, "failed to close listener", slog.Error(err))
+		}
 		return xerrors.Errorf("listener returned invalid address: %T", listener.Addr())
 	}
 	s.apiPort = tcpAddr.Port

--- a/scaletest/smtpmock/server.go
+++ b/scaletest/smtpmock/server.go
@@ -77,7 +77,7 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) Stop() error {
-	var httpErr, listenerErr, smtpErr error
+	var httpErr, smtpErr error
 
 	if s.httpServer != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -87,19 +87,13 @@ func (s *Server) Stop() error {
 		}
 	}
 
-	if s.listener != nil {
-		if err := s.listener.Close(); err != nil {
-			listenerErr = xerrors.Errorf("close listener: %w", err)
-		}
-	}
-
 	if s.smtpServer != nil {
 		if err := s.smtpServer.Stop(); err != nil {
 			smtpErr = xerrors.Errorf("stop SMTP server: %w", err)
 		}
 	}
 
-	return errors.Join(httpErr, listenerErr, smtpErr)
+	return errors.Join(httpErr, smtpErr)
 }
 
 func (s *Server) SMTPAddress() string {

--- a/scaletest/smtpmock/server.go
+++ b/scaletest/smtpmock/server.go
@@ -1,0 +1,233 @@
+package smtpmock
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	smtpmocklib "github.com/mocktools/go-smtp-mock/v2"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+)
+
+// Server wraps the SMTP mock server and provides an HTTP API to retrieve emails.
+type Server struct {
+	smtpServer *smtpmocklib.Server
+	httpServer *http.Server
+	listener   net.Listener
+	logger     slog.Logger
+
+	host     string
+	smtpPort int
+	apiPort  int
+}
+
+type Config struct {
+	Host     string
+	SMTPPort int
+	APIPort  int
+	Logger   slog.Logger
+}
+
+type EmailSummary struct {
+	Subject        string    `json:"subject"`
+	Date           time.Time `json:"date"`
+	NotificationID uuid.UUID `json:"notification_id,omitempty"`
+}
+
+var notificationIDRegex = regexp.MustCompile(`notifications\?disabled=3D([a-f0-9-]+)`)
+
+func New(cfg Config) *Server {
+	return &Server{
+		host:     cfg.Host,
+		smtpPort: cfg.SMTPPort,
+		apiPort:  cfg.APIPort,
+		logger:   cfg.Logger,
+	}
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	s.smtpServer = smtpmocklib.New(smtpmocklib.ConfigurationAttr{
+		LogToStdout:       false,
+		LogServerActivity: true,
+		HostAddress:       s.host,
+		PortNumber:        s.smtpPort,
+	})
+	if err := s.smtpServer.Start(); err != nil {
+		return xerrors.Errorf("start SMTP server: %w", err)
+	}
+	s.smtpPort = s.smtpServer.PortNumber()
+
+	if err := s.startAPIServer(ctx); err != nil {
+		_ = s.smtpServer.Stop()
+		return xerrors.Errorf("start API server: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Server) Stop() error {
+	var httpErr, listenerErr, smtpErr error
+
+	if s.httpServer != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
+			httpErr = xerrors.Errorf("shutdown HTTP server: %w", err)
+		}
+	}
+
+	if s.listener != nil {
+		if err := s.listener.Close(); err != nil {
+			listenerErr = xerrors.Errorf("close listener: %w", err)
+		}
+	}
+
+	if s.smtpServer != nil {
+		if err := s.smtpServer.Stop(); err != nil {
+			smtpErr = xerrors.Errorf("stop SMTP server: %w", err)
+		}
+	}
+
+	return errors.Join(httpErr, listenerErr, smtpErr)
+}
+
+func (s *Server) SMTPAddress() string {
+	return fmt.Sprintf("%s:%d", s.host, s.smtpPort)
+}
+
+func (s *Server) APIAddress() string {
+	return fmt.Sprintf("%s:%d", s.host, s.apiPort)
+}
+
+func (s *Server) MessageCount() int {
+	if s.smtpServer == nil {
+		return 0
+	}
+	return len(s.smtpServer.Messages())
+}
+
+func (s *Server) Purge() {
+	if s.smtpServer != nil {
+		s.smtpServer.MessagesAndPurge()
+	}
+}
+
+func (s *Server) startAPIServer(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /purge", s.handlePurge)
+	mux.HandleFunc("GET /messages", s.handleMessages)
+
+	s.httpServer = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.host, s.apiPort))
+	if err != nil {
+		return xerrors.Errorf("listen on %s:%d: %w", s.host, s.apiPort, err)
+	}
+	s.listener = listener
+
+	tcpAddr, valid := listener.Addr().(*net.TCPAddr)
+	if !valid {
+		listener.Close()
+		return xerrors.Errorf("listener returned invalid address: %T", listener.Addr())
+	}
+	s.apiPort = tcpAddr.Port
+
+	go func() {
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error(ctx, "http API server error", slog.Error(err))
+		}
+	}()
+
+	return nil
+}
+
+func (s *Server) handlePurge(w http.ResponseWriter, _ *http.Request) {
+	s.smtpServer.MessagesAndPurge()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
+	email := r.URL.Query().Get("email")
+	msgs := s.smtpServer.Messages()
+
+	var summaries []EmailSummary
+	for _, msg := range msgs {
+		recipients := msg.RcpttoRequestResponse()
+		if !matchesRecipient(recipients, email) {
+			continue
+		}
+
+		summary, err := parseEmailSummary(msg.MsgRequest())
+		if err != nil {
+			s.logger.Warn(r.Context(), "failed to parse email summary", slog.Error(err))
+			continue
+		}
+		summaries = append(summaries, summary)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(summaries); err != nil {
+		s.logger.Warn(r.Context(), "failed to encode JSON response", slog.Error(err))
+	}
+}
+
+func matchesRecipient(recipients [][]string, email string) bool {
+	if email == "" {
+		return true
+	}
+	return slices.ContainsFunc(recipients, func(rcptPair []string) bool {
+		return len(rcptPair) > 0 && strings.Contains(rcptPair[0], email)
+	})
+}
+
+func parseEmailSummary(content string) (EmailSummary, error) {
+	var summary EmailSummary
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	// Extract Subject and Date from headers.
+	// Date is used to measure latency.
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+		if prefix, found := strings.CutPrefix(line, "Subject: "); found {
+			summary.Subject = prefix
+		} else if prefix, found := strings.CutPrefix(line, "Date: "); found {
+			if parsedDate, err := time.Parse(time.RFC1123Z, prefix); err == nil {
+				summary.Date = parsedDate
+			}
+		}
+	}
+
+	// Extract notification ID from email content
+	// Notification ID is present in the email footer like this
+	// <p><a href=3D"http://127.0.0.1:3000/settings/notifications?disabled=3D
+	// =3D4e19c0ac-94e1-4532-9515-d1801aa283b2" style=3D"color: #2563eb; text-deco=
+	// ration: none;">Stop receiving emails like this</a></p>
+	replacer := strings.NewReplacer("=\n", "", "=\r\n", "")
+	contentNormalized := replacer.Replace(content)
+	if matches := notificationIDRegex.FindStringSubmatch(contentNormalized); len(matches) > 1 {
+		var err error
+		summary.NotificationID, err = uuid.Parse(matches[1])
+		if err != nil {
+			return summary, xerrors.Errorf("failed to parse notification ID: %w", err)
+		}
+	}
+
+	return summary, nil
+}

--- a/scaletest/smtpmock/server.go
+++ b/scaletest/smtpmock/server.go
@@ -107,7 +107,7 @@ func (s *Server) SMTPAddress() string {
 }
 
 func (s *Server) APIAddress() string {
-	return fmt.Sprintf("%s:%d", s.host, s.apiPort)
+	return fmt.Sprintf("http://%s:%d", s.host, s.apiPort)
 }
 
 func (s *Server) MessageCount() int {

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -60,7 +60,7 @@ func TestServer_SendAndReceiveEmail(t *testing.T) {
 		return srv.MessageCount() == 1
 	}, testutil.WaitShort, testutil.IntervalMedium)
 
-	url := fmt.Sprintf("http://%s/messages", srv.APIAddress())
+	url := fmt.Sprintf("%s/messages", srv.APIAddress())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestServer_FilterByEmail(t *testing.T) {
 		return srv.MessageCount() == 2
 	}, testutil.WaitShort, testutil.IntervalMedium)
 
-	url := fmt.Sprintf("http://%s/messages?email=admin@coder.com", srv.APIAddress())
+	url := fmt.Sprintf("%s/messages?email=admin@coder.com", srv.APIAddress())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
@@ -142,7 +142,7 @@ func TestServer_NotificationID(t *testing.T) {
 		return srv.MessageCount() == 1
 	}, testutil.WaitShort, testutil.IntervalMedium)
 
-	url := fmt.Sprintf("http://%s/messages", srv.APIAddress())
+	url := fmt.Sprintf("%s/messages", srv.APIAddress())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestServer_Purge(t *testing.T) {
 		return srv.MessageCount() == 1
 	}, testutil.WaitShort, testutil.IntervalMedium)
 
-	url := fmt.Sprintf("http://%s/purge", srv.APIAddress())
+	url := fmt.Sprintf("%s/purge", srv.APIAddress())
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	require.NoError(t, err)
 

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -22,14 +22,13 @@ func TestServer_StartStop(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	srv := smtpmock.New(smtpmock.Config{
+	srv := new(smtpmock.Server)
+	err := srv.Start(ctx, smtpmock.Config{
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
 		Logger:      slogtest.Make(t, nil),
 	})
-
-	err := srv.Start(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, srv.SMTPAddress())
 	require.NotEmpty(t, srv.APIAddress())
@@ -42,14 +41,13 @@ func TestServer_SendAndReceiveEmail(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	srv := smtpmock.New(smtpmock.Config{
+	srv := new(smtpmock.Server)
+	err := srv.Start(ctx, smtpmock.Config{
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
 		Logger:      slogtest.Make(t, nil),
 	})
-
-	err := srv.Start(ctx)
 	require.NoError(t, err)
 	defer srv.Stop()
 
@@ -81,14 +79,13 @@ func TestServer_FilterByEmail(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	srv := smtpmock.New(smtpmock.Config{
+	srv := new(smtpmock.Server)
+	err := srv.Start(ctx, smtpmock.Config{
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
 		Logger:      slogtest.Make(t, nil),
 	})
-
-	err := srv.Start(ctx)
 	require.NoError(t, err)
 	defer srv.Stop()
 
@@ -121,14 +118,13 @@ func TestServer_NotificationTemplateID(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	srv := smtpmock.New(smtpmock.Config{
+	srv := new(smtpmock.Server)
+	err := srv.Start(ctx, smtpmock.Config{
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
 		Logger:      slogtest.Make(t, nil),
 	})
-
-	err := srv.Start(ctx)
 	require.NoError(t, err)
 	defer srv.Stop()
 
@@ -161,14 +157,13 @@ func TestServer_Purge(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	srv := smtpmock.New(smtpmock.Config{
+	srv := new(smtpmock.Server)
+	err := srv.Start(ctx, smtpmock.Config{
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
 		Logger:      slogtest.Make(t, nil),
 	})
-
-	err := srv.Start(ctx)
 	require.NoError(t, err)
 	defer srv.Stop()
 

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -1,0 +1,208 @@
+package smtpmock_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/smtp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/scaletest/smtpmock"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestServer_StartStop(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	srv := smtpmock.New(smtpmock.Config{
+		Host:     "127.0.0.1",
+		SMTPPort: 0,
+		APIPort:  0,
+		Logger:   slogtest.Make(t, nil),
+	})
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, srv.SMTPAddress())
+	require.NotEmpty(t, srv.APIAddress())
+
+	err = srv.Stop()
+	require.NoError(t, err)
+}
+
+func TestServer_SendAndReceiveEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	srv := smtpmock.New(smtpmock.Config{
+		Host:     "127.0.0.1",
+		SMTPPort: 0,
+		APIPort:  0,
+		Logger:   slogtest.Make(t, nil),
+	})
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	defer srv.Stop()
+
+	err = sendTestEmail(srv.SMTPAddress(), "test@example.com", "Test Subject", "Test Body")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return srv.MessageCount() == 1
+	}, testutil.WaitShort, testutil.IntervalMedium)
+
+	url := fmt.Sprintf("http://%s/messages", srv.APIAddress())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var summaries []smtpmock.EmailSummary
+	err = json.NewDecoder(resp.Body).Decode(&summaries)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	require.Equal(t, "Test Subject", summaries[0].Subject)
+}
+
+func TestServer_FilterByEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	srv := smtpmock.New(smtpmock.Config{
+		Host:     "127.0.0.1",
+		SMTPPort: 0,
+		APIPort:  0,
+		Logger:   slogtest.Make(t, nil),
+	})
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	defer srv.Stop()
+
+	err = sendTestEmail(srv.SMTPAddress(), "admin@coder.com", "Email for admin", "Body 1")
+	require.NoError(t, err)
+
+	err = sendTestEmail(srv.SMTPAddress(), "test-user@coder.com", "Email for test-user", "Body 2")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return srv.MessageCount() == 2
+	}, testutil.WaitShort, testutil.IntervalMedium)
+
+	url := fmt.Sprintf("http://%s/messages?email=admin@coder.com", srv.APIAddress())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var summaries []smtpmock.EmailSummary
+	err = json.NewDecoder(resp.Body).Decode(&summaries)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	require.Equal(t, "Email for admin", summaries[0].Subject)
+}
+
+func TestServer_NotificationID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	srv := smtpmock.New(smtpmock.Config{
+		Host:     "127.0.0.1",
+		SMTPPort: 0,
+		APIPort:  0,
+		Logger:   slogtest.Make(t, nil),
+	})
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	defer srv.Stop()
+
+	notificationID := uuid.New()
+	body := fmt.Sprintf(`<p><a href=3D"http://127.0.0.1:3000/settings/notifications?disabled=3D%s">Unsubscribe</a></p>`, notificationID.String())
+
+	err = sendTestEmail(srv.SMTPAddress(), "test-user@coder.com", "Notification", body)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return srv.MessageCount() == 1
+	}, testutil.WaitShort, testutil.IntervalMedium)
+
+	url := fmt.Sprintf("http://%s/messages", srv.APIAddress())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var summaries []smtpmock.EmailSummary
+	err = json.NewDecoder(resp.Body).Decode(&summaries)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	require.Equal(t, notificationID, summaries[0].NotificationID)
+}
+
+func TestServer_Purge(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	srv := smtpmock.New(smtpmock.Config{
+		Host:     "127.0.0.1",
+		SMTPPort: 0,
+		APIPort:  0,
+		Logger:   slogtest.Make(t, nil),
+	})
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	defer srv.Stop()
+
+	err = sendTestEmail(srv.SMTPAddress(), "test-user@coder.com", "Test", "Body")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return srv.MessageCount() == 1
+	}, testutil.WaitShort, testutil.IntervalMedium)
+
+	url := fmt.Sprintf("http://%s/purge", srv.APIAddress())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, 0, srv.MessageCount())
+}
+
+func sendTestEmail(smtpAddr, to, subject, body string) error {
+	from := "noreply@coder.com"
+	now := time.Now().Format(time.RFC1123Z)
+
+	msg := strings.Builder{}
+	msg.WriteString(fmt.Sprintf("From: %s\r\n", from))
+	msg.WriteString(fmt.Sprintf("To: %s\r\n", to))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	msg.WriteString(fmt.Sprintf("Date: %s\r\n", now))
+	msg.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	msg.WriteString("\r\n")
+	msg.WriteString(body)
+
+	return smtp.SendMail(smtpAddr, nil, from, []string{to}, []byte(msg.String()))
+}

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -23,10 +23,10 @@ func TestServer_StartStop(t *testing.T) {
 
 	ctx := context.Background()
 	srv := smtpmock.New(smtpmock.Config{
-		Host:     "127.0.0.1",
-		SMTPPort: 0,
-		APIPort:  0,
-		Logger:   slogtest.Make(t, nil),
+		HostAddress: "127.0.0.1",
+		SMTPPort:    0,
+		APIPort:     0,
+		Logger:      slogtest.Make(t, nil),
 	})
 
 	err := srv.Start(ctx)
@@ -43,10 +43,10 @@ func TestServer_SendAndReceiveEmail(t *testing.T) {
 
 	ctx := context.Background()
 	srv := smtpmock.New(smtpmock.Config{
-		Host:     "127.0.0.1",
-		SMTPPort: 0,
-		APIPort:  0,
-		Logger:   slogtest.Make(t, nil),
+		HostAddress: "127.0.0.1",
+		SMTPPort:    0,
+		APIPort:     0,
+		Logger:      slogtest.Make(t, nil),
 	})
 
 	err := srv.Start(ctx)
@@ -82,10 +82,10 @@ func TestServer_FilterByEmail(t *testing.T) {
 
 	ctx := context.Background()
 	srv := smtpmock.New(smtpmock.Config{
-		Host:     "127.0.0.1",
-		SMTPPort: 0,
-		APIPort:  0,
-		Logger:   slogtest.Make(t, nil),
+		HostAddress: "127.0.0.1",
+		SMTPPort:    0,
+		APIPort:     0,
+		Logger:      slogtest.Make(t, nil),
 	})
 
 	err := srv.Start(ctx)
@@ -117,15 +117,15 @@ func TestServer_FilterByEmail(t *testing.T) {
 	require.Equal(t, "Email for admin", summaries[0].Subject)
 }
 
-func TestServer_NotificationID(t *testing.T) {
+func TestServer_NotificationTemplateID(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	srv := smtpmock.New(smtpmock.Config{
-		Host:     "127.0.0.1",
-		SMTPPort: 0,
-		APIPort:  0,
-		Logger:   slogtest.Make(t, nil),
+		HostAddress: "127.0.0.1",
+		SMTPPort:    0,
+		APIPort:     0,
+		Logger:      slogtest.Make(t, nil),
 	})
 
 	err := srv.Start(ctx)
@@ -154,7 +154,7 @@ func TestServer_NotificationID(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&summaries)
 	require.NoError(t, err)
 	require.Len(t, summaries, 1)
-	require.Equal(t, notificationID, summaries[0].NotificationID)
+	require.Equal(t, notificationID, summaries[0].NotificationTemplateID)
 }
 
 func TestServer_Purge(t *testing.T) {
@@ -162,10 +162,10 @@ func TestServer_Purge(t *testing.T) {
 
 	ctx := context.Background()
 	srv := smtpmock.New(smtpmock.Config{
-		Host:     "127.0.0.1",
-		SMTPPort: 0,
-		APIPort:  0,
-		Logger:   slogtest.Make(t, nil),
+		HostAddress: "127.0.0.1",
+		SMTPPort:    0,
+		APIPort:     0,
+		Logger:      slogtest.Make(t, nil),
 	})
 
 	err := srv.Start(ctx)

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -196,13 +196,13 @@ func sendTestEmail(smtpAddr, to, subject, body string) error {
 	now := time.Now().Format(time.RFC1123Z)
 
 	msg := strings.Builder{}
-	msg.WriteString(fmt.Sprintf("From: %s\r\n", from))
-	msg.WriteString(fmt.Sprintf("To: %s\r\n", to))
-	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
-	msg.WriteString(fmt.Sprintf("Date: %s\r\n", now))
-	msg.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
-	msg.WriteString("\r\n")
-	msg.WriteString(body)
+	_, _ = msg.WriteString(fmt.Sprintf("From: %s\r\n", from))
+	_, _ = msg.WriteString(fmt.Sprintf("To: %s\r\n", to))
+	_, _ = msg.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	_, _ = msg.WriteString(fmt.Sprintf("Date: %s\r\n", now))
+	_, _ = msg.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	_, _ = msg.WriteString("\r\n")
+	_, _ = msg.WriteString(body)
 
 	return smtp.SendMail(smtpAddr, nil, from, []string{to}, []byte(msg.String()))
 }


### PR DESCRIPTION
This PR adds a fake SMTP server for scale testing. It collects emails sent during tests, which you can then check using the HTTP API.

#### Changes
- Added mock SMTP server  
- Added `coder scaletest smtp` CLI command  
- Implemented HTTP API endpoints to retrieve messages by email  
- Added auto-purge to prevent memory issues  

#### HTTP API Endpoints
- `GET /messages?email=<email>` – Get messages sent to an email address  
- `POST /purge` – Clear all messages from memory  

The HTTP API parses raw email messages to extract the **date**, **subject**, and **notification ID**.

Notification IDs are sent in emails like this:
```html
<p>
  <a href="http://127.0.0.1:3000/settings/notifications?disabled=4e19c0ac-94e1-4532-9515-d1801aa283b2"
     style="color: #2563eb; text-decoration: none;">
    Stop receiving emails like this
  </a>
</p>
```

#### CLI
```bash
coder scaletest smtp --host localhost --port 33199 --api-port 8080 --purge-at-count 1000
```

**Flags:**
- `--host`: Host for the mock SMTP and API server (default: localhost)  
- `--port`: Port for the mock SMTP server (random if not specified)  
- `--api-port`: Port for the HTTP API server (random if not specified)  
- `--purge-at-count`: Max number of messages before auto-purging (default: 100000)
