### PR TITLE
feat: add `<SyntaxHighlighter />` for AI Bridge `Token Usages Metadata`

### DIFF
--- a/site/src/components/Codeblock/Codeblock.tsx
+++ b/site/src/components/Codeblock/Codeblock.tsx
@@ -1,0 +1,49 @@
+import type React from "react";
+import { useEffect, useState } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+	darcula,
+	dracula,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
+
+export const Codeblock = ({
+	children,
+	...props
+}: React.ComponentProps<typeof SyntaxHighlighter>) => {
+	const [isDark, setIsDark] = useState(() => {
+		if (typeof document === "undefined") {
+			return true;
+		}
+		return document.documentElement.classList.contains("dark");
+	});
+
+	useEffect(() => {
+		if (typeof document === "undefined") {
+			return;
+		}
+		const root = document.documentElement;
+		const update = () => setIsDark(root.classList.contains("dark"));
+		update();
+
+		const mo = new MutationObserver(update);
+		mo.observe(root, { attributes: true, attributeFilter: ["class"] });
+		return () => {
+			mo.disconnect();
+		};
+	}, []);
+
+	return (
+		<SyntaxHighlighter
+			language="json"
+			style={isDark ? dracula : darcula}
+			customStyle={{
+				padding: 0,
+				border: "none",
+				background: "transparent",
+			}}
+			{...props}
+		>
+			{children}
+		</SyntaxHighlighter>
+	);
+};

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -19,6 +19,8 @@ import {
 	ChevronUpIcon,
 } from "lucide-react";
 import { type FC, useLayoutEffect, useRef, useState } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { dracula } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { cn } from "utils/cn";
 import { humanDuration } from "utils/time";
 import { AIBridgeProviderIcon } from "../AIBridgeProviderIcon";
@@ -477,7 +479,16 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 								<div className="flex flex-col gap-2 w-[800px]">
 									<div>Token Usage Metadata</div>
 									<div className="bg-surface-secondary rounded-md p-4">
-										<pre>{JSON.stringify(tokenUsagesMetadata, null, 2)}</pre>
+										<SyntaxHighlighter
+											language="json"
+											style={dracula}
+											customStyle={{
+												padding: 0,
+												background: "transparent",
+											}}
+										>
+											{JSON.stringify(tokenUsagesMetadata, null, 2)}
+										</SyntaxHighlighter>
 									</div>
 								</div>
 							)}

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -4,6 +4,7 @@ import type {
 } from "api/typesGenerated";
 import { Avatar } from "components/Avatar/Avatar";
 import { Badge } from "components/Badge/Badge";
+import { Codeblock } from "components/Codeblock/Codeblock";
 import { TableCell, TableRow } from "components/Table/Table";
 import {
 	Tooltip,
@@ -19,8 +20,6 @@ import {
 	ChevronUpIcon,
 } from "lucide-react";
 import { type FC, useLayoutEffect, useRef, useState } from "react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { dracula } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { cn } from "utils/cn";
 import { humanDuration } from "utils/time";
 import { AIBridgeProviderIcon } from "../AIBridgeProviderIcon";
@@ -180,7 +179,6 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	const [firstPrompt] = interception.user_prompts;
-
 	const inputTokens = interception.token_usages.reduce(
 		(acc, tokenUsage) => acc + tokenUsage.input_tokens,
 		0,
@@ -479,16 +477,9 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 								<div className="flex flex-col gap-2 w-[800px]">
 									<div>Token Usage Metadata</div>
 									<div className="bg-surface-secondary rounded-md p-4">
-										<SyntaxHighlighter
-											language="json"
-											style={dracula}
-											customStyle={{
-												padding: 0,
-												background: "transparent",
-											}}
-										>
+										<Codeblock>
 											{JSON.stringify(tokenUsagesMetadata, null, 2)}
-										</SyntaxHighlighter>
+										</Codeblock>
 									</div>
 								</div>
 							)}


### PR DESCRIPTION
This pull-request implements prettier printing of the JSON Codeblocks for `Token Usages Metadata`. We're trying to globalise on using the `light+`/`dark+` themes by default to be inline with our inline editors. To ensure that this stays globalised as we continue to develop this we're introducing a new `<Codeblock />` component which has the logic for the theme and style for light/dark modes.

| Position | Pull-request |
| -------- | ------------ |
|   | [fix: improve AI Bridge request logs UI/UX](https://github.com/coder/coder/pull/21252) |
|   | [feat: add AI Bridge request logs model filter](https://github.com/coder/coder/pull/21340) |
|   | [chore!: promote AIBridge from `ExperimentalHandler`](https://github.com/coder/coder/pull/21278) |
|   | [feat: implement request log collapsing prompt (`<RequestLogsPrompt />`)](https://github.com/coder/coder/pull/21313) |
| ✅ | [feat: add `<SyntaxHighlighter />` for AI Bridge `Token Usages Metadata`](https://github.com/coder/coder/pull/21318) |
