### PR TITLE
fix: reuse CODER_AGENT_TOKEN in subprocesses for instance identity auth

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -806,6 +806,14 @@ func (a *AgentAuth) CreateClient() (*agentsdk.Client, error) {
 		return nil, xerrors.Errorf("%s must be set", envAgentURL)
 	}
 
+	// If CODER_AGENT_TOKEN is set, use it directly. This allows subprocesses
+	// (like gitaskpass) to reuse the parent agent's session token instead of
+	// re-authenticating via instance identity. The agent sets CODER_AGENT_TOKEN
+	// for subprocesses that need it (see agent/agent.go).
+	if a.agentToken != "" {
+		return agentsdk.New(&a.agentURL, agentsdk.WithFixedToken(a.agentToken)), nil
+	}
+
 	switch a.agentAuth {
 	case "token":
 		token := a.agentToken


### PR DESCRIPTION
## Summary

When using instance identity authentication (google/aws/azure), subprocesses like `coder gitaskpass` fail to authenticate because `CreateClient()` ignores the `CODER_AGENT_TOKEN` environment variable.

Fixes #21503

## Changes

Added a check at the start of `CreateClient()` to use `CODER_AGENT_TOKEN` directly if it's available, before falling back to instance identity exchange.

```go
// If CODER_AGENT_TOKEN is set, use it directly. This allows subprocesses
// (like gitaskpass) to reuse the parent agent's session token instead of
// re-authenticating via instance identity.
if a.agentToken != "" {
    return agentsdk.New(&a.agentURL, agentsdk.WithFixedToken(a.agentToken)), nil
}
```

## Why this is correct

The agent deliberately sets `CODER_AGENT_TOKEN` for subprocesses that need it:

```go
// agent/agent.go:1437-1438
// Specific Coder subcommands require the agent token exposed!
"CODER_AGENT_TOKEN": a.client.GetSessionToken(),
```

This fix allows those subprocesses to actually use the token.

## Test plan

- Existing tests in `gitaskpass_test.go` already set `CODER_AGENT_TOKEN` directly, so this matches expected behavior
- Manual testing: Create workspace with `google-instance-identity` auth, verify git clone works with external auth

## Notes

This is a minimal 6-line fix that doesn't change behavior for the `token` auth type (which already works) - it only fixes the instance identity auth types by allowing them to use an already-available token.