### PR TITLE
feat: extend `biome.jsonc` with `"useConsistentCurlyBraces": "error"`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -36,12 +36,13 @@
 				"useAsConstAssertion": "error",
 				"useEnumInitializers": "error",
 				"useSingleVarDeclarator": "error",
+				"useConsistentCurlyBraces": "error",
 				"noUnusedTemplateLiteral": "error",
 				"useNumberNamespace": "error",
 				"noInferrableTypes": "error",
 				"noUselessElse": "error",
-			"noRestrictedImports": {
-				"level": "error",
+				"noRestrictedImports": {
+					"level": "error",
 					"options": {
 						"paths": {
 							// "@mui/material/Alert": "Use components/Alert/Alert instead.",

--- a/site/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/site/src/components/Breadcrumb/Breadcrumb.tsx
@@ -95,7 +95,7 @@ export const BreadcrumbSeparator: FC<ComponentProps<"li">> = ({
 		)}
 		{...props}
 	>
-		{"/"}
+		/
 	</li>
 );
 

--- a/site/src/components/SignInLayout/SignInLayout.tsx
+++ b/site/src/components/SignInLayout/SignInLayout.tsx
@@ -7,7 +7,7 @@ export const SignInLayout: FC<PropsWithChildren> = ({ children }) => {
 					{children}
 				</div>
 				<div className="text-xs text-content-secondary pt-6">
-					\u00a9 {new Date().getFullYear()} Coder Technologies, Inc.
+					&copy; {new Date().getFullYear()} Coder Technologies, Inc.
 				</div>
 			</div>
 		</div>

--- a/site/src/components/SignInLayout/SignInLayout.tsx
+++ b/site/src/components/SignInLayout/SignInLayout.tsx
@@ -7,7 +7,7 @@ export const SignInLayout: FC<PropsWithChildren> = ({ children }) => {
 					{children}
 				</div>
 				<div className="text-xs text-content-secondary pt-6">
-					{"\u00a9"} {new Date().getFullYear()} Coder Technologies, Inc.
+					\u00a9 {new Date().getFullYear()} Coder Technologies, Inc.
 				</div>
 			</div>
 		</div>

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -272,10 +272,7 @@ const SupportButton: FC<SupportButtonProps> = ({ name, target, icon }) => {
 				className="inline-block"
 			>
 				{icon && (
-					<SupportIcon
-						icon={icon}
-						className={"size-5 text-content-secondary"}
-					/>
+					<SupportIcon icon={icon} className="size-5 text-content-secondary" />
 				)}
 				{name}
 				<span className="sr-only"> (link opens in new tab)</span>

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -28,7 +28,7 @@ import { SupportIcon } from "../SupportIcon";
 export const Language = {
 	accountLabel: "Account",
 	signOutLabel: "Sign Out",
-	copyrightText: `&copy; ${new Date().getFullYear()} Coder Technologies, Inc.`,
+	copyrightText: `\u00a9 ${new Date().getFullYear()} Coder Technologies, Inc.`,
 };
 
 interface UserDropdownContentProps {

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -28,7 +28,7 @@ import { SupportIcon } from "../SupportIcon";
 export const Language = {
 	accountLabel: "Account",
 	signOutLabel: "Sign Out",
-	copyrightText: `\u00a9 ${new Date().getFullYear()} Coder Technologies, Inc.`,
+	copyrightText: `&copy; ${new Date().getFullYear()} Coder Technologies, Inc.`,
 };
 
 interface UserDropdownContentProps {

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.tsx
@@ -66,7 +66,7 @@ export const RequestLogsPageView: FC<RequestLogsPageViewProps> = ({
 						{isLoading ? (
 							<TableLoader />
 						) : interceptions?.length === 0 ? (
-							<TableEmpty message={"No request logs available"} />
+							<TableEmpty message="No request logs available" />
 						) : (
 							interceptions?.map((interception) => (
 								<RequestLogsRow

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -173,7 +173,7 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 							<Avatar
 								fallback={interception.initiator.username}
 								src={interception.initiator.avatar_url}
-								size={"lg"}
+								size="lg"
 								className="flex-shrink-0"
 							/>
 							<div className="font-medium truncate min-w-0 flex-1 overflow-hidden">
@@ -303,7 +303,7 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 									<Avatar
 										fallback={interception.initiator.username}
 										src={interception.initiator.avatar_url}
-										size={"sm"}
+										size="sm"
 										className="flex-shrink-0"
 									/>
 									<span className="truncate min-w-0 w-full">

--- a/site/src/pages/AIBridgePage/RequestLogsPage/filter/filter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/filter/filter.tsx
@@ -53,8 +53,8 @@ interface ProviderFilterProps {
 export const ProviderFilter: FC<ProviderFilterProps> = ({ menu }) => {
 	return (
 		<SelectFilter
-			label={"Select provider"}
-			placeholder={"All providers"}
+			label="Select provider"
+			placeholder="All providers"
 			emptyText="No providers found"
 			options={menu.searchOptions}
 			onSelect={(option) => menu.selectOption(option)}

--- a/site/src/pages/CliInstallPage/CliInstallPageView.tsx
+++ b/site/src/pages/CliInstallPage/CliInstallPageView.tsx
@@ -30,7 +30,7 @@ export const CliInstallPageView: FC<CliInstallPageViewProps> = ({ origin }) => {
 				</RouterLink>
 			</div>
 			<div css={styles.copyright}>
-				\u00a9 {new Date().getFullYear()} Coder Technologies, Inc.
+				&copy; {new Date().getFullYear()} Coder Technologies, Inc.
 			</div>
 		</div>
 	);

--- a/site/src/pages/CliInstallPage/CliInstallPageView.tsx
+++ b/site/src/pages/CliInstallPage/CliInstallPageView.tsx
@@ -30,7 +30,7 @@ export const CliInstallPageView: FC<CliInstallPageViewProps> = ({ origin }) => {
 				</RouterLink>
 			</div>
 			<div css={styles.copyright}>
-				{"\u00a9"} {new Date().getFullYear()} Coder Technologies, Inc.
+				\u00a9 {new Date().getFullYear()} Coder Technologies, Inc.
 			</div>
 		</div>
 	);

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/ExportPolicyButton.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/ExportPolicyButton.tsx
@@ -21,7 +21,7 @@ export const ExportPolicyButton: FC<ExportPolicyButtonProps> = ({
 
 	return (
 		<Button
-			variant={"outline"}
+			variant="outline"
 			disabled={!canCreatePolicyJson || isDownloading}
 			onClick={async () => {
 				if (canCreatePolicyJson) {

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPageView.tsx
@@ -376,7 +376,7 @@ const IdpMappingTable: FC<IdpMappingTableProps> = ({ isEmpty, children }) => {
 						<TableRow>
 							<TableCell colSpan={999}>
 								<EmptyState
-									message={"No organization mappings"}
+									message="No organization mappings"
 									isCompact
 									cta={
 										<Link

--- a/site/src/pages/TaskPage/ModifyPromptDialog.tsx
+++ b/site/src/pages/TaskPage/ModifyPromptDialog.tsx
@@ -108,7 +108,7 @@ export const ModifyPromptDialog: FC<ModifyPromptDialogProps> = ({
 						<ErrorAlert error={updatePromptMutation.error} />
 					)}
 					{workspaceBuildRunning && (
-						<ErrorAlert error={"Cannot modify the prompt of a running task"} />
+						<ErrorAlert error="Cannot modify the prompt of a running task" />
 					)}
 
 					<div>

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -228,13 +228,13 @@ const TemplateEmbedPageView: FC<TemplateEmbedPageViewProps> = ({
 								>
 									<div className="flex items-center gap-3">
 										<RadioGroupItem value="manual" id="manual" />
-										<Label htmlFor={"manual"} className="cursor-pointer">
+										<Label htmlFor="manual" className="cursor-pointer">
 											Manual
 										</Label>
 									</div>
 									<div className="flex items-center gap-3">
 										<RadioGroupItem value="auto" id="automatic" />
-										<Label htmlFor={"automatic"} className="cursor-pointer">
+										<Label htmlFor="automatic" className="cursor-pointer">
 											Automatic
 										</Label>
 									</div>

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -102,7 +102,7 @@ export const PublishTemplateVersionDialog: FC<
 								rows={5}
 							/>
 
-							<Stack direction={"row"}>
+							<Stack direction="row">
 								<FormControlLabel
 									label={Language.defaultCheckboxLabel}
 									control={


### PR DESCRIPTION
This pull-request tightens up our `biome.jsonc` configuration a little. We've added [`useConsistentCurlyBraces`](https://biomejs.dev/linter/rules/use-consistent-curly-braces/) to ensure that PR's like #21323 (and quite a few of my own, with my bad habit) don't get caught with having braces around props that don't require it.

Per the documentation:

```tsx
// invalid
<Foo>{'Hello world'}</Foo>
<Foo foo={'bar'} />
<Foo foo=<Bar /> />
// valid
<Foo>Hello world</Foo>
<Foo foo="bar" />
<Foo foo={5} />
<Foo foo={<Bar />} />
```

Furthermore, there seemed to be a funky formatting issue on lines 44 and 45, I indented these to match.