### PR TITLE
test: bump TestAgent_SessionTTYShell timeout

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -465,7 +465,7 @@ func TestAgent_SessionTTYShell(t *testing.T) {
 	for _, port := range sshPorts {
 		t.Run(fmt.Sprintf("(%d)", port), func(t *testing.T) {
 			t.Parallel()
-			ctx := testutil.Context(t, testutil.WaitShort)
+			ctx := testutil.Context(t, testutil.WaitMedium)
 
 			session := setupSSHSessionOnPort(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{}, nil, port)
 			command := "sh"


### PR DESCRIPTION
## Problem

The `TestAgent_SessionTTYShell` test was flaking on macOS CI runners with:

```
match deadline exceeded: context deadline exceeded (wanted 1 bytes; got 0: "")
```

The test uses `WaitShort` (10s) for the context timeout when waiting for shell prompt output via `Peek(ctx, 1)`. On slow macOS CI runners, the shell startup can exceed this timeout due to resource contention.

This is evidenced in the failure logs, the SSH session was not reported by the agent until the 10s timeout is nearly up - it took a while to connect.

## Solution

Increase the timeout from `WaitShort` (10s) to `WaitMedium` (30s). This matches the timeout used by `ExpectMatch` internally and gives the shell more time to initialize on slow CI machines.

---

This PR was entirely generated by [mux](https://github.com/coder/mux) but reviewed by a human.

Closes https://github.com/coder/internal/issues/1177