### PR TITLE
chore: update paywall grammar mistake

### DIFF
--- a/site/src/pages/AuditPage/AuditPageView.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.tsx
@@ -132,7 +132,7 @@ export const AuditPageView: FC<AuditPageViewProps> = ({
 				<Cond>
 					<Paywall
 						message="Audit logs"
-						description="Audit logs allow you to monitor user operations on your deployment. You need an Premium license to use this feature."
+						description="Audit logs allow you to monitor user operations on your deployment. You need a Premium license to use this feature."
 						documentationLink={docs("/admin/security/audit-logs")}
 					/>
 				</Cond>

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPage.tsx
@@ -80,7 +80,7 @@ const IdpOrgSyncPage: FC = () => {
 					<Cond condition={!isIdpSyncEnabled}>
 						<Paywall
 							message="IdP Organization Sync"
-							description="Configure organization mappings to synchronize claims in your auth provider to organizations within Coder. You need an Premium license to use this feature."
+							description="Configure organization mappings to synchronize claims in your auth provider to organizations within Coder. You need a Premium license to use this feature."
 							documentationLink={docs("/admin/users/idp-sync")}
 						/>
 					</Cond>

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -132,7 +132,7 @@ const IdpSyncPage: FC = () => {
 					<Cond condition={!isIdpSyncEnabled}>
 						<Paywall
 							message="IdP Sync"
-							description="Configure group and role mappings to manage permissions outside of Coder. You need an Premium license to use this feature."
+							description="Configure group and role mappings to manage permissions outside of Coder. You need a Premium license to use this feature."
 							documentationLink={docs("/admin/users/idp-sync")}
 						/>
 					</Cond>

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
@@ -30,7 +30,7 @@ const TemplatePermissionsPage: FC = () => {
 			{!isTemplateRBACEnabled ? (
 				<Paywall
 					message="Template permissions"
-					description="Control access of templates for users and groups to templates. You need an Premium license to use this feature."
+					description="Control access of templates for users and groups to templates. You need a Premium license to use this feature."
 					documentationLink={docs("/admin/templates/template-permissions")}
 				/>
 			) : (


### PR DESCRIPTION
Resolved issue from #20331 where the article `an` was incorrectly used before words not beginning with a vowel sound. Updated affected instances to use the correct article `a`.

```diff
- You need an Premium license to use this feature.
+ You need a Premium license to use this feature.
```

This was already correct on the following pages.

* [`ConnectionLogPageView.tsx`](https://github.com/coder/coder/blob/7182c53df7648cd7db8551629226c4a0a1cc8559/site/src/pages/ConnectionLogPage/ConnectionLogPageView.tsx#L130)
* [`GroupsPageView.tsx`](https://github.com/coder/coder/blob/7182c53df7648cd7db8551629226c4a0a1cc8559/site/src/pages/GroupsPage/GroupsPageView.tsx#L49)
