### PR TITLE
fix: avoid bad switch statement in license code

### DIFF
--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -490,15 +490,15 @@ func LicensesEntitlements(
 		if featureArguments.ManagedAgentCountFn != nil {
 			managedAgentCount, err = featureArguments.ManagedAgentCountFn(ctx, agentLimit.UsagePeriod.Start, agentLimit.UsagePeriod.End)
 		}
-		switch {
-		case xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded):
+		if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) {
 			// If the context is canceled, we want to bail the entire
 			// LicensesEntitlements call.
 			return entitlements, xerrors.Errorf("get managed agent count: %w", err)
-		case err != nil:
-			entitlements.Errors = append(entitlements.Errors,
-				fmt.Sprintf("Error getting managed agent count: %s", err.Error()))
-		default:
+		}
+		if err != nil {
+			entitlements.Errors = append(entitlements.Errors, fmt.Sprintf("Error getting managed agent count: %s", err.Error()))
+			// no return
+		} else {
 			agentLimit.Actual = &managedAgentCount
 			entitlements.AddFeature(codersdk.FeatureManagedAgentLimit, agentLimit)
 


### PR DESCRIPTION
Noticed this while trying to investigate a flake.

Relates to https://github.com/coder/internal/issues/788