### PR TITLE
feat(coderd/database/dbpurge): make API keys retention configurable

### DIFF
--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -85,9 +85,6 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 
 			var expiredAPIKeys int64
 			apiKeysRetention := vals.Retention.APIKeys.Value()
-			if apiKeysRetention == 0 {
-				apiKeysRetention = vals.Retention.Global.Value()
-			}
 			if apiKeysRetention > 0 {
 				// Delete keys that have been expired for at least the retention period.
 				// A higher retention period allows the backend to return a more helpful

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -90,8 +90,8 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, vals *coder
 			}
 			if apiKeysRetention > 0 {
 				// Delete keys that have been expired for at least the retention period.
-				// This allows the backend to return a more helpful error when a user
-				// tries to use an expired key.
+				// A higher retention period allows the backend to return a more helpful
+				// error message when a user tries to use an expired key.
 				deleteExpiredKeysBefore := start.Add(-apiKeysRetention)
 				expiredAPIKeys, err = tx.DeleteExpiredAPIKeys(ctx, database.DeleteExpiredAPIKeysParams{
 					Before: dbtime.Time(deleteExpiredKeysBefore),

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -1245,3 +1245,199 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 		require.NotContains(t, logIDs, oldCreateLog.ID, "old create log should be deleted by audit logs retention")
 	})
 }
+
+func TestDeleteExpiredAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RetentionEnabled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		clk := quartz.NewMock(t)
+		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
+		retentionPeriod := 7 * 24 * time.Hour                            // 7 days
+		expiredLongAgo := now.Add(-retentionPeriod).Add(-24 * time.Hour) // Expired 8 days ago (should be deleted)
+		expiredRecently := now.Add(-retentionPeriod).Add(24 * time.Hour) // Expired 6 days ago (should be kept)
+		notExpired := now.Add(24 * time.Hour)                            // Expires tomorrow (should be kept)
+		clk.Set(now).MustWait(ctx)
+
+		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		user := dbgen.User(t, db, database.User{})
+
+		// Create API key that expired long ago (should be deleted)
+		oldExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredLongAgo,
+			TokenName: "old-expired-key",
+		})
+
+		// Create API key that expired recently (should be kept)
+		recentExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredRecently,
+			TokenName: "recent-expired-key",
+		})
+
+		// Create API key that hasn't expired yet (should be kept)
+		activeKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: notExpired,
+			TokenName: "active-key",
+		})
+
+		// Run the purge with configured retention period
+		done := awaitDoTick(ctx, t, clk)
+		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+			Retention: codersdk.RetentionConfig{
+				APIKeys: serpent.Duration(retentionPeriod),
+			},
+		}, clk)
+		defer closer.Close()
+		testutil.TryReceive(ctx, t, done)
+
+		// Verify results
+		_, err := db.GetAPIKeyByID(ctx, oldExpiredKey.ID)
+		require.Error(t, err, "old expired key should be deleted")
+
+		_, err = db.GetAPIKeyByID(ctx, recentExpiredKey.ID)
+		require.NoError(t, err, "recently expired key should be kept")
+
+		_, err = db.GetAPIKeyByID(ctx, activeKey.ID)
+		require.NoError(t, err, "active key should be kept")
+	})
+
+	t.Run("RetentionDisabled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		clk := quartz.NewMock(t)
+		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
+		expiredLongAgo := now.Add(-365 * 24 * time.Hour) // Expired 1 year ago
+		clk.Set(now).MustWait(ctx)
+
+		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		user := dbgen.User(t, db, database.User{})
+
+		// Create API key that expired long ago (should NOT be deleted when retention is 0)
+		oldExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredLongAgo,
+			TokenName: "old-expired-key",
+		})
+
+		// Run the purge with retention disabled (0)
+		done := awaitDoTick(ctx, t, clk)
+		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+			Retention: codersdk.RetentionConfig{
+				APIKeys: serpent.Duration(0), // disabled
+			},
+		}, clk)
+		defer closer.Close()
+		testutil.TryReceive(ctx, t, done)
+
+		// Verify old expired key is still present
+		_, err := db.GetAPIKeyByID(ctx, oldExpiredKey.ID)
+		require.NoError(t, err, "old expired key should NOT be deleted when retention is disabled")
+	})
+
+	t.Run("GlobalRetentionFallback", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		clk := quartz.NewMock(t)
+		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
+		retentionPeriod := 14 * 24 * time.Hour                           // 14 days global
+		expiredLongAgo := now.Add(-retentionPeriod).Add(-24 * time.Hour) // Expired 15 days ago (should be deleted)
+		expiredRecently := now.Add(-retentionPeriod).Add(24 * time.Hour) // Expired 13 days ago (should be kept)
+		clk.Set(now).MustWait(ctx)
+
+		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		user := dbgen.User(t, db, database.User{})
+
+		// Create API key that expired long ago (should be deleted)
+		oldExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredLongAgo,
+			TokenName: "old-expired-key",
+		})
+
+		// Create API key that expired recently (should be kept)
+		recentExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredRecently,
+			TokenName: "recent-expired-key",
+		})
+
+		// Run the purge with global retention (API keys retention is 0, so it falls back)
+		done := awaitDoTick(ctx, t, clk)
+		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+			Retention: codersdk.RetentionConfig{
+				Global:  serpent.Duration(retentionPeriod), // Use global
+				APIKeys: serpent.Duration(0),               // Not set, should fall back to global
+			},
+		}, clk)
+		defer closer.Close()
+		testutil.TryReceive(ctx, t, done)
+
+		// Verify results
+		_, err := db.GetAPIKeyByID(ctx, oldExpiredKey.ID)
+		require.Error(t, err, "old expired key should be deleted via global retention")
+
+		_, err = db.GetAPIKeyByID(ctx, recentExpiredKey.ID)
+		require.NoError(t, err, "recently expired key should be kept")
+	})
+
+	t.Run("CustomRetention30Days", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		clk := quartz.NewMock(t)
+		now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
+		retentionPeriod := 30 * 24 * time.Hour                           // 30 days
+		expiredLongAgo := now.Add(-retentionPeriod).Add(-24 * time.Hour) // Expired 31 days ago (should be deleted)
+		expiredRecently := now.Add(-retentionPeriod).Add(24 * time.Hour) // Expired 29 days ago (should be kept)
+		clk.Set(now).MustWait(ctx)
+
+		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		user := dbgen.User(t, db, database.User{})
+
+		// Create API key that expired long ago (should be deleted)
+		oldExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredLongAgo,
+			TokenName: "old-expired-key",
+		})
+
+		// Create API key that expired recently (should be kept)
+		recentExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
+			UserID:    user.ID,
+			ExpiresAt: expiredRecently,
+			TokenName: "recent-expired-key",
+		})
+
+		// Run the purge with 30-day retention
+		done := awaitDoTick(ctx, t, clk)
+		closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+			Retention: codersdk.RetentionConfig{
+				APIKeys: serpent.Duration(retentionPeriod),
+			},
+		}, clk)
+		defer closer.Close()
+		testutil.TryReceive(ctx, t, done)
+
+		// Verify results
+		_, err := db.GetAPIKeyByID(ctx, oldExpiredKey.ID)
+		require.Error(t, err, "old expired key should be deleted with 30-day retention")
+
+		_, err = db.GetAPIKeyByID(ctx, recentExpiredKey.ID)
+		require.NoError(t, err, "recently expired key should be kept with 30-day retention")
+	})
+}

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -1282,18 +1282,7 @@ func TestDeleteExpiredAPIKeys(t *testing.T) {
 			expectOldExpiredDeleted: false,
 			expectedKeysRemaining:   1, // old expired is kept
 		},
-		{
-			name: "GlobalRetentionFallback",
-			retentionConfig: codersdk.RetentionConfig{
-				Global:  serpent.Duration(14 * 24 * time.Hour), // 14 days global
-				APIKeys: serpent.Duration(0),                   // Not set, should fall back to global
-			},
-			oldExpiredTime:          now.Add(-15 * 24 * time.Hour),      // Expired 15 days ago
-			recentExpiredTime:       ptr(now.Add(-13 * 24 * time.Hour)), // Expired 13 days ago
-			activeTime:              nil,
-			expectOldExpiredDeleted: true,
-			expectedKeysRemaining:   1, // only recent expired remains
-		},
+
 		{
 			name: "CustomRetention30Days",
 			retentionConfig: codersdk.RetentionConfig{

--- a/coderd/database/queries/apikeys.sql
+++ b/coderd/database/queries/apikeys.sql
@@ -85,25 +85,20 @@ DELETE FROM
 WHERE
 	user_id = $1;
 
--- name: DeleteExpiredAPIKeys :one
+-- name: DeleteExpiredAPIKeys :execrows
 WITH expired_keys AS (
 	SELECT id
 	FROM api_keys
 	-- expired keys only
 	WHERE expires_at < @before::timestamptz
 	LIMIT @limit_count
-),
-deleted_rows AS (
-	 DELETE FROM
-		 api_keys
-	 USING
-		 expired_keys
-	 WHERE
-		 api_keys.id = expired_keys.id
-	 RETURNING api_keys.id
- )
-SELECT COUNT(deleted_rows.id) AS deleted_count FROM deleted_rows;
-;
+)
+DELETE FROM
+	api_keys
+USING
+	expired_keys
+WHERE
+	api_keys.id = expired_keys.id;
 
 -- name: ExpirePrebuildsAPIKeys :exec
 -- Firstly, collect api_keys owned by the prebuilds user that correlate


### PR DESCRIPTION
Replace hardcoded 7-day retention for expired API keys with configurable
retention from deployment settings. Skips deletion entirely when effective retention is 0.

Depends on #21021
Updates #20743

---

### PR Stack

|  | PR | Title |
|:---:|:---:|:---|
|  | #21021 | feat(coderd): add retention policy configuration |
|  | #21022 | feat(coderd/database/dbpurge): add retention for connection logs |
|  | #21025 | feat(coderd/database/dbpurge): add retention for audit logs |
| 👉 | #21037 | feat(coderd/database/dbpurge): make API keys retention configurable |
|  | #21038 | docs: add data retention documentation |
|  | #21039 | feat: add retention config for `workspace_agent_logs` |

