### PR TITLE
fix(coderd): exclude sub-agents from workspace health calculation

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2598,6 +2598,13 @@ func convertWorkspace(
 	failingAgents := []uuid.UUID{}
 	for _, resource := range workspaceBuild.Resources {
 		for _, agent := range resource.Agents {
+			// Sub-agents (e.g., devcontainer agents) are excluded from the
+			// workspace health calculation. Their health is managed by
+			// their parent agent, and temporary disconnections during
+			// devcontainer rebuilds should not affect workspace health.
+			if agent.ParentID.Valid {
+				continue
+			}
 			if !agent.Health.Healthy {
 				failingAgents = append(failingAgents, agent.ID)
 			}


### PR DESCRIPTION
When a devcontainer rebuilds, its sub-agent temporarily disconnects, causing the workspace to show as unhealthy.

<img width="1281" height="425" alt="image" src="https://github.com/user-attachments/assets/8e6e369e-2881-45da-839c-4438913d4ffc" />

This is a simplistic fix that excludes sub-agents from the workspace health calculation entirely. Ideally we'd only exclude them during rebuilds, but showing a healthy workspace inaccurately is less harmful than the current confusing UX.