### PR TITLE
feat: add deployment-wide option to disable workspace sharing 

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -46,6 +46,13 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
+      --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
+          Disable workspace sharing (requires the "workspace-sharing" experiment
+          to be enabled). Workspace ACL checking is disabled and only owners can
+          have ssh, apps and terminal access to workspaces. Access based on the
+          'owner' role is also allowed unless disabled via
+          --disable-owner-workspace-access.
+
       --swagger-enable bool, $CODER_SWAGGER_ENABLE
           Expose the swagger endpoint via /swagger.
 

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -497,6 +497,12 @@ disablePathApps: false
 # workspaces.
 # (default: <unset>, type: bool)
 disableOwnerWorkspaceAccess: false
+# Disable workspace sharing (requires the "workspace-sharing" experiment to be
+# enabled). Workspace ACL checking is disabled and only owners can have ssh, apps
+# and terminal access to workspaces. Access based on the 'owner' role is also
+# allowed unless disabled via --disable-owner-workspace-access.
+# (default: <unset>, type: bool)
+disableWorkspaceSharing: false
 # These options change the behavior of how clients interact with the Coder.
 # Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14208,6 +14208,9 @@ const docTemplate = `{
                 "disable_path_apps": {
                     "type": "boolean"
                 },
+                "disable_workspace_sharing": {
+                    "type": "boolean"
+                },
                 "docs_url": {
                     "$ref": "#/definitions/serpent.URL"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12792,6 +12792,9 @@
 				"disable_path_apps": {
 					"type": "boolean"
 				},
+				"disable_workspace_sharing": {
+					"type": "boolean"
+				},
 				"docs_url": {
 					"$ref": "#/definitions/serpent.URL"
 				},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -334,7 +334,7 @@ func New(options *Options) *API {
 	}
 
 	if options.DeploymentValues.DisableWorkspaceSharing {
-		rbac.DisableWorkspaceACL()
+		rbac.SetWorkspaceACLDisabled(true)
 	}
 
 	if options.PrometheusRegistry == nil {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -333,6 +333,10 @@ func New(options *Options) *API {
 		})
 	}
 
+	if options.DeploymentValues.DisableWorkspaceSharing {
+		rbac.DisableWorkspaceACL()
+	}
+
 	if options.PrometheusRegistry == nil {
 		options.PrometheusRegistry = prometheus.NewRegistry()
 	}

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -439,6 +439,16 @@ func Workspace(t testing.TB, db database.Store, orig database.WorkspaceTable) da
 		require.NoError(t, err, "set workspace as dormant")
 		workspace.DormantAt = orig.DormantAt
 	}
+	if len(orig.UserACL) > 0 || len(orig.GroupACL) > 0 {
+		err = db.UpdateWorkspaceACLByID(genCtx, database.UpdateWorkspaceACLByIDParams{
+			ID:       workspace.ID,
+			UserACL:  orig.UserACL,
+			GroupACL: orig.GroupACL,
+		})
+		require.NoError(t, err, "set workspace ACL")
+		workspace.UserACL = orig.UserACL
+		workspace.GroupACL = orig.GroupACL
+	}
 	return workspace
 }
 

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -430,9 +430,16 @@ func (w WorkspaceTable) RBACObject() rbac.Object {
 		return w.DormantRBAC()
 	}
 
-	return rbac.ResourceWorkspace.WithID(w.ID).
+	obj := rbac.ResourceWorkspace.
+		WithID(w.ID).
 		InOrg(w.OrganizationID).
-		WithOwner(w.OwnerID.String()).
+		WithOwner(w.OwnerID.String())
+
+	if rbac.WorkspaceACLDisabled() {
+		return obj
+	}
+
+	return obj.
 		WithGroupACL(w.GroupACL.RBACACL()).
 		WithACLUserList(w.UserACL.RBACACL())
 }

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -241,9 +241,10 @@ func (z Object) WithGroupACL(groups map[string][]policy.Action) Object {
 // scoped to a coderd rather than a global.
 var workspaceACLDisabled bool
 
-// DisableWorkspaceACL disables workspace sharing for the deployment.
-func DisableWorkspaceACL() {
-	workspaceACLDisabled = true
+// SetWorkspaceACLDisabled disables/enables workspace sharing for the
+// deployment.
+func SetWorkspaceACLDisabled(v bool) {
+	workspaceACLDisabled = v
 }
 
 // WorkspaceACLDisabled returns true if workspace sharing is disabled

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -236,3 +236,18 @@ func (z Object) WithGroupACL(groups map[string][]policy.Action) Object {
 		AnyOrgOwner:  z.AnyOrgOwner,
 	}
 }
+
+// TODO(geokat): similar to builtInRoles, this should ideally be
+// scoped to a coderd rather than a global.
+var workspaceACLDisabled bool
+
+// DisableWorkspaceACL disables workspace sharing for the deployment.
+func DisableWorkspaceACL() {
+	workspaceACLDisabled = true
+}
+
+// WorkspaceACLDisabled returns true if workspace sharing is disabled
+// for the deployment.
+func WorkspaceACLDisabled() bool {
+	return workspaceACLDisabled
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -495,6 +495,7 @@ type DeploymentValues struct {
 	SSHConfig                       SSHConfig                            `json:"config_ssh,omitempty" typescript:",notnull"`
 	WgtunnelHost                    serpent.String                       `json:"wgtunnel_host,omitempty" typescript:",notnull"`
 	DisableOwnerWorkspaceExec       serpent.Bool                         `json:"disable_owner_workspace_exec,omitempty" typescript:",notnull"`
+	DisableWorkspaceSharing         serpent.Bool                         `json:"disable_workspace_sharing,omitempty" typescript:",notnull"`
 	ProxyHealthStatusInterval       serpent.Duration                     `json:"proxy_health_status_interval,omitempty" typescript:",notnull"`
 	EnableTerraformDebugMode        serpent.Bool                         `json:"enable_terraform_debug_mode,omitempty" typescript:",notnull"`
 	UserQuietHoursSchedule          UserQuietHoursScheduleConfig         `json:"user_quiet_hours_schedule,omitempty" typescript:",notnull"`
@@ -2727,6 +2728,15 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Value:       &c.DisableOwnerWorkspaceExec,
 			YAML:        "disableOwnerWorkspaceAccess",
 			Annotations: serpent.Annotations{}.Mark(annotationExternalProxies, "true"),
+		},
+		{
+			Name:        "Disable Workspace Sharing",
+			Description: `Disable workspace sharing (requires the "workspace-sharing" experiment to be enabled). Workspace ACL checking is disabled and only owners can have ssh, apps and terminal access to workspaces. Access based on the 'owner' role is also allowed unless disabled via --disable-owner-workspace-access.`,
+			Flag:        "disable-workspace-sharing",
+			Env:         "CODER_DISABLE_WORKSPACE_SHARING",
+
+			Value: &c.DisableWorkspaceSharing,
+			YAML:  "disableWorkspaceSharing",
 		},
 		{
 			Name:        "Session Duration",

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -233,6 +233,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
+    "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
       "fragment": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2917,6 +2917,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "disable_owner_workspace_exec": true,
     "disable_password_auth": true,
     "disable_path_apps": true,
+    "disable_workspace_sharing": true,
     "docs_url": {
       "forceQuery": true,
       "fragment": "string",
@@ -3439,6 +3440,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "disable_owner_workspace_exec": true,
   "disable_password_auth": true,
   "disable_path_apps": true,
+  "disable_workspace_sharing": true,
   "docs_url": {
     "forceQuery": true,
     "fragment": "string",
@@ -3793,6 +3795,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `disable_owner_workspace_exec`       | boolean                                                                                              | false    |              |                                                                    |
 | `disable_password_auth`              | boolean                                                                                              | false    |              |                                                                    |
 | `disable_path_apps`                  | boolean                                                                                              | false    |              |                                                                    |
+| `disable_workspace_sharing`          | boolean                                                                                              | false    |              |                                                                    |
 | `docs_url`                           | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
 | `enable_authz_recording`             | boolean                                                                                              | false    |              |                                                                    |
 | `enable_terraform_debug_mode`        | boolean                                                                                              | false    |              |                                                                    |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1115,6 +1115,16 @@ Disable workspace apps that are not served from subdomains. Path-based apps can 
 
 Remove the permission for the 'owner' role to have workspace execution on all workspaces. This prevents the 'owner' from ssh, apps, and terminal access based on the 'owner' role. They still have their user permissions to access their own workspaces.
 
+### --disable-workspace-sharing
+
+|             |                                               |
+|-------------|-----------------------------------------------|
+| Type        | <code>bool</code>                             |
+| Environment | <code>$CODER_DISABLE_WORKSPACE_SHARING</code> |
+| YAML        | <code>disableWorkspaceSharing</code>          |
+
+Disable workspace sharing (requires the "workspace-sharing" experiment to be enabled). Workspace ACL checking is disabled and only owners can have ssh, apps and terminal access to workspaces. Access based on the 'owner' role is also allowed unless disabled via --disable-owner-workspace-access.
+
 ### --session-duration
 
 |             |                                              |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -47,6 +47,13 @@ OPTIONS:
           the workspace serves malicious JavaScript. This is recommended for
           security purposes if a --wildcard-access-url is configured.
 
+      --disable-workspace-sharing bool, $CODER_DISABLE_WORKSPACE_SHARING
+          Disable workspace sharing (requires the "workspace-sharing" experiment
+          to be enabled). Workspace ACL checking is disabled and only owners can
+          have ssh, apps and terminal access to workspaces. Access based on the
+          'owner' role is also allowed unless disabled via
+          --disable-owner-workspace-access.
+
       --swagger-enable bool, $CODER_SWAGGER_ENABLE
           Expose the swagger endpoint via /swagger.
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1772,6 +1772,7 @@ export interface DeploymentValues {
 	readonly config_ssh?: SSHConfig;
 	readonly wgtunnel_host?: string;
 	readonly disable_owner_workspace_exec?: boolean;
+	readonly disable_workspace_sharing?: boolean;
 	readonly proxy_health_status_interval?: number;
 	readonly enable_terraform_debug_mode?: boolean;
 	readonly user_quiet_hours_schedule?: UserQuietHoursScheduleConfig;


### PR DESCRIPTION
Adds `--disable-workspace-sharing` option.

Workspace sharing is disabled by not including user and group ACLs in the workspace RBAC object, which prevents ACL-based authz.

Closes https://github.com/coder/internal/issues/1072

The commit also adds saving of workspace user/group ACLs in the test DB data generator.


