### PR TITLE
chore: use consistent function for statefile path

### DIFF
--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -608,7 +608,7 @@ func (e *executor) apply(
 	if err != nil {
 		return nil, err
 	}
-	statefilePath := filepath.Join(e.workdir, "terraform.tfstate")
+	statefilePath := getStateFilePath(e.workdir)
 	stateContent, err := os.ReadFile(statefilePath)
 	if err != nil {
 		return nil, xerrors.Errorf("read statefile %q: %w", statefilePath, err)


### PR DESCRIPTION
We use `getStateFilePath` in 2 locations, and a manual `filepath.Join` here. Just refactored to use the helper function