### PR TITLE
fix: handle scenario where provisionerdserver deletes task before coderd

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2267,6 +2267,13 @@ func (s *server) completeWorkspaceBuildJob(ctx context.Context, job database.Pro
 		if err != nil {
 			return xerrors.Errorf("update workspace deleted: %w", err)
 		}
+
+		// A user might delete their task workspace directly, instead of
+		// deleting the task. To avoid leaving the Task in a scenario where
+		// it has no workspace, we also attempt to delete the task.
+		//
+		// Deleting the task may fail if it has already been deleted as part
+		// of the typical task deletion workflow, so we explicitly allow that.
 		if workspace.TaskID.Valid {
 			if _, err := db.DeleteTask(ctx, database.DeleteTaskParams{
 				ID:        workspace.TaskID.UUID,


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1112

We introduced to provisionerdserver the ability to delete a workspace's associated task for the scenario where a user decided to delete a task workspace directly, instead of the task. This introduced a race between coderd and provisionerdserver. We accounted for this in provisionerdserver with an explicit `!errors.Is(err, sql.ErrNoRows)` but forgot to apply the same logic to coderd.

In the real world this will almost never happen but it does sometimes happen during our tests.
