### PR TITLE
chore: add dbtestutil.WithQueryTracking

### DIFF
--- a/coderd/database/dbtestutil/querytracking.go
+++ b/coderd/database/dbtestutil/querytracking.go
@@ -1,0 +1,157 @@
+package dbtestutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmetrics"
+)
+
+// wrapWithQueryTracking wraps the store with dbmetrics and sets up query
+// tracking with optional reset capability.
+func wrapWithQueryTracking(t testing.TB, db database.Store, logger slog.Logger, resetCh chan struct{}) (database.Store, func()) {
+	reg := prometheus.NewRegistry()
+	db = dbmetrics.NewQueryMetrics(db, logger, reg)
+
+	// Use a mutex to safely access baselineCounts from both the reset
+	// goroutine and the cleanup function.
+	var mu sync.Mutex
+	var baselineCounts map[string]uint64
+	done := make(chan struct{})
+
+	// If resetCh provided, listen for resets in a goroutine.
+	if resetCh != nil {
+		go func() {
+			defer close(done)
+			for range resetCh {
+				mu.Lock()
+				baselineCounts = getQueryCounts(reg)
+				mu.Unlock()
+			}
+		}()
+	} else {
+		close(done)
+	}
+
+	cleanup := func() {
+		// Close the channel to stop the goroutine.
+		if resetCh != nil {
+			close(resetCh)
+		}
+		<-done
+
+		finalCounts := getQueryCounts(reg)
+
+		mu.Lock()
+		reportCounts := diffCounts(baselineCounts, finalCounts)
+		mu.Unlock()
+
+		if len(reportCounts) == 0 {
+			return
+		}
+
+		writeQueryReport(t, reportCounts)
+	}
+
+	return db, cleanup
+}
+
+// getQueryCounts extracts per-query call counts from the registry.
+func getQueryCounts(reg prometheus.Gatherer) map[string]uint64 {
+	metrics, err := reg.Gather()
+	if err != nil {
+		return nil
+	}
+
+	counts := make(map[string]uint64)
+	for _, m := range metrics {
+		if m.GetName() != "coderd_db_query_latencies_seconds" {
+			continue
+		}
+		for _, metric := range m.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "query" {
+					counts[label.GetValue()] = metric.GetHistogram().GetSampleCount()
+				}
+			}
+		}
+	}
+	return counts
+}
+
+// diffCounts returns counts from 'after' minus counts from 'before'.
+// If before is nil, returns after unchanged.
+func diffCounts(before, after map[string]uint64) map[string]uint64 {
+	if before == nil {
+		return after
+	}
+	result := make(map[string]uint64)
+	for query, count := range after {
+		diff := count - before[query]
+		if diff > 0 {
+			result[query] = diff
+		}
+	}
+	return result
+}
+
+// writeQueryReport writes a TSV report of query counts.
+// If DBTRACKER_REPORT_DIR is set, writes to that directory; otherwise writes
+// to the test's package directory.
+func writeQueryReport(t testing.TB, counts map[string]uint64) {
+	testName := t.Name()
+	sanitizedName := regexp.MustCompile("[^a-zA-Z0-9-_]+").ReplaceAllString(testName, "_")
+
+	// Determine output directory.
+	outDir := os.Getenv("DBTRACKER_REPORT_DIR")
+	if outDir == "" {
+		var err error
+		outDir, err = filepath.Abs(".")
+		if err != nil {
+			t.Logf("query tracking: failed to get working directory: %v", err)
+			return
+		}
+	}
+
+	// Sort by count descending.
+	type row struct {
+		Query string
+		Count uint64
+	}
+	rows := make([]row, 0, len(counts))
+	for query, count := range counts {
+		rows = append(rows, row{query, count})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		return rows[i].Query < rows[j].Query
+	})
+
+	var buf strings.Builder
+	_, _ = buf.WriteString("Count\tQuery\tTestName\n")
+	for _, r := range rows {
+		_, _ = fmt.Fprintf(&buf, "%d\t%s\t%s\n", r.Count, r.Query, testName)
+	}
+
+	filename := filepath.Join(outDir, sanitizedName+".querytracking.tsv")
+
+	if err := os.WriteFile(filename, []byte(buf.String()), 0o600); err != nil {
+		t.Logf("query tracking: failed to write report: %v", err)
+		return
+	}
+
+	t.Logf("query tracking: wrote %d queries to %s", len(rows), filename)
+	t.Logf("query tracking: merge all reports with: (head -1 %s/*.tsv | head -1; tail -q -n +2 %s/*.tsv) | sort -t$'\\t' -k1 -rn", outDir, outDir)
+}

--- a/coderd/database/dbtestutil/querytracking_internal_test.go
+++ b/coderd/database/dbtestutil/querytracking_internal_test.go
@@ -1,0 +1,119 @@
+package dbtestutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
+)
+
+func TestWrapWithQueryTracking(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TracksQueries", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: a db wrapped with query tracking.
+		resetCh := make(chan struct{})
+		mockDB := dbmock.NewMockStore(gomock.NewController(t))
+		mockDB.EXPECT().GetUsers(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockDB.EXPECT().Wrappers().Return(nil).AnyTimes()
+		logger := slogtest.Make(t, nil)
+		db, cleanup := wrapWithQueryTracking(t, mockDB, logger, resetCh)
+
+		// When: some database queries are executed.
+		_, _ = db.GetUsers(t.Context(), database.GetUsersParams{})
+		_, _ = db.GetUsers(t.Context(), database.GetUsersParams{})
+
+		// Then: cleanup writes a report file.
+		cleanup()
+
+		reportPath := reportPathForTest(t)
+		t.Cleanup(func() { _ = os.Remove(reportPath) })
+
+		content, err := os.ReadFile(reportPath)
+		require.NoError(t, err)
+		require.Contains(t, string(content), "GetUsers")
+		require.Contains(t, string(content), "2\tGetUsers")
+	})
+
+	t.Run("ResetExcludesSetupQueries", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: a db wrapped with query tracking.
+		resetCh := make(chan struct{})
+		mockDB := dbmock.NewMockStore(gomock.NewController(t))
+		mockDB.EXPECT().GetUsers(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockDB.EXPECT().GetAuthorizedUsers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockDB.EXPECT().Wrappers().Return(nil).AnyTimes()
+		logger := slogtest.Make(t, nil)
+		db, cleanup := wrapWithQueryTracking(t, mockDB, logger, resetCh)
+
+		// When: setup queries run, then reset, then test queries run.
+		_, _ = db.GetUsers(t.Context(), database.GetUsersParams{})
+		_, _ = db.GetUsers(t.Context(), database.GetUsersParams{})
+		resetCh <- struct{}{}
+
+		// Only this query should be in the report.
+		_, _ = db.GetAuthorizedUsers(t.Context(), database.GetUsersParams{}, nil)
+
+		// Then: report only contains post-reset queries.
+		cleanup()
+
+		reportPath := reportPathForTest(t)
+		t.Cleanup(func() { _ = os.Remove(reportPath) })
+
+		content, err := os.ReadFile(reportPath)
+		require.NoError(t, err)
+		require.Contains(t, string(content), "1\tGetAuthorizedUsers")
+		require.NotContains(t, string(content), "GetUsers")
+	})
+
+	t.Run("NilChannelTracksAll", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: a db wrapped with query tracking and nil channel.
+		mockDB := dbmock.NewMockStore(gomock.NewController(t))
+		mockDB.EXPECT().GetUsers(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockDB.EXPECT().Wrappers().Return(nil).AnyTimes()
+		logger := slogtest.Make(t, nil)
+		db, cleanup := wrapWithQueryTracking(t, mockDB, logger, nil)
+
+		// When: some database queries are executed.
+		_, _ = db.GetUsers(t.Context(), database.GetUsersParams{})
+
+		// Then: all queries are in the report.
+		cleanup()
+
+		reportPath := reportPathForTest(t)
+		t.Cleanup(func() { _ = os.Remove(reportPath) })
+
+		content, err := os.ReadFile(reportPath)
+		require.NoError(t, err)
+		require.Contains(t, string(content), "GetUsers")
+	})
+}
+
+func reportPathForTest(t testing.TB) string {
+	t.Helper()
+	outDir := os.Getenv("DBTRACKER_REPORT_DIR")
+	if outDir == "" {
+		var err error
+		outDir, err = filepath.Abs(".")
+		require.NoError(t, err)
+	}
+	testName := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '_'
+	}, t.Name())
+	return filepath.Join(outDir, testName+".querytracking.tsv")
+}


### PR DESCRIPTION
Adds the ability to track and count db queries in tests.

Relates to https://github.com/coder/internal/issues/1214

🤖 Generated by Claude 4.5 Opus using `mux`

