### PR TITLE
perf: improve performance of metricsAggregator path by reducing memory allocations

### DIFF
--- a/coderd/prometheusmetrics/aggregator.go
+++ b/coderd/prometheusmetrics/aggregator.go
@@ -374,6 +374,8 @@ func (*MetricsAggregator) Describe(_ chan<- *prometheus.Desc) {
 }
 
 // cacheKeyForDesc is used to determine the cache key for a set of labels/extra labels. Used with the aggregators description cache.
+// for strings.Builder returned errors from these functions are always nil.
+// nolint:revive
 func cacheKeyForDesc(name string, baseLabelNames []string, extraLabels []*agentproto.Stats_Metric_Label) string {
 	var b strings.Builder
 	hint := len(name) + (len(baseLabelNames)+len(extraLabels))*8
@@ -389,6 +391,7 @@ func cacheKeyForDesc(name string, baseLabelNames []string, extraLabels []*agentp
 	}
 	return b.String()
 }
+
 // getOrCreateDec checks if we already have a metric description in the aggregators cache for a given combination of base
 // labels and extra labels. If we do not, we create a new description and cache it.
 func (ma *MetricsAggregator) getOrCreateDesc(name string, help string, baseLabelNames []string, extraLabels []*agentproto.Stats_Metric_Label) *prometheus.Desc {
@@ -412,7 +415,8 @@ func (ma *MetricsAggregator) getOrCreateDesc(name string, help string, baseLabel
 }
 
 // asPrometheus returns the annotatedMetric as a prometheus.Metric, it preallocates/fills by index, uses the aggregators
-//  metric description cache, and a small stack buffer for values in order to reduce memory allocations.
+//
+//	metric description cache, and a small stack buffer for values in order to reduce memory allocations.
 func (ma *MetricsAggregator) asPrometheus(am *annotatedMetric) (prometheus.Metric, error) {
 	baseLabelNames := am.aggregateByLabels
 	extraLabels := am.Labels

--- a/coderd/prometheusmetrics/aggregator.go
+++ b/coderd/prometheusmetrics/aggregator.go
@@ -408,6 +408,7 @@ func (ma *MetricsAggregator) getOrCreateDesc(name string, help string, baseLabel
 	key := cacheKeyForDesc(name, baseLabelNames, extraLabels)
 	if d, ok := ma.descCache[key]; ok {
 		d.lastUsed = time.Now()
+		ma.descCache[key] = d
 		return d.desc
 	}
 	nBase := len(baseLabelNames)

--- a/coderd/prometheusmetrics/aggregator.go
+++ b/coderd/prometheusmetrics/aggregator.go
@@ -357,11 +357,7 @@ func (ma *MetricsAggregator) Run(ctx context.Context) func() {
 					}
 				}
 
-				for key, entry := range ma.descCache {
-					if time.Since(entry.lastUsed) > ma.metricsCleanupInterval {
-						delete(ma.descCache, key)
-					}
-				}
+				ma.cleanupDescCache()
 
 				timer.ObserveDuration()
 				cleanupTicker.Reset(ma.metricsCleanupInterval)
@@ -506,6 +502,16 @@ func (ma *MetricsAggregator) Update(ctx context.Context, labels AgentMetricLabel
 		ma.log.Debug(ctx, "update request is canceled")
 	default:
 		ma.log.Error(ctx, "update queue is full")
+	}
+}
+
+// Move to a function for testability
+func (ma *MetricsAggregator) cleanupDescCache() {
+	now := time.Now()
+	for key, entry := range ma.descCache {
+		if now.Sub(entry.lastUsed) > ma.metricsCleanupInterval {
+			delete(ma.descCache, key)
+		}
 	}
 }
 

--- a/coderd/prometheusmetrics/aggregator.go
+++ b/coderd/prometheusmetrics/aggregator.go
@@ -238,6 +238,12 @@ func NewMetricsAggregator(logger slog.Logger, registerer prometheus.Registerer, 
 	}, nil
 }
 
+// asPrometheus on MetricsAggregator delegates to annotatedMetric.asPrometheus.
+func (ma *MetricsAggregator) asPrometheus(am *annotatedMetric) (prometheus.Metric, error) {
+	return am.asPrometheus()
+}
+
+
 // labelAggregator is used to control cardinality of collected Prometheus metrics by pre-aggregating series based on given labels.
 type labelAggregator struct {
 	aggregations map[string]float64

--- a/coderd/prometheusmetrics/aggregator.go
+++ b/coderd/prometheusmetrics/aggregator.go
@@ -38,8 +38,8 @@ const (
 var MetricLabelValueEncoder = strings.NewReplacer("\\", "\\\\", "|", "\\|", ",", "\\,", "=", "\\=")
 
 type descCacheEntry struct {
-    desc      *prometheus.Desc
-    lastUsed  time.Time
+	desc     *prometheus.Desc
+	lastUsed time.Time
 }
 
 type MetricsAggregator struct {
@@ -358,7 +358,7 @@ func (ma *MetricsAggregator) Run(ctx context.Context) func() {
 				}
 
 				for key, entry := range ma.descCache {
-					if time.Now().Sub(entry.lastUsed) > ma.metricsCleanupInterval {
+					if time.Since(entry.lastUsed) > ma.metricsCleanupInterval {
 						delete(ma.descCache, key)
 					}
 				}
@@ -411,7 +411,7 @@ func (ma *MetricsAggregator) getOrCreateDesc(name string, help string, baseLabel
 	}
 	key := cacheKeyForDesc(name, baseLabelNames, extraLabels)
 	if d, ok := ma.descCache[key]; ok {
-		d.lastUsed=time.Now()
+		d.lastUsed = time.Now()
 		return d.desc
 	}
 	nBase := len(baseLabelNames)

--- a/coderd/prometheusmetrics/aggregator_internal_test.go
+++ b/coderd/prometheusmetrics/aggregator_internal_test.go
@@ -36,12 +36,6 @@ func TestDescCache_DescExpire(t *testing.T) {
 	ma, err := NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Millisecond, agentmetrics.LabelAll)
 	require.NoError(t, err)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
-
-	closeFunc := ma.Run(ctx)
-	t.Cleanup(closeFunc)
-
 	given := []*agentproto.Stats_Metric{
 		{Name: "a_counter_one", Type: agentproto.Stats_Metric_COUNTER, Value: 1},
 	}
@@ -58,14 +52,8 @@ func TestDescCache_DescExpire(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// when
-	// metricsAggregator.Update(ctx, testLabels, given)
-	// ma.getOrCreateDec(given[0].Name, "a_counter_one counts some thing", testLabels, nil)
-
-	time.Sleep(time.Millisecond * 10) // Ensure that metric is expired
-
-	// then
 	require.Eventually(t, func() bool {
+		ma.cleanupDescCache()
 		return len(ma.descCache) == 0
 	}, testutil.WaitShort, testutil.IntervalFast)
 }

--- a/coderd/prometheusmetrics/aggregator_internal_test.go
+++ b/coderd/prometheusmetrics/aggregator_internal_test.go
@@ -1,18 +1,17 @@
 package prometheusmetrics
 
 import (
-	"testing"
 	"context"
+	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/sloggers/slogtest"
-	"github.com/coder/coder/v2/coderd/agentmetrics"
 	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/coderd/agentmetrics"
 	"github.com/coder/coder/v2/testutil"
-
 )
 
 func TestDescCache_DescExpire(t *testing.T) {
@@ -23,7 +22,7 @@ func TestDescCache_DescExpire(t *testing.T) {
 		testTemplateName  = "main-template"
 	)
 
-	var testLabels = AgentMetricLabels{
+	testLabels := AgentMetricLabels{
 		Username:      testUsername,
 		WorkspaceName: testWorkspaceName,
 		AgentName:     testAgentName,
@@ -47,7 +46,7 @@ func TestDescCache_DescExpire(t *testing.T) {
 		{Name: "a_counter_one", Type: agentproto.Stats_Metric_COUNTER, Value: 1},
 	}
 
-	ma.asPrometheus(&annotatedMetric{
+	_, err = ma.asPrometheus(&annotatedMetric{
 		given[0],
 		testLabels.Username,
 		testLabels.WorkspaceName,
@@ -57,6 +56,7 @@ func TestDescCache_DescExpire(t *testing.T) {
 		time.Now(),
 		[]string{},
 	})
+	require.NoError(t, err)
 
 	// when
 	// metricsAggregator.Update(ctx, testLabels, given)

--- a/coderd/prometheusmetrics/aggregator_internal_test.go
+++ b/coderd/prometheusmetrics/aggregator_internal_test.go
@@ -1,0 +1,71 @@
+package prometheusmetrics
+
+import (
+	"testing"
+	"context"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/agentmetrics"
+	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/testutil"
+
+)
+
+func TestDescCache_DescExpire(t *testing.T) {
+	const (
+		testWorkspaceName = "yogi-workspace"
+		testUsername      = "yogi-bear"
+		testAgentName     = "main-agent"
+		testTemplateName  = "main-template"
+	)
+
+	var testLabels = AgentMetricLabels{
+		Username:      testUsername,
+		WorkspaceName: testWorkspaceName,
+		AgentName:     testAgentName,
+		TemplateName:  testTemplateName,
+	}
+
+	t.Parallel()
+
+	// given
+	registry := prometheus.NewRegistry()
+	ma, err := NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Millisecond, agentmetrics.LabelAll)
+	require.NoError(t, err)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	closeFunc := ma.Run(ctx)
+	t.Cleanup(closeFunc)
+
+	given := []*agentproto.Stats_Metric{
+		{Name: "a_counter_one", Type: agentproto.Stats_Metric_COUNTER, Value: 1},
+	}
+
+	ma.asPrometheus(&annotatedMetric{
+		given[0],
+		testLabels.Username,
+		testLabels.WorkspaceName,
+		testLabels.AgentName,
+		testLabels.TemplateName,
+		// the rest doesn't matter for this test
+		time.Now(),
+		[]string{},
+	})
+
+	// when
+	// metricsAggregator.Update(ctx, testLabels, given)
+	// ma.getOrCreateDec(given[0].Name, "a_counter_one counts some thing", testLabels, nil)
+
+	time.Sleep(time.Millisecond * 10) // Ensure that metric is expired
+
+	// then
+	require.Eventually(t, func() bool {
+		return len(ma.descCache) == 0
+	}, testutil.WaitShort, testutil.IntervalFast)
+}

--- a/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/agentmetrics"
@@ -45,9 +45,9 @@ var sinkMetric prometheus.Metric
 func benchAsPrometheus(b *testing.B, base []string, extraN int) {
 	am := annotatedMetric{
 		Stats_Metric: &agentproto.Stats_Metric{
-			Name:  "blink_test_metric",
-			Type:  agentproto.Stats_Metric_GAUGE,
-			Value: 1,
+			Name:   "blink_test_metric",
+			Type:   agentproto.Stats_Metric_GAUGE,
+			Value:  1,
 			Labels: make([]*agentproto.Stats_Metric_Label, extraN),
 		},
 		username:          "user",
@@ -74,7 +74,7 @@ func benchAsPrometheus(b *testing.B, base []string, extraN int) {
 }
 
 func Benchmark_asPrometheus(b *testing.B) {
-	cases := []struct{
+	cases := []struct {
 		name   string
 		base   []string
 		extraN int

--- a/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	agentproto "github.com/coder/coder/v2/agent/proto"
@@ -40,8 +39,6 @@ func TestFilterAcceptableAgentLabels(t *testing.T) {
 	}
 }
 
-var sinkMetric prometheus.Metric
-
 func benchAsPrometheus(b *testing.B, base []string, extraN int) {
 	am := annotatedMetric{
 		Stats_Metric: &agentproto.Stats_Metric{
@@ -65,11 +62,10 @@ func benchAsPrometheus(b *testing.B, base []string, extraN int) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m, err := ma.asPrometheus(&am)
+		_, err := ma.asPrometheus(&am)
 		if err != nil {
 			b.Fatal(err)
 		}
-		sinkMetric = m
 	}
 }
 

--- a/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
@@ -1,10 +1,13 @@
 package prometheusmetrics
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/prometheus/client_golang/prometheus"
 
+	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/agentmetrics"
 )
 
@@ -33,6 +36,58 @@ func TestFilterAcceptableAgentLabels(t *testing.T) {
 			t.Parallel()
 
 			require.Equal(t, tc.expected, filterAcceptableAgentLabels(tc.input))
+		})
+	}
+}
+
+var sinkMetric prometheus.Metric
+
+func benchAsPrometheus(b *testing.B, base []string, extraN int) {
+	am := annotatedMetric{
+		Stats_Metric: &agentproto.Stats_Metric{
+			Name:  "blink_test_metric",
+			Type:  agentproto.Stats_Metric_GAUGE,
+			Value: 1,
+			Labels: make([]*agentproto.Stats_Metric_Label, extraN),
+		},
+		username:          "user",
+		workspaceName:     "ws",
+		agentName:         "agent",
+		templateName:      "tmpl",
+		aggregateByLabels: base,
+	}
+	for i := 0; i < extraN; i++ {
+		am.Labels[i] = &agentproto.Stats_Metric_Label{Name: fmt.Sprintf("l%d", i), Value: "v"}
+	}
+
+	ma := &MetricsAggregator{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m, err := ma.asPrometheus(&am)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sinkMetric = m
+	}
+}
+
+func Benchmark_asPrometheus(b *testing.B) {
+	cases := []struct{
+		name   string
+		base   []string
+		extraN int
+	}{
+		{"base4_extra0", defaultAgentMetricsLabels, 0},
+		{"base4_extra2", defaultAgentMetricsLabels, 2},
+		{"base4_extra5", defaultAgentMetricsLabels, 5},
+		{"base4_extra10", defaultAgentMetricsLabels, 10},
+		{"base2_extra5", []string{agentmetrics.LabelUsername, agentmetrics.LabelWorkspaceName}, 5},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			benchAsPrometheus(b, tc.base, tc.extraN)
 		})
 	}
 }


### PR DESCRIPTION
**NOTE:** this is still WIP as it introduces in-memory caching of some data, and there is currently no cleanup of that cache. To be decided; do we want to keep the cache or not based on benchmark results (see below), and if so do we want to introduce LRU caching or TTL caching. **I would lean towards basic TTL caching with cleanup via a goroutine unless there's an argument for more strict bounding of our memory usage here. We're likely already over allocating here at the moment, with this PR memory usage should be more stable for a given set of live Agents.**

Again, poking around in our profiling data this seemed like a quick win. This will be more impactful in larger organizations/with larger #'s of agents per workspace.

The `MetricsAggregator` `Run` function and the `asPrometheus` function, which previously was attached to the `annotatedMetric` type, are the source of ~11% of our memory allocations and ~7.5% of total memory allocated (24h period). This path itself is only ~1.6% of our CPU time but it should also have a knock on affect on garbage collection which is about ~7.6% of CPU time. 

<img width="1709" height="468" alt="Screenshot 2025-11-11 at 3 18 19 PM" src="https://github.com/user-attachments/assets/18712791-8be5-40b2-a70d-91dfc3d2fee4" />

<img width="1709" height="468" alt="Screenshot 2025-11-11 at 3 18 29 PM" src="https://github.com/user-attachments/assets/949c14c1-29a2-4357-af33-572ab9796556" />
<img width="1709" height="468" alt="Screenshot 2025-11-11 at 3 27 19 PM" src="https://github.com/user-attachments/assets/93eabb20-4a29-47f5-9d4e-50c46da62295" />

<img width="1709" height="468" alt="Screenshot 2025-11-11 at 3 27 40 PM" src="https://github.com/user-attachments/assets/005febca-8b24-43b3-b469-5f6cd427da26" />

The optimizations are relatively straightforward:
- preallocate the string slice for the final label set with the correct length based on the base labels and extra labels lengths
- move `asPrometheus` from the `annotatedMetric` to `MetricsAggregator` so we can cache metrics description structs for metrics (should be a big win, agents likely push the same metrics repeatedly over time)
- use a stack allocated slice in asPrometheus of a 'reasonable size' (16 in this case) to avoid heap allocation (most of the time) for smaller label sets (in terms of # of pairs)

Benchmark Results:
```
goos: linux
goarch: amd64
pkg: github.com/coder/coder/v2/coderd/prometheusmetrics
cpu: AMD EPYC 9254 24-Core Processor                
                               │ /workspace/bench/baseline.txt │  /workspace/bench/opt_stackbuf.txt  │  /workspace/bench/opt_nocache.txt   │
                               │            sec/op             │    sec/op     vs base               │    sec/op     vs base               │
_asPrometheus/base4_extra0-48                     2.128µ ± ∞ ¹   1.384µ ± ∞ ¹  -34.96% (p=0.008 n=5)   2.660µ ± ∞ ¹  +25.00% (p=0.016 n=5)
_asPrometheus/base4_extra2-48                     3.246µ ± ∞ ¹   1.842µ ± ∞ ¹  -43.25% (p=0.008 n=5)   3.492µ ± ∞ ¹        ~ (p=0.151 n=5)
_asPrometheus/base4_extra5-48                     5.423µ ± ∞ ¹   2.596µ ± ∞ ¹  -52.13% (p=0.008 n=5)   5.560µ ± ∞ ¹        ~ (p=0.421 n=5)
_asPrometheus/base4_extra10-48                    7.168µ ± ∞ ¹   3.747µ ± ∞ ¹  -47.73% (p=0.008 n=5)   8.239µ ± ∞ ¹  +14.94% (p=0.008 n=5)
_asPrometheus/base2_extra5-48                     3.636µ ± ∞ ¹   2.073µ ± ∞ ¹  -42.99% (p=0.008 n=5)   3.766µ ± ∞ ¹        ~ (p=0.310 n=5)
geomean                                           3.962µ         2.199µ        -44.50%                 4.375µ        +10.42%
¹ need >= 6 samples for confidence interval at level 0.95

                               │ /workspace/bench/baseline.txt │  /workspace/bench/opt_stackbuf.txt   │   /workspace/bench/opt_nocache.txt   │
                               │             B/op              │     B/op       vs base               │     B/op       vs base               │
_asPrometheus/base4_extra0-48                     1184.0 ± ∞ ¹     816.0 ± ∞ ¹  -31.08% (p=0.008 n=5)    1008.0 ± ∞ ¹  -14.86% (p=0.008 n=5)
_asPrometheus/base4_extra2-48                     1496.0 ± ∞ ¹     912.0 ± ∞ ¹  -39.04% (p=0.008 n=5)    1288.0 ± ∞ ¹  -13.90% (p=0.008 n=5)
_asPrometheus/base4_extra5-48                    2.375Ki ± ∞ ¹   1.219Ki ± ∞ ¹  -48.68% (p=0.008 n=5)   2.125Ki ± ∞ ¹  -10.53% (p=0.008 n=5)
_asPrometheus/base4_extra10-48                   3.125Ki ± ∞ ¹   1.766Ki ± ∞ ¹  -43.50% (p=0.008 n=5)   2.797Ki ± ∞ ¹  -10.50% (p=0.008 n=5)
_asPrometheus/base2_extra5-48                    1.539Ki ± ∞ ¹   1.000Ki ± ∞ ¹  -35.03% (p=0.008 n=5)   1.383Ki ± ∞ ¹  -10.15% (p=0.008 n=5)
geomean                                          1.808Ki         1.088Ki        -39.79%                 1.590Ki        -12.01%
¹ need >= 6 samples for confidence interval at level 0.95

                               │ /workspace/bench/baseline.txt │ /workspace/bench/opt_stackbuf.txt  │  /workspace/bench/opt_nocache.txt  │
                               │           allocs/op           │  allocs/op   vs base               │  allocs/op   vs base               │
_asPrometheus/base4_extra0-48                      33.00 ± ∞ ¹   20.00 ± ∞ ¹  -39.39% (p=0.008 n=5)   29.00 ± ∞ ¹  -12.12% (p=0.008 n=5)
_asPrometheus/base4_extra2-48                      41.00 ± ∞ ¹   25.00 ± ∞ ¹  -39.02% (p=0.008 n=5)   37.00 ± ∞ ¹   -9.76% (p=0.008 n=5)
_asPrometheus/base4_extra5-48                      56.00 ± ∞ ¹   34.00 ± ∞ ¹  -39.29% (p=0.008 n=5)   52.00 ± ∞ ¹   -7.14% (p=0.008 n=5)
_asPrometheus/base4_extra10-48                     76.00 ± ∞ ¹   49.00 ± ∞ ¹  -35.53% (p=0.008 n=5)   72.00 ± ∞ ¹   -5.26% (p=0.008 n=5)
_asPrometheus/base2_extra5-48                      44.00 ± ∞ ¹   28.00 ± ∞ ¹  -36.36% (p=0.008 n=5)   41.00 ± ∞ ¹   -6.82% (p=0.008 n=5)
geomean                                            47.95         29.76        -37.94%                 43.99         -8.25%
¹ need >= 6 samples for confidence interval at level 0.95

```