### PR TITLE
feat(cli): add --follow to coder exp task logs

### DIFF
--- a/cli/exp_task_logs.go
+++ b/cli/exp_task_logs.go
@@ -1,17 +1,27 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	aiagentapi "github.com/coder/agentapi-sdk-go"
+
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/serpent"
 )
 
 func (r *RootCmd) taskLogs() *serpent.Command {
+	var follow bool
+
 	formatter := cliui.NewOutputFormatter(
 		cliui.TableFormat(
 			[]codersdk.TaskLogEntry{},
@@ -30,6 +40,10 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 			Example{
 				Description: "Show logs for a given task.",
 				Command:     "coder exp task logs task1",
+			},
+			Example{
+				Description: "Follow logs in real-time.",
+				Command:     "coder exp task logs task1 --follow",
 			}),
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(1),
@@ -42,7 +56,6 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 
 			var (
 				ctx    = inv.Context()
-				exp    = codersdk.NewExperimentalClient(client)
 				task   = inv.Args[0]
 				taskID uuid.UUID
 			)
@@ -58,6 +71,11 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 				taskID = ws.ID
 			}
 
+			if follow {
+				return r.followTaskLogs(inv, client, taskID)
+			}
+
+			exp := codersdk.NewExperimentalClient(client)
 			logs, err := exp.TaskLogs(ctx, codersdk.Me, taskID)
 			if err != nil {
 				return xerrors.Errorf("get task logs: %w", err)
@@ -73,6 +91,150 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 		},
 	}
 
+	cmd.Options = append(cmd.Options, serpent.Option{
+		Flag:          "follow",
+		FlagShorthand: "f",
+		Env:           "",
+		Description:   "Follow logs in real-time, similar to 'tail -f'.",
+		Value:         serpent.BoolOf(&follow),
+	})
+
 	formatter.AttachOptions(&cmd.Options)
 	return cmd
+}
+
+func (*RootCmd) followTaskLogs(inv *serpent.Invocation, client *codersdk.Client, taskID uuid.UUID) error {
+	ctx := inv.Context()
+	workspace, err := client.Workspace(ctx, taskID)
+	if err != nil {
+		return xerrors.Errorf("fetch workspace: %w", err)
+	}
+	if workspace.LatestBuild.ID == uuid.Nil {
+		return xerrors.Errorf("workspace has no builds")
+	}
+	build := workspace.LatestBuild
+	if build.HasAITask == nil || !*build.HasAITask {
+		return xerrors.Errorf("workspace is not configured as an AI task")
+	}
+
+	if build.AITaskSidebarAppID == nil || *build.AITaskSidebarAppID == uuid.Nil {
+		return xerrors.Errorf("task is not configured with a sidebar app")
+	}
+
+	sidebarAppID := *build.AITaskSidebarAppID
+	var agentID uuid.UUID
+	var sidebarApp *codersdk.WorkspaceApp
+
+	for _, res := range build.Resources {
+		for _, agent := range res.Agents {
+			for _, app := range agent.Apps {
+				if app.ID == sidebarAppID {
+					agentID = agent.ID
+					sidebarApp = &app
+					break
+				}
+			}
+			if sidebarApp != nil {
+				break
+			}
+		}
+		if sidebarApp != nil {
+			break
+		}
+	}
+
+	if sidebarApp == nil {
+		return xerrors.Errorf("task sidebar app not found in latest build")
+	}
+	switch sidebarApp.Health {
+	case codersdk.WorkspaceAppHealthInitializing:
+		return xerrors.Errorf("task sidebar app is initializing, try again shortly")
+	case codersdk.WorkspaceAppHealthUnhealthy:
+		return xerrors.Errorf("task sidebar app is unhealthy")
+	}
+	if sidebarApp.URL == "" {
+		return xerrors.Errorf("task sidebar app URL is not configured")
+	}
+	parsedURL, err := url.Parse(sidebarApp.URL)
+	if err != nil {
+		return xerrors.Errorf("parse task app URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" {
+		return xerrors.Errorf("only http scheme is supported for direct agent-dial")
+	}
+
+	cliui.Infof(inv.Stderr, "Connecting to task workspace agent...")
+	dialCtx, dialCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer dialCancel()
+
+	agentConn, err := workspacesdk.New(client).DialAgent(dialCtx, agentID, &workspacesdk.DialAgentOptions{
+		Logger: inv.Logger,
+	})
+	if err != nil {
+		return xerrors.Errorf("dial workspace agent: %w", err)
+	}
+	defer agentConn.Close()
+
+	// Wait for the connection to be reachable
+	agentConn.AwaitReachable(ctx)
+
+	// Create HTTP client that dials through the agent
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return agentConn.DialContext(ctx, network, addr)
+			},
+		},
+	}
+
+	agentAPIClient, err := aiagentapi.NewClient(parsedURL.String(), aiagentapi.WithHTTPClient(httpClient))
+	if err != nil {
+		return xerrors.Errorf("create agent API client: %w", err)
+	}
+
+	cliui.Infof(inv.Stderr, "Subscribing to log events...")
+	eventsCh, errCh, err := agentAPIClient.SubscribeEvents(ctx)
+	if err != nil {
+		return xerrors.Errorf("subscribe to events: %w", err)
+	}
+
+	messagesResp, err := agentAPIClient.GetMessages(ctx)
+	if err != nil {
+		return xerrors.Errorf("get existing messages: %w", err)
+	}
+	for _, msg := range messagesResp.Messages {
+		_, _ = fmt.Fprintln(inv.Stdout, msg.Content)
+	}
+
+	lastSeenID := int64(-1)
+	if len(messagesResp.Messages) > 0 {
+		lastSeenID = messagesResp.Messages[len(messagesResp.Messages)-1].Id
+	}
+
+	cliui.Infof(inv.Stderr, "Following logs (Ctrl+C to stop)...")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-errCh:
+			if err != nil {
+				return xerrors.Errorf("error streaming events: %w", err)
+			}
+			return nil
+		case event := <-eventsCh:
+			switch msgEvent := event.(type) {
+			case aiagentapi.EventMessageUpdate:
+				if msgEvent.Id <= lastSeenID {
+					continue
+				}
+				// Prefix user messages
+				if msgEvent.Role == aiagentapi.RoleUser {
+					_, _ = fmt.Fprintf(inv.Stdout, "\t>")
+				}
+				_, _ = fmt.Fprintln(inv.Stdout, msgEvent.Message)
+			default: // ignore all other events
+			}
+		}
+	}
 }

--- a/cli/exp_task_logs.go
+++ b/cli/exp_task_logs.go
@@ -89,20 +89,21 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 			_, _ = fmt.Fprintln(inv.Stdout, out)
 			return nil
 		},
+		Options: serpent.OptionSet{
+			{
+				Flag:          "follow",
+				FlagShorthand: "f",
+				Description:   "Follow logs in real-time, similar to 'tail -f'.",
+				Value:         serpent.BoolOf(&follow),
+			},
+		},
 	}
-
-	cmd.Options = append(cmd.Options, serpent.Option{
-		Flag:          "follow",
-		FlagShorthand: "f",
-		Env:           "",
-		Description:   "Follow logs in real-time, similar to 'tail -f'.",
-		Value:         serpent.BoolOf(&follow),
-	})
 
 	formatter.AttachOptions(&cmd.Options)
 	return cmd
 }
 
+// TODO(cian): this will need to be updated when the task data model is updated.
 func (*RootCmd) followTaskLogs(inv *serpent.Invocation, client *codersdk.Client, taskID uuid.UUID) error {
 	ctx := inv.Context()
 	workspace, err := client.Workspace(ctx, taskID)
@@ -228,6 +229,7 @@ func (*RootCmd) followTaskLogs(inv *serpent.Invocation, client *codersdk.Client,
 				if msgEvent.Id <= lastSeenID {
 					continue
 				}
+				lastSeenID = msgEvent.Id
 				// Prefix user messages
 				if msgEvent.Role == aiagentapi.RoleUser {
 					_, _ = fmt.Fprintf(inv.Stdout, "\t>")

--- a/docs/ai-coder/cli.md
+++ b/docs/ai-coder/cli.md
@@ -157,9 +157,16 @@ USAGE:
 
         $ coder exp task logs task1
 
+    - Follow logs in real-time.:
+
+        $ coder exp task logs task1 --follow
+
 OPTIONS:
   -c, --column [id|content|type|time] (default: type,content)
           Columns to display in table output.
+
+  -f, --follow bool
+          Follow logs in real-time, similar to 'tail -f'.
 
   -o, --output table|json (default: table)
           Output format.


### PR DESCRIPTION
Updates `coder exp task logs` to add a `--follow` flag that dials the agent directly and tails the logs.

Authored by Claude, reviewed and cleaned up by me.
Note that this still needs to use the workspaces API (at least, for now).