### PR TITLE
fix(agent/agentcontainers): remove unneeded default branch

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -682,8 +682,6 @@ func (api *API) updaterLoop() {
 			} else {
 				prevErr = nil
 			}
-		default:
-			api.logger.Debug(api.ctx, "updater loop ticker skipped, update in progress")
 		}
 
 		return nil // Always nil to keep the ticker going.


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/769

According to the `time.NewTicker` documentation [^1] (which is used under the hood by https://github.com/coder/quartz) it will automatically adjust the time interval to make up for slow receivers. This means we should be safe to drop the default branch.

> NewTicker returns a new Ticker containing a channel that will send the current time on the channel after each tick. The period of the ticks is specified by the duration argument. The ticker will adjust the time interval or drop ticks to make up for slow receivers. The duration d must be greater than zero; if not, NewTicker will panic.

[^1]: https://pkg.go.dev/time#Ticker

