### PR TITLE
chore: git ignore jetbrains run configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .eslintcache
 .gitpod.yml
 .idea
+.run
 **/*.swp
 gotests.coverage
 gotests.xml


### PR DESCRIPTION
Jetbrains ide users can save their debug/test run configs to `.run`.

