### PR TITLE
chore!: send modules archive over the proto messages

### DIFF
--- a/coderd/provisionerdserver/upload_file_test.go
+++ b/coderd/provisionerdserver/upload_file_test.go
@@ -120,7 +120,7 @@ func TestUploadFileErrorScenarios(t *testing.T) {
 		stream.messages <- up
 
 		err := server.UploadFile(stream)
-		require.ErrorContains(t, err, "unexpected file upload while waiting for file completion")
+		require.ErrorContains(t, err, "unexpected file download while waiting for file completion")
 		require.True(t, stream.isDone(), "stream should be done after error")
 	})
 

--- a/provisioner/echo/serve.go
+++ b/provisioner/echo/serve.go
@@ -205,8 +205,8 @@ func (*echo) Parse(sess *provisionersdk.Session, _ *proto.ParseRequest, _ <-chan
 	return provisionersdk.ParseErrorf("complete response missing")
 }
 
-func (*echo) Init(sess *provisionersdk.Session, req *proto.InitRequest, canceledOrComplete <-chan struct{}) *proto.InitComplete {
-	err := sess.Files.ExtractArchive(sess.Context(), sess.Logger, afero.NewOsFs(), req.TemplateSourceArchive)
+func (*echo) Init(sess *provisionersdk.Session, req *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *proto.InitComplete {
+	err := sess.Files.ExtractArchive(sess.Context(), sess.Logger, afero.NewOsFs(), req.TemplateSourceArchive, nil)
 	if err != nil {
 		return provisionersdk.InitErrorf("extract archive: %s", err.Error())
 	}

--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -69,7 +69,7 @@ func (s *server) setupContexts(parent context.Context, canceledOrComplete <-chan
 }
 
 func (s *server) Init(
-	sess *provisionersdk.Session, request *proto.InitRequest, canceledOrComplete <-chan struct{},
+	sess *provisionersdk.Session, request *provisionersdk.InitRequest, canceledOrComplete <-chan struct{},
 ) *proto.InitComplete {
 	ctx, span := s.startTrace(sess.Context(), tracing.FuncName())
 	defer span.End()
@@ -84,7 +84,7 @@ func (s *server) Init(
 	logTerraformEnvVars(sess)
 
 	// TODO: These logs should probably be streamed back to the provisioner runner.
-	err := sess.Files.ExtractArchive(ctx, s.logger, afero.NewOsFs(), request.GetTemplateSourceArchive())
+	err := sess.Files.ExtractArchive(ctx, s.logger, afero.NewOsFs(), request.GetTemplateSourceArchive(), request.ModuleArchive)
 	if err != nil {
 		return provisionersdk.InitErrorf("extract template archive: %s", err)
 	}

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionerd/runner"
+	"github.com/coder/coder/v2/provisionersdk"
 	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/retry"
 )
@@ -417,6 +418,7 @@ func (p *Server) acquireAndRunOne(client proto.DRPCProvisionerDaemonClient) erro
 		runner.Options{
 			Updater:             p,
 			QuotaCommitter:      p,
+			FileDownloader:      p,
 			Logger:              p.opts.Logger.Named("runner"),
 			Provisioner:         resp.Client,
 			UpdateInterval:      p.opts.UpdateInterval,
@@ -527,7 +529,7 @@ func (p *Server) UploadModuleFiles(ctx context.Context, moduleFiles []byte) erro
 
 		stream, err := client.UploadFile(ctx)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to start CompleteJobWithFiles stream: %w", err)
+			return nil, xerrors.Errorf("failed to start UploadModuleFiles stream: %w", err)
 		}
 		defer stream.Close()
 
@@ -565,6 +567,36 @@ func (p *Server) UploadModuleFiles(ctx context.Context, moduleFiles []byte) erro
 	}
 
 	return nil
+}
+
+// DownloadFile will download a module file from coderd.
+func (p *Server) DownloadFile(ctx context.Context, request *proto.FileRequest) ([]byte, error) {
+	data, err := clientDoWithRetries(ctx, p.client, func(ctx context.Context, client proto.DRPCProvisionerDaemonClient) ([]byte, error) {
+		// Add some timeout to prevent the stream from hanging indefinitely if something goes wrong.
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		stream, err := client.DownloadFile(ctx, request)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to start DownloadFile stream: %w", err)
+		}
+		defer stream.Close()
+
+		file, err := provisionersdk.HandleReceivingDataUpload(stream)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to handle receiving data upload: %w", err)
+		}
+		data, err := file.Complete()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to download file: %w", err)
+		}
+		return data, nil
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("download file %s: %w", request.FileId, err)
+	}
+
+	return data, nil
 }
 
 func (p *Server) CompleteJob(ctx context.Context, in *proto.CompletedJob) error {

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -132,7 +132,7 @@ func TestProvisionerd(t *testing.T) {
 					}
 					return c
 				},
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					closerMutex.Lock()
 					defer closerMutex.Unlock()
 					err := closer.Close()
@@ -197,7 +197,7 @@ func TestProvisionerd(t *testing.T) {
 						Readme: make([]byte, largeSize),
 					}
 				},
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -276,7 +276,7 @@ func TestProvisionerd(t *testing.T) {
 					<-cancelOrComplete
 					return &sdkproto.ParseComplete{}
 				},
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 			}),
@@ -417,7 +417,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -488,7 +488,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -566,7 +566,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -641,7 +641,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				graph: func(s *provisionersdk.Session, r *sdkproto.GraphRequest, canceledOrComplete <-chan struct{}) *sdkproto.GraphComplete {
@@ -757,7 +757,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -848,7 +848,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -945,7 +945,7 @@ func TestProvisionerd(t *testing.T) {
 			return client, nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -1041,7 +1041,7 @@ func TestProvisionerd(t *testing.T) {
 			return client, nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				plan: func(
@@ -1141,7 +1141,7 @@ func TestProvisionerd(t *testing.T) {
 			}), nil
 		}, provisionerd.LocalProvisioners{
 			"someprovisioner": createProvisionerClient(t, done, provisionerTestServer{
-				init: func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+				init: func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 					return &sdkproto.InitComplete{}
 				},
 				graph: func(s *provisionersdk.Session, r *sdkproto.GraphRequest, canceledOrComplete <-chan struct{}) *sdkproto.GraphComplete {
@@ -1275,14 +1275,14 @@ func createProvisionerClient(t *testing.T, done <-chan struct{}, server provisio
 }
 
 type provisionerTestServer struct {
-	init  func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete
+	init  func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete
 	parse func(s *provisionersdk.Session, r *sdkproto.ParseRequest, canceledOrComplete <-chan struct{}) *sdkproto.ParseComplete
 	plan  func(s *provisionersdk.Session, r *sdkproto.PlanRequest, canceledOrComplete <-chan struct{}) *sdkproto.PlanComplete
 	apply func(s *provisionersdk.Session, r *sdkproto.ApplyRequest, canceledOrComplete <-chan struct{}) *sdkproto.ApplyComplete
 	graph func(s *provisionersdk.Session, r *sdkproto.GraphRequest, canceledOrComplete <-chan struct{}) *sdkproto.GraphComplete
 }
 
-func (p *provisionerTestServer) Init(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+func (p *provisionerTestServer) Init(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 	return p.init(s, r, canceledOrComplete)
 }
 
@@ -1399,10 +1399,10 @@ func (a *acquireOne) acquireWithCancel(stream proto.DRPCProvisionerDaemon_Acquir
 	return nil
 }
 
-func extractInit(t *testing.T) func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+func extractInit(t *testing.T) func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 	logger := slogtest.Make(t, nil)
-	return func(s *provisionersdk.Session, r *sdkproto.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
-		err := s.Files.ExtractArchive(s.Context(), logger, afero.NewOsFs(), r.TemplateSourceArchive)
+	return func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
+		err := s.Files.ExtractArchive(s.Context(), logger, afero.NewOsFs(), r.TemplateSourceArchive, nil)
 		if err != nil {
 			return &sdkproto.InitComplete{
 				Error: fmt.Sprintf("failed to extract template source archive: %v", err),

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -48,6 +48,7 @@ type Runner struct {
 	job                 *proto.AcquiredJob
 	sender              JobUpdater
 	quotaCommitter      QuotaCommitter
+	fileDownloader      FileDownloader
 	logger              slog.Logger
 	provisioner         sdkproto.DRPCProvisionerClient
 	lastUpdate          atomic.Pointer[time.Time]
@@ -96,13 +97,19 @@ type JobUpdater interface {
 	FailJob(ctx context.Context, in *proto.FailedJob) error
 	CompleteJob(ctx context.Context, in *proto.CompletedJob) error
 }
+
 type QuotaCommitter interface {
 	CommitQuota(ctx context.Context, in *proto.CommitQuotaRequest) (*proto.CommitQuotaResponse, error)
+}
+
+type FileDownloader interface {
+	DownloadFile(ctx context.Context, req *proto.FileRequest) ([]byte, error)
 }
 
 type Options struct {
 	Updater             JobUpdater
 	QuotaCommitter      QuotaCommitter
+	FileDownloader      FileDownloader
 	Logger              slog.Logger
 	Provisioner         sdkproto.DRPCProvisionerClient
 	UpdateInterval      time.Duration
@@ -142,6 +149,7 @@ func New(
 		job:                 job,
 		sender:              opts.Updater,
 		quotaCommitter:      opts.QuotaCommitter,
+		fileDownloader:      opts.FileDownloader,
 		logger:              logger,
 		provisioner:         opts.Provisioner,
 		updateInterval:      opts.UpdateInterval,
@@ -521,7 +529,7 @@ func (r *Runner) runTemplateImport(ctx context.Context) (*proto.CompletedJob, *p
 	}
 
 	// Initialize the Terraform working directory
-	initResp, failedInit := r.init(ctx, false, r.job.GetTemplateSourceArchive())
+	initResp, failedInit := r.init(ctx, false, r.job.GetTemplateSourceArchive(), nil)
 	if failedInit != nil {
 		return nil, failedInit
 	}
@@ -787,7 +795,7 @@ func (r *Runner) runTemplateDryRun(ctx context.Context) (*proto.CompletedJob, *p
 	}
 
 	// Initialize the Terraform working directory
-	initResp, failedJob := r.init(ctx, false, r.job.GetTemplateSourceArchive())
+	initResp, failedJob := r.init(ctx, false, r.job.GetTemplateSourceArchive(), nil)
 	if failedJob != nil {
 		return nil, failedJob
 	}
@@ -901,8 +909,25 @@ func (r *Runner) runWorkspaceBuild(ctx context.Context) (*proto.CompletedJob, *p
 	// timings collects all timings from each phase of the build
 	timings := make([]*sdkproto.Timing, 0)
 
+	var cachedModulesTar []byte
+	// Download modules if cached in coderd
+	if r.job.GetWorkspaceBuild().Metadata.TemplateVersionModulesFile != "" {
+		fileID, err := uuid.Parse(r.job.GetWorkspaceBuild().Metadata.TemplateVersionModulesFile)
+		if err != nil {
+			return nil, r.failedWorkspaceBuildf("invalid template version modules file ID: %s", err)
+		}
+		// Download the module tar file
+		cachedModulesTar, err = r.fileDownloader.DownloadFile(ctx, &proto.FileRequest{
+			FileId:     fileID.String(),
+			UploadType: sdkproto.DataUploadType_UPLOAD_TYPE_MODULE_FILES,
+		})
+		if err != nil {
+			return nil, r.failedWorkspaceBuildf("failed to download template version modules file: %s", err)
+		}
+	}
+
 	// Initialize the Terraform working directory
-	initComplete, failedJob := r.init(ctx, true, r.job.GetTemplateSourceArchive())
+	initComplete, failedJob := r.init(ctx, true, r.job.GetTemplateSourceArchive(), cachedModulesTar)
 	if failedJob != nil {
 		return nil, failedJob
 	}

--- a/provisionersdk/dataupload.go
+++ b/provisionersdk/dataupload.go
@@ -1,0 +1,85 @@
+package provisionersdk
+
+import (
+	"io"
+
+	"golang.org/x/xerrors"
+
+	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
+)
+
+// HandleReceivingDataUpload can download a multi-part file from a proto stream.
+// The stream is expected to be closed by the caller.
+func HandleReceivingDataUpload(stream interface {
+	Recv() (*sdkproto.FileUpload, error)
+},
+) (*sdkproto.DataBuilder, error) {
+	var file *sdkproto.DataBuilder
+UploadFileStream:
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			if xerrors.Is(err, io.EOF) {
+				// Do not return an EOF here, as it is a "retryable error" in the client context.
+				// This failure indicates the download stream was closed prematurely, and it is a
+				// fatal error.
+				return nil, xerrors.Errorf("stream closed before file download complete")
+			}
+			return nil, xerrors.Errorf("receive file download: %w", err)
+		}
+
+		switch typed := msg.Type.(type) {
+		case *sdkproto.FileUpload_Error:
+			return nil, xerrors.Errorf("download file: %s", typed.Error.Error)
+		case *sdkproto.FileUpload_DataUpload:
+			if file != nil {
+				return nil, xerrors.New("unexpected file download while waiting for file completion")
+			}
+
+			file, err = sdkproto.NewDataBuilder(&sdkproto.DataUpload{
+				UploadType: typed.DataUpload.UploadType,
+				DataHash:   typed.DataUpload.DataHash,
+				FileSize:   typed.DataUpload.FileSize,
+				Chunks:     typed.DataUpload.Chunks,
+			})
+			if err != nil {
+				return nil, xerrors.Errorf("unable to create file download: %w", err)
+			}
+
+			if file.IsDone() {
+				// If a file is 0 bytes, we can consider it done immediately.
+				// This should never really happen in practice, but we handle it gracefully.
+				break UploadFileStream
+			}
+		case *sdkproto.FileUpload_ChunkPiece:
+			if file == nil {
+				return nil, xerrors.New("unexpected chunk piece while waiting for file upload")
+			}
+
+			done, err := file.Add(&sdkproto.ChunkPiece{
+				Data:         typed.ChunkPiece.Data,
+				FullDataHash: typed.ChunkPiece.FullDataHash,
+				PieceIndex:   typed.ChunkPiece.PieceIndex,
+			})
+			if err != nil {
+				return nil, xerrors.Errorf("unable to add a chunk piece: %w", err)
+			}
+
+			if done {
+				break UploadFileStream
+			}
+		default:
+			// This should never happen
+			return nil, xerrors.Errorf("received unknown file upload message type: %T", msg.Type)
+		}
+	}
+
+	// This needs to be called again by the caller to retrieve the final payload.
+	// It is called here to do a hash check and ensure the file is correct.
+	_, err := file.Complete()
+	if err != nil {
+		return nil, xerrors.Errorf("complete file upload: %w", err)
+	}
+
+	return file, nil
+}

--- a/provisionersdk/serve.go
+++ b/provisionersdk/serve.go
@@ -33,8 +33,15 @@ type ServeOptions struct {
 	Experiments         codersdk.Experiments
 }
 
+// InitRequest wraps the InitRequest proto with the module archive bytes, which
+// is downloaded by the SDK from the hash field in the InitRequest proto.
+type InitRequest struct {
+	*proto.InitRequest
+	ModuleArchive []byte
+}
+
 type Server interface {
-	Init(s *Session, r *proto.InitRequest, canceledOrComplete <-chan struct{}) *proto.InitComplete
+	Init(s *Session, r *InitRequest, canceledOrComplete <-chan struct{}) *proto.InitComplete
 	Parse(s *Session, r *proto.ParseRequest, canceledOrComplete <-chan struct{}) *proto.ParseComplete
 	Plan(s *Session, r *proto.PlanRequest, canceledOrComplete <-chan struct{}) *proto.PlanComplete
 	Apply(s *Session, r *proto.ApplyRequest, canceledOrComplete <-chan struct{}) *proto.ApplyComplete

--- a/provisionersdk/serve_test.go
+++ b/provisionersdk/serve_test.go
@@ -149,7 +149,7 @@ var _ provisionersdk.Server = unimplementedServer{}
 
 type unimplementedServer struct{}
 
-func (unimplementedServer) Init(s *provisionersdk.Session, r *proto.InitRequest, canceledOrComplete <-chan struct{}) *proto.InitComplete {
+func (unimplementedServer) Init(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *proto.InitComplete {
 	return &proto.InitComplete{}
 }
 

--- a/provisionersdk/tfpath/tfpath.go
+++ b/provisionersdk/tfpath/tfpath.go
@@ -72,17 +72,39 @@ func (l Layout) ModulesFilePath() string {
 	return filepath.Join(l.ModulesDirectory(), "modules.json")
 }
 
-func (l Layout) ExtractArchive(ctx context.Context, logger slog.Logger, fs afero.Fs, templateSourceArchive []byte) error {
-	logger.Info(ctx, "unpacking template source archive",
-		slog.F("size_bytes", len(templateSourceArchive)),
-	)
-
-	err := fs.MkdirAll(l.WorkDirectory(), 0o700)
+// ExtractArchive extracts the provided template source archive and modules archive into the working directory.
+// `modulesArchive` is optional and can be nil or empty.
+func (l Layout) ExtractArchive(ctx context.Context, logger slog.Logger, fs afero.Fs, templateSourceArchive, modulesArchive []byte) error {
+	err := extractArchive(ctx, logger, fs, l.WorkDirectory(), templateSourceArchive)
 	if err != nil {
-		return xerrors.Errorf("create work directory %q: %w", l.WorkDirectory(), err)
+		return xerrors.Errorf("extract template source archive: %w", err)
 	}
 
-	reader := tar.NewReader(bytes.NewBuffer(templateSourceArchive))
+	if len(modulesArchive) > 0 {
+		err = extractArchive(ctx, logger, fs, l.WorkDirectory(), modulesArchive)
+		if err != nil {
+			return xerrors.Errorf("extract modules archive: %w", err)
+		}
+	}
+	return nil
+}
+
+func isValidSessionDir(dirName string) bool {
+	match, err := filepath.Match(sessionDirPrefix+"*", dirName)
+	return err == nil && match
+}
+
+func extractArchive(ctx context.Context, logger slog.Logger, fs afero.Fs, directory string, archive []byte) error {
+	logger.Info(ctx, "unpacking source archive",
+		slog.F("size_bytes", len(archive)),
+	)
+
+	err := fs.MkdirAll(directory, 0o700)
+	if err != nil {
+		return xerrors.Errorf("create work directory %q: %w", directory, err)
+	}
+
+	reader := tar.NewReader(bytes.NewBuffer(archive))
 	for {
 		header, err := reader.Next()
 		if err != nil {
@@ -103,8 +125,8 @@ func (l Layout) ExtractArchive(ctx context.Context, logger slog.Logger, fs afero
 		}
 
 		// nolint: gosec // Safe to no-lint because the filepath.IsLocal check above.
-		headerPath := filepath.Join(l.WorkDirectory(), header.Name)
-		if !strings.HasPrefix(headerPath, filepath.Clean(l.WorkDirectory())) {
+		headerPath := filepath.Join(directory, header.Name)
+		if !strings.HasPrefix(headerPath, filepath.Clean(directory)) {
 			return xerrors.New("tar attempts to target relative upper directory")
 		}
 		mode := header.FileInfo().Mode()
@@ -219,9 +241,4 @@ func (l Layout) CleanStaleSessions(ctx context.Context, logger slog.Logger, fs a
 		}
 	}
 	return nil
-}
-
-func isValidSessionDir(dirName string) bool {
-	match, err := filepath.Match(sessionDirPrefix+"*", dirName)
-	return err == nil && match
 }


### PR DESCRIPTION
# What this does

Dynamic parameters caches the `./terraform/modules` directory for parameter usage. What this PR does is send over this archive to the provisioner when building workspaces.

This allow terraform to skip downloading modules from their registries, a step that takes seconds. 

<img width="1223" height="429" alt="Screenshot From 2025-12-29 12-57-52" src="https://github.com/user-attachments/assets/16066e0a-ac79-4296-819d-924f4b0418dc" />


# Wire protocol

The wire protocol reuses the same mechanism used to download the modules `provisoner -> coder`. It splits up large archives into multiple protobuf messages so larger archives can be sent under the message size limit.

# :rotating_light:  Behavior Change (Breaking Change) :rotating_light: 

**Before this PR** modules were downloaded on every workspace build. This means unpinned modules always fetched the latest version

**After this PR** modules are cached at template import time, and their versions are effectively pinned for all subsequent workspace builds.