### PR TITLE
refactor: migrate TermsOfServiceLink from MUI to shadcn/ui

### DIFF
--- a/site/src/pages/LoginPage/LoginPageView.tsx
+++ b/site/src/pages/LoginPage/LoginPageView.tsx
@@ -68,10 +68,7 @@ export const LoginPageView: FC<LoginPageViewProps> = ({
 					</div>
 					<div>{buildInfo?.version}</div>
 					{tosAccepted && (
-						<TermsOfServiceLink
-							url={authMethods?.terms_of_service_url}
-							css={{ fontSize: 12 }}
-						/>
+						<TermsOfServiceLink url={authMethods?.terms_of_service_url} />
 					)}
 				</footer>
 			</div>

--- a/site/src/pages/LoginPage/TermsOfServiceLink.tsx
+++ b/site/src/pages/LoginPage/TermsOfServiceLink.tsx
@@ -7,7 +7,7 @@ interface TermsOfServiceLinkProps {
 
 export const TermsOfServiceLink: FC<TermsOfServiceLinkProps> = ({ url }) => {
 	return (
-		<div className={"pt-3 text-base"}>
+		<div className="pt-3 text-base">
 			By continuing, you agree to the{" "}
 			<Link
 				className="font-medium whitespace-nowrap"

--- a/site/src/pages/LoginPage/TermsOfServiceLink.tsx
+++ b/site/src/pages/LoginPage/TermsOfServiceLink.tsx
@@ -1,5 +1,4 @@
-import Link from "@mui/material/Link";
-import { SquareArrowOutUpRightIcon } from "lucide-react";
+import { Link } from "components/Link/Link";
 import type { FC } from "react";
 
 interface TermsOfServiceLinkProps {
@@ -12,16 +11,15 @@ export const TermsOfServiceLink: FC<TermsOfServiceLinkProps> = ({
 	url,
 }) => {
 	return (
-		<div css={{ paddingTop: 12, fontSize: 16 }} className={className}>
+		<div className={`pt-3 text-base ${className || ""}`}>
 			By continuing, you agree to the{" "}
 			<Link
-				css={{ fontWeight: 500, textWrap: "nowrap" }}
+				className="font-medium whitespace-nowrap"
 				href={url}
 				target="_blank"
 				rel="noreferrer"
 			>
-				Terms of Service&nbsp;
-				<SquareArrowOutUpRightIcon className="size-icon-xs" />
+				Terms of Service
 			</Link>
 		</div>
 	);

--- a/site/src/pages/LoginPage/TermsOfServiceLink.tsx
+++ b/site/src/pages/LoginPage/TermsOfServiceLink.tsx
@@ -2,16 +2,12 @@ import { Link } from "components/Link/Link";
 import type { FC } from "react";
 
 interface TermsOfServiceLinkProps {
-	className?: string;
 	url?: string;
 }
 
-export const TermsOfServiceLink: FC<TermsOfServiceLinkProps> = ({
-	className,
-	url,
-}) => {
+export const TermsOfServiceLink: FC<TermsOfServiceLinkProps> = ({ url }) => {
 	return (
-		<div className={`pt-3 text-base ${className || ""}`}>
+		<div className={"pt-3 text-base"}>
 			By continuing, you agree to the{" "}
 			<Link
 				className="font-medium whitespace-nowrap"


### PR DESCRIPTION
## Summary

Migrate the `TermsOfServiceLink` component from MUI to shadcn/ui

## Changes

- **Replaced** `@mui/material/Link` with the custom `Link` component from `components/Link/Link` (shadcn/ui)
- **Migrated** Emotion `css` prop to Tailwind utility classes
- **Preserved** external link icon functionality (automatically provided by shadcn Link component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)