### PR TITLE
feat(coderd/database/dbpurge): add retention for connection logs

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1749,6 +1749,13 @@ func (q *querier) DeleteOldAuditLogConnectionEvents(ctx context.Context, thresho
 	return q.db.DeleteOldAuditLogConnectionEvents(ctx, threshold)
 }
 
+func (q *querier) DeleteOldConnectionLogs(ctx context.Context, arg database.DeleteOldConnectionLogsParams) (int64, error) {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
+		return 0, err
+	}
+	return q.db.DeleteOldConnectionLogs(ctx, arg)
+}
+
 func (q *querier) DeleteOldNotificationMessages(ctx context.Context) error {
 	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceNotificationMessage); err != nil {
 		return err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -355,6 +355,10 @@ func (s *MethodTestSuite) TestConnectionLogs() {
 		dbm.EXPECT().CountConnectionLogs(gomock.Any(), database.CountConnectionLogsParams{}).Return(int64(0), nil).AnyTimes()
 		check.Args(database.CountConnectionLogsParams{}, emptyPreparedAuthorized{}).Asserts(rbac.ResourceConnectionLog, policy.ActionRead)
 	}))
+	s.Run("DeleteOldConnectionLogs", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().DeleteOldConnectionLogs(gomock.Any(), database.DeleteOldConnectionLogsParams{}).Return(int64(0), nil).AnyTimes()
+		check.Args(database.DeleteOldConnectionLogsParams{}).Asserts(rbac.ResourceSystem, policy.ActionDelete)
+	}))
 }
 
 func (s *MethodTestSuite) TestFile() {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -410,6 +410,13 @@ func (m queryMetricsStore) DeleteOldAuditLogConnectionEvents(ctx context.Context
 	return r0
 }
 
+func (m queryMetricsStore) DeleteOldConnectionLogs(ctx context.Context, arg database.DeleteOldConnectionLogsParams) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.DeleteOldConnectionLogs(ctx, arg)
+	m.queryLatencies.WithLabelValues("DeleteOldConnectionLogs").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) DeleteOldNotificationMessages(ctx context.Context) error {
 	start := time.Now()
 	r0 := m.s.DeleteOldNotificationMessages(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -753,6 +753,21 @@ func (mr *MockStoreMockRecorder) DeleteOldAuditLogConnectionEvents(ctx, arg any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldAuditLogConnectionEvents", reflect.TypeOf((*MockStore)(nil).DeleteOldAuditLogConnectionEvents), ctx, arg)
 }
 
+// DeleteOldConnectionLogs mocks base method.
+func (m *MockStore) DeleteOldConnectionLogs(ctx context.Context, arg database.DeleteOldConnectionLogsParams) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOldConnectionLogs", ctx, arg)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOldConnectionLogs indicates an expected call of DeleteOldConnectionLogs.
+func (mr *MockStoreMockRecorder) DeleteOldConnectionLogs(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldConnectionLogs", reflect.TypeOf((*MockStore)(nil).DeleteOldConnectionLogs), ctx, arg)
+}
+
 // DeleteOldNotificationMessages mocks base method.
 func (m *MockStore) DeleteOldNotificationMessages(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -25,9 +25,8 @@ const (
 	// The `connection_logs` table is purged based on the configured retention.
 	maxAuditLogConnectionEventAge    = 90 * 24 * time.Hour // 90 days
 	auditLogConnectionEventBatchSize = 1000
-	// Batch size for connection log deletion. Smaller batches prevent long-held
-	// locks that could impact concurrent database operations.
-	connectionLogsBatchSize = 1000
+	// Batch size for connection log deletion.
+	connectionLogsBatchSize = 10000
 	// Telemetry heartbeats are used to deduplicate events across replicas. We
 	// don't need to persist heartbeat rows for longer than 24 hours, as they
 	// are only used for deduplication across replicas. The time needs to be

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -762,218 +762,135 @@ func TestDeleteOldTelemetryHeartbeats(t *testing.T) {
 func TestDeleteOldConnectionLogs(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RetentionEnabled", func(t *testing.T) {
-		t.Parallel()
+	now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
+	retentionPeriod := 30 * 24 * time.Hour
+	afterThreshold := now.Add(-retentionPeriod).Add(-24 * time.Hour) // 31 days ago (older than threshold)
+	beforeThreshold := now.Add(-15 * 24 * time.Hour)                 // 15 days ago (newer than threshold)
 
-		ctx := testutil.Context(t, testutil.WaitShort)
-
-		clk := quartz.NewMock(t)
-		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
-		retentionPeriod := 30 * 24 * time.Hour                           // 30 days
-		afterThreshold := now.Add(-retentionPeriod).Add(-24 * time.Hour) // 31 days ago (older than threshold)
-		beforeThreshold := now.Add(-15 * 24 * time.Hour)                 // 15 days ago (newer than threshold)
-		clk.Set(now).MustWait(ctx)
-
-		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
-		tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
-		tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
-		workspace := dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     tmpl.ID,
-		})
-
-		// Create old connection log (should be deleted)
-		oldLog := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
-			ID:               uuid.New(),
-			Time:             afterThreshold,
-			OrganizationID:   org.ID,
-			WorkspaceOwnerID: user.ID,
-			WorkspaceID:      workspace.ID,
-			WorkspaceName:    workspace.Name,
-			AgentName:        "agent1",
-			Type:             database.ConnectionTypeSsh,
-			ConnectionStatus: database.ConnectionStatusConnected,
-		})
-
-		// Create recent connection log (should be kept)
-		recentLog := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
-			ID:               uuid.New(),
-			Time:             beforeThreshold,
-			OrganizationID:   org.ID,
-			WorkspaceOwnerID: user.ID,
-			WorkspaceID:      workspace.ID,
-			WorkspaceName:    workspace.Name,
-			AgentName:        "agent2",
-			Type:             database.ConnectionTypeSsh,
-			ConnectionStatus: database.ConnectionStatusConnected,
-		})
-
-		// Run the purge with configured retention period
-		done := awaitDoTick(ctx, t, clk)
-		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
-			Retention: codersdk.RetentionConfig{
+	testCases := []struct {
+		name                  string
+		retentionConfig       codersdk.RetentionConfig
+		oldLogTime            time.Time
+		recentLogTime         *time.Time // nil means no recent log created
+		expectOldDeleted      bool
+		expectedLogsRemaining int
+	}{
+		{
+			name: "RetentionEnabled",
+			retentionConfig: codersdk.RetentionConfig{
 				ConnectionLogs: serpent.Duration(retentionPeriod),
 			},
-		}, clk)
-		defer closer.Close()
-		testutil.TryReceive(ctx, t, done)
-
-		// Verify results by querying all connection logs
-		logs, err := db.GetConnectionLogsOffset(ctx, database.GetConnectionLogsOffsetParams{
-			LimitOpt: 100,
-		})
-		require.NoError(t, err)
-
-		logIDs := make([]uuid.UUID, len(logs))
-		for i, log := range logs {
-			logIDs[i] = log.ConnectionLog.ID
-		}
-
-		require.NotContains(t, logIDs, oldLog.ID, "old connection log should be deleted")
-		require.Contains(t, logIDs, recentLog.ID, "recent connection log should be kept")
-	})
-
-	t.Run("RetentionDisabled", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-
-		clk := quartz.NewMock(t)
-		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
-		oldTime := now.Add(-365 * 24 * time.Hour) // 1 year ago
-		clk.Set(now).MustWait(ctx)
-
-		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
-		tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
-		tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
-		workspace := dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     tmpl.ID,
-		})
-
-		// Create old connection log (should NOT be deleted when retention is 0)
-		oldLog := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
-			ID:               uuid.New(),
-			Time:             oldTime,
-			OrganizationID:   org.ID,
-			WorkspaceOwnerID: user.ID,
-			WorkspaceID:      workspace.ID,
-			WorkspaceName:    workspace.Name,
-			AgentName:        "agent1",
-			Type:             database.ConnectionTypeSsh,
-			ConnectionStatus: database.ConnectionStatusConnected,
-		})
-
-		// Run the purge with retention disabled (0)
-		done := awaitDoTick(ctx, t, clk)
-		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
-			Retention: codersdk.RetentionConfig{
-				ConnectionLogs: serpent.Duration(0), // disabled
+			oldLogTime:            afterThreshold,
+			recentLogTime:         &beforeThreshold,
+			expectOldDeleted:      true,
+			expectedLogsRemaining: 1, // only recent log remains
+		},
+		{
+			name: "RetentionDisabled",
+			retentionConfig: codersdk.RetentionConfig{
+				ConnectionLogs: serpent.Duration(0),
 			},
-		}, clk)
-		defer closer.Close()
-		testutil.TryReceive(ctx, t, done)
-
-		// Verify old log is still present
-		logs, err := db.GetConnectionLogsOffset(ctx, database.GetConnectionLogsOffsetParams{
-			LimitOpt: 100,
-		})
-		require.NoError(t, err)
-
-		logIDs := make([]uuid.UUID, len(logs))
-		for i, log := range logs {
-			logIDs[i] = log.ConnectionLog.ID
-		}
-
-		require.Contains(t, logIDs, oldLog.ID, "old connection log should NOT be deleted when retention is disabled")
-	})
-
-	t.Run("GlobalRetentionFallback", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-
-		clk := quartz.NewMock(t)
-		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
-		retentionPeriod := 30 * 24 * time.Hour                           // 30 days
-		afterThreshold := now.Add(-retentionPeriod).Add(-24 * time.Hour) // 31 days ago (older than threshold)
-		beforeThreshold := now.Add(-15 * 24 * time.Hour)                 // 15 days ago (newer than threshold)
-		clk.Set(now).MustWait(ctx)
-
-		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
-		tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
-		tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
-		workspace := dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     tmpl.ID,
-		})
-
-		// Create old connection log (should be deleted)
-		oldLog := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
-			ID:               uuid.New(),
-			Time:             afterThreshold,
-			OrganizationID:   org.ID,
-			WorkspaceOwnerID: user.ID,
-			WorkspaceID:      workspace.ID,
-			WorkspaceName:    workspace.Name,
-			AgentName:        "agent1",
-			Type:             database.ConnectionTypeSsh,
-			ConnectionStatus: database.ConnectionStatusConnected,
-		})
-
-		// Create recent connection log (should be kept)
-		recentLog := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
-			ID:               uuid.New(),
-			Time:             beforeThreshold,
-			OrganizationID:   org.ID,
-			WorkspaceOwnerID: user.ID,
-			WorkspaceID:      workspace.ID,
-			WorkspaceName:    workspace.Name,
-			AgentName:        "agent2",
-			Type:             database.ConnectionTypeSsh,
-			ConnectionStatus: database.ConnectionStatusConnected,
-		})
-
-		// Run the purge with global retention (connection logs retention is 0, so it falls back)
-		done := awaitDoTick(ctx, t, clk)
-		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
-			Retention: codersdk.RetentionConfig{
-				Global:         serpent.Duration(retentionPeriod), // Use global
-				ConnectionLogs: serpent.Duration(0),               // Not set, should fall back to global
+			oldLogTime:            now.Add(-365 * 24 * time.Hour), // 1 year ago
+			recentLogTime:         nil,
+			expectOldDeleted:      false,
+			expectedLogsRemaining: 1, // old log is kept
+		},
+		{
+			name: "GlobalRetentionFallback",
+			retentionConfig: codersdk.RetentionConfig{
+				Global:         serpent.Duration(retentionPeriod),
+				ConnectionLogs: serpent.Duration(0), // Not set, should fall back to global
 			},
-		}, clk)
-		defer closer.Close()
-		testutil.TryReceive(ctx, t, done)
+			oldLogTime:            afterThreshold,
+			recentLogTime:         &beforeThreshold,
+			expectOldDeleted:      true,
+			expectedLogsRemaining: 1, // only recent log remains
+		},
+	}
 
-		// Verify results
-		logs, err := db.GetConnectionLogsOffset(ctx, database.GetConnectionLogsOffsetParams{
-			LimitOpt: 100,
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+			clk := quartz.NewMock(t)
+			clk.Set(now).MustWait(ctx)
+
+			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+			// Setup test fixtures.
+			user := dbgen.User(t, db, database.User{})
+			org := dbgen.Organization(t, db, database.Organization{})
+			_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+			tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
+			tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
+			workspace := dbgen.Workspace(t, db, database.WorkspaceTable{
+				OwnerID:        user.ID,
+				OrganizationID: org.ID,
+				TemplateID:     tmpl.ID,
+			})
+
+			// Create old connection log.
+			oldLog := dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+				ID:               uuid.New(),
+				Time:             tc.oldLogTime,
+				OrganizationID:   org.ID,
+				WorkspaceOwnerID: user.ID,
+				WorkspaceID:      workspace.ID,
+				WorkspaceName:    workspace.Name,
+				AgentName:        "agent1",
+				Type:             database.ConnectionTypeSsh,
+				ConnectionStatus: database.ConnectionStatusConnected,
+			})
+
+			// Create recent connection log if specified.
+			var recentLog database.ConnectionLog
+			if tc.recentLogTime != nil {
+				recentLog = dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
+					ID:               uuid.New(),
+					Time:             *tc.recentLogTime,
+					OrganizationID:   org.ID,
+					WorkspaceOwnerID: user.ID,
+					WorkspaceID:      workspace.ID,
+					WorkspaceName:    workspace.Name,
+					AgentName:        "agent2",
+					Type:             database.ConnectionTypeSsh,
+					ConnectionStatus: database.ConnectionStatusConnected,
+				})
+			}
+
+			// Run the purge.
+			done := awaitDoTick(ctx, t, clk)
+			closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+				Retention: tc.retentionConfig,
+			}, clk)
+			defer closer.Close()
+			testutil.TryReceive(ctx, t, done)
+
+			// Verify results.
+			logs, err := db.GetConnectionLogsOffset(ctx, database.GetConnectionLogsOffsetParams{
+				LimitOpt: 100,
+			})
+			require.NoError(t, err)
+			require.Len(t, logs, tc.expectedLogsRemaining, "unexpected number of logs remaining")
+
+			logIDs := make([]uuid.UUID, len(logs))
+			for i, log := range logs {
+				logIDs[i] = log.ConnectionLog.ID
+			}
+
+			if tc.expectOldDeleted {
+				require.NotContains(t, logIDs, oldLog.ID, "old connection log should be deleted")
+			} else {
+				require.Contains(t, logIDs, oldLog.ID, "old connection log should NOT be deleted")
+			}
+
+			if tc.recentLogTime != nil {
+				require.Contains(t, logIDs, recentLog.ID, "recent connection log should be kept")
+			}
 		})
-		require.NoError(t, err)
-
-		logIDs := make([]uuid.UUID, len(logs))
-		for i, log := range logs {
-			logIDs[i] = log.ConnectionLog.ID
-		}
-
-		require.NotContains(t, logIDs, oldLog.ID, "old connection log should be deleted via global retention")
-		require.Contains(t, logIDs, recentLog.ID, "recent connection log should be kept")
-	})
+	}
 }
 
 func TestDeleteOldAIBridgeRecords(t *testing.T) {

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -795,17 +795,6 @@ func TestDeleteOldConnectionLogs(t *testing.T) {
 			expectOldDeleted:      false,
 			expectedLogsRemaining: 1, // old log is kept
 		},
-		{
-			name: "GlobalRetentionFallback",
-			retentionConfig: codersdk.RetentionConfig{
-				Global:         serpent.Duration(retentionPeriod),
-				ConnectionLogs: serpent.Duration(0), // Not set, should fall back to global
-			},
-			oldLogTime:            afterThreshold,
-			recentLogTime:         &beforeThreshold,
-			expectOldDeleted:      true,
-			expectedLogsRemaining: 1, // only recent log remains
-		},
 	}
 
 	for _, tc := range testCases {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -106,6 +106,7 @@ type sqlcQuerier interface {
 	// Cumulative count.
 	DeleteOldAIBridgeRecords(ctx context.Context, beforeTime time.Time) (int32, error)
 	DeleteOldAuditLogConnectionEvents(ctx context.Context, arg DeleteOldAuditLogConnectionEventsParams) error
+	DeleteOldConnectionLogs(ctx context.Context, arg DeleteOldConnectionLogsParams) (int64, error)
 	// Delete all notification messages which have not been updated for over a week.
 	DeleteOldNotificationMessages(ctx context.Context) error
 	// Delete provisioner daemons that have been created at least a week ago

--- a/coderd/database/queries/connectionlogs.sql
+++ b/coderd/database/queries/connectionlogs.sql
@@ -239,21 +239,17 @@ WHERE
 	-- @authorize_filter
 ;
 
--- name: DeleteOldConnectionLogs :one
+-- name: DeleteOldConnectionLogs :execrows
 WITH old_logs AS (
 	SELECT id
 	FROM connection_logs
 	WHERE connect_time < @before_time::timestamp with time zone
 	ORDER BY connect_time ASC
 	LIMIT @limit_count
-),
-deleted_rows AS (
-	DELETE FROM connection_logs
-	USING old_logs
-	WHERE connection_logs.id = old_logs.id
-	RETURNING connection_logs.id
 )
-SELECT COUNT(deleted_rows.id) AS deleted_count FROM deleted_rows;
+DELETE FROM connection_logs
+USING old_logs
+WHERE connection_logs.id = old_logs.id;
 
 -- name: UpsertConnectionLog :one
 INSERT INTO connection_logs (

--- a/coderd/database/queries/connectionlogs.sql
+++ b/coderd/database/queries/connectionlogs.sql
@@ -239,6 +239,22 @@ WHERE
 	-- @authorize_filter
 ;
 
+-- name: DeleteOldConnectionLogs :one
+WITH old_logs AS (
+	SELECT id
+	FROM connection_logs
+	WHERE connect_time < @before_time::timestamp with time zone
+	ORDER BY connect_time ASC
+	LIMIT @limit_count
+),
+deleted_rows AS (
+	DELETE FROM connection_logs
+	USING old_logs
+	WHERE connection_logs.id = old_logs.id
+	RETURNING connection_logs.id
+)
+SELECT COUNT(deleted_rows.id) AS deleted_count FROM deleted_rows;
+
 -- name: UpsertConnectionLog :one
 INSERT INTO connection_logs (
 	id,


### PR DESCRIPTION
Add `DeleteOldConnectionLogs` query and integrate it into the `dbpurge`
routine. Retention is controlled by `--retention-connection-logs` flag.
Disabled (0) by default.

Depends on #21021
Updates #20743

---

### PR Stack
| | PR | Title |
|:-:|:-:|:--|
| | #21021 | feat(coderd): add retention policy configuration |
| 👉 | #21022 | feat(coderd/database/dbpurge): add retention for connection logs |
| | #21025 | feat(coderd/database/dbpurge): add retention for audit logs |
| | #21037 | feat(coderd/database/dbpurge): make API keys retention configurable |
| | #21038 | docs: add data retention documentation |
| | #21039 | feat: add retention config for `workspace_agent_logs` |