### PR TITLE
fix: show exclamation mark on negated permissions in org custom roles page

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.tsx
@@ -59,7 +59,8 @@ const PermissionsPill: FC<PermissionPillProps> = ({
 
 	return (
 		<Pill css={styles.permissionPill}>
-			<b>{resource}</b>: {actions.map((p) => `${p.negate ? "!" : ""}${p.action}`).join(", ")}
+			<b>{resource}</b>:{" "}
+			{actions.map((p) => `${p.negate ? "!" : ""}${p.action}`).join(", ")}
 		</Pill>
 	);
 };

--- a/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CustomRolesPage/PermissionPillsList.tsx
@@ -59,7 +59,7 @@ const PermissionsPill: FC<PermissionPillProps> = ({
 
 	return (
 		<Pill css={styles.permissionPill}>
-			<b>{resource}</b>: {actions.map((p) => p.action).join(", ")}
+			<b>{resource}</b>: {actions.map((p) => `${p.negate ? "!" : ""}${p.action}`).join(", ")}
 		</Pill>
 	);
 };


### PR DESCRIPTION
Some permissions (in built-in roles only) have `Negated: true`, so the UI was misleading users by showing that they had those permissions when they really didn't.

<img width="1053" height="81" alt="image" src="https://github.com/user-attachments/assets/ccf072ed-5821-4eb6-ac75-a1a563cf55c5" />
