### PR TITLE
fix: correct Slack webhook example code in documentation

### DIFF
--- a/docs/admin/monitoring/notifications/slack.md
+++ b/docs/admin/monitoring/notifications/slack.md
@@ -89,11 +89,11 @@ To build the server to receive webhooks and interact with Slack:
                return res.status(400).send("Error: request body is missing");
            }
 
-           const { title_markdown, body_markdown } = req.body;
-              if (!title_markdown || !body_markdown) {
+           const { title, body_markdown } = req.body;
+              if (!title || !body_markdown) {
                   return res
                       .status(400)
-                      .send('Error: missing fields: "title_markdown", or "body_markdown"');
+                      .send('Error: missing fields: "title", or "body_markdown"');
            }
 
            const payload = req.body.payload;
@@ -115,11 +115,11 @@ To build the server to receive webhooks and interact with Slack:
 
            const slackMessage = {
                channel: userByEmail.user.id,
-               text: body,
+               text: body_markdown,
                blocks: [
                    {
                        type: "header",
-                       text: { type: "mrkdwn", text: title_markdown },
+                       text: { type: "plain_text", text: title },
                    },
                    {
                        type: "section",


### PR DESCRIPTION
## Summary

Fixes two bugs in the Slack webhook example code that prevented messages from being sent to Slack:

1. **ReferenceError: body is not defined** - Changed `text: body` to `text: body_markdown` (line 118)
   - The variable `body` was never defined in the webhook handler
   - Should use `body_markdown` which is extracted from the request body on line 92

2. **Invalid header block type** - Changed header block text type from `mrkdwn` to `plain_text` (line 122)
   - Slack's header block type only supports plain_text, not mrkdwn
   - This was causing "must be a valid enum value" errors from the Slack API

## Related Issue

Fixes #21294