### PR TITLE
perf: reduce DB calls to `GetWorkspaceByAgentID` via caching workspace info

### DIFF
--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -310,7 +310,7 @@ func (a *API) agent(ctx context.Context) (database.WorkspaceAgent, error) {
 	return agent, nil
 }
 
-func (a *API) workspace() (database.Workspace) {
+func (a *API) workspace() database.Workspace {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -327,7 +327,7 @@ func (a *API) workspace() database.Workspace {
 	}
 }
 
-func (a *API) rbacContext(ctx context.Context) context.Context {
+func (a *API) rbacContext(ctx context.Context) (context.Context, error) {
 	workspace := a.workspace()
 	return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
 }

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -329,7 +329,7 @@ func (a *API) refreshCachedWorkspace(ctx context.Context) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	ws, err := a.opts.Database.GetWorkspaceByID(ctx, a.cachedWorkspaceFields.ID)
+	ws, err := a.opts.Database.GetWorkspaceByID(ctx, a.opts.WorkspaceID)
 	if err != nil {
 		a.opts.Log.Warn(ctx, "failed to refresh cached workspace fields", slog.Error(err))
 		return

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -278,6 +278,7 @@ func (a *API) refreshCachedWorkspace(ctx context.Context) {
 	ws, err := a.opts.Database.GetWorkspaceByID(ctx, a.opts.WorkspaceID)
 	if err != nil {
 		a.opts.Log.Warn(ctx, "failed to refresh cached workspace fields", slog.Error(err))
+		a.cachedWorkspaceFields.Clear()
 		return
 	}
 

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -341,8 +341,12 @@ func (a *API) refreshCachedWorkspace(ctx context.Context) {
 	}
 
 	// Update fields that can change during workspace lifecycle (e.g., prebuild claim)
-	a.cachedWorkspaceFields = CachedWorkspaceFields{}
-
+	a.cachedWorkspaceFields.OwnerID = ws.OwnerID
+	a.cachedWorkspaceFields.Name = ws.Name
+	a.cachedWorkspaceFields.OwnerUsername = ws.OwnerUsername
+	a.cachedWorkspaceFields.ID = ws.ID
+	a.cachedWorkspaceFields.TemplateID = ws.TemplateID
+	a.cachedWorkspaceFields.TemplateName = ws.TemplateName
 
 	a.opts.Log.Debug(ctx, "refreshed cached workspace fields",
 		slog.F("workspace_id", ws.ID),

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -312,9 +312,9 @@ func (a *API) startCacheRefreshLoop(ctx context.Context) {
 	_ = ticker.Wait()
 
 	a.opts.Log.Debug(ctx, "cache refresh loop exited, invalidating the workspace cache on agent API",
-		slog.F("workspace_id", a.cachedWorkspaceFields.ID),
-		slog.F("owner_id", a.cachedWorkspaceFields.OwnerUsername),
-		slog.F("name", a.cachedWorkspaceFields.Name))
+		slog.F("workspace_id", a.cachedWorkspaceFields.identity.ID),
+		slog.F("owner_id", a.cachedWorkspaceFields.identity.OwnerUsername),
+		slog.F("name", a.cachedWorkspaceFields.identity.Name))
 	a.cachedWorkspaceFields.Clear()
 }
 

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -369,8 +369,11 @@ func (a *API) startCacheRefreshLoop(ctx context.Context) {
 		a.refreshCachedWorkspace(ctx)
 		return nil
 	}, "cache_refresh")
-
-	<-ctx.Done()
+	a.opts.Log.Debug(ctx, "cache refresh loop exited, invalidating the workspace cache on agent API",
+		slog.F("workspace_id", a.cachedWorkspaceFields.ID),
+		slog.F("owner_id", a.cachedWorkspaceFields.OwnerUsername),
+		slog.F("name", a.cachedWorkspaceFields.Name))
+	a.cachedWorkspaceFields = CachedWorkspaceFields{}
 }
 
 func (a *API) publishWorkspaceUpdate(ctx context.Context, agent *database.WorkspaceAgent, kind wspubsub.WorkspaceEventKind) error {

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -283,11 +283,14 @@ func (a *API) refreshCachedWorkspace(ctx context.Context) {
 	}
 
 	if ws.IsPrebuild() {
-		a.opts.Log.Debug(ctx, "workspace is a prebuild, not caching in AgentAPI")
 		return
 	}
 
-	// Update fields that can change during workspace lifecycle (e.g., prebuild claim)
+	// If we still have the same values, skip the update and logging calls.
+	if a.cachedWorkspaceFields.identity.Equal(database.WorkspaceIdentityFromWorkspace(ws)) {
+		return
+	}
+	// Update fields that can change during workspace lifecycle (e.g., AutostartSchedule)
 	a.cachedWorkspaceFields.UpdateValues(ws)
 
 	a.opts.Log.Debug(ctx, "refreshed cached workspace fields",

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -127,7 +127,7 @@ func New(opts Options, workspace database.Workspace) *API {
 
 	api := &API{
 		opts: opts,
-		mu: sync.Mutex{},
+		mu:   sync.Mutex{},
 	}
 
 	api.ManifestAPI = &ManifestAPI{
@@ -307,13 +307,13 @@ func (a *API) workspace() database.Workspace {
 	defer a.mu.Unlock()
 
 	return database.Workspace{
-		ID:                a.cachedWorkspaceFields.ID,
-		OwnerID:           a.cachedWorkspaceFields.OwnerID,
-		OrganizationID:    a.cachedWorkspaceFields.OrganizationID,
-		TemplateID:        a.cachedWorkspaceFields.TemplateID,
-		Name:              a.cachedWorkspaceFields.Name,
-		OwnerUsername:     a.cachedWorkspaceFields.OwnerUsername,
-		TemplateName:      a.cachedWorkspaceFields.TemplateName,
+		ID:             a.cachedWorkspaceFields.ID,
+		OwnerID:        a.cachedWorkspaceFields.OwnerID,
+		OrganizationID: a.cachedWorkspaceFields.OrganizationID,
+		TemplateID:     a.cachedWorkspaceFields.TemplateID,
+		Name:           a.cachedWorkspaceFields.Name,
+		OwnerUsername:  a.cachedWorkspaceFields.OwnerUsername,
+		TemplateName:   a.cachedWorkspaceFields.TemplateName,
 	}
 }
 

--- a/coderd/agentapi/cached_workspace.go
+++ b/coderd/agentapi/cached_workspace.go
@@ -21,18 +21,6 @@ type CachedWorkspaceFields struct {
 	identity database.WorkspaceIdentity
 }
 
-func (cws *CachedWorkspaceFields) Equal(cws2 *CachedWorkspaceFields) bool {
-	cws.lock.RLock()
-	defer cws.lock.RUnlock()
-	cws2.lock.RLock()
-	defer cws2.lock.RUnlock()
-
-	return cws.identity.ID == cws2.identity.ID && cws.identity.OwnerID == cws2.identity.OwnerID &&
-		cws.identity.OrganizationID == cws2.identity.OrganizationID && cws.identity.TemplateID == cws2.identity.TemplateID &&
-		cws.identity.Name == cws2.identity.Name && cws.identity.OwnerUsername == cws2.identity.OwnerUsername &&
-		cws.identity.TemplateName == cws2.identity.TemplateName && cws.identity.AutostartSchedule == cws2.identity.AutostartSchedule
-}
-
 func (cws *CachedWorkspaceFields) Clear() {
 	cws.lock.Lock()
 	defer cws.lock.Unlock()
@@ -57,7 +45,7 @@ func (cws *CachedWorkspaceFields) AsWorkspaceIdentity() (database.WorkspaceIdent
 	cws.lock.RLock()
 	defer cws.lock.RUnlock()
 	// Should we be more explicit about all fields being set to be valid?
-	if cws.Equal(&CachedWorkspaceFields{}) {
+	if cws.identity.Equal(database.WorkspaceIdentity{}) {
 		return database.WorkspaceIdentity{}, false
 	}
 	return cws.identity, true

--- a/coderd/agentapi/cached_workspace.go
+++ b/coderd/agentapi/cached_workspace.go
@@ -1,0 +1,78 @@
+package agentapi
+
+import (
+	"sync"
+	"database/sql"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// CachedWorkspaceFields contains workspace data that is safe to cache for the
+// duration of an agent connection. These fields are used to reduce database calls
+// in high-frequency operations like stats reporting and metadata updates.
+// Prebuild workspaces should not be cached using this struct within the API struct,
+// however some of these fields for a workspace can be updated live so there is a
+// routine in the API for refreshing the workspace on a timed interval.
+//
+// IMPORTANT: ACL fields (GroupACL, UserACL) are NOT cached because they can be
+// modified in the database and we must use fresh data for authorization checks.
+type CachedWorkspaceFields struct {
+	lock sync.RWMutex
+
+	// Identity fields
+	ID             uuid.UUID
+	OwnerID        uuid.UUID
+	OrganizationID uuid.UUID
+	TemplateID     uuid.UUID
+
+	// Display fields for logging/metrics
+	Name          string
+	OwnerUsername string
+	TemplateName  string
+
+	// Lifecycle fields needed for stats reporting
+	AutostartSchedule sql.NullString
+}
+
+func (cws *CachedWorkspaceFields) Clear() {
+	cws.lock.Lock()
+	defer cws.lock.Unlock()
+	cws.ID = uuid.UUID{}
+	cws.OwnerID = uuid.UUID{}
+	cws.OrganizationID = uuid.UUID{}
+	cws.TemplateID = uuid.UUID{}
+	cws.Name = ""
+	cws.OwnerUsername = ""
+	cws.TemplateName = ""
+	cws.AutostartSchedule = sql.NullString{}
+}
+
+func (cws *CachedWorkspaceFields) UpdateValues(ws database.Workspace) {
+	cws.lock.Lock()
+	defer cws.lock.Unlock()
+	cws.ID = ws.ID
+	cws.OwnerID = ws.OwnerID
+	cws.OrganizationID = ws.OrganizationID
+	cws.TemplateID = ws.TemplateID
+	cws.Name = ws.Name
+	cws.OwnerUsername = ws.OwnerUsername
+	cws.TemplateName = ws.TemplateName
+	cws.AutostartSchedule = ws.AutostartSchedule
+}
+
+func (cws *CachedWorkspaceFields) AsDatabaseWorkspace() database.Workspace {
+	cws.lock.RLock()
+	defer 	cws.lock.RUnlock()
+	return database.Workspace{
+		ID:                cws.ID,
+		OwnerID:           cws.OwnerID,
+		OrganizationID:    cws.OrganizationID,
+		TemplateID:        cws.TemplateID,
+		Name:              cws.Name,
+		OwnerUsername:     cws.OwnerUsername,
+		TemplateName:      cws.TemplateName,
+		AutostartSchedule: cws.AutostartSchedule,
+	}
+}

--- a/coderd/agentapi/cached_workspace.go
+++ b/coderd/agentapi/cached_workspace.go
@@ -1,10 +1,7 @@
 package agentapi
 
 import (
-	// "database/sql"
 	"sync"
-
-	// "github.com/google/uuid"
 
 	"github.com/coder/coder/v2/coderd/database"
 )
@@ -30,8 +27,8 @@ func (cws *CachedWorkspaceFields) Equal(cws2 *CachedWorkspaceFields) bool {
 	cws2.lock.RLock()
 	defer cws2.lock.RUnlock()
 
-	return cws.identity.ID == cws2.identity.ID && cws.identity.OwnerID == cws2.identity.OwnerID && 
-		cws.identity.OrganizationID == cws2.identity.OrganizationID && cws.identity.TemplateID == cws2.identity.TemplateID && 
+	return cws.identity.ID == cws2.identity.ID && cws.identity.OwnerID == cws2.identity.OwnerID &&
+		cws.identity.OrganizationID == cws2.identity.OrganizationID && cws.identity.TemplateID == cws2.identity.TemplateID &&
 		cws.identity.Name == cws2.identity.Name && cws.identity.OwnerUsername == cws2.identity.OwnerUsername &&
 		cws.identity.TemplateName == cws2.identity.TemplateName && cws.identity.AutostartSchedule == cws2.identity.AutostartSchedule
 }

--- a/coderd/agentapi/cached_workspace.go
+++ b/coderd/agentapi/cached_workspace.go
@@ -1,8 +1,8 @@
 package agentapi
 
 import (
-	"sync"
 	"database/sql"
+	"sync"
 
 	"github.com/google/uuid"
 
@@ -36,6 +36,17 @@ type CachedWorkspaceFields struct {
 	AutostartSchedule sql.NullString
 }
 
+func (cws *CachedWorkspaceFields) Equal(cws2 *CachedWorkspaceFields) bool {
+	cws.lock.RLock()
+	defer cws.lock.RUnlock()
+	cws2.lock.RLock()
+	defer cws2.lock.RUnlock()
+
+	return cws.ID == cws2.ID && cws.OwnerID == cws2.OwnerID && cws.OrganizationID == cws2.OrganizationID &&
+		cws.TemplateID == cws2.TemplateID && cws.Name == cws2.Name && cws.OwnerUsername == cws2.OwnerUsername &&
+		cws.TemplateName == cws2.TemplateName && cws.AutostartSchedule == cws2.AutostartSchedule
+}
+
 func (cws *CachedWorkspaceFields) Clear() {
 	cws.lock.Lock()
 	defer cws.lock.Unlock()
@@ -64,7 +75,7 @@ func (cws *CachedWorkspaceFields) UpdateValues(ws database.Workspace) {
 
 func (cws *CachedWorkspaceFields) AsDatabaseWorkspace() database.Workspace {
 	cws.lock.RLock()
-	defer 	cws.lock.RUnlock()
+	defer cws.lock.RUnlock()
 	return database.Workspace{
 		ID:                cws.ID,
 		OwnerID:           cws.OwnerID,

--- a/coderd/agentapi/cached_workspace.go
+++ b/coderd/agentapi/cached_workspace.go
@@ -73,9 +73,14 @@ func (cws *CachedWorkspaceFields) UpdateValues(ws database.Workspace) {
 	cws.AutostartSchedule = ws.AutostartSchedule
 }
 
-func (cws *CachedWorkspaceFields) AsDatabaseWorkspace() database.Workspace {
+// Returns the Workspace, true, unless the workspace has not been cached (nuked or was a prebuild).
+func (cws *CachedWorkspaceFields) AsDatabaseWorkspace() (database.Workspace, bool) {
 	cws.lock.RLock()
 	defer cws.lock.RUnlock()
+	// Should we be more explicit about all fields being set to be valid?
+	if cws.Equal(&CachedWorkspaceFields{}) {
+		return database.Workspace{}, false
+	}
 	return database.Workspace{
 		ID:                cws.ID,
 		OwnerID:           cws.OwnerID,
@@ -85,5 +90,5 @@ func (cws *CachedWorkspaceFields) AsDatabaseWorkspace() database.Workspace {
 		OwnerUsername:     cws.OwnerUsername,
 		TemplateName:      cws.TemplateName,
 		AutostartSchedule: cws.AutostartSchedule,
-	}
+	}, true
 }

--- a/coderd/agentapi/cached_workspace_test.go
+++ b/coderd/agentapi/cached_workspace_test.go
@@ -46,7 +46,11 @@ func TestCacheClear(t *testing.T) {
 
 	emptyCws := agentapi.CachedWorkspaceFields{}
 	workspaceAsCacheFields.Clear()
-	require.True(t, emptyCws.Equal(&workspaceAsCacheFields))
+	wsi, ok := workspaceAsCacheFields.AsWorkspaceIdentity()
+	require.False(t, ok)
+	ecwsi, ok := emptyCws.AsWorkspaceIdentity()
+	require.False(t, ok)
+	require.True(t, ecwsi.Equal(wsi))
 }
 
 func TestCacheUpdate(t *testing.T) {
@@ -85,5 +89,9 @@ func TestCacheUpdate(t *testing.T) {
 
 	cws := agentapi.CachedWorkspaceFields{}
 	cws.UpdateValues(workspace)
-	require.True(t, workspaceAsCacheFields.Equal(&cws))
+	wsi, ok := workspaceAsCacheFields.AsWorkspaceIdentity()
+	require.True(t, ok)
+	cwsi, ok := cws.AsWorkspaceIdentity()
+	require.True(t, ok)
+	require.True(t, wsi.Equal(cwsi))
 }

--- a/coderd/agentapi/cached_workspace_test.go
+++ b/coderd/agentapi/cached_workspace_test.go
@@ -1,16 +1,18 @@
 package agentapi_test
 
-import(
+import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/agentapi"
 	"github.com/coder/coder/v2/coderd/database"
 )
 
 func TestCacheClear(t *testing.T) {
+	t.Parallel()
+
 	var (
 		user = database.User{
 			ID:       uuid.New(),
@@ -41,10 +43,12 @@ func TestCacheClear(t *testing.T) {
 
 	emptyCws := agentapi.CachedWorkspaceFields{}
 	workspaceAsCacheFields.Clear()
-	require.Equal(t, emptyCws, workspaceAsCacheFields)
+	require.True(t, emptyCws.Equal(&workspaceAsCacheFields))
 }
 
 func TestCacheUpdate(t *testing.T) {
+	t.Parallel()
+
 	var (
 		user = database.User{
 			ID:       uuid.New(),
@@ -75,5 +79,5 @@ func TestCacheUpdate(t *testing.T) {
 
 	cws := agentapi.CachedWorkspaceFields{}
 	cws.UpdateValues(workspace)
-	require.Equal(t, workspaceAsCacheFields, cws)
+	require.True(t, workspaceAsCacheFields.Equal(&cws))
 }

--- a/coderd/agentapi/cached_workspace_test.go
+++ b/coderd/agentapi/cached_workspace_test.go
@@ -1,0 +1,79 @@
+package agentapi_test
+
+import(
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/agentapi"
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+func TestCacheClear(t *testing.T) {
+	var (
+		user = database.User{
+			ID:       uuid.New(),
+			Username: "bill",
+		}
+		template = database.Template{
+			ID:   uuid.New(),
+			Name: "tpl",
+		}
+		workspace = database.Workspace{
+			ID:            uuid.New(),
+			OwnerID:       user.ID,
+			OwnerUsername: user.Username,
+			TemplateID:    template.ID,
+			Name:          "xyz",
+			TemplateName:  template.Name,
+		}
+		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
+			ID:                workspace.ID,
+			OwnerID:           workspace.OwnerID,
+			OwnerUsername:     workspace.OwnerUsername,
+			TemplateID:        workspace.TemplateID,
+			Name:              workspace.Name,
+			TemplateName:      workspace.TemplateName,
+			AutostartSchedule: workspace.AutostartSchedule,
+		}
+	)
+
+	emptyCws := agentapi.CachedWorkspaceFields{}
+	workspaceAsCacheFields.Clear()
+	require.Equal(t, emptyCws, workspaceAsCacheFields)
+}
+
+func TestCacheUpdate(t *testing.T) {
+	var (
+		user = database.User{
+			ID:       uuid.New(),
+			Username: "bill",
+		}
+		template = database.Template{
+			ID:   uuid.New(),
+			Name: "tpl",
+		}
+		workspace = database.Workspace{
+			ID:            uuid.New(),
+			OwnerID:       user.ID,
+			OwnerUsername: user.Username,
+			TemplateID:    template.ID,
+			Name:          "xyz",
+			TemplateName:  template.Name,
+		}
+		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
+			ID:                workspace.ID,
+			OwnerID:           workspace.OwnerID,
+			OwnerUsername:     workspace.OwnerUsername,
+			TemplateID:        workspace.TemplateID,
+			Name:              workspace.Name,
+			TemplateName:      workspace.TemplateName,
+			AutostartSchedule: workspace.AutostartSchedule,
+		}
+	)
+
+	cws := agentapi.CachedWorkspaceFields{}
+	cws.UpdateValues(workspace)
+	require.Equal(t, workspaceAsCacheFields, cws)
+}

--- a/coderd/agentapi/cached_workspace_test.go
+++ b/coderd/agentapi/cached_workspace_test.go
@@ -30,15 +30,18 @@ func TestCacheClear(t *testing.T) {
 			Name:          "xyz",
 			TemplateName:  template.Name,
 		}
-		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
-			ID:                workspace.ID,
-			OwnerID:           workspace.OwnerID,
-			OwnerUsername:     workspace.OwnerUsername,
-			TemplateID:        workspace.TemplateID,
-			Name:              workspace.Name,
-			TemplateName:      workspace.TemplateName,
-			AutostartSchedule: workspace.AutostartSchedule,
-		}
+		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{}
+	)
+
+	workspaceAsCacheFields.UpdateValues(database.Workspace{
+		ID:                workspace.ID,
+		OwnerID:           workspace.OwnerID,
+		OwnerUsername:     workspace.OwnerUsername,
+		TemplateID:        workspace.TemplateID,
+		Name:              workspace.Name,
+		TemplateName:      workspace.TemplateName,
+		AutostartSchedule: workspace.AutostartSchedule,
+		},
 	)
 
 	emptyCws := agentapi.CachedWorkspaceFields{}
@@ -66,15 +69,18 @@ func TestCacheUpdate(t *testing.T) {
 			Name:          "xyz",
 			TemplateName:  template.Name,
 		}
-		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
-			ID:                workspace.ID,
-			OwnerID:           workspace.OwnerID,
-			OwnerUsername:     workspace.OwnerUsername,
-			TemplateID:        workspace.TemplateID,
-			Name:              workspace.Name,
-			TemplateName:      workspace.TemplateName,
-			AutostartSchedule: workspace.AutostartSchedule,
-		}
+		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{}
+	)
+
+	workspaceAsCacheFields.UpdateValues(database.Workspace{
+		ID:                workspace.ID,
+		OwnerID:           workspace.OwnerID,
+		OwnerUsername:     workspace.OwnerUsername,
+		TemplateID:        workspace.TemplateID,
+		Name:              workspace.Name,
+		TemplateName:      workspace.TemplateName,
+		AutostartSchedule: workspace.AutostartSchedule,
+		},
 	)
 
 	cws := agentapi.CachedWorkspaceFields{}

--- a/coderd/agentapi/cached_workspace_test.go
+++ b/coderd/agentapi/cached_workspace_test.go
@@ -41,7 +41,7 @@ func TestCacheClear(t *testing.T) {
 		Name:              workspace.Name,
 		TemplateName:      workspace.TemplateName,
 		AutostartSchedule: workspace.AutostartSchedule,
-		},
+	},
 	)
 
 	emptyCws := agentapi.CachedWorkspaceFields{}
@@ -80,7 +80,7 @@ func TestCacheUpdate(t *testing.T) {
 		Name:              workspace.Name,
 		TemplateName:      workspace.TemplateName,
 		AutostartSchedule: workspace.AutostartSchedule,
-		},
+	},
 	)
 
 	cws := agentapi.CachedWorkspaceFields{}

--- a/coderd/agentapi/metadata.go
+++ b/coderd/agentapi/metadata.go
@@ -110,8 +110,7 @@ func (a *MetadataAPI) BatchUpdateMetadata(ctx context.Context, req *agentproto.B
 
 	// Inject RBAC object into context for dbauthz fast path, avoid having to
 	// call GetWorkspaceByAgentID on every metadata update.
-	ctx = a.RBACContextFn(ctx)
-	err = a.Database.UpdateWorkspaceAgentMetadata(ctx, dbUpdate)
+	err = a.Database.UpdateWorkspaceAgentMetadata(a.RBACContextFn(ctx), dbUpdate)
 	if err != nil {
 		return nil, xerrors.Errorf("update workspace agent metadata in database: %w", err)
 	}

--- a/coderd/agentapi/metadata.go
+++ b/coderd/agentapi/metadata.go
@@ -112,7 +112,9 @@ func (a *MetadataAPI) BatchUpdateMetadata(ctx context.Context, req *agentproto.B
 	// call GetWorkspaceByAgentID on every metadata update.
 	rbacCtx, err := a.RBACContextFn(ctx)
 	if err != nil {
-		a.Log.Error(ctx, "cached RBAC Workspace context wrapping was invalid", slog.Error(err))
+		// Don't use error level here; that will fail the call but in reality an invalid object here is okay
+		// since we will then just fallback to the actual GetWorkspaceByAgentID call in dbauthz.
+		a.Log.Warn(ctx, "cached RBAC Workspace context wrapping was invalid", slog.Error(err))
 	}
 	err = a.Database.UpdateWorkspaceAgentMetadata(rbacCtx, dbUpdate)
 	if err != nil {

--- a/coderd/agentapi/metadata.go
+++ b/coderd/agentapi/metadata.go
@@ -112,7 +112,7 @@ func (a *MetadataAPI) BatchUpdateMetadata(ctx context.Context, req *agentproto.B
 	// Inject RBAC object into context for dbauthz fast path, avoid having to
 	// call GetWorkspaceByAgentID on every metadata update.
 	rbacCtx := ctx
-	if dbws, ok := a.Workspace.AsDatabaseWorkspace(); ok {
+	if dbws, ok := a.Workspace.AsWorkspaceIdentity(); ok {
 		rbacCtx, err = dbauthz.WithWorkspaceRBAC(ctx, dbws.RBACObject())
 		if err != nil {
 			// Don't error level log here, will exit the function. We want to fall back to GetWorkspaceByAgentID.

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -90,8 +90,8 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
-				return ctx
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
+				return ctx, nil
 			},
 			Database: dbM,
 			Pubsub:   pub,
@@ -178,8 +178,8 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
-				return ctx
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
+				return ctx, nil
 			},
 			Database: dbM,
 			Pubsub:   pub,
@@ -250,8 +250,8 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
-				return ctx
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
+				return ctx, nil
 			},
 			Database: dbM,
 			Pubsub:   pub,
@@ -349,7 +349,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
 				// Create a valid RBAC object with proper workspace ID, owner ID, and org ID
 				// These IDs match the workspace/owner/org that this agent belongs to
 				workspace := database.Workspace{
@@ -436,7 +436,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
 				// Create an invalid RBAC object with nil UUIDs for owner/org
 				// This will fail dbauthz fast path validation and trigger GetWorkspaceByAgentID
 				workspace := database.Workspace{
@@ -523,10 +523,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
 				// Don't attach any RBAC object - return context as-is
 				// This should trigger the slow path since no cached RBAC object exists
-				return ctx
+				return ctx, nil
 			},
 			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
 			Pubsub:   pub,
@@ -616,7 +616,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 				// Return agent directly without DB call
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) context.Context {
+			RBACContextFn: func(ctx context.Context) (context.Context, error) {
 				// Inject STALE cached RBAC object with prebuild owner
 				// This will cause fast path authorization to fail when real owner calls it
 				workspace := database.Workspace{

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -2,12 +2,14 @@ package agentapi_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -15,10 +17,14 @@ import (
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/agentapi"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 type fakePublisher struct {
@@ -83,6 +89,9 @@ func TestBatchUpdateMetadata(t *testing.T) {
 		api := &agentapi.MetadataAPI{
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
+			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				return ctx
 			},
 			Database: dbM,
 			Pubsub:   pub,
@@ -169,6 +178,9 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				return ctx
+			},
 			Database: dbM,
 			Pubsub:   pub,
 			Log:      testutil.Logger(t),
@@ -238,6 +250,9 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				return ctx
+			},
 			Database: dbM,
 			Pubsub:   pub,
 			Log:      testutil.Logger(t),
@@ -271,5 +286,575 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			// No key 4.
 			Keys: []string{req.Metadata[0].Key, req.Metadata[1].Key, req.Metadata[2].Key},
 		}, gotEvent)
+	})
+
+	// Test RBAC fast path with valid RBAC object - should NOT call GetWorkspaceByAgentID
+	// This test verifies that when a valid RBAC object is present in context, the dbauthz layer
+	// uses the fast path and skips the GetWorkspaceByAgentID database call.
+	t.Run("RBACFastPath_ValidObject", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl = gomock.NewController(t)
+			dbM  = dbmock.NewMockStore(ctrl)
+			pub  = &fakePublisher{}
+			now  = dbtime.Now()
+			// Set up consistent IDs that represent a valid workspace->agent relationship
+			workspaceID = uuid.MustParse("12345678-1234-1234-1234-123456789012")
+			ownerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321")
+			orgID       = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+			agentID     = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		)
+
+		agent := database.WorkspaceAgent{
+			ID: agentID,
+			// In a real scenario, this agent would belong to a resource in the workspace above
+		}
+
+		req := &agentproto.BatchUpdateMetadataRequest{
+			Metadata: []*agentproto.Metadata{
+				{
+					Key: "test_key",
+					Result: &agentproto.WorkspaceAgentMetadata_Result{
+						CollectedAt: timestamppb.New(now.Add(-time.Second)),
+						Age:         1,
+						Value:       "test_value",
+					},
+				},
+			},
+		}
+
+		// Expect UpdateWorkspaceAgentMetadata to be called
+		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), database.UpdateWorkspaceAgentMetadataParams{
+			WorkspaceAgentID: agent.ID,
+			Key:              []string{"test_key"},
+			Value:            []string{"test_value"},
+			Error:            []string{""},
+			CollectedAt:      []time.Time{now},
+		}).Return(nil)
+
+		// DO NOT expect GetWorkspaceByAgentID - the fast path should skip this call
+		// If GetWorkspaceByAgentID is called, the test will fail with "unexpected call"
+
+		// dbauthz will call Wrappers() to check for wrapped databases
+		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+
+		// Set up dbauthz to test the actual authorization layer
+		auth := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
+		accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
+		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
+		accessControlStore.Store(&acs)
+
+		api := &agentapi.MetadataAPI{
+			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
+				return agent, nil
+			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				// Create a valid RBAC object with proper workspace ID, owner ID, and org ID
+				// These IDs match the workspace/owner/org that this agent belongs to
+				workspace := database.Workspace{
+					ID:             workspaceID,
+					OwnerID:        ownerID,
+					OrganizationID: orgID,
+				}
+				return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
+			},
+			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:   pub,
+			Log:      testutil.Logger(t),
+			TimeNowFn: func() time.Time {
+				return now
+			},
+		}
+
+		// Create context with system actor so authorization passes
+		ctx := dbauthz.AsSystemRestricted(context.Background())
+		resp, err := api.BatchUpdateMetadata(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+	// Test RBAC slow path - invalid RBAC object should fall back to GetWorkspaceByAgentID
+	// This test verifies that when the RBAC object has invalid IDs (nil UUIDs), the dbauthz layer
+	// falls back to the slow path and calls GetWorkspaceByAgentID.
+	t.Run("RBACSlowPath_InvalidObject", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl        = gomock.NewController(t)
+			dbM         = dbmock.NewMockStore(ctrl)
+			pub         = &fakePublisher{}
+			now         = dbtime.Now()
+			workspaceID = uuid.MustParse("12345678-1234-1234-1234-123456789012")
+			ownerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321")
+			orgID       = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+			agentID     = uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		)
+
+		agent := database.WorkspaceAgent{
+			ID: agentID,
+		}
+
+		req := &agentproto.BatchUpdateMetadataRequest{
+			Metadata: []*agentproto.Metadata{
+				{
+					Key: "test_key",
+					Result: &agentproto.WorkspaceAgentMetadata_Result{
+						CollectedAt: timestamppb.New(now.Add(-time.Second)),
+						Age:         1,
+						Value:       "test_value",
+					},
+				},
+			},
+		}
+
+		// EXPECT GetWorkspaceByAgentID to be called because the RBAC fast path validation fails
+		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(database.Workspace{
+			ID:             workspaceID,
+			OwnerID:        ownerID,
+			OrganizationID: orgID,
+		}, nil)
+
+		// Expect UpdateWorkspaceAgentMetadata to be called after authorization
+		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), database.UpdateWorkspaceAgentMetadataParams{
+			WorkspaceAgentID: agent.ID,
+			Key:              []string{"test_key"},
+			Value:            []string{"test_value"},
+			Error:            []string{""},
+			CollectedAt:      []time.Time{now},
+		}).Return(nil)
+
+		// dbauthz will call Wrappers() to check for wrapped databases
+		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+
+		// Set up dbauthz to test the actual authorization layer
+		auth := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
+		accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
+		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
+		accessControlStore.Store(&acs)
+
+		api := &agentapi.MetadataAPI{
+			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
+				return agent, nil
+			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				// Create an invalid RBAC object with nil UUIDs for owner/org
+				// This will fail dbauthz fast path validation and trigger GetWorkspaceByAgentID
+				workspace := database.Workspace{
+					ID:             uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+					OwnerID:        uuid.Nil, // Invalid: fails dbauthz fast path validation
+					OrganizationID: uuid.Nil, // Invalid: fails dbauthz fast path validation
+				}
+				return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
+			},
+			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:   pub,
+			Log:      testutil.Logger(t),
+			TimeNowFn: func() time.Time {
+				return now
+			},
+		}
+
+		// Create context with system actor so authorization passes
+		ctx := dbauthz.AsSystemRestricted(context.Background())
+		resp, err := api.BatchUpdateMetadata(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+	// Test RBAC slow path - no RBAC object in context
+	// This test verifies that when no RBAC object is present in context, the dbauthz layer
+	// falls back to the slow path and calls GetWorkspaceByAgentID.
+	t.Run("RBACSlowPath_NoObject", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl        = gomock.NewController(t)
+			dbM         = dbmock.NewMockStore(ctrl)
+			pub         = &fakePublisher{}
+			now         = dbtime.Now()
+			workspaceID = uuid.MustParse("12345678-1234-1234-1234-123456789012")
+			ownerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321")
+			orgID       = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+			agentID     = uuid.MustParse("dddddddd-dddd-dddd-dddd-dddddddddddd")
+		)
+
+		agent := database.WorkspaceAgent{
+			ID: agentID,
+		}
+
+		req := &agentproto.BatchUpdateMetadataRequest{
+			Metadata: []*agentproto.Metadata{
+				{
+					Key: "test_key",
+					Result: &agentproto.WorkspaceAgentMetadata_Result{
+						CollectedAt: timestamppb.New(now.Add(-time.Second)),
+						Age:         1,
+						Value:       "test_value",
+					},
+				},
+			},
+		}
+
+		// EXPECT GetWorkspaceByAgentID to be called because no RBAC object is in context
+		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(database.Workspace{
+			ID:             workspaceID,
+			OwnerID:        ownerID,
+			OrganizationID: orgID,
+		}, nil)
+
+		// Expect UpdateWorkspaceAgentMetadata to be called after authorization
+		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), database.UpdateWorkspaceAgentMetadataParams{
+			WorkspaceAgentID: agent.ID,
+			Key:              []string{"test_key"},
+			Value:            []string{"test_value"},
+			Error:            []string{""},
+			CollectedAt:      []time.Time{now},
+		}).Return(nil)
+
+		// dbauthz will call Wrappers() to check for wrapped databases
+		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+
+		// Set up dbauthz to test the actual authorization layer
+		auth := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
+		accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
+		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
+		accessControlStore.Store(&acs)
+
+		api := &agentapi.MetadataAPI{
+			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
+				return agent, nil
+			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				// Don't attach any RBAC object - return context as-is
+				// This should trigger the slow path since no cached RBAC object exists
+				return ctx
+			},
+			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:   pub,
+			Log:      testutil.Logger(t),
+			TimeNowFn: func() time.Time {
+				return now
+			},
+		}
+
+		// Create context with system actor so authorization passes
+		ctx := dbauthz.AsSystemRestricted(context.Background())
+		resp, err := api.BatchUpdateMetadata(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+	// Test cache staleness - prebuild claimed but cache not refreshed yet
+	// This test verifies that when fast path authorization fails (stale cache),
+	// the dbauthz layer falls back to slow path (GetWorkspaceByAgentID).
+	t.Run("CacheStale_PrebuildClaimed", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl            = gomock.NewController(t)
+			dbM             = dbmock.NewMockStore(ctrl)
+			pub             = &fakePublisher{}
+			now             = dbtime.Now()
+			workspaceID     = uuid.MustParse("12345678-1234-1234-1234-123456789012")
+			prebuildOwnerID = database.PrebuildsSystemUserID                         // Prebuild system user
+			realOwnerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321") // Real user who claimed it
+			orgID           = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+			agentID         = uuid.MustParse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+		)
+
+		agent := database.WorkspaceAgent{
+			ID: agentID,
+		}
+
+		// Claimed workspace state - now owned by real user
+		claimedWorkspace := database.Workspace{
+			ID:             workspaceID,
+			OwnerID:        realOwnerID, // Owner changed!
+			OrganizationID: orgID,
+			Name:           "claimed-workspace",
+		}
+
+		req := &agentproto.BatchUpdateMetadataRequest{
+			Metadata: []*agentproto.Metadata{
+				{
+					Key: "test_key",
+					Result: &agentproto.WorkspaceAgentMetadata_Result{
+						CollectedAt: timestamppb.New(now.Add(-time.Second)),
+						Age:         1,
+						Value:       "test_value",
+					},
+				},
+			},
+		}
+
+		// EXPECT GetWorkspaceByAgentID to be called (slow path fallback)
+		// This should happen because fast path auth fails with stale cache
+		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(claimedWorkspace, nil)
+
+		// Expect UpdateWorkspaceAgentMetadata to be called after slow path succeeds
+		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, params database.UpdateWorkspaceAgentMetadataParams) error {
+				require.Equal(t, agent.ID, params.WorkspaceAgentID)
+				require.Equal(t, []string{"test_key"}, params.Key)
+				require.Equal(t, []string{"test_value"}, params.Value)
+				require.Equal(t, []string{""}, params.Error)
+				require.Len(t, params.CollectedAt, 1)
+				return nil
+			},
+		)
+
+		// dbauthz will call Wrappers()
+		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+
+		// Set up dbauthz
+		auth := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
+		accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
+		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
+		accessControlStore.Store(&acs)
+
+		// Create MetadataAPI directly (not full API) to avoid agent() authorization issues
+		api := &agentapi.MetadataAPI{
+			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
+				// Return agent directly without DB call
+				return agent, nil
+			},
+			RBACContextFn: func(ctx context.Context) context.Context {
+				// Inject STALE cached RBAC object with prebuild owner
+				// This will cause fast path authorization to fail when real owner calls it
+				workspace := database.Workspace{
+					ID:             workspaceID,
+					OwnerID:        prebuildOwnerID, // STALE! Still has prebuild owner
+					OrganizationID: orgID,
+				}
+				return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
+			},
+			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:   pub,
+			Log:      testutil.Logger(t),
+			TimeNowFn: func() time.Time {
+				return now
+			},
+		}
+
+		// Call metadata update as the REAL OWNER
+		// Fast path will try to authorize with stale prebuild owner
+		// This should FAIL, then fall back to slow path with real owner
+		ctx := context.Background()
+
+		// Create agent scope that allows access to the claimed workspace
+		agentScope := rbac.WorkspaceAgentScope(rbac.WorkspaceAgentScopeParams{
+			WorkspaceID: workspaceID,
+			OwnerID:     realOwnerID,
+			TemplateID:  uuid.New(), // Not important for this test
+			VersionID:   uuid.New(), // Not important for this test
+		})
+
+		// Create roles with user-level AND org-level workspace permissions
+		// This simulates what a real user would have
+		userRoles := rbac.Roles([]rbac.Role{
+			{
+				Identifier: rbac.RoleMember(),
+				User: []rbac.Permission{
+					{
+						Negate:       false,
+						ResourceType: rbac.ResourceWorkspace.Type,
+						Action:       policy.WildcardSymbol, // ← NEEDS policy import
+					},
+				},
+				ByOrgID: map[string]rbac.OrgPermissions{
+					orgID.String(): {
+						Member: []rbac.Permission{
+							{
+								Negate:       false,
+								ResourceType: rbac.ResourceWorkspace.Type,
+								Action:       policy.WildcardSymbol, // ← NEEDS policy import
+							},
+						},
+					},
+				},
+			},
+		})
+
+		ctxWithActor := dbauthz.As(ctx, rbac.Subject{
+			Type:         rbac.SubjectTypeUser,
+			FriendlyName: "testuser",
+			Email:        "testuser@example.com",
+			ID:           realOwnerID.String(),
+			Roles:        userRoles,
+			Groups:       []string{orgID.String()},
+			Scope:        agentScope,
+		}.WithCachedASTValue())
+		resp, err := api.BatchUpdateMetadata(ctxWithActor, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// Verify GetWorkspaceByAgentID was called (slow path fallback worked)
+	})
+	// Test cache refresh - prebuild claimed and cache refreshed
+	// This test verifies that the cache refresh mechanism actually calls GetWorkspaceByID
+	// and updates the cached workspace fields when the workspace is claimed.
+	t.Run("CacheRefreshed_PrebuildClaimed", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl            = gomock.NewController(t)
+			dbM             = dbmock.NewMockStore(ctrl)
+			pub             = &fakePublisher{}
+			now             = dbtime.Now()
+			mClock          = quartz.NewMock(t)
+			tickerTrap      = mClock.Trap().TickerFunc("cache_refresh")
+			workspaceID     = uuid.MustParse("12345678-1234-1234-1234-123456789012")
+			prebuildOwnerID = database.PrebuildsSystemUserID
+			realOwnerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321")
+			orgID           = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+			templateID      = uuid.MustParse("aaaabbbb-cccc-dddd-eeee-ffffffff0000")
+			agentID         = uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+		)
+
+		agent := database.WorkspaceAgent{
+			ID: agentID,
+		}
+
+		// Initial workspace - owned by prebuild system
+		initialWorkspace := database.Workspace{
+			ID:             workspaceID,
+			OwnerID:        prebuildOwnerID,
+			OrganizationID: orgID,
+			TemplateID:     templateID,
+			Name:           "prebuild-workspace",
+			OwnerUsername:  "prebuild-system",
+			TemplateName:   "test-template",
+		}
+
+		// Claimed workspace - now owned by real user
+		claimedWorkspace := database.Workspace{
+			ID:                workspaceID,
+			OwnerID:           realOwnerID, // Owner changed!
+			OrganizationID:    orgID,
+			TemplateID:        templateID,
+			Name:              "claimed-workspace",
+			OwnerUsername:     "real-user",
+			TemplateName:      "test-template",
+			AutostartSchedule: sql.NullString{Valid: true, String: "CRON_TZ=UTC 0 9 * * 1-5"},
+			DormantAt:         sql.NullTime{},
+		}
+
+		req := &agentproto.BatchUpdateMetadataRequest{
+			Metadata: []*agentproto.Metadata{
+				{
+					Key: "test_key",
+					Result: &agentproto.WorkspaceAgentMetadata_Result{
+						CollectedAt: timestamppb.New(now.Add(-time.Second)),
+						Age:         1,
+						Value:       "test_value",
+					},
+				},
+			},
+		}
+
+		// EXPECT GetWorkspaceByID to be called during cache refresh
+		// This proves the refresh mechanism is working
+		dbM.EXPECT().GetWorkspaceByID(gomock.Any(), workspaceID).Return(claimedWorkspace, nil)
+
+		// API needs to fetch the agent when calling metadata update
+		dbM.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).Return(agent, nil)
+
+		// After refresh, metadata update should work with updated cache
+		// We don't strictly require fast path here, just that it works
+		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, params database.UpdateWorkspaceAgentMetadataParams) error {
+				require.Equal(t, agent.ID, params.WorkspaceAgentID)
+				require.Equal(t, []string{"test_key"}, params.Key)
+				require.Equal(t, []string{"test_value"}, params.Value)
+				require.Equal(t, []string{""}, params.Error)
+				require.Len(t, params.CollectedAt, 1)
+				return nil
+			},
+		).AnyTimes() // May be called with or without slow path
+
+		// May call GetWorkspaceByAgentID if slow path is used
+		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(claimedWorkspace, nil).AnyTimes()
+
+		// dbauthz will call Wrappers()
+		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
+
+		// Set up dbauthz
+		auth := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
+		accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
+		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
+		accessControlStore.Store(&acs)
+
+		// Create context with system actor so refresh can authorize GetWorkspaceByID
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Create roles with user-level workspace permissions
+		// This simulates what a real user would have
+		userRoles := rbac.Roles([]rbac.Role{
+			{
+				Identifier: rbac.RoleMember(),
+				User: []rbac.Permission{
+					{
+						Negate:       false,
+						ResourceType: rbac.ResourceWorkspace.Type,
+						Action:       policy.WildcardSymbol,
+					},
+				},
+				ByOrgID: map[string]rbac.OrgPermissions{ // ← ADDED THIS
+					orgID.String(): {
+						Member: []rbac.Permission{
+							{
+								Negate:       false,
+								ResourceType: rbac.ResourceWorkspace.Type,
+								Action:       policy.WildcardSymbol,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		// Create agent scope that allows access to the claimed workspace
+		agentScope := rbac.WorkspaceAgentScope(rbac.WorkspaceAgentScopeParams{
+			WorkspaceID: workspaceID,
+			OwnerID:     realOwnerID,
+			TemplateID:  uuid.New(), // Not important for this test
+			VersionID:   uuid.New(), // Not important for this test
+		})
+		ctxWithActor := dbauthz.As(ctx, rbac.Subject{
+			Type:         rbac.SubjectTypeUser,
+			FriendlyName: "testuser",
+			Email:        "testuser@example.com",
+			ID:           realOwnerID.String(),
+			Roles:        userRoles, // ← Uses the roles with ByOrgID
+			Groups:       []string{orgID.String()},
+			Scope:        agentScope,
+		}.WithCachedASTValue())
+
+		// Create full API with cached workspace fields (prebuild owner)
+		api := agentapi.New(agentapi.Options{
+			Ctx:            ctxWithActor,
+			AgentID:        agentID,
+			WorkspaceID:    workspaceID,
+			OwnerID:        prebuildOwnerID, // Initially prebuild owner
+			OrganizationID: orgID,
+			Database:       dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Log:            testutil.Logger(t),
+			Clock:          mClock,
+			Pubsub:         pub,
+		}, initialWorkspace)
+
+		// Wait for ticker to be set up and release it so it can fire
+		tickerTrap.MustWait(ctx).MustRelease(ctx)
+		tickerTrap.Close()
+
+		// Advance clock to trigger cache refresh and wait for it to complete
+		_, aw := mClock.AdvanceNext()
+		aw.MustWait(ctx)
+
+		// At this point, GetWorkspaceByID should have been called and cache updated
+		// Now call metadata update to verify the refreshed cache works
+		resp, err := api.MetadataAPI.BatchUpdateMetadata(ctxWithActor, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// Success! The cache refresh worked and metadata update succeeded
 	})
 }

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -285,7 +285,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 	// Test RBAC fast path with valid RBAC object - should NOT call GetWorkspaceByAgentID
 	// This test verifies that when a valid RBAC object is present in context, the dbauthz layer
 	// uses the fast path and skips the GetWorkspaceByAgentID database call.
-	t.Run("RBACFastPath_ValidObject", func(t *testing.T) {
+	t.Run("WorkspaceCached_SkipsDBCall", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -367,7 +367,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 	// Test RBAC slow path - invalid RBAC object should fall back to GetWorkspaceByAgentID
 	// This test verifies that when the RBAC object has invalid IDs (nil UUIDs), the dbauthz layer
 	// falls back to the slow path and calls GetWorkspaceByAgentID.
-	t.Run("RBACSlowPath_InvalidObject", func(t *testing.T) {
+	t.Run("InvalidWorkspaceCached_RequiresDBCall", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -454,7 +454,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 	// Test RBAC slow path - no RBAC object in context
 	// This test verifies that when no RBAC object is present in context, the dbauthz layer
 	// falls back to the slow path and calls GetWorkspaceByAgentID.
-	t.Run("RBACSlowPath_NoObject", func(t *testing.T) {
+	t.Run("WorkspaceNotCached_RequiresDBCall", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -529,195 +529,54 @@ func TestBatchUpdateMetadata(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 	})
-	// Test cache staleness - prebuild claimed but cache not refreshed yet
-	// This test verifies that when fast path authorization fails (stale cache),
-	// the dbauthz layer falls back to slow path (GetWorkspaceByAgentID).
-	t.Run("CacheStale_PrebuildClaimed", func(t *testing.T) {
-		t.Parallel()
 
-		var (
-			ctrl            = gomock.NewController(t)
-			dbM             = dbmock.NewMockStore(ctrl)
-			pub             = &fakePublisher{}
-			now             = dbtime.Now()
-			workspaceID     = uuid.MustParse("12345678-1234-1234-1234-123456789012")
-			prebuildOwnerID = database.PrebuildsSystemUserID                         // Prebuild system user
-			realOwnerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321") // Real user who claimed it
-			orgID           = uuid.MustParse("11111111-1111-1111-1111-111111111111")
-			agentID         = uuid.MustParse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
-		)
-
-		agent := database.WorkspaceAgent{
-			ID: agentID,
-		}
-
-		// Claimed workspace state - now owned by real user
-		claimedWorkspace := database.Workspace{
-			ID:             workspaceID,
-			OwnerID:        realOwnerID, // Owner changed!
-			OrganizationID: orgID,
-			Name:           "claimed-workspace",
-		}
-
-		req := &agentproto.BatchUpdateMetadataRequest{
-			Metadata: []*agentproto.Metadata{
-				{
-					Key: "test_key",
-					Result: &agentproto.WorkspaceAgentMetadata_Result{
-						CollectedAt: timestamppb.New(now.Add(-time.Second)),
-						Age:         1,
-						Value:       "test_value",
-					},
-				},
-			},
-		}
-
-		// EXPECT GetWorkspaceByAgentID to be called (slow path fallback)
-		// This should happen because fast path auth fails with stale cache
-		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(claimedWorkspace, nil)
-
-		// Expect UpdateWorkspaceAgentMetadata to be called after slow path succeeds
-		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, params database.UpdateWorkspaceAgentMetadataParams) error {
-				require.Equal(t, agent.ID, params.WorkspaceAgentID)
-				require.Equal(t, []string{"test_key"}, params.Key)
-				require.Equal(t, []string{"test_value"}, params.Value)
-				require.Equal(t, []string{""}, params.Error)
-				require.Len(t, params.CollectedAt, 1)
-				return nil
-			},
-		)
-
-		// dbauthz will call Wrappers()
-		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
-
-		// Set up dbauthz
-		auth := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
-		accessControlStore := &atomic.Pointer[dbauthz.AccessControlStore]{}
-		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
-		accessControlStore.Store(&acs)
-
-		// Create MetadataAPI directly (not full API) to avoid agent() authorization issues
-		api := &agentapi.MetadataAPI{
-			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
-				// Return agent directly without DB call
-				return agent, nil
-			},
-			Workspace: &agentapi.CachedWorkspaceFields{},
-			Database:  dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
-			Pubsub:    pub,
-			Log:       testutil.Logger(t),
-			TimeNowFn: func() time.Time {
-				return now
-			},
-		}
-
-		api.Workspace.UpdateValues(database.Workspace{
-			ID:             workspaceID,
-			OwnerID:        prebuildOwnerID, // STALE! Still has prebuild owner
-			OrganizationID: orgID,
-		})
-
-		// Call metadata update as the REAL OWNER
-		// Fast path will try to authorize with stale prebuild owner
-		// This should FAIL, then fall back to slow path with real owner
-		ctx := context.Background()
-
-		// Create agent scope that allows access to the claimed workspace
-		agentScope := rbac.WorkspaceAgentScope(rbac.WorkspaceAgentScopeParams{
-			WorkspaceID: workspaceID,
-			OwnerID:     realOwnerID,
-			TemplateID:  uuid.New(), // Not important for this test
-			VersionID:   uuid.New(), // Not important for this test
-		})
-
-		// Create roles with user-level AND org-level workspace permissions
-		// This simulates what a real user would have
-		userRoles := rbac.Roles([]rbac.Role{
-			{
-				Identifier: rbac.RoleMember(),
-				User: []rbac.Permission{
-					{
-						Negate:       false,
-						ResourceType: rbac.ResourceWorkspace.Type,
-						Action:       policy.WildcardSymbol, // ← NEEDS policy import
-					},
-				},
-				ByOrgID: map[string]rbac.OrgPermissions{
-					orgID.String(): {
-						Member: []rbac.Permission{
-							{
-								Negate:       false,
-								ResourceType: rbac.ResourceWorkspace.Type,
-								Action:       policy.WildcardSymbol, // ← NEEDS policy import
-							},
-						},
-					},
-				},
-			},
-		})
-
-		ctxWithActor := dbauthz.As(ctx, rbac.Subject{
-			Type:         rbac.SubjectTypeUser,
-			FriendlyName: "testuser",
-			Email:        "testuser@example.com",
-			ID:           realOwnerID.String(),
-			Roles:        userRoles,
-			Groups:       []string{orgID.String()},
-			Scope:        agentScope,
-		}.WithCachedASTValue())
-		resp, err := api.BatchUpdateMetadata(ctxWithActor, req)
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-
-		// Verify GetWorkspaceByAgentID was called (slow path fallback worked)
-	})
-	// Test cache refresh - prebuild claimed and cache refreshed
+	// Test cache refresh - AutostartSchedule updated
 	// This test verifies that the cache refresh mechanism actually calls GetWorkspaceByID
-	// and updates the cached workspace fields when the workspace is claimed.
-	t.Run("CacheRefreshed_PrebuildClaimed", func(t *testing.T) {
+	// and updates the cached workspace fields when the workspace is modified (e.g., autostart schedule changes).
+	t.Run("CacheRefreshed_AutostartScheduleUpdated", func(t *testing.T) {
 		t.Parallel()
 
 		var (
-			ctrl            = gomock.NewController(t)
-			dbM             = dbmock.NewMockStore(ctrl)
-			pub             = &fakePublisher{}
-			now             = dbtime.Now()
-			mClock          = quartz.NewMock(t)
-			tickerTrap      = mClock.Trap().TickerFunc("cache_refresh")
-			workspaceID     = uuid.MustParse("12345678-1234-1234-1234-123456789012")
-			prebuildOwnerID = database.PrebuildsSystemUserID
-			realOwnerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321")
-			orgID           = uuid.MustParse("11111111-1111-1111-1111-111111111111")
-			templateID      = uuid.MustParse("aaaabbbb-cccc-dddd-eeee-ffffffff0000")
-			agentID         = uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+			ctrl       = gomock.NewController(t)
+			dbM        = dbmock.NewMockStore(ctrl)
+			pub        = &fakePublisher{}
+			now        = dbtime.Now()
+			mClock     = quartz.NewMock(t)
+			tickerTrap = mClock.Trap().TickerFunc("cache_refresh")
+
+			workspaceID = uuid.MustParse("12345678-1234-1234-1234-123456789012")
+			ownerID     = uuid.MustParse("87654321-4321-4321-4321-210987654321")
+			orgID       = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+			templateID  = uuid.MustParse("aaaabbbb-cccc-dddd-eeee-ffffffff0000")
+			agentID     = uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
 		)
 
 		agent := database.WorkspaceAgent{
 			ID: agentID,
 		}
 
-		// Initial workspace - owned by prebuild system
+		// Initial workspace - has Monday-Friday 9am autostart
 		initialWorkspace := database.Workspace{
-			ID:             workspaceID,
-			OwnerID:        prebuildOwnerID,
-			OrganizationID: orgID,
-			TemplateID:     templateID,
-			Name:           "prebuild-workspace",
-			OwnerUsername:  "prebuild-system",
-			TemplateName:   "test-template",
-		}
-
-		// Claimed workspace - now owned by real user
-		claimedWorkspace := database.Workspace{
 			ID:                workspaceID,
-			OwnerID:           realOwnerID, // Owner changed!
+			OwnerID:           ownerID,
 			OrganizationID:    orgID,
 			TemplateID:        templateID,
-			Name:              "claimed-workspace",
-			OwnerUsername:     "real-user",
+			Name:              "my-workspace",
+			OwnerUsername:     "testuser",
 			TemplateName:      "test-template",
 			AutostartSchedule: sql.NullString{Valid: true, String: "CRON_TZ=UTC 0 9 * * 1-5"},
+		}
+
+		// Updated workspace - user changed autostart to 5pm and renamed workspace
+		updatedWorkspace := database.Workspace{
+			ID:                workspaceID,
+			OwnerID:           ownerID,
+			OrganizationID:    orgID,
+			TemplateID:        templateID,
+			Name:              "my-workspace-renamed", // Changed!
+			OwnerUsername:     "testuser",
+			TemplateName:      "test-template",
+			AutostartSchedule: sql.NullString{Valid: true, String: "CRON_TZ=UTC 0 17 * * 1-5"}, // Changed!
 			DormantAt:         sql.NullTime{},
 		}
 
@@ -735,14 +594,13 @@ func TestBatchUpdateMetadata(t *testing.T) {
 		}
 
 		// EXPECT GetWorkspaceByID to be called during cache refresh
-		// This proves the refresh mechanism is working
-		dbM.EXPECT().GetWorkspaceByID(gomock.Any(), workspaceID).Return(claimedWorkspace, nil)
+		// This is the key assertion - proves the refresh mechanism is working
+		dbM.EXPECT().GetWorkspaceByID(gomock.Any(), workspaceID).Return(updatedWorkspace, nil)
 
 		// API needs to fetch the agent when calling metadata update
 		dbM.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).Return(agent, nil)
 
 		// After refresh, metadata update should work with updated cache
-		// We don't strictly require fast path here, just that it works
 		dbM.EXPECT().UpdateWorkspaceAgentMetadata(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, params database.UpdateWorkspaceAgentMetadataParams) error {
 				require.Equal(t, agent.ID, params.WorkspaceAgentID)
@@ -752,10 +610,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 				require.Len(t, params.CollectedAt, 1)
 				return nil
 			},
-		).AnyTimes() // May be called with or without slow path
+		).AnyTimes()
 
-		// May call GetWorkspaceByAgentID if slow path is used
-		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(claimedWorkspace, nil).AnyTimes()
+		// May call GetWorkspaceByAgentID if slow path is used before refresh
+		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(updatedWorkspace, nil).AnyTimes()
 
 		// dbauthz will call Wrappers()
 		dbM.EXPECT().Wrappers().Return([]string{}).AnyTimes()
@@ -766,11 +624,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 		var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
 		accessControlStore.Store(&acs)
 
-		// Create context with system actor so refresh can authorize GetWorkspaceByID
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Create roles with user-level workspace permissions
-		// This simulates what a real user would have
+
+		// Create roles with workspace permissions
 		userRoles := rbac.Roles([]rbac.Role{
 			{
 				Identifier: rbac.RoleMember(),
@@ -781,7 +638,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 						Action:       policy.WildcardSymbol,
 					},
 				},
-				ByOrgID: map[string]rbac.OrgPermissions{ // ← ADDED THIS
+				ByOrgID: map[string]rbac.OrgPermissions{
 					orgID.String(): {
 						Member: []rbac.Permission{
 							{
@@ -795,35 +652,35 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			},
 		})
 
-		// Create agent scope that allows access to the claimed workspace
 		agentScope := rbac.WorkspaceAgentScope(rbac.WorkspaceAgentScopeParams{
 			WorkspaceID: workspaceID,
-			OwnerID:     realOwnerID,
-			TemplateID:  uuid.New(), // Not important for this test
-			VersionID:   uuid.New(), // Not important for this test
+			OwnerID:     ownerID,
+			TemplateID:  templateID,
+			VersionID:   uuid.New(),
 		})
+
 		ctxWithActor := dbauthz.As(ctx, rbac.Subject{
 			Type:         rbac.SubjectTypeUser,
 			FriendlyName: "testuser",
 			Email:        "testuser@example.com",
-			ID:           realOwnerID.String(),
-			Roles:        userRoles, // ← Uses the roles with ByOrgID
+			ID:           ownerID.String(),
+			Roles:        userRoles,
 			Groups:       []string{orgID.String()},
 			Scope:        agentScope,
 		}.WithCachedASTValue())
 
-		// Create full API with cached workspace fields (prebuild owner)
+		// Create full API with cached workspace fields (initial state)
 		api := agentapi.New(agentapi.Options{
 			Ctx:            ctxWithActor,
 			AgentID:        agentID,
 			WorkspaceID:    workspaceID,
-			OwnerID:        prebuildOwnerID, // Initially prebuild owner
+			OwnerID:        ownerID,
 			OrganizationID: orgID,
 			Database:       dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
 			Log:            testutil.Logger(t),
 			Clock:          mClock,
 			Pubsub:         pub,
-		}, initialWorkspace)
+		}, initialWorkspace) // Cache is initialized with 9am schedule and "my-workspace" name
 
 		// Wait for ticker to be set up and release it so it can fire
 		tickerTrap.MustWait(ctx).MustRelease(ctx)
@@ -834,11 +691,11 @@ func TestBatchUpdateMetadata(t *testing.T) {
 		aw.MustWait(ctx)
 
 		// At this point, GetWorkspaceByID should have been called and cache updated
+		// The cache now has the 5pm schedule and "my-workspace-renamed" name
+
 		// Now call metadata update to verify the refreshed cache works
 		resp, err := api.MetadataAPI.BatchUpdateMetadata(ctxWithActor, req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-
-		// Success! The cache refresh worked and metadata update succeeded
 	})
 }

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -343,11 +343,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			Workspace: &agentapi.CachedWorkspaceFields{
-			},
-			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Workspace: &agentapi.CachedWorkspaceFields{},
+			Database:  dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
@@ -429,12 +428,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 				return agent, nil
 			},
 
-			Workspace: &agentapi.CachedWorkspaceFields{
-				
-			},
-			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Workspace: &agentapi.CachedWorkspaceFields{},
+			Database:  dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
@@ -607,18 +604,18 @@ func TestBatchUpdateMetadata(t *testing.T) {
 				return agent, nil
 			},
 			Workspace: &agentapi.CachedWorkspaceFields{},
-			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Database:  dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
 		}
 
 		api.Workspace.UpdateValues(database.Workspace{
-				ID:             workspaceID,
-				OwnerID:        prebuildOwnerID, // STALE! Still has prebuild owner
-				OrganizationID: orgID,
+			ID:             workspaceID,
+			OwnerID:        prebuildOwnerID, // STALE! Still has prebuild owner
+			OrganizationID: orgID,
 		})
 
 		// Call metadata update as the REAL OWNER

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -90,12 +90,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				return ctx, nil
-			},
-			Database: dbM,
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Workspace: &agentapi.CachedWorkspaceFields{},
+			Database:  dbM,
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
@@ -178,12 +176,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				return ctx, nil
-			},
-			Database: dbM,
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Workspace: &agentapi.CachedWorkspaceFields{},
+			Database:  dbM,
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
@@ -250,12 +246,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				return ctx, nil
-			},
-			Database: dbM,
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Workspace: &agentapi.CachedWorkspaceFields{},
+			Database:  dbM,
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
@@ -349,15 +343,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				// Create a valid RBAC object with proper workspace ID, owner ID, and org ID
-				// These IDs match the workspace/owner/org that this agent belongs to
-				workspace := database.Workspace{
-					ID:             workspaceID,
-					OwnerID:        ownerID,
-					OrganizationID: orgID,
-				}
-				return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
+			Workspace: &agentapi.CachedWorkspaceFields{
+				ID:             workspaceID,
+				OwnerID:        ownerID,
+				OrganizationID: orgID,
 			},
 			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
 			Pubsub:   pub,
@@ -436,15 +425,12 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				// Create an invalid RBAC object with nil UUIDs for owner/org
-				// This will fail dbauthz fast path validation and trigger GetWorkspaceByAgentID
-				workspace := database.Workspace{
-					ID:             uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
-					OwnerID:        uuid.Nil, // Invalid: fails dbauthz fast path validation
-					OrganizationID: uuid.Nil, // Invalid: fails dbauthz fast path validation
-				}
-				return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
+			// Create an invalid RBAC object with nil UUIDs for owner/org
+			// This will fail dbauthz fast path validation and trigger GetWorkspaceByAgentID
+			Workspace: &agentapi.CachedWorkspaceFields{
+				ID:             uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+				OwnerID:        uuid.Nil, // Invalid: fails dbauthz fast path validation
+				OrganizationID: uuid.Nil, // Invalid: fails dbauthz fast path validation
 			},
 			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
 			Pubsub:   pub,
@@ -523,14 +509,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 			AgentFn: func(_ context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				// Don't attach any RBAC object - return context as-is
-				// This should trigger the slow path since no cached RBAC object exists
-				return ctx, nil
-			},
-			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
-			Pubsub:   pub,
-			Log:      testutil.Logger(t),
+			Workspace: &agentapi.CachedWorkspaceFields{},
+			Database:  dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Pubsub:    pub,
+			Log:       testutil.Logger(t),
 			TimeNowFn: func() time.Time {
 				return now
 			},
@@ -616,15 +598,10 @@ func TestBatchUpdateMetadata(t *testing.T) {
 				// Return agent directly without DB call
 				return agent, nil
 			},
-			RBACContextFn: func(ctx context.Context) (context.Context, error) {
-				// Inject STALE cached RBAC object with prebuild owner
-				// This will cause fast path authorization to fail when real owner calls it
-				workspace := database.Workspace{
-					ID:             workspaceID,
-					OwnerID:        prebuildOwnerID, // STALE! Still has prebuild owner
-					OrganizationID: orgID,
-				}
-				return dbauthz.WithWorkspaceRBAC(ctx, workspace.RBACObject())
+			Workspace: &agentapi.CachedWorkspaceFields{
+				ID:             workspaceID,
+				OwnerID:        prebuildOwnerID, // STALE! Still has prebuild owner
+				OrganizationID: orgID,
 			},
 			Database: dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
 			Pubsub:   pub,

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -17,7 +17,7 @@ import (
 
 type StatsAPI struct {
 	AgentFn                   func(context.Context) (database.WorkspaceAgent, error)
-	WorkspaceFn               func() (database.Workspace, error)
+	WorkspaceFn               func() database.Workspace
 	Database                  database.Store
 	Log                       slog.Logger
 	StatsReporter             *workspacestats.Reporter
@@ -48,10 +48,7 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 		return nil, err
 	}
 	// Construct workspace from cached fields to avoid DB query
-	workspace, err := a.WorkspaceFn()
-	if err != nil {
-		return nil, err
-	}
+	workspace:= a.WorkspaceFn()
 
 	a.Log.Debug(ctx, "read stats report",
 		slog.F("interval", a.AgentStatsRefreshInterval),

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -48,7 +48,7 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 		return nil, err
 	}
 	// Construct workspace from cached fields to avoid DB query
-	workspace:= a.WorkspaceFn()
+	workspace := a.WorkspaceFn()
 
 	a.Log.Debug(ctx, "read stats report",
 		slog.F("interval", a.AgentStatsRefreshInterval),

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -50,8 +49,9 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 	}
 
 	// If cache is empty (prebuild or invalid), fall back to DB
-	ws := a.Workspace.AsDatabaseWorkspace()
-	if a.Workspace.ID == uuid.Nil {
+	var ws database.Workspace
+	var ok bool
+	if ws, ok = a.Workspace.AsDatabaseWorkspace(); !ok {
 		ws, err = a.Database.GetWorkspaceByAgentID(ctx, workspaceAgent.ID)
 		if err != nil {
 			return nil, xerrors.Errorf("get workspace by agent ID %q: %w", workspaceAgent.ID, err)

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -50,14 +50,12 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 	}
 
 	// If cache is empty (prebuild or invalid), fall back to DB
+	ws := a.Workspace.AsDatabaseWorkspace()
 	if a.Workspace.ID == uuid.Nil {
-		ws, err := a.Database.GetWorkspaceByAgentID(ctx, workspaceAgent.ID)
+		ws, err = a.Database.GetWorkspaceByAgentID(ctx, workspaceAgent.ID)
 		if err != nil {
 			return nil, xerrors.Errorf("get workspace by agent ID %q: %w", workspaceAgent.ID, err)
 		}
-		// a.refre
-		// todo updates
-		a.Workspace.ID = ws.ID
 	}
 
 	a.Log.Debug(ctx, "read stats report",
@@ -79,9 +77,9 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 	err = a.StatsReporter.ReportAgentStats(
 		ctx,
 		a.now(),
-		a.Workspace.AsDatabaseWorkspace(),
+		ws,
 		workspaceAgent,
-		a.Workspace.TemplateName,
+		ws.TemplateName,
 		req.Stats,
 		false,
 	)

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"golang.org/x/xerrors"
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"cdr.dev/slog"

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -52,16 +52,18 @@ func TestUpdateStates(t *testing.T) {
 			ID:   uuid.New(),
 			Name: "abc",
 		}
-		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
-			ID:                workspace.ID,
-			OwnerID:           workspace.OwnerID,
-			OwnerUsername:     workspace.OwnerUsername,
-			TemplateID:        workspace.TemplateID,
-			Name:              workspace.Name,
-			TemplateName:      workspace.TemplateName,
-			AutostartSchedule: workspace.AutostartSchedule,
-		}
+		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{}
 	)
+
+	workspaceAsCacheFields.UpdateValues(database.Workspace{
+		ID:                workspace.ID,
+		OwnerID:           workspace.OwnerID,
+		OwnerUsername:     workspace.OwnerUsername,
+		TemplateID:        workspace.TemplateID,
+		Name:              workspace.Name,
+		TemplateName:      workspace.TemplateName,
+		AutostartSchedule: workspace.AutostartSchedule,
+	})
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
@@ -342,7 +344,7 @@ func TestUpdateStates(t *testing.T) {
 		// need to overwrite the cached fields for this test, but the struct has a lock
 		ws := agentapi.CachedWorkspaceFields{}
 		ws.UpdateValues(workspace)
-		ws.AutostartSchedule = workspace.AutostartSchedule
+		// ws.AutostartSchedule = workspace.AutostartSchedule
 
 		api := agentapi.StatsAPI{
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -339,8 +339,9 @@ func TestUpdateStates(t *testing.T) {
 				},
 			}
 		)
-		// need to overwrite the cached fields for this test
-		ws := workspaceAsCacheFields
+		// need to overwrite the cached fields for this test, but the struct has a lock
+		ws := agentapi.CachedWorkspaceFields{}
+		ws.UpdateValues(workspace)
 		ws.AutostartSchedule = workspace.AutostartSchedule
 
 		api := agentapi.StatsAPI{

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -52,6 +52,14 @@ func TestUpdateStates(t *testing.T) {
 			ID:   uuid.New(),
 			Name: "abc",
 		}
+		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
+			ID:            workspace.ID,
+			OwnerID:       workspace.OwnerID,
+			OwnerUsername: workspace.OwnerUsername,
+			TemplateID:    workspace.TemplateID,
+			Name:          workspace.Name,
+			TemplateName:  workspace.TemplateName,
+		}
 	)
 
 	t.Run("OK", func(t *testing.T) {
@@ -111,10 +119,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() database.Workspace {
-				return workspace
-			},
-			Database: dbM,
+			Workspace: &workspaceAsCacheFields,
+			Database:  dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
 				Pubsub:                ps,
@@ -223,10 +229,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() database.Workspace {
-				return workspace
-			},
-			Database: dbM,
+			Workspace: &workspaceAsCacheFields,
+			Database:  dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
 				Pubsub:                ps,
@@ -260,10 +264,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() database.Workspace {
-				return workspace
-			},
-			Database: dbM,
+			Workspace: &workspaceAsCacheFields,
+			Database:  dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
 				Pubsub:                ps,
@@ -340,10 +342,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() database.Workspace {
-				return workspace
-			},
-			Database: dbM,
+			Workspace: &workspaceAsCacheFields,
+			Database:  dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
 				Pubsub:                ps,
@@ -454,10 +454,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() database.Workspace {
-				return workspace
-			},
-			Database: dbM,
+			Workspace: &workspaceAsCacheFields,
+			Database:  dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
 				Pubsub:                ps,

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -111,8 +111,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() (database.Workspace, error) {
-				return workspace, nil
+			WorkspaceFn: func() database.Workspace {
+				return workspace
 			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
@@ -223,8 +223,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() (database.Workspace, error) {
-				return workspace, nil
+			WorkspaceFn: func() database.Workspace {
+				return workspace
 			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
@@ -260,8 +260,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() (database.Workspace, error) {
-				return workspace, nil
+			WorkspaceFn: func() database.Workspace {
+				return workspace
 			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
@@ -340,8 +340,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() (database.Workspace, error) {
-				return workspace, nil
+			WorkspaceFn: func() database.Workspace {
+				return workspace
 			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
@@ -454,8 +454,8 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			WorkspaceFn: func() (database.Workspace, error) {
-				return workspace, nil
+			WorkspaceFn: func() database.Workspace {
+				return workspace
 			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -53,12 +53,13 @@ func TestUpdateStates(t *testing.T) {
 			Name: "abc",
 		}
 		workspaceAsCacheFields = agentapi.CachedWorkspaceFields{
-			ID:            workspace.ID,
-			OwnerID:       workspace.OwnerID,
-			OwnerUsername: workspace.OwnerUsername,
-			TemplateID:    workspace.TemplateID,
-			Name:          workspace.Name,
-			TemplateName:  workspace.TemplateName,
+			ID:                workspace.ID,
+			OwnerID:           workspace.OwnerID,
+			OwnerUsername:     workspace.OwnerUsername,
+			TemplateID:        workspace.TemplateID,
+			Name:              workspace.Name,
+			TemplateName:      workspace.TemplateName,
+			AutostartSchedule: workspace.AutostartSchedule,
 		}
 	)
 
@@ -338,11 +339,15 @@ func TestUpdateStates(t *testing.T) {
 				},
 			}
 		)
+		// need to overwrite the cached fields for this test
+		ws := workspaceAsCacheFields
+		ws.AutostartSchedule = workspace.AutostartSchedule
+
 		api := agentapi.StatsAPI{
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
-			Workspace: &workspaceAsCacheFields,
+			Workspace: &ws,
 			Database:  dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -111,6 +111,9 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
+			WorkspaceFn: func() (database.Workspace, error) {
+				return workspace, nil
+			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
@@ -135,9 +138,6 @@ func TestUpdateStates(t *testing.T) {
 			},
 		}
 		defer wut.Close()
-
-		// Workspace gets fetched.
-		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
 
 		// We expect an activity bump because ConnectionCount > 0.
 		dbM.EXPECT().ActivityBumpWorkspace(gomock.Any(), database.ActivityBumpWorkspaceParams{
@@ -223,6 +223,9 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
+			WorkspaceFn: func() (database.Workspace, error) {
+				return workspace, nil
+			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
@@ -238,9 +241,6 @@ func TestUpdateStates(t *testing.T) {
 				return now
 			},
 		}
-
-		// Workspace gets fetched.
-		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
 
 		_, err := api.UpdateStats(context.Background(), req)
 		require.NoError(t, err)
@@ -259,6 +259,9 @@ func TestUpdateStates(t *testing.T) {
 		api := agentapi.StatsAPI{
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
+			},
+			WorkspaceFn: func() (database.Workspace, error) {
+				return workspace, nil
 			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
@@ -337,6 +340,9 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
+			WorkspaceFn: func() (database.Workspace, error) {
+				return workspace, nil
+			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
@@ -361,9 +367,6 @@ func TestUpdateStates(t *testing.T) {
 			},
 		}
 		defer wut.Close()
-
-		// Workspace gets fetched.
-		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
 
 		// We expect an activity bump because ConnectionCount > 0. However, the
 		// next autostart time will be set on the bump.
@@ -451,6 +454,9 @@ func TestUpdateStates(t *testing.T) {
 			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 				return agent, nil
 			},
+			WorkspaceFn: func() (database.Workspace, error) {
+				return workspace, nil
+			},
 			Database: dbM,
 			StatsReporter: workspacestats.NewReporter(workspacestats.ReporterOptions{
 				Database:              dbM,
@@ -477,9 +483,6 @@ func TestUpdateStates(t *testing.T) {
 				codersdk.ExperimentWorkspaceUsage,
 			},
 		}
-
-		// Workspace gets fetched.
-		dbM.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agent.ID).Return(workspace, nil)
 
 		// We expect an activity bump because ConnectionCount > 0.
 		dbM.EXPECT().ActivityBumpWorkspace(gomock.Any(), database.ActivityBumpWorkspaceParams{

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -208,8 +209,17 @@ type workspaceRBACContextKey struct{}
 //
 // This is primarily used by the workspace agent RPC handler to cache workspace
 // authorization data for the duration of an agent connection.
-func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) context.Context {
-	return context.WithValue(ctx, workspaceRBACContextKey{}, rbacObj)
+func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) (context.Context, error) {
+	if rbacObj.Type != rbac.ResourceWorkspace.Type {
+		return ctx, errors.New("RBAC Object must be of type Workspace")
+	}
+	if rbacObj.IsEmpty() {
+		return ctx, fmt.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
+	}
+	if rbacObj.ACLGroupList != nil || len(rbacObj.ACLGroupList) != 0 || rbacObj.ACLUserList != nil || len(rbacObj.ACLUserList) != 0 {
+		return ctx, errors.New("ACL fields for Workspace RBAC object must be nil, the can be changed during runtime and should not be cached")
+	}
+	return context.WithValue(ctx, workspaceRBACContextKey{}, rbacObj), nil
 }
 
 // WorkspaceRBACFromContext attempts to retrieve the workspace RBAC object from context.

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5522,7 +5522,7 @@ func (q *querier) UpdateWorkspaceAgentMetadata(ctx context.Context, arg database
 			}
 			// Errors here will result in falling back to the GetWorkspaceAgentByID query, skipping
 			// the cache in case the cached data is stale.
-			
+
 			if err := q.auth.Authorize(ctx, act, policy.ActionUpdate, rbacObj); err == nil {
 				return q.db.UpdateWorkspaceAgentMetadata(ctx, arg)
 			}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -211,13 +210,13 @@ type workspaceRBACContextKey struct{}
 // authorization data for the duration of an agent connection.
 func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) (context.Context, error) {
 	if rbacObj.Type != rbac.ResourceWorkspace.Type {
-		return ctx, errors.New("RBAC Object must be of type Workspace")
+		return ctx, xerrors.New("RBAC Object must be of type Workspace")
 	}
 	if rbacObj.IsEmpty() {
-		return ctx, fmt.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
+		return ctx, xerrors.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
 	}
 	if rbacObj.ACLGroupList != nil || len(rbacObj.ACLGroupList) != 0 || rbacObj.ACLUserList != nil || len(rbacObj.ACLUserList) != 0 {
-		return ctx, errors.New("ACL fields for Workspace RBAC object must be nil, the can be changed during runtime and should not be cached")
+		return ctx, xerrors.New("ACL fields for Workspace RBAC object must be nil, the can be changed during runtime and should not be cached")
 	}
 	return context.WithValue(ctx, workspaceRBACContextKey{}, rbacObj), nil
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -215,8 +215,8 @@ func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) (context.Contex
 	if rbacObj.IsEmpty() {
 		return ctx, xerrors.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
 	}
-	if rbacObj.ACLGroupList != nil || len(rbacObj.ACLGroupList) != 0 || rbacObj.ACLUserList != nil || len(rbacObj.ACLUserList) != 0 {
-		return ctx, xerrors.New("ACL fields for Workspace RBAC object must be nil, the can be changed during runtime and should not be cached")
+	if len(rbacObj.ACLGroupList) != 0 || len(rbacObj.ACLUserList) != 0 {
+		return ctx, xerrors.New("ACL fields for Workspace RBAC object must be nullified, the can be changed during runtime and should not be cached")
 	}
 	return context.WithValue(ctx, workspaceRBACContextKey{}, rbacObj), nil
 }

--- a/coderd/database/dbauthz/workspace_rbac_context.go
+++ b/coderd/database/dbauthz/workspace_rbac_context.go
@@ -3,10 +3,16 @@ package dbauthz
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/rbac"
 )
+
+func isWorkspaceRBACObjectEmtpy(rbacObj rbac.Object) bool {
+	// if any of these are true then the rbac.Object work a workspace is considered empty
+	return rbacObj.Owner == "" || rbacObj.OrgID == "" || rbacObj.Owner == uuid.Nil.String() || rbacObj.OrgID == uuid.Nil.String()
+}
 
 type workspaceRBACContextKey struct{}
 
@@ -19,7 +25,7 @@ func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) (context.Contex
 	if rbacObj.Type != rbac.ResourceWorkspace.Type {
 		return ctx, xerrors.New("RBAC Object must be of type Workspace")
 	}
-	if rbacObj.IsEmpty() {
+	if isWorkspaceRBACObjectEmtpy(rbacObj) {
 		return ctx, xerrors.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
 	}
 	if len(rbacObj.ACLGroupList) != 0 || len(rbacObj.ACLUserList) != 0 {

--- a/coderd/database/dbauthz/workspace_rbac_context.go
+++ b/coderd/database/dbauthz/workspace_rbac_context.go
@@ -1,0 +1,35 @@
+package dbauthz
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/rbac"
+)
+
+type workspaceRBACContextKey struct{}
+
+// WithWorkspaceRBAC attaches a workspace RBAC object to the context.
+// RBAC fields on this RBAC object should not be used.
+//
+// This is primarily used by the workspace agent RPC handler to cache workspace
+// authorization data for the duration of an agent connection.
+func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) (context.Context, error) {
+	if rbacObj.Type != rbac.ResourceWorkspace.Type {
+		return ctx, xerrors.New("RBAC Object must be of type Workspace")
+	}
+	if rbacObj.IsEmpty() {
+		return ctx, xerrors.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
+	}
+	if len(rbacObj.ACLGroupList) != 0 || len(rbacObj.ACLUserList) != 0 {
+		return ctx, xerrors.New("ACL fields for Workspace RBAC object must be nullified, the can be changed during runtime and should not be cached")
+	}
+	return context.WithValue(ctx, workspaceRBACContextKey{}, rbacObj), nil
+}
+
+// WorkspaceRBACFromContext attempts to retrieve the workspace RBAC object from context.
+func WorkspaceRBACFromContext(ctx context.Context) (rbac.Object, bool) {
+	obj, ok := ctx.Value(workspaceRBACContextKey{}).(rbac.Object)
+	return obj, ok
+}

--- a/coderd/database/dbauthz/workspace_rbac_context.go
+++ b/coderd/database/dbauthz/workspace_rbac_context.go
@@ -9,7 +9,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 )
 
-func isWorkspaceRBACObjectEmtpy(rbacObj rbac.Object) bool {
+func isWorkspaceRBACObjectEmpty(rbacObj rbac.Object) bool {
 	// if any of these are true then the rbac.Object work a workspace is considered empty
 	return rbacObj.Owner == "" || rbacObj.OrgID == "" || rbacObj.Owner == uuid.Nil.String() || rbacObj.OrgID == uuid.Nil.String()
 }
@@ -25,7 +25,7 @@ func WithWorkspaceRBAC(ctx context.Context, rbacObj rbac.Object) (context.Contex
 	if rbacObj.Type != rbac.ResourceWorkspace.Type {
 		return ctx, xerrors.New("RBAC Object must be of type Workspace")
 	}
-	if isWorkspaceRBACObjectEmtpy(rbacObj) {
+	if isWorkspaceRBACObjectEmpty(rbacObj) {
 		return ctx, xerrors.Errorf("cannot attach empty RBAC object to context: %+v", rbacObj)
 	}
 	if len(rbacObj.ACLGroupList) != 0 || len(rbacObj.ACLUserList) != 0 {

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -817,6 +817,12 @@ func (w WorkspaceIdentity) IsPrebuild() bool {
 	return w.OwnerID == PrebuildsSystemUserID
 }
 
+func (w WorkspaceIdentity) Equal(w2 WorkspaceIdentity) bool {
+	return w.ID == w2.ID && w.OwnerID == w2.OwnerID && w.OrganizationID == w2.OrganizationID &&
+		w.TemplateID == w2.TemplateID && w.Name == w2.Name && w.OwnerUsername == w2.OwnerUsername &&
+		w.TemplateName == w2.TemplateName && w.AutostartSchedule == w2.AutostartSchedule
+}
+
 func WorkspaceIdentityFromWorkspace(w Workspace) WorkspaceIdentity {
 	return WorkspaceIdentity{
 		ID:                w.ID,

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -1,8 +1,8 @@
 package database
 
 import (
-	"encoding/hex"
 	"database/sql"
+	"encoding/hex"
 	"slices"
 	"sort"
 	"strconv"
@@ -782,8 +782,8 @@ func (s AIBridgeInterception) RBACObject() rbac.Object {
 // WorkspaceIdentity contains the minimal workspace fields needed for agent API metadata/stats reporting
 // and RBAC checks, without requiring a full database.Workspace object.
 type WorkspaceIdentity struct {
-    // Add any other fields needed for IsPrebuild() if it relies on workspace fields
-		// Identity fields
+	// Add any other fields needed for IsPrebuild() if it relies on workspace fields
+	// Identity fields
 	ID             uuid.UUID
 	OwnerID        uuid.UUID
 	OrganizationID uuid.UUID
@@ -799,33 +799,33 @@ type WorkspaceIdentity struct {
 }
 
 func (w WorkspaceIdentity) RBACObject() rbac.Object {
-    return Workspace{
-        ID:                w.ID,
-        OwnerID:           w.OwnerID,
-		OrganizationID: w.OrganizationID,
-        TemplateID:        w.TemplateID,
-		Name: w.Name,
-		OwnerUsername: w.OwnerUsername,
-		TemplateName: w.TemplateName,
+	return Workspace{
+		ID:                w.ID,
+		OwnerID:           w.OwnerID,
+		OrganizationID:    w.OrganizationID,
+		TemplateID:        w.TemplateID,
+		Name:              w.Name,
+		OwnerUsername:     w.OwnerUsername,
+		TemplateName:      w.TemplateName,
 		AutostartSchedule: w.AutostartSchedule,
-    }.RBACObject()
+	}.RBACObject()
 }
 
 // IsPrebuild returns true if the workspace is a prebuild workspace.
 // A workspace is considered a prebuild if its owner is the prebuild system user.
 func (w WorkspaceIdentity) IsPrebuild() bool {
-    return w.OwnerID == PrebuildsSystemUserID
+	return w.OwnerID == PrebuildsSystemUserID
 }
 
 func WorkspaceIdentityFromWorkspace(w Workspace) WorkspaceIdentity {
 	return WorkspaceIdentity{
 		ID:                w.ID,
-        OwnerID:           w.OwnerID,
-		OrganizationID: w.OrganizationID,
-        TemplateID:        w.TemplateID,
-		Name: w.Name,
-		OwnerUsername: w.OwnerUsername,
-		TemplateName: w.TemplateName,
+		OwnerID:           w.OwnerID,
+		OrganizationID:    w.OrganizationID,
+		TemplateID:        w.TemplateID,
+		Name:              w.Name,
+		OwnerUsername:     w.OwnerUsername,
+		TemplateName:      w.TemplateName,
 		AutostartSchedule: w.AutostartSchedule,
 	}
 }

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -236,3 +236,8 @@ func (z Object) WithGroupACL(groups map[string][]policy.Action) Object {
 		AnyOrgOwner:  z.AnyOrgOwner,
 	}
 }
+
+// IsEmpty checks whether the minimum set of rbac Object fields are empty.
+func (z Object) IsEmpty() bool {
+	return z.Owner == "" || z.Owner == uuid.Nil.String() || z.OrgID == "" || z.OrgID == uuid.Nil.String()
+}

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -236,8 +236,3 @@ func (z Object) WithGroupACL(groups map[string][]policy.Action) Object {
 		AnyOrgOwner:  z.AnyOrgOwner,
 	}
 }
-
-// IsEmpty checks whether the minimum set of rbac Object fields are empty.
-func (z Object) IsEmpty() bool {
-	return z.Owner == "" || z.Owner == uuid.Nil.String() || z.OrgID == "" || z.OrgID == uuid.Nil.String()
-}

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -158,7 +158,7 @@ func (api *API) workspaceAgentRPC(rw http.ResponseWriter, r *http.Request) {
 
 		// Optional:
 		UpdateAgentMetricsFn: api.UpdateAgentMetrics,
-	})
+	}, workspace)
 
 	streamID := tailnet.StreamID{
 		Name: fmt.Sprintf("%s-%s-%s", workspace.OwnerUsername, workspace.Name, workspaceAgent.Name),

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1717,13 +1717,13 @@ func (api *API) postWorkspaceUsage(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	template, err := api.Database.GetTemplateByID(ctx, workspace.TemplateID)
-	if err != nil {
-		httpapi.InternalServerError(rw, err)
-		return
-	}
+	// template, err := api.Database.GetTemplateByID(ctx, workspace.TemplateID)
+	// if err != nil {
+	// 	httpapi.InternalServerError(rw, err)
+	// 	return
+	// }
 
-	err = api.statsReporter.ReportAgentStats(ctx, dbtime.Now(), workspace, agent, template.Name, stat, true)
+	err = api.statsReporter.ReportAgentStats(ctx, dbtime.Now(), database.WorkspaceIdentityFromWorkspace(workspace), agent, stat, true)
 	if err != nil {
 		httpapi.InternalServerError(rw, err)
 		return

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -120,7 +120,7 @@ func (r *Reporter) ReportAppStats(ctx context.Context, stats []workspaceapps.Sta
 }
 
 // nolint:revive // usage is a control flag while we have the experiment
-func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspace database.Workspace, workspaceAgent database.WorkspaceAgent, templateName string, stats *agentproto.Stats, usage bool) error {
+func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspace database.WorkspaceIdentity, workspaceAgent database.WorkspaceAgent, stats *agentproto.Stats, usage bool) error {
 	// update agent stats
 	r.opts.StatsBatcher.Add(now, workspaceAgent.ID, workspace.TemplateID, workspace.OwnerID, workspace.ID, stats, usage)
 
@@ -130,7 +130,7 @@ func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspac
 			Username:      workspace.OwnerUsername,
 			WorkspaceName: workspace.Name,
 			AgentName:     workspaceAgent.Name,
-			TemplateName:  templateName,
+			TemplateName:  workspace.TemplateName,
 		}, stats.Metrics)
 	}
 


### PR DESCRIPTION
This query is still relatively expensive because of its call volume, at least 1 million times per day over the last week. After https://github.com/coder/coder/pull/20430 the two main remaining call paths are via the Workspace Agents Stats and Metadata APIs.

Disclaimer: Blink helped write tests, identify usage of `database.Workspace` fields in downstream functions, identify existing pattern for and write the ticker function, and write comments.

This PR adds caching of the Workspace information on the AgentAPI struct for usage in both child APIs, Notably, for the Metadata API we need to also implement a "fast path" for the section that currently calls `GetWorkspaceByAgentID` since it's nested within a dbauthz call. We do this by attaching the relevant RBAC object from the Workspace object to the request context, then checking in `UpdateWorkspaceAgentMetadata` if we have the RBAC object in the context _and_ if it is correct for authorization purposes. If we do not have the object or it is invalid we fall back to still calling `GetWorkspaceByAgentID`.

Note that while the workspace agent API struct is constructed at startup and (IIUC) is persistent for the lifetime of the agent/workspace, and makes a call to `GetWorkspaceByAgentID` during this process, we also need to handle updating of some of the cached fields since the entries within the database _can_ change as part of the workspace prebuild process. We could potentially due this via subscribing, via pubsub, to updates about prebuild workspace claims. However, for now this has simply been solved with a 5m ticker to make a call to `GetWorkspaceByAgentID`.

This should mean we on average call `GetWorkspaceByAgentID` once every 5 minutes per agent, as opposed to multiple times per-minute per agent for the Stats API and again for the Metadata API. Even in the worst case scenario of a workspace prebuild being claimed at t=N and the next ticker not occurring until t=N+5minutes we should have at most 5 minutes of the current behaviour for each agent in a workspace.

**NOTE:** there is a remaining issue here; caching of the workspace for stats as it is currently implemented is actually invalid, at least for the ~5 minute period between when a prebuild is claimed and the next update of the ticker the cached Owner information will be incorrect and we'll update some incorrect metrics + skip the entire `if !workspace.IsPrebuild()` block.

We can either:
1. revert this optimization here and still just always call `GetWorkspaceByAgentID` for every stats update
2. similar to option 1, but only _always_ call `GetWorkspaceByAgentID` if the workspace is a prebuild, and the first time it _is not_ we could grab the lock and update the cached workspace information
3. do the _right_ thing for both stats and metadata, and hook into pubsub to get the prebuild claim update ASAP while still avoiding extra calls to `GetWorkspaceByAgentID`