### PR TITLE
feat(coderd): add retention policy configuration

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -709,21 +709,13 @@ that data type.
           deletion of expired keys.
 
       --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
-          How long audit log entries are retained. Set to 0 to use the global
-          retention value, or to disable if global is also 0. We advise keeping
-          audit logs for at least a year, and in accordance with your compliance
-          requirements.
+          How long audit log entries are retained. Set to 0 to disable (keep
+          indefinitely). We advise keeping audit logs for at least a year, and
+          in accordance with your compliance requirements.
 
       --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
-          How long connection log entries are retained. Set to 0 to use the
-          global retention value, or to disable if global is also 0.
-
-      --global-retention duration, $CODER_GLOBAL_RETENTION (default: 0)
-          Default retention policy for audit logs, connection logs, and API
-          keys. Individual retention settings override this value when set to a
-          non-zero duration. Does not affect AI Bridge retention. Set to 0 to
-          disable (data is kept indefinitely unless individual settings are
-          configured).
+          How long connection log entries are retained. Set to 0 to disable
+          (keep indefinitely).
 
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -710,7 +710,9 @@ that data type.
 
       --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
           How long audit log entries are retained. Set to 0 to use the global
-          retention value, or to disable if global is also 0.
+          retention value, or to disable if global is also 0. We advise keeping
+          audit logs for at least a year, and in accordance with your compliance
+          requirements.
 
       --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
           How long connection log entries are retained. Set to 0 to use the

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -696,6 +696,33 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
+RETENTION OPTIONS: 
+Configure data retention policies for various database tables. Retention
+policies automatically purge old data to reduce database size and improve
+performance. Setting a retention duration to 0 disables automatic purging for
+that data type.
+
+      --api-keys-retention duration, $CODER_API_KEYS_RETENTION (default: 7d)
+          How long expired API keys are retained before being deleted. Keeping
+          expired keys allows the backend to return a more helpful error when a
+          user tries to use an expired key. Set to 0 to disable automatic
+          deletion of expired keys.
+
+      --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
+          How long audit log entries are retained. Set to 0 to use the global
+          retention value, or to disable if global is also 0.
+
+      --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
+          How long connection log entries are retained. Set to 0 to use the
+          global retention value, or to disable if global is also 0.
+
+      --global-retention duration, $CODER_GLOBAL_RETENTION (default: 0)
+          Default retention policy for audit logs, connection logs, and API
+          keys. Individual retention settings override this value when set to a
+          non-zero duration. Does not affect AI Bridge retention. Set to 0 to
+          disable (data is kept indefinitely unless individual settings are
+          configured).
+
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -742,3 +742,27 @@ aibridge:
   # (token, prompt, tool use).
   # (default: 60d, type: duration)
   retention: 1440h0m0s
+# Configure data retention policies for various database tables. Retention
+# policies automatically purge old data to reduce database size and improve
+# performance. Setting a retention duration to 0 disables automatic purging for
+# that data type.
+retention:
+  # Default retention policy for audit logs, connection logs, and API keys.
+  # Individual retention settings override this value when set to a non-zero
+  # duration. Does not affect AI Bridge retention. Set to 0 to disable (data is kept
+  # indefinitely unless individual settings are configured).
+  # (default: 0, type: duration)
+  global: 0s
+  # How long audit log entries are retained. Set to 0 to use the global retention
+  # value, or to disable if global is also 0.
+  # (default: 0, type: duration)
+  audit_logs: 0s
+  # How long connection log entries are retained. Set to 0 to use the global
+  # retention value, or to disable if global is also 0.
+  # (default: 0, type: duration)
+  connection_logs: 0s
+  # How long expired API keys are retained before being deleted. Keeping expired
+  # keys allows the backend to return a more helpful error when a user tries to use
+  # an expired key. Set to 0 to disable automatic deletion of expired keys.
+  # (default: 7d, type: duration)
+  api_keys: 168h0m0s

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -754,7 +754,8 @@ retention:
   # (default: 0, type: duration)
   global: 0s
   # How long audit log entries are retained. Set to 0 to use the global retention
-  # value, or to disable if global is also 0.
+  # value, or to disable if global is also 0. We advise keeping audit logs for at
+  # least a year, and in accordance with your compliance requirements.
   # (default: 0, type: duration)
   audit_logs: 0s
   # How long connection log entries are retained. Set to 0 to use the global

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -747,19 +747,13 @@ aibridge:
 # performance. Setting a retention duration to 0 disables automatic purging for
 # that data type.
 retention:
-  # Default retention policy for audit logs, connection logs, and API keys.
-  # Individual retention settings override this value when set to a non-zero
-  # duration. Does not affect AI Bridge retention. Set to 0 to disable (data is kept
-  # indefinitely unless individual settings are configured).
-  # (default: 0, type: duration)
-  global: 0s
-  # How long audit log entries are retained. Set to 0 to use the global retention
-  # value, or to disable if global is also 0. We advise keeping audit logs for at
-  # least a year, and in accordance with your compliance requirements.
+  # How long audit log entries are retained. Set to 0 to disable (keep
+  # indefinitely). We advise keeping audit logs for at least a year, and in
+  # accordance with your compliance requirements.
   # (default: 0, type: duration)
   audit_logs: 0s
-  # How long connection log entries are retained. Set to 0 to use the global
-  # retention value, or to disable if global is also 0.
+  # How long connection log entries are retained. Set to 0 to disable (keep
+  # indefinitely).
   # (default: 0, type: duration)
   connection_logs: 0s
   # How long expired API keys are retained before being deleted. Keeping expired

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14302,6 +14302,9 @@ const docTemplate = `{
                 "redirect_to_access_url": {
                     "type": "boolean"
                 },
+                "retention": {
+                    "$ref": "#/definitions/codersdk.RetentionConfig"
+                },
                 "scim_api_key": {
                     "type": "string"
                 },
@@ -17725,6 +17728,27 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.ValidationError"
                     }
+                }
+            }
+        },
+        "codersdk.RetentionConfig": {
+            "type": "object",
+            "properties": {
+                "api_keys": {
+                    "description": "APIKeys controls how long expired API keys are retained before being deleted.\nKeys are only deleted if they have been expired for at least this duration.\nDefaults to 7 days to preserve existing behavior.",
+                    "type": "integer"
+                },
+                "audit_logs": {
+                    "description": "AuditLogs controls how long audit log entries are retained.\nSet to 0 to use the global retention value.",
+                    "type": "integer"
+                },
+                "connection_logs": {
+                    "description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to use the global retention value.",
+                    "type": "integer"
+                },
+                "global": {
+                    "description": "Global is the default retention policy for audit logs, connection logs,\nand API keys. Individual retention settings override this value when set\nto a non-zero duration. Does not affect AI Bridge retention which has its\nown setting.",
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17739,15 +17739,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "audit_logs": {
-                    "description": "AuditLogs controls how long audit log entries are retained.\nSet to 0 to use the global retention value.",
+                    "description": "AuditLogs controls how long audit log entries are retained.\nSet to 0 to disable (keep indefinitely).",
                     "type": "integer"
                 },
                 "connection_logs": {
-                    "description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to use the global retention value.",
-                    "type": "integer"
-                },
-                "global": {
-                    "description": "Global is the default retention policy for audit logs, connection logs,\nand API keys. Individual retention settings override this value when set\nto a non-zero duration. Does not affect AI Bridge retention which has its\nown setting.",
+                    "description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to disable (keep indefinitely).",
                     "type": "integer"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12886,6 +12886,9 @@
 				"redirect_to_access_url": {
 					"type": "boolean"
 				},
+				"retention": {
+					"$ref": "#/definitions/codersdk.RetentionConfig"
+				},
 				"scim_api_key": {
 					"type": "string"
 				},
@@ -16187,6 +16190,27 @@
 					"items": {
 						"$ref": "#/definitions/codersdk.ValidationError"
 					}
+				}
+			}
+		},
+		"codersdk.RetentionConfig": {
+			"type": "object",
+			"properties": {
+				"api_keys": {
+					"description": "APIKeys controls how long expired API keys are retained before being deleted.\nKeys are only deleted if they have been expired for at least this duration.\nDefaults to 7 days to preserve existing behavior.",
+					"type": "integer"
+				},
+				"audit_logs": {
+					"description": "AuditLogs controls how long audit log entries are retained.\nSet to 0 to use the global retention value.",
+					"type": "integer"
+				},
+				"connection_logs": {
+					"description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to use the global retention value.",
+					"type": "integer"
+				},
+				"global": {
+					"description": "Global is the default retention policy for audit logs, connection logs,\nand API keys. Individual retention settings override this value when set\nto a non-zero duration. Does not affect AI Bridge retention which has its\nown setting.",
+					"type": "integer"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16201,15 +16201,11 @@
 					"type": "integer"
 				},
 				"audit_logs": {
-					"description": "AuditLogs controls how long audit log entries are retained.\nSet to 0 to use the global retention value.",
+					"description": "AuditLogs controls how long audit log entries are retained.\nSet to 0 to disable (keep indefinitely).",
 					"type": "integer"
 				},
 				"connection_logs": {
-					"description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to use the global retention value.",
-					"type": "integer"
-				},
-				"global": {
-					"description": "Global is the default retention policy for audit logs, connection logs,\nand API keys. Individual retention settings override this value when set\nto a non-zero duration. Does not affect AI Bridge retention which has its\nown setting.",
+					"description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to disable (keep indefinitely).",
 					"type": "integer"
 				}
 			}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -819,16 +819,11 @@ type HealthcheckConfig struct {
 // before being automatically purged. Setting a value to 0 disables retention for that
 // data type (data is kept indefinitely).
 type RetentionConfig struct {
-	// Global is the default retention policy for audit logs, connection logs,
-	// and API keys. Individual retention settings override this value when set
-	// to a non-zero duration. Does not affect AI Bridge retention which has its
-	// own setting.
-	Global serpent.Duration `json:"global" typescript:",notnull"`
 	// AuditLogs controls how long audit log entries are retained.
-	// Set to 0 to use the global retention value.
+	// Set to 0 to disable (keep indefinitely).
 	AuditLogs serpent.Duration `json:"audit_logs" typescript:",notnull"`
 	// ConnectionLogs controls how long connection log entries are retained.
-	// Set to 0 to use the global retention value.
+	// Set to 0 to disable (keep indefinitely).
 	ConnectionLogs serpent.Duration `json:"connection_logs" typescript:",notnull"`
 	// APIKeys controls how long expired API keys are retained before being deleted.
 	// Keys are only deleted if they have been expired for at least this duration.
@@ -3393,19 +3388,8 @@ Write out the current server config as YAML to stdout.`,
 		},
 		// Retention settings
 		{
-			Name:        "Global Retention",
-			Description: "Default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention. Set to 0 to disable (data is kept indefinitely unless individual settings are configured).",
-			Flag:        "global-retention",
-			Env:         "CODER_GLOBAL_RETENTION",
-			Value:       &c.Retention.Global,
-			Default:     "0",
-			Group:       &deploymentGroupRetention,
-			YAML:        "global",
-			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
-		},
-		{
 			Name:        "Audit Logs Retention",
-			Description: "How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0. We advise keeping audit logs for at least a year, and in accordance with your compliance requirements.",
+			Description: "How long audit log entries are retained. Set to 0 to disable (keep indefinitely). We advise keeping audit logs for at least a year, and in accordance with your compliance requirements.",
 			Flag:        "audit-logs-retention",
 			Env:         "CODER_AUDIT_LOGS_RETENTION",
 			Value:       &c.Retention.AuditLogs,
@@ -3416,7 +3400,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Connection Logs Retention",
-			Description: "How long connection log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0.",
+			Description: "How long connection log entries are retained. Set to 0 to disable (keep indefinitely).",
 			Flag:        "connection-logs-retention",
 			Env:         "CODER_CONNECTION_LOGS_RETENTION",
 			Value:       &c.Retention.ConnectionLogs,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3405,7 +3405,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Audit Logs Retention",
-			Description: "How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0.",
+			Description: "How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0. We advise keeping audit logs for at least a year, and in accordance with your compliance requirements.",
 			Flag:        "audit-logs-retention",
 			Env:         "CODER_AUDIT_LOGS_RETENTION",
 			Value:       &c.Retention.AuditLogs,

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -710,7 +710,6 @@ func TestRetentionConfigParsing(t *testing.T) {
 	tests := []struct {
 		name                   string
 		environment            []serpent.EnvVar
-		expectedGlobal         time.Duration
 		expectedAuditLogs      time.Duration
 		expectedConnectionLogs time.Duration
 		expectedAPIKeys        time.Duration
@@ -718,20 +717,9 @@ func TestRetentionConfigParsing(t *testing.T) {
 		{
 			name:                   "Defaults",
 			environment:            []serpent.EnvVar{},
-			expectedGlobal:         0,
 			expectedAuditLogs:      0,
 			expectedConnectionLogs: 0,
 			expectedAPIKeys:        7 * 24 * time.Hour, // 7 days default
-		},
-		{
-			name: "GlobalRetentionSet",
-			environment: []serpent.EnvVar{
-				{Name: "CODER_GLOBAL_RETENTION", Value: "90d"},
-			},
-			expectedGlobal:         90 * 24 * time.Hour,
-			expectedAuditLogs:      0,
-			expectedConnectionLogs: 0,
-			expectedAPIKeys:        7 * 24 * time.Hour,
 		},
 		{
 			name: "IndividualRetentionSet",
@@ -740,7 +728,6 @@ func TestRetentionConfigParsing(t *testing.T) {
 				{Name: "CODER_CONNECTION_LOGS_RETENTION", Value: "60d"},
 				{Name: "CODER_API_KEYS_RETENTION", Value: "14d"},
 			},
-			expectedGlobal:         0,
 			expectedAuditLogs:      30 * 24 * time.Hour,
 			expectedConnectionLogs: 60 * 24 * time.Hour,
 			expectedAPIKeys:        14 * 24 * time.Hour,
@@ -748,12 +735,10 @@ func TestRetentionConfigParsing(t *testing.T) {
 		{
 			name: "AllRetentionSet",
 			environment: []serpent.EnvVar{
-				{Name: "CODER_GLOBAL_RETENTION", Value: "90d"},
 				{Name: "CODER_AUDIT_LOGS_RETENTION", Value: "365d"},
 				{Name: "CODER_CONNECTION_LOGS_RETENTION", Value: "30d"},
 				{Name: "CODER_API_KEYS_RETENTION", Value: "0"},
 			},
-			expectedGlobal:         90 * 24 * time.Hour,
 			expectedAuditLogs:      365 * 24 * time.Hour,
 			expectedConnectionLogs: 30 * 24 * time.Hour,
 			expectedAPIKeys:        0, // Explicitly disabled
@@ -774,7 +759,6 @@ func TestRetentionConfigParsing(t *testing.T) {
 			err = opts.ParseEnv(tt.environment)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.expectedGlobal, dv.Retention.Global.Value(), "global retention mismatch")
 			assert.Equal(t, tt.expectedAuditLogs, dv.Retention.AuditLogs.Value(), "audit logs retention mismatch")
 			assert.Equal(t, tt.expectedConnectionLogs, dv.Retention.ConnectionLogs.Value(), "connection logs retention mismatch")
 			assert.Equal(t, tt.expectedAPIKeys, dv.Retention.APIKeys.Value(), "api keys retention mismatch")

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -466,8 +466,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "retention": {
       "api_keys": 0,
       "audit_logs": 0,
-      "connection_logs": 0,
-      "global": 0
+      "connection_logs": 0
     },
     "scim_api_key": "string",
     "session_lifetime": {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -463,6 +463,12 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "disable_all": true
     },
     "redirect_to_access_url": true,
+    "retention": {
+      "api_keys": 0,
+      "audit_logs": 0,
+      "connection_logs": 0,
+      "global": 0
+    },
     "scim_api_key": "string",
     "session_lifetime": {
       "default_duration": 0,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3150,8 +3150,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "retention": {
       "api_keys": 0,
       "audit_logs": 0,
-      "connection_logs": 0,
-      "global": 0
+      "connection_logs": 0
     },
     "scim_api_key": "string",
     "session_lifetime": {
@@ -3672,8 +3671,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "retention": {
     "api_keys": 0,
     "audit_logs": 0,
-    "connection_logs": 0,
-    "global": 0
+    "connection_logs": 0
   },
   "scim_api_key": "string",
   "session_lifetime": {
@@ -7525,19 +7523,17 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 {
   "api_keys": 0,
   "audit_logs": 0,
-  "connection_logs": 0,
-  "global": 0
+  "connection_logs": 0
 }
 ```
 
 ### Properties
 
-| Name              | Type    | Required | Restrictions | Description                                                                                                                                                                                                                             |
-|-------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `api_keys`        | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior.                            |
-| `audit_logs`      | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to use the global retention value.                                                                                                                                |
-| `connection_logs` | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to use the global retention value.                                                                                                                      |
-| `global`          | integer | false    |              | Global is the default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention which has its own setting. |
+| Name              | Type    | Required | Restrictions | Description                                                                                                                                                                                                  |
+|-------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_keys`        | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior. |
+| `audit_logs`      | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                                        |
+| `connection_logs` | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                              |
 
 ## codersdk.Role
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3147,6 +3147,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "disable_all": true
     },
     "redirect_to_access_url": true,
+    "retention": {
+      "api_keys": 0,
+      "audit_logs": 0,
+      "connection_logs": 0,
+      "global": 0
+    },
     "scim_api_key": "string",
     "session_lifetime": {
       "default_duration": 0,
@@ -3663,6 +3669,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_all": true
   },
   "redirect_to_access_url": true,
+  "retention": {
+    "api_keys": 0,
+    "audit_logs": 0,
+    "connection_logs": 0,
+    "global": 0
+  },
   "scim_api_key": "string",
   "session_lifetime": {
     "default_duration": 0,
@@ -3808,6 +3820,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `proxy_trusted_origins`              | array of string                                                                                      | false    |              |                                                                    |
 | `rate_limit`                         | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                 | false    |              |                                                                    |
 | `redirect_to_access_url`             | boolean                                                                                              | false    |              |                                                                    |
+| `retention`                          | [codersdk.RetentionConfig](#codersdkretentionconfig)                                                 | false    |              |                                                                    |
 | `scim_api_key`                       | string                                                                                               | false    |              |                                                                    |
 | `session_lifetime`                   | [codersdk.SessionLifetime](#codersdksessionlifetime)                                                 | false    |              |                                                                    |
 | `ssh_keygen_algorithm`               | string                                                                                               | false    |              |                                                                    |
@@ -7505,6 +7518,26 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `detail`      | string                                                        | false    |              | Detail is a debug message that provides further insight into why the action failed. This information can be technical and a regular golang err.Error() text. - "database: too many open connections" - "stat: too many open files" |
 | `message`     | string                                                        | false    |              | Message is an actionable message that depicts actions the request took. These messages should be fully formed sentences with proper punctuation. Examples: - "A user has been created." - "Failed to create a user."               |
 | `validations` | array of [codersdk.ValidationError](#codersdkvalidationerror) | false    |              | Validations are form field-specific friendly error messages. They will be shown on a form field in the UI. These can also be used to add additional context if there is a set of errors in the primary 'Message'.                  |
+
+## codersdk.RetentionConfig
+
+```json
+{
+  "api_keys": 0,
+  "audit_logs": 0,
+  "connection_logs": 0,
+  "global": 0
+}
+```
+
+### Properties
+
+| Name              | Type    | Required | Restrictions | Description                                                                                                                                                                                                                             |
+|-------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_keys`        | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior.                            |
+| `audit_logs`      | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to use the global retention value.                                                                                                                                |
+| `connection_logs` | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to use the global retention value.                                                                                                                      |
+| `global`          | integer | false    |              | Global is the default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention which has its own setting. |
 
 ## codersdk.Role
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1791,7 +1791,7 @@ Default retention policy for audit logs, connection logs, and API keys. Individu
 | YAML        | <code>retention.audit_logs</code>        |
 | Default     | <code>0</code>                           |
 
-How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0.
+How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0. We advise keeping audit logs for at least a year, and in accordance with your compliance requirements.
 
 ### --connection-logs-retention
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1770,3 +1770,47 @@ Whether to inject Coder's MCP tools into intercepted AI Bridge requests (require
 | Default     | <code>60d</code>                       |
 
 Length of time to retain data such as interceptions and all related records (token, prompt, tool use).
+
+### --global-retention
+
+|             |                                      |
+|-------------|--------------------------------------|
+| Type        | <code>duration</code>                |
+| Environment | <code>$CODER_GLOBAL_RETENTION</code> |
+| YAML        | <code>retention.global</code>        |
+| Default     | <code>0</code>                       |
+
+Default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention. Set to 0 to disable (data is kept indefinitely unless individual settings are configured).
+
+### --audit-logs-retention
+
+|             |                                          |
+|-------------|------------------------------------------|
+| Type        | <code>duration</code>                    |
+| Environment | <code>$CODER_AUDIT_LOGS_RETENTION</code> |
+| YAML        | <code>retention.audit_logs</code>        |
+| Default     | <code>0</code>                           |
+
+How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0.
+
+### --connection-logs-retention
+
+|             |                                               |
+|-------------|-----------------------------------------------|
+| Type        | <code>duration</code>                         |
+| Environment | <code>$CODER_CONNECTION_LOGS_RETENTION</code> |
+| YAML        | <code>retention.connection_logs</code>        |
+| Default     | <code>0</code>                                |
+
+How long connection log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0.
+
+### --api-keys-retention
+
+|             |                                        |
+|-------------|----------------------------------------|
+| Type        | <code>duration</code>                  |
+| Environment | <code>$CODER_API_KEYS_RETENTION</code> |
+| YAML        | <code>retention.api_keys</code>        |
+| Default     | <code>7d</code>                        |
+
+How long expired API keys are retained before being deleted. Keeping expired keys allows the backend to return a more helpful error when a user tries to use an expired key. Set to 0 to disable automatic deletion of expired keys.

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1771,17 +1771,6 @@ Whether to inject Coder's MCP tools into intercepted AI Bridge requests (require
 
 Length of time to retain data such as interceptions and all related records (token, prompt, tool use).
 
-### --global-retention
-
-|             |                                      |
-|-------------|--------------------------------------|
-| Type        | <code>duration</code>                |
-| Environment | <code>$CODER_GLOBAL_RETENTION</code> |
-| YAML        | <code>retention.global</code>        |
-| Default     | <code>0</code>                       |
-
-Default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention. Set to 0 to disable (data is kept indefinitely unless individual settings are configured).
-
 ### --audit-logs-retention
 
 |             |                                          |
@@ -1791,7 +1780,7 @@ Default retention policy for audit logs, connection logs, and API keys. Individu
 | YAML        | <code>retention.audit_logs</code>        |
 | Default     | <code>0</code>                           |
 
-How long audit log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0. We advise keeping audit logs for at least a year, and in accordance with your compliance requirements.
+How long audit log entries are retained. Set to 0 to disable (keep indefinitely). We advise keeping audit logs for at least a year, and in accordance with your compliance requirements.
 
 ### --connection-logs-retention
 
@@ -1802,7 +1791,7 @@ How long audit log entries are retained. Set to 0 to use the global retention va
 | YAML        | <code>retention.connection_logs</code>        |
 | Default     | <code>0</code>                                |
 
-How long connection log entries are retained. Set to 0 to use the global retention value, or to disable if global is also 0.
+How long connection log entries are retained. Set to 0 to disable (keep indefinitely).
 
 ### --api-keys-retention
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -697,6 +697,33 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
+RETENTION OPTIONS: 
+Configure data retention policies for various database tables. Retention
+policies automatically purge old data to reduce database size and improve
+performance. Setting a retention duration to 0 disables automatic purging for
+that data type.
+
+      --api-keys-retention duration, $CODER_API_KEYS_RETENTION (default: 7d)
+          How long expired API keys are retained before being deleted. Keeping
+          expired keys allows the backend to return a more helpful error when a
+          user tries to use an expired key. Set to 0 to disable automatic
+          deletion of expired keys.
+
+      --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
+          How long audit log entries are retained. Set to 0 to use the global
+          retention value, or to disable if global is also 0.
+
+      --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
+          How long connection log entries are retained. Set to 0 to use the
+          global retention value, or to disable if global is also 0.
+
+      --global-retention duration, $CODER_GLOBAL_RETENTION (default: 0)
+          Default retention policy for audit logs, connection logs, and API
+          keys. Individual retention settings override this value when set to a
+          non-zero duration. Does not affect AI Bridge retention. Set to 0 to
+          disable (data is kept indefinitely unless individual settings are
+          configured).
+
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -711,7 +711,9 @@ that data type.
 
       --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
           How long audit log entries are retained. Set to 0 to use the global
-          retention value, or to disable if global is also 0.
+          retention value, or to disable if global is also 0. We advise keeping
+          audit logs for at least a year, and in accordance with your compliance
+          requirements.
 
       --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
           How long connection log entries are retained. Set to 0 to use the

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -710,21 +710,13 @@ that data type.
           deletion of expired keys.
 
       --audit-logs-retention duration, $CODER_AUDIT_LOGS_RETENTION (default: 0)
-          How long audit log entries are retained. Set to 0 to use the global
-          retention value, or to disable if global is also 0. We advise keeping
-          audit logs for at least a year, and in accordance with your compliance
-          requirements.
+          How long audit log entries are retained. Set to 0 to disable (keep
+          indefinitely). We advise keeping audit logs for at least a year, and
+          in accordance with your compliance requirements.
 
       --connection-logs-retention duration, $CODER_CONNECTION_LOGS_RETENTION (default: 0)
-          How long connection log entries are retained. Set to 0 to use the
-          global retention value, or to disable if global is also 0.
-
-      --global-retention duration, $CODER_GLOBAL_RETENTION (default: 0)
-          Default retention policy for audit logs, connection logs, and API
-          keys. Individual retention settings override this value when set to a
-          non-zero duration. Does not affect AI Bridge retention. Set to 0 to
-          disable (data is kept indefinitely unless individual settings are
-          configured).
+          How long connection log entries are retained. Set to 0 to disable
+          (keep indefinitely).
 
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1778,6 +1778,7 @@ export interface DeploymentValues {
 	readonly web_terminal_renderer?: string;
 	readonly allow_workspace_renames?: boolean;
 	readonly healthcheck?: HealthcheckConfig;
+	readonly retention?: RetentionConfig;
 	readonly cli_upgrade_message?: string;
 	readonly terms_of_service_url?: string;
 	readonly notifications?: NotificationsConfig;
@@ -4154,6 +4155,39 @@ export interface Response {
 	 * context if there is a set of errors in the primary 'Message'.
 	 */
 	readonly validations?: readonly ValidationError[];
+}
+
+// From codersdk/deployment.go
+/**
+ * RetentionConfig contains configuration for data retention policies.
+ * These settings control how long various types of data are retained in the database
+ * before being automatically purged. Setting a value to 0 disables retention for that
+ * data type (data is kept indefinitely).
+ */
+export interface RetentionConfig {
+	/**
+	 * Global is the default retention policy for audit logs, connection logs,
+	 * and API keys. Individual retention settings override this value when set
+	 * to a non-zero duration. Does not affect AI Bridge retention which has its
+	 * own setting.
+	 */
+	readonly global: number;
+	/**
+	 * AuditLogs controls how long audit log entries are retained.
+	 * Set to 0 to use the global retention value.
+	 */
+	readonly audit_logs: number;
+	/**
+	 * ConnectionLogs controls how long connection log entries are retained.
+	 * Set to 0 to use the global retention value.
+	 */
+	readonly connection_logs: number;
+	/**
+	 * APIKeys controls how long expired API keys are retained before being deleted.
+	 * Keys are only deleted if they have been expired for at least this duration.
+	 * Defaults to 7 days to preserve existing behavior.
+	 */
+	readonly api_keys: number;
 }
 
 // From codersdk/roles.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4166,20 +4166,13 @@ export interface Response {
  */
 export interface RetentionConfig {
 	/**
-	 * Global is the default retention policy for audit logs, connection logs,
-	 * and API keys. Individual retention settings override this value when set
-	 * to a non-zero duration. Does not affect AI Bridge retention which has its
-	 * own setting.
-	 */
-	readonly global: number;
-	/**
 	 * AuditLogs controls how long audit log entries are retained.
-	 * Set to 0 to use the global retention value.
+	 * Set to 0 to disable (keep indefinitely).
 	 */
 	readonly audit_logs: number;
 	/**
 	 * ConnectionLogs controls how long connection log entries are retained.
-	 * Set to 0 to use the global retention value.
+	 * Set to 0 to disable (keep indefinitely).
 	 */
 	readonly connection_logs: number;
 	/**


### PR DESCRIPTION
Add `RetentionConfig` with server flags for configuring data retention:

- `--audit-logs-retention`: retention for audit log entries
- `--connection-logs-retention`: retention for connection logs
- `--api-keys-retention`: retention for expired API keys (default 7d)

Note: AI Bridge already has retention flags which are kept separate from `RetentionConfig`, which only affects core `coderd`.

Updates #20743

---

### PR Stack

|  | PR | Title |
|:---:|:---:|:---|
| 👉 | #21021 | feat(coderd): add retention policy configuration |
|  | #21022 | feat(coderd/database/dbpurge): add retention for connection logs |
|  | #21025 | feat(coderd/database/dbpurge): add retention for audit logs |
|  | #21037 | feat(coderd/database/dbpurge): make API keys retention configurable |
|  | #21038 | docs: add data retention documentation |
|  | #21039 | feat: add retention config for `workspace_agent_logs` |

