### PR TITLE
docs: fix boundary log proto docs

### DIFF
--- a/agent/proto/agent.pb.go
+++ b/agent/proto/agent.pb.go
@@ -4538,8 +4538,9 @@ type BoundaryLog_HttpRequest struct {
 
 	Method string `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`
 	Url    string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
-	// The rule that resulted in this HTTP request not being allowed.
-	// Only populated when allowed = false.
+	// The rule that resulted in this HTTP request being allowed. Only populated
+	// when allowed = true because boundary denies requests by default and
+	// requires rule(s) that allow requests.
 	MatchedRule string `protobuf:"bytes,3,opt,name=matched_rule,json=matchedRule,proto3" json:"matched_rule,omitempty"`
 }
 

--- a/agent/proto/agent.proto
+++ b/agent/proto/agent.proto
@@ -466,8 +466,9 @@ message BoundaryLog {
 	message HttpRequest {
 		string method = 1;
 		string url = 2;
-		// The rule that resulted in this HTTP request not being allowed.
-		// Only populated when allowed = false.
+		// The rule that resulted in this HTTP request being allowed. Only populated
+		// when allowed = true because boundary denies requests by default and
+		// requires rule(s) that allow requests.
 		string matched_rule = 3;
 	}
 


### PR DESCRIPTION
Simple docs fix to correctly reflect how boundary actually works in terms of allowing HTTP requests.