### PR TITLE
perf: reduce calls to GetWorkspaceByAgentID in GetWorkspaceAgentByID

### DIFF
--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -197,6 +197,7 @@ func New(opts Options, workspace database.Workspace) *API {
 		AgentFn:          api.agent,
 		ConnectionLogger: opts.ConnectionLogger,
 		Database:         opts.Database,
+		Workspace:        api.cachedWorkspaceFields,
 		Log:              opts.Log,
 	}
 

--- a/coderd/agentapi/connectionlog_test.go
+++ b/coderd/agentapi/connectionlog_test.go
@@ -117,6 +117,7 @@ func TestConnectionLog(t *testing.T) {
 				AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
 					return agent, nil
 				},
+				Workspace: &agentapi.CachedWorkspaceFields{},
 			}
 			api.ReportConnection(context.Background(), &agentproto.ReportConnectionRequest{
 				Connection: &agentproto.Connection{

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -10,6 +10,7 @@ import (
 	"cdr.dev/slog"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
@@ -43,7 +44,21 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 		return res, nil
 	}
 
-	workspaceAgent, err := a.AgentFn(ctx)
+	// Inject RBAC object into context for dbauthz fast path, avoid having to
+	// call GetWorkspaceAgentByID on every stats update.
+
+	rbacCtx := ctx
+	if dbws, ok := a.Workspace.AsWorkspaceIdentity(); ok {
+		var err error
+		rbacCtx, err = dbauthz.WithWorkspaceRBAC(ctx, dbws.RBACObject())
+		if err != nil {
+			// Don't error level log here, will exit the function. We want to fall back to GetWorkspaceByAgentID.
+			//nolint:gocritic
+			a.Log.Debug(ctx, "Cached workspace was present but RBAC object was invalid", slog.F("err", err))
+		}
+	}
+
+	workspaceAgent, err := a.AgentFn(rbacCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3560,6 +3560,21 @@ func (q *querier) GetWorkspaceAgentAndLatestBuildByAuthToken(ctx context.Context
 }
 
 func (q *querier) GetWorkspaceAgentByID(ctx context.Context, id uuid.UUID) (database.WorkspaceAgent, error) {
+	// Fast path: Check if we have a workspace RBAC object in context.
+	// In the agent API this is set at agent connection time to avoid the expensive
+	// GetWorkspaceByAgentID query for every agent operation.
+	// NOTE: The cached RBAC object is refreshed every 5 minutes in agentapi/api.go.
+	if rbacObj, ok := WorkspaceRBACFromContext(ctx); ok {
+		// Errors here will result in falling back to GetWorkspaceByAgentID,
+		// in case the cached data is stale.
+		if err := q.authorizeContext(ctx, policy.ActionRead, rbacObj); err == nil {
+			return q.db.GetWorkspaceAgentByID(ctx, id)
+		}
+		q.log.Debug(ctx, "fast path authorization failed for GetWorkspaceAgentByID, using slow path",
+			slog.F("agent_id", id))
+	}
+
+	// Slow path: Fallback to fetching the workspace for authorization
 	if _, err := q.GetWorkspaceByAgentID(ctx, id); err != nil {
 		return database.WorkspaceAgent{}, err
 	}


### PR DESCRIPTION
This PR piggy backs on the agent API cached workspace added in https://github.com/coder/coder/pull/20662 to provide a fast path for avoiding `GetWorkspaceByAgentID` calls in dbauthz's `GetWorkspaceAgentByID`. This query is not the most expensive, but has a significant call volume at ~16 million calls per week. 

Profiling shows that the majority of these calls are via the agent API's `agentFn`. 
<img width="1688" height="210" alt="Screenshot 2025-12-01 at 2 37 21 PM" src="https://github.com/user-attachments/assets/167aaef5-8e5e-406e-a8f2-c2da21b330ef" />
