### PR TITLE
chore: make authz recorder opt in

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13832,6 +13832,9 @@ const docTemplate = `{
                 "docs_url": {
                     "$ref": "#/definitions/serpent.URL"
                 },
+                "enable_authz_recording": {
+                    "type": "boolean"
+                },
                 "enable_terraform_debug_mode": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12462,6 +12462,9 @@
 				"docs_url": {
 					"$ref": "#/definitions/serpent.URL"
 				},
+				"enable_authz_recording": {
+					"type": "boolean"
+				},
 				"enable_terraform_debug_mode": {
 					"type": "boolean"
 				},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -491,7 +491,7 @@ func New(options *Options) *API {
 	// We add this middleware early, to make sure that authorization checks made
 	// by other middleware get recorded.
 	if buildinfo.IsDev() {
-		r.Use(httpmw.RecordAuthzChecks)
+		r.Use(httpmw.RecordAuthzChecks(options.DeploymentValues.EnableAuthzRecording.Value()))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/coderd/httpmw/authz.go
+++ b/coderd/httpmw/authz.go
@@ -48,6 +48,8 @@ func AsAuthzSystem(mws ...func(http.Handler) http.Handler) func(http.Handler) ht
 // a per-request basis by setting the `x-record-authz-checks` header to a truthy value.
 //
 // Requires using a Recorder Authorizer.
+//
+//nolint:revive
 func RecordAuthzChecks(always bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -487,6 +487,7 @@ type DeploymentValues struct {
 	Sessions                        SessionLifetime                      `json:"session_lifetime,omitempty" typescript:",notnull"`
 	DisablePasswordAuth             serpent.Bool                         `json:"disable_password_auth,omitempty" typescript:",notnull"`
 	Support                         SupportConfig                        `json:"support,omitempty" typescript:",notnull"`
+	EnableAuthzRecording            serpent.Bool                         `json:"enable_authz_recording,omitempty" typescript:",notnull"`
 	ExternalAuthConfigs             serpent.Struct[[]ExternalAuthConfig] `json:"external_auth,omitempty" typescript:",notnull"`
 	SSHConfig                       SSHConfig                            `json:"config_ssh,omitempty" typescript:",notnull"`
 	WgtunnelHost                    serpent.String                       `json:"wgtunnel_host,omitempty" typescript:",notnull"`
@@ -3292,6 +3293,20 @@ Write out the current server config as YAML to stdout.`,
 			Group:       &deploymentGroupAIBridge,
 			YAML:        "key",
 			Hidden:      true,
+		},
+		{
+			Name: "Enable Authorization Recordings",
+			Description: "All api requests will have a header including all authorization calls made during the request. " +
+				"This is used for debugging purposes and only available for dev builds.",
+			Required: false,
+			Flag:     "enable-authz-recordings",
+			Env:      "CODER_ENABLE_AUTHZ_RECORDINGS",
+			YAML:     "enable_authz_recordings",
+			Default:  "false",
+			Value:    &c.EnableAuthzRecording,
+			// Do not show this option ever. It is a developer tool only, and not to be
+			// used externally.
+			Hidden: true,
 		},
 	}
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3301,7 +3301,6 @@ Write out the current server config as YAML to stdout.`,
 			Required: false,
 			Flag:     "enable-authz-recordings",
 			Env:      "CODER_ENABLE_AUTHZ_RECORDINGS",
-			YAML:     "enable_authz_recordings",
 			Default:  "false",
 			Value:    &c.EnableAuthzRecording,
 			// Do not show this option ever. It is a developer tool only, and not to be

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -237,6 +237,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "scheme": "string",
       "user": {}
     },
+    "enable_authz_recording": true,
     "enable_terraform_debug_mode": true,
     "ephemeral_deployment": true,
     "experiments": [

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2883,6 +2883,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "scheme": "string",
       "user": {}
     },
+    "enable_authz_recording": true,
     "enable_terraform_debug_mode": true,
     "ephemeral_deployment": true,
     "experiments": [
@@ -3388,6 +3389,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "scheme": "string",
     "user": {}
   },
+  "enable_authz_recording": true,
   "enable_terraform_debug_mode": true,
   "ephemeral_deployment": true,
   "experiments": [
@@ -3722,6 +3724,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `disable_password_auth`              | boolean                                                                                              | false    |              |                                                                    |
 | `disable_path_apps`                  | boolean                                                                                              | false    |              |                                                                    |
 | `docs_url`                           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
+| `enable_authz_recording`             | boolean                                                                                              | false    |              |                                                                    |
 | `enable_terraform_debug_mode`        | boolean                                                                                              | false    |              |                                                                    |
 | `ephemeral_deployment`               | boolean                                                                                              | false    |              |                                                                    |
 | `experiments`                        | array of string                                                                                      | false    |              |                                                                    |

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1307,6 +1307,7 @@ export interface DeploymentValues {
 	readonly session_lifetime?: SessionLifetime;
 	readonly disable_password_auth?: boolean;
 	readonly support?: SupportConfig;
+	readonly enable_authz_recording?: boolean;
 	readonly external_auth?: SerpentStruct<ExternalAuthConfig[]>;
 	readonly config_ssh?: SSHConfig;
 	readonly wgtunnel_host?: string;


### PR DESCRIPTION
The authz recorder is causing a lot of memory to be allocated, and is a memory leak for websocket connections.

This change makes it opt-in on a per request basis (ontop of `isDev`). To get the authz headers, use `Copy as cURL` on chrome and append the header `x-authz-checks=true`.

This is preferred to disabling this imo.