### PR TITLE
chore: clean up coder build directory on shutdown

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -632,6 +632,9 @@ resource "coder_agent" "dev" {
     # accumulating waste and growing too large.
     go clean -cache
 
+    # Clean up the coder build directory as this can get quite large
+    rm -rf ${local.repo_dir}/build
+
     # Clean up the unused resources to keep storage usage low.
     #
     # WARNING! This will remove:

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -633,7 +633,7 @@ resource "coder_agent" "dev" {
     go clean -cache
 
     # Clean up the coder build directory as this can get quite large
-    rm -rf ${local.repo_dir}/build
+    rm -rf "${local.repo_dir}/build"
 
     # Clean up the unused resources to keep storage usage low.
     #


### PR DESCRIPTION
Adds a step to delete the `build/` directory inside the Coder repo on shutdown.