### PR TITLE
chore(dogfood): replace filebrowser with copyparty

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -393,12 +393,20 @@ module "jetbrains" {
   tooltip       = "You need to [Install Coder Desktop](https://coder.com/docs/user-guides/desktop#install-coder-desktop) to use this button."
 }
 
-module "filebrowser" {
-  count      = data.coder_workspace.me.start_count
-  source     = "dev.registry.coder.com/coder/filebrowser/coder"
-  version    = "1.1.2"
-  agent_id   = coder_agent.dev.id
-  agent_name = "dev"
+module "copyparty" {
+  count     = data.coder_workspace.me.start_count
+  source    = "dev.registry.coder.com/djarbz/copyparty/coder"
+  version   = "1.0.1"
+  agent_id  = coder_agent.dev.id
+  subdomain = true
+  arguments = [
+    "-v", "/tmp:/tmp:r",
+    "-v", "/home/coder:/home:rw",
+    "-v", "${local.repo_dir}:/coder:A:c,dotsrch",
+    "-e2dsa",
+    "--re-maxage", "900",
+    "--see-dots",
+  ]
 }
 
 module "coder-login" {


### PR DESCRIPTION
copyparty is a new community contributed module that is superior to our current file-browser module. I wanted to add it to the dogfood template so everyone can test it out, and reap the benefits.