### PR TITLE
fix: complete Tasks GA promotion (docs, site)

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -35,7 +35,7 @@ import (
 // @Security CoderSessionToken
 // @Accept json
 // @Produce json
-// @Tags Experimental
+// @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param request body codersdk.CreateTaskRequest true "Create task request"
 // @Success 201 {object} codersdk.Task
@@ -401,7 +401,7 @@ func deriveTaskCurrentState(
 // @ID list-ai-tasks
 // @Security CoderSessionToken
 // @Produce json
-// @Tags Experimental
+// @Tags Tasks
 // @Param q query string false "Search query for filtering tasks. Supports: owner:<username/uuid/me>, organization:<org-name/uuid>, status:<status>"
 // @Success 200 {object} codersdk.TasksListResponse
 // @Router /tasks [get]
@@ -501,7 +501,7 @@ func (api *API) convertTasks(ctx context.Context, requesterID uuid.UUID, dbTasks
 // @ID get-ai-task-by-id-or-name
 // @Security CoderSessionToken
 // @Produce json
-// @Tags Experimental
+// @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param task path string true "Task ID, or task name"
 // @Success 200 {object} codersdk.Task
@@ -573,7 +573,7 @@ func (api *API) taskGet(rw http.ResponseWriter, r *http.Request) {
 // @Summary Delete AI task
 // @ID delete-ai-task
 // @Security CoderSessionToken
-// @Tags Experimental
+// @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param task path string true "Task ID, or task name"
 // @Success 202
@@ -642,7 +642,7 @@ func (api *API) taskDelete(rw http.ResponseWriter, r *http.Request) {
 // @ID update-ai-task-input
 // @Security CoderSessionToken
 // @Accept json
-// @Tags Experimental
+// @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param task path string true "Task ID, or task name"
 // @Param request body codersdk.UpdateTaskInputRequest true "Update task input request"
@@ -722,7 +722,7 @@ func (api *API) taskUpdateInput(rw http.ResponseWriter, r *http.Request) {
 // @ID send-input-to-ai-task
 // @Security CoderSessionToken
 // @Accept json
-// @Tags Experimental
+// @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param task path string true "Task ID, or task name"
 // @Param request body codersdk.TaskSendRequest true "Task input request"
@@ -791,7 +791,7 @@ func (api *API) taskSend(rw http.ResponseWriter, r *http.Request) {
 // @ID get-ai-task-logs
 // @Security CoderSessionToken
 // @Produce json
-// @Tags Experimental
+// @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param task path string true "Task ID, or task name"
 // @Success 200 {object} codersdk.TaskLogsResponse

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -1,4 +1,4 @@
-# Experimental
+# Tasks
 
 ## List AI tasks
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -440,9 +440,11 @@ export type GetProvisionerDaemonsParams = {
  */
 class ApiMethods {
 	experimental: ExperimentalApiMethods;
+	tasks: TasksApiMethods;
 
 	constructor(protected readonly axios: AxiosInstance) {
 		this.experimental = new ExperimentalApiMethods(this.axios);
+		this.tasks = new TasksApiMethods(this.axios);
 	}
 
 	login = async (
@@ -2646,8 +2648,7 @@ class ApiMethods {
 	};
 }
 
-// Experimental API methods call endpoints under the /api/experimental/ prefix.
-// These endpoints are not stable and may change or be removed at any time.
+// Tasks API methods call endpoints under the /api/v2/tasks prefix.
 //
 // All methods must be defined with arrow function syntax. See the docstring
 // above the ApiMethods class for a full explanation.
@@ -2658,7 +2659,8 @@ export type CreateTaskFeedbackRequest = {
 	rate: TaskFeedbackRating;
 	comment?: string;
 };
-class ExperimentalApiMethods {
+
+class TasksApiMethods {
 	constructor(protected readonly axios: AxiosInstance) {}
 
 	createTask = async (
@@ -2716,6 +2718,15 @@ class ExperimentalApiMethods {
 			setTimeout(() => res(), 500);
 		});
 	};
+}
+
+// Experimental API methods call endpoints under the /api/experimental/ prefix.
+// These endpoints are not stable and may change or be removed at any time.
+//
+// All methods must be defined with arrow function syntax. See the docstring
+// above the ApiMethods class for a full explanation.
+class ExperimentalApiMethods {
+	constructor(protected readonly axios: AxiosInstance) {}
 
 	getAIBridgeInterceptions = async (options: SearchParamOptions) => {
 		const url = getURLWithSearchParams(

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -207,7 +207,7 @@ const TasksNavItem: FC<TasksNavItemProps> = ({ user }) => {
 	};
 	const { data: idleCount } = useQuery({
 		queryKey: ["tasks", filter],
-		queryFn: () => API.experimental.getTasks(filter),
+		queryFn: () => API.tasks.getTasks(filter),
 		refetchInterval: 1_000 * 60,
 		enabled: canSeeTasks,
 		refetchOnWindowFocus: true,

--- a/site/src/modules/tasks/TaskDeleteDialog/TaskDeleteDialog.stories.tsx
+++ b/site/src/modules/tasks/TaskDeleteDialog/TaskDeleteDialog.stories.tsx
@@ -27,7 +27,7 @@ export const DeleteTaskSuccess: Story = {
 		},
 	},
 	beforeEach: () => {
-		spyOn(API.experimental, "deleteTask").mockResolvedValue();
+		spyOn(API.tasks, "deleteTask").mockResolvedValue();
 	},
 	play: async ({ canvasElement, step }) => {
 		const body = within(canvasElement.ownerDocument.body);
@@ -39,7 +39,7 @@ export const DeleteTaskSuccess: Story = {
 			await userEvent.click(confirmButton);
 			await step("Confirm delete", async () => {
 				await waitFor(() => {
-					expect(API.experimental.deleteTask).toHaveBeenCalledWith(
+					expect(API.tasks.deleteTask).toHaveBeenCalledWith(
 						MockTask.owner_name,
 						MockTask.id,
 					);

--- a/site/src/modules/tasks/TaskDeleteDialog/TaskDeleteDialog.tsx
+++ b/site/src/modules/tasks/TaskDeleteDialog/TaskDeleteDialog.tsx
@@ -20,7 +20,7 @@ export const TaskDeleteDialog: FC<TaskDeleteDialogProps> = ({
 }) => {
 	const queryClient = new QueryClient();
 	const deleteTaskMutation = useMutation({
-		mutationFn: () => API.experimental.deleteTask(task.owner_name, task.id),
+		mutationFn: () => API.tasks.deleteTask(task.owner_name, task.id),
 		onSuccess: async () => {
 			await queryClient.invalidateQueries({ queryKey: ["tasks"] });
 		},

--- a/site/src/modules/tasks/TaskFeedbackDialog/TaskFeedbackDialog.stories.tsx
+++ b/site/src/modules/tasks/TaskFeedbackDialog/TaskFeedbackDialog.stories.tsx
@@ -21,7 +21,7 @@ export const Idle: Story = {};
 
 export const Submitting: Story = {
 	beforeEach: async () => {
-		spyOn(API.experimental, "createTaskFeedback").mockImplementation(() => {
+		spyOn(API.tasks, "createTaskFeedback").mockImplementation(() => {
 			return new Promise(() => {});
 		});
 	},
@@ -53,7 +53,7 @@ export const Success: Story = {
 	},
 	decorators: [withGlobalSnackbar],
 	beforeEach: async () => {
-		spyOn(API.experimental, "createTaskFeedback").mockResolvedValue();
+		spyOn(API.tasks, "createTaskFeedback").mockResolvedValue();
 	},
 	play: async ({ canvasElement, step }) => {
 		const body = within(canvasElement.ownerDocument.body);
@@ -77,7 +77,7 @@ export const Success: Story = {
 
 		step("submitted successfully", async () => {
 			await body.findByText("Feedback submitted successfully");
-			expect(API.experimental.createTaskFeedback).toHaveBeenCalledWith(
+			expect(API.tasks.createTaskFeedback).toHaveBeenCalledWith(
 				MockTask.id,
 				{
 					rate: "regular",
@@ -90,7 +90,7 @@ export const Success: Story = {
 
 export const Failure: Story = {
 	beforeEach: async () => {
-		spyOn(API.experimental, "createTaskFeedback").mockRejectedValue(
+		spyOn(API.tasks, "createTaskFeedback").mockRejectedValue(
 			mockApiError({
 				message: "Failed to submit feedback",
 				detail: "Server is down",

--- a/site/src/modules/tasks/TaskFeedbackDialog/TaskFeedbackDialog.tsx
+++ b/site/src/modules/tasks/TaskFeedbackDialog/TaskFeedbackDialog.tsx
@@ -42,7 +42,7 @@ export const TaskFeedbackDialog: FC<TaskFeedbackDialogProps> = ({
 		isPending,
 	} = useMutation({
 		mutationFn: (req: CreateTaskFeedbackRequest) =>
-			API.experimental.createTaskFeedback(taskId, req),
+			API.tasks.createTaskFeedback(taskId, req),
 		onSuccess: () => {
 			displaySuccess("Feedback submitted successfully");
 		},

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -114,7 +114,7 @@ export const SubmitDisabledWhenPromptEmpty: Story = {
 export const Submitting: Story = {
 	decorators: [withGlobalSnackbar],
 	beforeEach: () => {
-		spyOn(API.experimental, "createTask").mockImplementation(
+		spyOn(API.tasks, "createTask").mockImplementation(
 			() =>
 				// Never resolve to keep the component in the submitting state for visual testing.
 				new Promise(() => {}),
@@ -153,7 +153,7 @@ export const OnSuccess: Story = {
 			...MockTemplate,
 			active_version_id: activeVersionId,
 		});
-		spyOn(API.experimental, "createTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "createTask").mockResolvedValue(MockTask);
 	},
 	play: async ({ canvasElement, step }) => {
 		const canvas = within(canvasElement);
@@ -167,7 +167,7 @@ export const OnSuccess: Story = {
 		});
 
 		await step("Uses latest template version", () => {
-			expect(API.experimental.createTask).toHaveBeenCalledWith(
+			expect(API.tasks.createTask).toHaveBeenCalledWith(
 				MockUserOwner.id,
 				{
 					input: MockNewTaskData.initial_prompt,
@@ -232,7 +232,7 @@ export const ChangeTemplate: Story = {
 			}
 			return Promise.resolve([]);
 		});
-		spyOn(API.experimental, "createTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "createTask").mockResolvedValue(MockTask);
 	},
 	play: async ({ canvasElement, step }) => {
 		const canvas = within(canvasElement);
@@ -268,7 +268,7 @@ export const SelectTemplateVersion: Story = {
 				name: "v1.0.0",
 			},
 		]);
-		spyOn(API.experimental, "createTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "createTask").mockResolvedValue(MockTask);
 	},
 	play: async ({ canvasElement, step }) => {
 		const canvas = within(canvasElement);
@@ -295,7 +295,7 @@ export const SelectTemplateVersion: Story = {
 		});
 
 		await step("Uses selected version", () => {
-			expect(API.experimental.createTask).toHaveBeenCalledWith(
+			expect(API.tasks.createTask).toHaveBeenCalledWith(
 				MockUserOwner.id,
 				{
 					input: MockNewTaskData.initial_prompt,
@@ -317,8 +317,8 @@ export const OnError: Story = {
 	decorators: [withGlobalSnackbar],
 	beforeEach: () => {
 		spyOn(API, "getTemplate").mockResolvedValue(MockTemplate);
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
-		spyOn(API.experimental, "createTask").mockRejectedValue(
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "createTask").mockRejectedValue(
 			mockApiError({
 				message: "Failed to create task",
 				detail: "You don't have permission to create tasks.",
@@ -344,10 +344,10 @@ export const OnError: Story = {
 
 export const AuthenticatedExternalAuth: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks")
+		spyOn(API.tasks, "getTasks")
 			.mockResolvedValueOnce(MockTasks)
 			.mockResolvedValue([MockNewTaskData, ...MockTasks]);
-		spyOn(API.experimental, "createTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "createTask").mockResolvedValue(MockTask);
 		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
 			MockTemplateVersionExternalAuthGithubAuthenticated,
 		]);
@@ -370,10 +370,10 @@ export const AuthenticatedExternalAuth: Story = {
 
 export const MissingExternalAuth: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks")
+		spyOn(API.tasks, "getTasks")
 			.mockResolvedValueOnce(MockTasks)
 			.mockResolvedValue([MockNewTaskData, ...MockTasks]);
-		spyOn(API.experimental, "createTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "createTask").mockResolvedValue(MockTask);
 		spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
 			MockTemplateVersionExternalAuthGithub,
 		]);
@@ -396,10 +396,10 @@ export const MissingExternalAuth: Story = {
 
 export const ExternalAuthError: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks")
+		spyOn(API.tasks, "getTasks")
 			.mockResolvedValueOnce(MockTasks)
 			.mockResolvedValue([MockNewTaskData, ...MockTasks]);
-		spyOn(API.experimental, "createTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "createTask").mockResolvedValue(MockTask);
 		spyOn(API, "getTemplateVersionExternalAuth").mockRejectedValue(
 			mockApiError({
 				message: "Failed to load external auth",

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -193,7 +193,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 		mutationFn: async ({ prompt }: CreateTaskMutationFnProps) => {
 			// Users with updateTemplates permission can select the version to use.
 			if (permissions.updateTemplates) {
-				return API.experimental.createTask(user.id, {
+				return API.tasks.createTask(user.id, {
 					input: prompt,
 					template_version_id: selectedVersionId,
 					template_version_preset_id: selectedPresetId,
@@ -453,7 +453,7 @@ async function createTaskWithLatestTemplateVersion(
 	presetId: string | undefined,
 ): Promise<Task> {
 	const template = await API.getTemplate(templateId);
-	return API.experimental.createTask(userId, {
+	return API.tasks.createTask(userId, {
 		input,
 		template_version_id: template.active_version_id,
 		template_version_preset_id: presetId,

--- a/site/src/modules/tasks/TasksSidebar/TasksSidebar.stories.tsx
+++ b/site/src/modules/tasks/TasksSidebar/TasksSidebar.stories.tsx
@@ -44,13 +44,13 @@ type Story = StoryObj<typeof TasksSidebar>;
 
 export const Loading: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockReturnValue(new Promise(() => {}));
+		spyOn(API.tasks, "getTasks").mockReturnValue(new Promise(() => {}));
 	},
 };
 
 export const Failed: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockRejectedValue(
+		spyOn(API.tasks, "getTasks").mockRejectedValue(
 			mockApiError({
 				message: "Failed to fetch tasks",
 			}),
@@ -60,19 +60,19 @@ export const Failed: Story = {
 
 export const Loaded: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 };
 
 export const Empty: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockResolvedValue([]);
+		spyOn(API.tasks, "getTasks").mockResolvedValue([]);
 	},
 };
 
 export const Closed: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -83,7 +83,7 @@ export const Closed: Story = {
 
 export const OpenOptionsMenu: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -96,7 +96,7 @@ export const OpenOptionsMenu: Story = {
 
 export const OpenDeleteDialog: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 	play: async ({ canvasElement, step }) => {
 		await step("Open menu", async () => {

--- a/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
+++ b/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
@@ -135,7 +135,7 @@ const TasksSidebarGroup: FC<TasksSidebarGroupProps> = ({ owner }) => {
 	const filter: TasksFilter = { owner };
 	const tasksQuery = useQuery({
 		queryKey: ["tasks", filter],
-		queryFn: () => API.experimental.getTasks(filter),
+		queryFn: () => API.tasks.getTasks(filter),
 		refetchInterval: 10_000,
 	});
 

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -66,7 +66,7 @@ const meta: Meta<typeof TaskPage> = {
 	component: TaskPage,
 	decorators: [withProxyProvider(), withAuthProvider],
 	beforeEach: () => {
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 	parameters: {
 		layout: "fullscreen",
@@ -88,13 +88,13 @@ type Story = StoryObj<typeof TaskPage>;
 
 export const LoadingTask: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockImplementation(
+		spyOn(API.tasks, "getTask").mockImplementation(
 			() => new Promise(() => {}),
 		);
 	},
 	play: async () => {
 		await waitFor(() => {
-			expect(API.experimental.getTask).toHaveBeenCalledWith(
+			expect(API.tasks.getTask).toHaveBeenCalledWith(
 				MockTask.owner_name,
 				MockTask.id,
 			);
@@ -104,7 +104,7 @@ export const LoadingTask: Story = {
 
 export const LoadingWorkspace: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockImplementation(
 			() => new Promise(() => {}),
 		);
@@ -113,7 +113,7 @@ export const LoadingWorkspace: Story = {
 
 export const LoadingTaskError: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockRejectedValue(
+		spyOn(API.tasks, "getTask").mockRejectedValue(
 			mockApiError({
 				message: "Failed to load task",
 				detail: "You don't have permission to access this resource.",
@@ -124,7 +124,7 @@ export const LoadingTaskError: Story = {
 
 export const LoadingWorkspaceError: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockRejectedValue(
 			mockApiError({
 				message: "Failed to load workspace",
@@ -136,7 +136,7 @@ export const LoadingWorkspaceError: Story = {
 
 export const WaitingOnBuild: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStartingWorkspace,
 		);
@@ -145,7 +145,7 @@ export const WaitingOnBuild: Story = {
 
 export const FailedBuild: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockFailedWorkspace,
 		);
@@ -154,7 +154,7 @@ export const FailedBuild: Story = {
 
 export const TerminatedBuild: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
@@ -163,7 +163,7 @@ export const TerminatedBuild: Story = {
 
 export const TerminatedBuildWithStatus: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue({
 			...MockStoppedWorkspace,
 			latest_app_status: MockWorkspaceAppStatus,
@@ -173,7 +173,7 @@ export const TerminatedBuildWithStatus: Story = {
 
 export const DeletedWorkspace: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockDeletedWorkspace,
 		);
@@ -182,7 +182,7 @@ export const DeletedWorkspace: Story = {
 
 export const WaitingStartupScripts: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue({
 			...MockWorkspace,
 			latest_build: {
@@ -336,7 +336,7 @@ export const SidebarAppNotFound: Story = {
 			MockClaudeCodeApp,
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue({
+		spyOn(API.tasks, "getTask").mockResolvedValue({
 			...task,
 			workspace_app_id: null,
 		});
@@ -350,7 +350,7 @@ export const SidebarAppHealthDisabled: Story = {
 			{ ...MockClaudeCodeApp, health: "disabled" },
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 };
@@ -361,7 +361,7 @@ export const SidebarAppInitializing: Story = {
 			{ ...MockClaudeCodeApp, health: "initializing" },
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 };
@@ -372,7 +372,7 @@ export const SidebarAppHealthy: Story = {
 			{ ...MockClaudeCodeApp, health: "healthy" },
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 };
@@ -383,7 +383,7 @@ export const SidebarAppUnhealthy: Story = {
 			{ ...MockClaudeCodeApp, health: "unhealthy" },
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 };
@@ -394,7 +394,7 @@ const mainAppHealthStory = (health: WorkspaceApp["health"]) => ({
 			...MockVSCodeApp,
 			health,
 		});
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 });
@@ -410,7 +410,7 @@ export const Active: Story = {
 			MockClaudeCodeApp,
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 	play: async ({ canvasElement }) => {
@@ -433,7 +433,7 @@ export const ActivePreview: Story = {
 			MockClaudeCodeApp,
 			MockVSCodeApp,
 		);
-		spyOn(API.experimental, "getTask").mockResolvedValue(task);
+		spyOn(API.tasks, "getTask").mockResolvedValue(task);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(workspace);
 	},
 	play: async ({ canvasElement }) => {
@@ -446,7 +446,7 @@ export const ActivePreview: Story = {
 export const WorkspaceStarting: Story = {
 	decorators: [withGlobalSnackbar],
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
@@ -484,7 +484,7 @@ export const WorkspaceStarting: Story = {
 export const WorkspaceStartFailure: Story = {
 	decorators: [withGlobalSnackbar],
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
@@ -522,7 +522,7 @@ export const WorkspaceStartFailure: Story = {
 
 export const WorkspaceStartFailureWithDialog: Story = {
 	beforeEach: () => {
-		spyOn(API.experimental, "getTask").mockResolvedValue(MockTask);
+		spyOn(API.tasks, "getTask").mockResolvedValue(MockTask);
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -62,7 +62,7 @@ const TaskPage = () => {
 	};
 	const { data: task, ...taskQuery } = useQuery({
 		queryKey: ["tasks", username, taskId],
-		queryFn: () => API.experimental.getTask(username, taskId),
+		queryFn: () => API.tasks.getTask(username, taskId),
 		refetchInterval: ({ state }) => {
 			return state.error ? false : 5_000;
 		},

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -82,7 +82,7 @@ export const LoadingTemplatesError: Story = {
 export const LoadingTasks: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockImplementation(
+		spyOn(API.tasks, "getTasks").mockImplementation(
 			() => new Promise(() => 1000 * 60 * 60),
 		);
 	},
@@ -100,7 +100,7 @@ export const LoadingTasks: Story = {
 export const LoadingTasksError: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockRejectedValue(
+		spyOn(API.tasks, "getTasks").mockRejectedValue(
 			mockApiError({
 				message: "Failed to load tasks",
 			}),
@@ -111,14 +111,14 @@ export const LoadingTasksError: Story = {
 export const EmptyTasks: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockResolvedValue([]);
+		spyOn(API.tasks, "getTasks").mockResolvedValue([]);
 	},
 };
 
 export const LoadedTasks: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 };
 
@@ -126,7 +126,7 @@ export const LoadedTasksWaitingForInputTab: Story = {
 	beforeEach: () => {
 		const [firstTask, ...otherTasks] = MockTasks;
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockResolvedValue([
+		spyOn(API.tasks, "getTasks").mockResolvedValue([
 			{
 				...firstTask,
 				current_state: {
@@ -157,7 +157,7 @@ export const NonAdmin: Story = {
 	},
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 	play: async ({ canvasElement, step }) => {
 		const canvas = within(canvasElement);
@@ -174,7 +174,7 @@ export const NonAdmin: Story = {
 export const OpenDeleteDialog: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API.experimental, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API.tasks, "getTasks").mockResolvedValue(MockTasks);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -40,7 +40,7 @@ const TasksPage: FC = () => {
 	};
 	const tasksQuery = useQuery({
 		queryKey: ["tasks", filter],
-		queryFn: () => API.experimental.getTasks(filter),
+		queryFn: () => API.tasks.getTasks(filter),
 		refetchInterval: 10_000,
 	});
 	const idleTasks = tasksQuery.data?.filter(


### PR DESCRIPTION
## Summary

This change completes the Coder Tasks GA promotion by cleaning up remaining experimental references in documentation and code organization.

## Changes

### Documentation
- **Moved API docs**: Renamed `docs/reference/api/experimental.md` to `tasks.md` with updated heading
- **Updated swagger tags**: Changed all task endpoint handlers from `@Tags Experimental` to `@Tags Tasks`

### Frontend Refactoring
- **Created TasksApiMethods class**: Extracted task-related methods from `ExperimentalApiMethods` into dedicated `TasksApiMethods` class
- **Updated all references**: Changed `API.experimental.{createTask,getTasks,getTask,deleteTask,createTaskFeedback}` to `API.tasks.*` throughout codebase
- **Updated tests**: Fixed all test mocks and story files to reference `API.tasks`

## Related

Follows up on #20923 and #20921 which promoted Tasks from Beta/Experimental to GA.

---

🤖 This change was written by Claude Sonnet 4.5 Thinking using [mux](https://github.com/coder/mux) and reviewed by a human 🏂