### PR TITLE
chore: add perplexica icon

### DIFF
--- a/site/src/theme/externalImages.ts
+++ b/site/src/theme/externalImages.ts
@@ -169,4 +169,5 @@ export const defaultParametersForBuiltinIcons = new Map<string, string>([
 	["/icon/zed.svg", "monochrome"],
 	["/icon/tasks.svg", "monochrome"],
 	["/icon/openwebui.svg", "monochrome"],
+	["/icon/perplexica.svg", "monochrome"],
 ]);

--- a/site/src/theme/icons.json
+++ b/site/src/theme/icons.json
@@ -96,6 +96,7 @@
 	"openai.svg",
 	"opencode.svg",
 	"openwebui.svg",
+	"perplexica.svg",
 	"personalize.svg",
 	"php.svg",
 	"phpstorm.svg",

--- a/site/static/icon/perplexica.svg
+++ b/site/static/icon/perplexica.svg
@@ -1,0 +1,8 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="128" cy="128" r="120" fill="black"/>
+  <polygon
+    points="128,70 178,170 78,170"
+    fill="white"
+  />
+</svg>
+


### PR DESCRIPTION
Related: https://github.com/coder/registry/pull/596

This PR adds an SVG icon for the incoming Perplexica module.