### PR TITLE
docs: add troubleshooting steps for prebuilt workspaces

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -26,5 +26,6 @@ ignorePatterns:
   - pattern: "claude.ai"
   - pattern: "splunk.com"
   - pattern: "stackoverflow.com/questions"
+  - pattern: "developer.hashicorp.com/terraform/language"
 aliveStatusCodes:
   - 200

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -310,7 +310,7 @@ If you need to expedite the processing of human-related jobs at the cost of some
 coder provisioner jobs list --status=running --initiator=prebuilds | jq -r '.[].id' | xargs -n1 -P2 -I{} coder provisioner jobs cancel {}
 ```
 
-This will cancel running prebuild jobs (orphaning any resources that have already been deployed) and immediately make room for human-initiated jobs.
+This should be done as a last resort. It will cancel running prebuild jobs (orphaning any resources that have already been deployed) and immediately make room for human-initiated jobs. Orphaned infrastructure will need to be manually cleaned up by a human operator. The process to identify and clear these orphaned resources will likely require administrative access to the infrastructure that hosts Coder workspaces. Furthermore, the ability to identify such orphaned resources will depend on metadata that should be included in the workspace template.
 
 Once the provisioner queue has been cleared and all templates have been fixed, resume prebuild reconciliation by running:
 

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -286,7 +286,7 @@ coder provisioner jobs list --status=pending --initiator=prebuilds
 
 This will show a list of all pending jobs that have been enqueued by the prebuilt workspace system. The length of this list indicates whether prebuilt workspaces have overwhelmed your Coder deployment.
 
-Human-initiated jobs have priority over pending prebuild jobs, but running prebuild jobs cannot be preempted. A long list of pending prebuild jobs increases the likelihood that all provisioners are already occupied when a user wants to create a workspace. This increases the likelihood that users will experience delays waiting for the next available provisioner.
+Human-initiated jobs have priority over pending prebuild jobs, but running prebuild jobs cannot be preempted. A long list of pending prebuild jobs increases the likelihood that all provisioners are already occupied when a user wants to create a workspace or import a new template version. This increases the likelihood that users will experience delays waiting for the next available provisioner.
 
 #### Cancel pending prebuild jobs
 

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -252,7 +252,8 @@ If a quota is exceeded, the prebuilt workspace will fail provisioning the same w
 Prebuilt workspaces can overwhelm a Coder deployment, causing significant delays when users and template administrators create new workspaces or manage their templates. Fundamentally, this happens when provisioners are not able to meet the demand for provisioner jobs. Prebuilds contribute to provisioner demand by scheduling many jobs in bursts whenever templates are updated. The solution is to either increase the number of provisioners or decrease the number of requested prebuilt workspaces across the entire system.
 
 To identify if prebuilt workspaces have overwhelmed the available provisioners in your Coder deployment, look for:
-- Large or growing queue of prebuild‑related jobs
+
+- Large or growing queue of prebuild-related jobs
 - User workspace creation is slow
 - Publishing a new template version is not reflected in the UI because the associated template import job has not yet finished
 

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -249,14 +249,14 @@ If a quota is exceeded, the prebuilt workspace will fail provisioning the same w
 
 ### Managing prebuild provisioning queues
 
-Prebuilt workspaces can overwhelm a Coder deployment, causing significant delays when users and template administrators attempt to create new workspaces or manage their templates. A few factors can work together to contribute to this scenario:
+Prebuilt workspaces can overwhelm a Coder deployment, causing significant delays when users and template administrators create new workspaces or manage their templates. Fundamentally, this happens when provisioners are not able to meet the demand for provisioner jobs. Prebuilds contribute to provisioner demand by scheduling many jobs in bursts whenever templates are updated. The solution is to either increase the number of provisioners or decrease the number of requested prebuilt workspaces across the entire system.
 
-1. **Organic overload**: Not enough provisioners to meet the deployment's needs
-2. **Broken templates**: A template that mistakenly requests too many prebuilt workspaces
+To identify if prebuilt workspaces have overwhelmed the available provisioners in your Coder deployment, look for:
+- Large or growing queue of prebuild‑related jobs
+- User workspace creation is slow
+- Publishing a new template version is not reflected in the UI because the associated template import job has not yet finished
 
-In the second case, it can be difficult to fix the situation because you cannot upload a corrected template version while the provisioners are overloaded.
-
-The troubleshooting steps below will help you resolve this situation:
+The troubleshooting steps below will help you assess and resolve this situation:
 
 1) Pause prebuilt workspace reconciliation to stop the problem from getting worse
 2) Check how many prebuild jobs are clogging your provisioner queue
@@ -355,7 +355,7 @@ resource "docker_container" "workspace" {
 Limit the scope of `ignore_changes` to include only the fields specified in the notification.
 If you include too many fields, Terraform might ignore changes that wouldn't otherwise cause drift.
 
-Learn more about `ignore_changes` in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/v1.13.x/meta-arguments#lifecycle).
+Learn more about `ignore_changes` in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/meta-arguments#lifecycle).
 
 _A note on "immutable" attributes: Terraform providers may specify `ForceNew` on their resources' attributes. Any change
 to these attributes require the replacement (destruction and recreation) of the managed resource instance, rather than an in-place update.

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -355,7 +355,7 @@ resource "docker_container" "workspace" {
 Limit the scope of `ignore_changes` to include only the fields specified in the notification.
 If you include too many fields, Terraform might ignore changes that wouldn't otherwise cause drift.
 
-Learn more about `ignore_changes` in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
+Learn more about `ignore_changes` in the [Terraform documentation](https://developer.hashicorp.com/terraform/language/v1.13.x/meta-arguments#lifecycle).
 
 _A note on "immutable" attributes: Terraform providers may specify `ForceNew` on their resources' attributes. Any change
 to these attributes require the replacement (destruction and recreation) of the managed resource instance, rather than an in-place update.

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -254,6 +254,7 @@ It is possible for prebuilt workspaces to overwhelm a Coder deployment to the po
 If your Coder deployment is exhibiting the above symptoms, follow these instructions to verify and then rectify the situation:
 
 First, run:
+
 ```bash
 coder prebuilds pause
 ```
@@ -261,6 +262,7 @@ coder prebuilds pause
 This prevents further pollution of your provisioner queues. Specifically, it will prevent the prebuilt workspaces feature from scheduling new prebuilt workspace creation jobs. Jobs that have already been enqueued will still be processed at this point. Regardless of the steps taken in the rest of your troubleshooting process, remember to run `coder prebuilds resume` once all impact has been mitigated. See the last step in this section for more information.
 
 Next, run:
+
 ```bash
 coder provisioner jobs list --status=pending --initiator=prebuilds
 ```
@@ -268,6 +270,7 @@ coder provisioner jobs list --status=pending --initiator=prebuilds
 This will show a list of all pending jobs that have been enqueued by the prebuilt workspace system. The length of this list is an indicator of whether prebuilt workspaces have overwhelmed your Coder deployment. Human initiated jobs do have priority over pending prebuild jobs, but a prebuild job that is already running will not be preempted to process a human initiated job. An extended list of pending prebuild jobs therefore increases the likelihood that all provisioners may already be occopied when a human user would like to create a workspace. This then transitively increases the likelihood that users will experience delays waiting for the next available provisioner to become available when they try to manage their workspaces or templates.
 
 To ensure that the next available provisioner will be given to a human initiated job, run:
+
 ```bash
 coder provisioner jobs list --status=pending --initiator=prebuilds | jq '...' | xargs -n1 -P2 -I{} coder provisioner jobs cancel {}
 ```
@@ -277,6 +280,7 @@ This will clear the provisioner queue of all jobs that were not initiated by a h
 At this stage, most prebuild related impact will have been mitigated. There may still be a bugged template version, but it will no longer pollute provisioner queues with prebuilt workspace jobs. If the latest version of a template is also broken for reasons unrelated to prebuilds, then users are able to create workspaces using a previous template version. Some running jobs may have been initiated by the prebuild system, but these cannot be cancelled without potentially orphaning resources that have already been deployed by Terraform. Depending on your deployment and template provisioning times, it might be best to upload a new template version and wait for it to be processed organically.
 
 If you need to expedite the processing of human-related jobs at the cost of some infrastructure house-keeping, then you can run:
+
 ```bash
 coder provisioner jobs list --status=running --initiator=prebuilds | jq '...' | xargs -n1 -P2 -I{} coder provisioner jobs cancel {}
 ```
@@ -284,6 +288,7 @@ coder provisioner jobs list --status=running --initiator=prebuilds | jq '...' | 
 This will cancel running prebuild jobs (orphaning any resources that have already been deployed) and immediately make room for human-initiated jobs.
 
 Once the provisioner queue has been cleared and all templates have been fixed, remember to resume prebuild reconciliation by running:
+
 ```bash
 coder prebuilds resume
 ```

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -247,6 +247,47 @@ When prebuilt workspaces are configured for an organization, Coder creates a "pr
 
 If a quota is exceeded, the prebuilt workspace will fail provisioning the same way other workspaces do.
 
+### Managing prebuild provisioning queues
+
+It is possible for prebuilt workspaces to overwhelm a Coder deployment to the point that users and template administrators experience significant delays when they attempt to create new workspaces or manage their templates. This may happen organically, if there are not enough provisioners to meet the needs of the Coder deployment. It may also happen if a broken template is uploaded, which mistakenly requests too many prebuilt workspaces. In the latter case, it may be hard to correct the situation because a fixed template version cannot be uploaded while the Coder deployment's provisioners are overloaded.
+
+If your Coder deployment is exhibiting the above symptoms, follow these instructions to verify and then rectify the situation:
+
+First, run:
+```bash
+coder prebuilds pause
+```
+
+This prevents further pollution of your provisioner queues. Specifically, it will prevent the prebuilt workspaces feature from scheduling new prebuilt workspace creation jobs. Jobs that have already been enqueued will still be processed at this point. Regardless of the steps taken in the rest of your troubleshooting process, remember to run `coder prebuilds resume` once all impact has been mitigated. See the last step in this section for more information.
+
+Next, run:
+```bash
+coder provisioner jobs list --status=pending --initiator=prebuilds
+```
+
+This will show a list of all pending jobs that have been enqueued by the prebuilt workspace system. The length of this list is an indicator of whether prebuilt workspaces have overwhelmed your Coder deployment. Human initiated jobs do have priority over pending prebuild jobs, but a prebuild job that is already running will not be preempted to process a human initiated job. An extended list of pending prebuild jobs therefore increases the likelihood that all provisioners may already be occopied when a human user would like to create a workspace. This then transitively increases the likelihood that users will experience delays waiting for the next available provisioner to become available when they try to manage their workspaces or templates.
+
+To ensure that the next available provisioner will be given to a human initiated job, run:
+```bash
+coder provisioner jobs list --status=pending --initiator=prebuilds | jq '...' | xargs -n1 -P2 -I{} coder provisioner jobs cancel {}
+```
+
+This will clear the provisioner queue of all jobs that were not initiated by a human being, which increases the probability that a provisioner will be available when the next human operator needs it. It does not cancel running provisioner jobs, so there may still be some delay in processing new provisioner jobs at least until a provisioner completes its current job.
+
+At this stage, most prebuild related impact will have been mitigated. There may still be a bugged template version, but it will no longer pollute provisioner queues with prebuilt workspace jobs. If the latest version of a template is also broken for reasons unrelated to prebuilds, then users are able to create workspaces using a previous template version. Some running jobs may have been initiated by the prebuild system, but these cannot be cancelled without potentially orphaning resources that have already been deployed by Terraform. Depending on your deployment and template provisioning times, it might be best to upload a new template version and wait for it to be processed organically.
+
+If you need to expedite the processing of human-related jobs at the cost of some infrastructure house-keeping, then you can run:
+```bash
+coder provisioner jobs list --status=running --initiator=prebuilds | jq '...' | xargs -n1 -P2 -I{} coder provisioner jobs cancel {}
+```
+
+This will cancel running prebuild jobs (orphaning any resources that have already been deployed) and immediately make room for human-initiated jobs.
+
+Once the provisioner queue has been cleared and all templates have been fixed, remember to resume prebuild reconciliation by running:
+```bash
+coder prebuilds resume
+```
+
 ### Template configuration best practices
 
 #### Preventing resource replacement

--- a/docs/admin/templates/extending-templates/prebuilt-workspaces.md
+++ b/docs/admin/templates/extending-templates/prebuilt-workspaces.md
@@ -258,11 +258,11 @@ In the second case, it can be difficult to fix the situation because you cannot 
 
 The troubleshooting steps below will help you resolve this situation:
 
-* Pause prebuilt workspace reconciliation to stop the problem from getting worse
-* Check how many prebuild jobs are clogging your provisioner queue
-* Cancel excess prebuild jobs to free up provisioners for human users
-* Fix any problematic templates that are causing the issue
-* Resume prebuilt reconciliation once everything is back to normal
+- Pause prebuilt workspace reconciliation to stop the problem from getting worse
+- Check how many prebuild jobs are clogging your provisioner queue
+- Cancel excess prebuild jobs to free up provisioners for human users
+- Fix any problematic templates that are causing the issue
+- Resume prebuilt reconciliation once everything is back to normal
 
 If your Coder deployment is exhibiting the above symptoms, follow these instructions to verify and then rectify the situation:
 


### PR DESCRIPTION
This PR adds troubleshooting steps to guide Coder operators when they suspect that prebuilds might have overwhelmed their deployments.

Closes https://github.com/coder/coder/issues/19490