### PR TITLE
fix(site): display error message when template file access fails

### DIFF
--- a/site/src/pages/TemplatePage/TemplateFilesPage/TemplateFilesPage.jest.tsx
+++ b/site/src/pages/TemplatePage/TemplateFilesPage/TemplateFilesPage.jest.tsx
@@ -54,3 +54,45 @@ test("displays the template files even when there is no previous version", async
 
 	await screen.findByTestId("syntax-highlighter");
 });
+
+test("displays an error when file access fails", async () => {
+	server.use(
+		http.get("/api/v2/files/:fileId", () => {
+			return new HttpResponse(null, {
+				status: 404,
+				statusText: "Not Found",
+			});
+		}),
+	);
+
+	render(
+		<AppProviders>
+			<RouterProvider
+				router={createMemoryRouter(
+					[
+						{
+							element: <RequireAuth />,
+							children: [
+								{
+									element: <TemplateLayout />,
+									children: [
+										{
+											path: "/templates/:template/files",
+											element: <TemplateFilesPage />,
+										},
+									],
+								},
+							],
+						},
+					],
+					{
+						initialEntries: [`/templates/${MockTemplate.name}/files`],
+					},
+				)}
+			/>
+		</AppProviders>,
+	);
+
+	// The error alert should be displayed
+	await screen.findByRole("alert");
+});


### PR DESCRIPTION
## Summary
Fixes #20708 - Members accessing template files now see a clear error message instead of an infinite loader when they don't have the necessary permissions.

## Changes
- Updated `TemplateFilesPage.tsx` to handle query errors for both current and previous version files
- Added `ErrorAlert` component import and error handling logic
- Added test coverage in `TemplateFilesPage.jest.tsx` to verify error display

## Test Plan
- [x] Added unit test that verifies error alert is displayed when file access fails
- [x] Existing test for successful file access still passes
- [x] Frontend type checks pass (`pnpm check`)
- [x] Code formatting passes (`pnpm format`)

## Behavior
**Before:** Users without update permissions on templates would see an infinite loader when trying to view template source code.

**After:** Users see a clear error message: "Resource not found or you do not have access to this resource" via the ErrorAlert component.

## Security Considerations
- No changes to authorization logic
- No changes to backend error responses
- The 404 response remains intentionally vague (as designed) to prevent information leakage
- Only the frontend error handling was improved to provide better UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)