### PR TITLE
fix: avoid connection logging crashes in agent [2.26]

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -790,10 +790,14 @@ func (a *agent) reportConnectionsLoop(ctx context.Context, aAPI proto.DRPCAgentC
 			logger.Debug(ctx, "reporting connection")
 			_, err := aAPI.ReportConnection(ctx, payload)
 			if err != nil {
-				return xerrors.Errorf("failed to report connection: %w", err)
+				// Do not fail the loop if we fail to report a connection, just
+				// log a warning.
+				// Related to https://github.com/coder/coder/issues/20194
+				logger.Warn(ctx, "failed to report connection to server", slog.Error(err))
+				// no continue here, we still need to remove it from the slice
+			} else {
+				logger.Debug(ctx, "successfully reported connection")
 			}
-
-			logger.Debug(ctx, "successfully reported connection")
 
 			// Remove the payload we sent.
 			a.reportConnectionsMu.Lock()
@@ -823,6 +827,13 @@ func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_T
 	} else {
 		// Best effort.
 		ip = host
+	}
+
+	// If the IP is "localhost" (which it can be in some cases), set it to
+	// 127.0.0.1 instead.
+	// Related to https://github.com/coder/coder/issues/20194
+	if ip == "localhost" {
+		ip = "127.0.0.1"
 	}
 
 	a.reportConnectionsMu.Lock()

--- a/coderd/agentapi/connectionlog_test.go
+++ b/coderd/agentapi/connectionlog_test.go
@@ -110,6 +110,11 @@ func TestConnectionLog(t *testing.T) {
 			mDB := dbmock.NewMockStore(gomock.NewController(t))
 			mDB.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
 
+			// TEMPORARY FIX for https://github.com/coder/coder/issues/20194
+			if tt.ip == "" {
+				tt.ip = "127.0.0.1"
+			}
+
 			api := &agentapi.ConnLogAPI{
 				ConnectionLogger: asAtomicPointer[connectionlog.ConnectionLogger](connLogger),
 				Database:         mDB,


### PR DESCRIPTION
# For release 2.26

- Ignore errors when reporting a connection from the server, just log them instead
- Translate connection log IP `localhost` to `127.0.0.1` on both the server and the agent
- Temporary fix: convert invalid IPs to `127.0.0.1` since the database forbids NULL

Relates to #20194