### PR TITLE
chore: update OIDC scopes to include offline_access

### DIFF
--- a/docs/admin/users/oidc-auth/microsoft.md
+++ b/docs/admin/users/oidc-auth/microsoft.md
@@ -44,7 +44,7 @@ CODER_OIDC_ICON_URL=/icon/microsoft.svg
 
 ```env
 # Keep standard scopes
-CODER_OIDC_SCOPES=openid,profile,email
+CODER_OIDC_SCOPES=openid,profile,email,offline_access
 ```
 
 After changing settings, users must log out and back in once to obtain refresh tokens


### PR DESCRIPTION
This is an update to https://coder.com/docs/admin/users/oidc-auth/microsoft#enable-refresh-tokens-recommended. We recommend users enable refresh tokens but don't actually give them the env var value to add. 

https://coder.com/docs/admin/users/oidc-auth/refresh-tokens does a good job of including `offline_access` in the list, so the first page should align with this.