### PR TITLE
chore: fix test errors on newer debian-based systems due to deprecated TZ

### DIFF
--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -76,7 +76,7 @@ func NewDBWithSQLDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub
 	return db, ps, sqlDB
 }
 
-var DefaultTimezone = "Canada/Newfoundland"
+var DefaultTimezone = "America/St_Johns"
 
 // NowInDefaultTimezone returns the current time rounded to the nearest microsecond in the default timezone
 // used by postgres in tests. Useful for object equality checks.

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -4082,7 +4082,7 @@ func TestGetUserStatusCounts(t *testing.T) {
 	t.Skip("https://github.com/coder/internal/issues/464")
 
 	timezones := []string{
-		"Canada/Newfoundland",
+		"America/St_Johns",
 		"Africa/Johannesburg",
 		"America/New_York",
 		"Europe/London",

--- a/coderd/workspacestats/activitybump_test.go
+++ b/coderd/workspacestats/activitybump_test.go
@@ -25,11 +25,11 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 	// We test the below in multiple timezones specifically
 	// chosen to trigger timezone-related bugs.
 	timezones := []string{
-		"Asia/Kolkata",        // No DST, positive fractional offset
-		"Canada/Newfoundland", // DST, negative fractional offset
-		"Europe/Paris",        // DST, positive offset
-		"US/Arizona",          // No DST, negative offset
-		"UTC",                 // Baseline
+		"Asia/Kolkata",     // No DST, positive fractional offset
+		"America/St_Johns", // DST, negative fractional offset
+		"Europe/Paris",     // DST, positive offset
+		"US/Arizona",       // No DST, negative offset
+		"UTC",              // Baseline
 	}
 
 	for _, tt := range []struct {


### PR DESCRIPTION
It appears on newer Debian systems `Canada/Newfoundland` TZ is not present and `America/St_Johns` should be used instead. Coder tests use a docker PG image where `Canada/Newfoundland` is still supported:

```
$ docker run --rm -it us-docker.pkg.dev/coder-v2-images-public/public/postgres:17 bash
root@ca99e82721dc:/# ls -l /usr/share/zoneinfo/Canada/Newfoundland
lrwxrwxrwx 1 root root 19 Mar 26  2025 /usr/share/zoneinfo/Canada/Newfoundland -> ../America/St_Johns
```
However, if a local PG instance is running on a Debian Trixie host, coder test will use it and error out due to the zone being unavailable:

```
$ docker run --rm -it debian:trixie bash
root@f285092767e4:/# ls -l /usr/share/zoneinfo/Canada/Newfoundland
ls: cannot access '/usr/share/zoneinfo/Canada/Newfoundland': No such file or directory
root@f285092767e4:/# ls -l /usr/share/zoneinfo/America/St_Johns
-rw-r--r-- 1 root root 3655 Aug 24 20:12 /usr/share/zoneinfo/America/St_Johns
```

... which causes the tests to error out:

```
$ go test ./enterprise/coderd
--- FAIL: TestWorkspaceTemplateParamsChange (0.13s)
    workspaces_test.go:3097: TestWorkspaceTagsTerraform: using cached terraform providers
    workspaces_test.go:3097: Set TF_CLI_CONFIG_FILE=/home/geo/.cache/coderv2-test/terraform_workspace_tags_test/a28ed341dee8/terraform.rc
    coderdenttest.go:84:
        	Error Trace:	/home/geo/coder/coderd/database/dbtestutil/db.go:161
        	            				/home/geo/coder/coderd/database/dbtestutil/db.go:122
        	            				/home/geo/coder/coderd/coderdtest/coderdtest.go:270
        	            				/home/geo/coder/enterprise/coderd/coderdenttest/coderdenttest.go:105
        	            				/home/geo/coder/enterprise/coderd/coderdenttest/coderdenttest.go:84
        	            				/home/geo/coder/enterprise/coderd/coderdenttest/coderdenttest.go:84
        	            				/home/geo/coder/enterprise/coderd/workspaces_test.go:3103
        	Error:      	Received unexpected error:
        	            	pq: invalid value for parameter "TimeZone": "Canada/Newfoundland"
        	Test:       	TestWorkspaceTemplateParamsChange
        	Messages:   	failed to set timezone for database
...
```

This PR replaces the problematic TZ with the canonical one.