### PR TITLE
docs: add guidance on when to use Project Discovery for Dev Containers

### DIFF
--- a/docs/admin/integrations/devcontainers/integration.md
+++ b/docs/admin/integrations/devcontainers/integration.md
@@ -32,6 +32,9 @@ Alternatively, enable automatic discovery of Dev Containers in Git repositories.
 The agent scans for `devcontainer.json` files and surfaces them in the Coder UI.
 See [Environment Variables](#environment-variables) for configuration options.
 
+This approach is useful when developers frequently switch between repositories
+or work with many projects, as it reduces template maintenance overhead.
+
 ## Install the Dev Containers CLI
 
 Use the


### PR DESCRIPTION
Addresses the review feedback from #21157 where @david-fraley asked for more context about when to use Project Discovery.

Adds a sentence explaining that Project Discovery is useful when developers frequently switch between repositories or work with many projects, as it reduces template maintenance overhead.

Refs #21157