### PR TITLE
fix(site): only show active tasks in waiting for input tab (#20933)

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -44,7 +44,7 @@ const TasksPage: FC = () => {
 		refetchInterval: 10_000,
 	});
 	const idleTasks = tasksQuery.data?.filter(
-		(task) => task.current_state?.state === "idle",
+		(task) => task.status === "active" && task.current_state?.state === "idle",
 	);
 	const displayedTasks =
 		tab.value === "waiting-for-input" ? idleTasks : tasksQuery.data;


### PR DESCRIPTION
This change filters out non-active tasks from the "Waiting for input"
tab filter for the tasks list.

---

🤖 This change was initially written by Claude Code using Coder Tasks, then reviewed and edited by a human 🏂

(cherry picked from commit b7d8918d6072fb2aa4daff74e4910d0e1e9dc28b)