### PR TITLE
feat: purge expired api keys in dbpurge

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1641,6 +1641,15 @@ func (q *querier) DeleteCustomRole(ctx context.Context, arg database.DeleteCusto
 	return q.db.DeleteCustomRole(ctx, arg)
 }
 
+func (q *querier) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) error {
+	// Requires DELETE across all API keys.
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceApiKey); err != nil {
+		return err
+	}
+
+	return q.db.DeleteExpiredAPIKeys(ctx, arg)
+}
+
 func (q *querier) DeleteExternalAuthLink(ctx context.Context, arg database.DeleteExternalAuthLinkParams) error {
 	return fetchAndExec(q.log, q.auth, policy.ActionUpdatePersonal, func(ctx context.Context, arg database.DeleteExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 		//nolint:gosimple

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1641,10 +1641,10 @@ func (q *querier) DeleteCustomRole(ctx context.Context, arg database.DeleteCusto
 	return q.db.DeleteCustomRole(ctx, arg)
 }
 
-func (q *querier) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) error {
+func (q *querier) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) (int64, error) {
 	// Requires DELETE across all API keys.
 	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceApiKey); err != nil {
-		return err
+		return 0, err
 	}
 
 	return q.db.DeleteExpiredAPIKeys(ctx, arg)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -221,8 +221,8 @@ func (s *MethodTestSuite) TestAPIKey() {
 			Before:     time.Date(2025, 11, 21, 0, 0, 0, 0, time.UTC),
 			LimitCount: 1000,
 		}
-		dbm.EXPECT().DeleteExpiredAPIKeys(gomock.Any(), args).Return(nil).AnyTimes()
-		check.Args(args).Asserts(rbac.ResourceApiKey, policy.ActionDelete).Returns()
+		dbm.EXPECT().DeleteExpiredAPIKeys(gomock.Any(), args).Return(int64(0), nil).AnyTimes()
+		check.Args(args).Asserts(rbac.ResourceApiKey, policy.ActionDelete).Returns(int64(0))
 	}))
 	s.Run("GetAPIKeyByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		key := testutil.Fake(s.T(), faker, database.APIKey{})

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -216,6 +216,14 @@ func (s *MethodTestSuite) TestAPIKey() {
 		dbm.EXPECT().DeleteAPIKeyByID(gomock.Any(), key.ID).Return(nil).AnyTimes()
 		check.Args(key.ID).Asserts(key, policy.ActionDelete).Returns()
 	}))
+	s.Run("DeleteExpiredAPIKeys", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		args := database.DeleteExpiredAPIKeysParams{
+			Before:     time.Date(2025, 11, 21, 0, 0, 0, 0, time.UTC),
+			LimitCount: 1000,
+		}
+		dbm.EXPECT().DeleteExpiredAPIKeys(gomock.Any(), args).Return(nil).AnyTimes()
+		check.Args(args).Asserts(rbac.ResourceApiKey, policy.ActionDelete).Returns()
+	}))
 	s.Run("GetAPIKeyByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		key := testutil.Fake(s.T(), faker, database.APIKey{})
 		dbm.EXPECT().GetAPIKeyByID(gomock.Any(), key.ID).Return(key, nil).AnyTimes()

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -175,6 +175,13 @@ func APIKey(t testing.TB, db database.Store, seed database.APIKey, munge ...func
 		}
 	}
 
+	// It does not make sense for the created_at to be after the expires_at.
+	// So if expires is set, change the default created_at to be 24 hours before.
+	var createdAt time.Time
+	if !seed.ExpiresAt.IsZero() && seed.CreatedAt.IsZero() {
+		createdAt = seed.ExpiresAt.Add(-24 * time.Hour)
+	}
+
 	params := database.InsertAPIKeyParams{
 		ID: takeFirst(seed.ID, id),
 		// 0 defaults to 86400 at the db layer
@@ -184,7 +191,7 @@ func APIKey(t testing.TB, db database.Store, seed database.APIKey, munge ...func
 		UserID:          takeFirst(seed.UserID, uuid.New()),
 		LastUsed:        takeFirst(seed.LastUsed, dbtime.Now()),
 		ExpiresAt:       takeFirst(seed.ExpiresAt, dbtime.Now().Add(time.Hour)),
-		CreatedAt:       takeFirst(seed.CreatedAt, dbtime.Now()),
+		CreatedAt:       takeFirst(seed.CreatedAt, createdAt, dbtime.Now()),
 		UpdatedAt:       takeFirst(seed.UpdatedAt, dbtime.Now()),
 		LoginType:       takeFirst(seed.LoginType, database.LoginTypePassword),
 		Scopes:          takeFirstSlice([]database.APIKeyScope(seed.Scopes), []database.APIKeyScope{database.ApiKeyScopeCoderAll}),

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -314,9 +314,9 @@ func (m queryMetricsStore) DeleteCustomRole(ctx context.Context, arg database.De
 
 func (m queryMetricsStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) (int64, error) {
 	start := time.Now()
-	r0 := m.s.DeleteExpiredAPIKeys(ctx, arg)
+	r0, r1 := m.s.DeleteExpiredAPIKeys(ctx, arg)
 	m.queryLatencies.WithLabelValues("DeleteExpiredAPIKeys").Observe(time.Since(start).Seconds())
-	return r0
+	return r0, r1
 }
 
 func (m queryMetricsStore) DeleteExternalAuthLink(ctx context.Context, arg database.DeleteExternalAuthLinkParams) error {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -312,6 +312,13 @@ func (m queryMetricsStore) DeleteCustomRole(ctx context.Context, arg database.De
 	return r0
 }
 
+func (m queryMetricsStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) error {
+	start := time.Now()
+	r0 := m.s.DeleteExpiredAPIKeys(ctx, arg)
+	m.queryLatencies.WithLabelValues("DeleteExpiredAPIKeys").Observe(time.Since(start).Seconds())
+	return r0
+}
+
 func (m queryMetricsStore) DeleteExternalAuthLink(ctx context.Context, arg database.DeleteExternalAuthLinkParams) error {
 	start := time.Now()
 	r0 := m.s.DeleteExternalAuthLink(ctx, arg)

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -312,7 +312,7 @@ func (m queryMetricsStore) DeleteCustomRole(ctx context.Context, arg database.De
 	return r0
 }
 
-func (m queryMetricsStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) error {
+func (m queryMetricsStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) (int64, error) {
 	start := time.Now()
 	r0 := m.s.DeleteExpiredAPIKeys(ctx, arg)
 	m.queryLatencies.WithLabelValues("DeleteExpiredAPIKeys").Observe(time.Since(start).Seconds())

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -555,11 +555,12 @@ func (mr *MockStoreMockRecorder) DeleteCustomRole(ctx, arg any) *gomock.Call {
 }
 
 // DeleteExpiredAPIKeys mocks base method.
-func (m *MockStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) error {
+func (m *MockStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteExpiredAPIKeys", ctx, arg)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DeleteExpiredAPIKeys indicates an expected call of DeleteExpiredAPIKeys.

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -554,6 +554,20 @@ func (mr *MockStoreMockRecorder) DeleteCustomRole(ctx, arg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomRole", reflect.TypeOf((*MockStore)(nil).DeleteCustomRole), ctx, arg)
 }
 
+// DeleteExpiredAPIKeys mocks base method.
+func (m *MockStore) DeleteExpiredAPIKeys(ctx context.Context, arg database.DeleteExpiredAPIKeysParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteExpiredAPIKeys", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteExpiredAPIKeys indicates an expected call of DeleteExpiredAPIKeys.
+func (mr *MockStoreMockRecorder) DeleteExpiredAPIKeys(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpiredAPIKeys", reflect.TypeOf((*MockStore)(nil).DeleteExpiredAPIKeys), ctx, arg)
+}
+
 // DeleteExternalAuthLink mocks base method.
 func (m *MockStore) DeleteExternalAuthLink(ctx context.Context, arg database.DeleteExternalAuthLinkParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -83,7 +83,7 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 				// between a 404 and an expired key. This purge code is just to bound the size of
 				// the table to something more reasonable.
 				// TODO: Does this matter?
-				Now: dbtime.Time(start.Add(time.Hour * 24 * 7 * -1)),
+				Before: dbtime.Time(start.Add(time.Hour * 24 * 7 * -1)),
 				// There could be a lot of expired keys here, so set a limit to prevent this
 				// taking too long.
 				// TODO: Arbitrary numbers are arbitrary...

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -110,11 +110,10 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 			if err != nil {
 				return xerrors.Errorf("failed to delete old aibridge records: %w", err)
 			}
-			logger.Debug(ctx, "purged aibridge entries", slog.F("purged", purgedAIBridgeRecords), slog.F("since", deleteAIBridgeRecordsBefore.Format(time.RFC3339)))
 
 			logger.Debug(ctx, "purged old database entries",
 				slog.F("expired_api_keys", expiredAPIKeys),
-				slog.F("ai_bridge_records", purgedAIBridgeRecords),
+				slog.F("aibridge_records", purgedAIBridgeRecords),
 				slog.F("duration", clk.Since(start)),
 			)
 

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -78,6 +78,19 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 			if err := tx.ExpirePrebuildsAPIKeys(ctx, dbtime.Time(start)); err != nil {
 				return xerrors.Errorf("failed to expire prebuilds user api keys: %w", err)
 			}
+			if err := tx.DeleteExpiredAPIKeys(ctx, database.DeleteExpiredAPIKeysParams{
+				// Leave expired keys for a week to allow the backend to know the difference
+				// between a 404 and an expired key. This purge code is just to bound the size of
+				// the table to something more reasonable.
+				// TODO: Does this matter?
+				Now: dbtime.Time(start.Add(time.Hour * 24 * 7 * -1)),
+				// There could be a lot of expired keys here, so set a limit to prevent this
+				// taking too long.
+				// TODO: Arbitrary numbers are arbitrary...
+				LimitCount: 10000,
+			}); err != nil {
+				return xerrors.Errorf("failed to delete expired api keys: %w", err)
+			}
 			deleteOldTelemetryLocksBefore := start.Add(-maxTelemetryHeartbeatAge)
 			if err := tx.DeleteOldTelemetryLocks(ctx, deleteOldTelemetryLocksBefore); err != nil {
 				return xerrors.Errorf("failed to delete old telemetry locks: %w", err)

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -110,7 +110,7 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 			if err != nil {
 				return xerrors.Errorf("failed to delete old aibridge records: %w", err)
 			}
-			logger.Debug(ctx, "purged aibridge entries", slog.F("purgedAIBridgeRecords", purgedAIBridgeRecords), slog.F("since", deleteAIBridgeRecordsBefore.Format(time.RFC3339)))
+			logger.Debug(ctx, "purged aibridge entries", slog.F("purged", purgedAIBridgeRecords), slog.F("since", deleteAIBridgeRecordsBefore.Format(time.RFC3339)))
 
 			logger.Debug(ctx, "purged old database entries",
 				slog.F("expired_api_keys", expiredAPIKeys),

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -82,11 +82,9 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 				// Leave expired keys for a week to allow the backend to know the difference
 				// between a 404 and an expired key. This purge code is just to bound the size of
 				// the table to something more reasonable.
-				// TODO: Does this matter?
 				Before: dbtime.Time(start.Add(time.Hour * 24 * 7 * -1)),
 				// There could be a lot of expired keys here, so set a limit to prevent this
 				// taking too long.
-				// TODO: Arbitrary numbers are arbitrary...
 				LimitCount: 10000,
 			}); err != nil {
 				return xerrors.Errorf("failed to delete expired api keys: %w", err)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -91,6 +91,7 @@ type sqlcQuerier interface {
 	DeleteCoordinator(ctx context.Context, id uuid.UUID) error
 	DeleteCryptoKey(ctx context.Context, arg DeleteCryptoKeyParams) (CryptoKey, error)
 	DeleteCustomRole(ctx context.Context, arg DeleteCustomRoleParams) error
+	DeleteExpiredAPIKeys(ctx context.Context, arg DeleteExpiredAPIKeysParams) error
 	DeleteExternalAuthLink(ctx context.Context, arg DeleteExternalAuthLinkParams) error
 	DeleteGitSSHKey(ctx context.Context, userID uuid.UUID) error
 	DeleteGroupByID(ctx context.Context, id uuid.UUID) error

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -91,7 +91,7 @@ type sqlcQuerier interface {
 	DeleteCoordinator(ctx context.Context, id uuid.UUID) error
 	DeleteCryptoKey(ctx context.Context, arg DeleteCryptoKeyParams) (CryptoKey, error)
 	DeleteCustomRole(ctx context.Context, arg DeleteCustomRoleParams) error
-	DeleteExpiredAPIKeys(ctx context.Context, arg DeleteExpiredAPIKeysParams) error
+	DeleteExpiredAPIKeys(ctx context.Context, arg DeleteExpiredAPIKeysParams) (int64, error)
 	DeleteExternalAuthLink(ctx context.Context, arg DeleteExternalAuthLinkParams) error
 	DeleteGitSSHKey(ctx context.Context, userID uuid.UUID) error
 	DeleteGroupByID(ctx context.Context, id uuid.UUID) error

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -7882,11 +7882,12 @@ func TestDeleteExpiredAPIKeys(t *testing.T) {
 
 	// Delete expired keys
 	// First verify the limit works by deleting one at a time
-	err = db.DeleteExpiredAPIKeys(ctx, database.DeleteExpiredAPIKeysParams{
+	deletedCount, err := db.DeleteExpiredAPIKeys(ctx, database.DeleteExpiredAPIKeysParams{
 		Before:     expiredBefore,
 		LimitCount: 1,
 	})
 	require.NoError(t, err)
+	require.Equal(t, int64(1), deletedCount)
 
 	// Ensure it was deleted
 	remaining, err := db.GetAPIKeysByUserID(ctx, database.GetAPIKeysByUserIDParams{
@@ -7897,11 +7898,12 @@ func TestDeleteExpiredAPIKeys(t *testing.T) {
 	require.Len(t, remaining, len(expiredTimes)+len(unexpiredTimes)-1)
 
 	// Delete the rest of the expired keys
-	err = db.DeleteExpiredAPIKeys(ctx, database.DeleteExpiredAPIKeysParams{
+	deletedCount, err = db.DeleteExpiredAPIKeys(ctx, database.DeleteExpiredAPIKeysParams{
 		Before:     expiredBefore,
 		LimitCount: 100,
 	})
 	require.NoError(t, err)
+	require.Equal(t, int64(len(expiredTimes)-1), deletedCount)
 
 	// Ensure only unexpired keys remain
 	remaining, err = db.GetAPIKeysByUserID(ctx, database.GetAPIKeysByUserIDParams{

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1107,7 +1107,8 @@ const deleteExpiredAPIKeys = `-- name: DeleteExpiredAPIKeys :exec
 WITH expired_keys AS (
 	SELECT id
 	FROM api_keys
-	WHERE expires_at <= $1::timestamptz
+	-- expired keys only
+	WHERE expires_at < $1::timestamptz
 	LIMIT $2
 )
 DELETE FROM
@@ -1119,12 +1120,12 @@ WHERE
 `
 
 type DeleteExpiredAPIKeysParams struct {
-	Now        time.Time `db:"now" json:"now"`
+	Before     time.Time `db:"before" json:"before"`
 	LimitCount int32     `db:"limit_count" json:"limit_count"`
 }
 
 func (q *sqlQuerier) DeleteExpiredAPIKeys(ctx context.Context, arg DeleteExpiredAPIKeysParams) error {
-	_, err := q.db.ExecContext(ctx, deleteExpiredAPIKeys, arg.Now, arg.LimitCount)
+	_, err := q.db.ExecContext(ctx, deleteExpiredAPIKeys, arg.Before, arg.LimitCount)
 	return err
 }
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1120,7 +1120,7 @@ deleted_rows AS (
 		 api_keys.id = expired_keys.id
 	 RETURNING api_keys.id
  )
-SELECT COUNT(*) AS deleted_count FROM deleted_rows
+SELECT COUNT(deleted_rows.id) AS deleted_count FROM deleted_rows
 `
 
 type DeleteExpiredAPIKeysParams struct {

--- a/coderd/database/queries/apikeys.sql
+++ b/coderd/database/queries/apikeys.sql
@@ -85,6 +85,22 @@ DELETE FROM
 WHERE
 	user_id = $1;
 
+-- name: DeleteExpiredAPIKeys :exec
+WITH expired_keys AS (
+	SELECT id
+	FROM api_keys
+	-- expired keys only
+	WHERE expires_at < @now::timestamptz
+	LIMIT @limit_count
+)
+DELETE FROM
+	api_keys
+USING
+	expired_keys
+WHERE
+	api_keys.id = expired_keys.id
+;
+
 -- name: ExpirePrebuildsAPIKeys :exec
 -- Firstly, collect api_keys owned by the prebuilds user that correlate
 -- to workspaces no longer owned by the prebuilds user.

--- a/coderd/database/queries/apikeys.sql
+++ b/coderd/database/queries/apikeys.sql
@@ -90,7 +90,7 @@ WITH expired_keys AS (
 	SELECT id
 	FROM api_keys
 	-- expired keys only
-	WHERE expires_at < @now::timestamptz
+	WHERE expires_at < @before::timestamptz
 	LIMIT @limit_count
 )
 DELETE FROM

--- a/coderd/oauth2_test.go
+++ b/coderd/oauth2_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
-	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/oauth2provider"
 	"github.com/coder/coder/v2/coderd/userpassword"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -1608,22 +1607,18 @@ func TestOAuth2RegistrationAccessToken(t *testing.T) {
 func TestOAuth2CoderClient(t *testing.T) {
 	t.Parallel()
 
-	db, pubsub := dbtestutil.NewDB(t)
-	owner := coderdtest.New(t, &coderdtest.Options{
-		Database: db,
-		Pubsub:   pubsub,
-	})
+	owner := coderdtest.New(t, nil)
 	first := coderdtest.CreateFirstUser(t, owner)
 
 	// Setup an oauth app
-	setupCtx := testutil.Context(t, testutil.WaitLong)
-	app, err := owner.PostOAuth2ProviderApp(setupCtx, codersdk.PostOAuth2ProviderAppRequest{
+	ctx := testutil.Context(t, testutil.WaitLong)
+	app, err := owner.PostOAuth2ProviderApp(ctx, codersdk.PostOAuth2ProviderAppRequest{
 		Name:        "new-app",
 		CallbackURL: "http://localhost",
 	})
 	require.NoError(t, err)
 
-	appsecret, err := owner.PostOAuth2ProviderAppSecret(setupCtx, app.ID)
+	appsecret, err := owner.PostOAuth2ProviderAppSecret(ctx, app.ID)
 	require.NoError(t, err)
 
 	cfg := &oauth2.Config{
@@ -1640,76 +1635,47 @@ func TestOAuth2CoderClient(t *testing.T) {
 	}
 
 	// Make a new user
-	userClient, user := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID)
+	client, user := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID)
 
-	// userOAuthFlow is a helper function that runs the oauth flow and returns
-	// the codersdk userClient using oauth as the means of authentication.
-	userOAuthFlow := func(t *testing.T) (*codersdk.Client, *oauth2.Token) {
-		// Do an OAuth2 token exchange and get a new userClient with an oauth token
-		state := uuid.NewString()
+	// Do an OAuth2 token exchange and get a new client with an oauth token
+	state := uuid.NewString()
 
-		// Get an OAuth2 code for a token exchange
-		code, err := oidctest.OAuth2GetCode(
-			cfg.AuthCodeURL(state),
-			func(req *http.Request) (*http.Response, error) {
-				// Change to POST to simulate the form submission
-				req.Method = http.MethodPost
+	// Get an OAuth2 code for a token exchange
+	code, err := oidctest.OAuth2GetCode(
+		cfg.AuthCodeURL(state),
+		func(req *http.Request) (*http.Response, error) {
+			// Change to POST to simulate the form submission
+			req.Method = http.MethodPost
 
-				// Prevent automatic redirect following
-				userClient.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-					return http.ErrUseLastResponse
-				}
-				return userClient.Request(setupCtx, req.Method, req.URL.String(), nil)
-			},
-		)
-		require.NoError(t, err)
+			// Prevent automatic redirect following
+			client.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+			return client.Request(ctx, req.Method, req.URL.String(), nil)
+		},
+	)
+	require.NoError(t, err)
 
-		token, err := cfg.Exchange(setupCtx, code)
-		require.NoError(t, err)
+	token, err := cfg.Exchange(ctx, code)
+	require.NoError(t, err)
 
-		// Use the oauth userClient's authentication
-		// TODO: The SDK could probably support this with a better syntax/api.
-		oauthClient := oauth2.NewClient(setupCtx, oauth2.StaticTokenSource(token))
-		usingOauth := codersdk.New(owner.URL)
-		usingOauth.HTTPClient = oauthClient
+	// Use the oauth client's authentication
+	// TODO: The SDK could probably support this with a better syntax/api.
+	oauthClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(token))
+	usingOauth := codersdk.New(owner.URL)
+	usingOauth.HTTPClient = oauthClient
 
-		me, err := usingOauth.User(setupCtx, codersdk.Me)
-		require.NoError(t, err)
-		require.Equal(t, user.ID, me.ID)
-		return usingOauth, token
-	}
+	me, err := usingOauth.User(ctx, codersdk.Me)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, me.ID)
 
-	//nolint:tparallel,paralleltest
-	t.Run("OauthRevoke", func(t *testing.T) {
-		// OauthRevoke uses the proper oauth revocation endpoint to revoke the token.
-		ctx := testutil.Context(t, testutil.WaitShort)
-		client, token := userOAuthFlow(t)
-		// Revoking the refresh token should prevent further access
-		// Revoking the refresh also invalidates the associated access token.
-		err = client.RevokeOAuth2Token(ctx, app.ID, token.RefreshToken)
-		require.NoError(t, err)
+	// Revoking the refresh token should prevent further access
+	// Revoking the refresh also invalidates the associated access token.
+	err = usingOauth.RevokeOAuth2Token(ctx, app.ID, token.RefreshToken)
+	require.NoError(t, err)
 
-		_, err = client.User(ctx, codersdk.Me)
-		require.Error(t, err)
-	})
-
-	//nolint:tparallel,paralleltest
-	t.Run("DeleteAPIKey", func(t *testing.T) {
-		// DeleteAPIKey uses the coder api to delete the underlying api key used by the
-		// oauth token. This is not the recommended way to revoke oauth tokens, but is
-		// supported and should work.
-		ctx := testutil.Context(t, testutil.WaitShort)
-		client, token := userOAuthFlow(t)
-
-		id, _, err := httpmw.SplitAPIToken(token.AccessToken)
-		require.NoError(t, err)
-
-		err = db.DeleteAPIKeyByID(ctx, id)
-		require.NoError(t, err)
-
-		_, err = client.User(ctx, codersdk.Me)
-		require.Error(t, err)
-	})
+	_, err = usingOauth.User(ctx, codersdk.Me)
+	require.Error(t, err)
 }
 
 // NOTE: OAuth2 client registration validation tests have been migrated to


### PR DESCRIPTION
closes https://github.com/coder/coder/issues/19889

This is in response to a migration in v2.27 that takes very long on deployments with large `api_key` tables.