### PR TITLE
fix: increase workspace `<Avatar />` size props

### DIFF
--- a/site/src/components/FullPageLayout/Topbar.tsx
+++ b/site/src/components/FullPageLayout/Topbar.tsx
@@ -83,7 +83,7 @@ export const TopbarDivider: FC<HTMLAttributes<HTMLSpanElement>> = (props) => {
 };
 
 export const TopbarAvatar: FC<AvatarProps> = (props) => {
-	return <Avatar {...props} variant="icon" size="sm" />;
+	return <Avatar {...props} variant="icon" size="md" />;
 };
 
 type TopbarIconProps = HTMLAttributes<HTMLOrSVGElement>;

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -266,7 +266,7 @@ const OwnerBreadcrumb: FC<OwnerBreadcrumbProps> = ({
 		<HelpTooltip>
 			<HelpTooltipTrigger asChild>
 				<span css={styles.breadcrumbSegment}>
-					<Avatar size="sm" fallback={ownerName} src={ownerAvatarUrl} />
+					<Avatar size="md" fallback={ownerName} src={ownerAvatarUrl} />
 					<span css={styles.breadcrumbText}>{ownerName}</span>
 				</span>
 			</HelpTooltipTrigger>
@@ -294,7 +294,7 @@ const OrganizationBreadcrumb: FC<OrganizationBreadcrumbProps> = ({
 			<HelpTooltipTrigger asChild>
 				<span css={styles.breadcrumbSegment}>
 					<Avatar
-						size="sm"
+						size="md"
 						variant="icon"
 						src={orgIconUrl}
 						fallback={orgName}
@@ -321,7 +321,12 @@ const OrganizationBreadcrumb: FC<OrganizationBreadcrumbProps> = ({
 					subtitle="Organization"
 					avatar={
 						orgIconUrl && (
-							<Avatar variant="icon" src={orgIconUrl} fallback={orgName} />
+							<Avatar
+								variant="icon"
+								src={orgIconUrl}
+								fallback={orgName}
+								size="md"
+							/>
 						)
 					}
 					imgFallbackText={orgName}
@@ -389,6 +394,7 @@ const WorkspaceBreadcrumb: FC<WorkspaceBreadcrumbProps> = ({
 								variant="icon"
 								src={templateIconUrl}
 								fallback={templateDisplayName}
+								size="md"
 							/>
 						}
 						imgFallbackText={templateDisplayName}


### PR DESCRIPTION
Closes #21319

This pull-request ensures that our `<Avatar />` components are a consistent legible size within the breadcrumbs of the content. It bumps them from their default of `sm` to at-least `md` in both their `<TooltipTrigger />`'s and and `<TooltipContent />`'s.

This change also affects the Template page views a bit as they share use of the `<TopbarAvatar />` in `site/src/components/FullPageLayout/Topbar.tsx` 

It should be noted the spec in #21319 stated `24px` however the `md` is equal to `22px`.

<img width="510" height="483" alt="preview-breadcrumb-avatars" src="https://github.com/user-attachments/assets/d05ba826-c7e0-44b1-b81e-c5bd57a7c3cc" />


