### PR TITLE
fix(site): allow updating workspace in TaskPage

### DIFF
--- a/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -17,7 +17,7 @@ import {
 } from "components/HelpTooltip/HelpTooltip";
 import { InfoIcon, RotateCcwIcon } from "lucide-react";
 import { linkToTemplate, useLinks } from "modules/navigation";
-import { type FC, type PropsWithChildren, useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 import { useQuery } from "react-query";
 import {
 	useWorkspaceUpdate,
@@ -26,11 +26,13 @@ import {
 
 interface WorkspaceOutdatedTooltipProps {
 	workspace: Workspace;
+	children?: ReactNode;
 }
 
-export const WorkspaceOutdatedTooltip: FC<
-	PropsWithChildren<WorkspaceOutdatedTooltipProps>
-> = ({ workspace, children }) => {
+export const WorkspaceOutdatedTooltip: FC<WorkspaceOutdatedTooltipProps> = ({
+	workspace,
+	children,
+}) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (

--- a/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -9,11 +9,11 @@ import {
 	HelpTooltip,
 	HelpTooltipAction,
 	HelpTooltipContent,
-	HelpTooltipTrigger,
 	HelpTooltipIconTrigger,
 	HelpTooltipLinksGroup,
 	HelpTooltipText,
 	HelpTooltipTitle,
+	HelpTooltipTrigger,
 } from "components/HelpTooltip/HelpTooltip";
 import { InfoIcon, RotateCcwIcon } from "lucide-react";
 import { linkToTemplate, useLinks } from "modules/navigation";

--- a/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -9,6 +9,7 @@ import {
 	HelpTooltip,
 	HelpTooltipAction,
 	HelpTooltipContent,
+	HelpTooltipTrigger,
 	HelpTooltipIconTrigger,
 	HelpTooltipLinksGroup,
 	HelpTooltipText,
@@ -16,7 +17,7 @@ import {
 } from "components/HelpTooltip/HelpTooltip";
 import { InfoIcon, RotateCcwIcon } from "lucide-react";
 import { linkToTemplate, useLinks } from "modules/navigation";
-import { type FC, useState } from "react";
+import { type FC, type PropsWithChildren, useState } from "react";
 import { useQuery } from "react-query";
 import {
 	useWorkspaceUpdate,
@@ -27,18 +28,27 @@ interface WorkspaceOutdatedTooltipProps {
 	workspace: Workspace;
 }
 
-export const WorkspaceOutdatedTooltip: FC<WorkspaceOutdatedTooltipProps> = (
-	props,
-) => {
+export const WorkspaceOutdatedTooltip: FC<
+	PropsWithChildren<WorkspaceOutdatedTooltipProps>
+> = ({ workspace, children }) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (
 		<HelpTooltip open={isOpen} onOpenChange={setIsOpen}>
-			<HelpTooltipIconTrigger size="small" hoverEffect={false}>
-				<InfoIcon css={styles.icon} />
-				<span className="sr-only">Outdated info</span>
-			</HelpTooltipIconTrigger>
-			<WorkspaceOutdatedTooltipContent isOpen={isOpen} {...props} />
+			{children ? (
+				<HelpTooltipTrigger asChild>
+					<span className="flex items-center gap-1.5 cursor-help">
+						<InfoIcon css={styles.icon} size={14} />
+						<span>{children}</span>
+					</span>
+				</HelpTooltipTrigger>
+			) : (
+				<HelpTooltipIconTrigger size="small" hoverEffect={false}>
+					<InfoIcon css={styles.icon} />
+					<span className="sr-only">Outdated info</span>
+				</HelpTooltipIconTrigger>
+			)}
+			<WorkspaceOutdatedTooltipContent isOpen={isOpen} workspace={workspace} />
 		</HelpTooltip>
 	);
 };

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -20,6 +20,7 @@ import {
 } from "testHelpers/entities";
 import {
 	withAuthProvider,
+	withDashboardProvider,
 	withGlobalSnackbar,
 	withProxyProvider,
 	withWebSocket,
@@ -30,7 +31,6 @@ import type { Task, Workspace, WorkspaceApp } from "api/typesGenerated";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import TaskPage from "./TaskPage";
-import { withDashboardProvider } from "testHelpers/storybook";
 
 const MockClaudeCodeApp: WorkspaceApp = {
 	...MockWorkspaceApp,

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -6,7 +6,6 @@ import {
 	MockStoppedWorkspace,
 	MockTask,
 	MockTasks,
-	MockTemplate,
 	MockUserOwner,
 	MockWorkspace,
 	MockWorkspaceAgent,
@@ -406,18 +405,37 @@ export const MainAppUnhealthy: Story = mainAppHealthStory("unhealthy");
 
 export const OutdatedWorkspace: Story = {
 	// Given: an 'outdated' workspace (that is, the latest build does not use template's active version)
-	beforeEach: () => {
-		spyOn(API, "getTask").mockResolvedValue(MockTask);
-		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue({
-			...MockStoppedWorkspace,
-			outdated: true,
-		});
-		spyOn(API, "getTemplate").mockResolvedValue({
-			...MockTemplate,
-			active_version_id: "some-other-version-id",
-		});
-		spyOn(API, "getTemplateVersionRichParameters").mockResolvedValue([]);
-		spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+	parameters: {
+		queries: [
+			{
+				key: ["tasks", { owner: MockTask.owner_name }],
+				data: [MockTask],
+			},
+			{
+				key: ["tasks", MockTask.owner_name, MockTask.id],
+				data: MockTask,
+			},
+			{
+				key: [
+					"workspace",
+					MockTask.owner_name,
+					MockTask.workspace_name,
+					"settings",
+				],
+				data: {
+					...MockStoppedWorkspace,
+					outdated: true,
+				},
+			},
+			{
+				key: [
+					"workspaceBuilds",
+					MockStoppedWorkspace.latest_build.id,
+					"parameters",
+				],
+				data: [],
+			},
+		],
 	},
 	// Then: a tooltip should be displayed prompting the user to update the workspace.
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -282,9 +282,7 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({
 							className="flex items-center gap-1.5 mt-1 text-content-secondary text-sm"
 						>
 							<WorkspaceOutdatedTooltip workspace={workspace}>
-								<span>
-									You can update your task workspace to a newer version
-								</span>
+								You can update your task workspace to a newer version
 							</WorkspaceOutdatedTooltip>
 						</div>
 					)}

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -300,7 +300,7 @@ const WorkspaceNotRunning: FC<WorkspaceNotRunningProps> = ({
 							}}
 						>
 							<Spinner loading={isWaitingForStart} />
-							Start Workspace
+							Start workspace
 						</Button>
 						<Button size="sm" onClick={onEditPrompt} variant="outline">
 							Edit Prompt


### PR DESCRIPTION
Relates to #20925 

This PR modifies TaskPage to update an outdated workspace instead of starting it. Before, starting an outdated workspace where the template required the active version would fail with the error "cannot use non-active version: rbac: forbidden". 

For the case of a dormant workspace, I deemed it safe enough to simply unset dormancy on an attempted start (ref: https://github.com/coder/coder/pull/21306). However, automatically updating a workspace is a more risky option, so I instead elected to give the user the option of updating their workspace using the existing tooltip.

<img width="505" height="200" alt="Screenshot 2025-12-18 at 13 52 15" src="https://github.com/user-attachments/assets/b377c336-372d-481f-a1ab-833352153e3d" />

<img width="502" height="427" alt="Screenshot 2025-12-18 at 13 52 29" src="https://github.com/user-attachments/assets/cc802da8-39b9-40ea-abec-1508a49c491c" />


**Note:** I made a change to the `WorkspaceOutdatedTooltip` components to allow it to have children so that the tooltip could trigger over a wider element instead of just the info icon.

```
<🤖 AI Disclaimer>I got some help from Gemini 3 Flash in "Ask" mode.</🤖 AI Disclaimer>
```