### PR TITLE
feat: add flag to disable template insights

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -223,12 +223,6 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
-INTROSPECTION OPTIONS: 
-Configure logging, tracing, and metrics exporting.
-
-      --disable-template-insights bool, $CODER_DISABLE_TEMPLATE_INSIGHTS (default: false)
-          Disable storage and display of template insights.
-
 INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
@@ -274,6 +268,16 @@ INTROSPECTION / PROMETHEUS OPTIONS:
 
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
+
+INTROSPECTION / TEMPLATE INSIGHTS OPTIONS: 
+      --template-insights-enable bool, $CODER_TEMPLATE_INSIGHTS_ENABLE (default: true)
+          Enable the collection and display of template insights along with the
+          associated API endpoints. This will also enable aggregating these
+          insights into daily active users, application usage, and transmission
+          rates for overall deployment stats. When disabled, these values will
+          be zero, which will also affect what the bottom deployment overview
+          bar displays. Disabling will also prevent Prometheus collection of
+          these values.
 
 INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -223,6 +223,12 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
+INTROSPECTION OPTIONS: 
+Configure logging, tracing, and metrics exporting.
+
+      --disable-template-insights bool, $CODER_DISABLE_TEMPLATE_INSIGHTS (default: false)
+          Disable storage and display of template insights.
+
 INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -190,11 +190,16 @@ autobuildPollInterval: 1m0s
 # Interval to poll for hung and pending jobs and automatically terminate them.
 # (default: 1m0s, type: duration)
 jobHangDetectorInterval: 1m0s
-# Configure logging, tracing, and metrics exporting.
 introspection:
-  # Disable storage and display of template insights.
-  # (default: false, type: bool)
-  disableTemplateInsights: false
+  templateInsights:
+    # Enable the collection and display of template insights along with the associated
+    # API endpoints. This will also enable aggregating these insights into daily
+    # active users, application usage, and transmission rates for overall deployment
+    # stats. When disabled, these values will be zero, which will also affect what the
+    # bottom deployment overview bar displays. Disabling will also prevent Prometheus
+    # collection of these values.
+    # (default: true, type: bool)
+    enable: true
   prometheus:
     # Serve prometheus metrics on the address defined by prometheus address.
     # (default: <unset>, type: bool)

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -190,7 +190,11 @@ autobuildPollInterval: 1m0s
 # Interval to poll for hung and pending jobs and automatically terminate them.
 # (default: 1m0s, type: duration)
 jobHangDetectorInterval: 1m0s
+# Configure logging, tracing, and metrics exporting.
 introspection:
+  # Disable storage and display of template insights.
+  # (default: false, type: bool)
+  disableTemplateInsights: false
   prometheus:
     # Serve prometheus metrics on the address defined by prometheus address.
     # (default: <unset>, type: bool)

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -617,7 +617,7 @@ func TestUpdateStats(t *testing.T) {
 					}, labels)
 					assert.Equal(t, req.Stats.Metrics, metrics)
 				},
-				DisableDatabaseStorage: true,
+				DisableDatabaseInserts: true,
 			}),
 			AgentStatsRefreshInterval: 10 * time.Second,
 			TimeNowFn: func() time.Time {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14214,9 +14214,6 @@ const docTemplate = `{
                 "disable_path_apps": {
                     "type": "boolean"
                 },
-                "disable_template_insights": {
-                    "type": "boolean"
-                },
                 "disable_workspace_sharing": {
                     "type": "boolean"
                 },
@@ -14343,6 +14340,9 @@ const docTemplate = `{
                 },
                 "telemetry": {
                     "$ref": "#/definitions/codersdk.TelemetryConfig"
+                },
+                "template_insights": {
+                    "$ref": "#/definitions/codersdk.TemplateInsightsConfig"
                 },
                 "terms_of_service_url": {
                     "type": "string"
@@ -18590,6 +18590,14 @@ const docTemplate = `{
                 "total_member_count": {
                     "description": "How many members are in this group. Shows the total count,\neven if the user is not authorized to read group member details.\nMay be greater than ` + "`" + `len(Group.Members)` + "`" + `.",
                     "type": "integer"
+                }
+            }
+        },
+        "codersdk.TemplateInsightsConfig": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14214,6 +14214,9 @@ const docTemplate = `{
                 "disable_path_apps": {
                     "type": "boolean"
                 },
+                "disable_template_insights": {
+                    "type": "boolean"
+                },
                 "disable_workspace_sharing": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12798,9 +12798,6 @@
 				"disable_path_apps": {
 					"type": "boolean"
 				},
-				"disable_template_insights": {
-					"type": "boolean"
-				},
 				"disable_workspace_sharing": {
 					"type": "boolean"
 				},
@@ -12927,6 +12924,9 @@
 				},
 				"telemetry": {
 					"$ref": "#/definitions/codersdk.TelemetryConfig"
+				},
+				"template_insights": {
+					"$ref": "#/definitions/codersdk.TemplateInsightsConfig"
 				},
 				"terms_of_service_url": {
 					"type": "string"
@@ -17026,6 +17026,14 @@
 				"total_member_count": {
 					"description": "How many members are in this group. Shows the total count,\neven if the user is not authorized to read group member details.\nMay be greater than `len(Group.Members)`.",
 					"type": "integer"
+				}
+			}
+		},
+		"codersdk.TemplateInsightsConfig": {
+			"type": "object",
+			"properties": {
+				"enable": {
+					"type": "boolean"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12798,6 +12798,9 @@
 				"disable_path_apps": {
 					"type": "boolean"
 				},
+				"disable_template_insights": {
+					"type": "boolean"
+				},
 				"disable_workspace_sharing": {
 					"type": "boolean"
 				},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -776,7 +776,7 @@ func New(options *Options) *API {
 		UsageTracker:           options.WorkspaceUsageTracker,
 		UpdateAgentMetricsFn:   options.UpdateAgentMetrics,
 		AppStatBatchSize:       workspaceapps.DefaultStatsDBReporterBatchSize,
-		DisableDatabaseStorage: options.DeploymentValues.DisableTemplateInsights.Value(),
+		DisableDatabaseStorage: !options.DeploymentValues.TemplateInsights.Enable.Value(),
 	})
 	workspaceAppsLogger := options.Logger.Named("workspaceapps")
 	if options.WorkspaceAppsStatsCollectorOptions.Logger == nil {
@@ -1533,7 +1533,7 @@ func New(options *Options) *API {
 				r.Use(
 					func(next http.Handler) http.Handler {
 						return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-							if options.DeploymentValues.DisableTemplateInsights.Value() {
+							if !options.DeploymentValues.TemplateInsights.Enable.Value() {
 								httpapi.Write(context.Background(), rw, http.StatusForbidden, codersdk.Response{
 									Message: "Forbidden.",
 									Detail:  "Template insights are disabled.",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -768,14 +768,15 @@ func New(options *Options) *API {
 	}
 
 	api.statsReporter = workspacestats.NewReporter(workspacestats.ReporterOptions{
-		Database:              options.Database,
-		Logger:                options.Logger.Named("workspacestats"),
-		Pubsub:                options.Pubsub,
-		TemplateScheduleStore: options.TemplateScheduleStore,
-		StatsBatcher:          options.StatsBatcher,
-		UsageTracker:          options.WorkspaceUsageTracker,
-		UpdateAgentMetricsFn:  options.UpdateAgentMetrics,
-		AppStatBatchSize:      workspaceapps.DefaultStatsDBReporterBatchSize,
+		Database:               options.Database,
+		Logger:                 options.Logger.Named("workspacestats"),
+		Pubsub:                 options.Pubsub,
+		TemplateScheduleStore:  options.TemplateScheduleStore,
+		StatsBatcher:           options.StatsBatcher,
+		UsageTracker:           options.WorkspaceUsageTracker,
+		UpdateAgentMetricsFn:   options.UpdateAgentMetrics,
+		AppStatBatchSize:       workspaceapps.DefaultStatsDBReporterBatchSize,
+		DisableDatabaseStorage: options.DeploymentValues.DisableTemplateInsights.Value(),
 	})
 	workspaceAppsLogger := options.Logger.Named("workspaceapps")
 	if options.WorkspaceAppsStatsCollectorOptions.Logger == nil {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1534,8 +1534,8 @@ func New(options *Options) *API {
 					func(next http.Handler) http.Handler {
 						return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 							if !options.DeploymentValues.TemplateInsights.Enable.Value() {
-								httpapi.Write(context.Background(), rw, http.StatusForbidden, codersdk.Response{
-									Message: "Forbidden.",
+								httpapi.Write(context.Background(), rw, http.StatusNotFound, codersdk.Response{
+									Message: "Not Found.",
 									Detail:  "Template insights are disabled.",
 								})
 								return

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -776,7 +776,7 @@ func New(options *Options) *API {
 		UsageTracker:           options.WorkspaceUsageTracker,
 		UpdateAgentMetricsFn:   options.UpdateAgentMetrics,
 		AppStatBatchSize:       workspaceapps.DefaultStatsDBReporterBatchSize,
-		DisableDatabaseStorage: !options.DeploymentValues.TemplateInsights.Enable.Value(),
+		DisableDatabaseInserts: !options.DeploymentValues.TemplateInsights.Enable.Value(),
 	})
 	workspaceAppsLogger := options.Logger.Named("workspaceapps")
 	if options.WorkspaceAppsStatsCollectorOptions.Logger == nil {

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -2407,7 +2407,9 @@ func TestGenericInsights_Disabled(t *testing.T) {
 			dbrollup.WithInterval(time.Millisecond*100),
 		),
 		DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
-			dv.DisableTemplateInsights = true
+			dv.TemplateInsights = codersdk.TemplateInsightsConfig{
+				Enable: false,
+			}
 		}),
 	})
 	user := coderdtest.CreateFirstUser(t, client)

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -2418,8 +2418,8 @@ func TestGenericInsights_Disabled(t *testing.T) {
 	tests := []struct {
 		name string
 		fn   func(ctx context.Context) error
-		// ok means there should be no error, otherwise assume forbidden due to
-		// being disabled.
+		// ok means there should be no error, otherwise assume 404 due to being
+		// disabled.
 		ok bool
 	}{
 		{
@@ -2478,7 +2478,7 @@ func TestGenericInsights_Disabled(t *testing.T) {
 				require.Error(t, err)
 				cerr := coderdtest.SDKError(t, err)
 				require.Contains(t, cerr.Error(), "disabled")
-				require.Equal(t, http.StatusForbidden, cerr.StatusCode())
+				require.Equal(t, http.StatusNotFound, cerr.StatusCode())
 			}
 		})
 	}

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -754,7 +754,7 @@ func TestTemplateInsights_Golden(t *testing.T) {
 		reporter := workspacestats.NewReporter(workspacestats.ReporterOptions{
 			Database:               db,
 			AppStatBatchSize:       workspaceapps.DefaultStatsDBReporterBatchSize,
-			DisableDatabaseStorage: disableStorage,
+			DisableDatabaseInserts: disableStorage,
 		})
 		err = reporter.ReportAppStats(dbauthz.AsSystemRestricted(ctx), stats)
 		require.NoError(t, err, "want no error inserting app stats")
@@ -1665,7 +1665,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 		reporter := workspacestats.NewReporter(workspacestats.ReporterOptions{
 			Database:               db,
 			AppStatBatchSize:       workspaceapps.DefaultStatsDBReporterBatchSize,
-			DisableDatabaseStorage: disableStorage,
+			DisableDatabaseInserts: disableStorage,
 		})
 		err = reporter.ReportAppStats(dbauthz.AsSystemRestricted(ctx), stats)
 		require.NoError(t, err, "want no error inserting app stats")

--- a/coderd/testdata/insights/template/disabled_week_deployment_wide.json.golden
+++ b/coderd/testdata/insights/template/disabled_week_deployment_wide.json.golden
@@ -1,0 +1,107 @@
+{
+  "report": {
+    "start_time": "2023-08-15T00:00:00Z",
+    "end_time": "2023-08-22T00:00:00Z",
+    "template_ids": [],
+    "active_users": 0,
+    "apps_usage": [
+      {
+        "template_ids": [],
+        "type": "builtin",
+        "display_name": "Visual Studio Code",
+        "slug": "vscode",
+        "icon": "/icon/code.svg",
+        "seconds": 0,
+        "times_used": 0
+      },
+      {
+        "template_ids": [],
+        "type": "builtin",
+        "display_name": "JetBrains",
+        "slug": "jetbrains",
+        "icon": "/icon/intellij.svg",
+        "seconds": 0,
+        "times_used": 0
+      },
+      {
+        "template_ids": [],
+        "type": "builtin",
+        "display_name": "Web Terminal",
+        "slug": "reconnecting-pty",
+        "icon": "/icon/terminal.svg",
+        "seconds": 0,
+        "times_used": 0
+      },
+      {
+        "template_ids": [],
+        "type": "builtin",
+        "display_name": "SSH",
+        "slug": "ssh",
+        "icon": "/icon/terminal.svg",
+        "seconds": 0,
+        "times_used": 0
+      },
+      {
+        "template_ids": [],
+        "type": "builtin",
+        "display_name": "SFTP",
+        "slug": "sftp",
+        "icon": "/icon/terminal.svg",
+        "seconds": 0,
+        "times_used": 0
+      }
+    ],
+    "parameters_usage": []
+  },
+  "interval_reports": [
+    {
+      "start_time": "2023-08-15T00:00:00Z",
+      "end_time": "2023-08-16T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-16T00:00:00Z",
+      "end_time": "2023-08-17T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-17T00:00:00Z",
+      "end_time": "2023-08-18T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-18T00:00:00Z",
+      "end_time": "2023-08-19T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-19T00:00:00Z",
+      "end_time": "2023-08-20T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-20T00:00:00Z",
+      "end_time": "2023-08-21T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-21T00:00:00Z",
+      "end_time": "2023-08-22T00:00:00Z",
+      "template_ids": [],
+      "interval": "day",
+      "active_users": 0
+    }
+  ]
+}

--- a/coderd/testdata/insights/user-activity/disabled_week_deployment_wide.json.golden
+++ b/coderd/testdata/insights/user-activity/disabled_week_deployment_wide.json.golden
@@ -1,0 +1,8 @@
+{
+  "report": {
+    "start_time": "2023-08-15T00:00:00Z",
+    "end_time": "2023-08-22T00:00:00Z",
+    "template_ids": [],
+    "users": []
+  }
+}

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -48,9 +48,9 @@ type ReporterOptions struct {
 	UsageTracker          *UsageTracker
 	UpdateAgentMetricsFn  func(ctx context.Context, labels prometheusmetrics.AgentMetricLabels, metrics []*agentproto.Stats_Metric)
 
-	// DisableDatabaseStorage prevents storing stats in the database.  The
+	// DisableDatabaseInserts prevents inserting stats in the database.  The
 	// reporter will still call UpdateAgentMetricsFn and bump workspace activity.
-	DisableDatabaseStorage bool
+	DisableDatabaseInserts bool
 
 	AppStatBatchSize int
 }
@@ -114,7 +114,7 @@ func (r *Reporter) ReportAppStats(ctx context.Context, stats []workspaceapps.Sta
 			return nil
 		}
 
-		if !r.opts.DisableDatabaseStorage {
+		if !r.opts.DisableDatabaseInserts {
 			if err := tx.InsertWorkspaceAppStats(ctx, batch); err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ func (r *Reporter) ReportAppStats(ctx context.Context, stats []workspaceapps.Sta
 // nolint:revive // usage is a control flag while we have the experiment
 func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspace database.WorkspaceIdentity, workspaceAgent database.WorkspaceAgent, stats *agentproto.Stats, usage bool) error {
 	// update agent stats
-	if !r.opts.DisableDatabaseStorage {
+	if !r.opts.DisableDatabaseInserts {
 		r.opts.StatsBatcher.Add(now, workspaceAgent.ID, workspace.TemplateID, workspace.OwnerID, workspace.ID, stats, usage)
 	}
 

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -36,6 +36,8 @@ import (
 // activity bumping from stat reporting so we can disable stats collection
 // entirely when template insights are disabled rather than having to still
 // collect stats but then drop them here.
+//
+// https://github.com/coder/internal/issues/196
 
 type ReporterOptions struct {
 	Database              database.Store

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -511,6 +511,7 @@ type DeploymentValues struct {
 	Prebuilds                       PrebuildsConfig                      `json:"workspace_prebuilds,omitempty" typescript:",notnull"`
 	HideAITasks                     serpent.Bool                         `json:"hide_ai_tasks,omitempty" typescript:",notnull"`
 	AI                              AIConfig                             `json:"ai,omitempty"`
+	DisableTemplateInsights         serpent.Bool                         `json:"disable_template_insights,omitempty" typescript:",notnull"`
 
 	Config      serpent.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig serpent.Bool           `json:"write_config,omitempty" typescript:",notnull"`
@@ -1700,6 +1701,16 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.DERP.Config.Path,
 			Group:       &deploymentGroupNetworkingDERP,
 			YAML:        "configPath",
+		},
+		{
+			Name:        "Disable Template Insights",
+			Description: "Disable storage and display of template insights.",
+			Flag:        "disable-template-insights",
+			Env:         "CODER_DISABLE_TEMPLATE_INSIGHTS",
+			Default:     "false",
+			Value:       &c.DisableTemplateInsights,
+			Group:       &deploymentGroupIntrospection,
+			YAML:        "disableTemplateInsights",
 		},
 		// TODO: support Git Auth settings.
 		// Prometheus settings

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -511,7 +511,7 @@ type DeploymentValues struct {
 	Prebuilds                       PrebuildsConfig                      `json:"workspace_prebuilds,omitempty" typescript:",notnull"`
 	HideAITasks                     serpent.Bool                         `json:"hide_ai_tasks,omitempty" typescript:",notnull"`
 	AI                              AIConfig                             `json:"ai,omitempty"`
-	DisableTemplateInsights         serpent.Bool                         `json:"disable_template_insights,omitempty" typescript:",notnull"`
+	TemplateInsights                TemplateInsightsConfig               `json:"template_insights,omitempty" typescript:",notnull"`
 
 	Config      serpent.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig serpent.Bool           `json:"write_config,omitempty" typescript:",notnull"`
@@ -609,6 +609,10 @@ type DERPConfig struct {
 	ForceWebSockets serpent.Bool   `json:"force_websockets" typescript:",notnull"`
 	URL             serpent.String `json:"url" typescript:",notnull"`
 	Path            serpent.String `json:"path" typescript:",notnull"`
+}
+
+type TemplateInsightsConfig struct {
+	Enable serpent.Bool `json:"enable" typescript:",notnull"`
 }
 
 type PrometheusConfig struct {
@@ -1080,6 +1084,11 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Parent: &deploymentGroupIntrospection,
 			Name:   "pprof",
 			YAML:   "pprof",
+		}
+		deploymentGroupIntrospectionTemplateInsights = serpent.Group{
+			Parent: &deploymentGroupIntrospection,
+			Name:   "Template Insights",
+			YAML:   "templateInsights",
 		}
 		deploymentGroupIntrospectionPrometheus = serpent.Group{
 			Parent: &deploymentGroupIntrospection,
@@ -1703,14 +1712,14 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			YAML:        "configPath",
 		},
 		{
-			Name:        "Disable Template Insights",
-			Description: "Disable storage and display of template insights.",
-			Flag:        "disable-template-insights",
-			Env:         "CODER_DISABLE_TEMPLATE_INSIGHTS",
-			Default:     "false",
-			Value:       &c.DisableTemplateInsights,
-			Group:       &deploymentGroupIntrospection,
-			YAML:        "disableTemplateInsights",
+			Name:        "Enable Template Insights",
+			Description: "Enable the collection and display of template insights along with the associated API endpoints. This will also enable aggregating these insights into daily active users, application usage, and transmission rates for overall deployment stats. When disabled, these values will be zero, which will also affect what the bottom deployment overview bar displays. Disabling will also prevent Prometheus collection of these values.",
+			Flag:        "template-insights-enable",
+			Env:         "CODER_TEMPLATE_INSIGHTS_ENABLE",
+			Default:     "true",
+			Value:       &c.TemplateInsights.Enable,
+			Group:       &deploymentGroupIntrospectionTemplateInsights,
+			YAML:        "enable",
 		},
 		// TODO: support Git Auth settings.
 		// Prometheus settings

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -293,12 +294,14 @@ type UserStatusChangeCount struct {
 }
 
 type GetUserStatusCountsRequest struct {
-	Offset time.Time `json:"offset" format:"date-time"`
+	// Timezone offset in hours. Use 0 for UTC, and TimezoneOffsetHour(time.Local)
+	// for the local timezone.
+	Offset int `json:"offset"`
 }
 
 func (c *Client) GetUserStatusCounts(ctx context.Context, req GetUserStatusCountsRequest) (GetUserStatusCountsResponse, error) {
 	qp := url.Values{}
-	qp.Add("offset", req.Offset.Format(insightsTimeLayout))
+	qp.Add("tz_offset", strconv.Itoa(req.Offset))
 
 	reqURL := fmt.Sprintf("/api/v2/insights/user-status-counts?%s", qp.Encode())
 	resp, err := c.Request(ctx, http.MethodGet, reqURL, nil)

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -233,7 +233,6 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
-    "disable_template_insights": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -516,6 +515,9 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
         "scheme": "string",
         "user": {}
       }
+    },
+    "template_insights": {
+      "enable": true
     },
     "terms_of_service_url": "string",
     "tls": {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -233,6 +233,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
+    "disable_template_insights": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2917,7 +2917,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
-    "disable_template_insights": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -3201,6 +3200,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         "user": {}
       }
     },
+    "template_insights": {
+      "enable": true
+    },
     "terms_of_service_url": "string",
     "tls": {
       "address": {
@@ -3441,7 +3443,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "disable_owner_workspace_exec": true,
   "disable_password_auth": true,
   "disable_path_apps": true,
-  "disable_template_insights": true,
   "disable_workspace_sharing": true,
   "docs_url": {
     "forceQuery": true,
@@ -3725,6 +3726,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "user": {}
     }
   },
+  "template_insights": {
+    "enable": true
+  },
   "terms_of_service_url": "string",
   "tls": {
     "address": {
@@ -3797,7 +3801,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `disable_owner_workspace_exec`       | boolean                                                                                              | false    |              |                                                                    |
 | `disable_password_auth`              | boolean                                                                                              | false    |              |                                                                    |
 | `disable_path_apps`                  | boolean                                                                                              | false    |              |                                                                    |
-| `disable_template_insights`          | boolean                                                                                              | false    |              |                                                                    |
 | `disable_workspace_sharing`          | boolean                                                                                              | false    |              |                                                                    |
 | `docs_url`                           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
 | `enable_authz_recording`             | boolean                                                                                              | false    |              |                                                                    |
@@ -3835,6 +3838,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `support`                            | [codersdk.SupportConfig](#codersdksupportconfig)                                                     | false    |              |                                                                    |
 | `swagger`                            | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                     | false    |              |                                                                    |
 | `telemetry`                          | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                 | false    |              |                                                                    |
+| `template_insights`                  | [codersdk.TemplateInsightsConfig](#codersdktemplateinsightsconfig)                                   | false    |              |                                                                    |
 | `terms_of_service_url`               | string                                                                                               | false    |              |                                                                    |
 | `tls`                                | [codersdk.TLSConfig](#codersdktlsconfig)                                                             | false    |              |                                                                    |
 | `trace`                              | [codersdk.TraceConfig](#codersdktraceconfig)                                                         | false    |              |                                                                    |
@@ -8509,6 +8513,20 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |----------|---------|
 | `role`   | `admin` |
 | `role`   | `use`   |
+
+## codersdk.TemplateInsightsConfig
+
+```json
+{
+  "enable": true
+}
+```
+
+### Properties
+
+| Name     | Type    | Required | Restrictions | Description |
+|----------|---------|----------|--------------|-------------|
+| `enable` | boolean | false    |              |             |
 
 ## codersdk.TemplateInsightsIntervalReport
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2917,6 +2917,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
+    "disable_template_insights": true,
     "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
@@ -3440,6 +3441,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "disable_owner_workspace_exec": true,
   "disable_password_auth": true,
   "disable_path_apps": true,
+  "disable_template_insights": true,
   "disable_workspace_sharing": true,
   "docs_url": {
     "forceQuery": true,
@@ -3795,6 +3797,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `disable_owner_workspace_exec`       | boolean                                                                                              | false    |              |                                                                    |
 | `disable_password_auth`              | boolean                                                                                              | false    |              |                                                                    |
 | `disable_path_apps`                  | boolean                                                                                              | false    |              |                                                                    |
+| `disable_template_insights`          | boolean                                                                                              | false    |              |                                                                    |
 | `disable_workspace_sharing`          | boolean                                                                                              | false    |              |                                                                    |
 | `docs_url`                           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
 | `enable_authz_recording`             | boolean                                                                                              | false    |              |                                                                    |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -269,16 +269,16 @@ URL to fetch a DERP mapping on startup. See: https://tailscale.com/kb/1118/custo
 
 Path to read a DERP mapping from. See: https://tailscale.com/kb/1118/custom-derp-servers/.
 
-### --disable-template-insights
+### --template-insights-enable
 
 |             |                                                    |
 |-------------|----------------------------------------------------|
 | Type        | <code>bool</code>                                  |
-| Environment | <code>$CODER_DISABLE_TEMPLATE_INSIGHTS</code>      |
-| YAML        | <code>introspection.disableTemplateInsights</code> |
-| Default     | <code>false</code>                                 |
+| Environment | <code>$CODER_TEMPLATE_INSIGHTS_ENABLE</code>       |
+| YAML        | <code>introspection.templateInsights.enable</code> |
+| Default     | <code>true</code>                                  |
 
-Disable storage and display of template insights.
+Enable the collection and display of template insights along with the associated API endpoints. This will also enable aggregating these insights into daily active users, application usage, and transmission rates for overall deployment stats. When disabled, these values will be zero, which will also affect what the bottom deployment overview bar displays. Disabling will also prevent Prometheus collection of these values.
 
 ### --prometheus-enable
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -269,6 +269,17 @@ URL to fetch a DERP mapping on startup. See: https://tailscale.com/kb/1118/custo
 
 Path to read a DERP mapping from. See: https://tailscale.com/kb/1118/custom-derp-servers/.
 
+### --disable-template-insights
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>bool</code>                                  |
+| Environment | <code>$CODER_DISABLE_TEMPLATE_INSIGHTS</code>      |
+| YAML        | <code>introspection.disableTemplateInsights</code> |
+| Default     | <code>false</code>                                 |
+
+Disable storage and display of template insights.
+
 ### --prometheus-enable
 
 |             |                                              |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -224,12 +224,6 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
-INTROSPECTION OPTIONS: 
-Configure logging, tracing, and metrics exporting.
-
-      --disable-template-insights bool, $CODER_DISABLE_TEMPLATE_INSIGHTS (default: false)
-          Disable storage and display of template insights.
-
 INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
@@ -275,6 +269,16 @@ INTROSPECTION / PROMETHEUS OPTIONS:
 
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
+
+INTROSPECTION / TEMPLATE INSIGHTS OPTIONS: 
+      --template-insights-enable bool, $CODER_TEMPLATE_INSIGHTS_ENABLE (default: true)
+          Enable the collection and display of template insights along with the
+          associated API endpoints. This will also enable aggregating these
+          insights into daily active users, application usage, and transmission
+          rates for overall deployment stats. When disabled, these values will
+          be zero, which will also affect what the bottom deployment overview
+          bar displays. Disabling will also prevent Prometheus collection of
+          these values.
 
 INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -224,6 +224,12 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
+INTROSPECTION OPTIONS: 
+Configure logging, tracing, and metrics exporting.
+
+      --disable-template-insights bool, $CODER_DISABLE_TEMPLATE_INSIGHTS (default: false)
+          Disable storage and display of template insights.
+
 INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2178,7 +2178,11 @@ export interface GetInboxNotificationResponse {
 
 // From codersdk/insights.go
 export interface GetUserStatusCountsRequest {
-	readonly offset: string;
+	/**
+	 * Timezone offset in hours. Use 0 for UTC, and TimezoneOffsetHour(time.Local)
+	 * for the local timezone.
+	 */
+	readonly offset: number;
 }
 
 // From codersdk/insights.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1788,6 +1788,7 @@ export interface DeploymentValues {
 	readonly workspace_prebuilds?: PrebuildsConfig;
 	readonly hide_ai_tasks?: boolean;
 	readonly ai?: AIConfig;
+	readonly disable_template_insights?: boolean;
 	readonly config?: string;
 	readonly write_config?: boolean;
 	/**

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1788,7 +1788,7 @@ export interface DeploymentValues {
 	readonly workspace_prebuilds?: PrebuildsConfig;
 	readonly hide_ai_tasks?: boolean;
 	readonly ai?: AIConfig;
-	readonly disable_template_insights?: boolean;
+	readonly template_insights?: TemplateInsightsConfig;
 	readonly config?: string;
 	readonly write_config?: boolean;
 	/**
@@ -5077,6 +5077,11 @@ export interface TemplateFilter {
 // From codersdk/templates.go
 export interface TemplateGroup extends Group {
 	readonly role: TemplateRole;
+}
+
+// From codersdk/deployment.go
+export interface TemplateInsightsConfig {
+	readonly enable: boolean;
 }
 
 // From codersdk/insights.go

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
@@ -29,8 +29,8 @@ export const Loading: Story = {
 	},
 };
 
-const forbidden = mockApiError({
-	message: "Forbidden.",
+const notFound = mockApiError({
+	message: "Not Found.",
 	detail: "Template insights are disabled.",
 });
 
@@ -38,15 +38,15 @@ export const LoadingError: Story = {
 	args: {
 		templateInsights: {
 			data: undefined,
-			error: forbidden,
+			error: notFound,
 		},
 		userLatency: {
 			data: undefined,
-			error: forbidden,
+			error: notFound,
 		},
 		userActivity: {
 			data: undefined,
-			error: forbidden,
+			error: notFound,
 		},
 	},
 };

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
@@ -1,4 +1,5 @@
 import { chromatic } from "testHelpers/chromatic";
+import { mockApiError } from "testHelpers/entities";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { TemplateInsightsPageView } from "./TemplateInsightsPage";
 
@@ -13,39 +14,80 @@ type Story = StoryObj<typeof TemplateInsightsPageView>;
 
 export const Loading: Story = {
 	args: {
-		templateInsights: undefined,
-		userLatency: undefined,
+		templateInsights: {
+			data: undefined,
+			error: null,
+		},
+		userLatency: {
+			data: undefined,
+			error: null,
+		},
+		userActivity: {
+			data: undefined,
+			error: null,
+		},
+	},
+};
+
+const forbidden = mockApiError({
+	message: "Forbidden.",
+	detail: "Template insights are disabled.",
+});
+
+export const LoadingError: Story = {
+	args: {
+		templateInsights: {
+			data: undefined,
+			error: forbidden,
+		},
+		userLatency: {
+			data: undefined,
+			error: forbidden,
+		},
+		userActivity: {
+			data: undefined,
+			error: forbidden,
+		},
 	},
 };
 
 export const Empty: Story = {
 	args: {
 		templateInsights: {
-			interval_reports: [],
-			report: {
-				active_users: 0,
-				end_time: "",
-				start_time: "",
-				template_ids: [],
-				apps_usage: [],
-				parameters_usage: [],
+			data: {
+				interval_reports: [],
+				report: {
+					active_users: 0,
+					end_time: "",
+					start_time: "",
+					template_ids: [],
+					apps_usage: [],
+					parameters_usage: [],
+				},
 			},
+			error: null,
 		},
 		userLatency: {
-			report: {
-				end_time: "",
-				start_time: "",
-				template_ids: [],
-				users: [],
+			data: {
+				report: {
+					end_time: "",
+					start_time: "",
+					template_ids: [],
+					users: [],
+				},
 			},
+			error: null,
 		},
 		userActivity: {
-			report: {
-				end_time: "",
-				start_time: "",
-				template_ids: [],
-				users: [],
+			data: {
+				report: {
+					end_time: "",
+					start_time: "",
+					template_ids: [],
+					users: [],
+				},
 			},
+			error: null,
 		},
 	},
 };
@@ -54,816 +96,837 @@ export const Loaded: Story = {
 	args: {
 		// Got from dev.coder.com network calls
 		templateInsights: {
-			report: {
-				start_time: "2023-07-18T00:00:00Z",
-				end_time: "2023-07-25T00:00:00Z",
-				template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-				active_users: 14,
-				apps_usage: [
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						type: "builtin",
-						display_name: "Visual Studio Code",
-						slug: "vscode",
-						icon: "/icon/code.svg",
-						seconds: 2513400,
-						times_used: 0,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						type: "builtin",
-						display_name: "JetBrains",
-						slug: "jetbrains",
-						icon: "/icon/intellij.svg",
-						seconds: 2013400,
-						times_used: 20,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						type: "builtin",
-						display_name: "Web Terminal",
-						slug: "reconnecting-pty",
-						icon: "/icon/terminal.svg",
-						seconds: 110400,
-						times_used: 0,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						type: "builtin",
-						display_name: "SSH",
-						slug: "ssh",
-						icon: "/icon/terminal.svg",
-						seconds: 1020900,
-						times_used: 0,
-					},
-				],
-				parameters_usage: [
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "",
-						name: "Compute instances",
-						type: "number",
-						description: "Let's set the expected number of instances.",
-						values: [
-							{
-								value: "3",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "",
-						name: "Docker Image",
-						type: "string",
-						description: "Docker image for the development container",
-						values: [
-							{
-								value: "ghcr.io/harrison-ai/coder-dev:base",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "Very random string",
-						name: "Optional random string",
-						type: "string",
-						description: "This string is optional",
-						values: [
-							{
-								value: "ksjdlkajs;djálskd'l ;a k;aosdk ;oaids ;li",
-								count: 1,
-							},
-							{
-								value: "some other any string here",
-								count: 1,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "",
-						name: "Region",
-						type: "string",
-						description: "These are options.",
-						options: [
-							{
-								name: "US Central",
-								description: "Select for central!",
-								value: "us-central1-a",
-								icon: "/icon/goland.svg",
-							},
-							{
-								name: "US East",
-								description: "Select for east!",
-								value: "us-east1-a",
-								icon: "/icon/folder.svg",
-							},
-							{
-								name: "US West",
-								description: "Select for west!",
-								value: "us-west2-a",
-								icon: "",
-							},
-						],
-						values: [
-							{
-								value: "us-central1-a",
-								count: 1,
-							},
-							{
-								value: "us-west2-a",
-								count: 1,
-							},
-							// Test orphan values
-							{
-								value: "us-west-orphan",
-								count: 1,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "",
-						name: "Security groups",
-						type: "list(string)",
-						description: "Select appropriate security groups.",
-						values: [
-							{
-								value:
-									'["Web Server Security Group","Database Security Group","Backend Security Group"]',
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "Very random string",
-						name: "buggy-1",
-						type: "string",
-						description: "This string is buggy",
-						values: [
-							{
-								value: "",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "Force rebuild",
-						name: "force-rebuild",
-						type: "bool",
-						description: "Rebuild the project code",
-						values: [
-							{
-								value: "false",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "Location",
-						name: "location",
-						type: "string",
-						description: "What location should your workspace live in?",
-						options: [
-							{
-								name: "US (Virginia)",
-								description: "",
-								value: "eastus",
-								icon: "/emojis/1f1fa-1f1f8.png",
-							},
-							{
-								name: "US (Virginia) 2",
-								description: "",
-								value: "eastus2",
-								icon: "/emojis/1f1fa-1f1f8.png",
-							},
-							{
-								name: "US (Texas)",
-								description: "",
-								value: "southcentralus",
-								icon: "/emojis/1f1fa-1f1f8.png",
-							},
-							{
-								name: "US (Washington)",
-								description: "",
-								value: "westus2",
-								icon: "/emojis/1f1fa-1f1f8.png",
-							},
-							{
-								name: "US (Arizona)",
-								description: "",
-								value: "westus3",
-								icon: "/emojis/1f1fa-1f1f8.png",
-							},
-							{
-								name: "US (Iowa)",
-								description: "",
-								value: "centralus",
-								icon: "/emojis/1f1fa-1f1f8.png",
-							},
-							{
-								name: "Canada (Toronto)",
-								description: "",
-								value: "canadacentral",
-								icon: "/emojis/1f1e8-1f1e6.png",
-							},
-							{
-								name: "Brazil (Sao Paulo)",
-								description: "",
-								value: "brazilsouth",
-								icon: "/emojis/1f1e7-1f1f7.png",
-							},
-							{
-								name: "East Asia (Hong Kong)",
-								description: "",
-								value: "eastasia",
-								icon: "/emojis/1f1f0-1f1f7.png",
-							},
-							{
-								name: "Southeast Asia (Singapore)",
-								description: "",
-								value: "southeastasia",
-								icon: "/emojis/1f1f0-1f1f7.png",
-							},
-							{
-								name: "Australia (New South Wales)",
-								description: "",
-								value: "australiaeast",
-								icon: "/emojis/1f1e6-1f1fa.png",
-							},
-							{
-								name: "China (Hebei)",
-								description: "",
-								value: "chinanorth3",
-								icon: "/emojis/1f1e8-1f1f3.png",
-							},
-							{
-								name: "India (Pune)",
-								description: "",
-								value: "centralindia",
-								icon: "/emojis/1f1ee-1f1f3.png",
-							},
-							{
-								name: "Japan (Tokyo)",
-								description: "",
-								value: "japaneast",
-								icon: "/emojis/1f1ef-1f1f5.png",
-							},
-							{
-								name: "Korea (Seoul)",
-								description: "",
-								value: "koreacentral",
-								icon: "/emojis/1f1f0-1f1f7.png",
-							},
-							{
-								name: "Europe (Ireland)",
-								description: "",
-								value: "northeurope",
-								icon: "/emojis/1f1ea-1f1fa.png",
-							},
-							{
-								name: "Europe (Netherlands)",
-								description: "",
-								value: "westeurope",
-								icon: "/emojis/1f1ea-1f1fa.png",
-							},
-							{
-								name: "France (Paris)",
-								description: "",
-								value: "francecentral",
-								icon: "/emojis/1f1eb-1f1f7.png",
-							},
-							{
-								name: "Germany (Frankfurt)",
-								description: "",
-								value: "germanywestcentral",
-								icon: "/emojis/1f1e9-1f1ea.png",
-							},
-							{
-								name: "Norway (Oslo)",
-								description: "",
-								value: "norwayeast",
-								icon: "/emojis/1f1f3-1f1f4.png",
-							},
-							{
-								name: "Sweden (Gävle)",
-								description: "",
-								value: "swedencentral",
-								icon: "/emojis/1f1f8-1f1ea.png",
-							},
-							{
-								name: "Switzerland (Zurich)",
-								description: "",
-								value: "switzerlandnorth",
-								icon: "/emojis/1f1e8-1f1ed.png",
-							},
-							{
-								name: "Qatar (Doha)",
-								description: "",
-								value: "qatarcentral",
-								icon: "/emojis/1f1f6-1f1e6.png",
-							},
-							{
-								name: "UAE (Dubai)",
-								description: "",
-								value: "uaenorth",
-								icon: "/emojis/1f1e6-1f1ea.png",
-							},
-							{
-								name: "South Africa (Johannesburg)",
-								description: "",
-								value: "southafricanorth",
-								icon: "/emojis/1f1ff-1f1e6.png",
-							},
-							{
-								name: "UK (London)",
-								description: "",
-								value: "uksouth",
-								icon: "/emojis/1f1ec-1f1e7.png",
-							},
-						],
-						values: [
-							{
-								value: "brazilsouth",
-								count: 1,
-							},
-							{
-								value: "switzerlandnorth",
-								count: 1,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "",
-						name: "mtojek_region",
-						type: "string",
-						description: "What region should your workspace live in?",
-						options: [
-							{
-								name: "Los Angeles, CA",
-								description: "",
-								value: "Los Angeles, CA",
-								icon: "",
-							},
-							{
-								name: "Moncks Corner, SC",
-								description: "",
-								value: "Moncks Corner, SC",
-								icon: "",
-							},
-							{
-								name: "Eemshaven, NL",
-								description: "",
-								value: "Eemshaven, NL",
-								icon: "",
-							},
-						],
-						values: [
-							{
-								value: "Los Angeles, CA",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "My Project ID",
-						name: "project_id",
-						type: "string",
-						description: "This is the Project ID.",
-						values: [
-							{
-								value: "12345",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "Force devcontainer rebuild",
-						name: "rebuild_devcontainer",
-						type: "bool",
-						description: "",
-						values: [
-							{
-								value: "false",
-								count: 2,
-							},
-						],
-					},
-					{
-						template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
-						display_name: "Git Repo URL",
-						name: "repo_url",
-						type: "string",
-						description:
-							"See sample projects (https://github.com/microsoft/vscode-dev-containers#sample-projects)",
-						values: [
-							{
-								value: "https://github.com/mtojek/coder",
-								count: 2,
-							},
-						],
-					},
-				],
-			},
-			interval_reports: [
-				{
+			data: {
+				report: {
 					start_time: "2023-07-18T00:00:00Z",
-					end_time: "2023-07-19T00:00:00Z",
-					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 13,
-				},
-				{
-					start_time: "2023-07-19T00:00:00Z",
-					end_time: "2023-07-20T00:00:00Z",
-					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 11,
-				},
-				{
-					start_time: "2023-07-20T00:00:00Z",
-					end_time: "2023-07-21T00:00:00Z",
-					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 11,
-				},
-				{
-					start_time: "2023-07-21T00:00:00Z",
-					end_time: "2023-07-22T00:00:00Z",
-					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 13,
-				},
-				{
-					start_time: "2023-07-22T00:00:00Z",
-					end_time: "2023-07-23T00:00:00Z",
-					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 7,
-				},
-				{
-					start_time: "2023-07-23T00:00:00Z",
-					end_time: "2023-07-24T00:00:00Z",
-					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 5,
-				},
-				{
-					start_time: "2023-07-24T00:00:00Z",
 					end_time: "2023-07-25T00:00:00Z",
 					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-					interval: "day",
-					active_users: 16,
+					active_users: 14,
+					apps_usage: [
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							type: "builtin",
+							display_name: "Visual Studio Code",
+							slug: "vscode",
+							icon: "/icon/code.svg",
+							seconds: 2513400,
+							times_used: 0,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							type: "builtin",
+							display_name: "JetBrains",
+							slug: "jetbrains",
+							icon: "/icon/intellij.svg",
+							seconds: 2013400,
+							times_used: 20,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							type: "builtin",
+							display_name: "Web Terminal",
+							slug: "reconnecting-pty",
+							icon: "/icon/terminal.svg",
+							seconds: 110400,
+							times_used: 0,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							type: "builtin",
+							display_name: "SSH",
+							slug: "ssh",
+							icon: "/icon/terminal.svg",
+							seconds: 1020900,
+							times_used: 0,
+						},
+					],
+					parameters_usage: [
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "",
+							name: "Compute instances",
+							type: "number",
+							description: "Let's set the expected number of instances.",
+							values: [
+								{
+									value: "3",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "",
+							name: "Docker Image",
+							type: "string",
+							description: "Docker image for the development container",
+							values: [
+								{
+									value: "ghcr.io/harrison-ai/coder-dev:base",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "Very random string",
+							name: "Optional random string",
+							type: "string",
+							description: "This string is optional",
+							values: [
+								{
+									value: "ksjdlkajs;djálskd'l ;a k;aosdk ;oaids ;li",
+									count: 1,
+								},
+								{
+									value: "some other any string here",
+									count: 1,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "",
+							name: "Region",
+							type: "string",
+							description: "These are options.",
+							options: [
+								{
+									name: "US Central",
+									description: "Select for central!",
+									value: "us-central1-a",
+									icon: "/icon/goland.svg",
+								},
+								{
+									name: "US East",
+									description: "Select for east!",
+									value: "us-east1-a",
+									icon: "/icon/folder.svg",
+								},
+								{
+									name: "US West",
+									description: "Select for west!",
+									value: "us-west2-a",
+									icon: "",
+								},
+							],
+							values: [
+								{
+									value: "us-central1-a",
+									count: 1,
+								},
+								{
+									value: "us-west2-a",
+									count: 1,
+								},
+								// Test orphan values
+								{
+									value: "us-west-orphan",
+									count: 1,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "",
+							name: "Security groups",
+							type: "list(string)",
+							description: "Select appropriate security groups.",
+							values: [
+								{
+									value:
+										'["Web Server Security Group","Database Security Group","Backend Security Group"]',
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "Very random string",
+							name: "buggy-1",
+							type: "string",
+							description: "This string is buggy",
+							values: [
+								{
+									value: "",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "Force rebuild",
+							name: "force-rebuild",
+							type: "bool",
+							description: "Rebuild the project code",
+							values: [
+								{
+									value: "false",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "Location",
+							name: "location",
+							type: "string",
+							description: "What location should your workspace live in?",
+							options: [
+								{
+									name: "US (Virginia)",
+									description: "",
+									value: "eastus",
+									icon: "/emojis/1f1fa-1f1f8.png",
+								},
+								{
+									name: "US (Virginia) 2",
+									description: "",
+									value: "eastus2",
+									icon: "/emojis/1f1fa-1f1f8.png",
+								},
+								{
+									name: "US (Texas)",
+									description: "",
+									value: "southcentralus",
+									icon: "/emojis/1f1fa-1f1f8.png",
+								},
+								{
+									name: "US (Washington)",
+									description: "",
+									value: "westus2",
+									icon: "/emojis/1f1fa-1f1f8.png",
+								},
+								{
+									name: "US (Arizona)",
+									description: "",
+									value: "westus3",
+									icon: "/emojis/1f1fa-1f1f8.png",
+								},
+								{
+									name: "US (Iowa)",
+									description: "",
+									value: "centralus",
+									icon: "/emojis/1f1fa-1f1f8.png",
+								},
+								{
+									name: "Canada (Toronto)",
+									description: "",
+									value: "canadacentral",
+									icon: "/emojis/1f1e8-1f1e6.png",
+								},
+								{
+									name: "Brazil (Sao Paulo)",
+									description: "",
+									value: "brazilsouth",
+									icon: "/emojis/1f1e7-1f1f7.png",
+								},
+								{
+									name: "East Asia (Hong Kong)",
+									description: "",
+									value: "eastasia",
+									icon: "/emojis/1f1f0-1f1f7.png",
+								},
+								{
+									name: "Southeast Asia (Singapore)",
+									description: "",
+									value: "southeastasia",
+									icon: "/emojis/1f1f0-1f1f7.png",
+								},
+								{
+									name: "Australia (New South Wales)",
+									description: "",
+									value: "australiaeast",
+									icon: "/emojis/1f1e6-1f1fa.png",
+								},
+								{
+									name: "China (Hebei)",
+									description: "",
+									value: "chinanorth3",
+									icon: "/emojis/1f1e8-1f1f3.png",
+								},
+								{
+									name: "India (Pune)",
+									description: "",
+									value: "centralindia",
+									icon: "/emojis/1f1ee-1f1f3.png",
+								},
+								{
+									name: "Japan (Tokyo)",
+									description: "",
+									value: "japaneast",
+									icon: "/emojis/1f1ef-1f1f5.png",
+								},
+								{
+									name: "Korea (Seoul)",
+									description: "",
+									value: "koreacentral",
+									icon: "/emojis/1f1f0-1f1f7.png",
+								},
+								{
+									name: "Europe (Ireland)",
+									description: "",
+									value: "northeurope",
+									icon: "/emojis/1f1ea-1f1fa.png",
+								},
+								{
+									name: "Europe (Netherlands)",
+									description: "",
+									value: "westeurope",
+									icon: "/emojis/1f1ea-1f1fa.png",
+								},
+								{
+									name: "France (Paris)",
+									description: "",
+									value: "francecentral",
+									icon: "/emojis/1f1eb-1f1f7.png",
+								},
+								{
+									name: "Germany (Frankfurt)",
+									description: "",
+									value: "germanywestcentral",
+									icon: "/emojis/1f1e9-1f1ea.png",
+								},
+								{
+									name: "Norway (Oslo)",
+									description: "",
+									value: "norwayeast",
+									icon: "/emojis/1f1f3-1f1f4.png",
+								},
+								{
+									name: "Sweden (Gävle)",
+									description: "",
+									value: "swedencentral",
+									icon: "/emojis/1f1f8-1f1ea.png",
+								},
+								{
+									name: "Switzerland (Zurich)",
+									description: "",
+									value: "switzerlandnorth",
+									icon: "/emojis/1f1e8-1f1ed.png",
+								},
+								{
+									name: "Qatar (Doha)",
+									description: "",
+									value: "qatarcentral",
+									icon: "/emojis/1f1f6-1f1e6.png",
+								},
+								{
+									name: "UAE (Dubai)",
+									description: "",
+									value: "uaenorth",
+									icon: "/emojis/1f1e6-1f1ea.png",
+								},
+								{
+									name: "South Africa (Johannesburg)",
+									description: "",
+									value: "southafricanorth",
+									icon: "/emojis/1f1ff-1f1e6.png",
+								},
+								{
+									name: "UK (London)",
+									description: "",
+									value: "uksouth",
+									icon: "/emojis/1f1ec-1f1e7.png",
+								},
+							],
+							values: [
+								{
+									value: "brazilsouth",
+									count: 1,
+								},
+								{
+									value: "switzerlandnorth",
+									count: 1,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "",
+							name: "mtojek_region",
+							type: "string",
+							description: "What region should your workspace live in?",
+							options: [
+								{
+									name: "Los Angeles, CA",
+									description: "",
+									value: "Los Angeles, CA",
+									icon: "",
+								},
+								{
+									name: "Moncks Corner, SC",
+									description: "",
+									value: "Moncks Corner, SC",
+									icon: "",
+								},
+								{
+									name: "Eemshaven, NL",
+									description: "",
+									value: "Eemshaven, NL",
+									icon: "",
+								},
+							],
+							values: [
+								{
+									value: "Los Angeles, CA",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "My Project ID",
+							name: "project_id",
+							type: "string",
+							description: "This is the Project ID.",
+							values: [
+								{
+									value: "12345",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "Force devcontainer rebuild",
+							name: "rebuild_devcontainer",
+							type: "bool",
+							description: "",
+							values: [
+								{
+									value: "false",
+									count: 2,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "Git Repo URL",
+							name: "repo_url",
+							type: "string",
+							description:
+								"See sample projects (https://github.com/microsoft/vscode-dev-containers#sample-projects)",
+							values: [
+								{
+									value: "https://github.com/mtojek/coder",
+									count: 2,
+								},
+							],
+						},
+					],
 				},
-			],
+				interval_reports: [
+					{
+						start_time: "2023-07-18T00:00:00Z",
+						end_time: "2023-07-19T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 13,
+					},
+					{
+						start_time: "2023-07-19T00:00:00Z",
+						end_time: "2023-07-20T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 11,
+					},
+					{
+						start_time: "2023-07-20T00:00:00Z",
+						end_time: "2023-07-21T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 11,
+					},
+					{
+						start_time: "2023-07-21T00:00:00Z",
+						end_time: "2023-07-22T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 13,
+					},
+					{
+						start_time: "2023-07-22T00:00:00Z",
+						end_time: "2023-07-23T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 7,
+					},
+					{
+						start_time: "2023-07-23T00:00:00Z",
+						end_time: "2023-07-24T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 5,
+					},
+					{
+						start_time: "2023-07-24T00:00:00Z",
+						end_time: "2023-07-25T00:00:00Z",
+						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+						interval: "day",
+						active_users: 16,
+					},
+				],
+			},
+			error: null,
 		},
 		userLatency: {
-			report: {
-				start_time: "2023-07-18T00:00:00Z",
-				end_time: "2023-07-25T00:00:00Z",
-				template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-				users: [
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "0bac0dfd-b086-4b6d-b8ba-789e0eca7451",
-						username: "kylecarbs",
-						avatar_url: "https://avatars.githubusercontent.com/u/7122116?v=4",
-						latency_ms: {
-							p50: 63.826,
-							p95: 139.328,
+			data: {
+				report: {
+					start_time: "2023-07-18T00:00:00Z",
+					end_time: "2023-07-25T00:00:00Z",
+					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+					users: [
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "0bac0dfd-b086-4b6d-b8ba-789e0eca7451",
+							username: "kylecarbs",
+							avatar_url: "https://avatars.githubusercontent.com/u/7122116?v=4",
+							latency_ms: {
+								p50: 63.826,
+								p95: 139.328,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "12b03f43-1bb7-4fca-967a-585c97f31682",
-						username: "coadler",
-						avatar_url: "https://avatars.githubusercontent.com/u/6332295?v=4",
-						latency_ms: {
-							p50: 51.0745,
-							p95: 54.62562499999999,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "12b03f43-1bb7-4fca-967a-585c97f31682",
+							username: "coadler",
+							avatar_url: "https://avatars.githubusercontent.com/u/6332295?v=4",
+							latency_ms: {
+								p50: 51.0745,
+								p95: 54.62562499999999,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "15890ddb-142c-443d-8fd5-cd8307256ab1",
-						username: "jsjoeio",
-						avatar_url: "https://avatars.githubusercontent.com/u/3806031?v=4",
-						latency_ms: {
-							p50: 37.444,
-							p95: 37.8488,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "15890ddb-142c-443d-8fd5-cd8307256ab1",
+							username: "jsjoeio",
+							avatar_url: "https://avatars.githubusercontent.com/u/3806031?v=4",
+							latency_ms: {
+								p50: 37.444,
+								p95: 37.8488,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "3f8c0eef-6a45-4759-a4d6-d00bbffb1369",
-						username: "dean",
-						avatar_url: "https://avatars.githubusercontent.com/u/11241812?v=4",
-						latency_ms: {
-							p50: 7.1295,
-							p95: 70.34084999999999,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "3f8c0eef-6a45-4759-a4d6-d00bbffb1369",
+							username: "dean",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/11241812?v=4",
+							latency_ms: {
+								p50: 7.1295,
+								p95: 70.34084999999999,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "59da0bfe-9c99-47fa-a563-f9fdb18449d0",
-						username: "cian",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a/AAcHTtdsYrtIfkXU52rHXhY9DHehpw-slUKe9v6UELLJgXT2mDM=s96-c",
-						latency_ms: {
-							p50: 42.14975,
-							p95: 125.5441,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "59da0bfe-9c99-47fa-a563-f9fdb18449d0",
+							username: "cian",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a/AAcHTtdsYrtIfkXU52rHXhY9DHehpw-slUKe9v6UELLJgXT2mDM=s96-c",
+							latency_ms: {
+								p50: 42.14975,
+								p95: 125.5441,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "5ccd3128-cbbb-4cfb-8139-5a1edbb60c71",
-						username: "bpmct",
-						avatar_url: "https://avatars.githubusercontent.com/u/22407953?v=4",
-						latency_ms: {
-							p50: 42.175,
-							p95: 43.437599999999996,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "5ccd3128-cbbb-4cfb-8139-5a1edbb60c71",
+							username: "bpmct",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/22407953?v=4",
+							latency_ms: {
+								p50: 42.175,
+								p95: 43.437599999999996,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "631f78f6-098e-4cb0-ae4f-418fafb0a406",
-						username: "matifali",
-						avatar_url: "https://avatars.githubusercontent.com/u/10648092?v=4",
-						latency_ms: {
-							p50: 78.02,
-							p95: 86.3328,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "631f78f6-098e-4cb0-ae4f-418fafb0a406",
+							username: "matifali",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/10648092?v=4",
+							latency_ms: {
+								p50: 78.02,
+								p95: 86.3328,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "740bba7f-356d-4203-8f15-03ddee381998",
-						username: "eric",
-						avatar_url: "https://avatars.githubusercontent.com/u/9683576?v=4",
-						latency_ms: {
-							p50: 34.533,
-							p95: 110.52659999999999,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "740bba7f-356d-4203-8f15-03ddee381998",
+							username: "eric",
+							avatar_url: "https://avatars.githubusercontent.com/u/9683576?v=4",
+							latency_ms: {
+								p50: 34.533,
+								p95: 110.52659999999999,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "78dd2361-4a5a-42b0-9ec3-3eea23af1094",
-						username: "code-asher",
-						avatar_url: "https://avatars.githubusercontent.com/u/45609798?v=4",
-						latency_ms: {
-							p50: 74.78875,
-							p95: 114.80699999999999,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "78dd2361-4a5a-42b0-9ec3-3eea23af1094",
+							username: "code-asher",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/45609798?v=4",
+							latency_ms: {
+								p50: 74.78875,
+								p95: 114.80699999999999,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "7f5cc5e9-20ee-48ce-959d-081b3f52273e",
-						username: "mafredri",
-						avatar_url: "https://avatars.githubusercontent.com/u/147409?v=4",
-						latency_ms: {
-							p50: 19.2115,
-							p95: 96.44249999999992,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "7f5cc5e9-20ee-48ce-959d-081b3f52273e",
+							username: "mafredri",
+							avatar_url: "https://avatars.githubusercontent.com/u/147409?v=4",
+							latency_ms: {
+								p50: 19.2115,
+								p95: 96.44249999999992,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "9ed91bb9-db45-4cef-b39c-819856e98c30",
-						username: "jon",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a/AAcHTtddhPxiGYniy6_rFhdAi2C1YwKvDButlCvJ6G-166mG=s96-c",
-						latency_ms: {
-							p50: 42.0445,
-							p95: 133.846,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "9ed91bb9-db45-4cef-b39c-819856e98c30",
+							username: "jon",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a/AAcHTtddhPxiGYniy6_rFhdAi2C1YwKvDButlCvJ6G-166mG=s96-c",
+							latency_ms: {
+								p50: 42.0445,
+								p95: 133.846,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "a73425d1-53a7-43d3-b6ae-cae9ba59b92b",
-						username: "ammar",
-						avatar_url: "https://avatars.githubusercontent.com/u/7416144?v=4",
-						latency_ms: {
-							p50: 49.249,
-							p95: 56.773250000000004,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "a73425d1-53a7-43d3-b6ae-cae9ba59b92b",
+							username: "ammar",
+							avatar_url: "https://avatars.githubusercontent.com/u/7416144?v=4",
+							latency_ms: {
+								p50: 49.249,
+								p95: 56.773250000000004,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "af657bc3-6949-4b1b-bc2d-d41a40b546a4",
-						username: "BrunoQuaresma",
-						avatar_url: "https://avatars.githubusercontent.com/u/3165839?v=4",
-						latency_ms: {
-							p50: 82.97,
-							p95: 147.3868,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "af657bc3-6949-4b1b-bc2d-d41a40b546a4",
+							username: "BrunoQuaresma",
+							avatar_url: "https://avatars.githubusercontent.com/u/3165839?v=4",
+							latency_ms: {
+								p50: 82.97,
+								p95: 147.3868,
+							},
 						},
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "b006209d-fdd2-4716-afb2-104dafb32dfb",
-						username: "mtojek",
-						avatar_url: "https://avatars.githubusercontent.com/u/14044910?v=4",
-						latency_ms: {
-							p50: 36.758,
-							p95: 101.31679999999983,
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "b006209d-fdd2-4716-afb2-104dafb32dfb",
+							username: "mtojek",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/14044910?v=4",
+							latency_ms: {
+								p50: 36.758,
+								p95: 101.31679999999983,
+							},
 						},
-					},
-				],
+					],
+				},
 			},
+			error: null,
 		},
 		userActivity: {
-			report: {
-				start_time: "2023-09-03T00:00:00-03:00",
-				end_time: "2023-10-01T00:00:00-03:00",
-				template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-				users: [
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "0bac0dfd-b086-4b6d-b8ba-789e0eca7451",
-						username: "kylecarbs",
-						avatar_url: "https://avatars.githubusercontent.com/u/7122116?v=4",
-						seconds: 671040,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "12b03f43-1bb7-4fca-967a-585c97f31682",
-						username: "coadler",
-						avatar_url: "https://avatars.githubusercontent.com/u/6332295?v=4",
-						seconds: 1487460,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "15890ddb-142c-443d-8fd5-cd8307256ab1",
-						username: "jsjoeio",
-						avatar_url: "https://avatars.githubusercontent.com/u/3806031?v=4",
-						seconds: 6600,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "1c3e3fff-6a0e-4179-9ba3-27f5443e6fce",
-						username: "Kira-Pilot",
-						avatar_url: "https://avatars.githubusercontent.com/u/19142439?v=4",
-						seconds: 195240,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "2e1e7f76-ae77-424a-a209-f35a99731ec9",
-						username: "phorcys420",
-						avatar_url: "https://avatars.githubusercontent.com/u/57866459?v=4",
-						seconds: 16320,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "3f8c0eef-6a45-4759-a4d6-d00bbffb1369",
-						username: "dean",
-						avatar_url: "https://avatars.githubusercontent.com/u/11241812?v=4",
-						seconds: 533520,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "59da0bfe-9c99-47fa-a563-f9fdb18449d0",
-						username: "cian",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a/ACg8ocKKaBWosY_nuQvecIaUPh5RYjxkEN-C8FNGVPlC0Ch2fx0=s96-c",
-						seconds: 607080,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "5ccd3128-cbbb-4cfb-8139-5a1edbb60c71",
-						username: "bpmct",
-						avatar_url: "https://avatars.githubusercontent.com/u/22407953?v=4",
-						seconds: 161340,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "631f78f6-098e-4cb0-ae4f-418fafb0a406",
-						username: "matifali",
-						avatar_url: "https://avatars.githubusercontent.com/u/10648092?v=4",
-						seconds: 202500,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "740bba7f-356d-4203-8f15-03ddee381998",
-						username: "eric",
-						avatar_url: "https://avatars.githubusercontent.com/u/9683576?v=4",
-						seconds: 352680,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "78dd2361-4a5a-42b0-9ec3-3eea23af1094",
-						username: "code-asher",
-						avatar_url: "https://avatars.githubusercontent.com/u/45609798?v=4",
-						seconds: 518640,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "7f5cc5e9-20ee-48ce-959d-081b3f52273e",
-						username: "mafredri",
-						avatar_url: "https://avatars.githubusercontent.com/u/147409?v=4",
-						seconds: 218100,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "8b474a55-d414-4b53-a6ba-760f3d4eed7b",
-						username: "kirby",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a-/ALV-UjUHd9l3CaO99BfVlP8L9D9HqKFOUac7zVCA_Bb_2lj0hcPkQvHkMk4HRaMw4b1YF7E-uHnJO-w8sXf3pqRA2EUP9sDvX6ITd2S2YN23kttVCJKTiI-YEIS8eVDfrF8YLqjfKL3PWsxyiPcgtcdfmPiEnlh4mpUMRXZudwtINfk0W3B9KEpwJTpipdlb57HdYO-mD3DEfmwnpZIO_iVjwnpWZZimXH5g15NVregb8VH_vlsW-vHrMsZ1fRGpm6GWnTcWx2rTImz5Qq5dd15MPKYUxc4wpyYImg07eD41ShzHDJhmDaj_n3hjOwFLuyloLBck-t9skQLWf2r7Voq42jVhzJ2-GAv9atC41_ohG1kq8TpCf9ak6S4hE3xMIB4yzDC0VZxl-BlsBHCuKBRTwC-58yTL2GZI31a0Q9PpR720AyiZaOWhX1QOVZmPZey8b8SG7jWTOfzNa9Shf9E0pz3yyIxFx7KSY5Qeye5AmO1au-rXuWr4whXXY6fsn0tnG4nxdyetCiXd0mOmvYHoJuuQFfqYNjdObduRD0yaVZGL-hPFDYH6K-wiedT1y-66jKXcqjVqe0Rwo7YzcVcP-IeV5RGuJ36TEpC1lhi2V-AnG7pmvIn_4AmXfycclrISO10LgQsrx8bxeBW61t9oTFTZCXXBDAd9bLRxndLi_mWYEfOSnWODgfCrapL_GNZsV0tkQ9x-zvlSXQXtze5bg__uAo7CEnZ20yWT5Gr25_NPsH6vyR3hplKn67qBti5_rKzFQ1sVbcuab2BRmF_Al9MTQw-R2gmd0mle9JRr8tyuwCYh82mBrM-dGebXSdqvabws7_WmF5TNwDHHzeeiHq1_6FYB0tBldx3yWk3U8olZ3SiPAe_NRnY0vUKI3ZANOA-IRYxyTAfjShJE0fRMCe70BsqzJj3RDAciqt5IaP2vZQeImjPZLd2NGo-Bbw=s96-c",
-						seconds: 543960,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "9ed91bb9-db45-4cef-b39c-819856e98c30",
-						username: "jon",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a/ACg8ocJEE9R4__Pdh40DHGD-3noKezyw-1qo2auV_cb2gxBg=s96-c",
-						seconds: 464100,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "a73425d1-53a7-43d3-b6ae-cae9ba59b92b",
-						username: "ammar",
-						avatar_url: "https://avatars.githubusercontent.com/u/7416144?v=4",
-						seconds: 316200,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "af657bc3-6949-4b1b-bc2d-d41a40b546a4",
-						username: "BrunoQuaresma",
-						avatar_url: "https://avatars.githubusercontent.com/u/3165839?v=4",
-						seconds: 329100,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "b006209d-fdd2-4716-afb2-104dafb32dfb",
-						username: "mtojek",
-						avatar_url: "https://avatars.githubusercontent.com/u/14044910?v=4",
-						seconds: 11520,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "b3e1b884-1a5b-44eb-b8b3-423f8eddc503",
-						username: "spikecurtis",
-						avatar_url: "https://avatars.githubusercontent.com/u/5375600?v=4",
-						seconds: 523140,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "baf63990-16a9-472f-b715-64e24c6bcefb",
-						username: "atif",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a-/ALV-UjVWiI2I5XOkxxi5KwAyfzZlfcOSYlMw8dIwJVwg2satTlOaLUy2PXcFcHCYtMg41DImXlB4F7YFIEW-CR_ANiCol7LnHTFomTyeh5N4ZvVQ4rx_sCl3PARywl0-UBW6usVGRVB8CnHve95q4ZDzJA6wJGVvr7gceCpgGe2A2597_KM1L5KIWKr5SAn41AZgQHZc7pgYJtiyKNleDN8LYzmceOtR3GJgFKjMrSOczNLNI3S2TrRPmIBIr_pZFDI3_npKDmQu9fPiVip5RDTAsuP9PdqruNJ4rB0rBae4Gog-RhqUV4L_i01-bJ6aepjH9gqxEkHHkXi7W0ldH8uV2fsQ4Eul78OQp0NrWxx9xZmFseTPK0toiop3EAWnuyp5ikaAnLodtvJ8L3iZXh45LvDv1ADESYPVAeuyHY5eee54O5xy72HABVB_UTE45Zhq086i4zaTNZoObXPrgiU3uNo0EhDQKa2jPNY2oQO0oZa991Oo9zCT9AULz5RP_3GTnfRMgD8ofCKr8Y3dVmSGI0RYOMI5Yqi76sEROCT5LqwAqRTFeGSMIF7-VI9qCctCtZ50n0OVtbFjPCgUGFVN1gZxe2qb66XCQnZOklTaMadj7KvtgIIJFlBSZJLkoPhSyIdiUAOp3VpDn8jOuEI0109YHzEM7l5KFNL-cHxQQyYB9hquld6y6EVRJdro8uVQdwkZ-_Yu4oD70A-WLb-Gi5RLdbB1iFwr99Lg-l4HNDWhh0h1wT5yhn4kgjPMgeTNT7F6fkiteAIvK_jJjVVh-PtKTt48kPv9c7rbc_jCBP70zUQ9X4Xxf9917BPUfvMgLk0gShSaFXxAGTgA7TzRaEsWSi9_DuJ0Q-yQZXwCJ1Y_1VrSF9B2FKsrugotVoC5BORu9tiaWi9jRP6RymM2X0HxsLv0lUFFVjgV0SZnynBNCgqyS02xAs8vEYpw-T7RJg=s96-c",
-						seconds: 2040,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "c0240345-f14a-4632-b713-a0f09c2ed927",
-						username: "asher-user",
-						avatar_url: "",
-						seconds: 0,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "c5eb8310-cf4f-444c-b223-0e991f828b40",
-						username: "Emyrk",
-						avatar_url: "https://avatars.githubusercontent.com/u/5446298?v=4",
-						seconds: 24540,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "d96bf761-3f94-46b3-a1da-6316e2e4735d",
-						username: "aslilac",
-						avatar_url: "https://avatars.githubusercontent.com/u/418348?v=4",
-						seconds: 824820,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "db38462b-e63d-4304-87e9-2640eea4a3b8",
-						username: "marc",
-						avatar_url: "",
-						seconds: 120,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "e9b24091-a633-4ba0-9746-ca325a86f0f5",
-						username: "michaelsmith",
-						avatar_url:
-							"https://lh3.googleusercontent.com/a-/ALV-UjXDMd9gEl4aMyM5ENfj4Ruzzn57AETWW6UuNC3Od03Y3AjvrCDhp8iE4I8L0393C_peQF9PZQyVklGCW-FCzODkvyVojUFqafbFi6AtvxjKn59ZyUVtG0ELoDNZOtRQaqUuMNIjtafNQ19LgwYm7LSB47My__oafDZ6jw6Kd_H-qtx19Vh62t3ACoJBHpDrF0BdDxWGBCkUAlC8aJcnqdRqPbKB5WGGcEfwLzrhLc5REN4CuXzm09_ZpU2jdvMUKCBX9H_8j2wcPwtgY0JG0DfIOX_VgTdM6Zy7BLiVQHSjD-uSkwqOEoXvsuKWlEBt74rqjyNDjjM1NyHiUdKpUd26hI2jcro_yrf4Jli7MCf5SjnkGMxQCgrD6-D9bcyBNzXpc1_5mDWrGpSh0X6pVK6GsmuYAc68hfTIHYVs-jB97mls9ClOJ2m51AdOAlizT80Ram2yJ09l-YbTVd4fG3L9FajMsvRhcvwwvN5tGcOk36KcIm0wFy9NQyH09QP3M1Rr2kDn9MzYYuyAZ9Um0tZydrPN9FA59JUytq8GtwnZZVmlZk2X2fXsCgJBv3dCwuF3THqSvL0M3lQa89-slrp2qgSRekiCmbb0-b62T413mOA9KNXcCvct_NN-JAE0b6o7To8B1WW8-AZiFQ2DesSEXL-CWYfqfecs4hoIrSBnQLa3Pm2Q5O-R7R99eRD7H3EqPihl_TiG2s_8gvLUF7ft55hYkV0j-YzTS4nOnUtEAXSqN-JYAd_BTJPJ0kyJLGIScwUQGoNFUQYs5nmlKPepeNpoQYYpQe0zK4ZVYm6fnRXUgv1cWvkD5RuxbBs1kgoVyZrZSNco8apuIjg6sBejRJFre_m0N6emp-Jn5wIkFB1f6IRb7S1aPvCqrqgqI8mTcI6Z-4Z3E3YwiYsn8_zVF9EPa1f1zpzeoppGd_YKaAxLjyOv_nC15bN3eio43A=s96-c",
-						seconds: 449820,
-					},
-					{
-						template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
-						user_id: "fdc2dab9-dabd-4980-843f-2e93042db566",
-						username: "sharkymark",
-						avatar_url: "https://avatars.githubusercontent.com/u/2022166?v=4",
-						seconds: 124440,
-					},
-				],
+			data: {
+				report: {
+					start_time: "2023-09-03T00:00:00-03:00",
+					end_time: "2023-10-01T00:00:00-03:00",
+					template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+					users: [
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "0bac0dfd-b086-4b6d-b8ba-789e0eca7451",
+							username: "kylecarbs",
+							avatar_url: "https://avatars.githubusercontent.com/u/7122116?v=4",
+							seconds: 671040,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "12b03f43-1bb7-4fca-967a-585c97f31682",
+							username: "coadler",
+							avatar_url: "https://avatars.githubusercontent.com/u/6332295?v=4",
+							seconds: 1487460,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "15890ddb-142c-443d-8fd5-cd8307256ab1",
+							username: "jsjoeio",
+							avatar_url: "https://avatars.githubusercontent.com/u/3806031?v=4",
+							seconds: 6600,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "1c3e3fff-6a0e-4179-9ba3-27f5443e6fce",
+							username: "Kira-Pilot",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/19142439?v=4",
+							seconds: 195240,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "2e1e7f76-ae77-424a-a209-f35a99731ec9",
+							username: "phorcys420",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/57866459?v=4",
+							seconds: 16320,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "3f8c0eef-6a45-4759-a4d6-d00bbffb1369",
+							username: "dean",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/11241812?v=4",
+							seconds: 533520,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "59da0bfe-9c99-47fa-a563-f9fdb18449d0",
+							username: "cian",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a/ACg8ocKKaBWosY_nuQvecIaUPh5RYjxkEN-C8FNGVPlC0Ch2fx0=s96-c",
+							seconds: 607080,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "5ccd3128-cbbb-4cfb-8139-5a1edbb60c71",
+							username: "bpmct",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/22407953?v=4",
+							seconds: 161340,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "631f78f6-098e-4cb0-ae4f-418fafb0a406",
+							username: "matifali",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/10648092?v=4",
+							seconds: 202500,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "740bba7f-356d-4203-8f15-03ddee381998",
+							username: "eric",
+							avatar_url: "https://avatars.githubusercontent.com/u/9683576?v=4",
+							seconds: 352680,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "78dd2361-4a5a-42b0-9ec3-3eea23af1094",
+							username: "code-asher",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/45609798?v=4",
+							seconds: 518640,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "7f5cc5e9-20ee-48ce-959d-081b3f52273e",
+							username: "mafredri",
+							avatar_url: "https://avatars.githubusercontent.com/u/147409?v=4",
+							seconds: 218100,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "8b474a55-d414-4b53-a6ba-760f3d4eed7b",
+							username: "kirby",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a-/ALV-UjUHd9l3CaO99BfVlP8L9D9HqKFOUac7zVCA_Bb_2lj0hcPkQvHkMk4HRaMw4b1YF7E-uHnJO-w8sXf3pqRA2EUP9sDvX6ITd2S2YN23kttVCJKTiI-YEIS8eVDfrF8YLqjfKL3PWsxyiPcgtcdfmPiEnlh4mpUMRXZudwtINfk0W3B9KEpwJTpipdlb57HdYO-mD3DEfmwnpZIO_iVjwnpWZZimXH5g15NVregb8VH_vlsW-vHrMsZ1fRGpm6GWnTcWx2rTImz5Qq5dd15MPKYUxc4wpyYImg07eD41ShzHDJhmDaj_n3hjOwFLuyloLBck-t9skQLWf2r7Voq42jVhzJ2-GAv9atC41_ohG1kq8TpCf9ak6S4hE3xMIB4yzDC0VZxl-BlsBHCuKBRTwC-58yTL2GZI31a0Q9PpR720AyiZaOWhX1QOVZmPZey8b8SG7jWTOfzNa9Shf9E0pz3yyIxFx7KSY5Qeye5AmO1au-rXuWr4whXXY6fsn0tnG4nxdyetCiXd0mOmvYHoJuuQFfqYNjdObduRD0yaVZGL-hPFDYH6K-wiedT1y-66jKXcqjVqe0Rwo7YzcVcP-IeV5RGuJ36TEpC1lhi2V-AnG7pmvIn_4AmXfycclrISO10LgQsrx8bxeBW61t9oTFTZCXXBDAd9bLRxndLi_mWYEfOSnWODgfCrapL_GNZsV0tkQ9x-zvlSXQXtze5bg__uAo7CEnZ20yWT5Gr25_NPsH6vyR3hplKn67qBti5_rKzFQ1sVbcuab2BRmF_Al9MTQw-R2gmd0mle9JRr8tyuwCYh82mBrM-dGebXSdqvabws7_WmF5TNwDHHzeeiHq1_6FYB0tBldx3yWk3U8olZ3SiPAe_NRnY0vUKI3ZANOA-IRYxyTAfjShJE0fRMCe70BsqzJj3RDAciqt5IaP2vZQeImjPZLd2NGo-Bbw=s96-c",
+							seconds: 543960,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "9ed91bb9-db45-4cef-b39c-819856e98c30",
+							username: "jon",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a/ACg8ocJEE9R4__Pdh40DHGD-3noKezyw-1qo2auV_cb2gxBg=s96-c",
+							seconds: 464100,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "a73425d1-53a7-43d3-b6ae-cae9ba59b92b",
+							username: "ammar",
+							avatar_url: "https://avatars.githubusercontent.com/u/7416144?v=4",
+							seconds: 316200,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "af657bc3-6949-4b1b-bc2d-d41a40b546a4",
+							username: "BrunoQuaresma",
+							avatar_url: "https://avatars.githubusercontent.com/u/3165839?v=4",
+							seconds: 329100,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "b006209d-fdd2-4716-afb2-104dafb32dfb",
+							username: "mtojek",
+							avatar_url:
+								"https://avatars.githubusercontent.com/u/14044910?v=4",
+							seconds: 11520,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "b3e1b884-1a5b-44eb-b8b3-423f8eddc503",
+							username: "spikecurtis",
+							avatar_url: "https://avatars.githubusercontent.com/u/5375600?v=4",
+							seconds: 523140,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "baf63990-16a9-472f-b715-64e24c6bcefb",
+							username: "atif",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a-/ALV-UjVWiI2I5XOkxxi5KwAyfzZlfcOSYlMw8dIwJVwg2satTlOaLUy2PXcFcHCYtMg41DImXlB4F7YFIEW-CR_ANiCol7LnHTFomTyeh5N4ZvVQ4rx_sCl3PARywl0-UBW6usVGRVB8CnHve95q4ZDzJA6wJGVvr7gceCpgGe2A2597_KM1L5KIWKr5SAn41AZgQHZc7pgYJtiyKNleDN8LYzmceOtR3GJgFKjMrSOczNLNI3S2TrRPmIBIr_pZFDI3_npKDmQu9fPiVip5RDTAsuP9PdqruNJ4rB0rBae4Gog-RhqUV4L_i01-bJ6aepjH9gqxEkHHkXi7W0ldH8uV2fsQ4Eul78OQp0NrWxx9xZmFseTPK0toiop3EAWnuyp5ikaAnLodtvJ8L3iZXh45LvDv1ADESYPVAeuyHY5eee54O5xy72HABVB_UTE45Zhq086i4zaTNZoObXPrgiU3uNo0EhDQKa2jPNY2oQO0oZa991Oo9zCT9AULz5RP_3GTnfRMgD8ofCKr8Y3dVmSGI0RYOMI5Yqi76sEROCT5LqwAqRTFeGSMIF7-VI9qCctCtZ50n0OVtbFjPCgUGFVN1gZxe2qb66XCQnZOklTaMadj7KvtgIIJFlBSZJLkoPhSyIdiUAOp3VpDn8jOuEI0109YHzEM7l5KFNL-cHxQQyYB9hquld6y6EVRJdro8uVQdwkZ-_Yu4oD70A-WLb-Gi5RLdbB1iFwr99Lg-l4HNDWhh0h1wT5yhn4kgjPMgeTNT7F6fkiteAIvK_jJjVVh-PtKTt48kPv9c7rbc_jCBP70zUQ9X4Xxf9917BPUfvMgLk0gShSaFXxAGTgA7TzRaEsWSi9_DuJ0Q-yQZXwCJ1Y_1VrSF9B2FKsrugotVoC5BORu9tiaWi9jRP6RymM2X0HxsLv0lUFFVjgV0SZnynBNCgqyS02xAs8vEYpw-T7RJg=s96-c",
+							seconds: 2040,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "c0240345-f14a-4632-b713-a0f09c2ed927",
+							username: "asher-user",
+							avatar_url: "",
+							seconds: 0,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "c5eb8310-cf4f-444c-b223-0e991f828b40",
+							username: "Emyrk",
+							avatar_url: "https://avatars.githubusercontent.com/u/5446298?v=4",
+							seconds: 24540,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "d96bf761-3f94-46b3-a1da-6316e2e4735d",
+							username: "aslilac",
+							avatar_url: "https://avatars.githubusercontent.com/u/418348?v=4",
+							seconds: 824820,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "db38462b-e63d-4304-87e9-2640eea4a3b8",
+							username: "marc",
+							avatar_url: "",
+							seconds: 120,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "e9b24091-a633-4ba0-9746-ca325a86f0f5",
+							username: "michaelsmith",
+							avatar_url:
+								"https://lh3.googleusercontent.com/a-/ALV-UjXDMd9gEl4aMyM5ENfj4Ruzzn57AETWW6UuNC3Od03Y3AjvrCDhp8iE4I8L0393C_peQF9PZQyVklGCW-FCzODkvyVojUFqafbFi6AtvxjKn59ZyUVtG0ELoDNZOtRQaqUuMNIjtafNQ19LgwYm7LSB47My__oafDZ6jw6Kd_H-qtx19Vh62t3ACoJBHpDrF0BdDxWGBCkUAlC8aJcnqdRqPbKB5WGGcEfwLzrhLc5REN4CuXzm09_ZpU2jdvMUKCBX9H_8j2wcPwtgY0JG0DfIOX_VgTdM6Zy7BLiVQHSjD-uSkwqOEoXvsuKWlEBt74rqjyNDjjM1NyHiUdKpUd26hI2jcro_yrf4Jli7MCf5SjnkGMxQCgrD6-D9bcyBNzXpc1_5mDWrGpSh0X6pVK6GsmuYAc68hfTIHYVs-jB97mls9ClOJ2m51AdOAlizT80Ram2yJ09l-YbTVd4fG3L9FajMsvRhcvwwvN5tGcOk36KcIm0wFy9NQyH09QP3M1Rr2kDn9MzYYuyAZ9Um0tZydrPN9FA59JUytq8GtwnZZVmlZk2X2fXsCgJBv3dCwuF3THqSvL0M3lQa89-slrp2qgSRekiCmbb0-b62T413mOA9KNXcCvct_NN-JAE0b6o7To8B1WW8-AZiFQ2DesSEXL-CWYfqfecs4hoIrSBnQLa3Pm2Q5O-R7R99eRD7H3EqPihl_TiG2s_8gvLUF7ft55hYkV0j-YzTS4nOnUtEAXSqN-JYAd_BTJPJ0kyJLGIScwUQGoNFUQYs5nmlKPepeNpoQYYpQe0zK4ZVYm6fnRXUgv1cWvkD5RuxbBs1kgoVyZrZSNco8apuIjg6sBejRJFre_m0N6emp-Jn5wIkFB1f6IRb7S1aPvCqrqgqI8mTcI6Z-4Z3E3YwiYsn8_zVF9EPa1f1zpzeoppGd_YKaAxLjyOv_nC15bN3eio43A=s96-c",
+							seconds: 449820,
+						},
+						{
+							template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
+							user_id: "fdc2dab9-dabd-4980-843f-2e93042db566",
+							username: "sharkymark",
+							avatar_url: "https://avatars.githubusercontent.com/u/2022166?v=4",
+							seconds: 124440,
+						},
+					],
+				},
 			},
+			error: null,
 		},
 	},
 };

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -256,26 +256,23 @@ export const TemplateInsightsPageView: FC<TemplateInsightsPageViewProps> = ({
 							? entitlements?.features.user_limit.limit
 							: undefined
 					}
-					data={templateInsights?.data?.interval_reports}
-					error={templateInsights?.error}
+					data={templateInsights.data?.interval_reports}
+					error={templateInsights.error}
 				/>
-				<UsersLatencyPanel
-					data={userLatency?.data}
-					error={userLatency?.error}
-				/>
+				<UsersLatencyPanel data={userLatency.data} error={userLatency.error} />
 				<TemplateUsagePanel
 					css={{ gridColumn: "span 2" }}
-					data={templateInsights?.data?.report?.apps_usage}
-					error={templateInsights?.error}
+					data={templateInsights.data?.report?.apps_usage}
+					error={templateInsights.error}
 				/>
 				<UsersActivityPanel
-					data={userActivity?.data}
-					error={userActivity?.error}
+					data={userActivity.data}
+					error={userActivity.error}
 				/>
 				<TemplateParametersUsagePanel
 					css={{ gridColumn: "span 3" }}
-					data={templateInsights?.data?.report?.parameters_usage}
-					error={templateInsights?.error}
+					data={templateInsights.data?.report?.parameters_usage}
+					error={templateInsights.error}
 				/>
 			</div>
 		</>


### PR DESCRIPTION
Closes #20399 

I think half of the added lines are just moving the big mock template insights object in the related story.

To summarize the commit messages:

- Do not log stats to the database.
- Return errors on the insight endpoints.
- Update the frontend to show those errors.
- Also fixes an issue with getting the user status count via codersdk, since I added a test to ensure it was not disabled by this flag and it was sending the wrong payload.