### PR TITLE
feat: add cleanup to task-status load test runner

### DIFF
--- a/cli/exp_scaletest_taskstatus.go
+++ b/cli/exp_scaletest_taskstatus.go
@@ -206,6 +206,17 @@ After all runners connect, it waits for the baseline duration before triggering 
 				}
 			}
 
+			cleanupCtx, cleanupCancel := cleanupStrategy.toContext(ctx)
+			defer cleanupCancel()
+			err = th.Cleanup(cleanupCtx)
+			if err != nil {
+				return xerrors.Errorf("cleanup tests: %w", err)
+			}
+
+			if res.TotalFail > 0 {
+				return xerrors.New("load test failed, see above for more details")
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
Implement Cleanup in the task status Runner, to delete the external workspaces created.
