### PR TITLE
feat(scaletest): add runner for prebuilds

### DIFF
--- a/enterprise/scaletest/prebuilds/run_test.go
+++ b/enterprise/scaletest/prebuilds/run_test.go
@@ -1,0 +1,164 @@
+package prebuilds_test
+
+import (
+	"io"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/scaletest/prebuilds"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	t.Skip("This test takes several minutes to run, and is intended as a manual regression test")
+
+	ctx := testutil.Context(t, testutil.WaitSuperLong*3)
+
+	client, user := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureWorkspacePrebuilds:         1,
+				codersdk.FeatureExternalProvisionerDaemons: 1,
+			},
+		},
+	})
+
+	// This is a real Terraform provisioner
+	_ = coderdenttest.NewExternalProvisionerDaemonTerraform(t, client, user.OrganizationID, nil)
+
+	numTemplates := 2
+	numPresets := 1
+	numPresetPrebuilds := 1
+
+	//nolint:gocritic // It's fine to use the owner user to pause prebuilds
+	err := client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{
+		ReconciliationPaused: true,
+	})
+	require.NoError(t, err)
+
+	setupBarrier := new(sync.WaitGroup)
+	setupBarrier.Add(numTemplates)
+	deletionBarrier := new(sync.WaitGroup)
+	deletionBarrier.Add(numTemplates)
+
+	metrics := prebuilds.NewMetrics(prometheus.NewRegistry())
+
+	eg, runCtx := errgroup.WithContext(ctx)
+
+	runners := make([]*prebuilds.Runner, 0, numTemplates)
+	for i := range numTemplates {
+		cfg := prebuilds.Config{
+			OrganizationID:            user.OrganizationID,
+			NumPresets:                numPresets,
+			NumPresetPrebuilds:        numPresetPrebuilds,
+			TemplateVersionJobTimeout: testutil.WaitSuperLong * 2,
+			PrebuildWorkspaceTimeout:  testutil.WaitSuperLong * 2,
+			Metrics:                   metrics,
+			SetupBarrier:              setupBarrier,
+			DeletionBarrier:           deletionBarrier,
+			Clock:                     quartz.NewReal(),
+		}
+		err := cfg.Validate()
+		require.NoError(t, err)
+
+		runner := prebuilds.NewRunner(client, cfg)
+		runners = append(runners, runner)
+		eg.Go(func() error {
+			return runner.Run(runCtx, strconv.Itoa(i), io.Discard)
+		})
+	}
+
+	// Wait for all runners to reach the setup barrier (templates created)
+	setupBarrier.Wait()
+
+	// Resume prebuilds to trigger prebuild creation
+	err = client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{
+		ReconciliationPaused: false,
+	})
+	require.NoError(t, err)
+
+	err = eg.Wait()
+	require.NoError(t, err)
+
+	//nolint:gocritic // Owner user is fine here as we want to view all workspaces
+	workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	expectedWorkspaces := numTemplates * numPresets * numPresetPrebuilds
+	require.Equal(t, workspaces.Count, expectedWorkspaces)
+
+	// Now run Cleanup which measures deletion
+	// First pause prebuilds again
+	err = client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{
+		ReconciliationPaused: true,
+	})
+	require.NoError(t, err)
+
+	cleanupEg, cleanupCtx := errgroup.WithContext(ctx)
+	for i, runner := range runners {
+		cleanupEg.Go(func() error {
+			return runner.Cleanup(cleanupCtx, strconv.Itoa(i), io.Discard)
+		})
+	}
+
+	// Wait for all runners to reach the deletion barrier (template versions updated to 0 prebuilds)
+	deletionBarrier.Wait()
+
+	// Resume prebuilds to trigger prebuild deletion
+	err = client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{
+		ReconciliationPaused: false,
+	})
+	require.NoError(t, err)
+
+	err = cleanupEg.Wait()
+	require.NoError(t, err)
+
+	// Verify all prebuild workspaces were deleted
+	workspaces, err = client.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err)
+	require.Equal(t, workspaces.Count, 0)
+
+	for _, runner := range runners {
+		metrics := runner.GetMetrics()
+
+		require.Contains(t, metrics, prebuilds.PrebuildsTotalLatencyMetric)
+		require.Contains(t, metrics, prebuilds.PrebuildJobCreationLatencyMetric)
+		require.Contains(t, metrics, prebuilds.PrebuildJobAcquiredLatencyMetric)
+
+		creationLatency, ok := metrics[prebuilds.PrebuildsTotalLatencyMetric].(int64)
+		require.True(t, ok)
+		jobCreationLatency, ok := metrics[prebuilds.PrebuildJobCreationLatencyMetric].(int64)
+		require.True(t, ok)
+		jobAcquiredLatency, ok := metrics[prebuilds.PrebuildJobAcquiredLatencyMetric].(int64)
+		require.True(t, ok)
+
+		require.Greater(t, creationLatency, int64(0))
+		require.Greater(t, jobCreationLatency, int64(0))
+		require.Greater(t, jobAcquiredLatency, int64(0))
+
+		require.Contains(t, metrics, prebuilds.PrebuildDeletionTotalLatencyMetric)
+		require.Contains(t, metrics, prebuilds.PrebuildDeletionJobCreationLatencyMetric)
+		require.Contains(t, metrics, prebuilds.PrebuildDeletionJobAcquiredLatencyMetric)
+
+		deletionLatency, ok := metrics[prebuilds.PrebuildDeletionTotalLatencyMetric].(int64)
+		require.True(t, ok)
+		deletionJobCreationLatency, ok := metrics[prebuilds.PrebuildDeletionJobCreationLatencyMetric].(int64)
+		require.True(t, ok)
+		deletionJobAcquiredLatency, ok := metrics[prebuilds.PrebuildDeletionJobAcquiredLatencyMetric].(int64)
+		require.True(t, ok)
+
+		require.Greater(t, deletionLatency, int64(0))
+		require.Greater(t, deletionJobCreationLatency, int64(0))
+		require.Greater(t, deletionJobAcquiredLatency, int64(0))
+	}
+}

--- a/enterprise/scaletest/prebuilds/run_test.go
+++ b/enterprise/scaletest/prebuilds/run_test.go
@@ -51,6 +51,8 @@ func TestRun(t *testing.T) {
 	setupBarrier.Add(numTemplates)
 	creationBarrier := new(sync.WaitGroup)
 	creationBarrier.Add(numTemplates)
+	deletionSetupBarrier := new(sync.WaitGroup)
+	deletionSetupBarrier.Add(1)
 	deletionBarrier := new(sync.WaitGroup)
 	deletionBarrier.Add(numTemplates)
 
@@ -69,6 +71,7 @@ func TestRun(t *testing.T) {
 			Metrics:                   metrics,
 			SetupBarrier:              setupBarrier,
 			CreationBarrier:           creationBarrier,
+			DeletionSetupBarrier:      deletionSetupBarrier,
 			DeletionBarrier:           deletionBarrier,
 			Clock:                     quartz.NewReal(),
 		}
@@ -105,6 +108,9 @@ func TestRun(t *testing.T) {
 		ReconciliationPaused: true,
 	})
 	require.NoError(t, err)
+
+	// Signal runners that prebuilds are paused and they can prepare for deletion
+	deletionSetupBarrier.Done()
 
 	// Wait for all runners to reach the deletion barrier (template versions updated to 0 prebuilds)
 	deletionBarrier.Wait()

--- a/scaletest/loadtestutil/files.go
+++ b/scaletest/loadtestutil/files.go
@@ -1,0 +1,50 @@
+package loadtestutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"path/filepath"
+	"slices"
+)
+
+func CreateTarFromFiles(files map[string][]byte) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	writer := tar.NewWriter(buf)
+	dirs := []string{}
+	for name, content := range files {
+		// We need to add directories before any files that use them. But, we only need to do this
+		// once.
+		dir := filepath.Dir(name)
+		if dir != "." && !slices.Contains(dirs, dir) {
+			dirs = append(dirs, dir)
+			err := writer.WriteHeader(&tar.Header{
+				Name:     dir,
+				Mode:     0o755,
+				Typeflag: tar.TypeDir,
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err := writer.WriteHeader(&tar.Header{
+			Name: name,
+			Size: int64(len(content)),
+			Mode: 0o644,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = writer.Write(content)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// `writer.Close()` function flushes the writer buffer, and adds extra padding to create a legal tarball.
+	err := writer.Close()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/scaletest/prebuilds/config.go
+++ b/scaletest/prebuilds/config.go
@@ -37,6 +37,11 @@ type Config struct {
 	// before pausing prebuilds for deletion.
 	CreationBarrier *sync.WaitGroup `json:"-"`
 
+	// DeletionSetupBarrier is used by the runner owner (CLI/test) to signal when
+	// prebuilds have been paused, allowing runners to create new template versions
+	// with 0 prebuilds. Only the owner calls Done(), runners only Wait().
+	DeletionSetupBarrier *sync.WaitGroup `json:"-"`
+
 	// DeletionBarrier is used to ensure all templates have been updated
 	// with 0 prebuilds before resuming prebuilds.
 	DeletionBarrier *sync.WaitGroup `json:"-"`
@@ -59,6 +64,10 @@ func (c Config) Validate() error {
 
 	if c.CreationBarrier == nil {
 		return xerrors.New("creation barrier must be set")
+	}
+
+	if c.DeletionSetupBarrier == nil {
+		return xerrors.New("deletion setup barrier must be set")
 	}
 
 	if c.DeletionBarrier == nil {

--- a/scaletest/prebuilds/config.go
+++ b/scaletest/prebuilds/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	// before unpausing prebuilds.
 	SetupBarrier *sync.WaitGroup `json:"-"`
 
+	// CreationBarrier is used to ensure all prebuild creation has completed
+	// before pausing prebuilds for deletion.
+	CreationBarrier *sync.WaitGroup `json:"-"`
+
 	// DeletionBarrier is used to ensure all templates have been updated
 	// with 0 prebuilds before resuming prebuilds.
 	DeletionBarrier *sync.WaitGroup `json:"-"`
@@ -51,6 +55,10 @@ func (c Config) Validate() error {
 
 	if c.SetupBarrier == nil {
 		return xerrors.New("setup barrier must be set")
+	}
+
+	if c.CreationBarrier == nil {
+		return xerrors.New("creation barrier must be set")
 	}
 
 	if c.DeletionBarrier == nil {

--- a/scaletest/prebuilds/config.go
+++ b/scaletest/prebuilds/config.go
@@ -1,0 +1,69 @@
+package prebuilds
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/quartz"
+)
+
+type Config struct {
+	// OrganizationID is the ID of the organization to create the prebuilds in.
+	OrganizationID uuid.UUID `json:"organization_id"`
+	// NumPresets is the number of presets the template should have.
+	NumPresets int `json:"num_presets"`
+	// NumPresetPrebuilds is the number of prebuilds per preset.
+	// Total prebuilds = NumPresets * NumPresetPrebuilds
+	NumPresetPrebuilds int `json:"num_preset_prebuilds"`
+
+	// TemplateVersionJobTimeout is how long to wait for template version
+	// provisioning jobs to complete.
+	TemplateVersionJobTimeout time.Duration `json:"template_version_job_timeout"`
+
+	// PrebuildWorkspaceTimeout is how long to wait for all prebuild
+	// workspaces to be created and completed.
+	PrebuildWorkspaceTimeout time.Duration `json:"prebuild_workspace_timeout"`
+
+	Metrics *Metrics `json:"-"`
+
+	// SetupBarrier is used to ensure all templates have been created
+	// before unpausing prebuilds.
+	SetupBarrier *sync.WaitGroup `json:"-"`
+
+	// DeletionBarrier is used to ensure all templates have been updated
+	// with 0 prebuilds before resuming prebuilds.
+	DeletionBarrier *sync.WaitGroup `json:"-"`
+
+	Clock quartz.Clock `json:"-"`
+}
+
+func (c Config) Validate() error {
+	if c.TemplateVersionJobTimeout <= 0 {
+		return xerrors.New("template_version_job_timeout must be greater than 0")
+	}
+
+	if c.PrebuildWorkspaceTimeout <= 0 {
+		return xerrors.New("prebuild_workspace_timeout must be greater than 0")
+	}
+
+	if c.SetupBarrier == nil {
+		return xerrors.New("setup barrier must be set")
+	}
+
+	if c.DeletionBarrier == nil {
+		return xerrors.New("deletion barrier must be set")
+	}
+
+	if c.Metrics == nil {
+		return xerrors.New("metrics must be set")
+	}
+
+	if c.Clock == nil {
+		return xerrors.New("clock must be set")
+	}
+
+	return nil
+}

--- a/scaletest/prebuilds/metrics.go
+++ b/scaletest/prebuilds/metrics.go
@@ -1,0 +1,103 @@
+package prebuilds
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	PrebuildJobCreationLatencySeconds prometheus.HistogramVec
+	PrebuildJobAcquiredLatencySeconds prometheus.HistogramVec
+	PrebuildTotalLatencySeconds       prometheus.HistogramVec
+
+	PrebuildDeletionJobCreationLatencySeconds prometheus.HistogramVec
+	PrebuildDeletionJobAcquiredLatencySeconds prometheus.HistogramVec
+	PrebuildDeletionTotalLatencySeconds       prometheus.HistogramVec
+
+	PrebuildErrorsTotal prometheus.CounterVec
+}
+
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		PrebuildJobCreationLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_job_creation_latency_seconds",
+			Help:      "Time from when prebuilds are unpaused to when all the template build jobs have been created.",
+		}, []string{"template_name"}),
+		PrebuildJobAcquiredLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_job_acquired_latency_seconds",
+			Help:      "Time from when prebuilds are unpaused to when all the prebuild jobs have been acquired by a provisioner daemon.",
+		}, []string{"template_name"}),
+		PrebuildTotalLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_total_latency_seconds",
+			Help:      "Time from when prebuilds are unpaused to when all the prebuild builds have finished.",
+		}, []string{"template_name"}),
+		PrebuildDeletionJobCreationLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_deletion_job_creation_latency_seconds",
+			Help:      "Time from when prebuilds are resumed for deletion to when all the deletion jobs have been created.",
+		}, []string{"template_name"}),
+		PrebuildDeletionJobAcquiredLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_deletion_job_acquired_latency_seconds",
+			Help:      "Time from when prebuilds are resumed for deletion to when all the deletion jobs have been acquired by a provisioner daemon.",
+		}, []string{"template_name"}),
+		PrebuildDeletionTotalLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_deletion_total_latency_seconds",
+			Help:      "Time from when prebuilds are resumed for deletion to when all the prebuild workspaces have been deleted.",
+		}, []string{"template_name"}),
+		PrebuildErrorsTotal: *prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_errors_total",
+			Help:      "Total number of prebuild errors",
+		}, []string{"template_name", "action"}),
+	}
+
+	reg.MustRegister(m.PrebuildTotalLatencySeconds)
+	reg.MustRegister(m.PrebuildJobCreationLatencySeconds)
+	reg.MustRegister(m.PrebuildJobAcquiredLatencySeconds)
+	reg.MustRegister(m.PrebuildDeletionTotalLatencySeconds)
+	reg.MustRegister(m.PrebuildDeletionJobCreationLatencySeconds)
+	reg.MustRegister(m.PrebuildDeletionJobAcquiredLatencySeconds)
+	reg.MustRegister(m.PrebuildErrorsTotal)
+	return m
+}
+
+func (m *Metrics) RecordCompletion(elapsed time.Duration, templateName string) {
+	m.PrebuildTotalLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordJobCreation(elapsed time.Duration, templateName string) {
+	m.PrebuildJobCreationLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordJobAcquired(elapsed time.Duration, templateName string) {
+	m.PrebuildJobAcquiredLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordDeletionCompletion(elapsed time.Duration, templateName string) {
+	m.PrebuildDeletionTotalLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordDeletionJobCreation(elapsed time.Duration, templateName string) {
+	m.PrebuildDeletionJobCreationLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordDeletionJobAcquired(elapsed time.Duration, templateName string) {
+	m.PrebuildDeletionJobAcquiredLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) AddError(templateName string, action string) {
+	m.PrebuildErrorsTotal.WithLabelValues(templateName, action).Inc()
+}

--- a/scaletest/prebuilds/metrics.go
+++ b/scaletest/prebuilds/metrics.go
@@ -1,60 +1,72 @@
 package prebuilds
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Metrics struct {
-	PrebuildJobCreationLatencySeconds prometheus.HistogramVec
-	PrebuildJobAcquiredLatencySeconds prometheus.HistogramVec
-	PrebuildTotalLatencySeconds       prometheus.HistogramVec
+	PrebuildJobsCreated   prometheus.GaugeVec
+	PrebuildJobsRunning   prometheus.GaugeVec
+	PrebuildJobsFailed    prometheus.GaugeVec
+	PrebuildJobsCompleted prometheus.GaugeVec
 
-	PrebuildDeletionJobCreationLatencySeconds prometheus.HistogramVec
-	PrebuildDeletionJobAcquiredLatencySeconds prometheus.HistogramVec
-	PrebuildDeletionTotalLatencySeconds       prometheus.HistogramVec
+	PrebuildDeletionJobsCreated   prometheus.GaugeVec
+	PrebuildDeletionJobsRunning   prometheus.GaugeVec
+	PrebuildDeletionJobsFailed    prometheus.GaugeVec
+	PrebuildDeletionJobsCompleted prometheus.GaugeVec
 
 	PrebuildErrorsTotal prometheus.CounterVec
 }
 
 func NewMetrics(reg prometheus.Registerer) *Metrics {
 	m := &Metrics{
-		PrebuildJobCreationLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PrebuildJobsCreated: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "coderd",
 			Subsystem: "scaletest",
-			Name:      "prebuild_job_creation_latency_seconds",
-			Help:      "Time from when prebuilds are unpaused to when all the template build jobs have been created.",
+			Name:      "prebuild_jobs_created",
+			Help:      "Number of prebuild jobs that have been created.",
 		}, []string{"template_name"}),
-		PrebuildJobAcquiredLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PrebuildJobsRunning: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "coderd",
 			Subsystem: "scaletest",
-			Name:      "prebuild_job_acquired_latency_seconds",
-			Help:      "Time from when prebuilds are unpaused to when all the prebuild jobs have been acquired by a provisioner daemon.",
+			Name:      "prebuild_jobs_running",
+			Help:      "Number of prebuild jobs that are currently running.",
 		}, []string{"template_name"}),
-		PrebuildTotalLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PrebuildJobsFailed: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "coderd",
 			Subsystem: "scaletest",
-			Name:      "prebuild_total_latency_seconds",
-			Help:      "Time from when prebuilds are unpaused to when all the prebuild builds have finished.",
+			Name:      "prebuild_jobs_failed",
+			Help:      "Number of prebuild jobs that have failed.",
 		}, []string{"template_name"}),
-		PrebuildDeletionJobCreationLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PrebuildJobsCompleted: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "coderd",
 			Subsystem: "scaletest",
-			Name:      "prebuild_deletion_job_creation_latency_seconds",
-			Help:      "Time from when prebuilds are resumed for deletion to when all the deletion jobs have been created.",
+			Name:      "prebuild_jobs_completed",
+			Help:      "Number of prebuild jobs that have completed successfully.",
 		}, []string{"template_name"}),
-		PrebuildDeletionJobAcquiredLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PrebuildDeletionJobsCreated: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "coderd",
 			Subsystem: "scaletest",
-			Name:      "prebuild_deletion_job_acquired_latency_seconds",
-			Help:      "Time from when prebuilds are resumed for deletion to when all the deletion jobs have been acquired by a provisioner daemon.",
+			Name:      "prebuild_deletion_jobs_created",
+			Help:      "Number of prebuild deletion jobs that have been created.",
 		}, []string{"template_name"}),
-		PrebuildDeletionTotalLatencySeconds: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PrebuildDeletionJobsRunning: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "coderd",
 			Subsystem: "scaletest",
-			Name:      "prebuild_deletion_total_latency_seconds",
-			Help:      "Time from when prebuilds are resumed for deletion to when all the prebuild workspaces have been deleted.",
+			Name:      "prebuild_deletion_jobs_running",
+			Help:      "Number of prebuild deletion jobs that are currently running.",
+		}, []string{"template_name"}),
+		PrebuildDeletionJobsFailed: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_deletion_jobs_failed",
+			Help:      "Number of prebuild deletion jobs that have failed.",
+		}, []string{"template_name"}),
+		PrebuildDeletionJobsCompleted: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "coderd",
+			Subsystem: "scaletest",
+			Name:      "prebuild_deletion_jobs_completed",
+			Help:      "Number of prebuild deletion jobs that have completed successfully.",
 		}, []string{"template_name"}),
 		PrebuildErrorsTotal: *prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "coderd",
@@ -64,38 +76,48 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		}, []string{"template_name", "action"}),
 	}
 
-	reg.MustRegister(m.PrebuildTotalLatencySeconds)
-	reg.MustRegister(m.PrebuildJobCreationLatencySeconds)
-	reg.MustRegister(m.PrebuildJobAcquiredLatencySeconds)
-	reg.MustRegister(m.PrebuildDeletionTotalLatencySeconds)
-	reg.MustRegister(m.PrebuildDeletionJobCreationLatencySeconds)
-	reg.MustRegister(m.PrebuildDeletionJobAcquiredLatencySeconds)
+	reg.MustRegister(m.PrebuildJobsCreated)
+	reg.MustRegister(m.PrebuildJobsRunning)
+	reg.MustRegister(m.PrebuildJobsFailed)
+	reg.MustRegister(m.PrebuildJobsCompleted)
+	reg.MustRegister(m.PrebuildDeletionJobsCreated)
+	reg.MustRegister(m.PrebuildDeletionJobsRunning)
+	reg.MustRegister(m.PrebuildDeletionJobsFailed)
+	reg.MustRegister(m.PrebuildDeletionJobsCompleted)
 	reg.MustRegister(m.PrebuildErrorsTotal)
 	return m
 }
 
-func (m *Metrics) RecordCompletion(elapsed time.Duration, templateName string) {
-	m.PrebuildTotalLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+func (m *Metrics) SetJobsCreated(count int, templateName string) {
+	m.PrebuildJobsCreated.WithLabelValues(templateName).Set(float64(count))
 }
 
-func (m *Metrics) RecordJobCreation(elapsed time.Duration, templateName string) {
-	m.PrebuildJobCreationLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+func (m *Metrics) SetJobsRunning(count int, templateName string) {
+	m.PrebuildJobsRunning.WithLabelValues(templateName).Set(float64(count))
 }
 
-func (m *Metrics) RecordJobAcquired(elapsed time.Duration, templateName string) {
-	m.PrebuildJobAcquiredLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+func (m *Metrics) SetJobsFailed(count int, templateName string) {
+	m.PrebuildJobsFailed.WithLabelValues(templateName).Set(float64(count))
 }
 
-func (m *Metrics) RecordDeletionCompletion(elapsed time.Duration, templateName string) {
-	m.PrebuildDeletionTotalLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+func (m *Metrics) SetJobsCompleted(count int, templateName string) {
+	m.PrebuildJobsCompleted.WithLabelValues(templateName).Set(float64(count))
 }
 
-func (m *Metrics) RecordDeletionJobCreation(elapsed time.Duration, templateName string) {
-	m.PrebuildDeletionJobCreationLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+func (m *Metrics) SetDeletionJobsCreated(count int, templateName string) {
+	m.PrebuildDeletionJobsCreated.WithLabelValues(templateName).Set(float64(count))
 }
 
-func (m *Metrics) RecordDeletionJobAcquired(elapsed time.Duration, templateName string) {
-	m.PrebuildDeletionJobAcquiredLatencySeconds.WithLabelValues(templateName).Observe(elapsed.Seconds())
+func (m *Metrics) SetDeletionJobsRunning(count int, templateName string) {
+	m.PrebuildDeletionJobsRunning.WithLabelValues(templateName).Set(float64(count))
+}
+
+func (m *Metrics) SetDeletionJobsFailed(count int, templateName string) {
+	m.PrebuildDeletionJobsFailed.WithLabelValues(templateName).Set(float64(count))
+}
+
+func (m *Metrics) SetDeletionJobsCompleted(count int, templateName string) {
+	m.PrebuildDeletionJobsCompleted.WithLabelValues(templateName).Set(float64(count))
 }
 
 func (m *Metrics) AddError(templateName string, action string) {

--- a/scaletest/prebuilds/run.go
+++ b/scaletest/prebuilds/run.go
@@ -213,7 +213,7 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 			if ws.LatestBuild.Transition == codersdk.WorkspaceTransitionDelete {
 				createdCount++
 				switch ws.LatestBuild.Job.Status {
-				case codersdk.ProvisionerJobRunning, codersdk.ProvisionerJobSucceeded:
+				case codersdk.ProvisionerJobRunning:
 					runningCount++
 				case codersdk.ProvisionerJobFailed, codersdk.ProvisionerJobCanceled:
 					failedCount++
@@ -222,6 +222,7 @@ func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error 
 		}
 
 		completedCount := targetNumWorkspaces - len(workspaces.Workspaces)
+		createdCount += completedCount
 
 		r.cfg.Metrics.SetDeletionJobsCreated(createdCount, r.template.Name)
 		r.cfg.Metrics.SetDeletionJobsRunning(runningCount, r.template.Name)

--- a/scaletest/prebuilds/run.go
+++ b/scaletest/prebuilds/run.go
@@ -100,7 +100,11 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	reachedCreationBarrier = true
 	r.cfg.CreationBarrier.Done()
 	r.cfg.CreationBarrier.Wait()
-	logger.Info(ctx, "all runners reached creation barrier, preparing for deletion")
+	logger.Info(ctx, "all runners reached creation barrier")
+
+	logger.Info(ctx, "waiting for runner owner to pause prebuilds (deletion setup barrier)")
+	r.cfg.DeletionSetupBarrier.Wait()
+	logger.Info(ctx, "prebuilds paused, preparing for deletion")
 
 	// Now prepare for deletion by creating an empty template version
 	// At this point, prebuilds should be paused by the caller

--- a/scaletest/prebuilds/run.go
+++ b/scaletest/prebuilds/run.go
@@ -1,0 +1,365 @@
+package prebuilds
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"html/template"
+	"io"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/google/uuid"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/harness"
+	"github.com/coder/coder/v2/scaletest/loadtestutil"
+)
+
+type Runner struct {
+	client *codersdk.Client
+	cfg    Config
+
+	template codersdk.Template
+
+	prebuildTotalLatency       time.Duration
+	prebuildJobCreationLatency time.Duration
+	prebuildJobAcquiredLatency time.Duration
+
+	prebuildDeletionTotalLatency       time.Duration
+	prebuildDeletionJobCreationLatency time.Duration
+	prebuildDeletionJobAcquiredLatency time.Duration
+}
+
+var (
+	_ harness.Runnable    = &Runner{}
+	_ harness.Cleanable   = &Runner{}
+	_ harness.Collectable = &Runner{}
+)
+
+func NewRunner(client *codersdk.Client, cfg Config) *Runner {
+	return &Runner{
+		client: client,
+		cfg:    cfg,
+	}
+}
+
+func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	reachedBarrier := false
+	defer func() {
+		if !reachedBarrier {
+			r.cfg.SetupBarrier.Done()
+		}
+	}()
+
+	logs = loadtestutil.NewSyncWriter(logs)
+	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
+	r.client.SetLogger(logger)
+	r.client.SetLogBodies(true)
+
+	templateName := "scaletest-prebuilds-template-" + id
+
+	version, err := r.createTemplateVersion(ctx, uuid.Nil, r.cfg.NumPresets, r.cfg.NumPresetPrebuilds)
+	if err != nil {
+		r.cfg.Metrics.AddError(templateName, "create_template_version")
+		return err
+	}
+
+	templateReq := codersdk.CreateTemplateRequest{
+		Name:        templateName,
+		Description: "`coder exp scaletest prebuilds` template",
+		VersionID:   version.ID,
+	}
+	templ, err := r.client.CreateTemplate(ctx, r.cfg.OrganizationID, templateReq)
+	if err != nil {
+		r.cfg.Metrics.AddError(templateName, "create_template")
+		return xerrors.Errorf("create template: %w", err)
+	}
+	logger.Info(ctx, "created template", slog.F("template_id", templ.ID))
+
+	r.template = templ
+
+	logger.Info(ctx, "waiting for all runners to reach barrier")
+	reachedBarrier = true
+	r.cfg.SetupBarrier.Done()
+	r.cfg.SetupBarrier.Wait()
+	logger.Info(ctx, "all runners reached barrier, proceeding with prebuilds test")
+
+	err = r.measureCreation(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Runner) measureCreation(ctx context.Context, logger slog.Logger) error {
+	testStartTime := time.Now().UTC()
+	const workspacesPollInterval = 500 * time.Millisecond
+
+	targetNumWorkspaces := r.cfg.NumPresets * r.cfg.NumPresetPrebuilds
+
+	workspacesCtx, cancel := context.WithTimeout(ctx, r.cfg.PrebuildWorkspaceTimeout)
+	defer cancel()
+
+	tkr := r.cfg.Clock.TickerFunc(workspacesCtx, workspacesPollInterval, func() error {
+		workspaces, err := r.client.Workspaces(workspacesCtx, codersdk.WorkspaceFilter{
+			Template: r.template.Name,
+		})
+		if err != nil {
+			return xerrors.Errorf("list workspaces: %w", err)
+		}
+
+		acquiredCount := 0
+		succeededCount := 0
+
+		for _, ws := range workspaces.Workspaces {
+			if ws.LatestBuild.Job.Status == codersdk.ProvisionerJobRunning ||
+				ws.LatestBuild.Job.Status == codersdk.ProvisionerJobSucceeded {
+				acquiredCount++
+			}
+			if ws.LatestBuild.Job.Status == codersdk.ProvisionerJobSucceeded {
+				succeededCount++
+			}
+		}
+
+		if r.prebuildJobCreationLatency == 0 && len(workspaces.Workspaces) >= targetNumWorkspaces {
+			// All jobs created
+			r.prebuildJobCreationLatency = time.Since(testStartTime)
+			r.cfg.Metrics.RecordJobCreation(r.prebuildJobCreationLatency, r.template.Name)
+		}
+
+		if r.prebuildJobAcquiredLatency == 0 && acquiredCount >= targetNumWorkspaces {
+			// All jobs acquired
+			r.prebuildJobAcquiredLatency = time.Since(testStartTime)
+			r.cfg.Metrics.RecordJobAcquired(r.prebuildJobAcquiredLatency, r.template.Name)
+		}
+
+		if succeededCount >= targetNumWorkspaces {
+			// All jobs succeeded
+			r.prebuildTotalLatency = time.Since(testStartTime)
+			r.cfg.Metrics.RecordCompletion(r.prebuildTotalLatency, r.template.Name)
+			return errTickerDone
+		}
+
+		return nil
+	}, "waitForPrebuildWorkspaces")
+	err := tkr.Wait()
+	if !xerrors.Is(err, errTickerDone) {
+		r.cfg.Metrics.AddError(r.template.Name, "wait_for_workspaces")
+		return xerrors.Errorf("wait for workspaces: %w", err)
+	}
+
+	logger.Info(ctx, "all prebuild workspaces created successfully", slog.F("template_name", r.template.Name), slog.F("duration", time.Since(testStartTime).String()))
+	return nil
+}
+
+func (r *Runner) measureDeletion(ctx context.Context, logger slog.Logger) error {
+	deletionStartTime := time.Now().UTC()
+	const deletionPollInterval = 500 * time.Millisecond
+
+	targetNumWorkspaces := r.cfg.NumPresets * r.cfg.NumPresetPrebuilds
+
+	deletionCtx, cancel := context.WithTimeout(ctx, r.cfg.PrebuildWorkspaceTimeout)
+	defer cancel()
+
+	tkr := r.cfg.Clock.TickerFunc(deletionCtx, deletionPollInterval, func() error {
+		workspaces, err := r.client.Workspaces(deletionCtx, codersdk.WorkspaceFilter{
+			Template: r.template.Name,
+		})
+		if err != nil {
+			return xerrors.Errorf("list workspaces: %w", err)
+		}
+
+		currentCount := len(workspaces.Workspaces)
+		deletingCount := 0
+
+		for _, ws := range workspaces.Workspaces {
+			if ws.LatestBuild.Transition == codersdk.WorkspaceTransitionDelete {
+				if ws.LatestBuild.Job.Status == codersdk.ProvisionerJobRunning ||
+					ws.LatestBuild.Job.Status == codersdk.ProvisionerJobSucceeded {
+					deletingCount++
+				}
+			}
+		}
+
+		if r.prebuildDeletionJobCreationLatency == 0 && (currentCount < targetNumWorkspaces || deletingCount > 0) {
+			r.prebuildDeletionJobCreationLatency = time.Since(deletionStartTime)
+			r.cfg.Metrics.RecordDeletionJobCreation(r.prebuildDeletionJobCreationLatency, r.template.Name)
+		}
+
+		if r.prebuildDeletionJobAcquiredLatency == 0 && deletingCount > 0 {
+			r.prebuildDeletionJobAcquiredLatency = time.Since(deletionStartTime)
+			r.cfg.Metrics.RecordDeletionJobAcquired(r.prebuildDeletionJobAcquiredLatency, r.template.Name)
+		}
+
+		if currentCount == 0 {
+			r.prebuildDeletionTotalLatency = time.Since(deletionStartTime)
+			r.cfg.Metrics.RecordDeletionCompletion(r.prebuildDeletionTotalLatency, r.template.Name)
+			return errTickerDone
+		}
+
+		return nil
+	}, "waitForPrebuildWorkspacesDeletion")
+	err := tkr.Wait()
+	if !xerrors.Is(err, errTickerDone) {
+		r.cfg.Metrics.AddError(r.template.Name, "wait_for_workspace_deletion")
+		return xerrors.Errorf("wait for workspace deletion: %w", err)
+	}
+
+	logger.Info(ctx, "all prebuild workspaces deleted successfully", slog.F("template_name", r.template.Name), slog.F("duration", time.Since(deletionStartTime).String()))
+	return nil
+}
+
+func (r *Runner) createTemplateVersion(ctx context.Context, templateID uuid.UUID, numPresets, numPresetPrebuilds int) (codersdk.TemplateVersion, error) {
+	tarData, err := TemplateTarData(numPresets, numPresetPrebuilds)
+	if err != nil {
+		return codersdk.TemplateVersion{}, xerrors.Errorf("create prebuilds template tar: %w", err)
+	}
+	uploadResp, err := r.client.Upload(ctx, codersdk.ContentTypeTar, bytes.NewReader(tarData))
+	if err != nil {
+		return codersdk.TemplateVersion{}, xerrors.Errorf("upload prebuilds template tar: %w", err)
+	}
+
+	versionReq := codersdk.CreateTemplateVersionRequest{
+		TemplateID:    templateID,
+		FileID:        uploadResp.ID,
+		Message:       "Template version for scaletest prebuilds",
+		StorageMethod: codersdk.ProvisionerStorageMethodFile,
+		Provisioner:   codersdk.ProvisionerTypeTerraform,
+	}
+	version, err := r.client.CreateTemplateVersion(ctx, r.cfg.OrganizationID, versionReq)
+	if err != nil {
+		return codersdk.TemplateVersion{}, xerrors.Errorf("create template version: %w", err)
+	}
+	if version.MatchedProvisioners != nil && version.MatchedProvisioners.Count == 0 {
+		return codersdk.TemplateVersion{}, xerrors.Errorf("no provisioners matched for template version")
+	}
+
+	const pollInterval = 2 * time.Second
+	versionCtx, cancel := context.WithTimeout(ctx, r.cfg.TemplateVersionJobTimeout)
+	defer cancel()
+
+	tkr := r.cfg.Clock.TickerFunc(versionCtx, pollInterval, func() error {
+		version, err := r.client.TemplateVersion(versionCtx, version.ID)
+		if err != nil {
+			return xerrors.Errorf("get template version: %w", err)
+		}
+		switch version.Job.Status {
+		case codersdk.ProvisionerJobSucceeded:
+			return errTickerDone
+		case codersdk.ProvisionerJobPending, codersdk.ProvisionerJobRunning:
+			return nil
+		default:
+			return xerrors.Errorf("template version provisioning failed: status %s", version.Job.Status)
+		}
+	})
+	err = tkr.Wait()
+	if !xerrors.Is(err, errTickerDone) {
+		return codersdk.TemplateVersion{}, xerrors.Errorf("wait for template version provisioning: %w", err)
+	}
+	return version, nil
+}
+
+var errTickerDone = xerrors.New("done")
+
+func (r *Runner) Cleanup(ctx context.Context, _ string, logs io.Writer) error {
+	logs = loadtestutil.NewSyncWriter(logs)
+	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
+
+	reachedDeletionBarrier := false
+	defer func() {
+		if !reachedDeletionBarrier {
+			r.cfg.DeletionBarrier.Done()
+		}
+	}()
+
+	version, err := r.createTemplateVersion(ctx, r.template.ID, 0, 0)
+	if err != nil {
+		r.cfg.Metrics.AddError(r.template.Name, "create_empty_template_version")
+		return xerrors.Errorf("create empty template version for deletion: %w", err)
+	}
+
+	err = r.client.UpdateActiveTemplateVersion(context.Background(), r.template.ID, codersdk.UpdateActiveTemplateVersion{
+		ID: version.ID,
+	})
+	if err != nil {
+		r.cfg.Metrics.AddError(r.template.Name, "update_active_template_version")
+		return xerrors.Errorf("update active template version to empty for deletion: %w", err)
+	}
+
+	logger.Info(ctx, "waiting for all runners to reach deletion barrier")
+	reachedDeletionBarrier = true
+	r.cfg.DeletionBarrier.Done()
+	r.cfg.DeletionBarrier.Wait()
+	logger.Info(ctx, "all runners reached deletion barrier, proceeding with prebuild deletion")
+
+	err = r.measureDeletion(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.Info(ctx, "deleting template", slog.F("template_name", r.template.Name))
+
+	err = r.client.DeleteTemplate(ctx, r.template.ID)
+	if err != nil {
+		return xerrors.Errorf("delete template: %w", err)
+	}
+
+	logger.Info(ctx, "template deleted successfully", slog.F("template_name", r.template.Name))
+	return nil
+}
+
+const (
+	PrebuildsTotalLatencyMetric              = "prebuild_total_latency_ms"
+	PrebuildJobCreationLatencyMetric         = "prebuild_job_creation_latency_ms"
+	PrebuildJobAcquiredLatencyMetric         = "prebuild_job_acquired_latency_ms"
+	PrebuildDeletionTotalLatencyMetric       = "prebuild_deletion_total_latency_ms"
+	PrebuildDeletionJobCreationLatencyMetric = "prebuild_deletion_job_creation_latency_ms"
+	PrebuildDeletionJobAcquiredLatencyMetric = "prebuild_deletion_job_acquired_latency_ms"
+)
+
+func (r *Runner) GetMetrics() map[string]any {
+	return map[string]any{
+		PrebuildsTotalLatencyMetric:              r.prebuildTotalLatency.Milliseconds(),
+		PrebuildJobCreationLatencyMetric:         r.prebuildJobCreationLatency.Milliseconds(),
+		PrebuildJobAcquiredLatencyMetric:         r.prebuildJobAcquiredLatency.Milliseconds(),
+		PrebuildDeletionTotalLatencyMetric:       r.prebuildDeletionTotalLatency.Milliseconds(),
+		PrebuildDeletionJobCreationLatencyMetric: r.prebuildDeletionJobCreationLatency.Milliseconds(),
+		PrebuildDeletionJobAcquiredLatencyMetric: r.prebuildDeletionJobAcquiredLatency.Milliseconds(),
+	}
+}
+
+//go:embed tf/main.tf.tpl
+var templateContent string
+
+func TemplateTarData(numPresets, numPresetPrebuilds int) ([]byte, error) {
+	tmpl, err := template.New("prebuilds-template").Parse(templateContent)
+	if err != nil {
+		return nil, err
+	}
+	var result strings.Builder
+	err = tmpl.Execute(&result, map[string]int{
+		"NumPresets":         numPresets,
+		"NumPresetPrebuilds": numPresetPrebuilds,
+	})
+	if err != nil {
+		return nil, err
+	}
+	files := map[string][]byte{
+		"main.tf": []byte(result.String()),
+	}
+	tarBytes, err := loadtestutil.CreateTarFromFiles(files)
+	if err != nil {
+		return nil, err
+	}
+	return tarBytes, nil
+}

--- a/scaletest/prebuilds/tf/main.tf.tpl
+++ b/scaletest/prebuilds/tf/main.tf.tpl
@@ -7,16 +7,11 @@ terraform {
   }
 }
 
-locals {
-  num_presets = {{.NumPresets}}
-}
-
 resource "null_resource" "workspace" {}
 
-
 data "coder_workspace_preset" "presets" {
-  count = local.num_presets
-  name     = "preset-${count.index + 1}"
+  count = {{.NumPresets}}
+  name  = "preset-${count.index + 1}"
   prebuilds {
     instances = {{.NumPresetPrebuilds}}
   }

--- a/scaletest/prebuilds/tf/main.tf.tpl
+++ b/scaletest/prebuilds/tf/main.tf.tpl
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "2.5.3"
+    }
+  }
+}
+
+locals {
+  num_presets = {{.NumPresets}}
+}
+
+resource "null_resource" "workspace" {}
+
+
+data "coder_workspace_preset" "presets" {
+  count = local.num_presets
+  name     = "preset-${count.index + 1}"
+  prebuilds {
+    instances = {{.NumPresetPrebuilds}}
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/914

Adds a runner for scaletesting prebuilds. The runner uploads a no-op template with prebuilds, watches for the corresponding workspaces to be created, and then does the same to tear them down. I didn't originally plan on having metrics for the teardown, but I figured we might as well as it's still the same prebuilds reconciliation loop mechanism being tested.