### PR TITLE
chore(docs): update Docs Release Cal for 2.29

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -136,7 +136,7 @@ We support two release channels: mainline and stable - read the
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.28.3
+        --version 2.29.0
     ```
 
   - **OCI Registry**
@@ -147,7 +147,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.28.3
+        --version 2.29.0
     ```
 
 - **Stable** Coder release:
@@ -160,7 +160,7 @@ We support two release channels: mainline and stable - read the
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.27.6
+        --version 2.28.5
     ```
 
   - **OCI Registry**
@@ -171,7 +171,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.27.6
+        --version 2.28.5
     ```
 
 You can watch Coder start up by running `kubectl get pods -n coder`. Once Coder

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -134,8 +134,8 @@ kubectl create secret generic coder-db-url -n coder \
 
 1. Select a Coder version:
 
-   - **Mainline**: `2.28.3`
-   - **Stable**: `2.27.6`
+   - **Mainline**: `2.29.0`
+   - **Stable**: `2.28.5`
 
    Learn more about release channels in the [Releases documentation](./releases/index.md).
 

--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -10,7 +10,7 @@ deployment.
 ## Release channels
 
 We support two release channels:
-[mainline](https://github.com/coder/coder/releases/tag/v2.24.2) for the bleeding
+[mainline](https://github.com/coder/coder/releases/tag/v2.29.0) for the bleeding
 edge version of Coder and
 [stable](https://github.com/coder/coder/releases/latest) for those with lower
 tolerance for fault. We field our mainline releases publicly for one month
@@ -57,13 +57,13 @@ pages.
 <!-- RELEASE_CALENDAR_START -->
 | Release name                                   | Release Date       | Status           | Latest Release                                                 |
 |------------------------------------------------|--------------------|------------------|----------------------------------------------------------------|
-| [2.23](https://coder.com/changelog/coder-2-23) | June 03, 2025      | Not Supported    | [v2.23.5](https://github.com/coder/coder/releases/tag/v2.23.5) |
 | [2.24](https://coder.com/changelog/coder-2-24) | July 01, 2025      | Not Supported    | [v2.24.4](https://github.com/coder/coder/releases/tag/v2.24.4) |
 | [2.25](https://coder.com/changelog/coder-2-25) | August 05, 2025    | Not Supported    | [v2.25.3](https://github.com/coder/coder/releases/tag/v2.25.3) |
-| [2.26](https://coder.com/changelog/coder-2-26) | September 03, 2025 | Security Support | [v2.26.4](https://github.com/coder/coder/releases/tag/v2.26.4) |
-| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Stable           | [v2.27.6](https://github.com/coder/coder/releases/tag/v2.27.6) |
-| [2.28](https://coder.com/changelog/coder-2-28) | November 04, 2025  | Mainline         | [v2.28.3](https://github.com/coder/coder/releases/tag/v2.28.3) |
-| 2.29                                           |                    | Not Released     | N/A                                                            |
+| [2.26](https://coder.com/changelog/coder-2-26) | September 03, 2025 | Not Supported    | [v2.26.6](https://github.com/coder/coder/releases/tag/v2.26.6) |
+| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Security Support | [v2.27.8](https://github.com/coder/coder/releases/tag/v2.27.8) |
+| [2.28](https://coder.com/changelog/coder-2-28) | November 04, 2025  | Stable           | [v2.28.5](https://github.com/coder/coder/releases/tag/v2.28.5) |
+| [2.29](https://coder.com/changelog/coder-2-29) | December 02, 2025  | Mainline         | [v2.29.0](https://github.com/coder/coder/releases/tag/v2.29.0) |
+| 2.30                                           |                    | Not Released     | N/A                                                            |
 <!-- RELEASE_CALENDAR_END -->
 
 > [!TIP]


### PR DESCRIPTION
## Description
We made available the [2.29 release](https://github.com/coder/coder/releases/tag/v2.29.0); this PR updates our docs to appropriately reference the latest versions of mainline/stable. 

Note: this did not happen for the patches that happened last week and yesterday, which is why we jump from 2.28.3 -> 2.28.5