### PR TITLE
chore(dogfood): update claude-code module version to 3.3.1

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -850,7 +850,7 @@ locals {
 module "claude-code" {
   count               = local.has_ai_prompt ? data.coder_workspace.me.start_count : 0
   source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "3.1.1"
+  version             = "3.3.1"
   agent_id            = coder_agent.dev.id
   workdir             = local.repo_dir
   claude_code_version = "latest"


### PR DESCRIPTION
Bumps Claude code to version 3.3.1, removing extra coder MCP tools.