### PR TITLE
fix: make `make test` runnable again

### DIFF
--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -71,6 +71,7 @@ runs:
 
         if [[ ${RACE_DETECTION} == true ]]; then
           gotestsum --junitfile="gotests.xml" --packages="${TEST_PACKAGES}" -- \
+            -tags=testsmallbuffers \
             -race \
             -parallel "${TEST_NUM_PARALLEL_TESTS}" \
             -p "${TEST_NUM_PARALLEL_PACKAGES}"

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -71,7 +71,7 @@ runs:
 
         if [[ ${RACE_DETECTION} == true ]]; then
           gotestsum --junitfile="gotests.xml" --packages="${TEST_PACKAGES}" -- \
-            -tags=testsmallbuffers \
+            -tags=testsmallbatch \
             -race \
             -parallel "${TEST_NUM_PARALLEL_TESTS}" \
             -p "${TEST_NUM_PARALLEL_PACKAGES}"

--- a/Makefile
+++ b/Makefile
@@ -1018,7 +1018,8 @@ endif
 
 # default to 8x8 parallelism to avoid overwhelming our workspaces. Hopefully we can remove these defaults
 # when we get our test suite's resource utilization under control.
-GOTEST_FLAGS := -v -p $(or $(TEST_NUM_PARALLEL_PACKAGES),"8") -parallel=$(or $(TEST_NUM_PARALLEL_TESTS),"8")
+# Use testsmallbuffers tag to reduce wireguard memory allocation in tests (from ~18GB to negligible).
+GOTEST_FLAGS := -tags=testsmallbuffers -v -p $(or $(TEST_NUM_PARALLEL_PACKAGES),"8") -parallel=$(or $(TEST_NUM_PARALLEL_TESTS),"8")
 
 # The most common use is to set TEST_COUNT=1 to avoid Go's test cache.
 ifdef TEST_COUNT
@@ -1089,6 +1090,7 @@ test-postgres: test-postgres-docker
 		--jsonfile="gotests.json" \
 		$(GOTESTSUM_RETRY_FLAGS) \
 		--packages="./..." -- \
+		-tags=testsmallbuffers \
 		-timeout=20m \
 		-count=1
 .PHONY: test-postgres
@@ -1161,7 +1163,7 @@ test-postgres-docker:
 
 # Make sure to keep this in sync with test-go-race from .github/workflows/ci.yaml.
 test-race:
-	$(GIT_FLAGS) gotestsum --junitfile="gotests.xml" -- -race -count=1 -parallel 4 -p 4 ./...
+	$(GIT_FLAGS) gotestsum --junitfile="gotests.xml" -- -tags=testsmallbuffers -race -count=1 -parallel 4 -p 4 ./...
 .PHONY: test-race
 
 test-tailnet-integration:
@@ -1171,6 +1173,7 @@ test-tailnet-integration:
 		TS_DEBUG_NETCHECK=true \
 		GOTRACEBACK=single \
 		go test \
+			-tags=testsmallbuffers \
 			-exec "sudo -E" \
 			-timeout=5m \
 			-count=1 \

--- a/Makefile
+++ b/Makefile
@@ -1018,8 +1018,8 @@ endif
 
 # default to 8x8 parallelism to avoid overwhelming our workspaces. Hopefully we can remove these defaults
 # when we get our test suite's resource utilization under control.
-# Use testsmallbuffers tag to reduce wireguard memory allocation in tests (from ~18GB to negligible).
-GOTEST_FLAGS := -tags=testsmallbuffers -v -p $(or $(TEST_NUM_PARALLEL_PACKAGES),"8") -parallel=$(or $(TEST_NUM_PARALLEL_TESTS),"8")
+# Use testsmallbatch tag to reduce wireguard memory allocation in tests (from ~18GB to negligible).
+GOTEST_FLAGS := -tags=testsmallbatch -v -p $(or $(TEST_NUM_PARALLEL_PACKAGES),"8") -parallel=$(or $(TEST_NUM_PARALLEL_TESTS),"8")
 
 # The most common use is to set TEST_COUNT=1 to avoid Go's test cache.
 ifdef TEST_COUNT
@@ -1090,7 +1090,7 @@ test-postgres: test-postgres-docker
 		--jsonfile="gotests.json" \
 		$(GOTESTSUM_RETRY_FLAGS) \
 		--packages="./..." -- \
-		-tags=testsmallbuffers \
+		-tags=testsmallbatch \
 		-timeout=20m \
 		-count=1
 .PHONY: test-postgres
@@ -1163,7 +1163,7 @@ test-postgres-docker:
 
 # Make sure to keep this in sync with test-go-race from .github/workflows/ci.yaml.
 test-race:
-	$(GIT_FLAGS) gotestsum --junitfile="gotests.xml" -- -tags=testsmallbuffers -race -count=1 -parallel 4 -p 4 ./...
+	$(GIT_FLAGS) gotestsum --junitfile="gotests.xml" -- -tags=testsmallbatch -race -count=1 -parallel 4 -p 4 ./...
 .PHONY: test-race
 
 test-tailnet-integration:
@@ -1173,7 +1173,7 @@ test-tailnet-integration:
 		TS_DEBUG_NETCHECK=true \
 		GOTRACEBACK=single \
 		go test \
-			-tags=testsmallbuffers \
+			-tags=testsmallbatch \
 			-exec "sudo -E" \
 			-timeout=5m \
 			-count=1 \

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,8 @@ replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20250829055706-6eaf
 // This is replaced to include
 // 1. a fix for a data race: c.f. https://github.com/tailscale/wireguard-go/pull/25
 // 2. update to the latest gVisor
-replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20240522052547-769cdd7f7818
+// 3. testsmallbuffers build tag for reduced memory usage in tests
+replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20251212125616-14162b99a46a
 
 // Switch to our fork that imports fixes from http://github.com/tailscale/ssh.
 // See: https://github.com/coder/coder/issues/3371

--- a/go.mod
+++ b/go.mod
@@ -41,8 +41,7 @@ replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20250829055706-6eaf
 // This is replaced to include
 // 1. a fix for a data race: c.f. https://github.com/tailscale/wireguard-go/pull/25
 // 2. update to the latest gVisor
-// 3. testsmallbuffers build tag for reduced memory usage in tests
-replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20251212134302-bb12dfe22d7f
+replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20260113095422-f1923d28a9f7
 
 // Switch to our fork that imports fixes from http://github.com/tailscale/ssh.
 // See: https://github.com/coder/coder/issues/3371

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20250829055706-6eaf
 // This is replaced to include
 // 1. a fix for a data race: c.f. https://github.com/tailscale/wireguard-go/pull/25
 // 2. update to the latest gVisor
-replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20260113095422-f1923d28a9f7
+replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20260113101225-9b7a56210e49
 
 // Switch to our fork that imports fixes from http://github.com/tailscale/ssh.
 // See: https://github.com/coder/coder/issues/3371

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20250829055706-6eaf
 // 1. a fix for a data race: c.f. https://github.com/tailscale/wireguard-go/pull/25
 // 2. update to the latest gVisor
 // 3. testsmallbuffers build tag for reduced memory usage in tests
-replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20251212125616-14162b99a46a
+replace github.com/tailscale/wireguard-go => github.com/coder/wireguard-go v0.0.0-20251212134302-bb12dfe22d7f
 
 // Switch to our fork that imports fixes from http://github.com/tailscale/ssh.
 // See: https://github.com/coder/coder/issues/3371

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9F
 github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coder/wgtunnel v0.2.0 h1:yy9dE9ntoNdx/q98CH9uV2cQk1UEKSwPgITy3Xx+Wiw=
 github.com/coder/wgtunnel v0.2.0/go.mod h1:4Ne8vzzdHwkM9BnPW2zDvidvFi5IfEbkecx5JH+0zjY=
-github.com/coder/wireguard-go v0.0.0-20251212134302-bb12dfe22d7f h1:EV5L4DiIuaoQNsM/9Ftm3C7mE2rr+PDf9ncGo+MqgeM=
-github.com/coder/wireguard-go v0.0.0-20251212134302-bb12dfe22d7f/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
+github.com/coder/wireguard-go v0.0.0-20260113095422-f1923d28a9f7 h1:L+Sf4SZTOqRHIyXhK/83tQCZhcBYzpZJUyQSeM0Vf44=
+github.com/coder/wireguard-go v0.0.0-20260113095422-f1923d28a9f7/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9F
 github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coder/wgtunnel v0.2.0 h1:yy9dE9ntoNdx/q98CH9uV2cQk1UEKSwPgITy3Xx+Wiw=
 github.com/coder/wgtunnel v0.2.0/go.mod h1:4Ne8vzzdHwkM9BnPW2zDvidvFi5IfEbkecx5JH+0zjY=
-github.com/coder/wireguard-go v0.0.0-20251212125616-14162b99a46a h1:mwX1GlLKArnLVujQRIZJkM9BUCR2GIQe7q/wK7cWX8o=
-github.com/coder/wireguard-go v0.0.0-20251212125616-14162b99a46a/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
+github.com/coder/wireguard-go v0.0.0-20251212134302-bb12dfe22d7f h1:EV5L4DiIuaoQNsM/9Ftm3C7mE2rr+PDf9ncGo+MqgeM=
+github.com/coder/wireguard-go v0.0.0-20251212134302-bb12dfe22d7f/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9F
 github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coder/wgtunnel v0.2.0 h1:yy9dE9ntoNdx/q98CH9uV2cQk1UEKSwPgITy3Xx+Wiw=
 github.com/coder/wgtunnel v0.2.0/go.mod h1:4Ne8vzzdHwkM9BnPW2zDvidvFi5IfEbkecx5JH+0zjY=
-github.com/coder/wireguard-go v0.0.0-20240522052547-769cdd7f7818 h1:bNhUTaKl3q0bFn78bBRq7iIwo72kNTvUD9Ll5TTzDDk=
-github.com/coder/wireguard-go v0.0.0-20240522052547-769cdd7f7818/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
+github.com/coder/wireguard-go v0.0.0-20251212125616-14162b99a46a h1:mwX1GlLKArnLVujQRIZJkM9BUCR2GIQe7q/wK7cWX8o=
+github.com/coder/wireguard-go v0.0.0-20251212125616-14162b99a46a/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9F
 github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coder/wgtunnel v0.2.0 h1:yy9dE9ntoNdx/q98CH9uV2cQk1UEKSwPgITy3Xx+Wiw=
 github.com/coder/wgtunnel v0.2.0/go.mod h1:4Ne8vzzdHwkM9BnPW2zDvidvFi5IfEbkecx5JH+0zjY=
-github.com/coder/wireguard-go v0.0.0-20260113095422-f1923d28a9f7 h1:L+Sf4SZTOqRHIyXhK/83tQCZhcBYzpZJUyQSeM0Vf44=
-github.com/coder/wireguard-go v0.0.0-20260113095422-f1923d28a9f7/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
+github.com/coder/wireguard-go v0.0.0-20260113101225-9b7a56210e49 h1:go72mN+u8M26ji5XE3N2qV+h136Ie0ZBjq+Ccf4wig0=
+github.com/coder/wireguard-go v0.0.0-20260113101225-9b7a56210e49/go.mod h1:fAlLM6hUgnf4Sagxn2Uy5Us0PBgOYWz+63HwHUVGEbw=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=


### PR DESCRIPTION
_All credit for this fix goes to Opus 4.5 ❤️_ 

I identified a problem this morning; we _thought_ the reason for tests were using up to 25GiB of RAM due to excessive postgres databases being created after we moved away from dbmem. As it turns out, about half of the in-use heap is caused by Wireguard device buffers.

<img width="2560" height="1294" alt="image" src="https://github.com/user-attachments/assets/37912ccf-8839-40c5-a7d1-9170419bfa3b" />

<details>
<summary>Reproduction steps</summary>


```bash
$ make test TEST_MEMPROFILE=mem.prof TEST_PACKAGES=./coderd TEST_COUNT=1

$ go tool pprof -top -focus=github.com/tailscale/wireguard-go -sample_index=alloc_space mem.prof
File: coderd.test
Build ID: 06abac78cf59dfc8c94606ce0e9505e937c7cb0a
Type: alloc_space
Time: 2026-01-13 10:56:11 SAST
Active filters:
   focus=github.com/tailscale/wireguard-go
Showing nodes accounting for 28991.37MB, 69.40% of 41772.75MB total
Dropped 290 nodes (cum <= 208.86MB)
      flat  flat%   sum%        cum   cum%
28949.24MB 69.30% 69.30% 28949.24MB 69.30%  github.com/tailscale/wireguard-go/device.(*Device).PopulatePools.func3
   32.60MB 0.078% 69.38% 21729.27MB 52.02%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReceiveIncoming
    9.53MB 0.023% 69.40%  7342.26MB 17.58%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReadFromTUN
         0     0% 69.40% 28950.24MB 69.30%  github.com/tailscale/wireguard-go/device.(*Device).GetMessageBuffer (inline)
         0     0% 69.40%  7326.30MB 17.54%  github.com/tailscale/wireguard-go/device.(*Device).NewOutboundElement
         0     0% 69.40% 28961.75MB 69.33%  github.com/tailscale/wireguard-go/device.(*WaitPool).Get
         0     0% 69.40% 28991.96MB 69.40%  sync.(*Pool).Get

$ go tool pprof -top -focus=github.com/tailscale/wireguard-go -sample_index=inuse_space mem.prof
File: coderd.test
Build ID: 06abac78cf59dfc8c94606ce0e9505e937c7cb0a
Type: inuse_space
Time: 2026-01-13 10:56:11 SAST
Active filters:
   focus=github.com/tailscale/wireguard-go
Showing nodes accounting for 3283.51MB, 71.88% of 4568.31MB total
Dropped 147 nodes (cum <= 22.84MB)
      flat  flat%   sum%        cum   cum%
 3232.89MB 70.77% 70.77%  3232.89MB 70.77%  github.com/tailscale/wireguard-go/device.(*Device).PopulatePools.func3
   49.62MB  1.09% 71.85%    49.62MB  1.09%  github.com/tailscale/wireguard-go/device.newHandshakeQueue
       1MB 0.022% 71.88%    66.25MB  1.45%  github.com/tailscale/wireguard-go/device.NewDevice
         0     0% 71.88%    64.14MB  1.40%  github.com/coder/coder/v2/coderd.New
         0     0% 71.88%    64.67MB  1.42%  github.com/coder/coder/v2/coderd.NewServerTailnet
         0     0% 71.88%    49.46MB  1.08%  github.com/coder/coder/v2/coderd/coderdtest.New
         0     0% 71.88%    64.14MB  1.40%  github.com/coder/coder/v2/coderd/coderdtest.NewWithAPI
         0     0% 71.88%    49.98MB  1.09%  github.com/coder/coder/v2/coderd/coderdtest.newWithCloser (inline)
         0     0% 71.88%    66.25MB  1.45%  github.com/coder/coder/v2/tailnet.NewConn
         0     0% 71.88%  3232.89MB 70.77%  github.com/tailscale/wireguard-go/device.(*Device).GetMessageBuffer (inline)
         0     0% 71.88%   822.16MB 18.00%  github.com/tailscale/wireguard-go/device.(*Device).NewOutboundElement
         0     0% 71.88%   823.66MB 18.03%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReadFromTUN
         0     0% 71.88%  2419.28MB 52.96%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReceiveIncoming
         0     0% 71.88%  3235.39MB 70.82%  github.com/tailscale/wireguard-go/device.(*WaitPool).Get
         0     0% 71.88%  3240.95MB 70.94%  sync.(*Pool).Get
         0     0% 71.88%    66.25MB  1.45%  tailscale.com/wgengine.NewUserspaceEngine
         0     0% 71.88%    66.25MB  1.45%  tailscale.com/wgengine/wgcfg.NewDevice
         0     0% 71.88%    65.20MB  1.43%  testing.tRunner
```
</details>

---

https://github.com/coder/wireguard-go/pull/5 is a (initially vibed) solution to this problem whereby the batch size is tuned way down when a build tag is used. This reduces the per-connection memory usage _significantly_.

```bash
$ make test TEST_COUNT=1
...
DONE 13594 tests, 53 skipped in 173.448s
```

This uses about 5GiB of RAM (high watermark).

_The RAM usage observations were purely just eyeballing using `top` and comparing against the baseline; confounding factors abound, but it's much better than it was at least. **Needs validation.**_

Running the reproduction steps above again, comparing to previous profile:

```bash
# Produce new profile
$ make test TEST_MEMPROFILE=mem-new.prof TEST_PACKAGES=./coderd TEST_COUNT=1
```

**70% reduction in heap usage:**

```bash
$ go tool pprof -top -nodecount=10 -cum -sample_index=inuse_space -diff_base=mem.prof mem-new.prof 
File: coderd.test
Build ID: 6dbae1215833f69b877eeef4def99ac0fb99bb1d
Type: inuse_space
Time: 2026-01-13 10:56:11 SAST
Showing nodes accounting for -3213.24MB, 70.34% of 4568.31MB total
Dropped 2065 nodes (cum <= 22.84MB)
Showing top 10 nodes out of 19
      flat  flat%   sum%        cum   cum%
         0     0%     0% -3221.78MB 70.52%  sync.(*Pool).Get
         0     0%     0% -3216.25MB 70.40%  github.com/tailscale/wireguard-go/device.(*WaitPool).Get
         0     0%     0% -3213.75MB 70.35%  github.com/tailscale/wireguard-go/device.(*Device).GetMessageBuffer (inline)
-3213.75MB 70.35% 70.35% -3213.75MB 70.35%  github.com/tailscale/wireguard-go/device.(*Device).PopulatePools.func3
         0     0% 70.35% -2404.95MB 52.64%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReceiveIncoming
         0     0% 70.35%  -818.34MB 17.91%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReadFromTUN
         0     0% 70.35%  -816.84MB 17.88%  github.com/tailscale/wireguard-go/device.(*Device).NewOutboundElement
         0     0% 70.35%   -27.50MB   0.6%  github.com/coder/coder/v2/coderd/coderdtest.newWithCloser (inline)
         0     0% 70.35%   -25.56MB  0.56%  github.com/coder/coder/v2/coderd/coderdtest.New
    0.50MB 0.011% 70.34%   -24.10MB  0.53%  github.com/coder/coder/v2/coderd/coderdtest.NewWithAPI
```

**66% reduction in allocs:**

```bash
$ go tool pprof -top -nodecount=10 -cum -sample_index=alloc_space -diff_base=mem.prof mem-new.prof 
File: coderd.test
Build ID: 6dbae1215833f69b877eeef4def99ac0fb99bb1d
Type: alloc_space
Time: 2026-01-13 10:56:11 SAST
Showing nodes accounting for -27768.49MB, 66.48% of 41772.75MB total
Dropped 5170 nodes (cum <= 208.86MB)
Showing top 10 nodes out of 18
      flat  flat%   sum%        cum   cum%
         0     0%     0% -28044.47MB 67.14%  sync.(*Pool).Get
         0     0%     0% -28038.61MB 67.12%  github.com/tailscale/wireguard-go/device.(*WaitPool).Get
-28030.11MB 67.10% 67.10% -28030.11MB 67.10%  github.com/tailscale/wireguard-go/device.(*Device).PopulatePools.func3
         0     0% 67.10% -28029.11MB 67.10%  github.com/tailscale/wireguard-go/device.(*Device).GetMessageBuffer (inline)
  -32.10MB 0.077% 67.18% -21024.95MB 50.33%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReceiveIncoming
   -9.03MB 0.022% 67.20% -7100.49MB 17.00%  github.com/tailscale/wireguard-go/device.(*Device).RoutineReadFromTUN
         0     0% 67.20% -7084.47MB 16.96%  github.com/tailscale/wireguard-go/device.(*Device).NewOutboundElement
  297.76MB  0.71% 66.49%   295.76MB  0.71%  syscall.NetlinkRIB
         0     0% 66.49%   287.21MB  0.69%  net.Interfaces
       5MB 0.012% 66.48%   287.21MB  0.69%  net.interfaceTable
```
