### PR TITLE
fix: replace http.DefaultClient in telemetry with dedicated client

### DIFF
--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -355,7 +355,7 @@ func (r *remoteReporter) deployment() error {
 		return xerrors.Errorf("create deployment request: %w", err)
 	}
 	req.Header.Set(VersionHeader, buildinfo.Version())
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return xerrors.Errorf("perform request: %w", err)
 	}


### PR DESCRIPTION
Replaces a call to the http default client in telemetry.go. Looks like it was missed in https://github.com/coder/coder/pull/20128.

Related to https://github.com/coder/internal/issues/1020 and https://github.com/coder/internal/issues/645.