### PR TITLE
fix: remove and ban usages of http types/functions with global state

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,16 @@ linters-settings:
       # We want to enforce all values are specified when inserting or updating
       # a database row. Ref: #9936
       - 'github.com/coder/coder/v2/coderd/database\.[^G][^e][^t]\w+Params'
+
+  forbidigo:
+    forbid:
+      # Usage of the http package global DefaultClient and the associated
+      # functions that wrap said global are known to cause flakiness with
+      # parallel tests. They also introduce global state to production code.
+      # Prefer isolated instances of an http.Client.
+      - {p: '^http\.(Get|Post|Head|PostForm)(\(|$)', msg: 'methods wrap http.DefaultClient which introduces global state. Use a http.Client with timeouts.'}
+      - {p: '^http\.DefaultClient(\.|$)', msg: 'http.DefaultClient introduces global state. Use a http.Client with timeouts.'}
+
   gocognit:
     min-complexity: 300
 
@@ -232,6 +242,7 @@ linters:
     - errname
     - errorlint
     - exhaustruct
+    - forbidigo
     - forcetypeassert
     - gocritic
     # gocyclo is may be useful in the future when we start caring

--- a/cli/server.go
+++ b/cli/server.go
@@ -398,9 +398,9 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				return xerrors.Errorf("create cache directory: %w", err)
 			}
 
-			// Clean up idle connections at the end, e.g.
-			// embedded-postgres can leave an idle connection
-			// which is caught by goleaks.
+			//nolint:forbidigo // Clean up idle connections at the end, e.g.
+			// embedded-postgres can leave an idle connection which is caught
+			// by goleak.
 			defer http.DefaultClient.CloseIdleConnections()
 
 			tracerProvider, sqlDriver, closeTracing := ConfigureTraceProvider(ctx, logger, vals)

--- a/coderd/azureidentity/azureidentity.go
+++ b/coderd/azureidentity/azureidentity.go
@@ -78,6 +78,7 @@ func Validate(ctx context.Context, signature string, options Options) (string, e
 			return "", xerrors.Errorf("certificate from %v is not cached: %w", signer.IssuingCertificateURL, err)
 		}
 
+		client := &http.Client{}
 		ctx, cancelFunc := context.WithTimeout(ctx, 5*time.Second)
 		defer cancelFunc()
 		for _, certURL := range signer.IssuingCertificateURL {
@@ -85,7 +86,7 @@ func Validate(ctx context.Context, signature string, options Options) (string, e
 			if err != nil {
 				return "", xerrors.Errorf("new request %q: %w", certURL, err)
 			}
-			res, err := http.DefaultClient.Do(req)
+			res, err := client.Do(req)
 			if err != nil {
 				return "", xerrors.Errorf("no cached certificate for %q found. error fetching: %w", certURL, err)
 			}

--- a/coderd/healthcheck/accessurl.go
+++ b/coderd/healthcheck/accessurl.go
@@ -36,7 +36,7 @@ func (r *AccessURLReport) Run(ctx context.Context, opts *AccessURLReportOptions)
 	r.AccessURL = opts.AccessURL.String()
 
 	if opts.Client == nil {
-		opts.Client = http.DefaultClient
+		opts.Client = &http.Client{}
 	}
 
 	accessURL, err := opts.AccessURL.Parse("/healthz")

--- a/coderd/oauthpki/oidcpki.go
+++ b/coderd/oauthpki/oidcpki.go
@@ -178,11 +178,13 @@ func (src *jwtTokenSource) Token() (*oauth2.Token, error) {
 	if src.refreshToken == "" {
 		return nil, xerrors.New("oauth2: token expired and refresh token is not set")
 	}
-	cli := http.DefaultClient
+	var cli *http.Client
 	if v, ok := src.ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
 		// This client should be the instrumented client already. So no need to
 		// handle this manually.
 		cli = v
+	} else {
+		cli = &http.Client{}
 	}
 
 	token, err := src.cfg.jwtToken()

--- a/coderd/updatecheck/updatecheck.go
+++ b/coderd/updatecheck/updatecheck.go
@@ -42,7 +42,7 @@ type Checker struct {
 // Options set optional parameters for the update check.
 type Options struct {
 	// Client is the HTTP client to use for the update check,
-	// if omitted, http.DefaultClient will be used.
+	// if omitted, an internal http.Client will be used.
 	Client *http.Client
 	// URL is the URL to check for the latest version of Coder,
 	// if omitted, the default URL will be used.
@@ -61,7 +61,7 @@ type Options struct {
 // New returns a new Checker that periodically checks for Coder updates.
 func New(db database.Store, log slog.Logger, opts Options) *Checker {
 	if opts.Client == nil {
-		opts.Client = http.DefaultClient
+		opts.Client = &http.Client{}
 	}
 	if opts.URL == "" {
 		opts.URL = defaultURL

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -147,10 +147,11 @@ func (r *RootCmd) proxyServer() *serpent.Command {
 			notifyCtx, notifyStop := inv.SignalNotifyContext(ctx, cli.StopSignals...)
 			defer notifyStop()
 
-			// Clean up idle connections at the end, e.g.
-			// embedded-postgres can leave an idle connection
-			// which is caught by goleaks.
+			//nolint:forbidigo // Clean up idle connections at the end, e.g.
+			// embedded-postgres can leave an idle connection which is caught
+			// by goleak.
 			defer http.DefaultClient.CloseIdleConnections()
+			//nolint:forbidigo
 			closers.Add(http.DefaultClient.CloseIdleConnections)
 
 			tracer, _, closeTracing := cli.ConfigureTraceProvider(ctx, logger, cfg)

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -85,7 +85,7 @@ func New(opts *Options) (*ProxyHealth, error) {
 
 	client := opts.Client
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{}
 	}
 	// Set a timeout on the client, so we don't wait forever for a healthz response.
 	tmp := *client

--- a/enterprise/coderd/usage/publisher.go
+++ b/enterprise/coderd/usage/publisher.go
@@ -79,7 +79,7 @@ func NewTallymanPublisher(ctx context.Context, log slog.Logger, db database.Stor
 		done:        make(chan struct{}),
 
 		ingestURL:  tallymanIngestURLV1,
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{},
 		clock:      quartz.NewReal(),
 	}
 	for _, opt := range opts {
@@ -94,7 +94,7 @@ type TallymanPublisherOption func(*tallymanPublisher)
 func PublisherWithHTTPClient(httpClient *http.Client) TallymanPublisherOption {
 	return func(p *tallymanPublisher) {
 		if httpClient == nil {
-			httpClient = http.DefaultClient
+			httpClient = &http.Client{}
 		}
 		p.httpClient = httpClient
 	}

--- a/enterprise/trialer/trialer.go
+++ b/enterprise/trialer/trialer.go
@@ -34,7 +34,8 @@ func New(db database.Store, url string, keys map[string]ed25519.PublicKey) func(
 		if err != nil {
 			return xerrors.Errorf("create license request: %w", err)
 		}
-		res, err := http.DefaultClient.Do(req)
+		client := &http.Client{}
+		res, err := client.Do(req)
 		if err != nil {
 			return xerrors.Errorf("perform license request: %w", err)
 		}

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -62,7 +62,8 @@ func TestServer_SendAndReceiveEmail(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -103,7 +104,8 @@ func TestServer_FilterByEmail(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -142,7 +144,8 @@ func TestServer_NotificationTemplateID(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -178,7 +181,8 @@ func TestServer_Purge(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	require.NoError(t, err)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/tailnet/derpmap.go
+++ b/tailnet/derpmap.go
@@ -86,7 +86,8 @@ func NewDERPMap(ctx context.Context, region *tailcfg.DERPRegion, stunAddrs []str
 		if err != nil {
 			return nil, xerrors.Errorf("create request: %w", err)
 		}
-		res, err := http.DefaultClient.Do(req)
+		client := &http.Client{}
+		res, err := client.Do(req)
 		if err != nil {
 			return nil, xerrors.Errorf("get derpmap: %w", err)
 		}

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -35,7 +35,8 @@ func sendRestart(t *testing.T, serverURL *url.URL, derp bool, coordinator bool) 
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL.String(), nil)
 	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/testutil/http.go
+++ b/testutil/http.go
@@ -16,12 +16,13 @@ import (
 func RequireEventuallyResponseOK(ctx context.Context, t testing.TB, endpoint string, target interface{}) {
 	t.Helper()
 
+	client := &http.Client{}
 	ok := Eventually(ctx, t, func(ctx context.Context) (done bool) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
 			return false
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			return false
 		}

--- a/testutil/oauth2.go
+++ b/testutil/oauth2.go
@@ -12,12 +12,13 @@ import (
 )
 
 type OAuth2Config struct {
+	client          http.Client
 	Token           *oauth2.Token
 	TokenSourceFunc OAuth2TokenSource
 }
 
-func (*OAuth2Config) Do(_ context.Context, _ promoauth.Oauth2Source, req *http.Request) (*http.Response, error) {
-	return http.DefaultClient.Do(req)
+func (c *OAuth2Config) Do(_ context.Context, _ promoauth.Oauth2Source, req *http.Request) (*http.Response, error) {
+	return c.client.Do(req)
 }
 
 func (*OAuth2Config) AuthCodeURL(state string, _ ...oauth2.AuthCodeOption) string {


### PR DESCRIPTION
Usage of these types/functions in the http package meant global state caused test flakiness. Remove their usage and ban any future usage to ensure flakiness doesn't sneak in and push us to build more robust production code.

https://github.com/coder/internal/issues/1020