### PR TITLE
fix(agent/agentssh)!: use configured directory for SFTP connections

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -829,13 +829,19 @@ func (s *Server) sftpHandler(logger slog.Logger, session ssh.Session) error {
 	session.DisablePTYEmulation()
 
 	var opts []sftp.ServerOption
-	// Change current working directory to the users home
-	// directory so that SFTP connections land there.
-	homedir, err := userHomeDir()
-	if err != nil {
-		logger.Warn(ctx, "get sftp working directory failed, unable to get home dir", slog.Error(err))
-	} else {
-		opts = append(opts, sftp.WithServerWorkingDirectory(homedir))
+	// Change current working directory to the configured
+	// directory (or home directory if not set) so that SFTP
+	// connections land there.
+	dir := s.config.WorkingDirectory()
+	if dir == "" {
+		var err error
+		dir, err = userHomeDir()
+		if err != nil {
+			logger.Warn(ctx, "get sftp working directory failed, unable to get home dir", slog.Error(err))
+		}
+	}
+	if dir != "" {
+		opts = append(opts, sftp.WithServerWorkingDirectory(dir))
 	}
 
 	server, err := sftp.NewServer(session, opts...)


### PR DESCRIPTION
When a workspace agent has a configured directory, SSH sessions and `rsync` land there, but SFTP/SCP land in `$HOME`. This means `rsync file.txt coder:.` and `scp file.txt coder:.` put the file in different places, which is confusing.

The SFTP handler was hardcoded to use the home directory instead of checking the configured working directory like SSH does. Now it checks the config first and falls back to home only if unset.

---

For release notes:

**BREAKING CHANGE**: SFTP/SCP now respects the agent's configured directory.

If your workspace agent has a custom `dir` configured in Terraform, SFTP and SCP connections will now land there instead of `$HOME`. Previously, only SSH and rsync respected this setting, which caused confusing behavior where `scp file.txt coder:.` and `rsync file.txt coder:.` would put files in different places. If you have scripts that relied on SFTP/SCP always using `$HOME` regardless of agent configuration, you may need to use explicit paths instead.