### PR TITLE
feat: add profiling options to tests in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1033,6 +1033,14 @@ ifdef RUN
 GOTEST_FLAGS += -run $(RUN)
 endif
 
+ifdef TEST_CPUPROFILE
+GOTEST_FLAGS += -cpuprofile=$(TEST_CPUPROFILE)
+endif
+
+ifdef TEST_MEMPROFILE
+GOTEST_FLAGS += -memprofile=$(TEST_MEMPROFILE)
+endif
+
 TEST_PACKAGES ?= ./...
 
 test:


### PR DESCRIPTION
Usage example:

```bash
$ make test TEST_CPUPROFILE=cpu.prof TEST_MEMPROFILE=mem.prof TEST_PACKAGES=./coderd
```

Note that `TEST_PACKAGES` has to be specified, otherwise you get `cannot use -{cpu,memory}profile flag with multiple packages`.