### PR TITLE
fix(docs): add newlines to display GFM alerts correctly

### DIFF
--- a/docs/ai-coder/tasks-core-principles.md
+++ b/docs/ai-coder/tasks-core-principles.md
@@ -56,7 +56,8 @@ Coder maintains various agentic modules; see [Coder Labs](https://registry.coder
 
 The following code snippet can be dropped into any existing template in Coder v2.28 or above to modify it into a Claude-Code enabled task template. This snippet also includes space for a setup script that will prime the agent for execution.
 
-> [!NOTE] This requires at least version 2.13.0 of the `coder/coder` Terraform provider.
+> [!NOTE]
+> This requires at least version 2.13.0 of the `coder/coder` Terraform provider.
 
 ```hcl
 data "coder_parameter" "setup_script" {

--- a/docs/ai-coder/tasks-migration.md
+++ b/docs/ai-coder/tasks-migration.md
@@ -50,7 +50,8 @@ module "claude-code" {
 
 1. Add the `coder_ai_task` resource and set `app_id` to the `task_app_id` output of the Claude module.
 
-> [!NOTE] Refer to the documentation for the specific module you are using for the exact name of the output.
+> [!NOTE]
+> Refer to the documentation for the specific module you are using for the exact name of the output.
 
 ```diff
 resource "coder_ai_task" "task" {

--- a/docs/ai-coder/tasks.md
+++ b/docs/ai-coder/tasks.md
@@ -45,7 +45,8 @@ To import the template and begin configuring it, import the example [Run Coder T
 
 A template becomes a Task-capable template if it defines a `coder_ai_task` resource. Coder analyzes template files during template version import to determine if these requirements are met. Try adding this terraform block to an existing template where you'll add our Claude Code module.
 
-> [!NOTE] The `coder_ai_task` resource is not defined within the [Claude Code Module](https://registry.coder.com/modules/coder/claude-code?tab=readme). You need to define it yourself.
+> [!NOTE]
+> The `coder_ai_task` resource is not defined within the [Claude Code Module](https://registry.coder.com/modules/coder/claude-code?tab=readme). You need to define it yourself.
 
 ```hcl
 terraform {
@@ -121,7 +122,8 @@ Because Tasks run unpredictable AI agents, often for background tasks, we recomm
 
 Alternatively, follow our guide for [custom agents](./custom-agents.md).
 
-> [!IMPORTANT] Upgrading from Coder v2.27 or earlier? See the [Tasks Migration Guide](./tasks-migration.md) for breaking changes in v2.28.0.
+> [!IMPORTANT]
+> Upgrading from Coder v2.27 or earlier? See the [Tasks Migration Guide](./tasks-migration.md) for breaking changes in v2.28.0.
 
 ## Customizing the Task UI
 


### PR DESCRIPTION
Fixes this bug called out by @matifali on https://coder.com/docs/ai-coder/tasks: 
<img width="718" height="165" alt="image" src="https://github.com/user-attachments/assets/5ac5c70d-c677-44f6-984d-8538a8e7c6cc" />

[The docs for GFM alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) specify that the alert type (`[!NOTE]`, `[!IMPORTANT]`, etc) should be on its own line within the blockquote, with the alert text on the following line(s).