### PR TITLE
perf(coderd/database): add index on workspace_app_statuses.app_id

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -1680,8 +1680,8 @@ func TestTasksNotification(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, workspaceAgent.Apps, 1)
 			require.GreaterOrEqual(t, len(workspaceAgent.Apps[0].Statuses), 1)
-			latestStatusIndex := len(workspaceAgent.Apps[0].Statuses) - 1
-			require.Equal(t, tc.newAppStatus, workspaceAgent.Apps[0].Statuses[latestStatusIndex].State)
+			// Statuses are ordered by created_at DESC, so the first element is the latest.
+			require.Equal(t, tc.newAppStatus, workspaceAgent.Apps[0].Statuses[0].State)
 
 			if tc.isNotificationSent {
 				// Then: A notification is sent to the workspace owner (memberUser)

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -3449,6 +3449,8 @@ COMMENT ON INDEX workspace_app_audit_sessions_unique_index IS 'Unique index to e
 
 CREATE INDEX workspace_app_stats_workspace_id_idx ON workspace_app_stats USING btree (workspace_id);
 
+CREATE INDEX workspace_app_statuses_app_id_idx ON workspace_app_statuses USING btree (app_id, created_at DESC);
+
 CREATE INDEX workspace_modules_created_at_idx ON workspace_modules USING btree (created_at);
 
 CREATE INDEX workspace_next_start_at_idx ON workspaces USING btree (next_start_at) WHERE (deleted = false);

--- a/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.down.sql
+++ b/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS workspace_app_statuses_app_id_idx;

--- a/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.up.sql
+++ b/coderd/database/migrations/000402_workspace_app_statuses_app_id_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX workspace_app_statuses_app_id_idx ON workspace_app_statuses (app_id, created_at DESC);

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -20246,6 +20246,7 @@ func (q *sqlQuerier) GetWorkspaceAppByAgentIDAndSlug(ctx context.Context, arg Ge
 
 const getWorkspaceAppStatusesByAppIDs = `-- name: GetWorkspaceAppStatusesByAppIDs :many
 SELECT id, created_at, agent_id, app_id, workspace_id, state, message, uri FROM workspace_app_statuses WHERE app_id = ANY($1 :: uuid [ ])
+ORDER BY created_at DESC, id DESC
 `
 
 func (q *sqlQuerier) GetWorkspaceAppStatusesByAppIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAppStatus, error) {

--- a/coderd/database/queries/workspaceapps.sql
+++ b/coderd/database/queries/workspaceapps.sql
@@ -71,7 +71,8 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
 -- name: GetWorkspaceAppStatusesByAppIDs :many
-SELECT * FROM workspace_app_statuses WHERE app_id = ANY(@ids :: uuid [ ]);
+SELECT * FROM workspace_app_statuses WHERE app_id = ANY(@ids :: uuid [ ])
+ORDER BY created_at DESC, id DESC;
 
 -- name: GetLatestWorkspaceAppStatusByAppID :one
 SELECT *


### PR DESCRIPTION
The queries `GetWorkspaceAppStatusesByAppIDs` and `GetLatestWorkspaceAppStatusByAppID` both filter by `app_id` but there was no index to support this, causing sequential scans.

Each query took ~30ms on average with 80 requests/second to the cluster, resulting in ~5.2 query-seconds every second.

Use a composite index on `(app_id, created_at DESC)` to support both queries efficiently, and add `ORDER BY` to `GetWorkspaceAppStatusesByAppIDs` for consistent ordering (newest first).

**NOTE**: This migration creates an index on `workspace_app_statuses`. For deployments with heavy task usage, this may take a moment to complete. The concern is minor since tasks are a new feature and most tables will be small.

Refs https://www.notion.so/coderhq/2k-Task-Status-Updates-retest-2bfd579be59280ca8f86eb376d05e0fa