### PR TITLE
feat: add default resource types to composite API key scopes

### DIFF
--- a/coderd/authorize.go
+++ b/coderd/authorize.go
@@ -84,6 +84,7 @@ func (h *HTTPAuthorizer) Authorize(r *http.Request, action policy.Action, object
 			slog.F("route", r.URL.Path),
 			slog.F("action", action),
 			slog.F("object", object),
+			slog.F("allow_list", roles.SafeAllowList()),
 		)
 
 		return false

--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -160,6 +160,17 @@ func (s Subject) SafeScopeName() string {
 	return s.Scope.Name().String()
 }
 
+func (s Subject) SafeAllowList() []string {
+	if scope, err := s.Scope.Expand(); err == nil {
+		safeAllowList := make([]string, 0, len(scope.AllowIDList))
+		for _, v := range scope.AllowIDList {
+			safeAllowList = append(safeAllowList, v.String())
+		}
+		return safeAllowList
+	}
+	return []string{}
+}
+
 // SafeRoleNames prevent nil pointer dereference.
 func (s Subject) SafeRoleNames() []RoleIdentifier {
 	if s.Roles == nil {

--- a/coderd/rbac/scopes_catalog.go
+++ b/coderd/rbac/scopes_catalog.go
@@ -40,7 +40,8 @@ var externalLowLevel = map[ScopeName]struct{}{
 	"file:create": {},
 	"file:*":      {},
 
-	// Users (personal profile only)
+	// Users
+	"user:read":            {},
 	"user:read_personal":   {},
 	"user:update_personal": {},
 

--- a/codersdk/apikey_scopes_gen.go
+++ b/codersdk/apikey_scopes_gen.go
@@ -232,6 +232,7 @@ var PublicAPIKeyScopes = []APIKeyScope{
 	APIKeyScopeTemplateRead,
 	APIKeyScopeTemplateUpdate,
 	APIKeyScopeTemplateUse,
+	APIKeyScopeUserRead,
 	APIKeyScopeUserReadPersonal,
 	APIKeyScopeUserUpdatePersonal,
 	APIKeyScopeUserSecretAll,


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

Add automatic template access to workspace API tokens

This PR enhances API tokens with composite scopes like `coder:workspaces.create` to automatically include required resource types in their allow lists. For example, when a user creates a token with `coder:workspaces.create` scope and only specifies a workspace ID in the allow list, the system now automatically adds template access, which is required for workspace creation.

The implementation:
1. Adds a `DefaultAllowIDList` to composite scopes to define required resource types
2. Introduces `collectCompositeDefaults()` to gather defaults from all scopes in a token
3. Adds `MergeDefaultsForMissingTypes()` to apply defaults only for resource types not already in the allow list
4. Improves authorization logging by including the allow list in error logs

This change makes API tokens more intuitive to use, as users no longer need to manually specify all required resource types for composite operations.