### PR TITLE
test: fix path seperator on windows for unit test

### DIFF
--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -3075,7 +3075,7 @@ func TestWorkspaceProvisionerdServerMetrics(t *testing.T) {
 // This is testing that dynamic params defers input validation to terraform.
 // It does not try to do this in coder/coder.
 func TestWorkspaceTemplateParamsChange(t *testing.T) {
-	indicatorFile := filepath.Join(t.TempDir(), "workspace_indicator.txt")
+	indicatorFile := filepath.ToSlash(filepath.Join(t.TempDir(), "workspace_indicator.txt"))
 	mainTfTemplate := fmt.Sprintf(`
 		terraform {
 			required_providers {


### PR DESCRIPTION
Test TestWorkspaceTemplateParamsChange writes a file to disk

Closes https://github.com/coder/internal/issues/1213