### PR TITLE
chore: add revocation endpoint to oauth well-known

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15435,6 +15435,9 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "revocation_endpoint": {
+                    "type": "string"
+                },
                 "scopes_supported": {
                     "type": "array",
                     "items": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13989,6 +13989,9 @@
 						"type": "string"
 					}
 				},
+				"revocation_endpoint": {
+					"type": "string"
+				},
 				"scopes_supported": {
 					"type": "array",
 					"items": {

--- a/coderd/oauth2provider/metadata.go
+++ b/coderd/oauth2provider/metadata.go
@@ -18,6 +18,7 @@ func GetAuthorizationServerMetadata(accessURL *url.URL) http.HandlerFunc {
 			AuthorizationEndpoint:             accessURL.JoinPath("/oauth2/authorize").String(),
 			TokenEndpoint:                     accessURL.JoinPath("/oauth2/tokens").String(),
 			RegistrationEndpoint:              accessURL.JoinPath("/oauth2/register").String(), // RFC 7591
+			RevocationEndpoint:                accessURL.JoinPath("/oauth2/revoke").String(),   // RFC 7009
 			ResponseTypesSupported:            []string{"code"},
 			GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 			CodeChallengeMethodsSupported:     []string{"S256"},

--- a/codersdk/oauth2.go
+++ b/codersdk/oauth2.go
@@ -262,6 +262,7 @@ type OAuth2AuthorizationServerMetadata struct {
 	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
 	TokenEndpoint                     string   `json:"token_endpoint"`
 	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
+	RevocationEndpoint                string   `json:"revocation_endpoint,omitempty"`
 	ResponseTypesSupported            []string `json:"response_types_supported"`
 	GrantTypesSupported               []string `json:"grant_types_supported"`
 	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -30,6 +30,7 @@ curl -X GET http://coder-server:8080/api/v2/.well-known/oauth-authorization-serv
   "response_types_supported": [
     "string"
   ],
+  "revocation_endpoint": "string",
   "scopes_supported": [
     "string"
   ],

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5322,6 +5322,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   "response_types_supported": [
     "string"
   ],
+  "revocation_endpoint": "string",
   "scopes_supported": [
     "string"
   ],
@@ -5342,6 +5343,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `issuer`                                | string          | false    |              |             |
 | `registration_endpoint`                 | string          | false    |              |             |
 | `response_types_supported`              | array of string | false    |              |             |
+| `revocation_endpoint`                   | string          | false    |              |             |
 | `scopes_supported`                      | array of string | false    |              |             |
 | `token_endpoint`                        | string          | false    |              |             |
 | `token_endpoint_auth_methods_supported` | array of string | false    |              |             |

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2913,6 +2913,7 @@ export interface OAuth2AuthorizationServerMetadata {
 	readonly authorization_endpoint: string;
 	readonly token_endpoint: string;
 	readonly registration_endpoint?: string;
+	readonly revocation_endpoint?: string;
 	readonly response_types_supported: readonly string[];
 	readonly grant_types_supported: readonly string[];
 	readonly code_challenge_methods_supported: readonly string[];


### PR DESCRIPTION
Was added to apps endpoints, but not the wider site ones. This is a site wide oauth route