### PR TITLE
feat: allow modifying a task prompt prior to workspace running

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -629,6 +629,10 @@ func (api *API) taskUpdatePrompt(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// NOTE(DanielleMaywood):
+	// If there is a workspace associated with this task, we should check it isn't actively running.
+	// If it is running, we do not want to update the prompt as updating the prompt of a running
+	// workspace doesn't make sense.
 	if task.WorkspaceID.Valid {
 		build, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(ctx, task.WorkspaceID.UUID)
 		if err != nil {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -318,6 +318,51 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/tasks/{user}/{task}/prompt": {
+            "patch": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "tags": [
+                    "Experimental"
+                ],
+                "summary": "Update AI task prompt",
+                "operationId": "update-task-prompt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username, user ID, or 'me' for the authenticated user",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Task ID",
+                        "name": "task",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update task prompt request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateTaskPromptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/api/experimental/tasks/{user}/{task}/send": {
             "post": {
                 "security": [
@@ -18959,6 +19004,14 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "codersdk.UpdateTaskPromptRequest": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -284,6 +284,49 @@
 				}
 			}
 		},
+		"/api/experimental/tasks/{user}/{task}/prompt": {
+			"patch": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"tags": ["Experimental"],
+				"summary": "Update AI task prompt",
+				"operationId": "update-task-prompt",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Username, user ID, or 'me' for the authenticated user",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Task ID",
+						"name": "task",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update task prompt request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateTaskPromptRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				}
+			}
+		},
 		"/api/experimental/tasks/{user}/{task}/send": {
 			"post": {
 				"security": [
@@ -17390,6 +17433,14 @@
 					"items": {
 						"type": "string"
 					}
+				}
+			}
+		},
+		"codersdk.UpdateTaskPromptRequest": {
+			"type": "object",
+			"properties": {
+				"prompt": {
+					"type": "string"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1035,6 +1035,7 @@ func New(options *Options) *API {
 					r.Use(httpmw.ExtractTaskParam(options.Database))
 					r.Get("/", api.taskGet)
 					r.Delete("/", api.taskDelete)
+					r.Patch("/prompt", api.taskUpdatePrompt)
 					r.Post("/send", api.taskSend)
 					r.Get("/logs", api.taskLogs)
 				})

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5100,6 +5100,21 @@ func (q *querier) UpdateTailnetPeerStatusByCoordinator(ctx context.Context, arg 
 	return q.db.UpdateTailnetPeerStatusByCoordinator(ctx, arg)
 }
 
+func (q *querier) UpdateTaskPrompt(ctx context.Context, arg database.UpdateTaskPromptParams) (database.TaskTable, error) {
+	// An actor is allowed to update the prompt of a task if they have
+	// permission to update the task (same as UpdateTaskWorkspaceID).
+	task, err := q.db.GetTaskByID(ctx, arg.ID)
+	if err != nil {
+		return database.TaskTable{}, err
+	}
+
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, task.RBACObject()); err != nil {
+		return database.TaskTable{}, err
+	}
+
+	return q.db.UpdateTaskPrompt(ctx, arg)
+}
+
 func (q *querier) UpdateTaskWorkspaceID(ctx context.Context, arg database.UpdateTaskWorkspaceIDParams) (database.TaskTable, error) {
 	// An actor is allowed to update the workspace ID of a task if they are the
 	// owner of the task and workspace or have the appropriate permissions.

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2442,6 +2442,22 @@ func (s *MethodTestSuite) TestTasks() {
 
 		check.Args(arg).Asserts(task, policy.ActionUpdate, ws, policy.ActionUpdate).Returns(database.TaskTable{})
 	}))
+	s.Run("UpdateTaskPrompt", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		task := testutil.Fake(s.T(), faker, database.Task{})
+		arg := database.UpdateTaskPromptParams{
+			ID:     task.ID,
+			Prompt: "Updated prompt text",
+		}
+
+		// Create a copy of the task with the updated prompt
+		updatedTask := task
+		updatedTask.Prompt = arg.Prompt
+
+		dbm.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(task, nil).AnyTimes()
+		dbm.EXPECT().UpdateTaskPrompt(gomock.Any(), arg).Return(updatedTask.TaskTable(), nil).AnyTimes()
+
+		check.Args(arg).Asserts(task, policy.ActionUpdate).Returns(updatedTask.TaskTable())
+	}))
 	s.Run("GetTaskByWorkspaceID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		task := testutil.Fake(s.T(), faker, database.Task{})
 		task.WorkspaceID = uuid.NullUUID{UUID: uuid.New(), Valid: true}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3133,6 +3133,13 @@ func (m queryMetricsStore) UpdateTailnetPeerStatusByCoordinator(ctx context.Cont
 	return r0
 }
 
+func (m queryMetricsStore) UpdateTaskPrompt(ctx context.Context, arg database.UpdateTaskPromptParams) (database.TaskTable, error) {
+	start := time.Now()
+	r0, r1 := m.s.UpdateTaskPrompt(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateTaskPrompt").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) UpdateTaskWorkspaceID(ctx context.Context, arg database.UpdateTaskWorkspaceIDParams) (database.TaskTable, error) {
 	start := time.Now()
 	r0, r1 := m.s.UpdateTaskWorkspaceID(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6725,6 +6725,21 @@ func (mr *MockStoreMockRecorder) UpdateTailnetPeerStatusByCoordinator(ctx, arg a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTailnetPeerStatusByCoordinator", reflect.TypeOf((*MockStore)(nil).UpdateTailnetPeerStatusByCoordinator), ctx, arg)
 }
 
+// UpdateTaskPrompt mocks base method.
+func (m *MockStore) UpdateTaskPrompt(ctx context.Context, arg database.UpdateTaskPromptParams) (database.TaskTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTaskPrompt", ctx, arg)
+	ret0, _ := ret[0].(database.TaskTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateTaskPrompt indicates an expected call of UpdateTaskPrompt.
+func (mr *MockStoreMockRecorder) UpdateTaskPrompt(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskPrompt", reflect.TypeOf((*MockStore)(nil).UpdateTaskPrompt), ctx, arg)
+}
+
 // UpdateTaskWorkspaceID mocks base method.
 func (m *MockStore) UpdateTaskWorkspaceID(ctx context.Context, arg database.UpdateTaskWorkspaceIDParams) (database.TaskTable, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -132,11 +132,28 @@ func (w ConnectionLog) RBACObject() rbac.Object {
 	return obj
 }
 
+// TaskTable converts a Task to it's reduced version.
+// A more generalized solution is to use json marshaling to
+// consistently keep these two structs in sync.
+// That would be a lot of overhead, and a more costly unit test is
+// written to make sure these match up.
+func (t Task) TaskTable() TaskTable {
+	return TaskTable{
+		ID:                 t.ID,
+		OrganizationID:     t.OrganizationID,
+		OwnerID:            t.OwnerID,
+		Name:               t.Name,
+		WorkspaceID:        t.WorkspaceID,
+		TemplateVersionID:  t.TemplateVersionID,
+		TemplateParameters: t.TemplateParameters,
+		Prompt:             t.Prompt,
+		CreatedAt:          t.CreatedAt,
+		DeletedAt:          t.DeletedAt,
+	}
+}
+
 func (t Task) RBACObject() rbac.Object {
-	return rbac.ResourceTask.
-		WithID(t.ID).
-		WithOwner(t.OwnerID.String()).
-		InOrg(t.OrganizationID)
+	return t.TaskTable().RBACObject()
 }
 
 func (t TaskTable) RBACObject() rbac.Object {

--- a/coderd/database/modelqueries_internal_test.go
+++ b/coderd/database/modelqueries_internal_test.go
@@ -58,6 +58,44 @@ func TestWorkspaceTableConvert(t *testing.T) {
 			"To resolve this, go to the 'func (w Workspace) WorkspaceTable()' and ensure all fields are converted.")
 }
 
+// TestTaskTableConvert verifies all task fields are converted
+// when reducing a `Task` to a `TaskTable`.
+// This test is a guard rail to prevent developer oversight mistakes.
+func TestTaskTableConvert(t *testing.T) {
+	t.Parallel()
+
+	staticRandoms := &testutil.Random{
+		String:  func() string { return "foo" },
+		Bool:    func() bool { return true },
+		Int:     func() int64 { return 500 },
+		Uint:    func() uint64 { return 126 },
+		Float:   func() float64 { return 3.14 },
+		Complex: func() complex128 { return 6.24 },
+		Time: func() time.Time {
+			return time.Date(2020, 5, 2, 5, 19, 21, 30, time.UTC)
+		},
+	}
+
+	// This feels a bit janky, but it works.
+	// If you use 'PopulateStruct' to create 2 workspaces, using the same
+	// "random" values for each type. Then they should be identical.
+	//
+	// So if 'workspace.WorkspaceTable()' was missing any fields in its
+	// conversion, the comparison would fail.
+
+	var task Task
+	err := testutil.PopulateStruct(&task, staticRandoms)
+	require.NoError(t, err)
+
+	var subset TaskTable
+	err = testutil.PopulateStruct(&subset, staticRandoms)
+	require.NoError(t, err)
+
+	require.Equal(t, task.TaskTable(), subset,
+		"'task.TaskTable()' is not missing at least 1 field when converting to 'TaskTable'. "+
+			"To resolve this, go to the 'func (t Task) TaskTable()' and ensure all fields are converted.")
+}
+
 // TestAuditLogsQueryConsistency ensures that GetAuditLogsOffset and CountAuditLogs
 // have identical WHERE clauses to prevent filtering inconsistencies.
 // This test is a guard rail to prevent developer oversight mistakes.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -682,6 +682,7 @@ type sqlcQuerier interface {
 	UpdateProvisionerJobWithCompleteWithStartedAtByID(ctx context.Context, arg UpdateProvisionerJobWithCompleteWithStartedAtByIDParams) error
 	UpdateReplica(ctx context.Context, arg UpdateReplicaParams) (Replica, error)
 	UpdateTailnetPeerStatusByCoordinator(ctx context.Context, arg UpdateTailnetPeerStatusByCoordinatorParams) error
+	UpdateTaskPrompt(ctx context.Context, arg UpdateTaskPromptParams) (TaskTable, error)
 	UpdateTaskWorkspaceID(ctx context.Context, arg UpdateTaskWorkspaceIDParams) (TaskTable, error)
 	UpdateTemplateACLByID(ctx context.Context, arg UpdateTemplateACLByIDParams) error
 	UpdateTemplateAccessControlByID(ctx context.Context, arg UpdateTemplateAccessControlByIDParams) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -13283,6 +13283,39 @@ func (q *sqlQuerier) ListTasks(ctx context.Context, arg ListTasksParams) ([]Task
 	return items, nil
 }
 
+const updateTaskPrompt = `-- name: UpdateTaskPrompt :one
+UPDATE tasks
+SET
+	prompt = $1::text
+WHERE
+	id = $2::uuid
+	AND deleted_at IS NULL
+RETURNING id, organization_id, owner_id, name, workspace_id, template_version_id, template_parameters, prompt, created_at, deleted_at
+`
+
+type UpdateTaskPromptParams struct {
+	Prompt string    `db:"prompt" json:"prompt"`
+	ID     uuid.UUID `db:"id" json:"id"`
+}
+
+func (q *sqlQuerier) UpdateTaskPrompt(ctx context.Context, arg UpdateTaskPromptParams) (TaskTable, error) {
+	row := q.db.QueryRowContext(ctx, updateTaskPrompt, arg.Prompt, arg.ID)
+	var i TaskTable
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.OwnerID,
+		&i.Name,
+		&i.WorkspaceID,
+		&i.TemplateVersionID,
+		&i.TemplateParameters,
+		&i.Prompt,
+		&i.CreatedAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
 const updateTaskWorkspaceID = `-- name: UpdateTaskWorkspaceID :one
 UPDATE
 	tasks

--- a/coderd/database/queries/tasks.sql
+++ b/coderd/database/queries/tasks.sql
@@ -64,3 +64,13 @@ WHERE
 	id = @id::uuid
 	AND deleted_at IS NULL
 RETURNING *;
+
+
+-- name: UpdateTaskPrompt :one
+UPDATE tasks
+SET
+	prompt = @prompt::text
+WHERE
+	id = @id::uuid
+	AND deleted_at IS NULL
+RETURNING *;

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -352,6 +352,28 @@ func (c *ExperimentalClient) TaskSend(ctx context.Context, user string, id uuid.
 	return nil
 }
 
+// UpdateTaskPromptRequest is used to update a task's prompt.
+//
+// Experimental: This type is experimental and may change in the future.
+type UpdateTaskPromptRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+// UpdateTaskPrompt updates the task's prompt.
+//
+// Experimental: This method is experimental and may change in the future.
+func (c *ExperimentalClient) UpdateTaskPrompt(ctx context.Context, user string, id uuid.UUID, req UpdateTaskPromptRequest) error {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/tasks/%s/%s/prompt", user, id.String()), req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
 // TaskLogType indicates the source of a task log entry.
 //
 // Experimental: This type is experimental and may change in the future.

--- a/docs/reference/api/experimental.md
+++ b/docs/reference/api/experimental.md
@@ -166,6 +166,43 @@ curl -X GET http://coder-server:8080/api/v2/api/experimental/tasks/{user}/{task}
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Update AI task prompt
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PATCH http://coder-server:8080/api/v2/api/experimental/tasks/{user}/{task}/prompt \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PATCH /api/experimental/tasks/{user}/{task}/prompt`
+
+> Body parameter
+
+```json
+{
+  "prompt": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                           | Required | Description                                           |
+|--------|------|--------------------------------------------------------------------------------|----------|-------------------------------------------------------|
+| `user` | path | string                                                                         | true     | Username, user ID, or 'me' for the authenticated user |
+| `task` | path | string(uuid)                                                                   | true     | Task ID                                               |
+| `body` | body | [codersdk.UpdateTaskPromptRequest](schemas.md#codersdkupdatetaskpromptrequest) | true     | Update task prompt request                            |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Send input to AI task
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -9155,6 +9155,20 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |---------|-----------------|----------|--------------|-------------|
 | `roles` | array of string | false    |              |             |
 
+## codersdk.UpdateTaskPromptRequest
+
+```json
+{
+  "prompt": "string"
+}
+```
+
+### Properties
+
+| Name     | Type   | Required | Restrictions | Description |
+|----------|--------|----------|--------------|-------------|
+| `prompt` | string | false    |              |             |
+
 ## codersdk.UpdateTemplateACL
 
 ```json

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2708,6 +2708,16 @@ class ExperimentalApiMethods {
 		await this.axios.delete(`/api/experimental/tasks/${user}/${id}`);
 	};
 
+	updateTaskPrompt = async (
+		user: string,
+		id: string,
+		prompt: string,
+	): Promise<void> => {
+		await this.axios.patch(`/api/experimental/tasks/${user}/${id}/prompt`, {
+			prompt,
+		});
+	};
+
 	createTaskFeedback = async (
 		_taskId: string,
 		_req: CreateTaskFeedbackRequest,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5358,6 +5358,16 @@ export interface UpdateRoles {
 	readonly roles: readonly string[];
 }
 
+// From codersdk/aitasks.go
+/**
+ * UpdateTaskPromptRequest is used to update a task's prompt.
+ *
+ * Experimental: This type is experimental and may change in the future.
+ */
+export interface UpdateTaskPromptRequest {
+	readonly prompt: string;
+}
+
 // From codersdk/templates.go
 export interface UpdateTemplateACL {
 	/**

--- a/site/src/pages/TaskPage/ModifyPromptDialog.stories.tsx
+++ b/site/src/pages/TaskPage/ModifyPromptDialog.stories.tsx
@@ -1,0 +1,251 @@
+import {
+	MockTask,
+	MockTaskWorkspace,
+	mockApiError,
+} from "testHelpers/entities";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { API } from "api/api";
+import { workspaceBuildParametersKey } from "api/queries/workspaceBuilds";
+import {
+	AITaskPromptParameterName,
+	type Workspace,
+	type WorkspaceBuildParameter,
+} from "api/typesGenerated";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { ModifyPromptDialog } from "./ModifyPromptDialog";
+
+const mockTaskWorkspaceStarting: Workspace = {
+	...MockTaskWorkspace,
+	latest_build: {
+		...MockTaskWorkspace.latest_build,
+		status: "starting",
+	},
+};
+
+// Mock build parameters for the workspace
+const mockBuildParameters: WorkspaceBuildParameter[] = [
+	{
+		name: AITaskPromptParameterName,
+		value: MockTask.initial_prompt,
+	},
+	{
+		name: "region",
+		value: "us-east-1",
+	},
+];
+
+const meta: Meta<typeof ModifyPromptDialog> = {
+	title: "pages/TaskPage/ModifyPromptDialog",
+	component: ModifyPromptDialog,
+	args: {
+		task: MockTask,
+		workspace: mockTaskWorkspaceStarting,
+		open: true,
+		onOpenChange: () => {},
+	},
+	parameters: {
+		queries: [
+			{
+				key: workspaceBuildParametersKey(MockTaskWorkspace.latest_build.id),
+				data: mockBuildParameters,
+			},
+		],
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ModifyPromptDialog>;
+
+export const WithModifiedPrompt: Story = {
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const promptTextarea = body.getByLabelText("Prompt");
+
+		// Given: The user modifies the prompt
+		await userEvent.clear(promptTextarea);
+		await userEvent.type(promptTextarea, "Build a web server in Go");
+
+		// Then: We expect the submit button to not be disabled
+		const submitButton = body.getByRole("button", {
+			name: /update and restart build/i,
+		});
+		expect(submitButton).not.toBeDisabled();
+	},
+};
+
+export const EmptyPrompt: Story = {
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const promptTextarea = body.getByLabelText("Prompt");
+
+		// Given: The prompt is empty
+		await userEvent.clear(promptTextarea);
+
+		// Then: We expect the submit button to be disabled
+		const submitButton = body.getByRole("button", {
+			name: /update and restart build/i,
+		});
+		expect(submitButton).toBeDisabled();
+	},
+};
+
+export const UnchangedPrompt: Story = {
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		// Given: The prompt is unchanged
+
+		// Then: We expect the submit button to be disabled
+		const submitButton = body.getByRole("button", {
+			name: /update and restart build/i,
+		});
+		expect(submitButton).toBeDisabled();
+	},
+};
+
+export const Submitting: Story = {
+	beforeEach: async () => {
+		// Mock updateTaskPrompt to never resolve (keeps it in pending state)
+		spyOn(API.experimental, "updateTaskPrompt").mockImplementation(() => {
+			return new Promise(() => {});
+		});
+	},
+	play: async ({ canvasElement, step }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await step("Modify and submit the form", async () => {
+			const promptTextarea = body.getByLabelText("Prompt");
+			await userEvent.clear(promptTextarea);
+			await userEvent.type(promptTextarea, "Create a REST API");
+
+			const submitButton = body.getByRole("button", {
+				name: /update and restart build/i,
+			});
+			await userEvent.click(submitButton);
+		});
+
+		await step("Shows loading state with spinner", async () => {
+			const spinner = await body.findByTitle("Loading spinner");
+			expect(spinner).toBeInTheDocument();
+
+			const submitButton = body.getByRole("button", {
+				name: /update and restart build/i,
+			});
+			expect(submitButton).toBeDisabled();
+		});
+	},
+};
+
+export const Success: Story = {
+	beforeEach: async () => {
+		spyOn(API.experimental, "updateTaskPrompt").mockResolvedValue();
+		spyOn(API, "cancelWorkspaceBuild").mockResolvedValue({
+			message: "Workspace build canceled",
+		});
+		spyOn(API, "getWorkspaceBuildByNumber").mockResolvedValue({
+			...MockTaskWorkspace.latest_build,
+			status: "canceled",
+		});
+		spyOn(API, "waitForBuild").mockResolvedValue(undefined);
+		spyOn(API, "startWorkspace").mockResolvedValue(
+			MockTaskWorkspace.latest_build,
+		);
+	},
+	play: async ({ canvasElement, step }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await step("Modify and submit the form", async () => {
+			const promptTextarea = body.getByLabelText("Prompt");
+			await userEvent.clear(promptTextarea);
+			await userEvent.type(promptTextarea, "Create a REST API in Python");
+
+			const submitButton = body.getByRole("button", {
+				name: /update and restart build/i,
+			});
+			await userEvent.click(submitButton);
+		});
+
+		await step("API calls are made", async () => {
+			await waitFor(() => {
+				expect(API.cancelWorkspaceBuild).toHaveBeenCalledWith(
+					mockTaskWorkspaceStarting.latest_build.id,
+				);
+				expect(API.experimental.updateTaskPrompt).toHaveBeenCalledWith(
+					MockTask.owner_name,
+					MockTask.id,
+					"Create a REST API in Python",
+				);
+				expect(API.startWorkspace).toHaveBeenCalledWith(
+					mockTaskWorkspaceStarting.id,
+					MockTask.template_version_id,
+					undefined,
+					[
+						{
+							name: AITaskPromptParameterName,
+							value: "Create a REST API in Python",
+						},
+						{
+							name: "region",
+							value: "us-east-1",
+						},
+					],
+				);
+			});
+		});
+	},
+};
+
+export const Failure: Story = {
+	beforeEach: async () => {
+		spyOn(API.experimental, "updateTaskPrompt").mockRejectedValue(
+			mockApiError({
+				message: "Failed to update task prompt",
+				detail: "Build is not in a valid state for modification",
+			}),
+		);
+	},
+	play: async ({ canvasElement, step }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await step("Modify and submit the form", async () => {
+			const promptTextarea = body.getByLabelText("Prompt");
+			await userEvent.clear(promptTextarea);
+			await userEvent.type(promptTextarea, "Create a REST API");
+
+			const submitButton = body.getByRole("button", {
+				name: /update and restart build/i,
+			});
+			await userEvent.click(submitButton);
+		});
+
+		await step("Shows error message", async () => {
+			await body.findByText(/Failed to update task prompt/i);
+		});
+	},
+};
+
+export const RunningBuild: Story = {
+	args: {
+		workspace: {
+			...MockTaskWorkspace,
+			latest_build: {
+				...MockTaskWorkspace.latest_build,
+				status: "running",
+			},
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		// Verify error message is displayed
+		expect(
+			body.getByText(/Cannot modify the prompt of a running task/i),
+		).toBeInTheDocument();
+
+		// Verify submit button is disabled
+		const submitButton = body.getByRole("button", {
+			name: /update and restart build/i,
+		});
+		expect(submitButton).toBeDisabled();
+	},
+};

--- a/site/src/pages/TaskPage/ModifyPromptDialog.tsx
+++ b/site/src/pages/TaskPage/ModifyPromptDialog.tsx
@@ -1,0 +1,160 @@
+import { API } from "api/api";
+import { workspaceBuildParameters } from "api/queries/workspaceBuilds";
+import { workspaceByOwnerAndNameKey } from "api/queries/workspaces";
+import {
+	AITaskPromptParameterName,
+	type Task,
+	type Workspace,
+} from "api/typesGenerated";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { Button } from "components/Button/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
+import { Spinner } from "components/Spinner/Spinner";
+import { Textarea } from "components/Textarea/Textarea";
+import type { FC } from "react";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+
+type ModifyPromptDialogProps = {
+	task: Task;
+	workspace: Workspace;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+};
+
+export const ModifyPromptDialog: FC<ModifyPromptDialogProps> = ({
+	task,
+	workspace,
+	open,
+	onOpenChange,
+}) => {
+	const [prompt, setPrompt] = useState(task.initial_prompt);
+	const queryClient = useQueryClient();
+
+	const buildParametersQuery = useQuery(
+		workspaceBuildParameters(workspace.latest_build.id),
+	);
+
+	const updatePromptMutation = useMutation({
+		mutationFn: async () => {
+			await API.cancelWorkspaceBuild(workspace.latest_build.id);
+
+			// Wait for the cancellation to complete before starting a new build
+			// Note: We handle failures here because a canceling build might fail,
+			// but we still want to try starting a new one
+			try {
+				const currentBuild = await API.getWorkspaceBuildByNumber(
+					workspace.owner_name,
+					workspace.name,
+					workspace.latest_build.build_number,
+				);
+				await API.waitForBuild(currentBuild);
+			} catch {
+				// If waiting fails (e.g., build goes to "failed" instead of "canceled"),
+				// that's OK - the build is no longer active, so we can start a new one
+			}
+
+			await API.experimental.updateTaskPrompt(task.owner_name, task.id, prompt);
+
+			// Start a new build with the updated prompt
+			await API.startWorkspace(
+				workspace.id,
+				task.template_version_id,
+				undefined,
+				buildParametersQuery.data?.map((parameter) =>
+					parameter.name === AITaskPromptParameterName
+						? { ...parameter, value: prompt }
+						: parameter,
+				),
+			);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["tasks", task.owner_name, task.id],
+			});
+			queryClient.invalidateQueries({
+				queryKey: workspaceByOwnerAndNameKey(
+					workspace.owner_name,
+					workspace.name,
+				),
+			});
+
+			onOpenChange(false);
+		},
+	});
+
+	const workspaceBuildRunning = workspace.latest_build.status === "running";
+	const promptModified = prompt !== task.initial_prompt;
+	const promptCanBeModified =
+		prompt.length !== 0 && promptModified && !workspaceBuildRunning;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>Modify Task Prompt</DialogTitle>
+					<DialogDescription>
+						Modifying the prompt will cancel the current workspace build and
+						restart it with the updated prompt. This is only possible while the
+						build is pending or starting.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					{updatePromptMutation.error && (
+						<ErrorAlert error={updatePromptMutation.error} />
+					)}
+					{workspaceBuildRunning && (
+						<ErrorAlert error={"Cannot modify the prompt of a running task"} />
+					)}
+
+					<div>
+						<label
+							htmlFor="prompt"
+							className="block text-sm font-medium text-content-primary mb-2"
+						>
+							Prompt
+						</label>
+						<Textarea
+							id="prompt"
+							value={prompt}
+							onChange={(e) => setPrompt(e.target.value)}
+							rows={10}
+							disabled={updatePromptMutation.isPending || workspaceBuildRunning}
+							className="w-full"
+							placeholder="Enter your task prompt..."
+						/>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={updatePromptMutation.isPending}
+					>
+						Cancel
+					</Button>
+					<Button
+						onClick={() => updatePromptMutation.mutate()}
+						disabled={
+							!promptCanBeModified ||
+							updatePromptMutation.isPending ||
+							buildParametersQuery.isLoading
+						}
+					>
+						<Spinner loading={updatePromptMutation.isPending} />
+						Update and Restart Build
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};


### PR DESCRIPTION
## Overview

This PR enables users to modify a task's prompt before the agent executes it. Users can edit the prompt from the TaskPage, and the system will automatically cancel the current workspace build and restart it with the updated prompt.

## Related Issues
Closes #XXXX (if applicable)