### PR TITLE
fix(dogfood): revert unpin of containerd.io and pin docker-ce

### DIFF
--- a/dogfood/coder/files/etc/apt/preferences.d/containerd
+++ b/dogfood/coder/files/etc/apt/preferences.d/containerd
@@ -1,0 +1,6 @@
+# Ref: https://github.com/nestybox/sysbox/issues/879
+# We need to pin containerd to a specific version to avoid breaking
+# Docker-in-Docker.
+Package: containerd.io
+Pin: version 1.7.23-1
+Pin-Priority: 1001

--- a/dogfood/coder/files/etc/apt/preferences.d/docker
+++ b/dogfood/coder/files/etc/apt/preferences.d/docker
@@ -4,8 +4,12 @@ Pin: origin download.docker.com
 Pin-Priority: 1
 
 # Docker Community Edition
+# We need to pin docker-ce to a specific version because containerd is pinned
+# to an older version. Newer major versions of docker-ce require a version of
+# containerd.io greater than our pinned version.
 Package: docker-ce
 Pin: origin download.docker.com
+Pin: version 5:27.*
 Pin-Priority: 500
 
 # Docker command-line tool


### PR DESCRIPTION
Previously we unpinned the containerd.io package since the dogfood template image build was failing due to docker-ce requiring a newer version of containerd.io. The build was fixed, but some dogfood machines experienced docker-in-docker problems again because their OS version didn't have the fixed containerd.io packages available.

This PR first reverts the unpinning of the containerd.io package, and pins the docker-ce major version for compatibility with the containerd.io package version we have pinned. Newer versions of docker-ce have a higher min version of containerd.io. While the underlying issue that caused us to pin containerd.io is fixed in newer versions, we can't yet remove the pin because some machines running dogfood are not yet updated to a version of Linux that have a version of the fixed package (e.g. ubuntu 20.04).