### PR TITLE
chore(dogfood): use pre-release terraform provider

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "~> 2.9"
+      version = "= 2.12.0-pre0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
Set the terraform provider version to `2.12.0-pre0` so we can dogfood it before releasing. This provider version contains an update to the `coder_ai_task` resource in preparation for the upcoming 2.28 Coder release.

