### PR TITLE
fix(dogfood): fix dogfood template image build

### DIFF
--- a/dogfood/coder/files/etc/apt/preferences.d/containerd
+++ b/dogfood/coder/files/etc/apt/preferences.d/containerd
@@ -1,6 +1,0 @@
-# Ref: https://github.com/nestybox/sysbox/issues/879
-# We need to pin containerd to a specific version to avoid breaking
-# Docker-in-Docker.
-Package: containerd.io
-Pin: version 1.7.23-1
-Pin-Priority: 1001


### PR DESCRIPTION
Previously the dogfood action was failing because the image for the dogfood template pulls a version of docker-ce that depended on a version of containerd.io greater than the pinned version. The pinned version was a workaround for an old sysbox issue (see #15723).

Example action I kicked off main recently that failed: https://github.com/coder/coder/actions/runs/18507966953
```
4.879 The following packages have unmet dependencies:
4.955  docker-ce : Depends: containerd.io (>= 1.7.27) but 1.7.23-1 is to be installed
4.963 E: Unable to correct problems, you have held broken packages.
```
