### PR TITLE
chore: remove `@emotion/react` from `<404Page />`

### DIFF
--- a/site/src/pages/404Page/404Page.tsx
+++ b/site/src/pages/404Page/404Page.tsx
@@ -2,26 +2,11 @@ import type { FC } from "react";
 
 const NotFoundPage: FC = () => {
 	return (
-		<div
-			css={{
-				width: "100%",
-				height: "100%",
-				display: "flex",
-				flexDirection: "row",
-				justifyContent: "center",
-				alignItems: "center",
-			}}
-		>
-			<div
-				css={(theme) => ({
-					margin: 8,
-					padding: 8,
-					borderRight: theme.palette.divider,
-				})}
-			>
-				<h4>404</h4>
-			</div>
-			<p>This page could not be found.</p>
+		<div className="w-full h-full flex flex-row justify-center items-center">
+			<p className="flex gap-4">
+				<span className="font-bold">404</span>
+				This page could not be found.
+			</p>
 		</div>
 	);
 };


### PR DESCRIPTION
This PR removes the dependency on `@emotion/react` from the 404 page as part of our ongoing effort to eliminate `@mui/` dependencies across the codebase.

I’m slightly concerned that these Tailwind classes might not apply correctly if Tailwind fails to load. If thats an issue, it might be worth converting this page to raw CSS.