### PR TITLE
chore: refactor terraform paths to a central structure

### DIFF
--- a/provisioner/echo/serve.go
+++ b/provisioner/echo/serve.go
@@ -122,8 +122,8 @@ func readResponses(sess *provisionersdk.Session, trans string, suffix string) ([
 	for i := 0; ; i++ {
 		paths := []string{
 			// Try more specific path first, then fallback to generic.
-			filepath.Join(sess.WorkDirectory, fmt.Sprintf("%d.%s.%s", i, trans, suffix)),
-			filepath.Join(sess.WorkDirectory, fmt.Sprintf("%d.%s", i, suffix)),
+			filepath.Join(sess.Files.WorkDirectory(), fmt.Sprintf("%d.%s.%s", i, trans, suffix)),
+			filepath.Join(sess.Files.WorkDirectory(), fmt.Sprintf("%d.%s", i, suffix)),
 		}
 		for pathIndex, path := range paths {
 			_, err := os.Stat(path)

--- a/provisioner/terraform/modules.go
+++ b/provisioner/terraform/modules.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/util/xio"
 	"github.com/coder/coder/v2/provisionersdk/proto"
+	"github.com/coder/coder/v2/provisionersdk/tfpath"
 )
 
 const (
@@ -39,10 +39,6 @@ type modulesFile struct {
 	Modules []*module `json:"Modules"`
 }
 
-func getModulesFilePath(workdir string) string {
-	return filepath.Join(workdir, ".terraform", "modules", "modules.json")
-}
-
 func parseModulesFile(filePath string) ([]*proto.Module, error) {
 	modules := &modulesFile{}
 	data, err := os.ReadFile(filePath)
@@ -62,8 +58,8 @@ func parseModulesFile(filePath string) ([]*proto.Module, error) {
 // getModules returns the modules from the modules file if it exists.
 // It returns nil if the file does not exist.
 // Modules become available after terraform init.
-func getModules(workdir string) ([]*proto.Module, error) {
-	filePath := getModulesFilePath(workdir)
+func getModules(files tfpath.Layout) ([]*proto.Module, error) {
+	filePath := files.ModulesFilePath()
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return nil, nil
 	}

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -25,9 +25,9 @@ func (s *server) Parse(sess *provisionersdk.Session, _ *proto.ParseRequest, _ <-
 	defer span.End()
 
 	// Load the module and print any parse errors.
-	parser, diags := tfparse.New(sess.WorkDirectory, tfparse.WithLogger(s.logger.Named("tfparse")))
+	parser, diags := tfparse.New(sess.Files.WorkDirectory(), tfparse.WithLogger(s.logger.Named("tfparse")))
 	if diags.HasErrors() {
-		return provisionersdk.ParseErrorf("load module: %s", formatDiagnostics(sess.WorkDirectory, diags))
+		return provisionersdk.ParseErrorf("load module: %s", formatDiagnostics(sess.Files.WorkDirectory(), diags))
 	}
 
 	workspaceTags, _, err := parser.WorkspaceTags(ctx)

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/provisionersdk/tfpath"
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/jobreaper"
@@ -160,14 +161,14 @@ func (s *server) startTrace(ctx context.Context, name string, opts ...trace.Span
 	))...)
 }
 
-func (s *server) executor(workdir string, stage database.ProvisionerJobTimingStage) *executor {
+func (s *server) executor(files tfpath.Layout, stage database.ProvisionerJobTimingStage) *executor {
 	return &executor{
 		server:        s,
 		mut:           s.execMut,
 		binaryPath:    s.binaryPath,
 		cachePath:     s.cachePath,
 		cliConfigPath: s.cliConfigPath,
-		workdir:       workdir,
+		files:         files,
 		logger:        s.logger.Named("executor"),
 		timings:       newTimingAggregator(stage),
 	}

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -353,7 +353,7 @@ func TestProvisionerd(t *testing.T) {
 					_ *sdkproto.ParseRequest,
 					cancelOrComplete <-chan struct{},
 				) *sdkproto.ParseComplete {
-					data, err := os.ReadFile(filepath.Join(s.Files, "test.txt"))
+					data, err := os.ReadFile(filepath.Join(s.Files.WorkDirectory(), "test.txt"))
 					require.NoError(t, err)
 					require.Equal(t, "content", string(data))
 					s.ProvisionLog(sdkproto.LogLevel_INFO, "hello")

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -353,7 +353,7 @@ func TestProvisionerd(t *testing.T) {
 					_ *sdkproto.ParseRequest,
 					cancelOrComplete <-chan struct{},
 				) *sdkproto.ParseComplete {
-					data, err := os.ReadFile(filepath.Join(s.WorkDirectory, "test.txt"))
+					data, err := os.ReadFile(filepath.Join(s.Files, "test.txt"))
 					require.NoError(t, err)
 					require.Equal(t, "content", string(data))
 					s.ProvisionLog(sdkproto.LogLevel_INFO, "hello")

--- a/provisionersdk/cleanup_test.go
+++ b/provisionersdk/cleanup_test.go
@@ -12,6 +12,7 @@ import (
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/provisionersdk"
+	"github.com/coder/coder/v2/provisionersdk/tfpath"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -40,11 +41,11 @@ func TestStaleSessions(t *testing.T) {
 		fs, logger := prepare()
 
 		// given
-		first := provisionersdk.SessionDir(uuid.NewString())
+		first := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, first, now.Add(-7*24*time.Hour))
-		second := provisionersdk.SessionDir(uuid.NewString())
+		second := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, second, now.Add(-8*24*time.Hour))
-		third := provisionersdk.SessionDir(uuid.NewString())
+		third := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, third, now.Add(-9*24*time.Hour))
 
 		// when
@@ -65,9 +66,9 @@ func TestStaleSessions(t *testing.T) {
 		fs, logger := prepare()
 
 		// given
-		first := provisionersdk.SessionDir(uuid.NewString())
+		first := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, first, now.Add(-7*24*time.Hour))
-		second := provisionersdk.SessionDir(uuid.NewString())
+		second := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, second, now.Add(-6*24*time.Hour))
 
 		// when
@@ -77,7 +78,7 @@ func TestStaleSessions(t *testing.T) {
 		entries, err := afero.ReadDir(fs, workDirectory)
 		require.NoError(t, err)
 		require.Len(t, entries, 1, "one session should be present")
-		require.Equal(t, second, entries[0].Name(), 1)
+		require.Equal(t, second.WorkDirectory(), filepath.Join(workDirectory, entries[0].Name()), 1)
 	})
 
 	t.Run("no stale sessions", func(t *testing.T) {
@@ -89,9 +90,9 @@ func TestStaleSessions(t *testing.T) {
 		fs, logger := prepare()
 
 		// given
-		first := provisionersdk.SessionDir(uuid.NewString())
+		first := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, first, now.Add(-6*24*time.Hour))
-		second := provisionersdk.SessionDir(uuid.NewString())
+		second := tfpath.Session(workDirectory, uuid.NewString())
 		addSessionFolder(t, fs, second, now.Add(-5*24*time.Hour))
 
 		// when
@@ -104,9 +105,10 @@ func TestStaleSessions(t *testing.T) {
 	})
 }
 
-func addSessionFolder(t *testing.T, fs afero.Fs, sessionName string, modTime time.Time) {
-	err := fs.MkdirAll(filepath.Join(workDirectory, sessionName), 0o755)
+func addSessionFolder(t *testing.T, fs afero.Fs, files tfpath.Layout, modTime time.Time) {
+	workdir := files.WorkDirectory()
+	err := fs.MkdirAll(workdir, 0o755)
 	require.NoError(t, err, "can't create session folder")
-	require.NoError(t, fs.Chtimes(filepath.Join(workDirectory, sessionName), now, modTime), "can't chtime of session dir")
+	require.NoError(t, fs.Chtimes(workdir, now, modTime), "can't chtime of session dir")
 	require.NoError(t, err, "can't set times")
 }

--- a/provisionersdk/session.go
+++ b/provisionersdk/session.go
@@ -1,14 +1,10 @@
 package provisionersdk
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,6 +14,7 @@ import (
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
+	"github.com/coder/coder/v2/provisionersdk/tfpath"
 
 	protobuf "google.golang.org/protobuf/proto"
 
@@ -48,34 +45,15 @@ func (p *protoServer) Session(stream proto.DRPCProvisioner_SessionStream) error 
 
 	err := CleanStaleSessions(s.Context(), p.opts.WorkDirectory, afero.NewOsFs(), time.Now(), s.Logger)
 	if err != nil {
-		return xerrors.Errorf("unable to clean stale sessions %q: %w", s.WorkDirectory, err)
+		return xerrors.Errorf("unable to clean stale sessions %q: %w", s.Files, err)
 	}
 
-	s.WorkDirectory = filepath.Join(p.opts.WorkDirectory, SessionDir(sessID))
-	err = os.MkdirAll(s.WorkDirectory, 0o700)
-	if err != nil {
-		return xerrors.Errorf("create work directory %q: %w", s.WorkDirectory, err)
-	}
+	s.Files = tfpath.Session(p.opts.WorkDirectory, sessID)
+
 	defer func() {
-		var err error
-		// Cleanup the work directory after execution.
-		for attempt := 0; attempt < 5; attempt++ {
-			err = os.RemoveAll(s.WorkDirectory)
-			if err != nil {
-				// On Windows, open files cannot be removed.
-				// When the provisioner daemon is shutting down,
-				// it may take a few milliseconds for processes to exit.
-				// See: https://github.com/golang/go/issues/50510
-				s.Logger.Debug(s.Context(), "failed to clean work directory; trying again", slog.Error(err))
-				time.Sleep(250 * time.Millisecond)
-				continue
-			}
-			s.Logger.Debug(s.Context(), "cleaned up work directory")
-			return
-		}
-		s.Logger.Error(s.Context(), "failed to clean up work directory after multiple attempts",
-			slog.F("path", s.WorkDirectory), slog.Error(err))
+		s.Files.Cleanup(s.Context(), s.Logger, afero.NewOsFs())
 	}()
+
 	req, err := stream.Recv()
 	if err != nil {
 		return xerrors.Errorf("receive config: %w", err)
@@ -89,7 +67,7 @@ func (p *protoServer) Session(stream proto.DRPCProvisioner_SessionStream) error 
 		s.logLevel = proto.LogLevel_value[strings.ToUpper(s.Config.ProvisionerLogLevel)]
 	}
 
-	err = s.extractArchive()
+	err = s.Files.ExtractArchive(s.Context(), s.Logger, afero.NewOsFs(), s.Config)
 	if err != nil {
 		return xerrors.Errorf("extract archive: %w", err)
 	}
@@ -144,7 +122,7 @@ func (s *Session) handleRequests() error {
 				return err
 			}
 			// Handle README centrally, so that individual provisioners don't need to mess with it.
-			readme, err := os.ReadFile(filepath.Join(s.WorkDirectory, ReadmeFile))
+			readme, err := os.ReadFile(s.Files.ReadmeFilePath())
 			if err == nil {
 				complete.Readme = readme
 			} else {
@@ -220,9 +198,9 @@ func (s *Session) handleRequests() error {
 }
 
 type Session struct {
-	Logger        slog.Logger
-	WorkDirectory string
-	Config        *proto.Config
+	Logger slog.Logger
+	Files  tfpath.Layout
+	Config *proto.Config
 
 	server   Server
 	stream   proto.DRPCProvisioner_SessionStream
@@ -231,92 +209,6 @@ type Session struct {
 
 func (s *Session) Context() context.Context {
 	return s.stream.Context()
-}
-
-func (s *Session) extractArchive() error {
-	ctx := s.Context()
-
-	s.Logger.Info(ctx, "unpacking template source archive",
-		slog.F("size_bytes", len(s.Config.TemplateSourceArchive)),
-	)
-
-	reader := tar.NewReader(bytes.NewBuffer(s.Config.TemplateSourceArchive))
-	// for safety, nil out the reference on Config, since the reader now owns it.
-	s.Config.TemplateSourceArchive = nil
-	for {
-		header, err := reader.Next()
-		if err != nil {
-			if xerrors.Is(err, io.EOF) {
-				break
-			}
-			return xerrors.Errorf("read template source archive: %w", err)
-		}
-		s.Logger.Debug(context.Background(), "read archive entry",
-			slog.F("name", header.Name),
-			slog.F("mod_time", header.ModTime),
-			slog.F("size", header.Size))
-
-		// Security: don't untar absolute or relative paths, as this can allow a malicious tar to overwrite
-		// files outside the workdir.
-		if !filepath.IsLocal(header.Name) {
-			return xerrors.Errorf("refusing to extract to non-local path")
-		}
-		// nolint: gosec
-		headerPath := filepath.Join(s.WorkDirectory, header.Name)
-		if !strings.HasPrefix(headerPath, filepath.Clean(s.WorkDirectory)) {
-			return xerrors.New("tar attempts to target relative upper directory")
-		}
-		mode := header.FileInfo().Mode()
-		if mode == 0 {
-			mode = 0o600
-		}
-
-		// Always check for context cancellation before reading the next header.
-		// This is mainly important for unit tests, since a canceled context means
-		// the underlying directory is going to be deleted. There still exists
-		// the small race condition that the context is canceled after this, and
-		// before the disk write.
-		if ctx.Err() != nil {
-			return xerrors.Errorf("context canceled: %w", ctx.Err())
-		}
-		switch header.Typeflag {
-		case tar.TypeDir:
-			err = os.MkdirAll(headerPath, mode)
-			if err != nil {
-				return xerrors.Errorf("mkdir %q: %w", headerPath, err)
-			}
-			s.Logger.Debug(context.Background(), "extracted directory",
-				slog.F("path", headerPath),
-				slog.F("mode", fmt.Sprintf("%O", mode)))
-		case tar.TypeReg:
-			file, err := os.OpenFile(headerPath, os.O_CREATE|os.O_RDWR, mode)
-			if err != nil {
-				return xerrors.Errorf("create file %q (mode %s): %w", headerPath, mode, err)
-			}
-
-			hash := crc32.NewIEEE()
-			hashReader := io.TeeReader(reader, hash)
-			// Max file size of 10MiB.
-			size, err := io.CopyN(file, hashReader, 10<<20)
-			if xerrors.Is(err, io.EOF) {
-				err = nil
-			}
-			if err != nil {
-				_ = file.Close()
-				return xerrors.Errorf("copy file %q: %w", headerPath, err)
-			}
-			err = file.Close()
-			if err != nil {
-				return xerrors.Errorf("close file %q: %s", headerPath, err)
-			}
-			s.Logger.Debug(context.Background(), "extracted file",
-				slog.F("size_bytes", size),
-				slog.F("path", headerPath),
-				slog.F("mode", mode),
-				slog.F("checksum", fmt.Sprintf("%x", hash.Sum(nil))))
-		}
-	}
-	return nil
 }
 
 func (s *Session) ProvisionLog(level proto.LogLevel, output string) {
@@ -378,9 +270,4 @@ func (r *request[R, C]) do() (C, error) {
 		close(canceledOrComplete)
 		return c, nil
 	}
-}
-
-// SessionDir returns the directory name with mandatory prefix.
-func SessionDir(sessID string) string {
-	return sessionDirPrefix + sessID
 }

--- a/provisionersdk/tfpath/tfpath.go
+++ b/provisionersdk/tfpath/tfpath.go
@@ -176,7 +176,9 @@ func (l Layout) Cleanup(ctx context.Context, logger slog.Logger, fs afero.Fs) {
 		return
 	}
 
+	// Returning an error at this point cannot do any good. The caller cannot resolve
+	// this. There is a routine cleanup task that will remove old work directories
+	// when this fails.
 	logger.Error(ctx, "failed to clean up work directory after multiple attempts",
 		slog.F("path", path), slog.Error(err))
-	return
 }

--- a/provisionersdk/tfpath/tfpath.go
+++ b/provisionersdk/tfpath/tfpath.go
@@ -27,12 +27,7 @@ const (
 )
 
 func Session(parent, sessionID string) Layout {
-	return Layout(filepath.Join(parent, SessionDir(sessionID)))
-}
-
-// SessionDir returns the directory name with mandatory prefix.
-func SessionDir(sessID string) string {
-	return sessionDirPrefix + sessID
+	return Layout(filepath.Join(parent, sessionDirPrefix+sessionID))
 }
 
 // TODO: Maybe we should include the afero.FS here as well, then all operations

--- a/provisionersdk/tfpath/tfpath.go
+++ b/provisionersdk/tfpath/tfpath.go
@@ -1,0 +1,187 @@
+package tfpath
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"github.com/coder/coder/v2/provisionersdk/proto"
+)
+
+const (
+	// ReadmeFile is the location we look for to extract documentation from template versions.
+	ReadmeFile = "README.md"
+
+	sessionDirPrefix = "Session"
+)
+
+func Session(parent, sessionID string) Layout {
+	return Layout(filepath.Join(parent, SessionDir(sessionID)))
+}
+
+// SessionDir returns the directory name with mandatory prefix.
+func SessionDir(sessID string) string {
+	return sessionDirPrefix + sessID
+}
+
+// TODO: Maybe we should include the afero.FS here as well, then all operations
+// would be on the same FS?
+type Layout string
+
+// WorkDirectory returns the root working directory for Terraform files.
+func (l Layout) WorkDirectory() string { return string(l) }
+
+func (l Layout) StateFilePath() string {
+	return filepath.Join(l.WorkDirectory(), "terraform.tfstate")
+}
+
+func (l Layout) PlanFilePath() string {
+	return filepath.Join(l.WorkDirectory(), "terraform.tfplan")
+}
+
+func (l Layout) TerraformLockFile() string {
+	return filepath.Join(l.WorkDirectory(), ".terraform.lock.hcl")
+}
+
+func (l Layout) ReadmeFilePath() string {
+	return filepath.Join(l.WorkDirectory(), ReadmeFile)
+}
+
+func (l Layout) TerraformMetadataDir() string {
+	return filepath.Join(l.WorkDirectory(), ".terraform")
+}
+
+func (l Layout) ModulesDirectory() string {
+	return filepath.Join(l.TerraformMetadataDir(), "modules")
+}
+
+func (l Layout) ModulesFilePath() string {
+	return filepath.Join(l.ModulesDirectory(), "modules.json")
+}
+
+func (l Layout) ExtractArchive(ctx context.Context, logger slog.Logger, fs afero.Fs, cfg *proto.Config) error {
+	logger.Info(ctx, "unpacking template source archive",
+		slog.F("size_bytes", len(cfg.TemplateSourceArchive)),
+	)
+
+	err := fs.MkdirAll(l.WorkDirectory(), 0o700)
+	if err != nil {
+		return xerrors.Errorf("create work directory %q: %w", l.WorkDirectory(), err)
+	}
+
+	reader := tar.NewReader(bytes.NewBuffer(cfg.TemplateSourceArchive))
+	// for safety, nil out the reference on Config, since the reader now owns it.
+	cfg.TemplateSourceArchive = nil
+	for {
+		header, err := reader.Next()
+		if err != nil {
+			if xerrors.Is(err, io.EOF) {
+				break
+			}
+			return xerrors.Errorf("read template source archive: %w", err)
+		}
+		logger.Debug(context.Background(), "read archive entry",
+			slog.F("name", header.Name),
+			slog.F("mod_time", header.ModTime),
+			slog.F("size", header.Size))
+
+		// Security: don't untar absolute or relative paths, as this can allow a malicious tar to overwrite
+		// files outside the workdir.
+		if !filepath.IsLocal(header.Name) {
+			return xerrors.Errorf("refusing to extract to non-local path")
+		}
+		// nolint: gosec
+		headerPath := filepath.Join(l.WorkDirectory(), header.Name)
+		if !strings.HasPrefix(headerPath, filepath.Clean(l.WorkDirectory())) {
+			return xerrors.New("tar attempts to target relative upper directory")
+		}
+		mode := header.FileInfo().Mode()
+		if mode == 0 {
+			mode = 0o600
+		}
+
+		// Always check for context cancellation before reading the next header.
+		// This is mainly important for unit tests, since a canceled context means
+		// the underlying directory is going to be deleted. There still exists
+		// the small race condition that the context is canceled after this, and
+		// before the disk write.
+		if ctx.Err() != nil {
+			return xerrors.Errorf("context canceled: %w", ctx.Err())
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			err = fs.MkdirAll(headerPath, mode)
+			if err != nil {
+				return xerrors.Errorf("mkdir %q: %w", headerPath, err)
+			}
+			logger.Debug(context.Background(), "extracted directory",
+				slog.F("path", headerPath),
+				slog.F("mode", fmt.Sprintf("%O", mode)))
+		case tar.TypeReg:
+			file, err := fs.OpenFile(headerPath, os.O_CREATE|os.O_RDWR, mode)
+			if err != nil {
+				return xerrors.Errorf("create file %q (mode %s): %w", headerPath, mode, err)
+			}
+
+			hash := crc32.NewIEEE()
+			hashReader := io.TeeReader(reader, hash)
+			// Max file size of 10MiB.
+			size, err := io.CopyN(file, hashReader, 10<<20)
+			if xerrors.Is(err, io.EOF) {
+				err = nil
+			}
+			if err != nil {
+				_ = file.Close()
+				return xerrors.Errorf("copy file %q: %w", headerPath, err)
+			}
+			err = file.Close()
+			if err != nil {
+				return xerrors.Errorf("close file %q: %s", headerPath, err)
+			}
+			logger.Debug(context.Background(), "extracted file",
+				slog.F("size_bytes", size),
+				slog.F("path", headerPath),
+				slog.F("mode", mode),
+				slog.F("checksum", fmt.Sprintf("%x", hash.Sum(nil))))
+		}
+	}
+
+	return nil
+}
+
+// Cleanup removes the work directory and all of its contents.
+func (l Layout) Cleanup(ctx context.Context, logger slog.Logger, fs afero.Fs) {
+	var err error
+	path := l.WorkDirectory()
+
+	for attempt := 0; attempt < 5; attempt++ {
+		err := fs.RemoveAll(path)
+		if err != nil {
+			// On Windows, open files cannot be removed.
+			// When the provisioner daemon is shutting down,
+			// it may take a few milliseconds for processes to exit.
+			// See: https://github.com/golang/go/issues/50510
+			logger.Debug(ctx, "failed to clean work directory; trying again", slog.Error(err))
+			// TODO: Should we abort earlier if the context is done?
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		logger.Debug(ctx, "cleaned up work directory")
+		return
+	}
+
+	logger.Error(ctx, "failed to clean up work directory after multiple attempts",
+		slog.F("path", path), slog.Error(err))
+	return
+}


### PR DESCRIPTION
Refactors all Terraform file path logic into a centralized tfpath package. This consolidates all path construction into a single, testable Layout type. 

Instead of passing around `string` for directories, pass around the `Layout` which has the file location methods on it.

This design is also to support an experiment where the filepaths will be changed if the experiment is enabled. Allowing for a singular struct to determine filepath locations based on some config. The code that uses said paths will remain unchanged.

### Prior Art

Inspired from our `cli` handling of config files

https://github.com/coder/coder/blob/c61fca44bb616603effc1adf418b579ee07ad210/cli/config/file.go#L18-L18

### Naming

I was going back and forth on names. Some others I thought about:
- `tfpath`
- `tfdir`
- `tflayout`
- `terradir`

### Thoughts

Should possibly add `afero.FS` to this type. Then our tests can run without using the actual FS :shrug: 