### PR TITLE
feat: add GitHub Action for automatic docs preview comments

### DIFF
--- a/.github/workflows/docs-preview-comment.yaml
+++ b/.github/workflows/docs-preview-comment.yaml
@@ -1,0 +1,90 @@
+# Automatically comment on PRs with doc preview links when docs/ files are changed
+name: Docs Preview Comment
+
+on:
+  # zizmor: ignore[dangerous-triggers] We explicitly want to run on pull_request_target for write permissions.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/**'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment-preview-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Get changed docs files
+        id: changed-files
+        run: |
+          # Get the list of changed files in docs/
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          CHANGED_DOCS=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | grep '^docs/' | grep '\.md$' || true)
+
+          if [ -z "$CHANGED_DOCS" ]; then
+            echo "No markdown files changed in docs/"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+
+          # URI-encode the branch name
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          ENCODED_BRANCH=$(echo -n "$BRANCH_NAME" | jq -sRr @uri)
+
+          # Build the comment with preview links
+          COMMENT="## 📚 Documentation Preview Links\n\n"
+          COMMENT+="The following documentation pages have been modified and are available for preview:\n\n"
+
+          while IFS= read -r file; do
+            # Remove 'docs/' prefix and '.md' suffix
+            DOC_PATH="${file#docs/}"
+            DOC_PATH="${DOC_PATH%.md}"
+
+            # Build the preview URL
+            PREVIEW_URL="https://coder.com/docs/@${ENCODED_BRANCH}/${DOC_PATH}"
+
+            # Add to comment
+            COMMENT+="- [\`${file}\`](${PREVIEW_URL})\n"
+          done <<< "$CHANGED_DOCS"
+
+          COMMENT+="\n---\n"
+          COMMENT+="_Preview links are generated for branch: \`${BRANCH_NAME}\`_"
+
+          # Save comment to file for next step
+          echo -e "$COMMENT" > comment.txt
+
+          echo "Generated comment:"
+          cat comment.txt
+
+      - name: Find existing comment
+        if: steps.changed-files.outputs.has_changes == 'true'
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## 📚 Documentation Preview Links'
+
+      - name: Create or update comment
+        if: steps.changed-files.outputs.has_changes == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: comment.txt
+          edit-mode: replace

--- a/.github/workflows/docs-preview-comment.yaml
+++ b/.github/workflows/docs-preview-comment.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get changed docs files
         id: changed-files
@@ -39,11 +40,11 @@ jobs:
 
           if [ -z "$CHANGED_DOCS" ]; then
             echo "No markdown files changed in docs/"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
           # URI-encode the branch name
           ENCODED_BRANCH=$(echo -n "$HEAD_REF" | jq -sRr @uri)

--- a/.github/workflows/docs-preview-comment.yaml
+++ b/.github/workflows/docs-preview-comment.yaml
@@ -29,10 +29,13 @@ jobs:
 
       - name: Get changed docs files
         id: changed-files
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # Get the list of changed files in docs/
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          CHANGED_DOCS=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | grep '^docs/' | grep '\.md$' || true)
+          git fetch origin "$BASE_REF"
+          CHANGED_DOCS=$(git diff --name-only "origin/$BASE_REF...HEAD" | grep '^docs/' | grep '\.md$' || true)
 
           if [ -z "$CHANGED_DOCS" ]; then
             echo "No markdown files changed in docs/"
@@ -43,8 +46,7 @@ jobs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
 
           # URI-encode the branch name
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          ENCODED_BRANCH=$(echo -n "$BRANCH_NAME" | jq -sRr @uri)
+          ENCODED_BRANCH=$(echo -n "$HEAD_REF" | jq -sRr @uri)
 
           # Build the comment with preview links
           COMMENT="## 📚 Documentation Preview Links\n\n"
@@ -63,7 +65,7 @@ jobs:
           done <<< "$CHANGED_DOCS"
 
           COMMENT+="\n---\n"
-          COMMENT+="_Preview links are generated for branch: \`${BRANCH_NAME}\`_"
+          COMMENT+="_Preview links are generated for branch: \`${HEAD_REF}\`_"
 
           # Save comment to file for next step
           echo -e "$COMMENT" > comment.txt


### PR DESCRIPTION
## Summary

This PR adds a GitHub Action that automatically comments on pull requests with preview links when documentation files in the `docs/` directory are modified.

## Implementation Details

The action:
- Triggers on PR open, synchronize (new commits), and reopen events
- Only runs when markdown files in `docs/` are changed
- Properly URI-encodes branch names (e.g., `df/claude-code-mod-v3` → `df%2Fclaude-code-mod-v3`)
- Creates or updates a single comment with all changed documentation preview links
- Follows the preview URL format: `https://coder.com/docs/@{encoded-branch}/{doc-path}`

## Example

For a branch named `df/claude-code-mod-v3` with changes to `docs/ai-coder/tasks-core-principles.md`, the action will comment:

**📚 Documentation Preview Links**

The following documentation pages have been modified and are available for preview:

- [`docs/ai-coder/tasks-core-principles.md`](https://coder.com/docs/@df%2Fclaude-code-mod-v3/ai-coder/tasks-core-principles)

---
_Preview links are generated for branch: `df/claude-code-mod-v3`_

## Testing

The workflow has been tested locally for:
- ✅ URI encoding of branch names with special characters
- ✅ Proper URL generation matching the expected format
- ✅ Handling multiple changed documentation files

## Resolves

Addresses the request from @david-fraley to automatically comment preview links for documentation changes.