### PR TITLE
feat(site): add cmd+enter to submit tasks immediately

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -216,7 +216,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 		},
 	});
 
-	const onSubmit = async (e: React.SyntheticEvent) => {
+	const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 
 		try {
@@ -228,6 +228,18 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 			const message = getErrorMessage(error, "Error creating task");
 			const detail = getErrorDetail(error) ?? "Please try again";
 			displayError(message, detail);
+		}
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		// Submit form on Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
+		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			// Get the form element and submit it
+			const form = e.currentTarget.form;
+			if (form) {
+				form.requestSubmit();
+			}
 		}
 	};
 
@@ -259,7 +271,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 					onChange={(e) => setPrompt(e.target.value)}
 					readOnly={isPromptReadOnly}
 					isSubmitting={createTaskMutation.isPending}
-					onFormSubmit={onSubmit}
+					onKeyDown={handleKeyDown}
 				/>
 				<div className="flex items-center justify-between pt-2">
 					<div className="flex items-center gap-1">
@@ -463,33 +475,16 @@ async function createTaskWithLatestTemplateVersion(
 
 type PromptTextareaProps = TextareaAutosizeProps & {
 	isSubmitting?: boolean;
-	onFormSubmit?: (e: React.SyntheticEvent) => void;
 };
 
 const PromptTextarea: FC<PromptTextareaProps> = ({
 	isSubmitting,
-	onFormSubmit,
 	...props
 }) => {
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		// Submit form on Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
-		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-			e.preventDefault();
-			if (onFormSubmit) {
-				onFormSubmit(e);
-			}
-		}
-		// Call the original onKeyDown if it exists
-		if (props.onKeyDown) {
-			props.onKeyDown(e);
-		}
-	};
-
 	return (
 		<div className="relative">
 			<TextareaAutosize
 				{...props}
-				onKeyDown={handleKeyDown}
 				required
 				id="prompt"
 				name="prompt"

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -216,7 +216,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 		},
 	});
 
-	const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+	const onSubmit = async (e: React.SyntheticEvent) => {
 		e.preventDefault();
 
 		try {
@@ -235,11 +235,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 		// Submit form on Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
 		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();
-			// Get the form element and submit it
-			const form = e.currentTarget.form;
-			if (form) {
-				form.requestSubmit();
-			}
+			onSubmit(e);
 		}
 	};
 

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -468,10 +468,27 @@ const PromptTextarea: FC<PromptTextareaProps> = ({
 	isSubmitting,
 	...props
 }) => {
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		// Submit form on Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
+		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			// Trigger form submission by finding the closest form and submitting it
+			const form = e.currentTarget.closest("form");
+			if (form) {
+				form.requestSubmit();
+			}
+		}
+		// Call the original onKeyDown if it exists
+		if (props.onKeyDown) {
+			props.onKeyDown(e);
+		}
+	};
+
 	return (
 		<div className="relative">
 			<TextareaAutosize
 				{...props}
+				onKeyDown={handleKeyDown}
 				required
 				id="prompt"
 				name="prompt"

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -259,6 +259,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 					onChange={(e) => setPrompt(e.target.value)}
 					readOnly={isPromptReadOnly}
 					isSubmitting={createTaskMutation.isPending}
+					onFormSubmit={onSubmit}
 				/>
 				<div className="flex items-center justify-between pt-2">
 					<div className="flex items-center gap-1">
@@ -462,20 +463,20 @@ async function createTaskWithLatestTemplateVersion(
 
 type PromptTextareaProps = TextareaAutosizeProps & {
 	isSubmitting?: boolean;
+	onFormSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
 };
 
 const PromptTextarea: FC<PromptTextareaProps> = ({
 	isSubmitting,
+	onFormSubmit,
 	...props
 }) => {
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		// Submit form on Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
 		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();
-			// Trigger form submission by finding the closest form and submitting it
-			const form = e.currentTarget.closest("form");
-			if (form) {
-				form.requestSubmit();
+			if (onFormSubmit) {
+				onFormSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
 			}
 		}
 		// Call the original onKeyDown if it exists

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -216,7 +216,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 		},
 	});
 
-	const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+	const onSubmit = async (e: React.SyntheticEvent) => {
 		e.preventDefault();
 
 		try {

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -463,7 +463,7 @@ async function createTaskWithLatestTemplateVersion(
 
 type PromptTextareaProps = TextareaAutosizeProps & {
 	isSubmitting?: boolean;
-	onFormSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
+	onFormSubmit?: (e: React.SyntheticEvent) => void;
 };
 
 const PromptTextarea: FC<PromptTextareaProps> = ({
@@ -476,7 +476,7 @@ const PromptTextarea: FC<PromptTextareaProps> = ({
 		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();
 			if (onFormSubmit) {
-				onFormSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
+				onFormSubmit(e);
 			}
 		}
 		// Call the original onKeyDown if it exists

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -234,7 +234,6 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		// Submit form on Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
 		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-			e.preventDefault();
 			onSubmit(e);
 		}
 	};


### PR DESCRIPTION
Implements cmd+enter (Mac) / ctrl+enter (Windows/Linux) keyboard shortcut for submitting tasks on the tasks page. Regular enter key still creates new lines as expected.

Fixes #21179

🤖 Generated with [Claude Code](https://claude.com/claude-code)