### PR TITLE
feat: toggle aibridge upstream request logging

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -136,6 +136,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/aibridge/log-requests": {
+            "post": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AIBridge"
+                ],
+                "summary": "Set AI Bridge request logging",
+                "operationId": "set-aibridge-request-logging",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.AIBridgeSetRequestLoggingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/api/experimental/tasks": {
             "get": {
                 "security": [
@@ -11746,6 +11785,14 @@ const docTemplate = `{
                 },
                 "key": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.AIBridgeSetRequestLoggingRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -112,6 +112,39 @@
 				}
 			}
 		},
+		"/api/experimental/aibridge/log-requests": {
+			"post": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["AIBridge"],
+				"summary": "Set AI Bridge request logging",
+				"operationId": "set-aibridge-request-logging",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.AIBridgeSetRequestLoggingRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Response"
+						}
+					}
+				}
+			}
+		},
 		"/api/experimental/tasks": {
 			"get": {
 				"security": [
@@ -10446,6 +10479,14 @@
 				},
 				"key": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.AIBridgeSetRequestLoggingRequest": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"type": "boolean"
 				}
 			}
 		},

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -124,3 +124,21 @@ func (c *ExperimentalClient) AIBridgeListInterceptions(ctx context.Context, filt
 	var resp AIBridgeListInterceptionsResponse
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
+
+type AIBridgeSetRequestLoggingRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// AIBridgeSetRequestLogging toggles upstream request/response logging for AI Bridge providers.
+// Only users with the owner role can toggle request logging.
+func (c *ExperimentalClient) AIBridgeSetRequestLogging(ctx context.Context, req AIBridgeSetRequestLoggingRequest) error {
+	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/aibridge/log-requests", req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}

--- a/docs/reference/api/aibridge.md
+++ b/docs/reference/api/aibridge.md
@@ -101,3 +101,56 @@ curl -X GET http://coder-server:8080/api/v2/api/experimental/aibridge/intercepti
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.AIBridgeListInterceptionsResponse](schemas.md#codersdkaibridgelistinterceptionsresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Set AI Bridge request logging
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/api/experimental/aibridge/log-requests \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/aibridge/log-requests`
+
+> Body parameter
+
+```json
+{
+  "enabled": true
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                             | Required | Description  |
+|--------|------|--------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.AIBridgeSetRequestLoggingRequest](schemas.md#codersdkaibridgesetrequestloggingrequest) | true     | Request body |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "detail": "string",
+  "message": "string",
+  "validations": [
+    {
+      "detail": "string",
+      "field": "string"
+    }
+  ]
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                           |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Response](schemas.md#codersdkresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -604,6 +604,20 @@
 | `base_url` | string | false    |              |             |
 | `key`      | string | false    |              |             |
 
+## codersdk.AIBridgeSetRequestLoggingRequest
+
+```json
+{
+  "enabled": true
+}
+```
+
+### Properties
+
+| Name      | Type    | Required | Restrictions | Description |
+|-----------|---------|----------|--------------|-------------|
+| `enabled` | boolean | false    |              |             |
+
 ## codersdk.AIBridgeTokenUsage
 
 ```json

--- a/enterprise/cli/aibridge_log_requests.go
+++ b/enterprise/cli/aibridge_log_requests.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli"
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) aibridgeLogRequests() *serpent.Command {
+	var (
+		enable  bool
+		disable bool
+	)
+
+	cmd := &serpent.Command{
+		Use:   "log-requests",
+		Short: "Toggle upstream request/response logging for AI Bridge providers",
+		Long: cli.FormatExamples(
+			cli.Example{
+				Description: "Enable request logging (owner only)",
+				Command:     "coder exp aibridge log-requests --enable",
+			},
+			cli.Example{
+				Description: "Disable request logging (owner only)",
+				Command:     "coder exp aibridge log-requests --disable",
+			},
+		),
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(0),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+
+			ctx := inv.Context()
+
+			if enable == disable {
+				return xerrors.New("must specify either --enable or --disable")
+			}
+
+			experimental := codersdk.NewExperimentalClient(client)
+			err = experimental.AIBridgeSetRequestLogging(ctx, codersdk.AIBridgeSetRequestLoggingRequest{
+				Enabled: enable,
+			})
+			if err != nil {
+				return err
+			}
+
+			state := "disabled"
+			if enable {
+				state = "enabled"
+			}
+
+			_, err = fmt.Fprintf(inv.Stdout, "Request logging %s successfully.\n", cliui.Bold(state))
+			return err
+		},
+		Options: serpent.OptionSet{
+			{
+				Flag:        "enable",
+				Description: "Enable request logging.",
+				Value:       serpent.BoolOf(&enable),
+			},
+			{
+				Flag:        "disable",
+				Description: "Disable request logging.",
+				Value:       serpent.BoolOf(&disable),
+			},
+		},
+	}
+
+	return cmd
+}

--- a/enterprise/cli/aibridged.go
+++ b/enterprise/cli/aibridged.go
@@ -21,12 +21,14 @@ func newAIBridgeDaemon(coderAPI *coderd.API) (*aibridged.Server, error) {
 	// Setup supported providers.
 	providers := []aibridge.Provider{
 		aibridge.NewOpenAIProvider(aibridge.ProviderConfig{
-			BaseURL: coderAPI.DeploymentValues.AI.BridgeConfig.OpenAI.BaseURL.String(),
-			Key:     coderAPI.DeploymentValues.AI.BridgeConfig.OpenAI.Key.String(),
+			BaseURL:               coderAPI.DeploymentValues.AI.BridgeConfig.OpenAI.BaseURL.String(),
+			Key:                   coderAPI.DeploymentValues.AI.BridgeConfig.OpenAI.Key.String(),
+			EnableUpstreamLogging: true,
 		}),
 		aibridge.NewAnthropicProvider(aibridge.ProviderConfig{
-			BaseURL: coderAPI.DeploymentValues.AI.BridgeConfig.Anthropic.BaseURL.String(),
-			Key:     coderAPI.DeploymentValues.AI.BridgeConfig.Anthropic.Key.String(),
+			BaseURL:               coderAPI.DeploymentValues.AI.BridgeConfig.Anthropic.BaseURL.String(),
+			Key:                   coderAPI.DeploymentValues.AI.BridgeConfig.Anthropic.Key.String(),
+			EnableUpstreamLogging: true,
 		}),
 	}
 

--- a/enterprise/cli/exp_aibridge.go
+++ b/enterprise/cli/exp_aibridge.go
@@ -23,6 +23,7 @@ func (r *RootCmd) aibridge() *serpent.Command {
 		},
 		Children: []*serpent.Command{
 			r.aibridgeInterceptions(),
+			r.aibridgeLogRequests(),
 		},
 	}
 	return cmd

--- a/enterprise/coderd/aibridge/logging.go
+++ b/enterprise/coderd/aibridge/logging.go
@@ -1,0 +1,29 @@
+package aibridge
+
+import (
+	"sync/atomic"
+
+	"github.com/coder/aibridge"
+)
+
+var (
+	upstreamLoggingEnabled atomic.Bool
+	providerConfigs        []*aibridge.ProviderConfig
+)
+
+// SetProviderConfigs stores the provider configs so they can be updated at runtime.
+func SetProviderConfigs(configs []*aibridge.ProviderConfig) {
+	providerConfigs = configs
+}
+
+// SetUpstreamLoggingEnabled sets whether upstream request/response logging is enabled
+// and updates all registered provider configs.
+func SetUpstreamLoggingEnabled(enabled bool) {
+	upstreamLoggingEnabled.Store(enabled)
+	// Update all provider configs.
+	for _, cfg := range providerConfigs {
+		if cfg != nil {
+			cfg.SetEnableUpstreamLogging(enabled)
+		}
+	}
+}

--- a/enterprise/coderd/aibridge/logging.go
+++ b/enterprise/coderd/aibridge/logging.go
@@ -1,6 +1,7 @@
 package aibridge
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/coder/aibridge"
@@ -8,17 +9,24 @@ import (
 
 var (
 	upstreamLoggingEnabled atomic.Bool
-	providerConfigs        []*aibridge.ProviderConfig
+
+	providerConfigsMu sync.Mutex
+	providerConfigs   []*aibridge.ProviderConfig
 )
 
 // SetProviderConfigs stores the provider configs so they can be updated at runtime.
 func SetProviderConfigs(configs []*aibridge.ProviderConfig) {
+	providerConfigsMu.Lock()
+	defer providerConfigsMu.Unlock()
 	providerConfigs = configs
 }
 
 // SetUpstreamLoggingEnabled sets whether upstream request/response logging is enabled
 // and updates all registered provider configs.
 func SetUpstreamLoggingEnabled(enabled bool) {
+	providerConfigsMu.Lock()
+	defer providerConfigsMu.Unlock()
+
 	upstreamLoggingEnabled.Store(enabled)
 	// Update all provider configs.
 	for _, cfg := range providerConfigs {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -235,6 +235,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Group(func(r chi.Router) {
 				r.Use(apiKeyMiddleware)
 				r.Get("/interceptions", api.aiBridgeListInterceptions)
+				r.Post("/log-requests", api.aiBridgeSetRequestLogging)
 			})
 
 			// This is a bit funky but since aibridge only exposes a HTTP

--- a/enterprise/x/aibridged/aibridged_integration_test.go
+++ b/enterprise/x/aibridged/aibridged_integration_test.go
@@ -164,7 +164,9 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := testutil.Logger(t)
-	providers := []aibridge.Provider{aibridge.NewOpenAIProvider(aibridge.ProviderConfig{BaseURL: mockOpenAI.URL})}
+	openAIProvider, err := aibridge.NewOpenAIProvider(aibridge.NewProviderConfig(mockOpenAI.URL, "", ""))
+	require.NoError(t, err)
+	providers := []aibridge.Provider{openAIProvider}
 	pool, err := aibridged.NewCachedBridgePool(aibridged.DefaultPoolOptions, providers, logger)
 	require.NoError(t, err)
 

--- a/enterprise/x/aibridged/aibridged_test.go
+++ b/enterprise/x/aibridged/aibridged_test.go
@@ -287,10 +287,16 @@ func TestRouting(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			client := mock.NewMockDRPCClient(ctrl)
 
+			openAIProvider, err := aibridge.NewOpenAIProvider(aibridge.NewProviderConfig(openaiSrv.URL, "", ""))
+			require.NoError(t, err)
+			anthropicProvider, err := aibridge.NewAnthropicProvider(aibridge.NewProviderConfig(antSrv.URL, "", ""))
+			require.NoError(t, err)
+
 			providers := []aibridge.Provider{
-				aibridge.NewOpenAIProvider(aibridge.ProviderConfig{BaseURL: openaiSrv.URL}),
-				aibridge.NewAnthropicProvider(aibridge.ProviderConfig{BaseURL: antSrv.URL}),
+				openAIProvider,
+				anthropicProvider,
 			}
+
 			pool, err := aibridged.NewCachedBridgePool(aibridged.DefaultPoolOptions, providers, logger)
 			require.NoError(t, err)
 			conn := &mockDRPCConn{}

--- a/go.mod
+++ b/go.mod
@@ -555,3 +555,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 )
+
+replace github.com/coder/aibridge v0.1.3 => /home/coder/aibridge

--- a/go.mod
+++ b/go.mod
@@ -555,5 +555,3 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 )
-
-replace github.com/coder/aibridge v0.1.3 => /home/coder/aibridge

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -50,6 +50,11 @@ export interface AIBridgeOpenAIConfig {
 }
 
 // From codersdk/aibridge.go
+export interface AIBridgeSetRequestLoggingRequest {
+	readonly enabled: boolean;
+}
+
+// From codersdk/aibridge.go
 export interface AIBridgeTokenUsage {
 	readonly id: string;
 	readonly interception_id: string;


### PR DESCRIPTION
_Disclaimer: largely implemented by Claude Code._

Adds a new CLI command `exp aibridge log-requests --{enable,disable}`.

Depends on https://github.com/coder/aibridge/pull/37.

Run `go mod edit -replace github.com/coder/aibridge@v0.1.4=/home/coder/aibridge && go mod tidy` if you want to work with the branch.