### PR TITLE
fix: remove response setting for the first message

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -98,6 +98,7 @@ const WorkspaceParametersPageExperimental: FC = () => {
 
 		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
 			sendInitialParameters();
+			return;
 		}
 
 		setLatestResponse(response);

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -98,7 +98,6 @@ const WorkspaceParametersPageExperimental: FC = () => {
 
 		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
 			sendInitialParameters();
-			return;
 		}
 
 		setLatestResponse(response);

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -86,12 +86,12 @@ export const WorkspaceParametersPageViewExperimental: FC<
 	);
 
 	useEffect(() => {
-		parameters.forEach((parameter) => {
+		for (const parameter of parameters) {
 			if (autofillByName[parameter.name] === undefined) {
 				return;
 			}
 			setFormFieldTouched(parameter);
-		});
+		};
 	}, [autofillByName, parameters, setFormFieldTouched]);
 
 	const handleChange = async (
@@ -117,14 +117,14 @@ export const WorkspaceParametersPageViewExperimental: FC<
 		const values = form.values.rich_parameter_values ?? [];
 
 		const touchedNames = new Set<string>();
-		values.forEach((param, idx) => {
+		for (const [idx, param] of values.entries()) {
 			const valuePath = `rich_parameter_values.${idx}.value`;
 			if (getIn(form.touched, valuePath)) {
 				touchedNames.add(param.name);
 			}
-		});
+		};
 
-		values.forEach((param) => {
+		for (const param of values) {
 			if (
 				param?.name &&
 				param.name !== parameter.name &&
@@ -133,7 +133,7 @@ export const WorkspaceParametersPageViewExperimental: FC<
 			) {
 				formInputs[param.name] = param.value;
 			}
-		});
+		};
 
 		sendMessage(formInputs);
 	};

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -73,8 +73,8 @@ export const WorkspaceParametersPageViewExperimental: FC<
 
 	const setFormFieldTouched = useCallback(
 		(parameter: PreviewParameter) => {
-			const parameters = form.values.rich_parameter_values ?? [];
-			const index = parameters.findIndex((p) => p.name === parameter.name);
+			const values = form.values.rich_parameter_values ?? [];
+			const index = values.findIndex((p) => p.name === parameter.name);
 			if (index !== -1) {
 				const path = `rich_parameter_values.${index}.value`;
 				if (getIn(form.touched, path) !== true) {
@@ -114,17 +114,17 @@ export const WorkspaceParametersPageViewExperimental: FC<
 	) => {
 		const formInputs: Record<string, string> = {};
 		formInputs[parameter.name] = value;
-		const parameters = form.values.rich_parameter_values ?? [];
+		const values = form.values.rich_parameter_values ?? [];
 
 		const touchedNames = new Set<string>();
-		parameters.forEach((param, idx) => {
+		values.forEach((param, idx) => {
 			const valuePath = `rich_parameter_values.${idx}.value`;
 			if (getIn(form.touched, valuePath)) {
 				touchedNames.add(param.name);
 			}
 		});
 
-		parameters.forEach((param) => {
+		values.forEach((param) => {
 			if (
 				param?.name &&
 				param.name !== parameter.name &&

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -77,7 +77,7 @@ export const WorkspaceParametersPageViewExperimental: FC<
 			const index = values.findIndex((p) => p.name === parameter.name);
 			if (index !== -1) {
 				const path = `rich_parameter_values.${index}.value`;
-				if (getIn(form.touched, path) !== true) {
+				if (!getIn(form.touched, path)) {
 					form.setFieldTouched(path, true, false);
 				}
 			}
@@ -114,24 +114,24 @@ export const WorkspaceParametersPageViewExperimental: FC<
 	) => {
 		const formInputs: Record<string, string> = {};
 		formInputs[parameter.name] = value;
-		const values = form.values.rich_parameter_values ?? [];
+		const formParameters = form.values.rich_parameter_values ?? [];
 
 		const touchedNames = new Set<string>();
-		for (const [idx, param] of values.entries()) {
+		for (const [idx, param] of formParameters.entries()) {
 			const valuePath = `rich_parameter_values.${idx}.value`;
 			if (getIn(form.touched, valuePath)) {
 				touchedNames.add(param.name);
 			}
 		};
 
-		for (const param of values) {
+		for (const formParam of formParameters) {
 			if (
-				param?.name &&
-				param.name !== parameter.name &&
-				touchedNames.has(param.name) &&
-				param.value
+				formParam?.name &&
+				formParam.name !== parameter.name &&
+				touchedNames.has(formParam.name) &&
+				formParam.value
 			) {
-				formInputs[param.name] = param.value;
+				formInputs[formParam.name] = formParam.value;
 			}
 		};
 


### PR DESCRIPTION
I noticed that the connection wasn’t returning all the parameters in the first message, which caused the form to miss some field values. I was able to fix it by not setting the latest message before sending the initial parameters. After running some tests, everything seems to work nicely. Because of that, I also noticed that `useSyncFormParameters` might not be necessary anymore.


Update ----

The root cause is that formik's form.initialTouched was being used with the assumption that it would retain the touched state of the fields. However, this state was getting lost when handleChange was getting called when a dynamic parameter changed.

If the websocket request does not include a field on the form with an existing value, the server will respond with the default for that parameter, which cause that parameter to lose the existing value that is set.

The fix is to keep track explicitly keep track of touched fields on the form using form.setFieldTouched.

Fix https://github.com/coder/coder/issues/20257
