### PR TITLE
feat: create endpoint for providing feedback for a task

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -296,6 +296,51 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/tasks/{user}/{id}/feedback": {
+            "post": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "tags": [
+                    "Experimental"
+                ],
+                "summary": "Submit task feedback",
+                "operationId": "post-task-feedback",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username, user ID, or 'me' for the authenticated user",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Task ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task feedback",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.TaskFeedbackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/api/experimental/tasks/{user}/{id}/logs": {
             "get": {
                 "security": [
@@ -17540,6 +17585,12 @@ const docTemplate = `{
                 "current_state": {
                     "$ref": "#/definitions/codersdk.TaskStateEntry"
                 },
+                "feedback_comment": {
+                    "type": "string"
+                },
+                "feedback_score": {
+                    "type": "number"
+                },
                 "id": {
                     "type": "string",
                     "format": "uuid"
@@ -17618,6 +17669,17 @@ const docTemplate = `{
                             "$ref": "#/definitions/uuid.NullUUID"
                         }
                     ]
+                }
+            }
+        },
+        "codersdk.TaskFeedbackRequest": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "number"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -264,6 +264,49 @@
 				}
 			}
 		},
+		"/api/experimental/tasks/{user}/{id}/feedback": {
+			"post": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"tags": ["Experimental"],
+				"summary": "Submit task feedback",
+				"operationId": "post-task-feedback",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Username, user ID, or 'me' for the authenticated user",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Task ID",
+						"name": "id",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Task feedback",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.TaskFeedbackRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				}
+			}
+		},
 		"/api/experimental/tasks/{user}/{id}/logs": {
 			"get": {
 				"security": [
@@ -16048,6 +16091,12 @@
 				"current_state": {
 					"$ref": "#/definitions/codersdk.TaskStateEntry"
 				},
+				"feedback_comment": {
+					"type": "string"
+				},
+				"feedback_score": {
+					"type": "number"
+				},
 				"id": {
 					"type": "string",
 					"format": "uuid"
@@ -16126,6 +16175,17 @@
 							"$ref": "#/definitions/uuid.NullUUID"
 						}
 					]
+				}
+			}
+		},
+		"codersdk.TaskFeedbackRequest": {
+			"type": "object",
+			"properties": {
+				"comment": {
+					"type": "string"
+				},
+				"score": {
+					"type": "number"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1024,6 +1024,7 @@ func New(options *Options) *API {
 				r.Delete("/{id}", api.taskDelete)
 				r.Post("/{id}/send", api.taskSend)
 				r.Get("/{id}/logs", api.taskLogs)
+				r.Post("/{id}/feedback", api.postTaskFeedback)
 				r.Post("/", api.tasksCreate)
 			})
 		})

--- a/coderd/database/check_constraint.go
+++ b/coderd/database/check_constraint.go
@@ -9,6 +9,7 @@ const (
 	CheckOneTimePasscodeSet                        CheckConstraint = "one_time_passcode_set"                            // users
 	CheckUsersUsernameMinLength                    CheckConstraint = "users_username_min_length"                        // users
 	CheckMaxProvisionerLogsLength                  CheckConstraint = "max_provisioner_logs_length"                      // provisioner_jobs
+	CheckTasksFeedbackScoreRange                   CheckConstraint = "tasks_feedback_score_range"                       // tasks
 	CheckMaxLogsLength                             CheckConstraint = "max_logs_length"                                  // workspace_agents
 	CheckSubsystemsNotNone                         CheckConstraint = "subsystems_not_none"                              // workspace_agents
 	CheckWorkspaceBuildsAiTaskSidebarAppIDRequired CheckConstraint = "workspace_builds_ai_task_sidebar_app_id_required" // workspace_builds

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -4953,6 +4953,18 @@ func (q *querier) UpdateTailnetPeerStatusByCoordinator(ctx context.Context, arg 
 	return q.db.UpdateTailnetPeerStatusByCoordinator(ctx, arg)
 }
 
+func (q *querier) UpdateTaskFeedback(ctx context.Context, arg database.UpdateTaskFeedbackParams) (database.TaskTable, error) {
+	// Fetch the task to derive the RBAC object and authorize update on it.
+	task, err := q.db.GetTaskByID(ctx, arg.TaskID)
+	if err != nil {
+		return database.TaskTable{}, err
+	}
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, task); err != nil {
+		return database.TaskTable{}, err
+	}
+	return q.db.UpdateTaskFeedback(ctx, arg)
+}
+
 func (q *querier) UpdateTemplateACLByID(ctx context.Context, arg database.UpdateTemplateACLByIDParams) error {
 	fetch := func(ctx context.Context, arg database.UpdateTemplateACLByIDParams) (database.Template, error) {
 		return q.db.GetTemplateByID(ctx, arg.ID)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2404,6 +2404,13 @@ func (s *MethodTestSuite) TestTasks() {
 		dbm.EXPECT().ListTasks(gomock.Any(), gomock.Any()).Return([]database.Task{t1, t2}, nil).AnyTimes()
 		check.Args(database.ListTasksParams{}).Asserts(t1, policy.ActionRead, t2, policy.ActionRead).Returns([]database.Task{t1, t2})
 	}))
+	s.Run("UpdateTaskFeedback", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		task := testutil.Fake(s.T(), faker, database.Task{})
+		arg := database.UpdateTaskFeedbackParams{TaskID: task.ID}
+		dbm.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(task, nil).AnyTimes()
+		dbm.EXPECT().UpdateTaskFeedback(gomock.Any(), arg).Return(database.TaskTable{ID: task.ID}, nil).AnyTimes()
+		check.Args(arg).Asserts(task, policy.ActionUpdate).Returns(database.TaskTable{ID: task.ID})
+	}))
 }
 
 func (s *MethodTestSuite) TestProvisionerKeys() {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3043,6 +3043,13 @@ func (m queryMetricsStore) UpdateTailnetPeerStatusByCoordinator(ctx context.Cont
 	return r0
 }
 
+func (m queryMetricsStore) UpdateTaskFeedback(ctx context.Context, arg database.UpdateTaskFeedbackParams) (database.TaskTable, error) {
+	start := time.Now()
+	r0, r1 := m.s.UpdateTaskFeedback(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateTaskFeedback").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) UpdateTemplateACLByID(ctx context.Context, arg database.UpdateTemplateACLByIDParams) error {
 	start := time.Now()
 	err := m.s.UpdateTemplateACLByID(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6518,6 +6518,21 @@ func (mr *MockStoreMockRecorder) UpdateTailnetPeerStatusByCoordinator(ctx, arg a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTailnetPeerStatusByCoordinator", reflect.TypeOf((*MockStore)(nil).UpdateTailnetPeerStatusByCoordinator), ctx, arg)
 }
 
+// UpdateTaskFeedback mocks base method.
+func (m *MockStore) UpdateTaskFeedback(ctx context.Context, arg database.UpdateTaskFeedbackParams) (database.TaskTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTaskFeedback", ctx, arg)
+	ret0, _ := ret[0].(database.TaskTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateTaskFeedback indicates an expected call of UpdateTaskFeedback.
+func (mr *MockStoreMockRecorder) UpdateTaskFeedback(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskFeedback", reflect.TypeOf((*MockStore)(nil).UpdateTaskFeedback), ctx, arg)
+}
+
 // UpdateTemplateACLByID mocks base method.
 func (m *MockStore) UpdateTemplateACLByID(ctx context.Context, arg database.UpdateTemplateACLByIDParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1820,7 +1820,10 @@ CREATE TABLE tasks (
     template_parameters jsonb DEFAULT '{}'::jsonb NOT NULL,
     prompt text NOT NULL,
     created_at timestamp with time zone NOT NULL,
-    deleted_at timestamp with time zone
+    deleted_at timestamp with time zone,
+    feedback_score real,
+    feedback_comment character varying(512),
+    CONSTRAINT tasks_feedback_score_range CHECK (((feedback_score IS NULL) OR ((feedback_score >= (0.0)::double precision) AND (feedback_score <= (1.0)::double precision))))
 );
 
 CREATE TABLE workspace_agents (
@@ -1951,6 +1954,8 @@ CREATE VIEW tasks_with_status AS
     tasks.prompt,
     tasks.created_at,
     tasks.deleted_at,
+    tasks.feedback_score,
+    tasks.feedback_comment,
         CASE
             WHEN ((tasks.workspace_id IS NULL) OR (latest_build.job_status IS NULL)) THEN 'pending'::task_status
             WHEN (latest_build.job_status = 'failed'::provisioner_job_status) THEN 'error'::task_status

--- a/coderd/database/migrations/000381_create_task_feedback_columns.down.sql
+++ b/coderd/database/migrations/000381_create_task_feedback_columns.down.sql
@@ -1,0 +1,77 @@
+-- Recreate the tasks_with_status view
+DROP VIEW IF EXISTS tasks_with_status;
+
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_feedback_score_range;
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_feedback_comment_length;
+ALTER TABLE tasks DROP COLUMN IF EXISTS feedback_score;
+ALTER TABLE tasks DROP COLUMN IF EXISTS feedback_comment;
+
+CREATE VIEW
+	tasks_with_status
+AS
+	SELECT
+		tasks.*,
+		CASE
+			WHEN tasks.workspace_id IS NULL OR latest_build.job_status IS NULL THEN 'pending'::task_status
+
+			WHEN latest_build.job_status = 'failed' THEN 'error'::task_status
+
+			WHEN latest_build.transition IN ('stop', 'delete')
+				AND latest_build.job_status = 'succeeded' THEN 'paused'::task_status
+
+			WHEN latest_build.transition = 'start'
+				AND latest_build.job_status = 'pending' THEN 'initializing'::task_status
+
+			WHEN latest_build.transition = 'start' AND latest_build.job_status IN ('running', 'succeeded') THEN
+				CASE
+					WHEN agent_status.none THEN 'initializing'::task_status
+					WHEN agent_status.connecting THEN 'initializing'::task_status
+					WHEN agent_status.connected THEN
+						CASE
+							WHEN app_status.any_unhealthy THEN 'error'::task_status
+							WHEN app_status.any_initializing THEN 'initializing'::task_status
+							WHEN app_status.all_healthy_or_disabled THEN 'active'::task_status
+							ELSE 'unknown'::task_status
+						END
+					ELSE 'unknown'::task_status
+				END
+
+			ELSE 'unknown'::task_status
+		END AS status
+	FROM
+		tasks
+	LEFT JOIN LATERAL (
+		SELECT workspace_build_number, workspace_agent_id, workspace_app_id
+		FROM task_workspace_apps task_app
+		WHERE task_id = tasks.id
+		ORDER BY workspace_build_number DESC
+		LIMIT 1
+	) task_app ON TRUE
+	LEFT JOIN LATERAL (
+		SELECT
+			workspace_build.transition,
+			provisioner_job.job_status,
+			workspace_build.job_id
+		FROM workspace_builds workspace_build
+		JOIN provisioner_jobs provisioner_job ON provisioner_job.id = workspace_build.job_id
+		WHERE workspace_build.workspace_id = tasks.workspace_id
+			AND workspace_build.build_number = task_app.workspace_build_number
+	) latest_build ON TRUE
+	CROSS JOIN LATERAL (
+		SELECT
+			COUNT(*) = 0 AS none,
+			bool_or(workspace_agent.lifecycle_state IN ('created', 'starting')) AS connecting,
+			bool_and(workspace_agent.lifecycle_state = 'ready') AS connected
+		FROM workspace_agents workspace_agent
+		WHERE workspace_agent.id = task_app.workspace_agent_id
+	) agent_status
+	CROSS JOIN LATERAL (
+		SELECT
+			bool_or(workspace_app.health = 'unhealthy') AS any_unhealthy,
+			bool_or(workspace_app.health = 'initializing') AS any_initializing,
+			bool_and(workspace_app.health IN ('healthy', 'disabled')) AS all_healthy_or_disabled
+		FROM workspace_apps workspace_app
+		WHERE workspace_app.id = task_app.workspace_app_id
+	) app_status
+	WHERE
+		tasks.deleted_at IS NULL;

--- a/coderd/database/migrations/000381_create_task_feedback_columns.up.sql
+++ b/coderd/database/migrations/000381_create_task_feedback_columns.up.sql
@@ -1,0 +1,78 @@
+ALTER TABLE tasks ADD COLUMN feedback_score REAL;
+ALTER TABLE tasks ADD COLUMN feedback_comment VARCHAR(512);
+
+ALTER TABLE tasks ADD CONSTRAINT tasks_feedback_score_range
+    CHECK (feedback_score IS NULL OR (feedback_score >= 0.0 AND feedback_score <= 1.0));
+
+-- Recreate the tasks_with_status view
+DROP VIEW IF EXISTS tasks_with_status;
+
+CREATE VIEW
+	tasks_with_status
+AS
+	SELECT
+		tasks.*,
+		CASE
+			WHEN tasks.workspace_id IS NULL OR latest_build.job_status IS NULL THEN 'pending'::task_status
+
+			WHEN latest_build.job_status = 'failed' THEN 'error'::task_status
+
+			WHEN latest_build.transition IN ('stop', 'delete')
+				AND latest_build.job_status = 'succeeded' THEN 'paused'::task_status
+
+			WHEN latest_build.transition = 'start'
+				AND latest_build.job_status = 'pending' THEN 'initializing'::task_status
+
+			WHEN latest_build.transition = 'start' AND latest_build.job_status IN ('running', 'succeeded') THEN
+				CASE
+					WHEN agent_status.none THEN 'initializing'::task_status
+					WHEN agent_status.connecting THEN 'initializing'::task_status
+					WHEN agent_status.connected THEN
+						CASE
+							WHEN app_status.any_unhealthy THEN 'error'::task_status
+							WHEN app_status.any_initializing THEN 'initializing'::task_status
+							WHEN app_status.all_healthy_or_disabled THEN 'active'::task_status
+							ELSE 'unknown'::task_status
+						END
+					ELSE 'unknown'::task_status
+				END
+
+			ELSE 'unknown'::task_status
+		END AS status
+	FROM
+		tasks
+	LEFT JOIN LATERAL (
+		SELECT workspace_build_number, workspace_agent_id, workspace_app_id
+		FROM task_workspace_apps task_app
+		WHERE task_id = tasks.id
+		ORDER BY workspace_build_number DESC
+		LIMIT 1
+	) task_app ON TRUE
+	LEFT JOIN LATERAL (
+		SELECT
+			workspace_build.transition,
+			provisioner_job.job_status,
+			workspace_build.job_id
+		FROM workspace_builds workspace_build
+		JOIN provisioner_jobs provisioner_job ON provisioner_job.id = workspace_build.job_id
+		WHERE workspace_build.workspace_id = tasks.workspace_id
+			AND workspace_build.build_number = task_app.workspace_build_number
+	) latest_build ON TRUE
+	CROSS JOIN LATERAL (
+		SELECT
+			COUNT(*) = 0 AS none,
+			bool_or(workspace_agent.lifecycle_state IN ('created', 'starting')) AS connecting,
+			bool_and(workspace_agent.lifecycle_state = 'ready') AS connected
+		FROM workspace_agents workspace_agent
+		WHERE workspace_agent.id = task_app.workspace_agent_id
+	) agent_status
+	CROSS JOIN LATERAL (
+		SELECT
+			bool_or(workspace_app.health = 'unhealthy') AS any_unhealthy,
+			bool_or(workspace_app.health = 'initializing') AS any_initializing,
+			bool_and(workspace_app.health IN ('healthy', 'disabled')) AS all_healthy_or_disabled
+		FROM workspace_apps workspace_app
+		WHERE workspace_app.id = task_app.workspace_app_id
+	) app_status
+	WHERE
+		tasks.deleted_at IS NULL;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4207,6 +4207,8 @@ type Task struct {
 	Prompt             string          `db:"prompt" json:"prompt"`
 	CreatedAt          time.Time       `db:"created_at" json:"created_at"`
 	DeletedAt          sql.NullTime    `db:"deleted_at" json:"deleted_at"`
+	FeedbackScore      sql.NullFloat64 `db:"feedback_score" json:"feedback_score"`
+	FeedbackComment    sql.NullString  `db:"feedback_comment" json:"feedback_comment"`
 	Status             TaskStatus      `db:"status" json:"status"`
 }
 
@@ -4221,6 +4223,8 @@ type TaskTable struct {
 	Prompt             string          `db:"prompt" json:"prompt"`
 	CreatedAt          time.Time       `db:"created_at" json:"created_at"`
 	DeletedAt          sql.NullTime    `db:"deleted_at" json:"deleted_at"`
+	FeedbackScore      sql.NullFloat64 `db:"feedback_score" json:"feedback_score"`
+	FeedbackComment    sql.NullString  `db:"feedback_comment" json:"feedback_comment"`
 }
 
 type TaskWorkspaceApp struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -654,6 +654,7 @@ type sqlcQuerier interface {
 	UpdateProvisionerJobWithCompleteWithStartedAtByID(ctx context.Context, arg UpdateProvisionerJobWithCompleteWithStartedAtByIDParams) error
 	UpdateReplica(ctx context.Context, arg UpdateReplicaParams) (Replica, error)
 	UpdateTailnetPeerStatusByCoordinator(ctx context.Context, arg UpdateTailnetPeerStatusByCoordinatorParams) error
+	UpdateTaskFeedback(ctx context.Context, arg UpdateTaskFeedbackParams) (TaskTable, error)
 	UpdateTemplateACLByID(ctx context.Context, arg UpdateTemplateACLByIDParams) error
 	UpdateTemplateAccessControlByID(ctx context.Context, arg UpdateTemplateAccessControlByIDParams) error
 	UpdateTemplateActiveVersionByID(ctx context.Context, arg UpdateTemplateActiveVersionByIDParams) error

--- a/coderd/database/queries/tasks.sql
+++ b/coderd/database/queries/tasks.sql
@@ -28,3 +28,11 @@ WHERE tws.deleted_at IS NULL
 AND CASE WHEN @owner_id::UUID != '00000000-0000-0000-0000-000000000000' THEN tws.owner_id = @owner_id::UUID ELSE TRUE END
 AND CASE WHEN @organization_id::UUID != '00000000-0000-0000-0000-000000000000' THEN tws.organization_id = @organization_id::UUID ELSE TRUE END
 ORDER BY tws.created_at DESC;
+
+-- name: UpdateTaskFeedback :one
+UPDATE tasks
+SET
+    feedback_score = @score,
+    feedback_comment = @comment
+WHERE id = @task_id::uuid
+RETURNING *;

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -124,6 +124,8 @@ type Task struct {
 	CurrentState            *TaskStateEntry          `json:"current_state" table:"cs,recursive_inline"`
 	CreatedAt               time.Time                `json:"created_at" format:"date-time" table:"created at"`
 	UpdatedAt               time.Time                `json:"updated_at" format:"date-time" table:"updated at"`
+	FeedbackScore           *float64                 `json:"feedback_score,omitempty" table:"feedback score"`
+	FeedbackComment         *string                  `json:"feedback_comment,omitempty" table:"feedback comment"`
 }
 
 // TaskStateEntry represents a single entry in the task's state history.
@@ -294,4 +296,27 @@ func (c *ExperimentalClient) TaskLogs(ctx context.Context, user string, id uuid.
 	}
 
 	return logs, nil
+}
+
+// TaskFeedbackRequest represents feedback for a task.
+//
+// Experimental: This type is experimental and may change in the future.
+type TaskFeedbackRequest struct {
+	Score   float64 `json:"score"`
+	Comment string  `json:"comment,omitempty"`
+}
+
+// PostTaskFeedback submits feedback for a task.
+//
+// Experimental: This method is experimental and may change in the future.
+func (c *ExperimentalClient) PostTaskFeedback(ctx context.Context, user string, taskID uuid.UUID, req TaskFeedbackRequest) error {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/tasks/%s/%s/feedback", user, taskID.String()), req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
 }

--- a/docs/reference/api/experimental.md
+++ b/docs/reference/api/experimental.md
@@ -137,6 +137,44 @@ curl -X DELETE http://coder-server:8080/api/v2/api/experimental/tasks/{user}/{id
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Submit task feedback
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/api/experimental/tasks/{user}/{id}/feedback \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/tasks/{user}/{id}/feedback`
+
+> Body parameter
+
+```json
+{
+  "comment": "string",
+  "score": 0
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                   | Required | Description                                           |
+|--------|------|------------------------------------------------------------------------|----------|-------------------------------------------------------|
+| `user` | path | string                                                                 | true     | Username, user ID, or 'me' for the authenticated user |
+| `id`   | path | string(uuid)                                                           | true     | Task ID                                               |
+| `body` | body | [codersdk.TaskFeedbackRequest](schemas.md#codersdktaskfeedbackrequest) | true     | Task feedback                                         |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get AI task logs
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -291,6 +291,8 @@
         "timestamp": "2019-08-24T14:15:22Z",
         "uri": "string"
       },
+      "feedback_comment": "string",
+      "feedback_score": 0,
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
       "initial_prompt": "string",
       "name": "string",
@@ -7683,6 +7685,8 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
     "timestamp": "2019-08-24T14:15:22Z",
     "uri": "string"
   },
+  "feedback_comment": "string",
+  "feedback_score": 0,
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
   "initial_prompt": "string",
   "name": "string",
@@ -7717,6 +7721,8 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 |-----------------------------|----------------------------------------------------------------------|----------|--------------|-------------|
 | `created_at`                | string                                                               | false    |              |             |
 | `current_state`             | [codersdk.TaskStateEntry](#codersdktaskstateentry)                   | false    |              |             |
+| `feedback_comment`          | string                                                               | false    |              |             |
+| `feedback_score`            | number                                                               | false    |              |             |
 | `id`                        | string                                                               | false    |              |             |
 | `initial_prompt`            | string                                                               | false    |              |             |
 | `name`                      | string                                                               | false    |              |             |
@@ -7748,6 +7754,22 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `status` | `canceled`  |
 | `status` | `deleting`  |
 | `status` | `deleted`   |
+
+## codersdk.TaskFeedbackRequest
+
+```json
+{
+  "comment": "string",
+  "score": 0
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description |
+|-----------|--------|----------|--------------|-------------|
+| `comment` | string | false    |              |             |
+| `score`   | number | false    |              |             |
 
 ## codersdk.TaskLogEntry
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3354,6 +3354,14 @@ export interface Task {
 	readonly current_state: TaskStateEntry | null;
 	readonly created_at: string;
 	readonly updated_at: string;
+	readonly feedback_score?: number;
+	readonly feedback_comment?: string;
+}
+
+// From codersdk/aitasks.go
+export interface TaskFeedbackRequest {
+	readonly score: number;
+	readonly comment?: string;
 }
 
 // From codersdk/aitasks.go


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/20216

Introduces new endpoint `POST /tasks/{user}/{id}/feedback` with the following body

```
{
  "score": 0.00,
  "comment": ""
}
```

Where `score` can be a floating point number between `0.0` and `1.0` inclusive, and `comment` can be a string 500 characters or less.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
