### PR TITLE
test: move context to after db creation

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -6082,7 +6082,6 @@ func TestGetWorkspaceAgentsByParentID(t *testing.T) {
 	t.Run("NilParentDoesNotReturnAllParentAgents", func(t *testing.T) {
 		t.Parallel()
 
-
 		// Given: A workspace agent
 		db, _ := dbtestutil.NewDB(t)
 		org := dbgen.Organization(t, db, database.Organization{})

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -6082,7 +6082,6 @@ func TestGetWorkspaceAgentsByParentID(t *testing.T) {
 	t.Run("NilParentDoesNotReturnAllParentAgents", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testutil.Context(t, testutil.WaitShort)
 
 		// Given: A workspace agent
 		db, _ := dbtestutil.NewDB(t)
@@ -6097,6 +6096,8 @@ func TestGetWorkspaceAgentsByParentID(t *testing.T) {
 		_ = dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{
 			ResourceID: resource.ID,
 		})
+
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		// When: We attempt to select agents with a null parent id
 		agents, err := db.GetWorkspaceAgentsByParentID(ctx, uuid.Nil)


### PR DESCRIPTION
Closes  https://github.com/coder/internal/issues/1040

We move the context to just before it is used to avoid the scenario where NewDB takes a while to spin up and runs up the context to the deadline.