### PR TITLE
feat(agent): add Cursor and Windsurf as recognized IDE session types

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -312,7 +312,7 @@ func (a *agent) init() {
 			switch magicType {
 			case agentssh.MagicSessionTypeSSH:
 				connectionType = proto.Connection_SSH
-			case agentssh.MagicSessionTypeVSCode:
+			case agentssh.MagicSessionTypeVSCode, agentssh.MagicSessionTypeCursor, agentssh.MagicSessionTypeWindsurf:
 				connectionType = proto.Connection_VSCODE
 			case agentssh.MagicSessionTypeJetBrains:
 				connectionType = proto.Connection_JETBRAINS

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -84,6 +84,11 @@ const (
 	// MagicSessionTypeJetBrains is set in the SSH config by the JetBrains
 	// extension to identify itself.
 	MagicSessionTypeJetBrains MagicSessionType = "jetbrains"
+	// MagicSessionTypeCursor is set in the SSH config by the Cursor extension to identify itself.
+	MagicSessionTypeCursor MagicSessionType = "cursor"
+	// MagicSessionTypeWindsurf is set in the SSH config by the Windsurf
+	// extension to identify itself.
+	MagicSessionTypeWindsurf MagicSessionType = "windsurf"
 )
 
 // BlockedFileTransferCommands contains a list of restricted file transfer commands.
@@ -320,6 +325,10 @@ func extractMagicSessionType(env []string) (magicType MagicSessionType, rawType 
 		magicType = MagicSessionTypeVSCode
 	case MagicSessionTypeJetBrains:
 		magicType = MagicSessionTypeJetBrains
+	case MagicSessionTypeCursor:
+		magicType = MagicSessionTypeCursor
+	case MagicSessionTypeWindsurf:
+		magicType = MagicSessionTypeWindsurf
 	case "", MagicSessionTypeSSH:
 		magicType = MagicSessionTypeSSH
 	default:
@@ -416,7 +425,7 @@ func (s *Server) sessionHandler(session ssh.Session) {
 	reportSession := true
 
 	switch magicType {
-	case MagicSessionTypeVSCode:
+	case MagicSessionTypeVSCode, MagicSessionTypeCursor, MagicSessionTypeWindsurf:
 		s.connCountVSCode.Add(1)
 		defer s.connCountVSCode.Add(-1)
 	case MagicSessionTypeJetBrains:

--- a/agent/agentssh/metrics.go
+++ b/agent/agentssh/metrics.go
@@ -76,6 +76,8 @@ func magicTypeMetricLabel(magicType MagicSessionType) string {
 	case MagicSessionTypeVSCode:
 	case MagicSessionTypeJetBrains:
 	case MagicSessionTypeSSH:
+	case MagicSessionTypeCursor:
+	case MagicSessionTypeWindsurf:
 	case MagicSessionTypeUnknown:
 	default:
 		magicType = MagicSessionTypeUnknown


### PR DESCRIPTION
## Summary

Adds Cursor and Windsurf as recognized IDE session types for usage tracking.

Fixes #21361

## Changes

- Add `MagicSessionTypeCursor` and `MagicSessionTypeWindsurf` constants in `agent/agentssh/agentssh.go`
- Update `extractMagicSessionType()` to recognize the new session types
- Update `magicTypeMetricLabel()` in `agent/agentssh/metrics.go` to handle the new types
- Update connection reporting in `agent/agent.go` to map Cursor and Windsurf to `Connection_VSCODE` (since they are VS Code variants and share the same underlying protocol)

Both Cursor and Windsurf are VS Code-based IDEs that set the `CODER_SSH_SESSION_TYPE` environment variable when connecting. They are now properly tracked alongside VS Code for usage metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>