### PR TITLE
docs: add rules to avoid unnecessary changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,23 @@ ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 ```
 
+### Avoid Unnecessary Changes
+
+When fixing a bug or adding a feature, don't modify code unrelated to your
+task. Unnecessary changes make PRs harder to review and can introduce
+regressions.
+
+**Don't reword existing comments or code** unless the change is directly
+motivated by your task. Rewording comments to be shorter or "cleaner" wastes
+reviewer time and clutters the diff.
+
+**Don't delete existing comments** that explain non-obvious behavior. These
+comments preserve important context about why code works a certain way.
+
+**When adding tests for new behavior**, add new test cases instead of modifying
+existing ones. This preserves coverage for the original behavior and makes it
+clear what the new test covers.
+
 ## Detailed Development Guides
 
 @.claude/docs/ARCHITECTURE.md


### PR DESCRIPTION
Add guidelines to prevent common PR feedback issues:

- Don't reword existing comments or code unless directly motivated by the task
- Don't delete existing comments that explain non-obvious behavior
- Add new test cases instead of modifying existing ones

Refs #21073