### PR TITLE
fix(site): center warning boxes on task error pages

### DIFF
--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -77,7 +77,7 @@ const TaskPage = () => {
 			<TaskPageLayout>
 				<title>{pageTitle("Error loading task")}</title>
 
-				<div className="w-full min-h-80 flex items-center justify-center">
+				<div className="w-full h-full flex items-center justify-center">
 					<div className="flex flex-col items-center">
 						<h3 className="m-0 font-medium text-content-primary text-base">
 							{getErrorMessage(error, "Failed to load task")}
@@ -119,7 +119,7 @@ const TaskPage = () => {
 		content = <TaskBuildingWorkspace task={task} />;
 	} else if (task.workspace.latest_build.status === "failed") {
 		content = (
-			<div className="w-full min-h-80 flex items-center justify-center">
+			<div className="w-full h-full flex items-center justify-center">
 				<div className="flex flex-col items-center">
 					<h3 className="m-0 font-medium text-content-primary text-base">
 						Task build failed
@@ -218,7 +218,7 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({ task }) => {
 
 	return (
 		<Margins>
-			<div className="w-full min-h-80 flex items-center justify-center">
+			<div className="w-full h-full flex items-center justify-center">
 				<div className="flex flex-col items-center">
 					<h3 className="m-0 font-medium text-content-primary text-base">
 						Workspace is not running


### PR DESCRIPTION
## Description

This PR fixes the UI bug where warning boxes are not centered on task error pages. The issue occurred when visiting another user's task or encountering various error states.

## Changes

Changed `min-h-80` to `h-full` for error container divs in TaskPage.tsx to properly center warning boxes both vertically and horizontally.

The fix applies to three error states:
- Error loading task (e.g., 404 when accessing another user's task)
- Task build failed state
- Workspace not running state

## Testing

- ✅ TypeScript checks pass (`pnpm check`)
- ✅ Code formatting applied (`pnpm format`)
- ✅ No linting errors

## Visual Impact

The warning boxes now properly center in the available space within the TaskPage layout, providing a better user experience when encountering errors.

Fixes #20369