### PR TITLE
chore: upgrade coder/clistat to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -462,7 +462,7 @@ require (
 	sigs.k8s.io/yaml v1.5.0 // indirect
 )
 
-require github.com/coder/clistat v1.0.2
+require github.com/coder/clistat v1.1.0
 
 require github.com/SherClockHolmes/webpush-go v1.4.0
 

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/coder/boundary v1.0.1-0.20250925154134-55a44f2a7945 h1:hDUf02kTX8EGR3
 github.com/coder/boundary v1.0.1-0.20250925154134-55a44f2a7945/go.mod h1:d1AMFw81rUgrGHuZzWdPNhkY0G8w7pvLNLYF0e3ceC4=
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwuWwPHPYoCZ/KLAjHv5g4h2MS4f2/MTI=
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
-github.com/coder/clistat v1.0.2 h1:9SjtcTVMGfM5LbdhjnkyxO3RCngrLvVu1+NXBs9QUy0=
-github.com/coder/clistat v1.0.2/go.mod h1:F+gLef+F9chVrleq808RBxdaoq52R4VLopuLdAsh8Y4=
+github.com/coder/clistat v1.1.0 h1:RTCLX+0/Uur/qFHSlbT2lKen+fWdicSlT9AMaF5jZWs=
+github.com/coder/clistat v1.1.0/go.mod h1:F+gLef+F9chVrleq808RBxdaoq52R4VLopuLdAsh8Y4=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/glog v1.0.1-0.20220322161911-7365fe7f2cd1/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=


### PR DESCRIPTION
Upgrades coder/clistat to v1.1.0. This version contains a significant refactor to the cgroupv2 implementation that improves how we calculate memory and cpu limits.
