### PR TITLE
chore(dogfood): remove JetBrains Fleet module

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -291,11 +291,6 @@ data "coder_parameter" "ide_choices" {
     icon  = "/icon/jetbrains.svg"
   }
   option {
-    name  = "JetBrains Fleet"
-    value = "fleet"
-    icon  = "/icon/fleet.svg"
-  }
-  option {
     name  = "Cursor"
     value = "cursor"
     icon  = "/icon/cursor.svg"
@@ -453,15 +448,6 @@ module "zed" {
   count      = contains(jsondecode(data.coder_parameter.ide_choices.value), "zed") ? data.coder_workspace.me.start_count : 0
   source     = "dev.registry.coder.com/coder/zed/coder"
   version    = "1.1.4"
-  agent_id   = coder_agent.dev.id
-  agent_name = "dev"
-  folder     = local.repo_dir
-}
-
-module "jetbrains-fleet" {
-  count      = contains(jsondecode(data.coder_parameter.ide_choices.value), "fleet") ? data.coder_workspace.me.start_count : 0
-  source     = "registry.coder.com/coder/jetbrains-fleet/coder"
-  version    = "1.0.2"
   agent_id   = coder_agent.dev.id
   agent_name = "dev"
   folder     = local.repo_dir


### PR DESCRIPTION
JetBrains Fleet has been sunsetted and is no longer available.

Reference: https://blog.jetbrains.com/fleet/2025/12/the-future-of-fleet/

## Changes
- Removed Fleet IDE option from the IDE choices parameter
- Removed the `jetbrains-fleet` module

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `medium`_
