### PR TITLE
fix(coderd): disallow POSTing a workspace build on a deleted workspace (#20584)

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -335,6 +335,15 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We want to allow a delete build for a deleted workspace, but not a start or stop build.
+	if workspace.Deleted && createBuild.Transition != codersdk.WorkspaceTransitionDelete {
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+			Message: fmt.Sprintf("Cannot %s a deleted workspace!", createBuild.Transition),
+			Detail:  "This workspace has been deleted and cannot be modified.",
+		})
+		return
+	}
+
 	apiBuild, err := api.postWorkspaceBuildsInternal(
 		ctx,
 		apiKey,


### PR DESCRIPTION
- Adds a check on /api/v2/workspacebuilds to disallow creating a START or STOP build if the workspace is deleted.
- DELETEs are still allowed.

(cherry picked from commit 38017010cec19bb0fc5479a7debcc341a5a63a9d)
