### PR TITLE
perf: reduce calls to GetWorkspaceBuildByJobID

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1990,6 +1990,26 @@ func (s *MethodTestSuite) TestWorkspace() {
 		dbm.EXPECT().GetWorkspaceByID(gomock.Any(), build.WorkspaceID).Return(ws, nil).AnyTimes()
 		check.Args(res.ID).Asserts(ws, policy.ActionRead).Returns(res)
 	}))
+	s.Run("GetWorkspaceResourceWithJobByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		res := testutil.Fake(s.T(), faker, database.WorkspaceResource{})
+		resWithJob := database.GetWorkspaceResourceWithJobByIDRow{
+			ID:           res.ID,
+			CreatedAt:    res.CreatedAt,
+			JobID:        res.JobID,
+			Transition:   res.Transition,
+			Type:         res.Type,
+			Name:         res.Name,
+			Hide:         res.Hide,
+			Icon:         res.Icon,
+			InstanceType: res.InstanceType,
+			DailyCost:    res.DailyCost,
+			ModulePath:   res.ModulePath,
+			JobType:      database.ProvisionerJobTypeWorkspaceBuild,
+			JobInput:     []byte(`{}`),
+		}
+		dbm.EXPECT().GetWorkspaceResourceWithJobByID(gomock.Any(), res.ID).Return(resWithJob, nil).AnyTimes()
+		check.Args(res.ID).Asserts(rbac.ResourceSystem, policy.ActionRead).Returns(resWithJob)
+	}))
 	s.Run("Build/GetWorkspaceResourcesByJobID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		ws := testutil.Fake(s.T(), faker, database.Workspace{})
 		build := testutil.Fake(s.T(), faker, database.WorkspaceBuild{WorkspaceID: ws.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2258,6 +2258,13 @@ func (m queryMetricsStore) GetWorkspaceResourceMetadataCreatedAfter(ctx context.
 	return metadata, err
 }
 
+func (m queryMetricsStore) GetWorkspaceResourceWithJobByID(ctx context.Context, id uuid.UUID) (database.GetWorkspaceResourceWithJobByIDRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetWorkspaceResourceWithJobByID(ctx, id)
+	m.queryLatencies.WithLabelValues("GetWorkspaceResourceWithJobByID").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.UUID) ([]database.WorkspaceResource, error) {
 	start := time.Now()
 	resources, err := m.s.GetWorkspaceResourcesByJobID(ctx, jobID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -4828,6 +4828,21 @@ func (mr *MockStoreMockRecorder) GetWorkspaceResourceMetadataCreatedAfter(ctx, c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceResourceMetadataCreatedAfter", reflect.TypeOf((*MockStore)(nil).GetWorkspaceResourceMetadataCreatedAfter), ctx, createdAt)
 }
 
+// GetWorkspaceResourceWithJobByID mocks base method.
+func (m *MockStore) GetWorkspaceResourceWithJobByID(ctx context.Context, id uuid.UUID) (database.GetWorkspaceResourceWithJobByIDRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkspaceResourceWithJobByID", ctx, id)
+	ret0, _ := ret[0].(database.GetWorkspaceResourceWithJobByIDRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkspaceResourceWithJobByID indicates an expected call of GetWorkspaceResourceWithJobByID.
+func (mr *MockStoreMockRecorder) GetWorkspaceResourceWithJobByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceResourceWithJobByID", reflect.TypeOf((*MockStore)(nil).GetWorkspaceResourceWithJobByID), ctx, id)
+}
+
 // GetWorkspaceResourcesByJobID mocks base method.
 func (m *MockStore) GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.UUID) ([]database.WorkspaceResource, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -521,6 +521,7 @@ type sqlcQuerier interface {
 	GetWorkspaceResourceByID(ctx context.Context, id uuid.UUID) (WorkspaceResource, error)
 	GetWorkspaceResourceMetadataByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceResourceMetadatum, error)
 	GetWorkspaceResourceMetadataCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceResourceMetadatum, error)
+	GetWorkspaceResourceWithJobByID(ctx context.Context, id uuid.UUID) (GetWorkspaceResourceWithJobByIDRow, error)
 	GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesByJobIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceResource, error)

--- a/coderd/database/queries/workspaceresources.sql
+++ b/coderd/database/queries/workspaceresources.sql
@@ -52,3 +52,25 @@ SELECT
 SELECT * FROM workspace_resource_metadata WHERE workspace_resource_id = ANY(
 	SELECT id FROM workspace_resources WHERE created_at > $1
 );
+
+-- name: GetWorkspaceResourceWithJobByID :one
+SELECT
+	wr.id,
+	wr.created_at,
+	wr.job_id,
+	wr.transition,
+	wr.type,
+	wr.name,
+	wr.hide,
+	wr.icon,
+	wr.instance_type,
+	wr.daily_cost,
+	wr.module_path,
+	pj.type AS job_type,
+	pj.input AS job_input
+FROM
+	workspace_resources wr
+JOIN
+	provisioner_jobs pj ON wr.job_id = pj.id
+WHERE
+	wr.id = $1;


### PR DESCRIPTION
Another optimization with the help of tasks. 

GetWorkspaceBuildByJobID is our most expensive query in the last 7d, called 3.3M times in that period. AFAICT this is called most frequently as a result of the `<provider>-instance-identity` endpoint calls, which I believe are associated with agent -> coderd connection establishment. We may have an issue with connections having to be re-established frequently, but in any case we have at least two cascaded calls to this query as a result of the chain of DB calls in [this](https://github.com/coder/coder/blob/55f4efd01194ba74c58fde55446b70b9f7cad285/coderd/workspaceresourceauth.go#L128-L209) function. 

Looking at a trace for this endpoint we can see that there's at least 13 RT to the database for the endpoint, 2 of which are `GetWorkspaceBuildByJobID`. There's also ~0.4 calls per second to these endpoints, which means 0.8 calls per second to `GetWorkspaceBuildByJobID`, or ~484k per week. So this should result in just under 15% reduction in the call volume to this query.

We're achieving this by circumventing the calls to `api.Database.GetWorkspaceResourceByID` and `api.Database.GetProvisionerJobByID`, both of which eventually call `GetWorkspaceBuildByJobID` as part of their auth checks in dbauthz, and instead calling a new function/query `GetWorkspaceResourceWithJobByID` which combines the two queries we actually need into one and checks the authorization context to ensure we have the right permissions without the need for an additional DB query to do so.
