### PR TITLE
feat: add support for reading db connection string from a file

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -445,6 +445,9 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				if err := vals.PostgresURL.Set(postgresURL); err != nil {
 					return xerrors.Errorf("set postgres URL from file: %w", err)
 				}
+				logger.Info(ctx, "loaded postgres connection URL from file")
+			} else if vals.PostgresURL != "" {
+				logger.Info(ctx, "loaded postgres connection URL from environment or flag")
 			}
 
 			builtinPostgres := false

--- a/cli/server.go
+++ b/cli/server.go
@@ -442,7 +442,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					return xerrors.Errorf("cannot specify both --postgres-url and --postgres-url-file flags")
 				}
 				// Read the URL once for initial validation and migrations.
-				logger.Debug(ctx, "database connection URL sourced from file")
+				logger.Debug(ctx, "coderd: database connection URL sourced from file")
 				postgresURL, err := ReadPostgresURLFromFile(vals.PostgresURLFile.String())
 				if err != nil {
 					return err

--- a/cli/server.go
+++ b/cli/server.go
@@ -445,9 +445,6 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				if err := vals.PostgresURL.Set(postgresURL); err != nil {
 					return xerrors.Errorf("set postgres URL from file: %w", err)
 				}
-				logger.Info(ctx, "loaded postgres connection URL from file")
-			} else if vals.PostgresURL != "" {
-				logger.Info(ctx, "loaded postgres connection URL from environment or flag")
 			}
 
 			builtinPostgres := false

--- a/cli/testdata/coder_reset-password_--help.golden
+++ b/cli/testdata/coder_reset-password_--help.golden
@@ -12,5 +12,11 @@ OPTIONS:
       --postgres-url string, $CODER_PG_CONNECTION_URL
           URL of a PostgreSQL database to connect to.
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the URL of a PostgreSQL database. The file
+          contents will be read and used as the connection URL. This is an
+          alternative to --postgres-url for cases where the URL is stored in a
+          file, such as a Docker or Kubernetes secret.
+
 ———
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -65,6 +65,12 @@ OPTIONS:
           server postgres-builtin-url". Note that any special characters in the
           URL must be URL-encoded.
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the URL of a PostgreSQL database. The file
+          contents will be read and used as the connection URL. This is an
+          alternative to --postgres-url for cases where the URL is stored in a
+          file, such as a Docker or Kubernetes secret.
+
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are
           "ed25519", "ecdsa", or "rsa4096".

--- a/cli/testdata/coder_server_create-admin-user_--help.golden
+++ b/cli/testdata/coder_server_create-admin-user_--help.golden
@@ -23,6 +23,12 @@ OPTIONS:
           deployment will be used (Coder must not be already running in this
           case).
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the URL of a PostgreSQL database. The file
+          contents will be read and used as the connection URL. This is an
+          alternative to --postgres-url for cases where the URL is stored in a
+          file, such as a Docker or Kubernetes secret.
+
       --raw-url bool
           Output the raw connection URL instead of a psql command.
 

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -470,6 +470,12 @@ cacheDir: [cache dir]
 # temporary directory and deleted when the server is stopped.
 # (default: <unset>, type: bool)
 ephemeralDeployment: false
+# Path to a file containing the URL of a PostgreSQL database. The file contents
+# will be read and used as the connection URL. This is an alternative to
+# --postgres-url for cases where the URL is stored in a file, such as a Docker or
+# Kubernetes secret.
+# (default: <unset>, type: string)
+pgConnectionURLFile: ""
 # Type of auth to use when connecting to postgres. For AWS RDS, using IAM
 # authentication (awsiamrds) is recommended.
 # (default: password, type: enum[password\|awsiamrds])

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14272,6 +14272,9 @@ const docTemplate = `{
                 "pg_connection_url": {
                     "type": "string"
                 },
+                "pg_connection_url_file": {
+                    "type": "string"
+                },
                 "pprof": {
                     "$ref": "#/definitions/codersdk.PprofConfig"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12856,6 +12856,9 @@
 				"pg_connection_url": {
 					"type": "string"
 				},
+				"pg_connection_url_file": {
+					"type": "string"
+				},
 				"pprof": {
 					"$ref": "#/definitions/codersdk.PprofConfig"
 				},

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -100,6 +100,14 @@ func NewDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub) {
 	var ps pubsub.Pubsub
 
 	connectionURL := os.Getenv("CODER_PG_CONNECTION_URL")
+	if connectionURL == "" {
+		// Check if a file path is provided instead.
+		if filePath := os.Getenv("CODER_PG_CONNECTION_URL_FILE"); filePath != "" {
+			content, err := os.ReadFile(filePath)
+			require.NoError(t, err, "read postgres URL file")
+			connectionURL = strings.TrimSpace(string(content))
+		}
+	}
 	if connectionURL == "" && o.url != "" {
 		connectionURL = o.url
 	}

--- a/coderd/database/pgfileurl/pgfileurl.go
+++ b/coderd/database/pgfileurl/pgfileurl.go
@@ -1,0 +1,97 @@
+// Package pgfileurl provides a SQL driver that reads the database connection
+// URL from a file on each connection attempt. This supports credential rotation
+// in environments like Kubernetes where secrets may be updated without
+// restarting the application.
+package pgfileurl
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"strings"
+	"sync"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+)
+
+// hashString returns a simple hash of the string for use in driver names.
+func hashString(s string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum32()
+}
+
+// driver name registry to avoid duplicate registration.
+var (
+	registryMu sync.Mutex
+	registry   = make(map[string]bool)
+)
+
+type fileURLDriver struct {
+	parent   driver.Driver
+	filePath string
+	logger   slog.Logger
+}
+
+var _ driver.Driver = &fileURLDriver{}
+
+// Register creates and registers a SQL driver that reads the connection URL
+// from a file on each connection attempt. This supports credential rotation
+// in environments like Kubernetes where secrets may be updated.
+//
+// The returned driver name should be used with sql.Open(). The dsn parameter
+// to sql.Open() is ignored since the URL is read from the file.
+//
+// The logger parameter is used for debug logging when reading the file.
+func Register(parentName, filePath string, logger slog.Logger) (string, error) {
+	db, err := sql.Open(parentName, "")
+	if err != nil {
+		return "", xerrors.Errorf("open parent driver: %w", err)
+	}
+	defer db.Close()
+
+	d := &fileURLDriver{
+		parent:   db.Driver(),
+		filePath: filePath,
+		logger:   logger,
+	}
+
+	// Include a hash of the file path in the driver name to ensure uniqueness
+	// when multiple drivers are registered with different file paths (e.g., in tests).
+	name := fmt.Sprintf("%s-fileurl-%d", parentName, hashString(filePath))
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if !registry[name] {
+		sql.Register(name, d)
+		registry[name] = true
+	}
+
+	return name, nil
+}
+
+// Open reads the connection URL from the file and opens a connection.
+// The name parameter is ignored; the URL is always read from the file
+// specified during Register().
+func (d *fileURLDriver) Open(_ string) (driver.Conn, error) {
+	// Read fresh URL from file on every connection attempt.
+	content, err := os.ReadFile(d.filePath)
+	if err != nil {
+		return nil, xerrors.Errorf("read database URL file %q: %w", d.filePath, err)
+	}
+	dbURL := strings.TrimSpace(string(content))
+
+	d.logger.Debug(context.Background(), "re-reading database connection URL from file")
+
+	conn, err := d.parent.Open(dbURL)
+	if err != nil {
+		return nil, xerrors.Errorf("open connection: %w", err)
+	}
+
+	return conn, nil
+}

--- a/coderd/database/pgfileurl/pgfileurl.go
+++ b/coderd/database/pgfileurl/pgfileurl.go
@@ -86,7 +86,7 @@ func (d *fileURLDriver) Open(_ string) (driver.Conn, error) {
 	}
 	dbURL := strings.TrimSpace(string(content))
 
-	d.logger.Debug(context.Background(), "re-reading database connection URL from file")
+	d.logger.Debug(context.Background(), "coderd: re-reading database connection URL from file")
 
 	conn, err := d.parent.Open(dbURL)
 	if err != nil {

--- a/coderd/database/pgfileurl/pgfileurl_test.go
+++ b/coderd/database/pgfileurl/pgfileurl_test.go
@@ -1,0 +1,112 @@
+package pgfileurl_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/sloggers/slogtest"
+
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/pgfileurl"
+)
+
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReadsURLFromFile", func(t *testing.T) {
+		t.Parallel()
+
+		connectionURL, err := dbtestutil.Open(t)
+		require.NoError(t, err)
+
+		// Write connection URL to a temp file.
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "pg_url")
+		err = os.WriteFile(filePath, []byte(connectionURL), 0o600)
+		require.NoError(t, err)
+
+		// Register the file URL driver.
+		driverName, err := pgfileurl.Register("postgres", filePath, slogtest.Make(t, nil))
+		require.NoError(t, err)
+		require.Contains(t, driverName, "postgres-fileurl-")
+
+		// Open a connection using the file URL driver.
+		// The DSN is ignored since the URL is read from the file.
+		db, err := sql.Open(driverName, "ignored")
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Verify we can query the database.
+		var result int
+		err = db.QueryRow("SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, 1, result)
+	})
+
+	t.Run("ReReadsFileOnNewConnection", func(t *testing.T) {
+		t.Parallel()
+
+		connectionURL, err := dbtestutil.Open(t)
+		require.NoError(t, err)
+
+		// Write connection URL to a temp file.
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "pg_url")
+		err = os.WriteFile(filePath, []byte(connectionURL), 0o600)
+		require.NoError(t, err)
+
+		// Register the file URL driver.
+		driverName, err := pgfileurl.Register("postgres", filePath, slogtest.Make(t, nil))
+		require.NoError(t, err)
+
+		// Open a connection and verify it works.
+		db, err := sql.Open(driverName, "")
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Force only one connection in the pool so we can test reconnection.
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(0)
+
+		var result int
+		err = db.QueryRow("SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, 1, result)
+
+		// Update the file with an invalid URL.
+		err = os.WriteFile(filePath, []byte("postgres://invalid:5432/db"), 0o600)
+		require.NoError(t, err)
+
+		// Close existing connections to force a new one.
+		db.SetMaxIdleConns(0)
+
+		// The next query should fail because it will read the invalid URL.
+		// We need to force a new connection by closing the pool.
+		db2, err := sql.Open(driverName, "")
+		require.NoError(t, err)
+		defer db2.Close()
+
+		err = db2.Ping()
+		require.Error(t, err)
+	})
+
+	t.Run("FileNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		driverName, err := pgfileurl.Register("postgres", "/nonexistent/path", slogtest.Make(t, nil))
+		require.NoError(t, err) // Registration succeeds
+
+		db, err := sql.Open(driverName, "")
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Connection should fail when trying to read the file.
+		err = db.Ping()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "read database URL file")
+	})
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2559,6 +2559,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Flag:        "postgres-url-file",
 			Env:         "CODER_PG_CONNECTION_URL_FILE",
 			Value:       &c.PostgresURLFile,
+			YAML:        "pgConnectionURLFile",
 		},
 		{
 			Name:        "Postgres Auth",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -463,6 +463,7 @@ type DeploymentValues struct {
 	CacheDir                        serpent.String                       `json:"cache_directory,omitempty" typescript:",notnull"`
 	EphemeralDeployment             serpent.Bool                         `json:"ephemeral_deployment,omitempty" typescript:",notnull"`
 	PostgresURL                     serpent.String                       `json:"pg_connection_url,omitempty" typescript:",notnull"`
+	PostgresURLFile                 serpent.String                       `json:"pg_connection_url_file,omitempty" typescript:",notnull"`
 	PostgresAuth                    string                               `json:"pg_auth,omitempty" typescript:",notnull"`
 	OAuth2                          OAuth2Config                         `json:"oauth2,omitempty" typescript:",notnull"`
 	OIDC                            OIDCConfig                           `json:"oidc,omitempty" typescript:",notnull"`
@@ -2551,6 +2552,13 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Env:         "CODER_PG_CONNECTION_URL",
 			Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 			Value:       &c.PostgresURL,
+		},
+		{
+			Name:        "Postgres Connection URL File",
+			Description: "Path to a file containing the URL of a PostgreSQL database. The file contents will be read and used as the connection URL. This is an alternative to --postgres-url for cases where the URL is stored in a file, such as a Docker or Kubernetes secret.",
+			Flag:        "postgres-url-file",
+			Env:         "CODER_PG_CONNECTION_URL_FILE",
+			Value:       &c.PostgresURLFile,
 		},
 		{
 			Name:        "Postgres Auth",

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -422,6 +422,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     },
     "pg_auth": "string",
     "pg_connection_url": "string",
+    "pg_connection_url_file": "string",
     "pprof": {
       "address": {
         "host": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3106,6 +3106,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     },
     "pg_auth": "string",
     "pg_connection_url": "string",
+    "pg_connection_url_file": "string",
     "pprof": {
       "address": {
         "host": "string",
@@ -3622,6 +3623,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   },
   "pg_auth": "string",
   "pg_connection_url": "string",
+  "pg_connection_url_file": "string",
   "pprof": {
     "address": {
       "host": "string",
@@ -3800,6 +3802,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `oidc`                               | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                           | false    |              |                                                                    |
 | `pg_auth`                            | string                                                                                               | false    |              |                                                                    |
 | `pg_connection_url`                  | string                                                                                               | false    |              |                                                                    |
+| `pg_connection_url_file`             | string                                                                                               | false    |              |                                                                    |
 | `pprof`                              | [codersdk.PprofConfig](#codersdkpprofconfig)                                                         | false    |              |                                                                    |
 | `prometheus`                         | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                               | false    |              |                                                                    |
 | `provisioner`                        | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                             | false    |              |                                                                    |

--- a/docs/reference/cli/reset-password.md
+++ b/docs/reference/cli/reset-password.md
@@ -20,6 +20,15 @@ coder reset-password [flags] <username>
 
 URL of a PostgreSQL database to connect to.
 
+### --postgres-url-file
+
+|             |                                            |
+|-------------|--------------------------------------------|
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PG_CONNECTION_URL_FILE</code> |
+
+Path to a file containing the URL of a PostgreSQL database. The file contents will be read and used as the connection URL. This is an alternative to --postgres-url for cases where the URL is stored in a file, such as a Docker or Kubernetes secret.
+
 ### --postgres-connection-auth
 
 |             |                                        |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -993,6 +993,15 @@ The directory to cache temporary files. If unspecified and $CACHE_DIRECTORY is s
 
 URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with "coder server postgres-builtin-url". Note that any special characters in the URL must be URL-encoded.
 
+### --postgres-url-file
+
+|             |                                            |
+|-------------|--------------------------------------------|
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PG_CONNECTION_URL_FILE</code> |
+
+Path to a file containing the URL of a PostgreSQL database. The file contents will be read and used as the connection URL. This is an alternative to --postgres-url for cases where the URL is stored in a file, such as a Docker or Kubernetes secret.
+
 ### --postgres-auth
 
 |             |                                  |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -999,6 +999,7 @@ URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded f
 |-------------|--------------------------------------------|
 | Type        | <code>string</code>                        |
 | Environment | <code>$CODER_PG_CONNECTION_URL_FILE</code> |
+| YAML        | <code>pgConnectionURLFile</code>           |
 
 Path to a file containing the URL of a PostgreSQL database. The file contents will be read and used as the connection URL. This is an alternative to --postgres-url for cases where the URL is stored in a file, such as a Docker or Kubernetes secret.
 

--- a/docs/reference/cli/server_create-admin-user.md
+++ b/docs/reference/cli/server_create-admin-user.md
@@ -20,6 +20,15 @@ coder server create-admin-user [flags]
 
 URL of a PostgreSQL database. If empty, the built-in PostgreSQL deployment will be used (Coder must not be already running in this case).
 
+### --postgres-url-file
+
+|             |                                            |
+|-------------|--------------------------------------------|
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PG_CONNECTION_URL_FILE</code> |
+
+Path to a file containing the URL of a PostgreSQL database. The file contents will be read and used as the connection URL. This is an alternative to --postgres-url for cases where the URL is stored in a file, such as a Docker or Kubernetes secret.
+
 ### --postgres-connection-auth
 
 |             |                                        |

--- a/docs/reference/cli/server_dbcrypt_decrypt.md
+++ b/docs/reference/cli/server_dbcrypt_decrypt.md
@@ -20,6 +20,15 @@ coder server dbcrypt decrypt [flags]
 
 The connection URL for the Postgres database.
 
+### --postgres-url-file
+
+|             |                                            |
+|-------------|--------------------------------------------|
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PG_CONNECTION_URL_FILE</code> |
+
+Path to a file containing the connection URL for the Postgres database.
+
 ### --postgres-connection-auth
 
 |             |                                        |

--- a/docs/reference/cli/server_dbcrypt_delete.md
+++ b/docs/reference/cli/server_dbcrypt_delete.md
@@ -24,6 +24,15 @@ coder server dbcrypt delete [flags]
 
 The connection URL for the Postgres database.
 
+### --postgres-url-file
+
+|             |                                                                 |
+|-------------|-----------------------------------------------------------------|
+| Type        | <code>string</code>                                             |
+| Environment | <code>$CODER_EXTERNAL_TOKEN_ENCRYPTION_POSTGRES_URL_FILE</code> |
+
+Path to a file containing the connection URL for the Postgres database.
+
 ### --postgres-connection-auth
 
 |             |                                        |

--- a/docs/reference/cli/server_dbcrypt_rotate.md
+++ b/docs/reference/cli/server_dbcrypt_rotate.md
@@ -20,6 +20,15 @@ coder server dbcrypt rotate [flags]
 
 The connection URL for the Postgres database.
 
+### --postgres-url-file
+
+|             |                                            |
+|-------------|--------------------------------------------|
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PG_CONNECTION_URL_FILE</code> |
+
+Path to a file containing the connection URL for the Postgres database.
+
 ### --postgres-connection-auth
 
 |             |                                        |

--- a/enterprise/cli/server_dbcrypt.go
+++ b/enterprise/cli/server_dbcrypt.go
@@ -239,10 +239,11 @@ Are you sure you want to continue?`
 }
 
 type rotateFlags struct {
-	PostgresURL  string
-	PostgresAuth string
-	New          string
-	Old          []string
+	PostgresURL     string
+	PostgresURLFile string
+	PostgresAuth    string
+	New             string
+	Old             []string
 }
 
 func (f *rotateFlags) attach(opts *serpent.OptionSet) {
@@ -253,6 +254,12 @@ func (f *rotateFlags) attach(opts *serpent.OptionSet) {
 			Env:         "CODER_PG_CONNECTION_URL",
 			Description: "The connection URL for the Postgres database.",
 			Value:       serpent.StringOf(&f.PostgresURL),
+		},
+		serpent.Option{
+			Flag:        "postgres-url-file",
+			Env:         "CODER_PG_CONNECTION_URL_FILE",
+			Description: "Path to a file containing the connection URL for the Postgres database.",
+			Value:       serpent.StringOf(&f.PostgresURLFile),
 		},
 		serpent.Option{
 			Name:        "Postgres Connection Auth",
@@ -279,6 +286,17 @@ func (f *rotateFlags) attach(opts *serpent.OptionSet) {
 }
 
 func (f *rotateFlags) valid() error {
+	if f.PostgresURLFile != "" {
+		if f.PostgresURL != "" {
+			return xerrors.Errorf("cannot specify both --postgres-url and --postgres-url-file")
+		}
+		var err error
+		f.PostgresURL, err = cli.ReadPostgresURLFromFile(f.PostgresURLFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	if f.PostgresURL == "" {
 		return xerrors.Errorf("no database configured")
 	}
@@ -310,9 +328,10 @@ func (f *rotateFlags) valid() error {
 }
 
 type decryptFlags struct {
-	PostgresURL  string
-	PostgresAuth string
-	Keys         []string
+	PostgresURL     string
+	PostgresURLFile string
+	PostgresAuth    string
+	Keys            []string
 }
 
 func (f *decryptFlags) attach(opts *serpent.OptionSet) {
@@ -323,6 +342,12 @@ func (f *decryptFlags) attach(opts *serpent.OptionSet) {
 			Env:         "CODER_PG_CONNECTION_URL",
 			Description: "The connection URL for the Postgres database.",
 			Value:       serpent.StringOf(&f.PostgresURL),
+		},
+		serpent.Option{
+			Flag:        "postgres-url-file",
+			Env:         "CODER_PG_CONNECTION_URL_FILE",
+			Description: "Path to a file containing the connection URL for the Postgres database.",
+			Value:       serpent.StringOf(&f.PostgresURLFile),
 		},
 		serpent.Option{
 			Name:        "Postgres Connection Auth",
@@ -343,6 +368,17 @@ func (f *decryptFlags) attach(opts *serpent.OptionSet) {
 }
 
 func (f *decryptFlags) valid() error {
+	if f.PostgresURLFile != "" {
+		if f.PostgresURL != "" {
+			return xerrors.Errorf("cannot specify both --postgres-url and --postgres-url-file")
+		}
+		var err error
+		f.PostgresURL, err = cli.ReadPostgresURLFromFile(f.PostgresURLFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	if f.PostgresURL == "" {
 		return xerrors.Errorf("no database configured")
 	}
@@ -363,9 +399,10 @@ func (f *decryptFlags) valid() error {
 }
 
 type deleteFlags struct {
-	PostgresURL  string
-	PostgresAuth string
-	Confirm      bool
+	PostgresURL     string
+	PostgresURLFile string
+	PostgresAuth    string
+	Confirm         bool
 }
 
 func (f *deleteFlags) attach(opts *serpent.OptionSet) {
@@ -376,6 +413,12 @@ func (f *deleteFlags) attach(opts *serpent.OptionSet) {
 			Env:         "CODER_EXTERNAL_TOKEN_ENCRYPTION_POSTGRES_URL",
 			Description: "The connection URL for the Postgres database.",
 			Value:       serpent.StringOf(&f.PostgresURL),
+		},
+		serpent.Option{
+			Flag:        "postgres-url-file",
+			Env:         "CODER_EXTERNAL_TOKEN_ENCRYPTION_POSTGRES_URL_FILE",
+			Description: "Path to a file containing the connection URL for the Postgres database.",
+			Value:       serpent.StringOf(&f.PostgresURLFile),
 		},
 		serpent.Option{
 			Name:        "Postgres Connection Auth",
@@ -390,6 +433,17 @@ func (f *deleteFlags) attach(opts *serpent.OptionSet) {
 }
 
 func (f *deleteFlags) valid() error {
+	if f.PostgresURLFile != "" {
+		if f.PostgresURL != "" {
+			return xerrors.Errorf("cannot specify both --postgres-url and --postgres-url-file")
+		}
+		var err error
+		f.PostgresURL, err = cli.ReadPostgresURLFromFile(f.PostgresURLFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	if f.PostgresURL == "" {
 		return xerrors.Errorf("no database configured")
 	}

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -66,6 +66,12 @@ OPTIONS:
           server postgres-builtin-url". Note that any special characters in the
           URL must be URL-encoded.
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the URL of a PostgreSQL database. The file
+          contents will be read and used as the connection URL. This is an
+          alternative to --postgres-url for cases where the URL is stored in a
+          file, such as a Docker or Kubernetes secret.
+
       --ssh-keygen-algorithm string, $CODER_SSH_KEYGEN_ALGORITHM (default: ed25519)
           The algorithm to use for generating ssh keys. Accepted values are
           "ed25519", "ecdsa", or "rsa4096".

--- a/enterprise/cli/testdata/coder_server_create-admin-user_--help.golden
+++ b/enterprise/cli/testdata/coder_server_create-admin-user_--help.golden
@@ -23,6 +23,12 @@ OPTIONS:
           deployment will be used (Coder must not be already running in this
           case).
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the URL of a PostgreSQL database. The file
+          contents will be read and used as the connection URL. This is an
+          alternative to --postgres-url for cases where the URL is stored in a
+          file, such as a Docker or Kubernetes secret.
+
       --raw-url bool
           Output the raw connection URL instead of a psql command.
 

--- a/enterprise/cli/testdata/coder_server_dbcrypt_decrypt_--help.golden
+++ b/enterprise/cli/testdata/coder_server_dbcrypt_decrypt_--help.golden
@@ -16,6 +16,10 @@ OPTIONS:
       --postgres-url string, $CODER_PG_CONNECTION_URL
           The connection URL for the Postgres database.
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the connection URL for the Postgres
+          database.
+
   -y, --yes bool
           Bypass prompts.
 

--- a/enterprise/cli/testdata/coder_server_dbcrypt_delete_--help.golden
+++ b/enterprise/cli/testdata/coder_server_dbcrypt_delete_--help.golden
@@ -14,6 +14,10 @@ OPTIONS:
       --postgres-url string, $CODER_EXTERNAL_TOKEN_ENCRYPTION_POSTGRES_URL
           The connection URL for the Postgres database.
 
+      --postgres-url-file string, $CODER_EXTERNAL_TOKEN_ENCRYPTION_POSTGRES_URL_FILE
+          Path to a file containing the connection URL for the Postgres
+          database.
+
   -y, --yes bool
           Bypass prompts.
 

--- a/enterprise/cli/testdata/coder_server_dbcrypt_rotate_--help.golden
+++ b/enterprise/cli/testdata/coder_server_dbcrypt_rotate_--help.golden
@@ -19,6 +19,10 @@ OPTIONS:
       --postgres-url string, $CODER_PG_CONNECTION_URL
           The connection URL for the Postgres database.
 
+      --postgres-url-file string, $CODER_PG_CONNECTION_URL_FILE
+          Path to a file containing the connection URL for the Postgres
+          database.
+
   -y, --yes bool
           Bypass prompts.
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1740,6 +1740,7 @@ export interface DeploymentValues {
 	readonly cache_directory?: string;
 	readonly ephemeral_deployment?: boolean;
 	readonly pg_connection_url?: string;
+	readonly pg_connection_url_file?: string;
 	readonly pg_auth?: string;
 	readonly oauth2?: OAuth2Config;
 	readonly oidc?: OIDCConfig;


### PR DESCRIPTION
This is a pr to add support for reading the db connection string from a file, which is an alternative option to reading the connection string from an environment variable.

This is the first step in addressing a lack of support for rotating db credentials, as at present a rollout restart must be performed in order for the updated credentials to be picked up by the pod, i.e. env vars are not updated in a pod when the underlying secret is updated. A `pgfileurl` sql driver is also added to re-read the file on each connection attempt to support credential rotation.

This would be used by populating values.yaml with:
```
  env:
    - name: CODER_PG_CONNECTION_URL_FILE
      value: "/etc/coder/pg/pg-url.txt"

  volumes:
    - name: coder-pg-url-file
      secret:
        secretName: coder-pg-url-file

  volumeMounts:
    - name: coder-pg-url-file
      mountPath: /etc/coder/pg
      readOnly: true
```

With it referencing a secret created using:
```
kubectl create secret generic coder-pg-url-file \
  -n pg-coder \
  --from-file=pg-url.txt=./pg-url.txt

cat pg-url.txt     
postgres://coder_pg:coder_pg@my-local-db-host.tld:5432/coder_pg?sslmode=require 
```

created with mux!