### PR TITLE
chore: add import formatting to make fmt/go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -464,7 +464,7 @@ ifdef FILE
 	# Format single file
 	if [[ -f "$(FILE)" ]] && [[ "$(FILE)" == *.go ]] && ! grep -q "DO NOT EDIT" "$(FILE)"; then \
 		echo "$(GREEN)==>$(RESET) $(BOLD)fmt/go$(RESET) $(FILE)"; \
-		go run mvdan.cc/gofumpt@v0.8.0 -w -l "$(FILE)"; \
+		./scripts/format_go_file.sh "$(FILE)"; \
 	fi
 else
 	go mod tidy
@@ -473,7 +473,7 @@ else
 	# https://github.com/mvdan/gofumpt#visual-studio-code
 	find . $(FIND_EXCLUSIONS) -type f -name '*.go' -print0 | \
 		xargs -0 grep -E --null -L '^// Code generated .* DO NOT EDIT\.$$' | \
-		xargs -0 go run mvdan.cc/gofumpt@v0.8.0 -w -l
+		xargs -0 ./scripts/format_go_file.sh
 endif
 .PHONY: fmt/go
 

--- a/agent/agentcontainers/dcspec/dcspec_gen.go
+++ b/agent/agentcontainers/dcspec/dcspec_gen.go
@@ -10,10 +10,9 @@ package dcspec
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 )
-
-import "encoding/json"
 
 func UnmarshalDevContainer(data []byte) (DevContainer, error) {
 	var r DevContainer

--- a/agent/agentcontainers/dcspec/gen.sh
+++ b/agent/agentcontainers/dcspec/gen.sh
@@ -61,7 +61,7 @@ fi
 exec 3>&-
 
 # Format the generated code.
-go run mvdan.cc/gofumpt@v0.8.0 -w -l "${TMPDIR}/${DEST_FILENAME}"
+"${PROJECT_ROOT}/scripts/format_go_file.sh" "${TMPDIR}/${DEST_FILENAME}"
 
 # Add a header so that Go recognizes this as a generated file.
 if grep -q -- "\[-i extension\]" < <(sed -h 2>&1); then

--- a/scripts/format_go_file.sh
+++ b/scripts/format_go_file.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script formats Go file(s) with our project-specific configuration.
+
+# Usage: format_go_file <file>...
+
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+	echo "Usage: $0 <file>..."
+	exit 1
+fi
+
+go run mvdan.cc/gofumpt@v0.8.0 -w -l "${@}"
+go run github.com/daixiang0/gci@v0.13.7 write -s standard -s default -s "Prefix(github.com/coder,cdr.dev/)" "${@}"


### PR DESCRIPTION
Modifies `make fmt/go` to also use https://github.com/daixiang0/gci to format our imports to a standard format.

It introduces a new shell script to do the formatting so that our formatting tools are in one place.