### PR TITLE
feat: add --max-failures to coder exp scaletest create-workspaces

### DIFF
--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -54,6 +54,7 @@ func TestScaleTestCreateWorkspaces(t *testing.T) {
 		"--output", "json:"+outputFile,
 		"--parameter", "foo=baz",
 		"--rich-parameter-file", "/path/to/some/parameter/file.ext",
+		"--max-failures", "1",
 	)
 	clitest.SetupConfig(t, client, root)
 	pty := ptytest.New(t)


### PR DESCRIPTION
Adds `--max-failures` flag to `coder exp scaletest create-workspaces` so that we can tolerate a few failures without failing the command.

When running our scale test infra, we create Kubernetes Jobs to create the initial cluster workspaces, then we have load-generation jobs that depend on them. At high scale, it's kind of expected that some of the requests will fail: even with 99.9% success, you still expect one failure per 1000. It's useful to be able to carry on with the scale test anyway and proceed to traffic generation.
