### PR TITLE
fix: simplify JSON schema in classify-issue-severity workflow

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -31,7 +31,8 @@ jobs:
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: --json-schema '{"type":"object","properties":{"status":{"type":"string","enum":["classified","insufficient_info"]},"severity":{"type":"string","enum":["s0","s1","s2","s3","s4"]},"reasoning":{"type":"string"},"next_steps":{"type":"array","items":{"type":"string"}}},"required":["status","reasoning"],"allOf":[{"if":{"properties":{"status":{"const":"classified"}}},"then":{"required":["severity"]}},{"if":{"properties":{"status":{"const":"insufficient_info"}}},"then":{"required":["next_steps"]}}]}'
+          claude_args: |
+            --json-schema '{"type":"object","properties":{"status":{"type":"string"},"severity":{"type":"string"},"reasoning":{"type":"string"},"next_steps":{"type":"array","items":{"type":"string"}}},"required":["status","reasoning"]}'
           prompt: |
             You are an expert software engineer triaging customer-reported issues for Coder, a cloud development environment platform.
 


### PR DESCRIPTION
## Summary
Fixes the claude-code-action failure by simplifying the JSON schema that was too complex.

## Problem
The previous fix (#21240) used a JSON schema with `allOf` conditionals, `if/then` logic, and `enum` constraints. This complex schema likely caused the claude-code-action to fail during the "Analyze Issue Severity" step.

Error from run: https://github.com/coder/coder/actions/runs/20149538756

## Solution
Simplified the JSON schema to match patterns used in claude-code-action's test workflows:

1. **Removed complex conditionals**
   - No more `allOf`, `if/then`, or `const` checks
   - Removed `enum` constraints for `status` and `severity`

2. **Simplified to basic schema**
   - Only require: `status` and `reasoning`
   - Keep `severity` and `next_steps` as optional fields
   - Validation of values happens in the downstream parsing step

3. **Improved formatting**
   - Changed `claude_args` from single-line to multi-line with `|`
   - Better readability and avoids potential YAML escaping issues

## Schema Comparison

**Before (complex):**
```json
{
  "allOf": [
    {
      "if": {"properties": {"status": {"const": "classified"}}},
      "then": {"required": ["severity"]}
    },
    ...
  ],
  "enum": ["classified", "insufficient_info"],
  ...
}
```

**After (simple):**
```json
{
  "type": "object",
  "properties": {
    "status": {"type": "string"},
    "severity": {"type": "string"},
    "reasoning": {"type": "string"},
    "next_steps": {"type": "array", "items": {"type": "string"}}
  },
  "required": ["status", "reasoning"]
}
```

## References
- Similar simple schemas work in [claude-code-action tests](https://github.com/anthropics/claude-code-action/blob/main/.github/workflows/test-structured-output.yml)

## Supersedes
- #21240 (schema was too complex)
- #21238 (attempted to parse execution file manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)