### PR TITLE
ci(.github/workflows/traiage.yaml): use coder template with no preset

### DIFF
--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -13,12 +13,12 @@ on:
       template_name:
         description: "Coder template to use for workspace"
         required: true
-        default: "traiage"
+        default: "coder"
         type: string
       template_preset:
         description: "Template preset to use"
         required: true
-        default: "Default"
+        default: "none"
         type: string
       prefix:
         description: "Prefix for workspace name"
@@ -66,8 +66,8 @@ jobs:
           GITHUB_EVENT_USER_ID: ${{ github.event.sender.id }}
           GITHUB_EVENT_USER_LOGIN: ${{ github.event.sender.login }}
           INPUTS_ISSUE_URL: ${{ inputs.issue_url }}
-          INPUTS_TEMPLATE_NAME: ${{ inputs.template_name || 'traiage' }}
-          INPUTS_TEMPLATE_PRESET: ${{ inputs.template_preset || 'Default'}}
+          INPUTS_TEMPLATE_NAME: ${{ inputs.template_name || 'coder' }}
+          INPUTS_TEMPLATE_PRESET: ${{ inputs.template_preset || 'none'}}
           INPUTS_PREFIX: ${{ inputs.prefix || 'traiage' }}
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
Standardize on using the Write Coder on Coder template for the traiage workflow.