### PR TITLE
feat: add serviceAccount.labels for custom service account labels on helm chart

### DIFF
--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: coder
     app.kubernetes.io/part-of: coder
     app.kubernetes.io/version: 0.1.0
+    com.coder/sa-label: test-value
     helm.sh/chart: coder-0.1.0
   name: coder-service-account
   namespace: default

--- a/helm/coder/tests/testdata/sa.yaml
+++ b/helm/coder/tests/testdata/sa.yaml
@@ -5,4 +5,6 @@ coder:
     name: coder-service-account
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/coder-service-account
+    labels:
+      com.coder/sa-label: test-value
     workspacePerms: true

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: coder
     app.kubernetes.io/part-of: coder
     app.kubernetes.io/version: 0.1.0
+    com.coder/sa-label: test-value
     helm.sh/chart: coder-0.1.0
   name: coder-service-account
   namespace: coder

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -130,6 +130,8 @@ coder:
 
     # coder.serviceAccount.annotations -- The Coder service account annotations.
     annotations: {}
+    # coder.serviceAccount.labels -- The Coder service account labels.
+    labels: {}
     # coder.serviceAccount.name -- The service account name
     name: coder
     # coder.serviceAccount.disableCreate -- Whether to create the service account or use existing service account.

--- a/helm/libcoder/templates/_coder.yaml
+++ b/helm/libcoder/templates/_coder.yaml
@@ -101,6 +101,9 @@ metadata:
   annotations: {{ toYaml .Values.coder.serviceAccount.annotations | nindent 4 }}
   labels:
     {{- include "coder.labels" . | nindent 4 }}
+    {{- with .Values.coder.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end -}}
 {{- define "libcoder.serviceaccount" -}}
 {{- include "libcoder.util.merge" (append . "libcoder.serviceaccount.tpl") -}}


### PR DESCRIPTION
closes #20541 

adds `coder.serviceAccount.labels` var to support custom labels being added to the SA.

Current chart:
```
➜  helm-service-account-labels git:(rowansmithau/feat/helm_service_account_labels) helm template coder coder-v2/coder --set coder.image.tag=latest --set coder.serviceAccount.labels.mux=isnice | egrep -A13 '^kind: ServiceAccount$'
kind: ServiceAccount
metadata:
  annotations: {}
  labels:
    app.kubernetes.io/instance: coder
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: coder
    app.kubernetes.io/part-of: coder
    app.kubernetes.io/version: 2.28.3
    helm.sh/chart: coder-2.28.3
  name: coder
  namespace: default
---
# Source: coder/templates/rbac.yaml
```

With this PR:
```
➜  helm-service-account-labels git:(rowansmithau/feat/helm_service_account_labels) helm template coder helm/coder --set coder.image.tag=latest --set coder.serviceAccount.labels.mux=isnice | egrep -A13 '^kind: ServiceAccount$'
kind: ServiceAccount
metadata:
  annotations: {}
  labels:
    app.kubernetes.io/instance: coder
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: coder
    app.kubernetes.io/part-of: coder
    app.kubernetes.io/version: 0.1.0
    helm.sh/chart: coder-0.1.0
    mux: isnice
  name: coder
  namespace: default
---
```

A test with `disableCreate=true` still correctly shows no SA created:
```
➜  helm-service-account-labels git:(rowansmithau/feat/helm_service_account_labels) helm template coder helm/coder --set coder.image.tag=latest --set coder.serviceAccount.labels.mux=isnice --set coder.serviceAccount.disableCreate=true | egrep '^kind: ServiceAccount$'
```