### PR TITLE
Fix: enable tag preview caching for prebuilds

### DIFF
--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -728,6 +728,10 @@ workspace_prebuilds:
   # limit; disabled when set to zero.
   # (default: 3, type: int)
   failure_hard_limit: 3
+  # Enable caching of preview tag computations for prebuilds. Reduces CPU usage but
+  # may cache dynamic tag values.
+  # (default: false, type: bool)
+  tag_cache_enabled: false
 aibridge:
   # Whether to start an in-memory aibridged instance.
   # (default: false, type: bool)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16722,6 +16722,10 @@ const docTemplate = `{
                 "reconciliation_interval": {
                     "description": "ReconciliationInterval defines how often the workspace prebuilds state should be reconciled.",
                     "type": "integer"
+                },
+                "tag_cache_enabled": {
+                    "description": "TagCacheEnabled enables caching of preview tag computations for prebuilds.\nThis reduces CPU usage during prebuild reconciliation but is disabled by default\nas tag expressions may contain dynamic elements.",
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15226,6 +15226,10 @@
 				"reconciliation_interval": {
 					"description": "ReconciliationInterval defines how often the workspace prebuilds state should be reconciled.",
 					"type": "integer"
+				},
+				"tag_cache_enabled": {
+					"description": "TagCacheEnabled enables caching of preview tag computations for prebuilds.\nThis reduces CPU usage during prebuild reconciliation but is disabled by default\nas tag expressions may contain dynamic elements.",
+					"type": "boolean"
 				}
 			}
 		},

--- a/coderd/dynamicparameters/cache.go
+++ b/coderd/dynamicparameters/cache.go
@@ -1,0 +1,81 @@
+package dynamicparameters
+
+import (
+	"crypto/sha256"
+	"sort"
+	"time"
+
+	"github.com/ammario/tlru"
+	"github.com/google/uuid"
+
+	"github.com/coder/preview"
+)
+
+// PreviewCacheKey uniquely identifies a preview.Preview call's inputs.
+// TemplateVersionID determines PlanJSON, TFVars, and templateFS.
+// OwnerID determines the Owner struct.
+// ValuesHash captures the ParameterValues map.
+type PreviewCacheKey struct {
+	TemplateVersionID uuid.UUID
+	OwnerID           uuid.UUID
+	ValuesHash        [32]byte
+}
+
+// PreviewCache caches preview.Output results to avoid redundant computation.
+// This is particularly beneficial for prebuilds where inputs are deterministic
+// per preset.
+type PreviewCache struct {
+	cache *tlru.Cache[PreviewCacheKey, *preview.Output]
+}
+
+// DefaultPreviewCacheSize is the default number of entries in the cache.
+// This is generous for workspace builds since outputs are relatively small.
+const DefaultPreviewCacheSize = 64 * 1024
+
+// DefaultPreviewCacheTTL is how long cache entries are valid.
+// Template versions don't change frequently, so 5 minutes is reasonable.
+const DefaultPreviewCacheTTL = 5 * time.Minute
+
+// NewPreviewCache creates a new preview output cache.
+func NewPreviewCache() *PreviewCache {
+	return &PreviewCache{
+		cache: tlru.New[PreviewCacheKey](tlru.ConstantCost[*preview.Output], DefaultPreviewCacheSize),
+	}
+}
+
+// Get retrieves a cached preview output if it exists and is still valid.
+func (c *PreviewCache) Get(key PreviewCacheKey) (*preview.Output, bool) {
+	output, _, ok := c.cache.Get(key)
+	return output, ok
+}
+
+// Set stores a preview output in the cache with the default TTL.
+func (c *PreviewCache) Set(key PreviewCacheKey, output *preview.Output) {
+	c.cache.Set(key, output, DefaultPreviewCacheTTL)
+}
+
+// HashParameterValues creates a deterministic hash of the parameter values map.
+// The keys are sorted to ensure consistent hashing regardless of map iteration order.
+func HashParameterValues(values map[string]string) [32]byte {
+	// Sort keys for deterministic ordering
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		// Write key, separator, value, separator
+		// Using null bytes as separators to avoid collisions.
+		// sha256.Write never returns an error, so we ignore the return values.
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(values[k]))
+		_, _ = h.Write([]byte{0})
+	}
+
+	var result [32]byte
+	copy(result[:], h.Sum(nil))
+	return result
+}

--- a/coderd/dynamicparameters/cache_test.go
+++ b/coderd/dynamicparameters/cache_test.go
@@ -1,0 +1,158 @@
+package dynamicparameters_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/dynamicparameters"
+	"github.com/coder/preview"
+)
+
+func TestHashParameterValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		t.Parallel()
+		hash1 := dynamicparameters.HashParameterValues(map[string]string{})
+		hash2 := dynamicparameters.HashParameterValues(map[string]string{})
+		require.Equal(t, hash1, hash2, "empty maps should have the same hash")
+	})
+
+	t.Run("SameValuesDifferentOrder", func(t *testing.T) {
+		t.Parallel()
+		// Go maps iterate in random order, but the hash should be deterministic
+		values := map[string]string{
+			"param1": "value1",
+			"param2": "value2",
+			"param3": "value3",
+		}
+		hash1 := dynamicparameters.HashParameterValues(values)
+		hash2 := dynamicparameters.HashParameterValues(values)
+		require.Equal(t, hash1, hash2, "same values should produce the same hash")
+	})
+
+	t.Run("DifferentValues", func(t *testing.T) {
+		t.Parallel()
+		hash1 := dynamicparameters.HashParameterValues(map[string]string{"param1": "value1"})
+		hash2 := dynamicparameters.HashParameterValues(map[string]string{"param1": "value2"})
+		require.NotEqual(t, hash1, hash2, "different values should produce different hashes")
+	})
+
+	t.Run("DifferentKeys", func(t *testing.T) {
+		t.Parallel()
+		hash1 := dynamicparameters.HashParameterValues(map[string]string{"param1": "value"})
+		hash2 := dynamicparameters.HashParameterValues(map[string]string{"param2": "value"})
+		require.NotEqual(t, hash1, hash2, "different keys should produce different hashes")
+	})
+
+	t.Run("NoCollisionBetweenKeyAndValue", func(t *testing.T) {
+		t.Parallel()
+		// Ensure "key=a, value=b" doesn't hash the same as "key=ab, value="
+		hash1 := dynamicparameters.HashParameterValues(map[string]string{"a": "b"})
+		hash2 := dynamicparameters.HashParameterValues(map[string]string{"ab": ""})
+		require.NotEqual(t, hash1, hash2, "key/value boundaries should not cause collisions")
+	})
+}
+
+func TestPreviewCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetMiss", func(t *testing.T) {
+		t.Parallel()
+		cache := dynamicparameters.NewPreviewCache()
+		key := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: uuid.New(),
+			OwnerID:           uuid.New(),
+			ValuesHash:        dynamicparameters.HashParameterValues(map[string]string{}),
+		}
+		_, ok := cache.Get(key)
+		require.False(t, ok, "cache should miss on first access")
+	})
+
+	t.Run("SetAndGet", func(t *testing.T) {
+		t.Parallel()
+		cache := dynamicparameters.NewPreviewCache()
+		key := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: uuid.New(),
+			OwnerID:           uuid.New(),
+			ValuesHash:        dynamicparameters.HashParameterValues(map[string]string{"param": "value"}),
+		}
+		output := &preview.Output{}
+		cache.Set(key, output)
+
+		cached, ok := cache.Get(key)
+		require.True(t, ok, "cache should hit after set")
+		require.Same(t, output, cached, "cached value should be the same pointer")
+	})
+
+	t.Run("DifferentKeysMiss", func(t *testing.T) {
+		t.Parallel()
+		cache := dynamicparameters.NewPreviewCache()
+		key1 := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: uuid.New(),
+			OwnerID:           uuid.New(),
+			ValuesHash:        dynamicparameters.HashParameterValues(map[string]string{"param": "value1"}),
+		}
+		key2 := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: key1.TemplateVersionID,
+			OwnerID:           key1.OwnerID,
+			ValuesHash:        dynamicparameters.HashParameterValues(map[string]string{"param": "value2"}),
+		}
+
+		output := &preview.Output{}
+		cache.Set(key1, output)
+
+		_, ok := cache.Get(key2)
+		require.False(t, ok, "different keys should not hit")
+	})
+
+	t.Run("DifferentTemplateVersionMiss", func(t *testing.T) {
+		t.Parallel()
+		cache := dynamicparameters.NewPreviewCache()
+		valuesHash := dynamicparameters.HashParameterValues(map[string]string{"param": "value"})
+		ownerID := uuid.New()
+
+		key1 := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: uuid.New(),
+			OwnerID:           ownerID,
+			ValuesHash:        valuesHash,
+		}
+		key2 := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: uuid.New(), // Different template version
+			OwnerID:           ownerID,
+			ValuesHash:        valuesHash,
+		}
+
+		output := &preview.Output{}
+		cache.Set(key1, output)
+
+		_, ok := cache.Get(key2)
+		require.False(t, ok, "different template versions should not hit")
+	})
+
+	t.Run("DifferentOwnerMiss", func(t *testing.T) {
+		t.Parallel()
+		cache := dynamicparameters.NewPreviewCache()
+		valuesHash := dynamicparameters.HashParameterValues(map[string]string{"param": "value"})
+		templateVersionID := uuid.New()
+
+		key1 := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: templateVersionID,
+			OwnerID:           uuid.New(),
+			ValuesHash:        valuesHash,
+		}
+		key2 := dynamicparameters.PreviewCacheKey{
+			TemplateVersionID: templateVersionID,
+			OwnerID:           uuid.New(), // Different owner
+			ValuesHash:        valuesHash,
+		}
+
+		output := &preview.Output{}
+		cache.Set(key1, output)
+
+		_, ok := cache.Get(key2)
+		require.False(t, ok, "different owners should not hit")
+	})
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -970,6 +970,11 @@ type PrebuildsConfig struct {
 	// no new prebuilds will be created until the limit is reset.
 	// FailureHardLimit is disabled when set to zero.
 	FailureHardLimit serpent.Int64 `json:"failure_hard_limit" typescript:"failure_hard_limit"`
+
+	// TagCacheEnabled enables caching of preview tag computations for prebuilds.
+	// This reduces CPU usage during prebuild reconciliation but is disabled by default
+	// as tag expressions may contain dynamic elements.
+	TagCacheEnabled serpent.Bool `json:"tag_cache_enabled" typescript:",notnull"`
 }
 
 const (
@@ -3301,6 +3306,17 @@ Write out the current server config as YAML to stdout.`,
 			Default:     "3",
 			Group:       &deploymentGroupPrebuilds,
 			YAML:        "failure_hard_limit",
+			Hidden:      true,
+		},
+		{
+			Name:        "Tag Cache Enabled",
+			Description: "Enable caching of preview tag computations for prebuilds. Reduces CPU usage but may cache dynamic tag values.",
+			Flag:        "workspace-prebuilds-tag-cache-enabled",
+			Env:         "CODER_WORKSPACE_PREBUILDS_TAG_CACHE_ENABLED",
+			Value:       &c.Prebuilds.TagCacheEnabled,
+			Default:     "false",
+			Group:       &deploymentGroupPrebuilds,
+			YAML:        "tag_cache_enabled",
 			Hidden:      true,
 		},
 		{

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -576,7 +576,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "failure_hard_limit": 0,
       "reconciliation_backoff_interval": 0,
       "reconciliation_backoff_lookback": 0,
-      "reconciliation_interval": 0
+      "reconciliation_interval": 0,
+      "tag_cache_enabled": true
     },
     "write_config": true
   },

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3036,7 +3036,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "failure_hard_limit": 0,
       "reconciliation_backoff_interval": 0,
       "reconciliation_backoff_lookback": 0,
-      "reconciliation_interval": 0
+      "reconciliation_interval": 0,
+      "tag_cache_enabled": true
     },
     "write_config": true
   },
@@ -3575,7 +3576,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "failure_hard_limit": 0,
     "reconciliation_backoff_interval": 0,
     "reconciliation_backoff_lookback": 0,
-    "reconciliation_interval": 0
+    "reconciliation_interval": 0,
+    "tag_cache_enabled": true
   },
   "write_config": true
 }
@@ -6132,7 +6134,8 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   "failure_hard_limit": 0,
   "reconciliation_backoff_interval": 0,
   "reconciliation_backoff_lookback": 0,
-  "reconciliation_interval": 0
+  "reconciliation_interval": 0,
+  "tag_cache_enabled": true
 }
 ```
 
@@ -6144,6 +6147,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `reconciliation_backoff_interval` | integer | false    |              | Reconciliation backoff interval specifies the amount of time to increase the backoff interval when errors occur during reconciliation.                                                                                                                                                            |
 | `reconciliation_backoff_lookback` | integer | false    |              | Reconciliation backoff lookback determines the time window to look back when calculating the number of failed prebuilds, which influences the backoff strategy.                                                                                                                                   |
 | `reconciliation_interval`         | integer | false    |              | Reconciliation interval defines how often the workspace prebuilds state should be reconciled.                                                                                                                                                                                                     |
+| `tag_cache_enabled`               | boolean | false    |              | Tag cache enabled enables caching of preview tag computations for prebuilds. This reduces CPU usage during prebuild reconciliation but is disabled by default as tag expressions may contain dynamic elements.                                                                                    |
 
 ## codersdk.PrebuildsSettings
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3481,6 +3481,12 @@ export interface PrebuildsConfig {
 	 * FailureHardLimit is disabled when set to zero.
 	 */
 	readonly failure_hard_limit: number;
+	/**
+	 * TagCacheEnabled enables caching of preview tag computations for prebuilds.
+	 * This reduces CPU usage during prebuild reconciliation but is disabled by default
+	 * as tag expressions may contain dynamic elements.
+	 */
+	readonly tag_cache_enabled: boolean;
 }
 
 // From codersdk/prebuilds.go


### PR DESCRIPTION
The following is an LLM written proof of concept. It is not ready to merge and it meant to start a discussion:

Prebuilt workspaces as a feature have a measurable impact on two key resources.

CPU time:

Database connection contention:

These two footprints are coupled by the interaction between the following two root causes:
* `preview.Preview` takes a relatively long time (see the CPU profile linked above)
* `prebuilds.ReconcileAll` maintains a database connection for the duration of its run, which includes several calls to preview.Preview.

The prebuild reconciliation loop further acquires short-lived database connections from a limited pool, which further increases its database connection contention footprint.

Efforts to eliminate these root causes have proven unfeasible. We need preview to calculate tags in order to know which provisioners to run prebuild jobs on, and we need a transaction lock to avoid multiple prebuild reconciliation cycles running concurrently.

In search of a solution, we can realize that although tags for prebuilds are technically dynamic, they should be invariant over the tuple of (template_version, owner, parameters). We should therefore be able to cache preview output with a key based on these inputs.

At the cost of some cache memory overhead, we should be able to reduce the CPU time and memory footprint consumed by `preview.Preview` for prebuilds. This should then free up these resources to other parts of the Coderd system.