### PR TITLE
fix: pass context with authorization to agentapi

### DIFF
--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -36,7 +36,7 @@ import (
 	"github.com/coder/quartz"
 )
 
-const workspaceCacheRefreshInterval = 1 * time.Minute
+const workspaceCacheRefreshInterval = 5 * time.Minute
 
 // API implements the DRPC agent API interface from agent/proto. This struct is
 // instantiated once per agent connection and kept alive for the duration of the
@@ -275,7 +275,6 @@ func (a *API) agent(ctx context.Context) (database.WorkspaceAgent, error) {
 // This ensures that changes like prebuild claims (which modify owner_id, name, etc.)
 // are eventually reflected in the cache without requiring agent reconnection.
 func (a *API) refreshCachedWorkspace(ctx context.Context) {
-	a.opts.Log.Debug(ctx, "refreshing cached workspace", slog.F("test", "test"))
 	ws, err := a.opts.Database.GetWorkspaceByID(ctx, a.opts.WorkspaceID)
 	if err != nil {
 		a.opts.Log.Warn(ctx, "failed to refresh cached workspace fields", slog.Error(err))

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -671,15 +671,15 @@ func TestBatchUpdateMetadata(t *testing.T) {
 
 		// Create full API with cached workspace fields (initial state)
 		api := agentapi.New(agentapi.Options{
-			AuthenticatedCtx:            ctxWithActor,
-			AgentID:        agentID,
-			WorkspaceID:    workspaceID,
-			OwnerID:        ownerID,
-			OrganizationID: orgID,
-			Database:       dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
-			Log:            testutil.Logger(t),
-			Clock:          mClock,
-			Pubsub:         pub,
+			AuthenticatedCtx: ctxWithActor,
+			AgentID:          agentID,
+			WorkspaceID:      workspaceID,
+			OwnerID:          ownerID,
+			OrganizationID:   orgID,
+			Database:         dbauthz.New(dbM, auth, testutil.Logger(t), accessControlStore),
+			Log:              testutil.Logger(t),
+			Clock:            mClock,
+			Pubsub:           pub,
 		}, initialWorkspace) // Cache is initialized with 9am schedule and "my-workspace" name
 
 		// Wait for ticker to be set up and release it so it can fire

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -671,7 +671,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 
 		// Create full API with cached workspace fields (initial state)
 		api := agentapi.New(agentapi.Options{
-			Ctx:            ctxWithActor,
+			AuthenticatedCtx:            ctxWithActor,
 			AgentID:        agentID,
 			WorkspaceID:    workspaceID,
 			OwnerID:        ownerID,

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -132,7 +132,7 @@ func (api *API) workspaceAgentRPC(rw http.ResponseWriter, r *http.Request) {
 		WorkspaceID:    workspace.ID,
 		OrganizationID: workspace.OrganizationID,
 
-		Ctx:                               ctx,
+		AuthenticatedCtx:                  ctx,
 		Log:                               logger,
 		Clock:                             api.Clock,
 		Database:                          api.Database,

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -132,7 +132,7 @@ func (api *API) workspaceAgentRPC(rw http.ResponseWriter, r *http.Request) {
 		WorkspaceID:    workspace.ID,
 		OrganizationID: workspace.OrganizationID,
 
-		Ctx:                               api.ctx,
+		Ctx:                               ctx,
 		Log:                               logger,
 		Clock:                             api.Clock,
 		Database:                          api.Database,


### PR DESCRIPTION
The agentapi context needs to be a context with some amount of authorization attached to it via the context so that the cache refresh routine can fetch the workspace from the db via GetWorkspaceForAgentID.
