### PR TITLE
feat: implement selective MITM with configurable domain allowlist in aibridgeproxyd

### DIFF
--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -779,8 +779,9 @@ aibridgeproxy:
   # Path to the CA private key file for AI Bridge Proxy.
   # (default: <unset>, type: string)
   key_file: ""
-  # Comma-separated list of domains to intercept and route through AI Bridge.
-  # Requests to other domains will be tunneled directly.
+  # Comma-separated list of domains for which HTTPS traffic will be decrypted and
+  # routed through AI Bridge. Requests to other domains will be tunneled directly
+  # without decryption.
   # (default: api.anthropic.com,api.openai.com, type: string-array)
   domain_allowlist:
     - api.anthropic.com

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -779,6 +779,12 @@ aibridgeproxy:
   # Path to the CA private key file for AI Bridge Proxy.
   # (default: <unset>, type: string)
   key_file: ""
+  # Comma-separated list of domains to intercept and route through AI Bridge.
+  # Requests to other domains will be tunneled directly.
+  # (default: api.anthropic.com,api.openai.com, type: string-array)
+  domain_allowlist:
+    - api.anthropic.com
+    - api.openai.com
 # Configure data retention policies for various database tables. Retention
 # policies automatically purge old data to reduce database size and improve
 # performance. Setting a retention duration to 0 disables automatic purging for

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12016,6 +12016,12 @@ const docTemplate = `{
                 "cert_file": {
                     "type": "string"
                 },
+                "domain_allowlist": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "enabled": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10681,6 +10681,12 @@
 				"cert_file": {
 					"type": "string"
 				},
+				"domain_allowlist": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"enabled": {
 					"type": "boolean"
 				},

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3498,7 +3498,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "AI Bridge Proxy Domain Allowlist",
-			Description: "Comma-separated list of domains to intercept and route through AI Bridge. Requests to other domains will be tunneled directly.",
+			Description: "Comma-separated list of domains for which HTTPS traffic will be decrypted and routed through AI Bridge. Requests to other domains will be tunneled directly without decryption.",
 			Flag:        "aibridge-proxy-domain-allowlist",
 			Env:         "CODER_AIBRIDGE_PROXY_DOMAIN_ALLOWLIST",
 			Value:       &c.AI.BridgeProxyConfig.DomainAllowlist,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3496,6 +3496,17 @@ Write out the current server config as YAML to stdout.`,
 			Group:       &deploymentGroupAIBridgeProxy,
 			YAML:        "key_file",
 		},
+		{
+			Name:        "AI Bridge Proxy Domain Allowlist",
+			Description: "Comma-separated list of domains to intercept and route through AI Bridge. Requests to other domains will be tunneled directly.",
+			Flag:        "aibridge-proxy-domain-allowlist",
+			Env:         "CODER_AIBRIDGE_PROXY_DOMAIN_ALLOWLIST",
+			Value:       &c.AI.BridgeProxyConfig.DomainAllowlist,
+			Default:     "api.anthropic.com,api.openai.com",
+			Hidden:      true,
+			Group:       &deploymentGroupAIBridgeProxy,
+			YAML:        "domain_allowlist",
+		},
 
 		// Retention settings
 		{
@@ -3590,10 +3601,11 @@ type AIBridgeBedrockConfig struct {
 }
 
 type AIBridgeProxyConfig struct {
-	Enabled    serpent.Bool   `json:"enabled" typescript:",notnull"`
-	ListenAddr serpent.String `json:"listen_addr" typescript:",notnull"`
-	CertFile   serpent.String `json:"cert_file" typescript:",notnull"`
-	KeyFile    serpent.String `json:"key_file" typescript:",notnull"`
+	Enabled         serpent.Bool        `json:"enabled" typescript:",notnull"`
+	ListenAddr      serpent.String      `json:"listen_addr" typescript:",notnull"`
+	CertFile        serpent.String      `json:"cert_file" typescript:",notnull"`
+	KeyFile         serpent.String      `json:"key_file" typescript:",notnull"`
+	DomainAllowlist serpent.StringArray `json:"domain_allowlist" typescript:",notnull"`
 }
 
 type AIConfig struct {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -164,6 +164,9 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "ai": {
       "aibridge_proxy": {
         "cert_file": "string",
+        "domain_allowlist": [
+          "string"
+        ],
         "enabled": true,
         "key_file": "string",
         "listen_addr": "string"

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -597,6 +597,9 @@
 ```json
 {
   "cert_file": "string",
+  "domain_allowlist": [
+    "string"
+  ],
   "enabled": true,
   "key_file": "string",
   "listen_addr": "string"
@@ -605,12 +608,13 @@
 
 ### Properties
 
-| Name          | Type    | Required | Restrictions | Description |
-|---------------|---------|----------|--------------|-------------|
-| `cert_file`   | string  | false    |              |             |
-| `enabled`     | boolean | false    |              |             |
-| `key_file`    | string  | false    |              |             |
-| `listen_addr` | string  | false    |              |             |
+| Name               | Type            | Required | Restrictions | Description |
+|--------------------|-----------------|----------|--------------|-------------|
+| `cert_file`        | string          | false    |              |             |
+| `domain_allowlist` | array of string | false    |              |             |
+| `enabled`          | boolean         | false    |              |             |
+| `key_file`         | string          | false    |              |             |
+| `listen_addr`      | string          | false    |              |             |
 
 ## codersdk.AIBridgeTokenUsage
 
@@ -712,6 +716,9 @@
 {
   "aibridge_proxy": {
     "cert_file": "string",
+    "domain_allowlist": [
+      "string"
+    ],
     "enabled": true,
     "key_file": "string",
     "listen_addr": "string"
@@ -2624,6 +2631,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "ai": {
       "aibridge_proxy": {
         "cert_file": "string",
+        "domain_allowlist": [
+          "string"
+        ],
         "enabled": true,
         "key_file": "string",
         "listen_addr": "string"
@@ -3163,6 +3173,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "ai": {
     "aibridge_proxy": {
       "cert_file": "string",
+      "domain_allowlist": [
+        "string"
+      ],
       "enabled": true,
       "key_file": "string",
       "listen_addr": "string"

--- a/enterprise/aibridgeproxyd/aibridgeproxyd.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -69,6 +70,10 @@ type Options struct {
 	// CertStore is an optional certificate cache for MITM. If nil, a default
 	// cache is created. Exposed for testing.
 	CertStore goproxy.CertStorage
+	// DomainAllowlist is the list of domains to intercept and route through AI Bridge.
+	// Only requests to these domains will be MITM'd and forwarded to aibridged.
+	// Requests to other domains will be tunneled directly without decryption.
+	DomainAllowlist []string
 }
 
 func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error) {
@@ -78,10 +83,6 @@ func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error)
 		return nil, xerrors.New("listen address is required")
 	}
 
-	if opts.CertFile == "" || opts.KeyFile == "" {
-		return nil, xerrors.New("cert file and key file are required")
-	}
-
 	if strings.TrimSpace(opts.CoderAccessURL) == "" {
 		return nil, xerrors.New("coder access URL is required")
 	}
@@ -89,6 +90,31 @@ func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid coder access URL %q: %w", opts.CoderAccessURL, err)
 	}
+
+	if opts.CertFile == "" || opts.KeyFile == "" {
+		return nil, xerrors.New("cert file and key file are required")
+	}
+
+	allowedPorts := opts.AllowedPorts
+	if len(allowedPorts) == 0 {
+		allowedPorts = []string{"80", "443"}
+	}
+
+	if len(opts.DomainAllowlist) == 0 {
+		return nil, xerrors.New("domain allow list is required")
+	}
+	mitmHosts, err := convertDomainsToHosts(opts.DomainAllowlist, allowedPorts)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid domain allowlist: %w", err)
+	}
+	if len(mitmHosts) == 0 {
+		return nil, xerrors.New("domain allowlist is empty, at least one domain is required")
+	}
+
+	logger.Info(ctx, "configured domain allowlist for MITM",
+		slog.F("domains", opts.DomainAllowlist),
+		slog.F("hosts", mitmHosts),
+	)
 
 	// Load CA certificate for MITM
 	certPEM, err := loadMitmCertificate(opts.CertFile, opts.KeyFile)
@@ -100,9 +126,6 @@ func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error)
 
 	// Cache generated leaf certificates to avoid expensive RSA key generation
 	// and signing on every request to the same hostname.
-	// TODO(ssncferreira): Currently certs are cached for all MITM'd hosts, but once
-	//   host filtering is implemented, only AI provider certs will be cached.
-	//   Related to https://github.com/coder/internal/issues/1182
 	if opts.CertStore != nil {
 		proxy.CertStore = opts.CertStore
 	} else {
@@ -118,19 +141,19 @@ func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error)
 	}
 
 	// Reject CONNECT requests to non-standard ports.
-	allowedPorts := opts.AllowedPorts
-	if len(allowedPorts) == 0 {
-		allowedPorts = []string{"80", "443"}
-	}
 	proxy.OnRequest().HandleConnectFunc(srv.portMiddleware(allowedPorts))
 
-	// Extract Coder session token from proxy authentication to forward to aibridged.
-	proxy.OnRequest().HandleConnectFunc(srv.authMiddleware)
+	// Apply MITM with authentication only to allowlisted hosts.
+	proxy.OnRequest(
+		// Only CONNECT requests to these hosts will be intercepted and decrypted.
+		// All other requests will be tunneled directly to their destination.
+		goproxy.ReqHostIs(mitmHosts...),
+	).HandleConnectFunc(
+		// Extract Coder session token from proxy authentication to forward to aibridged.
+		srv.authMiddleware,
+	)
 
 	// Handle decrypted requests: route to aibridged for known AI providers, or passthrough to original destination.
-	// TODO(ssncferreira): Currently the proxy always behaves as MITM, but this should only happen for known
-	//   AI providers as all other requests should be tunneled. This will be implemented upstack.
-	//   Related to https://github.com/coder/internal/issues/1182
 	proxy.OnRequest().DoFunc(srv.handleRequest)
 
 	// Create listener first so we can get the actual address.
@@ -249,6 +272,38 @@ func (s *Server) portMiddleware(allowedPorts []string) func(host string, ctx *go
 	}
 }
 
+// convertDomainsToHosts converts a list of domain names to host:port combinations.
+// Each domain is combined with each allowed port.
+// Returns an error if a domain includes a port that's not in the allowed ports list.
+// For example, ["api.anthropic.com"] with ports ["443"] becomes ["api.anthropic.com:443"].
+func convertDomainsToHosts(domains []string, allowedPorts []string) ([]string, error) {
+	var hosts []string
+	for _, domain := range domains {
+		domain = strings.TrimSpace(strings.ToLower(domain))
+		if domain == "" {
+			continue
+		}
+
+		// If domain already includes a port, validate it's in the allowed list.
+		if strings.Contains(domain, ":") {
+			host, port, err := net.SplitHostPort(domain)
+			if err != nil {
+				return nil, xerrors.Errorf("invalid domain %q: %w", domain, err)
+			}
+			if !slices.Contains(allowedPorts, port) {
+				return nil, xerrors.Errorf("invalid port in domain %q: port %s is not in allowed ports %v", domain, port, allowedPorts)
+			}
+			hosts = append(hosts, host+":"+port)
+		} else {
+			// Otherwise, combine domain with all allowed ports.
+			for _, port := range allowedPorts {
+				hosts = append(hosts, domain+":"+port)
+			}
+		}
+	}
+	return hosts, nil
+}
+
 // authMiddleware is a CONNECT middleware that extracts the Coder session token
 // from the Proxy-Authorization header and stores it in ctx.UserData for use by
 // downstream request handlers.
@@ -317,10 +372,6 @@ func extractCoderTokenFromProxyAuth(proxyAuth string) string {
 //   - Known AI providers return their provider name, used to route to the
 //     corresponding aibridge endpoint.
 //   - Unknown hosts return empty string and are passed through directly.
-//
-// TODO(ssncferreira): Provider list configurable via domain allowlists will be implemented upstack.
-//
-//	Related to https://github.com/coder/internal/issues/1182.
 func providerFromURL(reqURL *url.URL) string {
 	if reqURL == nil {
 		return ""
@@ -345,14 +396,15 @@ func (s *Server) handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.
 	// Check if this request is for a supported AI provider.
 	provider := providerFromURL(req.URL)
 	if provider == "" {
-		// TODO(ssncferreira): After implementing selective MITM, this case should never
-		//   happen since unknown hosts will be tunneled, not decrypted.
-		//   Related to https://github.com/coder/internal/issues/1182
-		s.logger.Debug(s.ctx, "passthrough request to unknown host",
+		// This can happen if a domain is in the allowlist but doesn't have a
+		// corresponding provider mapping in providerFromURL(). The request was
+		// decrypted but we don't know how to route it to aibridged.
+		s.logger.Warn(s.ctx, "decrypted request has no provider mapping, passing through",
 			slog.F("host", req.Host),
 			slog.F("method", req.Method),
 			slog.F("path", originalPath),
 		)
+		// Passthrough to the original destination.
 		return req, nil
 	}
 

--- a/enterprise/cli/aibridgeproxyd.go
+++ b/enterprise/cli/aibridgeproxyd.go
@@ -18,10 +18,11 @@ func newAIBridgeProxyDaemon(coderAPI *coderd.API) (*aibridgeproxyd.Server, error
 	logger := coderAPI.Logger.Named("aibridgeproxyd")
 
 	srv, err := aibridgeproxyd.New(ctx, logger, aibridgeproxyd.Options{
-		ListenAddr:     coderAPI.DeploymentValues.AI.BridgeProxyConfig.ListenAddr.String(),
-		CoderAccessURL: coderAPI.AccessURL.String(),
-		CertFile:       coderAPI.DeploymentValues.AI.BridgeProxyConfig.CertFile.String(),
-		KeyFile:        coderAPI.DeploymentValues.AI.BridgeProxyConfig.KeyFile.String(),
+		ListenAddr:      coderAPI.DeploymentValues.AI.BridgeProxyConfig.ListenAddr.String(),
+		CoderAccessURL:  coderAPI.AccessURL.String(),
+		CertFile:        coderAPI.DeploymentValues.AI.BridgeProxyConfig.CertFile.String(),
+		KeyFile:         coderAPI.DeploymentValues.AI.BridgeProxyConfig.KeyFile.String(),
+		DomainAllowlist: coderAPI.DeploymentValues.AI.BridgeProxyConfig.DomainAllowlist.Value(),
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to start in-memory aibridgeproxy daemon: %w", err)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -71,6 +71,7 @@ export interface AIBridgeProxyConfig {
 	readonly listen_addr: string;
 	readonly cert_file: string;
 	readonly key_file: string;
+	readonly domain_allowlist: string;
 }
 
 // From codersdk/aibridge.go


### PR DESCRIPTION
## Description

Implements selective MITM (Man-in-the-Middle) in `aibridgeproxyd` so that only requests to allowlisted domains are intercepted and decrypted. Requests to all other domains are tunneled directly without decryption.

## Changes

* New config option: `CODER_AIBRIDGE_PROXY_DOMAIN_ALLOWLIST` (default: `api.anthropic.com`,`api.openai.com`)
* Selective MITM: Uses `goproxy.ReqHostIs()` to only intercept `CONNECT` requests to allowlisted hosts
* Certificate caching: Now only generates/caches certificates for allowlisted domains
* Validation: Startup fails if domain allowlist is empty or contains invalid entries

Closes: https://github.com/coder/internal/issues/1182