### PR TITLE
perf: remove pubsub usage for workspace agent metadata updates

### DIFF
--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -177,7 +177,6 @@ func New(opts Options, workspace database.Workspace) *API {
 		AgentFn:   api.agent,
 		Workspace: api.cachedWorkspaceFields,
 		Database:  opts.Database,
-		Pubsub:    opts.Pubsub,
 		Log:       opts.Log,
 	}
 

--- a/coderd/agentapi/metadata.go
+++ b/coderd/agentapi/metadata.go
@@ -2,7 +2,6 @@ package agentapi
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -14,14 +13,12 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
-	"github.com/coder/coder/v2/coderd/database/pubsub"
 )
 
 type MetadataAPI struct {
 	AgentFn   func(context.Context) (database.WorkspaceAgent, error)
 	Workspace *CachedWorkspaceFields
 	Database  database.Store
-	Pubsub    pubsub.Pubsub
 	Log       slog.Logger
 
 	TimeNowFn func() time.Time // defaults to dbtime.Now()
@@ -124,18 +121,6 @@ func (a *MetadataAPI) BatchUpdateMetadata(ctx context.Context, req *agentproto.B
 	err = a.Database.UpdateWorkspaceAgentMetadata(rbacCtx, dbUpdate)
 	if err != nil {
 		return nil, xerrors.Errorf("update workspace agent metadata in database: %w", err)
-	}
-
-	payload, err := json.Marshal(WorkspaceAgentMetadataChannelPayload{
-		CollectedAt: collectedAt,
-		Keys:        dbUpdate.Key,
-	})
-	if err != nil {
-		return nil, xerrors.Errorf("marshal workspace agent metadata channel payload: %w", err)
-	}
-	err = a.Pubsub.Publish(WatchWorkspaceAgentMetadataChannel(workspaceAgent.ID), payload)
-	if err != nil {
-		return nil, xerrors.Errorf("publish workspace agent metadata: %w", err)
 	}
 
 	// If the metadata keys were too large, we return an error so the agent can

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1428,6 +1428,7 @@ func New(options *Options) *API {
 					httpmw.ExtractWorkspaceParam(options.Database),
 				)
 				r.Get("/", api.workspaceAgent)
+				r.Get("/metadata", api.workspaceAgentMetadata)
 				r.Get("/watch-metadata", api.watchWorkspaceAgentMetadataSSE)
 				r.Get("/watch-metadata-ws", api.watchWorkspaceAgentMetadataWS)
 				r.Get("/startup-logs", api.workspaceAgentLogsDeprecated)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1594,6 +1594,32 @@ func convertScripts(dbScripts []database.WorkspaceAgentScript) []codersdk.Worksp
 	return scripts
 }
 
+// @Summary Get workspace agent metadata
+// @ID get-workspace-agent-metadata
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Agents
+// @Success 200 {array} codersdk.WorkspaceAgentMetadata
+// @Param workspaceagent path string true "Workspace agent ID" format(uuid)
+// @Router /workspaceagents/{workspaceagent}/metadata [get]
+func (api *API) workspaceAgentMetadata(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceAgent := httpmw.WorkspaceAgentParam(r)
+
+	metadata, err := api.Database.GetWorkspaceAgentMetadata(ctx,
+		database.GetWorkspaceAgentMetadataParams{
+			WorkspaceAgentID: workspaceAgent.ID,
+			Keys:             nil,
+		})
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK,
+		convertWorkspaceAgentMetadata(metadata))
+}
+
 // @Summary Watch for workspace agent metadata updates
 // @ID watch-for-workspace-agent-metadata-updates
 // @Security CoderSessionToken

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1647,6 +1647,16 @@ class ApiMethods {
 		return response.data;
 	};
 
+	getWorkspaceAgentMetadata = async (
+		agentID: string,
+	): Promise<TypesGen.WorkspaceAgentMetadata[]> => {
+		const response = await this.axios.get<TypesGen.WorkspaceAgentMetadata[]>(
+			`/api/v2/workspaceagents/${agentID}/metadata`,
+		);
+
+		return response.data;
+	};
+
 	putWorkspaceExtension = async (
 		workspaceId: string,
 		newDeadline: dayjs.Dayjs,


### PR DESCRIPTION
The pubsub usage for workspace metadata updates, where the `UpdateWorkspaceAgentMetadata` also calls `pubsub.Publish` can be quite expensive in deployments with a larger workspace/workspace agent count.

IIUC the `Publish` call leads to a DB wide lock on the message queue portion within PG. End users can try to reduce the impact of these calls by setting higher metadata update intervals for each agent metadata in a template, but in reality the end user facing functionality doesn't really need to be achieved via pubsub imo.

ATM, the only subscriber for these events is the `Workspace` UI page, where a user is viewing a single workspace. I would assume that _most_ of the time people don't leave the workspace page open after starting a workspace and connecting via some IDE. This assumption means that we're sending a lot of publish events when there's no subscriber that wants to receive them. This still puts some amount of processing load on the DB even though there's no one who wants the data. On top of that, it's easy for end users to set (or not set, and get the default) low metadata update intervals, and it's not immediately clear to them that the lowest interval in the whole template is the frequency on which that agent will send `UpdateWorkspaceAgentMetdata/Publish` calls to the DB.

I am also assuming that having the UI show to-the-second up to dateThis is doubly true for workspaces that are used by AI related tasks.

Therefore, of someone is really viewing their workspace UI page it seems reasonable to simply poll the database for that workspaces agent metadata.

**NOTE:** I've built and tested this within a workspace using `develop.sh` and verified the polling works. We likely still want to add a frontend test and potentially change the interval and/or retry behaviour as well as the message in the FE when the metadata cannot be retrieved.

Also blink tasks helped with these changes.