### PR TITLE
chore: add license check for prebuilds

### DIFF
--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -460,6 +460,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		})
 		r.Route("/templates/{template}/prebuilds", func(r chi.Router) {
 			r.Use(
+				api.RequireFeatureMW(codersdk.FeatureWorkspacePrebuilds),
 				apiKeyMiddleware,
 				httpmw.ExtractTemplateParam(api.Database),
 			)

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -460,7 +460,6 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		})
 		r.Route("/templates/{template}/prebuilds", func(r chi.Router) {
 			r.Use(
-				api.templateRBACEnabledMW,
 				apiKeyMiddleware,
 				httpmw.ExtractTemplateParam(api.Database),
 			)

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -378,7 +378,12 @@ func (api *API) postInvalidateTemplatePresets(rw http.ResponseWriter, r *http.Re
 		slog.F("preset_count", len(invalidatedPresets)),
 	)
 
+	invalidated := db2sdk.InvalidatedPresets(invalidatedPresets)
+	if invalidated == nil {
+		invalidated = []codersdk.InvalidatedPreset{} // need to avoid nil value
+	}
+
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.InvalidatePresetsResponse{
-		Invalidated: db2sdk.InvalidatedPresets(invalidatedPresets),
+		Invalidated: invalidated,
 	})
 }

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -2153,6 +2153,11 @@ func TestInvalidateTemplatePrebuilds(t *testing.T) {
 		Options: &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 		},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureWorkspacePrebuilds: 1,
+			},
+		},
 	})
 	templateAdminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleTemplateAdmin())
 
@@ -2223,6 +2228,11 @@ func TestInvalidateTemplatePrebuilds_RegularUser(t *testing.T) {
 		Options: &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 		},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureWorkspacePrebuilds: 1,
+			},
+		},
 	})
 	regularUserClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
 
@@ -2263,6 +2273,11 @@ func TestInvalidateTemplatePrebuilds_NoPresets(t *testing.T) {
 	ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
+		},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureWorkspacePrebuilds: 1,
+			},
 		},
 	})
 	templateAdminClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleTemplateAdmin())

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -2230,7 +2230,7 @@ func TestInvalidateTemplatePrebuilds_RegularUser(t *testing.T) {
 	version1 := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, &echo.Responses{
 		Parse: echo.ParseComplete,
 		ProvisionPlan: []*proto.Response{
-			&proto.Response{
+			{
 				Type: &proto.Response_Plan{
 					Plan: &proto.PlanComplete{
 						Presets:    []*proto.Preset{presetWithParameters1},


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/20864

This PR relaxes the requirement for template rbac for template preset invalidation, and replaces it with a dedicated license check for workspace prebuilds.