### PR TITLE
chore: fix typo in organization roles create help text

### DIFF
--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -129,7 +129,7 @@ func (r *RootCmd) createOrganizationRole(orgContext *OrganizationContext) *serpe
 		Long: FormatExamples(
 			Example{
 				Description: "Run with an input.json file",
-				Command:     "coder organization -O <organization_name> roles create --stidin < role.json",
+				Command:     "coder organization -O <organization_name> roles create --stdin < role.json",
 			},
 		),
 		Options: []serpent.Option{

--- a/cli/testdata/coder_organizations_roles_create_--help.golden
+++ b/cli/testdata/coder_organizations_roles_create_--help.golden
@@ -7,7 +7,7 @@ USAGE:
 
     - Run with an input.json file:
   
-       $ coder organization -O <organization_name> roles create --stidin <
+       $ coder organization -O <organization_name> roles create --stdin <
   role.json
 
 OPTIONS:

--- a/docs/reference/cli/organizations_roles_create.md
+++ b/docs/reference/cli/organizations_roles_create.md
@@ -14,7 +14,7 @@ coder organizations roles create [flags] <role_name>
 ```console
   - Run with an input.json file:
 
-     $ coder organization -O <organization_name> roles create --stidin < role.json
+     $ coder organization -O <organization_name> roles create --stdin < role.json
 ```
 
 ## Options


### PR DESCRIPTION
A simple typo fix to the help text

stidin > stdin

```
➜  coder git:(org_role_fix) ✗ coder organizations roles create -h                            
coder v2.29.1+59cdd7e

USAGE:
  coder organizations roles create [flags] <role_name>

  Create a new organization custom role

    - Run with an input.json file:
  
        $ coder organization -O <organization_name> roles create --stidin < role.json 
```