### PR TITLE
fix(agent/agentcontainers): broadcast devcontainer dirty status over websocket

### DIFF
--- a/agent/agentcontainers/api.go
+++ b/agent/agentcontainers/api.go
@@ -1457,6 +1457,8 @@ func (api *API) markDevcontainerDirty(configPath string, modifiedAt time.Time) {
 
 		api.knownDevcontainers[dc.WorkspaceFolder] = dc
 	}
+
+	api.broadcastUpdatesLocked()
 }
 
 // cleanupSubAgents removes subagents that are no longer managed by


### PR DESCRIPTION
Previously, when a devcontainer config file was modified, the dirty status was updated internally but not broadcast to websocket listeners. This meant the UI would not show the dirty indicator until some other event triggered a broadcast (e.g., container restart).

Add `broadcastUpdatesLocked()` call in `markDevcontainerDirty` to notify websocket listeners immediately when a config file changes.