### PR TITLE
fix(coderd/notifications): support RFC 5322 "From" address with display name

### DIFF
--- a/coderd/notifications/dispatch/smtp.go
+++ b/coderd/notifications/dispatch/smtp.go
@@ -161,7 +161,7 @@ func (s *SMTPHandler) dispatch(subject, htmlBody, plainBody, to string) Delivery
 		if err != nil {
 			return false, xerrors.Errorf("'from' validation: %w", err)
 		}
-		err = c.Mail(fromAddr, &smtp.MailOptions{})
+		err = c.Mail(fromAddr.Address, &smtp.MailOptions{})
 		if err != nil {
 			// This is retryable because the server may be temporarily down.
 			return true, xerrors.Errorf("sender identification: %w", err)


### PR DESCRIPTION
The `CODER_EMAIL_FROM` setting was previously used for both the SMTP `MAIL FROM` command (envelope) and the `From:` message header.

This caused an error when a standard "Display Name" format (e.g., "Code <notify@example.com>") was used, as the `MAIL FROM` command only accepts a bare email address.

This commit updates the logic to:
1.  Parse the `from` string into a `*mail.Address` struct in `validateFromAddr`.
2.  Use the `fromAddr.Address` (bare email) for the SMTP `c.Mail()` command.
3.  Use the `fromAddr.String()` (full display name and email) for the `From:` message header.

This allows the 'mail from' setting to correctly use display names while maintaining compatibility with the SMTP protocol.

#20727 
