### PR TITLE
test: use toHaveValue() to avoid flaky parameter verification

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -207,8 +207,7 @@ export const verifyParameters = async (
 			case "number":
 				{
 					const parameterField = parameterLabel.locator("input");
-					const value = await parameterField.inputValue();
-					expect(value).toEqual(buildParameter.value);
+					await expect(parameterField).toHaveValue(buildParameter.value);
 				}
 				break;
 			default:


### PR DESCRIPTION
## Problem

The test `create workspace with default and required parameters` was flaky because `verifyParameters` in `site/e2e/helpers.ts` didn't wait for input values to be populated before asserting.

After PR #20710 removed classic parameters, the form now uses dynamic parameters loaded asynchronously via WebSocket. The input field can be visible before its value is populated.

Closes https://github.com/coder/internal/issues/1154

## Fix

Replace immediate read + assertion:
```typescript
const value = await parameterField.inputValue();
expect(value).toEqual(buildParameter.value);
```

With Playwright's auto-retrying assertion:
```typescript
await expect(parameterField).toHaveValue(buildParameter.value);
```

From [Playwright docs for `inputValue()`](https://playwright.dev/docs/api/class-locator#locator-input-value):

> **NOTE** If you need to assert input value, prefer `expect(locator).toHaveValue(value[, options])` to avoid flakiness. See assertions guide for more details.

---

This PR was fully generated by [mux](https://github.com/coder/mux), and reviewed by a human.