### PR TITLE
chore(scripts/rules.go): ignore db imports in _test.go files

### DIFF
--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -133,7 +133,10 @@ func databaseImport(m dsl.Matcher) {
 	m.Import("github.com/coder/coder/v2/coderd/database")
 	m.Match("database.$_").
 		Report("Do not import any database types into codersdk").
-		Where(m.File().PkgPath.Matches("github.com/coder/coder/v2/codersdk"))
+		Where(
+			m.File().PkgPath.Matches("github.com/coder/coder/v2/codersdk") &&
+				!m.File().Name.Matches(`_test\.go$`),
+		)
 }
 
 // publishInTransaction detects calls to Publish inside database transactions


### PR DESCRIPTION
This change allows us to stop adding the following for every invokation:

```
//nolint:gocritic // This is in a test package and does not end up in the build
```
