### PR TITLE
chore(compose.yaml): allow overriding CODER_REPO

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   coder:
     # This MUST be stable for our documentation and
     # other automations.
-    image: ghcr.io/coder/coder:${CODER_VERSION:-latest}
+    image: ${CODER_REPO:-ghcr.io/coder/coder}:${CODER_VERSION:-latest}
     ports:
       - "7080:7080"
     environment:


### PR DESCRIPTION
Allows running a vendored version of Coder in our `compose.yaml` as follows:

```
CODER_REPO=my.repo.tld/mycoder/coder CODER_VERSION=my-tag docker compose up
```

Also allows running the current "dogfood" version of Coder as follows:

```
CODER_REPO=ghcr.io/coder/coder-preview CODER_VERSION=dogfood docker compose up
```