### PR TITLE
fix: add id-token permission to classify-issue-severity workflow

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions] - Required by claude-code-action for OIDC auth
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the classify-issue-severity workflow

## Problem
The [workflow](https://github.com/coder/coder/actions/runs/20145494191/job/57824586833) was failing with:
```
Failed to setup GitHub token: Error: Could not fetch an OIDC token. 
Did you remember to add `id-token: write` to your workflow permissions?
```

## Solution
The `claude-code-action` requires OIDC token authentication. Added the required `id-token: write` permission to the workflow's permissions block.

## Test plan
- [ ] Merge PR
- [ ] Apply `triage-check` label to a test issue
- [ ] Verify workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)