### PR TITLE
docs(install): remove broken ghfm alerts

### DIFF
--- a/docs/admin/users/idp-sync.md
+++ b/docs/admin/users/idp-sync.md
@@ -519,8 +519,7 @@ Steps to troubleshoot.
 
 ### Active Directory Federation Services (ADFS)
 
-> [!NOTE]
-> Tested on ADFS 4.0, Windows Server 2019
+Tested on ADFS 4.0, Windows Server 2019
 
 1. In your Federation Server, create a new application group for Coder.
    Follow the steps as described in the [Windows Server documentation]

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -27,8 +27,7 @@ curl -L https://coder.com/install.sh | sh
 Refer to [GitHub releases](https://github.com/coder/coder/releases) for
 alternate installation methods (e.g. standalone binaries, system packages).
 
-> [!Warning]
-> If you're using an Apple Silicon Mac with ARM64 architecture, so M1/M2/M3/M4, you'll need to use an external PostgreSQL Database using the following commands:
+If you're using an Apple Silicon Mac with ARM64 architecture, so M1/M2/M3/M4, you'll need to use an external PostgreSQL Database using the following commands:
 
 ``` bash
 # Install PostgreSQL


### PR DESCRIPTION
These are broken within tabs, see https://github.com/coder/coder.com/issues/215

This PR was generated by mux.

<img width="720" height="548" alt="image" src="https://github.com/user-attachments/assets/a4c6087e-65c6-41fa-861a-7a5a6a0f2714" />
