### PR TITLE
WIP feat: support retries/hard failure limit for prebuilds in reconcile prior to provisioner

### DIFF
--- a/enterprise/coderd/prebuilds/reconcile_test.go
+++ b/enterprise/coderd/prebuilds/reconcile_test.go
@@ -2973,7 +2973,6 @@ func TestReconciliationRespectsPauseSetting(t *testing.T) {
 	require.Len(t, workspaces, 2, "should have recreated 2 prebuilds after resuming")
 }
 
-
 func TestIncrementalBackoffOnCreationFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR is meant to address the recent issues we saw regarding heavy CPU/memory usage in profiling related prebuilds, specifically endless retrying of prebuilds for presets that have invalid config and thus will never succeed.

The wsbuilder.Build is where this error can occur, though IIUC there can also be transient errors there (for example network connection issues or DB load related), so the changes here are twofold:
- a backoff retry in the reconcile loop for prebuilds which hit 500 error codes (transient issues)
- the writing of a DB entry for 400s (config related issues) that will never succeed until the template is updated, these are the same records that the reconcile loop should already be looking for as part of the `GetPresetsAtFailureLimit` query
