### PR TITLE
chore: add index on app_id in workspace_app_statuses

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -3373,6 +3373,8 @@ CREATE UNIQUE INDEX idx_users_email ON users USING btree (email) WHERE (deleted 
 
 CREATE UNIQUE INDEX idx_users_username ON users USING btree (username) WHERE (deleted = false);
 
+CREATE INDEX idx_workspace_app_statuses_app_id ON workspace_app_statuses USING btree (app_id);
+
 CREATE INDEX idx_workspace_app_statuses_workspace_id_created_at ON workspace_app_statuses USING btree (workspace_id, created_at DESC);
 
 CREATE INDEX idx_workspace_builds_initiator_id ON workspace_builds USING btree (initiator_id);

--- a/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.down.sql
+++ b/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_workspace_app_statuses_app_id;

--- a/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.up.sql
+++ b/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_workspace_app_statuses_app_id ON workspace_app_statuses(app_id);


### PR DESCRIPTION
Adds an index on the `app_id` column in the `workspace_app_statuses` table to improve query performance when filtering by app.

The table already has an index on `(workspace_id, created_at)` but queries that look up statuses by `app_id` (the foreign key to `workspace_apps`) would benefit from a dedicated index.

Improves the `GetWorkspaceAppStatusesByAppIDs` query which filters on `app_id = ANY($1 :: uuid [ ])` and previously resulted in a sequential scan.