### PR TITLE
chore: revert runner sizes & parallelism from #21091

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -343,7 +343,7 @@ jobs:
   test-go-pg:
     # make sure to adjust NUM_PARALLEL_PACKAGES and NUM_PARALLEL_TESTS below
     # when changing runner sizes
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || matrix.os && matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'depot-windows-2022-32' || matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || matrix.os && matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'depot-windows-2022-16' || matrix.os }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
@@ -470,8 +470,8 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          # Our Linux runners have 16 cores.
-          test-parallelism-packages: "16"
+          # Our Linux runners have 8 cores.
+          test-parallelism-packages: "8"
           test-parallelism-tests: "8"
           # By default, run tests with cache for improved speed (possibly at the expense of correctness).
           # On main, run tests without cache for the inverse.
@@ -500,8 +500,12 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "13"
-          # Our Windows runners have 32 cores.
-          test-parallelism-packages: "32"
+          # Our Windows runners have 16 cores.
+          # On Windows Postgres chokes up when we have 16x16=256 tests
+          # running in parallel, and dbtestutil.NewDB starts to take more than
+          # 10s to complete sometimes causing test timeouts. With 16x8=128 tests
+          # Postgres tends not to choke.
+          test-parallelism-packages: "8"
           test-parallelism-tests: "16"
           # By default, run tests with cache for improved speed (possibly at the expense of correctness).
           # On main, run tests without cache for the inverse.
@@ -539,7 +543,7 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   test-go-pg-17:
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     needs:
       - changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
@@ -585,8 +589,8 @@ jobs:
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "17"
-          # Our Linux runners have 16 cores.
-          test-parallelism-packages: "16"
+          # Our Linux runners have 8 cores.
+          test-parallelism-packages: "8"
           test-parallelism-tests: "8"
           # By default, run tests with cache for improved speed (possibly at the expense of correctness).
           # On main, run tests without cache for the inverse.
@@ -606,7 +610,7 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
   test-go-race-pg:
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     timeout-minutes: 25
@@ -647,13 +651,13 @@ jobs:
       # instances where tests appear to hang for multiple seconds, resulting in flaky tests when
       # short timeouts are used.
       # c.f. discussion on https://github.com/coder/coder/pull/15106
-      # Our Linux runners have 32 cores, but we reduce parallelism since race detection adds a lot of overhead.
-      # We aim to have parallelism match CPU count (8*4=32) to avoid making flakes worse.
+      # Our Linux runners have 16 cores, but we reduce parallelism since race detection adds a lot of overhead.
+      # We aim to have parallelism match CPU count (4*4=16) to avoid making flakes worse.
       - name: Run Tests
         uses: ./.github/actions/test-go-pg
         with:
           postgres-version: "17"
-          test-parallelism-packages: "8"
+          test-parallelism-packages: "4"
           test-parallelism-tests: "4"
           race-detection: "true"
 


### PR DESCRIPTION
The juice wasn't worth the squeeze. We reduced our median run times by 33% but also increased the failure rate. Even if the latter is a misattribution to this change, doubling costs for only a 33% speedup is not worth it.

The refactorings from #21091 are worthwhile keeping, so I've just reverted the runner sizes & parallelism to [previous levels](https://github.com/coder/coder/blob/8ed1c1d3720b40a5dcc41c8a17debf93b36d3537/.github/workflows/ci.yaml).

---

Before:

<img width="2028" height="373" alt="image" src="https://github.com/user-attachments/assets/be527e63-d14d-4bab-ac35-214e7a73c675" />

After:

<img width="2040" height="403" alt="image" src="https://github.com/user-attachments/assets/fd834ae6-f310-492a-90c4-814545cda7f5" />