### PR TITLE
fix: use correct slog arguments (#20721)

### DIFF
--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -391,7 +391,7 @@ func (i *InstanceIdentitySessionTokenProvider) GetSessionToken() string {
 	defer cancel()
 	resp, err := i.TokenExchanger.exchange(ctx)
 	if err != nil {
-		i.logger.Error(ctx, "failed to exchange session token: %v", err)
+		i.logger.Error(ctx, "failed to exchange session token", slog.Error(err))
 		return ""
 	}
 	i.sessionToken = resp.SessionToken


### PR DESCRIPTION
Fixes a bad slog.Error() command that didn't wrap the error in `slog.Error`

(cherry pick form https://github.com/coder/coder/pull/20721)
