### PR TITLE
chore: log with %s on unexpected non-sdk err

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1604,7 +1604,7 @@ func (nopcloser) Close() error { return nil }
 // SDKError coerces err into an SDK error.
 func SDKError(t testing.TB, err error) *codersdk.Error {
 	var cerr *codersdk.Error
-	require.True(t, errors.As(err, &cerr), "should be SDK error, got %w", err)
+	require.True(t, errors.As(err, &cerr), "should be SDK error, got %s", err)
 	return cerr
 }
 


### PR DESCRIPTION
With `%w` it prints an address instead of the error, like `<op> <url> 0xc001329370` instead of `<op> <url>: some error`, honestly idk why you even can log with `%w` it seems like it makes no sense to use `%w` outside of `fmt.Errorf`.

This is to help debug https://github.com/coder/internal/issues/1010.
