### PR TITLE
fix: use task display_name in browser tab title

### DIFF
--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -182,7 +182,7 @@ const TaskPage = () => {
 
 	return (
 		<TaskPageLayout>
-			<title>{pageTitle(task.name)}</title>
+			<title>{pageTitle(task.display_name)}</title>
 
 			<TaskTopbar task={task} workspace={workspace} />
 			{content}


### PR DESCRIPTION
Fixes #21145

The browser tab title for tasks was showing the machine-readable name (e.g., `kyle/my-workspace.main`) instead of the user-friendly display name (e.g., `Create Documentation`).

Changed `site/src/pages/TaskPage/TaskPage.tsx` to use `task.display_name` for the page title. The `display_name` field is always set by the backend (NOT NULL constraint, auto-generated if empty), so no fallback is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>