### PR TITLE
fix(docs): show dynamic parameters demo in local GIF instead of Imgur link

### DIFF
--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -5,7 +5,7 @@ enriched input types, and user identity awareness.
 This allows template authors to create interactive workspace creation forms with more environment customization,
 and that means fewer templates to maintain.
 
-![Dynamic Parameters in Action](https://i.imgur.com/uR8mpRJ.gif)
+![Dynamic Parameters in Action](../../../images/admin/templates/extend-templates/dyn-params/dynamic-parameters-in-action.gif)
 
 All parameters are parsed from Terraform, so your workspace creation forms live in the same location as your provisioning code.
 You can use all the native Terraform functions and conditionality to create a self-service tooling catalog for every template.


### PR DESCRIPTION
fixes this bug where the dynamic parameters demo GIF isn't viewable in the UK:

<img width="720" height="798" alt="image" src="https://github.com/user-attachments/assets/757cd4fb-6b32-4db8-87fa-31a01588d69d" />