### PR TITLE
chore: rename flag to disable template insights

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -291,15 +291,13 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / TEMPLATE INSIGHTS OPTIONS: 
-      --template-insights-enable bool, $CODER_TEMPLATE_INSIGHTS_ENABLE (default: true)
-          Enable the collection and display of template insights along with the
-          associated API endpoints. This will also enable aggregating these
-          insights into daily active users, application usage, and transmission
-          rates for overall deployment stats. When disabled, these values will
-          be zero, which will also affect what the bottom deployment overview
-          bar displays. Disabling will also prevent Prometheus collection of
-          these values.
+INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS: 
+      --stats-collection-usage-stats-enable bool, $CODER_STATS_COLLECTION_USAGE_STATS_ENABLE (default: true)
+          Enable the collection of application and workspace usage along with
+          the associated API endpoints and the template insights page. Disabling
+          this will also disable traffic and connection insights in the
+          deployment stats shown to admins in the bottom bar of the Coder UI,
+          and will prevent Prometheus collection of these values.
 
 INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -191,15 +191,15 @@ autobuildPollInterval: 1m0s
 # (default: 1m0s, type: duration)
 jobHangDetectorInterval: 1m0s
 introspection:
-  templateInsights:
-    # Enable the collection and display of template insights along with the associated
-    # API endpoints. This will also enable aggregating these insights into daily
-    # active users, application usage, and transmission rates for overall deployment
-    # stats. When disabled, these values will be zero, which will also affect what the
-    # bottom deployment overview bar displays. Disabling will also prevent Prometheus
-    # collection of these values.
-    # (default: true, type: bool)
-    enable: true
+  statsCollection:
+    usageStats:
+      # Enable the collection of application and workspace usage along with the
+      # associated API endpoints and the template insights page. Disabling this will
+      # also disable traffic and connection insights in the deployment stats shown to
+      # admins in the bottom bar of the Coder UI, and will prevent Prometheus collection
+      # of these values.
+      # (default: true, type: bool)
+      enable: true
   prometheus:
     # Serve prometheus metrics on the address defined by prometheus address.
     # (default: <unset>, type: bool)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18054,7 +18054,7 @@ const docTemplate = `{
         "codersdk.StatsCollectionConfig": {
             "type": "object",
             "properties": {
-                "usage": {
+                "usage_stats": {
                     "$ref": "#/definitions/codersdk.UsageStatsConfig"
                 }
             }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14385,6 +14385,9 @@ const docTemplate = `{
                 "ssh_keygen_algorithm": {
                     "type": "string"
                 },
+                "stats_collection": {
+                    "$ref": "#/definitions/codersdk.StatsCollectionConfig"
+                },
                 "strict_transport_security": {
                     "type": "integer"
                 },
@@ -14402,9 +14405,6 @@ const docTemplate = `{
                 },
                 "telemetry": {
                     "$ref": "#/definitions/codersdk.TelemetryConfig"
-                },
-                "template_insights": {
-                    "$ref": "#/definitions/codersdk.TemplateInsightsConfig"
                 },
                 "terms_of_service_url": {
                     "type": "string"
@@ -18051,6 +18051,14 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.StatsCollectionConfig": {
+            "type": "object",
+            "properties": {
+                "usage": {
+                    "$ref": "#/definitions/codersdk.UsageStatsConfig"
+                }
+            }
+        },
         "codersdk.SupportConfig": {
             "type": "object",
             "properties": {
@@ -18703,14 +18711,6 @@ const docTemplate = `{
                 "total_member_count": {
                     "description": "How many members are in this group. Shows the total count,\neven if the user is not authorized to read group member details.\nMay be greater than ` + "`" + `len(Group.Members)` + "`" + `.",
                     "type": "integer"
-                }
-            }
-        },
-        "codersdk.TemplateInsightsConfig": {
-            "type": "object",
-            "properties": {
-                "enable": {
-                    "type": "boolean"
                 }
             }
         },
@@ -19656,6 +19656,14 @@ const docTemplate = `{
                 "start": {
                     "type": "string",
                     "format": "date-time"
+                }
+            }
+        },
+        "codersdk.UsageStatsConfig": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16504,7 +16504,7 @@
 		"codersdk.StatsCollectionConfig": {
 			"type": "object",
 			"properties": {
-				"usage": {
+				"usage_stats": {
 					"$ref": "#/definitions/codersdk.UsageStatsConfig"
 				}
 			}

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12967,6 +12967,9 @@
 				"ssh_keygen_algorithm": {
 					"type": "string"
 				},
+				"stats_collection": {
+					"$ref": "#/definitions/codersdk.StatsCollectionConfig"
+				},
 				"strict_transport_security": {
 					"type": "integer"
 				},
@@ -12984,9 +12987,6 @@
 				},
 				"telemetry": {
 					"$ref": "#/definitions/codersdk.TelemetryConfig"
-				},
-				"template_insights": {
-					"$ref": "#/definitions/codersdk.TemplateInsightsConfig"
 				},
 				"terms_of_service_url": {
 					"type": "string"
@@ -16501,6 +16501,14 @@
 				}
 			}
 		},
+		"codersdk.StatsCollectionConfig": {
+			"type": "object",
+			"properties": {
+				"usage": {
+					"$ref": "#/definitions/codersdk.UsageStatsConfig"
+				}
+			}
+		},
 		"codersdk.SupportConfig": {
 			"type": "object",
 			"properties": {
@@ -17131,14 +17139,6 @@
 				"total_member_count": {
 					"description": "How many members are in this group. Shows the total count,\neven if the user is not authorized to read group member details.\nMay be greater than `len(Group.Members)`.",
 					"type": "integer"
-				}
-			}
-		},
-		"codersdk.TemplateInsightsConfig": {
-			"type": "object",
-			"properties": {
-				"enable": {
-					"type": "boolean"
 				}
 			}
 		},
@@ -18027,6 +18027,14 @@
 				"start": {
 					"type": "string",
 					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.UsageStatsConfig": {
+			"type": "object",
+			"properties": {
+				"enable": {
+					"type": "boolean"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -776,7 +776,7 @@ func New(options *Options) *API {
 		UsageTracker:           options.WorkspaceUsageTracker,
 		UpdateAgentMetricsFn:   options.UpdateAgentMetrics,
 		AppStatBatchSize:       workspaceapps.DefaultStatsDBReporterBatchSize,
-		DisableDatabaseInserts: !options.DeploymentValues.TemplateInsights.Enable.Value(),
+		DisableDatabaseInserts: !options.DeploymentValues.StatsCollection.UsageStats.Enable.Value(),
 	})
 	workspaceAppsLogger := options.Logger.Named("workspaceapps")
 	if options.WorkspaceAppsStatsCollectorOptions.Logger == nil {
@@ -1535,7 +1535,8 @@ func New(options *Options) *API {
 				r.Use(
 					func(next http.Handler) http.Handler {
 						return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-							if !options.DeploymentValues.TemplateInsights.Enable.Value() {
+							// Template insights depend on the usage stats.
+							if !options.DeploymentValues.StatsCollection.UsageStats.Enable.Value() {
 								httpapi.Write(context.Background(), rw, http.StatusNotFound, codersdk.Response{
 									Message: "Not Found.",
 									Detail:  "Template insights are disabled.",

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -2401,8 +2401,10 @@ func TestGenericInsights_Disabled(t *testing.T) {
 			dbrollup.WithInterval(time.Millisecond*100),
 		),
 		DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
-			dv.TemplateInsights = codersdk.TemplateInsightsConfig{
-				Enable: false,
+			dv.StatsCollection = codersdk.StatsCollectionConfig{
+				UsageStats: codersdk.UsageStatsConfig{
+					Enable: false,
+				},
 			}
 		}),
 	})

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -616,7 +616,7 @@ type UsageStatsConfig struct {
 }
 
 type StatsCollectionConfig struct {
-	UsageStats UsageStatsConfig `json:"usage" tyescript:",notnull"`
+	UsageStats UsageStatsConfig `json:"usage_stats" tyescript:",notnull"`
 }
 
 type PrometheusConfig struct {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -511,7 +511,7 @@ type DeploymentValues struct {
 	Prebuilds                       PrebuildsConfig                      `json:"workspace_prebuilds,omitempty" typescript:",notnull"`
 	HideAITasks                     serpent.Bool                         `json:"hide_ai_tasks,omitempty" typescript:",notnull"`
 	AI                              AIConfig                             `json:"ai,omitempty"`
-	TemplateInsights                TemplateInsightsConfig               `json:"template_insights,omitempty" typescript:",notnull"`
+	StatsCollection                 StatsCollectionConfig                `json:"stats_collection,omitempty" typescript:",notnull"`
 
 	Config      serpent.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig serpent.Bool           `json:"write_config,omitempty" typescript:",notnull"`
@@ -611,8 +611,12 @@ type DERPConfig struct {
 	Path            serpent.String `json:"path" typescript:",notnull"`
 }
 
-type TemplateInsightsConfig struct {
+type UsageStatsConfig struct {
 	Enable serpent.Bool `json:"enable" typescript:",notnull"`
+}
+
+type StatsCollectionConfig struct {
+	UsageStats UsageStatsConfig `json:"usage" tyescript:",notnull"`
 }
 
 type PrometheusConfig struct {
@@ -1080,7 +1084,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		}
 		deploymentGroupIntrospection = serpent.Group{
 			Name:        "Introspection",
-			Description: `Configure logging, tracing, and metrics exporting.`,
+			Description: `Configure logging, tracing, stat collection, and metrics exporting.`,
 			YAML:        "introspection",
 		}
 		deploymentGroupIntrospectionPPROF = serpent.Group{
@@ -1088,10 +1092,15 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Name:   "pprof",
 			YAML:   "pprof",
 		}
-		deploymentGroupIntrospectionTemplateInsights = serpent.Group{
+		deploymentGroupIntrospectionStatsCollection = serpent.Group{
 			Parent: &deploymentGroupIntrospection,
-			Name:   "Template Insights",
-			YAML:   "templateInsights",
+			Name:   "Stats Collection",
+			YAML:   "statsCollection",
+		}
+		deploymentGroupIntrospectionStatsCollectionUsageStats = serpent.Group{
+			Parent: &deploymentGroupIntrospectionStatsCollection,
+			Name:   "Usage Stats",
+			YAML:   "usageStats",
 		}
 		deploymentGroupIntrospectionPrometheus = serpent.Group{
 			Parent: &deploymentGroupIntrospection,
@@ -1718,13 +1727,13 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			YAML:        "configPath",
 		},
 		{
-			Name:        "Enable Template Insights",
-			Description: "Enable the collection and display of template insights along with the associated API endpoints. This will also enable aggregating these insights into daily active users, application usage, and transmission rates for overall deployment stats. When disabled, these values will be zero, which will also affect what the bottom deployment overview bar displays. Disabling will also prevent Prometheus collection of these values.",
-			Flag:        "template-insights-enable",
-			Env:         "CODER_TEMPLATE_INSIGHTS_ENABLE",
+			Name:        "Stats Collection Usage Stats Enable",
+			Description: "Enable the collection of application and workspace usage along with the associated API endpoints and the template insights page. Disabling this will also disable traffic and connection insights in the deployment stats shown to admins in the bottom bar of the Coder UI, and will prevent Prometheus collection of these values.",
+			Flag:        "stats-collection-usage-stats-enable",
+			Env:         "CODER_STATS_COLLECTION_USAGE_STATS_ENABLE",
 			Default:     "true",
-			Value:       &c.TemplateInsights.Enable,
-			Group:       &deploymentGroupIntrospectionTemplateInsights,
+			Value:       &c.StatsCollection.UsageStats.Enable,
+			Group:       &deploymentGroupIntrospectionStatsCollectionUsageStats,
 			YAML:        "enable",
 		},
 		// TODO: support Git Auth settings.

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -492,7 +492,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     },
     "ssh_keygen_algorithm": "string",
     "stats_collection": {
-      "usage": {
+      "usage_stats": {
         "enable": true
       }
     },

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -491,6 +491,11 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "refresh_default_duration": 0
     },
     "ssh_keygen_algorithm": "string",
+    "stats_collection": {
+      "usage": {
+        "enable": true
+      }
+    },
     "strict_transport_security": 0,
     "strict_transport_security_options": [
       "string"
@@ -526,9 +531,6 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
         "scheme": "string",
         "user": {}
       }
-    },
-    "template_insights": {
-      "enable": true
     },
     "terms_of_service_url": "string",
     "tls": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2951,6 +2951,11 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "refresh_default_duration": 0
     },
     "ssh_keygen_algorithm": "string",
+    "stats_collection": {
+      "usage": {
+        "enable": true
+      }
+    },
     "strict_transport_security": 0,
     "strict_transport_security_options": [
       "string"
@@ -2986,9 +2991,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         "scheme": "string",
         "user": {}
       }
-    },
-    "template_insights": {
-      "enable": true
     },
     "terms_of_service_url": "string",
     "tls": {
@@ -3488,6 +3490,11 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "refresh_default_duration": 0
   },
   "ssh_keygen_algorithm": "string",
+  "stats_collection": {
+    "usage": {
+      "enable": true
+    }
+  },
   "strict_transport_security": 0,
   "strict_transport_security_options": [
     "string"
@@ -3523,9 +3530,6 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "scheme": "string",
       "user": {}
     }
-  },
-  "template_insights": {
-    "enable": true
   },
   "terms_of_service_url": "string",
   "tls": {
@@ -3631,12 +3635,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `scim_api_key`                       | string                                                                                               | false    |              |                                                                    |
 | `session_lifetime`                   | [codersdk.SessionLifetime](#codersdksessionlifetime)                                                 | false    |              |                                                                    |
 | `ssh_keygen_algorithm`               | string                                                                                               | false    |              |                                                                    |
+| `stats_collection`                   | [codersdk.StatsCollectionConfig](#codersdkstatscollectionconfig)                                     | false    |              |                                                                    |
 | `strict_transport_security`          | integer                                                                                              | false    |              |                                                                    |
 | `strict_transport_security_options`  | array of string                                                                                      | false    |              |                                                                    |
 | `support`                            | [codersdk.SupportConfig](#codersdksupportconfig)                                                     | false    |              |                                                                    |
 | `swagger`                            | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                     | false    |              |                                                                    |
 | `telemetry`                          | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                 | false    |              |                                                                    |
-| `template_insights`                  | [codersdk.TemplateInsightsConfig](#codersdktemplateinsightsconfig)                                   | false    |              |                                                                    |
 | `terms_of_service_url`               | string                                                                                               | false    |              |                                                                    |
 | `tls`                                | [codersdk.TLSConfig](#codersdktlsconfig)                                                             | false    |              |                                                                    |
 | `trace`                              | [codersdk.TraceConfig](#codersdktraceconfig)                                                         | false    |              |                                                                    |
@@ -7445,6 +7449,22 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `name`            | string | false    |              |             |
 | `organization_id` | string | false    |              |             |
 
+## codersdk.StatsCollectionConfig
+
+```json
+{
+  "usage": {
+    "enable": true
+  }
+}
+```
+
+### Properties
+
+| Name    | Type                                                   | Required | Restrictions | Description |
+|---------|--------------------------------------------------------|----------|--------------|-------------|
+| `usage` | [codersdk.UsageStatsConfig](#codersdkusagestatsconfig) | false    |              |             |
+
 ## codersdk.SupportConfig
 
 ```json
@@ -8176,20 +8196,6 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Property | Value(s)       |
 |----------|----------------|
 | `role`   | `admin`, `use` |
-
-## codersdk.TemplateInsightsConfig
-
-```json
-{
-  "enable": true
-}
-```
-
-### Properties
-
-| Name     | Type    | Required | Restrictions | Description |
-|----------|---------|----------|--------------|-------------|
-| `enable` | boolean | false    |              |             |
 
 ## codersdk.TemplateInsightsIntervalReport
 
@@ -9259,6 +9265,20 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `end`       | string | false    |              |             |
 | `issued_at` | string | false    |              |             |
 | `start`     | string | false    |              |             |
+
+## codersdk.UsageStatsConfig
+
+```json
+{
+  "enable": true
+}
+```
+
+### Properties
+
+| Name     | Type    | Required | Restrictions | Description |
+|----------|---------|----------|--------------|-------------|
+| `enable` | boolean | false    |              |             |
 
 ## codersdk.User
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2952,7 +2952,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     },
     "ssh_keygen_algorithm": "string",
     "stats_collection": {
-      "usage": {
+      "usage_stats": {
         "enable": true
       }
     },
@@ -3491,7 +3491,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   },
   "ssh_keygen_algorithm": "string",
   "stats_collection": {
-    "usage": {
+    "usage_stats": {
       "enable": true
     }
   },
@@ -7453,7 +7453,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ```json
 {
-  "usage": {
+  "usage_stats": {
     "enable": true
   }
 }
@@ -7461,9 +7461,9 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ### Properties
 
-| Name    | Type                                                   | Required | Restrictions | Description |
-|---------|--------------------------------------------------------|----------|--------------|-------------|
-| `usage` | [codersdk.UsageStatsConfig](#codersdkusagestatsconfig) | false    |              |             |
+| Name          | Type                                                   | Required | Restrictions | Description |
+|---------------|--------------------------------------------------------|----------|--------------|-------------|
+| `usage_stats` | [codersdk.UsageStatsConfig](#codersdkusagestatsconfig) | false    |              |             |
 
 ## codersdk.SupportConfig
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -269,16 +269,16 @@ URL to fetch a DERP mapping on startup. See: https://tailscale.com/kb/1118/custo
 
 Path to read a DERP mapping from. See: https://tailscale.com/kb/1118/custom-derp-servers/.
 
-### --template-insights-enable
+### --stats-collection-usage-stats-enable
 
-|             |                                                    |
-|-------------|----------------------------------------------------|
-| Type        | <code>bool</code>                                  |
-| Environment | <code>$CODER_TEMPLATE_INSIGHTS_ENABLE</code>       |
-| YAML        | <code>introspection.templateInsights.enable</code> |
-| Default     | <code>true</code>                                  |
+|             |                                                              |
+|-------------|--------------------------------------------------------------|
+| Type        | <code>bool</code>                                            |
+| Environment | <code>$CODER_STATS_COLLECTION_USAGE_STATS_ENABLE</code>      |
+| YAML        | <code>introspection.statsCollection.usageStats.enable</code> |
+| Default     | <code>true</code>                                            |
 
-Enable the collection and display of template insights along with the associated API endpoints. This will also enable aggregating these insights into daily active users, application usage, and transmission rates for overall deployment stats. When disabled, these values will be zero, which will also affect what the bottom deployment overview bar displays. Disabling will also prevent Prometheus collection of these values.
+Enable the collection of application and workspace usage along with the associated API endpoints and the template insights page. Disabling this will also disable traffic and connection insights in the deployment stats shown to admins in the bottom bar of the Coder UI, and will prevent Prometheus collection of these values.
 
 ### --prometheus-enable
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -292,15 +292,13 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / TEMPLATE INSIGHTS OPTIONS: 
-      --template-insights-enable bool, $CODER_TEMPLATE_INSIGHTS_ENABLE (default: true)
-          Enable the collection and display of template insights along with the
-          associated API endpoints. This will also enable aggregating these
-          insights into daily active users, application usage, and transmission
-          rates for overall deployment stats. When disabled, these values will
-          be zero, which will also affect what the bottom deployment overview
-          bar displays. Disabling will also prevent Prometheus collection of
-          these values.
+INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS: 
+      --stats-collection-usage-stats-enable bool, $CODER_STATS_COLLECTION_USAGE_STATS_ENABLE (default: true)
+          Enable the collection of application and workspace usage along with
+          the associated API endpoints and the template insights page. Disabling
+          this will also disable traffic and connection insights in the
+          deployment stats shown to admins in the bottom bar of the Coder UI,
+          and will prevent Prometheus collection of these values.
 
 INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1783,7 +1783,7 @@ export interface DeploymentValues {
 	readonly workspace_prebuilds?: PrebuildsConfig;
 	readonly hide_ai_tasks?: boolean;
 	readonly ai?: AIConfig;
-	readonly template_insights?: TemplateInsightsConfig;
+	readonly stats_collection?: StatsCollectionConfig;
 	readonly config?: string;
 	readonly write_config?: boolean;
 	/**
@@ -4593,6 +4593,11 @@ export interface SlimRole {
 	readonly organization_id?: string;
 }
 
+// From codersdk/deployment.go
+export interface StatsCollectionConfig {
+	readonly usage: UsageStatsConfig;
+}
+
 // From codersdk/client.go
 /**
  * SubdomainAppSessionTokenCookie is the name of the cookie that stores an
@@ -5103,11 +5108,6 @@ export interface TemplateFilter {
 // From codersdk/templates.go
 export interface TemplateGroup extends Group {
 	readonly role: TemplateRole;
-}
-
-// From codersdk/deployment.go
-export interface TemplateInsightsConfig {
-	readonly enable: boolean;
 }
 
 // From codersdk/insights.go
@@ -5675,6 +5675,11 @@ export interface UsagePeriod {
 	readonly issued_at: string;
 	readonly start: string;
 	readonly end: string;
+}
+
+// From codersdk/deployment.go
+export interface UsageStatsConfig {
+	readonly enable: boolean;
 }
 
 // From codersdk/users.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4595,7 +4595,7 @@ export interface SlimRole {
 
 // From codersdk/deployment.go
 export interface StatsCollectionConfig {
-	readonly usage: UsageStatsConfig;
+	readonly usage_stats: UsageStatsConfig;
 }
 
 // From codersdk/client.go


### PR DESCRIPTION
Because this affects more than just the template insights page (specifically it also affects the deployment stats endpoint which is shown on bottom bar and Prometheus), the group is being renamed generically to just "stats".  In the future if we need to affect all stats or the other stats we can put those options here.

Then, because this flag only affects a portion of stats, specifically usage stats like connection and application time, bytes sent, etc, add a new sub-group called "usage".

Then finally add back the "enable" flag.  This also gives us a place to one day place an "anonymize" flag if we need to go that route.

----

What do y'all think?  One unfortunate thing about this name is that `--stats-usage-enable` kind of sounds like "enable the usage **of** stats" rather than "enable the collection of usage stats".  But if I flip it around like `usage-stats-enable` then there is no longer a section that can affect all stats, not just usage stats, if we need that one day (but maybe we will never need that):

```
usageStats:
  enable: boolean
```

We could maybe do something like have two vars that separately control the agent and app stat tables, but although that lines up nicely code-wise, not sure it would make sense to a user unless they know what the database schema looks like (of course the descriptions would help though):

```
stats:
  agent:
    enable: boolean
  app:
    enable: boolean
```