### PR TITLE
chore: update coder/dogfood template to reference coder_task.prompt

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -37,7 +37,7 @@ locals {
   repo_base_dir  = data.coder_parameter.repo_base_dir.value == "~" ? "/home/coder" : replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
   repo_dir       = replace(try(module.git-clone[0].repo_dir, ""), "/^~\\//", "/home/coder/")
   container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
-  is_task        = coder_task.task.id != ""
+  is_task        = coder_task.task.prompt != "default"
 }
 
 data "coder_workspace_preset" "cpt" {

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -818,7 +818,7 @@ locals {
 module "claude-code" {
   count               = data.coder_ai_task_prompt.me.enabled ? data.coder_workspace.me.start_count : 0
   source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "3.4.4"
+  version             = "4.0.0"
   agent_id            = coder_agent.dev.id
   workdir             = local.repo_dir
   claude_code_version = "latest"

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -229,7 +229,7 @@ data "coder_external_auth" "github" {
 
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
-data "coder_ai_task_prompt" "me" {}
+data "coder_task" "me" {}
 data "coder_workspace_tags" "tags" {
   tags = {
     "cluster" : "dogfood-v2"
@@ -782,7 +782,7 @@ resource "coder_metadata" "container_info" {
   }
   item {
     key   = "ai_task"
-    value = data.coder_ai_task_prompt.me.enabled ? "yes" : "no"
+    value = data.coder_task.me.enabled ? "yes" : "no"
   }
 }
 
@@ -816,7 +816,7 @@ locals {
 }
 
 module "claude-code" {
-  count               = data.coder_ai_task_prompt.me.enabled ? data.coder_workspace.me.start_count : 0
+  count               = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   source              = "dev.registry.coder.com/coder/claude-code/coder"
   version             = "4.0.0"
   agent_id            = coder_agent.dev.id
@@ -827,7 +827,7 @@ module "claude-code" {
   agentapi_version    = "latest"
 
   system_prompt       = local.claude_system_prompt
-  ai_prompt           = data.coder_ai_task_prompt.me.value
+  ai_prompt           = data.coder_task.me.value
   post_install_script = <<-EOT
     claude mcp add playwright npx -- @playwright/mcp@latest --headless --isolated --no-sandbox
     claude mcp add desktop-commander npx -- @wonderwhy-er/desktop-commander@latest
@@ -835,12 +835,12 @@ module "claude-code" {
 }
 
 resource "coder_ai_task" "task" {
-  count  = data.coder_ai_task_prompt.me.enabled ? data.coder_workspace.me.start_count : 0
+  count  = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   app_id = module.claude-code[count.index].task_app_id
 }
 
 resource "coder_app" "develop_sh" {
-  count        = data.coder_ai_task_prompt.me.enabled ? data.coder_workspace.me.start_count : 0
+  count        = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   agent_id     = coder_agent.dev.id
   slug         = "develop-sh"
   display_name = "develop.sh"
@@ -853,7 +853,7 @@ resource "coder_app" "develop_sh" {
 }
 
 resource "coder_script" "develop_sh" {
-  count              = data.coder_ai_task_prompt.me.enabled ? data.coder_workspace.me.start_count : 0
+  count              = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   display_name       = "develop.sh"
   agent_id           = coder_agent.dev.id
   run_on_start       = true
@@ -876,7 +876,7 @@ resource "coder_script" "develop_sh" {
 }
 
 resource "coder_app" "preview" {
-  count        = data.coder_ai_task_prompt.me.enabled ? data.coder_workspace.me.start_count : 0
+  count        = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   agent_id     = coder_agent.dev.id
   slug         = "preview"
   display_name = "Preview"

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 2.12.0"
+      version = ">= 2.13.0"
     }
     docker = {
       source  = "kreuzwerker/docker"
@@ -827,7 +827,7 @@ module "claude-code" {
   agentapi_version    = "latest"
 
   system_prompt       = local.claude_system_prompt
-  ai_prompt           = data.coder_task.me.value
+  ai_prompt           = data.coder_task.me.prompt
   post_install_script = <<-EOT
     claude mcp add playwright npx -- @playwright/mcp@latest --headless --isolated --no-sandbox
     claude mcp add desktop-commander npx -- @wonderwhy-er/desktop-commander@latest


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/1065

Updates the coder/dogfood template to reference new Task features in provider version ~2.12.0~ 2.13.0:
- Adds a `coder_ai_task` resource and a `coder_task` data source
- Passes `coder_task.me.prompt` into Claude Code module
- Updates Claude Code module to 4.0.0 (ref: https://github.com/coder/registry/pull/488)
- Removes "AI Prompt" parameter

Update: to avoid a cycle that only appears to occur when using a `count`, leveraging a data source (ref: https://github.com/coder/terraform-provider-coder/pull/460)