### PR TITLE
chore: show build timeline regardless of agent scripts count

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -278,7 +278,6 @@ export const InvalidTimeRange: Story = {
 	},
 };
 
-
 // A template with no agent scripts.
 export const NoAgentScripts: Story = {
 	args: {

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -277,3 +277,48 @@ export const InvalidTimeRange: Story = {
 		],
 	},
 };
+
+
+// A template with no agent scripts.
+export const NoAgentScripts: Story = {
+	args: {
+		provisionerTimings: [
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "init",
+				started_at: "2025-01-01T00:00:00Z",
+				ended_at: "2025-01-01T00:01:00Z",
+			},
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "plan",
+				started_at: "2025-01-01T00:01:00Z",
+				ended_at: "0001-01-01T00:00:00Z",
+			},
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "graph",
+				started_at: "0001-01-01T00:00:00Z",
+				ended_at: "2025-01-01T00:03:00Z",
+			},
+			{
+				...WorkspaceTimingsResponse.provisioner_timings[0],
+				stage: "apply",
+				started_at: "2025-01-01T00:03:00Z",
+				ended_at: "2025-01-01T00:04:00Z",
+			},
+		],
+		agentConnectionTimings: [
+			{
+				started_at: "2025-01-01T00:05:00Z",
+				ended_at: "2025-01-01T00:06:00Z",
+				stage: "connect",
+				workspace_agent_id: "67e37a9d-ccac-497e-8f48-4093bcc4f3e7",
+				workspace_agent_name: "main",
+			},
+		],
+		agentScriptTimings: [
+			// No agent scripts in the template
+		],
+	},
+};

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -69,8 +69,10 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 	// filled in different moments.
 	const isLoading = [
 		provisionerTimings,
-		agentScriptTimings,
 		agentConnectionTimings,
+		// agentScriptTimings might be an empty array if there are no scripts to run.
+		// Only provisionerTimings and agentConnectionTimings are guaranteed to have
+		// at least one entry.
 	].some((t) => t.length === 0);
 
 	// Each agent connection timing is a stage in the timeline to make it easier


### PR DESCRIPTION
Prior would only display if >0 script timings existed. A template can have 0 `RunOnStart` scripts, and report 0 timings.

If scripts are still being run, the agent script timings could be incomplete. However, UI should refetch if more scripts are expected.

I do not think the UI needs to know definitively if all scripts are done. If so, maybe the agent needs to submit some entry that signals "all `RunOnStart` scripts complete".

# Before

The `fast` template on dogfood showcases this bug.

<img width="1441" height="549" alt="Screenshot From 2025-10-24 14-17-43" src="https://github.com/user-attachments/assets/4b3a2786-c203-4852-85ad-66b6a6e9a8d6" />

