### PR TITLE
feat(helm): add com.coder/component pod annotation to identify component type

### DIFF
--- a/helm/coder/templates/_coder.tpl
+++ b/helm/coder/templates/_coder.tpl
@@ -9,9 +9,9 @@ Component annotation for pod metadata.
 */}}
 {{- define "coder.componentAnnotation" -}}
 {{- if .Values.coder.workspaceProxy -}}
-com.coder/component: wsproxy
+app.kubernetes.io/component: wsproxy
 {{- else -}}
-com.coder/component: coderd
+app.kubernetes.io/component: coderd
 {{- end -}}
 {{- end }}
 

--- a/helm/coder/templates/_coder.tpl
+++ b/helm/coder/templates/_coder.tpl
@@ -5,6 +5,17 @@ Service account to merge into the libcoder template
 {{- end -}}
 
 {{/*
+Component annotation for pod metadata.
+*/}}
+{{- define "coder.componentAnnotation" -}}
+{{- if .Values.coder.workspaceProxy -}}
+com.coder/component: wsproxy
+{{- else -}}
+com.coder/component: coderd
+{{- end -}}
+{{- end }}
+
+{{/*
 Deployment to merge into the libcoder template
 */}}
 {{- define "coder.deployment" -}}

--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_1_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_1_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_2_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_2_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_3_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/auto_access_url_3_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command_args_coder.golden
+++ b/helm/coder/tests/testdata/command_args_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command_args_coder.golden
+++ b/helm/coder/tests/testdata/command_args_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command_coder.golden
+++ b/helm/coder/tests/testdata/command_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/command_coder.golden
+++ b/helm/coder/tests/testdata/command_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/custom_resources.golden
+++ b/helm/coder/tests/testdata/custom_resources.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/custom_resources.golden
+++ b/helm/coder/tests/testdata/custom_resources.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/custom_resources_coder.golden
+++ b/helm/coder/tests/testdata/custom_resources_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/custom_resources_coder.golden
+++ b/helm/coder/tests/testdata/custom_resources_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/default_values_coder.golden
+++ b/helm/coder/tests/testdata/default_values_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/default_values_coder.golden
+++ b/helm/coder/tests/testdata/default_values_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/env_from_coder.golden
+++ b/helm/coder/tests/testdata/env_from_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/env_from_coder.golden
+++ b/helm/coder/tests/testdata/env_from_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -131,7 +131,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -132,7 +132,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/extra_templates_coder.golden
+++ b/helm/coder/tests/testdata/extra_templates_coder.golden
@@ -131,7 +131,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/extra_templates_coder.golden
+++ b/helm/coder/tests/testdata/extra_templates_coder.golden
@@ -132,7 +132,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -127,6 +127,7 @@ spec:
   template:
     metadata:
       annotations:
+        com.coder/component: coderd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -127,7 +127,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/coder/tests/testdata/labels_annotations_coder.golden
+++ b/helm/coder/tests/testdata/labels_annotations_coder.golden
@@ -127,6 +127,7 @@ spec:
   template:
     metadata:
       annotations:
+        com.coder/component: coderd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/coder/tests/testdata/labels_annotations_coder.golden
+++ b/helm/coder/tests/testdata/labels_annotations_coder.golden
@@ -127,7 +127,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/coder/tests/testdata/namespace_rbac.golden
+++ b/helm/coder/tests/testdata/namespace_rbac.golden
@@ -313,7 +313,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/namespace_rbac.golden
+++ b/helm/coder/tests/testdata/namespace_rbac.golden
@@ -312,7 +312,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/namespace_rbac_coder.golden
+++ b/helm/coder/tests/testdata/namespace_rbac_coder.golden
@@ -313,7 +313,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/namespace_rbac_coder.golden
+++ b/helm/coder/tests/testdata/namespace_rbac_coder.golden
@@ -312,7 +312,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/partial_resources.golden
+++ b/helm/coder/tests/testdata/partial_resources.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/partial_resources.golden
+++ b/helm/coder/tests/testdata/partial_resources.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/partial_resources_coder.golden
+++ b/helm/coder/tests/testdata/partial_resources_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/partial_resources_coder.golden
+++ b/helm/coder/tests/testdata/partial_resources_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/pod_securitycontext.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/pod_securitycontext.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/pod_securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/pod_securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/priority_class_name.golden
+++ b/helm/coder/tests/testdata/priority_class_name.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/priority_class_name.golden
+++ b/helm/coder/tests/testdata/priority_class_name.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/priority_class_name_coder.golden
+++ b/helm/coder/tests/testdata/priority_class_name_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/priority_class_name_coder.golden
+++ b/helm/coder/tests/testdata/priority_class_name_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -122,7 +122,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -121,7 +121,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/prometheus_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_coder.golden
@@ -122,7 +122,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/prometheus_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_coder.golden
@@ -121,7 +121,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -125,7 +125,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -124,7 +124,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -125,7 +125,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -124,7 +124,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_disabled.golden
+++ b/helm/coder/tests/testdata/sa_disabled.golden
@@ -108,7 +108,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_disabled.golden
+++ b/helm/coder/tests/testdata/sa_disabled.golden
@@ -109,7 +109,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_disabled_coder.golden
+++ b/helm/coder/tests/testdata/sa_disabled_coder.golden
@@ -108,7 +108,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_disabled_coder.golden
+++ b/helm/coder/tests/testdata/sa_disabled_coder.golden
@@ -109,7 +109,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -135,7 +135,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -136,7 +136,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_extra_rules_coder.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules_coder.golden
@@ -135,7 +135,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/sa_extra_rules_coder.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules_coder.golden
@@ -136,7 +136,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/securitycontext.golden
+++ b/helm/coder/tests/testdata/securitycontext.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/securitycontext.golden
+++ b/helm/coder/tests/testdata/securitycontext.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/securitycontext_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/securitycontext_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer_class.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class.golden
@@ -124,7 +124,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer_class.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class.golden
@@ -123,7 +123,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
@@ -124,7 +124,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
@@ -123,7 +123,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_nodeport.golden
+++ b/helm/coder/tests/testdata/svc_nodeport.golden
@@ -122,7 +122,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_nodeport.golden
+++ b/helm/coder/tests/testdata/svc_nodeport.golden
@@ -121,7 +121,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_nodeport_coder.golden
+++ b/helm/coder/tests/testdata/svc_nodeport_coder.golden
@@ -122,7 +122,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/svc_nodeport_coder.golden
+++ b/helm/coder/tests/testdata/svc_nodeport_coder.golden
@@ -121,7 +121,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -127,7 +127,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -128,7 +128,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/tls_coder.golden
+++ b/helm/coder/tests/testdata/tls_coder.golden
@@ -127,7 +127,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/tls_coder.golden
+++ b/helm/coder/tests/testdata/tls_coder.golden
@@ -128,7 +128,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/topology.golden
+++ b/helm/coder/tests/testdata/topology.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/topology.golden
+++ b/helm/coder/tests/testdata/topology.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/topology_coder.golden
+++ b/helm/coder/tests/testdata/topology_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: coderd
+        app.kubernetes.io/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/topology_coder.golden
+++ b/helm/coder/tests/testdata/topology_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: coderd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: wsproxy
+        app.kubernetes.io/component: wsproxy
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: wsproxy
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/workspace_proxy_coder.golden
+++ b/helm/coder/tests/testdata/workspace_proxy_coder.golden
@@ -123,7 +123,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: wsproxy
+        app.kubernetes.io/component: wsproxy
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/tests/testdata/workspace_proxy_coder.golden
+++ b/helm/coder/tests/testdata/workspace_proxy_coder.golden
@@ -122,7 +122,8 @@ spec:
       app.kubernetes.io/name: coder
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: wsproxy
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -76,6 +76,8 @@ coder:
 
   # coder.podAnnotations -- The Coder pod annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  # Note: The annotation `com.coder/component` is automatically added to identify
+  # the component type (coderd, wsproxy, or provisionerd).
   podAnnotations: {}
 
   # coder.podLabels -- The Coder pod labels. See:

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -76,7 +76,7 @@ coder:
 
   # coder.podAnnotations -- The Coder pod annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  # Note: The annotation `com.coder/component` is automatically added to identify
+  # Note: The annotation `app.kubernetes.io/component` is automatically added to identify
   # the component type (coderd, wsproxy, or provisionerd).
   podAnnotations: {}
 

--- a/helm/libcoder/templates/_coder.yaml
+++ b/helm/libcoder/templates/_coder.yaml
@@ -23,7 +23,11 @@ spec:
           {{- toYaml . | nindent 8 }}
           {{- end }}
       annotations:
-        {{- toYaml .Values.coder.podAnnotations | nindent 8  }}
+        {{- include "coder.componentAnnotation" . | nindent 8 }}
+          {{- with .Values.coder.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+
     spec:
       serviceAccountName: {{ .Values.coder.serviceAccount.name | quote }}
       {{- with .Values.coder.priorityClassName }}

--- a/helm/libcoder/templates/_coder.yaml
+++ b/helm/libcoder/templates/_coder.yaml
@@ -24,9 +24,9 @@ spec:
           {{- end }}
       annotations:
         {{- include "coder.componentAnnotation" . | nindent 8 }}
-          {{- with .Values.coder.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
-          {{- end }}
+        {{- with .Values.coder.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 
     spec:
       serviceAccountName: {{ .Values.coder.serviceAccount.name | quote }}

--- a/helm/libcoder/templates/_helpers.tpl
+++ b/helm/libcoder/templates/_helpers.tpl
@@ -240,3 +240,9 @@ Usage:
   - watch
 {{- end }}
 
+{{/*
+Component annotation for pod metadata.
+This should be overridden in each chart to specify the component type.
+*/}}
+{{- define "coder.componentAnnotation" -}}
+{{- end }}

--- a/helm/provisioner/templates/_coder.tpl
+++ b/helm/provisioner/templates/_coder.tpl
@@ -5,6 +5,13 @@ Service account to merge into the libcoder template
 {{- end }}
 
 {{/*
+Component annotation for pod metadata.
+*/}}
+{{- define "coder.componentAnnotation" -}}
+com.coder/component: provisionerd
+{{- end }}
+
+{{/*
 Deployment to merge into the libcoder template
 */}}
 {{- define "coder.deployment" -}}

--- a/helm/provisioner/templates/_coder.tpl
+++ b/helm/provisioner/templates/_coder.tpl
@@ -8,7 +8,7 @@ Service account to merge into the libcoder template
 Component annotation for pod metadata.
 */}}
 {{- define "coder.componentAnnotation" -}}
-com.coder/component: provisionerd
+app.kubernetes.io/component: provisionerd
 {{- end }}
 
 {{/*

--- a/helm/provisioner/tests/testdata/command.golden
+++ b/helm/provisioner/tests/testdata/command.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command.golden
+++ b/helm/provisioner/tests/testdata/command.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command_args.golden
+++ b/helm/provisioner/tests/testdata/command_args.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command_args.golden
+++ b/helm/provisioner/tests/testdata/command_args.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command_args_coder.golden
+++ b/helm/provisioner/tests/testdata/command_args_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command_args_coder.golden
+++ b/helm/provisioner/tests/testdata/command_args_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command_coder.golden
+++ b/helm/provisioner/tests/testdata/command_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/command_coder.golden
+++ b/helm/provisioner/tests/testdata/command_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/custom_resources.golden
+++ b/helm/provisioner/tests/testdata/custom_resources.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/custom_resources.golden
+++ b/helm/provisioner/tests/testdata/custom_resources.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/custom_resources_coder.golden
+++ b/helm/provisioner/tests/testdata/custom_resources_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/custom_resources_coder.golden
+++ b/helm/provisioner/tests/testdata/custom_resources_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/default_values.golden
+++ b/helm/provisioner/tests/testdata/default_values.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/default_values.golden
+++ b/helm/provisioner/tests/testdata/default_values.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/default_values_coder.golden
+++ b/helm/provisioner/tests/testdata/default_values_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/default_values_coder.golden
+++ b/helm/provisioner/tests/testdata/default_values_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/extra_templates.golden
+++ b/helm/provisioner/tests/testdata/extra_templates.golden
@@ -102,7 +102,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/extra_templates.golden
+++ b/helm/provisioner/tests/testdata/extra_templates.golden
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/extra_templates_coder.golden
+++ b/helm/provisioner/tests/testdata/extra_templates_coder.golden
@@ -102,7 +102,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/extra_templates_coder.golden
+++ b/helm/provisioner/tests/testdata/extra_templates_coder.golden
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/labels_annotations.golden
+++ b/helm/provisioner/tests/testdata/labels_annotations.golden
@@ -98,6 +98,7 @@ spec:
   template:
     metadata:
       annotations:
+        com.coder/component: provisionerd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/provisioner/tests/testdata/labels_annotations.golden
+++ b/helm/provisioner/tests/testdata/labels_annotations.golden
@@ -98,7 +98,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/provisioner/tests/testdata/labels_annotations_coder.golden
+++ b/helm/provisioner/tests/testdata/labels_annotations_coder.golden
@@ -98,6 +98,7 @@ spec:
   template:
     metadata:
       annotations:
+        com.coder/component: provisionerd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/provisioner/tests/testdata/labels_annotations_coder.golden
+++ b/helm/provisioner/tests/testdata/labels_annotations_coder.golden
@@ -98,7 +98,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
         com.coder/podAnnotation/baz: qux
         com.coder/podAnnotation/foo: bar
       labels:

--- a/helm/provisioner/tests/testdata/name_override.golden
+++ b/helm/provisioner/tests/testdata/name_override.golden
@@ -102,7 +102,8 @@ spec:
       app.kubernetes.io/name: other-coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override.golden
+++ b/helm/provisioner/tests/testdata/name_override.golden
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override_coder.golden
+++ b/helm/provisioner/tests/testdata/name_override_coder.golden
@@ -102,7 +102,8 @@ spec:
       app.kubernetes.io/name: other-coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override_coder.golden
+++ b/helm/provisioner/tests/testdata/name_override_coder.golden
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override_existing_sa.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa.golden
@@ -22,7 +22,8 @@ spec:
       app.kubernetes.io/name: other-coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override_existing_sa.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa.golden
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override_existing_sa_coder.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa_coder.golden
@@ -22,7 +22,8 @@ spec:
       app.kubernetes.io/name: other-coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/name_override_existing_sa_coder.golden
+++ b/helm/provisioner/tests/testdata/name_override_existing_sa_coder.golden
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/partial_resources.golden
+++ b/helm/provisioner/tests/testdata/partial_resources.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/partial_resources.golden
+++ b/helm/provisioner/tests/testdata/partial_resources.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/partial_resources_coder.golden
+++ b/helm/provisioner/tests/testdata/partial_resources_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/partial_resources_coder.golden
+++ b/helm/provisioner/tests/testdata/partial_resources_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key_psk_empty_workaround_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_psk.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_psk.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk_coder.golden
@@ -93,7 +93,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk_coder.golden
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa.golden
+++ b/helm/provisioner/tests/testdata/sa.golden
@@ -94,7 +94,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa.golden
+++ b/helm/provisioner/tests/testdata/sa.golden
@@ -95,7 +95,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa_coder.golden
+++ b/helm/provisioner/tests/testdata/sa_coder.golden
@@ -94,7 +94,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa_coder.golden
+++ b/helm/provisioner/tests/testdata/sa_coder.golden
@@ -95,7 +95,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa_disabled.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled.golden
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa_disabled.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled.golden
@@ -22,7 +22,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa_disabled_coder.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled_coder.golden
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        com.coder/component: provisionerd
+        app.kubernetes.io/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/tests/testdata/sa_disabled_coder.golden
+++ b/helm/provisioner/tests/testdata/sa_disabled_coder.golden
@@ -22,7 +22,8 @@ spec:
       app.kubernetes.io/name: coder-provisioner
   template:
     metadata:
-      annotations: {}
+      annotations:
+        com.coder/component: provisionerd
       labels:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -50,6 +50,8 @@ coder:
 
   # coder.podAnnotations -- The Coder pod annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  # Note: The annotation `com.coder/component` is automatically added to identify
+  # the component type (coderd, wsproxy, or provisionerd).
   podAnnotations: {}
 
   # coder.podLabels -- The Coder pod labels. See:

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -50,7 +50,7 @@ coder:
 
   # coder.podAnnotations -- The Coder pod annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  # Note: The annotation `com.coder/component` is automatically added to identify
+  # The annotation `app.kubernetes.io/component` is automatically added to identify
   # the component type (coderd, wsproxy, or provisionerd).
   podAnnotations: {}
 


### PR DESCRIPTION
Fixes #13353

## Summary

Adds a default pod annotation `com.coder/component` to all pods created by the Helm charts. This helps users easily target specific Coder components when creating dashboards or alerts.

## Changes

- Added `coder.componentAnnotation` helper template in `helm/libcoder/templates/_helpers.tpl`
- Modified `helm/libcoder/templates/_coder.yaml` to include the component annotation in pod metadata
- Coder chart (`helm/coder/templates/_coder.tpl`) sets:
  - `com.coder/component: coderd` for main server
  - `com.coder/component: wsproxy` when `workspaceProxy: true`
- Provisioner chart (`helm/provisioner/templates/_coder.tpl`) sets:
  - `com.coder/component: provisionerd`
- Updated all golden test files
- Tested changes via `helm template`

## Annotation Values

| Pod | Annotation Value |
|------------|------------------|
| Coder server | `com.coder/component: coderd` |
| Workspace proxy | `com.coder/component: wsproxy` |
| Provisioner daemon | `com.coder/component: provisionerd` |

## Example

```yaml
# Pod metadata after deploying coder chart
metadata:
  annotations:
    com.coder/component: coderd
    # ... user-provided podAnnotations merged here
