### PR TITLE
fix(cli): remove defaulting to keyring when --global-config set

### DIFF
--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -61,10 +61,10 @@ func NewWithCommand(
 	t testing.TB, cmd *serpent.Command, args ...string,
 ) (*serpent.Invocation, config.Root) {
 	configDir := config.Root(t.TempDir())
-	// Keyring usage is disabled here because many existing tests expect the session token
-	// to be stored on disk and is not properly instrumented for parallel testing against
-	// the actual operating system keyring.
-	invArgs := append([]string{"--global-config", string(configDir), "--use-keyring=false"}, args...)
+	// Keyring usage is disabled here when --global-config is set because many existing
+	// tests expect the session token to be stored on disk and is not properly instrumented
+	// for parallel testing against the actual operating system keyring.
+	invArgs := append([]string{"--global-config", string(configDir)}, args...)
 	return setupInvocation(t, cmd, invArgs...), configDir
 }
 

--- a/cli/keyring_test.go
+++ b/cli/keyring_test.go
@@ -54,6 +54,7 @@ func setupKeyringTestEnv(t *testing.T, clientURL string, args ...string) keyring
 
 	serviceName := keyringTestServiceName(t)
 	root.WithKeyringServiceName(serviceName)
+	root.UseKeyringWithGlobalConfig()
 
 	inv, cfg := clitest.NewWithDefaultKeyringCommand(t, cmd, args...)
 
@@ -169,6 +170,7 @@ func TestUseKeyring(t *testing.T) {
 		logoutCmd, err := logoutRoot.Command(logoutRoot.AGPL())
 		require.NoError(t, err)
 		logoutRoot.WithKeyringServiceName(env.serviceName)
+		logoutRoot.UseKeyringWithGlobalConfig()
 
 		logoutInv, _ := clitest.NewWithDefaultKeyringCommand(t, logoutCmd,
 			"logout",

--- a/cli/root.go
+++ b/cli/root.go
@@ -484,9 +484,9 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 			Flag: varUseKeyring,
 			Env:  envUseKeyring,
 			Description: "Store and retrieve session tokens using the operating system " +
-				"keyring. Enabled by default when --global-config is not set. If the " +
-				"keyring is not supported on the current platform, file-based storage is " +
-				"used automatically. Set to false to force file-based storage.",
+				"keyring. This flag is ignored and file-based storage is used when " +
+				"--global-config is set or keyring usage is not supported on the current " +
+				"platform. Set to false to force file-based storage on supported platforms.",
 			Default: "true",
 			Value:   serpent.BoolOf(&r.useKeyring),
 			Group:   globalGroup,

--- a/cli/root.go
+++ b/cli/root.go
@@ -723,7 +723,7 @@ func (r *RootCmd) createUnauthenticatedClient(ctx context.Context, serverURL *ur
 func (r *RootCmd) ensureTokenBackend() sessionstore.Backend {
 	if r.tokenBackend == nil {
 		// Checking for the --global-config directory being set is a bit wonky but necessary
-		// to allow extensions that invoke the CLi with this flag (e.g. VS code) to continue
+		// to allow extensions that invoke the CLI with this flag (e.g. VS code) to continue
 		// working without modification. In the future we should modify these extensions to
 		// either access the credential in the keyring (like Coder Desktop) or some other
 		// approach that doesn't rely on the session token being stored on disk. We set the

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -111,9 +111,10 @@ variables or flags.
 
       --use-keyring bool, $CODER_USE_KEYRING (default: true)
           Store and retrieve session tokens using the operating system keyring.
-          Enabled by default when --global-config is not set. If the keyring is
-          not supported on the current platform, file-based storage is used
-          automatically. Set to false to force file-based storage.
+          This flag is ignored and file-based storage is used when
+          --global-config is set or keyring usage is not supported on the
+          current platform. Set to false to force file-based storage on
+          supported platforms.
 
   -v, --verbose bool, $CODER_VERBOSE
           Enable verbose output.

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -111,9 +111,9 @@ variables or flags.
 
       --use-keyring bool, $CODER_USE_KEYRING (default: true)
           Store and retrieve session tokens using the operating system keyring.
-          Enabled by default. If the keyring is not supported on the current
-          platform, file-based storage is used automatically. Set to false to
-          force file-based storage.
+          Enabled by default when --global-config is not set. If the keyring is
+          not supported on the current platform, file-based storage is used
+          automatically. Set to false to force file-based storage.
 
   -v, --verbose bool, $CODER_VERBOSE
           Enable verbose output.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -179,7 +179,7 @@ Disable network telemetry. Network telemetry is collected when connecting to wor
 | Environment | <code>$CODER_USE_KEYRING</code> |
 | Default     | <code>true</code>               |
 
-Store and retrieve session tokens using the operating system keyring. Enabled by default. If the keyring is not supported on the current platform, file-based storage is used automatically. Set to false to force file-based storage.
+Store and retrieve session tokens using the operating system keyring. Enabled by default when --global-config is not set. If the keyring is not supported on the current platform, file-based storage is used automatically. Set to false to force file-based storage.
 
 ### --global-config
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -179,7 +179,7 @@ Disable network telemetry. Network telemetry is collected when connecting to wor
 | Environment | <code>$CODER_USE_KEYRING</code> |
 | Default     | <code>true</code>               |
 
-Store and retrieve session tokens using the operating system keyring. Enabled by default when --global-config is not set. If the keyring is not supported on the current platform, file-based storage is used automatically. Set to false to force file-based storage.
+Store and retrieve session tokens using the operating system keyring. This flag is ignored and file-based storage is used when --global-config is set or keyring usage is not supported on the current platform. Set to false to force file-based storage on supported platforms.
 
 ### --global-config
 

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -70,9 +70,10 @@ variables or flags.
 
       --use-keyring bool, $CODER_USE_KEYRING (default: true)
           Store and retrieve session tokens using the operating system keyring.
-          Enabled by default when --global-config is not set. If the keyring is
-          not supported on the current platform, file-based storage is used
-          automatically. Set to false to force file-based storage.
+          This flag is ignored and file-based storage is used when
+          --global-config is set or keyring usage is not supported on the
+          current platform. Set to false to force file-based storage on
+          supported platforms.
 
   -v, --verbose bool, $CODER_VERBOSE
           Enable verbose output.

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -70,9 +70,9 @@ variables or flags.
 
       --use-keyring bool, $CODER_USE_KEYRING (default: true)
           Store and retrieve session tokens using the operating system keyring.
-          Enabled by default. If the keyring is not supported on the current
-          platform, file-based storage is used automatically. Set to false to
-          force file-based storage.
+          Enabled by default when --global-config is not set. If the keyring is
+          not supported on the current platform, file-based storage is used
+          automatically. Set to false to force file-based storage.
 
   -v, --verbose bool, $CODER_VERBOSE
           Enable verbose output.


### PR DESCRIPTION
This fixes a regression that caused the VS code extension to be unable to authenticate after making keyring usage on by default. This is because the VS code extension assumes the CLI will always use the session token stored on disk, specifically in the directory specified by --global-config.

This fix makes keyring usage enabled when the --global-config directory is not set. This is a bit wonky but necessary to allow the extension to continue working without modification and without backwards compat concerns. In the future we should modify these extensions to either access the credential in the keyring (like Coder Desktop) or some other approach that doesn't rely on the session token being stored on disk.

Tests:
`coder login dev.coder.com` -> token stored in keyring
`coder login --global-config=/tmp/ dev.coder.com` -> token stored in `/tmp/session`