### PR TITLE
fix: promote AIBridge from `ExperimentalHandler`

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1019,8 +1019,6 @@ func New(options *Options) *API {
 
 	// Experimental routes are not guaranteed to be stable and may change at any time.
 	r.Route("/api/experimental", func(r chi.Router) {
-		api.ExperimentalHandler = r
-
 		r.NotFound(func(rw http.ResponseWriter, _ *http.Request) { httpapi.RouteNotFound(rw) })
 		r.Use(
 			// Specific routes can specify different limits, but every rate
@@ -1828,8 +1826,6 @@ type API struct {
 
 	// APIHandler serves "/api/v2"
 	APIHandler chi.Router
-	// ExperimentalHandler serves "/api/experimental"
-	ExperimentalHandler chi.Router
 	// RootHandler serves "/"
 	RootHandler chi.Router
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -226,12 +226,6 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		return api.refreshEntitlements(ctx)
 	}
 
-	api.AGPL.ExperimentalHandler.Group(func(r chi.Router) {
-		// Deprecated.
-		// TODO: remove with Beta release.
-		r.Route("/aibridge", aibridgeHandler(api, apiKeyMiddleware))
-	})
-
 	api.AGPL.APIHandler.Group(func(r chi.Router) {
 		r.Route("/aibridge", aibridgeHandler(api, apiKeyMiddleware))
 	})

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2744,6 +2744,23 @@ class ApiMethods {
 			setTimeout(() => res(), 500);
 		});
 	};
+
+	getAIBridgeInterceptions = async (options: SearchParamOptions) => {
+		const url = getURLWithSearchParams(
+			"/api/v2/aibridge/interceptions",
+			options,
+		);
+		const response =
+			await this.axios.get<TypesGen.AIBridgeListInterceptionsResponse>(url);
+		return response.data;
+	};
+
+	getAIBridgeModels = async (options: SearchParamOptions) => {
+		const url = getURLWithSearchParams("/api/v2/aibridge/models", options);
+
+		const response = await this.axios.get<string[]>(url);
+		return response.data;
+	};
 }
 
 export type TaskFeedbackRating = "good" | "okay" | "bad";
@@ -2760,26 +2777,6 @@ export type CreateTaskFeedbackRequest = {
 // above the ApiMethods class for a full explanation.
 class ExperimentalApiMethods {
 	constructor(protected readonly axios: AxiosInstance) {}
-
-	getAIBridgeInterceptions = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams(
-			"/api/experimental/aibridge/interceptions",
-			options,
-		);
-		const response =
-			await this.axios.get<TypesGen.AIBridgeListInterceptionsResponse>(url);
-		return response.data;
-	};
-
-	getAIBridgeModels = async (options: SearchParamOptions) => {
-		const url = getURLWithSearchParams(
-			"/api/experimental/aibridge/models",
-			options,
-		);
-
-		const response = await this.axios.get<string[]>(url);
-		return response.data;
-	};
 }
 
 // This is a hard coded CSRF token/cookie pair for local development. In prod,

--- a/site/src/api/queries/aiBridge.ts
+++ b/site/src/api/queries/aiBridge.ts
@@ -13,7 +13,7 @@ export const paginatedInterceptions = (
 			return ["aiBridgeInterceptions", payload, pageNumber] as const;
 		},
 		queryFn: ({ limit, offset, payload }) =>
-			API.experimental.getAIBridgeInterceptions({
+			API.getAIBridgeInterceptions({
 				offset,
 				limit,
 				q: payload,

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ModelFilter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ModelFilter.tsx
@@ -17,7 +17,7 @@ export const useModelFilterMenu = ({
 	return useFilterMenu({
 		id: "model",
 		getSelectedOption: async () => {
-			const modelsRes = await API.experimental.getAIBridgeModels({
+			const modelsRes = await API.getAIBridgeModels({
 				q: value,
 				limit: 1,
 			});
@@ -33,7 +33,7 @@ export const useModelFilterMenu = ({
 			return null;
 		},
 		getOptions: async (query) => {
-			const modelsRes = await API.experimental.getAIBridgeModels({
+			const modelsRes = await API.getAIBridgeModels({
 				q: query,
 				limit: 25,
 			});


### PR DESCRIPTION
> [!WARNING]  
> These changes were mistakenly merged into #21259, they have been recreated in #21278

Addressing feedback found in #21252

This pull-request removes `ExperimentalHandler` from `coderd.go` and promotes the endpoints within the frontend. This means that we will no longer be serving AI Bridge under the `/api/experimental/` prefix now that things reached release in [`v2.29.0`](https://github.com/coder/coder/releases/tag/v2.29.0). 

| Position | Pull-request |
| -------- | ------------ |
|   | [fix: improve AI Bridge request logs UI/UX](https://github.com/coder/coder/pull/21252) |
|   | [feat: add AI Bridge request logs model filter](https://github.com/coder/coder/pull/21259) |
| ✅ | [fix: promote AIBridge from `ExperimentalHandler`](https://github.com/coder/coder/pull/21277) |