### PR TITLE
docs: fix typo in aibridge MCP documentation

### DIFF
--- a/docs/ai-coder/ai-bridge/mcp.md
+++ b/docs/ai-coder/ai-bridge/mcp.md
@@ -51,7 +51,7 @@ AI Bridge marks automatically injected tools with a prefix `bmcp_` ("bridged MCP
 
 ## Tool Injection
 
-If a model decides to invoke a tool and it has a `bmcp_` suffix and AI Bridge has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client; all it seems is the result of this loop. See [Implementation Details](./reference.md#implementation-details).
+If a model decides to invoke a tool and it has a `bmcp_` suffix and AI Bridge has a connection with the related MCP server, it will invoke the tool. The tool result will be passed back to the upstream AI provider, and this will loop until the model has all of its required data. These inner loops are not relayed back to the client; all it sees is the result of this loop. See [Implementation Details](./reference.md#implementation-details).
 
 In contrast, tools which are defined by the client (i.e. the [`Bash` tool](https://docs.claude.com/en/docs/claude-code/settings#tools-available-to-claude) defined by _Claude Code_) cannot be invoked by AI Bridge, and the tool call from the model will be relayed to the client, after which it will invoke the tool.
 


### PR DESCRIPTION
Found while reading the docs.