### PR TITLE
fix(site): fix disappearing preset selector when switching task template (#20514)

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -270,7 +270,12 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 							</label>
 							<Select
 								name="templateID"
-								onValueChange={(value) => setSelectedTemplateId(value)}
+								onValueChange={(value) => {
+									setSelectedTemplateId(value);
+									if (value !== selectedTemplateId) {
+										setSelectedPresetId(undefined);
+									}
+								}}
 								defaultValue={templates[0].id}
 								required
 							>


### PR DESCRIPTION
Ensure we set `selectedPresetId` to `undefined` when we change `selectedTemplateId` to ensure we don't end up breaking the `<Select>` component by giving it an invalid preset id.

---

Cherry picked from 9629d873fbc7b9ee00f31e3da339a72bac2aba23 (#20514)