### PR TITLE
test(agent/agentcontainers): fix data race and flake in DuringUpWithContainerID test

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -235,7 +235,7 @@ func (w *fakeWatcher) sendEventWaitNextCalled(ctx context.Context, event fsnotif
 type fakeSubAgentClient struct {
 	logger slog.Logger
 
-	mu     sync.Mutex
+	mu     sync.Mutex // Protects following.
 	agents map[uuid.UUID]agentcontainers.SubAgent
 
 	listErrC   chan error // If set, send to return error, close to return nil.

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -233,6 +233,7 @@ func (w *fakeWatcher) sendEventWaitNextCalled(ctx context.Context, event fsnotif
 
 // fakeSubAgentClient implements SubAgentClient for testing purposes.
 type fakeSubAgentClient struct {
+	mu     sync.Mutex
 	logger slog.Logger
 	agents map[uuid.UUID]agentcontainers.SubAgent
 
@@ -254,6 +255,8 @@ func (m *fakeSubAgentClient) List(ctx context.Context) ([]agentcontainers.SubAge
 			}
 		}
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	var agents []agentcontainers.SubAgent
 	for _, agent := range m.agents {
 		agents = append(agents, agent)
@@ -282,6 +285,9 @@ func (m *fakeSubAgentClient) Create(ctx context.Context, agent agentcontainers.S
 	if agent.OperatingSystem == "" {
 		return agentcontainers.SubAgent{}, xerrors.New("operating system must be set")
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	for _, a := range m.agents {
 		if a.Name == agent.Name {
@@ -314,6 +320,8 @@ func (m *fakeSubAgentClient) Delete(ctx context.Context, id uuid.UUID) error {
 			}
 		}
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.agents == nil {
 		m.agents = make(map[uuid.UUID]agentcontainers.SubAgent)
 	}
@@ -2162,6 +2170,10 @@ func TestAPI(t *testing.T) {
 			nowRecreateSuccessTrap.MustWait(ctx).MustRelease(ctx)
 			nowRecreateSuccessTrap.Close()
 
+			// Advance the clock to run the devcontainer state update routine.
+			_, aw := mClock.AdvanceNext()
+			aw.MustWait(ctx)
+
 			req = httptest.NewRequest(http.MethodGet, "/", nil)
 			rec = httptest.NewRecorder()
 			r.ServeHTTP(rec, req)
@@ -2178,7 +2190,7 @@ func TestAPI(t *testing.T) {
 			// available for use.
 			require.Len(t, response.Devcontainers, 1)
 			assert.Equal(t, codersdk.WorkspaceAgentDevcontainerStatusRunning, response.Devcontainers[0].Status)
-			assert.NotNil(t, response.Devcontainers[0].Container)
+			require.NotNil(t, response.Devcontainers[0].Container)
 			assert.Equal(t, testContainer.ID, response.Devcontainers[0].Container.ID)
 		})
 

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -233,8 +233,9 @@ func (w *fakeWatcher) sendEventWaitNextCalled(ctx context.Context, event fsnotif
 
 // fakeSubAgentClient implements SubAgentClient for testing purposes.
 type fakeSubAgentClient struct {
-	mu     sync.Mutex
 	logger slog.Logger
+
+	mu     sync.Mutex
 	agents map[uuid.UUID]agentcontainers.SubAgent
 
 	listErrC   chan error // If set, send to return error, close to return nil.


### PR DESCRIPTION
The test had two issues:

1. Data race in fakeSubAgentClient: The test helper was accessed
   concurrently from the API's updater loop and from API.Close()
   without synchronization. Added a mutex to protect shared map
   and slice access.

2. Missing clock advance: After nowRecreateSuccessTrap fires,
   CreateDevcontainer still calls RefreshContainers which needs
   to complete before the test checks the response. Added clock
   advance to match the pattern used in other similar tests.

Also changed assert.NotNil to require.NotNil to prevent nil pointer
dereference if the assertion fails.

Fixes coder/internal#1169
