### PR TITLE
fix: rename `total` to `count` in `AIBridgeListInterceptionsResponse`

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11727,14 +11727,14 @@ const docTemplate = `{
         "codersdk.AIBridgeListInterceptionsResponse": {
             "type": "object",
             "properties": {
+                "count": {
+                    "type": "integer"
+                },
                 "results": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.AIBridgeInterception"
                     }
-                },
-                "total": {
-                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10427,14 +10427,14 @@
 		"codersdk.AIBridgeListInterceptionsResponse": {
 			"type": "object",
 			"properties": {
+				"count": {
+					"type": "integer"
+				},
 				"results": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.AIBridgeInterception"
 					}
-				},
-				"total": {
-					"type": "integer"
 				}
 			}
 		},

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -56,7 +56,7 @@ type AIBridgeToolUsage struct {
 }
 
 type AIBridgeListInterceptionsResponse struct {
-	Total   int64                  `json:"total"`
+	Count   int64                  `json:"count"`
 	Results []AIBridgeInterception `json:"results"`
 }
 

--- a/docs/reference/api/aibridge.md
+++ b/docs/reference/api/aibridge.md
@@ -28,6 +28,7 @@ curl -X GET http://coder-server:8080/api/v2/api/experimental/aibridge/intercepti
 
 ```json
 {
+  "count": 0,
   "results": [
     {
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
@@ -89,8 +90,7 @@ curl -X GET http://coder-server:8080/api/v2/api/experimental/aibridge/intercepti
         }
       ]
     }
-  ],
-  "total": 0
+  ]
 }
 ```
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -515,6 +515,7 @@
 
 ```json
 {
+  "count": 0,
   "results": [
     {
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
@@ -576,8 +577,7 @@
         }
       ]
     }
-  ],
-  "total": 0
+  ]
 }
 ```
 
@@ -585,8 +585,8 @@
 
 | Name      | Type                                                                    | Required | Restrictions | Description |
 |-----------|-------------------------------------------------------------------------|----------|--------------|-------------|
+| `count`   | integer                                                                 | false    |              |             |
 | `results` | array of [codersdk.AIBridgeInterception](#codersdkaibridgeinterception) | false    |              |             |
-| `total`   | integer                                                                 | false    |              |             |
 
 ## codersdk.AIBridgeOpenAIConfig
 

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -127,7 +127,7 @@ func (api *API) aiBridgeListInterceptions(rw http.ResponseWriter, r *http.Reques
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.AIBridgeListInterceptionsResponse{
-		Total:   count,
+		Count:   count,
 		Results: items,
 	})
 }

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -269,7 +269,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 						if len(res.Results) == 0 {
 							break
 						}
-						require.EqualValues(t, len(allInterceptionIDs), res.Total)
+						require.EqualValues(t, len(allInterceptionIDs), res.Count)
 						require.Len(t, res.Results, 1)
 						interceptionIDs = append(interceptionIDs, res.Results[0].ID)
 					}
@@ -322,7 +322,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		// Admin can see all interceptions.
 		res, err := adminExperimentalClient.AIBridgeListInterceptions(ctx, codersdk.AIBridgeListInterceptionsFilter{})
 		require.NoError(t, err)
-		require.EqualValues(t, 2, res.Total)
+		require.EqualValues(t, 2, res.Count)
 		require.Len(t, res.Results, 2)
 		require.Equal(t, i1.ID, res.Results[0].ID)
 		require.Equal(t, i2.ID, res.Results[1].ID)
@@ -330,7 +330,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		// Second user can only see their own interceptions.
 		res, err = secondUserExperimentalClient.AIBridgeListInterceptions(ctx, codersdk.AIBridgeListInterceptionsFilter{})
 		require.NoError(t, err)
-		require.EqualValues(t, 1, res.Total)
+		require.EqualValues(t, 1, res.Count)
 		require.Len(t, res.Results, 1)
 		require.Equal(t, i2.ID, res.Results[0].ID)
 	})
@@ -501,7 +501,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 				ctx := testutil.Context(t, testutil.WaitLong)
 				res, err := experimentalClient.AIBridgeListInterceptions(ctx, tc.filter)
 				require.NoError(t, err)
-				require.EqualValues(t, len(tc.want), res.Total)
+				require.EqualValues(t, len(tc.want), res.Count)
 				// We just compare UUID strings for the sake of this test.
 				wantIDs := make([]string, len(tc.want))
 				for i, r := range tc.want {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -39,7 +39,7 @@ export interface AIBridgeInterception {
 
 // From codersdk/aibridge.go
 export interface AIBridgeListInterceptionsResponse {
-	readonly total: number;
+	readonly count: number;
 	readonly results: readonly AIBridgeInterception[];
 }
 


### PR DESCRIPTION
Thanks to the great work in #20393, we’ve successfully introduced offset-based pagination for this endpoint. However, the frontend expects a `count` field in the response rather than `total`. This PR updates the response payload to rename the returned key to `count` for consistency with frontend expectations and existing API patterns.

This is necessary to unblock the work in #20331