### PR TITLE
feat(agent): add agent unit manager

### DIFF
--- a/agent/unit/graph.go
+++ b/agent/unit/graph.go
@@ -58,7 +58,7 @@ func (g *Graph[EdgeType, VertexType]) AddEdge(from, to VertexType, edge EdgeType
 	toID := g.getOrCreateVertexID(to)
 
 	if g.canReach(to, from) {
-		return xerrors.Errorf("adding edge (%v -> %v) would create a cycle", from, to)
+		return xerrors.Errorf("adding edge (%v -> %v): %w", from, to, ErrCycleDetected)
 	}
 
 	g.gonumGraph.SetEdge(simple.Edge{F: simple.Node(fromID), T: simple.Node(toID)})

--- a/agent/unit/graph_test.go
+++ b/agent/unit/graph_test.go
@@ -148,7 +148,7 @@ func TestGraph(t *testing.T) {
 			graph := &testGraph{}
 			unit1 := &testGraphVertex{Name: "unit1"}
 			err := graph.AddEdge(unit1, unit1, testEdgeCompleted)
-			require.ErrorIs(t, err, unit.ErrCycleDetected)
+			require.ErrorContains(t, err, unit.ErrCycleDetected)
 
 			return graph
 		},
@@ -159,7 +159,7 @@ func TestGraph(t *testing.T) {
 			err := graph.AddEdge(unit1, unit2, testEdgeCompleted)
 			require.NoError(t, err)
 			err = graph.AddEdge(unit2, unit1, testEdgeStarted)
-			require.ErrorIs(t, err, unit.ErrCycleDetected)
+			require.ErrorContains(t, err, unit.ErrCycleDetected)
 
 			return graph
 		},
@@ -339,7 +339,7 @@ func TestGraphThreadSafety(t *testing.T) {
 		// Verify all attempts correctly returned cycle error
 		for i, err := range cycleErrors {
 			require.Error(t, err, "goroutine %d should have detected cycle", i)
-			require.ErrorIs(t, err, unit.ErrCycleDetected)
+			require.ErrorContains(t, err, unit.ErrCycleDetected)
 		}
 
 		// Verify graph remains valid (original chain intact)

--- a/agent/unit/graph_test.go
+++ b/agent/unit/graph_test.go
@@ -148,8 +148,7 @@ func TestGraph(t *testing.T) {
 			graph := &testGraph{}
 			unit1 := &testGraphVertex{Name: "unit1"}
 			err := graph.AddEdge(unit1, unit1, testEdgeCompleted)
-			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf("adding edge (%v -> %v) would create a cycle", unit1, unit1))
+			require.ErrorIs(t, err, unit.ErrCycleDetected)
 
 			return graph
 		},
@@ -160,8 +159,7 @@ func TestGraph(t *testing.T) {
 			err := graph.AddEdge(unit1, unit2, testEdgeCompleted)
 			require.NoError(t, err)
 			err = graph.AddEdge(unit2, unit1, testEdgeStarted)
-			require.Error(t, err)
-			require.ErrorContains(t, err, fmt.Sprintf("adding edge (%v -> %v) would create a cycle", unit2, unit1))
+			require.ErrorIs(t, err, unit.ErrCycleDetected)
 
 			return graph
 		},
@@ -341,7 +339,7 @@ func TestGraphThreadSafety(t *testing.T) {
 		// Verify all attempts correctly returned cycle error
 		for i, err := range cycleErrors {
 			require.Error(t, err, "goroutine %d should have detected cycle", i)
-			require.Contains(t, err.Error(), "would create a cycle")
+			require.ErrorIs(t, err, unit.ErrCycleDetected)
 		}
 
 		// Verify graph remains valid (original chain intact)

--- a/agent/unit/graph_test.go
+++ b/agent/unit/graph_test.go
@@ -148,7 +148,7 @@ func TestGraph(t *testing.T) {
 			graph := &testGraph{}
 			unit1 := &testGraphVertex{Name: "unit1"}
 			err := graph.AddEdge(unit1, unit1, testEdgeCompleted)
-			require.ErrorContains(t, err, unit.ErrCycleDetected)
+			require.ErrorIs(t, err, unit.ErrCycleDetected)
 
 			return graph
 		},
@@ -159,7 +159,7 @@ func TestGraph(t *testing.T) {
 			err := graph.AddEdge(unit1, unit2, testEdgeCompleted)
 			require.NoError(t, err)
 			err = graph.AddEdge(unit2, unit1, testEdgeStarted)
-			require.ErrorContains(t, err, unit.ErrCycleDetected)
+			require.ErrorIs(t, err, unit.ErrCycleDetected)
 
 			return graph
 		},
@@ -339,7 +339,7 @@ func TestGraphThreadSafety(t *testing.T) {
 		// Verify all attempts correctly returned cycle error
 		for i, err := range cycleErrors {
 			require.Error(t, err, "goroutine %d should have detected cycle", i)
-			require.ErrorContains(t, err, unit.ErrCycleDetected)
+			require.ErrorIs(t, err, unit.ErrCycleDetected)
 		}
 
 		// Verify graph remains valid (original chain intact)

--- a/agent/unit/manager.go
+++ b/agent/unit/manager.go
@@ -6,20 +6,22 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// ErrUnitNotFound is returned when a unit ID is not registered.
-var ErrUnitNotFound = xerrors.New("unit not found")
+var (
+	// ErrUnitNotFound is returned when a unit ID is not registered.
+	ErrUnitNotFound = xerrors.New("unit not found")
 
-// ErrUnitAlreadyRegistered is returned when a unit ID is already registered.
-var ErrUnitAlreadyRegistered = xerrors.New("unit already registered")
+	// ErrUnitAlreadyRegistered is returned when a unit ID is already registered.
+	ErrUnitAlreadyRegistered = xerrors.New("unit already registered")
 
-// ErrCannotUpdateOtherUnit is returned when attempting to update another unit's status.
-var ErrCannotUpdateOtherUnit = xerrors.New("cannot update other unit's status")
+	// ErrCannotUpdateOtherUnit is returned when attempting to update another unit's status.
+	ErrCannotUpdateOtherUnit = xerrors.New("cannot update other unit's status")
 
-// ErrDependenciesNotSatisfied is returned when a unit's dependencies are not satisfied.
-var ErrDependenciesNotSatisfied = xerrors.New("unit dependencies not satisfied")
+	// ErrDependenciesNotSatisfied is returned when a unit's dependencies are not satisfied.
+	ErrDependenciesNotSatisfied = xerrors.New("unit dependencies not satisfied")
 
-// ErrSameStatusAlreadySet is returned when attempting to set the same status as the current status.
-var ErrSameStatusAlreadySet = xerrors.New("same status already set")
+	// ErrSameStatusAlreadySet is returned when attempting to set the same status as the current status.
+	ErrSameStatusAlreadySet = xerrors.New("same status already set")
+)
 
 // Status constants for dependency tracking
 const (

--- a/agent/unit/manager.go
+++ b/agent/unit/manager.go
@@ -181,12 +181,13 @@ func (dt *Manager[StatusType, UnitID]) GetUnmetDependencies(unit UnitID) ([]Depe
 		currentStatus, exists := dt.unitStatus[dependsOnUnit]
 		if !exists {
 			// If the dependency unit has no status, it's not satisfied
-			var zeroStatus StatusType
+			// Zero value represents StatusPending
+			var pendingStatus StatusType
 			unmetDependencies = append(unmetDependencies, Dependency[StatusType, UnitID]{
 				Unit:           unit,
 				DependsOn:      dependsOnUnit,
 				RequiredStatus: requiredStatus,
-				CurrentStatus:  zeroStatus, // Zero value
+				CurrentStatus:  pendingStatus, // StatusPending (zero value)
 				IsSatisfied:    false,
 			})
 		} else {
@@ -245,14 +246,16 @@ func (dt *Manager[StatusType, UnitID]) GetStatus(unit UnitID) (StatusType, error
 	defer dt.mu.RUnlock()
 
 	if !dt.registeredUnits[unit] {
-		var zeroStatus StatusType
-		return zeroStatus, ErrUnitNotFound
+		// Zero value represents StatusPending
+		var pendingStatus StatusType
+		return pendingStatus, ErrUnitNotFound
 	}
 
 	status, exists := dt.unitStatus[unit]
 	if !exists {
-		var zeroStatus StatusType
-		return zeroStatus, nil
+		// Zero value represents StatusPending
+		var pendingStatus StatusType
+		return pendingStatus, nil
 	}
 
 	return status, nil
@@ -278,12 +281,13 @@ func (dt *Manager[StatusType, UnitID]) GetAllDependencies(unit UnitID) ([]Depend
 		currentStatus, exists := dt.unitStatus[dependsOnUnit]
 		if !exists {
 			// If the dependency unit has no status, it's not satisfied
-			var zeroStatus StatusType
+			// Zero value represents StatusPending
+			var pendingStatus StatusType
 			allDependencies = append(allDependencies, Dependency[StatusType, UnitID]{
 				Unit:           unit,
 				DependsOn:      dependsOnUnit,
 				RequiredStatus: requiredStatus,
-				CurrentStatus:  zeroStatus, // Zero value
+				CurrentStatus:  pendingStatus, // StatusPending (zero value)
 				IsSatisfied:    false,
 			})
 		} else {

--- a/agent/unit/manager.go
+++ b/agent/unit/manager.go
@@ -1,0 +1,307 @@
+package unit
+
+import (
+	"sync"
+
+	"golang.org/x/xerrors"
+)
+
+// ErrConsumerNotFound is returned when a consumer ID is not registered.
+var ErrConsumerNotFound = xerrors.New("consumer not found")
+
+// ErrConsumerAlreadyRegistered is returned when a consumer ID is already registered.
+var ErrConsumerAlreadyRegistered = xerrors.New("consumer already registered")
+
+// ErrCannotUpdateOtherConsumer is returned when attempting to update another consumer's status.
+var ErrCannotUpdateOtherConsumer = xerrors.New("cannot update other consumer's status")
+
+// ErrDependenciesNotSatisfied is returned when a consumer's dependencies are not satisfied.
+var ErrDependenciesNotSatisfied = xerrors.New("unit dependencies not satisfied")
+
+// ErrSameStatusAlreadySet is returned when attempting to set the same status as the current status.
+var ErrSameStatusAlreadySet = xerrors.New("same status already set")
+
+// Status constants for dependency tracking
+const (
+	StatusStarted  = "started"
+	StatusComplete = "completed"
+)
+
+// dependencyVertex represents a vertex in the dependency graph that is associated with a consumer.
+type dependencyVertex[ConsumerID comparable] struct {
+	ID ConsumerID
+}
+
+// Dependency represents a dependency relationship between consumers.
+type Dependency[StatusType, ConsumerID comparable] struct {
+	Consumer       ConsumerID
+	DependsOn      ConsumerID
+	RequiredStatus StatusType
+	CurrentStatus  StatusType
+	IsSatisfied    bool
+}
+
+// Manager provides reactive dependency tracking over a Graph.
+// It manages consumer registration, dependency relationships, and status updates
+// with automatic recalculation of readiness when dependencies are satisfied.
+type Manager[StatusType, ConsumerID comparable] struct {
+	mu sync.RWMutex
+
+	// The underlying graph that stores dependency relationships
+	graph *Graph[StatusType, *dependencyVertex[ConsumerID]]
+
+	// Track current status of each consumer
+	consumerStatus map[ConsumerID]StatusType
+
+	// Track readiness state (cached to avoid repeated graph traversal)
+	consumerReadiness map[ConsumerID]bool
+
+	// Track which consumers are registered
+	registeredConsumers map[ConsumerID]bool
+
+	// Store vertex instances for each consumer to ensure consistent references
+	consumerVertices map[ConsumerID]*dependencyVertex[ConsumerID]
+}
+
+// NewManager creates a new Manager instance.
+func NewManager[StatusType, ConsumerID comparable]() *Manager[StatusType, ConsumerID] {
+	return &Manager[StatusType, ConsumerID]{
+		graph:               &Graph[StatusType, *dependencyVertex[ConsumerID]]{},
+		consumerStatus:      make(map[ConsumerID]StatusType),
+		consumerReadiness:   make(map[ConsumerID]bool),
+		registeredConsumers: make(map[ConsumerID]bool),
+		consumerVertices:    make(map[ConsumerID]*dependencyVertex[ConsumerID]),
+	}
+}
+
+// Register registers a new consumer as a vertex in the dependency graph.
+func (dt *Manager[StatusType, ConsumerID]) Register(id ConsumerID) error {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+
+	if dt.registeredConsumers[id] {
+		return ErrConsumerAlreadyRegistered
+	}
+
+	// Create and store the vertex for this consumer
+	vertex := &dependencyVertex[ConsumerID]{ID: id}
+	dt.consumerVertices[id] = vertex
+	dt.registeredConsumers[id] = true
+	dt.consumerReadiness[id] = true // New consumers start as ready (no dependencies)
+
+	return nil
+}
+
+// AddDependency adds a dependency relationship between consumers.
+// The consumer depends on the dependsOn consumer reaching the requiredStatus.
+func (dt *Manager[StatusType, ConsumerID]) AddDependency(consumer ConsumerID, dependsOn ConsumerID, requiredStatus StatusType) error {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+
+	if !dt.registeredConsumers[consumer] {
+		return xerrors.Errorf("consumer %v is not registered", consumer)
+	}
+	if !dt.registeredConsumers[dependsOn] {
+		return xerrors.Errorf("consumer %v is not registered", dependsOn)
+	}
+
+	// Get the stored vertices for both consumers
+	consumerVertex := dt.consumerVertices[consumer]
+	dependsOnVertex := dt.consumerVertices[dependsOn]
+
+	// Add the dependency edge to the graph
+	// The edge goes from consumer to dependsOn, representing the dependency
+	err := dt.graph.AddEdge(consumerVertex, dependsOnVertex, requiredStatus)
+	if err != nil {
+		return xerrors.Errorf("failed to add dependency: %w", err)
+	}
+
+	// Recalculate readiness for the consumer since it now has a dependency
+	dt.recalculateReadinessUnsafe(consumer)
+
+	return nil
+}
+
+// UpdateStatus updates a consumer's status and recalculates readiness for affected dependents.
+func (dt *Manager[StatusType, ConsumerID]) UpdateStatus(consumer ConsumerID, newStatus StatusType) error {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+
+	if !dt.registeredConsumers[consumer] {
+		return ErrConsumerNotFound
+	}
+
+	// Update the consumer's status
+	if dt.consumerStatus[consumer] == newStatus {
+		return ErrSameStatusAlreadySet
+	}
+	dt.consumerStatus[consumer] = newStatus
+
+	// Get all consumers that depend on this one (reverse adjacent vertices)
+	consumerVertex := dt.consumerVertices[consumer]
+	dependentEdges := dt.graph.GetReverseAdjacentVertices(consumerVertex)
+
+	// Recalculate readiness for all dependents
+	for _, edge := range dependentEdges {
+		dt.recalculateReadinessUnsafe(edge.From.ID)
+	}
+
+	return nil
+}
+
+// IsReady checks if all dependencies for a consumer are satisfied.
+func (dt *Manager[StatusType, ConsumerID]) IsReady(consumer ConsumerID) (bool, error) {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+
+	if !dt.registeredConsumers[consumer] {
+		return false, ErrConsumerNotFound
+	}
+
+	return dt.consumerReadiness[consumer], nil
+}
+
+// GetUnmetDependencies returns a list of unsatisfied dependencies for a consumer.
+func (dt *Manager[StatusType, ConsumerID]) GetUnmetDependencies(consumer ConsumerID) ([]Dependency[StatusType, ConsumerID], error) {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+
+	if !dt.registeredConsumers[consumer] {
+		return nil, ErrConsumerNotFound
+	}
+
+	consumerVertex := dt.consumerVertices[consumer]
+	forwardEdges := dt.graph.GetForwardAdjacentVertices(consumerVertex)
+
+	var unmetDependencies []Dependency[StatusType, ConsumerID]
+
+	for _, edge := range forwardEdges {
+		dependsOnConsumer := edge.To.ID
+		requiredStatus := edge.Edge
+		currentStatus, exists := dt.consumerStatus[dependsOnConsumer]
+		if !exists {
+			// If the dependency consumer has no status, it's not satisfied
+			var zeroStatus StatusType
+			unmetDependencies = append(unmetDependencies, Dependency[StatusType, ConsumerID]{
+				Consumer:       consumer,
+				DependsOn:      dependsOnConsumer,
+				RequiredStatus: requiredStatus,
+				CurrentStatus:  zeroStatus, // Zero value
+				IsSatisfied:    false,
+			})
+		} else {
+			isSatisfied := currentStatus == requiredStatus
+			if !isSatisfied {
+				unmetDependencies = append(unmetDependencies, Dependency[StatusType, ConsumerID]{
+					Consumer:       consumer,
+					DependsOn:      dependsOnConsumer,
+					RequiredStatus: requiredStatus,
+					CurrentStatus:  currentStatus,
+					IsSatisfied:    false,
+				})
+			}
+		}
+	}
+
+	return unmetDependencies, nil
+}
+
+// recalculateReadinessUnsafe recalculates the readiness state for a consumer.
+// This method assumes the caller holds the write lock.
+func (dt *Manager[StatusType, ConsumerID]) recalculateReadinessUnsafe(consumer ConsumerID) {
+	consumerVertex := dt.consumerVertices[consumer]
+	forwardEdges := dt.graph.GetForwardAdjacentVertices(consumerVertex)
+
+	// If there are no dependencies, the consumer is ready
+	if len(forwardEdges) == 0 {
+		dt.consumerReadiness[consumer] = true
+		return
+	}
+
+	// Check if all dependencies are satisfied
+	allSatisfied := true
+	for _, edge := range forwardEdges {
+		dependsOnConsumer := edge.To.ID
+		requiredStatus := edge.Edge
+		currentStatus, exists := dt.consumerStatus[dependsOnConsumer]
+		if !exists || currentStatus != requiredStatus {
+			allSatisfied = false
+			break
+		}
+	}
+
+	dt.consumerReadiness[consumer] = allSatisfied
+}
+
+// GetGraph returns the underlying graph for visualization and debugging.
+// This should be used carefully as it exposes the internal graph structure.
+func (dt *Manager[StatusType, ConsumerID]) GetGraph() *Graph[StatusType, *dependencyVertex[ConsumerID]] {
+	return dt.graph
+}
+
+// GetStatus returns the current status of a consumer.
+func (dt *Manager[StatusType, ConsumerID]) GetStatus(consumer ConsumerID) (StatusType, error) {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+
+	if !dt.registeredConsumers[consumer] {
+		var zeroStatus StatusType
+		return zeroStatus, ErrConsumerNotFound
+	}
+
+	status, exists := dt.consumerStatus[consumer]
+	if !exists {
+		var zeroStatus StatusType
+		return zeroStatus, nil
+	}
+
+	return status, nil
+}
+
+// GetAllDependencies returns all dependencies for a consumer, both satisfied and unsatisfied.
+func (dt *Manager[StatusType, ConsumerID]) GetAllDependencies(consumer ConsumerID) ([]Dependency[StatusType, ConsumerID], error) {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+
+	if !dt.registeredConsumers[consumer] {
+		return nil, ErrConsumerNotFound
+	}
+
+	consumerVertex := dt.consumerVertices[consumer]
+	forwardEdges := dt.graph.GetForwardAdjacentVertices(consumerVertex)
+
+	var allDependencies []Dependency[StatusType, ConsumerID]
+
+	for _, edge := range forwardEdges {
+		dependsOnConsumer := edge.To.ID
+		requiredStatus := edge.Edge
+		currentStatus, exists := dt.consumerStatus[dependsOnConsumer]
+		if !exists {
+			// If the dependency consumer has no status, it's not satisfied
+			var zeroStatus StatusType
+			allDependencies = append(allDependencies, Dependency[StatusType, ConsumerID]{
+				Consumer:       consumer,
+				DependsOn:      dependsOnConsumer,
+				RequiredStatus: requiredStatus,
+				CurrentStatus:  zeroStatus, // Zero value
+				IsSatisfied:    false,
+			})
+		} else {
+			isSatisfied := currentStatus == requiredStatus
+			allDependencies = append(allDependencies, Dependency[StatusType, ConsumerID]{
+				Consumer:       consumer,
+				DependsOn:      dependsOnConsumer,
+				RequiredStatus: requiredStatus,
+				CurrentStatus:  currentStatus,
+				IsSatisfied:    isSatisfied,
+			})
+		}
+	}
+
+	return allDependencies, nil
+}
+
+// ExportDOT exports the dependency graph to DOT format for visualization.
+func (dt *Manager[StatusType, ConsumerID]) ExportDOT(name string) (string, error) {
+	return dt.graph.ToDOT(name)
+}

--- a/agent/unit/manager.go
+++ b/agent/unit/manager.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/util/slice"
 )
 
 var (
@@ -177,13 +179,9 @@ func (dt *Manager[UnitID]) GetUnmetDependencies(unit UnitID) ([]Dependency[Statu
 		return nil, err
 	}
 
-	var unmetDependencies []Dependency[Status, UnitID]
-
-	for _, dependency := range allDependencies {
-		if !dependency.IsSatisfied {
-			unmetDependencies = append(unmetDependencies, dependency)
-		}
-	}
+	var unmetDependencies []Dependency[Status, UnitID] = slice.Filter(allDependencies, func(dependency Dependency[Status, UnitID]) bool {
+		return !dependency.IsSatisfied
+	})
 
 	return unmetDependencies, nil
 }

--- a/agent/unit/manager.go
+++ b/agent/unit/manager.go
@@ -21,6 +21,9 @@ var (
 
 	// ErrSameStatusAlreadySet is returned when attempting to set the same status as the current status.
 	ErrSameStatusAlreadySet = xerrors.New("same status already set")
+
+	// ErrCycleDetected is returned when a cycle is detected in the dependency graph.
+	ErrCycleDetected = xerrors.New("cycle detected")
 )
 
 // Status constants for dependency tracking
@@ -101,10 +104,10 @@ func (dt *Manager[StatusType, UnitID]) AddDependency(unit UnitID, dependsOn Unit
 	defer dt.mu.Unlock()
 
 	if !dt.registeredUnits[unit] {
-		return xerrors.Errorf("unit %v is not registered", unit)
+		return xerrors.Errorf("unit %v is not registered: %w", unit, ErrUnitNotFound)
 	}
 	if !dt.registeredUnits[dependsOn] {
-		return xerrors.Errorf("unit %v is not registered", dependsOn)
+		return xerrors.Errorf("unit %v is not registered: %w", dependsOn, ErrUnitNotFound)
 	}
 
 	// Get the stored vertices for both units

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -21,11 +21,10 @@ const (
 func TestDependencyTracker_Register(t *testing.T) {
 	t.Parallel()
 
-	tracker := unit.NewManager[testUnitID]()
-
 	t.Run("RegisterNewUnit", func(t *testing.T) {
 		t.Parallel()
 
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -53,7 +53,7 @@ func TestManager_Register(t *testing.T) {
 		err = manager.Register(unitA)
 
 		// Then: a descriptive error should be returned
-		require.ErrorContains(t, err, unit.ErrUnitAlreadyRegistered)
+		require.ErrorIs(t, err, unit.ErrUnitAlreadyRegistered)
 
 		// Then: the unit status should not be overwritten
 		u := manager.Unit(unitA)
@@ -139,7 +139,7 @@ func TestManager_AddDependency(t *testing.T) {
 
 		// Then: a descriptive error communicates that the dependency cannot be added
 		// because the dependent unit must be registered first.
-		require.ErrorContains(t, err, unit.ErrUnitNotFound)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 	})
 
 	t.Run("AddDependencyOnAnUnregisteredUnit", func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestManager_AddDependency(t *testing.T) {
 
 		// Try to make D depend on A (creates indirect cycle)
 		err = manager.AddDependency(unitD, unitA, unit.StatusStarted)
-		require.ErrorContains(t, err, unit.ErrCycleDetected)
+		require.ErrorIs(t, err, unit.ErrCycleDetected)
 	})
 }
 
@@ -253,7 +253,7 @@ func TestManager_UpdateStatus(t *testing.T) {
 		err := manager.UpdateStatus(unitA, unit.StatusStarted)
 
 		// Then: a descriptive error communicates that the unit must be registered first.
-		require.ErrorContains(t, err, unit.ErrUnitNotFound)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 	})
 
 	t.Run("LinearChainDependencies", func(t *testing.T) {
@@ -392,7 +392,7 @@ func TestManager_GetUnmetDependencies(t *testing.T) {
 		unmet, err := manager.GetUnmetDependencies(unitA)
 
 		// Then: a descriptive error communicates that the unit must be registered first.
-		require.ErrorContains(t, err, unit.ErrUnitNotFound)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 		assert.Nil(t, unmet)
 	})
 }

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -21,7 +21,7 @@ const (
 func TestDependencyTracker_Register(t *testing.T) {
 	t.Parallel()
 
-	tracker := unit.NewManager[string, testUnitID]()
+	tracker := unit.NewManager[testUnitID]()
 
 	t.Run("RegisterNewUnit", func(t *testing.T) {
 		t.Parallel()
@@ -38,7 +38,7 @@ func TestDependencyTracker_Register(t *testing.T) {
 	t.Run("RegisterDuplicateUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestDependencyTracker_Register(t *testing.T) {
 	t.Run("RegisterMultipleUnits", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		units := []testUnitID{unitA, unitB, unitC}
 		for _, unit := range units {
@@ -72,7 +72,7 @@ func TestDependencyTracker_AddDependency(t *testing.T) {
 	t.Run("AddDependencyBetweenRegisteredUnits", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 		err = tracker.Register(unitB)
@@ -96,7 +96,7 @@ func TestDependencyTracker_AddDependency(t *testing.T) {
 	t.Run("AddDependencyWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
@@ -108,7 +108,7 @@ func TestDependencyTracker_AddDependency(t *testing.T) {
 	t.Run("AddDependencyFromUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitB)
 		require.NoError(t, err)
 
@@ -124,7 +124,7 @@ func TestDependencyTracker_UpdateStatus(t *testing.T) {
 	t.Run("UpdateStatusTriggersReadinessRecalculation", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 		err = tracker.Register(unitB)
@@ -151,7 +151,7 @@ func TestDependencyTracker_UpdateStatus(t *testing.T) {
 	t.Run("UpdateStatusWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		err := tracker.UpdateStatus(unitA, unit.StatusStarted)
 		require.ErrorIs(t, err, unit.ErrUnitNotFound)
@@ -160,7 +160,7 @@ func TestDependencyTracker_UpdateStatus(t *testing.T) {
 	t.Run("LinearChainDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register all units
 		units := []testUnitID{unitA, unitB, unitC}
@@ -216,7 +216,7 @@ func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
 	t.Run("GetUnmetDependenciesForUnitWithNoDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
@@ -228,7 +228,7 @@ func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
 	t.Run("GetUnmetDependenciesForUnitWithUnsatisfiedDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 		err = tracker.Register(unitB)
@@ -251,7 +251,7 @@ func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
 	t.Run("GetUnmetDependenciesForUnitWithSatisfiedDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 		err := tracker.Register(unitA)
 		require.NoError(t, err)
 		err = tracker.Register(unitB)
@@ -273,7 +273,7 @@ func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
 	t.Run("GetUnmetDependenciesForUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.ErrorIs(t, err, unit.ErrUnitNotFound)
@@ -287,7 +287,7 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 	t.Run("UnitWithMultipleDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register all units
 		units := []testUnitID{unitA, unitB, unitC, unitD}
@@ -327,7 +327,7 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 	t.Run("ComplexDependencyChain", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register all units
 		units := []testUnitID{unitA, unitB, unitC, unitD}
@@ -402,7 +402,7 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 	t.Run("DifferentStatusTypes", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register units
 		err := tracker.Register(unitA)
@@ -442,7 +442,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Run("UpdateStatusWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		err := tracker.UpdateStatus(unitA, unit.StatusStarted)
 		require.ErrorIs(t, err, unit.ErrUnitNotFound)
@@ -451,7 +451,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Run("IsReadyWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		ready, err := tracker.IsReady(unitA)
 		require.ErrorIs(t, err, unit.ErrUnitNotFound)
@@ -461,7 +461,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Run("GetUnmetDependenciesWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.Error(t, err)
@@ -472,7 +472,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Run("AddDependencyWithUnregisteredUnits", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Try to add dependency with unregistered units
 		err := tracker.AddDependency(unitA, unitB, unit.StatusStarted)
@@ -483,7 +483,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Run("CyclicDependencyDetection", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register units
 		err := tracker.Register(unitA)
@@ -518,7 +518,7 @@ func TestDependencyTracker_ToDOT(t *testing.T) {
 	t.Run("ExportSimpleGraph", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register units
 		err := tracker.Register(unitA)
@@ -539,7 +539,7 @@ func TestDependencyTracker_ToDOT(t *testing.T) {
 	t.Run("ExportComplexGraph", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[string, testUnitID]()
+		tracker := unit.NewManager[testUnitID]()
 
 		// Register all units
 		units := []testUnitID{unitA, unitB, unitC, unitD}

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -497,15 +497,26 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		err = tracker.Register(unitB)
 		require.NoError(t, err)
+		err = tracker.Register(unitC)
+		require.NoError(t, err)
+		err = tracker.Register(unitD)
+		require.NoError(t, err)
 
 		// A depends on B
 		err = tracker.AddDependency(unitA, unitB, unit.StatusStarted)
 		require.NoError(t, err)
+		// B depends on C
+		err = tracker.AddDependency(unitB, unitC, unit.StatusStarted)
+		require.NoError(t, err)
 
-		// Try to make B depend on A (creates cycle)
-		err = tracker.AddDependency(unitB, unitA, unit.StatusStarted)
+		// C depends on D
+		err = tracker.AddDependency(unitC, unitD, unit.StatusStarted)
+		require.NoError(t, err)
+
+		// Try to make D depend on A (creates indirect cycle)
+		err = tracker.AddDependency(unitD, unitA, unit.StatusStarted)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "would create a cycle")
+		assert.ErrorContains(t, err, "would create a cycle")
 	})
 }
 

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -1,0 +1,691 @@
+package unit_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/unit"
+)
+
+type testStatus string
+
+const (
+	statusStarted   testStatus = "started"
+	statusRunning   testStatus = "running"
+	statusCompleted testStatus = "completed"
+)
+
+type testConsumerID string
+
+const (
+	consumerA testConsumerID = "serviceA"
+	consumerB testConsumerID = "serviceB"
+	consumerC testConsumerID = "serviceC"
+	consumerD testConsumerID = "serviceD"
+)
+
+func TestDependencyTracker_Register(t *testing.T) {
+	t.Parallel()
+
+	tracker := unit.NewManager[testStatus, testConsumerID]()
+
+	t.Run("RegisterNewConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+
+		// Consumer should be ready initially (no dependencies)
+		ready, err := tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+
+	t.Run("RegisterDuplicateConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+
+		err = tracker.Register(consumerA)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already registered")
+	})
+
+	t.Run("RegisterMultipleConsumers", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		consumers := []testConsumerID{consumerA, consumerB, consumerC}
+		for _, consumer := range consumers {
+			err := tracker.Register(consumer)
+			require.NoError(t, err)
+		}
+
+		// All should be ready initially
+		for _, consumer := range consumers {
+			ready, err := tracker.IsReady(consumer)
+			require.NoError(t, err)
+			assert.True(t, ready)
+		}
+	})
+}
+
+func TestDependencyTracker_AddDependency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AddDependencyBetweenRegisteredConsumers", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// A depends on B being "running"
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		// A should no longer be ready (depends on B)
+		ready, err := tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// B should still be ready (no dependencies)
+		ready, err = tracker.IsReady(consumerB)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+
+	t.Run("AddDependencyWithUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+
+		// Try to add dependency to unregistered consumer
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not registered")
+	})
+
+	t.Run("AddDependencyFromUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// Try to add dependency from unregistered consumer
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not registered")
+	})
+}
+
+func TestDependencyTracker_UpdateStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UpdateStatusTriggersReadinessRecalculation", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// A depends on B being "running"
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		// Initially A is not ready
+		ready, err := tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update B to "running" - A should become ready
+		err = tracker.UpdateStatus(consumerB, statusRunning)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+
+	t.Run("UpdateStatusWithUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		err := tracker.UpdateStatus(consumerA, statusRunning)
+		require.Error(t, err)
+		assert.Equal(t, unit.ErrConsumerNotFound, err)
+	})
+
+	t.Run("LinearChainDependencies", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register all consumers
+		consumers := []testConsumerID{consumerA, consumerB, consumerC}
+		for _, consumer := range consumers {
+			err := tracker.Register(consumer)
+			require.NoError(t, err)
+		}
+
+		// Create chain: A depends on B being "started", B depends on C being "completed"
+		err := tracker.AddDependency(consumerA, consumerB, statusStarted)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerB, consumerC, statusCompleted)
+		require.NoError(t, err)
+
+		// Initially only C is ready
+		ready, err := tracker.IsReady(consumerC)
+		require.NoError(t, err)
+		assert.True(t, ready)
+
+		ready, err = tracker.IsReady(consumerB)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update C to "completed" - B should become ready
+		err = tracker.UpdateStatus(consumerC, statusCompleted)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerB)
+		require.NoError(t, err)
+		assert.True(t, ready)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update B to "started" - A should become ready
+		err = tracker.UpdateStatus(consumerB, statusStarted)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+}
+
+func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetUnmetDependenciesForConsumerWithNoDependencies", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+
+		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		require.NoError(t, err)
+		assert.Empty(t, unmet)
+	})
+
+	t.Run("GetUnmetDependenciesForConsumerWithUnsatisfiedDependencies", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// A depends on B being "running"
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		require.NoError(t, err)
+		require.Len(t, unmet, 1)
+
+		assert.Equal(t, consumerA, unmet[0].Consumer)
+		assert.Equal(t, consumerB, unmet[0].DependsOn)
+		assert.Equal(t, statusRunning, unmet[0].RequiredStatus)
+		assert.False(t, unmet[0].IsSatisfied)
+	})
+
+	t.Run("GetUnmetDependenciesForConsumerWithSatisfiedDependencies", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// A depends on B being "running"
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		// Update B to "running"
+		err = tracker.UpdateStatus(consumerB, statusRunning)
+		require.NoError(t, err)
+
+		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		require.NoError(t, err)
+		assert.Empty(t, unmet)
+	})
+
+	t.Run("GetUnmetDependenciesForUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		require.Error(t, err)
+		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Nil(t, unmet)
+	})
+}
+
+func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ConcurrentStatusUpdates", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register consumers
+		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
+		for _, consumer := range consumers {
+			err := tracker.Register(consumer)
+			require.NoError(t, err)
+		}
+
+		// Create dependencies: A depends on B, B depends on C, C depends on D
+		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerB, consumerC, statusStarted)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerC, consumerD, statusCompleted)
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		const numGoroutines = 10
+
+		// Launch goroutines that update statuses
+		errors := make([]error, numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(goroutineID int) {
+				defer wg.Done()
+
+				// Update D to completed (should make C ready)
+				err := tracker.UpdateStatus(consumerD, statusCompleted)
+				if err != nil {
+					errors[goroutineID] = err
+					return
+				}
+
+				// Update C to started (should make B ready)
+				err = tracker.UpdateStatus(consumerC, statusStarted)
+				if err != nil {
+					errors[goroutineID] = err
+					return
+				}
+
+				// Update B to running (should make A ready)
+				err = tracker.UpdateStatus(consumerB, statusRunning)
+				if err != nil {
+					errors[goroutineID] = err
+					return
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Check for any errors in goroutines
+		for i, err := range errors {
+			require.NoError(t, err, "goroutine %d had error", i)
+		}
+
+		// All consumers should be ready after the updates
+		for _, consumer := range consumers {
+			ready, err := tracker.IsReady(consumer)
+			require.NoError(t, err)
+			assert.True(t, ready)
+		}
+	})
+
+	t.Run("ConcurrentReadinessChecks", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register consumers
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// A depends on B being "running"
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		const numGoroutines = 20
+
+		// Launch goroutines that check readiness
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(goroutineID int) {
+				defer wg.Done()
+
+				// Check readiness multiple times
+				for j := 0; j < 10; j++ {
+					ready, err := tracker.IsReady(consumerA)
+					require.NoError(t, err)
+					// Initially should be false, then true after B is updated
+					_ = ready
+
+					ready, err = tracker.IsReady(consumerB)
+					require.NoError(t, err)
+					// B should always be ready (no dependencies)
+					assert.True(t, ready)
+				}
+			}(i)
+		}
+
+		// Update B to "running" in the middle of readiness checks
+		err = tracker.UpdateStatus(consumerB, statusRunning)
+		require.NoError(t, err)
+
+		wg.Wait()
+	})
+}
+
+func TestDependencyTracker_MultipleDependencies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ConsumerWithMultipleDependencies", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register all consumers
+		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
+		for _, consumer := range consumers {
+			err := tracker.Register(consumer)
+			require.NoError(t, err)
+		}
+
+		// A depends on B being "running" AND C being "started"
+		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerA, consumerC, statusStarted)
+		require.NoError(t, err)
+
+		// A should not be ready (depends on both B and C)
+		ready, err := tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update B to "running" - A should still not be ready (needs C too)
+		err = tracker.UpdateStatus(consumerB, statusRunning)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update C to "started" - A should now be ready
+		err = tracker.UpdateStatus(consumerC, statusStarted)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+
+	t.Run("ComplexDependencyChain", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register all consumers
+		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
+		for _, consumer := range consumers {
+			err := tracker.Register(consumer)
+			require.NoError(t, err)
+		}
+
+		// Create complex dependency graph:
+		// A depends on B being "running" AND C being "started"
+		// B depends on D being "completed"
+		// C depends on D being "completed"
+		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerA, consumerC, statusStarted)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerB, consumerD, statusCompleted)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerC, consumerD, statusCompleted)
+		require.NoError(t, err)
+
+		// Initially only D is ready
+		ready, err := tracker.IsReady(consumerD)
+		require.NoError(t, err)
+		assert.True(t, ready)
+
+		ready, err = tracker.IsReady(consumerB)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		ready, err = tracker.IsReady(consumerC)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update D to "completed" - B and C should become ready
+		err = tracker.UpdateStatus(consumerD, statusCompleted)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerB)
+		require.NoError(t, err)
+		assert.True(t, ready)
+
+		ready, err = tracker.IsReady(consumerC)
+		require.NoError(t, err)
+		assert.True(t, ready)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update B to "running" - A should still not be ready (needs C)
+		err = tracker.UpdateStatus(consumerB, statusRunning)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update C to "started" - A should now be ready
+		err = tracker.UpdateStatus(consumerC, statusStarted)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+
+	t.Run("DifferentStatusTypes", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register consumers
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+		err = tracker.Register(consumerC)
+		require.NoError(t, err)
+
+		// A depends on B being "running" AND C being "completed"
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerA, consumerC, statusCompleted)
+		require.NoError(t, err)
+
+		// Update B to "running" but not C - A should not be ready
+		err = tracker.UpdateStatus(consumerB, statusRunning)
+		require.NoError(t, err)
+
+		ready, err := tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.False(t, ready)
+
+		// Update C to "completed" - A should now be ready
+		err = tracker.UpdateStatus(consumerC, statusCompleted)
+		require.NoError(t, err)
+
+		ready, err = tracker.IsReady(consumerA)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+}
+
+func TestDependencyTracker_ErrorCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UpdateStatusWithUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		err := tracker.UpdateStatus(consumerA, statusRunning)
+		require.Error(t, err)
+		assert.Equal(t, unit.ErrConsumerNotFound, err)
+	})
+
+	t.Run("IsReadyWithUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		ready, err := tracker.IsReady(consumerA)
+		require.Error(t, err)
+		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.False(t, ready)
+	})
+
+	t.Run("GetUnmetDependenciesWithUnregisteredConsumer", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		require.Error(t, err)
+		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Nil(t, unmet)
+	})
+
+	t.Run("AddDependencyWithUnregisteredConsumers", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Try to add dependency with unregistered consumers
+		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not registered")
+	})
+
+	t.Run("CyclicDependencyDetection", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register consumers
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// A depends on B
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		// Try to make B depend on A (creates cycle)
+		err = tracker.AddDependency(consumerB, consumerA, statusStarted)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "would create a cycle")
+	})
+}
+
+func TestDependencyTracker_ToDOT(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ExportSimpleGraph", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register consumers
+		err := tracker.Register(consumerA)
+		require.NoError(t, err)
+		err = tracker.Register(consumerB)
+		require.NoError(t, err)
+
+		// Add dependency
+		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+
+		dot, err := tracker.ExportDOT("test")
+		require.NoError(t, err)
+		assert.NotEmpty(t, dot)
+		assert.Contains(t, dot, "digraph")
+	})
+
+	t.Run("ExportComplexGraph", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := unit.NewManager[testStatus, testConsumerID]()
+
+		// Register all consumers
+		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
+		for _, consumer := range consumers {
+			err := tracker.Register(consumer)
+			require.NoError(t, err)
+		}
+
+		// Create complex dependency graph
+		// A depends on B and C, B depends on D, C depends on D
+		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerA, consumerC, statusStarted)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerB, consumerD, statusCompleted)
+		require.NoError(t, err)
+		err = tracker.AddDependency(consumerC, consumerD, statusCompleted)
+		require.NoError(t, err)
+
+		dot, err := tracker.ExportDOT("complex")
+		require.NoError(t, err)
+		assert.NotEmpty(t, dot)
+		assert.Contains(t, dot, "digraph")
+	})
+}

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -19,58 +19,58 @@ const (
 	statusCompleted testStatus = "completed"
 )
 
-type testConsumerID string
+type testUnitID string
 
 const (
-	consumerA testConsumerID = "serviceA"
-	consumerB testConsumerID = "serviceB"
-	consumerC testConsumerID = "serviceC"
-	consumerD testConsumerID = "serviceD"
+	unitA testUnitID = "serviceA"
+	unitB testUnitID = "serviceB"
+	unitC testUnitID = "serviceC"
+	unitD testUnitID = "serviceD"
 )
 
 func TestDependencyTracker_Register(t *testing.T) {
 	t.Parallel()
 
-	tracker := unit.NewManager[testStatus, testConsumerID]()
+	tracker := unit.NewManager[testStatus, testUnitID]()
 
-	t.Run("RegisterNewConsumer", func(t *testing.T) {
+	t.Run("RegisterNewUnit", func(t *testing.T) {
 		t.Parallel()
 
-		err := tracker.Register(consumerA)
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
-		// Consumer should be ready initially (no dependencies)
-		ready, err := tracker.IsReady(consumerA)
+		// Unit should be ready initially (no dependencies)
+		ready, err := tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
 
-	t.Run("RegisterDuplicateConsumer", func(t *testing.T) {
+	t.Run("RegisterDuplicateUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
-		err = tracker.Register(consumerA)
+		err = tracker.Register(unitA)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already registered")
 	})
 
-	t.Run("RegisterMultipleConsumers", func(t *testing.T) {
+	t.Run("RegisterMultipleUnits", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		consumers := []testConsumerID{consumerA, consumerB, consumerC}
-		for _, consumer := range consumers {
-			err := tracker.Register(consumer)
+		units := []testUnitID{unitA, unitB, unitC}
+		for _, unit := range units {
+			err := tracker.Register(unit)
 			require.NoError(t, err)
 		}
 
 		// All should be ready initially
-		for _, consumer := range consumers {
-			ready, err := tracker.IsReady(consumer)
+		for _, unit := range units {
+			ready, err := tracker.IsReady(unit)
 			require.NoError(t, err)
 			assert.True(t, ready)
 		}
@@ -80,52 +80,52 @@ func TestDependencyTracker_Register(t *testing.T) {
 func TestDependencyTracker_AddDependency(t *testing.T) {
 	t.Parallel()
 
-	t.Run("AddDependencyBetweenRegisteredConsumers", func(t *testing.T) {
+	t.Run("AddDependencyBetweenRegisteredUnits", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// A depends on B being "running"
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
 		// A should no longer be ready (depends on B)
-		ready, err := tracker.IsReady(consumerA)
+		ready, err := tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// B should still be ready (no dependencies)
-		ready, err = tracker.IsReady(consumerB)
+		ready, err = tracker.IsReady(unitB)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
 
-	t.Run("AddDependencyWithUnregisteredConsumer", func(t *testing.T) {
+	t.Run("AddDependencyWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
-		// Try to add dependency to unregistered consumer
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		// Try to add dependency to unregistered unit
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not registered")
 	})
 
-	t.Run("AddDependencyFromUnregisteredConsumer", func(t *testing.T) {
+	t.Run("AddDependencyFromUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerB)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitB)
 		require.NoError(t, err)
 
-		// Try to add dependency from unregistered consumer
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		// Try to add dependency from unregistered unit
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not registered")
 	})
@@ -137,88 +137,88 @@ func TestDependencyTracker_UpdateStatus(t *testing.T) {
 	t.Run("UpdateStatusTriggersReadinessRecalculation", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// A depends on B being "running"
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
 		// Initially A is not ready
-		ready, err := tracker.IsReady(consumerA)
+		ready, err := tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update B to "running" - A should become ready
-		err = tracker.UpdateStatus(consumerB, statusRunning)
+		err = tracker.UpdateStatus(unitB, statusRunning)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
 
-	t.Run("UpdateStatusWithUnregisteredConsumer", func(t *testing.T) {
+	t.Run("UpdateStatusWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		err := tracker.UpdateStatus(consumerA, statusRunning)
+		err := tracker.UpdateStatus(unitA, statusRunning)
 		require.Error(t, err)
-		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Equal(t, unit.ErrUnitNotFound, err)
 	})
 
 	t.Run("LinearChainDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register all consumers
-		consumers := []testConsumerID{consumerA, consumerB, consumerC}
-		for _, consumer := range consumers {
-			err := tracker.Register(consumer)
+		// Register all units
+		units := []testUnitID{unitA, unitB, unitC}
+		for _, unit := range units {
+			err := tracker.Register(unit)
 			require.NoError(t, err)
 		}
 
 		// Create chain: A depends on B being "started", B depends on C being "completed"
-		err := tracker.AddDependency(consumerA, consumerB, statusStarted)
+		err := tracker.AddDependency(unitA, unitB, statusStarted)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerB, consumerC, statusCompleted)
+		err = tracker.AddDependency(unitB, unitC, statusCompleted)
 		require.NoError(t, err)
 
 		// Initially only C is ready
-		ready, err := tracker.IsReady(consumerC)
+		ready, err := tracker.IsReady(unitC)
 		require.NoError(t, err)
 		assert.True(t, ready)
 
-		ready, err = tracker.IsReady(consumerB)
+		ready, err = tracker.IsReady(unitB)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update C to "completed" - B should become ready
-		err = tracker.UpdateStatus(consumerC, statusCompleted)
+		err = tracker.UpdateStatus(unitC, statusCompleted)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerB)
+		ready, err = tracker.IsReady(unitB)
 		require.NoError(t, err)
 		assert.True(t, ready)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update B to "started" - A should become ready
-		err = tracker.UpdateStatus(consumerB, statusStarted)
+		err = tracker.UpdateStatus(unitB, statusStarted)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
@@ -227,71 +227,71 @@ func TestDependencyTracker_UpdateStatus(t *testing.T) {
 func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
 	t.Parallel()
 
-	t.Run("GetUnmetDependenciesForConsumerWithNoDependencies", func(t *testing.T) {
+	t.Run("GetUnmetDependenciesForUnitWithNoDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
 
-		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.NoError(t, err)
 		assert.Empty(t, unmet)
 	})
 
-	t.Run("GetUnmetDependenciesForConsumerWithUnsatisfiedDependencies", func(t *testing.T) {
+	t.Run("GetUnmetDependenciesForUnitWithUnsatisfiedDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// A depends on B being "running"
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
-		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.NoError(t, err)
 		require.Len(t, unmet, 1)
 
-		assert.Equal(t, consumerA, unmet[0].Consumer)
-		assert.Equal(t, consumerB, unmet[0].DependsOn)
+		assert.Equal(t, unitA, unmet[0].Unit)
+		assert.Equal(t, unitB, unmet[0].DependsOn)
 		assert.Equal(t, statusRunning, unmet[0].RequiredStatus)
 		assert.False(t, unmet[0].IsSatisfied)
 	})
 
-	t.Run("GetUnmetDependenciesForConsumerWithSatisfiedDependencies", func(t *testing.T) {
+	t.Run("GetUnmetDependenciesForUnitWithSatisfiedDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
-		err := tracker.Register(consumerA)
+		tracker := unit.NewManager[testStatus, testUnitID]()
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// A depends on B being "running"
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
 		// Update B to "running"
-		err = tracker.UpdateStatus(consumerB, statusRunning)
+		err = tracker.UpdateStatus(unitB, statusRunning)
 		require.NoError(t, err)
 
-		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.NoError(t, err)
 		assert.Empty(t, unmet)
 	})
 
-	t.Run("GetUnmetDependenciesForUnregisteredConsumer", func(t *testing.T) {
+	t.Run("GetUnmetDependenciesForUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.Error(t, err)
-		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Equal(t, unit.ErrUnitNotFound, err)
 		assert.Nil(t, unmet)
 	})
 }
@@ -302,21 +302,21 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 	t.Run("ConcurrentStatusUpdates", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register consumers
-		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
-		for _, consumer := range consumers {
-			err := tracker.Register(consumer)
+		// Register units
+		units := []testUnitID{unitA, unitB, unitC, unitD}
+		for _, unit := range units {
+			err := tracker.Register(unit)
 			require.NoError(t, err)
 		}
 
 		// Create dependencies: A depends on B, B depends on C, C depends on D
-		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err := tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerB, consumerC, statusStarted)
+		err = tracker.AddDependency(unitB, unitC, statusStarted)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerC, consumerD, statusCompleted)
+		err = tracker.AddDependency(unitC, unitD, statusCompleted)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -330,21 +330,21 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 				defer wg.Done()
 
 				// Update D to completed (should make C ready)
-				err := tracker.UpdateStatus(consumerD, statusCompleted)
+				err := tracker.UpdateStatus(unitD, statusCompleted)
 				if err != nil {
 					goroutineErrors[goroutineID] = err
 					return
 				}
 
 				// Update C to started (should make B ready)
-				err = tracker.UpdateStatus(consumerC, statusStarted)
+				err = tracker.UpdateStatus(unitC, statusStarted)
 				if err != nil {
 					goroutineErrors[goroutineID] = err
 					return
 				}
 
 				// Update B to running (should make A ready)
-				err = tracker.UpdateStatus(consumerB, statusRunning)
+				err = tracker.UpdateStatus(unitB, statusRunning)
 				if err != nil {
 					goroutineErrors[goroutineID] = err
 					return
@@ -362,9 +362,9 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 			}
 		}
 
-		// All consumers should be ready after the updates
-		for _, consumer := range consumers {
-			ready, err := tracker.IsReady(consumer)
+		// All units should be ready after the updates
+		for _, unit := range units {
+			ready, err := tracker.IsReady(unit)
 			require.NoError(t, err)
 			assert.True(t, ready)
 		}
@@ -373,16 +373,16 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 	t.Run("ConcurrentReadinessChecks", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register consumers
-		err := tracker.Register(consumerA)
+		// Register units
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// A depends on B being "running"
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -396,12 +396,12 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 
 				// Check readiness multiple times
 				for j := 0; j < 10; j++ {
-					ready, err := tracker.IsReady(consumerA)
+					ready, err := tracker.IsReady(unitA)
 					require.NoError(t, err)
 					// Initially should be false, then true after B is updated
 					_ = ready
 
-					ready, err = tracker.IsReady(consumerB)
+					ready, err = tracker.IsReady(unitB)
 					require.NoError(t, err)
 					// B should always be ready (no dependencies)
 					assert.True(t, ready)
@@ -410,7 +410,7 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 		}
 
 		// Update B to "running" in the middle of readiness checks
-		err = tracker.UpdateStatus(consumerB, statusRunning)
+		err = tracker.UpdateStatus(unitB, statusRunning)
 		require.NoError(t, err)
 
 		wg.Wait()
@@ -420,42 +420,42 @@ func TestDependencyTracker_ConcurrentOperations(t *testing.T) {
 func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ConsumerWithMultipleDependencies", func(t *testing.T) {
+	t.Run("UnitWithMultipleDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register all consumers
-		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
-		for _, consumer := range consumers {
-			err := tracker.Register(consumer)
+		// Register all units
+		units := []testUnitID{unitA, unitB, unitC, unitD}
+		for _, unit := range units {
+			err := tracker.Register(unit)
 			require.NoError(t, err)
 		}
 
 		// A depends on B being "running" AND C being "started"
-		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err := tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerA, consumerC, statusStarted)
+		err = tracker.AddDependency(unitA, unitC, statusStarted)
 		require.NoError(t, err)
 
 		// A should not be ready (depends on both B and C)
-		ready, err := tracker.IsReady(consumerA)
+		ready, err := tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update B to "running" - A should still not be ready (needs C too)
-		err = tracker.UpdateStatus(consumerB, statusRunning)
+		err = tracker.UpdateStatus(unitB, statusRunning)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update C to "started" - A should now be ready
-		err = tracker.UpdateStatus(consumerC, statusStarted)
+		err = tracker.UpdateStatus(unitC, statusStarted)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
@@ -463,12 +463,12 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 	t.Run("ComplexDependencyChain", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register all consumers
-		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
-		for _, consumer := range consumers {
-			err := tracker.Register(consumer)
+		// Register all units
+		units := []testUnitID{unitA, unitB, unitC, unitD}
+		for _, unit := range units {
+			err := tracker.Register(unit)
 			require.NoError(t, err)
 		}
 
@@ -476,61 +476,61 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 		// A depends on B being "running" AND C being "started"
 		// B depends on D being "completed"
 		// C depends on D being "completed"
-		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err := tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerA, consumerC, statusStarted)
+		err = tracker.AddDependency(unitA, unitC, statusStarted)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerB, consumerD, statusCompleted)
+		err = tracker.AddDependency(unitB, unitD, statusCompleted)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerC, consumerD, statusCompleted)
+		err = tracker.AddDependency(unitC, unitD, statusCompleted)
 		require.NoError(t, err)
 
 		// Initially only D is ready
-		ready, err := tracker.IsReady(consumerD)
+		ready, err := tracker.IsReady(unitD)
 		require.NoError(t, err)
 		assert.True(t, ready)
 
-		ready, err = tracker.IsReady(consumerB)
+		ready, err = tracker.IsReady(unitB)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
-		ready, err = tracker.IsReady(consumerC)
+		ready, err = tracker.IsReady(unitC)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update D to "completed" - B and C should become ready
-		err = tracker.UpdateStatus(consumerD, statusCompleted)
+		err = tracker.UpdateStatus(unitD, statusCompleted)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerB)
-		require.NoError(t, err)
-		assert.True(t, ready)
-
-		ready, err = tracker.IsReady(consumerC)
+		ready, err = tracker.IsReady(unitB)
 		require.NoError(t, err)
 		assert.True(t, ready)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitC)
+		require.NoError(t, err)
+		assert.True(t, ready)
+
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update B to "running" - A should still not be ready (needs C)
-		err = tracker.UpdateStatus(consumerB, statusRunning)
+		err = tracker.UpdateStatus(unitB, statusRunning)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update C to "started" - A should now be ready
-		err = tracker.UpdateStatus(consumerC, statusStarted)
+		err = tracker.UpdateStatus(unitC, statusStarted)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
@@ -538,35 +538,35 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 	t.Run("DifferentStatusTypes", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register consumers
-		err := tracker.Register(consumerA)
+		// Register units
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
-		err = tracker.Register(consumerC)
+		err = tracker.Register(unitC)
 		require.NoError(t, err)
 
 		// A depends on B being "running" AND C being "completed"
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerA, consumerC, statusCompleted)
+		err = tracker.AddDependency(unitA, unitC, statusCompleted)
 		require.NoError(t, err)
 
 		// Update B to "running" but not C - A should not be ready
-		err = tracker.UpdateStatus(consumerB, statusRunning)
+		err = tracker.UpdateStatus(unitB, statusRunning)
 		require.NoError(t, err)
 
-		ready, err := tracker.IsReady(consumerA)
+		ready, err := tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.False(t, ready)
 
 		// Update C to "completed" - A should now be ready
-		err = tracker.UpdateStatus(consumerC, statusCompleted)
+		err = tracker.UpdateStatus(unitC, statusCompleted)
 		require.NoError(t, err)
 
-		ready, err = tracker.IsReady(consumerA)
+		ready, err = tracker.IsReady(unitA)
 		require.NoError(t, err)
 		assert.True(t, ready)
 	})
@@ -575,45 +575,45 @@ func TestDependencyTracker_MultipleDependencies(t *testing.T) {
 func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Parallel()
 
-	t.Run("UpdateStatusWithUnregisteredConsumer", func(t *testing.T) {
+	t.Run("UpdateStatusWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		err := tracker.UpdateStatus(consumerA, statusRunning)
+		err := tracker.UpdateStatus(unitA, statusRunning)
 		require.Error(t, err)
-		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Equal(t, unit.ErrUnitNotFound, err)
 	})
 
-	t.Run("IsReadyWithUnregisteredConsumer", func(t *testing.T) {
+	t.Run("IsReadyWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		ready, err := tracker.IsReady(consumerA)
+		ready, err := tracker.IsReady(unitA)
 		require.Error(t, err)
-		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Equal(t, unit.ErrUnitNotFound, err)
 		assert.False(t, ready)
 	})
 
-	t.Run("GetUnmetDependenciesWithUnregisteredConsumer", func(t *testing.T) {
+	t.Run("GetUnmetDependenciesWithUnregisteredUnit", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		unmet, err := tracker.GetUnmetDependencies(consumerA)
+		unmet, err := tracker.GetUnmetDependencies(unitA)
 		require.Error(t, err)
-		assert.Equal(t, unit.ErrConsumerNotFound, err)
+		assert.Equal(t, unit.ErrUnitNotFound, err)
 		assert.Nil(t, unmet)
 	})
 
-	t.Run("AddDependencyWithUnregisteredConsumers", func(t *testing.T) {
+	t.Run("AddDependencyWithUnregisteredUnits", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Try to add dependency with unregistered consumers
-		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		// Try to add dependency with unregistered units
+		err := tracker.AddDependency(unitA, unitB, statusRunning)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not registered")
 	})
@@ -621,20 +621,20 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 	t.Run("CyclicDependencyDetection", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register consumers
-		err := tracker.Register(consumerA)
+		// Register units
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// A depends on B
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
 		// Try to make B depend on A (creates cycle)
-		err = tracker.AddDependency(consumerB, consumerA, statusStarted)
+		err = tracker.AddDependency(unitB, unitA, statusStarted)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "would create a cycle")
 	})
@@ -646,16 +646,16 @@ func TestDependencyTracker_ToDOT(t *testing.T) {
 	t.Run("ExportSimpleGraph", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register consumers
-		err := tracker.Register(consumerA)
+		// Register units
+		err := tracker.Register(unitA)
 		require.NoError(t, err)
-		err = tracker.Register(consumerB)
+		err = tracker.Register(unitB)
 		require.NoError(t, err)
 
 		// Add dependency
-		err = tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err = tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
 
 		dot, err := tracker.ExportDOT("test")
@@ -667,24 +667,24 @@ func TestDependencyTracker_ToDOT(t *testing.T) {
 	t.Run("ExportComplexGraph", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := unit.NewManager[testStatus, testConsumerID]()
+		tracker := unit.NewManager[testStatus, testUnitID]()
 
-		// Register all consumers
-		consumers := []testConsumerID{consumerA, consumerB, consumerC, consumerD}
-		for _, consumer := range consumers {
-			err := tracker.Register(consumer)
+		// Register all units
+		units := []testUnitID{unitA, unitB, unitC, unitD}
+		for _, unit := range units {
+			err := tracker.Register(unit)
 			require.NoError(t, err)
 		}
 
 		// Create complex dependency graph
 		// A depends on B and C, B depends on D, C depends on D
-		err := tracker.AddDependency(consumerA, consumerB, statusRunning)
+		err := tracker.AddDependency(unitA, unitB, statusRunning)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerA, consumerC, statusStarted)
+		err = tracker.AddDependency(unitA, unitC, statusStarted)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerB, consumerD, statusCompleted)
+		err = tracker.AddDependency(unitB, unitD, statusCompleted)
 		require.NoError(t, err)
-		err = tracker.AddDependency(consumerC, consumerD, statusCompleted)
+		err = tracker.AddDependency(unitC, unitD, statusCompleted)
 		require.NoError(t, err)
 
 		dot, err := tracker.ExportDOT("complex")

--- a/agent/unit/manager_test.go
+++ b/agent/unit/manager_test.go
@@ -43,8 +43,7 @@ func TestDependencyTracker_Register(t *testing.T) {
 		require.NoError(t, err)
 
 		err = tracker.Register(unitA)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "already registered")
+		require.ErrorIs(t, err, unit.ErrUnitAlreadyRegistered)
 	})
 
 	t.Run("RegisterMultipleUnits", func(t *testing.T) {
@@ -103,8 +102,7 @@ func TestDependencyTracker_AddDependency(t *testing.T) {
 
 		// Try to add dependency to unregistered unit
 		err = tracker.AddDependency(unitA, unitB, unit.StatusStarted)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not registered")
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 	})
 
 	t.Run("AddDependencyFromUnregisteredUnit", func(t *testing.T) {
@@ -116,8 +114,7 @@ func TestDependencyTracker_AddDependency(t *testing.T) {
 
 		// Try to add dependency from unregistered unit
 		err = tracker.AddDependency(unitA, unitB, unit.StatusStarted)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not registered")
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 	})
 }
 
@@ -157,8 +154,7 @@ func TestDependencyTracker_UpdateStatus(t *testing.T) {
 		tracker := unit.NewManager[string, testUnitID]()
 
 		err := tracker.UpdateStatus(unitA, unit.StatusStarted)
-		require.Error(t, err)
-		assert.Equal(t, unit.ErrUnitNotFound, err)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 	})
 
 	t.Run("LinearChainDependencies", func(t *testing.T) {
@@ -280,8 +276,7 @@ func TestDependencyTracker_GetUnmetDependencies(t *testing.T) {
 		tracker := unit.NewManager[string, testUnitID]()
 
 		unmet, err := tracker.GetUnmetDependencies(unitA)
-		require.Error(t, err)
-		assert.Equal(t, unit.ErrUnitNotFound, err)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 		assert.Nil(t, unmet)
 	})
 }
@@ -450,8 +445,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 		tracker := unit.NewManager[string, testUnitID]()
 
 		err := tracker.UpdateStatus(unitA, unit.StatusStarted)
-		require.Error(t, err)
-		assert.Equal(t, unit.ErrUnitNotFound, err)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 	})
 
 	t.Run("IsReadyWithUnregisteredUnit", func(t *testing.T) {
@@ -460,8 +454,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 		tracker := unit.NewManager[string, testUnitID]()
 
 		ready, err := tracker.IsReady(unitA)
-		require.Error(t, err)
-		assert.Equal(t, unit.ErrUnitNotFound, err)
+		require.ErrorIs(t, err, unit.ErrUnitNotFound)
 		assert.False(t, ready)
 	})
 
@@ -515,8 +508,7 @@ func TestDependencyTracker_ErrorCases(t *testing.T) {
 
 		// Try to make D depend on A (creates indirect cycle)
 		err = tracker.AddDependency(unitD, unitA, unit.StatusStarted)
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "would create a cycle")
+		require.ErrorIs(t, err, unit.ErrCycleDetected)
 	})
 }
 


### PR DESCRIPTION
relates to: https://github.com/coder/internal/issues/1094

This is number 1 of 5 pull requests in an effort to add agent script ordering. It adds a unit manager, which uses an underlying DAG and a list of subscribers to inform units when their dependencies have changed in status.

In follow-up PRs:
* This unit manager will be plumbed into the workspace agent struct. 
* It will then be exposed to users via a new socket based drpc API 
* The agentsocket API will then become accessible via CLI commands that allow coder scripts to express their dependencies on one another.

This is an experimental feature. There may be ways to improve the efficiency of the manager struct, but it is more important to validate this feature with customers before we invest in such optimizations.

See the tests for examples of how units may communicate with one another. Actual CLI usage will be analogous.

I used an LLM to produce some of these changes, but I have conducted thorough self review and consider this contribution to be ready for an external reviewer.