### PR TITLE
fix(site): disable task prompt submit button when prompt empty

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -72,6 +72,37 @@ export const ReadOnlyPresetPrompt: Story = {
 	},
 };
 
+export const SubmitEnabledWhenPromptNotEmpty: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		const prompt = await canvas.findByLabelText(/prompt/i);
+		await userEvent.type(prompt, MockNewTaskData.prompt);
+
+		const submitButton = canvas.getByRole("button", { name: /run task/i });
+		expect(submitButton).toBeEnabled();
+	},
+};
+
+export const SubmitDisabledWhenPromptEmpty: Story = {
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+
+		await step("No prompt", async () => {
+			const submitButton = canvas.getByRole("button", { name: /run task/i });
+			expect(submitButton).toBeDisabled();
+		});
+
+		await step("Whitespace prompt", async () => {
+			const prompt = await canvas.findByLabelText(/prompt/i);
+			await userEvent.type(prompt, "   ");
+
+			const submitButton = canvas.getByRole("button", { name: /run task/i });
+			expect(submitButton).toBeDisabled();
+		});
+	},
+};
+
 export const OnSuccess: Story = {
 	decorators: [withGlobalSnackbar],
 	parameters: {

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -368,7 +368,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						<Button
 							size="icon"
 							type="submit"
-							disabled={prompt.length === 0 || isMissingExternalAuth}
+							disabled={prompt.trim().length === 0 || isMissingExternalAuth}
 							className="rounded-full disabled:bg-surface-invert-primary disabled:opacity-70"
 						>
 							<Spinner

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -368,7 +368,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						<Button
 							size="icon"
 							type="submit"
-							disabled={isMissingExternalAuth}
+							disabled={prompt.length === 0 || isMissingExternalAuth}
 							className="rounded-full disabled:bg-surface-invert-primary disabled:opacity-70"
 						>
 							<Spinner


### PR DESCRIPTION
Currently it is possible to press the submit button on the Tasks Page, only to then find out the prompt is required. This instead disables the submit button when there has been no prompt entered.

Before:
<img width="1365" height="191" alt="image" src="https://github.com/user-attachments/assets/9422f48c-a247-4882-abe7-5aad3a591f77" />


After:
<img width="1367" height="192" alt="image" src="https://github.com/user-attachments/assets/2eeb09f0-9199-45c1-9f2a-f4b5524dc822" />
