### PR TITLE
fix: report correct request paths from workspace proxy metrics

### DIFF
--- a/coderd/httpmw/prometheus.go
+++ b/coderd/httpmw/prometheus.go
@@ -106,11 +106,6 @@ func getRoutePattern(r *http.Request) string {
 		return ""
 	}
 
-	if pattern := rctx.RoutePattern(); pattern != "" {
-		// Pattern is already available
-		return pattern
-	}
-
 	routePath := r.URL.Path
 	if r.URL.RawPath != "" {
 		routePath = r.URL.RawPath


### PR DESCRIPTION
I noticed while looking at scale test metrics that we don't always report a useful path in the API request metrics.

![image.png](https://app.graphite.com/user-attachments/assets/a5b0dadf-9c2f-46a8-a6c1-3ad5f6201edb.png)

There are a lot of requests with path `/*`. I chased this problem to the workspace proxy, where we mount a the proxy router as a child of a "root" router to support some high level endpoints like `latency-check`.

Because we query the path from the Chi route context in the prometheus middleware _before_ the request is actually handled, we can have a partially resolved pattern match only corresponding to the root router. The fix is to always re-resolve the path, rather than accept a partially resolved path.