### PR TITLE
perf: don't calculate build times for deleted templates

### DIFF
--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -87,7 +87,9 @@ func (c *Cache) refreshTemplateBuildTimes(ctx context.Context) error {
 	//nolint:gocritic // This is a system service.
 	ctx = dbauthz.AsSystemRestricted(ctx)
 
-	templates, err := c.database.GetTemplates(ctx)
+	templates, err := c.database.GetTemplatesWithFilter(ctx, database.GetTemplatesWithFilterParams{
+		Deleted: false,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The metrics cache to calculate and expose build time metrics for templates currently calls `GetTemplates`, which returns all templates even if they are deleted. We can use the `GetTemplatesWithFilter` query to easily filter out deleted templates from the results, and thus not call `GetTemplateAverageBuildTime` for those deleted templates. Delete time for workspaces for non-deleted templates is still calculated.
