### PR TITLE
fix: mark users seen when activating on login

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -580,9 +580,10 @@ func User(t testing.TB, db database.Store, orig database.User) database.User {
 	require.NoError(t, err, "insert user")
 
 	user, err = db.UpdateUserStatus(genCtx, database.UpdateUserStatusParams{
-		ID:        user.ID,
-		Status:    takeFirst(orig.Status, database.UserStatusActive),
-		UpdatedAt: dbtime.Now(),
+		ID:         user.ID,
+		Status:     takeFirst(orig.Status, database.UserStatusActive),
+		UpdatedAt:  dbtime.Now(),
+		UserIsSeen: false,
 	})
 	require.NoError(t, err, "insert user")
 

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -325,7 +325,9 @@ UPDATE
 	users
 SET
 	status = $2,
-	updated_at = $3
+	updated_at = $3,
+	-- If the user is logging in, set last_seen_at to updated_at.
+	last_seen_at = CASE WHEN @user_is_seen :: boolean THEN $3 :: timestamptz ELSE last_seen_at END
 WHERE
 	id = $1 RETURNING *;
 

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -648,9 +648,10 @@ func ActivateDormantUser(logger slog.Logger, auditor *atomic.Pointer[audit.Audit
 
 		//nolint:gocritic // System needs to update status of the user account (dormant -> active).
 		newUser, err := db.UpdateUserStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateUserStatusParams{
-			ID:        user.ID,
-			Status:    database.UserStatusActive,
-			UpdatedAt: dbtime.Now(),
+			ID:         user.ID,
+			Status:     database.UserStatusActive,
+			UpdatedAt:  dbtime.Now(),
+			UserIsSeen: true,
 		})
 		if err != nil {
 			logger.Error(ctx, "unable to update user status to active", slog.Error(err))
@@ -1799,9 +1800,10 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 			dormantConvertAudit.Old = user
 			//nolint:gocritic // System needs to update status of the user account (dormant -> active).
 			user, err = tx.UpdateUserStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateUserStatusParams{
-				ID:        user.ID,
-				Status:    database.UserStatusActive,
-				UpdatedAt: dbtime.Now(),
+				ID:         user.ID,
+				Status:     database.UserStatusActive,
+				UpdatedAt:  dbtime.Now(),
+				UserIsSeen: true,
 			})
 			if err != nil {
 				logger.Error(ctx, "unable to update user status to active", slog.Error(err))

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -885,9 +885,10 @@ func (api *API) putUserStatus(status database.UserStatus) func(rw http.ResponseW
 		}
 
 		targetUser, err := api.Database.UpdateUserStatus(ctx, database.UpdateUserStatusParams{
-			ID:        user.ID,
-			Status:    status,
-			UpdatedAt: dbtime.Now(),
+			ID:         user.ID,
+			Status:     status,
+			UpdatedAt:  dbtime.Now(),
+			UserIsSeen: false,
 		})
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -256,8 +256,9 @@ func (api *API) scimPostUser(rw http.ResponseWriter, r *http.Request) {
 			newUser, err := api.Database.UpdateUserStatus(dbauthz.AsSystemRestricted(r.Context()), database.UpdateUserStatusParams{
 				ID: dbUser.ID,
 				// The user will get transitioned to Active after logging in.
-				Status:    database.UserStatusDormant,
-				UpdatedAt: dbtime.Now(),
+				Status:     database.UserStatusDormant,
+				UpdatedAt:  dbtime.Now(),
+				UserIsSeen: false,
 			})
 			if err != nil {
 				_ = handlerutil.WriteError(rw, err) // internal error
@@ -395,9 +396,10 @@ func (api *API) scimPatchUser(rw http.ResponseWriter, r *http.Request) {
 	if dbUser.Status != newStatus {
 		//nolint:gocritic // needed for SCIM
 		userNew, err := api.Database.UpdateUserStatus(dbauthz.AsSystemRestricted(r.Context()), database.UpdateUserStatusParams{
-			ID:        dbUser.ID,
-			Status:    newStatus,
-			UpdatedAt: dbtime.Now(),
+			ID:         dbUser.ID,
+			Status:     newStatus,
+			UpdatedAt:  dbtime.Now(),
+			UserIsSeen: false,
 		})
 		if err != nil {
 			_ = handlerutil.WriteError(rw, err) // internal error
@@ -490,9 +492,10 @@ func (api *API) scimPutUser(rw http.ResponseWriter, r *http.Request) {
 	if dbUser.Status != newStatus {
 		//nolint:gocritic // needed for SCIM
 		userNew, err := api.Database.UpdateUserStatus(dbauthz.AsSystemRestricted(r.Context()), database.UpdateUserStatusParams{
-			ID:        dbUser.ID,
-			Status:    newStatus,
-			UpdatedAt: dbtime.Now(),
+			ID:         dbUser.ID,
+			Status:     newStatus,
+			UpdatedAt:  dbtime.Now(),
+			UserIsSeen: false,
 		})
 		if err != nil {
 			_ = handlerutil.WriteError(rw, err) // internal error


### PR DESCRIPTION
fixes #21303

Update user last_seen_at when we mark them active on login. This prevents a narrow race where they can be re-marked dormant and fail to log in.