### PR TITLE
feat(coderd/provisioner): support resources for devcontainer subagents

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -3725,8 +3725,17 @@ func TestInsertWorkspaceResource(t *testing.T) {
 		require.Len(t, resources, 1)
 		agents, err := db.GetWorkspaceAgentsByResourceIDs(ctx, []uuid.UUID{resources[0].ID})
 		require.NoError(t, err)
-		require.Len(t, agents, 1)
-		agent := agents[0]
+		// Expect 2 agents: the parent agent "dev" and the subagent "baz".
+		require.Len(t, agents, 2)
+		// Find the parent agent (no parent ID).
+		var agent database.WorkspaceAgent
+		for _, a := range agents {
+			if !a.ParentID.Valid {
+				agent = a
+				break
+			}
+		}
+		require.Equal(t, "dev", agent.Name)
 		devcontainers, err := db.GetWorkspaceAgentDevcontainersByAgentID(ctx, agent.ID)
 		sort.Slice(devcontainers, func(i, j int) bool {
 			return devcontainers[i].Name > devcontainers[j].Name


### PR DESCRIPTION
This change allows devcontainer subagents defined in Terraform to specify their own apps, scripts, and environment variables.

## Changes

When a devcontainer has apps, scripts, or envs defined, this code inserts a proper workspace agent record with:
- Environment variables from envs
- Apps with proper slug validation, health checks, and sharing levels
- Scripts for startup, cron, and shutdown operations

The subagent inherits properties from the parent agent where appropriate (architecture, OS, connection timeout, troubleshooting URL) while having its own distinct configuration.

## Refactoring

Extracts helper functions to reduce code duplication:
- `appSharingLevelToDatabase`
- `appOpenInToDatabase`
- `appHealthFromHealthcheck`
- `insertDevcontainerSubagent`
- `insertDevcontainerSubagentApps`
- `insertDevcontainerSubagentScripts`

Fixes coder/internal#1241