### PR TITLE
feat: skip deprecated:false in templates search bar

### DIFF
--- a/site/src/pages/TemplatesPage/TemplatesFilter.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesFilter.tsx
@@ -56,7 +56,7 @@ export const TemplatesFilter: FC<TemplatesFilterProps> = ({
 		<Filter
 			presets={[
 				{ query: "", name: "All templates" },
-				{ query: "deprecated:false author:me", name: "Templates you authored" },
+				{ query: "author:me", name: "Templates you authored" },
 				{ query: "deprecated:true", name: "Deprecated templates" },
 			]}
 			// TODO: Add docs for this

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -73,7 +73,6 @@ const useTemplatesFilter = ({
 	onSearchParamsChange,
 }: UseTemplatesFilterOptions): TemplateFilterState => {
 	const filter = useFilter({
-		fallbackFilter: "deprecated:false",
 		searchParams,
 		onSearchParamsChange,
 	});

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -16,7 +16,6 @@ import type { TemplateFilterState } from "./TemplatesPage";
 import { TemplatesPageView } from "./TemplatesPageView";
 
 const defaultFilterProps = getDefaultFilterProps<TemplateFilterState>({
-	query: "deprecated:false",
 	menus: {
 		organizations: MockMenu,
 	},
@@ -118,7 +117,7 @@ export const WithFilteredAllTemplates: Story = {
 		filterState: {
 			filter: {
 				...defaultFilterProps.filter,
-				query: "deprecated:false searchnotfound",
+				query: "searchnotfound",
 				values: {},
 				used: true,
 			},


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/19746

This PR removes `deprecated:false` filter from the search bar since it is assumed by default.