### PR TITLE
fix: use separate HTTP clients in scale test load generators

### DIFF
--- a/cli/exp_scaletest_prebuilds.go
+++ b/cli/exp_scaletest_prebuilds.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"fmt"
-	"net/http"
 	"os/signal"
 	"strconv"
 	"sync"
@@ -13,6 +12,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/scaletest/loadtestutil"
 
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/harness"
@@ -54,15 +55,6 @@ func (r *RootCmd) scaletestPrebuilds() *serpent.Command {
 			me, err := requireAdmin(ctx, client)
 			if err != nil {
 				return err
-			}
-
-			client.HTTPClient = &http.Client{
-				Transport: &codersdk.HeaderTransport{
-					Transport: http.DefaultTransport,
-					Header: map[string][]string{
-						codersdk.BypassRatelimitHeader: {"true"},
-					},
-				},
 			}
 
 			if numTemplates <= 0 {
@@ -140,7 +132,13 @@ func (r *RootCmd) scaletestPrebuilds() *serpent.Command {
 					return xerrors.Errorf("validate config: %w", err)
 				}
 
-				var runner harness.Runnable = prebuilds.NewRunner(client, cfg)
+				// use an independent client for each Runner, so they don't reuse TCP connections. This can lead to
+				// requests being unbalanced among Coder instances.
+				runnerClient, err := loadtestutil.DupClientCopyingHeaders(client, BypassHeader)
+				if err != nil {
+					return xerrors.Errorf("create runner client: %w", err)
+				}
+				var runner harness.Runnable = prebuilds.NewRunner(runnerClient, cfg)
 				if tracingEnabled {
 					runner = &runnableTraceWrapper{
 						tracer:   tracer,

--- a/scaletest/loadtestutil/client.go
+++ b/scaletest/loadtestutil/client.go
@@ -1,0 +1,45 @@
+package loadtestutil
+
+import (
+	"maps"
+	"net/http"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// DupClientCopyingHeaders duplicates the Client, but with an independent underlying HTTP transport, so that it will not
+// share connections with the client being duplicated. It copies any headers already on the existing transport as
+// [codersdk.HeaderTransport] and add the headers in the argument.
+func DupClientCopyingHeaders(client *codersdk.Client, header http.Header) (*codersdk.Client, error) {
+	nc := codersdk.New(client.URL, codersdk.WithLogger(client.Logger()))
+	nc.SessionTokenProvider = client.SessionTokenProvider
+	newHeader, t, err := extractHeaderAndInnerTransport(client.HTTPClient.Transport)
+	if err != nil {
+		return nil, xerrors.Errorf("extract headers: %w", err)
+	}
+	maps.Copy(newHeader, header)
+
+	nc.HTTPClient.Transport = &codersdk.HeaderTransport{
+		Transport: t.Clone(),
+		Header:    newHeader,
+	}
+	return nc, nil
+}
+
+func extractHeaderAndInnerTransport(rt http.RoundTripper) (http.Header, *http.Transport, error) {
+	if t, ok := rt.(*http.Transport); ok {
+		// base case
+		return make(http.Header), t, nil
+	}
+	if ht, ok := rt.(*codersdk.HeaderTransport); ok {
+		headers, t, err := extractHeaderAndInnerTransport(ht.Transport)
+		if err != nil {
+			return nil, nil, err
+		}
+		maps.Copy(headers, ht.Header)
+		return headers, t, nil
+	}
+	return nil, nil, xerrors.New("round tripper is neither HeaderTransport nor Transport")
+}

--- a/scaletest/loadtestutil/client_test.go
+++ b/scaletest/loadtestutil/client_test.go
@@ -1,0 +1,50 @@
+package loadtestutil_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/loadtestutil"
+)
+
+func TestDupClientCopyingHeaders(t *testing.T) {
+	t.Parallel()
+	httpClient := &http.Client{
+		Transport: &codersdk.HeaderTransport{
+			Transport: &codersdk.HeaderTransport{
+				Transport: http.DefaultTransport,
+				Header: map[string][]string{
+					"X-Coder-Test":  {"foo"},
+					"X-Coder-Test3": {"socks"},
+				},
+			},
+			Header: map[string][]string{
+				"X-Coder-Test":  {"bar"},
+				"X-Coder-Test2": {"baz"},
+			},
+		},
+	}
+	serverURL, err := url.Parse("http://coder.example.com")
+	require.NoError(t, err)
+	sdkClient := codersdk.New(serverURL,
+		codersdk.WithSessionToken("test-token"), codersdk.WithHTTPClient(httpClient))
+
+	dup, err := loadtestutil.DupClientCopyingHeaders(sdkClient, map[string][]string{
+		"X-Coder-Test3": {"clocks"},
+		"X-Coder-Test4": {"bears"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://coder.example.com", dup.URL.String())
+	require.Equal(t, "test-token", dup.SessionToken())
+	ht, ok := dup.HTTPClient.Transport.(*codersdk.HeaderTransport)
+	require.True(t, ok)
+	require.Equal(t, "bar", ht.Header.Get("X-Coder-Test"))
+	require.Equal(t, "baz", ht.Header.Get("X-Coder-Test2"))
+	require.Equal(t, "clocks", ht.Header.Get("X-Coder-Test3"))
+	require.Equal(t, "bears", ht.Header.Get("X-Coder-Test4"))
+	require.NotEqual(t, http.DefaultTransport, ht.Transport)
+}


### PR DESCRIPTION
While scale testing, I noticed that our load generators send basically all requests to a single Coderd instance.

e.g. 

![image.png](https://app.graphite.com/user-attachments/assets/e259862a-adf1-47e7-a37b-fd14e420058e.png)


This is because our scale test commands create all `Runner`s using the same codersdk Client, which means they share an underlying HTTP client. With HTTP/2 a single TCP session can multiplex many different HTTP requests (including websockets). So, it creates a single TCP connection to a single coderd, and then sends all the requests down the one TCP connections.

This PR modifies the `exp scaletest` load generator commands to create an independent HTTP client per `Runner`. This means that each runner will create its own TCP connection. This should help spread the load and make a more realistic test, because in a real deployment, scaled out load will be coming over different TCP connections.
