### PR TITLE
fix: avoid connection logging crashes in agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -785,7 +785,7 @@ func (a *agent) reportConnectionsLoop(ctx context.Context, aAPI proto.DRPCAgentC
 				// log a warning.
 				// Related to https://github.com/coder/coder/issues/20194
 				logger.Warn(ctx, "failed to report connection to server", slog.Error(err))
-				// no continue here, we still need to remove it from the slice
+				// keep going, we still need to remove it from the slice
 			} else {
 				logger.Debug(ctx, "successfully reported connection")
 			}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -781,10 +781,14 @@ func (a *agent) reportConnectionsLoop(ctx context.Context, aAPI proto.DRPCAgentC
 			logger.Debug(ctx, "reporting connection")
 			_, err := aAPI.ReportConnection(ctx, payload)
 			if err != nil {
-				return xerrors.Errorf("failed to report connection: %w", err)
+				// Do not fail the loop if we fail to report a connection, just
+				// log a warning.
+				// Related to https://github.com/coder/coder/issues/20194
+				logger.Warn(ctx, "failed to report connection to server", slog.Error(err))
+				// no continue here, we still need to remove it from the slice
+			} else {
+				logger.Debug(ctx, "successfully reported connection")
 			}
-
-			logger.Debug(ctx, "successfully reported connection")
 
 			// Remove the payload we sent.
 			a.reportConnectionsMu.Lock()
@@ -814,6 +818,13 @@ func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_T
 	} else {
 		// Best effort.
 		ip = host
+	}
+
+	// If the IP is "localhost" (which it can be in some cases), set it to
+	// 127.0.0.1 instead.
+	// Related to https://github.com/coder/coder/issues/20194
+	if ip == "localhost" {
+		ip = "127.0.0.1"
 	}
 
 	a.reportConnectionsMu.Lock()

--- a/coderd/connectionlog/connectionlog.go
+++ b/coderd/connectionlog/connectionlog.go
@@ -86,56 +86,28 @@ func (m *FakeConnectionLogger) Contains(t testing.TB, expected database.UpsertCo
 			t.Logf("connection log %d: expected Type %s, got %s", idx+1, expected.Type, cl.Type)
 			continue
 		}
-		if expected.Code.Valid != cl.Code.Valid {
-			t.Logf("connection log %d: expected Code valid %t, got %t", idx+1, expected.Code.Valid, cl.Code.Valid)
-			continue
-		}
 		if expected.Code.Valid && cl.Code.Int32 != expected.Code.Int32 {
 			t.Logf("connection log %d: expected Code %d, got %d", idx+1, expected.Code.Int32, cl.Code.Int32)
-			continue
-		}
-		if expected.Ip.Valid != cl.Ip.Valid {
-			t.Logf("connection log %d: expected IP valid %t, got %t", idx+1, expected.Ip.Valid, cl.Ip.Valid)
 			continue
 		}
 		if expected.Ip.Valid && cl.Ip.IPNet.String() != expected.Ip.IPNet.String() {
 			t.Logf("connection log %d: expected IP %s, got %s", idx+1, expected.Ip.IPNet, cl.Ip.IPNet)
 			continue
 		}
-		if expected.UserAgent.Valid != cl.UserAgent.Valid {
-			t.Logf("connection log %d: expected UserAgent valid %t, got %t", idx+1, expected.UserAgent.Valid, cl.UserAgent.Valid)
-			continue
-		}
 		if expected.UserAgent.Valid && cl.UserAgent.String != expected.UserAgent.String {
 			t.Logf("connection log %d: expected UserAgent %s, got %s", idx+1, expected.UserAgent.String, cl.UserAgent.String)
-			continue
-		}
-		if expected.UserID.Valid != cl.UserID.Valid {
-			t.Logf("connection log %d: expected UserID valid %t, got %t", idx+1, expected.UserID.Valid, cl.UserID.Valid)
 			continue
 		}
 		if expected.UserID.Valid && cl.UserID.UUID != expected.UserID.UUID {
 			t.Logf("connection log %d: expected UserID %s, got %s", idx+1, expected.UserID.UUID, cl.UserID.UUID)
 			continue
 		}
-		if expected.SlugOrPort.Valid != cl.SlugOrPort.Valid {
-			t.Logf("connection log %d: expected SlugOrPort valid %t, got %t", idx+1, expected.SlugOrPort.Valid, cl.SlugOrPort.Valid)
-			continue
-		}
 		if expected.SlugOrPort.Valid && cl.SlugOrPort.String != expected.SlugOrPort.String {
 			t.Logf("connection log %d: expected SlugOrPort %s, got %s", idx+1, expected.SlugOrPort.String, cl.SlugOrPort.String)
 			continue
 		}
-		if expected.ConnectionID.Valid != cl.ConnectionID.Valid {
-			t.Logf("connection log %d: expected ConnectionID valid %t, got %t", idx+1, expected.ConnectionID.Valid, cl.ConnectionID.Valid)
-			continue
-		}
 		if expected.ConnectionID.Valid && cl.ConnectionID.UUID != expected.ConnectionID.UUID {
 			t.Logf("connection log %d: expected ConnectionID %s, got %s", idx+1, expected.ConnectionID.UUID, cl.ConnectionID.UUID)
-			continue
-		}
-		if expected.DisconnectReason.Valid != cl.DisconnectReason.Valid {
-			t.Logf("connection log %d: expected DisconnectReason valid %t, got %t", idx+1, expected.DisconnectReason.Valid, cl.DisconnectReason.Valid)
 			continue
 		}
 		if expected.DisconnectReason.Valid && cl.DisconnectReason.String != expected.DisconnectReason.String {
@@ -146,7 +118,7 @@ func (m *FakeConnectionLogger) Contains(t testing.TB, expected database.UpsertCo
 			t.Logf("connection log %d: expected Time %s, got %s", idx+1, expected.Time, cl.Time)
 			continue
 		}
-		if expected.ConnectionStatus != cl.ConnectionStatus {
+		if expected.ConnectionStatus != "" && expected.ConnectionStatus != cl.ConnectionStatus {
 			t.Logf("connection log %d: expected ConnectionStatus %s, got %s", idx+1, expected.ConnectionStatus, cl.ConnectionStatus)
 			continue
 		}

--- a/coderd/connectionlog/connectionlog.go
+++ b/coderd/connectionlog/connectionlog.go
@@ -62,10 +62,6 @@ func (m *FakeConnectionLogger) Contains(t testing.TB, expected database.UpsertCo
 			t.Logf("connection log %d: expected ID %s, got %s", idx+1, expected.ID, cl.ID)
 			continue
 		}
-		if !expected.Time.IsZero() && expected.Time != cl.Time {
-			t.Logf("connection log %d: expected Time %s, got %s", idx+1, expected.Time, cl.Time)
-			continue
-		}
 		if expected.OrganizationID != uuid.Nil && cl.OrganizationID != expected.OrganizationID {
 			t.Logf("connection log %d: expected OrganizationID %s, got %s", idx+1, expected.OrganizationID, cl.OrganizationID)
 			continue
@@ -90,28 +86,68 @@ func (m *FakeConnectionLogger) Contains(t testing.TB, expected database.UpsertCo
 			t.Logf("connection log %d: expected Type %s, got %s", idx+1, expected.Type, cl.Type)
 			continue
 		}
+		if expected.Code.Valid != cl.Code.Valid {
+			t.Logf("connection log %d: expected Code valid %t, got %t", idx+1, expected.Code.Valid, cl.Code.Valid)
+			continue
+		}
 		if expected.Code.Valid && cl.Code.Int32 != expected.Code.Int32 {
 			t.Logf("connection log %d: expected Code %d, got %d", idx+1, expected.Code.Int32, cl.Code.Int32)
+			continue
+		}
+		if expected.Ip.Valid != cl.Ip.Valid {
+			t.Logf("connection log %d: expected IP valid %t, got %t", idx+1, expected.Ip.Valid, cl.Ip.Valid)
 			continue
 		}
 		if expected.Ip.Valid && cl.Ip.IPNet.String() != expected.Ip.IPNet.String() {
 			t.Logf("connection log %d: expected IP %s, got %s", idx+1, expected.Ip.IPNet, cl.Ip.IPNet)
 			continue
 		}
+		if expected.UserAgent.Valid != cl.UserAgent.Valid {
+			t.Logf("connection log %d: expected UserAgent valid %t, got %t", idx+1, expected.UserAgent.Valid, cl.UserAgent.Valid)
+			continue
+		}
 		if expected.UserAgent.Valid && cl.UserAgent.String != expected.UserAgent.String {
 			t.Logf("connection log %d: expected UserAgent %s, got %s", idx+1, expected.UserAgent.String, cl.UserAgent.String)
+			continue
+		}
+		if expected.UserID.Valid != cl.UserID.Valid {
+			t.Logf("connection log %d: expected UserID valid %t, got %t", idx+1, expected.UserID.Valid, cl.UserID.Valid)
 			continue
 		}
 		if expected.UserID.Valid && cl.UserID.UUID != expected.UserID.UUID {
 			t.Logf("connection log %d: expected UserID %s, got %s", idx+1, expected.UserID.UUID, cl.UserID.UUID)
 			continue
 		}
+		if expected.SlugOrPort.Valid != cl.SlugOrPort.Valid {
+			t.Logf("connection log %d: expected SlugOrPort valid %t, got %t", idx+1, expected.SlugOrPort.Valid, cl.SlugOrPort.Valid)
+			continue
+		}
 		if expected.SlugOrPort.Valid && cl.SlugOrPort.String != expected.SlugOrPort.String {
 			t.Logf("connection log %d: expected SlugOrPort %s, got %s", idx+1, expected.SlugOrPort.String, cl.SlugOrPort.String)
 			continue
 		}
+		if expected.ConnectionID.Valid != cl.ConnectionID.Valid {
+			t.Logf("connection log %d: expected ConnectionID valid %t, got %t", idx+1, expected.ConnectionID.Valid, cl.ConnectionID.Valid)
+			continue
+		}
 		if expected.ConnectionID.Valid && cl.ConnectionID.UUID != expected.ConnectionID.UUID {
 			t.Logf("connection log %d: expected ConnectionID %s, got %s", idx+1, expected.ConnectionID.UUID, cl.ConnectionID.UUID)
+			continue
+		}
+		if expected.DisconnectReason.Valid != cl.DisconnectReason.Valid {
+			t.Logf("connection log %d: expected DisconnectReason valid %t, got %t", idx+1, expected.DisconnectReason.Valid, cl.DisconnectReason.Valid)
+			continue
+		}
+		if expected.DisconnectReason.Valid && cl.DisconnectReason.String != expected.DisconnectReason.String {
+			t.Logf("connection log %d: expected DisconnectReason %s, got %s", idx+1, expected.DisconnectReason.String, cl.DisconnectReason.String)
+			continue
+		}
+		if !expected.Time.IsZero() && expected.Time != cl.Time {
+			t.Logf("connection log %d: expected Time %s, got %s", idx+1, expected.Time, cl.Time)
+			continue
+		}
+		if expected.ConnectionStatus != cl.ConnectionStatus {
+			t.Logf("connection log %d: expected ConnectionStatus %s, got %s", idx+1, expected.ConnectionStatus, cl.ConnectionStatus)
 			continue
 		}
 		return true


### PR DESCRIPTION
# For main

- Ignore errors when reporting a connection from the server, just log them instead
- Translate connection log IP `localhost` to `127.0.0.1` on both the server and the agent

Note that the temporary fix for converting invalid IPs to localhost is not required in main since the database no longer forbids NULL for the IP column since https://github.com/coder/coder/pull/19788

Relates to #20194