### PR TITLE
fix: initialize pseudo console with default size for SSH sessions [2.26]

### DIFF
--- a/pty/pty_windows.go
+++ b/pty/pty_windows.go
@@ -54,10 +54,19 @@ func newPty(opt ...Option) (*ptyWindows, error) {
 		return nil, err
 	}
 
-	consoleSize := uintptr(80) + (uintptr(80) << 16)
+	// Default dimensions
+	width, height := 80, 80
 	if opts.sshReq != nil {
-		consoleSize = uintptr(opts.sshReq.Window.Width) + (uintptr(opts.sshReq.Window.Height) << 16)
+		if w := opts.sshReq.Window.Width; w > 0 && w <= 65535 {
+			width = w
+		}
+		if h := opts.sshReq.Window.Height; h > 0 && h <= 65535 {
+			height = h
+		}
 	}
+
+	consoleSize := uintptr(width) + (uintptr(height) << 16)
+
 	ret, _, err := procCreatePseudoConsole.Call(
 		consoleSize,
 		uintptr(pty.inputRead.Fd()),


### PR DESCRIPTION
> Resolved an invalid parameter error (-2147024809) during PTY creation on Windows 11 22H2 (but not only) when connecting via JetBrains Toolbox which spawns the native SSH client with `-tt`  forcing PTY allocation even though there is no "terminal" on the client side to query its size. 
>
> CreatePseudoConsole doesn't accept a 0x0 (zero width and zero height) console size and unfortunately, there is NO explicit documentation in the official Microsoft documentation that states the minimum valid values or explicitly prohibits 0x0.
>
> Looking at real-world implementations in the search results, all examples use reasonable non-zero values.
>
> I tested this with a local Windows VM registered to dev.coder.com i.e. externally managed workspace.

Relates to #20468