### PR TITLE
refactor: use SDK types as source of truth for OAuth2 operations

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -2628,7 +2628,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "code"
+                            "code",
+                            "token"
                         ],
                         "type": "string",
                         "description": "Response type",
@@ -2683,7 +2684,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "code"
+                            "code",
+                            "token"
                         ],
                         "type": "string",
                         "description": "Response type",
@@ -2914,7 +2916,10 @@ const docTemplate = `{
                     {
                         "enum": [
                             "authorization_code",
-                            "refresh_token"
+                            "refresh_token",
+                            "password",
+                            "client_credentials",
+                            "implicit"
                         ],
                         "type": "string",
                         "description": "Grant type",
@@ -16156,10 +16161,12 @@ const docTemplate = `{
         "codersdk.OAuth2PKCECodeChallengeMethod": {
             "type": "string",
             "enum": [
-                "S256"
+                "S256",
+                "plain"
             ],
             "x-enum-varnames": [
-                "OAuth2PKCECodeChallengeMethodS256"
+                "OAuth2PKCECodeChallengeMethodS256",
+                "OAuth2PKCECodeChallengeMethodPlain"
             ]
         },
         "codersdk.OAuth2ProtectedResourceMetadata": {
@@ -16245,20 +16252,28 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "authorization_code",
-                "refresh_token"
+                "refresh_token",
+                "password",
+                "client_credentials",
+                "implicit"
             ],
             "x-enum-varnames": [
                 "OAuth2ProviderGrantTypeAuthorizationCode",
-                "OAuth2ProviderGrantTypeRefreshToken"
+                "OAuth2ProviderGrantTypeRefreshToken",
+                "OAuth2ProviderGrantTypePassword",
+                "OAuth2ProviderGrantTypeClientCredentials",
+                "OAuth2ProviderGrantTypeImplicit"
             ]
         },
         "codersdk.OAuth2ProviderResponseType": {
             "type": "string",
             "enum": [
-                "code"
+                "code",
+                "token"
             ],
             "x-enum-varnames": [
-                "OAuth2ProviderResponseTypeCode"
+                "OAuth2ProviderResponseTypeCode",
+                "OAuth2ProviderResponseTypeToken"
             ]
         },
         "codersdk.OAuth2TokenEndpointAuthMethod": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15844,13 +15844,13 @@ const docTemplate = `{
                 "code_challenge_methods_supported": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2PKCECodeChallengeMethod"
                     }
                 },
                 "grant_types_supported": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
                     }
                 },
                 "issuer": {
@@ -15862,7 +15862,7 @@ const docTemplate = `{
                 "response_types_supported": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
                     }
                 },
                 "revocation_endpoint": {
@@ -15880,7 +15880,7 @@ const docTemplate = `{
                 "token_endpoint_auth_methods_supported": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
                     }
                 }
             }
@@ -15912,7 +15912,7 @@ const docTemplate = `{
                 "grant_types": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
                     }
                 },
                 "jwks": {
@@ -15934,10 +15934,7 @@ const docTemplate = `{
                     }
                 },
                 "registration_access_token": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "string"
                 },
                 "registration_client_uri": {
                     "type": "string"
@@ -15945,7 +15942,7 @@ const docTemplate = `{
                 "response_types": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
                     }
                 },
                 "scope": {
@@ -15958,7 +15955,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "token_endpoint_auth_method": {
-                    "type": "string"
+                    "$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
                 },
                 "tos_uri": {
                     "type": "string"
@@ -15983,7 +15980,7 @@ const docTemplate = `{
                 "grant_types": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
                     }
                 },
                 "jwks": {
@@ -16007,7 +16004,7 @@ const docTemplate = `{
                 "response_types": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
                     }
                 },
                 "scope": {
@@ -16023,7 +16020,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "token_endpoint_auth_method": {
-                    "type": "string"
+                    "$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
                 },
                 "tos_uri": {
                     "type": "string"
@@ -16060,7 +16057,7 @@ const docTemplate = `{
                 "grant_types": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
                     }
                 },
                 "jwks": {
@@ -16090,7 +16087,7 @@ const docTemplate = `{
                 "response_types": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
                     }
                 },
                 "scope": {
@@ -16103,7 +16100,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "token_endpoint_auth_method": {
-                    "type": "string"
+                    "$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
                 },
                 "tos_uri": {
                     "type": "string"
@@ -16155,6 +16152,15 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "codersdk.OAuth2PKCECodeChallengeMethod": {
+            "type": "string",
+            "enum": [
+                "S256"
+            ],
+            "x-enum-varnames": [
+                "OAuth2PKCECodeChallengeMethodS256"
+            ]
         },
         "codersdk.OAuth2ProtectedResourceMetadata": {
             "type": "object",
@@ -16234,6 +16240,39 @@ const docTemplate = `{
                     "format": "uuid"
                 }
             }
+        },
+        "codersdk.OAuth2ProviderGrantType": {
+            "type": "string",
+            "enum": [
+                "authorization_code",
+                "refresh_token"
+            ],
+            "x-enum-varnames": [
+                "OAuth2ProviderGrantTypeAuthorizationCode",
+                "OAuth2ProviderGrantTypeRefreshToken"
+            ]
+        },
+        "codersdk.OAuth2ProviderResponseType": {
+            "type": "string",
+            "enum": [
+                "code"
+            ],
+            "x-enum-varnames": [
+                "OAuth2ProviderResponseTypeCode"
+            ]
+        },
+        "codersdk.OAuth2TokenEndpointAuthMethod": {
+            "type": "string",
+            "enum": [
+                "client_secret_basic",
+                "client_secret_post",
+                "none"
+            ],
+            "x-enum-varnames": [
+                "OAuth2TokenEndpointAuthMethodClientSecretBasic",
+                "OAuth2TokenEndpointAuthMethodClientSecretPost",
+                "OAuth2TokenEndpointAuthMethodNone"
+            ]
         },
         "codersdk.OAuthConversionResponse": {
             "type": "object",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -2304,7 +2304,7 @@
 						"required": true
 					},
 					{
-						"enum": ["code"],
+						"enum": ["code", "token"],
 						"type": "string",
 						"description": "Response type",
 						"name": "response_type",
@@ -2355,7 +2355,7 @@
 						"required": true
 					},
 					{
-						"enum": ["code"],
+						"enum": ["code", "token"],
 						"type": "string",
 						"description": "Response type",
 						"name": "response_type",
@@ -2555,7 +2555,13 @@
 						"in": "formData"
 					},
 					{
-						"enum": ["authorization_code", "refresh_token"],
+						"enum": [
+							"authorization_code",
+							"refresh_token",
+							"password",
+							"client_credentials",
+							"implicit"
+						],
 						"type": "string",
 						"description": "Grant type",
 						"name": "grant_type",
@@ -14664,8 +14670,11 @@
 		},
 		"codersdk.OAuth2PKCECodeChallengeMethod": {
 			"type": "string",
-			"enum": ["S256"],
-			"x-enum-varnames": ["OAuth2PKCECodeChallengeMethodS256"]
+			"enum": ["S256", "plain"],
+			"x-enum-varnames": [
+				"OAuth2PKCECodeChallengeMethodS256",
+				"OAuth2PKCECodeChallengeMethodPlain"
+			]
 		},
 		"codersdk.OAuth2ProtectedResourceMetadata": {
 			"type": "object",
@@ -14748,16 +14757,28 @@
 		},
 		"codersdk.OAuth2ProviderGrantType": {
 			"type": "string",
-			"enum": ["authorization_code", "refresh_token"],
+			"enum": [
+				"authorization_code",
+				"refresh_token",
+				"password",
+				"client_credentials",
+				"implicit"
+			],
 			"x-enum-varnames": [
 				"OAuth2ProviderGrantTypeAuthorizationCode",
-				"OAuth2ProviderGrantTypeRefreshToken"
+				"OAuth2ProviderGrantTypeRefreshToken",
+				"OAuth2ProviderGrantTypePassword",
+				"OAuth2ProviderGrantTypeClientCredentials",
+				"OAuth2ProviderGrantTypeImplicit"
 			]
 		},
 		"codersdk.OAuth2ProviderResponseType": {
 			"type": "string",
-			"enum": ["code"],
-			"x-enum-varnames": ["OAuth2ProviderResponseTypeCode"]
+			"enum": ["code", "token"],
+			"x-enum-varnames": [
+				"OAuth2ProviderResponseTypeCode",
+				"OAuth2ProviderResponseTypeToken"
+			]
 		},
 		"codersdk.OAuth2TokenEndpointAuthMethod": {
 			"type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14353,13 +14353,13 @@
 				"code_challenge_methods_supported": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2PKCECodeChallengeMethod"
 					}
 				},
 				"grant_types_supported": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
 					}
 				},
 				"issuer": {
@@ -14371,7 +14371,7 @@
 				"response_types_supported": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
 					}
 				},
 				"revocation_endpoint": {
@@ -14389,7 +14389,7 @@
 				"token_endpoint_auth_methods_supported": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
 					}
 				}
 			}
@@ -14421,7 +14421,7 @@
 				"grant_types": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
 					}
 				},
 				"jwks": {
@@ -14443,10 +14443,7 @@
 					}
 				},
 				"registration_access_token": {
-					"type": "array",
-					"items": {
-						"type": "integer"
-					}
+					"type": "string"
 				},
 				"registration_client_uri": {
 					"type": "string"
@@ -14454,7 +14451,7 @@
 				"response_types": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
 					}
 				},
 				"scope": {
@@ -14467,7 +14464,7 @@
 					"type": "string"
 				},
 				"token_endpoint_auth_method": {
-					"type": "string"
+					"$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
 				},
 				"tos_uri": {
 					"type": "string"
@@ -14492,7 +14489,7 @@
 				"grant_types": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
 					}
 				},
 				"jwks": {
@@ -14516,7 +14513,7 @@
 				"response_types": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
 					}
 				},
 				"scope": {
@@ -14532,7 +14529,7 @@
 					"type": "string"
 				},
 				"token_endpoint_auth_method": {
-					"type": "string"
+					"$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
 				},
 				"tos_uri": {
 					"type": "string"
@@ -14569,7 +14566,7 @@
 				"grant_types": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderGrantType"
 					}
 				},
 				"jwks": {
@@ -14599,7 +14596,7 @@
 				"response_types": {
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "#/definitions/codersdk.OAuth2ProviderResponseType"
 					}
 				},
 				"scope": {
@@ -14612,7 +14609,7 @@
 					"type": "string"
 				},
 				"token_endpoint_auth_method": {
-					"type": "string"
+					"$ref": "#/definitions/codersdk.OAuth2TokenEndpointAuthMethod"
 				},
 				"tos_uri": {
 					"type": "string"
@@ -14664,6 +14661,11 @@
 					"type": "string"
 				}
 			}
+		},
+		"codersdk.OAuth2PKCECodeChallengeMethod": {
+			"type": "string",
+			"enum": ["S256"],
+			"x-enum-varnames": ["OAuth2PKCECodeChallengeMethodS256"]
 		},
 		"codersdk.OAuth2ProtectedResourceMetadata": {
 			"type": "object",
@@ -14743,6 +14745,28 @@
 					"format": "uuid"
 				}
 			}
+		},
+		"codersdk.OAuth2ProviderGrantType": {
+			"type": "string",
+			"enum": ["authorization_code", "refresh_token"],
+			"x-enum-varnames": [
+				"OAuth2ProviderGrantTypeAuthorizationCode",
+				"OAuth2ProviderGrantTypeRefreshToken"
+			]
+		},
+		"codersdk.OAuth2ProviderResponseType": {
+			"type": "string",
+			"enum": ["code"],
+			"x-enum-varnames": ["OAuth2ProviderResponseTypeCode"]
+		},
+		"codersdk.OAuth2TokenEndpointAuthMethod": {
+			"type": "string",
+			"enum": ["client_secret_basic", "client_secret_post", "none"],
+			"x-enum-varnames": [
+				"OAuth2TokenEndpointAuthMethodClientSecretBasic",
+				"OAuth2TokenEndpointAuthMethodClientSecretPost",
+				"OAuth2TokenEndpointAuthMethodNone"
+			]
 		},
 		"codersdk.OAuthConversionResponse": {
 			"type": "object",

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -493,16 +493,10 @@ func OneWayWebSocketEventSender(rw http.ResponseWriter, r *http.Request) (
 	return sendEvent, closed, nil
 }
 
-// OAuth2Error represents an OAuth2-compliant error response per RFC 6749.
-type OAuth2Error struct {
-	Error            string `json:"error"`
-	ErrorDescription string `json:"error_description,omitempty"`
-}
-
 // WriteOAuth2Error writes an OAuth2-compliant error response per RFC 6749.
 // This should be used for all OAuth2 endpoints (/oauth2/*) to ensure compliance.
-func WriteOAuth2Error(ctx context.Context, rw http.ResponseWriter, status int, errorCode, description string) {
-	Write(ctx, rw, status, OAuth2Error{
+func WriteOAuth2Error(ctx context.Context, rw http.ResponseWriter, status int, errorCode codersdk.OAuth2ErrorCode, description string) {
+	Write(ctx, rw, status, codersdk.OAuth2Error{
 		Error:            errorCode,
 		ErrorDescription: description,
 	})

--- a/coderd/httpmw/oauth2.go
+++ b/coderd/httpmw/oauth2.go
@@ -290,15 +290,15 @@ func (*codersdkErrorWriter) writeClientNotFound(ctx context.Context, rw http.Res
 type oauth2ErrorWriter struct{}
 
 func (*oauth2ErrorWriter) writeMissingClientID(ctx context.Context, rw http.ResponseWriter) {
-	httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, "invalid_request", "Missing client_id parameter")
+	httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, "Missing client_id parameter")
 }
 
 func (*oauth2ErrorWriter) writeInvalidClientID(ctx context.Context, rw http.ResponseWriter, _ error) {
-	httpapi.WriteOAuth2Error(ctx, rw, http.StatusUnauthorized, "invalid_client", "The client credentials are invalid")
+	httpapi.WriteOAuth2Error(ctx, rw, http.StatusUnauthorized, codersdk.OAuth2ErrorCodeInvalidClient, "The client credentials are invalid")
 }
 
 func (*oauth2ErrorWriter) writeClientNotFound(ctx context.Context, rw http.ResponseWriter) {
-	httpapi.WriteOAuth2Error(ctx, rw, http.StatusUnauthorized, "invalid_client", "The client credentials are invalid")
+	httpapi.WriteOAuth2Error(ctx, rw, http.StatusUnauthorized, codersdk.OAuth2ErrorCodeInvalidClient, "The client credentials are invalid")
 }
 
 // extractOAuth2ProviderAppBase is the internal implementation that uses the strategy pattern

--- a/coderd/oauth2_error_compliance_test.go
+++ b/coderd/oauth2_error_compliance_test.go
@@ -99,7 +99,7 @@ func TestOAuth2RegistrationErrorCodes(t *testing.T) {
 			req: codersdk.OAuth2ClientRegistrationRequest{
 				RedirectURIs: []string{"https://example.com/callback"},
 				ClientName:   fmt.Sprintf("test-client-%d", time.Now().UnixNano()),
-				GrantTypes:   []string{"unsupported_grant_type"},
+				GrantTypes:   []codersdk.OAuth2ProviderGrantType{"unsupported_grant_type"},
 			},
 			expectedError: "invalid_client_metadata",
 			expectedCode:  http.StatusBadRequest,
@@ -109,7 +109,7 @@ func TestOAuth2RegistrationErrorCodes(t *testing.T) {
 			req: codersdk.OAuth2ClientRegistrationRequest{
 				RedirectURIs:  []string{"https://example.com/callback"},
 				ClientName:    fmt.Sprintf("test-client-%d", time.Now().UnixNano()),
-				ResponseTypes: []string{"unsupported_response_type"},
+				ResponseTypes: []codersdk.OAuth2ProviderResponseType{"unsupported_response_type"},
 			},
 			expectedError: "invalid_client_metadata",
 			expectedCode:  http.StatusBadRequest,

--- a/coderd/oauth2_metadata_test.go
+++ b/coderd/oauth2_metadata_test.go
@@ -44,10 +44,10 @@ func TestOAuth2AuthorizationServerMetadata(t *testing.T) {
 	require.NotEmpty(t, metadata.Issuer)
 	require.NotEmpty(t, metadata.AuthorizationEndpoint)
 	require.NotEmpty(t, metadata.TokenEndpoint)
-	require.Contains(t, metadata.ResponseTypesSupported, "code")
-	require.Contains(t, metadata.GrantTypesSupported, "authorization_code")
-	require.Contains(t, metadata.GrantTypesSupported, "refresh_token")
-	require.Contains(t, metadata.CodeChallengeMethodsSupported, "S256")
+	require.Contains(t, metadata.ResponseTypesSupported, codersdk.OAuth2ProviderResponseTypeCode)
+	require.Contains(t, metadata.GrantTypesSupported, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
+	require.Contains(t, metadata.GrantTypesSupported, codersdk.OAuth2ProviderGrantTypeRefreshToken)
+	require.Contains(t, metadata.CodeChallengeMethodsSupported, codersdk.OAuth2PKCECodeChallengeMethodS256)
 	// Supported scopes are published from the curated catalog
 	require.Equal(t, rbac.ExternalScopeNames(), metadata.ScopesSupported)
 }

--- a/coderd/oauth2_metadata_validation_test.go
+++ b/coderd/oauth2_metadata_validation_test.go
@@ -659,14 +659,14 @@ func TestOAuth2ClientMetadataDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should default to authorization_code
-	require.Contains(t, config.GrantTypes, "authorization_code")
+	require.Contains(t, config.GrantTypes, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
 
 	// Should default to code
-	require.Contains(t, config.ResponseTypes, "code")
+	require.Contains(t, config.ResponseTypes, codersdk.OAuth2ProviderResponseTypeCode)
 
 	// Should default to client_secret_basic or client_secret_post
-	require.True(t, config.TokenEndpointAuthMethod == "client_secret_basic" ||
-		config.TokenEndpointAuthMethod == "client_secret_post" ||
+	require.True(t, config.TokenEndpointAuthMethod == codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic ||
+		config.TokenEndpointAuthMethod == codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost ||
 		config.TokenEndpointAuthMethod == "")
 
 	// Client secret should be generated

--- a/coderd/oauth2_metadata_validation_test.go
+++ b/coderd/oauth2_metadata_validation_test.go
@@ -277,47 +277,47 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 		tests := []struct {
 			name        string
-			grantTypes  []string
+			grantTypes  []codersdk.OAuth2ProviderGrantType
 			expectError bool
 		}{
 			{
 				name:        "DefaultEmpty",
-				grantTypes:  []string{},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{},
 				expectError: false,
 			},
 			{
 				name:        "ValidAuthorizationCode",
-				grantTypes:  []string{"authorization_code"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"authorization_code"},
 				expectError: false,
 			},
 			{
 				name:        "InvalidRefreshTokenAlone",
-				grantTypes:  []string{"refresh_token"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"refresh_token"},
 				expectError: true, // refresh_token requires authorization_code to be present
 			},
 			{
 				name:        "ValidMultiple",
-				grantTypes:  []string{"authorization_code", "refresh_token"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"authorization_code", "refresh_token"},
 				expectError: false,
 			},
 			{
 				name:        "InvalidUnsupported",
-				grantTypes:  []string{"client_credentials"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"client_credentials"},
 				expectError: true,
 			},
 			{
 				name:        "InvalidPassword",
-				grantTypes:  []string{"password"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"password"},
 				expectError: true,
 			},
 			{
 				name:        "InvalidImplicit",
-				grantTypes:  []string{"implicit"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"implicit"},
 				expectError: true,
 			},
 			{
 				name:        "MixedValidInvalid",
-				grantTypes:  []string{"authorization_code", "client_credentials"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"authorization_code", "client_credentials"},
 				expectError: true,
 			},
 		}
@@ -352,32 +352,32 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 		tests := []struct {
 			name          string
-			responseTypes []string
+			responseTypes []codersdk.OAuth2ProviderResponseType
 			expectError   bool
 		}{
 			{
 				name:          "DefaultEmpty",
-				responseTypes: []string{},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{},
 				expectError:   false,
 			},
 			{
 				name:          "ValidCode",
-				responseTypes: []string{"code"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"code"},
 				expectError:   false,
 			},
 			{
 				name:          "InvalidToken",
-				responseTypes: []string{"token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"token"},
 				expectError:   true,
 			},
 			{
 				name:          "InvalidImplicit",
-				responseTypes: []string{"id_token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"id_token"},
 				expectError:   true,
 			},
 			{
 				name:          "InvalidMultiple",
-				responseTypes: []string{"code", "token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"code", "token"},
 				expectError:   true,
 			},
 		}
@@ -412,7 +412,7 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 		tests := []struct {
 			name        string
-			authMethod  string
+			authMethod  codersdk.OAuth2TokenEndpointAuthMethod
 			expectError bool
 		}{
 			{

--- a/coderd/oauth2_test.go
+++ b/coderd/oauth2_test.go
@@ -1329,10 +1329,10 @@ func TestOAuth2DynamicClientRegistration(t *testing.T) {
 		require.Equal(t, int64(0), resp.ClientSecretExpiresAt) // Non-expiring
 
 		// Verify default values
-		require.Contains(t, resp.GrantTypes, "authorization_code")
-		require.Contains(t, resp.GrantTypes, "refresh_token")
-		require.Contains(t, resp.ResponseTypes, "code")
-		require.Equal(t, "client_secret_basic", resp.TokenEndpointAuthMethod)
+		require.Contains(t, resp.GrantTypes, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
+		require.Contains(t, resp.GrantTypes, codersdk.OAuth2ProviderGrantTypeRefreshToken)
+		require.Contains(t, resp.ResponseTypes, codersdk.OAuth2ProviderResponseTypeCode)
+		require.Equal(t, codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic, resp.TokenEndpointAuthMethod)
 
 		// Verify request values are preserved
 		require.Equal(t, req.RedirectURIs, resp.RedirectURIs)
@@ -1363,9 +1363,9 @@ func TestOAuth2DynamicClientRegistration(t *testing.T) {
 		require.NotEmpty(t, resp.RegistrationClientURI)
 
 		// Should have defaults applied
-		require.Contains(t, resp.GrantTypes, "authorization_code")
-		require.Contains(t, resp.ResponseTypes, "code")
-		require.Equal(t, "client_secret_basic", resp.TokenEndpointAuthMethod)
+		require.Contains(t, resp.GrantTypes, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
+		require.Contains(t, resp.ResponseTypes, codersdk.OAuth2ProviderResponseTypeCode)
+		require.Equal(t, codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic, resp.TokenEndpointAuthMethod)
 	})
 
 	t.Run("InvalidRedirectURI", func(t *testing.T) {

--- a/coderd/oauth2provider/authorize.go
+++ b/coderd/oauth2provider/authorize.go
@@ -151,10 +151,10 @@ func ProcessAuthorize(db database.Store) http.HandlerFunc {
 		if params.codeChallenge != "" {
 			// If code_challenge is provided but method is not, default to S256
 			if params.codeChallengeMethod == "" {
-				params.codeChallengeMethod = "S256"
+				params.codeChallengeMethod = string(codersdk.OAuth2PKCECodeChallengeMethodS256)
 			}
-			if params.codeChallengeMethod != "S256" {
-				httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, "Invalid code_challenge_method: only S256 is supported")
+			if err := codersdk.ValidatePKCECodeChallengeMethod(params.codeChallengeMethod); err != nil {
+				httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, err.Error())
 				return
 			}
 		}

--- a/coderd/oauth2provider/authorize.go
+++ b/coderd/oauth2provider/authorize.go
@@ -137,13 +137,13 @@ func ProcessAuthorize(db database.Store) http.HandlerFunc {
 
 		callbackURL, err := url.Parse(app.CallbackURL)
 		if err != nil {
-			httpapi.WriteOAuth2Error(r.Context(), rw, http.StatusInternalServerError, "server_error", "Failed to validate query parameters")
+			httpapi.WriteOAuth2Error(r.Context(), rw, http.StatusInternalServerError, codersdk.OAuth2ErrorCodeServerError, "Failed to validate query parameters")
 			return
 		}
 
 		params, _, err := extractAuthorizeParams(r, callbackURL)
 		if err != nil {
-			httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, "invalid_request", err.Error())
+			httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, err.Error())
 			return
 		}
 
@@ -154,7 +154,7 @@ func ProcessAuthorize(db database.Store) http.HandlerFunc {
 				params.codeChallengeMethod = "S256"
 			}
 			if params.codeChallengeMethod != "S256" {
-				httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, "invalid_request", "Invalid code_challenge_method: only S256 is supported")
+				httpapi.WriteOAuth2Error(ctx, rw, http.StatusBadRequest, codersdk.OAuth2ErrorCodeInvalidRequest, "Invalid code_challenge_method: only S256 is supported")
 				return
 			}
 		}
@@ -162,7 +162,7 @@ func ProcessAuthorize(db database.Store) http.HandlerFunc {
 		// TODO: Ignoring scope for now, but should look into implementing.
 		code, err := GenerateSecret()
 		if err != nil {
-			httpapi.WriteOAuth2Error(r.Context(), rw, http.StatusInternalServerError, "server_error", "Failed to generate OAuth2 app authorization code")
+			httpapi.WriteOAuth2Error(r.Context(), rw, http.StatusInternalServerError, codersdk.OAuth2ErrorCodeServerError, "Failed to generate OAuth2 app authorization code")
 			return
 		}
 		err = db.InTx(func(tx database.Store) error {
@@ -202,7 +202,7 @@ func ProcessAuthorize(db database.Store) http.HandlerFunc {
 			return nil
 		}, nil)
 		if err != nil {
-			httpapi.WriteOAuth2Error(ctx, rw, http.StatusInternalServerError, "server_error", "Failed to generate OAuth2 authorization code")
+			httpapi.WriteOAuth2Error(ctx, rw, http.StatusInternalServerError, codersdk.OAuth2ErrorCodeServerError, "Failed to generate OAuth2 authorization code")
 			return
 		}
 

--- a/coderd/oauth2provider/metadata.go
+++ b/coderd/oauth2provider/metadata.go
@@ -19,11 +19,11 @@ func GetAuthorizationServerMetadata(accessURL *url.URL) http.HandlerFunc {
 			TokenEndpoint:                     accessURL.JoinPath("/oauth2/tokens").String(),
 			RegistrationEndpoint:              accessURL.JoinPath("/oauth2/register").String(), // RFC 7591
 			RevocationEndpoint:                accessURL.JoinPath("/oauth2/revoke").String(),   // RFC 7009
-			ResponseTypesSupported:            []string{"code"},
-			GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
-			CodeChallengeMethodsSupported:     []string{"S256"},
+			ResponseTypesSupported:            []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode},
+			GrantTypesSupported:               []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeRefreshToken},
+			CodeChallengeMethodsSupported:     []codersdk.OAuth2PKCECodeChallengeMethod{codersdk.OAuth2PKCECodeChallengeMethodS256},
 			ScopesSupported:                   rbac.ExternalScopeNames(),
-			TokenEndpointAuthMethodsSupported: []string{"client_secret_post"},
+			TokenEndpointAuthMethodsSupported: []codersdk.OAuth2TokenEndpointAuthMethod{codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost},
 		}
 		httpapi.Write(ctx, rw, http.StatusOK, metadata)
 	}

--- a/coderd/oauth2provider/metadata_test.go
+++ b/coderd/oauth2provider/metadata_test.go
@@ -32,10 +32,10 @@ func TestOAuth2AuthorizationServerMetadata(t *testing.T) {
 	require.NotEmpty(t, metadata.Issuer)
 	require.NotEmpty(t, metadata.AuthorizationEndpoint)
 	require.NotEmpty(t, metadata.TokenEndpoint)
-	require.Contains(t, metadata.ResponseTypesSupported, "code")
-	require.Contains(t, metadata.GrantTypesSupported, "authorization_code")
-	require.Contains(t, metadata.GrantTypesSupported, "refresh_token")
-	require.Contains(t, metadata.CodeChallengeMethodsSupported, "S256")
+	require.Contains(t, metadata.ResponseTypesSupported, codersdk.OAuth2ProviderResponseTypeCode)
+	require.Contains(t, metadata.GrantTypesSupported, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
+	require.Contains(t, metadata.GrantTypesSupported, codersdk.OAuth2ProviderGrantTypeRefreshToken)
+	require.Contains(t, metadata.CodeChallengeMethodsSupported, codersdk.OAuth2PKCECodeChallengeMethodS256)
 	// Supported scopes are published from the curated catalog
 	require.Equal(t, rbac.ExternalScopeNames(), metadata.ScopesSupported)
 }

--- a/coderd/oauth2provider/provider_test.go
+++ b/coderd/oauth2provider/provider_test.go
@@ -248,7 +248,7 @@ func TestOAuth2ClientRegistrationValidation(t *testing.T) {
 		req := codersdk.OAuth2ClientRegistrationRequest{
 			RedirectURIs: []string{"https://example.com/callback"},
 			ClientName:   fmt.Sprintf("valid-grant-types-client-%d", time.Now().UnixNano()),
-			GrantTypes:   []string{"authorization_code", "refresh_token"},
+			GrantTypes:   []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeRefreshToken},
 		}
 
 		resp, err := client.PostOAuth2ClientRegistration(ctx, req)
@@ -266,7 +266,7 @@ func TestOAuth2ClientRegistrationValidation(t *testing.T) {
 		req := codersdk.OAuth2ClientRegistrationRequest{
 			RedirectURIs: []string{"https://example.com/callback"},
 			ClientName:   fmt.Sprintf("invalid-grant-types-client-%d", time.Now().UnixNano()),
-			GrantTypes:   []string{"unsupported_grant"},
+			GrantTypes:   []codersdk.OAuth2ProviderGrantType{"unsupported_grant"},
 		}
 
 		_, err := client.PostOAuth2ClientRegistration(ctx, req)
@@ -284,7 +284,7 @@ func TestOAuth2ClientRegistrationValidation(t *testing.T) {
 		req := codersdk.OAuth2ClientRegistrationRequest{
 			RedirectURIs:  []string{"https://example.com/callback"},
 			ClientName:    fmt.Sprintf("valid-response-types-client-%d", time.Now().UnixNano()),
-			ResponseTypes: []string{"code"},
+			ResponseTypes: []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode},
 		}
 
 		resp, err := client.PostOAuth2ClientRegistration(ctx, req)
@@ -302,7 +302,7 @@ func TestOAuth2ClientRegistrationValidation(t *testing.T) {
 		req := codersdk.OAuth2ClientRegistrationRequest{
 			RedirectURIs:  []string{"https://example.com/callback"},
 			ClientName:    fmt.Sprintf("invalid-response-types-client-%d", time.Now().UnixNano()),
-			ResponseTypes: []string{"token"}, // Not supported
+			ResponseTypes: []codersdk.OAuth2ProviderResponseType{"token"}, // Not supported
 		}
 
 		_, err := client.PostOAuth2ClientRegistration(ctx, req)

--- a/coderd/oauth2provider/registration.go
+++ b/coderd/oauth2provider/registration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -85,8 +86,8 @@ func CreateDynamicClientRegistration(db database.Store, accessURL *url.URL, audi
 			DynamicallyRegistered:   sql.NullBool{Bool: true, Valid: true},
 			ClientIDIssuedAt:        sql.NullTime{Time: now, Valid: true},
 			ClientSecretExpiresAt:   sql.NullTime{}, // No expiration for now
-			GrantTypes:              enumSliceToStrings(req.GrantTypes),
-			ResponseTypes:           enumSliceToStrings(req.ResponseTypes),
+			GrantTypes:              slice.ToStrings(req.GrantTypes),
+			ResponseTypes:           slice.ToStrings(req.ResponseTypes),
 			TokenEndpointAuthMethod: sql.NullString{String: string(req.TokenEndpointAuthMethod), Valid: true},
 			Scope:                   sql.NullString{String: req.Scope, Valid: true},
 			Contacts:                req.Contacts,
@@ -154,8 +155,8 @@ func CreateDynamicClientRegistration(db database.Store, accessURL *url.URL, audi
 			JWKS:                    app.Jwks.RawMessage,
 			SoftwareID:              app.SoftwareID.String,
 			SoftwareVersion:         app.SoftwareVersion.String,
-			GrantTypes:              stringsToEnumSlice[codersdk.OAuth2ProviderGrantType](app.GrantTypes),
-			ResponseTypes:           stringsToEnumSlice[codersdk.OAuth2ProviderResponseType](app.ResponseTypes),
+			GrantTypes:              slice.StringEnums[codersdk.OAuth2ProviderGrantType](app.GrantTypes),
+			ResponseTypes:           slice.StringEnums[codersdk.OAuth2ProviderResponseType](app.ResponseTypes),
 			TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethod(app.TokenEndpointAuthMethod.String),
 			Scope:                   app.Scope.String,
 			Contacts:                app.Contacts,
@@ -217,8 +218,8 @@ func GetClientConfiguration(db database.Store) http.HandlerFunc {
 			JWKS:                    app.Jwks.RawMessage,
 			SoftwareID:              app.SoftwareID.String,
 			SoftwareVersion:         app.SoftwareVersion.String,
-			GrantTypes:              stringsToEnumSlice[codersdk.OAuth2ProviderGrantType](app.GrantTypes),
-			ResponseTypes:           stringsToEnumSlice[codersdk.OAuth2ProviderResponseType](app.ResponseTypes),
+			GrantTypes:              slice.StringEnums[codersdk.OAuth2ProviderGrantType](app.GrantTypes),
+			ResponseTypes:           slice.StringEnums[codersdk.OAuth2ProviderResponseType](app.ResponseTypes),
 			TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethod(app.TokenEndpointAuthMethod.String),
 			Scope:                   app.Scope.String,
 			Contacts:                app.Contacts,
@@ -303,8 +304,8 @@ func UpdateClientConfiguration(db database.Store, auditor *audit.Auditor, logger
 			RedirectUris:            req.RedirectURIs,
 			ClientType:              sql.NullString{String: req.DetermineClientType(), Valid: true},
 			ClientSecretExpiresAt:   sql.NullTime{}, // No expiration for now
-			GrantTypes:              enumSliceToStrings(req.GrantTypes),
-			ResponseTypes:           enumSliceToStrings(req.ResponseTypes),
+			GrantTypes:              slice.ToStrings(req.GrantTypes),
+			ResponseTypes:           slice.ToStrings(req.ResponseTypes),
 			TokenEndpointAuthMethod: sql.NullString{String: string(req.TokenEndpointAuthMethod), Valid: true},
 			Scope:                   sql.NullString{String: req.Scope, Valid: true},
 			Contacts:                req.Contacts,
@@ -341,8 +342,8 @@ func UpdateClientConfiguration(db database.Store, auditor *audit.Auditor, logger
 			JWKS:                    updatedApp.Jwks.RawMessage,
 			SoftwareID:              updatedApp.SoftwareID.String,
 			SoftwareVersion:         updatedApp.SoftwareVersion.String,
-			GrantTypes:              stringsToEnumSlice[codersdk.OAuth2ProviderGrantType](updatedApp.GrantTypes),
-			ResponseTypes:           stringsToEnumSlice[codersdk.OAuth2ProviderResponseType](updatedApp.ResponseTypes),
+			GrantTypes:              slice.StringEnums[codersdk.OAuth2ProviderGrantType](updatedApp.GrantTypes),
+			ResponseTypes:           slice.StringEnums[codersdk.OAuth2ProviderResponseType](updatedApp.ResponseTypes),
 			TokenEndpointAuthMethod: codersdk.OAuth2TokenEndpointAuthMethod(updatedApp.TokenEndpointAuthMethod.String),
 			Scope:                   updatedApp.Scope.String,
 			Contacts:                updatedApp.Contacts,
@@ -535,20 +536,4 @@ func createDisplaySecret(secret string) string {
 	visiblePart := secret[len(secret)-displaySecretLength:]
 	hiddenLength := len(secret) - displaySecretLength
 	return strings.Repeat("*", hiddenLength) + visiblePart
-}
-
-func enumSliceToStrings[T ~string](enums []T) []string {
-	result := make([]string, len(enums))
-	for i, e := range enums {
-		result[i] = string(e)
-	}
-	return result
-}
-
-func stringsToEnumSlice[T ~string](strs []string) []T {
-	result := make([]T, len(strs))
-	for i, s := range strs {
-		result[i] = T(s)
-	}
-	return result
 }

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -337,7 +337,7 @@ func authorizationCodeGrant(ctx context.Context, db database.Store, app database
 		TokenType:    codersdk.OAuth2TokenTypeBearer,
 		RefreshToken: refreshToken.Formatted,
 		ExpiresIn:    int64(time.Until(key.ExpiresAt).Seconds()),
-		Expiry:       key.ExpiresAt,
+		Expiry:       &key.ExpiresAt,
 	}, nil
 }
 
@@ -450,7 +450,7 @@ func refreshTokenGrant(ctx context.Context, db database.Store, app database.OAut
 		TokenType:    codersdk.OAuth2TokenTypeBearer,
 		RefreshToken: refreshToken.Formatted,
 		ExpiresIn:    int64(time.Until(key.ExpiresAt).Seconds()),
-		Expiry:       key.ExpiresAt,
+		Expiry:       &key.ExpiresAt,
 	}, nil
 }
 

--- a/coderd/oauth2provider/tokens_internal_test.go
+++ b/coderd/oauth2provider/tokens_internal_test.go
@@ -358,6 +358,6 @@ func TestRefreshTokenGrant_Scopes(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, validationErrs)
-	require.Equal(t, codersdk.OAuth2ProviderGrantTypeRefreshToken, params.grantType)
+	require.Equal(t, codersdk.OAuth2ProviderGrantTypeRefreshToken, params.req.GrantType)
 	require.Equal(t, []string{"reduced:scope", "subset:scope"}, params.scopes)
 }

--- a/coderd/oauth2provider/validation_test.go
+++ b/coderd/oauth2provider/validation_test.go
@@ -302,22 +302,22 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 			},
 			{
 				name:        "InvalidUnsupported",
-				grantTypes:  []codersdk.OAuth2ProviderGrantType{"client_credentials"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeClientCredentials},
 				expectError: true,
 			},
 			{
 				name:        "InvalidPassword",
-				grantTypes:  []codersdk.OAuth2ProviderGrantType{"password"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypePassword},
 				expectError: true,
 			},
 			{
 				name:        "InvalidImplicit",
-				grantTypes:  []codersdk.OAuth2ProviderGrantType{"implicit"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeImplicit},
 				expectError: true,
 			},
 			{
 				name:        "MixedValidInvalid",
-				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, "client_credentials"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeClientCredentials},
 				expectError: true,
 			},
 		}
@@ -367,17 +367,17 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 			},
 			{
 				name:          "InvalidToken",
-				responseTypes: []codersdk.OAuth2ProviderResponseType{"token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeToken},
 				expectError:   true,
 			},
 			{
-				name:          "InvalidImplicit",
-				responseTypes: []codersdk.OAuth2ProviderResponseType{"id_token"},
+				name:          "InvalidIDToken",
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"id_token"}, // OIDC-specific, no constant
 				expectError:   true,
 			},
 			{
 				name:          "InvalidMultiple",
-				responseTypes: []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode, "token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode, codersdk.OAuth2ProviderResponseTypeToken},
 				expectError:   true,
 			},
 		}
@@ -437,12 +437,12 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 			},
 			{
 				name:        "InvalidPrivateKeyJWT",
-				authMethod:  "private_key_jwt",
+				authMethod:  "private_key_jwt", // OIDC-specific, no constant defined
 				expectError: true,
 			},
 			{
 				name:        "InvalidClientSecretJWT",
-				authMethod:  "client_secret_jwt",
+				authMethod:  "client_secret_jwt", // OIDC-specific, no constant defined
 				expectError: true,
 			},
 			{

--- a/coderd/oauth2provider/validation_test.go
+++ b/coderd/oauth2provider/validation_test.go
@@ -277,47 +277,47 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 		tests := []struct {
 			name        string
-			grantTypes  []string
+			grantTypes  []codersdk.OAuth2ProviderGrantType
 			expectError bool
 		}{
 			{
 				name:        "DefaultEmpty",
-				grantTypes:  []string{},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{},
 				expectError: false,
 			},
 			{
 				name:        "ValidAuthorizationCode",
-				grantTypes:  []string{"authorization_code"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode},
 				expectError: false,
 			},
 			{
 				name:        "InvalidRefreshTokenAlone",
-				grantTypes:  []string{"refresh_token"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeRefreshToken},
 				expectError: true, // refresh_token requires authorization_code to be present
 			},
 			{
 				name:        "ValidMultiple",
-				grantTypes:  []string{"authorization_code", "refresh_token"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeRefreshToken},
 				expectError: false,
 			},
 			{
 				name:        "InvalidUnsupported",
-				grantTypes:  []string{"client_credentials"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"client_credentials"},
 				expectError: true,
 			},
 			{
 				name:        "InvalidPassword",
-				grantTypes:  []string{"password"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"password"},
 				expectError: true,
 			},
 			{
 				name:        "InvalidImplicit",
-				grantTypes:  []string{"implicit"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{"implicit"},
 				expectError: true,
 			},
 			{
 				name:        "MixedValidInvalid",
-				grantTypes:  []string{"authorization_code", "client_credentials"},
+				grantTypes:  []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, "client_credentials"},
 				expectError: true,
 			},
 		}
@@ -352,32 +352,32 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 		tests := []struct {
 			name          string
-			responseTypes []string
+			responseTypes []codersdk.OAuth2ProviderResponseType
 			expectError   bool
 		}{
 			{
 				name:          "DefaultEmpty",
-				responseTypes: []string{},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{},
 				expectError:   false,
 			},
 			{
 				name:          "ValidCode",
-				responseTypes: []string{"code"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode},
 				expectError:   false,
 			},
 			{
 				name:          "InvalidToken",
-				responseTypes: []string{"token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"token"},
 				expectError:   true,
 			},
 			{
 				name:          "InvalidImplicit",
-				responseTypes: []string{"id_token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{"id_token"},
 				expectError:   true,
 			},
 			{
 				name:          "InvalidMultiple",
-				responseTypes: []string{"code", "token"},
+				responseTypes: []codersdk.OAuth2ProviderResponseType{codersdk.OAuth2ProviderResponseTypeCode, "token"},
 				expectError:   true,
 			},
 		}
@@ -412,7 +412,7 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 		tests := []struct {
 			name        string
-			authMethod  string
+			authMethod  codersdk.OAuth2TokenEndpointAuthMethod
 			expectError bool
 		}{
 			{
@@ -422,17 +422,17 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 			},
 			{
 				name:        "ValidClientSecretBasic",
-				authMethod:  "client_secret_basic",
+				authMethod:  codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic,
 				expectError: false,
 			},
 			{
 				name:        "ValidClientSecretPost",
-				authMethod:  "client_secret_post",
+				authMethod:  codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost,
 				expectError: false,
 			},
 			{
 				name:        "ValidNone",
-				authMethod:  "none",
+				authMethod:  codersdk.OAuth2TokenEndpointAuthMethodNone,
 				expectError: false, // "none" is valid for public clients per RFC 7591
 			},
 			{
@@ -659,14 +659,14 @@ func TestOAuth2ClientMetadataDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should default to authorization_code
-	require.Contains(t, config.GrantTypes, "authorization_code")
+	require.Contains(t, config.GrantTypes, codersdk.OAuth2ProviderGrantTypeAuthorizationCode)
 
 	// Should default to code
-	require.Contains(t, config.ResponseTypes, "code")
+	require.Contains(t, config.ResponseTypes, codersdk.OAuth2ProviderResponseTypeCode)
 
 	// Should default to client_secret_basic or client_secret_post
-	require.True(t, config.TokenEndpointAuthMethod == "client_secret_basic" ||
-		config.TokenEndpointAuthMethod == "client_secret_post" ||
+	require.True(t, config.TokenEndpointAuthMethod == codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic ||
+		config.TokenEndpointAuthMethod == codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost ||
 		config.TokenEndpointAuthMethod == "")
 
 	// Client secret should be generated

--- a/codersdk/oauth2.go
+++ b/codersdk/oauth2.go
@@ -187,14 +187,22 @@ func (c *Client) DeleteOAuth2ProviderAppSecret(ctx context.Context, appID uuid.U
 
 type OAuth2ProviderGrantType string
 
+// OAuth2ProviderGrantType values (RFC 6749).
 const (
 	OAuth2ProviderGrantTypeAuthorizationCode OAuth2ProviderGrantType = "authorization_code"
 	OAuth2ProviderGrantTypeRefreshToken      OAuth2ProviderGrantType = "refresh_token"
+	OAuth2ProviderGrantTypePassword          OAuth2ProviderGrantType = "password"
+	OAuth2ProviderGrantTypeClientCredentials OAuth2ProviderGrantType = "client_credentials"
+	OAuth2ProviderGrantTypeImplicit          OAuth2ProviderGrantType = "implicit"
 )
 
 func (e OAuth2ProviderGrantType) Valid() bool {
 	switch e {
-	case OAuth2ProviderGrantTypeAuthorizationCode, OAuth2ProviderGrantTypeRefreshToken:
+	case OAuth2ProviderGrantTypeAuthorizationCode,
+		OAuth2ProviderGrantTypeRefreshToken,
+		OAuth2ProviderGrantTypePassword,
+		OAuth2ProviderGrantTypeClientCredentials,
+		OAuth2ProviderGrantTypeImplicit:
 		return true
 	}
 	return false
@@ -202,14 +210,15 @@ func (e OAuth2ProviderGrantType) Valid() bool {
 
 type OAuth2ProviderResponseType string
 
+// OAuth2ProviderResponseType values (RFC 6749).
 const (
-	OAuth2ProviderResponseTypeCode OAuth2ProviderResponseType = "code"
+	OAuth2ProviderResponseTypeCode  OAuth2ProviderResponseType = "code"
+	OAuth2ProviderResponseTypeToken OAuth2ProviderResponseType = "token"
 )
 
 func (e OAuth2ProviderResponseType) Valid() bool {
-	//nolint:gocritic,revive // More cases might be added later.
 	switch e {
-	case OAuth2ProviderResponseTypeCode:
+	case OAuth2ProviderResponseTypeCode, OAuth2ProviderResponseTypeToken:
 		return true
 	}
 	return false
@@ -233,27 +242,33 @@ func (m OAuth2TokenEndpointAuthMethod) Valid() bool {
 	return false
 }
 
-// OAuth 2.1 only supports S256 (plain is rejected).
 type OAuth2PKCECodeChallengeMethod string
 
+// OAuth2PKCECodeChallengeMethod values (RFC 7636).
 const (
-	OAuth2PKCECodeChallengeMethodS256 OAuth2PKCECodeChallengeMethod = "S256"
+	OAuth2PKCECodeChallengeMethodS256  OAuth2PKCECodeChallengeMethod = "S256"
+	OAuth2PKCECodeChallengeMethodPlain OAuth2PKCECodeChallengeMethod = "plain"
 )
 
 func (m OAuth2PKCECodeChallengeMethod) Valid() bool {
-	return m == OAuth2PKCECodeChallengeMethodS256
+	switch m {
+	case OAuth2PKCECodeChallengeMethodS256, OAuth2PKCECodeChallengeMethodPlain:
+		return true
+	}
+	return false
 }
 
 type OAuth2TokenType string
 
+// OAuth2TokenType values (RFC 6749, RFC 9449).
 const (
 	OAuth2TokenTypeBearer OAuth2TokenType = "Bearer"
+	OAuth2TokenTypeDPoP   OAuth2TokenType = "DPoP"
 )
 
 func (t OAuth2TokenType) Valid() bool {
-	//nolint:gocritic,revive // More cases might be added later.
 	switch t {
-	case OAuth2TokenTypeBearer:
+	case OAuth2TokenTypeBearer, OAuth2TokenTypeDPoP:
 		return true
 	}
 	return false
@@ -276,17 +291,28 @@ func (h OAuth2RevocationTokenTypeHint) Valid() bool {
 
 type OAuth2ErrorCode string
 
+// OAuth2 error codes per RFC 6749, RFC 7009, RFC 8707.
+// This is not comprehensive; it includes only codes relevant to this implementation.
 const (
-	OAuth2ErrorCodeInvalidRequest         OAuth2ErrorCode = "invalid_request"
-	OAuth2ErrorCodeInvalidClient          OAuth2ErrorCode = "invalid_client"
-	OAuth2ErrorCodeInvalidGrant           OAuth2ErrorCode = "invalid_grant"
-	OAuth2ErrorCodeUnauthorizedClient     OAuth2ErrorCode = "unauthorized_client"
-	OAuth2ErrorCodeUnsupportedGrantType   OAuth2ErrorCode = "unsupported_grant_type"
-	OAuth2ErrorCodeInvalidScope           OAuth2ErrorCode = "invalid_scope"
-	OAuth2ErrorCodeInvalidTarget          OAuth2ErrorCode = "invalid_target"         // RFC 8707
-	OAuth2ErrorCodeUnsupportedTokenType   OAuth2ErrorCode = "unsupported_token_type" // RFC 7009
-	OAuth2ErrorCodeServerError            OAuth2ErrorCode = "server_error"
-	OAuth2ErrorCodeTemporarilyUnavailable OAuth2ErrorCode = "temporarily_unavailable"
+	// RFC 6749 - Token endpoint errors.
+	OAuth2ErrorCodeInvalidRequest       OAuth2ErrorCode = "invalid_request"
+	OAuth2ErrorCodeInvalidClient        OAuth2ErrorCode = "invalid_client"
+	OAuth2ErrorCodeInvalidGrant         OAuth2ErrorCode = "invalid_grant"
+	OAuth2ErrorCodeUnauthorizedClient   OAuth2ErrorCode = "unauthorized_client"
+	OAuth2ErrorCodeUnsupportedGrantType OAuth2ErrorCode = "unsupported_grant_type"
+	OAuth2ErrorCodeInvalidScope         OAuth2ErrorCode = "invalid_scope"
+
+	// RFC 6749 - Authorization endpoint errors.
+	OAuth2ErrorCodeAccessDenied            OAuth2ErrorCode = "access_denied"
+	OAuth2ErrorCodeUnsupportedResponseType OAuth2ErrorCode = "unsupported_response_type"
+	OAuth2ErrorCodeServerError             OAuth2ErrorCode = "server_error"
+	OAuth2ErrorCodeTemporarilyUnavailable  OAuth2ErrorCode = "temporarily_unavailable"
+
+	// RFC 7009 - Token revocation errors.
+	OAuth2ErrorCodeUnsupportedTokenType OAuth2ErrorCode = "unsupported_token_type"
+
+	// RFC 8707 - Resource indicator errors.
+	OAuth2ErrorCodeInvalidTarget OAuth2ErrorCode = "invalid_target"
 )
 
 func (c OAuth2ErrorCode) Valid() bool {
@@ -297,10 +323,12 @@ func (c OAuth2ErrorCode) Valid() bool {
 		OAuth2ErrorCodeUnauthorizedClient,
 		OAuth2ErrorCodeUnsupportedGrantType,
 		OAuth2ErrorCodeInvalidScope,
-		OAuth2ErrorCodeInvalidTarget,
-		OAuth2ErrorCodeUnsupportedTokenType,
+		OAuth2ErrorCodeAccessDenied,
+		OAuth2ErrorCodeUnsupportedResponseType,
 		OAuth2ErrorCodeServerError,
-		OAuth2ErrorCodeTemporarilyUnavailable:
+		OAuth2ErrorCodeTemporarilyUnavailable,
+		OAuth2ErrorCodeUnsupportedTokenType,
+		OAuth2ErrorCodeInvalidTarget:
 		return true
 	}
 	return false

--- a/codersdk/oauth2.go
+++ b/codersdk/oauth2.go
@@ -336,7 +336,7 @@ type OAuth2TokenResponse struct {
 	Scope        string          `json:"scope,omitempty"`
 	// Expiry is not part of RFC 6749 but is included for compatibility with
 	// golang.org/x/oauth2.Token and clients that expect a timestamp.
-	Expiry time.Time `json:"expiry,omitempty"`
+	Expiry *time.Time `json:"expiry,omitempty" format:"date-time"`
 }
 
 // OAuth2TokenRevocationRequest represents a token revocation request per RFC 7009.

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -20,15 +20,15 @@ curl -X GET http://coder-server:8080/api/v2/.well-known/oauth-authorization-serv
 {
   "authorization_endpoint": "string",
   "code_challenge_methods_supported": [
-    "string"
+    "S256"
   ],
   "grant_types_supported": [
-    "string"
+    "authorization_code"
   ],
   "issuer": "string",
   "registration_endpoint": "string",
   "response_types_supported": [
-    "string"
+    "code"
   ],
   "revocation_endpoint": "string",
   "scopes_supported": [
@@ -36,7 +36,7 @@ curl -X GET http://coder-server:8080/api/v2/.well-known/oauth-authorization-serv
   ],
   "token_endpoint": "string",
   "token_endpoint_auth_methods_supported": [
-    "string"
+    "client_secret_basic"
   ]
 }
 ```
@@ -1346,7 +1346,7 @@ curl -X GET http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -1355,17 +1355,15 @@ curl -X GET http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
   "redirect_uris": [
     "string"
   ],
-  "registration_access_token": [
-    0
-  ],
+  "registration_access_token": "string",
   "registration_client_uri": "string",
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
@@ -1399,7 +1397,7 @@ curl -X PUT http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -1409,13 +1407,13 @@ curl -X PUT http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
     "string"
   ],
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_statement": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
@@ -1442,7 +1440,7 @@ curl -X PUT http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -1451,17 +1449,15 @@ curl -X PUT http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
   "redirect_uris": [
     "string"
   ],
-  "registration_access_token": [
-    0
-  ],
+  "registration_access_token": "string",
   "registration_client_uri": "string",
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
@@ -1519,7 +1515,7 @@ curl -X POST http://coder-server:8080/api/v2/oauth2/register \
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -1529,13 +1525,13 @@ curl -X POST http://coder-server:8080/api/v2/oauth2/register \
     "string"
   ],
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_statement": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
@@ -1562,7 +1558,7 @@ curl -X POST http://coder-server:8080/api/v2/oauth2/register \
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -1574,12 +1570,12 @@ curl -X POST http://coder-server:8080/api/v2/oauth2/register \
   "registration_access_token": "string",
   "registration_client_uri": "string",
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -1265,9 +1265,9 @@ curl -X GET http://coder-server:8080/api/v2/oauth2/authorize?client_id=string&st
 
 #### Enumerated Values
 
-| Parameter       | Value(s) |
-|-----------------|----------|
-| `response_type` | `code`   |
+| Parameter       | Value(s)        |
+|-----------------|-----------------|
+| `response_type` | `code`, `token` |
 
 ### Responses
 
@@ -1301,9 +1301,9 @@ curl -X POST http://coder-server:8080/api/v2/oauth2/authorize?client_id=string&s
 
 #### Enumerated Values
 
-| Parameter       | Value(s) |
-|-----------------|----------|
-| `response_type` | `code`   |
+| Parameter       | Value(s)        |
+|-----------------|-----------------|
+| `response_type` | `code`, `token` |
 
 ### Responses
 
@@ -1658,9 +1658,9 @@ grant_type: authorization_code
 
 #### Enumerated Values
 
-| Parameter      | Value(s)                              |
-|----------------|---------------------------------------|
-| `» grant_type` | `authorization_code`, `refresh_token` |
+| Parameter      | Value(s)                                                                            |
+|----------------|-------------------------------------------------------------------------------------|
+| `» grant_type` | `authorization_code`, `client_credentials`, `implicit`, `password`, `refresh_token` |
 
 ### Example responses
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5188,15 +5188,15 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 {
   "authorization_endpoint": "string",
   "code_challenge_methods_supported": [
-    "string"
+    "S256"
   ],
   "grant_types_supported": [
-    "string"
+    "authorization_code"
   ],
   "issuer": "string",
   "registration_endpoint": "string",
   "response_types_supported": [
-    "string"
+    "code"
   ],
   "revocation_endpoint": "string",
   "scopes_supported": [
@@ -5204,25 +5204,25 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   ],
   "token_endpoint": "string",
   "token_endpoint_auth_methods_supported": [
-    "string"
+    "client_secret_basic"
   ]
 }
 ```
 
 ### Properties
 
-| Name                                    | Type            | Required | Restrictions | Description |
-|-----------------------------------------|-----------------|----------|--------------|-------------|
-| `authorization_endpoint`                | string          | false    |              |             |
-| `code_challenge_methods_supported`      | array of string | false    |              |             |
-| `grant_types_supported`                 | array of string | false    |              |             |
-| `issuer`                                | string          | false    |              |             |
-| `registration_endpoint`                 | string          | false    |              |             |
-| `response_types_supported`              | array of string | false    |              |             |
-| `revocation_endpoint`                   | string          | false    |              |             |
-| `scopes_supported`                      | array of string | false    |              |             |
-| `token_endpoint`                        | string          | false    |              |             |
-| `token_endpoint_auth_methods_supported` | array of string | false    |              |             |
+| Name                                    | Type                                                                                      | Required | Restrictions | Description |
+|-----------------------------------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `authorization_endpoint`                | string                                                                                    | false    |              |             |
+| `code_challenge_methods_supported`      | array of [codersdk.OAuth2PKCECodeChallengeMethod](#codersdkoauth2pkcecodechallengemethod) | false    |              |             |
+| `grant_types_supported`                 | array of [codersdk.OAuth2ProviderGrantType](#codersdkoauth2providergranttype)             | false    |              |             |
+| `issuer`                                | string                                                                                    | false    |              |             |
+| `registration_endpoint`                 | string                                                                                    | false    |              |             |
+| `response_types_supported`              | array of [codersdk.OAuth2ProviderResponseType](#codersdkoauth2providerresponsetype)       | false    |              |             |
+| `revocation_endpoint`                   | string                                                                                    | false    |              |             |
+| `scopes_supported`                      | array of string                                                                           | false    |              |             |
+| `token_endpoint`                        | string                                                                                    | false    |              |             |
+| `token_endpoint_auth_methods_supported` | array of [codersdk.OAuth2TokenEndpointAuthMethod](#codersdkoauth2tokenendpointauthmethod) | false    |              |             |
 
 ## codersdk.OAuth2ClientConfiguration
 
@@ -5237,7 +5237,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -5246,45 +5246,43 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   "redirect_uris": [
     "string"
   ],
-  "registration_access_token": [
-    0
-  ],
+  "registration_access_token": "string",
   "registration_client_uri": "string",
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
 
 ### Properties
 
-| Name                         | Type             | Required | Restrictions | Description |
-|------------------------------|------------------|----------|--------------|-------------|
-| `client_id`                  | string           | false    |              |             |
-| `client_id_issued_at`        | integer          | false    |              |             |
-| `client_name`                | string           | false    |              |             |
-| `client_secret_expires_at`   | integer          | false    |              |             |
-| `client_uri`                 | string           | false    |              |             |
-| `contacts`                   | array of string  | false    |              |             |
-| `grant_types`                | array of string  | false    |              |             |
-| `jwks`                       | object           | false    |              |             |
-| `jwks_uri`                   | string           | false    |              |             |
-| `logo_uri`                   | string           | false    |              |             |
-| `policy_uri`                 | string           | false    |              |             |
-| `redirect_uris`              | array of string  | false    |              |             |
-| `registration_access_token`  | array of integer | false    |              |             |
-| `registration_client_uri`    | string           | false    |              |             |
-| `response_types`             | array of string  | false    |              |             |
-| `scope`                      | string           | false    |              |             |
-| `software_id`                | string           | false    |              |             |
-| `software_version`           | string           | false    |              |             |
-| `token_endpoint_auth_method` | string           | false    |              |             |
-| `tos_uri`                    | string           | false    |              |             |
+| Name                         | Type                                                                                | Required | Restrictions | Description |
+|------------------------------|-------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `client_id`                  | string                                                                              | false    |              |             |
+| `client_id_issued_at`        | integer                                                                             | false    |              |             |
+| `client_name`                | string                                                                              | false    |              |             |
+| `client_secret_expires_at`   | integer                                                                             | false    |              |             |
+| `client_uri`                 | string                                                                              | false    |              |             |
+| `contacts`                   | array of string                                                                     | false    |              |             |
+| `grant_types`                | array of [codersdk.OAuth2ProviderGrantType](#codersdkoauth2providergranttype)       | false    |              |             |
+| `jwks`                       | object                                                                              | false    |              |             |
+| `jwks_uri`                   | string                                                                              | false    |              |             |
+| `logo_uri`                   | string                                                                              | false    |              |             |
+| `policy_uri`                 | string                                                                              | false    |              |             |
+| `redirect_uris`              | array of string                                                                     | false    |              |             |
+| `registration_access_token`  | string                                                                              | false    |              |             |
+| `registration_client_uri`    | string                                                                              | false    |              |             |
+| `response_types`             | array of [codersdk.OAuth2ProviderResponseType](#codersdkoauth2providerresponsetype) | false    |              |             |
+| `scope`                      | string                                                                              | false    |              |             |
+| `software_id`                | string                                                                              | false    |              |             |
+| `software_version`           | string                                                                              | false    |              |             |
+| `token_endpoint_auth_method` | [codersdk.OAuth2TokenEndpointAuthMethod](#codersdkoauth2tokenendpointauthmethod)    | false    |              |             |
+| `tos_uri`                    | string                                                                              | false    |              |             |
 
 ## codersdk.OAuth2ClientRegistrationRequest
 
@@ -5296,7 +5294,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -5306,37 +5304,37 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
     "string"
   ],
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_statement": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
 
 ### Properties
 
-| Name                         | Type            | Required | Restrictions | Description |
-|------------------------------|-----------------|----------|--------------|-------------|
-| `client_name`                | string          | false    |              |             |
-| `client_uri`                 | string          | false    |              |             |
-| `contacts`                   | array of string | false    |              |             |
-| `grant_types`                | array of string | false    |              |             |
-| `jwks`                       | object          | false    |              |             |
-| `jwks_uri`                   | string          | false    |              |             |
-| `logo_uri`                   | string          | false    |              |             |
-| `policy_uri`                 | string          | false    |              |             |
-| `redirect_uris`              | array of string | false    |              |             |
-| `response_types`             | array of string | false    |              |             |
-| `scope`                      | string          | false    |              |             |
-| `software_id`                | string          | false    |              |             |
-| `software_statement`         | string          | false    |              |             |
-| `software_version`           | string          | false    |              |             |
-| `token_endpoint_auth_method` | string          | false    |              |             |
-| `tos_uri`                    | string          | false    |              |             |
+| Name                         | Type                                                                                | Required | Restrictions | Description |
+|------------------------------|-------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `client_name`                | string                                                                              | false    |              |             |
+| `client_uri`                 | string                                                                              | false    |              |             |
+| `contacts`                   | array of string                                                                     | false    |              |             |
+| `grant_types`                | array of [codersdk.OAuth2ProviderGrantType](#codersdkoauth2providergranttype)       | false    |              |             |
+| `jwks`                       | object                                                                              | false    |              |             |
+| `jwks_uri`                   | string                                                                              | false    |              |             |
+| `logo_uri`                   | string                                                                              | false    |              |             |
+| `policy_uri`                 | string                                                                              | false    |              |             |
+| `redirect_uris`              | array of string                                                                     | false    |              |             |
+| `response_types`             | array of [codersdk.OAuth2ProviderResponseType](#codersdkoauth2providerresponsetype) | false    |              |             |
+| `scope`                      | string                                                                              | false    |              |             |
+| `software_id`                | string                                                                              | false    |              |             |
+| `software_statement`         | string                                                                              | false    |              |             |
+| `software_version`           | string                                                                              | false    |              |             |
+| `token_endpoint_auth_method` | [codersdk.OAuth2TokenEndpointAuthMethod](#codersdkoauth2tokenendpointauthmethod)    | false    |              |             |
+| `tos_uri`                    | string                                                                              | false    |              |             |
 
 ## codersdk.OAuth2ClientRegistrationResponse
 
@@ -5352,7 +5350,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
     "string"
   ],
   "grant_types": [
-    "string"
+    "authorization_code"
   ],
   "jwks": {},
   "jwks_uri": "string",
@@ -5364,41 +5362,41 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
   "registration_access_token": "string",
   "registration_client_uri": "string",
   "response_types": [
-    "string"
+    "code"
   ],
   "scope": "string",
   "software_id": "string",
   "software_version": "string",
-  "token_endpoint_auth_method": "string",
+  "token_endpoint_auth_method": "client_secret_basic",
   "tos_uri": "string"
 }
 ```
 
 ### Properties
 
-| Name                         | Type            | Required | Restrictions | Description |
-|------------------------------|-----------------|----------|--------------|-------------|
-| `client_id`                  | string          | false    |              |             |
-| `client_id_issued_at`        | integer         | false    |              |             |
-| `client_name`                | string          | false    |              |             |
-| `client_secret`              | string          | false    |              |             |
-| `client_secret_expires_at`   | integer         | false    |              |             |
-| `client_uri`                 | string          | false    |              |             |
-| `contacts`                   | array of string | false    |              |             |
-| `grant_types`                | array of string | false    |              |             |
-| `jwks`                       | object          | false    |              |             |
-| `jwks_uri`                   | string          | false    |              |             |
-| `logo_uri`                   | string          | false    |              |             |
-| `policy_uri`                 | string          | false    |              |             |
-| `redirect_uris`              | array of string | false    |              |             |
-| `registration_access_token`  | string          | false    |              |             |
-| `registration_client_uri`    | string          | false    |              |             |
-| `response_types`             | array of string | false    |              |             |
-| `scope`                      | string          | false    |              |             |
-| `software_id`                | string          | false    |              |             |
-| `software_version`           | string          | false    |              |             |
-| `token_endpoint_auth_method` | string          | false    |              |             |
-| `tos_uri`                    | string          | false    |              |             |
+| Name                         | Type                                                                                | Required | Restrictions | Description |
+|------------------------------|-------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `client_id`                  | string                                                                              | false    |              |             |
+| `client_id_issued_at`        | integer                                                                             | false    |              |             |
+| `client_name`                | string                                                                              | false    |              |             |
+| `client_secret`              | string                                                                              | false    |              |             |
+| `client_secret_expires_at`   | integer                                                                             | false    |              |             |
+| `client_uri`                 | string                                                                              | false    |              |             |
+| `contacts`                   | array of string                                                                     | false    |              |             |
+| `grant_types`                | array of [codersdk.OAuth2ProviderGrantType](#codersdkoauth2providergranttype)       | false    |              |             |
+| `jwks`                       | object                                                                              | false    |              |             |
+| `jwks_uri`                   | string                                                                              | false    |              |             |
+| `logo_uri`                   | string                                                                              | false    |              |             |
+| `policy_uri`                 | string                                                                              | false    |              |             |
+| `redirect_uris`              | array of string                                                                     | false    |              |             |
+| `registration_access_token`  | string                                                                              | false    |              |             |
+| `registration_client_uri`    | string                                                                              | false    |              |             |
+| `response_types`             | array of [codersdk.OAuth2ProviderResponseType](#codersdkoauth2providerresponsetype) | false    |              |             |
+| `scope`                      | string                                                                              | false    |              |             |
+| `software_id`                | string                                                                              | false    |              |             |
+| `software_version`           | string                                                                              | false    |              |             |
+| `token_endpoint_auth_method` | [codersdk.OAuth2TokenEndpointAuthMethod](#codersdkoauth2tokenendpointauthmethod)    | false    |              |             |
+| `tos_uri`                    | string                                                                              | false    |              |             |
 
 ## codersdk.OAuth2Config
 
@@ -5461,6 +5459,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `default_provider_enable` | boolean         | false    |              |             |
 | `device_flow`             | boolean         | false    |              |             |
 | `enterprise_base_url`     | string          | false    |              |             |
+
+## codersdk.OAuth2PKCECodeChallengeMethod
+
+```json
+"S256"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s) |
+|----------|
+| `S256`   |
 
 ## codersdk.OAuth2ProtectedResourceMetadata
 
@@ -5548,6 +5560,48 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 |----------------------|--------|----------|--------------|-------------|
 | `client_secret_full` | string | false    |              |             |
 | `id`                 | string | false    |              |             |
+
+## codersdk.OAuth2ProviderGrantType
+
+```json
+"authorization_code"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                              |
+|---------------------------------------|
+| `authorization_code`, `refresh_token` |
+
+## codersdk.OAuth2ProviderResponseType
+
+```json
+"code"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s) |
+|----------|
+| `code`   |
+
+## codersdk.OAuth2TokenEndpointAuthMethod
+
+```json
+"client_secret_basic"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                            |
+|-----------------------------------------------------|
+| `client_secret_basic`, `client_secret_post`, `none` |
 
 ## codersdk.OAuthConversionResponse
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5470,9 +5470,9 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 #### Enumerated Values
 
-| Value(s) |
-|----------|
-| `S256`   |
+| Value(s)        |
+|-----------------|
+| `S256`, `plain` |
 
 ## codersdk.OAuth2ProtectedResourceMetadata
 
@@ -5571,9 +5571,9 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 #### Enumerated Values
 
-| Value(s)                              |
-|---------------------------------------|
-| `authorization_code`, `refresh_token` |
+| Value(s)                                                                            |
+|-------------------------------------------------------------------------------------|
+| `authorization_code`, `client_credentials`, `implicit`, `password`, `refresh_token` |
 
 ## codersdk.OAuth2ProviderResponseType
 
@@ -5585,9 +5585,9 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 #### Enumerated Values
 
-| Value(s) |
-|----------|
-| `code`   |
+| Value(s)        |
+|-----------------|
+| `code`, `token` |
 
 ## codersdk.OAuth2TokenEndpointAuthMethod
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3049,6 +3049,7 @@ export interface OAuth2Error {
 
 // From codersdk/oauth2.go
 export type OAuth2ErrorCode =
+	| "access_denied"
 	| "invalid_client"
 	| "invalid_grant"
 	| "invalid_request"
@@ -3058,9 +3059,11 @@ export type OAuth2ErrorCode =
 	| "temporarily_unavailable"
 	| "unauthorized_client"
 	| "unsupported_grant_type"
+	| "unsupported_response_type"
 	| "unsupported_token_type";
 
 export const OAuth2ErrorCodes: OAuth2ErrorCode[] = [
+	"access_denied",
 	"invalid_client",
 	"invalid_grant",
 	"invalid_request",
@@ -3070,6 +3073,7 @@ export const OAuth2ErrorCodes: OAuth2ErrorCode[] = [
 	"temporarily_unavailable",
 	"unauthorized_client",
 	"unsupported_grant_type",
+	"unsupported_response_type",
 	"unsupported_token_type",
 ];
 
@@ -3087,9 +3091,10 @@ export interface OAuth2GithubConfig {
 }
 
 // From codersdk/oauth2.go
-export type OAuth2PKCECodeChallengeMethod = "S256";
+export type OAuth2PKCECodeChallengeMethod = "plain" | "S256";
 
 export const OAuth2PKCECodeChallengeMethods: OAuth2PKCECodeChallengeMethod[] = [
+	"plain",
 	"S256",
 ];
 
@@ -3145,18 +3150,27 @@ export interface OAuth2ProviderAppSecretFull {
 }
 
 // From codersdk/oauth2.go
-export type OAuth2ProviderGrantType = "authorization_code" | "refresh_token";
+export type OAuth2ProviderGrantType =
+	| "authorization_code"
+	| "client_credentials"
+	| "implicit"
+	| "password"
+	| "refresh_token";
 
 export const OAuth2ProviderGrantTypes: OAuth2ProviderGrantType[] = [
 	"authorization_code",
+	"client_credentials",
+	"implicit",
+	"password",
 	"refresh_token",
 ];
 
 // From codersdk/oauth2.go
-export type OAuth2ProviderResponseType = "code";
+export type OAuth2ProviderResponseType = "code" | "token";
 
 export const OAuth2ProviderResponseTypes: OAuth2ProviderResponseType[] = [
 	"code",
+	"token",
 ];
 
 // From codersdk/client.go
@@ -3237,9 +3251,9 @@ export interface OAuth2TokenRevocationRequest {
 }
 
 // From codersdk/oauth2.go
-export type OAuth2TokenType = "Bearer";
+export type OAuth2TokenType = "Bearer" | "DPoP";
 
-export const OAuth2TokenTypes: OAuth2TokenType[] = ["Bearer"];
+export const OAuth2TokenTypes: OAuth2TokenType[] = ["Bearer", "DPoP"];
 
 // From codersdk/users.go
 export interface OAuthConversionResponse {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2934,7 +2934,7 @@ export interface OAuth2AppEndpoints {
 
 // From codersdk/oauth2.go
 /**
- * OAuth2AuthorizationServerMetadata represents RFC 8414 OAuth 2.0 Authorization Server Metadata
+ * OAuth2AuthorizationServerMetadata represents RFC 8414 OAuth 2.0 Authorization Server Metadata.
  */
 export interface OAuth2AuthorizationServerMetadata {
 	readonly issuer: string;
@@ -2942,17 +2942,16 @@ export interface OAuth2AuthorizationServerMetadata {
 	readonly token_endpoint: string;
 	readonly registration_endpoint?: string;
 	readonly revocation_endpoint?: string;
-	readonly response_types_supported: readonly string[];
-	readonly grant_types_supported: readonly string[];
-	readonly code_challenge_methods_supported: readonly string[];
+	readonly response_types_supported: readonly OAuth2ProviderResponseType[];
+	readonly grant_types_supported?: readonly OAuth2ProviderGrantType[];
+	readonly code_challenge_methods_supported?: readonly OAuth2PKCECodeChallengeMethod[];
 	readonly scopes_supported?: readonly string[];
-	readonly token_endpoint_auth_methods_supported?: readonly string[];
+	readonly token_endpoint_auth_methods_supported?: readonly OAuth2TokenEndpointAuthMethod[];
 }
 
 // From codersdk/oauth2.go
 /**
- * OAuth2ClientConfiguration represents RFC 7592 Client Configuration (for GET/PUT operations)
- * Same as OAuth2ClientRegistrationResponse but without client_secret in GET responses
+ * OAuth2ClientConfiguration represents RFC 7592 Client Read Response.
  */
 export interface OAuth2ClientConfiguration {
 	readonly client_id: string;
@@ -2968,18 +2967,18 @@ export interface OAuth2ClientConfiguration {
 	readonly jwks?: Record<string, string>;
 	readonly software_id?: string;
 	readonly software_version?: string;
-	readonly grant_types: readonly string[];
-	readonly response_types: readonly string[];
-	readonly token_endpoint_auth_method: string;
+	readonly grant_types: readonly OAuth2ProviderGrantType[];
+	readonly response_types: readonly OAuth2ProviderResponseType[];
+	readonly token_endpoint_auth_method: OAuth2TokenEndpointAuthMethod;
 	readonly scope?: string;
 	readonly contacts?: readonly string[];
-	readonly registration_access_token: string;
+	readonly registration_access_token?: string;
 	readonly registration_client_uri: string;
 }
 
 // From codersdk/oauth2.go
 /**
- * OAuth2ClientRegistrationRequest represents RFC 7591 Dynamic Client Registration Request
+ * OAuth2ClientRegistrationRequest represents RFC 7591 Dynamic Client Registration Request.
  */
 export interface OAuth2ClientRegistrationRequest {
 	readonly redirect_uris?: readonly string[];
@@ -2993,21 +2992,21 @@ export interface OAuth2ClientRegistrationRequest {
 	readonly software_id?: string;
 	readonly software_version?: string;
 	readonly software_statement?: string;
-	readonly grant_types?: readonly string[];
-	readonly response_types?: readonly string[];
-	readonly token_endpoint_auth_method?: string;
+	readonly grant_types?: readonly OAuth2ProviderGrantType[];
+	readonly response_types?: readonly OAuth2ProviderResponseType[];
+	readonly token_endpoint_auth_method?: OAuth2TokenEndpointAuthMethod;
 	readonly scope?: string;
 	readonly contacts?: readonly string[];
 }
 
 // From codersdk/oauth2.go
 /**
- * OAuth2ClientRegistrationResponse represents RFC 7591 Dynamic Client Registration Response
+ * OAuth2ClientRegistrationResponse represents RFC 7591 Dynamic Client Registration Response.
  */
 export interface OAuth2ClientRegistrationResponse {
 	readonly client_id: string;
 	readonly client_secret?: string;
-	readonly client_id_issued_at: number;
+	readonly client_id_issued_at?: number;
 	readonly client_secret_expires_at?: number;
 	readonly redirect_uris?: readonly string[];
 	readonly client_name?: string;
@@ -3019,9 +3018,9 @@ export interface OAuth2ClientRegistrationResponse {
 	readonly jwks?: Record<string, string>;
 	readonly software_id?: string;
 	readonly software_version?: string;
-	readonly grant_types: readonly string[];
-	readonly response_types: readonly string[];
-	readonly token_endpoint_auth_method: string;
+	readonly grant_types: readonly OAuth2ProviderGrantType[];
+	readonly response_types: readonly OAuth2ProviderResponseType[];
+	readonly token_endpoint_auth_method: OAuth2TokenEndpointAuthMethod;
 	readonly scope?: string;
 	readonly contacts?: readonly string[];
 	readonly registration_access_token: string;
@@ -3038,6 +3037,42 @@ export interface OAuth2DeviceFlowCallbackResponse {
 	readonly redirect_url: string;
 }
 
+// From codersdk/oauth2.go
+/**
+ * OAuth2Error represents an OAuth2-compliant error response per RFC 6749.
+ */
+export interface OAuth2Error {
+	readonly error: OAuth2ErrorCode;
+	readonly error_description?: string;
+	readonly error_uri?: string;
+}
+
+// From codersdk/oauth2.go
+export type OAuth2ErrorCode =
+	| "invalid_client"
+	| "invalid_grant"
+	| "invalid_request"
+	| "invalid_scope"
+	| "invalid_target"
+	| "server_error"
+	| "temporarily_unavailable"
+	| "unauthorized_client"
+	| "unsupported_grant_type"
+	| "unsupported_token_type";
+
+export const OAuth2ErrorCodes: OAuth2ErrorCode[] = [
+	"invalid_client",
+	"invalid_grant",
+	"invalid_request",
+	"invalid_scope",
+	"invalid_target",
+	"server_error",
+	"temporarily_unavailable",
+	"unauthorized_client",
+	"unsupported_grant_type",
+	"unsupported_token_type",
+];
+
 // From codersdk/deployment.go
 export interface OAuth2GithubConfig {
 	readonly client_id: string;
@@ -3050,6 +3085,13 @@ export interface OAuth2GithubConfig {
 	readonly allow_everyone: boolean;
 	readonly enterprise_base_url: string;
 }
+
+// From codersdk/oauth2.go
+export type OAuth2PKCECodeChallengeMethod = "S256";
+
+export const OAuth2PKCECodeChallengeMethods: OAuth2PKCECodeChallengeMethod[] = [
+	"S256",
+];
 
 // From codersdk/client.go
 /**
@@ -3123,11 +3165,81 @@ export const OAuth2ProviderResponseTypes: OAuth2ProviderResponseType[] = [
  */
 export const OAuth2RedirectCookie = "oauth_redirect";
 
+// From codersdk/oauth2.go
+export type OAuth2RevocationTokenTypeHint = "access_token" | "refresh_token";
+
+export const OAuth2RevocationTokenTypeHints: OAuth2RevocationTokenTypeHint[] = [
+	"access_token",
+	"refresh_token",
+];
+
 // From codersdk/client.go
 /**
  * OAuth2StateCookie is the name of the cookie that stores the oauth2 state.
  */
 export const OAuth2StateCookie = "oauth_state";
+
+// From codersdk/oauth2.go
+export type OAuth2TokenEndpointAuthMethod =
+	| "client_secret_basic"
+	| "client_secret_post"
+	| "none";
+
+export const OAuth2TokenEndpointAuthMethods: OAuth2TokenEndpointAuthMethod[] = [
+	"client_secret_basic",
+	"client_secret_post",
+	"none",
+];
+
+// From codersdk/oauth2.go
+/**
+ * OAuth2TokenRequest represents a token request per RFC 6749. The actual wire
+ * format is application/x-www-form-urlencoded; this struct is for SDK docs.
+ */
+export interface OAuth2TokenRequest {
+	readonly grant_type: OAuth2ProviderGrantType;
+	readonly code?: string;
+	readonly redirect_uri?: string;
+	readonly client_id?: string;
+	readonly client_secret?: string;
+	readonly code_verifier?: string;
+	readonly refresh_token?: string;
+	readonly resource?: string;
+	readonly scope?: string;
+}
+
+// From codersdk/oauth2.go
+/**
+ * OAuth2TokenResponse represents a successful token response per RFC 6749.
+ */
+export interface OAuth2TokenResponse {
+	readonly access_token: string;
+	readonly token_type: OAuth2TokenType;
+	readonly expires_in?: number;
+	readonly refresh_token?: string;
+	readonly scope?: string;
+	/**
+	 * Expiry is not part of RFC 6749 but is included for compatibility with
+	 * golang.org/x/oauth2.Token and clients that expect a timestamp.
+	 */
+	readonly expiry?: string;
+}
+
+// From codersdk/oauth2.go
+/**
+ * OAuth2TokenRevocationRequest represents a token revocation request per RFC 7009.
+ */
+export interface OAuth2TokenRevocationRequest {
+	readonly token: string;
+	readonly token_type_hint?: OAuth2RevocationTokenTypeHint;
+	readonly client_id?: string;
+	readonly client_secret?: string;
+}
+
+// From codersdk/oauth2.go
+export type OAuth2TokenType = "Bearer";
+
+export const OAuth2TokenTypes: OAuth2TokenType[] = ["Bearer"];
 
 // From codersdk/users.go
 export interface OAuthConversionResponse {


### PR DESCRIPTION
## Summary

Makes `codersdk` OAuth2 types the single source of truth for token request, response, and revocation operations. This eliminates duplication between SDK types and server-side structs and enforces type safety by using enum types instead of raw strings.

## Changes

**codersdk/oauth2.go:**
- Added enum types: `OAuth2TokenEndpointAuthMethod`, `OAuth2PKCECodeChallengeMethod`, `OAuth2TokenType`, `OAuth2RevocationTokenTypeHint`, `OAuth2ErrorCode`
- Added struct types: `OAuth2Error`, `OAuth2TokenRequest`, `OAuth2TokenResponse`, `OAuth2TokenRevocationRequest`
- Updated `OAuth2AuthorizationServerMetadata`, `OAuth2ClientRegistrationRequest`, `OAuth2ClientRegistrationResponse`, `OAuth2ClientConfiguration` to use enum types instead of `string`/`[]string`
- Updated `ApplyDefaults()` to use enum constants

**coderd/oauth2provider/tokens.go:**
- Embed `codersdk.OAuth2TokenRequest` in `tokenParams`
- Return `codersdk.OAuth2TokenResponse` instead of `oauth2.Token`
- Use enum types for grant type validation and token type

**coderd/oauth2provider/revoke.go:**
- Parse into `codersdk.OAuth2TokenRevocationRequest`
- Use `OAuth2RevocationTokenTypeHint` enum

**Tests:**
- Use enum constants instead of string literals

**Generated files:**
- Regenerated TypeScript types and Swagger docs

Closes #21476