### PR TITLE
fix(site): hide empty tasks list when templates are empty

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -51,6 +51,21 @@ export const LoadingTemplates: Story = {
 	},
 };
 
+export const EmptyTemplates: Story = {
+	parameters: {
+		queries: [
+			{
+				key: ["templates", { q: "has-ai-task:true" }],
+				data: [],
+			},
+			{
+				key: ["tasks", { owner: MockUserOwner.username }],
+				data: [],
+			},
+		],
+	},
+};
+
 export const LoadingTemplatesError: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockRejectedValue(

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -68,52 +68,54 @@ const TasksPage: FC = () => {
 						error={aiTemplatesQuery.error}
 						onRetry={aiTemplatesQuery.refetch}
 					/>
-					{aiTemplatesQuery.isSuccess && (
-						<section className="py-8">
-							{permissions.viewDeploymentConfig && (
-								<section
-									className="mt-6 flex justify-between"
-									aria-label="Controls"
-								>
-									<div className="flex items-center bg-surface-secondary rounded p-1">
-										<PillButton
-											active={tab.value === "all"}
-											onClick={() => tab.setValue("all")}
-										>
-											All tasks
-										</PillButton>
-										<PillButton
-											disabled={!idleTasks || idleTasks.length === 0}
-											active={tab.value === "waiting-for-input"}
-											onClick={() => tab.setValue("waiting-for-input")}
-										>
-											Waiting for input
-											{idleTasks && idleTasks.length > 0 && (
-												<Badge className="-mr-0.5" size="xs" variant="info">
-													{idleTasks.length}
-												</Badge>
-											)}
-										</PillButton>
-									</div>
+					{aiTemplatesQuery.isSuccess &&
+						aiTemplatesQuery.data &&
+						aiTemplatesQuery.data.length > 0 && (
+							<section className="py-8">
+								{permissions.viewDeploymentConfig && (
+									<section
+										className="mt-6 flex justify-between"
+										aria-label="Controls"
+									>
+										<div className="flex items-center bg-surface-secondary rounded p-1">
+											<PillButton
+												active={tab.value === "all"}
+												onClick={() => tab.setValue("all")}
+											>
+												All tasks
+											</PillButton>
+											<PillButton
+												disabled={!idleTasks || idleTasks.length === 0}
+												active={tab.value === "waiting-for-input"}
+												onClick={() => tab.setValue("waiting-for-input")}
+											>
+												Waiting for input
+												{idleTasks && idleTasks.length > 0 && (
+													<Badge className="-mr-0.5" size="xs" variant="info">
+														{idleTasks.length}
+													</Badge>
+												)}
+											</PillButton>
+										</div>
 
-									<UsersCombobox
-										value={ownerFilter.value}
-										onValueChange={(username) => {
-											ownerFilter.setValue(
-												username === ownerFilter.value ? "" : username,
-											);
-										}}
-									/>
-								</section>
-							)}
+										<UsersCombobox
+											value={ownerFilter.value}
+											onValueChange={(username) => {
+												ownerFilter.setValue(
+													username === ownerFilter.value ? "" : username,
+												);
+											}}
+										/>
+									</section>
+								)}
 
-							<TasksTable
-								tasks={displayedTasks}
-								error={tasksQuery.error}
-								onRetry={tasksQuery.refetch}
-							/>
-						</section>
-					)}
+								<TasksTable
+									tasks={displayedTasks}
+									error={tasksQuery.error}
+									onRetry={tasksQuery.refetch}
+								/>
+							</section>
+						)}
 				</main>
 			</Margins>
 		</>


### PR DESCRIPTION
## Description

Fixes an issue where both the empty templates state and empty tasks state were shown simultaneously on the Tasks page.

Now, when there are no AI-enabled templates, only the empty templates prompt is displayed, and the tasks section (including controls and table) is hidden.

## Changes

- **TasksPage.tsx**: Added condition to only render tasks section when `aiTemplatesQuery.data.length > 0`
- **TasksPage.stories.tsx**: Added `EmptyTemplates` story to demonstrate the correct behavior

## Testing

View the new `EmptyTemplates` story in Storybook to verify that only the empty templates state is shown.

Closes https://github.com/coder/internal/issues/1085

---

🤖 PR was written by Claude Sonnet 4.5 Thinking using [Coder Mux](https://github.com/coder/cmux) and reviewed by a human 👩