### PR TITLE
chore: simplify implicit echo provision responses

### DIFF
--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -760,7 +760,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
-			ProvisionApply: []*proto.Response{{
+			ProvisionPlan: []*proto.Response{{
 				Type: &proto.Response_Log{
 					Log: &proto.Log{},
 				},
@@ -793,7 +793,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
-			ProvisionApply: []*proto.Response{{
+			ProvisionPlan: []*proto.Response{{
 				Type: &proto.Response_Log{
 					Log: &proto.Log{},
 				},

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -1500,18 +1500,18 @@ func TestPostWorkspaceBuild(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
-			ProvisionApply: []*proto.Response{
+			ProvisionPlan: []*proto.Response{
 				{
-					Type: &proto.Response_Apply{
-						Apply: &proto.ApplyComplete{
-							Error: "failed to import",
+					Type: &proto.Response_Plan{
+						Plan: &proto.PlanComplete{
+							Error: "failed to plan",
 						},
 					},
 				},
 			},
 		})
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		version = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()


### PR DESCRIPTION
@spikecurtis this simplifies that "magic" logic in the responses, but it still implicitly adds `<Step>Complete` when things are nil. To prevent a massive diff.

We have >100 tests that would require adding the `Init/Plan/ApplyComplete`. I think this diff is a good middle ground.