### PR TITLE
feat: add perplexica icon with monochrome transformation

### DIFF
--- a/site/src/theme/externalImages.ts
+++ b/site/src/theme/externalImages.ts
@@ -162,6 +162,7 @@ export const defaultParametersForBuiltinIcons = new Map<string, string>([
 	["/icon/nexus-repository.svg", "blackWithColor"],
 	["/icon/okta.svg", "monochrome"],
 	["/icon/openai.svg", "monochrome"],
+	["/icon/perplexica.svg", "monochrome"],
 	["/icon/rust.svg", "monochrome"],
 	["/icon/terminal.svg", "monochrome"],
 	["/icon/widgets.svg", "monochrome"],

--- a/site/src/theme/externalImages.ts
+++ b/site/src/theme/externalImages.ts
@@ -162,7 +162,7 @@ export const defaultParametersForBuiltinIcons = new Map<string, string>([
 	["/icon/nexus-repository.svg", "blackWithColor"],
 	["/icon/okta.svg", "monochrome"],
 	["/icon/openai.svg", "monochrome"],
-	["/icon/perplexica.svg", "monochrome"],
+	["/icon/perplexica.svg", "blackWithColor"],
 	["/icon/rust.svg", "monochrome"],
 	["/icon/terminal.svg", "monochrome"],
 	["/icon/widgets.svg", "monochrome"],

--- a/site/src/theme/icons.json
+++ b/site/src/theme/icons.json
@@ -96,6 +96,7 @@
 	"openai.svg",
 	"opencode.svg",
 	"openwebui.svg",
+	"perplexica.svg",
 	"personalize.svg",
 	"php.svg",
 	"phpstorm.svg",

--- a/site/static/icon/perplexica.svg
+++ b/site/static/icon/perplexica.svg
@@ -1,0 +1,8 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="128" cy="128" r="120" fill="black"/>
+  <polygon 
+    points="128,70 178,170 78,170"
+    fill="white"
+  />
+</svg>
+


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
Adds `perplexica.svg` with monochrome transformation.