### PR TITLE
test: close provisioner before creating workspace build

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -811,6 +811,12 @@ func TestTasks(t *testing.T) {
 					require.NoError(t, err)
 					coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
+					// If we're going to cancel the transition, we want to close the provisioner
+					// to stop the job completing before we can cancel it.
+					if tt.cancelTransition {
+						provisioner.Close()
+					}
+
 					// Given: We transition the task's workspace
 					build := coderdtest.CreateWorkspaceBuild(t, client, workspace, tt.transition)
 					if tt.cancelTransition {


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1178

I verified the fix works by adding a `time.Sleep(100 * time.Millisecond)` between the `CreateWorkspaceBuild` and `CancelWorkspaceBuild` calls. Adding this reliably triggered the flake, and when I added the fix the flake stopped happening.
