### PR TITLE
fix: fix scaletest sdkclient duplication

### DIFF
--- a/scaletest/loadtestutil/client.go
+++ b/scaletest/loadtestutil/client.go
@@ -41,5 +41,11 @@ func extractHeaderAndInnerTransport(rt http.RoundTripper) (http.Header, *http.Tr
 		maps.Copy(headers, ht.Header)
 		return headers, t, nil
 	}
-	return nil, nil, xerrors.New("round tripper is neither HeaderTransport nor Transport")
+	// unrecognized RoundTripper. Just return a default transport, since we only care about preserving headers.
+	t, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// unhittable, unless the Go stdlib changes.
+		return nil, nil, xerrors.New("DefaultTransport is not *http.Transport")
+	}
+	return make(http.Header), t, nil
 }

--- a/scaletest/loadtestutil/client_test.go
+++ b/scaletest/loadtestutil/client_test.go
@@ -20,6 +20,7 @@ func TestDupClientCopyingHeaders(t *testing.T) {
 				Header: map[string][]string{
 					"X-Coder-Test":  {"foo"},
 					"X-Coder-Test3": {"socks"},
+					"X-Coder-Test5": {"ninjas"},
 				},
 			},
 			Header: map[string][]string{
@@ -46,5 +47,6 @@ func TestDupClientCopyingHeaders(t *testing.T) {
 	require.Equal(t, "baz", ht.Header.Get("X-Coder-Test2"))
 	require.Equal(t, "clocks", ht.Header.Get("X-Coder-Test3"))
 	require.Equal(t, "bears", ht.Header.Get("X-Coder-Test4"))
+	require.Equal(t, "ninjas", ht.Header.Get("X-Coder-Test5"))
 	require.NotEqual(t, http.DefaultTransport, ht.Transport)
 }


### PR DESCRIPTION
Fixes an issue introduce in #21288 

The default sdkclient created by the CLI root includes several additional http.RoundTripper wrappers to check versions and attach telemetry, so `DupClientCopyingHeaders` would break and scale tests would fail.

Instead of explicitly adding support for these additional wrappers to `DupClientCopyingHeaders` I think we should just stop unwrapping and move on. Scale tests don't need these wrapped functions.

This is a bit fragile, since it depends on the fact that the headers wrapper needs to be outermost, but that needs to be true for other uses, since things like dialing DERP do a similar thing where they unwrap and extract the auth headers. More long term this needs a refactor to make HTTP headers in the SDK a more first-class resource instead of this hacky RoundTripper wrapping, but that's for a different day.