### PR TITLE
chore(docs): update example URL format in AI Bridge docs

### DIFF
--- a/docs/ai-coder/ai-bridge/client-config.md
+++ b/docs/ai-coder/ai-bridge/client-config.md
@@ -4,7 +4,7 @@ Once AI Bridge is setup on your deployment, the AI coding tools used by your use
 
 ## Base URLs
 
-Most AI coding tools allow the "base URL" to be customized. In other words, when a request is made to OpenAI's API from your coding tool, the API endpoint such as [/v1/chat/completions](https://platform.openai.com/docs/api-reference/chat) will be appended to the configured base. Therefore, instead of the default base URL of "https://api.openai.com/v1", you'll need to set it to "https://coder.example.com/api/v2/aibridge/openai/v1".
+Most AI coding tools allow the "base URL" to be customized. In other words, when a request is made to OpenAI's API from your coding tool, the API endpoint such as [`/v1/chat/completions`](https://platform.openai.com/docs/api-reference/chat) will be appended to the configured base. Therefore, instead of the default base URL of `https://api.openai.com/v1`, you'll need to set it to `https://coder.example.com/api/v2/aibridge/openai/v1`.
 
 The exact configuration method varies by client — some use environment variables, others use configuration files or UI settings:
 


### PR DESCRIPTION
We are using a mix of styles for the URL, so moving the example URLs to be code blocks.
This is a cosmetic change.  

<table>
<tr>
 <td> Before
 <td> After
<tr>
 <td> <img width="712" height="607" alt="image" src="https://github.com/user-attachments/assets/05733e45-b83f-4801-9657-db72095a0300" />
 <td> <img width="701" height="584" alt="image" src="https://github.com/user-attachments/assets/61418ea6-0882-4fb5-81fd-ec1a67473579" />
</table>