### PR TITLE
chore: fix race condition on aggregating terraform logs

### DIFF
--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -325,9 +325,7 @@ func (e *executor) plan(ctx, killCtx context.Context, env, vars []string, logr l
 		<-doneErr
 	}()
 
-	endStage := e.timings.startStage(database.ProvisionerJobTimingStagePlan)
 	err := e.execWriteOutput(ctx, killCtx, args, env, outWriter, errWriter)
-	endStage(err)
 	if err != nil {
 		return nil, xerrors.Errorf("terraform plan: %w", err)
 	}
@@ -386,13 +384,11 @@ func (e *executor) plan(ctx, killCtx context.Context, env, vars []string, logr l
 		}
 	}
 
-	// DoneOut must be completed before we aggregate timings to ensure all logs have been processed.
-	<-doneOut
 	msg := &proto.PlanComplete{
 		Parameters:            state.Parameters,
 		Resources:             state.Resources,
 		ExternalAuthProviders: state.ExternalAuthProviders,
-		Timings:               append(e.timings.aggregate(), graphTimings.aggregate()...),
+		Timings:               graphTimings.aggregate(),
 		Presets:               state.Presets,
 		Plan:                  planJSON,
 		ResourceReplacements:  resReps,
@@ -601,9 +597,7 @@ func (e *executor) apply(
 	}()
 
 	// `terraform apply`
-	endStage := e.timings.startStage(database.ProvisionerJobTimingStageApply)
 	err := e.execWriteOutput(ctx, killCtx, args, env, outWriter, errWriter)
-	endStage(err)
 	if err != nil {
 		return nil, xerrors.Errorf("terraform apply: %w", err)
 	}
@@ -619,15 +613,11 @@ func (e *executor) apply(
 		return nil, xerrors.Errorf("read statefile %q: %w", statefilePath, err)
 	}
 
-	// DoneOut must be completed before we aggregate timings to ensure all logs have been processed.
-	<-doneOut
-	agg := e.timings.aggregate()
 	return &proto.ApplyComplete{
 		Parameters:            state.Parameters,
 		Resources:             state.Resources,
 		ExternalAuthProviders: state.ExternalAuthProviders,
 		State:                 stateContent,
-		Timings:               agg,
 		AiTasks:               state.AITasks,
 	}, nil
 }

--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -386,6 +386,8 @@ func (e *executor) plan(ctx, killCtx context.Context, env, vars []string, logr l
 		}
 	}
 
+	// DoneOut must be completed before we aggregate timings to ensure all logs have been processed.
+	<-doneOut
 	msg := &proto.PlanComplete{
 		Parameters:            state.Parameters,
 		Resources:             state.Resources,
@@ -617,6 +619,8 @@ func (e *executor) apply(
 		return nil, xerrors.Errorf("read statefile %q: %w", statefilePath, err)
 	}
 
+	// DoneOut must be completed before we aggregate timings to ensure all logs have been processed.
+	<-doneOut
 	agg := e.timings.aggregate()
 	return &proto.ApplyComplete{
 		Parameters:            state.Parameters,


### PR DESCRIPTION
I noticed we have a defer to make sure all log output is captured by the async log handling routine.

```golang
	defer func() {
		_ = outWriter.Close()
		_ = errWriter.Close()
		<-doneOut
		<-doneErr
	}()
```

But `e.timings.aggregate()` compiles the **current** parsed logs. I was getting some race conditions in testing if the logs did not completely parse before `aggregate` was called.

So now `aggregate` happens outside the cmd exec function, to make sure it is completed before logs are accumulated.