### PR TITLE
feat(dogfood): use coder exp sync to synchronize scripts

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -356,12 +356,12 @@ module "git-config" {
 }
 
 module "git-clone" {
-  count    = data.coder_workspace.me.start_count
-  source   = "dev.registry.coder.com/coder/git-clone/coder"
-  version  = "1.2.2"
-  agent_id = coder_agent.dev.id
-  url      = "https://github.com/coder/coder"
-  base_dir = local.repo_base_dir
+  count             = data.coder_workspace.me.start_count
+  source            = "dev.registry.coder.com/coder/git-clone/coder"
+  version           = "1.2.2"
+  agent_id          = coder_agent.dev.id
+  url               = "https://github.com/coder/coder"
+  base_dir          = local.repo_base_dir
   post_clone_script = <<-EOT
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -599,7 +599,7 @@ resource "coder_agent" "dev" {
   startup_script = <<-EOT
     #!/usr/bin/env bash
     set -eux -o pipefail
-
+    # Allow other scripts to wait for agent startup.
     trap 'coder exp sync complete agent-startup' EXIT
     coder exp sync start agent-startup
 


### PR DESCRIPTION
Updates the `coder` template to use `coder exp sync` to synchronize `coder_script` startup dependencies.

To test this out, visit `/templates/coder/coder/workspace?version=4c1a1f32-1136-496f-8b40-51c1cf501385`