### PR TITLE
chore: add timing flag context to warn message

### DIFF
--- a/coderd/provisionerdserver/metrics.go
+++ b/coderd/provisionerdserver/metrics.go
@@ -153,6 +153,9 @@ func (m *Metrics) UpdateWorkspaceTimingsMetrics(
 		m.workspaceClaimTimings.
 			WithLabelValues(organizationName, templateName, presetName).Observe(buildTime)
 	default:
-		m.logger.Warn(ctx, "unsupported workspace timing flags")
+		m.logger.Warn(ctx, "unsupported workspace timing flags",
+			"isPrebuild", flags.IsPrebuild,
+			"isClaim", flags.IsClaim,
+			"isWorkspaceFirstBuild", flags.IsFirstBuild)
 	}
 }


### PR DESCRIPTION
`prometheus.provisionerd_server_metrics: unsupported workspace timing flags` appears in the logs, but without knowledge of the available flags it's not possible to troubleshoot this.