### PR TITLE
[DNM]: POC for ACP integration

### DIFF
--- a/cli/exp_acp_poc.go
+++ b/cli/exp_acp_poc.go
@@ -1,0 +1,469 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	stdslog "log/slog"
+	"net/http"
+	"os/exec"
+	"sync"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
+	"github.com/coder/acp-go-sdk"
+	"github.com/coder/coder/v2/buildinfo"
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+	"github.com/coder/websocket"
+)
+
+func (r *RootCmd) experimentalAcpCommand() *serpent.Command {
+	return &serpent.Command{
+		Use:   "acp",
+		Short: "Experimental commands for ACP (Agent Communication Protocol)",
+		Long:  `Experimental commands for ACP (Agent Communication Protocol).`,
+		Children: []*serpent.Command{
+			r.experimentalAcpStdioWsCommand(),
+			r.experimentalAcpClientCommand(),
+		},
+	}
+}
+
+func (r *RootCmd) experimentalAcpStdioWsCommand() *serpent.Command {
+	var (
+		hostArg string
+		portArg int64
+	)
+
+	cmd := &serpent.Command{
+		Use:   "stdio-ws <command> [args...]",
+		Short: "Bridge a stdio JSON-RPC API to WebSocket (experimental POC)",
+		Long: `Starts a subprocess and bridges its stdio JSON-RPC protocol to WebSocket, enabling integration with Coder's network-based architecture.
+
+This is a simplified proof of concept that only supports a single client at a time.
+
+Example usage in coder_script:
+  export PORT=8080
+  export HOST=0.0.0.0
+  coder exp acp stdio-ws -- gemini --experimental-acp`,
+		Handler: func(inv *serpent.Invocation) error {
+			if len(inv.Args) == 0 {
+				return xerrors.New("command required: specify child command to run")
+			}
+
+			childCmd, childArgs := inv.Args[0], inv.Args[1:]
+
+			ctx, cancel := context.WithCancel(inv.Context())
+			defer cancel()
+			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Named("stdio-ws")
+			if r.verbose {
+				logger = logger.Leveled(slog.LevelDebug)
+			}
+
+			child := exec.CommandContext(ctx, childCmd, childArgs...)
+			childStdin, err := child.StdinPipe()
+			if err != nil {
+				return xerrors.Errorf("getting child stdin: %w", err)
+			}
+			childStdout, err := child.StdoutPipe()
+			if err != nil {
+				return xerrors.Errorf("getting child stdout: %w", err)
+			}
+			childStderr, err := child.StderrPipe()
+			if err != nil {
+				return xerrors.Errorf("getting child stderr: %w", err)
+			}
+
+			// Log child stderr
+			stderrReader := bufio.NewScanner(childStderr)
+			go func() {
+				for stderrReader.Scan() {
+					logger.Info(ctx, "child stderr", slog.F("msg", stderrReader.Text()))
+				}
+				if err := stderrReader.Err(); err != nil {
+					logger.Error(ctx, "reading child stderr", slog.Error(err))
+				}
+			}()
+			if err := child.Start(); err != nil {
+				return xerrors.Errorf("starting child process: %w", err)
+			}
+			defer func() {
+				if err := child.Process.Kill(); err != nil {
+					logger.Error(ctx, "killing child process", slog.Error(err))
+				}
+			}()
+
+			logger.Info(ctx, "started child process",
+				slog.F("pid", child.Process.Pid),
+				slog.F("cmd", childCmd),
+				slog.F("args", childArgs),
+			)
+
+			go func() {
+				if err := child.Wait(); err != nil {
+					logger.Error(ctx, "child process exited with error", slog.Error(err))
+				}
+				cancel()
+			}()
+
+			wsIn := make(chan []byte)
+			wsOut := make(chan []byte)
+
+			// Read from child stdout and send to wsOut
+			go func() {
+				defer close(wsIn)
+				childReader := bufio.NewScanner(childStdout)
+				for childReader.Scan() {
+					line := childReader.Bytes()
+					if !bytes.HasSuffix(line, []byte("\n")) {
+						line = append(line, '\n')
+					}
+					wsOut <- append([]byte(nil), line...)
+				}
+			}()
+			// Read from wsIn and write to child stdin
+			go func() {
+				defer childStdin.Close()
+				for line := range wsIn {
+					if !bytes.HasSuffix(line, []byte("\n")) {
+						line = append(line, '\n')
+					}
+					if _, err := childStdin.Write(line); err != nil {
+						logger.Error(ctx, "writing to child stdin", slog.Error(err))
+						return
+					}
+				}
+			}()
+
+			sb := &stdioBridge{
+				log:    logger,
+				stdin:  wsIn,
+				stdout: wsOut,
+			}
+
+			srv := &http.Server{
+				Addr:    fmt.Sprintf("%s:%d", hostArg, portArg),
+				Handler: sb,
+			}
+
+			go func() {
+				<-ctx.Done()
+				srv.Close()
+			}()
+
+			logger.Info(ctx, "starting WebSocket server",
+				slog.F("host", hostArg),
+				slog.F("port", portArg),
+			)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logger.Error(ctx, "WebSocket server error", slog.Error(err))
+			}
+			return nil
+		},
+	}
+
+	cmd.Options = serpent.OptionSet{
+		{
+			Flag:        "host",
+			Env:         "HOST",
+			Default:     "0.0.0.0",
+			Value:       serpent.StringOf(&hostArg),
+			Description: "Host to bind WebSocket server to.",
+		},
+		{
+			Flag:        "port",
+			Env:         "PORT",
+			Default:     "8080",
+			Value:       serpent.Int64Of(&portArg),
+			Description: "Port to bind WebSocket server to.",
+		},
+	}
+
+	return cmd
+}
+
+type stdioBridge struct {
+	log    slog.Logger
+	conn   websocket.Conn
+	mu     sync.Mutex // Protects the fields below. NOTE: by design, this limits us to a single client at a time.
+	stdin  chan<- []byte
+	stdout <-chan []byte
+}
+
+func (sb *stdioBridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !sb.mu.TryLock() {
+		sb.log.Error(r.Context(), "multiple clients attempted to connect", slog.F("remote_addr", r.RemoteAddr), slog.F("url", r.URL.String()), slog.F("user_agent", r.UserAgent()))
+		http.Error(w, "only one client supported at a time", http.StatusServiceUnavailable)
+		return
+	}
+	defer sb.mu.Unlock()
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: buildinfo.IsDev(),
+	})
+	if err != nil {
+		sb.log.Error(r.Context(), "accept WebSocket connection", slog.Error(err))
+		return
+	}
+	defer func() {
+		conn.Close(websocket.StatusNormalClosure, "closing connection")
+		sb.log.Info(r.Context(), "client disconnected", slog.F("remote_addr", r.RemoteAddr), slog.F("url", r.URL.String()), slog.F("user_agent", r.UserAgent()))
+	}()
+
+	sb.log.Info(r.Context(), "client connected", slog.F("remote_addr", r.RemoteAddr), slog.F("url", r.URL.String()), slog.F("user_agent", r.UserAgent()))
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				sb.log.Info(ctx, "stopping ws->child bridge")
+				return
+			default:
+				msgType, data, err := conn.Read(ctx)
+				if err != nil {
+					sb.log.Error(ctx, "reading from WebSocket", slog.Error(err))
+					cancel()
+					return
+				}
+				if msgType != websocket.MessageText && msgType != websocket.MessageBinary {
+					sb.log.Error(ctx, "unexpected message type", slog.F("type", msgType))
+					continue
+				}
+				if !json.Valid(data) {
+					sb.log.Error(ctx, "invalid JSON message from WebSocket")
+					continue
+				}
+				sb.log.Debug(ctx, "got msg", slog.F("src", "ws"), slog.F("dst", "child"), slog.F("msg", string(data)))
+				select {
+				case <-ctx.Done():
+					return
+				case sb.stdin <- data:
+				}
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				sb.log.Info(ctx, "stopping child->ws bridge")
+				return
+			case line := <-sb.stdout:
+				sb.log.Debug(ctx, "got msg", slog.F("src", "child"), slog.F("dst", "ws"), slog.F("msg", string(line)))
+				if err := conn.Write(ctx, websocket.MessageText, line); err != nil {
+					sb.log.Error(ctx, "writing to WebSocket", slog.Error(err))
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+func (r *RootCmd) experimentalAcpClientCommand() *serpent.Command {
+	var (
+		url string
+	)
+
+	cmd := &serpent.Command{
+		Use:   "client <command> [args...]",
+		Short: "Run an ACP client over websocket (experimental POC)",
+		Long:  `Connects to an ACP server over WebSocket.`,
+		Handler: func(inv *serpent.Invocation) error {
+			var client acp.Client = &acpClient{inv: inv}
+
+			ctx := inv.Context()
+			logger := slog.Make(sloghuman.Sink(inv.Stderr)).Named("acp-client")
+			if r.verbose {
+				logger = logger.Leveled(slog.LevelDebug)
+				stdslog.SetLogLoggerLevel(stdslog.LevelDebug)
+			}
+
+			wsConn, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{})
+			if err != nil {
+				return xerrors.Errorf("dialing ACP server: %w", err)
+			}
+			defer wsConn.Close(websocket.StatusNormalClosure, "closing connection")
+			cliui.Infof(inv.Stdout, "Connected to %s", url)
+			_, wnc := codersdk.WebsocketNetConn(ctx, wsConn, websocket.MessageText)
+			defer wnc.Close()
+
+			csc := acp.NewClientSideConnection(client, wnc, wnc)
+			csc.SetLogger(stdslog.Default())
+			initResp, err := csc.Initialize(ctx, acp.InitializeRequest{
+				ProtocolVersion: acp.ProtocolVersionNumber,
+				ClientCapabilities: acp.ClientCapabilities{
+					Fs: acp.FileSystemCapability{
+						ReadTextFile:  true, // this is a lie
+						WriteTextFile: true,
+					},
+					Terminal: false,
+				},
+				ClientInfo: &acp.Implementation{
+					Name:    "coder-cli",
+					Version: buildinfo.Version(),
+				},
+			})
+			if err != nil {
+				return xerrors.Errorf("initializing ACP connection: %w", err)
+			}
+			cliui.Infof(inv.Stdout, "Connected to ACP server (protocol version %d)", initResp.ProtocolVersion)
+			sess, err := csc.NewSession(ctx, acp.NewSessionRequest{
+				Cwd:        ".",
+				McpServers: []acp.McpServer{},
+			})
+			if err != nil {
+				if re, ok := err.(*acp.RequestError); ok {
+					return xerrors.Errorf("client error: %s", re.Message)
+				}
+				return xerrors.Errorf("creating ACP session: %w", err)
+			}
+			cliui.Infof(inv.Stdout, "ACP session established: %s", sess.SessionId)
+			for {
+				msg, err := cliui.Prompt(inv, cliui.PromptOptions{})
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						cliui.Infof(inv.Stdout, "Exiting ACP client.")
+						return nil
+					}
+				}
+				_, err = csc.Prompt(ctx, acp.PromptRequest{
+					SessionId: sess.SessionId,
+					Prompt:    []acp.ContentBlock{acp.TextBlock(msg)},
+				})
+				if err != nil {
+					if re, ok := err.(*acp.RequestError); ok {
+						cliui.Errorf(inv.Stderr, "client error: %s", re.Message)
+						continue
+					} else {
+						return xerrors.Errorf("sending prompt: %w", err)
+					}
+				}
+			}
+		},
+	}
+	cmd.Options = serpent.OptionSet{
+		{
+			Flag:        "url",
+			Env:         "ACP_SERVER_URL",
+			Default:     "ws://localhost:8080",
+			Value:       serpent.StringOf(&url),
+			Description: "WebSocket URL of the ACP server to connect to.",
+		},
+	}
+	return cmd
+}
+
+type acpClient struct {
+	inv *serpent.Invocation
+}
+
+var _ acp.Client = (*acpClient)(nil)
+
+func (c *acpClient) RequestPermission(ctx context.Context, req acp.RequestPermissionRequest) (acp.RequestPermissionResponse, error) {
+	opts := make([]string, len(req.Options))
+	for i, option := range req.Options {
+		opts[i] = option.Name
+	}
+	resp, err := cliui.Select(c.inv, cliui.SelectOptions{
+		Message: fmt.Sprintf("Approve tool call: %s", *req.ToolCall.Title),
+		Options: opts,
+	})
+	if err != nil {
+		return acp.RequestPermissionResponse{}, err
+	}
+	var selectedID acp.PermissionOptionId
+	for _, option := range req.Options {
+		if option.Name == resp {
+			selectedID = option.OptionId
+			break
+		}
+	}
+	if selectedID == "" {
+		return acp.RequestPermissionResponse{
+			Outcome: acp.RequestPermissionOutcome{
+				Cancelled: &acp.RequestPermissionOutcomeCancelled{},
+			},
+		}, nil
+	}
+	return acp.RequestPermissionResponse{
+		Outcome: acp.RequestPermissionOutcome{
+			Selected: &acp.RequestPermissionOutcomeSelected{
+				OptionId: selectedID,
+			},
+		},
+	}, nil
+}
+
+func (c *acpClient) SessionUpdate(ctx context.Context, req acp.SessionNotification) error {
+	u := req.Update
+	switch {
+	case u.AgentMessageChunk != nil:
+		content := u.AgentMessageChunk.Content
+		if content.Text != nil {
+			cliui.Infof(c.inv.Stdout, "[agent_message_chunk] \n%s\n", content.Text.Text)
+		}
+	case u.ToolCall != nil:
+		cliui.Infof(c.inv.Stdout, "\n🔧 %s (%s)\n", u.ToolCall.Title, u.ToolCall.Status)
+	case u.ToolCallUpdate != nil:
+		cliui.Infof(c.inv.Stdout, "\n🔧 Tool call `%s` updated: %v\n\n", u.ToolCallUpdate.ToolCallId, u.ToolCallUpdate.Status)
+	case u.Plan != nil:
+		cliui.Infof(c.inv.Stdout, "[plan update]")
+	case u.AgentThoughtChunk != nil:
+		thought := u.AgentThoughtChunk.Content
+		if thought.Text != nil {
+			cliui.Infof(c.inv.Stdout, "[agent_thought_chunk] \n%s\n", thought.Text.Text)
+		}
+	case u.UserMessageChunk != nil:
+		cliui.Infof(c.inv.Stdout, "[user_message_chunk]")
+	}
+	return nil
+}
+
+// Below methods not implemented for this POC.
+func (c *acpClient) ReadTextFile(ctx context.Context, req acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
+	return acp.ReadTextFileResponse{}, fmt.Errorf("not implemented")
+}
+
+func (c *acpClient) WriteTextFile(ctx context.Context, req acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
+	return acp.WriteTextFileResponse{}, fmt.Errorf("not implemented")
+}
+
+func (c *acpClient) CreateTerminal(ctx context.Context, req acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
+	return acp.CreateTerminalResponse{}, fmt.Errorf("not implemented")
+}
+
+func (c *acpClient) KillTerminalCommand(ctx context.Context, req acp.KillTerminalCommandRequest) (acp.KillTerminalCommandResponse, error) {
+	return acp.KillTerminalCommandResponse{}, fmt.Errorf("not implemented")
+}
+
+func (c *acpClient) TerminalOutput(ctx context.Context, req acp.TerminalOutputRequest) (acp.TerminalOutputResponse, error) {
+	return acp.TerminalOutputResponse{}, fmt.Errorf("not implemented")
+}
+
+func (c *acpClient) ReleaseTerminal(ctx context.Context, req acp.ReleaseTerminalRequest) (acp.ReleaseTerminalResponse, error) {
+	return acp.ReleaseTerminalResponse{}, fmt.Errorf("not implemented")
+}
+
+func (c *acpClient) WaitForTerminalExit(ctx context.Context, req acp.WaitForTerminalExitRequest) (acp.WaitForTerminalExitResponse, error) {
+	return acp.WaitForTerminalExitResponse{}, fmt.Errorf("not implemented")
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -151,6 +151,7 @@ func (r *RootCmd) AGPLExperimental() []*serpent.Command {
 		r.rptyCommand(),
 		r.syncCommand(),
 		r.boundary(),
+		r.experimentalAcpCommand(),
 	}
 }
 

--- a/examples/templates/tasks-docker/main.tf
+++ b/examples/templates/tasks-docker/main.tf
@@ -10,160 +10,18 @@ terraform {
   }
 }
 
-# This template requires a valid Docker socket
-# However, you can reference our Kubernetes/VM
-# example templates and adapt the Claude Code module
-#
-# See: https://registry.coder.com/templates
 provider "docker" {}
 
-# A `coder_ai_task` resource enables Tasks and associates
-# the task with the coder_app that will act as an AI agent.
-resource "coder_ai_task" "task" {
-  count  = data.coder_workspace.me.start_count
-  app_id = module.claude-code[count.index].task_app_id
-}
-
-# You can read the task prompt from the `coder_task` data source.
 data "coder_task" "me" {}
-
-# The Claude Code module does the automatic task reporting
-# Other agent modules: https://registry.coder.com/modules?search=agent
-# Or use a custom agent:
-module "claude-code" {
-  count               = data.coder_workspace.me.start_count
-  source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.2.8"
-  agent_id            = coder_agent.main.id
-  workdir             = "/home/coder/projects"
-  order               = 999
-  claude_api_key      = ""
-  ai_prompt           = data.coder_task.me.prompt
-  system_prompt       = data.coder_parameter.system_prompt.value
-  model               = "sonnet"
-  permission_mode     = "plan"
-  post_install_script = data.coder_parameter.setup_script.value
-}
-
-# We are using presets to set the prompts, image, and set up instructions
-# See https://coder.com/docs/admin/templates/extending-templates/parameters#workspace-presets
-data "coder_workspace_preset" "default" {
-  name    = "Real World App: Angular + Django"
-  default = true
-  parameters = {
-    "system_prompt" = <<-EOT
-      -- Framing --
-      You are a helpful assistant that can help with code. You are running inside a Coder Workspace and provide status updates to the user via Coder MCP. Stay on track, feel free to debug, but when the original plan fails, do not choose a different route/architecture without checking the user first.
-
-      -- Tool Selection --
-      - playwright: previewing your changes after you made them
-        to confirm it worked as expected
-	    -	desktop-commander - use only for commands that keep running
-        (servers, dev watchers, GUI apps).
-      -	Built-in tools - use for everything else:
-       (file operations, git commands, builds & installs, one-off shell commands)
-
-      Remember this decision rule:
-      - Stays running? → desktop-commander
-      - Finishes immediately? → built-in tools
-
-      -- Context --
-      There is an existing app and tmux dev server running on port 8000. Be sure to read it's CLAUDE.md (./realworld-django-rest-framework-angular/CLAUDE.md) to learn more about it.
-
-      Since this app is for demo purposes and the user is previewing the homepage and subsequent pages, aim to make the first visual change/prototype very quickly so the user can preview it, then focus on backend or logic which can be a more involved, long-running architecture plan.
-
-    EOT
-
-    "setup_script"    = <<-EOT
-    # Set up projects dir
-    mkdir -p /home/coder/projects
-    cd $HOME/projects
-
-    # Packages: Install additional packages
-    sudo apt-get update && sudo apt-get install -y tmux
-    if ! command -v google-chrome >/dev/null 2>&1; then
-      yes | npx playwright install chrome
-    fi
-
-    # MCP: Install and configure MCP Servers
-    npm install -g @wonderwhy-er/desktop-commander
-    claude mcp add playwright npx -- @playwright/mcp@latest --headless --isolated --no-sandbox
-    claude mcp add desktop-commander desktop-commander
-
-    # Repo: Clone and pull changes from the git repository
-    if [ ! -d "realworld-django-rest-framework-angular" ]; then
-      git clone https://github.com/coder-contrib/realworld-django-rest-framework-angular.git
-    else
-      cd realworld-django-rest-framework-angular
-      git fetch
-      # Check for uncommitted changes
-      if git diff-index --quiet HEAD -- && \
-        [ -z "$(git status --porcelain --untracked-files=no)" ] && \
-        [ -z "$(git log --branches --not --remotes)" ]; then
-        echo "Repo is clean. Pulling latest changes..."
-        git pull
-      else
-        echo "Repo has uncommitted or unpushed changes. Skipping pull."
-      fi
-
-      cd ..
-    fi
-
-    # Initialize: Start the development server
-    cd realworld-django-rest-framework-angular && ./start-dev.sh
-    EOT
-    "preview_port"    = "4200"
-    "container_image" = "codercom/example-universal:ubuntu"
-  }
-
-  # Pre-builds is a Coder Premium
-  # feature to speed up workspace creation
-  #
-  # see https://coder.com/docs/admin/templates/extending-templates/prebuilt-workspaces
-  # prebuilds {
-  #   instances = 1
-  #   expiration_policy {
-  #      ttl = 86400  # Time (in seconds) after which unclaimed prebuilds are expired (1 day)
-  #  }
-  # }
-}
-
-# Advanced parameters (these are all set via preset)
-data "coder_parameter" "system_prompt" {
-  name         = "system_prompt"
-  display_name = "System Prompt"
-  type         = "string"
-  form_type    = "textarea"
-  description  = "System prompt for the agent with generalized instructions"
-  mutable      = false
-}
-data "coder_parameter" "setup_script" {
-  name         = "setup_script"
-  display_name = "Setup Script"
-  type         = "string"
-  form_type    = "textarea"
-  description  = "Script to run before running the agent"
-  mutable      = false
-}
-data "coder_parameter" "container_image" {
-  name         = "container_image"
-  display_name = "Container Image"
-  type         = "string"
-  default      = "codercom/example-universal:ubuntu"
-  mutable      = false
-}
-data "coder_parameter" "preview_port" {
-  name         = "preview_port"
-  display_name = "Preview Port"
-  description  = "The port the web app is running to preview in Tasks"
-  type         = "number"
-  default      = "3000"
-  mutable      = false
-}
-
 data "coder_provisioner" "me" {}
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
+
+variable "claude_api_key" {
+  description = "API key for Claude"
+  type        = string
+  sensitive   = true
+}
 
 resource "coder_agent" "main" {
   arch           = data.coder_provisioner.me.arch
@@ -175,87 +33,18 @@ resource "coder_agent" "main" {
       cp -rT /etc/skel ~
       touch ~/.init_done
     fi
+    mkdir -p /home/coder/projects
   EOT
 
-  # These environment variables allow you to make Git commits right away after creating a
-  # workspace. Note that they take precedence over configuration defined in ~/.gitconfig!
-  # You can remove this block if you'd prefer to configure Git manually or using
-  # dotfiles. (see docs/dotfiles.md)
   env = {
     GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace_owner.me.email}"
     GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace_owner.me.email}"
-  }
-
-  # The following metadata blocks are optional. They are used to display
-  # information about your workspace in the dashboard. You can remove them
-  # if you don't want to display any information.
-  # For basic resources, you can use the `coder stat` command.
-  # If you need more control, you can write your own script.
-  metadata {
-    display_name = "CPU Usage"
-    key          = "0_cpu_usage"
-    script       = "coder stat cpu"
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "RAM Usage"
-    key          = "1_ram_usage"
-    script       = "coder stat mem"
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "Home Disk"
-    key          = "3_home_disk"
-    script       = "coder stat disk --path $${HOME}"
-    interval     = 60
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "CPU Usage (Host)"
-    key          = "4_cpu_usage_host"
-    script       = "coder stat cpu --host"
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "Memory Usage (Host)"
-    key          = "5_mem_usage_host"
-    script       = "coder stat mem --host"
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "Load Average (Host)"
-    key          = "6_load_host"
-    # get load avg scaled by number of cores
-    script   = <<EOT
-      echo "`cat /proc/loadavg | awk '{ print $1 }'` `nproc`" | awk '{ printf "%0.2f", $1/$2 }'
-    EOT
-    interval = 60
-    timeout  = 1
-  }
-
-  metadata {
-    display_name = "Swap Usage (Host)"
-    key          = "7_swap_host"
-    script       = <<EOT
-      free -b | awk '/^Swap/ { printf("%.1f/%.1f", $3/1024.0/1024.0/1024.0, $2/1024.0/1024.0/1024.0) }'
-    EOT
-    interval     = 10
-    timeout      = 1
+    ANTHROPIC_API_KEY   = var.claude_api_key
   }
 }
 
-# See https://registry.coder.com/modules/coder/code-server
 module "code-server" {
   count  = data.coder_workspace.me.start_count
   folder = "/home/coder/projects"
@@ -272,93 +61,55 @@ module "code-server" {
   order    = 1
 }
 
-module "windsurf" {
-  count    = data.coder_workspace.me.start_count
-  source   = "registry.coder.com/coder/windsurf/coder"
-  version  = "1.3.0"
-  agent_id = coder_agent.main.id
-}
-
-module "cursor" {
-  count    = data.coder_workspace.me.start_count
-  source   = "registry.coder.com/coder/cursor/coder"
-  version  = "1.4.0"
-  agent_id = coder_agent.main.id
-}
-
-module "jetbrains" {
-  count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/coder/jetbrains/coder"
-  version    = "~> 1.0"
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  folder     = "/home/coder/projects"
-}
-
-resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.id}-home"
-  # Protect the volume from being deleted due to changes in attributes.
-  lifecycle {
-    ignore_changes = all
-  }
-  # Add labels in Docker to keep track of orphan resources.
-  labels {
-    label = "coder.owner"
-    value = data.coder_workspace_owner.me.name
-  }
-  labels {
-    label = "coder.owner_id"
-    value = data.coder_workspace_owner.me.id
-  }
-  labels {
-    label = "coder.workspace_id"
-    value = data.coder_workspace.me.id
-  }
-  # This field becomes outdated if the workspace is renamed but can
-  # be useful for debugging or cleaning out dangling volumes.
-  labels {
-    label = "coder.workspace_name_at_creation"
-    value = data.coder_workspace.me.name
-  }
-}
-
-resource "coder_app" "preview" {
-  agent_id     = coder_agent.main.id
-  slug         = "preview"
-  display_name = "Preview your app"
-  icon         = "${data.coder_workspace.me.access_url}/emojis/1f50e.png"
-  url          = "http://localhost:${data.coder_parameter.preview_port.value}"
-  share        = "authenticated"
-  subdomain    = true
-  open_in      = "tab"
-  order        = 0
-  healthcheck {
-    url       = "http://localhost:${data.coder_parameter.preview_port.value}/"
-    interval  = 5
-    threshold = 15
-  }
-}
+# Keeping statless for experimentation
+# resource "docker_volume" "home_volume" {
+# name = "coder-${data.coder_workspace.me.id}-home"
+# Protect the volume from being deleted due to changes in attributes.
+# lifecycle {
+# ignore_changes = all
+# }
+# Add labels in Docker to keep track of orphan resources.
+# labels {
+# label = "coder.owner"
+# value = data.coder_workspace_owner.me.name
+# }
+# labels {
+# label = "coder.owner_id"
+# value = data.coder_workspace_owner.me.id
+# }
+# labels {
+# label = "coder.workspace_id"
+# value = data.coder_workspace.me.id
+# }
+# This field becomes outdated if the workspace is renamed but can
+# be useful for debugging or cleaning out dangling volumes.
+# labels {
+# label = "coder.workspace_name_at_creation"
+# value = data.coder_workspace.me.name
+# }
+# }
 
 resource "docker_container" "workspace" {
-  count = data.coder_workspace.me.start_count
-  image = data.coder_parameter.container_image.value
-  # Uses lower() to avoid Docker restriction on container names.
-  name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
-  # Hostname makes the shell more user friendly: coder@my-workspace:~$
-  hostname = data.coder_workspace.me.name
-  user     = "coder"
-  # Use the docker gateway if the access URL is 127.0.0.1
+  count      = data.coder_workspace.me.start_count
+  image      = "codercom/enterprise-node:ubuntu"
+  name       = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname   = data.coder_workspace.me.name
+  user       = "coder"
   entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
-  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.main.token}",
+    "CODER_AGENT_SOCKET_SERVER_ENABLED=true",
+  ]
   host {
     host = "host.docker.internal"
     ip   = "host-gateway"
   }
-  volumes {
-    container_path = "/home/coder"
-    volume_name    = docker_volume.home_volume.name
-    read_only      = false
-  }
+  # Keeping stateless for experimentation
+  # volumes {
+  # container_path = "/home/coder"
+  # volume_name    = docker_volume.home_volume.name
+  # read_only      = false
+  # }
 
   # Add labels in Docker to keep track of orphan resources.
   labels {
@@ -377,4 +128,45 @@ resource "docker_container" "workspace" {
     label = "coder.workspace_name"
     value = data.coder_workspace.me.name
   }
+}
+
+resource "coder_script" "claude-code-acp" {
+  count        = data.coder_workspace.me.start_count
+  agent_id     = coder_agent.main.id
+  display_name = "Sets up the ACP client for Claude Code"
+  run_on_start = true
+  script       = <<EOT
+    #!/bin/bash
+    set -euo pipefail
+    set -x
+
+    trap 'coder exp sync complete script-claude-code-acp' EXIT
+    #coder exp sync want script-claude-code-acp module-claude-code
+    coder exp sync start script-claude-code-acp
+
+    sudo apt-get update
+    sudo apt-get install -y screen
+    # For some reason, this fails with a Killed signal
+    # curl -fsSL https://claude.ai/install.sh > /tmp/install-claude.sh
+    # sudo bash /tmp/install-claude.sh
+    sudo npm install -g @anthropic-ai/claude-code
+    sudo npm install -g @zed-industries/claude-code-acp
+    screen -dmS claude-code-acp /bin/sh -c 'coder exp acp stdio-ws --verbose -- claude-code-acp'
+  EOT
+}
+
+resource "coder_app" "claude-code-acp" {
+  count        = data.coder_workspace.me.start_count
+  agent_id     = coder_agent.main.id
+  slug         = "claude-code-acp"
+  display_name = "Stdio WebSocket for Claude Code ACP"
+  url          = "http://localhost:8080" # Default port for stdio-ws is 8080
+  share        = "authenticated"
+  open_in      = "tab"
+  order        = 0
+}
+
+resource "coder_ai_task" "task" {
+  count  = data.coder_workspace.me.start_count
+  app_id = coder_app.claude-code-acp[count.index].id
 }

--- a/examples/templates/tasks-docker/main.tf
+++ b/examples/templates/tasks-docker/main.tf
@@ -99,6 +99,8 @@ resource "docker_container" "workspace" {
   env = [
     "CODER_AGENT_TOKEN=${coder_agent.main.token}",
     "CODER_AGENT_SOCKET_SERVER_ENABLED=true",
+    "CODER_TASK_ID=${data.coder_task.me.id}",
+    "CODER_TASK_INITIAL_PROMPT=${data.coder_task.me.prompt}",
   ]
   host {
     host = "host.docker.internal"

--- a/go.mod
+++ b/go.mod
@@ -473,6 +473,7 @@ require (
 require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
+	github.com/coder/acp-go-sdk v0.6.3
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
 	github.com/coder/aibridge v0.3.1-0.20260105111716-7535a71e91a1
 	github.com/coder/aisdk-go v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -925,6 +925,8 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y+bSQAYZnetRJ70VMVKm5CKI0=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
+github.com/coder/acp-go-sdk v0.6.3 h1:LsXQytehdjKIYJnoVWON/nf7mqbiarnyuyE3rrjBsXQ=
+github.com/coder/acp-go-sdk v0.6.3/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
 github.com/coder/aibridge v0.3.1-0.20260105111716-7535a71e91a1 h1:cr2K36NgU1fHKtjzfOCMVH1QBhW7AGUg4lq+GjvJ41I=

--- a/site/package.json
+++ b/site/package.json
@@ -117,6 +117,7 @@
 		"ufuzzy": "npm:@leeoniya/ufuzzy@1.0.10",
 		"undici": "6.22.0",
 		"unique-names-generator": "4.7.1",
+		"use-acp": "0.2.5",
 		"uuid": "9.0.1",
 		"websocket-ts": "2.2.1",
 		"yup": "1.7.1"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
       unique-names-generator:
         specifier: 4.7.1
         version: 4.7.1
+      use-acp:
+        specifier: 0.2.5
+        version: 0.2.5(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)(use-sync-external-store@1.6.0(react@19.2.2))
       uuid:
         specifier: 9.0.1
         version: 9.0.1
@@ -470,6 +473,9 @@ packages:
 
   '@adobe/css-tools@4.4.1':
     resolution: {integrity: sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==, tarball: https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.1.tgz}
+
+  '@agentclientprotocol/sdk@0.4.9':
+    resolution: {integrity: sha512-ExwH828LaTGoTTjxuw49l+fwOLA+Yx0+qkWn1TcHMOsY5mVI9CUfkj7ZDhv2klgZ7mJeT+lxX/Dn/KINv1AkNQ==, tarball: https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.4.9.tgz}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==, tarball: https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz}
@@ -6139,6 +6145,12 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==, tarball: https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz}
 
+  use-acp@0.2.5:
+    resolution: {integrity: sha512-4TUEb4dlNzv1oOb0LboB5zYTNHBY6wSXS/3QCa1Fe9jLJ5x8xVY5rA+89FSzCnlDnd7XTwkLMJgaSXsQOOkoDA==, tarball: https://registry.npmjs.org/use-acp/-/use-acp-0.2.5.tgz}
+    peerDependencies:
+      react: ^19
+      react-dom: ^19
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==, tarball: https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz}
     engines: {node: '>=10'}
@@ -6501,8 +6513,29 @@ packages:
   yup@1.7.1:
     resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==, tarball: https://registry.npmjs.org/yup/-/yup-1.7.1.tgz}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==, tarball: https://registry.npmjs.org/zod/-/zod-3.25.76.tgz}
+
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==, tarball: https://registry.npmjs.org/zod/-/zod-4.1.13.tgz}
+
+  zustand@5.0.9:
+    resolution: {integrity: sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==, tarball: https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==, tarball: https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz}
@@ -6515,6 +6548,10 @@ snapshots:
   '@acemir/cssom@0.9.24': {}
 
   '@adobe/css-tools@4.4.1': {}
+
+  '@agentclientprotocol/sdk@0.4.9':
+    dependencies:
+      zod: 3.25.76
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -12887,6 +12924,17 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  use-acp@0.2.5(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)(use-sync-external-store@1.6.0(react@19.2.2)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.4.9
+      react: 19.2.2
+      react-dom: 19.2.2(react@19.2.2)
+      zustand: 5.0.9(@types/react@19.2.7)(react@19.2.2)(use-sync-external-store@1.6.0(react@19.2.2))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
+
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.2):
     dependencies:
       react: 19.2.2
@@ -13193,6 +13241,14 @@ snapshots:
       toposort: 2.0.2
       type-fest: 2.19.0
 
+  zod@3.25.76: {}
+
   zod@4.1.13: {}
+
+  zustand@5.0.9(@types/react@19.2.7)(react@19.2.2)(use-sync-external-store@1.6.0(react@19.2.2)):
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react: 19.2.2
+      use-sync-external-store: 1.6.0(react@19.2.2)
 
   zwitch@2.0.4: {}

--- a/site/src/pages/TaskPage/TaskAcpChat.tsx
+++ b/site/src/pages/TaskPage/TaskAcpChat.tsx
@@ -1,0 +1,327 @@
+import type { Workspace } from "api/typesGenerated";
+import { Button } from "components/Button/Button";
+import { Spinner } from "components/Spinner/Spinner";
+import { useAppLink } from "modules/apps/useAppLink";
+import type { WorkspaceAppWithAgent } from "modules/tasks/apps";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "utils/cn";
+import { useAcpClient } from "use-acp";
+import type { NotificationEvent } from "use-acp";
+
+type TaskAcpChatProps = {
+	workspace: Workspace;
+	app: WorkspaceAppWithAgent;
+	active: boolean;
+};
+
+export const TaskAcpChat: FC<TaskAcpChatProps> = ({
+	workspace,
+	app,
+	active,
+}) => {
+	const link = useAppLink(app, {
+		agent: app.agent,
+		workspace,
+	});
+
+	// Convert HTTP URL to WebSocket URL
+	const wsUrl = constructWsUrl(link.href);
+
+	const {
+		connect,
+		connectionState,
+		notifications,
+		pendingPermission,
+		resolvePermission,
+		agent: acpAgent,
+		activeSessionId,
+		setActiveSessionId,
+	} = useAcpClient({
+		wsUrl,
+		autoConnect: false, // Manual control for health checks
+		reconnectAttempts: 3,
+		reconnectDelay: 2000,
+	});
+
+	const [promptText, setPromptText] = useState("");
+	const [isPrompting, setIsPrompting] = useState(false);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+
+	// Auto-approve permissions for POC
+	useEffect(() => {
+		if (pendingPermission && pendingPermission.options.length > 0) {
+			resolvePermission({
+				outcome: {
+					outcome: "selected",
+					optionId: pendingPermission.options[0].optionId,
+				},
+			});
+		}
+	}, [pendingPermission, resolvePermission]);
+
+	// Create session when connected
+	useEffect(() => {
+		const createSession = async () => {
+			if (
+				connectionState.status === "connected" &&
+				acpAgent &&
+				!activeSessionId
+			) {
+				try {
+					const response = await acpAgent.newSession({
+						cwd: "/tmp",
+						mcpServers: [],
+					});
+					// biome-ignore lint/suspicious/noExplicitAny: SessionId is a branded type not exported from use-acp
+					setActiveSessionId(response.sessionId as any);
+				} catch (error) {
+					console.error("Failed to create ACP session:", error);
+				}
+			}
+		};
+
+		void createSession();
+	}, [connectionState.status, acpAgent, activeSessionId, setActiveSessionId]);
+
+	// Auto-scroll to bottom when new messages arrive
+	// biome-ignore lint/correctness/useExhaustiveDependencies: We want to scroll when notifications change
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [notifications]);
+
+	// Connect when app becomes healthy and active
+	useEffect(() => {
+		if (active && (app.health === "healthy" || app.health === "disabled")) {
+			void connect();
+		}
+	}, [active, app.health, connect]);
+
+	const handleSendPrompt = useCallback(async () => {
+		if (!acpAgent || !activeSessionId || !promptText.trim()) {
+			return;
+		}
+
+		setIsPrompting(true);
+		try {
+			await acpAgent.prompt({
+				sessionId: activeSessionId,
+				prompt: [
+					{
+						type: "text",
+						text: promptText,
+					},
+				],
+			});
+			setPromptText("");
+		} catch (error) {
+			console.error("Failed to send prompt:", error);
+		} finally {
+			setIsPrompting(false);
+		}
+	}, [acpAgent, activeSessionId, promptText]);
+
+	if (app.health === "unhealthy") {
+		return (
+			<div
+				className={cn([
+					active ? "flex" : "hidden",
+					"w-full h-full flex-col items-center justify-center p-4",
+				])}
+			>
+				<h3 className="m-0 font-medium text-content-primary text-base text-center">
+					App "{app.display_name}" is unhealthy
+				</h3>
+				<div className="text-content-secondary text-sm">
+					<span className="block text-center">
+						Here are some troubleshooting steps you can take:
+					</span>
+					<ul className="m-0 pt-4 flex flex-col gap-4">
+						{app.healthcheck && (
+							<li>
+								<span className="block font-medium text-content-primary mb-1">
+									Verify healthcheck
+								</span>
+								Try running the following inside your workspace:{" "}
+								<code className="font-mono text-content-primary select-all">
+									curl -v "{app.healthcheck.url}"
+								</code>
+							</li>
+						)}
+						<li>
+							<span className="block font-medium text-content-primary mb-1">
+								Check logs
+							</span>
+							See{" "}
+							<code className="font-mono text-content-primary select-all">
+								/tmp/coder-agent.log
+							</code>{" "}
+							inside your workspace "{workspace.name}" for more information.
+						</li>
+					</ul>
+				</div>
+			</div>
+		);
+	}
+
+	if (app.health === "initializing") {
+		return (
+			<div
+				className={cn([
+					active ? "flex" : "hidden",
+					"w-full h-full items-center justify-center",
+				])}
+			>
+				<Spinner loading />
+			</div>
+		);
+	}
+
+	return (
+		<div className={cn([active ? "flex" : "hidden", "w-full h-full flex-col"])}>
+			{/* Connection Status Bar */}
+			{connectionState.status !== "connected" && (
+				<div className="bg-surface-tertiary p-2 text-sm text-center border-b border-border">
+					{connectionState.status === "connecting" && (
+						<span className="text-content-secondary">
+							<Spinner loading className="inline-block w-4 h-4 mr-2" />
+							Connecting to ACP server...
+						</span>
+					)}
+					{connectionState.status === "error" && (
+						<span className="text-red-600">
+							Connection error: {connectionState.error}
+						</span>
+					)}
+					{connectionState.status === "disconnected" && (
+						<span className="text-content-secondary">Disconnected</span>
+					)}
+				</div>
+			)}
+
+			{/* Messages Area */}
+			<div className="flex-1 overflow-y-auto p-4 space-y-4">
+				{!activeSessionId && connectionState.status === "connected" && (
+					<div className="text-center text-content-secondary text-sm">
+						Creating session...
+					</div>
+				)}
+
+				{notifications.map((notification) => (
+					<MessageItem key={notification.id} notification={notification} />
+				))}
+				<div ref={messagesEndRef} />
+			</div>
+
+			{/* Input Area */}
+			{activeSessionId && (
+				<div className="border-t border-border p-4">
+					<div className="flex gap-2">
+						<input
+							type="text"
+							value={promptText}
+							onChange={(e) => setPromptText(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" && !e.shiftKey && !isPrompting) {
+									e.preventDefault();
+									void handleSendPrompt();
+								}
+							}}
+							placeholder="Type a message..."
+							disabled={isPrompting || connectionState.status !== "connected"}
+							className="flex-1 px-3 py-2 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-highlight text-sm bg-surface-primary"
+						/>
+						<Button
+							onClick={handleSendPrompt}
+							disabled={isPrompting || !promptText.trim()}
+							size="sm"
+						>
+							{isPrompting ? <Spinner loading /> : "Send"}
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+const MessageItem: FC<{ notification: NotificationEvent }> = ({
+	notification,
+}) => {
+	if (notification.type !== "session_notification") {
+		return null;
+	}
+
+	const update = notification.data.update;
+
+	// User messages
+	if (
+		update.sessionUpdate === "user_message_chunk" &&
+		update.content?.type === "text"
+	) {
+		return (
+			<div className="flex justify-end">
+				<div className="bg-highlight text-white px-4 py-2 rounded-lg max-w-[80%]">
+					{update.content.text}
+				</div>
+			</div>
+		);
+	}
+
+	// Agent messages
+	if (
+		update.sessionUpdate === "agent_message_chunk" &&
+		update.content?.type === "text"
+	) {
+		return (
+			<div className="flex justify-start">
+				<div className="bg-surface-secondary px-4 py-2 rounded-lg max-w-[80%]">
+					{update.content.text}
+				</div>
+			</div>
+		);
+	}
+
+	// Tool calls
+	if (update.sessionUpdate === "tool_call") {
+		return (
+			<div className="flex justify-start">
+				<div className="bg-surface-tertiary px-4 py-2 rounded-lg max-w-[80%] text-sm">
+					<div className="font-medium text-content-primary mb-1">
+						🔧 {update.title || "Tool call"}
+					</div>
+					<div className="text-content-secondary text-xs">
+						Status: {update.status}
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	// Agent thoughts (optional)
+	if (
+		update.sessionUpdate === "agent_thought_chunk" &&
+		update.content?.type === "text"
+	) {
+		return (
+			<div className="flex justify-start">
+				<div className="bg-surface-tertiary px-4 py-2 rounded-lg max-w-[80%] text-sm italic text-content-secondary">
+					{update.content.text}
+				</div>
+			</div>
+		);
+	}
+
+	return null;
+};
+
+function constructWsUrl(httpUrl: string): string {
+	try {
+		// Handle relative URLs by providing a base
+		const url = new URL(httpUrl, window.location.origin);
+		url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+		return url.toString();
+	} catch (error) {
+		console.error("Failed to construct WebSocket URL:", error);
+		return httpUrl;
+	}
+}

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -45,7 +45,7 @@ import {
 	WorkspaceBuildProgress,
 } from "../WorkspacePage/WorkspaceBuildProgress";
 import { ModifyPromptDialog } from "./ModifyPromptDialog";
-import { TaskAppIFrame } from "./TaskAppIframe";
+import { TaskAcpChat } from "./TaskAcpChat";
 import { TaskApps } from "./TaskApps";
 import { TaskTopbar } from "./TaskTopbar";
 
@@ -169,7 +169,7 @@ const TaskPage = () => {
 			<PanelGroup autoSaveId="task" direction="horizontal">
 				<Panel defaultSize={25} minSize={20}>
 					{chatApp ? (
-						<TaskAppIFrame active workspace={workspace} app={chatApp} />
+						<TaskAcpChat active workspace={workspace} app={chatApp} />
 					) : (
 						<div className="h-full flex items-center justify-center p-6 text-center">
 							<div className="flex flex-col items-center">


### PR DESCRIPTION
This PR adds a proof-of-concept integration for ACP.

- Adds a CLI command `exp acp stdio-ws` that acts as a bridge between the ACP agent's stdin/stdout and a websocket connection
- Adds a CLI command `exp acp client` to connect to an ACP agent over websocket
- Replaces the existing iframed Tasks UI with an ACP-enabled variant using https://github.com/marimo-team/use-acp.

Notes: 
- I gutted the `tasks-docker` template for testing purposes. This template just runs Zed's `claude-code-acp` adapter in a screen session.
- The `stdio-ws` command does some finagling to restrict the ACP agent to a single session by sending a `session/new` request and storing the returned session ID. Further `session/new` requests from clients are intercepted and the existing session ID is used. 
- Replaying the conversation history is normally done with `session/load` but not all clients support this. 
- Dynamically fetching the prompt from `coderd` and bypassing the maximum prompt length due to environment variables will likely require exposing some API endpoint that enables fetching task data without having to mint a Coder access token. We may wish to mint a scoped access token automatically for tasks that grants access only to task-related information. 

⚠️ This code was mostly generated by Claude. This should not be merged to main without significant redesign and refactoring.