### PR TITLE
fix(site): show command apps in Tasks view

### DIFF
--- a/site/src/pages/TaskPage/TaskApps.tsx
+++ b/site/src/pages/TaskPage/TaskApps.tsx
@@ -34,7 +34,7 @@ export const TaskApps: FC<TaskAppsProps> = ({ task, workspace }) => {
 	const apps = getAllAppsWithAgent(workspace).filter(
 		// The Chat UI app will be displayed in the sidebar, so we don't want to
 		// show it as a web app.
-		(app) => app.id !== task.workspace_app_id && app.health !== "disabled",
+		(app) => app.id !== task.workspace_app_id,
 	);
 	const [embeddedApps, externalApps] = splitEmbeddedAndExternalApps(apps);
 	const [activeAppId, setActiveAppId] = useState(embeddedApps.at(0)?.id);


### PR DESCRIPTION
Command apps (terminal apps with `command` field) were being filtered out from the Tasks view because they have health "disabled" when no healthcheck is defined.

Updated the filter in `TaskApps.tsx` to allow command apps through regardless of health status so they appear as tabs alongside web apps.

<img width="1378" height="790" alt="Screenshot 2025-12-08 at 8 10 47 PM" src="https://github.com/user-attachments/assets/90a73bb2-d49c-4241-a4d5-798e2dd8118b" />

Closes https://github.com/coder/coder/issues/21183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>