### PR TITLE
chore: add timing information to the `terraform graph` post apply

### DIFF
--- a/provisioner/terraform/timings.go
+++ b/provisioner/terraform/timings.go
@@ -261,11 +261,20 @@ func createInitTimingsEvent(event timingKind) (time.Time, *timingSpan) {
 	}
 }
 
-func createGraphTimingsEvent(event timingKind) (time.Time, *timingSpan) {
+func createPostPlanGraphTimingsEvent(event timingKind) (time.Time, *timingSpan) {
 	return dbtime.Now(), &timingSpan{
 		kind:     event,
 		action:   "building terraform dependency graph",
 		provider: "terraform",
-		resource: "state file",
+		resource: "post plan",
+	}
+}
+
+func createPostApplyGraphTimingsEvent(event timingKind) (time.Time, *timingSpan) {
+	return dbtime.Now(), &timingSpan{
+		kind:     event,
+		action:   "building terraform dependency graph",
+		provider: "terraform",
+		resource: "post apply",
 	}
 }


### PR DESCRIPTION
It looks weird because the timing constants and ui are not made for a stage surrounding another stage. That being said, calling graph twice is redundant and I will remove it.

<img width="1216" height="317" alt="Screenshot From 2025-11-14 10-56-45" src="https://github.com/user-attachments/assets/f2855b4e-1b11-4b45-a6bd-6a680e5cf221" />

<img width="1216" height="317" alt="Screenshot From 2025-11-14 10-56-48" src="https://github.com/user-attachments/assets/559154dd-b9ba-4ed0-9581-e8849d560f5c" />
