### PR TITLE
chore: update boundary to v0.2.1

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -862,7 +862,7 @@ module "claude-code" {
   source              = "dev.registry.coder.com/coder/claude-code/coder"
   version             = "4.2.1"
   enable_boundary     = true
-  boundary_version    = "v0.2.0"
+  boundary_version    = "v0.2.1"
   agent_id            = coder_agent.dev.id
   workdir             = local.repo_dir
   claude_code_version = "latest"


### PR DESCRIPTION
Update boundary to v0.2.1 which uses sys-admin permissions to work with newer kernel versions.