### PR TITLE
fix: fix API docs manifest generation

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1131,6 +1131,10 @@
 							"path": "./reference/api/general.md"
 						},
 						{
+							"title": "AI Bridge",
+							"path": "./reference/api/aibridge.md"
+						},
+						{
 							"title": "Agents",
 							"path": "./reference/api/agents.md"
 						},
@@ -1163,12 +1167,20 @@
 							"path": "./reference/api/enterprise.md"
 						},
 						{
+							"title": "Experimental",
+							"path": "./reference/api/experimental.md"
+						},
+						{
 							"title": "Files",
 							"path": "./reference/api/files.md"
 						},
 						{
 							"title": "Git",
 							"path": "./reference/api/git.md"
+						},
+						{
+							"title": "InitScript",
+							"path": "./reference/api/initscript.md"
 						},
 						{
 							"title": "Insights",
@@ -1179,12 +1191,24 @@
 							"path": "./reference/api/members.md"
 						},
 						{
+							"title": "Notifications",
+							"path": "./reference/api/notifications.md"
+						},
+						{
 							"title": "Organizations",
 							"path": "./reference/api/organizations.md"
 						},
 						{
 							"title": "PortSharing",
 							"path": "./reference/api/portsharing.md"
+						},
+						{
+							"title": "Prebuilds",
+							"path": "./reference/api/prebuilds.md"
+						},
+						{
+							"title": "Provisioning",
+							"path": "./reference/api/provisioning.md"
 						},
 						{
 							"title": "Schemas",

--- a/scripts/apidocgen/postprocess/main.go
+++ b/scripts/apidocgen/postprocess/main.go
@@ -198,20 +198,26 @@ func writeDocs(sections [][]byte) error {
 	}
 
 	for i, r := range m.Routes {
-		if r.Title != "API" {
+		if r.Title != "Reference" {
 			continue
 		}
-
-		var children []route
-		for _, mdf := range mdFiles {
-			docRoute := route{
-				Title: mdf.title,
-				Path:  mdf.path,
+		for j, child := range r.Children {
+			if child.Title != "REST API" {
+				continue
 			}
-			children = append(children, docRoute)
-		}
 
-		m.Routes[i].Children = children
+			var children []route
+			for _, mdf := range mdFiles {
+				docRoute := route{
+					Title: mdf.title,
+					Path:  mdf.path,
+				}
+				children = append(children, docRoute)
+			}
+
+			m.Routes[i].Children[j].Children = children
+			break
+		}
 		break
 	}
 


### PR DESCRIPTION
- Include new documentation sections: AI Bridge, Experimental, InitScript, Notifications, Prebuilds, Provisioning in the manifest.
- Adjust routing logic in postprocess script to correctly insert newly added sections under the "REST API" child node of the "Reference" category.
- This fixes a bug introduced in #14241

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
