### PR TITLE
fix: suppress startup script logs in non-blocking SSH mode

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -152,7 +152,13 @@ func Agent(ctx context.Context, writer io.Writer, agentID uuid.UUID, opts AgentO
 				sw.Log(time.Time{}, codersdk.LogLevelInfo, "==> ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.")
 			}
 
-			err = func() error { // Use func because of defer in for loop.
+			err = func() error {
+				// In non-blocking mode, skip streaming logs.
+				// See: https://github.com/coder/coder/issues/13580
+				if !opts.Wait {
+					return nil
+				}
+
 				logStream, logsCloser, err := opts.FetchLogs(ctx, agent.ID, 0, follow)
 				if err != nil {
 					return xerrors.Errorf("fetch workspace agent startup logs: %w", err)


### PR DESCRIPTION
## Summary

This PR improves parity between `ssh` behavior for Coder workspaces vs non-Coder hosts. When you run `ssh server -- echo hello`, you get `hello`. But `ssh workspace.coder -- echo hello` would dump hundreds of lines of startup script logs first—even when not waiting for them.

This is part of making Coder Workspaces and Mux work better together.

Fixes #13580

## Changes

- **Non-blocking mode** (`--wait=no` or via ProxyCommand): Show only a concise warning if startup failed/timed out, no logs
- **Non-TTY** (e.g., `ssh workspace.coder -- cmd`): Suppress all agent status output via new `Quiet` option
- **Blocking mode** (`--wait=yes`): Unchanged—still streams logs

## Before/After

| Scenario | Before | After |
|----------|--------|-------|
| `ssh workspace.coder -- echo hello` | Dumps full startup logs | Just `hello` |
| `coder ssh --wait=no ws` (TTY) | "Running" stage + logs | Concise warning if failed |
| `coder ssh --wait=yes ws` | Streams logs | Unchanged |

---

_Generated with [mux](https://github.com/anthropics/mux)_