### PR TITLE
chore(docs): update release cal for patch

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -129,7 +129,7 @@ We support two release channels: mainline and stable - read the
 - **Mainline** Coder release:
 
   - **Chart Registry**
-         
+  
     <!-- autoversion(mainline): "--version [version]" -->
 
     ```shell

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -129,7 +129,6 @@ We support two release channels: mainline and stable - read the
 - **Mainline** Coder release:
 
   - **Chart Registry**
-
     <!-- autoversion(mainline): "--version [version]" -->
 
     ```shell

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -129,7 +129,7 @@ We support two release channels: mainline and stable - read the
 - **Mainline** Coder release:
 
   - **Chart Registry**
-  
+
     <!-- autoversion(mainline): "--version [version]" -->
 
     ```shell

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -129,14 +129,14 @@ We support two release channels: mainline and stable - read the
 - **Mainline** Coder release:
 
   - **Chart Registry**
-
+         
     <!-- autoversion(mainline): "--version [version]" -->
 
     ```shell
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.29.0
+        --version 2.29.1
     ```
 
   - **OCI Registry**
@@ -147,7 +147,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.29.0
+        --version 2.29.1
     ```
 
 - **Stable** Coder release:
@@ -160,7 +160,7 @@ We support two release channels: mainline and stable - read the
     helm install coder coder-v2/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.28.5
+        --version 2.28.6
     ```
 
   - **OCI Registry**
@@ -171,7 +171,7 @@ We support two release channels: mainline and stable - read the
     helm install coder oci://ghcr.io/coder/chart/coder \
         --namespace coder \
         --values values.yaml \
-        --version 2.28.5
+        --version 2.28.6
     ```
 
 You can watch Coder start up by running `kubectl get pods -n coder`. Once Coder

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -134,8 +134,8 @@ kubectl create secret generic coder-db-url -n coder \
 
 1. Select a Coder version:
 
-   - **Mainline**: `2.29.0`
-   - **Stable**: `2.28.5`
+   - **Mainline**: `2.29.1`
+   - **Stable**: `2.28.6`
 
    Learn more about release channels in the [Releases documentation](./releases/index.md).
 

--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -72,9 +72,9 @@ pages.
 | [2.24](https://coder.com/changelog/coder-2-24) | July 01, 2025      | Extended Support Release | [v2.24.4](https://github.com/coder/coder/releases/tag/v2.24.4) |
 | [2.25](https://coder.com/changelog/coder-2-25) | August 05, 2025    | Not Supported            | [v2.25.3](https://github.com/coder/coder/releases/tag/v2.25.3) |
 | [2.26](https://coder.com/changelog/coder-2-26) | September 03, 2025 | Not Supported            | [v2.26.6](https://github.com/coder/coder/releases/tag/v2.26.6) |
-| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Security Support         | [v2.27.8](https://github.com/coder/coder/releases/tag/v2.27.8) |
-| [2.28](https://coder.com/changelog/coder-2-28) | November 04, 2025  | Stable                   | [v2.28.5](https://github.com/coder/coder/releases/tag/v2.28.5) |
-| [2.29](https://coder.com/changelog/coder-2-29) | December 02, 2025  | Mainline + ESR           | [v2.29.0](https://github.com/coder/coder/releases/tag/v2.29.0) |
+| [2.27](https://coder.com/changelog/coder-2-27) | October 02, 2025   | Security Support         | [v2.27.9](https://github.com/coder/coder/releases/tag/v2.27.9) |
+| [2.28](https://coder.com/changelog/coder-2-28) | November 04, 2025  | Stable                   | [v2.28.6](https://github.com/coder/coder/releases/tag/v2.28.6) |
+| [2.29](https://coder.com/changelog/coder-2-29) | December 02, 2025  | Mainline + ESR           | [v2.29.1](https://github.com/coder/coder/releases/tag/v2.29.1) |
 | 2.30                                           |                    | Not Released             | N/A                                                            |
 <!-- RELEASE_CALENDAR_END -->
 


### PR DESCRIPTION
## Description

Updating our release calendar and other hard-coded for the recent security patch we pushed - https://github.com/coder/coder/releases/tag/v2.29.1
