### PR TITLE
perf: support fastpath in dbauthz GetLatestWorkspaceBuildByWorkspaceID

### DIFF
--- a/coderd/agentapi/cached_workspace.go
+++ b/coderd/agentapi/cached_workspace.go
@@ -2,8 +2,9 @@ package agentapi
 
 import (
 	"context"
-	"fmt"
 	"sync"
+
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -64,7 +65,7 @@ func (cws *CachedWorkspaceFields) ContextInject(ctx context.Context) (context.Co
 		if err != nil {
 			// Don't error level log here, will exit the function. We want to fall back to GetWorkspaceByAgentID.
 			//nolint:gocritic
-			return ctx, fmt.Errorf("Cached workspace was present but RBAC object was invalid: %w", err)
+			return ctx, xerrors.Errorf("Cached workspace was present but RBAC object was invalid: %w", err)
 		}
 	}
 	return rbacCtx, nil

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -231,6 +231,8 @@ func (api *API) startAgentYamuxMonitor(ctx context.Context,
 		workspace:         workspace,
 		workspaceAgent:    workspaceAgent,
 		workspaceBuild:    workspaceBuild,
+		cachedWs: &agentapi.CachedWorkspaceFields{},
+
 		conn:              &yamuxPingerCloser{mux: mux},
 		pingPeriod:        api.AgentConnectionUpdateFrequency,
 		db:                api.Database,
@@ -242,6 +244,7 @@ func (api *API) startAgentYamuxMonitor(ctx context.Context,
 			slog.F("agent_id", workspaceAgent.ID),
 		),
 	}
+	monitor.cachedWs.UpdateValues(workspace)
 	monitor.init()
 	monitor.start(ctx)
 

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -227,10 +227,10 @@ func (api *API) startAgentYamuxMonitor(ctx context.Context,
 	mux *yamux.Session,
 ) *agentConnectionMonitor {
 	monitor := &agentConnectionMonitor{
-		apiCtx:            api.ctx,
-		workspace:         workspace,
-		workspaceAgent:    workspaceAgent,
-		workspaceBuild:    workspaceBuild,
+		apiCtx:         api.ctx,
+		workspace:      workspace,
+		workspaceAgent: workspaceAgent,
+		workspaceBuild: workspaceBuild,
 
 		conn:              &yamuxPingerCloser{mux: mux},
 		pingPeriod:        api.AgentConnectionUpdateFrequency,

--- a/coderd/workspaceagentsrpc_internal_test.go
+++ b/coderd/workspaceagentsrpc_internal_test.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/agentapi"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -48,7 +47,6 @@ func TestAgentConnectionMonitor_ContextCancel(t *testing.T) {
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
-		cachedWs: &agentapi.CachedWorkspaceFields{},
 		conn:              fConn,
 		db:                mDB,
 		replicaID:         replicaID,
@@ -123,7 +121,6 @@ func TestAgentConnectionMonitor_PingTimeout(t *testing.T) {
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
-		cachedWs: &agentapi.CachedWorkspaceFields{},
 		conn:              fConn,
 		db:                mDB,
 		replicaID:         replicaID,
@@ -189,7 +186,6 @@ func TestAgentConnectionMonitor_BuildOutdated(t *testing.T) {
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
-		cachedWs: &agentapi.CachedWorkspaceFields{},
 		conn:              fConn,
 		db:                mDB,
 		replicaID:         replicaID,

--- a/coderd/workspaceagentsrpc_internal_test.go
+++ b/coderd/workspaceagentsrpc_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/agentapi"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -47,6 +48,7 @@ func TestAgentConnectionMonitor_ContextCancel(t *testing.T) {
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
+		cachedWs: &agentapi.CachedWorkspaceFields{},
 		conn:              fConn,
 		db:                mDB,
 		replicaID:         replicaID,
@@ -121,6 +123,7 @@ func TestAgentConnectionMonitor_PingTimeout(t *testing.T) {
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
+		cachedWs: &agentapi.CachedWorkspaceFields{},
 		conn:              fConn,
 		db:                mDB,
 		replicaID:         replicaID,
@@ -186,6 +189,7 @@ func TestAgentConnectionMonitor_BuildOutdated(t *testing.T) {
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
+		cachedWs: &agentapi.CachedWorkspaceFields{},
 		conn:              fConn,
 		db:                mDB,
 		replicaID:         replicaID,


### PR DESCRIPTION
This PR piggy backs on the agent API cached workspace added in https://github.com/coder/coder/pull/20662 to provide a fast path for avoiding `GetWorkspaceByID` calls in `GetLatestWorkspaceBuildByWorkspaceID` via injection of the workspaces RBAC object into the context. We can do this from the `agentConnectionMonitor` easily since we already cache the workspace.
