### PR TITLE
feat: add boundary log forwarding from agent to coderd

### DIFF
--- a/agent/boundary_logs_test.go
+++ b/agent/boundary_logs_test.go
@@ -1,0 +1,173 @@
+//go:build linux || darwin
+
+package agent_test
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"cdr.dev/slog"
+
+	"github.com/coder/coder/v2/agent/boundarylogproxy"
+	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/coderd/agentapi"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// logSink captures structured log entries for testing.
+type logSink struct {
+	mu      sync.Mutex
+	entries []slog.SinkEntry
+}
+
+func (s *logSink) LogEntry(_ context.Context, e slog.SinkEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, e)
+}
+
+func (*logSink) Sync() {}
+
+func (s *logSink) getEntries() []slog.SinkEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]slog.SinkEntry{}, s.entries...)
+}
+
+// getField returns the value of a field by name from a slog.Map.
+func getField(fields slog.Map, name string) interface{} {
+	for _, f := range fields {
+		if f.Name == name {
+			return f.Value
+		}
+	}
+	return nil
+}
+
+func sendBoundaryLogsRequest(t *testing.T, conn net.Conn, req *agentproto.ReportBoundaryLogsRequest) {
+	t.Helper()
+
+	data, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	var header uint32
+	//nolint:gosec // In tests we're not worried about possible integer overflow.
+	header |= uint32(len(data))
+	header |= 1 << 28
+
+	err = binary.Write(conn, binary.BigEndian, header)
+	require.NoError(t, err)
+
+	_, err = conn.Write(data)
+	require.NoError(t, err)
+}
+
+// TestBoundaryLogs_EndToEnd is an end-to-end test that sends a protobuf
+// message over the agent's unix socket (as boundary would) and verifies
+// it is ultimately logged by coderd with the correct structured fields.
+func TestBoundaryLogs_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	sink := &logSink{}
+	logger := slog.Make(sink)
+	workspaceID := uuid.New()
+	reporter := &agentapi.BoundaryLogsAPI{
+		Log:         logger,
+		WorkspaceID: workspaceID,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Allowed HTTP request.
+	req := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: true,
+				Time:    timestamppb.Now(),
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method:      "GET",
+						Url:         "https://example.com/allowed",
+						MatchedRule: "*.example.com",
+					},
+				},
+			},
+		},
+	}
+	sendBoundaryLogsRequest(t, conn, req)
+
+	require.Eventually(t, func() bool {
+		return len(sink.getEntries()) >= 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	entries := sink.getEntries()
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	require.Equal(t, slog.LevelInfo, entry.Level)
+	require.Equal(t, "boundary_request", entry.Message)
+	require.Equal(t, "allow", getField(entry.Fields, "decision"))
+	require.Equal(t, workspaceID.String(), getField(entry.Fields, "workspace_id"))
+	require.Equal(t, "GET", getField(entry.Fields, "http_method"))
+	require.Equal(t, "https://example.com/allowed", getField(entry.Fields, "http_url"))
+	require.Equal(t, "*.example.com", getField(entry.Fields, "matched_rule"))
+
+	// Denied HTTP request.
+	req2 := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: false,
+				Time:    timestamppb.Now(),
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method: "POST",
+						Url:    "https://blocked.com/denied",
+					},
+				},
+			},
+		},
+	}
+	sendBoundaryLogsRequest(t, conn, req2)
+
+	require.Eventually(t, func() bool {
+		return len(sink.getEntries()) >= 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	entries = sink.getEntries()
+	entry = entries[1]
+	require.Len(t, entries, 2)
+	require.Equal(t, slog.LevelInfo, entry.Level)
+	require.Equal(t, "boundary_request", entry.Message)
+	require.Equal(t, "deny", getField(entry.Fields, "decision"))
+	require.Equal(t, workspaceID.String(), getField(entry.Fields, "workspace_id"))
+	require.Equal(t, "POST", getField(entry.Fields, "http_method"))
+	require.Equal(t, "https://blocked.com/denied", getField(entry.Fields, "http_url"))
+	require.Equal(t, nil, getField(entry.Fields, "matched_rule"))
+
+	cancel()
+	<-forwarderDone
+}

--- a/agent/boundarylogproxy/codec/codec.go
+++ b/agent/boundarylogproxy/codec/codec.go
@@ -53,10 +53,13 @@ func WriteFrame(w io.Writer, tag Tag, data []byte) error {
 	header |= uint32(tag) << DataLength
 
 	if err := binary.Write(w, binary.BigEndian, header); err != nil {
-		return err
+		return xerrors.Errorf("write header error: %w", err)
 	}
-	_, err := w.Write(data)
-	return err
+	if _, err := w.Write(data); err != nil {
+		return xerrors.Errorf("write data error: %w", err)
+	}
+
+	return nil
 }
 
 // ReadFrame reads a framed message, returning the decoded tag and data. If the

--- a/agent/boundarylogproxy/codec/codec.go
+++ b/agent/boundarylogproxy/codec/codec.go
@@ -1,0 +1,98 @@
+// Package codec implements the wire format for agent <-> boundary communication.
+//
+// Wire Format:
+//   - 4 bits: big-endian tag
+//   - 28 bits: big-endian length of the protobuf data
+//   - length bytes: encoded protobuf data
+//
+// Note that while there are 28 bits for the length, in practice the messages should
+// be much smaller. 28 bits is chosen because sizing down the header to 16 bits would
+// sacrifice future flexibility. For example, a 3 bit tag and 13 bit length doesn't
+// have much length headroom should the batching strategy change.
+package codec
+
+import (
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	// DataLength is the number of bits used for the length of encoded protobuf data.
+	DataLength = 28
+
+	// tagLength is the number of bits used for the tag.
+	tagLength = 4
+
+	// TagV1 identifies the first revision of the protocol.
+	TagV1 = 1
+
+	// MaxMessageSize is the practical maximum size of the protobuf messages
+	// sent over the wire. While the wire format allows for messages much larger
+	// than this, practically they are not expected to be.
+	MaxMessageSize = 1 << 15
+)
+
+var ErrTooLarge = xerrors.New("message too large")
+
+// WriteFrame writes a framed message with the given tag and data. The tag must
+// fit in 4 bits (0-15), and data must not exceed 2^28 bytes in length.
+func WriteFrame(w io.Writer, tag uint8, data []byte) error {
+	if len(data) > 1<<DataLength {
+		return xerrors.Errorf("data too large: %d bytes", len(data))
+	}
+
+	var header uint32
+	//nolint:gosec // The length check above ensures there's no overflow.
+	header |= uint32(len(data))
+	header |= uint32(tag) << DataLength
+
+	if err := binary.Write(w, binary.BigEndian, header); err != nil {
+		return err
+	}
+	_, err := w.Write(data)
+	return err
+}
+
+// ReadFrame reads a framed message, returning the decoded tag and data. If the
+// message size exceeds maxSize, ErrTooLarge is returned. The provided buf is
+// used if it has sufficient capacity; otherwise a new buffer is allocated. To
+// reuse the buffer across calls, pass in the returned data slice:
+//
+//	buf := make([]byte, initialSize)
+//	for {
+//	    _, buf, _ = ReadFrame(r, maxSize, buf)
+//	}
+func ReadFrame(r io.Reader, maxSize uint32, buf []byte) (uint8, []byte, error) {
+	var header uint32
+	if err := binary.Read(r, binary.BigEndian, &header); err != nil {
+		return 0, nil, xerrors.Errorf("read header error: %w", err)
+	}
+
+	length := header & 0x0FFFFFFF
+	const tagMask = (1 << tagLength) - 1 // 0x0F
+	shifted := (header >> DataLength) & tagMask
+	if shifted > tagMask {
+		// This is really only here to satisfy the gosec linter. We know from above that
+		// shifted <= tagMask.
+		return 0, nil, xerrors.Errorf("invalid tag: %d", shifted)
+	}
+	tag := uint8(shifted)
+
+	if length > maxSize {
+		return 0, nil, ErrTooLarge
+	}
+
+	if cap(buf) < int(length) {
+		buf = make([]byte, length)
+	} else {
+		buf = buf[:length:cap(buf)]
+	}
+
+	if _, err := io.ReadFull(r, buf[:length]); err != nil {
+		return 0, nil, xerrors.Errorf("read full error: %w", err)
+	}
+
+	return tag, buf[:length], nil
+}

--- a/agent/boundarylogproxy/codec/codec_test.go
+++ b/agent/boundarylogproxy/codec/codec_test.go
@@ -14,7 +14,7 @@ func TestRoundTrip(t *testing.T) {
 
 	tests := []struct {
 		name string
-		tag  uint8
+		tag  codec.Tag
 		data []byte
 	}{
 		{

--- a/agent/boundarylogproxy/codec/codec_test.go
+++ b/agent/boundarylogproxy/codec/codec_test.go
@@ -2,6 +2,7 @@ package codec_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,11 +33,6 @@ func TestRoundTrip(t *testing.T) {
 			tag:  codec.TagV1,
 			data: []byte{0x00, 0x01, 0x02, 0xff, 0xfe},
 		},
-		{
-			name: "max tag value",
-			tag:  15,
-			data: []byte("use all the tag bits"),
-		},
 	}
 
 	for _, tt := range tests {
@@ -47,8 +43,8 @@ func TestRoundTrip(t *testing.T) {
 			err := codec.WriteFrame(&buf, tt.tag, tt.data)
 			require.NoError(t, err)
 
-			readBuf := make([]byte, codec.MaxMessageSize)
-			tag, data, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
+			readBuf := make([]byte, codec.MaxMessageSizeV1)
+			tag, data, err := codec.ReadFrame(&buf, readBuf)
 			require.NoError(t, err)
 			require.Equal(t, tt.tag, tag)
 			require.Equal(t, tt.data, data)
@@ -59,24 +55,53 @@ func TestRoundTrip(t *testing.T) {
 func TestReadFrameTooLarge(t *testing.T) {
 	t.Parallel()
 
+	// Hand construct a header that indicates the message size exceeds the maximum
+	// message size for codec.TagV1 by one. We just write the header to buf because
+	// we expect codec.ReadFrame to bail out when reading the invalid length.
+	header := uint32(codec.TagV1)<<codec.DataLength | (codec.MaxMessageSizeV1 + 1)
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, header)
+
 	var buf bytes.Buffer
-	data := make([]byte, 1000)
-	err := codec.WriteFrame(&buf, codec.TagV1, data)
+	_, err := buf.Write(data)
 	require.NoError(t, err)
 
-	readBuf := make([]byte, 100)
-	_, _, err = codec.ReadFrame(&buf, 100, readBuf)
-	require.ErrorIs(t, err, codec.ErrTooLarge)
+	readBuf := make([]byte, 1)
+	_, _, err = codec.ReadFrame(&buf, readBuf)
+	require.ErrorIs(t, err, codec.ErrMessageTooLarge)
 }
 
 func TestReadFrameEmptyReader(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	readBuf := make([]byte, codec.MaxMessageSize)
-	_, _, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
+	readBuf := make([]byte, codec.MaxMessageSizeV1)
+	_, _, err := codec.ReadFrame(&buf, readBuf)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "read header error")
+}
+
+func TestReadFrameInvalidTag(t *testing.T) {
+	t.Parallel()
+
+	// Hand construct a header that indicates a tag we don't know about. We just
+	// write the header to buf because we expect codec.ReadFrame to bail out when
+	// reading the invalid tag.
+	const (
+		dataLength uint32 = 10
+		bogusTag   uint32 = 2
+	)
+	header := bogusTag<<codec.DataLength | dataLength
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, header)
+
+	var buf bytes.Buffer
+	_, err := buf.Write(data)
+	require.NoError(t, err)
+
+	readBuf := make([]byte, 1)
+	_, _, err = codec.ReadFrame(&buf, readBuf)
+	require.Error(t, err)
 }
 
 func TestReadFrameAllocatesWhenNeeded(t *testing.T) {
@@ -89,8 +114,32 @@ func TestReadFrameAllocatesWhenNeeded(t *testing.T) {
 
 	// Buffer with insufficient capacity triggers allocation.
 	readBuf := make([]byte, 4)
-	tag, got, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
+	tag, got, err := codec.ReadFrame(&buf, readBuf)
 	require.NoError(t, err)
 	require.Equal(t, codec.TagV1, tag)
 	require.Equal(t, data, got)
+}
+
+func TestWriteFrameDataSize(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	data := make([]byte, codec.MaxMessageSizeV1)
+	err := codec.WriteFrame(&buf, codec.TagV1, data)
+	require.NoError(t, err)
+
+	//nolint: makezero // This intentionally increases the slice length.
+	data = append(data, 0) // One byte over the maximum
+	err = codec.WriteFrame(&buf, codec.TagV1, data)
+	require.Error(t, err)
+}
+
+func TestWriteFrameInvalidTag(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	readBuf := make([]byte, 1)
+	const bogusTag = 2
+	err := codec.WriteFrame(&buf, codec.Tag(bogusTag), readBuf)
+	require.Error(t, err)
 }

--- a/agent/boundarylogproxy/codec/codec_test.go
+++ b/agent/boundarylogproxy/codec/codec_test.go
@@ -1,0 +1,96 @@
+package codec_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/agent/boundarylogproxy/codec"
+)
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tag  uint8
+		data []byte
+	}{
+		{
+			name: "empty data",
+			tag:  codec.TagV1,
+			data: []byte{},
+		},
+		{
+			name: "simple data",
+			tag:  codec.TagV1,
+			data: []byte("hello world"),
+		},
+		{
+			name: "binary data",
+			tag:  codec.TagV1,
+			data: []byte{0x00, 0x01, 0x02, 0xff, 0xfe},
+		},
+		{
+			name: "max tag value",
+			tag:  15,
+			data: []byte("use all the tag bits"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			err := codec.WriteFrame(&buf, tt.tag, tt.data)
+			require.NoError(t, err)
+
+			readBuf := make([]byte, codec.MaxMessageSize)
+			tag, data, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
+			require.NoError(t, err)
+			require.Equal(t, tt.tag, tag)
+			require.Equal(t, tt.data, data)
+		})
+	}
+}
+
+func TestReadFrameTooLarge(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	data := make([]byte, 1000)
+	err := codec.WriteFrame(&buf, codec.TagV1, data)
+	require.NoError(t, err)
+
+	readBuf := make([]byte, 100)
+	_, _, err = codec.ReadFrame(&buf, 100, readBuf)
+	require.ErrorIs(t, err, codec.ErrTooLarge)
+}
+
+func TestReadFrameEmptyReader(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	readBuf := make([]byte, codec.MaxMessageSize)
+	_, _, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read header error")
+}
+
+func TestReadFrameAllocatesWhenNeeded(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	data := []byte("this message is longer than the buffer")
+	err := codec.WriteFrame(&buf, codec.TagV1, data)
+	require.NoError(t, err)
+
+	// Buffer with insufficient capacity triggers allocation.
+	readBuf := make([]byte, 4)
+	tag, got, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
+	require.NoError(t, err)
+	require.Equal(t, uint8(codec.TagV1), tag)
+	require.Equal(t, data, got)
+}

--- a/agent/boundarylogproxy/codec/codec_test.go
+++ b/agent/boundarylogproxy/codec/codec_test.go
@@ -91,6 +91,6 @@ func TestReadFrameAllocatesWhenNeeded(t *testing.T) {
 	readBuf := make([]byte, 4)
 	tag, got, err := codec.ReadFrame(&buf, codec.MaxMessageSize, readBuf)
 	require.NoError(t, err)
-	require.Equal(t, uint8(codec.TagV1), tag)
+	require.Equal(t, codec.TagV1, tag)
 	require.Equal(t, data, got)
 }

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -146,7 +146,7 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 		}
 
 		var (
-			tag uint8
+			tag codec.Tag
 			err error
 		)
 		tag, buf, err = codec.ReadFrame(conn, codec.MaxMessageSize, buf)

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -108,6 +108,7 @@ func (s *Server) acceptLoop(ctx context.Context) {
 		conn, err := s.listener.Accept()
 		if err != nil {
 			if ctx.Err() != nil {
+				s.logger.Warn(ctx, "accept loop terminated", slog.Error(ctx.Err()))
 				return
 			}
 			s.logger.Warn(ctx, "socket accept error", slog.Error(err))

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 
 	"golang.org/x/xerrors"
@@ -28,7 +28,7 @@ const (
 
 // DefaultSocketPath returns the default path for the boundary audit log socket.
 func DefaultSocketPath() string {
-	return path.Join(os.TempDir(), "boundary-audit.sock")
+	return filepath.Join(os.TempDir(), "boundary-audit.sock")
 }
 
 // Reporter reports boundary logs from workspaces.

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -1,7 +1,214 @@
 // Package boundarylogproxy provides a Unix socket server that receives boundary
 // audit logs and forwards them to coderd via the agent API.
+//
+// Wire Format:
+// Boundary sends tag and length prefixed protobuf messages over the Unix socket (TLV).
+//   - 4 bits: big-endian tag (always 1 for now)
+//   - 28 bits: big-endian length of the protobuf data
+//   - length bytes: encoded protobuf data
 package boundarylogproxy
 
-// Server a placeholder for the server that will listen on a Unix socket for
-// boundary logs to be forwarded.
-type Server struct{}
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"sync"
+
+	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/proto"
+
+	"cdr.dev/slog"
+	agentproto "github.com/coder/coder/v2/agent/proto"
+)
+
+const (
+	// logBufferSize is the size of the channel buffer for incoming log requests
+	// from workspaces. This buffer size is intended to handle short bursts of workspaces
+	// forwarding batches of logs in parallel.
+	logBufferSize = 100
+)
+
+// Reporter reports boundary logs from workspaces.
+type Reporter interface {
+	ReportBoundaryLogs(ctx context.Context, req *agentproto.ReportBoundaryLogsRequest) (*agentproto.ReportBoundaryLogsResponse, error)
+}
+
+// Server listens on a Unix socket for boundary log messages and buffers them
+// for forwarding to coderd. The socket server and the forwarder are decoupled:
+// - Start() creates the socket and accepts a connection from boundary
+// - RunForwarder() drains the buffer and sends logs to coderd via AgentAPI
+type Server struct {
+	logger     slog.Logger
+	socketPath string
+
+	listener net.Listener
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+
+	// logs buffers incoming log requests for the forwarder to drain.
+	logs chan *agentproto.ReportBoundaryLogsRequest
+}
+
+// NewServer creates a new boundary log proxy server.
+func NewServer(logger slog.Logger, socketPath string) *Server {
+	return &Server{
+		logger:     logger.Named("boundary-log-proxy"),
+		socketPath: socketPath,
+		logs:       make(chan *agentproto.ReportBoundaryLogsRequest, logBufferSize),
+	}
+}
+
+// Start begins listening for connections on the Unix socket, and handles new
+// connections in a separate goroutine. Incoming logs from connections are
+// buffered until RunForwarder drains them.
+func (s *Server) Start() error {
+	if err := os.Remove(s.socketPath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("remove existing socket: %w", err)
+	}
+
+	listener, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return xerrors.Errorf("listen on socket: %w", err)
+	}
+
+	s.listener = listener
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+
+	s.wg.Add(1)
+	go s.acceptLoop(ctx)
+
+	s.logger.Info(ctx, "boundary log proxy started", slog.F("socket_path", s.socketPath))
+	return nil
+}
+
+// RunForwarder drains the log buffer and forwards logs to coderd.
+// It blocks until ctx is canceled.
+func (s *Server) RunForwarder(ctx context.Context, sender Reporter) error {
+	s.logger.Debug(ctx, "boundary log forwarder started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case req := <-s.logs:
+			_, err := sender.ReportBoundaryLogs(ctx, req)
+			if err != nil {
+				s.logger.Warn(ctx, "failed to forward boundary logs",
+					slog.Error(err),
+					slog.F("log_count", len(req.Logs)))
+				// Continue forwarding other logs. The current batch is lost,
+				// but the socket stays alive.
+			}
+		}
+	}
+}
+
+func (s *Server) acceptLoop(ctx context.Context) {
+	defer s.wg.Done()
+
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			s.logger.Warn(ctx, "socket accept error", slog.Error(err))
+			continue
+		}
+
+		s.wg.Add(1)
+		go s.handleConnection(ctx, conn)
+	}
+}
+
+func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
+	defer s.wg.Done()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	// Even though the length of data received can be larger than maxMsgSize,
+	// practically they are not expected to be. This is a sanity check and
+	// allows re-using a small fixed size read buffer.
+	const maxMsgSize = 1 << 15
+	buf := make([]byte, maxMsgSize)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		var header uint32
+		if err := binary.Read(conn, binary.BigEndian, &header); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			s.logger.Warn(ctx, "read length error", slog.Error(err))
+			return
+		}
+
+		length := header & 0x0FFFFFFF
+		tag := header >> 28
+
+		if tag != 1 {
+			s.logger.Warn(ctx, "invalid tag value", slog.F("tag", tag))
+			return
+		}
+
+		if length > maxMsgSize {
+			s.logger.Warn(ctx, "message too large", slog.F("length", length))
+			return
+		}
+
+		if _, err := io.ReadFull(conn, buf[:length]); err != nil {
+			s.logger.Warn(ctx, "read full request error", slog.Error(err))
+			return
+		}
+
+		var req agentproto.ReportBoundaryLogsRequest
+		if err := proto.Unmarshal(buf[:length], &req); err != nil {
+			s.logger.Warn(ctx, "proto unmarshal error", slog.Error(err))
+			continue
+		}
+
+		select {
+		case s.logs <- &req:
+		default:
+			s.logger.Warn(ctx, "dropping boundary logs, buffer full",
+				slog.F("log_count", len(req.Logs)))
+		}
+	}
+}
+
+// Close stops the server and blocks until resources have been cleaned up.
+// It must be called after Start.
+func (s *Server) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+
+	s.wg.Wait()
+
+	err := os.Remove(s.socketPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path"
 	"sync"
 
 	"golang.org/x/xerrors"
@@ -24,6 +25,11 @@ const (
 	// forwarding batches of logs in parallel.
 	logBufferSize = 100
 )
+
+// DefaultSocketPath returns the default path for the boundary audit log socket.
+func DefaultSocketPath() string {
+	return path.Join(os.TempDir(), "boundary-audit.sock")
+}
 
 // Reporter reports boundary logs from workspaces.
 type Reporter interface {

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -149,7 +149,7 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 			tag codec.Tag
 			err error
 		)
-		tag, buf, err = codec.ReadFrame(conn, codec.MaxMessageSize, buf)
+		tag, buf, err = codec.ReadFrame(conn, buf)
 		switch {
 		case errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed):
 			return

--- a/agent/boundarylogproxy/proxy_test.go
+++ b/agent/boundarylogproxy/proxy_test.go
@@ -437,7 +437,7 @@ func TestServer_InvalidProtobuf(t *testing.T) {
 	// The server should log an unmarshal error but continue processing.
 	invalidProto := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
 	//nolint: gosec // codec.DataLength is always less than the size of the header.
-	header := (codec.TagV1 << codec.DataLength) | uint32(len(invalidProto))
+	header := (uint32(codec.TagV1) << codec.DataLength) | uint32(len(invalidProto))
 	err = binary.Write(conn, binary.BigEndian, header)
 	require.NoError(t, err)
 	_, err = conn.Write(invalidProto)
@@ -512,7 +512,7 @@ func TestServer_InvalidHeader(t *testing.T) {
 	sendInvalidHeader(t, "garbage", 0xFFFFFFFF)
 
 	// Valid tag, invalid length (exceeds max message size).
-	sendInvalidHeader(t, "invalid length", (codec.TagV1<<codec.DataLength)|0x00FFFFFF)
+	sendInvalidHeader(t, "invalid length", (uint32(codec.TagV1)<<codec.DataLength)|0x00FFFFFF)
 
 	// Invalid tag, valid length.
 	sendInvalidHeader(t, "invalid tag", (15<<codec.DataLength)|100)

--- a/agent/boundarylogproxy/proxy_test.go
+++ b/agent/boundarylogproxy/proxy_test.go
@@ -1,0 +1,588 @@
+//go:build linux || darwin
+
+package boundarylogproxy_test
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/coder/coder/v2/agent/boundarylogproxy"
+	agentproto "github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// sendMessage writes a length-prefixed protobuf message to the connection.
+func sendMessage(t *testing.T, conn net.Conn, req *agentproto.ReportBoundaryLogsRequest) {
+	t.Helper()
+
+	data, err := proto.Marshal(req)
+	if err != nil {
+		//nolint:gocritic // In tests we're not worried about conn being nil.
+		t.Errorf("%s marshal req: %s", conn.LocalAddr().String(), err)
+	}
+
+	var header uint32
+	//nolint:gosec // In tests we're not worried about possible integer overflow.
+	header |= uint32(len(data))
+	header |= 1 << 28
+
+	err = binary.Write(conn, binary.BigEndian, header)
+	if err != nil {
+		//nolint:gocritic // In tests we're not worried about conn being nil.
+		t.Errorf("%s write conn length: %s", conn.LocalAddr().String(), err)
+	}
+
+	_, err = conn.Write(data)
+	if err != nil {
+		//nolint:gocritic // In tests we're not worried about conn being nil.
+		t.Errorf("%s write conn data: %s", conn.LocalAddr().String(), err)
+	}
+}
+
+// fakeReporter implements boundarylogproxy.Reporter for testing.
+type fakeReporter struct {
+	mu      sync.Mutex
+	logs    []*agentproto.ReportBoundaryLogsRequest
+	err     error
+	errOnce bool // only error once, then succeed
+
+	// reportCb is called when a ReportBoundaryLogsRequest is processed. It must not
+	// block.
+	reportCb func()
+}
+
+func (f *fakeReporter) ReportBoundaryLogs(_ context.Context, req *agentproto.ReportBoundaryLogsRequest) (*agentproto.ReportBoundaryLogsResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.reportCb != nil {
+		f.reportCb()
+	}
+
+	if f.err != nil {
+		if f.errOnce {
+			err := f.err
+			f.err = nil
+			return nil, err
+		}
+		return nil, f.err
+	}
+	f.logs = append(f.logs, req)
+	return &agentproto.ReportBoundaryLogsResponse{}, nil
+}
+
+func (f *fakeReporter) getLogs() []*agentproto.ReportBoundaryLogsRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*agentproto.ReportBoundaryLogsRequest{}, f.logs...)
+}
+
+func TestServer_StartAndClose(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+
+	// Verify socket exists and is connectable.
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	err = conn.Close()
+	require.NoError(t, err)
+
+	err = srv.Close()
+	require.NoError(t, err)
+}
+
+func TestServer_ReceiveAndForwardLogs(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reporter := &fakeReporter{}
+
+	// Start forwarder in background.
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	// Connect and send a log message.
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	req := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: true,
+				Time:    timestamppb.Now(),
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method: "GET",
+						Url:    "https://example.com",
+					},
+				},
+			},
+		},
+	}
+
+	sendMessage(t, conn, req)
+
+	// Wait for the reporter to receive the log.
+	require.Eventually(t, func() bool {
+		logs := reporter.getLogs()
+		return len(logs) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	logs := reporter.getLogs()
+	require.Len(t, logs, 1)
+	require.Len(t, logs[0].Logs, 1)
+	require.True(t, logs[0].Logs[0].Allowed)
+	require.Equal(t, "GET", logs[0].Logs[0].GetHttpRequest().Method)
+	require.Equal(t, "https://example.com", logs[0].Logs[0].GetHttpRequest().Url)
+
+	cancel()
+	<-forwarderDone
+}
+
+func TestServer_MultipleMessages(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := srv.Start()
+	require.NoError(t, err)
+	defer srv.Close()
+
+	reporter := &fakeReporter{}
+
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send multiple messages and verify they are all received.
+	for range 5 {
+		req := &agentproto.ReportBoundaryLogsRequest{
+			Logs: []*agentproto.BoundaryLog{
+				{
+					Allowed: true,
+					Time:    timestamppb.Now(),
+					Resource: &agentproto.BoundaryLog_HttpRequest_{
+						HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+							Method: "POST",
+							Url:    "https://example.com/api",
+						},
+					},
+				},
+			},
+		}
+		sendMessage(t, conn, req)
+	}
+
+	require.Eventually(t, func() bool {
+		logs := reporter.getLogs()
+		return len(logs) == 5
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	cancel()
+	<-forwarderDone
+}
+
+func TestServer_MultipleConnections(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reporter := &fakeReporter{}
+
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	// Create multiple connections and send from each.
+	const numConns = 3
+	var wg sync.WaitGroup
+	wg.Add(numConns)
+	for i := range numConns {
+		go func(connID int) {
+			defer wg.Done()
+			conn, err := net.Dial("unix", socketPath)
+			if err != nil {
+				t.Errorf("conn %d dial: %s", connID, err)
+			}
+			defer conn.Close()
+
+			req := &agentproto.ReportBoundaryLogsRequest{
+				Logs: []*agentproto.BoundaryLog{
+					{
+						Allowed: true,
+						Time:    timestamppb.Now(),
+						Resource: &agentproto.BoundaryLog_HttpRequest_{
+							HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+								Method: "GET",
+								Url:    "https://example.com",
+							},
+						},
+					},
+				},
+			}
+			sendMessage(t, conn, req)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		logs := reporter.getLogs()
+		return len(logs) == numConns
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	cancel()
+	<-forwarderDone
+}
+
+func TestServer_MessageTooLarge(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send a message claiming to be larger than the max message size.
+	var length uint32 = 1 << 16
+	err = binary.Write(conn, binary.BigEndian, length)
+	require.NoError(t, err)
+
+	// The server should close the connection after receiving an oversized
+	// message length.
+	buf := make([]byte, 1)
+	err = conn.SetReadDeadline(time.Now().Add(time.Second))
+	require.NoError(t, err)
+	_, err = conn.Read(buf)
+	require.Error(t, err) // Should get EOF or closed connection.
+}
+
+func TestServer_ForwarderContinuesAfterError(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reportNotify := make(chan struct{}, 1)
+	reporter := &fakeReporter{
+		// Simulate an error on the first call.
+		err:     context.DeadlineExceeded,
+		errOnce: true,
+		reportCb: func() {
+			reportNotify <- struct{}{}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send the first message to be processed and wait for failure.
+	req1 := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: true,
+				Time:    timestamppb.Now(),
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method: "GET",
+						Url:    "https://example.com/first",
+					},
+				},
+			},
+		},
+	}
+	sendMessage(t, conn, req1)
+
+	select {
+	case <-reportNotify:
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("timed out waiting for first message to be processed")
+	}
+
+	// Send the second message, which should succeed.
+	req2 := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: false,
+				Time:    timestamppb.Now(),
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method: "POST",
+						Url:    "https://example.com/second",
+					},
+				},
+			},
+		},
+	}
+	sendMessage(t, conn, req2)
+
+	// Only the second message should be recorded.
+	require.Eventually(t, func() bool {
+		logs := reporter.getLogs()
+		return len(logs) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	logs := reporter.getLogs()
+	require.Len(t, logs, 1)
+	require.Equal(t, "https://example.com/second", logs[0].Logs[0].GetHttpRequest().Url)
+
+	cancel()
+	<-forwarderDone
+}
+
+func TestServer_CloseStopsForwarder(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reporter := &fakeReporter{}
+
+	forwarderCtx, forwarderCancel := context.WithCancel(context.Background())
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(forwarderCtx, reporter)
+	}()
+
+	// Cancel the forwarder context and verify it stops.
+	forwarderCancel()
+
+	select {
+	case err := <-forwarderDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(testutil.WaitShort):
+		t.Fatal("forwarder did not stop")
+	}
+}
+
+func TestServer_InvalidProtobuf(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reporter := &fakeReporter{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send a valid header (tag=1) with garbage protobuf data.
+	// The server should log an unmarshal error but continue processing.
+	var header uint32 = (1 << 28) | 5 // tag=1, length=5
+	err = binary.Write(conn, binary.BigEndian, header)
+	require.NoError(t, err)
+	_, err = conn.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF}) // invalid protobuf
+	require.NoError(t, err)
+
+	// Now send a valid message. The server should continue processing.
+	req := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: true,
+				Time:    timestamppb.Now(),
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method: "GET",
+						Url:    "https://example.com/valid",
+					},
+				},
+			},
+		},
+	}
+	sendMessage(t, conn, req)
+
+	require.Eventually(t, func() bool {
+		logs := reporter.getLogs()
+		return len(logs) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	cancel()
+	<-forwarderDone
+}
+
+func TestServer_InvalidHeader(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reporter := &fakeReporter{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	// sendInvalidHeader sends a header and verifies the server closes the
+	// connection.
+	sendInvalidHeader := func(t *testing.T, name string, header uint32) {
+		t.Helper()
+
+		conn, err := net.Dial("unix", socketPath)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		err = binary.Write(conn, binary.BigEndian, header)
+		require.NoError(t, err, name)
+
+		// The server closes the connection on invalid header, so the next
+		// write should fail with a broken pipe error.
+		require.Eventually(t, func() bool {
+			_, err := conn.Write([]byte{0x00})
+			return err != nil
+		}, testutil.WaitShort, testutil.IntervalFast, name)
+	}
+
+	// Garbage header: invalid tag and invalid length.
+	sendInvalidHeader(t, "garbage", 0xFFFFFFFF)
+
+	// Valid tag, invalid length (exceeds max message size).
+	sendInvalidHeader(t, "invalid length", (1<<28)|0x00FFFFFF)
+
+	// Invalid tag, valid length.
+	sendInvalidHeader(t, "invalid tag", (15<<28)|100)
+
+	cancel()
+	<-forwarderDone
+}
+
+func TestServer_AllowRequest(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(testutil.TempDirUnixSocket(t), "boundary.sock")
+	srv := boundarylogproxy.NewServer(testutil.Logger(t), socketPath)
+
+	err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	reporter := &fakeReporter{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	forwarderDone := make(chan error, 1)
+	go func() {
+		forwarderDone <- srv.RunForwarder(ctx, reporter)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send an allowed request with a matched rule.
+	logTime := timestamppb.Now()
+	req := &agentproto.ReportBoundaryLogsRequest{
+		Logs: []*agentproto.BoundaryLog{
+			{
+				Allowed: true,
+				Time:    logTime,
+				Resource: &agentproto.BoundaryLog_HttpRequest_{
+					HttpRequest: &agentproto.BoundaryLog_HttpRequest{
+						Method:      "GET",
+						Url:         "https://malicious.com/attack",
+						MatchedRule: "*.malicious.com",
+					},
+				},
+			},
+		},
+	}
+	sendMessage(t, conn, req)
+
+	require.Eventually(t, func() bool {
+		logs := reporter.getLogs()
+		return len(logs) == 1
+	}, testutil.WaitShort, testutil.IntervalFast)
+
+	logs := reporter.getLogs()
+	require.Len(t, logs, 1)
+	require.True(t, logs[0].Logs[0].Allowed)
+	require.Equal(t, logTime.Seconds, logs[0].Logs[0].Time.Seconds)
+	require.Equal(t, logTime.Nanos, logs[0].Logs[0].Time.Nanos)
+	require.Equal(t, "*.malicious.com", logs[0].Logs[0].GetHttpRequest().MatchedRule)
+
+	cancel()
+	<-forwarderDone
+}

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -59,6 +59,7 @@ func workspaceAgent() *serpent.Command {
 		devcontainerDiscoveryAutostart bool
 		socketServerEnabled            bool
 		socketPath                     string
+		boundaryLogProxySocketPath     string
 	)
 	agentAuth := &AgentAuth{}
 	cmd := &serpent.Command{
@@ -319,8 +320,9 @@ func workspaceAgent() *serpent.Command {
 						agentcontainers.WithProjectDiscovery(devcontainerProjectDiscovery),
 						agentcontainers.WithDiscoveryAutostart(devcontainerDiscoveryAutostart),
 					},
-					SocketPath:          socketPath,
-					SocketServerEnabled: socketServerEnabled,
+					SocketPath:                 socketPath,
+					SocketServerEnabled:        socketServerEnabled,
+					BoundaryLogProxySocketPath: boundaryLogProxySocketPath,
 				})
 
 				if debugAddress != "" {
@@ -493,6 +495,13 @@ func workspaceAgent() *serpent.Command {
 			Env:         "CODER_AGENT_SOCKET_PATH",
 			Description: "Specify the path for the agent socket.",
 			Value:       serpent.StringOf(&socketPath),
+		},
+		{
+			Flag:        "boundary-proxy-socket-path",
+			Default:     "/tmp/boundary-proxy.sock",
+			Env:         "CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH",
+			Description: "The path for the boundary log proxy server Unix socket. Boundary should write audit logs to this socket.",
+			Value:       serpent.StringOf(&boundaryLogProxySocketPath),
 		},
 	}
 	agentAuth.AttachOptions(cmd, false)

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentssh"
+	"github.com/coder/coder/v2/agent/boundarylogproxy"
 	"github.com/coder/coder/v2/agent/reaper"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/clilog"
@@ -497,8 +498,8 @@ func workspaceAgent() *serpent.Command {
 			Value:       serpent.StringOf(&socketPath),
 		},
 		{
-			Flag:        "boundary-proxy-socket-path",
-			Default:     "/tmp/boundary-proxy.sock",
+			Flag:        "boundary-log-proxy-socket-path",
+			Default:     boundarylogproxy.DefaultSocketPath(),
 			Env:         "CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH",
 			Description: "The path for the boundary log proxy server Unix socket. Boundary should write audit logs to this socket.",
 			Value:       serpent.StringOf(&boundaryLogProxySocketPath),

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -39,6 +39,10 @@ OPTIONS:
       --block-file-transfer bool, $CODER_AGENT_BLOCK_FILE_TRANSFER (default: false)
           Block file transfer using known applications: nc,rsync,scp,sftp.
 
+      --boundary-proxy-socket-path string, $CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH (default: /tmp/boundary-proxy.sock)
+          The path for the boundary log proxy server Unix socket. Boundary
+          should write audit logs to this socket.
+
       --debug-address string, $CODER_AGENT_DEBUG_ADDRESS (default: 127.0.0.1:2113)
           The bind address to serve a debug HTTP server.
 

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -39,7 +39,7 @@ OPTIONS:
       --block-file-transfer bool, $CODER_AGENT_BLOCK_FILE_TRANSFER (default: false)
           Block file transfer using known applications: nc,rsync,scp,sftp.
 
-      --boundary-proxy-socket-path string, $CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH (default: /tmp/boundary-proxy.sock)
+      --boundary-log-proxy-socket-path string, $CODER_AGENT_BOUNDARY_LOG_PROXY_SOCKET_PATH (default: /tmp/boundary-audit.sock)
           The path for the boundary log proxy server Unix socket. Boundary
           should write audit logs to this socket.
 

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -220,7 +220,10 @@ func New(opts Options, workspace database.Workspace) *API {
 		Database:       opts.Database,
 	}
 
-	api.BoundaryLogsAPI = &BoundaryLogsAPI{}
+	api.BoundaryLogsAPI = &BoundaryLogsAPI{
+		Log:         opts.Log,
+		WorkspaceID: opts.WorkspaceID,
+	}
 
 	// Start background cache refresh loop to handle workspace changes
 	// like prebuild claims where owner_id and other fields may be modified in the DB.

--- a/coderd/agentapi/boundary_logs.go
+++ b/coderd/agentapi/boundary_logs.go
@@ -2,14 +2,56 @@ package agentapi
 
 import (
 	"context"
+	"time"
 
-	"golang.org/x/xerrors"
+	"github.com/google/uuid"
+
+	"cdr.dev/slog"
 
 	agentproto "github.com/coder/coder/v2/agent/proto"
 )
 
-type BoundaryLogsAPI struct{}
+type BoundaryLogsAPI struct {
+	Log         slog.Logger
+	WorkspaceID uuid.UUID
+}
 
-func (*BoundaryLogsAPI) ReportBoundaryLogs(context.Context, *agentproto.ReportBoundaryLogsRequest) (*agentproto.ReportBoundaryLogsResponse, error) {
-	return nil, xerrors.New("not implemented")
+func (a *BoundaryLogsAPI) ReportBoundaryLogs(ctx context.Context, req *agentproto.ReportBoundaryLogsRequest) (*agentproto.ReportBoundaryLogsResponse, error) {
+	for _, l := range req.Logs {
+		var logTime time.Time
+		if l.Time != nil {
+			logTime = l.Time.AsTime()
+		}
+
+		switch r := l.Resource.(type) {
+		case *agentproto.BoundaryLog_HttpRequest_:
+			if r.HttpRequest == nil {
+				continue
+			}
+
+			fields := []slog.Field{
+				slog.F("decision", allowBoolToString(l.Allowed)),
+				slog.F("workspace_id", a.WorkspaceID.String()),
+				slog.F("http_method", r.HttpRequest.Method),
+				slog.F("http_url", r.HttpRequest.Url),
+				slog.F("event_time", logTime.Format(time.RFC3339Nano)),
+			}
+			if l.Allowed {
+				fields = append(fields, slog.F("matched_rule", r.HttpRequest.MatchedRule))
+			}
+
+			a.Log.With(fields...).Info(ctx, "boundary_request")
+		default:
+		}
+	}
+
+	return &agentproto.ReportBoundaryLogsResponse{}, nil
+}
+
+//nolint:revive // This stringifies the boolean argument.
+func allowBoolToString(b bool) string {
+	if b {
+		return "allow"
+	}
+	return "deny"
 }

--- a/coderd/agentapi/boundary_logs.go
+++ b/coderd/agentapi/boundary_logs.go
@@ -26,6 +26,7 @@ func (a *BoundaryLogsAPI) ReportBoundaryLogs(ctx context.Context, req *agentprot
 		switch r := l.Resource.(type) {
 		case *agentproto.BoundaryLog_HttpRequest_:
 			if r.HttpRequest == nil {
+				a.Log.Warn(ctx, "empty http request resource")
 				continue
 			}
 
@@ -42,6 +43,7 @@ func (a *BoundaryLogsAPI) ReportBoundaryLogs(ctx context.Context, req *agentprot
 
 			a.Log.With(fields...).Info(ctx, "boundary_request")
 		default:
+			a.Log.Warn(ctx, "unexpected resource type", slog.F("type", r))
 		}
 	}
 

--- a/coderd/agentapi/boundary_logs.go
+++ b/coderd/agentapi/boundary_logs.go
@@ -26,7 +26,8 @@ func (a *BoundaryLogsAPI) ReportBoundaryLogs(ctx context.Context, req *agentprot
 		switch r := l.Resource.(type) {
 		case *agentproto.BoundaryLog_HttpRequest_:
 			if r.HttpRequest == nil {
-				a.Log.Warn(ctx, "empty http request resource")
+				a.Log.Warn(ctx, "empty http request resource",
+					slog.F("workspace_id", a.WorkspaceID.String()))
 				continue
 			}
 
@@ -43,7 +44,8 @@ func (a *BoundaryLogsAPI) ReportBoundaryLogs(ctx context.Context, req *agentprot
 
 			a.Log.With(fields...).Info(ctx, "boundary_request")
 		default:
-			a.Log.Warn(ctx, "unexpected resource type", slog.F("type", r))
+			a.Log.Warn(ctx, "unknown resource type",
+				slog.F("workspace_id", a.WorkspaceID.String()))
 		}
 	}
 


### PR DESCRIPTION
Add the agent forwarding of boundary audit logs from workspaces to coderd via the agent API, and re-emission of boundary logs to coderd stderr.

Log format example:
```
[API] 2025-12-23 18:31:46.755 [info] coderd.agentrpc: boundary_request owner=.. workspace_name=.. agent_name=.. decision=.. workspace_id=.. http_method=.. http_url=.. event_time=.. request_id=..
```

Corresponding boundary PR: https://github.com/coder/boundary/pull/124
RFC: https://www.notion.so/coderhq/Agent-Boundary-Logs-2afd579be59280f29629fc9823ac41ba
https://github.com/coder/coder/issues/21280
