### PR TITLE
chore: update Go to 1.24.10 (#20684)

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.24.6"
+    default: "1.24.10"
   use-preinstalled-go:
     description: "Whether to use preinstalled Go."
     default: "false"

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -11,8 +11,8 @@ RUN cargo install jj-cli typos-cli watchexec-cli
 FROM ubuntu:jammy@sha256:4e0171b9275e12d375863f2b3ae9ce00a4c53ddda176bd55868df97ac6f21a6e AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.24.6
-ARG GO_CHECKSUM="bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712"
+ARG GO_VERSION=1.24.10
+ARG GO_CHECKSUM="dd52b974e3d9c5a7bbfb222c685806def6be5d6f7efd10f9caa9ca1fa2f47955"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.24.6
+go 1.24.10
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
(cherry picked from commit 81c33756707ce699b9d116d7c3aba0ea2b4c6e5c)

