### PR TITLE
fix: manually override pagination sizes

### DIFF
--- a/site/src/components/PaginationWidget/PageButtons.tsx
+++ b/site/src/components/PaginationWidget/PageButtons.tsx
@@ -69,11 +69,11 @@ const BasePageButton: FC<BasePageButtonProps> = ({
 	return (
 		<Button
 			variant={highlighted ? "default" : "outline"}
+			size="icon"
 			aria-label={ariaLabel}
 			name={name}
 			disabled={disabled}
 			onClick={onClick}
-			size="icon"
 			className="min-w-8 w-auto"
 		>
 			{children}

--- a/site/src/components/PaginationWidget/PageButtons.tsx
+++ b/site/src/components/PaginationWidget/PageButtons.tsx
@@ -69,11 +69,12 @@ const BasePageButton: FC<BasePageButtonProps> = ({
 	return (
 		<Button
 			variant={highlighted ? "default" : "outline"}
-			size="icon"
 			aria-label={ariaLabel}
 			name={name}
 			disabled={disabled}
 			onClick={onClick}
+			size="icon"
+			className="min-w-8 w-auto"
 		>
 			{children}
 		</Button>


### PR DESCRIPTION
Closes #21260

Pagination buttons could overflow their container on narrower pages (e.g. audit / logs) because the page button was effectively fixed-width. This updates the pagination button styling to allow it to expand with its content (`min-w-8 w-auto`), preventing overflow while keeping the same icon-button look.

| Previously | Now |
| --- | --- | 
| <img width="451" height="118" alt="pagination-old-treatment" src="https://github.com/user-attachments/assets/ae77e604-89fb-4dc3-9233-d103494e1906" /> | <img width="451" height="118" alt="pagination-new-treatment" src="https://github.com/user-attachments/assets/5a948d8a-4643-4eff-95b9-4c2852850447" /> | 