### PR TITLE
feat: POC to limit prebuild actions

### DIFF
--- a/coderd/prebuilds/global_snapshot.go
+++ b/coderd/prebuilds/global_snapshot.go
@@ -53,6 +53,15 @@ func NewGlobalSnapshot(
 	}
 }
 
+// TotalPendingCount get total number of prebuild-related jobs in the queue and currently in progress
+func (s GlobalSnapshot) TotalPendingCount() int {
+	var total int
+	for _, row := range s.PrebuildsInProgress {
+		total += int(row.Count)
+	}
+	return total
+}
+
 func (s GlobalSnapshot) FilterByPreset(presetID uuid.UUID) (*PresetSnapshot, error) {
 	preset, found := slice.Find(s.Presets, func(preset database.GetTemplatePresetsWithPrebuildsRow) bool {
 		return preset.ID == presetID

--- a/enterprise/coderd/prebuilds/scheduler.go
+++ b/enterprise/coderd/prebuilds/scheduler.go
@@ -1,0 +1,109 @@
+package prebuilds
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+
+	"github.com/coder/coder/v2/coderd/prebuilds"
+)
+
+// TODO: configuration value or calculated based on the total number of daemons?
+//   Should the prebuild scheduler be aware of the number of daemons?
+//   If configurable we can define a value (e.g., 0) to not limit the number of actions
+const maxPendingPrebuildActions = 2
+
+// PresetActions is a batch of actions computed for a single preset.
+type PresetActions struct {
+	Preset  prebuilds.PresetSnapshot
+	Actions []*prebuilds.ReconciliationActions
+}
+
+// JobsScheduler executes reconciliation actions by scheduling the required provisioner jobs
+type JobsScheduler struct {
+	logger slog.Logger
+	// Remaining provisioner jobs this reconciliation loop may execute; decremented per executed action.
+	remainingActions int
+	exec             ActionExecutor
+}
+
+type ActionExecutor func(context.Context, slog.Logger, prebuilds.PresetSnapshot, *prebuilds.ReconciliationActions) error
+
+func NewJobsScheduler(logger slog.Logger, pending int, exec ActionExecutor) (*JobsScheduler, error) {
+	// TODO: if pending == 0 should we consider this unlimited (same as before)
+
+	if pending >= maxPendingPrebuildActions {
+		return nil, xerrors.Errorf("pending jobs exceed max pending prebuild actions")
+	}
+	return &JobsScheduler{
+		logger:           logger,
+		remainingActions: maxPendingPrebuildActions - pending,
+		exec:             exec,
+	}, nil
+}
+
+// Run executes all actions for all presets by calling exec for each action.
+func (s *JobsScheduler) Run(
+	ctx context.Context,
+	presetActions []PresetActions,
+) error {
+	var multiErr multierror.Error
+
+	// TODO: This could probably be done concurrently
+	for _, item := range presetActions {
+		for _, action := range item.Actions {
+
+			// TODO: a ReconciliationActions can correspond to multiple actions (multiple create or multiple delete)
+			//   Goroutines should return multiple unit actions, instead of a set of actions where each one can correspond to a set
+			//   By doing this change, there is also a higher change for a distribution of actions of different presets
+			switch {
+			case action.ActionType == prebuilds.ActionTypeDelete:
+				for _, deleteID := range action.DeleteIDs {
+					if s.remainingActions <= 0 {
+						s.logger.Info(ctx, "no more allowed actions, stopping job scheduling")
+						return multiErr.ErrorOrNil()
+					}
+					// Create unit action
+					singleDeleteAction := &prebuilds.ReconciliationActions{
+						ActionType: prebuilds.ActionTypeDelete,
+						DeleteIDs:  []uuid.UUID{deleteID},
+					}
+					if err := s.exec(ctx, s.logger, item.Preset, singleDeleteAction); err != nil {
+						s.logger.Error(ctx, "failed to execute scheduled action", slog.Error(err))
+						multiErr.Errors = append(multiErr.Errors, err)
+					}
+					// Count this action against the budget
+					s.remainingActions--
+				}
+			case action.ActionType == prebuilds.ActionTypeCreate:
+				for range action.Create {
+					if s.remainingActions <= 0 {
+						s.logger.Info(ctx, "no more allowed actions, stopping job scheduling")
+						return multiErr.ErrorOrNil()
+					}
+					// Create unit action
+					singleCreateAction := &prebuilds.ReconciliationActions{
+						ActionType: prebuilds.ActionTypeCreate,
+						Create:     1,
+					}
+					if err := s.exec(ctx, s.logger, item.Preset, singleCreateAction); err != nil {
+						s.logger.Error(ctx, "failed to execute scheduled action", slog.Error(err))
+						multiErr.Errors = append(multiErr.Errors, err)
+					}
+					// Count this action against the budget
+					s.remainingActions--
+				}
+			default:
+				continue
+			}
+		}
+	}
+
+	s.logger.Info(ctx, "all actions successfully scheduled")
+
+	return multiErr.ErrorOrNil()
+}


### PR DESCRIPTION
Related to: https://github.com/coder/coder/issues/18972 (sub-issue: https://github.com/coder/coder/issues/19937)

**Note**: This PR is complemented by the following document: https://www.notion.so/coderhq/Limit-Prebuilds-Actions-28bd579be59280c28e27c489c84a4f0f?source=copy_link
The document provides background, problem definition, proposed solution, and future improvements related to this POC.
Please review that document first for full context before diving into the implementation details here.

## Implementation changes

The prebuild reconciliation loop handles presets as tuples in the form of `(template, version, preset)`.
For example, if there is a template `T1` with version `V1` that has one preset `P1`, and a version `V2` that has two presets (`P1` and `P2`), the reconciliation loop will handle the following presets:
* `(T1, V1, P1)`
* `(T1, V2, P1)`
* `(T1, V2, P2)`

Each of these tuples is considered a preset in the following sections.

### Current implementation

In the current implementation, each preset is handled by a dedicated goroutine.
Each goroutine:
* Retrieves the state of the preset’s prebuild instances.
* Calculates the actions required for the deployed state to match the template definition.
* Executes those actions by creating prebuild-related provisioner jobs (for creating or deleting prebuilt workspaces).

```
goroutine:
  > ReconcilePreset()
    preset.CalculateState()
    preset.CalculateActions()
    for each action:
      > executeReconciliationAction()
        > Write Transaction:
           Builder.build() // DB.InsertProvisionerJob() and DB.InsertWorkspaceBuild()
           PublishProvisionerJobEvent()
```

Once the jobs are created, the provisionerd server takes over and processes them from the queue.
The goroutine only ensures that the job creation is scheduled, it does not wait for the prebuilds to complete.

### POC implementation

_(Note: The solution proposed in this PR is a POC implementation, meaning that the implementation might not be the best and can definitely be improved. The goal is to validate the design and assess the level of refactoring required, rather than to deliver a production-ready solution. There are several TODOs in the code with ideas for improvements and possible alternatives)_

To minimize refactoring, the POC retains the overall structure of the current implementation but introduces a new component: a prebuild scheduler. The scheduler is responsible for scheduling provisioner jobs and limiting the number of jobs created during each reconciliation loop.

Under this new design:
* The preset goroutines still compute the state and determine the full list of required actions (to match the template definition).
* Instead of scheduling all actions directly, they pass them to the scheduler.
* The scheduler enforces a limit on the number of actions that can be scheduled per loop, based on a configurable value (currently defined as a constant in `scheduler.go` for simplicity) and the number of currently pending prebuild jobs.

```
goroutine:
  > ReconcilePreset()
    preset.CalculateState()
    preset.CalculateActions()

scheduler (after all goroutines finish):
  for each action:
    > executeReconciliationAction()
      > Write Transaction:
        Builder.build() // DB.InsertProvisionerJob() and DB.InsertWorkspaceBuild()
        PublishProvisionerJobEvent()
```

Currently, the scheduler executes actions sequentially, but scheduling could likely be performed concurrently in the future to improve throughput once the throttling mechanism and concurrency boundaries are better defined.