### PR TITLE
ci: allow more time for gen & fmt jobs to be acquired

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,7 +238,7 @@ jobs:
         shell: bash
 
   gen:
-    timeout-minutes: 8
+    timeout-minutes: 20
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}
     steps:
@@ -279,6 +279,7 @@ jobs:
           popd
 
       - name: make gen
+        timeout-minutes: 8
         run: |
           # Remove golden files to detect discrepancy in generated files.
           make clean/golden-files
@@ -296,7 +297,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.offlinedocs-only == 'false' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
-    timeout-minutes: 7
+    timeout-minutes: 20
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -323,6 +324,7 @@ jobs:
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0
 
       - name: make fmt
+        timeout-minutes: 7
         run: |
           PATH="${PATH}:$(go env GOPATH)/bin" \
             make --output-sync -j -B fmt


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1081

The time taken for a runner to acquire a job counts towards the job-wide `timeout-minutes`. Recently we've been seeing outages in the runner infrastructure lead to a ~5-6m runner start time, causing fmt & gen jobs to be cancelled due to their 7 or 8 minute timeouts.

This PR extends the job-wide timeout on fmt & gen to 20 minutes, but adds the original 7 and 8 minute timeouts to the `make [fmt|gen]` portion of the job -- the part of the job we have the most control over, and that we want to be made aware of timeouts for. 