### PR TITLE
fix(coderd): disallow POSTing a workspace build on a deleted workspace

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -335,6 +335,15 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We want to allow a delete build for a deleted workspace, but not a start or stop build.
+	if workspace.Deleted && createBuild.Transition != codersdk.WorkspaceTransitionDelete {
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+			Message: fmt.Sprintf("Cannot %s a deleted workspace!", createBuild.Transition),
+			Detail:  "This workspace has been deleted and cannot be modified.",
+		})
+		return
+	}
+
 	apiBuild, err := api.postWorkspaceBuildsInternal(
 		ctx,
 		apiKey,


### PR DESCRIPTION
# Problem

It looks like, for a good long while, we have allows POSTing a workspace build on a deleted workspace. As far as I can tell, this goes _way_ back (to at least 2.21, but maybe earlier).

Credit to @DanielleMaywood 

# Impact

- You can "start" a deleted workspace if you would have previously had access to it (either due to your role or owning the workspace) and know its ID. 
- It won't show up in the UI.
- Resources will be created (most likely re-created due to the previous DELETE transition).
- The agent won't connect so you won't be able to access the resources via coder.

# Proposed Solution

This PR adds a check on `/api/v2/workspacebuilds` to disallow creating a START or STOP build if the workspace is deleted. I elected to allow a DELETE build however.

# Remediation

I haven't added any automatic remediation, but below is a (Claude-coded) SQL query that should show affected workspaces and associated resources:

```sql
WITH successful_deletes AS (
    SELECT wb.workspace_id, wb.created_at as delete_time, wb.id as delete_build_id
    FROM workspace_builds wb
    JOIN provisioner_jobs pj ON wb.job_id = pj.id
    WHERE wb.transition = 'delete'
      AND pj.completed_at IS NOT NULL
      AND pj.error IS NULL
  )
  SELECT
    w.id as workspace_id,
    u.username || '/' || w.name as workspace,
    wb.id as violating_build_id,
    wb.transition as violating_transition,
    wb.created_at as violating_build_time,
    sd.delete_time,
    sd.delete_build_id,
    wb.created_at - sd.delete_time as time_after_delete,
    COALESCE(
      string_agg(
        DISTINCT wr.name || ' (' || wr.type || ')',
        ', ' ORDER BY wr.name || ' (' || wr.type || ')'
      ),
      'No resources'
    ) as workspace_resources
  FROM workspace_builds wb
  JOIN successful_deletes sd ON wb.workspace_id = sd.workspace_id
  JOIN workspaces w ON wb.workspace_id = w.id
  JOIN users u ON w.owner_id = u.id
  LEFT JOIN workspace_resources wr ON wb.job_id = wr.job_id
    AND wr.type NOT LIKE 'coder_%'
  WHERE wb.transition IN ('start', 'stop')
    AND wb.created_at > sd.delete_time
  GROUP BY
    w.id, w.name, u.username, wb.id, wb.transition,
    wb.created_at, sd.delete_time, sd.delete_build_id
  ORDER BY wb.created_at DESC;
```