### PR TITLE
feat(scaletest): switch notification trigger from creating a user to template deletion

### DIFF
--- a/scaletest/notifications/config.go
+++ b/scaletest/notifications/config.go
@@ -37,6 +37,9 @@ type Config struct {
 
 	// SMTPApiUrl is the URL of the SMTP mock HTTP API
 	SMTPApiURL string `json:"smtp_api_url"`
+
+	// SMTPRequestTimeout is the timeout for SMTP requests.
+	SMTPRequestTimeout time.Duration `json:"smtp_request_timeout"`
 }
 
 func (c Config) Validate() error {
@@ -59,6 +62,10 @@ func (c Config) Validate() error {
 
 	if c.NotificationTimeout <= 0 {
 		return xerrors.New("notification_timeout must be greater than 0")
+	}
+
+	if c.SMTPApiURL != "" && c.SMTPRequestTimeout <= 0 {
+		return xerrors.New("smtp_request_timeout must be set if smtp_api_url is set")
 	}
 
 	if c.DialTimeout <= 0 {

--- a/scaletest/notifications/metrics.go
+++ b/scaletest/notifications/metrics.go
@@ -28,6 +28,12 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Subsystem: "scaletest",
 		Name:      "notification_delivery_latency_seconds",
 		Help:      "Time between notification-creating action and receipt of notification by client",
+		Buckets: []float64{
+			1, 5, 10, 30, 60,
+			120, 180, 240, 300, 360, 420, 480, 540, 600, 660, 720, 780, 840, 900,
+			1200, 1500, 1800, 2100, 2400, 2700, 3000, 3300, 3600, 3900, 4200, 4500,
+			5400, 7200,
+		},
 	}, []string{"notification_id", "notification_type"})
 	errors := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "coderd",

--- a/scaletest/notifications/run.go
+++ b/scaletest/notifications/run.go
@@ -299,7 +299,7 @@ func (r *Runner) watchNotificationsSMTP(ctx context.Context, user codersdk.User,
 
 	apiURL := fmt.Sprintf("%s/messages?email=%s", r.cfg.SMTPApiURL, user.Email)
 	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: r.cfg.SMTPRequestTimeout,
 	}
 
 	const smtpPollInterval = 2 * time.Second

--- a/scaletest/notifications/run_test.go
+++ b/scaletest/notifications/run_test.go
@@ -228,6 +228,7 @@ func TestRunWithSMTP(t *testing.T) {
 			ReceivingWatchBarrier:    receivingWatchBarrier,
 			ExpectedNotificationsIDs: expectedNotificationsIDs,
 			SMTPApiURL:               smtpAPIServer.URL,
+			SMTPRequestTimeout:       testutil.WaitLong,
 		}
 		err := runnerCfg.Validate()
 		require.NoError(t, err)


### PR DESCRIPTION
This PR refactors the notification scale test to use template admins and template deletion as the notification trigger. Additionally, I've added a configurable timeout for SMTP requests.

Previously, notifications were triggered by creating/deleting a user, and notifications were received by users with the owner role. However, because of how many notifications were generated by the runners, we had too many notifications to reliably test notification delivery.