### PR TITLE
fix: add checkout step to classify-issue-severity workflow

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Analyze Issue Severity
         id: analysis

--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -21,6 +21,9 @@ jobs:
       result: ${{ steps.analysis.outputs.result }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Analyze Issue Severity
         id: analysis
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23


### PR DESCRIPTION
## Summary
- Adds `actions/checkout@v4` step before the claude-code-action

## Problem
The workflow was failing with two related errors:
```
fatal: not in a git directory
error: Executable not found in $PATH: "claude"
```

The `claude-code-action` requires a git repository to be present because it:
1. Configures git authentication during setup
2. Installs Claude Code which needs to operate in a git directory

## Solution
Added the missing `actions/checkout@v4` step before running the claude-code-action. This ensures the repository is cloned and available as a git directory.

## Test plan
- [x] Create PR
- [ ] Merge PR
- [ ] Apply `triage-check` label to a test issue
- [ ] Verify workflow runs successfully without git errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)