### PR TITLE
fix: update dogfood boundary and claude-code module versions

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -897,18 +897,17 @@ resource "coder_script" "boundary_config_setup" {
 }
 
 module "claude-code" {
-  count                        = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
-  source                       = "dev.registry.coder.com/coder/claude-code/coder"
-  version                      = "4.2.8"
-  enable_boundary              = true
-  compile_boundary_from_source = true
-  boundary_version             = "960680fd4c9a7faf6261880e36ba9f1c3bde323b"
-  agent_id                     = coder_agent.dev.id
-  workdir                      = local.repo_dir
-  claude_code_version          = "latest"
-  order                        = 999
-  claude_api_key               = data.coder_parameter.use_ai_bridge.value ? data.coder_workspace_owner.me.session_token : var.anthropic_api_key
-  agentapi_version             = "latest"
+  count               = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
+  source              = "dev.registry.coder.com/coder/claude-code/coder"
+  version             = "4.2.8"
+  enable_boundary     = true
+  boundary_version    = "v0.5.0"
+  agent_id            = coder_agent.dev.id
+  workdir             = local.repo_dir
+  claude_code_version = "latest"
+  order               = 999
+  claude_api_key      = data.coder_parameter.use_ai_bridge.value ? data.coder_workspace_owner.me.session_token : var.anthropic_api_key
+  agentapi_version    = "latest"
 
   system_prompt       = local.claude_system_prompt
   ai_prompt           = data.coder_task.me.prompt

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -899,7 +899,7 @@ resource "coder_script" "boundary_config_setup" {
 module "claude-code" {
   count               = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "4.2.8"
+  version             = "4.2.9"
   enable_boundary     = true
   boundary_version    = "v0.5.0"
   agent_id            = coder_agent.dev.id


### PR DESCRIPTION
Using the compile_boundary_from_source option resulted in a ~45sec compilation time, which then hit agentapi-wait-for-start.sh's timeout. Move back to just using a release tag instead to avoid hitting this timeout.

Also bump the claude-code module version to pick up changes from https://github.com/coder/registry/pull/637