### PR TITLE
fix: retain `searchParams` in `paginatedInterceptions` during filter updates

### DIFF
--- a/site/src/api/queries/aiBridge.ts
+++ b/site/src/api/queries/aiBridge.ts
@@ -7,6 +7,7 @@ export const paginatedInterceptions = (
 	searchParams: URLSearchParams,
 ): UsePaginatedQueryOptions<AIBridgeListInterceptionsResponse, string> => {
 	return {
+		searchParams,
 		queryPayload: () => searchParams.get(useFilterParamsKey) ?? "",
 		queryKey: ({ payload, pageNumber }) => {
 			return ["aiBridgeInterceptions", payload, pageNumber] as const;


### PR DESCRIPTION
This pull-request ensures that when we attempt to navigate in-between pages or actually attempt to update the filters that they will persist as we expect. This was also causing an issue where on first load (or where it lacked `page=1` to be specific) that these would seem to lose their input. 