### PR TITLE
chore: protect build timings insert for invalid enums

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2190,8 +2190,11 @@ func (s *server) completeWorkspaceBuildJob(ctx context.Context, job database.Pro
 		}
 		_, err = db.InsertProvisionerJobTimings(ctx, params)
 		if err != nil {
-			// Log error but don't fail the whole transaction for non-critical data
+			// A database error here will "fail" this transaction. Making this error fatal.
+			// If this error is seen, add checks above to validate the insert parameters. In
+			// production, timings should not be a fatal error.
 			s.Logger.Warn(ctx, "failed to update provisioner job timings", slog.F("job_id", jobID), slog.Error(err))
+			return xerrors.Errorf("update provisioner job timings: %w", err)
 		}
 
 		// On start, we want to ensure that workspace agents timeout statuses

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2175,6 +2175,12 @@ func (s *server) completeWorkspaceBuildJob(ctx context.Context, job database.Pro
 				continue
 			}
 
+			// Scan does not guarantee validity
+			if !stg.Valid() {
+				s.Logger.Warn(ctx, "invalid stage, will fail insert based one enum", slog.F("value", t.Stage))
+				continue
+			}
+
 			params.Stage = append(params.Stage, stg)
 			params.Source = append(params.Source, t.Source)
 			params.Resource = append(params.Resource, t.Resource)


### PR DESCRIPTION
You get this error when an insert fails:
```
Workspace build failed
internal provisionerserver error: complete job: commit transaction: pq: Could not complete operation in a failed transaction
```

Database insert errors will fail the transaction. So this error is fatal. Properly return it for a better error call stack, and not just hiding the error in the logs.


# Error

I broke something in a side branch, and this was the error. Pretty opaque, debugged it down to what you see in this PR. This fixes it in prod by skipping the timing. It also makes the insert a fatal error.

<img width="1272" height="647" alt="Screenshot From 2025-11-18 10-27-41" src="https://github.com/user-attachments/assets/46e2f05e-6b85-418c-a94c-921cc5e9af93" />

