### PR TITLE
fix(coderd): wake dormant workspace when attempting to start it

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -400,9 +400,8 @@ func (api *API) postWorkspaceBuildsInternal(
 				Message: "Internal error unsetting workspace dormant status",
 				Detail:  err.Error(),
 			})
-		} else {
-			api.Logger.Info(ctx, "unset dormant status for workspace due to start", slog.F("workspace_id", workspace.ID))
 		}
+		api.Logger.Info(ctx, "unset dormant status for workspace due to start", slog.F("workspace_id", workspace.ID))
 	}
 
 	var (

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -405,7 +405,7 @@ func (api *API) postWorkspaceBuildsInternal(
 		// done outside the transaction so that an attempt to start a workspace will
 		// also unset dormancy.
 		if workspace.DormantAt.Valid && transition == database.WorkspaceTransitionStart {
-			if _, err := api.Database.UpdateWorkspaceDormantDeletingAt(ctx, database.UpdateWorkspaceDormantDeletingAtParams{
+			if _, err := tx.UpdateWorkspaceDormantDeletingAt(ctx, database.UpdateWorkspaceDormantDeletingAtParams{
 				ID:        workspace.ID,
 				DormantAt: sql.NullTime{Valid: false},
 			}); err != nil {

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -4244,7 +4244,12 @@ func TestWorkspaceDormant(t *testing.T) {
 		require.True(t, workspace.LastUsedAt.After(lastUsedAt))
 	})
 
-	t.Run("CannotStart", func(t *testing.T) {
+	// #20925: this test originally validated that you could **not** start a dormant workspace.
+	// The client was required to explicitly update the dormancy status before starting.
+	// This led to a 'whack-a-mole' situation where various code paths that create a workspace build
+	// would need to special case dormant workspaces.
+	// Now, a dormant workspace will automatically 'wake up' on start.
+	t.Run("StartWakesUpDormantWorkspace", func(t *testing.T) {
 		t.Parallel()
 		var (
 			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
@@ -4267,18 +4272,17 @@ func TestWorkspaceDormant(t *testing.T) {
 		// Should be able to stop a workspace while it is dormant.
 		coderdtest.MustTransitionWorkspace(t, client, workspace.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
 
-		// Should not be able to start a workspace while it is dormant.
+		// Starting a dormant workspace should 'wake' it.
 		_, err = client.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
 			TemplateVersionID: template.ActiveVersionID,
 			Transition:        codersdk.WorkspaceTransition(database.WorkspaceTransitionStart),
 		})
-		require.Error(t, err)
-
-		err = client.UpdateWorkspaceDormancy(ctx, workspace.ID, codersdk.UpdateWorkspaceDormancy{
-			Dormant: false,
-		})
 		require.NoError(t, err)
-		coderdtest.MustTransitionWorkspace(t, client, workspace.ID, codersdk.WorkspaceTransitionStop, codersdk.WorkspaceTransitionStart)
+
+		// After starting, the workspace should no longer be dormant.
+		updatedWs, err := client.Workspace(ctx, workspace.ID)
+		require.NoError(t, err, "fetch updated workspace")
+		require.Nil(t, updatedWs.DormantAt)
 	})
 }
 


### PR DESCRIPTION
Relates to #20925

This PR modifies the `postWorkspaceBuild` handler to automatically unset dormancy on a workspace when a start transition is requested. Previously, the client was responsible for unsetting the dormancy on the workspace prior to posting a workspace build.