### PR TITLE
chore: migrate from tenv linter to usetesting linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -169,6 +169,16 @@ linters-settings:
       - name: var-declaration
       - name: var-naming
       - name: waitgroup-by-value
+  usetesting:
+    # Only os-setenv is enabled because we migrated to usetesting from another linter that
+    # only covered os-setenv.
+    os-setenv: true
+    os-create-temp: false
+    os-mkdir-temp: false
+    os-temp-dir: false
+    os-chdir: false
+    context-background: false
+    context-todo: false
 
   # irrelevant as of Go v1.22: https://go.dev/blog/loopvar-preview
   govet:
@@ -252,7 +262,6 @@ linters:
     # - wastedassign
 
     - staticcheck
-    - tenv
     # In Go, it's possible for a package to test it's internal functionality
     # without testing any exported functions. This is enabled to promote
     # decomposing a package before testing it's internals. A function caller
@@ -265,4 +274,5 @@ linters:
     - typecheck
     - unconvert
     - unused
+    - usetesting
     - dupl

--- a/coderd/util/tz/tz_test.go
+++ b/coderd/util/tz/tz_test.go
@@ -35,12 +35,9 @@ func Test_TimezoneIANA(t *testing.T) {
 			// This test can be flaky on some Windows runners :(
 			t.Skip("This test is flaky under Windows.")
 		}
-		oldEnv, found := os.LookupEnv("TZ")
+		_, found := os.LookupEnv("TZ")
 		if found {
 			require.NoError(t, os.Unsetenv("TZ"))
-			t.Cleanup(func() {
-				_ = os.Setenv("TZ", oldEnv)
-			})
 		}
 
 		zone, err := tz.TimezoneIANA()


### PR DESCRIPTION
The tenv linter is deprecated in favor of usetesting which offers a superset of lint checks. This message is seen when running `make lint`

```
[nix-shell:~/src/coder]$ make lint
<snip>
WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting.
<snip>
```


This PR swaps out the deprecated tenv linter for the usetesting linter, and configures it for linting parity.


https://github.com/coder/coder/issues/20398
