### PR TITLE
chore(cli): add integration-style test for exp task logs and send

### DIFF
--- a/cli/exp_task_logs_test.go
+++ b/cli/exp_task_logs_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	aiagentapi "github.com/coder/agentapi-sdk-go"
+	agentapisdk "github.com/coder/agentapi-sdk-go"
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -23,16 +23,16 @@ import (
 func Test_TaskLogs(t *testing.T) {
 	t.Parallel()
 
-	testMessages := []aiagentapi.Message{
+	testMessages := []agentapisdk.Message{
 		{
 			Id:      0,
-			Role:    aiagentapi.RoleUser,
+			Role:    agentapisdk.RoleUser,
 			Content: "What is 1 + 1?",
 			Time:    time.Now().Add(-2 * time.Minute),
 		},
 		{
 			Id:      1,
-			Role:    aiagentapi.RoleAgent,
+			Role:    agentapisdk.RoleAgent,
 			Content: "2",
 			Time:    time.Now().Add(-1 * time.Minute),
 		},
@@ -163,7 +163,7 @@ func Test_TaskLogs(t *testing.T) {
 	})
 }
 
-func fakeAgentAPITaskLogsOK(messages []aiagentapi.Message) map[string]http.HandlerFunc {
+func fakeAgentAPITaskLogsOK(messages []agentapisdk.Message) map[string]http.HandlerFunc {
 	return map[string]http.HandlerFunc{
 		"/messages": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/cli/exp_task_logs_test.go
+++ b/cli/exp_task_logs_test.go
@@ -1,12 +1,9 @@
 package cli_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -16,15 +13,10 @@ import (
 
 	aiagentapi "github.com/coder/agentapi-sdk-go"
 
-	"github.com/coder/coder/v2/agent"
-	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/codersdk/agentsdk"
-	"github.com/coder/coder/v2/provisioner/echo"
-	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -171,155 +163,6 @@ func Test_TaskLogs(t *testing.T) {
 	})
 }
 
-// createAITaskTemplate creates a template configured for AI tasks with a sidebar app.
-func createAITaskTemplate(t *testing.T, client *codersdk.Client, orgID uuid.UUID, opts ...aiTemplateOpt) codersdk.Template {
-	t.Helper()
-
-	opt := aiTemplateOpts{
-		authToken: uuid.NewString(),
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
-
-	taskAppID := uuid.New()
-	version := coderdtest.CreateTemplateVersion(t, client, orgID, &echo.Responses{
-		Parse: echo.ParseComplete,
-		ProvisionPlan: []*proto.Response{
-			{
-				Type: &proto.Response_Plan{
-					Plan: &proto.PlanComplete{
-						Parameters: []*proto.RichParameter{{Name: codersdk.AITaskPromptParameterName, Type: "string"}},
-						HasAiTasks: true,
-					},
-				},
-			},
-		},
-		ProvisionApply: []*proto.Response{
-			{
-				Type: &proto.Response_Apply{
-					Apply: &proto.ApplyComplete{
-						Resources: []*proto.Resource{
-							{
-								Name: "example",
-								Type: "aws_instance",
-								Agents: []*proto.Agent{
-									{
-										Id:   uuid.NewString(),
-										Name: "example",
-										Auth: &proto.Agent_Token{
-											Token: opt.authToken,
-										},
-										Apps: []*proto.App{
-											{
-												Id:          taskAppID.String(),
-												Slug:        "task-sidebar",
-												DisplayName: "Task Sidebar",
-												Url:         opt.appURL,
-											},
-										},
-									},
-								},
-							},
-						},
-						AiTasks: []*proto.AITask{
-							{
-								SidebarApp: &proto.AITaskSidebarApp{
-									Id: taskAppID.String(),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-	template := coderdtest.CreateTemplate(t, client, orgID, version.ID)
-
-	return template
-}
-
-// fakeAgentAPI implements a fake AgentAPI HTTP server for testing.
-type fakeAgentAPI struct {
-	t        *testing.T
-	server   *httptest.Server
-	handlers map[string]http.HandlerFunc
-	called   map[string]bool
-	mu       sync.Mutex
-}
-
-// startFakeAgentAPI starts an HTTP server that implements the AgentAPI endpoints.
-// handlers is a map of path -> handler function.
-func startFakeAgentAPI(t *testing.T, handlers map[string]http.HandlerFunc) *fakeAgentAPI {
-	t.Helper()
-
-	fake := &fakeAgentAPI{
-		t:        t,
-		handlers: handlers,
-		called:   make(map[string]bool),
-	}
-
-	mux := http.NewServeMux()
-
-	// Register all provided handlers with call tracking
-	for path, handler := range handlers {
-		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			fake.mu.Lock()
-			fake.called[path] = true
-			fake.mu.Unlock()
-			handler(w, r)
-		})
-	}
-
-	knownEndpoints := []string{"/status", "/messages", "/message"}
-	for _, endpoint := range knownEndpoints {
-		if handlers[endpoint] == nil {
-			endpoint := endpoint // capture loop variable
-			mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
-				t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, endpoint)
-			})
-		}
-	}
-	// Default handler for unknown endpoints should cause the test to fail.
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, r.URL.Path)
-	})
-
-	fake.server = httptest.NewServer(mux)
-
-	// Register cleanup to check that all defined handlers were called
-	t.Cleanup(func() {
-		fake.server.Close()
-		fake.mu.Lock()
-		for path := range handlers {
-			if !fake.called[path] {
-				t.Errorf("handler for %s was defined but never called", path)
-			}
-		}
-	})
-	return fake
-}
-
-func (f *fakeAgentAPI) URL() string {
-	return f.server.URL
-}
-
-type aiTemplateOpts struct {
-	appURL    string
-	authToken string
-}
-
-type aiTemplateOpt func(*aiTemplateOpts)
-
-func withSidebarURL(url string) aiTemplateOpt {
-	return func(o *aiTemplateOpts) { o.appURL = url }
-}
-
-func withAgentToken(token string) aiTemplateOpt {
-	return func(o *aiTemplateOpts) { o.authToken = token }
-}
-
 func fakeAgentAPITaskLogsOK(messages []aiagentapi.Message) map[string]http.HandlerFunc {
 	return map[string]http.HandlerFunc{
 		"/messages": func(w http.ResponseWriter, r *http.Request) {
@@ -341,38 +184,4 @@ func fakeAgentAPITaskLogsErr(err error) map[string]http.HandlerFunc {
 			})
 		},
 	}
-}
-
-// setupCLITaskTest creates a test workspace with an AI task template and agent,
-// with a fake agent API configured with the provided set of handlers.
-// Returns the user client and workspace.
-func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[string]http.HandlerFunc) (*codersdk.Client, codersdk.Workspace) {
-	t.Helper()
-
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
-	owner := coderdtest.CreateFirstUser(t, client)
-	userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-
-	fakeAPI := startFakeAgentAPI(t, agentAPIHandlers)
-
-	authToken := uuid.NewString()
-	template := createAITaskTemplate(t, client, owner.OrganizationID, withSidebarURL(fakeAPI.URL()), withAgentToken(authToken))
-
-	wantPrompt := "test prompt"
-	workspace := coderdtest.CreateWorkspace(t, userClient, template.ID, func(req *codersdk.CreateWorkspaceRequest) {
-		req.RichParameterValues = []codersdk.WorkspaceBuildParameter{
-			{Name: codersdk.AITaskPromptParameterName, Value: wantPrompt},
-		}
-	})
-	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
-
-	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
-	_ = agenttest.New(t, client.URL, authToken, func(o *agent.Options) {
-		o.Client = agentClient
-	})
-
-	coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).
-		WaitFor(coderdtest.AgentsReady)
-
-	return userClient, workspace
 }

--- a/cli/exp_task_logs_test.go
+++ b/cli/exp_task_logs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,9 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	aiagentapi "github.com/coder/agentapi-sdk-go"
+
+	"github.com/coder/coder/v2/agent"
+	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -197,4 +206,264 @@ output  2`,
 			}
 		})
 	}
+}
+
+func Test_TaskLogs_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	owner := coderdtest.CreateFirstUser(t, client)
+	userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+	testMessages := []aiagentapi.Message{
+		{
+			Id:      0,
+			Role:    aiagentapi.RoleUser,
+			Content: "What is 2 + 2?",
+			Time:    time.Now().Add(-2 * time.Minute),
+		},
+		{
+			Id:      1,
+			Role:    aiagentapi.RoleAgent,
+			Content: "The answer is 4",
+			Time:    time.Now().Add(-1 * time.Minute),
+		},
+		{
+			Id:      2,
+			Role:    aiagentapi.RoleUser,
+			Content: "Thanks!",
+			Time:    time.Now(),
+		},
+	}
+
+	fakeAPI := startFakeAgentAPI(t, map[string]http.HandlerFunc{
+		"/messages": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"messages": testMessages,
+			})
+		},
+	})
+	authToken := uuid.NewString()
+	template := createAITaskTemplate(t, client, owner.OrganizationID, withSidebarURL(fakeAPI.URL()), withAgentToken(authToken))
+
+	wantPrompt := "build me a calculator"
+	workspace := coderdtest.CreateWorkspace(t, userClient, template.ID, func(req *codersdk.CreateWorkspaceRequest) {
+		req.RichParameterValues = []codersdk.WorkspaceBuildParameter{
+			{Name: codersdk.AITaskPromptParameterName, Value: wantPrompt},
+		}
+	})
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
+	_ = agenttest.New(t, client.URL, authToken, func(o *agent.Options) {
+		o.Client = agentClient
+	})
+
+	coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).
+		WaitFor(coderdtest.AgentsReady)
+
+	ws := coderdtest.MustWorkspace(t, client, workspace.ID)
+	resources := ws.LatestBuild.Resources
+
+	require.Len(t, resources, 1)
+	require.Len(t, resources[0].Agents, 1)
+	agentResource := resources[0].Agents[0]
+	require.Len(t, agentResource.Apps, 1)
+	// App health may be disabled since we're using a fake API without proper health checks
+	require.NotEqual(t, codersdk.WorkspaceAppHealthUnhealthy, agentResource.Apps[0].Health)
+
+	t.Run("WithoutFollow_JSON", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		var stdout strings.Builder
+		inv, root := clitest.New(t, "exp", "task", "logs", workspace.Name, "--output", "json")
+		inv.Stdout = &stdout
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		var logs []codersdk.TaskLogEntry
+		err = json.NewDecoder(strings.NewReader(stdout.String())).Decode(&logs)
+		require.NoError(t, err)
+
+		require.Len(t, logs, 3)
+		require.Equal(t, "What is 2 + 2?", logs[0].Content)
+		require.Equal(t, codersdk.TaskLogTypeInput, logs[0].Type)
+		require.Equal(t, "The answer is 4", logs[1].Content)
+		require.Equal(t, codersdk.TaskLogTypeOutput, logs[1].Type)
+		require.Equal(t, "Thanks!", logs[2].Content)
+		require.Equal(t, codersdk.TaskLogTypeInput, logs[2].Type)
+	})
+
+	t.Run("WithoutFollow_Table", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		var stdout strings.Builder
+		inv, root := clitest.New(t, "exp", "task", "logs", workspace.Name)
+		inv.Stdout = &stdout
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		output := stdout.String()
+		require.Contains(t, output, "What is 2 + 2?")
+		require.Contains(t, output, "The answer is 4")
+		require.Contains(t, output, "Thanks!")
+		require.Contains(t, output, "input")
+		require.Contains(t, output, "output")
+	})
+}
+
+// createAITaskTemplate creates a template configured for AI tasks with a sidebar app.
+func createAITaskTemplate(t *testing.T, client *codersdk.Client, orgID uuid.UUID, opts ...aiTemplateOpt) codersdk.Template {
+	t.Helper()
+
+	opt := aiTemplateOpts{
+		authToken: uuid.NewString(),
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	taskAppID := uuid.New()
+	version := coderdtest.CreateTemplateVersion(t, client, orgID, &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Response{
+			{
+				Type: &proto.Response_Plan{
+					Plan: &proto.PlanComplete{
+						Parameters: []*proto.RichParameter{{Name: codersdk.AITaskPromptParameterName, Type: "string"}},
+						HasAiTasks: true,
+					},
+				},
+			},
+		},
+		ProvisionApply: []*proto.Response{
+			{
+				Type: &proto.Response_Apply{
+					Apply: &proto.ApplyComplete{
+						Resources: []*proto.Resource{
+							{
+								Name: "example",
+								Type: "aws_instance",
+								Agents: []*proto.Agent{
+									{
+										Id:   uuid.NewString(),
+										Name: "example",
+										Auth: &proto.Agent_Token{
+											Token: opt.authToken,
+										},
+										Apps: []*proto.App{
+											{
+												Id:          taskAppID.String(),
+												Slug:        "task-sidebar",
+												DisplayName: "Task Sidebar",
+												Url:         opt.appURL,
+											},
+										},
+									},
+								},
+							},
+						},
+						AiTasks: []*proto.AITask{
+							{
+								SidebarApp: &proto.AITaskSidebarApp{
+									Id: taskAppID.String(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, orgID, version.ID)
+
+	return template
+}
+
+// fakeAgentAPI implements a fake AgentAPI HTTP server for testing.
+type fakeAgentAPI struct {
+	t        *testing.T
+	server   *httptest.Server
+	handlers map[string]http.HandlerFunc
+	called   map[string]bool
+	mu       sync.Mutex
+}
+
+// startFakeAgentAPI starts an HTTP server that implements the AgentAPI endpoints.
+// handlers is a map of path -> handler function.
+func startFakeAgentAPI(t *testing.T, handlers map[string]http.HandlerFunc) *fakeAgentAPI {
+	t.Helper()
+
+	fake := &fakeAgentAPI{
+		t:        t,
+		handlers: handlers,
+		called:   make(map[string]bool),
+	}
+
+	mux := http.NewServeMux()
+
+	// Register all provided handlers with call tracking
+	for path, handler := range handlers {
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			fake.mu.Lock()
+			fake.called[path] = true
+			fake.mu.Unlock()
+			handler(w, r)
+		})
+	}
+
+	knownEndpoints := []string{"/status", "/messages", "/message"}
+	for _, endpoint := range knownEndpoints {
+		if handlers[endpoint] == nil {
+			endpoint := endpoint // capture loop variable
+			mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
+				t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, endpoint)
+			})
+		}
+	}
+	// Default handler for unknown endpoints should cause the test to fail.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, r.URL.Path)
+	})
+
+	fake.server = httptest.NewServer(mux)
+
+	// Register cleanup to check that all defined handlers were called
+	t.Cleanup(func() {
+		fake.server.Close()
+		fake.mu.Lock()
+		for path := range handlers {
+			if !fake.called[path] {
+				t.Errorf("handler for %s was defined but never called", path)
+			}
+		}
+	})
+	return fake
+}
+
+func (f *fakeAgentAPI) URL() string {
+	return f.server.URL
+}
+
+type aiTemplateOpts struct {
+	appURL    string
+	authToken string
+}
+
+type aiTemplateOpt func(*aiTemplateOpts)
+
+func withSidebarURL(url string) aiTemplateOpt {
+	return func(o *aiTemplateOpts) { o.appURL = url }
+}
+
+func withAgentToken(token string) aiTemplateOpt {
+	return func(o *aiTemplateOpts) { o.authToken = token }
 }

--- a/cli/exp_task_send_test.go
+++ b/cli/exp_task_send_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	aiagentapi "github.com/coder/agentapi-sdk-go"
+	agentapisdk "github.com/coder/agentapi-sdk-go"
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -134,15 +134,15 @@ func fakeAgentAPITaskSendOK(t *testing.T, expectMessage, returnMessage string) m
 		"/message": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			var msg aiagentapi.PostMessageParams
+			var msg agentapisdk.PostMessageParams
 			if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 			assert.Equal(t, expectMessage, msg.Content)
-			message := aiagentapi.Message{
+			message := agentapisdk.Message{
 				Id:      999,
-				Role:    aiagentapi.RoleAgent,
+				Role:    agentapisdk.RoleAgent,
 				Content: returnMessage,
 				Time:    time.Now(),
 			}

--- a/cli/exp_task_send_test.go
+++ b/cli/exp_task_send_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -14,13 +13,9 @@ import (
 
 	aiagentapi "github.com/coder/agentapi-sdk-go"
 
-	"github.com/coder/coder/v2/agent"
-	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/httpapi"
-	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -31,7 +26,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		client, workspace := setupTaskSendTest(ctx, t, "carry on with the task")
+		client, workspace := setupCLITaskTest(ctx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 		userClient := client
 
 		var stdout strings.Builder
@@ -47,7 +42,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		client, workspace := setupTaskSendTest(ctx, t, "carry on with the task")
+		client, workspace := setupCLITaskTest(ctx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 		userClient := client
 
 		var stdout strings.Builder
@@ -63,7 +58,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		client, workspace := setupTaskSendTest(ctx, t, "carry on with the task")
+		client, workspace := setupCLITaskTest(ctx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 		userClient := client
 
 		var stdout strings.Builder
@@ -111,18 +106,25 @@ func Test_TaskSend(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, httpapi.ResourceNotFoundResponse.Message)
 	})
+
+	t.Run("SendError", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		userClient, workspace := setupCLITaskTest(ctx, t, fakeAgentAPITaskSendErr(t, assert.AnError))
+
+		var stdout strings.Builder
+		inv, root := clitest.New(t, "exp", "task", "send", workspace.Name, "some task input")
+		inv.Stdout = &stdout
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.ErrorContains(t, err, assert.AnError.Error())
+	})
 }
 
-// setupTaskSendTest creates a test workspace with an AI task template and agent,
-// configured to expect a specific message input for testing task send functionality.
-func setupTaskSendTest(ctx context.Context, t *testing.T, expectedInput string) (*codersdk.Client, codersdk.Workspace) {
-	t.Helper()
-
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
-	owner := coderdtest.CreateFirstUser(t, client)
-	userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-
-	fakeAPI := startFakeAgentAPI(t, map[string]http.HandlerFunc{
+func fakeAgentAPITaskSendOK(t *testing.T, expectMessage, returnMessage string) map[string]http.HandlerFunc {
+	return map[string]http.HandlerFunc{
 		"/status": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]string{
@@ -137,35 +139,33 @@ func setupTaskSendTest(ctx context.Context, t *testing.T, expectedInput string) 
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			assert.Equal(t, expectedInput, msg.Content)
+			assert.Equal(t, expectMessage, msg.Content)
 			message := aiagentapi.Message{
 				Id:      999,
 				Role:    aiagentapi.RoleAgent,
-				Content: "Task received",
+				Content: returnMessage,
 				Time:    time.Now(),
 			}
 			_ = json.NewEncoder(w).Encode(message)
 		},
-	})
+	}
+}
 
-	authToken := uuid.NewString()
-	template := createAITaskTemplate(t, client, owner.OrganizationID, withSidebarURL(fakeAPI.URL()), withAgentToken(authToken))
-
-	wantPrompt := "test prompt"
-	workspace := coderdtest.CreateWorkspace(t, userClient, template.ID, func(req *codersdk.CreateWorkspaceRequest) {
-		req.RichParameterValues = []codersdk.WorkspaceBuildParameter{
-			{Name: codersdk.AITaskPromptParameterName, Value: wantPrompt},
-		}
-	})
-	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
-
-	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
-	_ = agenttest.New(t, client.URL, authToken, func(o *agent.Options) {
-		o.Client = agentClient
-	})
-
-	coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).
-		WaitFor(coderdtest.AgentsReady)
-
-	return userClient, workspace
+func fakeAgentAPITaskSendErr(t *testing.T, returnErr error) map[string]http.HandlerFunc {
+	return map[string]http.HandlerFunc{
+		"/status": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "stable",
+			})
+		},
+		"/message": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(returnErr.Error()))
+		},
+	}
 }

--- a/cli/exp_task_test.go
+++ b/cli/exp_task_test.go
@@ -1,0 +1,202 @@
+package cli_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/agent"
+	"github.com/coder/coder/v2/agent/agenttest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk/proto"
+)
+
+// setupCLITaskTest creates a test workspace with an AI task template and agent,
+// with a fake agent API configured with the provided set of handlers.
+// Returns the user client and workspace.
+func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[string]http.HandlerFunc) (*codersdk.Client, codersdk.Workspace) {
+	t.Helper()
+
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	owner := coderdtest.CreateFirstUser(t, client)
+	userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+
+	fakeAPI := startFakeAgentAPI(t, agentAPIHandlers)
+
+	authToken := uuid.NewString()
+	template := createAITaskTemplate(t, client, owner.OrganizationID, withSidebarURL(fakeAPI.URL()), withAgentToken(authToken))
+
+	wantPrompt := "test prompt"
+	workspace := coderdtest.CreateWorkspace(t, userClient, template.ID, func(req *codersdk.CreateWorkspaceRequest) {
+		req.RichParameterValues = []codersdk.WorkspaceBuildParameter{
+			{Name: codersdk.AITaskPromptParameterName, Value: wantPrompt},
+		}
+	})
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
+	_ = agenttest.New(t, client.URL, authToken, func(o *agent.Options) {
+		o.Client = agentClient
+	})
+
+	coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).
+		WaitFor(coderdtest.AgentsReady)
+
+	return userClient, workspace
+}
+
+// createAITaskTemplate creates a template configured for AI tasks with a sidebar app.
+func createAITaskTemplate(t *testing.T, client *codersdk.Client, orgID uuid.UUID, opts ...aiTemplateOpt) codersdk.Template {
+	t.Helper()
+
+	opt := aiTemplateOpts{
+		authToken: uuid.NewString(),
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	taskAppID := uuid.New()
+	version := coderdtest.CreateTemplateVersion(t, client, orgID, &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Response{
+			{
+				Type: &proto.Response_Plan{
+					Plan: &proto.PlanComplete{
+						Parameters: []*proto.RichParameter{{Name: codersdk.AITaskPromptParameterName, Type: "string"}},
+						HasAiTasks: true,
+					},
+				},
+			},
+		},
+		ProvisionApply: []*proto.Response{
+			{
+				Type: &proto.Response_Apply{
+					Apply: &proto.ApplyComplete{
+						Resources: []*proto.Resource{
+							{
+								Name: "example",
+								Type: "aws_instance",
+								Agents: []*proto.Agent{
+									{
+										Id:   uuid.NewString(),
+										Name: "example",
+										Auth: &proto.Agent_Token{
+											Token: opt.authToken,
+										},
+										Apps: []*proto.App{
+											{
+												Id:          taskAppID.String(),
+												Slug:        "task-sidebar",
+												DisplayName: "Task Sidebar",
+												Url:         opt.appURL,
+											},
+										},
+									},
+								},
+							},
+						},
+						AiTasks: []*proto.AITask{
+							{
+								SidebarApp: &proto.AITaskSidebarApp{
+									Id: taskAppID.String(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, orgID, version.ID)
+
+	return template
+}
+
+// fakeAgentAPI implements a fake AgentAPI HTTP server for testing.
+type fakeAgentAPI struct {
+	t        *testing.T
+	server   *httptest.Server
+	handlers map[string]http.HandlerFunc
+	called   map[string]bool
+	mu       sync.Mutex
+}
+
+// startFakeAgentAPI starts an HTTP server that implements the AgentAPI endpoints.
+// handlers is a map of path -> handler function.
+func startFakeAgentAPI(t *testing.T, handlers map[string]http.HandlerFunc) *fakeAgentAPI {
+	t.Helper()
+
+	fake := &fakeAgentAPI{
+		t:        t,
+		handlers: handlers,
+		called:   make(map[string]bool),
+	}
+
+	mux := http.NewServeMux()
+
+	// Register all provided handlers with call tracking
+	for path, handler := range handlers {
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			fake.mu.Lock()
+			fake.called[path] = true
+			fake.mu.Unlock()
+			handler(w, r)
+		})
+	}
+
+	knownEndpoints := []string{"/status", "/messages", "/message"}
+	for _, endpoint := range knownEndpoints {
+		if handlers[endpoint] == nil {
+			endpoint := endpoint // capture loop variable
+			mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
+				t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, endpoint)
+			})
+		}
+	}
+	// Default handler for unknown endpoints should cause the test to fail.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected call to %s %s - no handler defined", r.Method, r.URL.Path)
+	})
+
+	fake.server = httptest.NewServer(mux)
+
+	// Register cleanup to check that all defined handlers were called
+	t.Cleanup(func() {
+		fake.server.Close()
+		fake.mu.Lock()
+		for path := range handlers {
+			if !fake.called[path] {
+				t.Errorf("handler for %s was defined but never called", path)
+			}
+		}
+	})
+	return fake
+}
+
+func (f *fakeAgentAPI) URL() string {
+	return f.server.URL
+}
+
+type aiTemplateOpts struct {
+	appURL    string
+	authToken string
+}
+
+type aiTemplateOpt func(*aiTemplateOpts)
+
+func withSidebarURL(url string) aiTemplateOpt {
+	return func(o *aiTemplateOpts) { o.appURL = url }
+}
+
+func withAgentToken(token string) aiTemplateOpt {
+	return func(o *aiTemplateOpts) { o.authToken = token }
+}


### PR DESCRIPTION
Adds some coderd integration tests for `coder exp tasks (send|logs)`.
The actual agentapi interaction is faked out. I figure we don't want to actually start a real agentapi instance here.

Authored by Claude with some manual cleanup.