### PR TITLE
fix(coderd/database/dbfake): use transaction for workspace builder

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -161,6 +161,19 @@ func (b WorkspaceBuildBuilder) Canceled() WorkspaceBuildBuilder {
 // Workspace will be optionally populated if no ID is set on the provided
 // workspace.
 func (b WorkspaceBuildBuilder) Do() WorkspaceResponse {
+	var resp WorkspaceResponse
+	// Use transaction, like real wsbuilder.
+	err := b.db.InTx(func(tx database.Store) error {
+		//nolint:revive // calls do on modified struct
+		b.db = tx
+		resp = b.doInTX()
+		return nil
+	}, nil)
+	require.NoError(b.t, err)
+	return resp
+}
+
+func (b WorkspaceBuildBuilder) doInTX() WorkspaceResponse {
 	b.t.Helper()
 	jobID := uuid.New()
 	b.seed.ID = uuid.New()


### PR DESCRIPTION
While investigating a flake I noticed that the dbfake workspace builder
executes all database inserts without a transaction. Since our real
wsbuilder implementation utilizes one it makes sense to do here as well.

For example, our normal workspace <-> build relationship is such that a
workspace cannot exist with at least one build. However, our
GetWorkspaces query left joins workspace builds but has types that are
non-nullable, leading to flakes like coder/internal#1103.
