### PR TITLE
chore: remove references to dbtestutil.WillUsePostgres

### DIFF
--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -185,9 +185,6 @@ func TestDelete(t *testing.T) {
 
 	t.Run("WarnNoProvisioners", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
 
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
@@ -228,9 +225,6 @@ func TestDelete(t *testing.T) {
 
 	t.Run("Prebuilt workspace delete permissions", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
 
 		// Setup
 		db, pb := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())

--- a/cli/server_regenerate_vapid_keypair_test.go
+++ b/cli/server_regenerate_vapid_keypair_test.go
@@ -17,9 +17,6 @@ import (
 
 func TestRegenerateVapidKeypair(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test is only supported on postgres")
-	}
 
 	t.Run("NoExistingVAPIDKeys", func(t *testing.T) {
 		t.Parallel()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -348,9 +348,6 @@ func TestServer(t *testing.T) {
 
 		runGitHubProviderTest := func(t *testing.T, tc testCase) {
 			t.Parallel()
-			if !dbtestutil.WillUsePostgres() {
-				t.Skip("test requires postgres")
-			}
 
 			ctx, cancelFunc := context.WithCancel(testutil.Context(t, testutil.WaitLong))
 			defer cancelFunc()
@@ -2142,10 +2139,6 @@ func TestServerYAMLConfig(t *testing.T) {
 func TestConnectToPostgres(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test does not make sense without postgres")
-	}
-
 	t.Run("Migrate", func(t *testing.T) {
 		t.Parallel()
 
@@ -2255,10 +2248,6 @@ type runServerOpts struct {
 
 func TestServer_TelemetryDisabled_FinalReport(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	telemetryServerURL, deployment, snapshot := mockTelemetryServer(t)
 	dbConnURL, err := dbtestutil.Open(t)

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
@@ -53,10 +52,6 @@ func TestAITasksPrompts(t *testing.T) {
 
 	t.Run("MultipleBuilds", func(t *testing.T) {
 		t.Parallel()
-
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("This test checks RBAC, which is not supported in the in-memory database")
-		}
 
 		adminClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		first := coderdtest.CreateFirstUser(t, adminClient)

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -776,10 +776,6 @@ func TestExecutorWorkspaceAutostopNoWaitChangedMyMind(t *testing.T) {
 }
 
 func TestExecutorAutostartMultipleOK(t *testing.T) {
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip(`This test only really works when using a "real" database, similar to a HA setup`)
-	}
-
 	t.Parallel()
 
 	var (
@@ -1258,10 +1254,6 @@ func TestNotifications(t *testing.T) {
 // For enterprise-related functionality, see enterprise/coderd/workspaces_test.go.
 func TestExecutorPrebuilds(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	// Prebuild workspaces should not be autostopped when the deadline is reached.
 	// After being claimed, the workspace should stop at the deadline.

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -85,10 +85,6 @@ func TestNestedInTx(t *testing.T) {
 func testSQLDB(t testing.TB) *sql.DB {
 	t.Helper()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
-
 	connection, err := dbtestutil.Open(t)
 	require.NoError(t, err)
 

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -3188,7 +3188,7 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 	}))
 	s.Run("GetAppSecurityKey", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetAppSecurityKey(gomock.Any()).Return("", sql.ErrNoRows).AnyTimes()
-		check.Args().Asserts(rbac.ResourceSystem, policy.ActionRead).ErrorsWithPG(sql.ErrNoRows)
+		check.Args().Asserts(rbac.ResourceSystem, policy.ActionRead).Errors(sql.ErrNoRows)
 	}))
 	s.Run("UpsertAppSecurityKey", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().UpsertAppSecurityKey(gomock.Any(), "foo").Return(nil).AnyTimes()

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2946,7 +2946,6 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		dbm.EXPECT().GetParameterSchemasByJobID(gomock.Any(), jobID).Return([]database.ParameterSchema{}, nil).AnyTimes()
 		check.Args(jobID).
 			Asserts(tpl, policy.ActionRead).
-			ErrorsWithInMemDB(sql.ErrNoRows).
 			Returns([]database.ParameterSchema{})
 	}))
 	s.Run("GetWorkspaceAppsByAgentIDs", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -430,12 +430,6 @@ func (m *expects) Errors(err error) *expects {
 	return m
 }
 
-// ErrorsWithPG is optional. If it is never called, it will not be asserted.
-// Since we removed the in-memory database, this is now equivalent to Errors.
-func (m *expects) ErrorsWithPG(err error) *expects {
-	return m.Errors(err)
-}
-
 func (m *expects) FailSystemObjectChecks() *expects {
 	return m.WithSuccessAuthorizer(func(ctx context.Context, subject rbac.Subject, action policy.Action, obj rbac.Object) error {
 		if obj.Type == rbac.ResourceSystem.Type {

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -431,20 +431,14 @@ func (m *expects) Errors(err error) *expects {
 }
 
 // ErrorsWithPG is optional. If it is never called, it will not be asserted.
-// It will only be asserted if the test is running with a Postgres database.
+// Since we removed the in-memory database, this is now equivalent to Errors.
 func (m *expects) ErrorsWithPG(err error) *expects {
-	if dbtestutil.WillUsePostgres() {
-		return m.Errors(err)
-	}
-	return m
+	return m.Errors(err)
 }
 
-// ErrorsWithInMemDB is optional. If it is never called, it will not be asserted.
-// It will only be asserted if the test is running with an in-memory database.
+// ErrorsWithInMemDB is deprecated. The in-memory database has been removed.
+// This method is kept for backwards compatibility but does nothing.
 func (m *expects) ErrorsWithInMemDB(err error) *expects {
-	if !dbtestutil.WillUsePostgres() {
-		return m.Errors(err)
-	}
 	return m
 }
 

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -436,12 +436,6 @@ func (m *expects) ErrorsWithPG(err error) *expects {
 	return m.Errors(err)
 }
 
-// ErrorsWithInMemDB is deprecated. The in-memory database has been removed.
-// This method is kept for backwards compatibility but does nothing.
-func (m *expects) ErrorsWithInMemDB(err error) *expects {
-	return m
-}
-
 func (m *expects) FailSystemObjectChecks() *expects {
 	return m.WithSuccessAuthorizer(func(ctx context.Context, subject rbac.Subject, action policy.Action, obj rbac.Object) error {
 		if obj.Type == rbac.ResourceSystem.Type {

--- a/coderd/database/dbrollup/dbrollup_test.go
+++ b/coderd/database/dbrollup/dbrollup_test.go
@@ -52,10 +52,6 @@ func (w *wrapUpsertDB) UpsertTemplateUsageStats(ctx context.Context) error {
 func TestRollup_TwoInstancesUseLocking(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("Skipping test; only works with PostgreSQL.")
-	}
-
 	db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
 	logger := testutil.Logger(t)
 

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -23,13 +23,6 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-// WillUsePostgres returns true if a call to NewDB() will return a real, postgres-backed Store and Pubsub.
-// TODO(hugodutka): since we removed the in-memory database, this is always true,
-// and we need to remove this function. https://github.com/coder/internal/issues/758
-func WillUsePostgres() bool {
-	return true
-}
-
 type options struct {
 	fixedTimezone string
 	dumpOnFailure bool
@@ -74,10 +67,6 @@ func withReturnSQLDB(f func(*sql.DB)) Option {
 
 func NewDBWithSQLDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub, *sql.DB) {
 	t.Helper()
-
-	if !WillUsePostgres() {
-		t.Fatal("cannot use NewDBWithSQLDB without PostgreSQL, consider adding `if !dbtestutil.WillUsePostgres() { t.Skip() }` to this test")
-	}
 
 	var sqlDB *sql.DB
 	opts = append(opts, withReturnSQLDB(func(db *sql.DB) {

--- a/coderd/database/dbtestutil/postgres_test.go
+++ b/coderd/database/dbtestutil/postgres_test.go
@@ -20,9 +20,6 @@ func TestMain(m *testing.M) {
 
 func TestOpen(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	connect, err := dbtestutil.Open(t)
 	require.NoError(t, err)
@@ -37,9 +34,6 @@ func TestOpen(t *testing.T) {
 
 func TestOpen_InvalidDBFrom(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	_, err := dbtestutil.Open(t, dbtestutil.WithDBFrom("__invalid__"))
 	require.Error(t, err)
@@ -49,9 +43,6 @@ func TestOpen_InvalidDBFrom(t *testing.T) {
 
 func TestOpen_ValidDBFrom(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	// first check if we can create a new template db
 	dsn, err := dbtestutil.Open(t, dbtestutil.WithDBFrom(""))
@@ -115,9 +106,6 @@ func TestOpen_ValidDBFrom(t *testing.T) {
 func TestOpen_Panic(t *testing.T) {
 	t.Skip("unskip this to manually test that we don't leak a database into postgres")
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	_, err := dbtestutil.Open(t)
 	require.NoError(t, err)
@@ -127,9 +115,6 @@ func TestOpen_Panic(t *testing.T) {
 func TestOpen_Timeout(t *testing.T) {
 	t.Skip("unskip this and set a short timeout to manually test that we don't leak a database into postgres")
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	_, err := dbtestutil.Open(t)
 	require.NoError(t, err)

--- a/coderd/database/pubsub/pubsub_test.go
+++ b/coderd/database/pubsub/pubsub_test.go
@@ -19,9 +19,6 @@ import (
 
 func TestPGPubsub_Metrics(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := testutil.Logger(t)
 	connectionURL, err := dbtestutil.Open(t)
@@ -122,9 +119,6 @@ func TestPGPubsub_Metrics(t *testing.T) {
 
 func TestPGPubsubDriver(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	logger := slogtest.Make(t, &slogtest.Options{

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -3742,9 +3742,6 @@ func TestGetProvisionerJobsByIDsWithQueuePosition(t *testing.T) {
 
 func TestGetProvisionerJobsByIDsWithQueuePosition_MixedStatuses(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.SkipNow()
-	}
 
 	db, _ := dbtestutil.NewDB(t)
 	now := dbtime.Now()
@@ -4083,10 +4080,6 @@ func TestGroupRemovalTrigger(t *testing.T) {
 func TestGetUserStatusCounts(t *testing.T) {
 	t.Parallel()
 	t.Skip("https://github.com/coder/internal/issues/464")
-
-	if !dbtestutil.WillUsePostgres() {
-		t.SkipNow()
-	}
 
 	timezones := []string{
 		"Canada/Newfoundland",
@@ -4625,10 +4618,6 @@ func TestGetUserStatusCounts(t *testing.T) {
 func TestOrganizationDeleteTrigger(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.SkipNow()
-	}
-
 	t.Run("WorkspaceExists", func(t *testing.T) {
 		t.Parallel()
 		db, _ := dbtestutil.NewDB(t)
@@ -4942,9 +4931,6 @@ func createPrebuiltWorkspace(
 
 func TestWorkspacePrebuildsView(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.SkipNow()
-	}
 
 	now := dbtime.Now()
 	orgID := uuid.New()
@@ -5046,9 +5032,6 @@ func TestWorkspacePrebuildsView(t *testing.T) {
 
 func TestGetPresetsBackoff(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.SkipNow()
-	}
 
 	now := dbtime.Now()
 	orgID := uuid.New()
@@ -5565,9 +5548,6 @@ func TestGetPresetsBackoff(t *testing.T) {
 
 func TestGetPresetsAtFailureLimit(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.SkipNow()
-	}
 
 	now := dbtime.Now()
 	hourBefore := now.Add(-time.Hour)
@@ -5871,10 +5851,6 @@ func TestGetPresetsAtFailureLimit(t *testing.T) {
 func TestWorkspaceAgentNameUniqueTrigger(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test makes use of a database trigger not implemented in dbmem")
-	}
-
 	createWorkspaceWithAgent := func(t *testing.T, db database.Store, org database.Organization, agentName string) (database.WorkspaceBuild, database.WorkspaceResource, database.WorkspaceAgent) {
 		t.Helper()
 
@@ -6140,10 +6116,6 @@ func requireUsersMatch(t testing.TB, expected []database.User, found []database.
 // GetRunningPrebuiltWorkspaces query.
 func TestGetRunningPrebuiltWorkspaces(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("Test requires PostgreSQL for complex queries")
-	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	db, _ := dbtestutil.NewDB(t)

--- a/coderd/notifications/metrics_test.go
+++ b/coderd/notifications/metrics_test.go
@@ -33,9 +33,6 @@ func TestMetrics(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
 
 	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
@@ -390,13 +387,6 @@ func TestInflightDispatchesMetric(t *testing.T) {
 
 func TestCustomMethodMetricCollection(t *testing.T) {
 	t.Parallel()
-
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		// UpdateNotificationTemplateMethodByID only makes sense with a real database.
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
-
 	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -66,11 +66,6 @@ func TestMain(m *testing.M) {
 func TestBasicNotificationRoundtrip(t *testing.T) {
 	t.Parallel()
 
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
-
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
@@ -278,11 +273,6 @@ func TestWebhookDispatch(t *testing.T) {
 func TestBackpressure(t *testing.T) {
 	t.Parallel()
 
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
-
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitShort))
@@ -407,11 +397,6 @@ func TestBackpressure(t *testing.T) {
 func TestRetries(t *testing.T) {
 	t.Parallel()
 
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
-
 	const maxAttempts = 3
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
@@ -506,11 +491,6 @@ func TestRetries(t *testing.T) {
 // they have been processed.
 func TestExpiredLeaseIsRequeued(t *testing.T) {
 	t.Parallel()
-
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
 
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
@@ -750,10 +730,6 @@ func enumerateAllTemplates(t *testing.T) ([]string, error) {
 
 func TestNotificationTemplates_Golden(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on the notification templates added by migrations in the database")
-	}
 
 	const (
 		username = "bob"
@@ -1705,10 +1681,6 @@ func normalizeGoldenWebhook(content []byte) []byte {
 func TestDisabledByDefaultBeforeEnqueue(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it is testing business-logic implemented in the database")
-	}
-
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, _ := dbtestutil.NewDB(t)
 	logbuf := strings.Builder{}
@@ -1731,11 +1703,6 @@ func TestDisabledByDefaultBeforeEnqueue(t *testing.T) {
 // TestDisabledBeforeEnqueue ensures that notifications cannot be enqueued once a user has disabled that notification template
 func TestDisabledBeforeEnqueue(t *testing.T) {
 	t.Parallel()
-
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it is testing business-logic implemented in the database")
-	}
 
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, _ := dbtestutil.NewDB(t)
@@ -1770,11 +1737,6 @@ func TestDisabledBeforeEnqueue(t *testing.T) {
 // sent, and will instead be marked as "inhibited".
 func TestDisabledAfterEnqueue(t *testing.T) {
 	t.Parallel()
-
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it is testing business-logic implemented in the database")
-	}
 
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
@@ -1826,11 +1788,6 @@ func TestDisabledAfterEnqueue(t *testing.T) {
 
 func TestCustomNotificationMethod(t *testing.T) {
 	t.Parallel()
-
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
 
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
@@ -1929,12 +1886,6 @@ func TestCustomNotificationMethod(t *testing.T) {
 func TestNotificationsTemplates(t *testing.T) {
 	t.Parallel()
 
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		// Notification system templates are only served from the database and not dbmem at this time.
-		t.Skip("This test requires postgres; it relies on business-logic only implemented in the database")
-	}
-
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	api := coderdtest.New(t, createOpts(t))
 
@@ -1965,11 +1916,6 @@ func createOpts(t *testing.T) *coderdtest.Options {
 // TestNotificationDuplicates validates that identical notifications cannot be sent on the same day.
 func TestNotificationDuplicates(t *testing.T) {
 	t.Parallel()
-
-	// SETUP
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("This test requires postgres; it is testing the dedupe hash trigger in the database")
-	}
 
 	ctx := dbauthz.AsNotifier(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -944,10 +944,6 @@ func TestPatchTemplateMeta(t *testing.T) {
 	t.Run("AlreadyExists", func(t *testing.T) {
 		t.Parallel()
 
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("This test requires Postgres constraints")
-		}
-
 		ownerClient := coderdtest.New(t, nil)
 		owner := coderdtest.CreateFirstUser(t, ownerClient)
 		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.ScopedRoleOrgTemplateAdmin(owner.OrganizationID))

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1422,9 +1422,6 @@ func TestTemplateVersionDryRun(t *testing.T) {
 
 	t.Run("Pending", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
 
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closer := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -634,9 +634,7 @@ func TestPatchCancelWorkspaceBuild(t *testing.T) {
 
 	t.Run("Cancel with expect_state=pending", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
+
 		// Given: a coderd instance with a provisioner daemon
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
@@ -732,9 +730,7 @@ func TestPatchCancelWorkspaceBuild(t *testing.T) {
 
 	t.Run("Cancel with expect_state=running when job is pending - should fail with 412", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
+
 		// Given: a coderd instance with a provisioner daemon
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
@@ -1731,9 +1727,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 
 	t.Run("NoProvisionersAvailable", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
+
 		// Given: a coderd instance with a provisioner daemon
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
@@ -1777,9 +1771,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 
 	t.Run("AllProvisionersStale", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
+
 		// Given: a coderd instance with a provisioner daemon
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1240,9 +1240,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("NoProvisionersAvailable", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
+
 		// Given: a coderd instance with a provisioner daemon
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)
 		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
@@ -1283,9 +1281,6 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("AllProvisionersStale", func(t *testing.T) {
 		t.Parallel()
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test requires postgres")
-		}
 
 		// Given: a coderd instance with a provisioner daemon
 		store, ps, db := dbtestutil.NewDBWithSQLDB(t)

--- a/coderd/workspacestats/tracker_test.go
+++ b/coderd/workspacestats/tracker_test.go
@@ -110,9 +110,6 @@ func TestTracker(t *testing.T) {
 // This test performs a more 'integration-style' test with multiple instances.
 func TestTracker_MultipleInstances(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test only makes sense with postgres")
-	}
 
 	// Given we have two coderd instances connected to the same database
 	var (

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -24,10 +24,6 @@ import (
 //
 // nolint: paralleltest // use of t.Setenv
 func TestServerDBCrypt(t *testing.T) {
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires a postgres instance")
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -79,10 +79,6 @@ func TestEntitlements(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("%p", api.Entitlements), fmt.Sprintf("%p", api.AGPL.Entitlements))
 	})
 	t.Run("FullLicense", func(t *testing.T) {
-		// PGCoordinator requires a real postgres
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("test only with postgres")
-		}
 		t.Parallel()
 		adminClient, _ := coderdenttest.New(t, &coderdenttest.Options{
 			AuditLogging:   true,
@@ -881,10 +877,6 @@ func (s *restartableTestServer) startWithFirstUser(t *testing.T) (client *coders
 // This test uses a real server and real clients.
 func TestConn_CoordinatorRollingRestart(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	// Although DERP will have connection issues until the connection is
 	// reestablished, any open connections should be maintained.

--- a/enterprise/coderd/notifications_test.go
+++ b/enterprise/coderd/notifications_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
@@ -35,10 +34,6 @@ func TestUpdateNotificationTemplateMethod(t *testing.T) {
 
 	t.Run("Happy path", func(t *testing.T) {
 		t.Parallel()
-
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("This test requires postgres; it relies on read from and writing to the notification_templates table")
-		}
 
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		api, _ := coderdenttest.New(t, createOpts(t))
@@ -67,10 +62,6 @@ func TestUpdateNotificationTemplateMethod(t *testing.T) {
 	t.Run("Insufficient permissions", func(t *testing.T) {
 		t.Parallel()
 
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("This test requires postgres; it relies on read from and writing to the notification_templates table")
-		}
-
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 		// Given: the first user which has an "owner" role, and another user which does not.
@@ -90,10 +81,6 @@ func TestUpdateNotificationTemplateMethod(t *testing.T) {
 
 	t.Run("Invalid notification method", func(t *testing.T) {
 		t.Parallel()
-
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("This test requires postgres; it relies on read from and writing to the notification_templates table")
-		}
 
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
@@ -119,10 +106,6 @@ func TestUpdateNotificationTemplateMethod(t *testing.T) {
 
 	t.Run("Not modified", func(t *testing.T) {
 		t.Parallel()
-
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("This test requires postgres; it relies on read from and writing to the notification_templates table")
-		}
 
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		api, _ := coderdenttest.New(t, createOpts(t))

--- a/enterprise/coderd/prebuilds/membership_test.go
+++ b/enterprise/coderd/prebuilds/membership_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/enterprise/coderd/prebuilds"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -90,14 +89,6 @@ func TestReconcileAll(t *testing.T) {
 							// introduce an unrelated organization to ensure that the membership reconciler doesn't interfere with it.
 							unrelatedOrg := dbgen.Organization(t, db, database.Organization{})
 							targetOrg := dbgen.Organization(t, db, database.Organization{})
-
-							if !dbtestutil.WillUsePostgres() {
-								// dbmem doesn't ensure membership to the default organization
-								dbgen.OrganizationMember(t, db, database.OrganizationMember{
-									OrganizationID: defaultOrg.ID,
-									UserID:         database.PrebuildsSystemUserID,
-								})
-							}
 
 							// Ensure membership to unrelated org.
 							dbgen.OrganizationMember(t, db, database.OrganizationMember{OrganizationID: unrelatedOrg.ID, UserID: database.PrebuildsSystemUserID})

--- a/enterprise/coderd/prebuilds/metricscollector_test.go
+++ b/enterprise/coderd/prebuilds/metricscollector_test.go
@@ -30,10 +30,6 @@ import (
 func TestMetricsCollector(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
-
 	type metricCheck struct {
 		name      string
 		value     *float64
@@ -298,10 +294,6 @@ func TestMetricsCollector(t *testing.T) {
 func TestMetricsCollector_DuplicateTemplateNames(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
-
 	type metricCheck struct {
 		name      string
 		value     *float64
@@ -477,10 +469,6 @@ func findAllMetricSeries(metricsFamilies []*prometheus_client.MetricFamily, labe
 
 func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	t.Run("reconciliation_not_paused", func(t *testing.T) {
 		t.Parallel()

--- a/enterprise/coderd/replicas_test.go
+++ b/enterprise/coderd/replicas_test.go
@@ -20,9 +20,7 @@ import (
 
 func TestReplicas(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("only test with real postgres")
-	}
+
 	t.Run("ErrorWithoutLicense", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -89,10 +89,6 @@ func TestBlockNonBrowser(t *testing.T) {
 func TestReinitializeAgent(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("dbmem cannot currently claim a workspace")
-	}
-
 	if runtime.GOOS == "windows" {
 		t.Skip("test startup script is not supported on windows")
 	}

--- a/enterprise/coderd/workspacequota_test.go
+++ b/enterprise/coderd/workspacequota_test.go
@@ -660,10 +660,6 @@ func TestWorkspaceQuota(t *testing.T) {
 func TestWorkspaceSerialization(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("Serialization errors only occur in postgres")
-	}
-
 	db, _ := dbtestutil.NewDB(t)
 
 	user := dbgen.User(t, db, database.User{})

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -534,10 +534,6 @@ func TestCreateUserWorkspace(t *testing.T) {
 	t.Run("ClaimPrebuild", func(t *testing.T) {
 		t.Parallel()
 
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("dbmem cannot currently claim a workspace")
-		}
-
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: coderdtest.DeploymentValues(t),
@@ -844,10 +840,6 @@ func TestWorkspaceAutobuild(t *testing.T) {
 	// cause a deadlock.
 	t.Run("NoDeadlock", func(t *testing.T) {
 		t.Parallel()
-
-		if !dbtestutil.WillUsePostgres() {
-			t.Skipf("Skipping non-postgres run")
-		}
 
 		var (
 			ticker      = make(chan time.Time)
@@ -1654,10 +1646,6 @@ func TestWorkspaceAutobuild(t *testing.T) {
 	t.Run("NextStartAtIsNullifiedOnScheduleChange", func(t *testing.T) {
 		t.Parallel()
 
-		if !dbtestutil.WillUsePostgres() {
-			t.Skip("this test uses triggers so does not work with dbmem.go")
-		}
-
 		var (
 			tickCh  = make(chan time.Time)
 			statsCh = make(chan autobuild.Stats)
@@ -1780,10 +1768,6 @@ func TestTemplateDoesNotAllowUserAutostop(t *testing.T) {
 
 func TestPrebuildsAutobuild(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("this test requires postgres")
-	}
 
 	getRunningPrebuilds := func(
 		t *testing.T,

--- a/enterprise/tailnet/handshaker_test.go
+++ b/enterprise/tailnet/handshaker_test.go
@@ -14,9 +14,7 @@ import (
 
 func TestPGCoordinator_ReadyForHandshake_OK(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -30,9 +28,7 @@ func TestPGCoordinator_ReadyForHandshake_OK(t *testing.T) {
 
 func TestPGCoordinator_ReadyForHandshake_NoPermission(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()

--- a/enterprise/tailnet/multiagent_test.go
+++ b/enterprise/tailnet/multiagent_test.go
@@ -23,9 +23,6 @@ import (
 //	            +--------+
 func TestPGCoordinator_MultiAgent(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
@@ -60,9 +57,6 @@ func TestPGCoordinator_MultiAgent(t *testing.T) {
 
 func TestPGCoordinator_MultiAgent_CoordClose(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
@@ -90,9 +84,6 @@ func TestPGCoordinator_MultiAgent_CoordClose(t *testing.T) {
 //	            +--------+
 func TestPGCoordinator_MultiAgent_UnsubscribeRace(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
@@ -135,9 +126,6 @@ func TestPGCoordinator_MultiAgent_UnsubscribeRace(t *testing.T) {
 //	            +--------+
 func TestPGCoordinator_MultiAgent_Unsubscribe(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
@@ -197,9 +185,6 @@ func TestPGCoordinator_MultiAgent_Unsubscribe(t *testing.T) {
 //	            +--------+
 func TestPGCoordinator_MultiAgent_MultiCoordinator(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
@@ -247,9 +232,6 @@ func TestPGCoordinator_MultiAgent_MultiCoordinator(t *testing.T) {
 //	            +--------+
 func TestPGCoordinator_MultiAgent_MultiCoordinator_UpdateBeforeSubscribe(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
@@ -299,9 +281,6 @@ func TestPGCoordinator_MultiAgent_MultiCoordinator_UpdateBeforeSubscribe(t *test
 //	            +--------+
 func TestPGCoordinator_MultiAgent_TwoAgents(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)

--- a/enterprise/tailnet/pgcoord_internal_test.go
+++ b/enterprise/tailnet/pgcoord_internal_test.go
@@ -163,9 +163,7 @@ func TestHeartbeats_LostCoordinator_MarkLost(t *testing.T) {
 // that is, clean up peers and associated tunnels that have been lost for over 24 hours.
 func TestLostPeerCleanupQueries(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 	defer cancel()
@@ -326,9 +324,7 @@ func TestDebugTemplate(t *testing.T) {
 
 func TestGetDebug(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, _ := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 	defer cancel()

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -36,9 +36,7 @@ func TestMain(m *testing.M) {
 
 func TestPGCoordinatorSingle_ClientWithoutAgent(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -71,9 +69,7 @@ func TestPGCoordinatorSingle_ClientWithoutAgent(t *testing.T) {
 
 func TestPGCoordinatorSingle_AgentWithoutClients(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -105,9 +101,7 @@ func TestPGCoordinatorSingle_AgentWithoutClients(t *testing.T) {
 
 func TestPGCoordinatorSingle_AgentInvalidIP(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -132,9 +126,7 @@ func TestPGCoordinatorSingle_AgentInvalidIP(t *testing.T) {
 
 func TestPGCoordinatorSingle_AgentInvalidIPBits(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -160,9 +152,7 @@ func TestPGCoordinatorSingle_AgentInvalidIPBits(t *testing.T) {
 
 func TestPGCoordinatorSingle_AgentValidIP(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -199,9 +189,7 @@ func TestPGCoordinatorSingle_AgentValidIP(t *testing.T) {
 
 func TestPGCoordinatorSingle_AgentWithClient(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -248,9 +236,7 @@ func TestPGCoordinatorSingle_AgentWithClient(t *testing.T) {
 
 func TestPGCoordinatorSingle_MissedHeartbeats(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 	defer cancel()
@@ -333,9 +319,7 @@ func TestPGCoordinatorSingle_MissedHeartbeats(t *testing.T) {
 
 func TestPGCoordinatorSingle_MissedHeartbeats_NoDrop(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -379,9 +363,7 @@ func TestPGCoordinatorSingle_MissedHeartbeats_NoDrop(t *testing.T) {
 
 func TestPGCoordinatorSingle_SendsHeartbeats(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -429,9 +411,7 @@ func TestPGCoordinatorSingle_SendsHeartbeats(t *testing.T) {
 //	            +---------+
 func TestPGCoordinatorDual_Mainline(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -527,9 +507,7 @@ func TestPGCoordinatorDual_Mainline(t *testing.T) {
 //	            +---------+
 func TestPGCoordinator_MultiCoordinatorAgent(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -695,9 +673,7 @@ func TestPGCoordinator_Node_Empty(t *testing.T) {
 // do this now, but it's schematically possible, so we should make sure it doesn't break anything.
 func TestPGCoordinator_BidirectionalTunnels(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -710,9 +686,7 @@ func TestPGCoordinator_BidirectionalTunnels(t *testing.T) {
 
 func TestPGCoordinator_GracefulDisconnect(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -725,9 +699,7 @@ func TestPGCoordinator_GracefulDisconnect(t *testing.T) {
 
 func TestPGCoordinator_Lost(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -740,9 +712,7 @@ func TestPGCoordinator_Lost(t *testing.T) {
 
 func TestPGCoordinator_NoDeleteOnClose(t *testing.T) {
 	t.Parallel()
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
+
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -794,10 +764,6 @@ func TestPGCoordinator_NoDeleteOnClose(t *testing.T) {
 // a new coordinator and reestablish their tunnels.
 func TestPGCoordinatorDual_FailedHeartbeat(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	dburl, err := dbtestutil.Open(t)
 	require.NoError(t, err)
@@ -861,10 +827,6 @@ func TestPGCoordinatorDual_FailedHeartbeat(t *testing.T) {
 func TestPGCoordinatorDual_PeerReconnect(t *testing.T) {
 	t.Parallel()
 
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
-
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
@@ -917,10 +879,6 @@ func TestPGCoordinatorDual_PeerReconnect(t *testing.T) {
 // is propogated through to the `Authorize` method of the coordinatee auth
 func TestPGCoordinatorPropogatedPeerContext(t *testing.T) {
 	t.Parallel()
-
-	if !dbtestutil.WillUsePostgres() {
-		t.Skip("test only with postgres")
-	}
 
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	store, ps := dbtestutil.NewDB(t)


### PR DESCRIPTION
Addresses https://github.com/coder/internal/issues/758.

This PR only cleans up dead code, it makes no changes to test logic.