### PR TITLE
fix(site): fix task link generation in AppStatuses component

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -1445,7 +1445,6 @@ func TestTaskGetByWorkspaceID(t *testing.T) {
 	t.Parallel()
 
 	var (
-		ctx        = testutil.Context(t, testutil.WaitShort)
 		taskPrompt = "Build a dashboard"
 		client, db = coderdtest.NewWithDatabase(t, nil)
 		owner      = coderdtest.CreateFirstUser(t, client)
@@ -1484,6 +1483,7 @@ func TestTaskGetByWorkspaceID(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := testutil.Context(t, testutil.WaitShort)
 		// When: we query a task by its associated workspace
 		got, err := expClient.TaskByWorkspaceID(ctx, taskWorkspace.ID)
 		require.NoError(t, err)
@@ -1498,6 +1498,7 @@ func TestTaskGetByWorkspaceID(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := testutil.Context(t, testutil.WaitShort)
 		// When: we query a random UUID that should not exist
 		nonexistentWorkspaceID := uuid.New()
 		_, err := expClient.TaskByWorkspaceID(ctx, nonexistentWorkspaceID)
@@ -1512,6 +1513,7 @@ func TestTaskGetByWorkspaceID(t *testing.T) {
 	t.Run("OtherUser", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := testutil.Context(t, testutil.WaitShort)
 		// When: we query a workspace owned by another user
 		_, err := anotherExpClient.TaskByWorkspaceID(ctx, taskWorkspace.ID)
 
@@ -1525,6 +1527,7 @@ func TestTaskGetByWorkspaceID(t *testing.T) {
 	t.Run("NoTask", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := testutil.Context(t, testutil.WaitShort)
 		// When: we query for a "regular" workspace with no task
 		_, err := expClient.TaskByWorkspaceID(ctx, regularWorkspace.ID)
 

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -136,6 +136,38 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/task/workspace/{workspace}": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "tags": [
+                    "Experimental"
+                ],
+                "summary": "Get AI task by workspace ID",
+                "operationId": "get-task-by-workspace-id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace ID",
+                        "name": "workspace",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Task"
+                        }
+                    }
+                }
+            }
+        },
         "/api/experimental/tasks": {
             "get": {
                 "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -112,6 +112,36 @@
 				}
 			}
 		},
+		"/api/experimental/task/workspace/{workspace}": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"tags": ["Experimental"],
+				"summary": "Get AI task by workspace ID",
+				"operationId": "get-task-by-workspace-id",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Workspace ID",
+						"name": "workspace",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Task"
+						}
+					}
+				}
+			}
+		},
 		"/api/experimental/tasks": {
 			"get": {
 				"security": [

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1043,6 +1043,13 @@ func New(options *Options) *API {
 				})
 			})
 		})
+		r.Route("/task/workspace/{workspace}", func(r chi.Router) {
+			r.Use(
+				apiKeyMiddleware,
+				httpmw.ExtractWorkspaceParam(options.Database),
+			)
+			r.Get("/", api.taskGetByWorkspaceID)
+		})
 		r.Route("/mcp", func(r chi.Router) {
 			r.Use(
 				apiKeyMiddleware,

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -281,6 +281,27 @@ func (c *ExperimentalClient) TaskByID(ctx context.Context, id uuid.UUID) (Task, 
 	return task, nil
 }
 
+// TaskByWorkspaceID fetches a single experimental task by its workspace ID.
+//
+// Experimental: This method is experimental and may change in the future.
+func (c *ExperimentalClient) TaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (Task, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/task/workspace/%s", workspaceID.String()), nil)
+	if err != nil {
+		return Task{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return Task{}, ReadBodyAsError(res)
+	}
+
+	var task Task
+	if err := json.NewDecoder(res.Body).Decode(&task); err != nil {
+		return Task{}, err
+	}
+
+	return task, nil
+}
+
 func splitTaskIdentifier(identifier string) (owner string, taskName string, err error) {
 	parts := strings.Split(identifier, "/")
 

--- a/docs/reference/api/experimental.md
+++ b/docs/reference/api/experimental.md
@@ -1,5 +1,36 @@
 # Experimental
 
+## Get AI task by workspace ID
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/api/experimental/task/workspace/{workspace} \
+  -H 'Accept: */*' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/task/workspace/{workspace}`
+
+### Parameters
+
+| Name        | In   | Type         | Required | Description  |
+|-------------|------|--------------|----------|--------------|
+| `workspace` | path | string(uuid) | true     | Workspace ID |
+
+### Example responses
+
+> 200 Response
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                   |
+|--------|---------------------------------------------------------|-------------|------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Task](schemas.md#codersdktask) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## List AI tasks
 
 ### Code samples

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2725,6 +2725,16 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
+	getTaskByWorkspaceID = async (
+		workspaceId: string,
+	): Promise<TypesGen.Task> => {
+		const response = await this.axios.get<TypesGen.Task>(
+			`/api/experimental/task/workspace/${workspaceId}`,
+		);
+
+		return response.data;
+	};
+
 	deleteTask = async (user: string, id: string): Promise<void> => {
 		await this.axios.delete(`/api/experimental/tasks/${user}/${id}`);
 	};

--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -20,7 +20,6 @@ import {
 } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { getPreferredProxy } from "contexts/ProxyContext";
-import { expect, within } from "storybook/test";
 import { AgentDevcontainerCard } from "./AgentDevcontainerCard";
 
 const meta: Meta<typeof AgentDevcontainerCard> = {
@@ -167,7 +166,9 @@ export const WithPortForwarding: Story = {
 
 export const WithTask: Story = {
 	args: {
-		task: MockTask,
+		task: {
+			...MockTask,
+		},
 		workspace: {
 			...MockWorkspace,
 			latest_app_status: {
@@ -183,13 +184,5 @@ export const WithTask: Story = {
 				apps: [MockWorkspaceApp],
 			},
 		],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const taskLink = canvas.getByRole("link", { name: /view task/i });
-		await expect(taskLink).toHaveAttribute(
-			"href",
-			`/tasks/${MockWorkspace.owner_name}/${MockTask.id}`,
-		);
 	},
 };

--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -2,6 +2,7 @@ import { chromatic } from "testHelpers/chromatic";
 import {
 	MockListeningPortsResponse,
 	MockPrimaryWorkspaceProxy,
+	MockTask,
 	MockTemplate,
 	MockWorkspace,
 	MockWorkspaceAgent,
@@ -9,6 +10,7 @@ import {
 	MockWorkspaceAgentContainerPorts,
 	MockWorkspaceAgentDevcontainer,
 	MockWorkspaceApp,
+	MockWorkspaceAppStatus,
 	MockWorkspaceProxies,
 	MockWorkspaceSubAgent,
 } from "testHelpers/entities";
@@ -18,6 +20,7 @@ import {
 } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { getPreferredProxy } from "contexts/ProxyContext";
+import { expect, within } from "storybook/test";
 import { AgentDevcontainerCard } from "./AgentDevcontainerCard";
 
 const meta: Meta<typeof AgentDevcontainerCard> = {
@@ -160,4 +163,33 @@ export const WithPortForwarding: Story = {
 			proxies: MockWorkspaceProxies,
 		}),
 	],
+};
+
+export const WithTask: Story = {
+	args: {
+		task: MockTask,
+		workspace: {
+			...MockWorkspace,
+			latest_app_status: {
+				...MockWorkspaceAppStatus,
+				agent_id: MockWorkspaceSubAgent.id,
+				message: "Task is running",
+				state: "working",
+			},
+		},
+		subAgents: [
+			{
+				...MockWorkspaceSubAgent,
+				apps: [MockWorkspaceApp],
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const taskLink = canvas.getByRole("link", { name: /view task/i });
+		await expect(taskLink).toHaveAttribute(
+			"href",
+			`/tasks/${MockWorkspace.owner_name}/${MockTask.id}`,
+		);
+	},
 };

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -1,5 +1,6 @@
 import Skeleton from "@mui/material/Skeleton";
 import type {
+	Task,
 	Template,
 	Workspace,
 	WorkspaceAgent,
@@ -43,6 +44,7 @@ type AgentDevcontainerCardProps = {
 	workspace: Workspace;
 	template: Template;
 	wildcardHostname: string;
+	task?: Task;
 };
 
 export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
@@ -52,6 +54,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 	workspace,
 	template,
 	wildcardHostname,
+	task,
 }) => {
 	const { browser_only } = useFeatureVisibility();
 	const { proxy } = useProxy();
@@ -290,7 +293,11 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 						workspace.latest_app_status?.agent_id === subAgent.id && (
 							<section>
 								<h3 className="sr-only">App statuses</h3>
-								<AppStatuses workspace={workspace} agent={subAgent} />
+								<AppStatuses
+									workspace={workspace}
+									agent={subAgent}
+									task={task}
+								/>
 							</section>
 						)}
 

--- a/site/src/pages/WorkspacePage/AppStatuses.stories.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.stories.tsx
@@ -20,8 +20,18 @@ const meta: Meta<typeof AppStatuses> = {
 		referenceDate: new Date("2024-03-26T15:15:00Z"),
 		agent: mockAgent(MockWorkspaceAppStatuses),
 		workspace: MockWorkspace,
+		task: MockTask,
 	},
 	decorators: [withProxyProvider()],
+	// Normally, we expect an AppStatus to have a related task to which you can navigate...
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const taskLink = canvas.getByRole("link", { name: /view task/i });
+		await expect(taskLink).toHaveAttribute(
+			"href",
+			`/tasks/${MockWorkspace.owner_name}/${MockTask.id}`,
+		);
+	},
 };
 
 export default meta;
@@ -146,32 +156,35 @@ export const MultipleStatuses: Story = {
 		const submitButton = canvas.getByRole("button");
 		await userEvent.click(submitButton);
 		await canvas.findByText(/working/i);
+		const taskLink = canvas.getByRole("link", { name: /view task/i });
+		await expect(taskLink).toHaveAttribute(
+			"href",
+			`/tasks/${MockWorkspace.owner_name}/${MockTask.id}`,
+		);
 	},
 };
 
-export const WithTask: Story = {
+export const NoTask: Story = {
 	args: {
 		agent: mockAgent([
 			{
 				...MockWorkspaceAppStatus,
 				id: "status-8",
 				icon: "",
-				message: "Task in progress",
+				message: "just messing with curl",
 				created_at: createTimestamp(5, 20),
 				uri: "",
-				state: "working" as const,
+				state: "idle" as const,
 			},
 			...MockWorkspaceAppStatuses,
 		]),
-		task: MockTask,
+		task: undefined,
 	},
 	play: async ({ canvasElement }) => {
+		/// ...except if there is no related task
 		const canvas = within(canvasElement);
-		const taskLink = canvas.getByRole("link", { name: /view task/i });
-		await expect(taskLink).toHaveAttribute(
-			"href",
-			`/tasks/${MockWorkspace.owner_name}/${MockTask.id}`,
-		);
+		const taskLink = canvas.queryByRole("link", { name: /view task/i });
+		await expect(taskLink).toBeNull();
 	},
 };
 

--- a/site/src/pages/WorkspacePage/AppStatuses.stories.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.stories.tsx
@@ -1,5 +1,6 @@
 import {
 	createTimestamp,
+	MockTask,
 	MockWorkspace,
 	MockWorkspaceAgent,
 	MockWorkspaceApp,
@@ -9,7 +10,7 @@ import {
 import { withProxyProvider } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { WorkspaceAppStatus } from "api/typesGenerated";
-import { userEvent, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import { AppStatuses } from "./AppStatuses";
 
 const meta: Meta<typeof AppStatuses> = {
@@ -145,6 +146,32 @@ export const MultipleStatuses: Story = {
 		const submitButton = canvas.getByRole("button");
 		await userEvent.click(submitButton);
 		await canvas.findByText(/working/i);
+	},
+};
+
+export const WithTask: Story = {
+	args: {
+		agent: mockAgent([
+			{
+				...MockWorkspaceAppStatus,
+				id: "status-8",
+				icon: "",
+				message: "Task in progress",
+				created_at: createTimestamp(5, 20),
+				uri: "",
+				state: "working" as const,
+			},
+			...MockWorkspaceAppStatuses,
+		]),
+		task: MockTask,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const taskLink = canvas.getByRole("link", { name: /view task/i });
+		await expect(taskLink).toHaveAttribute(
+			"href",
+			`/tasks/${MockWorkspace.owner_name}/${MockTask.id}`,
+		);
 	},
 };
 

--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -1,5 +1,6 @@
 import type {
 	WorkspaceAppStatus as APIWorkspaceAppStatus,
+	Task,
 	Workspace,
 	WorkspaceAgent,
 	WorkspaceApp,
@@ -34,6 +35,8 @@ interface AppStatusesProps {
 	agent: WorkspaceAgent;
 	/** Optional reference date for calculating relative time. Defaults to Date.now(). Useful for Storybook. */
 	referenceDate?: Date;
+	/** Optional task associated with this workspace. */
+	task?: Task;
 }
 
 // Extend the API status type to include the app icon and the app itself
@@ -46,6 +49,7 @@ export const AppStatuses: FC<AppStatusesProps> = ({
 	workspace,
 	agent,
 	referenceDate,
+	task,
 }) => {
 	const [displayStatuses, setDisplayStatuses] = useState(false);
 	const allStatuses: StatusWithAppInfo[] = agent.apps.flatMap((app) =>
@@ -121,12 +125,14 @@ export const AppStatuses: FC<AppStatusesProps> = ({
 							</Button>
 						))}
 
-					<Button asChild size="sm" variant="outline">
-						<RouterLink to={`/tasks/${workspace.owner_name}/${workspace.name}`}>
-							<SquareCheckBigIcon />
-							View task
-						</RouterLink>
-					</Button>
+					{task && (
+						<Button asChild size="sm" variant="outline">
+							<RouterLink to={`/tasks/${workspace.owner_name}/${task.id}`}>
+								<SquareCheckBigIcon />
+								View task
+							</RouterLink>
+						</Button>
+					)}
 
 					<TooltipProvider>
 						<Tooltip>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -4996,7 +4996,7 @@ export const MockAIPromptPresets: TypesGen.Preset[] = [
 ];
 
 export const MockTask = {
-	id: "test-task",
+	id: "f4d3c2b1-5a6e-4d7c-8e9f-1a2b3c4d5e6f",
 	name: "task-wild-test-123",
 	organization_id: MockOrganization.id,
 	owner_id: MockUserOwner.id,


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/20515

- Adds an `/api/experimental/task/workspace/{workspace}` endpoint
- Updates `AgentRow` to conditionally fetch the related `Task` if `workspace.has_ai_task`
- Plumbs the task into `AppStatuses` and updates the `View task` link with the task ID.

NB: Claude did help me out here, but I reviewed all of the generated code.

- Non-task template: 
<img width="1285" height="409" alt="Screenshot 2025-10-28 at 20 13 45" src="https://github.com/user-attachments/assets/f24ff942-f587-4bb1-b828-f705db9c5e0a" />

- Task template:
<img width="1268" height="638" alt="Screenshot 2025-10-28 at 20 12 41" src="https://github.com/user-attachments/assets/65005071-62c1-4e3c-ad9d-6d0de070fe3a" />

- App status without task:
<img width="1289" height="626" alt="Screenshot 2025-10-28 at 20 12 35" src="https://github.com/user-attachments/assets/72c9b268-75a8-4ea8-8a1a-93c6c75d01e7" />

