### PR TITLE
chore: fix dependabot terraform module grouping pattern

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -119,9 +119,9 @@ updates:
     commit-message:
       prefix: "chore"
     groups:
-      coder:
+      coder-modules:
         patterns:
-          - "registry.coder.com/coder/*/coder"
+          - "coder/*/coder"
     labels: []
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
Fixes the terraform module grouping pattern in dependabot.yaml that wasn't working.

## Problem

Dependabot was creating individual PRs for each Coder terraform module instead of grouping them together.

## Root Cause

The pattern `registry.coder.com/coder/*/coder` included the registry hostname, but dependabot strips the hostname when naming dependencies. So a module sourced from:

```hcl
source = "registry.coder.com/coder/code-server/coder"
```

Gets named `coder/code-server/coder` by dependabot (without the hostname).

## Fix

Changed the pattern from `registry.coder.com/coder/*/coder` to `coder/*/coder` to match the actual dependency names dependabot uses.

This will group updates for modules from both `registry.coder.com` and `dev.registry.coder.com` since the hostname is stripped in both cases.