### PR TITLE
chore: update `CODEOWNERS` to make ownership more granular

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,26 +9,19 @@ vpn/version.go @spikecurtis @johnstcn
 
 # This caching code is particularly tricky, and one must be very careful when
 # altering it.
-coderd/files/ @aslilac
+coderd/files/ @aslilac @Emyrk
 
-coderd/dynamicparameters/ @Emyrk
-coderd/rbac/ @Emyrk
+# This feature is still in active development
+coderd/dynamicparameters/ @Emyrk @aslilac
+# Permissions are important to get right
+coderd/rbac/ @Emyrk @aslilac
 
-# Mainly dependent on coder/guts, which is maintained by @Emyrk
-scripts/apitypings/ @Emyrk
-scripts/gensite/ @aslilac
+# Mainly dependent on coder/guts
+scripts/apitypings/ @Emyrk @aslilac
+scripts/gensite/ @aslilac @Emyrk
 
-site/ @aslilac @Parkreiner
-site/src/hooks/ @Parkreiner
-# These rules intentionally do not specify any owners. More specific rules
-# override less specific rules, so these files are "ignored" by the site/ rule.
-site/e2e/google/protobuf/timestampGenerated.ts
-site/e2e/provisionerGenerated.ts
-site/src/api/countriesGenerated.ts
-site/src/api/rbacresourcesGenerated.ts
-site/src/api/typesGenerated.ts
-site/src/testHelpers/entities.ts
-site/CLAUDE.md
+# Hooks are important to get right for frontend performance concerns
+site/src/hooks/ @Parkreiner @aslilac
 
 # The blood and guts of the autostop algorithm, which is quite complex and
 # requires elite ball knowledge of most of the scheduling code to make changes


### PR DESCRIPTION
This is pretty late, but a while back we discussed what we wanted to do with CODEOWNERS and the outcomes were:
- We want to make CODEOWNERS always have at least 2 people
- We want to start requiring them instead of making it optional

This means we do not want there to be CODEOWNERS for large swaths of the codebase, but more narrow packages and files are fine. I also think we should have comments for each logical section so we have more future context. 

After merging I'll get an admin to make the change to make the code owners review's required before merges moving forward. 
