### PR TITLE
feat: add scopes and resource allow-list to API tokens

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -531,6 +531,14 @@ class ApiMethods {
 		return response.data;
 	};
 
+	getToken = async (tokenName: string): Promise<TypesGen.APIKey> => {
+		const response = await this.axios.get<TypesGen.APIKey>(
+			`/api/v2/users/me/keys/tokens/${tokenName}`,
+		);
+
+		return response.data;
+	};
+
 	deleteToken = async (keyId: string): Promise<void> => {
 		await this.axios.delete(`/api/v2/users/me/keys/${keyId}`);
 	};
@@ -546,9 +554,29 @@ class ApiMethods {
 		return response.data;
 	};
 
+	updateToken = async (
+		tokenName: string,
+		params: TypesGen.UpdateTokenRequest,
+	): Promise<TypesGen.APIKey> => {
+		const response = await this.axios.patch<TypesGen.APIKey>(
+			`/api/v2/users/me/keys/tokens/${tokenName}`,
+			params,
+		);
+
+		return response.data;
+	};
+
 	getTokenConfig = async (): Promise<TypesGen.TokenConfig> => {
 		const response = await this.axios.get(
 			"/api/v2/users/me/keys/tokens/tokenconfig",
+		);
+
+		return response.data;
+	};
+
+	getScopeCatalog = async (): Promise<TypesGen.ScopeCatalog> => {
+		const response = await this.axios.get<TypesGen.ScopeCatalog>(
+			"/api/v2/auth/scopes",
 		);
 
 		return response.data;

--- a/site/src/api/queries/tokens.ts
+++ b/site/src/api/queries/tokens.ts
@@ -1,0 +1,10 @@
+import { API } from "api/api";
+import type { APIKeyWithOwner, TokensFilter } from "api/typesGenerated";
+import type { QueryOptions } from "react-query";
+
+export const tokens = (filter: TokensFilter) => {
+	return {
+		queryKey: ["tokens", filter.include_all],
+		queryFn: () => API.getTokens(filter),
+	} satisfies QueryOptions<APIKeyWithOwner[]>;
+};

--- a/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
+++ b/site/src/pages/CreateTokenPage/CreateTokenForm.tsx
@@ -1,27 +1,46 @@
 import { css } from "@emotion/css";
 import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";
+import type { APIAllowListTarget, ScopeCatalog } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
+import { Checkbox } from "components/Checkbox/Checkbox";
 import {
 	FormFields,
 	FormFooter,
 	FormSection,
 	HorizontalForm,
 } from "components/Form/Form";
+import {
+	MultiSelectCombobox,
+	type MultiSelectComboboxRef,
+	type Option,
+} from "components/MultiSelectCombobox/MultiSelectCombobox";
 import { Spinner } from "components/Spinner/Spinner";
 import { Stack } from "components/Stack/Stack";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import type { FormikContextType } from "formik";
-import { type FC, useEffect, useState } from "react";
+import {
+	type FC,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useNavigate } from "react-router";
 import { getFormHelpers, onChangeTrimmed } from "utils/formUtils";
 import {
+	allowListTargetsToStrings,
+	buildCompositeExpansionMap,
 	type CreateTokenData,
 	customLifetimeDay,
 	determineDefaultLtValue,
+	expandCompositeScopes,
 	filterByMaxTokenLifetime,
 	NANO_HOUR,
+	type ScopeSelectionMode,
+	sortScopes,
 } from "./utils";
 
 dayjs.extend(utc);
@@ -31,19 +50,105 @@ interface CreateTokenFormProps {
 	maxTokenLifetime?: number;
 	formError: unknown;
 	setFormError: (arg0: unknown) => void;
-	isCreating: boolean;
-	creationFailed: boolean;
+	isSubmitting: boolean;
+	submitFailed: boolean;
+	scopeCatalog?: ScopeCatalog;
+	initialAllowListTargets?: readonly APIAllowListTarget[];
+	resolveAllowListOptions: (query: string) => Promise<Option[]>;
+	submitLabel?: string;
+	nameDisabled?: boolean;
 }
+
+interface ParsedAllowListValue {
+	normalizedType: string;
+	type: string;
+	id: string;
+}
+
+const parseAllowListValue = (rawValue: string): ParsedAllowListValue => {
+	const trimmed = rawValue.trim();
+	if (trimmed === "") {
+		return { normalizedType: "", type: "", id: "" };
+	}
+	const [typePart = "", idPart = ""] = trimmed.split(":", 2);
+	const type = typePart.trim() || "*";
+	const id = idPart.trim() || "*";
+	return {
+		normalizedType: type === "*" ? "*" : type.toLowerCase(),
+		type,
+		id,
+	};
+};
+
+const formatAllowListOptionLabel = (value: string, label: string): string => {
+	const parsed = parseAllowListValue(value);
+	if (parsed.type === "" || parsed.type === "*") {
+		return label;
+	}
+	const trimmedLabel = label.trim();
+	const lowercaseLabel = trimmedLabel.toLowerCase();
+	const prefix = `${parsed.type} :`;
+	if (lowercaseLabel.startsWith(prefix.toLowerCase())) {
+		return trimmedLabel;
+	}
+	return `${parsed.type} : ${trimmedLabel}`;
+};
+
+const pluralizeResourceType = (type: string): string => {
+	if (type === "" || type === "*") {
+		return type;
+	}
+	return type.endsWith("s") ? type : `${type}s`;
+};
+
+const buildFallbackAllowListOption = (
+	value: string,
+	parsed: ParsedAllowListValue,
+): Option => {
+	if (parsed.type === "*" && parsed.id === "*") {
+		return { value, label: "Any resource", group: "Wildcard" };
+	}
+	if (parsed.id === "*") {
+		if (parsed.normalizedType === "*" || parsed.normalizedType === "") {
+			return {
+				value,
+				label: formatAllowListOptionLabel(value, value),
+				group: "wildcard",
+			};
+		}
+		const typeForLabel = parsed.normalizedType;
+		const plural = pluralizeResourceType(typeForLabel);
+		return {
+			value,
+			label: formatAllowListOptionLabel(value, `All ${plural}`),
+			group: plural,
+		};
+	}
+	const group = parsed.normalizedType
+		? pluralizeResourceType(parsed.normalizedType)
+		: undefined;
+	return {
+		value,
+		label: formatAllowListOptionLabel(value, parsed.id),
+		group,
+	};
+};
 
 export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 	form,
 	maxTokenLifetime,
 	formError,
 	setFormError,
-	isCreating,
-	creationFailed,
+	isSubmitting,
+	submitFailed,
+	scopeCatalog,
+	initialAllowListTargets,
+	resolveAllowListOptions,
+	submitLabel = "Create token",
+	nameDisabled = false,
 }) => {
 	const navigate = useNavigate();
+	const allowListComboboxRef = useRef<MultiSelectComboboxRef>(null);
 
 	const [expDays, setExpDays] = useState<number>(1);
 	const [lifetimeDays, setLifetimeDays] = useState<number | string>(
@@ -60,6 +165,309 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 	}, [lifetimeDays, expDays]);
 
 	const getFieldHelpers = getFormHelpers<CreateTokenData>(form, formError);
+	const scopeMode = form.values.scopeMode;
+
+	const compositeExpansionMap = useMemo(() => {
+		return buildCompositeExpansionMap(scopeCatalog);
+	}, [scopeCatalog]);
+
+	const autoLowLevelScopes = useMemo(() => {
+		return expandCompositeScopes(
+			form.values.compositeScopes,
+			compositeExpansionMap,
+		);
+	}, [form.values.compositeScopes, compositeExpansionMap]);
+
+	const effectiveLowLevelScopes = useMemo(() => {
+		return sortScopes([
+			...new Set([...autoLowLevelScopes, ...form.values.lowLevelScopes]),
+		]);
+	}, [autoLowLevelScopes, form.values.lowLevelScopes]);
+
+	const effectiveCompositeScopes = useMemo(() => {
+		return sortScopes(form.values.compositeScopes);
+	}, [form.values.compositeScopes]);
+
+	const lowLevelOptions = useMemo(() => {
+		if (!scopeCatalog) {
+			return [] as Option[];
+		}
+		return scopeCatalog.low_level.map((item) => ({
+			value: item.name,
+			label: formatLowLevelLabel(item.name),
+			group: item.resource,
+		}));
+	}, [scopeCatalog]);
+
+	const lowLevelOptionMap = useMemo(() => {
+		const map = new Map<string, Option>();
+		for (const option of lowLevelOptions) {
+			map.set(option.value, option);
+		}
+		return map;
+	}, [lowLevelOptions]);
+
+	const selectedLowLevelOptions = useMemo(() => {
+		return form.values.lowLevelScopes
+			.map((value) => lowLevelOptionMap.get(value))
+			.filter((option): option is Option => Boolean(option));
+	}, [form.values.lowLevelScopes, lowLevelOptionMap]);
+
+	const [hydratedAllowList, setHydratedAllowList] = useState<
+		Record<string, Option>
+	>({});
+	const hydrationAttemptsRef = useRef(new Set<string>());
+	const previousInitialAllowListSignatureRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!initialAllowListTargets) {
+			previousInitialAllowListSignatureRef.current = null;
+			return;
+		}
+		const normalizedInitial = allowListTargetsToStrings(initialAllowListTargets)
+			.map((entry) => entry.trim())
+			.filter((entry): entry is string => entry !== "");
+		const signature =
+			normalizedInitial.length === 0 ? "" : normalizedInitial.join("|");
+		if (signature === previousInitialAllowListSignatureRef.current) {
+			return;
+		}
+		previousInitialAllowListSignatureRef.current = signature;
+		if (normalizedInitial.length === 0) {
+			return;
+		}
+		void form.setFieldValue("allowList", normalizedInitial);
+	}, [form.setFieldValue, initialAllowListTargets]);
+
+	useEffect(() => {
+		if (!initialAllowListTargets || initialAllowListTargets.length === 0) {
+			return;
+		}
+		const updates: Record<string, Option> = {};
+		initialAllowListTargets.forEach((target) => {
+			const displayName = target.display_name?.trim();
+			if (!displayName) {
+				return;
+			}
+			const value = `${target.type}:${target.id}`;
+			const parsed = parseAllowListValue(value);
+			const baseOption = buildFallbackAllowListOption(value, parsed);
+			updates[value] = {
+				...baseOption,
+				value,
+				label: formatAllowListOptionLabel(value, displayName),
+			};
+		});
+		if (Object.keys(updates).length === 0) {
+			return;
+		}
+		setHydratedAllowList((prev) => {
+			let changed = false;
+			const next = { ...prev };
+			Object.entries(updates).forEach(([key, option]) => {
+				const existing = next[key];
+				if (
+					!existing ||
+					existing.label !== option.label ||
+					existing.description !== option.description
+				) {
+					next[key] = option;
+					changed = true;
+				}
+			});
+			return changed ? next : prev;
+		});
+	}, [initialAllowListTargets]);
+
+	const allowListValueOptions = useMemo(() => {
+		return form.values.allowList
+			.map((rawValue) => {
+				const value = rawValue.trim();
+				if (value === "") {
+					return undefined;
+				}
+				const parsed = parseAllowListValue(value);
+				const hydrated = hydratedAllowList[value];
+				if (hydrated) {
+					return {
+						...hydrated,
+						value,
+						label: formatAllowListOptionLabel(value, hydrated.label),
+					};
+				}
+				return buildFallbackAllowListOption(value, parsed);
+			})
+			.filter((option): option is Option => Boolean(option));
+	}, [form.values.allowList, hydratedAllowList]);
+
+	const handleAllowListSearch = useCallback(
+		(query: string) => resolveAllowListOptions(query),
+		[resolveAllowListOptions],
+	);
+
+	const handleScopeModeChange = (mode: ScopeSelectionMode) => {
+		if (mode === scopeMode) {
+			return;
+		}
+		void form.setFieldValue("scopeMode", mode);
+	};
+
+	const handleCompositeToggle = (scope: string) => {
+		const current = new Set(form.values.compositeScopes);
+		if (current.has(scope)) {
+			current.delete(scope);
+		} else {
+			current.add(scope);
+		}
+		void form.setFieldValue("compositeScopes", Array.from(current));
+	};
+
+	const handleLowLevelChange = (options: Option[]) => {
+		void form.setFieldValue(
+			"lowLevelScopes",
+			options.map((option) => option.value),
+		);
+	};
+
+	const handleAllowListChange = useCallback(
+		(options: Option[]) => {
+			const normalized: Option[] = [];
+			let pendingPrefix: string | undefined;
+
+			for (const option of options) {
+				const prefix = (option as { prefix?: string }).prefix;
+				if (prefix) {
+					pendingPrefix = prefix;
+					continue;
+				}
+				const trimmedValue = option.value.trim();
+				if (trimmedValue === "") {
+					continue;
+				}
+				const normalizedOption: Option = {
+					...option,
+					value: trimmedValue,
+					label: formatAllowListOptionLabel(trimmedValue, option.label),
+				};
+				normalized.push(normalizedOption);
+			}
+
+			if (normalized.length > 0) {
+				setHydratedAllowList((prev) => {
+					let changed = false;
+					const next = { ...prev };
+					for (const option of normalized) {
+						const existing = next[option.value];
+						if (
+							!existing ||
+							existing.label !== option.label ||
+							existing.description !== option.description
+						) {
+							next[option.value] = option;
+							changed = true;
+						}
+					}
+					return changed ? next : prev;
+				});
+			}
+
+			void form.setFieldValue(
+				"allowList",
+				normalized.map((option) => option.value),
+			);
+
+			if (pendingPrefix) {
+				allowListComboboxRef.current?.setInputValue(pendingPrefix, {
+					focus: true,
+					open: true,
+				});
+			}
+		},
+		[form],
+	);
+
+	useEffect(() => {
+		if (form.values.allowList.length === 0) {
+			hydrationAttemptsRef.current.clear();
+			return;
+		}
+
+		const currentValues = new Set(
+			form.values.allowList.map((raw) => raw.trim()).filter(Boolean),
+		);
+		for (const value of Array.from(hydrationAttemptsRef.current)) {
+			if (!currentValues.has(value)) {
+				hydrationAttemptsRef.current.delete(value);
+			}
+		}
+
+		const outstanding = Array.from(
+			new Set(
+				form.values.allowList
+					.map((raw) => raw.trim())
+					.filter((value) => {
+						if (value === "") {
+							return false;
+						}
+						const parsed = parseAllowListValue(value);
+						if (parsed.id === "*") {
+							return false;
+						}
+						if (hydrationAttemptsRef.current.has(value)) {
+							return false;
+						}
+						const hydrated = hydratedAllowList[value];
+						if (!hydrated) {
+							return true;
+						}
+						const friendlyLabel = hydrated.label?.trim();
+						return (
+							!friendlyLabel ||
+							friendlyLabel === parsed.id ||
+							friendlyLabel === value
+						);
+					}),
+			),
+		);
+
+		if (outstanding.length === 0) {
+			return;
+		}
+
+		let cancelled = false;
+
+		void (async () => {
+			const updates: Record<string, Option> = {};
+			for (const target of outstanding) {
+				hydrationAttemptsRef.current.add(target);
+				try {
+					const options = await resolveAllowListOptions(target);
+					const match = options.find(
+						(option) => option.value.trim() === target,
+					);
+					if (match) {
+						updates[target] = {
+							...match,
+							value: target,
+							label: formatAllowListOptionLabel(target, match.label),
+						};
+					}
+				} catch (error) {
+					console.error(`Failed to hydrate allow-list entry ${target}`, error);
+				}
+			}
+			if (!cancelled && Object.keys(updates).length > 0) {
+				setHydratedAllowList((prev) => ({
+					...prev,
+					...updates,
+				}));
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [form.values.allowList, hydratedAllowList, resolveAllowListOptions]);
 
 	return (
 		<HorizontalForm onSubmit={form.handleSubmit}>
@@ -74,7 +482,8 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 						label="Name"
 						required
 						onChange={onChangeTrimmed(form, () => setFormError(undefined))}
-						autoFocus
+						autoFocus={!nameDisabled}
+						disabled={nameDisabled}
 						fullWidth
 					/>
 				</FormFields>
@@ -153,14 +562,133 @@ export const CreateTokenForm: FC<CreateTokenFormProps> = ({
 					</Stack>
 				</FormFields>
 			</FormSection>
+			<FormSection
+				title="Scopes"
+				description="Select the capabilities this token should have. Composite scopes automatically include the low-level scope atoms they require."
+				classes={{ sectionInfo: classNames.sectionInfo }}
+			>
+				<FormFields>
+					<Stack spacing={3}>
+						<div className="flex gap-2">
+							<Button
+								type="button"
+								variant={scopeMode === "composite" ? "outline" : "subtle"}
+								size="sm"
+								onClick={() => handleScopeModeChange("composite")}
+							>
+								Composite scopes
+							</Button>
+							<Button
+								type="button"
+								variant={scopeMode === "low_level" ? "outline" : "subtle"}
+								size="sm"
+								onClick={() => handleScopeModeChange("low_level")}
+							>
+								Low-level scopes
+							</Button>
+						</div>
+
+						{scopeMode === "composite" ? (
+							<div className="flex flex-col gap-3">
+								{(scopeCatalog?.composites ?? []).map((composite) => {
+									const checked = form.values.compositeScopes.includes(
+										composite.name,
+									);
+									return (
+										<div
+											key={composite.name}
+											className="flex gap-3 items-start border border-border border-solid rounded-md p-3"
+										>
+											<Checkbox
+												checked={checked}
+												onCheckedChange={() =>
+													handleCompositeToggle(composite.name)
+												}
+											/>
+											<div>
+												<div className="font-medium">
+													{formatCompositeLabel(composite.name)}
+												</div>
+												<div className="text-sm text-content-secondary">
+													Includes{" "}
+													{formatCompositeExpansions(
+														composite.expands_to ?? [],
+													)}
+												</div>
+											</div>
+										</div>
+									);
+								})}
+							</div>
+						) : (
+							<MultiSelectCombobox
+								value={selectedLowLevelOptions}
+								options={lowLevelOptions}
+								groupBy="group"
+								placeholder="Search low-level scopes"
+								onSearchSync={(needle) =>
+									lowLevelOptions.filter((option) =>
+										option.label.toLowerCase().includes(needle.toLowerCase()),
+									)
+								}
+								onChange={handleLowLevelChange}
+								creatable={false}
+							/>
+						)}
+
+						<div className="rounded-md bg-surface-secondary px-3 py-2 text-sm text-content-secondary">
+							<div className="font-medium text-content-primary">
+								Selected scopes preview
+							</div>
+							<div className="mt-1">
+								<strong>Composite:</strong>{" "}
+								{effectiveCompositeScopes.length === 0
+									? "None"
+									: effectiveCompositeScopes
+											.map(formatCompositeLabel)
+											.join(", ")}
+							</div>
+							<div className="mt-1">
+								<strong>Low-level:</strong>{" "}
+								{effectiveLowLevelScopes.length === 0
+									? "None"
+									: effectiveLowLevelScopes.map(formatLowLevelLabel).join(", ")}
+							</div>
+						</div>
+					</Stack>
+				</FormFields>
+			</FormSection>
+			<FormSection
+				title="Allow-list"
+				description="Optionally restrict the token to specific resources. Leave empty to allow all resources."
+				classes={{ sectionInfo: classNames.sectionInfo }}
+			>
+				<FormFields>
+					<MultiSelectCombobox
+						ref={allowListComboboxRef}
+						value={allowListValueOptions}
+						onChange={handleAllowListChange}
+						onSearch={handleAllowListSearch}
+						placeholder="Type a resource prefix, e.g. workspace: or user:"
+						delay={200}
+						groupBy="group"
+						triggerSearchOnFocus
+					/>
+					<p className="text-xs text-content-secondary mt-1">
+						Examples: <code>workspace:All workspaces</code>,{" "}
+						<code>user:All users</code>, <code>template:my-template</code>,{" "}
+						<code>Any resource</code>
+					</p>
+				</FormFields>
+			</FormSection>
 
 			<FormFooter>
 				<Button onClick={() => navigate("/settings/tokens")} variant="outline">
 					Cancel
 				</Button>
-				<Button type="submit" disabled={isCreating}>
-					<Spinner loading={isCreating} />
-					{creationFailed ? "Retry" : "Create token"}
+				<Button type="submit" disabled={isSubmitting}>
+					<Spinner loading={isSubmitting} />
+					{submitFailed ? "Retry" : submitLabel}
 				</Button>
 			</FormFooter>
 		</HorizontalForm>
@@ -171,4 +699,32 @@ const classNames = {
 	sectionInfo: css`
     min-width: 300px;
   `,
+};
+
+const titleCase = (value: string) => {
+	if (value === "*" || value === "") {
+		return "Any";
+	}
+	return value
+		.split(/[^a-zA-Z0-9]+/)
+		.filter(Boolean)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+};
+
+const formatCompositeLabel = (scope: string) => {
+	const [, raw = scope] = scope.split(":", 2);
+	return titleCase(raw.replaceAll(".", " "));
+};
+
+const formatLowLevelLabel = (scope: string) => {
+	const [resource = scope, action = "*"] = scope.split(":", 2);
+	return `${titleCase(resource)} · ${titleCase(action)}`;
+};
+
+const formatCompositeExpansions = (scopes: readonly string[]) => {
+	if (!scopes || scopes.length === 0) {
+		return "no additional low-level scopes";
+	}
+	return scopes.map(formatLowLevelLabel).join(", ");
 };

--- a/site/src/pages/CreateTokenPage/CreateTokenPage.test.tsx
+++ b/site/src/pages/CreateTokenPage/CreateTokenPage.test.tsx
@@ -2,13 +2,39 @@ import {
 	renderWithAuth,
 	waitForLoaderToBeRemoved,
 } from "testHelpers/renderHelpers";
-import { screen, within } from "@testing-library/react";
+import { act, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { API } from "api/api";
+import type { ScopeCatalog } from "api/typesGenerated";
 import CreateTokenPage from "./CreateTokenPage";
+import { NANO_HOUR } from "./utils";
 
 describe("TokenPage", () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
 	it("shows the success modal", async () => {
+		const catalog: ScopeCatalog = {
+			specials: ["coder:all"],
+			low_level: [
+				{
+					name: "workspace:read",
+					resource: "workspace",
+					action: "read",
+				},
+			],
+			composites: [
+				{
+					name: "coder:workspaces.access",
+					expands_to: ["workspace:read"],
+				},
+			],
+		};
+		jest.spyOn(API, "getScopeCatalog").mockResolvedValueOnce(catalog);
+		jest.spyOn(API, "getTokenConfig").mockResolvedValueOnce({
+			max_token_lifetime: 90 * 24 * NANO_HOUR,
+		});
 		jest.spyOn(API, "createToken").mockResolvedValueOnce({
 			key: "abcd",
 		});
@@ -21,10 +47,14 @@ describe("TokenPage", () => {
 		await waitForLoaderToBeRemoved();
 
 		const form = container.querySelector("form") as HTMLFormElement;
-		await userEvent.type(screen.getByLabelText(/Name/), "my-token");
-		await userEvent.click(
-			within(form).getByRole("button", { name: /create token/i }),
-		);
+		await act(async () => {
+			await userEvent.type(screen.getByLabelText(/Name/), "my-token");
+		});
+		await act(async () => {
+			await userEvent.click(
+				within(form).getByRole("button", { name: /create token/i }),
+			);
+		});
 
 		// Then
 		expect(screen.getByText("abcd")).toBeInTheDocument();

--- a/site/src/pages/CreateTokenPage/allowListOptions.ts
+++ b/site/src/pages/CreateTokenPage/allowListOptions.ts
@@ -1,0 +1,6 @@
+export const ALLOW_LIST_QUICK_PICK_GROUP = "Quick picks";
+export const ALLOW_LIST_SPECIFIC_WORKSPACE_ACTION =
+	"__allow-list-action:workspace";
+export const ALLOW_LIST_SPECIFIC_TEMPLATE_ACTION =
+	"__allow-list-action:template";
+export const ALLOW_LIST_SPECIFIC_USER_ACTION = "__allow-list-action:user";

--- a/site/src/pages/CreateTokenPage/useAllowListResolver.ts
+++ b/site/src/pages/CreateTokenPage/useAllowListResolver.ts
@@ -1,0 +1,252 @@
+import { API } from "api/api";
+import type { Option } from "components/MultiSelectCombobox/MultiSelectCombobox";
+import { useCallback } from "react";
+import {
+	ALLOW_LIST_QUICK_PICK_GROUP,
+	ALLOW_LIST_SPECIFIC_TEMPLATE_ACTION,
+	ALLOW_LIST_SPECIFIC_USER_ACTION,
+	ALLOW_LIST_SPECIFIC_WORKSPACE_ACTION,
+} from "./allowListOptions";
+
+const pluralizeResourceType = (type: string) => {
+	if (type === "" || type === "*") {
+		return type;
+	}
+	return type.endsWith("s") ? type : `${type}s`;
+};
+
+const formatAllowListOptionLabel = (value: string, label: string) => {
+	const trimmedLabel = label.trim();
+	if (trimmedLabel === "") {
+		return label;
+	}
+	const [typePart = ""] = value.split(":", 1);
+	const type = typePart.trim();
+	if (type === "" || type === "*") {
+		return trimmedLabel;
+	}
+	const lowercaseLabel = trimmedLabel.toLowerCase();
+	const prefix = `${type} :`;
+	if (lowercaseLabel.startsWith(prefix.toLowerCase())) {
+		return trimmedLabel;
+	}
+	return `${type} : ${trimmedLabel}`;
+};
+
+export const useAllowListResolver = () => {
+	return useCallback(async (input: string): Promise<Option[]> => {
+		const trimmed = input.trim();
+		const wantsGlobalWildcard =
+			trimmed === "" || trimmed === "*" || trimmed === "*:*";
+		const [rawType, rawSearch = ""] = trimmed.includes(":")
+			? trimmed.split(":", 2)
+			: ["", trimmed];
+		const normalizedType = rawType.trim().toLowerCase();
+		const search = rawSearch.trim();
+		const fallbackNeedle = trimmed;
+
+		const matchesNeedle = (option: Option, needle: string) => {
+			if (needle === "") {
+				return true;
+			}
+			const lowered = needle.toLowerCase();
+			return (
+				option.value.toLowerCase().includes(lowered) ||
+				option.label.toLowerCase().includes(lowered)
+			);
+		};
+
+		const aggregator = new Map<string, Option>();
+		const addOption = (option: Option, needle: string) => {
+			if (!matchesNeedle(option, needle)) {
+				return;
+			}
+			if (!aggregator.has(option.value)) {
+				aggregator.set(option.value, option);
+			}
+		};
+
+		if (wantsGlobalWildcard) {
+			addOption({ value: "*:*", label: "Any resource", group: "Wildcard" }, "");
+			addOption(
+				{
+					value: ALLOW_LIST_SPECIFIC_WORKSPACE_ACTION,
+					label: formatAllowListOptionLabel(
+						"workspace:",
+						"Specific workspace…",
+					),
+					group: ALLOW_LIST_QUICK_PICK_GROUP,
+					prefix: "workspace:",
+				},
+				"",
+			);
+			addOption(
+				{
+					value: ALLOW_LIST_SPECIFIC_TEMPLATE_ACTION,
+					label: formatAllowListOptionLabel("template:", "Specific template…"),
+					group: ALLOW_LIST_QUICK_PICK_GROUP,
+					prefix: "template:",
+				},
+				"",
+			);
+			addOption(
+				{
+					value: ALLOW_LIST_SPECIFIC_USER_ACTION,
+					label: formatAllowListOptionLabel("user:", "Specific user…"),
+					group: ALLOW_LIST_QUICK_PICK_GROUP,
+					prefix: "user:",
+				},
+				"",
+			);
+		}
+
+		const shouldQueryWorkspaces =
+			normalizedType === "" || normalizedType === "workspace";
+		const shouldQueryTemplates =
+			normalizedType === "" || normalizedType === "template";
+		const shouldQueryUsers = normalizedType === "" || normalizedType === "user";
+
+		if (shouldQueryWorkspaces) {
+			const needle = normalizedType === "workspace" ? search : fallbackNeedle;
+			if (needle === "") {
+				addOption(
+					{
+						value: "workspace:*",
+						label: formatAllowListOptionLabel("workspace:*", "All workspaces"),
+						group: pluralizeResourceType("workspace"),
+					},
+					needle,
+				);
+			}
+			if (needle !== "") {
+				const request: { limit: number; q?: string } = { limit: 20 };
+				request.q = needle;
+				try {
+					const { workspaces } = await API.getWorkspaces(request);
+					for (const workspace of workspaces) {
+						addOption(
+							{
+								value: `workspace:${workspace.id}`,
+								label: formatAllowListOptionLabel(
+									`workspace:${workspace.id}`,
+									workspace.name?.trim() || workspace.id,
+								),
+								group: pluralizeResourceType("workspace"),
+								description: workspace.owner_name
+									? `Owner: ${workspace.owner_name}`
+									: undefined,
+							},
+							needle,
+						);
+					}
+				} catch (error) {
+					console.error("Failed to resolve workspaces for allow-list", error);
+				}
+			}
+		}
+
+		if (shouldQueryTemplates) {
+			const needle = normalizedType === "template" ? search : fallbackNeedle;
+			if (needle === "") {
+				addOption(
+					{
+						value: "template:*",
+						label: formatAllowListOptionLabel("template:*", "All templates"),
+						group: pluralizeResourceType("template"),
+					},
+					needle,
+				);
+			}
+			if (needle !== "") {
+				try {
+					const templates = await API.getTemplates({ q: needle });
+					for (const template of templates.slice(0, 20)) {
+						addOption(
+							{
+								value: `template:${template.id}`,
+								label: formatAllowListOptionLabel(
+									`template:${template.id}`,
+									template.display_name?.trim() || template.name,
+								),
+								group: pluralizeResourceType("template"),
+							},
+							needle,
+						);
+					}
+				} catch (error) {
+					console.error("Failed to resolve templates for allow-list", error);
+				}
+			}
+		}
+
+		if (shouldQueryUsers) {
+			const needle = normalizedType === "user" ? search : fallbackNeedle;
+			if (needle === "") {
+				addOption(
+					{
+						value: "user:*",
+						label: formatAllowListOptionLabel("user:*", "All users"),
+						group: pluralizeResourceType("user"),
+					},
+					needle,
+				);
+			}
+			if (needle !== "") {
+				const request = { limit: 20, q: needle };
+				try {
+					const response = await API.getUsers(request);
+					const { users } = response;
+					if (!Array.isArray(users)) {
+						// Defensive: API contract expectation; surface backend contract regressions early.
+						throw new Error("API.getUsers returned an unexpected payload.");
+					}
+					for (const user of users.slice(0, 20)) {
+						const userId = (user.id ?? "").trim();
+						if (userId === "") {
+							throw new Error(
+								"Encountered user without an id when resolving allow-list entries.",
+							);
+						}
+						const nameCandidate =
+							(user.name ?? "").trim() || (user.username ?? "").trim();
+						if (nameCandidate === "") {
+							throw new Error(
+								"Encountered user without a usable name while resolving allow-list entries.",
+							);
+						}
+						const descriptionParts: string[] = [];
+						if (
+							user.username &&
+							user.username.trim() !== "" &&
+							user.username.trim() !== nameCandidate
+						) {
+							descriptionParts.push(`Username: ${user.username}`);
+						}
+						if (user.email && user.email.trim() !== "") {
+							descriptionParts.push(`Email: ${user.email}`);
+						}
+						addOption(
+							{
+								value: `user:${userId}`,
+								label: formatAllowListOptionLabel(
+									`user:${userId}`,
+									nameCandidate,
+								),
+								group: pluralizeResourceType("user"),
+								description:
+									descriptionParts.length > 0
+										? descriptionParts.join(" • ")
+										: undefined,
+							},
+							needle,
+						);
+					}
+				} catch (error) {
+					console.error("Failed to resolve users for allow-list", error);
+				}
+			}
+		}
+
+		return [...aggregator.values()];
+	}, []);
+};

--- a/site/src/pages/CreateTokenPage/utils.ts
+++ b/site/src/pages/CreateTokenPage/utils.ts
@@ -1,9 +1,99 @@
+import type {
+	APIAllowListTarget,
+	APIKeyScope,
+	ScopeCatalog,
+} from "api/typesGenerated";
+
 export const NANO_HOUR = 3600000000000;
+
+export type ScopeSelectionMode = "composite" | "low_level";
 
 export interface CreateTokenData {
 	name: string;
 	lifetime: number;
+	scopeMode: ScopeSelectionMode;
+	compositeScopes: string[];
+	lowLevelScopes: string[];
+	allowList: string[];
 }
+
+export const buildCompositeExpansionMap = (catalog?: ScopeCatalog) => {
+	const map = new Map<string, string[]>();
+	if (!catalog) {
+		return map;
+	}
+	for (const composite of catalog.composites ?? []) {
+		map.set(composite.name, [...(composite.expands_to ?? [])]);
+	}
+	return map;
+};
+
+export const expandCompositeScopes = (
+	selected: readonly string[],
+	expansionMap: Map<string, string[]>,
+) => {
+	const expanded = new Set<string>();
+	for (const scope of selected) {
+		const matches = expansionMap.get(scope) ?? [];
+		for (const match of matches) {
+			expanded.add(match);
+		}
+	}
+	return Array.from(expanded).sort((a, b) => a.localeCompare(b));
+};
+
+export const sortScopes = (scopes: readonly string[]) => {
+	return [...scopes].sort((a, b) => a.localeCompare(b));
+};
+
+export const buildRequestScopes = (
+	selectedComposites: string[],
+	selectedLowLevel: string[],
+): APIKeyScope[] => {
+	const next = new Set<string>();
+	selectedComposites.forEach((scope) => next.add(scope));
+	selectedLowLevel.forEach((scope) => next.add(scope));
+	return Array.from(next) as APIKeyScope[];
+};
+
+export const serializeAllowList = (
+	entries: string[],
+): APIAllowListTarget[] | undefined => {
+	if (entries.length === 0) {
+		return undefined;
+	}
+	const uniqueEntries = Array.from(new Set(entries));
+	const targets: APIAllowListTarget[] = [];
+	const seen = new Set<string>();
+	for (const entry of uniqueEntries) {
+		const trimmed = entry.trim();
+		if (trimmed === "") {
+			continue;
+		}
+		const [typeRaw, idRaw] = trimmed.split(":", 2);
+		const type = typeRaw && typeRaw !== "" ? typeRaw : "*";
+		const id = idRaw && idRaw !== "" ? idRaw : "*";
+		const key = `${type}:${id}`;
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		targets.push({
+			type: type as APIAllowListTarget["type"],
+			id: id as APIAllowListTarget["id"],
+		});
+	}
+	return targets.length > 0 ? targets : undefined;
+};
+
+export const allowListTargetsToStrings = (
+	targets?: readonly APIAllowListTarget[],
+): string[] => {
+	if (!targets || targets.length === 0) {
+		return [];
+	}
+	return targets.map((target) => `${target.type}:${target.id}`);
+};
 
 export interface LifetimeDay {
 	label: string;

--- a/site/src/pages/EditTokenPage/EditTokenPage.test.tsx
+++ b/site/src/pages/EditTokenPage/EditTokenPage.test.tsx
@@ -1,0 +1,122 @@
+import {
+	renderWithAuth,
+	waitForLoaderToBeRemoved,
+} from "testHelpers/renderHelpers";
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { API } from "api/api";
+import type { APIKey, ScopeCatalog } from "api/typesGenerated";
+import * as reactRouter from "react-router";
+import { NANO_HOUR } from "../CreateTokenPage/utils";
+import EditTokenPage from "./EditTokenPage";
+
+const makeToken = (overrides: Partial<APIKey> = {}): APIKey => ({
+	id: "token-id",
+	user_id: "user-1",
+	last_used: new Date().toISOString(),
+	expires_at: new Date().toISOString(),
+	created_at: new Date().toISOString(),
+	updated_at: new Date().toISOString(),
+	login_type: "token",
+	scope: "all",
+	scopes: ["coder:workspaces.access"],
+	token_name: "ci-bot",
+	lifetime_seconds: 30 * 24 * 60 * 60,
+	allow_list: [],
+	...overrides,
+});
+
+const catalog: ScopeCatalog = {
+	specials: ["coder:all"],
+	low_level: [
+		{
+			name: "workspace:read",
+			resource: "workspace",
+			action: "read",
+		},
+	],
+	composites: [
+		{
+			name: "coder:workspaces.access",
+			expands_to: ["workspace:read"],
+		},
+	],
+};
+
+describe("EditTokenPage", () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("updates a token", async () => {
+		const navigateMock = jest.fn();
+		jest.spyOn(reactRouter, "useNavigate").mockReturnValue(navigateMock);
+		jest.spyOn(API, "getToken").mockResolvedValue(makeToken());
+		jest.spyOn(API, "getScopeCatalog").mockResolvedValue(catalog);
+		jest.spyOn(API, "getTokenConfig").mockResolvedValue({
+			max_token_lifetime: 90 * 24 * NANO_HOUR,
+		});
+		const updateSpy = jest
+			.spyOn(API, "updateToken")
+			.mockResolvedValue(makeToken({ lifetime_seconds: 60 * 24 * 60 * 60 }));
+
+		const user = userEvent.setup();
+
+		renderWithAuth(<EditTokenPage />, {
+			route: "/settings/tokens/ci-bot/edit",
+			path: "/settings/tokens/:tokenName/edit",
+		});
+
+		await waitForLoaderToBeRemoved();
+
+		await act(async () => {
+			await user.click(screen.getByLabelText(/Lifetime/i));
+		});
+		await act(async () => {
+			await user.click(screen.getByRole("option", { name: "60 days" }));
+		});
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /save changes/i }));
+		});
+
+		await waitFor(() => expect(updateSpy).toHaveBeenCalled());
+
+		expect(updateSpy).toHaveBeenCalledWith(
+			"ci-bot",
+			expect.objectContaining({ lifetime: 60 * 24 * NANO_HOUR }),
+		);
+		expect(navigateMock).toHaveBeenCalledWith("/settings/tokens");
+	});
+
+	it("preloads existing allow-list entries", async () => {
+		jest.spyOn(reactRouter, "useNavigate").mockReturnValue(jest.fn());
+		jest.spyOn(API, "getToken").mockResolvedValue(
+			makeToken({
+				allow_list: [
+					{ type: "workspace", id: "*", display_name: "All workspaces" },
+					{ type: "user", id: "user-123" },
+				],
+				lifetime_seconds: 7 * 24 * 60 * 60,
+			}),
+		);
+		jest.spyOn(API, "getScopeCatalog").mockResolvedValue(catalog);
+		jest.spyOn(API, "getTokenConfig").mockResolvedValue({
+			max_token_lifetime: 90 * 24 * NANO_HOUR,
+		});
+
+		renderWithAuth(<EditTokenPage />, {
+			route: "/settings/tokens/ci-bot/edit",
+			path: "/settings/tokens/:tokenName/edit",
+		});
+
+		await waitForLoaderToBeRemoved();
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("workspace : All workspaces"),
+			).toBeInTheDocument();
+			expect(screen.getByText("user : user-123")).toBeInTheDocument();
+		});
+	});
+});

--- a/site/src/pages/EditTokenPage/EditTokenPage.tsx
+++ b/site/src/pages/EditTokenPage/EditTokenPage.tsx
@@ -1,0 +1,226 @@
+import { API } from "api/api";
+import type {
+	APIAllowListTarget,
+	APIKey,
+	ScopeCatalog,
+	UpdateTokenRequest,
+} from "api/typesGenerated";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { FullPageHorizontalForm } from "components/FullPageForm/FullPageHorizontalForm";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
+import { Loader } from "components/Loader/Loader";
+import { useFormik } from "formik";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useNavigate, useParams } from "react-router";
+import { pageTitle } from "utils/page";
+import { CreateTokenForm } from "../CreateTokenPage/CreateTokenForm";
+import { useAllowListResolver } from "../CreateTokenPage/useAllowListResolver";
+import {
+	allowListTargetsToStrings,
+	buildRequestScopes,
+	type CreateTokenData,
+	NANO_HOUR,
+	serializeAllowList,
+} from "../CreateTokenPage/utils";
+
+const defaultValues: CreateTokenData = {
+	name: "",
+	lifetime: 30,
+	scopeMode: "composite",
+	compositeScopes: [],
+	lowLevelScopes: [],
+	allowList: [],
+};
+
+const lifetimeDaysFromSeconds = (seconds: number) => {
+	return Math.max(1, Math.ceil(seconds / (24 * 60 * 60)));
+};
+
+const scopesAreEqual = (a: readonly string[], b: readonly string[]) => {
+	if (a.length !== b.length) {
+		return false;
+	}
+	const setA = new Set(a);
+	return b.every((scope) => setA.has(scope));
+};
+
+const allowListsEqual = (
+	a?: readonly APIAllowListTarget[],
+	b?: readonly APIAllowListTarget[],
+): boolean => {
+	const stringify = (targets?: readonly APIAllowListTarget[]) =>
+		(targets ?? [])
+			.map((target) => `${target.type}:${target.id}`)
+			.sort()
+			.join("|");
+	return stringify(a) === stringify(b);
+};
+
+const convertTokenToFormValues = (
+	token: APIKey,
+	scopeCatalog?: ScopeCatalog,
+): CreateTokenData => {
+	const compositeNames = new Set(
+		scopeCatalog?.composites?.map((item) => item.name) ?? [],
+	);
+	const compositeScopes = token.scopes.filter((scope) =>
+		compositeNames.has(scope),
+	);
+	const lowLevelScopes = token.scopes.filter(
+		(scope) => !compositeNames.has(scope),
+	);
+
+	return {
+		name: token.token_name,
+		lifetime: lifetimeDaysFromSeconds(token.lifetime_seconds),
+		scopeMode: compositeScopes.length > 0 ? "composite" : "low_level",
+		compositeScopes,
+		lowLevelScopes,
+		allowList: allowListTargetsToStrings(token.allow_list),
+	};
+};
+
+const EditTokenPage = () => {
+	const { tokenName } = useParams<{ tokenName?: string }>();
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const [formError, setFormError] = useState<unknown>(undefined);
+	const resolveAllowListOptions = useAllowListResolver();
+
+	const {
+		data: token,
+		isLoading: loadingToken,
+		isError: tokenFailed,
+		error: tokenError,
+	} = useQuery({
+		queryKey: ["token", tokenName],
+		queryFn: () => API.getToken(tokenName ?? ""),
+		enabled: Boolean(tokenName),
+	});
+
+	const {
+		data: scopeCatalog,
+		isLoading: loadingCatalog,
+		isError: catalogFailed,
+		error: catalogError,
+	} = useQuery({
+		queryKey: ["scopecatalog"],
+		queryFn: API.getScopeCatalog,
+	});
+
+	const {
+		data: tokenConfig,
+		isLoading: loadingConfig,
+		isError: configFailed,
+		error: configError,
+	} = useQuery({
+		queryKey: ["tokenconfig"],
+		queryFn: API.getTokenConfig,
+	});
+
+	const {
+		mutate: runUpdate,
+		isPending: isUpdating,
+		isError: updateFailed,
+	} = useMutation({
+		mutationFn: (payload: UpdateTokenRequest) =>
+			API.updateToken(tokenName ?? "", payload),
+		onSuccess: async () => {
+			displaySuccess("Token has been updated");
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: ["token", tokenName] }),
+				queryClient.invalidateQueries({ queryKey: ["tokens"] }),
+			]);
+			navigate("/settings/tokens");
+		},
+		onError: (error: unknown) => {
+			setFormError(error);
+			displayError("Failed to update token");
+		},
+	});
+
+	const initialValues = token
+		? convertTokenToFormValues(token, scopeCatalog)
+		: defaultValues;
+
+	const form = useFormik<CreateTokenData>({
+		enableReinitialize: true,
+		initialValues,
+		onSubmit: (values) => {
+			if (!token) {
+				return;
+			}
+
+			const scopes = buildRequestScopes(
+				values.compositeScopes,
+				values.lowLevelScopes,
+			);
+			const allowList = serializeAllowList(values.allowList);
+			const currentAllowList = token.allow_list;
+
+			const scopesChanged = !scopesAreEqual(scopes, token.scopes);
+			const newLifetime = values.lifetime * 24 * NANO_HOUR;
+			const currentLifetime = token.lifetime_seconds * 1_000_000_000;
+			const lifetimeChanged = newLifetime !== currentLifetime;
+			const allowListChanged = !allowListsEqual(allowList, currentAllowList);
+			const nextAllowList =
+				values.allowList.length === 0 ? [] : (allowList ?? []);
+
+			const payload: UpdateTokenRequest = {
+				...(scopesChanged ? { scopes } : {}),
+				...(lifetimeChanged ? { lifetime: newLifetime } : {}),
+				...(allowListChanged ? { allow_list: nextAllowList } : {}),
+			};
+
+			if (Object.keys(payload).length === 0) {
+				displaySuccess("Nothing to update");
+				navigate("/settings/tokens");
+				return;
+			}
+
+			runUpdate(payload);
+		},
+	});
+
+	if (loadingToken || loadingCatalog || loadingConfig) {
+		return <Loader />;
+	}
+
+	if (!tokenName || tokenFailed || !token) {
+		return (
+			<ErrorAlert
+				error={tokenError ?? new Error("Token could not be loaded")}
+			/>
+		);
+	}
+
+	return (
+		<>
+			<title>{pageTitle(`Edit Token · ${token.token_name}`)}</title>
+			{catalogFailed && <ErrorAlert error={catalogError} />}
+			{configFailed && <ErrorAlert error={configError} />}
+			{updateFailed && <ErrorAlert error={formError} />}
+			<FullPageHorizontalForm
+				title={`Edit ${token.token_name}`}
+				detail="Adjust token permissions or allowed resources."
+			>
+				<CreateTokenForm
+					form={form}
+					maxTokenLifetime={tokenConfig?.max_token_lifetime}
+					formError={formError}
+					setFormError={setFormError}
+					isSubmitting={isUpdating}
+					submitFailed={updateFailed}
+					scopeCatalog={scopeCatalog}
+					initialAllowListTargets={token.allow_list}
+					resolveAllowListOptions={resolveAllowListOptions}
+					submitLabel="Save changes"
+					nameDisabled
+				/>
+			</FullPageHorizontalForm>
+		</>
+	);
+};
+
+export default EditTokenPage;

--- a/site/src/pages/UserSettingsPage/Layout.tsx
+++ b/site/src/pages/UserSettingsPage/Layout.tsx
@@ -18,7 +18,7 @@ const Layout: FC = () => {
 				<Stack css={{ padding: "48px 0" }} direction="row" spacing={6}>
 					<Sidebar user={me} />
 					<Suspense fallback={<Loader />}>
-						<main css={{ maxWidth: 800, width: "100%" }}>
+						<main css={{ maxWidth: 1100, width: "100%" }}>
 							<Outlet />
 						</main>
 					</Suspense>

--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
@@ -1,7 +1,7 @@
-import { useTheme } from "@emotion/react";
-import IconButton from "@mui/material/IconButton";
-import type { APIKeyWithOwner } from "api/typesGenerated";
+import { API } from "api/api";
+import type { APIAllowListTarget, APIKeyWithOwner } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { Button } from "components/Button/Button";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { Stack } from "components/Stack/Stack";
 import {
@@ -16,15 +16,234 @@ import { TableEmpty } from "components/TableEmpty/TableEmpty";
 import { TableLoader } from "components/TableLoader/TableLoader";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { TrashIcon } from "lucide-react";
-import type { FC, ReactNode } from "react";
+import { PencilIcon, TrashIcon } from "lucide-react";
+import { type FC, type ReactNode, useMemo } from "react";
+import { useQueries } from "react-query";
+import { Link as RouterLink } from "react-router";
 
 dayjs.extend(relativeTime);
 
-const lastUsedOrNever = (lastUsed: string) => {
-	const t = dayjs(lastUsed);
+const lastUsedOrNever = (lastUsed?: string | null) => {
+	if (!lastUsed) {
+		return "Never";
+	}
+
+	const parsed = dayjs(lastUsed);
+	if (!parsed.isValid()) {
+		return "Never";
+	}
+
 	const now = dayjs();
-	return now.isBefore(t.add(100, "year")) ? t.fromNow() : "Never";
+	return now.isBefore(parsed.add(100, "year")) ? parsed.fromNow() : "Never";
+};
+
+const getScopeList = (token?: APIKeyWithOwner | null) => {
+	if (!token) {
+		return ["coder:all (implicit)"];
+	}
+
+	const scopes =
+		token.scopes && token.scopes.length > 0
+			? token.scopes
+			: token.scope
+				? [token.scope]
+				: [];
+
+	if (scopes.length === 0) {
+		return ["coder:all (implicit)"];
+	}
+
+	return scopes;
+};
+
+type AllowListFetcher = (id: string) => Promise<string>;
+
+const allowListFetchers: Partial<Record<string, AllowListFetcher>> = {
+	template: async (templateId: string) => {
+		const template = await API.getTemplate(templateId);
+		return template.display_name?.trim() || template.name || templateId;
+	},
+	workspace: async (workspaceId: string) => {
+		const workspace = await API.getWorkspace(workspaceId);
+		return workspace.name?.trim() || workspaceId;
+	},
+};
+
+const normalizeAllowListEntry = (
+	entry: APIAllowListTarget | string | null | undefined,
+) => {
+	if (entry === null || entry === undefined) {
+		return "*:*";
+	}
+
+	if (typeof entry === "string") {
+		return entry;
+	}
+
+	const type = entry.type ?? "*";
+	const id = entry.id ?? "*";
+
+	return `${type}:${id}`;
+};
+
+const parseAllowListKey = (key: string) => {
+	const [type = "*", id = "*"] = key.split(":", 2);
+	return { type, id };
+};
+
+const formatResourceType = (rawType: string) => {
+	if (rawType === "*") {
+		return "Any resource";
+	}
+	return rawType
+		.split(/[_-]/g)
+		.filter(Boolean)
+		.map((segment) => segment.toLowerCase())
+		.join(" ");
+};
+
+const pluralizeResourceType = (type: string) => {
+	if (type === "*") {
+		return "resources";
+	}
+	const formatted = formatResourceType(type);
+	return /s$/i.test(formatted) ? formatted : `${formatted}s`;
+};
+
+const buildAllowListLabel = (
+	type: string,
+	id: string,
+	options?: { resolvedName?: string },
+) => {
+	if (type === "*" && id === "*") {
+		return "Any resource";
+	}
+	if (id === "*") {
+		return `All ${pluralizeResourceType(type)}`;
+	}
+	if (type === "*") {
+		return `Any resource (${id})`;
+	}
+	const resolved = options?.resolvedName?.trim();
+	if (resolved) {
+		return `${formatResourceType(type)}: ${resolved}`;
+	}
+	return `${formatResourceType(type)}: ${id}`;
+};
+
+const defaultLabelForKey = (key: string) => {
+	const { type, id } = parseAllowListKey(key);
+	return buildAllowListLabel(type, id);
+};
+
+const useAllowListLabelMap = (tokens?: APIKeyWithOwner[] | null) => {
+	const uniqueEntries = useMemo(() => {
+		const accumulator = new Map<
+			string,
+			{ key: string; type: string; id: string; displayName?: string }
+		>();
+		tokens?.forEach((token) => {
+			token.allow_list?.forEach((entry) => {
+				const key = normalizeAllowListEntry(entry);
+				if (!key) {
+					return;
+				}
+
+				if (!accumulator.has(key)) {
+					const { type, id } = parseAllowListKey(key);
+					const displayName =
+						typeof entry === "string"
+							? undefined
+							: entry.display_name?.trim() || undefined;
+					accumulator.set(key, { key, type, id, displayName });
+					return;
+				}
+
+				const existing = accumulator.get(key);
+				if (existing && !existing.displayName && typeof entry !== "string") {
+					const displayName = entry.display_name?.trim() || undefined;
+					if (displayName) {
+						accumulator.set(key, { ...existing, displayName });
+					}
+				}
+			});
+		});
+		return Array.from(accumulator.values());
+	}, [tokens]);
+
+	const entriesRequiringLookup = useMemo(
+		() =>
+			uniqueEntries.filter(
+				({ type, id, displayName }) =>
+					type !== "*" &&
+					id !== "*" &&
+					!displayName &&
+					Boolean(allowListFetchers[type]),
+			),
+		[uniqueEntries],
+	);
+
+	const lookupResults = useQueries({
+		queries: entriesRequiringLookup.map((entry) => {
+			const fetcher = allowListFetchers[entry.type];
+			return {
+				queryKey: ["allow-list", entry.type, entry.id] as const,
+				queryFn: async () => {
+					if (!fetcher) {
+						return entry.id;
+					}
+					return fetcher(entry.id);
+				},
+				staleTime: 5 * 60 * 1000,
+			};
+		}),
+	});
+
+	return useMemo(() => {
+		const map = new Map<string, string>();
+		uniqueEntries.forEach(({ key, type, id, displayName }) => {
+			map.set(
+				key,
+				buildAllowListLabel(
+					type,
+					id,
+					displayName ? { resolvedName: displayName } : undefined,
+				),
+			);
+		});
+		entriesRequiringLookup.forEach((entry, index) => {
+			const result = lookupResults[index];
+			if (result?.data) {
+				map.set(
+					entry.key,
+					buildAllowListLabel(entry.type, entry.id, {
+						resolvedName: result.data,
+					}),
+				);
+			}
+		});
+		return map;
+	}, [entriesRequiringLookup, lookupResults, uniqueEntries]);
+};
+
+const getAllowListLabels = (
+	entries: readonly APIAllowListTarget[] | null | undefined,
+	labelMap: Map<string, string>,
+) => {
+	if (!entries || entries.length === 0) {
+		return ["Any resource"];
+	}
+
+	const normalized = entries
+		.map(normalizeAllowListEntry)
+		.filter((value) => value && value.length > 0);
+
+	if (normalized.length === 0) {
+		return ["*:*"];
+	}
+
+	const unique = Array.from(new Set(normalized));
+	return unique.map((key) => labelMap.get(key) ?? defaultLabelForKey(key));
 };
 
 interface TokensPageViewProps {
@@ -44,23 +263,27 @@ export const TokensPageView: FC<TokensPageViewProps> = ({
 	hasLoaded,
 	onDelete,
 	deleteTokenError,
+	children,
 }) => {
-	const theme = useTheme();
+	const allowListLabels = useAllowListLabelMap(tokens);
 
 	return (
 		<Stack>
 			{Boolean(getTokensError) && <ErrorAlert error={getTokensError} />}
 			{Boolean(deleteTokenError) && <ErrorAlert error={deleteTokenError} />}
+			{children}
 
-			<Table>
+			<Table className="min-w-[1000px]">
 				<TableHeader>
 					<TableRow>
-						<TableHead className="w-1/5">ID</TableHead>
-						<TableHead className="w-1/5">Name</TableHead>
-						<TableHead className="w-1/5">Last Used</TableHead>
-						<TableHead className="w-1/5">Expires At</TableHead>
-						<TableHead className="w-1/5">Created At</TableHead>
-						<TableHead className="w-[1%]" />
+						<TableHead className="w-[12%]">ID</TableHead>
+						<TableHead className="w-[14%]">Name</TableHead>
+						<TableHead className="w-[18%]">Scopes</TableHead>
+						<TableHead className="w-[24%]">Allow List</TableHead>
+						<TableHead className="w-[8%]">Last Used</TableHead>
+						<TableHead className="w-[8%]">Expires At</TableHead>
+						<TableHead className="w-[8%]">Created At</TableHead>
+						<TableHead className="w-[8%] text-right">Actions</TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody>
@@ -73,53 +296,106 @@ export const TokensPageView: FC<TokensPageViewProps> = ({
 						</Cond>
 						<Cond>
 							{tokens?.map((token) => {
+								const scopeList = getScopeList(token);
+								const allowListEntries = getAllowListLabels(
+									token.allow_list,
+									allowListLabels,
+								);
+
 								return (
 									<TableRow
 										key={token.id}
 										data-testid={`token-${token.id}`}
 										tabIndex={0}
 									>
-										<TableCell>
-											<span style={{ color: theme.palette.text.secondary }}>
+										<TableCell className="align-top">
+											<div className="text-content-secondary break-all">
 												{token.id}
-											</span>
+											</div>
 										</TableCell>
 
-										<TableCell>
-											<span style={{ color: theme.palette.text.secondary }}>
+										<TableCell className="align-top">
+											<div className="text-content-secondary break-words">
 												{token.token_name}
-											</span>
+											</div>
 										</TableCell>
 
-										<TableCell>{lastUsedOrNever(token.last_used)}</TableCell>
+										<TableCell className="align-top">
+											<div className="text-content-secondary break-words space-y-1">
+												{scopeList.map((scope, index) => (
+													<div key={`${scope}-${index}`}>{scope}</div>
+												))}
+											</div>
+										</TableCell>
 
-										<TableCell>
+										<TableCell className="align-top">
+											<div className="text-content-secondary break-words space-y-1">
+												{allowListEntries.map((label, index) => (
+													<div key={`${label}-${index}`}>{label}</div>
+												))}
+											</div>
+										</TableCell>
+
+										<TableCell className="align-top">
+											{lastUsedOrNever(token.last_used)}
+										</TableCell>
+
+										<TableCell className="align-top">
 											<span
-												style={{ color: theme.palette.text.secondary }}
+												className="text-content-secondary"
 												data-chromatic="ignore"
 											>
 												{dayjs(token.expires_at).fromNow()}
 											</span>
 										</TableCell>
 
-										<TableCell>
-											<span style={{ color: theme.palette.text.secondary }}>
+										<TableCell className="align-top">
+											<div className="text-content-secondary">
 												{dayjs(token.created_at).fromNow()}
-											</span>
+											</div>
 										</TableCell>
 
-										<TableCell>
-											<span style={{ color: theme.palette.text.secondary }}>
-												<IconButton
+										<TableCell className="align-top text-right">
+											<Stack
+												direction="row"
+												spacing={1}
+												alignItems="center"
+												justifyContent="flex-end"
+											>
+												<Button
+													asChild
+													size="icon"
+													variant="subtle"
+													aria-label="Edit token"
+													className="text-content-secondary hover:text-content-primary"
+												>
+													<RouterLink
+														to={`${encodeURIComponent(token.token_name)}/edit`}
+													>
+														<PencilIcon
+															aria-hidden="true"
+															className="size-icon-sm"
+														/>
+														<span className="sr-only">Edit token</span>
+													</RouterLink>
+												</Button>
+
+												<Button
+													size="icon"
+													variant="subtle"
 													onClick={() => {
 														onDelete(token);
 													}}
-													size="medium"
 													aria-label="Delete token"
+													className="text-content-secondary hover:text-content-primary"
 												>
-													<TrashIcon className="size-icon-sm" />
-												</IconButton>
-											</span>
+													<TrashIcon
+														aria-hidden="true"
+														className="size-icon-sm"
+													/>
+													<span className="sr-only">Delete token</span>
+												</Button>
+											</Stack>
 										</TableCell>
 									</TableRow>
 								);

--- a/site/src/pages/UserSettingsPage/TokensPage/hooks.ts
+++ b/site/src/pages/UserSettingsPage/TokensPage/hooks.ts
@@ -1,4 +1,5 @@
 import { API } from "api/api";
+import { tokens as tokensQuery } from "api/queries/tokens";
 import type { TokensFilter } from "api/typesGenerated";
 import {
 	type QueryKey,
@@ -6,14 +7,12 @@ import {
 	useQuery,
 	useQueryClient,
 } from "react-query";
+import { tokens as tokensQuery } from "api/queries/tokens";
 
 // Load all tokens
 export const useTokensData = ({ include_all }: TokensFilter) => {
 	const queryKey = ["tokens", include_all];
-	const result = useQuery({
-		queryKey,
-		queryFn: () => API.getTokens({ include_all }),
-	});
+	const result = useQuery(tokensQuery({ include_all }));
 
 	return {
 		queryKey,

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -200,6 +200,7 @@ const WorkspaceSettingsPage = lazy(
 const CreateTokenPage = lazy(
 	() => import("./pages/CreateTokenPage/CreateTokenPage"),
 );
+const EditTokenPage = lazy(() => import("./pages/EditTokenPage/EditTokenPage"));
 const TemplateDocsPage = lazy(
 	() => import("./pages/TemplatePage/TemplateDocsPage/TemplateDocsPage"),
 );
@@ -534,6 +535,7 @@ export const router = createBrowserRouter(
 						<Route path="tokens">
 							<Route index element={<TokensPage />} />
 							<Route path="new" element={<CreateTokenPage />} />
+							<Route path=":tokenName/edit" element={<EditTokenPage />} />
 						</Route>
 						<Route path="notifications" element={<UserNotificationsPage />} />
 					</Route>


### PR DESCRIPTION
# Add Token Scopes and Allow-List Support

This PR adds support for token scopes and resource allow-lists, enabling more granular control over API token permissions. Users can now:

1. Create and edit tokens with specific scopes using either:
   - Composite scopes (high-level capabilities)
   - Low-level scopes (fine-grained permissions)

2. Restrict tokens to specific resources with an allow-list:
   - Limit to specific workspaces or templates
   - Use wildcards for resource types

The implementation includes:
- New API endpoints for token management
- UI for scope selection and resource filtering
- Token editing capabilities
- Enhanced token listing with scope and allow-list information

These changes improve security by supporting the principle of least privilege for API tokens.