### PR TITLE
chore(site): enable noUncheckedIndexedAccess TypeScript option

### DIFF
--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -26,7 +26,7 @@ export const getCurrentOrgId = async (): Promise<string> => {
 		return currentOrgId;
 	}
 	const currentUser = await API.getAuthenticatedUser();
-	currentOrgId = currentUser.organization_ids[0];
+	currentOrgId = currentUser.organization_ids[0]!;
 	return currentOrgId;
 };
 

--- a/site/e2e/tests/users/userSettings.spec.ts
+++ b/site/e2e/tests/users/userSettings.spec.ts
@@ -17,12 +17,12 @@ test("adjust user theme preference", async ({ page }) => {
 
 	// Make sure the page is actually updated to use the light theme
 	const [root] = await page.$$("html");
-	expect(await root.evaluate((it) => it.className)).toContain("light");
+	expect(await root!.evaluate((it) => it.className)).toContain("light");
 
 	await page.goto("/", { waitUntil: "domcontentloaded" });
 
 	// Make sure the page is still using the light theme after reloading and
 	// navigating away from the settings page.
 	const [homeRoot] = await page.$$("html");
-	expect(await homeRoot.evaluate((it) => it.className)).toContain("light");
+	expect(await homeRoot!.evaluate((it) => it.className)).toContain("light");
 });

--- a/site/e2e/tests/workspaces/createWorkspace.spec.ts
+++ b/site/e2e/tests/workspaces/createWorkspace.spec.ts
@@ -119,8 +119,8 @@ test("create workspace and overwrite default parameters", async ({ page }) => {
 	];
 
 	const buildParameters = [
-		{ name: richParameters[0].name, value: "AAAAA" },
-		{ name: richParameters[1].name, value: "false" },
+		{ name: richParameters[0]!.name, value: "AAAAA" },
+		{ name: richParameters[1]!.name, value: "false" },
 	];
 	const template = await createTemplate(
 		page,

--- a/site/e2e/tests/workspaces/startWorkspace.spec.ts
+++ b/site/e2e/tests/workspaces/startWorkspace.spec.ts
@@ -30,8 +30,8 @@ test("start workspace with ephemeral parameters", async ({ page }) => {
 
 	// Verify that build options are default (not selected).
 	await verifyParameters(page, workspaceName, richParameters, [
-		{ name: richParameters[0].name, value: firstBuildOption.defaultValue },
-		{ name: richParameters[1].name, value: secondBuildOption.defaultValue },
+		{ name: richParameters[0]!.name, value: firstBuildOption.defaultValue },
+		{ name: richParameters[1]!.name, value: secondBuildOption.defaultValue },
 	]);
 
 	// Stop the workspace
@@ -39,8 +39,8 @@ test("start workspace with ephemeral parameters", async ({ page }) => {
 
 	// Now, start the workspace with ephemeral parameters selected.
 	const buildParameters = [
-		{ name: richParameters[0].name, value: "AAAAA" },
-		{ name: richParameters[1].name, value: "true" },
+		{ name: richParameters[0]!.name, value: "AAAAA" },
+		{ name: richParameters[1]!.name, value: "true" },
 	];
 
 	await startWorkspaceWithEphemeralParameters(
@@ -55,7 +55,7 @@ test("start workspace with ephemeral parameters", async ({ page }) => {
 
 	// Verify that build options are default (not selected).
 	await verifyParameters(page, workspaceName, richParameters, [
-		{ name: richParameters[0].name, value: firstBuildOption.defaultValue },
-		{ name: richParameters[1].name, value: secondBuildOption.defaultValue },
+		{ name: richParameters[0]!.name, value: firstBuildOption.defaultValue },
+		{ name: richParameters[1]!.name, value: secondBuildOption.defaultValue },
 	]);
 });

--- a/site/e2e/tests/workspaces/updateWorkspace.spec.ts
+++ b/site/e2e/tests/workspaces/updateWorkspace.spec.ts
@@ -62,14 +62,14 @@ test.skip("update workspace, new optional, immutable parameter added", async ({
 	// Now, update the workspace, and select the value for immutable parameter.
 	await login(page, users.member);
 	await updateWorkspace(page, workspaceName, updatedRichParameters, [
-		{ name: fifthParameter.name, value: fifthParameter.options[0].value },
+		{ name: fifthParameter.name, value: fifthParameter.options[0]!.value },
 	]);
 
 	// Verify parameter values.
 	await verifyParameters(page, workspaceName, updatedRichParameters, [
 		{ name: firstParameter.name, value: firstParameter.defaultValue },
 		{ name: secondParameter.name, value: secondParameter.defaultValue },
-		{ name: fifthParameter.name, value: fifthParameter.options[0].value },
+		{ name: fifthParameter.name, value: fifthParameter.options[0]!.value },
 	]);
 });
 

--- a/site/src/api/queries/notifications.ts
+++ b/site/src/api/queries/notifications.ts
@@ -83,14 +83,14 @@ export function selectTemplatesByGroup(
 		if (!grouped[template.group]) {
 			grouped[template.group] = [];
 		}
-		grouped[template.group].push(template);
+		grouped[template.group]!.push(template);
 	}
 
 	// Sort groups by name, and sort templates within each group
 	const sortedGroups = Object.keys(grouped).sort((a, b) => a.localeCompare(b));
 	const sortedGrouped: Record<string, NotificationTemplate[]> = {};
 	for (const group of sortedGroups) {
-		sortedGrouped[group] = grouped[group].sort((a, b) =>
+		sortedGrouped[group] = grouped[group]!.sort((a, b) =>
 			a.name.localeCompare(b.name),
 		);
 	}

--- a/site/src/api/queries/workspaces.ts
+++ b/site/src/api/queries/workspaces.ts
@@ -187,7 +187,7 @@ async function findMatchWorkspace(q: string): Promise<Workspace | undefined> {
 	} catch (err) {
 		if (isApiValidationError(err)) {
 			const firstValidationErrorDetail =
-				err.response.data.validations?.[0].detail;
+				err.response.data.validations?.[0]?.detail;
 			throw new DetailedError(
 				"Invalid match value",
 				firstValidationErrorDetail,

--- a/site/src/components/ActiveUserChart/ActiveUserChart.tsx
+++ b/site/src/components/ActiveUserChart/ActiveUserChart.tsx
@@ -66,7 +66,7 @@ export const ActiveUserChart: FC<ActiveUserChartProps> = ({ data }) => {
 							labelClassName="text-content-primary"
 							labelFormatter={(_, p) => {
 								const item = p[0];
-								return `${item.value} active users`;
+								return `${item?.value} active users`;
 							}}
 							formatter={(_v, _n, item) => {
 								const date = new Date(item.payload.date);

--- a/site/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -62,7 +62,7 @@ export const Default: Story = {
 
 export const WithSelectedValue: Story = {
 	render: function WithSelectedValueStory() {
-		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[2]);
+		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[2]!);
 		return (
 			<div className="w-80">
 				<Autocomplete
@@ -96,7 +96,7 @@ export const WithSelectedValue: Story = {
 
 export const NotClearable: Story = {
 	render: function NotClearableStory() {
-		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[0]);
+		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[0]!);
 		return (
 			<div className="w-80">
 				<Autocomplete
@@ -142,7 +142,7 @@ export const Loading: Story = {
 
 export const Disabled: Story = {
 	render: function DisabledStory() {
-		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[1]);
+		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[1]!);
 		return (
 			<div className="w-80">
 				<Autocomplete
@@ -223,7 +223,7 @@ export const SearchAndFilter: Story = {
 
 export const ClearSelection: Story = {
 	render: function ClearSelectionStory() {
-		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[0]);
+		const [value, setValue] = useState<SimpleOption | null>(simpleOptions[0]!);
 		return (
 			<div className="w-80">
 				<Autocomplete
@@ -318,7 +318,7 @@ export const WithCustomRenderOption: Story = {
 
 export const WithStartAdornment: Story = {
 	render: function WithStartAdornmentStory() {
-		const [value, setValue] = useState<User | null>(users[0]);
+		const [value, setValue] = useState<User | null>(users[0]!);
 		return (
 			<div className="w-[350px]">
 				<Autocomplete

--- a/site/src/components/Chart/Chart.tsx
+++ b/site/src/components/Chart/Chart.tsx
@@ -154,7 +154,7 @@ export const ChartTooltipContent = React.forwardRef<
 			}
 
 			const [item] = payload;
-			const key = `${labelKey || item.dataKey || item.name || "value"}`;
+			const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
 			const itemConfig = getPayloadConfigFromPayload(config, item, key);
 			const value =
 				!labelKey && typeof label === "string"

--- a/site/src/components/Conditionals/ChooseOne.tsx
+++ b/site/src/components/Conditionals/ChooseOne.tsx
@@ -35,7 +35,7 @@ export const ChooseOne: FC<PropsWithChildren> = ({ children }) => {
 		return null;
 	}
 	const conditionedOptions = childArray.slice(0, childArray.length - 1);
-	const defaultCase = childArray[childArray.length - 1];
+	const defaultCase = childArray[childArray.length - 1]!;
 	if (defaultCase.props.condition !== undefined) {
 		throw new Error(
 			"The last Cond in a ChooseOne was given a condition prop, but it is the default case.",

--- a/site/src/components/GlobalSnackbar/utils.test.ts
+++ b/site/src/components/GlobalSnackbar/utils.test.ts
@@ -64,7 +64,7 @@ describe("Snackbar", () => {
 			// calls[0][0] is the first argument of the first call
 			// calls[0][0].detail is the 'detail' argument passed to the `CustomEvent` -
 			// this is the `NotificationMsg` object that gets sent to `dispatchEvent`
-			return dispatchEventMock.mock.calls[0][0].detail;
+			return dispatchEventMock.mock.calls[0]![0]!.detail;
 		};
 
 		beforeEach(() => {

--- a/site/src/components/IconField/EmojiPicker.tsx
+++ b/site/src/components/IconField/EmojiPicker.tsx
@@ -8,7 +8,7 @@ const custom = [
 		id: "icons",
 		name: "Icons",
 		emojis: icons.map((icon) => {
-			const id = icon.split(".")[0];
+			const id = icon.split(".")[0]!;
 
 			return {
 				id,

--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -63,7 +63,7 @@ export const Markdown: FC<MarkdownProps> = (props) => {
 					const firstChild = node.children[0];
 					// When pre is wrapping a code, the SyntaxHighlighter is already going
 					// to wrap it with a pre so we don't need it
-					if (firstChild.type === "element" && firstChild.tagName === "code") {
+					if (firstChild && firstChild.type === "element" && firstChild.tagName === "code") {
 						return <>{children}</>;
 					}
 					return <pre>{children}</pre>;
@@ -75,7 +75,7 @@ export const Markdown: FC<MarkdownProps> = (props) => {
 					return match ? (
 						<SyntaxHighlighter
 							style={dracula}
-							language={match[1].toLowerCase() ?? "language-shell"}
+							language={match[1]!.toLowerCase() ?? "language-shell"}
 							useInlineStyles={false}
 							codeTagProps={{ style: {} }}
 							{...restProps} // Exclude 'ref' from being passed here

--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.stories.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.stories.tsx
@@ -95,7 +95,7 @@ export const ClearFirstSelectedItem: Story = {
 		await userEvent.click(
 			canvas.getByRole("option", { name: "My Organization 2" }),
 		);
-		await userEvent.click(canvas.getAllByTestId("clear-option-button")[0]);
+		await userEvent.click(canvas.getAllByTestId("clear-option-button")[0]!);
 	},
 };
 

--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -257,10 +257,10 @@ export const MultiSelectCombobox = forwardRef<
 			if (input) {
 				if (e.key === "Delete" || e.key === "Backspace") {
 					if (input.value === "" && selected.length > 0) {
-						const lastSelectOption = selected[selected.length - 1];
+						const lastSelectOption = selected[selected.length - 1]!;
 						// If last item is fixed, we should not remove it.
 						if (!lastSelectOption.fixed) {
-							handleUnselect(selected[selected.length - 1]);
+							handleUnselect(selected[selected.length - 1]!);
 						}
 					}
 				}

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -64,7 +64,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	// its own data. Until we refactor, proceed cautiously!
 	useEffect(() => {
 		const org = options[0];
-		if (options.length !== 1 || org === selected) {
+		if (options.length !== 1 || org === selected || !org) {
 			return;
 		}
 

--- a/site/src/components/Slider/Slider.stories.tsx
+++ b/site/src/components/Slider/Slider.stories.tsx
@@ -32,7 +32,7 @@ export const Controlled: Story = {
 	render: (args) => {
 		const [value, setValue] = React.useState(50);
 		return (
-			<Slider {...args} value={[value]} onValueChange={([v]) => setValue(v)} />
+			<Slider {...args} value={[value]} onValueChange={([v]) => setValue(v!)} />
 		);
 	},
 	args: { value: [50], min: 0, max: 100, step: 1 },

--- a/site/src/components/TagInput/TagInput.tsx
+++ b/site/src/components/TagInput/TagInput.tsx
@@ -61,7 +61,7 @@ export const TagInput: FC<TagInputProps> = ({
 								return;
 							}
 
-							const lastValue = values[values.length - 1];
+							const lastValue = values[values.length - 1]!;
 							onChange(values.slice(0, -1));
 							event.currentTarget.value = lastValue;
 						}

--- a/site/src/components/Timeline/Timeline.tsx
+++ b/site/src/components/Timeline/Timeline.tsx
@@ -13,9 +13,9 @@ const groupByDate = <TData,>(
 		const dateKey = getDate(item).toDateString();
 
 		if (dateKey in itemsByDate) {
-			itemsByDate[dateKey].push(item);
+			itemsByDate[dateKey]!.push(item);
 		} else {
-			itemsByDate[dateKey] = [item];
+			itemsByDate[dateKey]! = [item];
 		}
 	}
 

--- a/site/src/contexts/useProxyLatency.ts
+++ b/site/src/contexts/useProxyLatency.ts
@@ -111,10 +111,10 @@ export const useProxyLatency = (
 				// 2. If the latest latency is after the latestFetchRequest, then skip the latency check.
 				if (
 					storedLatencies?.[proxy.id] &&
-					storedLatencies[proxy.id].length > 0
+					storedLatencies[proxy.id]!.length > 0
 				) {
 					const fetchRequestDate = new Date(latestFetchRequest);
-					const latest = storedLatencies[proxy.id].reduce((prev, next) =>
+					const latest = storedLatencies[proxy.id]!.reduce((prev, next) =>
 						prev.at > next.at ? prev : next,
 					);
 

--- a/site/src/contexts/useWebpushNotifications.ts
+++ b/site/src/contexts/useWebpushNotifications.ts
@@ -69,8 +69,8 @@ export const useWebpushNotifications = (): WebpushNotifications => {
 
 			await API.createWebPushSubscription("me", {
 				endpoint: json.endpoint,
-				auth_key: json.keys.auth,
-				p256dh_key: json.keys.p256dh,
+				auth_key: json.keys!.auth!,
+				p256dh_key: json.keys!.p256dh!,
 			});
 
 			setSubscribed(true);

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -67,14 +67,14 @@ export const LicenseBannerView: FC<LicenseBannerViewProps> = ({
 			<div css={containerStyles}>
 				<Pill type={type}>{Language.licenseIssue}</Pill>
 				<div css={styles.leftContent}>
-					<span>{formatMessage(messages[0])}</span>
+					<span>{formatMessage(messages[0]!)}</span>
 					&nbsp;
 					<Link
 						color={textColor}
 						fontWeight="medium"
 						href="mailto:sales@coder.com"
 					>
-						{messages[0] === LicenseTelemetryRequiredErrorText
+						{messages[0]! === LicenseTelemetryRequiredErrorText
 							? Language.exception
 							: Language.upgrade}
 					</Link>

--- a/site/src/modules/dashboard/Navbar/ProxyMenu.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/ProxyMenu.stories.tsx
@@ -69,7 +69,7 @@ export const SingleProxy: Story = {
 	args: {
 		proxyContextValue: {
 			...defaultProxyContextValue,
-			proxies: [MockWorkspaceProxies[0]],
+			proxies: [MockWorkspaceProxies[0]!],
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -101,13 +101,13 @@ export const OnMarkNotificationAsRead: Story = {
 	play: async ({ canvasElement, args }) => {
 		const body = within(canvasElement.ownerDocument.body);
 		const notifications = body.getAllByRole("menuitem");
-		const secondNotification = notifications[1];
+		const secondNotification = notifications[1]!;
 		await userEvent.click(secondNotification);
 		const markButton = body.getByRole("button", { name: /mark as read/i });
 		await userEvent.click(markButton);
 		await expect(args.onMarkNotificationAsRead).toHaveBeenCalledTimes(1);
 		await expect(args.onMarkNotificationAsRead).toHaveBeenCalledWith(
-			args.notifications?.[1].id,
+			args.notifications?.[1]!.id,
 		);
 	},
 	parameters: {

--- a/site/src/modules/notifications/NotificationsInbox/NotificationsInbox.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/NotificationsInbox.stories.tsx
@@ -139,7 +139,7 @@ export const MarkNotificationAsRead: Story = {
 		markNotificationAsRead: fn(async () => ({
 			unread_count: 1,
 			notification: {
-				...MockNotifications[1],
+				...MockNotifications[1]!,
 				read_at: new Date().toISOString(),
 			},
 		})),
@@ -147,7 +147,7 @@ export const MarkNotificationAsRead: Story = {
 	play: async ({ canvasElement }) => {
 		const body = within(canvasElement.ownerDocument.body);
 		const notifications = await body.findAllByRole("menuitem");
-		const secondNotification = notifications[1];
+		const secondNotification = notifications[1]!;
 		within(secondNotification).getByText(/unread/i);
 
 		await userEvent.click(secondNotification);
@@ -172,7 +172,7 @@ export const MarkNotificationAsReadFailure: Story = {
 	play: async ({ canvasElement }) => {
 		const body = within(canvasElement.ownerDocument.body);
 		const notifications = await body.findAllByRole("menuitem");
-		const secondNotification = notifications[1];
+		const secondNotification = notifications[1]!;
 		await userEvent.click(secondNotification);
 		const markButton = body.getByRole("button", { name: /mark as read/i });
 		await userEvent.click(markButton);

--- a/site/src/modules/notifications/NotificationsInbox/NotificationsInbox.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/NotificationsInbox.tsx
@@ -98,7 +98,7 @@ export const NotificationsInbox: FC<NotificationsInboxProps> = ({
 			}
 			const lastNotification =
 				inboxRes.notifications[inboxRes.notifications.length - 1];
-			const newRes = await fetchNotifications(lastNotification.id);
+			const newRes = await fetchNotifications(lastNotification!.id);
 			updateNotificationsCache((prev) => {
 				return {
 					unread_count: newRes.unread_count,

--- a/site/src/modules/provisioners/ProvisionerTags.tsx
+++ b/site/src/modules/provisioners/ProvisionerTags.tsx
@@ -39,8 +39,8 @@ export const ProvisionerTruncateTags: FC<ProvisionerTagsProps> = ({ tags }) => {
 		return null;
 	}
 
-	const firstKey = keys[0];
-	const firstValue = tags[firstKey];
+	const firstKey = keys[0]!;
+	const firstValue = tags[firstKey]!;
 	const remainderCount = keys.length - 1;
 
 	return (

--- a/site/src/modules/resources/AgentLogs/AgentLogs.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogs.tsx
@@ -55,7 +55,7 @@ export const AgentLogs = forwardRef<List, AgentLogsProps>(
 					)}
 				>
 					{({ index, style }) => {
-						const log = logs[index];
+						const log = logs[index]!;
 						const logSource = getLogSource(log.sourceId);
 
 						let assignedIcon = false;
@@ -87,7 +87,7 @@ export const AgentLogs = forwardRef<List, AgentLogsProps>(
 
 						const doesNextLineHaveDifferentSource =
 							index < logs.length - 1 &&
-							getLogSource(logs[index + 1].sourceId).id !== log.sourceId;
+							getLogSource(logs[index + 1]!.sourceId).id !== log.sourceId;
 
 						// We don't want every line to repeat the icon, because
 						// that is ugly and repetitive. This removes the icon
@@ -96,7 +96,7 @@ export const AgentLogs = forwardRef<List, AgentLogsProps>(
 						// same source.
 						const shouldHideSource =
 							index > 0 &&
-							getLogSource(logs[index - 1].sourceId).id === log.sourceId;
+							getLogSource(logs[index - 1]!.sourceId).id === log.sourceId;
 						if (shouldHideSource) {
 							icon = (
 								<div className="size-3.5 mr-2 flex justify-center relative shrink-0">
@@ -193,5 +193,5 @@ const determineScriptDisplayColor = (displayName: string): string => {
 	const hash = displayName.split("").reduce((hash, char) => {
 		return (hash << 5) + hash + char.charCodeAt(0); // bit-shift and add for our simple hash
 	}, 0);
-	return scriptDisplayColors[Math.abs(hash) % scriptDisplayColors.length];
+	return scriptDisplayColors[Math.abs(hash) % scriptDisplayColors.length]!;
 };

--- a/site/src/modules/resources/ResourceCard.test.tsx
+++ b/site/src/modules/resources/ResourceCard.test.tsx
@@ -14,7 +14,7 @@ describe("Resource Card", () => {
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByText(MockWorkspaceResource.metadata?.[0].value as string),
+			screen.getByText(MockWorkspaceResource!.metadata![0].value as string),
 		).toBeInTheDocument();
 	});
 
@@ -23,23 +23,23 @@ describe("Resource Card", () => {
 			...MockWorkspaceResource,
 			metadata: [
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "18GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "24GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "32GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "48GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "60GB",
 				},
 			],
@@ -48,17 +48,17 @@ describe("Resource Card", () => {
 		render(<ResourceCard resource={mockResource} agentRow={() => <></>} />);
 		expect(screen.getByText(mockResource.daily_cost)).toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[0].value),
+			screen.getByText(mockResource!.metadata![0].value),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[1].value),
+			screen.getByText(mockResource!.metadata![1].value),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[2].value),
+			screen.getByText(mockResource!.metadata![2].value),
 		).toBeInTheDocument();
 		// last element is hidden
 		expect(
-			screen.queryByText(mockResource.metadata?.[3].value),
+			screen.queryByText(mockResource!.metadata![3].value),
 		).not.toBeInTheDocument();
 	});
 
@@ -68,23 +68,23 @@ describe("Resource Card", () => {
 			daily_cost: 0,
 			metadata: [
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "18GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "24GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "32GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "48GB",
 				},
 				{
-					...(MockWorkspaceResource.metadata?.[0] as WorkspaceResourceMetadata),
+					...(MockWorkspaceResource!.metadata![0] as WorkspaceResourceMetadata),
 					value: "60GB",
 				},
 			],
@@ -93,16 +93,16 @@ describe("Resource Card", () => {
 		render(<ResourceCard resource={mockResource} agentRow={() => <></>} />);
 		expect(screen.queryByText(mockResource.daily_cost)).not.toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[0].value),
+			screen.getByText(mockResource!.metadata![0].value),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[1].value),
+			screen.getByText(mockResource!.metadata![1].value),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[2].value),
+			screen.getByText(mockResource!.metadata![2].value),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(mockResource.metadata?.[3].value),
+			screen.getByText(mockResource!.metadata![3].value),
 		).toBeInTheDocument();
 	});
 });

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -138,7 +138,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 
 	// Template
 	const [selectedTemplateId, setSelectedTemplateId] = useState<string>(
-		templates[0].id,
+		templates[0]!.id,
 	);
 	const selectedTemplate = templates.find(
 		(t) => t.id === selectedTemplateId,
@@ -260,7 +260,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 										setSelectedPresetId(undefined);
 									}
 								}}
-								defaultValue={templates[0].id}
+								defaultValue={templates[0]!.id}
 								required
 							>
 								<PromptSelectTrigger id="templateID" tooltip="Template">

--- a/site/src/modules/tasks/TaskPrompt/TemplateVersionSelect.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TemplateVersionSelect.stories.tsx
@@ -56,8 +56,8 @@ export const Loading: Story = {
 
 export const Loaded: Story = {
 	args: {
-		activeVersionId: MockVersions[2].id,
-		value: MockVersions[2].id,
+		activeVersionId: MockVersions[2]!.id,
+		value: MockVersions[2]!.id,
 	},
 	beforeEach: () => {
 		spyOn(API, "getTemplateVersions").mockResolvedValue(MockVersions);
@@ -66,8 +66,8 @@ export const Loaded: Story = {
 
 export const Open: Story = {
 	args: {
-		activeVersionId: MockVersions[2].id,
-		value: MockVersions[2].id,
+		activeVersionId: MockVersions[2]!.id,
+		value: MockVersions[2]!.id,
 	},
 	beforeEach: () => {
 		spyOn(API, "getTemplateVersions").mockResolvedValue(MockVersions);

--- a/site/src/modules/tasks/TasksSidebar/TasksSidebar.stories.tsx
+++ b/site/src/modules/tasks/TasksSidebar/TasksSidebar.stories.tsx
@@ -24,10 +24,10 @@ const meta: Meta<typeof TasksSidebar> = {
 		},
 		reactRouter: reactRouterParameters({
 			location: {
-				path: `/tasks/${MockTasks[0].owner_name}/${MockTasks[0].id}`,
+				path: `/tasks/${MockTasks[0]!.owner_name}/${MockTasks[0]!.id}`,
 				pathParams: {
-					owner_name: MockTasks[0].owner_name,
-					taskId: MockTasks[0].id,
+					owner_name: MockTasks[0]!.owner_name,
+					taskId: MockTasks[0]!.id,
 				},
 			},
 			routing: [

--- a/site/src/modules/tasks/TasksSidebar/UserCombobox.stories.tsx
+++ b/site/src/modules/tasks/TasksSidebar/UserCombobox.stories.tsx
@@ -61,7 +61,7 @@ export const SelectUser: Story = {
 		});
 
 		await step("select user", async () => {
-			const option = await body.findByText(MockUsers[1].name!, {
+			const option = await body.findByText(MockUsers[1]!.name!, {
 				exact: false,
 			});
 			await user.click(option);

--- a/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
@@ -84,8 +84,8 @@ export const TemplateFileTree: FC<TemplateFilesTreeProps> = ({
 		const isHiddenFile = currentPath.startsWith(".");
 
 		if (shouldGroupFolder) {
-			const firstChildFileName = Object.keys(content)[0];
-			const child = content[firstChildFileName];
+			const firstChildFileName = Object.keys(content)[0]!;
+			const child = content[firstChildFileName]!;
 			return buildTreeItems(
 				`${label} / ${firstChildFileName}`,
 				firstChildFileName,

--- a/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
@@ -33,7 +33,7 @@ export const TemplateFiles: FC<TemplateFilesProps> = ({
 
 	const fileInfo = useCallback(
 		(filename: string) => {
-			const value = currentFiles[filename].trim();
+			const value = currentFiles[filename]!.trim();
 			const previousValue = baseFiles ? baseFiles[filename]?.trim() : undefined;
 			const hasDiff = previousValue && value !== previousValue;
 

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -316,7 +316,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 						className="mt-2"
 						value={[numericValue]}
 						onValueChange={([value]) => {
-							onChange(value.toString());
+							onChange(value!.toString());
 						}}
 						min={min ?? undefined}
 						max={max ?? undefined}

--- a/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -25,7 +25,7 @@ const groupLogsByStage: GroupLogsByStageFn = (logs) => {
 
 	for (const log of logs) {
 		if (log.stage in logsByStage) {
-			logsByStage[log.stage].push(log);
+			logsByStage[log.stage]!.push(log);
 		} else {
 			logsByStage[log.stage] = [log];
 		}
@@ -39,8 +39,8 @@ const getStageDurationInSeconds = (logs: ProvisionerJobLog[]) => {
 		return;
 	}
 
-	const startedAt = dayjs(logs[0].created_at);
-	const completedAt = dayjs(logs[logs.length - 1].created_at);
+	const startedAt = dayjs(logs[0]!.created_at);
+	const completedAt = dayjs(logs[logs.length - 1]!.created_at);
 	return completedAt.diff(startedAt, "seconds");
 };
 

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/utils.ts
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/utils.ts
@@ -17,7 +17,7 @@ export const mergeTimeRanges = (ranges: TimeRange[]): TimeRange => {
 	const sortedEndDurations = [...ranges].sort(
 		(a, b) => a.endedAt.getTime() - b.endedAt.getTime(),
 	);
-	const end = sortedEndDurations[sortedEndDurations.length - 1].endedAt;
+	const end = sortedEndDurations[sortedEndDurations.length - 1]!.endedAt;
 
 	// Ref: #15432: if there start time is the 'zero' value, default
 	// to the end time. This will result in an 'instant'.
@@ -73,7 +73,7 @@ const pickScale = (totalTime: number): number => {
 			return s;
 		}
 	}
-	return scales[0];
+	return scales[0]!;
 };
 
 export const makeTicks = (time: number) => {

--- a/site/src/modules/workspaces/WorkspaceTiming/ScriptsChart.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/ScriptsChart.tsx
@@ -58,9 +58,9 @@ export const ScriptsChart: FC<ScriptsChartProps> = ({
 	const visibleTimings = timings.filter((t) => t.name.includes(filter));
 	const theme = useTheme();
 	const legendsByStatus = getLegendsByStatus(theme);
-	const visibleLegends = [...new Set(visibleTimings.map((t) => t.status))].map(
-		(s) => legendsByStatus[s],
-	);
+	const visibleLegends = [...new Set(visibleTimings.map((t) => t.status))]
+		.map((s) => legendsByStatus[s])
+		.filter((l): l is ChartLegend => l !== undefined);
 
 	return (
 		<Chart>
@@ -113,7 +113,7 @@ export const ScriptsChart: FC<ScriptsChartProps> = ({
 												value={duration}
 												offset={calcOffset(t.range, generalTiming)}
 												scale={scale}
-												colors={legendsByStatus[t.status].colors}
+												colors={legendsByStatus[t.status]!.colors}
 											/>
 										</TooltipTrigger>
 										<TooltipContent

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -71,7 +71,7 @@ const [first, ...others] = WorkspaceTimingsResponse.agent_script_timings;
 export const FailedScript: Story = {
 	args: {
 		agentScriptTimings: [
-			{ ...first, status: "exit_failure", exit_code: 1 },
+			{ ...first!, status: "exit_failure", exit_code: 1 },
 			...others,
 		],
 	},
@@ -109,9 +109,9 @@ export const NavigateToStartStage: Story = {
 export const DuplicatedScriptTiming: Story = {
 	args: {
 		agentScriptTimings: [
-			WorkspaceTimingsResponse.agent_script_timings[0],
+			WorkspaceTimingsResponse.agent_script_timings[0]!,
 			{
-				...WorkspaceTimingsResponse.agent_script_timings[0],
+				...WorkspaceTimingsResponse.agent_script_timings[0]!,
 				started_at: "2021-09-01T00:00:00Z",
 				ended_at: "2021-09-01T00:00:00Z",
 			},
@@ -131,21 +131,21 @@ export const LongTimeRange = {
 	args: {
 		provisionerTimings: [
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				started_at: "2021-09-01T00:00:00Z",
 				ended_at: "2021-09-01T00:10:00Z",
 			},
 		],
 		agentConnectionTimings: [
 			{
-				...WorkspaceTimingsResponse.agent_connection_timings[0],
+				...WorkspaceTimingsResponse.agent_connection_timings[0]!,
 				started_at: "2021-09-01T00:10:00Z",
 				ended_at: "2021-09-01T00:35:00Z",
 			},
 		],
 		agentScriptTimings: [
 			{
-				...WorkspaceTimingsResponse.agent_script_timings[0],
+				...WorkspaceTimingsResponse.agent_script_timings[0]!,
 				started_at: "2021-09-01T00:35:00Z",
 				ended_at: "2021-09-01T01:00:00Z",
 			},
@@ -234,25 +234,25 @@ export const InvalidTimeRange: Story = {
 	args: {
 		provisionerTimings: [
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "init",
 				started_at: "2025-01-01T00:00:00Z",
 				ended_at: "2025-01-01T00:01:00Z",
 			},
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "plan",
 				started_at: "2025-01-01T00:01:00Z",
 				ended_at: "0001-01-01T00:00:00Z",
 			},
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "graph",
 				started_at: "0001-01-01T00:00:00Z",
 				ended_at: "2025-01-01T00:03:00Z",
 			},
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "apply",
 				started_at: "2025-01-01T00:03:00Z",
 				ended_at: "2025-01-01T00:04:00Z",
@@ -269,7 +269,7 @@ export const InvalidTimeRange: Story = {
 		],
 		agentScriptTimings: [
 			{
-				...WorkspaceTimingsResponse.agent_script_timings[0],
+				...WorkspaceTimingsResponse.agent_script_timings[0]!,
 				display_name: "Startup Script 1",
 				started_at: "0001-01-01T00:00:00Z",
 				ended_at: "2025-01-01T00:10:00Z",
@@ -283,25 +283,25 @@ export const NoAgentScripts: Story = {
 	args: {
 		provisionerTimings: [
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "init",
 				started_at: "2025-01-01T00:00:00Z",
 				ended_at: "2025-01-01T00:01:00Z",
 			},
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "plan",
 				started_at: "2025-01-01T00:01:00Z",
 				ended_at: "0001-01-01T00:00:00Z",
 			},
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "graph",
 				started_at: "0001-01-01T00:00:00Z",
 				ended_at: "2025-01-01T00:03:00Z",
 			},
 			{
-				...WorkspaceTimingsResponse.provisioner_timings[0],
+				...WorkspaceTimingsResponse.provisioner_timings[0]!,
 				stage: "apply",
 				started_at: "2025-01-01T00:03:00Z",
 				ended_at: "2025-01-01T00:04:00Z",

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogDiff/auditUtils.ts
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogDiff/auditUtils.ts
@@ -19,7 +19,7 @@ export const determineGroupDiff = (auditLogDiff: AuditDiff): AuditDiff => {
 		members: {
 			old: old?.map((groupMember) => groupMember.user_id),
 			new: new_?.map((groupMember) => groupMember.user_id),
-			secret: auditLogDiff.members?.secret,
+			secret: auditLogDiff.members?.secret ?? false,
 		},
 	};
 };
@@ -45,7 +45,7 @@ export const determineIdPSyncMappingDiff = (
 		mapping: {
 			old: JSON.stringify(old),
 			new: JSON.stringify(new_),
-			secret: auditLogDiff.mapping?.secret,
+			secret: auditLogDiff.mapping?.secret ?? false,
 		},
 	};
 };

--- a/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
@@ -60,7 +60,7 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 		: undefined;
 	const activeTag = urlParams.get("tag") ?? "all";
 	const visibleTemplates = starterTemplatesByTag
-		? sortVisibleTemplates(starterTemplatesByTag[activeTag])
+		? sortVisibleTemplates(starterTemplatesByTag[activeTag] ?? [])
 		: undefined;
 
 	return (
@@ -75,7 +75,7 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 							to={`?tag=${tag}`}
 							css={[styles.tagLink, tag === activeTag && styles.tagLinkActive]}
 						>
-							{getTagLabel(tag)} ({starterTemplatesByTag[tag].length})
+							{getTagLabel(tag)} ({starterTemplatesByTag[tag]!.length})
 						</Link>
 					))}
 				</Stack>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -234,7 +234,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 		const selectedPresetOption = presetOptions[selectedPresetIndex];
 		let selectedPreset: TypesGen.Preset | undefined;
 		for (const preset of presets) {
-			if (preset.ID === selectedPresetOption.value) {
+			if (preset.ID === selectedPresetOption!.value) {
 				selectedPreset = preset;
 				break;
 			}

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.test.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseCard.test.tsx
@@ -8,7 +8,7 @@ describe("LicenseCard", () => {
 		// When
 		render(
 			<LicenseCard
-				license={MockLicenseResponse[0]}
+				license={MockLicenseResponse[0]!}
 				userLimitActual={1}
 				userLimitLimit={10}
 				onRemove={() => null}
@@ -26,7 +26,7 @@ describe("LicenseCard", () => {
 		// When
 		render(
 			<LicenseCard
-				license={MockLicenseResponse[0]}
+				license={MockLicenseResponse[0]!}
 				userLimitActual={1}
 				userLimitLimit={undefined}
 				onRemove={() => null}
@@ -43,11 +43,11 @@ describe("LicenseCard", () => {
 	it("renders license's user_limit when it is available instead of using the default", async () => {
 		const licenseUserLimit = 3;
 		const license = {
-			...MockLicenseResponse[0],
+			...MockLicenseResponse[0]!,
 			claims: {
-				...MockLicenseResponse[0].claims,
+				...MockLicenseResponse[0]!.claims,
 				features: {
-					...MockLicenseResponse[0].claims.features,
+					...MockLicenseResponse[0]!.claims.features,
 					user_limit: licenseUserLimit,
 				},
 			},

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseSeatConsumptionChart.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicenseSeatConsumptionChart.tsx
@@ -178,7 +178,7 @@ export const LicenseSeatConsumptionChart: FC<
 												labelClassName="text-content-primary"
 												labelFormatter={(_, p) => {
 													const item = p[0];
-													return `${item.value} seats`;
+													return `${item?.value} seats`;
 												}}
 												formatter={(_v, _n, item) => {
 													const date = new Date(item.payload.date);

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.stories.tsx
@@ -61,7 +61,7 @@ export const Toggle: Story = {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 		const tmpl = MockSystemNotificationTemplates[4];
-		const option = await canvas.findByText(tmpl.name);
+		const option = await canvas.findByText(tmpl!.name);
 		const li = option.closest("li");
 		if (!li) {
 			throw new Error("Could not find li");
@@ -80,7 +80,7 @@ export const ToggleError: Story = {
 		const user = userEvent.setup();
 		const canvas = within(canvasElement);
 		const tmpl = MockSystemNotificationTemplates[4];
-		const option = await canvas.findByText(tmpl.name);
+		const option = await canvas.findByText(tmpl!.name);
 		const li = option.closest("li");
 		if (!li) {
 			throw new Error("Could not find li");

--- a/site/src/pages/DeploymentSettingsPage/OverviewPage/UserEngagementChart.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OverviewPage/UserEngagementChart.tsx
@@ -128,7 +128,7 @@ export const UserEngagementChart: FC<UserEngagementChartProps> = ({ data }) => {
 												labelClassName="text-content-primary"
 												labelFormatter={(_, p) => {
 													const item = p[0];
-													return `${item.value} users`;
+													return `${item?.value} users`;
 												}}
 												formatter={(_v, _n, item) => {
 													const date = new Date(item.payload.date);

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/ProvisionerKeyRow.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/ProvisionerKeyRow.tsx
@@ -129,7 +129,7 @@ const TruncateProvisioners: FC<TruncateProvisionersProps> = ({
 
 	return (
 		<ProvisionerTags>
-			<Badge size="sm">{firstProvisioner.name}</Badge>
+			<Badge size="sm">{firstProvisioner!.name}</Badge>
 			{remainderCount > 0 && <Badge size="sm">+{remainderCount}</Badge>}
 		</ProvisionerTags>
 	);

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/DateRange.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/DateRange.tsx
@@ -67,8 +67,8 @@ export const DateRange: FC<DateRangeProps> = ({ value, onChange }) => {
 						}
 
 						selectionStatusRef.current = "idle";
-						const startDate = range.startDate as Date;
-						const endDate = range.endDate as Date;
+						const startDate = range!.startDate as Date;
+						const endDate = range!.endDate as Date;
 						const now = new Date();
 						onChange({
 							startDate: dayjs(startDate).startOf("day").toDate(),

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsControls.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsControls.stories.tsx
@@ -29,7 +29,7 @@ export const Day: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const datePicker = canvas.getAllByRole("button")[1];
+		const datePicker = canvas.getAllByRole("button")[1]!;
 		await userEvent.click(datePicker);
 	},
 };
@@ -41,7 +41,7 @@ export const Week: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const dropdown = canvas.getAllByRole("button")[1];
+		const dropdown = canvas.getAllByRole("button")[1]!;
 		await userEvent.click(dropdown);
 	},
 };

--- a/site/src/pages/TerminalPage/TerminalPage.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.stories.tsx
@@ -37,7 +37,7 @@ const createWorkspaceWithAgent = (lifecycle: WorkspaceAgentLifecycle) => {
 				...MockWorkspace.latest_build,
 				resources: [
 					{
-						...MockWorkspace.latest_build.resources[0],
+						...MockWorkspace.latest_build.resources[0]!,
 						agents: [{ ...MockWorkspaceAgent, lifecycle_state: lifecycle }],
 					},
 				],

--- a/site/src/pages/UsersPage/UsersPage.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPage.stories.tsx
@@ -92,7 +92,7 @@ export const SuspendUserSuccess: Story = {
 
 		// Return the updated user in the suspended response and ensure the users
 		// query will return updated data.
-		const updatedUser: User = { ...MockUsers[0], status: "suspended" };
+		const updatedUser: User = { ...MockUsers[0]!, status: "suspended" };
 		spyOn(API, "suspendUser").mockResolvedValue(updatedUser);
 		spyOn(API, "getUsers").mockResolvedValue({
 			users: replaceUser(MockUsers, 0, updatedUser),
@@ -151,7 +151,7 @@ export const DeleteUserSuccess: Story = {
 
 		const dialog = await within(document.body).findByRole("dialog");
 		const input = within(dialog).getByLabelText("Name of the user to delete");
-		await user.type(input, MockUsers[0].username);
+		await user.type(input, MockUsers[0]!.username);
 		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
 		await within(document.body).findByText("Successfully deleted the user.");
 	},
@@ -172,7 +172,7 @@ export const DeleteUserError: Story = {
 
 		const dialog = await within(document.body).findByRole("dialog");
 		const input = within(dialog).getByLabelText("Name of the user to delete");
-		await user.type(input, MockUsers[0].username);
+		await user.type(input, MockUsers[0]!.username);
 		await user.click(within(dialog).getByRole("button", { name: "Delete" }));
 		await within(document.body).findByText("Error deleting user.");
 	},
@@ -188,7 +188,7 @@ export const ActivateUserSuccess: Story = {
 				key: usersKey({ limit: 25, offset: 0, q: "" }),
 				data: {
 					users: replaceUser(MockUsers, 0, {
-						...MockUsers[0],
+						...MockUsers[0]!,
 						status: "suspended",
 					}),
 					count: 60,
@@ -205,7 +205,7 @@ export const ActivateUserSuccess: Story = {
 
 		// Return the updated user in the activate response and ensure the users
 		// query will return updated data.
-		const updatedUser: User = { ...MockUsers[0], status: "active" };
+		const updatedUser: User = { ...MockUsers[0]!, status: "active" };
 		spyOn(API, "activateUser").mockResolvedValue(updatedUser);
 		spyOn(API, "getUsers").mockResolvedValue({
 			users: replaceUser(MockUsers, 0, updatedUser),
@@ -318,7 +318,7 @@ export const UpdateUserRoleSuccess: Story = {
 				key: usersKey({ limit: 25, offset: 0, q: "" }),
 				data: {
 					users: replaceUser(MockUsers, 0, {
-						...MockUsers[0],
+						...MockUsers[0]!,
 						roles: [
 							{ name: "owner", display_name: "Owner" },
 							// We will update the user role to include auditor
@@ -340,7 +340,7 @@ export const UpdateUserRoleSuccess: Story = {
 		// Return the updated user in the update roles response and ensure the users
 		// query will return updated data.
 		const updatedUser: User = {
-			...MockUsers[0],
+			...MockUsers[0]!,
 			roles: [
 				{ name: "owner", display_name: "Owner" },
 				// We will update the user role to include auditor

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/schedule.ts
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/schedule.ts
@@ -71,13 +71,13 @@ const transformSchedule = (schedule: string) => {
 	}
 
 	return {
-		sunday: weeklyFlags[0],
-		monday: weeklyFlags[1],
-		tuesday: weeklyFlags[2],
-		wednesday: weeklyFlags[3],
-		thursday: weeklyFlags[4],
-		friday: weeklyFlags[5],
-		saturday: weeklyFlags[6],
+		sunday: weeklyFlags[0]!,
+		monday: weeklyFlags[1]!,
+		tuesday: weeklyFlags[2]!,
+		wednesday: weeklyFlags[3]!,
+		thursday: weeklyFlags[4]!,
+		friday: weeklyFlags[5]!,
+		saturday: weeklyFlags[6]!,
 		startTime: `${HH}:${mm}`,
 		timezone,
 	};

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -15,6 +15,7 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"target": "es2020",
 		"types": ["node", "react", "react-dom", "vite/client", "vitest/globals"],
 		"baseUrl": "src/"


### PR DESCRIPTION
## Description

This PR enables the `noUncheckedIndexedAccess` TypeScript compiler option as [suggested by @Emyrk](https://github.com/coder/coder/pull/21381#discussion_r2643352467).

This option makes array/object indexed access return `T | undefined` instead of `T`, improving type safety by ensuring we properly handle cases where indexed access might return undefined.

## Progress

| Status | Count |
|--------|-------|
| Original errors | 257 |
| Fixed | 125 |
| **Remaining** | **132** |

## Error Breakdown (Original 257)

| Error Code | Count | Description |
|------------|-------|-------------|
| TS2532 | 86 | Object is possibly 'undefined' |
| TS2345 | 62 | Argument type mismatch with undefined |
| TS2322 | 56 | Type assignment with undefined |
| TS18048 | 46 | Variable possibly undefined |
| Other | 7 | (TS2538, TS2339, TS2769, TS2488) |

## Remaining Work

The 132 remaining errors are primarily in:
- Test files (`.jest.tsx`, `.test.ts`)
- Storybook stories (`.stories.tsx`)
- Some production code in `pages/`

Most fixes involve adding:
- Non-null assertion (`!`) where we're certain the value exists
- Optional chaining (`?.`) where appropriate
- Guard clauses for genuine undefined checks

## Why This Change?

Before this option, TypeScript would assume indexed access always succeeds:
```typescript
const item = array[0]; // Type: T (assumed to exist)
item.property; // No error, but could crash at runtime!
```

After this option:
```typescript
const item = array[0]; // Type: T | undefined (safer)
item.property; // Error! Must check first
if (item) {
  item.property; // OK
}
```

---

> ⚠️ **Draft PR** - This is a work in progress. The remaining 132 errors need to be fixed before this can be merged.
