### PR TITLE
fix: correct jq parsing in classify-issue-severity workflow

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -150,8 +150,14 @@ jobs:
             exit 1
           fi
 
-          # Extract the result from the execution file
-          RESULT=$(jq -r '.result // empty' < "$EXECUTION_FILE")
+          # The execution file is an array of conversation messages
+          # Extract the last assistant message's text content
+          RESULT=$(jq -r '.[].content[]? | select(.type == "text") | .text' < "$EXECUTION_FILE" | tail -n 1)
+
+          if [ -z "$RESULT" ]; then
+            echo "No text content found in execution file"
+            exit 1
+          fi
 
           {
             echo "result<<EOF"


### PR DESCRIPTION
## Summary
Fixes the jq parsing error in the `classify-issue-severity.yml` workflow that was causing failures in the "Extract Result from Execution File" step.

## Problem
The `claude-code-action` outputs an array of conversation messages (following the Anthropic API message format), but the workflow was attempting to access `.result` as if it were an object property. This caused the error:
```
jq: error (at <stdin>:142): Cannot index array with string "result"
```

## Solution
Updated the extraction logic to properly parse the message array structure:
- Iterate through the message array
- Extract text content blocks from each message
- Select text-type content
- Get the last text content (the assistant's final response)

## Changes
- Updated `.github/workflows/classify-issue-severity.yml` line 155
- Changed from: `jq -r '.result // empty'`
- Changed to: `jq -r '.[].content[]? | select(.type == "text") | .text' | tail -n 1`
- Added validation to check if result is empty

## Test Plan
This fix addresses the error in workflow run: https://github.com/coder/coder/actions/runs/20148520999/job/57835360033

The workflow should now correctly:
1. Extract the assistant's response from the execution file
2. Parse the JSON classification result
3. Post the appropriate comment to the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)