### PR TITLE
fix: ensure we check if the user can actually see `ai bridge`

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -34,7 +34,8 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = ({
 		!canViewConnectionLog &&
 		!canViewOrganizations &&
 		!canViewDeployment &&
-		!canViewHealth
+		!canViewHealth &&
+		!canViewAIBridge
 	) {
 		return null;
 	}


### PR DESCRIPTION
This is a smaller commit ensuring that #20942 also makes this release.

> There was a mild regression here where-in if the user only had `AI Bridge` they wouldn't be able to see this content in the dropdown menu. This was necessary for reasons earlier with it being an experiment however its now fine to check for this and won't upset anything.