### PR TITLE
fix(site): preserve file path when building template version

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -104,12 +104,10 @@ const TemplateVersionEditorPage: FC = () => {
 	};
 
 	const navigateToVersion = (version: TemplateVersion) => {
-		return navigate(
-			`${getLink(linkToTemplate(organizationName, templateName))}/versions/${
-				version.name
-			}/edit`,
-			{ replace: true },
-		);
+		const url = `${getLink(linkToTemplate(organizationName, templateName))}/versions/${
+			version.name
+		}/edit?${searchParams.toString()}`;
+		return navigate(url, { replace: true });
 	};
 
 	const onBuildEnds = (newVersion: TemplateVersion) => {


### PR DESCRIPTION
Fixes issue where clicking Build in the template editor would always redirect to main.tf instead of keeping the currently open file.

Closes #14130

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
