### PR TITLE
perf: introduce a terraform template/dynamic parameter render cache on prebuilds path

### DIFF
--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -118,7 +118,6 @@ func WithRenderCache(cache RenderCache) func(r *loader) {
 	}
 }
 
-
 func (r *loader) loadData(ctx context.Context, db database.Store) error {
 	if r.templateVersion == nil {
 		tv, err := db.GetTemplateVersionByID(ctx, r.templateVersionID)

--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -39,6 +39,7 @@ var ErrTemplateVersionNotReady = xerrors.New("template version job not finished"
 type RenderCache interface {
 	get(templateVersionID, ownerID uuid.UUID, parameters map[string]string) (*preview.Output, bool)
 	put(templateVersionID, ownerID uuid.UUID, parameters map[string]string, output *preview.Output)
+	Close()
 }
 
 // noopRenderCache is a no-op implementation of RenderCache that doesn't cache anything.
@@ -49,6 +50,10 @@ func (noopRenderCache) get(uuid.UUID, uuid.UUID, map[string]string) (*preview.Ou
 }
 
 func (noopRenderCache) put(uuid.UUID, uuid.UUID, map[string]string, *preview.Output) {
+	// no-op
+}
+
+func (noopRenderCache) Close() {
 	// no-op
 }
 

--- a/coderd/dynamicparameters/rendercache.go
+++ b/coderd/dynamicparameters/rendercache.go
@@ -1,0 +1,87 @@
+package dynamicparameters
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"sort"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/preview"
+)
+
+// RenderCache is a simple in-memory cache for preview.Preview results.
+// It caches based on (templateVersionID, ownerID, parameterValues).
+type RenderCache struct {
+	mu      sync.RWMutex
+	entries map[cacheKey]*preview.Output
+}
+
+type cacheKey struct {
+	templateVersionID uuid.UUID
+	ownerID          uuid.UUID
+	parameterHash    string
+}
+
+// NewRenderCache creates a new render cache.
+func NewRenderCache() *RenderCache {
+	return &RenderCache{
+		entries: make(map[cacheKey]*preview.Output),
+	}
+}
+
+// NewRenderCacheForTest creates a new render cache for testing purposes.
+func NewRenderCacheForTest() *RenderCache {
+	return NewRenderCache()
+}
+
+func (c *RenderCache) get(templateVersionID, ownerID uuid.UUID, parameters map[string]string) (*preview.Output, bool) {
+	key := c.makeKey(templateVersionID, ownerID, parameters)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	output, ok := c.entries[key]
+	return output, ok
+}
+
+func (c *RenderCache) put(templateVersionID, ownerID uuid.UUID, parameters map[string]string, output *preview.Output) {
+	key := c.makeKey(templateVersionID, ownerID, parameters)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[key] = output
+}
+
+func (c *RenderCache) makeKey(templateVersionID, ownerID uuid.UUID, parameters map[string]string) cacheKey {
+	return cacheKey{
+		templateVersionID: templateVersionID,
+		ownerID:          ownerID,
+		parameterHash:    hashParameters(parameters),
+	}
+}
+
+// hashParameters creates a deterministic hash of the parameter map.
+func hashParameters(params map[string]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+
+	// Sort keys for deterministic hashing
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Hash the sorted key-value pairs
+	h := md5.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0}) // separator
+		h.Write([]byte(params[k]))
+		h.Write([]byte{0}) // separator
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/coderd/dynamicparameters/rendercache_internal_test.go
+++ b/coderd/dynamicparameters/rendercache_internal_test.go
@@ -19,6 +19,7 @@ func TestRenderCache_BasicOperations(t *testing.T) {
 	t.Parallel()
 
 	cache := NewRenderCache()
+	defer cache.Close()
 	templateVersionID := uuid.New()
 	ownerID := uuid.New()
 	params := map[string]string{"region": "us-west-2"}
@@ -50,6 +51,8 @@ func TestRenderCache_DifferentKeysAreSeparate(t *testing.T) {
 	t.Parallel()
 
 	cache := NewRenderCache()
+	defer cache.Close()
+
 	templateVersion1 := uuid.New()
 	templateVersion2 := uuid.New()
 	owner1 := uuid.New()
@@ -83,6 +86,8 @@ func TestRenderCache_ParameterHashConsistency(t *testing.T) {
 	t.Parallel()
 
 	cache := NewRenderCache()
+	defer cache.Close()
+
 	templateVersionID := uuid.New()
 	ownerID := uuid.New()
 
@@ -103,6 +108,8 @@ func TestRenderCache_EmptyParameters(t *testing.T) {
 	t.Parallel()
 
 	cache := NewRenderCache()
+	defer cache.Close()
+
 	templateVersionID := uuid.New()
 	ownerID := uuid.New()
 
@@ -123,6 +130,7 @@ func TestRenderCache_PrebuildScenario(t *testing.T) {
 	// This test simulates the prebuild scenario where multiple prebuilds
 	// are created from the same template version with the same preset parameters.
 	cache := NewRenderCache()
+	defer cache.Close()
 
 	// In prebuilds, all instances use the same fixed ownerID
 	prebuildOwnerID := uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0") // database.PrebuildsSystemUserID
@@ -168,6 +176,8 @@ func TestRenderCache_Metrics(t *testing.T) {
 	})
 
 	cache := NewRenderCacheWithMetrics(cacheHits, cacheMisses, cacheSize)
+	defer cache.Close()
+
 	templateVersionID := uuid.New()
 	ownerID := uuid.New()
 	params := map[string]string{"region": "us-west-2"}

--- a/coderd/dynamicparameters/rendercache_prebuild_internal_test.go
+++ b/coderd/dynamicparameters/rendercache_prebuild_internal_test.go
@@ -1,0 +1,192 @@
+package dynamicparameters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/preview"
+	previewtypes "github.com/coder/preview/types"
+	"github.com/coder/terraform-provider-coder/v2/provider"
+)
+
+// TestRenderCache_PrebuildWithResolveParameters simulates the actual prebuild flow
+// where ResolveParameters calls Render() twice - once with previous values and once
+// with the final computed values.
+func TestRenderCache_PrebuildWithResolveParameters(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	// Create test metrics
+	cacheHits := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_prebuild_cache_hits_total",
+	})
+	cacheMisses := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_prebuild_cache_misses_total",
+	})
+	cacheSize := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_prebuild_cache_entries",
+	})
+
+	cache := NewRenderCacheWithMetrics(cacheHits, cacheMisses, cacheSize)
+	defer cache.Close()
+
+	// Simulate prebuild scenario
+	prebuildOwnerID := uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0") // database.PrebuildsSystemUserID
+	templateVersionID := uuid.New()
+
+	// Preset parameters that all prebuilds share
+	presetParams := []database.TemplateVersionPresetParameter{
+		{Name: "instance_type", Value: "t3.micro"},
+		{Name: "region", Value: "us-west-2"},
+	}
+
+	// Create a mock renderer that returns consistent parameter definitions
+	mockRenderer := &mockRenderer{
+		cache:             cache,
+		templateVersionID: templateVersionID,
+		output: &preview.Output{
+			Parameters: []previewtypes.Parameter{
+				{
+					ParameterData: previewtypes.ParameterData{
+						Name:         "instance_type",
+						Type:         previewtypes.ParameterTypeString,
+						FormType:     provider.ParameterFormTypeInput,
+						Mutable:      true,
+						DefaultValue: previewtypes.StringLiteral("t3.micro"),
+						Required:     true,
+					},
+					Value:       previewtypes.StringLiteral("t3.micro"),
+					Diagnostics: nil,
+				},
+				{
+					ParameterData: previewtypes.ParameterData{
+						Name:         "region",
+						Type:         previewtypes.ParameterTypeString,
+						FormType:     provider.ParameterFormTypeInput,
+						Mutable:      true,
+						DefaultValue: previewtypes.StringLiteral("us-west-2"),
+						Required:     true,
+					},
+					Value:       previewtypes.StringLiteral("us-west-2"),
+					Diagnostics: nil,
+				},
+			},
+		},
+	}
+
+	// Initial metrics should be 0
+	require.Equal(t, float64(0), promtestutil.ToFloat64(cacheHits), "initial hits should be 0")
+	require.Equal(t, float64(0), promtestutil.ToFloat64(cacheMisses), "initial misses should be 0")
+	require.Equal(t, float64(0), promtestutil.ToFloat64(cacheSize), "initial size should be 0")
+
+	// === FIRST PREBUILD ===
+	// First build: no previous values, preset values provided
+	values1, err := ResolveParameters(ctx, prebuildOwnerID, mockRenderer, true,
+		[]database.WorkspaceBuildParameter{}, // No previous values (first build)
+		[]codersdk.WorkspaceBuildParameter{}, // No build-specific values
+		presetParams,                         // Preset values from template
+	)
+	require.NoError(t, err)
+	require.NotNil(t, values1)
+
+	// After first prebuild:
+	// - ResolveParameters calls Render() twice:
+	//   1. With previousValuesMap (empty {})  → miss, creates cache entry
+	//   2. With values.ValuesMap() ({preset}) → miss, creates cache entry
+	// Expected: 0 hits, 2 misses, 2 cache entries
+	t.Logf("After first prebuild: hits=%v, misses=%v, size=%v",
+		promtestutil.ToFloat64(cacheHits),
+		promtestutil.ToFloat64(cacheMisses),
+		promtestutil.ToFloat64(cacheSize))
+
+	require.Equal(t, float64(0), promtestutil.ToFloat64(cacheHits), "first prebuild should have 0 hits")
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheMisses), "first prebuild should have 2 misses")
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheSize), "should have 2 cache entries after first prebuild")
+
+	// === SECOND PREBUILD ===
+	// Second build: previous values now set to preset values
+	previousValues := []database.WorkspaceBuildParameter{
+		{Name: "instance_type", Value: "t3.micro"},
+		{Name: "region", Value: "us-west-2"},
+	}
+
+	values2, err := ResolveParameters(ctx, prebuildOwnerID, mockRenderer, false,
+		previousValues, // Previous values from first build
+		[]codersdk.WorkspaceBuildParameter{},
+		presetParams,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, values2)
+
+	// After second prebuild:
+	// - ResolveParameters calls Render() twice:
+	//   1. With previousValuesMap ({preset}) → HIT (cache entry from first prebuild's 2nd render)
+	//   2. With values.ValuesMap() ({preset})  → HIT (same cache entry)
+	// Expected: 2 hits, 2 misses (still), 2 cache entries (still)
+	t.Logf("After second prebuild: hits=%v, misses=%v, size=%v",
+		promtestutil.ToFloat64(cacheHits),
+		promtestutil.ToFloat64(cacheMisses),
+		promtestutil.ToFloat64(cacheSize))
+
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheHits), "second prebuild should have 2 hits")
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheMisses), "misses should still be 2")
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheSize), "should still have 2 cache entries")
+
+	// === THIRD PREBUILD ===
+	values3, err := ResolveParameters(ctx, prebuildOwnerID, mockRenderer, false,
+		previousValues,
+		[]codersdk.WorkspaceBuildParameter{},
+		presetParams,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, values3)
+
+	// After third prebuild:
+	// - ResolveParameters calls Render() twice:
+	//   1. With previousValuesMap ({preset}) → HIT
+	//   2. With values.ValuesMap() ({preset})  → HIT
+	// Expected: 4 hits, 2 misses (still), 2 cache entries (still)
+	t.Logf("After third prebuild: hits=%v, misses=%v, size=%v",
+		promtestutil.ToFloat64(cacheHits),
+		promtestutil.ToFloat64(cacheMisses),
+		promtestutil.ToFloat64(cacheSize))
+
+	require.Equal(t, float64(4), promtestutil.ToFloat64(cacheHits), "third prebuild should have 4 total hits")
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheMisses), "misses should still be 2")
+	require.Equal(t, float64(2), promtestutil.ToFloat64(cacheSize), "should still have 2 cache entries")
+
+	// Summary: With 3 prebuilds, we should have:
+	// - 4 cache hits (2 from 2nd prebuild, 2 from 3rd prebuild)
+	// - 2 cache misses (2 from 1st prebuild)
+	// - 2 cache entries (one for empty params, one for preset params)
+}
+
+// mockRenderer is a simple renderer that uses the cache for testing
+type mockRenderer struct {
+	cache             RenderCache
+	templateVersionID uuid.UUID
+	output            *preview.Output
+}
+
+func (m *mockRenderer) Render(ctx context.Context, ownerID uuid.UUID, values map[string]string) (*preview.Output, hcl.Diagnostics) {
+	// This simulates what dynamicRenderer does - check cache first
+	if cached, ok := m.cache.get(m.templateVersionID, ownerID, values); ok {
+		return cached, nil
+	}
+
+	// Not in cache, "render" (just return our mock output) and cache it
+	m.cache.put(m.templateVersionID, ownerID, values, m.output)
+	return m.output, nil
+}
+
+func (m *mockRenderer) Close() {}

--- a/coderd/dynamicparameters/rendercache_test.go
+++ b/coderd/dynamicparameters/rendercache_test.go
@@ -1,0 +1,149 @@
+package dynamicparameters
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/preview"
+	previewtypes "github.com/coder/preview/types"
+)
+
+func TestRenderCache_BasicOperations(t *testing.T) {
+	t.Parallel()
+
+	cache := NewRenderCache()
+	templateVersionID := uuid.New()
+	ownerID := uuid.New()
+	params := map[string]string{"region": "us-west-2"}
+
+	// Cache should be empty initially
+	_, ok := cache.get(templateVersionID, ownerID, params)
+	require.False(t, ok, "cache should be empty initially")
+
+	// Put an entry in the cache
+	expectedOutput := &preview.Output{
+		Parameters: []previewtypes.Parameter{
+			{
+				ParameterData: previewtypes.ParameterData{
+					Name: "region",
+					Type: previewtypes.ParameterTypeString,
+				},
+			},
+		},
+	}
+	cache.put(templateVersionID, ownerID, params, expectedOutput)
+
+	// Get should now return the cached value
+	cachedOutput, ok := cache.get(templateVersionID, ownerID, params)
+	require.True(t, ok, "cache should contain the entry")
+	require.Same(t, expectedOutput, cachedOutput, "should return same pointer")
+}
+
+func TestRenderCache_DifferentKeysAreSeparate(t *testing.T) {
+	t.Parallel()
+
+	cache := NewRenderCache()
+	templateVersion1 := uuid.New()
+	templateVersion2 := uuid.New()
+	owner1 := uuid.New()
+	owner2 := uuid.New()
+	params := map[string]string{"region": "us-west-2"}
+
+	output1 := &preview.Output{}
+	output2 := &preview.Output{}
+	output3 := &preview.Output{}
+
+	// Put different entries for different keys
+	cache.put(templateVersion1, owner1, params, output1)
+	cache.put(templateVersion2, owner1, params, output2)
+	cache.put(templateVersion1, owner2, params, output3)
+
+	// Verify each key returns its own entry
+	cached1, ok1 := cache.get(templateVersion1, owner1, params)
+	require.True(t, ok1)
+	require.Same(t, output1, cached1)
+
+	cached2, ok2 := cache.get(templateVersion2, owner1, params)
+	require.True(t, ok2)
+	require.Same(t, output2, cached2)
+
+	cached3, ok3 := cache.get(templateVersion1, owner2, params)
+	require.True(t, ok3)
+	require.Same(t, output3, cached3)
+}
+
+func TestRenderCache_ParameterHashConsistency(t *testing.T) {
+	t.Parallel()
+
+	cache := NewRenderCache()
+	templateVersionID := uuid.New()
+	ownerID := uuid.New()
+
+	// Parameters in different order should produce same cache key
+	params1 := map[string]string{"a": "1", "b": "2", "c": "3"}
+	params2 := map[string]string{"c": "3", "a": "1", "b": "2"}
+
+	output := &preview.Output{}
+	cache.put(templateVersionID, ownerID, params1, output)
+
+	// Should hit cache even with different parameter order
+	cached, ok := cache.get(templateVersionID, ownerID, params2)
+	require.True(t, ok, "different parameter order should still hit cache")
+	require.Same(t, output, cached)
+}
+
+func TestRenderCache_EmptyParameters(t *testing.T) {
+	t.Parallel()
+
+	cache := NewRenderCache()
+	templateVersionID := uuid.New()
+	ownerID := uuid.New()
+
+	// Test with empty parameters
+	emptyParams := map[string]string{}
+	output := &preview.Output{}
+
+	cache.put(templateVersionID, ownerID, emptyParams, output)
+
+	cached, ok := cache.get(templateVersionID, ownerID, emptyParams)
+	require.True(t, ok)
+	require.Same(t, output, cached)
+}
+
+func TestRenderCache_PrebuildScenario(t *testing.T) {
+	t.Parallel()
+
+	// This test simulates the prebuild scenario where multiple prebuilds
+	// are created from the same template version with the same preset parameters.
+	cache := NewRenderCache()
+
+	// In prebuilds, all instances use the same fixed ownerID
+	prebuildOwnerID := uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0") // database.PrebuildsSystemUserID
+	templateVersionID := uuid.New()
+	presetParams := map[string]string{
+		"instance_type": "t3.micro",
+		"region":        "us-west-2",
+	}
+
+	output := &preview.Output{}
+
+	// First prebuild - cache miss
+	_, ok := cache.get(templateVersionID, prebuildOwnerID, presetParams)
+	require.False(t, ok, "first prebuild should miss cache")
+
+	cache.put(templateVersionID, prebuildOwnerID, presetParams, output)
+
+	// Second prebuild with same template version and preset - cache hit
+	cached2, ok2 := cache.get(templateVersionID, prebuildOwnerID, presetParams)
+	require.True(t, ok2, "second prebuild should hit cache")
+	require.Same(t, output, cached2, "should return cached output")
+
+	// Third prebuild - also cache hit
+	cached3, ok3 := cache.get(templateVersionID, prebuildOwnerID, presetParams)
+	require.True(t, ok3, "third prebuild should hit cache")
+	require.Same(t, output, cached3, "should return cached output")
+
+	// All three prebuilds shared the same cache entry
+}

--- a/coderd/dynamicparameters/rendermock/rendermock.go
+++ b/coderd/dynamicparameters/rendermock/rendermock.go
@@ -69,3 +69,18 @@ func (mr *MockRendererMockRecorder) Render(ctx, ownerID, values any) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Render", reflect.TypeOf((*MockRenderer)(nil).Render), ctx, ownerID, values)
 }
+
+// RenderWithoutCache mocks base method.
+func (m *MockRenderer) RenderWithoutCache(ctx context.Context, ownerID uuid.UUID, values map[string]string) (*preview.Output, hcl.Diagnostics) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenderWithoutCache", ctx, ownerID, values)
+	ret0, _ := ret[0].(*preview.Output)
+	ret1, _ := ret[1].(hcl.Diagnostics)
+	return ret0, ret1
+}
+
+// RenderWithoutCache indicates an expected call of RenderWithoutCache.
+func (mr *MockRendererMockRecorder) RenderWithoutCache(ctx, ownerID, values any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderWithoutCache", reflect.TypeOf((*MockRenderer)(nil).RenderWithoutCache), ctx, ownerID, values)
+}

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -69,7 +69,10 @@ func ResolveParameters(
 	//
 	// This is how the form should look to the user on their workspace settings page.
 	// This is the original form truth that our validations should initially be based on.
-	output, diags := renderer.Render(ctx, ownerID, previousValuesMap)
+	//
+	// Skip caching this render - it's only used for introspection to identify ephemeral
+	// parameters. The actual values used for the build will be rendered and cached below.
+	output, diags := renderer.RenderWithoutCache(ctx, ownerID, previousValuesMap)
 	if diags.HasErrors() {
 		// Top level diagnostics should break the build. Previous values (and new) should
 		// always be valid. If there is a case where this is not true, then this has to

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -29,6 +29,25 @@ func TestResolveParameters(t *testing.T) {
 
 		// A single immutable parameter with no previous value.
 		render.EXPECT().
+			RenderWithoutCache(gomock.Any(), gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&preview.Output{
+				Parameters: []previewtypes.Parameter{
+					{
+						ParameterData: previewtypes.ParameterData{
+							Name:         "immutable",
+							Type:         previewtypes.ParameterTypeString,
+							FormType:     provider.ParameterFormTypeInput,
+							Mutable:      false,
+							DefaultValue: previewtypes.StringLiteral("foo"),
+							Required:     true,
+						},
+						Value:       previewtypes.StringLiteral("foo"),
+						Diagnostics: nil,
+					},
+				},
+			}, nil)
+		render.EXPECT().
 			Render(gomock.Any(), gomock.Any(), gomock.Any()).
 			AnyTimes().
 			Return(&preview.Output{
@@ -78,7 +97,7 @@ func TestResolveParameters(t *testing.T) {
 
 		// A single immutable parameter with no previous value.
 		render.EXPECT().
-			Render(gomock.Any(), gomock.Any(), gomock.Any()).
+			RenderWithoutCache(gomock.Any(), gomock.Any(), gomock.Any()).
 			// Return the mutable param first
 			Return(&preview.Output{
 				Parameters: []previewtypes.Parameter{

--- a/coderd/dynamicparameters/static.go
+++ b/coderd/dynamicparameters/static.go
@@ -40,6 +40,15 @@ func (r *loader) staticRender(ctx context.Context, db database.Store) (*staticRe
 }
 
 func (r *staticRender) Render(_ context.Context, _ uuid.UUID, values map[string]string) (*preview.Output, hcl.Diagnostics) {
+	return r.render(values)
+}
+
+func (r *staticRender) RenderWithoutCache(_ context.Context, _ uuid.UUID, values map[string]string) (*preview.Output, hcl.Diagnostics) {
+	// Static renderer doesn't use cache, so this is the same as Render
+	return r.render(values)
+}
+
+func (r *staticRender) render(values map[string]string) (*preview.Output, hcl.Diagnostics) {
 	params := r.staticParams
 	for i := range params {
 		param := &params[i]

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -89,7 +89,7 @@ type Builder struct {
 	workspaceTags                        *map[string]string
 
 	// renderCache caches template rendering results
-	renderCache *dynamicparameters.RenderCacheImpl
+	renderCache dynamicparameters.RenderCache
 
 	prebuiltWorkspaceBuildStage  sdkproto.PrebuiltWorkspaceBuildStage
 	verifyNoLegacyParametersOnce bool
@@ -258,7 +258,7 @@ func (b Builder) TemplateVersionPresetID(id uuid.UUID) Builder {
 
 // RenderCache sets the render cache to use for template rendering.
 // This allows multiple workspace builds to share cached render results.
-func (b Builder) RenderCache(cache *dynamicparameters.RenderCacheImpl) Builder {
+func (b Builder) RenderCache(cache dynamicparameters.RenderCache) Builder {
 	// nolint: revive
 	b.renderCache = cache
 	return b

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -89,7 +89,7 @@ type Builder struct {
 	workspaceTags                        *map[string]string
 
 	// renderCache caches template rendering results
-	renderCache *dynamicparameters.RenderCache
+	renderCache *dynamicparameters.RenderCacheImpl
 
 	prebuiltWorkspaceBuildStage  sdkproto.PrebuiltWorkspaceBuildStage
 	verifyNoLegacyParametersOnce bool
@@ -258,7 +258,7 @@ func (b Builder) TemplateVersionPresetID(id uuid.UUID) Builder {
 
 // RenderCache sets the render cache to use for template rendering.
 // This allows multiple workspace builds to share cached render results.
-func (b Builder) RenderCache(cache *dynamicparameters.RenderCache) Builder {
+func (b Builder) RenderCache(cache *dynamicparameters.RenderCacheImpl) Builder {
 	// nolint: revive
 	b.renderCache = cache
 	return b

--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -371,6 +371,9 @@ func TestEnterpriseCreateWithPreset(t *testing.T) {
 			notifications.NewNoopEnqueuer(),
 			newNoopUsageCheckerPtr(),
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 
@@ -482,6 +485,9 @@ func TestEnterpriseCreateWithPreset(t *testing.T) {
 			notifications.NewNoopEnqueuer(),
 			newNoopUsageCheckerPtr(),
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 

--- a/enterprise/coderd/prebuilds/claim_test.go
+++ b/enterprise/coderd/prebuilds/claim_test.go
@@ -168,6 +168,9 @@ func TestClaimPrebuild(t *testing.T) {
 
 				cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 				reconciler := prebuilds.NewStoreReconciler(spy, pubsub, cache, codersdk.PrebuildsConfig{}, logger, quartz.NewMock(t), prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+				t.Cleanup(func() {
+					reconciler.Stop(context.Background(), nil)
+				})
 				var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(spy)
 				api.AGPL.PrebuildsClaimer.Store(&claimer)
 

--- a/enterprise/coderd/prebuilds/metricscollector_test.go
+++ b/enterprise/coderd/prebuilds/metricscollector_test.go
@@ -1,6 +1,7 @@
 package prebuilds_test
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"testing"

--- a/enterprise/coderd/prebuilds/metricscollector_test.go
+++ b/enterprise/coderd/prebuilds/metricscollector_test.go
@@ -198,6 +198,9 @@ func TestMetricsCollector(t *testing.T) {
 									db, pubsub := dbtestutil.NewDB(t)
 									cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 									reconciler := prebuilds.NewStoreReconciler(db, pubsub, cache, codersdk.PrebuildsConfig{}, logger, quartz.NewMock(t), prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+									t.Cleanup(func() {
+										reconciler.Stop(context.Background(), nil)
+									})
 									ctx := testutil.Context(t, testutil.WaitLong)
 
 									createdUsers := []uuid.UUID{database.PrebuildsSystemUserID}
@@ -330,6 +333,9 @@ func TestMetricsCollector_DuplicateTemplateNames(t *testing.T) {
 	db, pubsub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(db, pubsub, cache, codersdk.PrebuildsConfig{}, logger, quartz.NewMock(t), prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	collector := prebuilds.NewMetricsCollector(db, logger, reconciler)
@@ -478,6 +484,9 @@ func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		registry := prometheus.NewPedanticRegistry()
 		reconciler := prebuilds.NewStoreReconciler(db, pubsub, cache, codersdk.PrebuildsConfig{}, logger, quartz.NewMock(t), registry, newNoopEnqueuer(), newNoopUsageCheckerPtr())
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Ensure no pause setting is set (default state)
@@ -507,6 +516,9 @@ func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		registry := prometheus.NewPedanticRegistry()
 		reconciler := prebuilds.NewStoreReconciler(db, pubsub, cache, codersdk.PrebuildsConfig{}, logger, quartz.NewMock(t), registry, newNoopEnqueuer(), newNoopUsageCheckerPtr())
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Set reconciliation to paused
@@ -536,6 +548,9 @@ func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		registry := prometheus.NewPedanticRegistry()
 		reconciler := prebuilds.NewStoreReconciler(db, pubsub, cache, codersdk.PrebuildsConfig{}, logger, quartz.NewMock(t), registry, newNoopEnqueuer(), newNoopUsageCheckerPtr())
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Set reconciliation back to not paused

--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -292,6 +292,11 @@ func (c *StoreReconciler) Stop(ctx context.Context, cause error) {
 	case <-c.done:
 		c.logger.Info(context.Background(), "reconciler stopped")
 	}
+
+	// Close the render cache to stop its cleanup goroutine
+	if c.renderCache != nil {
+		c.renderCache.Close()
+	}
 }
 
 // ReconcileAll will attempt to resolve the desired vs actual state of all templates which have presets with prebuilds configured.

--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -268,6 +268,10 @@ func (c *StoreReconciler) Stop(ctx context.Context, cause error) {
 		}
 	}
 
+	// Close the render cache to stop its cleanup goroutine
+	// This must be done regardless of whether the reconciler is running
+	c.renderCache.Close()
+
 	// If the reconciler is not running, there's nothing else to do.
 	if !c.running.Load() {
 		return
@@ -292,9 +296,6 @@ func (c *StoreReconciler) Stop(ctx context.Context, cause error) {
 	case <-c.done:
 		c.logger.Info(context.Background(), "reconciler stopped")
 	}
-
-	// Close the render cache to stop its cleanup goroutine
-	c.renderCache.Close()
 }
 
 // ReconcileAll will attempt to resolve the desired vs actual state of all templates which have presets with prebuilds configured.

--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -61,7 +61,7 @@ type StoreReconciler struct {
 	reconciliationDuration prometheus.Histogram
 
 	// renderCache caches template rendering results to avoid expensive re-parsing
-	renderCache *dynamicparameters.RenderCacheImpl
+	renderCache dynamicparameters.RenderCache
 }
 
 var _ prebuilds.ReconciliationOrchestrator = &StoreReconciler{}
@@ -294,9 +294,7 @@ func (c *StoreReconciler) Stop(ctx context.Context, cause error) {
 	}
 
 	// Close the render cache to stop its cleanup goroutine
-	if c.renderCache != nil {
-		c.renderCache.Close()
-	}
+	c.renderCache.Close()
 }
 
 // ReconcileAll will attempt to resolve the desired vs actual state of all templates which have presets with prebuilds configured.

--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -61,7 +61,7 @@ type StoreReconciler struct {
 	reconciliationDuration prometheus.Histogram
 
 	// renderCache caches template rendering results to avoid expensive re-parsing
-	renderCache *dynamicparameters.RenderCache
+	renderCache *dynamicparameters.RenderCacheImpl
 }
 
 var _ prebuilds.ReconciliationOrchestrator = &StoreReconciler{}

--- a/enterprise/coderd/prebuilds/reconcile_test.go
+++ b/enterprise/coderd/prebuilds/reconcile_test.go
@@ -1221,6 +1221,9 @@ func TestRunLoop(t *testing.T) {
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(db, pubSub, cache, cfg, logger, clock, prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 
 	ownerID := uuid.New()
 	dbgen.User(t, db, database.User{
@@ -1349,6 +1352,9 @@ func TestFailedBuildBackoff(t *testing.T) {
 	db, ps := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(db, ps, cache, cfg, logger, clock, prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 
 	// Given: an active template version with presets and prebuilds configured.
 	const desiredInstances = 2
@@ -1471,6 +1477,7 @@ func TestReconciliationLock(t *testing.T) {
 				prometheus.NewRegistry(),
 				newNoopEnqueuer(),
 				newNoopUsageCheckerPtr())
+			defer reconciler.Stop(context.Background(), nil)
 			reconciler.WithReconciliationLock(ctx, logger, func(_ context.Context, _ database.Store) error {
 				lockObtained := mutex.TryLock()
 				// As long as the postgres lock is held, this mutex should always be unlocked when we get here.
@@ -1501,6 +1508,9 @@ func TestTrackResourceReplacement(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	cache := files.New(registry, &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(db, ps, cache, codersdk.PrebuildsConfig{}, logger, clock, registry, fakeEnqueuer, newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 
 	// Given: a template admin to receive a notification.
 	templateAdmin := dbgen.User(t, db, database.User{
@@ -2108,6 +2118,9 @@ func TestCancelPendingPrebuilds(t *testing.T) {
 				cache := files.New(registry, &coderdtest.FakeAuthorizer{})
 				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
 				reconciler := prebuilds.NewStoreReconciler(db, ps, cache, codersdk.PrebuildsConfig{}, logger, clock, registry, fakeEnqueuer, newNoopUsageCheckerPtr())
+				t.Cleanup(func() {
+					reconciler.Stop(context.Background(), nil)
+				})
 				owner := coderdtest.CreateFirstUser(t, client)
 
 				// Given: a template with a version containing a preset with 1 prebuild instance
@@ -2345,6 +2358,9 @@ func TestCancelPendingPrebuilds(t *testing.T) {
 		cache := files.New(registry, &coderdtest.FakeAuthorizer{})
 		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
 		reconciler := prebuilds.NewStoreReconciler(db, ps, cache, codersdk.PrebuildsConfig{}, logger, clock, registry, fakeEnqueuer, newNoopUsageCheckerPtr())
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		owner := coderdtest.CreateFirstUser(t, client)
 
 		// Given: template A with 2 versions
@@ -2410,6 +2426,9 @@ func TestReconciliationStats(t *testing.T) {
 	cache := files.New(registry, &coderdtest.FakeAuthorizer{})
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
 	reconciler := prebuilds.NewStoreReconciler(db, ps, cache, codersdk.PrebuildsConfig{}, logger, clock, registry, fakeEnqueuer, newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 	owner := coderdtest.CreateFirstUser(t, client)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
@@ -2921,6 +2940,9 @@ func TestReconciliationRespectsPauseSetting(t *testing.T) {
 	logger := testutil.Logger(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(db, ps, cache, cfg, logger, clock, prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 
 	// Setup a template with a preset that should create prebuilds
 	org := dbgen.Organization(t, db, database.Organization{})

--- a/enterprise/coderd/prebuilds/reconcile_test.go
+++ b/enterprise/coderd/prebuilds/reconcile_test.go
@@ -53,6 +53,9 @@ func TestNoReconciliationActionsIfNoPresets(t *testing.T) {
 	logger := testutil.Logger(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	controller := prebuilds.NewStoreReconciler(db, ps, cache, cfg, logger, quartz.NewMock(t), prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		controller.Stop(context.Background(), nil)
+	})
 
 	// given a template version with no presets
 	org := dbgen.Organization(t, db, database.Organization{})
@@ -96,6 +99,9 @@ func TestNoReconciliationActionsIfNoPrebuilds(t *testing.T) {
 	logger := testutil.Logger(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	controller := prebuilds.NewStoreReconciler(db, ps, cache, cfg, logger, quartz.NewMock(t), prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+	t.Cleanup(func() {
+		controller.Stop(context.Background(), nil)
+	})
 
 	// given there are presets, but no prebuilds
 	org := dbgen.Organization(t, db, database.Organization{})
@@ -426,6 +432,9 @@ func (tc testCase) run(t *testing.T) {
 		}
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		controller := prebuilds.NewStoreReconciler(db, pubSub, cache, cfg, logger, quartz.NewMock(t), prometheus.NewRegistry(), newNoopEnqueuer(), newNoopUsageCheckerPtr())
+		t.Cleanup(func() {
+			controller.Stop(context.Background(), nil)
+		})
 
 		// Run the reconciliation multiple times to ensure idempotency
 		// 8 was arbitrary, but large enough to reasonably trust the result

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1978,6 +1978,9 @@ func TestPrebuildsAutobuild(t *testing.T) {
 			notificationsNoop,
 			api.AGPL.BuildUsageChecker,
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 
@@ -2100,6 +2103,9 @@ func TestPrebuildsAutobuild(t *testing.T) {
 			notificationsNoop,
 			api.AGPL.BuildUsageChecker,
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 
@@ -2222,6 +2228,9 @@ func TestPrebuildsAutobuild(t *testing.T) {
 			notificationsNoop,
 			api.AGPL.BuildUsageChecker,
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 
@@ -2366,6 +2375,9 @@ func TestPrebuildsAutobuild(t *testing.T) {
 			notificationsNoop,
 			api.AGPL.BuildUsageChecker,
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 
@@ -2511,6 +2523,9 @@ func TestPrebuildsAutobuild(t *testing.T) {
 			notificationsNoop,
 			api.AGPL.BuildUsageChecker,
 		)
+		t.Cleanup(func() {
+			reconciler.Stop(context.Background(), nil)
+		})
 		var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 		api.AGPL.PrebuildsClaimer.Store(&claimer)
 
@@ -2957,6 +2972,9 @@ func TestWorkspaceProvisionerdServerMetrics(t *testing.T) {
 		notifications.NewNoopEnqueuer(),
 		api.AGPL.BuildUsageChecker,
 	)
+	t.Cleanup(func() {
+		reconciler.Stop(context.Background(), nil)
+	})
 	var claimer agplprebuilds.Claimer = prebuilds.NewEnterpriseClaimer(db)
 	api.AGPL.PrebuildsClaimer.Store(&claimer)
 


### PR DESCRIPTION
Trying out tasks in dogfood for this one. 

I'm not in love with the metrics pattern here, nor the interface/`RenderCacheImpl` name the model chose, but it's nicer than everything being a pointer imo.

In this PR we're introducing a 'render cache' for rendered terraform templates. Currently the prebuilds portion of the system, via the path that calls out to dynamic parameters resolution and a terraform parser to then finally build a workspace, is responsible for a significant portion of our CPU usage and memory allocation internally. About 25% and 50% respectively.

The render cache will take the result of the terraform parsing and dynamic parameter resolution, and cache it for a given template version ID/ownerID/hash of parameters. The owner ID should always be consistent for prebuilds, and I believe both the parameters hash and template verison ID (which is a UUID, so it's globally unique meaning we don't need the template name or ID in the key) will change if a template is updated.

We can then include this cache in the prebuilds reconciler to avoid having to do the param resolution/terraform parsing the majority of the time. 

At the moment the cache cleanup is pretty basic; not hooking into template version publishing, just running a periodic check for cache entries that haven't been used in the last hour and removing them.
