### PR TITLE
feat(coderd/database): add subagent_id column to workspace_agent_devcontainers

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -402,6 +402,7 @@ func WorkspaceAgentDevcontainer(t testing.TB, db database.Store, orig database.W
 		Name:             []string{takeFirst(orig.Name, testutil.GetRandomName(t))},
 		WorkspaceFolder:  []string{takeFirst(orig.WorkspaceFolder, "/workspace")},
 		ConfigPath:       []string{takeFirst(orig.ConfigPath, "")},
+		SubagentID:       []uuid.UUID{takeFirst(orig.SubagentID, uuid.NullUUID{}).UUID},
 	})
 	require.NoError(t, err, "insert workspace agent devcontainer")
 	return devcontainers[0]

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -2505,7 +2505,8 @@ CREATE TABLE workspace_agent_devcontainers (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     workspace_folder text NOT NULL,
     config_path text NOT NULL,
-    name text NOT NULL
+    name text NOT NULL,
+    subagent_id uuid
 );
 
 COMMENT ON TABLE workspace_agent_devcontainers IS 'Workspace agent devcontainer configuration';

--- a/coderd/database/migrations/000409_add_devcontainer_subagent_id.down.sql
+++ b/coderd/database/migrations/000409_add_devcontainer_subagent_id.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_agent_devcontainers
+	DROP COLUMN subagent_id;

--- a/coderd/database/migrations/000409_add_devcontainer_subagent_id.up.sql
+++ b/coderd/database/migrations/000409_add_devcontainer_subagent_id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_agent_devcontainers
+	ADD COLUMN subagent_id UUID;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4743,7 +4743,8 @@ type WorkspaceAgentDevcontainer struct {
 	// Path to devcontainer.json.
 	ConfigPath string `db:"config_path" json:"config_path"`
 	// The name of the Dev Container.
-	Name string `db:"name" json:"name"`
+	Name       string        `db:"name" json:"name"`
+	SubagentID uuid.NullUUID `db:"subagent_id" json:"subagent_id"`
 }
 
 type WorkspaceAgentLog struct {

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -7994,7 +7994,6 @@ func TestWorkspaceAgentDevcontainersSubagentID(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
-	ctx := testutil.Context(t, testutil.WaitShort)
 
 	// Setup: create workspace agent
 	org := dbgen.Organization(t, db, database.Organization{})
@@ -8036,6 +8035,7 @@ func TestWorkspaceAgentDevcontainersSubagentID(t *testing.T) {
 
 	t.Run("InsertWithSubagentID", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		devcontainers, err := db.InsertWorkspaceAgentDevcontainers(ctx, database.InsertWorkspaceAgentDevcontainersParams{
 			WorkspaceAgentID: agent.ID,
@@ -8061,6 +8061,7 @@ func TestWorkspaceAgentDevcontainersSubagentID(t *testing.T) {
 
 	t.Run("InsertWithNilSubagentID", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 
 		// Create a separate agent for this subtest
 		agent2 := dbgen.WorkspaceAgent(t, db, database.WorkspaceAgent{

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -17336,7 +17336,7 @@ func (q *sqlQuerier) ValidateUserIDs(ctx context.Context, userIds []uuid.UUID) (
 
 const getWorkspaceAgentDevcontainersByAgentID = `-- name: GetWorkspaceAgentDevcontainersByAgentID :many
 SELECT
-	id, workspace_agent_id, created_at, workspace_folder, config_path, name
+	id, workspace_agent_id, created_at, workspace_folder, config_path, name, subagent_id
 FROM
 	workspace_agent_devcontainers
 WHERE
@@ -17361,6 +17361,7 @@ func (q *sqlQuerier) GetWorkspaceAgentDevcontainersByAgentID(ctx context.Context
 			&i.WorkspaceFolder,
 			&i.ConfigPath,
 			&i.Name,
+			&i.SubagentID,
 		); err != nil {
 			return nil, err
 		}
@@ -17377,15 +17378,16 @@ func (q *sqlQuerier) GetWorkspaceAgentDevcontainersByAgentID(ctx context.Context
 
 const insertWorkspaceAgentDevcontainers = `-- name: InsertWorkspaceAgentDevcontainers :many
 INSERT INTO
-	workspace_agent_devcontainers (workspace_agent_id, created_at, id, name, workspace_folder, config_path)
+	workspace_agent_devcontainers (workspace_agent_id, created_at, id, name, workspace_folder, config_path, subagent_id)
 SELECT
 	$1::uuid AS workspace_agent_id,
 	$2::timestamptz AS created_at,
 	unnest($3::uuid[]) AS id,
 	unnest($4::text[]) AS name,
 	unnest($5::text[]) AS workspace_folder,
-	unnest($6::text[]) AS config_path
-RETURNING workspace_agent_devcontainers.id, workspace_agent_devcontainers.workspace_agent_id, workspace_agent_devcontainers.created_at, workspace_agent_devcontainers.workspace_folder, workspace_agent_devcontainers.config_path, workspace_agent_devcontainers.name
+	unnest($6::text[]) AS config_path,
+	unnest($7::uuid[]) AS subagent_id
+RETURNING workspace_agent_devcontainers.id, workspace_agent_devcontainers.workspace_agent_id, workspace_agent_devcontainers.created_at, workspace_agent_devcontainers.workspace_folder, workspace_agent_devcontainers.config_path, workspace_agent_devcontainers.name, workspace_agent_devcontainers.subagent_id
 `
 
 type InsertWorkspaceAgentDevcontainersParams struct {
@@ -17395,6 +17397,7 @@ type InsertWorkspaceAgentDevcontainersParams struct {
 	Name             []string    `db:"name" json:"name"`
 	WorkspaceFolder  []string    `db:"workspace_folder" json:"workspace_folder"`
 	ConfigPath       []string    `db:"config_path" json:"config_path"`
+	SubagentID       []uuid.UUID `db:"subagent_id" json:"subagent_id"`
 }
 
 func (q *sqlQuerier) InsertWorkspaceAgentDevcontainers(ctx context.Context, arg InsertWorkspaceAgentDevcontainersParams) ([]WorkspaceAgentDevcontainer, error) {
@@ -17405,6 +17408,7 @@ func (q *sqlQuerier) InsertWorkspaceAgentDevcontainers(ctx context.Context, arg 
 		pq.Array(arg.Name),
 		pq.Array(arg.WorkspaceFolder),
 		pq.Array(arg.ConfigPath),
+		pq.Array(arg.SubagentID),
 	)
 	if err != nil {
 		return nil, err
@@ -17420,6 +17424,7 @@ func (q *sqlQuerier) InsertWorkspaceAgentDevcontainers(ctx context.Context, arg 
 			&i.WorkspaceFolder,
 			&i.ConfigPath,
 			&i.Name,
+			&i.SubagentID,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/workspaceagentdevcontainers.sql
+++ b/coderd/database/queries/workspaceagentdevcontainers.sql
@@ -1,13 +1,14 @@
 -- name: InsertWorkspaceAgentDevcontainers :many
 INSERT INTO
-	workspace_agent_devcontainers (workspace_agent_id, created_at, id, name, workspace_folder, config_path)
+	workspace_agent_devcontainers (workspace_agent_id, created_at, id, name, workspace_folder, config_path, subagent_id)
 SELECT
 	@workspace_agent_id::uuid AS workspace_agent_id,
 	@created_at::timestamptz AS created_at,
 	unnest(@id::uuid[]) AS id,
 	unnest(@name::text[]) AS name,
 	unnest(@workspace_folder::text[]) AS workspace_folder,
-	unnest(@config_path::text[]) AS config_path
+	unnest(@config_path::text[]) AS config_path,
+	unnest(@subagent_id::uuid[]) AS subagent_id
 RETURNING workspace_agent_devcontainers.*;
 
 -- name: GetWorkspaceAgentDevcontainersByAgentID :many

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2897,6 +2897,7 @@ func InsertWorkspaceResource(ctx context.Context, db database.Store, jobID uuid.
 				devcontainerNames            = make([]string, 0, len(devcontainers))
 				devcontainerWorkspaceFolders = make([]string, 0, len(devcontainers))
 				devcontainerConfigPaths      = make([]string, 0, len(devcontainers))
+				devcontainerSubagentIDs      = make([]uuid.UUID, 0, len(devcontainers))
 			)
 			for _, dc := range devcontainers {
 				id := uuid.New()
@@ -2904,6 +2905,9 @@ func InsertWorkspaceResource(ctx context.Context, db database.Store, jobID uuid.
 				devcontainerNames = append(devcontainerNames, dc.Name)
 				devcontainerWorkspaceFolders = append(devcontainerWorkspaceFolders, dc.WorkspaceFolder)
 				devcontainerConfigPaths = append(devcontainerConfigPaths, dc.ConfigPath)
+				var subagentID uuid.UUID
+				copy(subagentID[:], dc.GetSubagentId())
+				devcontainerSubagentIDs = append(devcontainerSubagentIDs, subagentID)
 
 				// Add a log source and script for each devcontainer so we can
 				// track logs and timings for each devcontainer.
@@ -2932,6 +2936,7 @@ func InsertWorkspaceResource(ctx context.Context, db database.Store, jobID uuid.
 				Name:             devcontainerNames,
 				WorkspaceFolder:  devcontainerWorkspaceFolders,
 				ConfigPath:       devcontainerConfigPaths,
+				SubagentID:       devcontainerSubagentIDs,
 			})
 			if err != nil {
 				return xerrors.Errorf("insert agent devcontainer: %w", err)


### PR DESCRIPTION
Adds a database migration to store the association between a devcontainer and its sub-agent. This enables the system to track which sub-agent ID was pre-defined in Terraform for a given dev container.

Fixes: coder/internal#1240