### PR TITLE
fix(site): only show active tasks in waiting for input tab

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -145,6 +145,29 @@ export const LoadedTasksWaitingForInputTab: Story = {
 		spyOn(API, "getTasks").mockResolvedValue([
 			{
 				...firstTask,
+				id: "active-idle-task",
+				display_name: "Active Idle Task",
+				status: "active",
+				current_state: {
+					...firstTask.current_state,
+					state: "idle",
+				},
+			},
+			{
+				...firstTask,
+				id: "paused-idle-task",
+				display_name: "Paused Idle Task",
+				status: "paused",
+				current_state: {
+					...firstTask.current_state,
+					state: "idle",
+				},
+			},
+			{
+				...firstTask,
+				id: "error-idle-task",
+				display_name: "Error Idle Task",
+				status: "error",
 				current_state: {
 					...firstTask.current_state,
 					state: "idle",
@@ -161,6 +184,13 @@ export const LoadedTasksWaitingForInputTab: Story = {
 				name: /waiting for input/i,
 			});
 			await userEvent.click(waitingForInputTab);
+
+			// Wait for the active idle task to appear.
+			await canvas.findByText("Active Idle Task");
+
+			// Only active idle tasks should be visible.
+			expect(canvas.queryByText("Paused Idle Task")).not.toBeInTheDocument();
+			expect(canvas.queryByText("Error Idle Task")).not.toBeInTheDocument();
 		});
 	},
 };

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -185,12 +185,19 @@ export const LoadedTasksWaitingForInputTab: Story = {
 			});
 			await userEvent.click(waitingForInputTab);
 
-			// Wait for the active idle task to appear.
-			await canvas.findByText("Active Idle Task");
+			// Query within the table to check only visible rows
+			const table = await canvas.findByRole("table");
+			const tableContent = within(table);
 
-			// Only active idle tasks should be visible.
-			expect(canvas.queryByText("Paused Idle Task")).not.toBeInTheDocument();
-			expect(canvas.queryByText("Error Idle Task")).not.toBeInTheDocument();
+			await tableContent.findByText("Active Idle Task");
+
+			// Only active idle tasks should be visible in the table
+			expect(
+				tableContent.queryByText("Paused Idle Task"),
+			).not.toBeInTheDocument();
+			expect(
+				tableContent.queryByText("Error Idle Task"),
+			).not.toBeInTheDocument();
 		});
 	},
 };

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -10,7 +10,7 @@ import { withAuthProvider, withProxyProvider } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
 import { MockUsers } from "pages/UsersPage/storybookData/users";
-import { expect, spyOn, userEvent, within } from "storybook/test";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { getTemplatesQueryKey } from "../../api/queries/templates";
 import TasksPage from "./TasksPage";
 
@@ -185,19 +185,22 @@ export const LoadedTasksWaitingForInputTab: Story = {
 			});
 			await userEvent.click(waitingForInputTab);
 
-			// Query within the table to check only visible rows
-			const table = await canvas.findByRole("table");
-			const tableContent = within(table);
+			// Wait for the table to update after tab switch
+			await waitFor(async () => {
+				const table = canvas.getByRole("table");
+				const tableContent = within(table);
 
-			await tableContent.findByText("Active Idle Task");
+				// Active idle task should be visible
+				expect(tableContent.getByText("Active Idle Task")).toBeInTheDocument();
 
-			// Only active idle tasks should be visible in the table
-			expect(
-				tableContent.queryByText("Paused Idle Task"),
-			).not.toBeInTheDocument();
-			expect(
-				tableContent.queryByText("Error Idle Task"),
-			).not.toBeInTheDocument();
+				// Only active idle tasks should be visible in the table
+				expect(
+					tableContent.queryByText("Paused Idle Task"),
+				).not.toBeInTheDocument();
+				expect(
+					tableContent.queryByText("Error Idle Task"),
+				).not.toBeInTheDocument();
+			});
 		});
 	},
 };

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -44,7 +44,7 @@ const TasksPage: FC = () => {
 		refetchInterval: 10_000,
 	});
 	const idleTasks = tasksQuery.data?.filter(
-		(task) => task.current_state?.state === "idle",
+		(task) => task.status === "active" && task.current_state?.state === "idle",
 	);
 	const displayedTasks =
 		tab.value === "waiting-for-input" ? idleTasks : tasksQuery.data;


### PR DESCRIPTION
## Summary

Fixes the issue where stopped or errored tasks were incorrectly showing in the "Waiting for input" tab on the TasksPage.

## Root Cause

The frontend was filtering tasks by checking only if `current_state.state === "idle"`. This caused tasks with `status === "paused"` or `status === "error"` to still appear in the "waiting for input" tab if they had an idle state.

## Solution

Updated the filter to check both:
- `current_state.state === "idle"` 
- `task.status === "active"`

This ensures only running tasks that are actually waiting for user input are shown in the "Waiting for input" tab.

---

🤖 This change was initially written by Claude Code using Coder Tasks, then reviewed and edited by a human 🏂