### PR TITLE
fix: ensure lifecycle executor has sufficient task permissions (#20539)

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -254,6 +254,7 @@ var (
 					rbac.ResourceFile.Type:                {policy.ActionRead}, // Required to read terraform files
 					rbac.ResourceNotificationMessage.Type: {policy.ActionCreate, policy.ActionRead},
 					rbac.ResourceSystem.Type:              {policy.WildcardSymbol},
+					rbac.ResourceTask.Type:                {policy.ActionRead, policy.ActionUpdate},
 					rbac.ResourceTemplate.Type:            {policy.ActionRead, policy.ActionUpdate},
 					rbac.ResourceUser.Type:                {policy.ActionRead},
 					rbac.ResourceWorkspace.Type:           {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStart, policy.ActionWorkspaceStop},


### PR DESCRIPTION
We recently made a change to the `wsbuilder` to handle task related logic. Our test coverage for the lifecycle executor didn't handle this scenario and so we missed that it had insufficient permissions.

This PR adds `Update` and `Read` permissions for `Task`s in the lifecycle executor, as well as an autostart/autostop test tailored to task workspaces to verify the change.

---

This is cherry picked from https://github.com/coder/coder/commit/06dbadab11760fe5fbf88c5bfcac2c48e11f7862 https://github.com/coder/coder/pull/20539