### PR TITLE
chore(cli): seed healthcheck cache in TestSupportBundle

### DIFF
--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -86,6 +86,7 @@ func TestSupportBundle(t *testing.T) {
 	})
 
 	t.Run("WorkspaceWithAgent", func(t *testing.T) {
+		t.Parallel()
 		r := dbfake.WorkspaceBuild(t, api.Database, database.WorkspaceTable{
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        owner.UserID,

--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -44,7 +44,6 @@ func TestSupportBundle(t *testing.T) {
 	}
 
 	// Support bundle tests can share a single coderdtest instance.
-	setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 	var dc codersdk.DeploymentConfig
 	secretValue := uuid.NewString()
 	seedSecretDeploymentOptions(t, &dc, secretValue)
@@ -60,6 +59,7 @@ func TestSupportBundle(t *testing.T) {
 	// Wait for healthcheck to complete successfully before continuing with sub-tests.
 	// The result is cached so subsequent requests will be fast.
 	healthcheckDone := make(chan *healthsdk.HealthcheckReport)
+	setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 	go func() {
 		defer close(healthcheckDone)
 		hc, err := healthsdk.New(client).DebugHealth(setupCtx)

--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -73,18 +73,6 @@ func TestSupportBundle(t *testing.T) {
 		t.Fatal("healthcheck did not complete in time -- this may be a transient issue")
 	}
 
-	t.Run("NoPrivilege", func(t *testing.T) {
-		t.Parallel()
-		r := dbfake.WorkspaceBuild(t, api.Database, database.WorkspaceTable{
-			OrganizationID: owner.OrganizationID,
-			OwnerID:        member.ID,
-		}).Do()
-		inv, root := clitest.New(t, "support", "bundle", r.Workspace.Name, "--yes")
-		clitest.SetupConfig(t, memberClient, root)
-		err := inv.Run()
-		require.ErrorContains(t, err, "failed authorization check")
-	})
-
 	t.Run("WorkspaceWithAgent", func(t *testing.T) {
 		t.Parallel()
 		r := dbfake.WorkspaceBuild(t, api.Database, database.WorkspaceTable{
@@ -168,6 +156,18 @@ func TestSupportBundle(t *testing.T) {
 		err := inv.Run()
 		require.NoError(t, err)
 		assertBundleContents(t, path, true, false, []string{secretValue})
+	})
+
+	t.Run("NoPrivilege", func(t *testing.T) {
+		t.Parallel()
+		r := dbfake.WorkspaceBuild(t, api.Database, database.WorkspaceTable{
+			OrganizationID: owner.OrganizationID,
+			OwnerID:        member.ID,
+		}).Do()
+		inv, root := clitest.New(t, "support", "bundle", r.Workspace.Name, "--yes")
+		clitest.SetupConfig(t, memberClient, root)
+		err := inv.Run()
+		require.ErrorContains(t, err, "failed authorization check")
 	})
 
 	// This ensures that the CLI does not panic when trying to generate a support bundle


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/272

This test periodically fails due to the healthcheck timing out.
The problem is compounded due to the fact that we stand up a new coderdtest instance for each test.

This PR does the following:
* Updates the subtests to share a single `coderdtest` instance.
* Hits the `/debug/health` endpoint before completing the setup phase so that the result is cached.

This will not completely remove the issue, as the healthcheck could still fail due to test-infrastructure-related issues. In this case we may decide to add a retry in this 'seed' function.