### PR TITLE
chore: clarify autostop behaviour for existing workspaces

### DIFF
--- a/docs/user-guides/workspace-scheduling.md
+++ b/docs/user-guides/workspace-scheduling.md
@@ -39,6 +39,9 @@ workspace if you're still using it. It will wait for the user to become inactive
 before checking connections again (1 hour by default). Template admins can
 modify this duration with the **activity bump** template setting.
 
+> [!NOTE]
+> Autostop must be enabled on the template prior to workspace creation, it is not applied to existing running workspaces.
+
 ![Autostop UI](../images/workspaces/autostop.png)
 
 ## Activity detection


### PR DESCRIPTION
[We have tests to ensure this behaviour](https://github.com/coder/coder/blob/152103bf788dc5a4c06586302a255a212e0fe77d/coderd/workspaces_test.go#L2957-L3004), but it is not clearly documented. This PR adds a note clarifying autostop must be enabled on the template prior to a workspace being created for it to apply to the workspace, i.e. it is not re-read if a workspace is restarted / stopped and started. This behaviour was raised by a customer.

https://coder.com/docs/user-guides/workspace-scheduling#autostop