### PR TITLE
fix(provisioner): use sidebar app id instead of app id

### DIFF
--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -1022,16 +1022,16 @@ func ConvertState(ctx context.Context, modules []*tfjson.StateModule, rawGraph s
 			return nil, xerrors.Errorf("decode coder_ai_task attributes: %w", err)
 		}
 
-		var sidebarAppID string
-		if len(task.SidebarApp) > 0 {
-			sidebarAppID = task.SidebarApp[0].ID
+		appID := task.AppID
+		if appID == "" && len(task.SidebarApp) > 0 {
+			appID = task.SidebarApp[0].ID
 		}
 
 		aiTasks = append(aiTasks, &proto.AITask{
 			Id:    task.ID,
-			AppId: task.AppID,
+			AppId: appID,
 			SidebarApp: &proto.AITaskSidebarApp{
-				Id: sidebarAppID,
+				Id: appID,
 			},
 		})
 	}

--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -1022,11 +1022,16 @@ func ConvertState(ctx context.Context, modules []*tfjson.StateModule, rawGraph s
 			return nil, xerrors.Errorf("decode coder_ai_task attributes: %w", err)
 		}
 
+		var sidebarAppID string
+		if len(task.SidebarApp) > 0 {
+			sidebarAppID = task.SidebarApp[0].ID
+		}
+
 		aiTasks = append(aiTasks, &proto.AITask{
 			Id:    task.ID,
 			AppId: task.AppID,
 			SidebarApp: &proto.AITaskSidebarApp{
-				Id: task.AppID,
+				Id: sidebarAppID,
 			},
 		})
 	}

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -1571,11 +1571,37 @@ func TestAITasks(t *testing.T) {
 		require.True(t, state.HasAITasks)
 		require.Len(t, state.AITasks, 1)
 
-		require.Empty(t, state.AITasks[0].AppId)
+		sidebarApp := state.AITasks[0].GetSidebarApp()
+		require.NotNil(t, sidebarApp)
+		require.Equal(t, "5ece4674-dd35-4f16-88c8-82e40e72e2fd", sidebarApp.GetId())
+		require.Equal(t, "5ece4674-dd35-4f16-88c8-82e40e72e2fd", state.AITasks[0].AppId)
+	})
+
+	t.Run("Can use app ID", func(t *testing.T) {
+		t.Parallel()
+
+		// nolint:dogsled
+		_, filename, _, _ := runtime.Caller(0)
+
+		dir := filepath.Join(filepath.Dir(filename), "testdata", "resources", "ai-tasks-app")
+		tfPlanRaw, err := os.ReadFile(filepath.Join(dir, "ai-tasks-app.tfplan.json"))
+		require.NoError(t, err)
+		var tfPlan tfjson.Plan
+		err = json.Unmarshal(tfPlanRaw, &tfPlan)
+		require.NoError(t, err)
+		tfPlanGraph, err := os.ReadFile(filepath.Join(dir, "ai-tasks-app.tfplan.dot"))
+		require.NoError(t, err)
+
+		state, err := terraform.ConvertState(ctx, []*tfjson.StateModule{tfPlan.PlannedValues.RootModule, tfPlan.PriorState.Values.RootModule}, string(tfPlanGraph), logger)
+		require.NotNil(t, state)
+		require.NoError(t, err)
+		require.True(t, state.HasAITasks)
+		require.Len(t, state.AITasks, 1)
 
 		sidebarApp := state.AITasks[0].GetSidebarApp()
 		require.NotNil(t, sidebarApp)
 		require.Equal(t, "5ece4674-dd35-4f16-88c8-82e40e72e2fd", sidebarApp.GetId())
+		require.Equal(t, "5ece4674-dd35-4f16-88c8-82e40e72e2fd", state.AITasks[0].AppId)
 	})
 }
 

--- a/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfplan.dot
+++ b/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfplan.dot
@@ -1,0 +1,20 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_ai_task.a (expand)" [label = "coder_ai_task.a", shape = "box"]
+		"[root] data.coder_provisioner.me (expand)" [label = "data.coder_provisioner.me", shape = "box"]
+		"[root] data.coder_workspace.me (expand)" [label = "data.coder_workspace.me", shape = "box"]
+		"[root] data.coder_workspace_owner.me (expand)" [label = "data.coder_workspace_owner.me", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] coder_ai_task.a (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_provisioner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace_owner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_ai_task.a (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_provisioner.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace_owner.me (expand)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfplan.json
+++ b/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfplan.json
@@ -1,0 +1,187 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_ai_task.a[0]",
+          "mode": "managed",
+          "type": "coder_ai_task",
+          "name": "a",
+          "index": 0,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "app_id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd",
+            "sidebar_app": []
+          },
+          "sensitive_values": {
+            "sidebar_app": []
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "coder_ai_task.a[0]",
+      "mode": "managed",
+      "type": "coder_ai_task",
+      "name": "a",
+      "index": 0,
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "app_id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd",
+          "sidebar_app": []
+        },
+        "after_unknown": {
+          "id": true,
+          "prompt": true,
+          "sidebar_app": []
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "sidebar_app": []
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.13.0",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "data.coder_provisioner.me",
+            "mode": "data",
+            "type": "coder_provisioner",
+            "name": "me",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "arch": "amd64",
+              "id": "6e0bee77-2319-4094-a29e-6d14412399d2",
+              "os": "linux"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "data.coder_workspace.me",
+            "mode": "data",
+            "type": "coder_workspace",
+            "name": "me",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "access_port": 443,
+              "access_url": "https://dev.coder.com/",
+              "id": "5c06d6ea-101b-4069-8d14-7179df66ebcc",
+              "is_prebuild": false,
+              "is_prebuild_claim": false,
+              "name": "coder",
+              "prebuild_count": 0,
+              "start_count": 1,
+              "template_id": "",
+              "template_name": "",
+              "template_version": "",
+              "transition": "start"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "data.coder_workspace_owner.me",
+            "mode": "data",
+            "type": "coder_workspace_owner",
+            "name": "me",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 0,
+            "values": {
+              "email": "default@example.com",
+              "full_name": "coder",
+              "groups": [],
+              "id": "8796d8d7-88f1-445a-bea7-65f5cf530b95",
+              "login_type": null,
+              "name": "default",
+              "oidc_access_token": "",
+              "rbac_roles": [],
+              "session_token": "",
+              "ssh_private_key": "",
+              "ssh_public_key": ""
+            },
+            "sensitive_values": {
+              "groups": [],
+              "oidc_access_token": true,
+              "rbac_roles": [],
+              "session_token": true,
+              "ssh_private_key": true
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "coder": {
+        "name": "coder",
+        "full_name": "registry.terraform.io/coder/coder",
+        "version_constraint": ">= 2.0.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_ai_task.a",
+          "mode": "managed",
+          "type": "coder_ai_task",
+          "name": "a",
+          "provider_config_key": "coder",
+          "expressions": {
+            "app_id": {
+              "constant_value": "5ece4674-dd35-4f16-88c8-82e40e72e2fd"
+            }
+          },
+          "schema_version": 1,
+          "count_expression": {
+            "constant_value": 1
+          }
+        },
+        {
+          "address": "data.coder_provisioner.me",
+          "mode": "data",
+          "type": "coder_provisioner",
+          "name": "me",
+          "provider_config_key": "coder",
+          "schema_version": 1
+        },
+        {
+          "address": "data.coder_workspace.me",
+          "mode": "data",
+          "type": "coder_workspace",
+          "name": "me",
+          "provider_config_key": "coder",
+          "schema_version": 1
+        },
+        {
+          "address": "data.coder_workspace_owner.me",
+          "mode": "data",
+          "type": "coder_workspace_owner",
+          "name": "me",
+          "provider_config_key": "coder",
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "timestamp": "2025-10-09T14:27:27Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfstate.dot
+++ b/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfstate.dot
@@ -1,0 +1,20 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_ai_task.a (expand)" [label = "coder_ai_task.a", shape = "box"]
+		"[root] data.coder_provisioner.me (expand)" [label = "data.coder_provisioner.me", shape = "box"]
+		"[root] data.coder_workspace.me (expand)" [label = "data.coder_workspace.me", shape = "box"]
+		"[root] data.coder_workspace_owner.me (expand)" [label = "data.coder_workspace_owner.me", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] coder_ai_task.a (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_provisioner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace_owner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_ai_task.a (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_provisioner.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace_owner.me (expand)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfstate.json
+++ b/provisioner/terraform/testdata/resources/ai-tasks-app/ai-tasks-app.tfstate.json
@@ -1,0 +1,93 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.13.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.coder_provisioner.me",
+          "mode": "data",
+          "type": "coder_provisioner",
+          "name": "me",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "arch": "amd64",
+            "id": "a1fe389c-ac5e-4e9d-ba76-bc23fe275cc0",
+            "os": "linux"
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "data.coder_workspace.me",
+          "mode": "data",
+          "type": "coder_workspace",
+          "name": "me",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "access_port": 443,
+            "access_url": "https://dev.coder.com/",
+            "id": "bca94359-107b-43c9-a272-99af4b239aad",
+            "is_prebuild": false,
+            "is_prebuild_claim": false,
+            "name": "coder",
+            "prebuild_count": 0,
+            "start_count": 1,
+            "template_id": "",
+            "template_name": "",
+            "template_version": "",
+            "transition": "start"
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "data.coder_workspace_owner.me",
+          "mode": "data",
+          "type": "coder_workspace_owner",
+          "name": "me",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 0,
+          "values": {
+            "email": "default@example.com",
+            "full_name": "coder",
+            "groups": [],
+            "id": "cb8c55f2-7f66-4e69-a584-eb08f4a7cf04",
+            "login_type": null,
+            "name": "default",
+            "oidc_access_token": "",
+            "rbac_roles": [],
+            "session_token": "",
+            "ssh_private_key": "",
+            "ssh_public_key": ""
+          },
+          "sensitive_values": {
+            "groups": [],
+            "oidc_access_token": true,
+            "rbac_roles": [],
+            "session_token": true,
+            "ssh_private_key": true
+          }
+        },
+        {
+          "address": "coder_ai_task.a[0]",
+          "mode": "managed",
+          "type": "coder_ai_task",
+          "name": "a",
+          "index": 0,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "app_id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd",
+            "id": "c4f032b8-97e4-42b0-aa2f-30a9e698f8d4",
+            "prompt": "default",
+            "sidebar_app": []
+          },
+          "sensitive_values": {
+            "sidebar_app": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-app/main.tf
+++ b/provisioner/terraform/testdata/resources/ai-tasks-app/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+resource "coder_ai_task" "a" {
+  count  = 1
+  app_id = "5ece4674-dd35-4f16-88c8-82e40e72e2fd" # fake ID to satisfy requirement, irrelevant otherwise
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfplan.dot
+++ b/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfplan.dot
@@ -1,0 +1,20 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_ai_task.a (expand)" [label = "coder_ai_task.a", shape = "box"]
+		"[root] data.coder_provisioner.me (expand)" [label = "data.coder_provisioner.me", shape = "box"]
+		"[root] data.coder_workspace.me (expand)" [label = "data.coder_workspace.me", shape = "box"]
+		"[root] data.coder_workspace_owner.me (expand)" [label = "data.coder_workspace_owner.me", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] coder_ai_task.a (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_provisioner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace_owner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_ai_task.a (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_provisioner.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace_owner.me (expand)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfplan.json
+++ b/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfplan.json
@@ -1,0 +1,202 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.12.2",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_ai_task.a[0]",
+          "mode": "managed",
+          "type": "coder_ai_task",
+          "name": "a",
+          "index": 0,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "sidebar_app": [
+              {
+                "id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd"
+              }
+            ]
+          },
+          "sensitive_values": {
+            "sidebar_app": [
+              {}
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "coder_ai_task.a[0]",
+      "mode": "managed",
+      "type": "coder_ai_task",
+      "name": "a",
+      "index": 0,
+      "provider_name": "registry.terraform.io/coder/coder",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "sidebar_app": [
+            {
+              "id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd"
+            }
+          ]
+        },
+        "after_unknown": {
+          "app_id": true,
+          "id": true,
+          "prompt": true,
+          "sidebar_app": [
+            {}
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "sidebar_app": [
+            {}
+          ]
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.12.2",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "data.coder_provisioner.me",
+            "mode": "data",
+            "type": "coder_provisioner",
+            "name": "me",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "arch": "amd64",
+              "id": "6b538d81-f0db-4e2b-8d85-4b87a1563d89",
+              "os": "linux"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "data.coder_workspace.me",
+            "mode": "data",
+            "type": "coder_workspace",
+            "name": "me",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 1,
+            "values": {
+              "access_port": 443,
+              "access_url": "https://dev.coder.com/",
+              "id": "344575c1-55b9-43bb-89b5-35f547e2cf08",
+              "is_prebuild": false,
+              "is_prebuild_claim": false,
+              "name": "sebenza-nonix",
+              "prebuild_count": 0,
+              "start_count": 1,
+              "template_id": "",
+              "template_name": "",
+              "template_version": "",
+              "transition": "start"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "data.coder_workspace_owner.me",
+            "mode": "data",
+            "type": "coder_workspace_owner",
+            "name": "me",
+            "provider_name": "registry.terraform.io/coder/coder",
+            "schema_version": 0,
+            "values": {
+              "email": "default@example.com",
+              "full_name": "default",
+              "groups": [],
+              "id": "acb465b5-2709-4392-9486-4ad6eb1c06e0",
+              "login_type": null,
+              "name": "default",
+              "oidc_access_token": "",
+              "rbac_roles": [],
+              "session_token": "",
+              "ssh_private_key": "",
+              "ssh_public_key": ""
+            },
+            "sensitive_values": {
+              "groups": [],
+              "rbac_roles": [],
+              "ssh_private_key": true
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "coder": {
+        "name": "coder",
+        "full_name": "registry.terraform.io/coder/coder",
+        "version_constraint": ">= 2.0.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "coder_ai_task.a",
+          "mode": "managed",
+          "type": "coder_ai_task",
+          "name": "a",
+          "provider_config_key": "coder",
+          "expressions": {
+            "sidebar_app": [
+              {
+                "id": {
+                  "constant_value": "5ece4674-dd35-4f16-88c8-82e40e72e2fd"
+                }
+              }
+            ]
+          },
+          "schema_version": 1,
+          "count_expression": {
+            "constant_value": 1
+          }
+        },
+        {
+          "address": "data.coder_provisioner.me",
+          "mode": "data",
+          "type": "coder_provisioner",
+          "name": "me",
+          "provider_config_key": "coder",
+          "schema_version": 1
+        },
+        {
+          "address": "data.coder_workspace.me",
+          "mode": "data",
+          "type": "coder_workspace",
+          "name": "me",
+          "provider_config_key": "coder",
+          "schema_version": 1
+        },
+        {
+          "address": "data.coder_workspace_owner.me",
+          "mode": "data",
+          "type": "coder_workspace_owner",
+          "name": "me",
+          "provider_config_key": "coder",
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "timestamp": "2025-06-19T14:30:00Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfstate.dot
+++ b/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfstate.dot
@@ -1,0 +1,20 @@
+digraph {
+	compound = "true"
+	newrank = "true"
+	subgraph "root" {
+		"[root] coder_ai_task.a (expand)" [label = "coder_ai_task.a", shape = "box"]
+		"[root] data.coder_provisioner.me (expand)" [label = "data.coder_provisioner.me", shape = "box"]
+		"[root] data.coder_workspace.me (expand)" [label = "data.coder_workspace.me", shape = "box"]
+		"[root] data.coder_workspace_owner.me (expand)" [label = "data.coder_workspace_owner.me", shape = "box"]
+		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
+		"[root] coder_ai_task.a (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_provisioner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] data.coder_workspace_owner.me (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_ai_task.a (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_provisioner.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace.me (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_workspace_owner.me (expand)"
+		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
+	}
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfstate.json
+++ b/provisioner/terraform/testdata/resources/ai-tasks-sidebar/ai-tasks-sidebar.tfstate.json
@@ -1,0 +1,97 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.12.2",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.coder_provisioner.me",
+          "mode": "data",
+          "type": "coder_provisioner",
+          "name": "me",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "arch": "amd64",
+            "id": "764f8b0b-d931-4356-b1a8-446fa95fbeb0",
+            "os": "linux"
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "data.coder_workspace.me",
+          "mode": "data",
+          "type": "coder_workspace",
+          "name": "me",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "access_port": 443,
+            "access_url": "https://dev.coder.com/",
+            "id": "b6713709-6736-4d2f-b3da-7b5b242df5f4",
+            "is_prebuild": false,
+            "is_prebuild_claim": false,
+            "name": "sebenza-nonix",
+            "prebuild_count": 0,
+            "start_count": 1,
+            "template_id": "",
+            "template_name": "",
+            "template_version": "",
+            "transition": "start"
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "data.coder_workspace_owner.me",
+          "mode": "data",
+          "type": "coder_workspace_owner",
+          "name": "me",
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 0,
+          "values": {
+            "email": "default@example.com",
+            "full_name": "default",
+            "groups": [],
+            "id": "0cc15fa2-24fc-4249-bdc7-56cf0af0f782",
+            "login_type": null,
+            "name": "default",
+            "oidc_access_token": "",
+            "rbac_roles": [],
+            "session_token": "",
+            "ssh_private_key": "",
+            "ssh_public_key": ""
+          },
+          "sensitive_values": {
+            "groups": [],
+            "rbac_roles": [],
+            "ssh_private_key": true
+          }
+        },
+        {
+          "address": "coder_ai_task.a[0]",
+          "mode": "managed",
+          "type": "coder_ai_task",
+          "name": "a",
+          "index": 0,
+          "provider_name": "registry.terraform.io/coder/coder",
+          "schema_version": 1,
+          "values": {
+            "app_id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd",
+            "id": "89e6ab36-2e98-4d13-9b4c-69b7588b7e1d",
+            "prompt": "default",
+            "sidebar_app": [
+              {
+                "id": "5ece4674-dd35-4f16-88c8-82e40e72e2fd"
+              }
+            ]
+          },
+          "sensitive_values": {
+            "sidebar_app": [
+              {}
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/provisioner/terraform/testdata/resources/ai-tasks-sidebar/main.tf
+++ b/provisioner/terraform/testdata/resources/ai-tasks-sidebar/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+resource "coder_ai_task" "a" {
+  count = 1
+  sidebar_app {
+    id = "5ece4674-dd35-4f16-88c8-82e40e72e2fd" # fake ID to satisfy requirement, irrelevant otherwise
+  }
+}


### PR DESCRIPTION
In a previous PR we set SidebarApp.Id equal to the appID instead of the sidebarAppID.
