### PR TITLE
chore: enforce cooldown period 

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -70,8 +70,6 @@ updates:
       interval: "monthly"
       time: "06:00"
       timezone: "America/Chicago"
-    reviewers:
-      - "coder/ts"
     cooldown:
       default-days: 7
     commit-message:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       time: "06:00"
       timezone: "America/Chicago"
+    cooldown:
+      default-days: 7
     labels: []
     commit-message:
       prefix: "ci"
@@ -70,6 +72,8 @@ updates:
       timezone: "America/Chicago"
     reviewers:
       - "coder/ts"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     labels: []


### PR DESCRIPTION
Closes:
https://github.com/coder/internal/issues/1170

Changes in scope:
- [enforce cooldown period](https://github.com/coder/coder/commit/829792e37fbe25b119fa658efd6d310dd507d7d6)
- [remove obsolete reviewers entry](https://github.com/coder/coder/commit/4875992bc6323249353518d4e361b3f7244c8a71)

Reference:
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/