### PR TITLE
Correct formatting in scale-coder.md

### DIFF
--- a/docs/tutorials/best-practices/scale-coder.md
+++ b/docs/tutorials/best-practices/scale-coder.md
@@ -24,8 +24,7 @@ deployment.
 - Metrics
   - Capture infrastructure metrics like CPU, memory, open files, and network I/O for all
     Coder Server, external provisioner daemon, workspace proxy, and PostgreSQL instances.
-  - Capture Coder Server and External Provisioner daemons metrics
-  [via Prometheus](#how-to-capture-coder-server-metrics-with-prometheus).
+  - Capture Coder Server and External Provisioner daemons metrics [via Prometheus](#how-to-capture-coder-server-metrics-with-prometheus).
 
 Retain metric time series for at least six months. This allows you to see
 performance trends relative to user growth.

--- a/docs/tutorials/best-practices/scale-coder.md
+++ b/docs/tutorials/best-practices/scale-coder.md
@@ -17,13 +17,13 @@ deployment.
 
 - Log output
   - Capture log output from from Coder Server instances and external provisioner daemons
-  and store them in a searchable log store like Loki, CloudWatch logs, or other tools.
+    and store them in a searchable log store like Loki, CloudWatch logs, or other tools.
   - Retain logs for a minimum of thirty days, ideally ninety days.
   This allows you investigate when anomalous behaviors began.
 
 - Metrics
   - Capture infrastructure metrics like CPU, memory, open files, and network I/O for all
-  Coder Server, external provisioner daemon, workspace proxy, and PostgreSQL instances.
+    Coder Server, external provisioner daemon, workspace proxy, and PostgreSQL instances.
   - Capture Coder Server and External Provisioner daemons metrics
   [via Prometheus](#how-to-capture-coder-server-metrics-with-prometheus).
 
@@ -47,7 +47,7 @@ they affect the end-user experience.
 
 - Tail latency of Coder Server API requests
   - High tail latency can indicate Coder Server or the PostgreSQL database is underprovisioned
-  for the load.
+    for the load.
   - Use the `coderd_api_request_latencies_seconds` metric.
 
 - Tail latency of database queries

--- a/docs/tutorials/best-practices/scale-coder.md
+++ b/docs/tutorials/best-practices/scale-coder.md
@@ -24,7 +24,8 @@ deployment.
 - Metrics
   - Capture infrastructure metrics like CPU, memory, open files, and network I/O for all
     Coder Server, external provisioner daemon, workspace proxy, and PostgreSQL instances.
-  - Capture Coder Server and External Provisioner daemons metrics [via Prometheus](#how-to-capture-coder-server-metrics-with-prometheus).
+  - Capture Coder Server and External Provisioner daemons metrics
+    [via Prometheus](#how-to-capture-coder-server-metrics-with-prometheus).
 
 Retain metric time series for at least six months. This allows you to see
 performance trends relative to user growth.


### PR DESCRIPTION
Fix indentation under a few bullet points.

Before (https://coder.com/docs/tutorials/best-practices/scale-coder):
<img width="706" height="765" alt="image" src="https://github.com/user-attachments/assets/e5f1209b-7d36-4305-a191-72d6fba4831c" />
