### PR TITLE
chore(codersdk): add TaskStateFromWorkspaceAppStatus helper

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -327,7 +327,7 @@ func taskFromDBTaskAndWorkspace(dbTask database.Task, ws codersdk.Workspace) cod
 		if ws.LatestBuild.Transition != codersdk.WorkspaceTransitionStart || ws.LatestAppStatus.CreatedAt.After(ws.LatestBuild.CreatedAt) {
 			currentState = &codersdk.TaskStateEntry{
 				Timestamp: ws.LatestAppStatus.CreatedAt,
-				State:     codersdk.TaskState(ws.LatestAppStatus.State),
+				State:     codersdk.TaskStateFromWorkspaceAppStatus(ws.LatestAppStatus.State),
 				Message:   ws.LatestAppStatus.Message,
 				URI:       ws.LatestAppStatus.URI,
 			}

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -148,6 +148,21 @@ const (
 	TaskStateFailed TaskState = "failed"
 )
 
+func TaskStateFromWorkspaceAppStatus(was WorkspaceAppStatusState) TaskState {
+	switch was {
+	case WorkspaceAppStatusStateWorking:
+		return TaskStateWorking
+	case WorkspaceAppStatusStateIdle:
+		return TaskStateIdle
+	case WorkspaceAppStatusStateComplete:
+		return TaskStateComplete
+	case WorkspaceAppStatusStateFailure:
+		return TaskStateFailed
+	default:
+		return TaskState("unknown")
+	}
+}
+
 // Task represents a task.
 //
 // Experimental: This type is experimental and may change in the future.

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -146,6 +146,8 @@ const (
 	// TaskStateFailed indicates the AI agent reported a failure state.
 	// Reported via the workspace app status.
 	TaskStateFailed TaskState = "failed"
+	// TaskStateUnknown is the zero value for TaskState.
+	TaskStateUnknown TaskState = ""
 )
 
 func TaskStateFromWorkspaceAppStatus(was WorkspaceAppStatusState) TaskState {
@@ -159,7 +161,7 @@ func TaskStateFromWorkspaceAppStatus(was WorkspaceAppStatusState) TaskState {
 	case WorkspaceAppStatusStateFailure:
 		return TaskStateFailed
 	default:
-		return TaskState("unknown")
+		return TaskStateUnknown
 	}
 }
 


### PR DESCRIPTION
The definitions of `codersdk.TaskState` and `codersdk.WorkspaceAppStatusState` don't line up exactly. Created a helper function to convert between the two.