### PR TITLE
fix(site): remove hardcoded max-width on task display name in sidebar

### DIFF
--- a/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
+++ b/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
@@ -203,9 +203,7 @@ const TaskSidebarMenuItem: FC<TaskSidebarMenuItemProps> = ({ task }) => {
 					}}
 				>
 					<TaskSidebarMenuItemStatus task={task} />
-					<span className="block max-w-[220px] truncate">
-						{task.display_name}
-					</span>
+					<span className="truncate">{task.display_name}</span>
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<Button


### PR DESCRIPTION
## Description

This PR fixes the task display name truncation issue in the sidebar where text was being unnecessarily ellipsized even when there was plenty of available space.

## Root Cause

PR #20918 added a hardcoded `max-w-[220px]` constraint to the task display name span. This was too restrictive given the sidebar's fixed width of 256px (w-64), causing unnecessary truncation.

## Changes

- Removed `max-w-[220px]` constraint from task display name span
- Removed `block` class (not needed in flex container)
- Kept `truncate` class for genuine overflow cases
- Let flex container naturally calculate available space

## Testing

- ✅ Linting passed (`pnpm lint`)
- ✅ Formatting passed (`pnpm format`)
- ✅ TypeScript compilation successful
- ✅ Existing Storybook story "Display Name Different Lengths" validates behavior

## Visual Impact

Task display names now use the full available width (~220-230px depending on spacing) before truncating, while maintaining:
- Fixed sidebar width of 256px
- Proper truncation with ellipsis for genuinely long names
- Correct spacing for status icon and dropdown menu

## Risk Assessment

**Low risk**: Single-line CSS change affecting only visual presentation.

Fixes #20932

🤖 Generated with [Claude Code](https://claude.com/claude-code)