### PR TITLE
feat: replace ExternalAPIKeyScopes with detailed ScopeCatalog

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -616,7 +616,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/codersdk.ExternalAPIKeyScopes"
+                            "$ref": "#/definitions/codersdk.ScopeCatalog"
                         }
                     }
                 }
@@ -14356,17 +14356,6 @@ const docTemplate = `{
                 "ExperimentAIBridge"
             ]
         },
-        "codersdk.ExternalAPIKeyScopes": {
-            "type": "object",
-            "properties": {
-                "external": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/codersdk.APIKeyScope"
-                    }
-                }
-            }
-        },
         "codersdk.ExternalAgentCredentials": {
             "type": "object",
             "properties": {
@@ -17613,6 +17602,57 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "codersdk.ScopeCatalog": {
+            "type": "object",
+            "properties": {
+                "composites": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ScopeCatalogComposite"
+                    }
+                },
+                "low_level": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ScopeCatalogLowLevel"
+                    }
+                },
+                "specials": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.APIKeyScope"
+                    }
+                }
+            }
+        },
+        "codersdk.ScopeCatalogComposite": {
+            "type": "object",
+            "properties": {
+                "expands_to": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.APIKeyScope"
+                    }
+                },
+                "name": {
+                    "$ref": "#/definitions/codersdk.APIKeyScope"
+                }
+            }
+        },
+        "codersdk.ScopeCatalogLowLevel": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/codersdk.APIKeyScope"
+                },
+                "resource": {
+                    "$ref": "#/definitions/codersdk.RBACResource"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -546,7 +546,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/codersdk.ExternalAPIKeyScopes"
+							"$ref": "#/definitions/codersdk.ScopeCatalog"
 						}
 					}
 				}
@@ -12957,17 +12957,6 @@
 				"ExperimentAIBridge"
 			]
 		},
-		"codersdk.ExternalAPIKeyScopes": {
-			"type": "object",
-			"properties": {
-				"external": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/codersdk.APIKeyScope"
-					}
-				}
-			}
-		},
 		"codersdk.ExternalAgentCredentials": {
 			"type": "object",
 			"properties": {
@@ -16099,6 +16088,57 @@
 					"additionalProperties": {
 						"type": "string"
 					}
+				}
+			}
+		},
+		"codersdk.ScopeCatalog": {
+			"type": "object",
+			"properties": {
+				"composites": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ScopeCatalogComposite"
+					}
+				},
+				"low_level": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ScopeCatalogLowLevel"
+					}
+				},
+				"specials": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.APIKeyScope"
+					}
+				}
+			}
+		},
+		"codersdk.ScopeCatalogComposite": {
+			"type": "object",
+			"properties": {
+				"expands_to": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.APIKeyScope"
+					}
+				},
+				"name": {
+					"$ref": "#/definitions/codersdk.APIKeyScope"
+				}
+			}
+		},
+		"codersdk.ScopeCatalogLowLevel": {
+			"type": "object",
+			"properties": {
+				"action": {
+					"type": "string"
+				},
+				"name": {
+					"$ref": "#/definitions/codersdk.APIKeyScope"
+				},
+				"resource": {
+					"$ref": "#/definitions/codersdk.RBACResource"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1067,7 +1067,7 @@ func New(options *Options) *API {
 		// All CSP errors will be logged
 		r.Post("/csp/reports", api.logReportCSPViolations)
 
-		r.Get("/auth/scopes", api.listExternalScopes)
+		r.Get("/auth/scopes", api.listScopeCatalog)
 
 		r.Get("/buildinfo", buildInfoHandler(buildInfo))
 		// /regions is overridden in the enterprise version

--- a/coderd/scopes_catalog_api_test.go
+++ b/coderd/scopes_catalog_api_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 func TestListPublicLowLevelScopes(t *testing.T) {
@@ -20,11 +21,38 @@ func TestListPublicLowLevelScopes(t *testing.T) {
 	defer res.Body.Close()
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
-	var got struct {
-		External []string `json:"external"`
-	}
+	var got codersdk.ScopeCatalog
 	require.NoError(t, json.NewDecoder(res.Body).Decode(&got))
 
-	want := rbac.ExternalScopeNames()
-	require.Equal(t, want, got.External)
+	expectedSpecials := rbac.ExternalSpecialScopes()
+	convertedSpecials := make([]codersdk.APIKeyScope, 0, len(expectedSpecials))
+	for _, scope := range expectedSpecials {
+		convertedSpecials = append(convertedSpecials, codersdk.APIKeyScope(scope))
+	}
+	require.Equal(t, convertedSpecials, got.Specials)
+
+	lowMeta := rbac.ExternalLowLevelCatalog()
+	expectedLow := make([]codersdk.ScopeCatalogLowLevel, 0, len(lowMeta))
+	for _, meta := range lowMeta {
+		expectedLow = append(expectedLow, codersdk.ScopeCatalogLowLevel{
+			Name:     codersdk.APIKeyScope(meta.Name),
+			Resource: codersdk.RBACResource(meta.Resource),
+			Action:   string(meta.Action),
+		})
+	}
+	require.Equal(t, expectedLow, got.LowLevel)
+
+	compMeta := rbac.ExternalCompositeCatalog()
+	expectedComposites := make([]codersdk.ScopeCatalogComposite, 0, len(compMeta))
+	for _, meta := range compMeta {
+		expands := make([]codersdk.APIKeyScope, 0, len(meta.ExpandsTo))
+		for _, name := range meta.ExpandsTo {
+			expands = append(expands, codersdk.APIKeyScope(name))
+		}
+		expectedComposites = append(expectedComposites, codersdk.ScopeCatalogComposite{
+			Name:      codersdk.APIKeyScope(meta.Name),
+			ExpandsTo: expands,
+		})
+	}
+	require.Equal(t, expectedComposites, got.Composites)
 }

--- a/codersdk/scope_catalog.go
+++ b/codersdk/scope_catalog.go
@@ -1,0 +1,23 @@
+package codersdk
+
+// ScopeCatalog describes the public API key scope catalog exposed by coderd.
+type ScopeCatalog struct {
+	Specials   []APIKeyScope           `json:"specials"`
+	LowLevel   []ScopeCatalogLowLevel  `json:"low_level"`
+	Composites []ScopeCatalogComposite `json:"composites"`
+}
+
+// ScopeCatalogLowLevel contains metadata about a low-level scope that maps
+// directly to a single resource/action tuple.
+type ScopeCatalogLowLevel struct {
+	Name     APIKeyScope  `json:"name"`
+	Resource RBACResource `json:"resource"`
+	Action   string       `json:"action"`
+}
+
+// ScopeCatalogComposite contains metadata about composite coder:* scopes
+// and the low-level scopes they expand to.
+type ScopeCatalogComposite struct {
+	Name      APIKeyScope   `json:"name"`
+	ExpandsTo []APIKeyScope `json:"expands_to"`
+}

--- a/codersdk/scopes_catalog.go
+++ b/codersdk/scopes_catalog.go
@@ -1,5 +1,0 @@
-package codersdk
-
-type ExternalAPIKeyScopes struct {
-	External []APIKeyScope `json:"external"`
-}

--- a/docs/reference/api/authorization.md
+++ b/docs/reference/api/authorization.md
@@ -18,7 +18,22 @@ curl -X GET http://coder-server:8080/api/v2/auth/scopes \
 
 ```json
 {
-  "external": [
+  "composites": [
+    {
+      "expands_to": [
+        "all"
+      ],
+      "name": "all"
+    }
+  ],
+  "low_level": [
+    {
+      "action": "string",
+      "name": "all",
+      "resource": "*"
+    }
+  ],
+  "specials": [
     "all"
   ]
 }
@@ -26,9 +41,9 @@ curl -X GET http://coder-server:8080/api/v2/auth/scopes \
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                                   |
-|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ExternalAPIKeyScopes](schemas.md#codersdkexternalapikeyscopes) |
+| Status | Meaning                                                 | Description | Schema                                                   |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ScopeCatalog](schemas.md#codersdkscopecatalog) |
 
 ## Check authorization
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3995,22 +3995,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `workspace-sharing`    |
 | `aibridge`             |
 
-## codersdk.ExternalAPIKeyScopes
-
-```json
-{
-  "external": [
-    "all"
-  ]
-}
-```
-
-### Properties
-
-| Name       | Type                                                  | Required | Restrictions | Description |
-|------------|-------------------------------------------------------|----------|--------------|-------------|
-| `external` | array of [codersdk.APIKeyScope](#codersdkapikeyscope) | false    |              |             |
-
 ## codersdk.ExternalAgentCredentials
 
 ```json
@@ -7490,6 +7474,75 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `hostname_suffix`    | string | false    |              | Hostname suffix is the suffix to append to workspace names for SSH hostnames.                                         |
 | `ssh_config_options` | object | false    |              |                                                                                                                       |
 | » `[any property]`   | string | false    |              |                                                                                                                       |
+
+## codersdk.ScopeCatalog
+
+```json
+{
+  "composites": [
+    {
+      "expands_to": [
+        "all"
+      ],
+      "name": "all"
+    }
+  ],
+  "low_level": [
+    {
+      "action": "string",
+      "name": "all",
+      "resource": "*"
+    }
+  ],
+  "specials": [
+    "all"
+  ]
+}
+```
+
+### Properties
+
+| Name         | Type                                                                      | Required | Restrictions | Description |
+|--------------|---------------------------------------------------------------------------|----------|--------------|-------------|
+| `composites` | array of [codersdk.ScopeCatalogComposite](#codersdkscopecatalogcomposite) | false    |              |             |
+| `low_level`  | array of [codersdk.ScopeCatalogLowLevel](#codersdkscopecataloglowlevel)   | false    |              |             |
+| `specials`   | array of [codersdk.APIKeyScope](#codersdkapikeyscope)                     | false    |              |             |
+
+## codersdk.ScopeCatalogComposite
+
+```json
+{
+  "expands_to": [
+    "all"
+  ],
+  "name": "all"
+}
+```
+
+### Properties
+
+| Name         | Type                                                  | Required | Restrictions | Description |
+|--------------|-------------------------------------------------------|----------|--------------|-------------|
+| `expands_to` | array of [codersdk.APIKeyScope](#codersdkapikeyscope) | false    |              |             |
+| `name`       | [codersdk.APIKeyScope](#codersdkapikeyscope)          | false    |              |             |
+
+## codersdk.ScopeCatalogLowLevel
+
+```json
+{
+  "action": "string",
+  "name": "all",
+  "resource": "*"
+}
+```
+
+### Properties
+
+| Name       | Type                                           | Required | Restrictions | Description |
+|------------|------------------------------------------------|----------|--------------|-------------|
+| `action`   | string                                         | false    |              |             |
+| `name`     | [codersdk.APIKeyScope](#codersdkapikeyscope)   | false    |              |             |
+| `resource` | [codersdk.RBACResource](#codersdkrbacresource) | false    |              |             |
 
 ## codersdk.ServerSentEvent
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1902,11 +1902,6 @@ export const Experiments: Experiment[] = [
 	"workspace-usage",
 ];
 
-// From codersdk/scopes_catalog.go
-export interface ExternalAPIKeyScopes {
-	readonly external: readonly APIKeyScope[];
-}
-
 // From codersdk/workspaces.go
 /**
  * ExternalAgentCredentials contains the credentials needed for an external agent to connect to Coder.
@@ -4266,6 +4261,26 @@ export interface STUNReport {
 	readonly Enabled: boolean;
 	readonly CanSTUN: boolean;
 	readonly Error: string | null;
+}
+
+// From codersdk/scope_catalog.go
+export interface ScopeCatalog {
+	readonly specials: readonly APIKeyScope[];
+	readonly low_level: readonly ScopeCatalogLowLevel[];
+	readonly composites: readonly ScopeCatalogComposite[];
+}
+
+// From codersdk/scope_catalog.go
+export interface ScopeCatalogComposite {
+	readonly name: APIKeyScope;
+	readonly expands_to: readonly APIKeyScope[];
+}
+
+// From codersdk/scope_catalog.go
+export interface ScopeCatalogLowLevel {
+	readonly name: APIKeyScope;
+	readonly resource: RBACResource;
+	readonly action: string;
 }
 
 // From serpent/serpent.go


### PR DESCRIPTION
# Enhance API Key Scopes Catalog

This PR enhances the API key scopes catalog by replacing the flat list of external scopes with a more structured and informative catalog. The new catalog organizes scopes into three categories:

1. **Special scopes** - Legacy scopes like "all" and "application_connect" that remain for backward compatibility
2. **Low-level scopes** - Basic resource:action pairs with metadata about the resource and action
3. **Composite scopes** - Higher-level "coder:*" scopes with information about what low-level scopes they expand to

The changes include:
- Replacing `ExternalAPIKeyScopes` with a more detailed `ScopeCatalog` structure
- Adding helper functions to extract metadata about each scope type
- Updating API documentation and tests to reflect the new structure
- Renaming the endpoint handler from `listExternalScopes` to `listScopeCatalog`

This enhancement provides more context about each scope, making it easier for users to understand what permissions they're requesting when creating API keys.