### PR TITLE
refactor: consolidate darwin unix socket test helpers

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -947,7 +947,7 @@ func TestAgent_UnixLocalForwarding(t *testing.T) {
 		t.Skip("unix domain sockets are not fully supported on Windows")
 	}
 	ctx := testutil.Context(t, testutil.WaitLong)
-	tmpdir := tempDirUnixSocket(t)
+	tmpdir := testutil.TempDirUnixSocket(t)
 	remoteSocketPath := filepath.Join(tmpdir, "remote-socket")
 
 	l, err := net.Listen("unix", remoteSocketPath)
@@ -975,7 +975,7 @@ func TestAgent_UnixRemoteForwarding(t *testing.T) {
 		t.Skip("unix domain sockets are not fully supported on Windows")
 	}
 
-	tmpdir := tempDirUnixSocket(t)
+	tmpdir := testutil.TempDirUnixSocket(t)
 	remoteSocketPath := filepath.Join(tmpdir, "remote-socket")
 
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -3429,29 +3429,6 @@ func testSessionOutput(t *testing.T, session *ssh.Session, expected, unexpected 
 	if expectedRe != nil {
 		require.Regexp(t, expectedRe, stdout.String())
 	}
-}
-
-// tempDirUnixSocket returns a temporary directory that can safely hold unix
-// sockets (probably).
-//
-// During tests on darwin we hit the max path length limit for unix sockets
-// pretty easily in the default location, so this function uses /tmp instead to
-// get shorter paths.
-func tempDirUnixSocket(t *testing.T) string {
-	t.Helper()
-	if runtime.GOOS == "darwin" {
-		testName := strings.ReplaceAll(t.Name(), "/", "_")
-		dir, err := os.MkdirTemp("/tmp", fmt.Sprintf("coder-test-%s-", testName))
-		require.NoError(t, err, "create temp dir for gpg test")
-
-		t.Cleanup(func() {
-			err := os.RemoveAll(dir)
-			assert.NoError(t, err, "remove temp dir", dir)
-		})
-		return dir
-	}
-
-	return t.TempDir()
 }
 
 func TestAgent_Metrics_SSH(t *testing.T) {

--- a/agent/agentsocket/service_test.go
+++ b/agent/agentsocket/service_test.go
@@ -2,15 +2,10 @@ package agentsocket_test
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog"
@@ -18,30 +13,6 @@ import (
 	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/testutil"
 )
-
-// tempDirUnixSocket returns a temporary directory that can safely hold unix
-// sockets (probably).
-//
-// During tests on darwin we hit the max path length limit for unix sockets
-// pretty easily in the default location, so this function uses /tmp instead to
-// get shorter paths. To keep paths short, we use a hash of the test name
-// instead of the full test name.
-func tempDirUnixSocket(t *testing.T) string {
-	t.Helper()
-	if runtime.GOOS == "darwin" {
-		// Use a short hash of the test name to keep the path under 104 chars
-		hash := sha256.Sum256([]byte(t.Name()))
-		hashStr := hex.EncodeToString(hash[:])[:8] // Use first 8 chars of hash
-		dir, err := os.MkdirTemp("/tmp", fmt.Sprintf("c-%s-", hashStr))
-		require.NoError(t, err, "create temp dir for unix socket test")
-		t.Cleanup(func() {
-			err := os.RemoveAll(dir)
-			assert.NoError(t, err, "remove temp dir", dir)
-		})
-		return dir
-	}
-	return t.TempDir()
-}
 
 // newSocketClient creates a DRPC client connected to the Unix socket at the given path.
 func newSocketClient(ctx context.Context, t *testing.T, socketPath string) *agentsocket.Client {
@@ -66,7 +37,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 	t.Run("Ping", func(t *testing.T) {
 		t.Parallel()
 
-		socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+		socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 		ctx := testutil.Context(t, testutil.WaitShort)
 		server, err := agentsocket.NewServer(
 			slog.Make().Leveled(slog.LevelDebug),
@@ -86,7 +57,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 
 		t.Run("NewUnit", func(t *testing.T) {
 			t.Parallel()
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -108,7 +79,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("UnitAlreadyStarted", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -138,7 +109,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("UnitAlreadyCompleted", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -177,7 +148,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("UnitNotReady", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -207,7 +178,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("NewUnits", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -232,7 +203,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("DependencyAlreadyRegistered", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -267,7 +238,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("DependencyAddedAfterDependentStarted", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -309,7 +280,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("UnregisteredUnit", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -328,7 +299,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("UnitNotReady", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),
@@ -352,7 +323,7 @@ func TestDRPCAgentSocketService(t *testing.T) {
 		t.Run("UnitReady", func(t *testing.T) {
 			t.Parallel()
 
-			socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+			socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 			ctx := testutil.Context(t, testutil.WaitShort)
 			server, err := agentsocket.NewServer(
 				slog.Make().Leveled(slog.LevelDebug),

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -851,7 +851,7 @@ func TestSSH(t *testing.T) {
 
 		sshClient := ssh.NewClient(conn, channels, requests)
 
-		tmpdir := tempDirUnixSocket(t)
+		tmpdir := testutil.TempDirUnixSocket(t)
 
 		remoteSock := path.Join(tmpdir, "remote.sock")
 		_, err = sshClient.ListenUnix(remoteSock)
@@ -937,7 +937,7 @@ func TestSSH(t *testing.T) {
 			<-ctx.Done()
 		})
 
-		tmpdir := tempDirUnixSocket(t)
+		tmpdir := testutil.TempDirUnixSocket(t)
 		localSock := filepath.Join(tmpdir, "local.sock")
 		remoteSock := path.Join(tmpdir, "remote.sock")
 		for i := 0; i < 2; i++ {
@@ -1143,7 +1143,7 @@ func TestSSH(t *testing.T) {
 		})
 
 		// Start up ssh agent listening on unix socket.
-		tmpdir := tempDirUnixSocket(t)
+		tmpdir := testutil.TempDirUnixSocket(t)
 		agentSock := filepath.Join(tmpdir, "agent.sock")
 		l, err := net.Listen("unix", agentSock)
 		require.NoError(t, err)
@@ -1318,7 +1318,7 @@ func TestSSH(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		tmpdir := tempDirUnixSocket(t)
+		tmpdir := testutil.TempDirUnixSocket(t)
 		localSock := filepath.Join(tmpdir, "local.sock")
 		remoteSock := filepath.Join(tmpdir, "remote.sock")
 
@@ -1408,7 +1408,7 @@ func TestSSH(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong*2)
 		defer cancel()
 
-		tmpdir := tempDirUnixSocket(t)
+		tmpdir := testutil.TempDirUnixSocket(t)
 
 		localSock := filepath.Join(tmpdir, "local.sock")
 		l, err := net.Listen("unix", localSock)
@@ -1521,7 +1521,7 @@ func TestSSH(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 		defer cancel()
 
-		tmpdir := tempDirUnixSocket(t)
+		tmpdir := testutil.TempDirUnixSocket(t)
 
 		type testSocket struct {
 			local  string
@@ -1904,7 +1904,7 @@ p7KeSZdlk47pMBGOfnvEmoQ=
 	}
 
 	// Setup GPG home directory on the "client".
-	gnupgHomeClient := tempDirUnixSocket(t)
+	gnupgHomeClient := testutil.TempDirUnixSocket(t)
 	t.Setenv("GNUPGHOME", gnupgHomeClient)
 
 	// Get the agent extra socket path.
@@ -1960,7 +1960,7 @@ Expire-Date: 0
 	}()
 
 	// Get the agent socket path in the "workspace".
-	gnupgHomeWorkspace := tempDirUnixSocket(t)
+	gnupgHomeWorkspace := testutil.TempDirUnixSocket(t)
 
 	stdout = bytes.NewBuffer(nil)
 	stderr = bytes.NewBuffer(nil)
@@ -2423,29 +2423,6 @@ func tGo(t *testing.T, fn func()) (done <-chan struct{}) {
 	}()
 
 	return doneC
-}
-
-// tempDirUnixSocket returns a temporary directory that can safely hold unix
-// sockets (probably).
-//
-// During tests on darwin we hit the max path length limit for unix sockets
-// pretty easily in the default location, so this function uses /tmp instead to
-// get shorter paths.
-func tempDirUnixSocket(t *testing.T) string {
-	t.Helper()
-	if runtime.GOOS == "darwin" {
-		testName := strings.ReplaceAll(t.Name(), "/", "_")
-		dir, err := os.MkdirTemp("/tmp", fmt.Sprintf("coder-test-%s-", testName))
-		require.NoError(t, err, "create temp dir for gpg test")
-
-		t.Cleanup(func() {
-			err := os.RemoveAll(dir)
-			assert.NoError(t, err, "remove temp dir", dir)
-		})
-		return dir
-	}
-
-	return t.TempDir()
 }
 
 func TestSSH_Completion(t *testing.T) {

--- a/cli/sync_test.go
+++ b/cli/sync_test.go
@@ -25,7 +25,7 @@ func setupSocketServer(t *testing.T) (path string, cleanup func()) {
 	t.Helper()
 
 	// Use a temporary socket path for each test
-	socketPath := filepath.Join(tempDirUnixSocket(t), "test.sock")
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "test.sock")
 
 	// Create parent directory if needed
 	parentDir := filepath.Dir(socketPath)

--- a/testutil/unixsocket.go
+++ b/testutil/unixsocket.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TempDirUnixSocket returns a temporary directory that can safely hold unix
+// sockets (probably).
+//
+// During tests on darwin we hit the max path length limit for unix sockets
+// pretty easily in the default location, so this function uses /tmp instead to
+// get shorter paths.
+func TempDirUnixSocket(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "darwin" {
+		testName := strings.ReplaceAll(t.Name(), "/", "_")
+		dir, err := os.MkdirTemp("/tmp", testName)
+		require.NoError(t, err, "create temp dir for gpg test")
+
+		t.Cleanup(func() {
+			err := os.RemoveAll(dir)
+			assert.NoError(t, err, "remove temp dir", dir)
+		})
+		return dir
+	}
+
+	return t.TempDir()
+}


### PR DESCRIPTION
I found three instances of a test helper function to deal with Darwin path length limits for unix sockets, and I'll need this helper somewhere else soon. This change consolidates them into one helper.
