### PR TITLE
ci(.github/workflows/traiage.yaml): explicitly fetch comments in gh cli invocation

### DIFF
--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -189,7 +189,9 @@ jobs:
           TEMPLATE_PRESET: ${{ steps.determine-inputs.outputs.template_preset }}
         run: |
           # Fetch issue description using `gh` CLI
-          issue_description=$(gh issue view "${ISSUE_URL}")
+          issue_description=$(gh issue view "${ISSUE_URL}" \
+            --json 'title,body,comments' \
+            --template '{{printf "%s\n" .title}}{{printf "%s\n\nComments:\n" .body}}{{range $k, $v := .comments}}  - {{index $v.author "login"}}: {{printf "%s\n" $v.body}}{{end}}')
 
           # Write a prompt to PROMPT_FILE
           PROMPT=$(cat <<EOF

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -189,6 +189,7 @@ jobs:
           TEMPLATE_PRESET: ${{ steps.determine-inputs.outputs.template_preset }}
         run: |
           # Fetch issue description using `gh` CLI
+          #shellcheck disable=SC2016 # The template string should not be subject to shell expansion
           issue_description=$(gh issue view "${ISSUE_URL}" \
             --json 'title,body,comments' \
             --template '{{printf "%s\n" .title}}{{printf "%s\n\nComments:\n" .body}}{{range $k, $v := .comments}}  - {{index $v.author "login"}}: {{printf "%s\n" $v.body}}{{end}}')

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -192,7 +192,7 @@ jobs:
           #shellcheck disable=SC2016 # The template string should not be subject to shell expansion
           issue_description=$(gh issue view "${ISSUE_URL}" \
             --json 'title,body,comments' \
-            --template '{{printf "%s\n" .title}}{{printf "%s\n\nComments:\n" .body}}{{range $k, $v := .comments}}  - {{index $v.author "login"}}: {{printf "%s\n" $v.body}}{{end}}')
+            --template '{{printf "%s\n\n%s\n\nComments:\n" .title .body}}{{range $k, $v := .comments}}  - {{index $v.author "login"}}: {{printf "%s\n" $v.body}}{{end}}')
 
           # Write a prompt to PROMPT_FILE
           PROMPT=$(cat <<EOF


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1053

Updated the `gh` command to fetch issue description with explicit JSON fields and formatting.

Validated with manual workflow run: https://github.com/coder/coder/actions/runs/18492815891/job/52690197479

Agent picked up additional instruction from comments: https://github.com/coder/coder/compare/cian/traiage-gh-20085-18492815891

<img width="1339" height="406" alt="Screenshot 2025-10-14 at 11 02 36" src="https://github.com/user-attachments/assets/c3daf103-3d88-4f11-b5ee-d3596912aaa8" />

