### PR TITLE
fix(coderd/database): reduce write load from UpsertWorkspaceAppAuditSession

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -3189,7 +3189,20 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		u := testutil.Fake(s.T(), faker, database.User{})
 		agent := testutil.Fake(s.T(), faker, database.WorkspaceAgent{})
 		app := testutil.Fake(s.T(), faker, database.WorkspaceApp{})
-		arg := database.UpsertWorkspaceAppAuditSessionParams{AgentID: agent.ID, AppID: app.ID, UserID: u.ID, Ip: "127.0.0.1"}
+		arg := database.UpsertWorkspaceAppAuditSessionParams{
+			ID:              uuid.New(),
+			AgentID:         agent.ID,
+			AppID:           app.ID,
+			UserID:          u.ID,
+			Ip:              "127.0.0.1",
+			UserAgent:       "test-agent",
+			SlugOrPort:      "8080",
+			StatusCode:      200,
+			StartedAt:       dbtime.Now(),
+			UpdatedAt:       dbtime.Now(),
+			Now:             dbtime.Now(),
+			StaleIntervalMS: 3600000,
+		}
 		dbm.EXPECT().UpsertWorkspaceAppAuditSession(gomock.Any(), arg).Return(true, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceSystem, policy.ActionUpdate)
 	}))

--- a/coderd/database/queries/workspaceappaudit.sql
+++ b/coderd/database/queries/workspaceappaudit.sql
@@ -3,8 +3,52 @@
 -- The returned boolean, new_or_stale, can be used to deduce if a new session
 -- was started. This means that a new row was inserted (no previous session) or
 -- the updated_at is older than stale interval.
-INSERT INTO
-	workspace_app_audit_sessions (
+WITH filtered_input AS (
+	-- By filtering the input this way, we can avoid upsert write operations
+	-- (which PostgreSQL does not optimize away even if the input is the same)
+	-- on a specified interval (1 minute). This means we lose some precision
+	-- but avoid unnecessary writes.
+	SELECT
+		@id::uuid AS id,
+		@agent_id::uuid AS agent_id,
+		@app_id::uuid AS app_id,
+		@user_id::uuid AS user_id,
+		@ip::text AS ip,
+		@user_agent::text AS user_agent,
+		@slug_or_port::text AS slug_or_port,
+		@status_code::int4 AS status_code,
+		@started_at::timestamptz AS started_at,
+		@updated_at::timestamptz AS updated_at
+	WHERE
+		NOT EXISTS (
+			SELECT 1
+			FROM workspace_app_audit_sessions w
+			WHERE
+				w.agent_id = @agent_id
+				AND w.app_id = @app_id
+				AND w.user_id = @user_id
+				AND w.ip = @ip
+				AND w.user_agent = @user_agent
+				AND w.slug_or_port = @slug_or_port
+				AND w.status_code = @status_code
+				AND w.updated_at >= NOW() - '1 minute'::interval
+		)
+),
+upsert_result AS (
+	INSERT INTO
+		workspace_app_audit_sessions (
+			id,
+			agent_id,
+			app_id,
+			user_id,
+			ip,
+			user_agent,
+			slug_or_port,
+			status_code,
+			started_at,
+			updated_at
+		)
+	SELECT
 		id,
 		agent_id,
 		app_id,
@@ -15,36 +59,26 @@ INSERT INTO
 		status_code,
 		started_at,
 		updated_at
-	)
-VALUES
-	(
-		$1,
-		$2,
-		$3,
-		$4,
-		$5,
-		$6,
-		$7,
-		$8,
-		$9,
-		$10
-	)
-ON CONFLICT
-	(agent_id, app_id, user_id, ip, user_agent, slug_or_port, status_code)
-DO
-	UPDATE
-	SET
-		-- ID is used to know if session was reset on upsert.
-		id = CASE
-			WHEN workspace_app_audit_sessions.updated_at > NOW() - (@stale_interval_ms::bigint || ' ms')::interval
-			THEN workspace_app_audit_sessions.id
-			ELSE EXCLUDED.id
-		END,
-		started_at = CASE
-			WHEN workspace_app_audit_sessions.updated_at > NOW() - (@stale_interval_ms::bigint || ' ms')::interval
-			THEN workspace_app_audit_sessions.started_at
-			ELSE EXCLUDED.started_at
-		END,
-		updated_at = EXCLUDED.updated_at
-RETURNING
-	id = $1 AS new_or_stale;
+	FROM
+		filtered_input
+	ON CONFLICT
+		(agent_id, app_id, user_id, ip, user_agent, slug_or_port, status_code)
+	DO UPDATE
+		SET
+			-- ID is used to know if session was reset on upsert.
+			id = CASE
+				WHEN workspace_app_audit_sessions.updated_at > NOW() - (@stale_interval_ms::bigint || ' ms')::interval
+				THEN workspace_app_audit_sessions.id
+				ELSE EXCLUDED.id
+			END,
+			started_at = CASE
+				WHEN workspace_app_audit_sessions.updated_at > NOW() - (@stale_interval_ms::bigint || ' ms')::interval
+				THEN workspace_app_audit_sessions.started_at
+				ELSE EXCLUDED.started_at
+			END,
+			updated_at = EXCLUDED.updated_at
+	RETURNING
+		id
+)
+SELECT
+	EXISTS(SELECT 1 FROM upsert_result WHERE id = @id) AS new_or_stale;

--- a/coderd/database/queries/workspaceappaudit.sql
+++ b/coderd/database/queries/workspaceappaudit.sql
@@ -31,7 +31,7 @@ WITH filtered_input AS (
 				AND w.user_agent = @user_agent
 				AND w.slug_or_port = @slug_or_port
 				AND w.status_code = @status_code
-				AND w.updated_at >= NOW() - '1 minute'::interval
+				AND w.updated_at >= (@now::timestamptz) - '1 minute'::interval
 		)
 ),
 upsert_result AS (
@@ -67,12 +67,12 @@ upsert_result AS (
 		SET
 			-- ID is used to know if session was reset on upsert.
 			id = CASE
-				WHEN workspace_app_audit_sessions.updated_at > NOW() - (@stale_interval_ms::bigint || ' ms')::interval
+				WHEN workspace_app_audit_sessions.updated_at > (@now::timestamptz) - (@stale_interval_ms::bigint || ' ms')::interval
 				THEN workspace_app_audit_sessions.id
 				ELSE EXCLUDED.id
 			END,
 			started_at = CASE
-				WHEN workspace_app_audit_sessions.updated_at > NOW() - (@stale_interval_ms::bigint || ' ms')::interval
+				WHEN workspace_app_audit_sessions.updated_at > (@now::timestamptz) - (@stale_interval_ms::bigint || ' ms')::interval
 				THEN workspace_app_audit_sessions.started_at
 				ELSE EXCLUDED.started_at
 			END,


### PR DESCRIPTION
This change reduces write load to the (unlogged) workspace_app_audit_sessions table. Previously, upserts were at the worst case being performed in sync with signed token expiry.

Since PostgreSQL upserts always write data, even if the data hasn't changed, the only option to avoid these writes is to perform check first. By utilizing a CTE here, we can create a condition where there is no input data unless we deem enough time has passed.

Updates #20744
