### PR TITLE
chore: fix mcp bash commands crashing or not exiting

### DIFF
--- a/codersdk/toolsdk/bash_test.go
+++ b/codersdk/toolsdk/bash_test.go
@@ -472,7 +472,7 @@ func sentinelCommand(time int64, filePath string) string {
 	// The extra sleep 1 is so the echo has a chance to flush (to test closed
 	// pipes), otherwise the command can exit before it crashes.
 	return fmt.Sprintf(
-		`trap "echo exited && echo exited >> %s" EXIT ; echo started && echo started > %s && sleep %d && echo slept && sleep 1 && echo done && echo done >> %s`,
+		`trap "echo exited | tee -a %s" EXIT ; echo started | tee %s && sleep %d && echo slept && sleep 1 && echo done | tee -a %s`,
 		filePath, filePath, time, filePath,
 	)
 }


### PR DESCRIPTION
There was an issue where if a command tries to write to stdout after the SSH session closed, it would crash.  For example if you spin up a python web server which  logs requests by default.

Now it writes to a temp file, we pick up the file name from the output, then we read the temp file for the real output.

This fix works although it feels somewhat janky.  I wonder if a better solution is to make a dedicated endpoint instead of trying to do it over SSH.

Also made a fix for non-backgrounded commands not being terminated when the session closes.