### PR TITLE
fix(site): fix disappearing preset selector when switching template

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -316,7 +316,6 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 								presets.length > 0 &&
 								selectedPresetId && (
 									<Select
-										key={`preset-select-${selectedTemplate.active_version_id}`}
 										name="presetID"
 										value={selectedPresetId}
 										onValueChange={setSelectedPresetId}

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -316,9 +316,14 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 								presets.length > 0 &&
 								selectedPresetId && (
 									<Select
+										key={`preset-select-${selectedTemplate.active_version_id}`}
 										name="presetID"
 										value={selectedPresetId}
-										onValueChange={setSelectedPresetId}
+										onValueChange={(value) => {
+											if (value) {
+												setSelectedPresetId(value);
+											}
+										}}
 									>
 										<PromptSelectTrigger id="presetID" tooltip="Preset">
 											<SelectValue placeholder="Select a preset" />

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -270,7 +270,12 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 							</label>
 							<Select
 								name="templateID"
-								onValueChange={(value) => setSelectedTemplateId(value)}
+								onValueChange={(value) => {
+									setSelectedTemplateId(value);
+									if (value !== selectedTemplateId) {
+										setSelectedPresetId(undefined);
+									}
+								}}
 								defaultValue={templates[0].id}
 								required
 							>
@@ -319,11 +324,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 										key={`preset-select-${selectedTemplate.active_version_id}`}
 										name="presetID"
 										value={selectedPresetId}
-										onValueChange={(value) => {
-											if (value) {
-												setSelectedPresetId(value);
-											}
-										}}
+										onValueChange={setSelectedPresetId}
 									>
 										<PromptSelectTrigger id="presetID" tooltip="Preset">
 											<SelectValue placeholder="Select a preset" />


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/20465

Ensure we set `selectedPresetId` to `undefined` when we change `selectedTemplateId` to ensure we don't end up breaking the `<Select>` component by giving it an invalid preset id.