### PR TITLE
docs: update release calendar for 2.27.3 patch

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -136,7 +136,7 @@ We support two release channels: mainline and stable - read the
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.27.1
+        --version 2.27.3
     ```
 
   - **OCI Registry**
@@ -147,7 +147,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.27.2
+        --version 2.27.3
     ```
 
 - **Stable** Coder release:

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -134,7 +134,7 @@ kubectl create secret generic coder-db-url -n coder \
 
 1. Select a Coder version:
 
-   - **Mainline**: `2.27.2`
+   - **Mainline**: `2.27.3`
    - **Stable**: `2.26.3`
 
    Learn more about release channels in the [Releases documentation](./releases/index.md).

--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -62,7 +62,7 @@ pages.
 | [2.24](https://coder.com/changelog/coder-2-24) | July 01, 2025      | Not Supported    | [v2.24.4](https://github.com/coder/coder/releases/tag/v2.24.4) |
 | [2.25](https://coder.com/changelog/coder-2-25) | August 05, 2025    | Security Support | [v2.25.3](https://github.com/coder/coder/releases/tag/v2.25.3) |
 | [2.26](https://coder.com/changelog/coder-2-26) | September 03, 2025 | Stable           | [v2.26.3](https://github.com/coder/coder/releases/tag/v2.26.3) |
-| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Mainline         | [v2.27.2](https://github.com/coder/coder/releases/tag/v2.27.2) |
+| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Mainline         | [v2.27.3](https://github.com/coder/coder/releases/tag/v2.27.3) |
 | 2.28                                           |                    | Not Released     | N/A                                                            |
 <!-- RELEASE_CALENDAR_END -->
 


### PR DESCRIPTION
## Description

Updating our release calendar for the https://github.com/coder/coder/releases/tag/v2.27.3 patch. 