### PR TITLE
fix: delete related task when deleting workspace

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -358,7 +358,7 @@ func TestTasks(t *testing.T) {
 		t.Run("NoWorkspace", func(t *testing.T) {
 			t.Parallel()
 
-			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user := coderdtest.CreateFirstUser(t, client)
 			template := createAITemplate(t, client, user)
 			ctx := testutil.Context(t, testutil.WaitLong)
@@ -372,13 +372,51 @@ func TestTasks(t *testing.T) {
 			ws, err := client.Workspace(ctx, task.WorkspaceID.UUID)
 			require.NoError(t, err)
 			coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
-			// Delete the task workspace
-			coderdtest.MustTransitionWorkspace(t, client, ws.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionDelete)
-			// We should still be able to fetch the task after deleting its workspace
+
+			// Dirty-delete the task workspace.
+			require.NoError(t, db.UpdateWorkspaceDeletedByID(dbauthz.AsProvisionerd(ctx), database.UpdateWorkspaceDeletedByIDParams{
+				ID:      ws.ID,
+				Deleted: true,
+			}))
+			// We should still be able to fetch the task if its workspace was deleted.
+			// Provisionerdserver should normally do this but we want to still be able to handle this edge case.
 			task, err = exp.TaskByID(ctx, task.ID)
 			require.NoError(t, err, "fetching a task should still work after deleting its related workspace")
 			err = exp.DeleteTask(ctx, task.OwnerID.String(), task.ID)
 			require.NoError(t, err, "should be possible to delete a task with no workspace")
+		})
+
+		t.Run("DeletingTaskWorkspaceDeletesTask", func(t *testing.T) {
+			t.Parallel()
+
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			user := coderdtest.CreateFirstUser(t, client)
+			template := createAITemplate(t, client, user)
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			exp := codersdk.NewExperimentalClient(client)
+			task, err := exp.CreateTask(ctx, "me", codersdk.CreateTaskRequest{
+				TemplateVersionID: template.ActiveVersionID,
+				Input:             "delete me",
+			})
+			require.NoError(t, err)
+			require.True(t, task.WorkspaceID.Valid, "task should have a workspace ID")
+			ws, err := client.Workspace(ctx, task.WorkspaceID.UUID)
+			require.NoError(t, err)
+			if assert.True(t, ws.TaskID.Valid, "task id should be set on workspace") {
+				assert.Equal(t, task.ID, ws.TaskID.UUID, "workspace task id should match")
+			}
+			coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
+
+			// When; the task workspace is deleted
+			coderdtest.MustTransitionWorkspace(t, client, ws.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionDelete)
+			// Then: the task associated with the workspace is also deleted
+			_, err = exp.TaskByID(ctx, task.ID)
+			require.Error(t, err, "expected an error fetching the task")
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr, "expected a codersdk.Error")
+			require.Equal(t, http.StatusNotFound, sdkErr.StatusCode())
 		})
 	})
 

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -219,7 +219,7 @@ var (
 					rbac.ResourceUser.Type:             {policy.ActionRead, policy.ActionReadPersonal, policy.ActionUpdatePersonal},
 					rbac.ResourceWorkspaceDormant.Type: {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStop},
 					rbac.ResourceWorkspace.Type:        {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStart, policy.ActionWorkspaceStop, policy.ActionCreateAgent},
-					// Provisionerd needs to read and update tasks associated with workspaces.
+					// Provisionerd needs to read, update, and delete tasks associated with workspaces.
 					rbac.ResourceTask.Type:   {policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 					rbac.ResourceApiKey.Type: {policy.WildcardSymbol},
 					// When org scoped provisioner credentials are implemented,

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -220,7 +220,7 @@ var (
 					rbac.ResourceWorkspaceDormant.Type: {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStop},
 					rbac.ResourceWorkspace.Type:        {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStart, policy.ActionWorkspaceStop, policy.ActionCreateAgent},
 					// Provisionerd needs to read and update tasks associated with workspaces.
-					rbac.ResourceTask.Type:   {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceTask.Type:   {policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 					rbac.ResourceApiKey.Type: {policy.WildcardSymbol},
 					// When org scoped provisioner credentials are implemented,
 					// this can be reduced to read a specific org.

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2278,6 +2278,14 @@ func (s *server) completeWorkspaceBuildJob(ctx context.Context, job database.Pro
 		if err != nil {
 			return xerrors.Errorf("update workspace deleted: %w", err)
 		}
+		if workspace.TaskID.Valid {
+			if _, err := db.DeleteTask(ctx, database.DeleteTaskParams{
+				ID:        workspace.TaskID.UUID,
+				DeletedAt: dbtime.Now(),
+			}); err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return xerrors.Errorf("delete task related to workspace: %w", err)
+			}
+		}
 
 		return nil
 	}, nil)

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.stories.tsx
@@ -1,4 +1,8 @@
-import { MockFailedWorkspace, MockWorkspace } from "testHelpers/entities";
+import {
+	MockFailedWorkspace,
+	MockTaskWorkspace,
+	MockWorkspace,
+} from "testHelpers/entities";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { daysAgo } from "utils/time";
 import { WorkspaceDeleteDialog } from "./WorkspaceDeleteDialog";
@@ -43,5 +47,11 @@ export const UnhealthyAdminView: Story = {
 	args: {
 		workspace: MockFailedWorkspace,
 		canDeleteFailedWorkspace: true,
+	},
+};
+
+export const WithTask: Story = {
+	args: {
+		workspace: MockTaskWorkspace,
 	},
 };

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -56,6 +56,8 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 		(workspace.latest_build.status === "failed" ||
 			workspace.latest_build.status === "canceled");
 
+	const hasTask = !!workspace.task_id;
+
 	return (
 		<ConfirmDialog
 			type="delete"
@@ -109,8 +111,24 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 								"data-testid": "delete-dialog-name-confirmation",
 							}}
 						/>
+						{hasTask && (
+							<div css={styles.warnContainer}>
+								<div css={{ flexDirection: "column" }}>
+									<p className="info">This workspace is related to a task</p>
+									<span css={{ fontSize: 12, marginTop: 4, display: "block" }}>
+										Deleting this workspace will also delete{" "}
+										<Link
+											href={`/tasks/${workspace.owner_name}/${workspace.task_id}`}
+										>
+											this task
+										</Link>
+										.
+									</span>
+								</div>
+							</div>
+						)}
 						{canOrphan && (
-							<div css={styles.orphanContainer}>
+							<div css={styles.warnContainer}>
 								<div css={{ flexDirection: "column" }}>
 									<Checkbox
 										id="orphan_resources"
@@ -178,7 +196,7 @@ const styles = {
 			color: theme.palette.text.primary,
 		},
 	}),
-	orphanContainer: (theme) => ({
+	warnContainer: (theme) => ({
 		marginTop: 24,
 		display: "flex",
 		backgroundColor: theme.roles.danger.background,

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -177,7 +177,7 @@ export const DeletedWorkspace: Story = {
 			MockDeletedWorkspace,
 		);
 	},
-}
+};
 
 export const WaitingStartupScripts: Story = {
 	beforeEach: () => {

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -1,4 +1,5 @@
 import {
+	MockDeletedWorkspace,
 	MockFailedWorkspace,
 	MockStartingWorkspace,
 	MockStoppedWorkspace,
@@ -168,6 +169,15 @@ export const TerminatedBuildWithStatus: Story = {
 		});
 	},
 };
+
+export const DeletedWorkspace: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			MockDeletedWorkspace,
+		);
+	},
+}
 
 export const WaitingStartupScripts: Story = {
 	beforeEach: () => {

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -231,7 +231,7 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({ workspace }) => {
 						Task workspace was deleted.
 					</h3>
 					<span className="text-content-secondary text-sm">
-						This task can't continue. Delete this task and create a new one.
+						This task cannot be resumed. Delete this task and create a new one.
 					</span>
 					<Button size="sm" variant="outline" asChild className="mt-4">
 						<RouterLink to="/tasks" data-testid="task-create-new">

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -221,7 +221,7 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({ workspace }) => {
 		? mutateStartWorkspace.error
 		: undefined;
 
-	const deleted = workspace.latest_build?.transition === "delete" as const;
+	const deleted = workspace.latest_build?.transition === ("delete" as const);
 
 	return deleted ? (
 		<Margins>
@@ -234,10 +234,10 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({ workspace }) => {
 						This task can't continue. Delete this task and create a new one.
 					</span>
 					<div className="flex flex-row mt-4 gap-4">
-						<Button
-							size="sm"
-						>
-							<RouterLink to="/tasks" data-testid="task-create-new">Create a new task</RouterLink>
+						<Button size="sm">
+							<RouterLink to="/tasks" data-testid="task-create-new">
+								Create a new task
+							</RouterLink>
 						</Button>
 					</div>
 				</div>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -233,13 +233,11 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({ workspace }) => {
 					<span className="text-content-secondary text-sm">
 						This task can't continue. Delete this task and create a new one.
 					</span>
-					<div className="flex flex-row mt-4 gap-4">
-						<Button size="sm">
-							<RouterLink to="/tasks" data-testid="task-create-new">
-								Create a new task
-							</RouterLink>
-						</Button>
-					</div>
+					<Button size="sm" variant="outline" asChild className="mt-4">
+						<RouterLink to="/tasks" data-testid="task-create-new">
+							Create a new task
+						</RouterLink>
+					</Button>
 				</div>
 			</div>
 		</Margins>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -221,7 +221,29 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({ workspace }) => {
 		? mutateStartWorkspace.error
 		: undefined;
 
-	return (
+	const deleted = workspace.latest_build?.transition === "delete" as const;
+
+	return deleted ? (
+		<Margins>
+			<div className="w-full min-h-80 flex items-center justify-center">
+				<div className="flex flex-col items-center">
+					<h3 className="m-0 font-medium text-content-primary text-base">
+						Task workspace was deleted.
+					</h3>
+					<span className="text-content-secondary text-sm">
+						This task can't continue. Delete this task and create a new one.
+					</span>
+					<div className="flex flex-row mt-4 gap-4">
+						<Button
+							size="sm"
+						>
+							<RouterLink to="/tasks" data-testid="task-create-new">Create a new task</RouterLink>
+						</Button>
+					</div>
+				</div>
+			</div>
+		</Margins>
+	) : (
 		<Margins>
 			<div className="w-full min-h-80 flex items-center justify-center">
 				<div className="flex flex-col items-center">


### PR DESCRIPTION
* Instead of prompting the user to start a deleted workspace (which is silly), prompt them to create a new task instead.

<img width="490" height="120" alt="Screenshot 2025-10-30 at 13 04 00" src="https://github.com/user-attachments/assets/17829413-323a-4e3b-b097-31b3d3255ba3" />


* Adds a warning dialog when deleting a workspace

<img width="457" height="504" alt="Screenshot 2025-10-30 at 13 04 06" src="https://github.com/user-attachments/assets/0d299f4e-8145-4d89-bb5c-87d186561c20" />


* Updates provisionerdserver to delete the related task if a workspace is related to a task