### PR TITLE
fix(site): show apps with disabled health status on workspaces list

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesPage.jest.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.jest.tsx
@@ -401,7 +401,8 @@ describe("WorkspaceApps filtering", () => {
 			await waitForLoaderToBeRemoved();
 
 			const appLink = screen.queryByRole("link", {
-				name: (name) => name.toLowerCase().includes(app.display_name!.toLowerCase()),
+				name: (name) =>
+					name.toLowerCase().includes(app.display_name!.toLowerCase()),
 			});
 			if (shouldBeVisible) {
 				expect(appLink).toBeInTheDocument();
@@ -446,7 +447,8 @@ describe("WorkspaceApps filtering", () => {
 
 		expect(
 			screen.queryByRole("link", {
-				name: (name) => name.toLowerCase().includes(hiddenApp.display_name!.toLowerCase()),
+				name: (name) =>
+					name.toLowerCase().includes(hiddenApp.display_name!.toLowerCase()),
 			}),
 		).not.toBeInTheDocument();
 	});

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -25,12 +25,13 @@ import type {
 } from "api/typesGenerated";
 import { HttpResponse, http } from "msw";
 import * as CreateDayString from "utils/createDayString";
+import { vi } from "vitest";
 import WorkspacesPage from "./WorkspacesPage";
 
 describe("WorkspacesPage", () => {
 	beforeEach(() => {
 		// Mocking the dayjs module within the createDayString file
-		const mock = jest.spyOn(CreateDayString, "createDayString");
+		const mock = vi.spyOn(CreateDayString, "createDayString");
 		mock.mockImplementation(() => "a minute ago");
 	});
 
@@ -63,10 +64,11 @@ describe("WorkspacesPage", () => {
 			{ ...MockWorkspace, id: "2" },
 			{ ...MockWorkspace, id: "3" },
 		];
-		jest
-			.spyOn(API, "getWorkspaces")
-			.mockResolvedValue({ workspaces, count: workspaces.length });
-		const deleteWorkspace = jest.spyOn(API, "deleteWorkspace");
+		vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces,
+			count: workspaces.length,
+		});
+		const deleteWorkspace = vi.spyOn(API, "deleteWorkspace");
 		const user = userEvent.setup();
 		renderWithAuth(<WorkspacesPage />);
 		await waitForLoaderToBeRemoved();
@@ -111,11 +113,12 @@ describe("WorkspacesPage", () => {
 					},
 				},
 			];
-			jest
-				.spyOn(API, "getWorkspaces")
-				.mockResolvedValue({ workspaces, count: workspaces.length });
+			vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+				workspaces,
+				count: workspaces.length,
+			});
 
-			const updateWorkspace = jest.spyOn(API, "updateWorkspace");
+			const updateWorkspace = vi.spyOn(API, "updateWorkspace");
 			const user = userEvent.setup();
 			renderWithAuth(<WorkspacesPage />);
 			await waitForLoaderToBeRemoved();
@@ -155,11 +158,12 @@ describe("WorkspacesPage", () => {
 				{ ...MockOutdatedWorkspace, id: "2" },
 				{ ...MockOutdatedWorkspace, id: "3" },
 			];
-			jest
-				.spyOn(API, "getWorkspaces")
-				.mockResolvedValue({ workspaces, count: workspaces.length });
+			vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+				workspaces,
+				count: workspaces.length,
+			});
 
-			const updateWorkspace = jest.spyOn(API, "updateWorkspace");
+			const updateWorkspace = vi.spyOn(API, "updateWorkspace");
 			const user = userEvent.setup();
 			renderWithAuth(<WorkspacesPage />);
 			await waitForLoaderToBeRemoved();
@@ -198,10 +202,11 @@ describe("WorkspacesPage", () => {
 				{ ...MockOutdatedWorkspace, id: "2" },
 				{ ...MockOutdatedWorkspace, id: "3" },
 			];
-			jest
-				.spyOn(API, "getWorkspaces")
-				.mockResolvedValue({ workspaces, count: workspaces.length });
-			const updateWorkspace = jest.spyOn(API, "updateWorkspace");
+			vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+				workspaces,
+				count: workspaces.length,
+			});
+			const updateWorkspace = vi.spyOn(API, "updateWorkspace");
 			const user = userEvent.setup();
 			renderWithAuth(<WorkspacesPage />);
 			await waitForLoaderToBeRemoved();
@@ -237,10 +242,11 @@ describe("WorkspacesPage", () => {
 			{ ...MockWorkspace, id: "2" },
 			{ ...MockWorkspace, id: "3" },
 		];
-		jest
-			.spyOn(API, "getWorkspaces")
-			.mockResolvedValue({ workspaces, count: workspaces.length });
-		const stopWorkspace = jest.spyOn(API, "stopWorkspace");
+		vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces,
+			count: workspaces.length,
+		});
+		const stopWorkspace = vi.spyOn(API, "stopWorkspace");
 		const user = userEvent.setup();
 		renderWithAuth(<WorkspacesPage />);
 		await waitForLoaderToBeRemoved();
@@ -264,10 +270,11 @@ describe("WorkspacesPage", () => {
 			{ ...MockStoppedWorkspace, id: "2" },
 			{ ...MockStoppedWorkspace, id: "3" },
 		];
-		jest
-			.spyOn(API, "getWorkspaces")
-			.mockResolvedValue({ workspaces, count: workspaces.length });
-		const startWorkspace = jest.spyOn(API, "startWorkspace");
+		vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces,
+			count: workspaces.length,
+		});
+		const startWorkspace = vi.spyOn(API, "startWorkspace");
 		const user = userEvent.setup();
 		renderWithAuth(<WorkspacesPage />);
 		await waitForLoaderToBeRemoved();
@@ -304,7 +311,7 @@ describe("WorkspacesPage", () => {
 			name: `page2-workspace-${i}`,
 		}));
 
-		const getWorkspacesSpy = jest.spyOn(API, "getWorkspaces");
+		const getWorkspacesSpy = vi.spyOn(API, "getWorkspaces");
 
 		getWorkspacesSpy.mockImplementation(({ offset }) => {
 			switch (offset) {
@@ -393,9 +400,10 @@ describe("WorkspaceApps filtering", () => {
 					],
 				},
 			};
-			jest
-				.spyOn(API, "getWorkspaces")
-				.mockResolvedValue({ workspaces: [workspace], count: 1 });
+			vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+				workspaces: [workspace],
+				count: 1,
+			});
 
 			renderWithAuth(<WorkspacesPage />);
 			await waitForLoaderToBeRemoved();
@@ -438,9 +446,10 @@ describe("WorkspaceApps filtering", () => {
 				],
 			},
 		};
-		jest
-			.spyOn(API, "getWorkspaces")
-			.mockResolvedValue({ workspaces: [workspace], count: 1 });
+		vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces: [workspace],
+			count: 1,
+		});
 
 		renderWithAuth(<WorkspacesPage />);
 		await waitForLoaderToBeRemoved();

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -25,7 +25,6 @@ import type {
 } from "api/typesGenerated";
 import { HttpResponse, http } from "msw";
 import * as CreateDayString from "utils/createDayString";
-import { vi } from "vitest";
 import WorkspacesPage from "./WorkspacesPage";
 
 describe("WorkspacesPage", () => {

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -666,7 +666,10 @@ const WorkspaceApps: FC<WorkspaceAppsProps> = ({ workspace }) => {
 
 	const remainingSlots = WORKSPACE_APPS_SLOTS - builtinApps.size;
 	const userApps = agent.apps
-		.filter((app) => app.health === "healthy" && !app.hidden)
+		.filter(
+			(app) =>
+				(app.health === "healthy" || app.health === "disabled") && !app.hidden,
+		)
 		.slice(0, remainingSlots);
 
 	const buttons: ReactNode[] = [];

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -78,6 +78,9 @@ export const handlers = [
 	),
 
 	// templates
+	http.get("/api/v2/templates", () => {
+		return HttpResponse.json([M.MockTemplate]);
+	}),
 	http.get("/api/v2/templates/examples", () => {
 		return HttpResponse.json([M.MockTemplateExample, M.MockTemplateExample2]);
 	}),
@@ -165,7 +168,7 @@ export const handlers = [
 	http.get("/api/v2/users/me/appearance", () => {
 		return HttpResponse.json(M.MockUserAppearanceSettings);
 	}),
-	http.get("/api/v2/users/me/keys", () => {
+	http.post("/api/v2/users/me/keys", () => {
 		return HttpResponse.json(M.MockAPIKey);
 	}),
 	http.get("/api/v2/users/authmethods", () => {

--- a/site/test/setup/domStubs.ts
+++ b/site/test/setup/domStubs.ts
@@ -1,0 +1,6 @@
+// Pointer capture stubs required for Radix UI in JSDOM.
+globalThis.HTMLElement.prototype.hasPointerCapture = vi
+	.fn()
+	.mockReturnValue(false);
+globalThis.HTMLElement.prototype.setPointerCapture = vi.fn();
+globalThis.HTMLElement.prototype.releasePointerCapture = vi.fn();

--- a/site/test/setup/mocks.ts
+++ b/site/test/setup/mocks.ts
@@ -1,0 +1,11 @@
+// Mock useProxyLatency to avoid real network requests to external proxy URLs.
+// Must use useMemo to return stable object references and prevent infinite re-renders.
+vi.mock("contexts/useProxyLatency", async () => {
+	const { useMemo } = await import("react");
+	return {
+		useProxyLatency: () => {
+			const proxyLatencies = useMemo(() => ({}), []);
+			return { proxyLatencies, refetch: () => new Date() };
+		},
+	};
+});

--- a/site/test/setup/msw.ts
+++ b/site/test/setup/msw.ts
@@ -1,0 +1,11 @@
+import { server } from "testHelpers/server";
+import { cleanup } from "@testing-library/react";
+
+// MSW server lifecycle
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => {
+	cleanup();
+	server.resetHandlers();
+	vi.clearAllMocks();
+});
+afterAll(() => server.close());

--- a/site/test/setup/polyfills.ts
+++ b/site/test/setup/polyfills.ts
@@ -1,0 +1,12 @@
+import { Blob as NativeBlob } from "node:buffer";
+
+// JSDom `Blob` is missing important methods[1] that have been standardized for
+// years. MDN categorizes this API as baseline[2].
+// [1]: https://github.com/jsdom/jsdom/issues/2555
+// [2]: https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer
+// @ts-expect-error - Minor type incompatibilities due to TypeScript's
+// introduction of the `ArrayBufferLife` type and the related generic parameters
+// changes.
+globalThis.Blob = NativeBlob;
+
+globalThis.ResizeObserver = require("resize-observer-polyfill");

--- a/site/test/vitestSetup.ts
+++ b/site/test/vitestSetup.ts
@@ -1,4 +1,11 @@
+import { server } from "testHelpers/server";
 import { Blob as NativeBlob } from "node:buffer";
+import crypto from "node:crypto";
+import { cleanup } from "@testing-library/react";
+import type { Region } from "api/typesGenerated";
+import type { ProxyLatencyReport } from "contexts/useProxyLatency";
+import { useMemo } from "react";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 
 // JSDom `Blob` is missing important methods[1] that have been standardized for
 // years. MDN categorizes this API as baseline[2].
@@ -8,3 +15,72 @@ import { Blob as NativeBlob } from "node:buffer";
 // introduction of the `ArrayBufferLife` type and the related generic parameters
 // changes.
 globalThis.Blob = NativeBlob;
+
+// useProxyLatency does some http requests to determine latency.
+// This would fail unit testing, or at least make it very slow with
+// actual network requests. So just globally mock this hook.
+vi.mock("contexts/useProxyLatency", () => ({
+	useProxyLatency: (proxies?: Region[]) => {
+		// Must use `useMemo` here to avoid infinite loop.
+		// Mocking the hook with a hook.
+		const proxyLatencies = useMemo(() => {
+			if (!proxies) {
+				return {} as Record<string, ProxyLatencyReport>;
+			}
+			return proxies.reduce(
+				(acc, proxy) => {
+					acc[proxy.id] = {
+						accurate: true,
+						// Return a constant latency of 8ms.
+						// If you make this random it could break stories.
+						latencyMS: 8,
+						at: new Date(),
+					};
+					return acc;
+				},
+				{} as Record<string, ProxyLatencyReport>,
+			);
+		}, [proxies]);
+
+		return { proxyLatencies, refetch: vi.fn() };
+	},
+}));
+
+globalThis.scrollTo = vi.fn();
+
+globalThis.HTMLElement.prototype.scrollIntoView = vi.fn();
+// Polyfill pointer capture methods for JSDOM compatibility with Radix UI
+globalThis.HTMLElement.prototype.hasPointerCapture = vi
+	.fn()
+	.mockReturnValue(false);
+globalThis.HTMLElement.prototype.setPointerCapture = vi.fn();
+globalThis.HTMLElement.prototype.releasePointerCapture = vi.fn();
+globalThis.open = vi.fn();
+navigator.sendBeacon = vi.fn();
+
+globalThis.ResizeObserver = require("resize-observer-polyfill");
+
+// Polyfill the getRandomValues that is used on utils/random.ts
+Object.defineProperty(globalThis.self, "crypto", {
+	value: {
+		getRandomValues: crypto.randomFillSync,
+	},
+});
+
+// Establish API mocking before all tests through MSW.
+beforeAll(() =>
+	server.listen({
+		onUnhandledRequest: "warn",
+	}),
+);
+
+// Reset any request handlers that we may add during the tests,
+// so they don't affect other tests.
+afterEach(() => {
+	cleanup();
+	server.resetHandlers();
+	vi.resetAllMocks();
+});
+
+// Clean up after the tests are finished.
+afterAll(() => server.close());

--- a/site/test/vitestSetup.ts
+++ b/site/test/vitestSetup.ts
@@ -1,43 +1,5 @@
-import { server } from "testHelpers/server";
-import { Blob as NativeBlob } from "node:buffer";
-import { cleanup } from "@testing-library/react";
-import { afterAll, afterEach, beforeAll, vi } from "vitest";
-
-// JSDom `Blob` is missing important methods[1] that have been standardized for
-// years. MDN categorizes this API as baseline[2].
-// [1]: https://github.com/jsdom/jsdom/issues/2555
-// [2]: https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer
-// @ts-expect-error - Minor type incompatibilities due to TypeScript's
-// introduction of the `ArrayBufferLife` type and the related generic parameters
-// changes.
-globalThis.Blob = NativeBlob;
-
-globalThis.ResizeObserver = require("resize-observer-polyfill");
-
-// Pointer capture stubs required for Radix UI in JSDOM.
-globalThis.HTMLElement.prototype.hasPointerCapture = vi
-	.fn()
-	.mockReturnValue(false);
-globalThis.HTMLElement.prototype.setPointerCapture = vi.fn();
-globalThis.HTMLElement.prototype.releasePointerCapture = vi.fn();
-
-// Mock useProxyLatency to avoid real network requests to external proxy URLs.
-// Must use useMemo to return stable object references and prevent infinite re-renders.
-vi.mock("contexts/useProxyLatency", async () => {
-	const { useMemo } = await import("react");
-	return {
-		useProxyLatency: () => {
-			const proxyLatencies = useMemo(() => ({}), []);
-			return { proxyLatencies, refetch: () => new Date() };
-		},
-	};
-});
-
-// MSW server lifecycle
-beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
-afterEach(() => {
-	cleanup();
-	server.resetHandlers();
-	vi.clearAllMocks();
-});
-afterAll(() => server.close());
+// Vitest setup entry point - imports modular setup files.
+import "./setup/polyfills";
+import "./setup/domStubs";
+import "./setup/mocks";
+import "./setup/msw";


### PR DESCRIPTION
Apps without health checks configured (`health === "disabled"`) were hidden from the workspaces list quick-access row. The filter only showed apps with `health === "healthy"`, excluding functional apps that simply don't have health monitoring configured.

Updated the filter to include both `healthy` and `disabled` apps while still excluding `unhealthy` and `initializing` apps.

Fixed #20319