### PR TITLE
fix: update openwebui icon to use whiteWithColor instead to fix rendering issue

### DIFF
--- a/site/src/theme/externalImages.ts
+++ b/site/src/theme/externalImages.ts
@@ -162,7 +162,7 @@ export const defaultParametersForBuiltinIcons = new Map<string, string>([
 	["/icon/nexus-repository.svg", "blackWithColor"],
 	["/icon/okta.svg", "monochrome"],
 	["/icon/openai.svg", "monochrome"],
-	["/icon/openwebui.svg", "blackWithColor"],
+	["/icon/openwebui.svg", "whiteWithColor"],
 	["/icon/rust.svg", "monochrome"],
 	["/icon/tasks.svg", "monochrome"],
 	["/icon/terminal.svg", "monochrome"],

--- a/site/src/theme/externalImages.ts
+++ b/site/src/theme/externalImages.ts
@@ -162,11 +162,11 @@ export const defaultParametersForBuiltinIcons = new Map<string, string>([
 	["/icon/nexus-repository.svg", "blackWithColor"],
 	["/icon/okta.svg", "monochrome"],
 	["/icon/openai.svg", "monochrome"],
+	["/icon/openwebui.svg", "blackWithColor"],
 	["/icon/rust.svg", "monochrome"],
+	["/icon/tasks.svg", "monochrome"],
 	["/icon/terminal.svg", "monochrome"],
 	["/icon/widgets.svg", "monochrome"],
 	["/icon/windsurf.svg", "monochrome"],
 	["/icon/zed.svg", "monochrome"],
-	["/icon/tasks.svg", "monochrome"],
-	["/icon/openwebui.svg", "monochrome"],
 ]);


### PR DESCRIPTION
change transformation for `openwebui.svg` to `whiteWithColor` to fix rendering issue

move `tasks.svg` up to fix icon order in `externalImages.ts`

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
