### PR TITLE
fix: use structured output for classify-issue-severity workflow

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -31,6 +31,7 @@ jobs:
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: --json-schema '{"type":"object","properties":{"status":{"type":"string","enum":["classified","insufficient_info"]},"severity":{"type":"string","enum":["s0","s1","s2","s3","s4"]},"reasoning":{"type":"string"},"next_steps":{"type":"array","items":{"type":"string"}}},"required":["status","reasoning"],"allOf":[{"if":{"properties":{"status":{"const":"classified"}}},"then":{"required":["severity"]}},{"if":{"properties":{"status":{"const":"insufficient_info"}}},"then":{"required":["next_steps"]}}]}'
           prompt: |
             You are an expert software engineer triaging customer-reported issues for Coder, a cloud development environment platform.
 
@@ -140,28 +141,20 @@ jobs:
 
             **Critical**: Output ONLY the JSON object, nothing else. The JSON will be parsed and validated.
 
-      - name: Extract Result from Execution File
+      - name: Extract Result from Structured Output
         id: extract
         env:
-          EXECUTION_FILE: ${{ steps.analysis.outputs.execution_file }} # zizmor: ignore[template-injection]
+          STRUCTURED_OUTPUT: ${{ steps.analysis.outputs.structured_output }}
         run: |
-          if [ ! -f "$EXECUTION_FILE" ]; then
-            echo "Execution file not found: $EXECUTION_FILE"
+          if [ -z "$STRUCTURED_OUTPUT" ]; then
+            echo "No structured output returned from Claude"
             exit 1
           fi
 
-          # The execution file is an array of conversation messages
-          # Extract the last assistant message's text content
-          RESULT=$(jq -r '.[].content[]? | select(.type == "text") | .text' < "$EXECUTION_FILE" | tail -n 1)
-
-          if [ -z "$RESULT" ]; then
-            echo "No text content found in execution file"
-            exit 1
-          fi
-
+          # The structured_output is already in JSON format matching our schema
           {
             echo "result<<EOF"
-            echo "$RESULT"
+            echo "$STRUCTURED_OUTPUT"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
Fixes the extraction error in the `classify-issue-severity.yml` workflow by using structured output instead of parsing the execution file.

## Root Cause
The claude-code-action uses its own stream-json format (not the Anthropic Messages API format). Without `--json-schema`, the assistant's text response isn't available in a structured field in the execution file. The previous fix (#21238) tried to extract text from `content` arrays, but that doesn't match the actual format.

## Solution
Use the claude-code-action's structured output feature:

1. **Add `--json-schema` parameter** with a JSON schema that matches the expected output format
   - Defines required fields: `status`, `reasoning`
   - Conditional requirements based on `status` value
   - Enforces valid enum values for `status` and `severity`

2. **Use `structured_output` output directly** from the claude-code-action
   - This is automatically populated when `--json-schema` is provided
   - No need to parse the execution file manually

3. **Simplify extraction step**
   - Removed complex jq parsing
   - Now just passes through the structured output

## Changes
- Updated `.github/workflows/classify-issue-severity.yml`:
  - Added `claude_args` with `--json-schema` parameter
  - Changed extraction step from parsing `execution_file` to using `structured_output`
  - Renamed step to "Extract Result from Structured Output" for clarity

## Verification
The structured output approach is the recommended way to extract data from claude-code-action, as shown in their test workflows:
https://github.com/anthropics/claude-code-action/blob/main/.github/workflows/test-structured-output.yml

## Supersedes
- #21238 (previous attempt that tried to parse execution file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)