### PR TITLE
feat(cli/cliui): output empty string for empty table

### DIFF
--- a/cli/cliui/output.go
+++ b/cli/cliui/output.go
@@ -106,6 +106,9 @@ var _ OutputFormat = &tableFormat{}
 //
 // defaultColumns is optional and specifies the default columns to display. If
 // not specified, all columns are displayed by default.
+//
+// If the data is empty, an empty string is returned. Callers should check for
+// this and provide an appropriate message to the user.
 func TableFormat(out any, defaultColumns []string) OutputFormat {
 	v := reflect.Indirect(reflect.ValueOf(out))
 	if v.Kind() != reflect.Slice {
@@ -150,6 +153,13 @@ func (f *tableFormat) AttachOptions(opts *serpent.OptionSet) {
 
 // Format implements OutputFormat.
 func (f *tableFormat) Format(_ context.Context, data any) (string, error) {
+	// Return empty string for empty data. Callers should check for this
+	// and provide an appropriate message to the user.
+	v := reflect.Indirect(reflect.ValueOf(data))
+	if v.Kind() == reflect.Slice && v.Len() == 0 {
+		return "", nil
+	}
+
 	headers := make(table.Row, len(f.allColumns))
 	for i, header := range f.allColumns {
 		headers[i] = header

--- a/cli/cliui/output.go
+++ b/cli/cliui/output.go
@@ -153,13 +153,6 @@ func (f *tableFormat) AttachOptions(opts *serpent.OptionSet) {
 
 // Format implements OutputFormat.
 func (f *tableFormat) Format(_ context.Context, data any) (string, error) {
-	// Return empty string for empty data. Callers should check for this
-	// and provide an appropriate message to the user.
-	v := reflect.Indirect(reflect.ValueOf(data))
-	if v.Kind() == reflect.Slice && v.Len() == 0 {
-		return "", nil
-	}
-
 	headers := make(table.Row, len(f.allColumns))
 	for i, header := range f.allColumns {
 		headers[i] = header

--- a/cli/cliui/output_test.go
+++ b/cli/cliui/output_test.go
@@ -136,3 +136,24 @@ func Test_OutputFormatter(t *testing.T) {
 		require.EqualValues(t, 2, atomic.LoadInt64(&called))
 	})
 }
+
+type tableFormatTestRow struct {
+	Name string `table:"name,default_sort"`
+	Age  int    `table:"age"`
+}
+
+func Test_TableFormat_EmptyData(t *testing.T) {
+	t.Parallel()
+
+	f := cliui.NewOutputFormatter(
+		cliui.TableFormat([]tableFormatTestRow{}, nil),
+		cliui.JSONFormat(),
+	)
+
+	ctx := context.Background()
+	var emptyData []tableFormatTestRow
+
+	out, err := f.Format(ctx, emptyData)
+	require.NoError(t, err)
+	require.Equal(t, "", out)
+}

--- a/cli/cliui/output_test.go
+++ b/cli/cliui/output_test.go
@@ -136,24 +136,3 @@ func Test_OutputFormatter(t *testing.T) {
 		require.EqualValues(t, 2, atomic.LoadInt64(&called))
 	})
 }
-
-type tableFormatTestRow struct {
-	Name string `table:"name,default_sort"`
-	Age  int    `table:"age"`
-}
-
-func Test_TableFormat_EmptyData(t *testing.T) {
-	t.Parallel()
-
-	f := cliui.NewOutputFormatter(
-		cliui.TableFormat([]tableFormatTestRow{}, nil),
-		cliui.JSONFormat(),
-	)
-
-	ctx := context.Background()
-	var emptyData []tableFormatTestRow
-
-	out, err := f.Format(ctx, emptyData)
-	require.NoError(t, err)
-	require.Equal(t, "", out)
-}

--- a/cli/cliui/table.go
+++ b/cli/cliui/table.go
@@ -180,6 +180,12 @@ func DisplayTable(out any, sort string, filterColumns []string) (string, error) 
 func renderTable(out any, sort string, headers table.Row, filterColumns []string) (string, error) {
 	v := reflect.Indirect(reflect.ValueOf(out))
 
+	// Return empty string for empty data. Callers should check for this
+	// and provide an appropriate message to the user.
+	if v.Kind() == reflect.Slice && v.Len() == 0 {
+		return "", nil
+	}
+
 	headers = filterHeaders(headers, filterColumns)
 	columnConfigs := createColumnConfigs(headers, filterColumns)
 

--- a/cli/cliui/table_test.go
+++ b/cli/cliui/table_test.go
@@ -472,6 +472,15 @@ alice  1
 		require.NoError(t, err)
 		compareTables(t, expected, out)
 	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
+		var in []tableTest4
+		out, err := cliui.DisplayTable(in, "", nil)
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
 }
 
 // compareTables normalizes the incoming table lines

--- a/cli/list.go
+++ b/cli/list.go
@@ -139,17 +139,17 @@ func (r *RootCmd) list() *serpent.Command {
 				return err
 			}
 
-			if len(res) == 0 && formatter.FormatID() != cliui.JSONFormat().ID() {
+			out, err := formatter.Format(inv.Context(), res)
+			if err != nil {
+				return err
+			}
+
+			if out == "" {
 				pretty.Fprintf(inv.Stderr, cliui.DefaultStyles.Prompt, "No workspaces found! Create one:\n")
 				_, _ = fmt.Fprintln(inv.Stderr)
 				_, _ = fmt.Fprintln(inv.Stderr, "  "+pretty.Sprint(cliui.DefaultStyles.Code, "coder create <name>"))
 				_, _ = fmt.Fprintln(inv.Stderr)
 				return nil
-			}
-
-			out, err := formatter.Format(inv.Context(), res)
-			if err != nil {
-				return err
 			}
 
 			_, err = fmt.Fprintln(inv.Stdout, out)

--- a/cli/organizationmembers.go
+++ b/cli/organizationmembers.go
@@ -171,7 +171,7 @@ func (r *RootCmd) listOrganizationMembers(orgContext *OrganizationContext) *serp
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No organization members found.")
+				cliui.Infof(inv.Stderr, "No organization members found.")
 				return nil
 			}
 

--- a/cli/organizationmembers.go
+++ b/cli/organizationmembers.go
@@ -170,6 +170,11 @@ func (r *RootCmd) listOrganizationMembers(orgContext *OrganizationContext) *serp
 				return err
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No organization members found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -93,7 +93,7 @@ func (r *RootCmd) showOrganizationRoles(orgContext *OrganizationContext) *serpen
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No organization roles found.")
+				cliui.Infof(inv.Stderr, "No organization roles found.")
 				return nil
 			}
 

--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -92,6 +92,11 @@ func (r *RootCmd) showOrganizationRoles(orgContext *OrganizationContext) *serpen
 				return err
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No organization roles found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -110,6 +110,11 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 				return xerrors.Errorf("display provisioner daemons: %w", err)
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No provisioner jobs found.")
+				return nil
+			}
+
 			_, _ = fmt.Fprintln(inv.Stdout, out)
 
 			return nil

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -111,7 +111,7 @@ func (r *RootCmd) provisionerJobsList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No provisioner jobs found.")
+				cliui.Infof(inv.Stderr, "No provisioner jobs found.")
 				return nil
 			}
 

--- a/cli/provisioners.go
+++ b/cli/provisioners.go
@@ -74,11 +74,6 @@ func (r *RootCmd) provisionerList() *serpent.Command {
 				return xerrors.Errorf("list provisioner daemons: %w", err)
 			}
 
-			if len(daemons) == 0 {
-				_, _ = fmt.Fprintln(inv.Stdout, "No provisioner daemons found")
-				return nil
-			}
-
 			var rows []provisionerDaemonRow
 			for _, daemon := range daemons {
 				rows = append(rows, provisionerDaemonRow{
@@ -90,6 +85,11 @@ func (r *RootCmd) provisionerList() *serpent.Command {
 			out, err := formatter.Format(ctx, rows)
 			if err != nil {
 				return xerrors.Errorf("display provisioner daemons: %w", err)
+			}
+
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No provisioner daemons found.")
+				return nil
 			}
 
 			_, _ = fmt.Fprintln(inv.Stdout, out)

--- a/cli/provisioners.go
+++ b/cli/provisioners.go
@@ -88,7 +88,7 @@ func (r *RootCmd) provisionerList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No provisioner daemons found.")
+				cliui.Infof(inv.Stderr, "No provisioner daemons found.")
 				return nil
 			}
 

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -129,6 +129,11 @@ func (r *RootCmd) scheduleShow() *serpent.Command {
 				return err
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No schedules found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -130,7 +130,7 @@ func (r *RootCmd) scheduleShow() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No schedules found.")
+				cliui.Infof(inv.Stderr, "No schedules found.")
 				return nil
 			}
 

--- a/cli/task_list.go
+++ b/cli/task_list.go
@@ -168,7 +168,7 @@ func (r *RootCmd) taskList() *serpent.Command {
 				return xerrors.Errorf("format tasks: %w", err)
 			}
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No tasks found.")
+				cliui.Infof(inv.Stderr, "No tasks found.")
 				return nil
 			}
 			_, _ = fmt.Fprintln(inv.Stdout, out)

--- a/cli/task_list.go
+++ b/cli/task_list.go
@@ -157,12 +157,6 @@ func (r *RootCmd) taskList() *serpent.Command {
 				return nil
 			}
 
-			// If no rows and not JSON, show a friendly message.
-			if len(tasks) == 0 && formatter.FormatID() != cliui.JSONFormat().ID() {
-				_, _ = fmt.Fprintln(inv.Stderr, "No tasks found.")
-				return nil
-			}
-
 			rows := make([]taskListRow, len(tasks))
 			now := time.Now()
 			for i := range tasks {
@@ -172,6 +166,10 @@ func (r *RootCmd) taskList() *serpent.Command {
 			out, err := formatter.Format(ctx, rows)
 			if err != nil {
 				return xerrors.Errorf("format tasks: %w", err)
+			}
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No tasks found.")
+				return nil
 			}
 			_, _ = fmt.Fprintln(inv.Stdout, out)
 			return nil

--- a/cli/task_logs.go
+++ b/cli/task_logs.go
@@ -60,7 +60,7 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No task logs found.")
+				cliui.Infof(inv.Stderr, "No task logs found.")
 				return nil
 			}
 

--- a/cli/task_logs.go
+++ b/cli/task_logs.go
@@ -59,6 +59,11 @@ func (r *RootCmd) taskLogs() *serpent.Command {
 				return xerrors.Errorf("format task logs: %w", err)
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No task logs found.")
+				return nil
+			}
+
 			_, _ = fmt.Fprintln(inv.Stdout, out)
 			return nil
 		},

--- a/cli/templatelist.go
+++ b/cli/templatelist.go
@@ -30,16 +30,16 @@ func (r *RootCmd) templateList() *serpent.Command {
 				return err
 			}
 
-			if len(templates) == 0 {
-				_, _ = fmt.Fprintf(inv.Stderr, "%s No templates found! Create one:\n\n", Caret)
-				_, _ = fmt.Fprintln(inv.Stderr, color.HiMagentaString("  $ coder templates push <directory>\n"))
-				return nil
-			}
-
 			rows := templatesToRows(templates...)
 			out, err := formatter.Format(inv.Context(), rows)
 			if err != nil {
 				return err
+			}
+
+			if out == "" {
+				_, _ = fmt.Fprintf(inv.Stderr, "%s No templates found! Create one:\n\n", Caret)
+				_, _ = fmt.Fprintln(inv.Stderr, color.HiMagentaString("  $ coder templates push <directory>\n"))
+				return nil
 			}
 
 			_, err = fmt.Fprintln(inv.Stdout, out)

--- a/cli/templatepresets.go
+++ b/cli/templatepresets.go
@@ -106,7 +106,7 @@ func (r *RootCmd) templatePresetsList() *serpent.Command {
 			if len(presets) == 0 {
 				cliui.Infof(
 					inv.Stdout,
-					"No presets found for template %q and template-version %q.\n", template.Name, version.Name,
+					"No presets found for template %q and template-version %q.", template.Name, version.Name,
 				)
 				return nil
 			}
@@ -115,7 +115,7 @@ func (r *RootCmd) templatePresetsList() *serpent.Command {
 			if formatter.FormatID() == "table" {
 				cliui.Infof(
 					inv.Stdout,
-					"Showing presets for template %q and template version %q.\n", template.Name, version.Name,
+					"Showing presets for template %q and template version %q.", template.Name, version.Name,
 				)
 			}
 			rows := templatePresetsToRows(presets...)
@@ -125,7 +125,7 @@ func (r *RootCmd) templatePresetsList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No template presets found.")
+				cliui.Infof(inv.Stderr, "No template presets found.")
 				return nil
 			}
 

--- a/cli/templatepresets.go
+++ b/cli/templatepresets.go
@@ -124,6 +124,11 @@ func (r *RootCmd) templatePresetsList() *serpent.Command {
 				return xerrors.Errorf("render table: %w", err)
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No template presets found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -122,7 +122,7 @@ func (r *RootCmd) templateVersionsList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No template versions found.")
+				cliui.Infof(inv.Stderr, "No template versions found.")
 				return nil
 			}
 

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -121,6 +121,11 @@ func (r *RootCmd) templateVersionsList() *serpent.Command {
 				return xerrors.Errorf("render table: %w", err)
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No template versions found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -258,7 +258,7 @@ func (r *RootCmd) listTokens() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No tokens found.")
+				cliui.Info(inv.Stderr, "No tokens found.")
 				return nil
 			}
 

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -246,13 +246,6 @@ func (r *RootCmd) listTokens() *serpent.Command {
 				return xerrors.Errorf("list tokens: %w", err)
 			}
 
-			if len(tokens) == 0 {
-				cliui.Infof(
-					inv.Stdout,
-					"No tokens found.\n",
-				)
-			}
-
 			displayTokens = make([]tokenListRow, len(tokens))
 
 			for i, token := range tokens {
@@ -262,6 +255,11 @@ func (r *RootCmd) listTokens() *serpent.Command {
 			out, err := formatter.Format(inv.Context(), displayTokens)
 			if err != nil {
 				return err
+			}
+
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No tokens found.")
+				return nil
 			}
 
 			_, err = fmt.Fprintln(inv.Stdout, out)

--- a/cli/tokens_test.go
+++ b/cli/tokens_test.go
@@ -34,6 +34,7 @@ func TestTokens(t *testing.T) {
 	clitest.SetupConfig(t, client, root)
 	buf := new(bytes.Buffer)
 	inv.Stdout = buf
+	inv.Stderr = buf
 	err := inv.WithContext(ctx).Run()
 	require.NoError(t, err)
 	res := buf.String()

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -59,7 +59,7 @@ func (r *RootCmd) userList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No users found.")
+				cliui.Infof(inv.Stderr, "No users found.")
 				return nil
 			}
 

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -58,6 +58,11 @@ func (r *RootCmd) userList() *serpent.Command {
 				return err
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No users found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/enterprise/cli/externalworkspaces.go
+++ b/enterprise/cli/externalworkspaces.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/pretty"
+
 	"github.com/coder/serpent"
 )
 
@@ -197,17 +198,17 @@ func (r *RootCmd) externalWorkspaceList() *serpent.Command {
 				return err
 			}
 
-			if len(res) == 0 && formatter.FormatID() != cliui.JSONFormat().ID() {
+			out, err := formatter.Format(inv.Context(), res)
+			if err != nil {
+				return err
+			}
+
+			if out == "" {
 				pretty.Fprintf(inv.Stderr, cliui.DefaultStyles.Prompt, "No workspaces found! Create one:\n")
 				_, _ = fmt.Fprintln(inv.Stderr)
 				_, _ = fmt.Fprintln(inv.Stderr, "  "+pretty.Sprint(cliui.DefaultStyles.Code, "coder external-workspaces create <name>"))
 				_, _ = fmt.Fprintln(inv.Stderr)
 				return nil
-			}
-
-			out, err := formatter.Format(inv.Context(), res)
-			if err != nil {
-				return err
 			}
 
 			_, err = fmt.Fprintln(inv.Stdout, out)

--- a/enterprise/cli/grouplist.go
+++ b/enterprise/cli/grouplist.go
@@ -43,16 +43,16 @@ func (r *RootCmd) groupList() *serpent.Command {
 				return xerrors.Errorf("get groups: %w", err)
 			}
 
-			if len(groups) == 0 {
-				_, _ = fmt.Fprintf(inv.Stderr, "%s No groups found in %s! Create one:\n\n", agpl.Caret, color.HiWhiteString(org.Name))
-				_, _ = fmt.Fprintln(inv.Stderr, color.HiMagentaString("  $ coder groups create <name>\n"))
-				return nil
-			}
-
 			rows := groupsToRows(groups...)
 			out, err := formatter.Format(inv.Context(), rows)
 			if err != nil {
 				return xerrors.Errorf("display groups: %w", err)
+			}
+
+			if out == "" {
+				_, _ = fmt.Fprintf(inv.Stderr, "%s No groups found in %s! Create one:\n\n", agpl.Caret, color.HiWhiteString(org.Name))
+				_, _ = fmt.Fprintln(inv.Stderr, color.HiMagentaString("  $ coder groups create <name>\n"))
+				return nil
 			}
 
 			_, _ = fmt.Fprintln(inv.Stdout, out)

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -167,7 +167,7 @@ func (r *RootCmd) licensesList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No licenses found.")
+				cliui.Infof(inv.Stderr, "No licenses found.")
 				return nil
 			}
 

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -166,6 +166,11 @@ func (r *RootCmd) licensesList() *serpent.Command {
 				return err
 			}
 
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No licenses found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, out)
 			return err
 		},

--- a/enterprise/cli/provisionerkeys.go
+++ b/enterprise/cli/provisionerkeys.go
@@ -132,7 +132,7 @@ func (r *RootCmd) provisionerKeysList() *serpent.Command {
 			}
 
 			if out == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No provisioner keys found.")
+				cliui.Infof(inv.Stderr, "No provisioner keys found.")
 				return nil
 			}
 

--- a/enterprise/cli/provisionerkeys.go
+++ b/enterprise/cli/provisionerkeys.go
@@ -126,14 +126,14 @@ func (r *RootCmd) provisionerKeysList() *serpent.Command {
 				return xerrors.Errorf("list provisioner keys: %w", err)
 			}
 
-			if len(keys) == 0 {
-				_, _ = fmt.Fprintln(inv.Stdout, "No provisioner keys found")
-				return nil
-			}
-
 			out, err := formatter.Format(inv.Context(), keys)
 			if err != nil {
 				return xerrors.Errorf("display provisioner keys: %w", err)
+			}
+
+			if out == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No provisioner keys found.")
+				return nil
 			}
 
 			_, _ = fmt.Fprintln(inv.Stdout, out)

--- a/enterprise/cli/provisionerkeys_test.go
+++ b/enterprise/cli/provisionerkeys_test.go
@@ -94,6 +94,7 @@ func TestProvisionerKeys(t *testing.T) {
 		)
 		pty = ptytest.New(t)
 		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
 		clitest.SetupConfig(t, orgAdminClient, conf)
 
 		err = inv.WithContext(ctx).Run()

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -393,7 +393,7 @@ func (r *RootCmd) listProxies() *serpent.Command {
 			}
 
 			if output == "" {
-				_, _ = fmt.Fprintln(inv.Stderr, "No workspace proxies found.")
+				cliui.Infof(inv.Stderr, "No workspace proxies found.")
 				return nil
 			}
 

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -392,6 +392,11 @@ func (r *RootCmd) listProxies() *serpent.Command {
 				return err
 			}
 
+			if output == "" {
+				_, _ = fmt.Fprintln(inv.Stderr, "No workspace proxies found.")
+				return nil
+			}
+
 			_, err = fmt.Fprintln(inv.Stdout, output)
 			return err
 		},


### PR DESCRIPTION
This changes makes it so that we output the empty string for Format
when there is no data. It turns out there are many places in the code
where we have such handling, but in a way that would break the JSON
formatter (since we'd output nothing on stdout or text rather than
`[]`/`null`).
