### PR TITLE
chore: backport fix #20769 to 2.27

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageViewExperimental.tsx
@@ -119,7 +119,7 @@ export const CreateWorkspacePageViewExperimental: FC<
 	// Only touched fields are sent to the websocket
 	// Autofilled parameters are marked as touched since they have been modified
 	const initialTouched = Object.fromEntries(
-		parameters.filter((p) => autofillByName[p.name]).map((p) => [p, true]),
+		parameters.filter((p) => autofillByName[p.name]).map((p) => [p.name, true]),
 	);
 
 	// The form parameters values hold the working state of the parameters that will be submitted when creating a workspace


### PR DESCRIPTION
backport #20769  to 2.27

Fix dynamic parameters for create workspace form when using autofill params from the url