### PR TITLE
feat: add retention config for `workspace_agent_logs`

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -717,6 +717,11 @@ that data type.
           How long connection log entries are retained. Set to 0 to disable
           (keep indefinitely).
 
+      --workspace-agent-logs-retention duration, $CODER_WORKSPACE_AGENT_LOGS_RETENTION (default: 7d)
+          How long workspace agent logs are retained. Logs from non-latest
+          workspace builds are deleted after this period to free up storage
+          space. Set to 0 to disable automatic deletion of workspace agent logs.
+
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -719,8 +719,9 @@ that data type.
 
       --workspace-agent-logs-retention duration, $CODER_WORKSPACE_AGENT_LOGS_RETENTION (default: 7d)
           How long workspace agent logs are retained. Logs from non-latest
-          workspace builds are deleted after this period to free up storage
-          space. Set to 0 to disable automatic deletion of workspace agent logs.
+          builds are deleted if the agent hasn't connected within this period.
+          Logs from the latest build are always retained. Set to 0 to disable
+          automatic deletion.
 
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -761,8 +761,8 @@ retention:
   # an expired key. Set to 0 to disable automatic deletion of expired keys.
   # (default: 7d, type: duration)
   api_keys: 168h0m0s
-  # How long workspace agent logs are retained. Logs from non-latest workspace
-  # builds are deleted after this period to free up storage space. Set to 0 to
-  # disable automatic deletion of workspace agent logs.
+  # How long workspace agent logs are retained. Logs from non-latest builds are
+  # deleted if the agent hasn't connected within this period. Logs from the latest
+  # build are always retained. Set to 0 to disable automatic deletion.
   # (default: 7d, type: duration)
   workspace_agent_logs: 168h0m0s

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -761,3 +761,8 @@ retention:
   # an expired key. Set to 0 to disable automatic deletion of expired keys.
   # (default: 7d, type: duration)
   api_keys: 168h0m0s
+  # How long workspace agent logs are retained. Logs from non-latest workspace
+  # builds are deleted after this period to free up storage space. Set to 0 to
+  # disable automatic deletion of workspace agent logs.
+  # (default: 7d, type: duration)
+  workspace_agent_logs: 168h0m0s

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17745,6 +17745,10 @@ const docTemplate = `{
                 "connection_logs": {
                     "description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to disable (keep indefinitely).",
                     "type": "integer"
+                },
+                "workspace_agent_logs": {
+                    "description": "WorkspaceAgentLogs controls how long workspace agent logs are retained.\nDefaults to 7 days to preserve existing behavior.",
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17747,7 +17747,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "workspace_agent_logs": {
-                    "description": "WorkspaceAgentLogs controls how long workspace agent logs are retained.\nDefaults to 7 days to preserve existing behavior.",
+                    "description": "WorkspaceAgentLogs controls how long workspace agent logs are retained.\nLogs are deleted if the agent hasn't connected within this period.\nLogs from the latest build are always retained regardless of age.\nDefaults to 7 days to preserve existing behavior.",
                     "type": "integer"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16207,6 +16207,10 @@
 				"connection_logs": {
 					"description": "ConnectionLogs controls how long connection log entries are retained.\nSet to 0 to disable (keep indefinitely).",
 					"type": "integer"
+				},
+				"workspace_agent_logs": {
+					"description": "WorkspaceAgentLogs controls how long workspace agent logs are retained.\nDefaults to 7 days to preserve existing behavior.",
+					"type": "integer"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16209,7 +16209,7 @@
 					"type": "integer"
 				},
 				"workspace_agent_logs": {
-					"description": "WorkspaceAgentLogs controls how long workspace agent logs are retained.\nDefaults to 7 days to preserve existing behavior.",
+					"description": "WorkspaceAgentLogs controls how long workspace agent logs are retained.\nLogs are deleted if the agent hasn't connected within this period.\nLogs from the latest build are always retained regardless of age.\nDefaults to 7 days to preserve existing behavior.",
 					"type": "integer"
 				}
 			}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1784,9 +1784,9 @@ func (q *querier) DeleteOldTelemetryLocks(ctx context.Context, beforeTime time.T
 	return q.db.DeleteOldTelemetryLocks(ctx, beforeTime)
 }
 
-func (q *querier) DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) error {
+func (q *querier) DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) (int64, error) {
 	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
-		return err
+		return 0, err
 	}
 	return q.db.DeleteOldWorkspaceAgentLogs(ctx, threshold)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -3227,7 +3227,7 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 	}))
 	s.Run("DeleteOldWorkspaceAgentLogs", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		t := time.Time{}
-		dbm.EXPECT().DeleteOldWorkspaceAgentLogs(gomock.Any(), t).Return(nil).AnyTimes()
+		dbm.EXPECT().DeleteOldWorkspaceAgentLogs(gomock.Any(), t).Return(int64(0), nil).AnyTimes()
 		check.Args(t).Asserts(rbac.ResourceSystem, policy.ActionDelete)
 	}))
 	s.Run("InsertWorkspaceAgentStats", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -445,11 +445,11 @@ func (m queryMetricsStore) DeleteOldTelemetryLocks(ctx context.Context, periodEn
 	return r0
 }
 
-func (m queryMetricsStore) DeleteOldWorkspaceAgentLogs(ctx context.Context, arg time.Time) error {
+func (m queryMetricsStore) DeleteOldWorkspaceAgentLogs(ctx context.Context, arg time.Time) (int64, error) {
 	start := time.Now()
-	r0 := m.s.DeleteOldWorkspaceAgentLogs(ctx, arg)
+	r0, r1 := m.s.DeleteOldWorkspaceAgentLogs(ctx, arg)
 	m.queryLatencies.WithLabelValues("DeleteOldWorkspaceAgentLogs").Observe(time.Since(start).Seconds())
-	return r0
+	return r0, r1
 }
 
 func (m queryMetricsStore) DeleteOldWorkspaceAgentStats(ctx context.Context) error {

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -826,11 +826,12 @@ func (mr *MockStoreMockRecorder) DeleteOldTelemetryLocks(ctx, periodEndingAtBefo
 }
 
 // DeleteOldWorkspaceAgentLogs mocks base method.
-func (m *MockStore) DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) error {
+func (m *MockStore) DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteOldWorkspaceAgentLogs", ctx, threshold)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DeleteOldWorkspaceAgentLogs indicates an expected call of DeleteOldWorkspaceAgentLogs.

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -246,7 +246,11 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 	// After dbpurge completes, the ticker is reset. Trap this call.
 
 	done := awaitDoTick(ctx, t, clk)
-	closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{}, clk)
+	closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+		Retention: codersdk.RetentionConfig{
+			WorkspaceAgentLogs: serpent.Duration(7 * 24 * time.Hour),
+		},
+	}, clk)
 	defer closer.Close()
 	<-done // doTick() has now run.
 
@@ -390,6 +394,98 @@ func mustCreateAgentLogs(ctx context.Context, t *testing.T, db database.Store, a
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, agentLogs, "agent logs must be present")
+}
+
+func TestDeleteOldWorkspaceAgentLogsRetention(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2025, 1, 15, 7, 30, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name            string
+		retentionConfig codersdk.RetentionConfig
+		logsAge         time.Duration
+		expectDeleted   bool
+	}{
+		{
+			name: "RetentionEnabled",
+			retentionConfig: codersdk.RetentionConfig{
+				WorkspaceAgentLogs: serpent.Duration(7 * 24 * time.Hour), // 7 days
+			},
+			logsAge:       8 * 24 * time.Hour, // 8 days ago
+			expectDeleted: true,
+		},
+		{
+			name: "RetentionDisabled",
+			retentionConfig: codersdk.RetentionConfig{
+				WorkspaceAgentLogs: serpent.Duration(0),
+			},
+			logsAge:       60 * 24 * time.Hour, // 60 days ago
+			expectDeleted: false,
+		},
+		{
+			name: "GlobalRetentionFallback",
+			retentionConfig: codersdk.RetentionConfig{
+				Global:             serpent.Duration(14 * 24 * time.Hour), // 14 days global
+				WorkspaceAgentLogs: serpent.Duration(0),                   // Not set, falls back to global
+			},
+			logsAge:       15 * 24 * time.Hour, // 15 days ago
+			expectDeleted: true,
+		},
+		{
+			name: "CustomRetention30Days",
+			retentionConfig: codersdk.RetentionConfig{
+				WorkspaceAgentLogs: serpent.Duration(30 * 24 * time.Hour), // 30 days
+			},
+			logsAge:       31 * 24 * time.Hour, // 31 days ago
+			expectDeleted: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+			clk := quartz.NewMock(t)
+			clk.Set(now).MustWait(ctx)
+
+			oldTime := now.Add(-tc.logsAge)
+
+			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			org := dbgen.Organization(t, db, database.Organization{})
+			user := dbgen.User(t, db, database.User{})
+			_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+			tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
+			tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
+
+			ws := dbgen.Workspace(t, db, database.WorkspaceTable{Name: "test-ws", OwnerID: user.ID, OrganizationID: org.ID, TemplateID: tmpl.ID})
+			wb1 := mustCreateWorkspaceBuild(t, db, org, tv, ws.ID, oldTime, 1)
+			wb2 := mustCreateWorkspaceBuild(t, db, org, tv, ws.ID, oldTime, 2)
+			agent1 := mustCreateAgent(t, db, wb1)
+			agent2 := mustCreateAgent(t, db, wb2)
+			mustCreateAgentLogs(ctx, t, db, agent1, &oldTime, "agent 1 logs")
+			mustCreateAgentLogs(ctx, t, db, agent2, &oldTime, "agent 2 logs")
+
+			// Run the purge.
+			done := awaitDoTick(ctx, t, clk)
+			closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{
+				Retention: tc.retentionConfig,
+			}, clk)
+			defer closer.Close()
+			testutil.TryReceive(ctx, t, done)
+
+			// Verify results.
+			if tc.expectDeleted {
+				assertNoWorkspaceAgentLogs(ctx, t, db, agent1.ID)
+			} else {
+				assertWorkspaceAgentLogs(ctx, t, db, agent1.ID, "agent 1 logs")
+			}
+			// Latest build logs are always retained.
+			assertWorkspaceAgentLogs(ctx, t, db, agent2.ID, "agent 2 logs")
+		})
+	}
 }
 
 //nolint:paralleltest // It uses LockIDDBPurge.

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -423,15 +423,7 @@ func TestDeleteOldWorkspaceAgentLogsRetention(t *testing.T) {
 			logsAge:       60 * 24 * time.Hour, // 60 days ago
 			expectDeleted: false,
 		},
-		{
-			name: "GlobalRetentionFallback",
-			retentionConfig: codersdk.RetentionConfig{
-				Global:             serpent.Duration(14 * 24 * time.Hour), // 14 days global
-				WorkspaceAgentLogs: serpent.Duration(0),                   // Not set, falls back to global
-			},
-			logsAge:       15 * 24 * time.Hour, // 15 days ago
-			expectDeleted: true,
-		},
+
 		{
 			name: "CustomRetention30Days",
 			retentionConfig: codersdk.RetentionConfig{

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -120,10 +120,10 @@ type sqlcQuerier interface {
 	DeleteOldProvisionerDaemons(ctx context.Context) error
 	// Deletes old telemetry locks from the telemetry_locks table.
 	DeleteOldTelemetryLocks(ctx context.Context, periodEndingAtBefore time.Time) error
-	// If an agent hasn't connected in the last 7 days, we purge it's logs.
+	// If an agent hasn't connected within the retention period, we purge its logs.
 	// Exception: if the logs are related to the latest build, we keep those around.
 	// Logs can take up a lot of space, so it's important we clean up frequently.
-	DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) error
+	DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) (int64, error)
 	DeleteOldWorkspaceAgentStats(ctx context.Context) error
 	DeleteOrganizationMember(ctx context.Context, arg DeleteOrganizationMemberParams) error
 	DeleteProvisionerKey(ctx context.Context, id uuid.UUID) error

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -199,10 +199,10 @@ INSERT INTO
 -- name: GetWorkspaceAgentLogSourcesByAgentIDs :many
 SELECT * FROM workspace_agent_log_sources WHERE workspace_agent_id = ANY(@ids :: uuid [ ]);
 
--- If an agent hasn't connected in the last 7 days, we purge it's logs.
+-- If an agent hasn't connected within the retention period, we purge its logs.
 -- Exception: if the logs are related to the latest build, we keep those around.
 -- Logs can take up a lot of space, so it's important we clean up frequently.
--- name: DeleteOldWorkspaceAgentLogs :exec
+-- name: DeleteOldWorkspaceAgentLogs :execrows
 WITH
 	latest_builds AS (
 		SELECT

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -829,6 +829,9 @@ type RetentionConfig struct {
 	// Keys are only deleted if they have been expired for at least this duration.
 	// Defaults to 7 days to preserve existing behavior.
 	APIKeys serpent.Duration `json:"api_keys" typescript:",notnull"`
+	// WorkspaceAgentLogs controls how long workspace agent logs are retained.
+	// Defaults to 7 days to preserve existing behavior.
+	WorkspaceAgentLogs serpent.Duration `json:"workspace_agent_logs" typescript:",notnull"`
 }
 
 type NotificationsConfig struct {
@@ -3418,6 +3421,17 @@ Write out the current server config as YAML to stdout.`,
 			Default:     "7d",
 			Group:       &deploymentGroupRetention,
 			YAML:        "api_keys",
+			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
+		},
+		{
+			Name:        "Workspace Agent Logs Retention",
+			Description: "How long workspace agent logs are retained. Logs from non-latest workspace builds are deleted after this period to free up storage space. Set to 0 to disable automatic deletion of workspace agent logs.",
+			Flag:        "workspace-agent-logs-retention",
+			Env:         "CODER_WORKSPACE_AGENT_LOGS_RETENTION",
+			Value:       &c.Retention.WorkspaceAgentLogs,
+			Default:     "7d",
+			Group:       &deploymentGroupRetention,
+			YAML:        "workspace_agent_logs",
 			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
 		},
 		{

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -830,6 +830,8 @@ type RetentionConfig struct {
 	// Defaults to 7 days to preserve existing behavior.
 	APIKeys serpent.Duration `json:"api_keys" typescript:",notnull"`
 	// WorkspaceAgentLogs controls how long workspace agent logs are retained.
+	// Logs are deleted if the agent hasn't connected within this period.
+	// Logs from the latest build are always retained regardless of age.
 	// Defaults to 7 days to preserve existing behavior.
 	WorkspaceAgentLogs serpent.Duration `json:"workspace_agent_logs" typescript:",notnull"`
 }
@@ -3425,7 +3427,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Workspace Agent Logs Retention",
-			Description: "How long workspace agent logs are retained. Logs from non-latest workspace builds are deleted after this period to free up storage space. Set to 0 to disable automatic deletion of workspace agent logs.",
+			Description: "How long workspace agent logs are retained. Logs from non-latest builds are deleted if the agent hasn't connected within this period. Logs from the latest build are always retained. Set to 0 to disable automatic deletion.",
 			Flag:        "workspace-agent-logs-retention",
 			Env:         "CODER_WORKSPACE_AGENT_LOGS_RETENTION",
 			Value:       &c.Retention.WorkspaceAgentLogs,

--- a/docs/admin/setup/data-retention.md
+++ b/docs/admin/setup/data-retention.md
@@ -1,8 +1,8 @@
 # Data Retention
 
 Coder supports configurable retention policies that automatically purge old
-Audit Logs, Connection Logs, and API keys. These policies help manage database
-growth by removing records older than a specified duration.
+Audit Logs, Connection Logs, Workspace Agent Logs, and API keys. These policies
+help manage database growth by removing records older than a specified duration.
 
 ## Overview
 
@@ -16,7 +16,8 @@ Retention policies help you:
 
 > [!NOTE]
 > Retention policies are disabled by default (set to `0`) to preserve existing
-> behavior. The only exception is API keys, which defaults to 7 days.
+> behavior. The exceptions are API keys and workspace agent logs, which default
+> to 7 days.
 
 ## Configuration
 
@@ -25,11 +26,12 @@ a YAML configuration file.
 
 ### Settings
 
-| Setting         | CLI Flag                      | Environment Variable              | Default        | Description                          |
-|-----------------|-------------------------------|-----------------------------------|----------------|--------------------------------------|
-| Audit Logs      | `--audit-logs-retention`      | `CODER_AUDIT_LOGS_RETENTION`      | `0` (disabled) | How long to retain Audit Log entries |
-| Connection Logs | `--connection-logs-retention` | `CODER_CONNECTION_LOGS_RETENTION` | `0` (disabled) | How long to retain Connection Logs   |
-| API Keys        | `--api-keys-retention`        | `CODER_API_KEYS_RETENTION`        | `7d`           | How long to retain expired API keys  |
+| Setting              | CLI Flag                           | Environment Variable                   | Default        | Description                              |
+|----------------------|------------------------------------|----------------------------------------|----------------|------------------------------------------|
+| Audit Logs           | `--audit-logs-retention`           | `CODER_AUDIT_LOGS_RETENTION`           | `0` (disabled) | How long to retain Audit Log entries     |
+| Connection Logs      | `--connection-logs-retention`      | `CODER_CONNECTION_LOGS_RETENTION`      | `0` (disabled) | How long to retain Connection Logs       |
+| API Keys             | `--api-keys-retention`             | `CODER_API_KEYS_RETENTION`             | `7d`           | How long to retain expired API keys      |
+| Workspace Agent Logs | `--workspace-agent-logs-retention` | `CODER_WORKSPACE_AGENT_LOGS_RETENTION` | `7d`           | How long to retain workspace agent logs  |
 
 ### Duration Format
 
@@ -48,7 +50,8 @@ Go duration units (`h`, `m`, `s`):
 coder server \
   --audit-logs-retention=365d \
   --connection-logs-retention=90d \
-  --api-keys-retention=7d
+  --api-keys-retention=7d \
+  --workspace-agent-logs-retention=7d
 ```
 
 ### Environment Variables Example
@@ -57,6 +60,7 @@ coder server \
 export CODER_AUDIT_LOGS_RETENTION=365d
 export CODER_CONNECTION_LOGS_RETENTION=90d
 export CODER_API_KEYS_RETENTION=7d
+export CODER_WORKSPACE_AGENT_LOGS_RETENTION=7d
 ```
 
 ### YAML Configuration Example
@@ -66,6 +70,7 @@ retention:
   audit_logs: 365d
   connection_logs: 90d
   api_keys: 7d
+  workspace_agent_logs: 7d
 ```
 
 ## How Retention Works
@@ -100,6 +105,16 @@ ago. Active keys are never deleted by the retention policy.
 Keeping expired keys for a short period allows Coder to return a more helpful
 error message when users attempt to use an expired key.
 
+### Workspace Agent Logs Behavior
+
+Workspace agent logs are retained based on the retention period, but **logs from
+the latest build of each workspace are always retained** regardless of age. This
+ensures you can always debug issues with active workspaces.
+
+Only logs from non-latest workspace builds that are older than the retention
+period are deleted. Setting `--workspace-agent-logs-retention=7d` keeps all logs
+from the latest build plus logs from previous builds for up to 7 days.
+
 ## Best Practices
 
 ### Recommended Starting Configuration
@@ -111,6 +126,7 @@ retention:
   audit_logs: 365d
   connection_logs: 90d
   api_keys: 7d
+  workspace_agent_logs: 7d
 ```
 
 ### Compliance Considerations
@@ -150,9 +166,10 @@ To keep data indefinitely for any data type, set its retention value to `0`:
 
 ```yaml
 retention:
-  audit_logs: 0s    # Keep audit logs forever
-  connection_logs: 0s # Keep connection logs forever
-  api_keys: 0s      # Keep expired API keys forever
+  audit_logs: 0s           # Keep audit logs forever
+  connection_logs: 0s      # Keep connection logs forever
+  api_keys: 0s             # Keep expired API keys forever
+  workspace_agent_logs: 0s # Keep workspace agent logs forever
 ```
 
 ## Monitoring

--- a/docs/admin/setup/data-retention.md
+++ b/docs/admin/setup/data-retention.md
@@ -26,12 +26,12 @@ a YAML configuration file.
 
 ### Settings
 
-| Setting              | CLI Flag                           | Environment Variable                   | Default        | Description                              |
-|----------------------|------------------------------------|----------------------------------------|----------------|------------------------------------------|
-| Audit Logs           | `--audit-logs-retention`           | `CODER_AUDIT_LOGS_RETENTION`           | `0` (disabled) | How long to retain Audit Log entries     |
-| Connection Logs      | `--connection-logs-retention`      | `CODER_CONNECTION_LOGS_RETENTION`      | `0` (disabled) | How long to retain Connection Logs       |
-| API Keys             | `--api-keys-retention`             | `CODER_API_KEYS_RETENTION`             | `7d`           | How long to retain expired API keys      |
-| Workspace Agent Logs | `--workspace-agent-logs-retention` | `CODER_WORKSPACE_AGENT_LOGS_RETENTION` | `7d`           | How long to retain workspace agent logs  |
+| Setting              | CLI Flag                           | Environment Variable                   | Default        | Description                             |
+|----------------------|------------------------------------|----------------------------------------|----------------|-----------------------------------------|
+| Audit Logs           | `--audit-logs-retention`           | `CODER_AUDIT_LOGS_RETENTION`           | `0` (disabled) | How long to retain Audit Log entries    |
+| Connection Logs      | `--connection-logs-retention`      | `CODER_CONNECTION_LOGS_RETENTION`      | `0` (disabled) | How long to retain Connection Logs      |
+| API Keys             | `--api-keys-retention`             | `CODER_API_KEYS_RETENTION`             | `7d`           | How long to retain expired API keys     |
+| Workspace Agent Logs | `--workspace-agent-logs-retention` | `CODER_WORKSPACE_AGENT_LOGS_RETENTION` | `7d`           | How long to retain workspace agent logs |
 
 ### Duration Format
 
@@ -107,13 +107,14 @@ error message when users attempt to use an expired key.
 
 ### Workspace Agent Logs Behavior
 
-Workspace agent logs are retained based on the retention period, but **logs from
-the latest build of each workspace are always retained** regardless of age. This
-ensures you can always debug issues with active workspaces.
+Workspace agent logs are deleted based on when the agent last connected, not the
+age of the logs themselves. **Logs from the latest build of each workspace are
+always retained** regardless of when the agent last connected. This ensures you
+can always debug issues with active workspaces.
 
-Only logs from non-latest workspace builds that are older than the retention
-period are deleted. Setting `--workspace-agent-logs-retention=7d` keeps all logs
-from the latest build plus logs from previous builds for up to 7 days.
+For non-latest builds, logs are deleted if the agent hasn't connected within the
+retention period. Setting `--workspace-agent-logs-retention=7d` deletes logs for
+agents that haven't connected in 7 days (excluding those from the latest build).
 
 ## Best Practices
 

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -467,7 +467,6 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "api_keys": 0,
       "audit_logs": 0,
       "connection_logs": 0,
-      "global": 0,
       "workspace_agent_logs": 0
     },
     "scim_api_key": "string",

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -466,7 +466,9 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "retention": {
       "api_keys": 0,
       "audit_logs": 0,
-      "connection_logs": 0
+      "connection_logs": 0,
+      "global": 0,
+      "workspace_agent_logs": 0
     },
     "scim_api_key": "string",
     "session_lifetime": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3151,7 +3151,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "api_keys": 0,
       "audit_logs": 0,
       "connection_logs": 0,
-      "global": 0,
       "workspace_agent_logs": 0
     },
     "scim_api_key": "string",
@@ -3674,7 +3673,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "api_keys": 0,
     "audit_logs": 0,
     "connection_logs": 0,
-    "global": 0,
     "workspace_agent_logs": 0
   },
   "scim_api_key": "string",
@@ -7528,20 +7526,18 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   "api_keys": 0,
   "audit_logs": 0,
   "connection_logs": 0,
-  "global": 0,
   "workspace_agent_logs": 0
 }
 ```
 
 ### Properties
 
-| Name                   | Type    | Required | Restrictions | Description                                                                                                                                                                                                                             |
-|------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `api_keys`             | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior.                            |
-| `audit_logs`           | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to use the global retention value.                                                                                                                                |
-| `connection_logs`      | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to use the global retention value.                                                                                                                      |
-| `global`               | integer | false    |              | Global is the default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention which has its own setting. |
-| `workspace_agent_logs` | integer | false    |              | Workspace agent logs controls how long workspace agent logs are retained. Defaults to 7 days to preserve existing behavior.                                                                                                             |
+| Name                   | Type    | Required | Restrictions | Description                                                                                                                                                                                                  |
+|------------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_keys`             | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior. |
+| `audit_logs`           | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                                        |
+| `connection_logs`      | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                              |
+| `workspace_agent_logs` | integer | false    |              | Workspace agent logs controls how long workspace agent logs are retained. Defaults to 7 days to preserve existing behavior.                                                                                  |
 
 ## codersdk.Role
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7532,12 +7532,12 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ### Properties
 
-| Name                   | Type    | Required | Restrictions | Description                                                                                                                                                                                                  |
-|------------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `api_keys`             | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior. |
-| `audit_logs`           | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                                        |
-| `connection_logs`      | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                              |
-| `workspace_agent_logs` | integer | false    |              | Workspace agent logs controls how long workspace agent logs are retained. Defaults to 7 days to preserve existing behavior.                                                                                  |
+| Name                   | Type    | Required | Restrictions | Description                                                                                                                                                                                                                                                      |
+|------------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_keys`             | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior.                                                     |
+| `audit_logs`           | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                                                                                            |
+| `connection_logs`      | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                                                                                  |
+| `workspace_agent_logs` | integer | false    |              | Workspace agent logs controls how long workspace agent logs are retained. Logs are deleted if the agent hasn't connected within this period. Logs from the latest build are always retained regardless of age. Defaults to 7 days to preserve existing behavior. |
 
 ## codersdk.Role
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3150,7 +3150,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "retention": {
       "api_keys": 0,
       "audit_logs": 0,
-      "connection_logs": 0
+      "connection_logs": 0,
+      "global": 0,
+      "workspace_agent_logs": 0
     },
     "scim_api_key": "string",
     "session_lifetime": {
@@ -3671,7 +3673,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "retention": {
     "api_keys": 0,
     "audit_logs": 0,
-    "connection_logs": 0
+    "connection_logs": 0,
+    "global": 0,
+    "workspace_agent_logs": 0
   },
   "scim_api_key": "string",
   "session_lifetime": {
@@ -7523,17 +7527,21 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 {
   "api_keys": 0,
   "audit_logs": 0,
-  "connection_logs": 0
+  "connection_logs": 0,
+  "global": 0,
+  "workspace_agent_logs": 0
 }
 ```
 
 ### Properties
 
-| Name              | Type    | Required | Restrictions | Description                                                                                                                                                                                                  |
-|-------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `api_keys`        | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior. |
-| `audit_logs`      | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                                        |
-| `connection_logs` | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to disable (keep indefinitely).                                                                                              |
+| Name                   | Type    | Required | Restrictions | Description                                                                                                                                                                                                                             |
+|------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_keys`             | integer | false    |              | Api keys controls how long expired API keys are retained before being deleted. Keys are only deleted if they have been expired for at least this duration. Defaults to 7 days to preserve existing behavior.                            |
+| `audit_logs`           | integer | false    |              | Audit logs controls how long audit log entries are retained. Set to 0 to use the global retention value.                                                                                                                                |
+| `connection_logs`      | integer | false    |              | Connection logs controls how long connection log entries are retained. Set to 0 to use the global retention value.                                                                                                                      |
+| `global`               | integer | false    |              | Global is the default retention policy for audit logs, connection logs, and API keys. Individual retention settings override this value when set to a non-zero duration. Does not affect AI Bridge retention which has its own setting. |
+| `workspace_agent_logs` | integer | false    |              | Workspace agent logs controls how long workspace agent logs are retained. Defaults to 7 days to preserve existing behavior.                                                                                                             |
 
 ## codersdk.Role
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1813,4 +1813,4 @@ How long expired API keys are retained before being deleted. Keeping expired key
 | YAML        | <code>retention.workspace_agent_logs</code>        |
 | Default     | <code>7d</code>                                    |
 
-How long workspace agent logs are retained. Logs from non-latest workspace builds are deleted after this period to free up storage space. Set to 0 to disable automatic deletion of workspace agent logs.
+How long workspace agent logs are retained. Logs from non-latest builds are deleted if the agent hasn't connected within this period. Logs from the latest build are always retained. Set to 0 to disable automatic deletion.

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1803,3 +1803,14 @@ How long connection log entries are retained. Set to 0 to disable (keep indefini
 | Default     | <code>7d</code>                        |
 
 How long expired API keys are retained before being deleted. Keeping expired keys allows the backend to return a more helpful error when a user tries to use an expired key. Set to 0 to disable automatic deletion of expired keys.
+
+### --workspace-agent-logs-retention
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>duration</code>                              |
+| Environment | <code>$CODER_WORKSPACE_AGENT_LOGS_RETENTION</code> |
+| YAML        | <code>retention.workspace_agent_logs</code>        |
+| Default     | <code>7d</code>                                    |
+
+How long workspace agent logs are retained. Logs from non-latest workspace builds are deleted after this period to free up storage space. Set to 0 to disable automatic deletion of workspace agent logs.

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -720,8 +720,9 @@ that data type.
 
       --workspace-agent-logs-retention duration, $CODER_WORKSPACE_AGENT_LOGS_RETENTION (default: 7d)
           How long workspace agent logs are retained. Logs from non-latest
-          workspace builds are deleted after this period to free up storage
-          space. Set to 0 to disable automatic deletion of workspace agent logs.
+          builds are deleted if the agent hasn't connected within this period.
+          Logs from the latest build are always retained. Set to 0 to disable
+          automatic deletion.
 
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -718,6 +718,11 @@ that data type.
           How long connection log entries are retained. Set to 0 to disable
           (keep indefinitely).
 
+      --workspace-agent-logs-retention duration, $CODER_WORKSPACE_AGENT_LOGS_RETENTION (default: 7d)
+          How long workspace agent logs are retained. Logs from non-latest
+          workspace builds are deleted after this period to free up storage
+          space. Set to 0 to disable automatic deletion of workspace agent logs.
+
 TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4183,6 +4183,8 @@ export interface RetentionConfig {
 	readonly api_keys: number;
 	/**
 	 * WorkspaceAgentLogs controls how long workspace agent logs are retained.
+	 * Logs are deleted if the agent hasn't connected within this period.
+	 * Logs from the latest build are always retained regardless of age.
 	 * Defaults to 7 days to preserve existing behavior.
 	 */
 	readonly workspace_agent_logs: number;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4181,6 +4181,11 @@ export interface RetentionConfig {
 	 * Defaults to 7 days to preserve existing behavior.
 	 */
 	readonly api_keys: number;
+	/**
+	 * WorkspaceAgentLogs controls how long workspace agent logs are retained.
+	 * Defaults to 7 days to preserve existing behavior.
+	 */
+	readonly workspace_agent_logs: number;
 }
 
 // From codersdk/roles.go


### PR DESCRIPTION
Replace hardcoded 7-day retention for workspace agent logs with configurable
retention from deployment settings. Defaults to 7d to preserve existing behavior.

Depends on #21038
Updates #20743

---

### PR Stack
| | PR | Title |
|:-:|:-:|:--|
| | #21021 | feat(coderd): add retention policy configuration |
| | #21022 | feat(coderd/database/dbpurge): add retention for connection logs |
| | #21025 | feat(coderd/database/dbpurge): add retention for audit logs |
| | #21037 | feat(coderd/database/dbpurge): make API keys retention configurable |
| | #21038 | docs: add data retention documentation |
| 👉 | #21039 | feat: add retention config for `workspace_agent_logs` |