### PR TITLE
docs: update release calendar for 2.28 release

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -136,7 +136,7 @@ We support two release channels: mainline and stable - read the
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.27.3
+        --version 2.28.0
     ```
 
   - **OCI Registry**
@@ -147,7 +147,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.27.3
+        --version 2.28.0
     ```
 
 - **Stable** Coder release:
@@ -160,7 +160,7 @@ We support two release channels: mainline and stable - read the
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.26.3
+        --version 2.27.3
     ```
 
   - **OCI Registry**
@@ -171,7 +171,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.26.3
+        --version 2.27.3
     ```
 
 You can watch Coder start up by running `kubectl get pods -n coder`. Once Coder

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -134,7 +134,7 @@ kubectl create secret generic coder-db-url -n coder \
 
 1. Select a Coder version:
 
-   - **Mainline**: `2.28.9`
+   - **Mainline**: `2.28.0`
    - **Stable**: `2.27.3`
 
    Learn more about release channels in the [Releases documentation](./releases/index.md).

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -134,8 +134,8 @@ kubectl create secret generic coder-db-url -n coder \
 
 1. Select a Coder version:
 
-   - **Mainline**: `2.27.3`
-   - **Stable**: `2.26.3`
+   - **Mainline**: `2.28.9`
+   - **Stable**: `2.27.3`
 
    Learn more about release channels in the [Releases documentation](./releases/index.md).
 

--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -57,13 +57,13 @@ pages.
 <!-- RELEASE_CALENDAR_START -->
 | Release name                                   | Release Date       | Status           | Latest Release                                                 |
 |------------------------------------------------|--------------------|------------------|----------------------------------------------------------------|
-| [2.22](https://coder.com/changelog/coder-2-22) | May 16, 2025       | Not Supported    | [v2.22.1](https://github.com/coder/coder/releases/tag/v2.22.1) |
 | [2.23](https://coder.com/changelog/coder-2-23) | June 03, 2025      | Not Supported    | [v2.23.5](https://github.com/coder/coder/releases/tag/v2.23.5) |
 | [2.24](https://coder.com/changelog/coder-2-24) | July 01, 2025      | Not Supported    | [v2.24.4](https://github.com/coder/coder/releases/tag/v2.24.4) |
-| [2.25](https://coder.com/changelog/coder-2-25) | August 05, 2025    | Security Support | [v2.25.3](https://github.com/coder/coder/releases/tag/v2.25.3) |
-| [2.26](https://coder.com/changelog/coder-2-26) | September 03, 2025 | Stable           | [v2.26.3](https://github.com/coder/coder/releases/tag/v2.26.3) |
-| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Mainline         | [v2.27.3](https://github.com/coder/coder/releases/tag/v2.27.3) |
-| 2.28                                           |                    | Not Released     | N/A                                                            |
+| [2.25](https://coder.com/changelog/coder-2-25) | August 05, 2025    | Not Supported    | [v2.25.3](https://github.com/coder/coder/releases/tag/v2.25.3) |
+| [2.26](https://coder.com/changelog/coder-2-26) | September 03, 2025 | Security Support | [v2.26.3](https://github.com/coder/coder/releases/tag/v2.26.3) |
+| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Stable           | [v2.27.3](https://github.com/coder/coder/releases/tag/v2.27.3) |
+| [2.28](https://coder.com/changelog/coder-2-28) | November 04, 2025  | Mainline         | [v2.28.0](https://github.com/coder/coder/releases/tag/v2.28.0) |
+| 2.29                                           |                    | Not Released     | N/A                                                            |
 <!-- RELEASE_CALENDAR_END -->
 
 > [!TIP]


### PR DESCRIPTION
## Description

Update our doc's release calendar for the [2.28 mainline](https://github.com/coder/coder/releases/tag/v2.28.0) release. 