### PR TITLE
fix(enterprise/cli): preserve actual error when getting provisioner key details

### DIFF
--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -107,7 +107,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			if provisionerKey != "" {
 				pkDetails, err := client.GetProvisionerKey(ctx, provisionerKey)
 				if err != nil {
-					return xerrors.New("unable to get provisioner key details")
+					return xerrors.Errorf("unable to get provisioner key details: %w", err)
 				}
 
 				for k, v := range pkDetails.Tags {


### PR DESCRIPTION
Fixes #20781

Previously, when `GetProvisionerKey()` failed, the actual error was swallowed:
```
error: unable to get provisioner key details
```

Now the actual error is preserved using error wrapping, so users can see the real cause (e.g., 404 Not Found, connection refused, invalid key, etc.):
```
error: unable to get provisioner key details: GET https://...: 404 Not Found
```

This makes it much easier to diagnose configuration issues.

---
*Generated by [mux](https://cmux.io)*