### PR TITLE
feat: add deployment-wide agent metadata minimum interval enforcement

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -14,6 +14,12 @@ SUBCOMMANDS:
                                 PostgreSQL deployment.
 
 OPTIONS:
+      --agent-metadata-min-interval duration, $CODER_AGENT_METADATA_MIN_INTERVAL (default: 0s)
+          Minimum interval for agent metadata collection. Template-defined
+          intervals below this value will cause template import to fail.
+          Existing workspaces with lower intervals will be silently upgraded on
+          restart. Set to 0 to disable enforcement.
+
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
           DEPRECATED: Allow users to rename their workspaces. Use only for
           temporary compatibility reasons, this will be removed in a future

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -485,6 +485,11 @@ sshKeygenAlgorithm: ed25519
 # URL to use for agent troubleshooting when not set in the template.
 # (default: https://coder.com/docs/admin/templates/troubleshooting, type: url)
 agentFallbackTroubleshootingURL: https://coder.com/docs/admin/templates/troubleshooting
+# Minimum interval for agent metadata collection. Template-defined intervals below
+# this value will cause template import to fail. Existing workspaces with lower
+# intervals will be silently upgraded on restart. Set to 0 to disable enforcement.
+# (default: 0s, type: duration)
+agentMetadataMinInterval: 0s
 # Disable workspace apps that are not served from subdomains. Path-based apps can
 # make requests to the Coder API and pose a security risk when the workspace
 # serves malicious JavaScript. This is recommended for security purposes if a

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14172,6 +14172,9 @@ const docTemplate = `{
                 "agent_fallback_troubleshooting_url": {
                     "$ref": "#/definitions/serpent.URL"
                 },
+                "agent_metadata_min_interval": {
+                    "type": "integer"
+                },
                 "agent_stat_refresh_interval": {
                     "type": "integer"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12756,6 +12756,9 @@
 				"agent_fallback_troubleshooting_url": {
 					"$ref": "#/definitions/serpent.URL"
 				},
+				"agent_metadata_min_interval": {
+					"type": "integer"
+				},
 				"agent_stat_refresh_interval": {
 					"type": "integer"
 				},

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -476,6 +476,7 @@ type DeploymentValues struct {
 	MetricsCacheRefreshInterval     serpent.Duration                     `json:"metrics_cache_refresh_interval,omitempty" typescript:",notnull"`
 	AgentStatRefreshInterval        serpent.Duration                     `json:"agent_stat_refresh_interval,omitempty" typescript:",notnull"`
 	AgentFallbackTroubleshootingURL serpent.URL                          `json:"agent_fallback_troubleshooting_url,omitempty" typescript:",notnull"`
+	AgentMetadataMinInterval        serpent.Duration                     `json:"agent_metadata_min_interval,omitempty" typescript:",notnull"`
 	BrowserOnly                     serpent.Bool                         `json:"browser_only,omitempty" typescript:",notnull"`
 	SCIMAPIKey                      serpent.String                       `json:"scim_api_key,omitempty" typescript:",notnull"`
 	ExternalTokenEncryptionKeys     serpent.StringArray                  `json:"external_token_encryption_keys,omitempty" typescript:",notnull"`
@@ -2682,6 +2683,17 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Default:     "https://coder.com/docs/admin/templates/troubleshooting",
 			Value:       &c.AgentFallbackTroubleshootingURL,
 			YAML:        "agentFallbackTroubleshootingURL",
+		},
+		{
+			Name:        "Agent Metadata Minimum Interval",
+			Description: `Minimum interval for agent metadata collection. Template-defined intervals below this value will cause template import to fail. Existing workspaces with lower intervals will be silently upgraded on restart. Set to 0 to disable enforcement.`,
+			Flag:        "agent-metadata-min-interval",
+			Env:         "CODER_AGENT_METADATA_MIN_INTERVAL",
+			YAML:        "agentMetadataMinInterval",
+			Hidden:      false,
+			Default:     (0 * time.Second).String(),
+			Value:       &c.AgentMetadataMinInterval,
+			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
 		},
 		{
 			Name:        "Browser Only",

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -160,6 +160,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "scheme": "string",
       "user": {}
     },
+    "agent_metadata_min_interval": 0,
     "agent_stat_refresh_interval": 0,
     "ai": {
       "bridge": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2844,6 +2844,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "scheme": "string",
       "user": {}
     },
+    "agent_metadata_min_interval": 0,
     "agent_stat_refresh_interval": 0,
     "ai": {
       "bridge": {
@@ -3367,6 +3368,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "scheme": "string",
     "user": {}
   },
+  "agent_metadata_min_interval": 0,
   "agent_stat_refresh_interval": 0,
   "ai": {
     "bridge": {
@@ -3781,6 +3783,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `additional_csp_policy`              | array of string                                                                                      | false    |              |                                                                    |
 | `address`                            | [serpent.HostPort](#serpenthostport)                                                                 | false    |              | Deprecated: Use HTTPAddress or TLS.Address instead.                |
 | `agent_fallback_troubleshooting_url` | [serpent.URL](#serpenturl)                                                                           | false    |              |                                                                    |
+| `agent_metadata_min_interval`        | integer                                                                                              | false    |              |                                                                    |
 | `agent_stat_refresh_interval`        | integer                                                                                              | false    |              |                                                                    |
 | `ai`                                 | [codersdk.AIConfig](#codersdkaiconfig)                                                               | false    |              |                                                                    |
 | `allow_workspace_renames`            | boolean                                                                                              | false    |              |                                                                    |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1067,6 +1067,17 @@ Two optional fields can be set in the Strict-Transport-Security header; 'include
 
 The algorithm to use for generating ssh keys. Accepted values are "ed25519", "ecdsa", or "rsa4096".
 
+### --agent-metadata-min-interval
+
+|             |                                                 |
+|-------------|-------------------------------------------------|
+| Type        | <code>duration</code>                           |
+| Environment | <code>$CODER_AGENT_METADATA_MIN_INTERVAL</code> |
+| YAML        | <code>agentMetadataMinInterval</code>           |
+| Default     | <code>0s</code>                                 |
+
+Minimum interval for agent metadata collection. Template-defined intervals below this value will cause template import to fail. Existing workspaces with lower intervals will be silently upgraded on restart. Set to 0 to disable enforcement.
+
 ### --browser-only
 
 |             |                                     |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -15,6 +15,12 @@ SUBCOMMANDS:
                                 PostgreSQL deployment.
 
 OPTIONS:
+      --agent-metadata-min-interval duration, $CODER_AGENT_METADATA_MIN_INTERVAL (default: 0s)
+          Minimum interval for agent metadata collection. Template-defined
+          intervals below this value will cause template import to fail.
+          Existing workspaces with lower intervals will be silently upgraded on
+          restart. Set to 0 to disable enforcement.
+
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
           DEPRECATED: Allow users to rename their workspaces. Use only for
           temporary compatibility reasons, this will be removed in a future

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1753,6 +1753,7 @@ export interface DeploymentValues {
 	readonly metrics_cache_refresh_interval?: number;
 	readonly agent_stat_refresh_interval?: number;
 	readonly agent_fallback_troubleshooting_url?: string;
+	readonly agent_metadata_min_interval?: number;
 	readonly browser_only?: boolean;
 	readonly scim_api_key?: string;
 	readonly external_token_encryption_keys?: string;


### PR DESCRIPTION
Used tasks to help out with this one, as I'm not super familiar with the template build and validation process yet.

The changes here introduce a deployment wide minimum agent metadata interval via CLI flag/env var. This is then applied in a _strict_ way to new templates/new builds of existing templates, such that the template build will fail if it has a metadata interval does not comply with the minimum set for the coderd config value. Additionally, workspaces from existing template versions will have their agent metadata intervals "silently" upgraded (we log the upgrade but don't fail the workspace build) to comply with the config value.

This should allow coder deployment admins more control over deamplifying the volume of `UpdateWorkspaceAgentMetadata` db calls, and the associated `pg_notify` calls that go to the Workspace UI page, which is particularly relevant in larger organizations with high workspace counts/more metadata per agent.

Logging of the upgrade for a workspace using an existing template verison.
<img width="730" height="304" alt="Screenshot 2025-12-12 at 1 07 13 PM" src="https://github.com/user-attachments/assets/60e6974f-fe83-493d-8593-0310147a1e34" />

The failure message for a new template build that contains an invalid agent metdata interval value.
<img width="830" height="957" alt="Screenshot 2025-12-12 at 12 58 42 PM" src="https://github.com/user-attachments/assets/dd84bd33-23ee-4ba5-b5db-8a2479b1b35f" />

For the workspace built from an existing template, I also manually verified that the 60s upgraded interval value was being respected by using a timer to track changes in values shown on the UI page.
