### PR TITLE
test(scaletest/workspacetraffic): fix test flake due to io.EOF on close

### DIFF
--- a/scaletest/workspacetraffic/conn.go
+++ b/scaletest/workspacetraffic/conn.go
@@ -147,8 +147,9 @@ func connectSSH(ctx context.Context, client *codersdk.Client, agentID uuid.UUID,
 	var closers []func() error
 	defer func() {
 		if err != nil {
-			for _, c := range closers {
-				if err2 := c(); err2 != nil {
+			// Reverse order, like defer.
+			for i := len(closers) - 1; i >= 0; i-- {
+				if err2 := closers[i](); err2 != nil {
 					err = errors.Join(err, err2)
 				}
 			}
@@ -227,8 +228,9 @@ func connectSSH(ctx context.Context, client *codersdk.Client, agentID uuid.UUID,
 				}
 			}
 		}
-		for _, c := range closers {
-			if err := c(); err != nil {
+		// Reverse order, like defer.
+		for i := len(closers) - 1; i >= 0; i-- {
+			if err := closers[i](); err != nil {
 				if !errors.Is(err, io.EOF) {
 					merr = errors.Join(merr, err)
 				}

--- a/scaletest/workspacetraffic/run.go
+++ b/scaletest/workspacetraffic/run.go
@@ -3,6 +3,7 @@ package workspacetraffic
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -131,8 +132,11 @@ func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) (err error) 
 	closeConn := func() error {
 		closeOnce.Do(func() {
 			closeErr = conn.Close()
-			if closeErr != nil {
+			if errors.Is(closeErr, io.EOF) {
+				closeErr = nil
+			} else if closeErr != nil {
 				logger.Error(ctx, "close agent connection", slog.Error(closeErr))
+				closeErr = xerrors.Errorf("close agent connection: %w", closeErr)
 			}
 		})
 		return closeErr


### PR DESCRIPTION
There are many cases where the code being called would return io.EOF, so
skipping it seems like a reasonable easy-fix to this flake.

Fixes coder/internal#119
