### PR TITLE
fix: sort latest key by sequence correctly

### DIFF
--- a/coderd/cryptokeys/cache_test.go
+++ b/coderd/cryptokeys/cache_test.go
@@ -42,9 +42,15 @@ func TestCryptoKeyCache(t *testing.T) {
 				Sequence: 2,
 				StartsAt: now,
 			}
+			olderKey := codersdk.CryptoKey{
+				Feature:  codersdk.CryptoKeyFeatureTailnetResume,
+				Secret:   generateKey(t, 64),
+				Sequence: 1,
+				StartsAt: now,
+			}
 
 			ff := &fakeFetcher{
-				keys: []codersdk.CryptoKey{expected},
+				keys: []codersdk.CryptoKey{expected, olderKey},
 			}
 
 			cache, err := cryptokeys.NewSigningCache(ctx, logger, ff, codersdk.CryptoKeyFeatureTailnetResume, cryptokeys.WithCacheClock(clock))

--- a/coderd/cryptokeys/rotate.go
+++ b/coderd/cryptokeys/rotate.go
@@ -80,14 +80,15 @@ func StartRotator(ctx context.Context, logger slog.Logger, db database.Store, op
 // start begins the process of rotating keys.
 // Canceling the context will stop the rotation process.
 func (k *rotator) start(ctx context.Context) {
-	k.clock.TickerFunc(ctx, defaultRotationInterval, func() error {
+	w := k.clock.TickerFunc(ctx, defaultRotationInterval, func() error {
 		err := k.rotateKeys(ctx)
 		if err != nil {
 			k.logger.Error(ctx, "failed to rotate keys", slog.Error(err))
 		}
 		return nil
 	})
-	k.logger.Debug(ctx, "ctx canceled, stopping key rotation")
+	err := w.Wait()
+	k.logger.Debug(ctx, "stopping key rotation", slog.Error(err))
 }
 
 // rotateKeys checks for any keys needing rotation or deletion and
@@ -194,7 +195,7 @@ func (k *rotator) insertNewKey(ctx context.Context, tx database.Store, feature d
 		return database.CryptoKey{}, xerrors.Errorf("inserting new key: %w", err)
 	}
 
-	k.logger.Debug(ctx, "inserted new key for feature", slog.F("feature", feature))
+	k.logger.Debug(ctx, "inserted new key for feature", slog.F("feature", feature), slog.F("sequence", newKey.Sequence))
 	return newKey, nil
 }
 


### PR DESCRIPTION
Fixes an issue where we will not correctly return the latest key by sequence number if the fetch returns them in a order where the latest key is not last. The db query uses `ORDER BY sequence DESC` it is likely we have been operating incorrectly.

Adds a second key to one of the test cases which fails without this fix.

Also includes some debug logging statements I found helpful while chasing key rotation issues.