### PR TITLE
chore: backport aibridge fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -478,7 +478,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.12.0
 	github.com/brianvoe/gofakeit/v7 v7.7.1
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v0.1.3
+	github.com/coder/aibridge v0.1.4-0.20251112094427-5899d515872f
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v1.0.1-0.20250925154134-55a44f2a7945
 	github.com/coder/preview v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,8 @@ github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v0.1.3 h1:7A9RQaHQUjtse47ShF3kBj2hMmT1R7BEFgiyByr8Vvc=
-github.com/coder/aibridge v0.1.3/go.mod h1:GWc0Owtlzz5iMHosDm6FhbO+SoG5W+VeOKyP9p9g9ZM=
+github.com/coder/aibridge v0.1.4-0.20251112094427-5899d515872f h1:uaBJAuI2t7Al+Q6G8JHZL2TmGwImLCGmkh+gyBK9Dvs=
+github.com/coder/aibridge v0.1.4-0.20251112094427-5899d515872f/go.mod h1:GWc0Owtlzz5iMHosDm6FhbO+SoG5W+VeOKyP9p9g9ZM=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v1.0.1-0.20250925154134-55a44f2a7945 h1:hDUf02kTX8EGR3+5B+v5KdYvORs4YNfDPci0zCs+pC0=


### PR DESCRIPTION
Backports https://github.com/coder/coder/pull/20730 to 2.27

2.27 is based on coder/aibridge@v0.1.3, but the fix is now in v0.1.7. We don't want to bring in all those changes now, so I've created a v0.1.3.1 tag which just has the change cherry-picked: https://github.com/coder/aibridge/compare/v0.1.3..v0.1.3.1

The pseudo-version `v0.1.4-0.20251112094427-5899d515872f` was set by `go get github.com/coder/aibridge@v0.1.3.1` because this new commit does not exist in main.