### PR TITLE
chore(cli): fix issue with running individual sub-tests of Test_Tasks

### DIFF
--- a/cli/exp_task_test.go
+++ b/cli/exp_task_test.go
@@ -53,18 +53,6 @@ func Test_Tasks(t *testing.T) {
 		taskName     = strings.ReplaceAll(testutil.GetRandomName(t), "_", "-")
 	)
 
-	// The below test cases are not real "sub-tests" as they depend on each other sequentially.
-	runTest := func(name string, cmdArgs []string, assertFn func(string, *codersdk.Client)) {
-		var stdout strings.Builder
-		inv, root := clitest.New(t, cmdArgs...)
-		inv.Stdout = &stdout
-		clitest.SetupConfig(t, userClient, root)
-		require.NoError(t, inv.WithContext(ctx).Run(), name)
-		if assertFn != nil {
-			assertFn(stdout.String(), userClient)
-		}
-	}
-
 	for _, tc := range []struct {
 		name     string
 		cmdArgs  []string
@@ -146,7 +134,15 @@ func Test_Tasks(t *testing.T) {
 			},
 		},
 	} {
-		runTest(tc.name, tc.cmdArgs, tc.assertFn)
+		t.Logf("test case: %q", tc.name)
+		var stdout strings.Builder
+		inv, root := clitest.New(t, tc.cmdArgs...)
+		inv.Stdout = &stdout
+		clitest.SetupConfig(t, userClient, root)
+		require.NoError(t, inv.WithContext(ctx).Run(), tc.name)
+		if tc.assertFn != nil {
+			tc.assertFn(stdout.String(), userClient)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1112

Turns out sub-tests aren't ideal when you're running things that depend on each other and need to be run in a certain order.