### PR TITLE
feat: add upstream proxy support to aiproxy for passthrough requests

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -165,6 +165,17 @@ AI BRIDGE PROXY OPTIONS:
       --aibridge-proxy-listen-addr string, $CODER_AIBRIDGE_PROXY_LISTEN_ADDR (default: :8888)
           The address the AI Bridge Proxy will listen on.
 
+      --aibridge-proxy-upstream string, $CODER_AIBRIDGE_PROXY_UPSTREAM
+          URL of an upstream HTTP proxy to chain passthrough (non-allowlisted)
+          requests through. Format: http://[user:pass@]host:port or
+          https://[user:pass@]host:port.
+
+      --aibridge-proxy-upstream-ca string, $CODER_AIBRIDGE_PROXY_UPSTREAM_CA
+          Path to a PEM-encoded CA certificate to trust for the upstream proxy's
+          TLS connection. Only needed for HTTPS upstream proxies with
+          certificates not trusted by the system. If not provided, the system
+          certificate pool is used.
+
 CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
 Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -798,6 +798,15 @@ aibridgeproxy:
   domain_allowlist:
     - api.anthropic.com
     - api.openai.com
+  # URL of an upstream HTTP proxy to chain passthrough (non-allowlisted) requests
+  # through. Format: http://[user:pass@]host:port or https://[user:pass@]host:port.
+  # (default: <unset>, type: string)
+  upstream_proxy: ""
+  # Path to a PEM-encoded CA certificate to trust for the upstream proxy's TLS
+  # connection. Only needed for HTTPS upstream proxies with certificates not trusted
+  # by the system. If not provided, the system certificate pool is used.
+  # (default: <unset>, type: string)
+  upstream_proxy_ca: ""
 # Configure data retention policies for various database tables. Retention
 # policies automatically purge old data to reduce database size and improve
 # performance. Setting a retention duration to 0 disables automatic purging for

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12157,6 +12157,12 @@ const docTemplate = `{
                 },
                 "listen_addr": {
                     "type": "string"
+                },
+                "upstream_proxy": {
+                    "type": "string"
+                },
+                "upstream_proxy_ca": {
+                    "type": "string"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10809,6 +10809,12 @@
 				},
 				"listen_addr": {
 					"type": "string"
+				},
+				"upstream_proxy": {
+					"type": "string"
+				},
+				"upstream_proxy_ca": {
+					"type": "string"
 				}
 			}
 		},

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3547,6 +3547,26 @@ Write out the current server config as YAML to stdout.`,
 			Group:       &deploymentGroupAIBridgeProxy,
 			YAML:        "domain_allowlist",
 		},
+		{
+			Name:        "AI Bridge Proxy Upstream Proxy",
+			Description: "URL of an upstream HTTP proxy to chain passthrough (non-allowlisted) requests through. Format: http://[user:pass@]host:port or https://[user:pass@]host:port.",
+			Flag:        "aibridge-proxy-upstream",
+			Env:         "CODER_AIBRIDGE_PROXY_UPSTREAM",
+			Value:       &c.AI.BridgeProxyConfig.UpstreamProxy,
+			Default:     "",
+			Group:       &deploymentGroupAIBridgeProxy,
+			YAML:        "upstream_proxy",
+		},
+		{
+			Name:        "AI Bridge Proxy Upstream Proxy CA",
+			Description: "Path to a PEM-encoded CA certificate to trust for the upstream proxy's TLS connection. Only needed for HTTPS upstream proxies with certificates not trusted by the system. If not provided, the system certificate pool is used.",
+			Flag:        "aibridge-proxy-upstream-ca",
+			Env:         "CODER_AIBRIDGE_PROXY_UPSTREAM_CA",
+			Value:       &c.AI.BridgeProxyConfig.UpstreamProxyCA,
+			Default:     "",
+			Group:       &deploymentGroupAIBridgeProxy,
+			YAML:        "upstream_proxy_ca",
+		},
 
 		// Retention settings
 		{
@@ -3647,6 +3667,8 @@ type AIBridgeProxyConfig struct {
 	CertFile        serpent.String      `json:"cert_file" typescript:",notnull"`
 	KeyFile         serpent.String      `json:"key_file" typescript:",notnull"`
 	DomainAllowlist serpent.StringArray `json:"domain_allowlist" typescript:",notnull"`
+	UpstreamProxy   serpent.String      `json:"upstream_proxy" typescript:",notnull"`
+	UpstreamProxyCA serpent.String      `json:"upstream_proxy_ca" typescript:",notnull"`
 }
 
 type AIConfig struct {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -169,7 +169,9 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
         ],
         "enabled": true,
         "key_file": "string",
-        "listen_addr": "string"
+        "listen_addr": "string",
+        "upstream_proxy": "string",
+        "upstream_proxy_ca": "string"
       },
       "bridge": {
         "anthropic": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -604,19 +604,23 @@
   ],
   "enabled": true,
   "key_file": "string",
-  "listen_addr": "string"
+  "listen_addr": "string",
+  "upstream_proxy": "string",
+  "upstream_proxy_ca": "string"
 }
 ```
 
 ### Properties
 
-| Name               | Type            | Required | Restrictions | Description |
-|--------------------|-----------------|----------|--------------|-------------|
-| `cert_file`        | string          | false    |              |             |
-| `domain_allowlist` | array of string | false    |              |             |
-| `enabled`          | boolean         | false    |              |             |
-| `key_file`         | string          | false    |              |             |
-| `listen_addr`      | string          | false    |              |             |
+| Name                | Type            | Required | Restrictions | Description |
+|---------------------|-----------------|----------|--------------|-------------|
+| `cert_file`         | string          | false    |              |             |
+| `domain_allowlist`  | array of string | false    |              |             |
+| `enabled`           | boolean         | false    |              |             |
+| `key_file`          | string          | false    |              |             |
+| `listen_addr`       | string          | false    |              |             |
+| `upstream_proxy`    | string          | false    |              |             |
+| `upstream_proxy_ca` | string          | false    |              |             |
 
 ## codersdk.AIBridgeTokenUsage
 
@@ -723,7 +727,9 @@
     ],
     "enabled": true,
     "key_file": "string",
-    "listen_addr": "string"
+    "listen_addr": "string",
+    "upstream_proxy": "string",
+    "upstream_proxy_ca": "string"
   },
   "bridge": {
     "anthropic": {
@@ -2639,7 +2645,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         ],
         "enabled": true,
         "key_file": "string",
-        "listen_addr": "string"
+        "listen_addr": "string",
+        "upstream_proxy": "string",
+        "upstream_proxy_ca": "string"
       },
       "bridge": {
         "anthropic": {
@@ -3184,7 +3192,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       ],
       "enabled": true,
       "key_file": "string",
-      "listen_addr": "string"
+      "listen_addr": "string",
+      "upstream_proxy": "string",
+      "upstream_proxy_ca": "string"
     },
     "bridge": {
       "anthropic": {

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1889,6 +1889,26 @@ Path to the CA certificate file for AI Bridge Proxy.
 
 Path to the CA private key file for AI Bridge Proxy.
 
+### --aibridge-proxy-upstream
+
+|             |                                             |
+|-------------|---------------------------------------------|
+| Type        | <code>string</code>                         |
+| Environment | <code>$CODER_AIBRIDGE_PROXY_UPSTREAM</code> |
+| YAML        | <code>aibridgeproxy.upstream_proxy</code>   |
+
+URL of an upstream HTTP proxy to chain passthrough (non-allowlisted) requests through. Format: http://[user:pass@]host:port or https://[user:pass@]host:port.
+
+### --aibridge-proxy-upstream-ca
+
+|             |                                                |
+|-------------|------------------------------------------------|
+| Type        | <code>string</code>                            |
+| Environment | <code>$CODER_AIBRIDGE_PROXY_UPSTREAM_CA</code> |
+| YAML        | <code>aibridgeproxy.upstream_proxy_ca</code>   |
+
+Path to a PEM-encoded CA certificate to trust for the upstream proxy's TLS connection. Only needed for HTTPS upstream proxies with certificates not trusted by the system. If not provided, the system certificate pool is used.
+
 ### --audit-logs-retention
 
 |             |                                          |

--- a/enterprise/aibridgeproxyd/aibridgeproxyd.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -74,6 +75,16 @@ type Options struct {
 	// Only requests to these domains will be MITM'd and forwarded to aibridged.
 	// Requests to other domains will be tunneled directly without decryption.
 	DomainAllowlist []string
+	// UpstreamProxy is the URL of an upstream HTTP proxy to chain passthrough
+	// (non-allowlisted) requests through. If empty, passthrough requests connect
+	// directly to their destinations.
+	// Format: http://[user:pass@]host:port or https://[user:pass@]host:port
+	UpstreamProxy string
+	// UpstreamProxyCA is the path to a PEM-encoded CA certificate file to trust
+	// for the upstream proxy's TLS connection. Only needed for HTTPS upstream
+	// proxies with certificates not trusted by the system. If empty, the system
+	// certificate pool is used.
+	UpstreamProxyCA string
 }
 
 func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error) {
@@ -130,6 +141,61 @@ func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error)
 		proxy.CertStore = opts.CertStore
 	} else {
 		proxy.CertStore = NewCertCache()
+	}
+
+	// Configure upstream proxy for passthrough (non-allowlisted) requests.
+	// This only affects CONNECT requests to domains not in the allowlist.
+	// MITM'd requests (allowlisted domains) are handled by aiproxy and forwarded
+	// to aibridge directly, not through the upstream proxy. AI Bridge respects
+	// proxy environment variables if set, so the upstream proxy is used at that
+	// layer instead.
+	if opts.UpstreamProxy != "" {
+		upstreamURL, err := url.Parse(opts.UpstreamProxy)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid upstream proxy URL %q: %w", opts.UpstreamProxy, err)
+		}
+
+		logger.Info(ctx, "configuring upstream proxy for passthrough requests",
+			slog.F("upstream", upstreamURL.Host),
+		)
+
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to load system certificate pool: %w", err)
+		}
+
+		// Add custom CA certificate if provided (for corporate proxies with private CAs).
+		// If no CA certificate is provided, the system certificate pool is used.
+		if opts.UpstreamProxyCA != "" {
+			if upstreamURL.Scheme == "https" {
+				caCert, err := os.ReadFile(opts.UpstreamProxyCA)
+				if err != nil {
+					return nil, xerrors.Errorf("failed to read upstream proxy CA certificate from %q: %w", opts.UpstreamProxyCA, err)
+				}
+				if !rootCAs.AppendCertsFromPEM(caCert) {
+					return nil, xerrors.Errorf("failed to parse upstream proxy CA certificate")
+				}
+				logger.Info(ctx, "configured upstream proxy CA certificate")
+			} else {
+				logger.Warn(ctx, "upstream proxy CA certificate is only used for HTTPS upstream proxies, ignoring",
+					slog.F("upstream_scheme", upstreamURL.Scheme),
+				)
+			}
+		}
+
+		// Set transport without Proxy to ensure MITM'd requests go directly to aibridge,
+		// not through any upstream proxy.
+		proxy.Tr = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    rootCAs,
+			},
+		}
+
+		// Configure passthrough CONNECT requests to go through upstream proxy.
+		// This only affects non-allowlisted domains; allowlisted domains are
+		// MITM'd and forwarded to aibridge.
+		proxy.ConnectDial = proxy.NewConnectDialToProxy(opts.UpstreamProxy)
 	}
 
 	srv := &Server{

--- a/enterprise/aibridgeproxyd/aibridgeproxyd_test.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd_test.go
@@ -1142,7 +1142,11 @@ func TestUpstreamProxy(t *testing.T) {
 			finalDestination, finalDestinationURL := newTargetServer(t, func(w http.ResponseWriter, r *http.Request) {
 				finalDestinationReceived = true
 				finalDestinationPath = r.URL.Path
-				body, _ := io.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
 				finalDestinationBody = string(body)
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("final destination response"))
@@ -1225,7 +1229,11 @@ func TestUpstreamProxy(t *testing.T) {
 				aibridgeReceived = true
 				aibridgePath = r.URL.Path
 				aibridgeAuthHeader = r.Header.Get("Authorization")
-				body, _ := io.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
 				aibridgeBody = string(body)
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("aibridge response"))

--- a/enterprise/cli/aibridgeproxyd.go
+++ b/enterprise/cli/aibridgeproxyd.go
@@ -23,6 +23,8 @@ func newAIBridgeProxyDaemon(coderAPI *coderd.API) (*aibridgeproxyd.Server, error
 		CertFile:        coderAPI.DeploymentValues.AI.BridgeProxyConfig.CertFile.String(),
 		KeyFile:         coderAPI.DeploymentValues.AI.BridgeProxyConfig.KeyFile.String(),
 		DomainAllowlist: coderAPI.DeploymentValues.AI.BridgeProxyConfig.DomainAllowlist.Value(),
+		UpstreamProxy:   coderAPI.DeploymentValues.AI.BridgeProxyConfig.UpstreamProxy.String(),
+		UpstreamProxyCA: coderAPI.DeploymentValues.AI.BridgeProxyConfig.UpstreamProxyCA.String(),
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to start in-memory aibridgeproxy daemon: %w", err)

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -166,6 +166,17 @@ AI BRIDGE PROXY OPTIONS:
       --aibridge-proxy-listen-addr string, $CODER_AIBRIDGE_PROXY_LISTEN_ADDR (default: :8888)
           The address the AI Bridge Proxy will listen on.
 
+      --aibridge-proxy-upstream string, $CODER_AIBRIDGE_PROXY_UPSTREAM
+          URL of an upstream HTTP proxy to chain passthrough (non-allowlisted)
+          requests through. Format: http://[user:pass@]host:port or
+          https://[user:pass@]host:port.
+
+      --aibridge-proxy-upstream-ca string, $CODER_AIBRIDGE_PROXY_UPSTREAM_CA
+          Path to a PEM-encoded CA certificate to trust for the upstream proxy's
+          TLS connection. Only needed for HTTPS upstream proxies with
+          certificates not trusted by the system. If not provided, the system
+          certificate pool is used.
+
 CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
 Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -73,6 +73,8 @@ export interface AIBridgeProxyConfig {
 	readonly cert_file: string;
 	readonly key_file: string;
 	readonly domain_allowlist: string;
+	readonly upstream_proxy: string;
+	readonly upstream_proxy_ca: string;
 }
 
 // From codersdk/aibridge.go


### PR DESCRIPTION
## Description

Adds upstream proxy support for AI Bridge Proxy passthrough requests. This allows aiproxy to forward non-allowlisted requests through an upstream proxy. Currently, the only supported configuration is when aiproxy is the first proxy in the chain (client → aiproxy → upstream proxy).

## Changes

* Add `--aibridge-proxy-upstream` option to configure an upstream HTTP/HTTPS proxy URL for passthrough requests
* Add `--aibridge-proxy-upstream-ca` option to trust custom CA certificates for HTTPS upstream proxies
* Passthrough requests (non-allowlisted domains) are forwarded through the upstream proxy
* MITM'd requests (allowlisted domains) continue to go directly to aibridge, not through the upstream proxy
* Add tests for upstream proxy configuration and request routing

Closes: https://github.com/coder/internal/issues/1204