### PR TITLE
fix(coderd/provisionerdserver): pipe through task id and prompt

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -597,13 +597,10 @@ func (s *server) acquireProtoJob(ctx context.Context, job database.ProvisionerJo
 			return nil, failJob(fmt.Sprintf("get workspace build parameters: %s", err))
 		}
 
-		// TODO(DanielleMaywood):
-		// Plumb a task prompt into this when we have the new data-model ready
-		var taskPrompt string
-
-		// TODO(DanielleMaywood):
-		// Plumb a task ID into this when we have the new data-model ready
-		var taskID string
+		task, err := s.Database.GetTaskByWorkspaceID(ctx, workspaceBuild.WorkspaceID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, xerrors.Errorf("failed to get task by workspace id: %w", err)
+		}
 
 		dbExternalAuthProviders := []database.ExternalAuthProvider{}
 		err = json.Unmarshal(templateVersion.ExternalAuthProviders, &dbExternalAuthProviders)
@@ -729,8 +726,8 @@ func (s *server) acquireProtoJob(ctx context.Context, job database.ProvisionerJo
 					WorkspaceOwnerRbacRoles:       ownerRbacRoles,
 					RunningAgentAuthTokens:        runningAgentAuthTokens,
 					PrebuiltWorkspaceBuildStage:   input.PrebuiltWorkspaceBuildStage,
-					TaskId:                        taskID,
-					TaskPrompt:                    taskPrompt,
+					TaskId:                        task.ID.String(),
+					TaskPrompt:                    task.Prompt,
 				},
 				LogLevel: input.LogLevel,
 			},

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -599,7 +599,7 @@ func (s *server) acquireProtoJob(ctx context.Context, job database.ProvisionerJo
 
 		task, err := s.Database.GetTaskByWorkspaceID(ctx, workspaceBuild.WorkspaceID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil, xerrors.Errorf("failed to get task by workspace id: %w", err)
+			return nil, xerrors.Errorf("get task by workspace id: %w", err)
 		}
 
 		dbExternalAuthProviders := []database.ExternalAuthProvider{}

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -334,6 +334,16 @@ func TestAcquireJob(t *testing.T) {
 					Transition:        database.WorkspaceTransitionStart,
 					Reason:            database.BuildReasonInitiator,
 				})
+				task := dbgen.Task(t, db, database.TaskTable{
+					OrganizationID:     pd.OrganizationID,
+					OwnerID:            user.ID,
+					WorkspaceID:        uuid.NullUUID{Valid: true, UUID: workspace.ID},
+					TemplateVersionID:  version.ID,
+					TemplateParameters: json.RawMessage("{}"),
+					Prompt:             "Build me a REST API",
+					CreatedAt:          dbtime.Now(),
+					DeletedAt:          sql.NullTime{},
+				})
 
 				var agent database.WorkspaceAgent
 				if prebuiltWorkspaceBuildStage == sdkproto.PrebuiltWorkspaceBuildStage_CLAIM {
@@ -446,6 +456,8 @@ func TestAcquireJob(t *testing.T) {
 					WorkspaceBuildId:              build.ID.String(),
 					WorkspaceOwnerLoginType:       string(user.LoginType),
 					WorkspaceOwnerRbacRoles:       []*sdkproto.Role{{Name: rbac.RoleOrgMember(), OrgId: pd.OrganizationID.String()}, {Name: "member", OrgId: ""}, {Name: rbac.RoleOrgAuditor(), OrgId: pd.OrganizationID.String()}},
+					TaskId:                        task.ID.String(),
+					TaskPrompt:                    task.Prompt,
 				}
 				if prebuiltWorkspaceBuildStage == sdkproto.PrebuiltWorkspaceBuildStage_CLAIM {
 					// For claimed prebuilds, we expect the prebuild state to be set to CLAIM


### PR DESCRIPTION
Pipes through the Task's ID and prompt into the provisioner. This is required to support the new `coder_ai_task.prompt` field and modified `coder_ai_task.id` field.