### PR TITLE
fix: correctly set touched for autofill dynamic parameters

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -119,7 +119,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 	// Only touched fields are sent to the websocket
 	// Autofilled parameters are marked as touched since they have been modified
 	const initialTouched = Object.fromEntries(
-		parameters.filter((p) => autofillByName[p.name]).map((p) => [p, true]),
+		parameters.filter((p) => autofillByName[p.name]).map((p) => [p.name, true]),
 	);
 
 	// The form parameters values hold the working state of the parameters that will be submitted when creating a workspace


### PR DESCRIPTION
this resolves #20187 

This bug was introduced in PR https://github.com/coder/coder/pull/18894 in CreateWorkspacePageViewExperimental.tsx

This PR made a change so that the entire parameter was used instead of just the parameter name to mark an autofilled parameter as touched.

The fix here is to just use the parameter name.
