### PR TITLE
docs: add support for AGENTS.local.md overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ __debug_bin*
 
 **/.claude/settings.local.json
 
+# Local agent configuration
+AGENTS.local.md
+
 /.env
 
 # Ignore plans written by AI agents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 @.claude/docs/TROUBLESHOOTING.md
 @.claude/docs/DATABASE.md
 
+@AGENTS.local.md
+
 ## Common Pitfalls
 
 1. **Audit table errors** → Update `enterprise/audit/table.go`


### PR DESCRIPTION
Adds support for local, gitignored `AGENTS.local.md` for environment-specific overrides.