### PR TITLE
chore: disable task notifications by default

### DIFF
--- a/coderd/database/migrations/000392_disable_tasks_notifications_by_default.down.sql
+++ b/coderd/database/migrations/000392_disable_tasks_notifications_by_default.down.sql
@@ -1,0 +1,8 @@
+UPDATE notification_templates
+SET enabled_by_default = true
+WHERE id IN (
+	'8c5a4d12-9f7e-4b3a-a1c8-6e4f2d9b5a7c',
+	'3b7e8f1a-4c2d-49a6-b5e9-7f3a1c8d6b4e',
+	'bd4b7168-d05e-4e19-ad0f-3593b77aa90f',
+	'd4a6271c-cced-4ed0-84ad-afd02a9c7799'
+);

--- a/coderd/database/migrations/000392_disable_tasks_notifications_by_default.up.sql
+++ b/coderd/database/migrations/000392_disable_tasks_notifications_by_default.up.sql
@@ -1,0 +1,8 @@
+UPDATE notification_templates
+SET enabled_by_default = false
+WHERE id IN (
+	'8c5a4d12-9f7e-4b3a-a1c8-6e4f2d9b5a7c',
+	'3b7e8f1a-4c2d-49a6-b5e9-7f3a1c8d6b4e',
+	'bd4b7168-d05e-4e19-ad0f-3593b77aa90f',
+	'd4a6271c-cced-4ed0-84ad-afd02a9c7799'
+);


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/1098

Currently task notifications are incredibly noisy. We should disable them by default for the upcoming release whilst we iron them out.