### PR TITLE
chore: update dogfood template to use new aibridge endpoint

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -479,7 +479,7 @@ resource "coder_agent" "dev" {
   dir  = local.repo_dir
   env = {
     OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
-    ANTHROPIC_BASE_URL : "https://dev.coder.com/api/experimental/aibridge/anthropic",
+    ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/aibridge/anthropic",
     ANTHROPIC_AUTH_TOKEN : data.coder_workspace_owner.me.session_token
   }
   startup_script_behavior = "blocking"


### PR DESCRIPTION
Also updating Nix to 2.28.5 since the previous version 404s.

Closes https://github.com/coder/internal/issues/1105