### PR TITLE
fix: fix incorrect rendering of RBAC in Helm chart when workspacePerms=false

### DIFF
--- a/helm/coder/tests/testdata/namespace_rbac.golden
+++ b/helm/coder/tests/testdata/namespace_rbac.golden
@@ -119,34 +119,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: coder-workspace-perms
-  namespace: test-namespace2
-rules:
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - networking.k8s.io
-    resources:
-    - ingresses
-    verbs:
-    - get
-    - list
----
-# Source: coder/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: coder-workspace-perms
   namespace: test-namespace3
 rules:
   - apiGroups: [""]
@@ -250,21 +222,6 @@ kind: RoleBinding
 metadata:
   name: "coder"
   namespace: test-namespace1
-subjects:
-  - kind: ServiceAccount
-    name: "coder"
-    namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: coder-workspace-perms
----
-# Source: coder/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: "coder"
-  namespace: test-namespace2
 subjects:
   - kind: ServiceAccount
     name: "coder"

--- a/helm/coder/tests/testdata/namespace_rbac_coder.golden
+++ b/helm/coder/tests/testdata/namespace_rbac_coder.golden
@@ -119,34 +119,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: coder-workspace-perms
-  namespace: test-namespace2
-rules:
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - networking.k8s.io
-    resources:
-    - ingresses
-    verbs:
-    - get
-    - list
----
-# Source: coder/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: coder-workspace-perms
   namespace: test-namespace3
 rules:
   - apiGroups: [""]
@@ -250,21 +222,6 @@ kind: RoleBinding
 metadata:
   name: "coder"
   namespace: test-namespace1
-subjects:
-  - kind: ServiceAccount
-    name: "coder"
-    namespace: coder
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: coder-workspace-perms
----
-# Source: coder/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: "coder"
-  namespace: test-namespace2
 subjects:
   - kind: ServiceAccount
     name: "coder"

--- a/helm/libcoder/templates/_rbac.yaml
+++ b/helm/libcoder/templates/_rbac.yaml
@@ -1,7 +1,9 @@
 {{- define "libcoder.rbac.forNamespace" -}}
   {{- $nsPerms := ternary .workspacePerms .Top.Values.coder.serviceAccount.workspacePerms (hasKey . "workspacePerms") -}}
-  {{- $nsDeploy := ternary .enableDeployments .Top.Values.coder.serviceAccount.enableDeployments (hasKey . "enableDeployments") -}}
-  {{- $nsExtra := ternary .extraRules .Top.Values.coder.serviceAccount.extraRules (hasKey . "extraRules") -}}
+  {{- $nsDeployRaw := ternary .enableDeployments .Top.Values.coder.serviceAccount.enableDeployments (hasKey . "enableDeployments") -}}
+  {{- $nsExtraRaw := ternary .extraRules .Top.Values.coder.serviceAccount.extraRules (hasKey . "extraRules") -}}
+  {{- $nsDeploy := and $nsPerms $nsDeployRaw -}}
+  {{- $nsExtra := ternary $nsExtraRaw (list) $nsPerms -}}
 
   {{- if or $nsPerms (or $nsDeploy $nsExtra) }}
 ---


### PR DESCRIPTION
closes #20562.

When I added `workspaceNamespaces` it caused an issue when `workspacePerms` is set to `false` in that the Role & RoleBinding was still created.

Update with `workspacePerms=false`:
```
➜  coder git:(rowan/helm_rbac_fix) ✗ helm template coder . --version=2.27.2  --set coder.image.tag=v2.27.2 --set coder.serviceAccount.workspacePerms=false | grep -A11 -B46 RoleBinding
➜  coder git:(rowan/helm_rbac_fix) ✗ 
```

Update with `workspacePerms=true`:
```
➜  coder git:(rowan/helm_rbac_fix) ✗ helm template coder . --version=2.27.2  --set coder.image.tag=v2.27.2 --set coder.serviceAccount.workspacePerms=true | grep -A12 -B60 RoleBinding

# Source: coder/templates/coder.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations: {}
  labels:
    app.kubernetes.io/instance: coder
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: coder
    app.kubernetes.io/part-of: coder
    app.kubernetes.io/version: 0.1.0
    helm.sh/chart: coder-0.1.0
  name: coder
  namespace: default
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: coder-workspace-perms
  namespace: default
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups:
    - apps
    resources:
    - deployments
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "coder"
  namespace: default
subjects:
  - kind: ServiceAccount
    name: "coder"
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: coder-workspace-perms
---
# Source: coder/templates/service.yaml
```

Update with `workspacePerms=false` and `workspaceNamespaces` populated:
```
➜  coder git:(rowan/helm_rbac_fix) ✗ helm template coder . --version=2.27.2  --set coder.image.tag=v2.27.2 --set coder.serviceAccount.workspacePerms=false --set-json 'coder.serviceAccount.workspaceNamespaces=[{"name":"dev-ws","workspacePerms":true,"enableDeployments":true,"extraRules":[]}]' | grep -A15 -B105 RoleBinding
---
# Source: coder/templates/coder.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations: {}
  labels:
    app.kubernetes.io/instance: coder
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: coder
    app.kubernetes.io/part-of: coder
    app.kubernetes.io/version: 0.1.0
    helm.sh/chart: coder-0.1.0
  name: coder
  namespace: default
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: coder-workspace-perms
  namespace: dev-ws
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups:
    - apps
    resources:
    - deployments
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "coder"
  namespace: dev-ws
subjects:
  - kind: ServiceAccount
    name: "coder"
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: coder-workspace-perms
---
# Source: coder/templates/service.yaml
apiVersion: v1
kind: Service
```

Update with `workspacePerms=true` and `workspaceNamespaces` populated:
```
➜  coder git:(rowan/helm_rbac_fix) ✗ helm template coder . --version=2.27.2  --set coder.image.tag=v2.27.2 --set coder.serviceAccount.workspacePerms=true --set-json 'coder.serviceAccount.workspaceNamespaces=[{"name":"dev-ws","workspacePerms":true,"enableDeployments":true,"extraRules":[]}]' | grep -A15 -B105 RoleBinding             
---
# Source: coder/templates/coder.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations: {}
  labels:
    app.kubernetes.io/instance: coder
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: coder
    app.kubernetes.io/part-of: coder
    app.kubernetes.io/version: 0.1.0
    helm.sh/chart: coder-0.1.0
  name: coder
  namespace: default
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: coder-workspace-perms
  namespace: default
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups:
    - apps
    resources:
    - deployments
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: coder-workspace-perms
  namespace: dev-ws
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups:
    - apps
    resources:
    - deployments
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "coder"
  namespace: default
subjects:
  - kind: ServiceAccount
    name: "coder"
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: coder-workspace-perms
---
# Source: coder/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "coder"
  namespace: dev-ws
subjects:
  - kind: ServiceAccount
    name: "coder"
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: coder-workspace-perms
---
# Source: coder/templates/service.yaml
apiVersion: v1
kind: Service
➜  coder git:(rowan/helm_rbac_fix) ✗ 
```