### PR TITLE
fix(coderd): fix template ai task check error message

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -92,7 +92,7 @@ func (api *API) tasksCreate(rw http.ResponseWriter, r *http.Request) {
 
 	if !templateVersion.HasAITask.Valid || !templateVersion.HasAITask.Bool {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf(`Template does not have required parameter %q`, codersdk.AITaskPromptParameterName),
+			Message: `Template does not have a valid "coder_ai_task" resource.`,
 		})
 		return
 	}

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -871,7 +871,7 @@ func TestTools(t *testing.T) {
 					TemplateVersionID: r.TemplateVersion.ID.String(),
 					Input:             "do yet another barrel roll",
 				},
-				error: "Template does not have required parameter \"AI Prompt\"",
+				error: "Template does not have a valid \"coder_ai_task\" resource.",
 			},
 			{
 				name: "WithPreset",
@@ -880,7 +880,7 @@ func TestTools(t *testing.T) {
 					TemplateVersionPresetID: presetID.String(),
 					Input:                   "not enough barrel rolls",
 				},
-				error: "Template does not have required parameter \"AI Prompt\"",
+				error: "Template does not have a valid \"coder_ai_task\" resource.",
 			},
 		}
 


### PR DESCRIPTION
Create task was still mentioning magic prompt parameter when checking template task validity. This change updates it to only mention validity of `coder_ai_task` resource.