### PR TITLE
docs: delete references to adding database replicas

### DIFF
--- a/docs/admin/infrastructure/validated-architectures/2k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/2k-users.md
@@ -47,16 +47,11 @@ deployment reliability under load.
 - Nodes can be distributed in 2 regions, not necessarily evenly split, depending
   on developer team sizes
 
-### Database nodes
+### Database node
 
-| Users       | Node capacity        | Replicas | Storage | GCP                 | AWS            | Azure             |
-|-------------|----------------------|----------|---------|---------------------|----------------|-------------------|
-| Up to 2,000 | 4 vCPU, 16 GB memory | 1 node   | 1 TB    | `db-custom-4-15360` | `db.m5.xlarge` | `Standard_D4s_v3` |
-
-**Footnotes**:
-
-- Consider adding more replicas if the workspace activity is higher than 500
-  workspace builds per day or to achieve higher RPS.
+| Users       | Node capacity        | Storage | GCP                 | AWS            | Azure             |
+|-------------|----------------------|---------|---------------------|----------------|-------------------|
+| Up to 2,000 | 4 vCPU, 16 GB memory | 1 TB    | `db-custom-4-15360` | `db.m5.xlarge` | `Standard_D4s_v3` |
 
 **Footnotes for AWS instance types**:
 

--- a/docs/admin/infrastructure/validated-architectures/3k-users.md
+++ b/docs/admin/infrastructure/validated-architectures/3k-users.md
@@ -50,16 +50,11 @@ continuously improve the reliability and performance of the platform.
   and cloud areas, consider different namespaces in favor of zero-trust or
   multi-cloud deployments.
 
-### Database nodes
+### Database node
 
-| Users       | Node capacity        | Replicas | Storage | GCP                 | AWS             | Azure             |
-|-------------|----------------------|----------|---------|---------------------|-----------------|-------------------|
-| Up to 3,000 | 8 vCPU, 32 GB memory | 2 nodes  | 1.5 TB  | `db-custom-8-30720` | `db.m5.2xlarge` | `Standard_D8s_v3` |
-
-**Footnotes**:
-
-- Consider adding more replicas if the workspace activity is higher than 1500
-  workspace builds per day or to achieve higher RPS.
+| Users       | Node capacity        | Storage | GCP                 | AWS             | Azure             |
+|-------------|----------------------|---------|---------------------|-----------------|-------------------|
+| Up to 3,000 | 8 vCPU, 32 GB memory | 1.5 TB  | `db-custom-8-30720` | `db.m5.2xlarge` | `Standard_D8s_v3` |
 
 **Footnotes for AWS instance types**:
 


### PR DESCRIPTION
Removes references to adding database replicas from the scaling docs, as Coder only allows a single connection URL. These passages where added in error.