### PR TITLE
chore(dogfood): remove extra ENV variable for claude code auth

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -479,8 +479,8 @@ resource "coder_agent" "dev" {
   dir  = local.repo_dir
   env = {
     OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
+    # To Enable AI Bridge integration
     ANTHROPIC_BASE_URL : "https://dev.coder.com/api/experimental/aibridge/anthropic",
-    ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token
   }
   startup_script_behavior = "blocking"
 
@@ -855,7 +855,7 @@ module "claude-code" {
   workdir             = local.repo_dir
   claude_code_version = "latest"
   order               = 999
-  claude_api_key      = data.coder_workspace_owner.me.session_token
+  claude_api_key      = data.coder_workspace_owner.me.session_token # To Enable AI Bridge integration
   agentapi_version    = "latest"
 
   system_prompt       = local.claude_system_prompt


### PR DESCRIPTION
This PR removes a warning in the Claude code, where it sees both a session token and an API key being set.
Added comments to clarify AI Bridge integration tokens.

