### PR TITLE
fix: use API, not request context to insert audit/connection logs

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -610,6 +610,7 @@ func New(options *Options) *API {
 		dbRolluper: options.DatabaseRolluper,
 	}
 	api.WorkspaceAppsProvider = workspaceapps.NewDBTokenProvider(
+		ctx,
 		options.Logger.Named("workspaceapps"),
 		options.AccessURL,
 		options.Authorizer,


### PR DESCRIPTION
Fixes: #20744

Upsert audit and connection log entries with a context derived from the API context, rather than the individual request so that we don't error out if the request is canceled or the client hangs up (e.g. if we return an error).