### PR TITLE
test: fix flake in TestAgent_Metrics_SSH

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3462,11 +3462,7 @@ func TestAgent_Metrics_SSH(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
 	//nolint:dogsled
-	conn, _, _, _, _ := setupAgent(t, agentsdk.Manifest{
-		// Make sure we always get a DERP connection for
-		// currently_reachable_peers.
-		DisableDirectConnections: true,
-	}, 0, func(_ *agenttest.Client, o *agent.Options) {
+	conn, _, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0, func(_ *agenttest.Client, o *agent.Options) {
 		o.PrometheusRegistry = registry
 	})
 
@@ -3550,11 +3546,11 @@ func TestAgent_Metrics_SSH(t *testing.T) {
 		{
 			Name: "coderd_agentstats_currently_reachable_peers",
 			Type: proto.Stats_Metric_GAUGE,
-			CheckFn: func(v float64) error {
-				if v == 1 {
-					return nil
-				}
-				return xerrors.Errorf("expected 1, got %f", v)
+			CheckFn: func(float64) error {
+				// We can't reliably ping a peer here, and networking is out of
+				// scope of this test, so we just test that the metric exists
+				// with the correct labels.
+				return nil
 			},
 			Labels: []*proto.Stats_Metric_Label{
 				{
@@ -3566,11 +3562,8 @@ func TestAgent_Metrics_SSH(t *testing.T) {
 		{
 			Name: "coderd_agentstats_currently_reachable_peers",
 			Type: proto.Stats_Metric_GAUGE,
-			CheckFn: func(f float64) error {
-				if f == 0 {
-					return nil
-				}
-				return xerrors.Errorf("expected 0, got %f", f)
+			CheckFn: func(float64) error {
+				return nil
 			},
 			Labels: []*proto.Stats_Metric_Label{
 				{


### PR DESCRIPTION
Second flake for this test today :face_exhaling:.

Flake seen here, though I couldn't replicate this locally, some CI exclusive networking issue.
https://github.com/coder/coder/actions/runs/18770305895/job/53553517887?pr=20448
```
    agent_test.go:3619: 
        	Error Trace:	/home/runner/work/coder/coder/agent/agent_test.go:3619
        	Error:      	Received unexpected error:
        	            	expected 1, got 0.000000:
        	            	    github.com/coder/coder/v2/agent_test.TestAgent_Metrics_SSH.func7
        	            	        /home/runner/work/coder/coder/agent/agent_test.go:3557
        	Test:       	TestAgent_Metrics_SSH
        	Messages:   	check fn for coderd_agentstats_currently_reachable_peers failed
```
This value is incremented by a successful ping to the peer from the agent, which is dependent on all the networking code, which I think is definitely out of scope of this test for agent metrics. So, we'll just assert that the metrics exist with the correct labels (`derp`, `p2p`)