### PR TITLE
chore: add `tzdata` to dockerfile base

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -12,7 +12,8 @@ RUN apk add --no-cache \
 		bash \
 		git \
 		openssl \
-		openssh-client && \
+		openssh-client \
+		tzdata && \
 	addgroup \
 		-g 1000 \
 		coder && \


### PR DESCRIPTION
When deploying Coder using the ghcr.io/coder/coder image, it is not possible to set the "timezone" field in a preset in an embedded provisioner. This is due to the container image not having the IANA time zone database installed, which causes an issue when the terraform provider attempts to validate the given timezone is valid.

I've confirmed locally via `docker run` and testing the deployment manually.