### PR TITLE
chore: improve healthcheck timeout message

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1863,7 +1863,6 @@ type API struct {
 
 	healthCheckGroup *singleflight.Group[string, *healthsdk.HealthcheckReport]
 	healthCheckCache atomic.Pointer[healthsdk.HealthcheckReport]
-	// healthCheckProgress atomic.Pointer[healthcheck.CheckProgress]
 	healthCheckProgress healthcheck.Progress
 
 	statsReporter *workspacestats.Reporter

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -205,7 +205,7 @@ type Options struct {
 	// tokens issued by and passed to the coordinator DRPC API.
 	CoordinatorResumeTokenProvider tailnet.ResumeTokenProvider
 
-	HealthcheckFunc              func(ctx context.Context, apiKey string, progress *healthcheck.CheckProgress) *healthsdk.HealthcheckReport
+	HealthcheckFunc              func(ctx context.Context, apiKey string, progress *healthcheck.Progress) *healthsdk.HealthcheckReport
 	HealthcheckTimeout           time.Duration
 	HealthcheckRefresh           time.Duration
 	WorkspaceProxiesFetchUpdater *atomic.Pointer[healthcheck.WorkspaceProxiesFetchUpdater]
@@ -681,7 +681,7 @@ func New(options *Options) *API {
 	}
 
 	if options.HealthcheckFunc == nil {
-		options.HealthcheckFunc = func(ctx context.Context, apiKey string, progress *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
+		options.HealthcheckFunc = func(ctx context.Context, apiKey string, progress *healthcheck.Progress) *healthsdk.HealthcheckReport {
 			// NOTE: dismissed healthchecks are marked in formatHealthcheck.
 			// Not here, as this result gets cached.
 			return healthcheck.Run(ctx, &healthcheck.ReportOptions{
@@ -1861,9 +1861,10 @@ type API struct {
 	// This is used to gate features that are not yet ready for production.
 	Experiments codersdk.Experiments
 
-	healthCheckGroup    *singleflight.Group[string, *healthsdk.HealthcheckReport]
-	healthCheckCache    atomic.Pointer[healthsdk.HealthcheckReport]
-	healthCheckProgress atomic.Pointer[healthcheck.CheckProgress]
+	healthCheckGroup *singleflight.Group[string, *healthsdk.HealthcheckReport]
+	healthCheckCache atomic.Pointer[healthsdk.HealthcheckReport]
+	// healthCheckProgress atomic.Pointer[healthcheck.CheckProgress]
+	healthCheckProgress healthcheck.Progress
 
 	statsReporter *workspacestats.Reporter
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1861,8 +1861,8 @@ type API struct {
 	// This is used to gate features that are not yet ready for production.
 	Experiments codersdk.Experiments
 
-	healthCheckGroup *singleflight.Group[string, *healthsdk.HealthcheckReport]
-	healthCheckCache atomic.Pointer[healthsdk.HealthcheckReport]
+	healthCheckGroup    *singleflight.Group[string, *healthsdk.HealthcheckReport]
+	healthCheckCache    atomic.Pointer[healthsdk.HealthcheckReport]
 	healthCheckProgress healthcheck.Progress
 
 	statsReporter *workspacestats.Reporter

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -69,6 +69,7 @@ import (
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/files"
 	"github.com/coder/coder/v2/coderd/gitsshkey"
+	"github.com/coder/coder/v2/coderd/healthcheck"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/jobreaper"
 	"github.com/coder/coder/v2/coderd/notifications"
@@ -131,7 +132,7 @@ type Options struct {
 	CoordinatorResumeTokenProvider tailnet.ResumeTokenProvider
 	ConnectionLogger               connectionlog.ConnectionLogger
 
-	HealthcheckFunc    func(ctx context.Context, apiKey string) *healthsdk.HealthcheckReport
+	HealthcheckFunc    func(ctx context.Context, apiKey string, progress *healthcheck.CheckProgress) *healthsdk.HealthcheckReport
 	HealthcheckTimeout time.Duration
 	HealthcheckRefresh time.Duration
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -132,7 +132,7 @@ type Options struct {
 	CoordinatorResumeTokenProvider tailnet.ResumeTokenProvider
 	ConnectionLogger               connectionlog.ConnectionLogger
 
-	HealthcheckFunc    func(ctx context.Context, apiKey string, progress *healthcheck.CheckProgress) *healthsdk.HealthcheckReport
+	HealthcheckFunc    func(ctx context.Context, apiKey string, progress *healthcheck.Progress) *healthsdk.HealthcheckReport
 	HealthcheckTimeout time.Duration
 	HealthcheckRefresh time.Duration
 

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -14,6 +14,7 @@ import (
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/healthcheck"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -28,7 +29,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel  = context.WithTimeout(context.Background(), testutil.WaitShort)
 			sessionToken string
 			client       = coderdtest.New(t, &coderdtest.Options{
-				HealthcheckFunc: func(_ context.Context, apiKey string) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
 					calls.Add(1)
 					assert.Equal(t, sessionToken, apiKey)
 					return &healthsdk.HealthcheckReport{
@@ -61,7 +62,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel  = context.WithTimeout(context.Background(), testutil.WaitShort)
 			sessionToken string
 			client       = coderdtest.New(t, &coderdtest.Options{
-				HealthcheckFunc: func(_ context.Context, apiKey string) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
 					calls.Add(1)
 					assert.Equal(t, sessionToken, apiKey)
 					return &healthsdk.HealthcheckReport{
@@ -96,7 +97,7 @@ func TestDebugHealth(t *testing.T) {
 			client      = coderdtest.New(t, &coderdtest.Options{
 				Logger:             &logger,
 				HealthcheckTimeout: time.Microsecond,
-				HealthcheckFunc: func(context.Context, string) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(context.Context, string, *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
 					t := time.NewTimer(time.Second)
 					defer t.Stop()
 
@@ -128,7 +129,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel = context.WithTimeout(context.Background(), testutil.WaitShort)
 			client      = coderdtest.New(t, &coderdtest.Options{
 				HealthcheckRefresh: time.Microsecond,
-				HealthcheckFunc: func(context.Context, string) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(context.Context, string, *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
 					calls <- struct{}{}
 					return &healthsdk.HealthcheckReport{}
 				},
@@ -173,7 +174,7 @@ func TestDebugHealth(t *testing.T) {
 			client      = coderdtest.New(t, &coderdtest.Options{
 				HealthcheckRefresh: time.Hour,
 				HealthcheckTimeout: time.Hour,
-				HealthcheckFunc: func(context.Context, string) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(context.Context, string, *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
 					calls++
 					return &healthsdk.HealthcheckReport{
 						Time: time.Now(),
@@ -207,7 +208,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel  = context.WithTimeout(context.Background(), testutil.WaitShort)
 			sessionToken string
 			client       = coderdtest.New(t, &coderdtest.Options{
-				HealthcheckFunc: func(_ context.Context, apiKey string) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
 					assert.Equal(t, sessionToken, apiKey)
 					return &healthsdk.HealthcheckReport{
 						Time:    time.Now(),

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -15,6 +15,7 @@ import (
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -29,7 +30,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel  = context.WithTimeout(context.Background(), testutil.WaitShort)
 			sessionToken string
 			client       = coderdtest.New(t, &coderdtest.Options{
-				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.Progress) *healthsdk.HealthcheckReport {
 					calls.Add(1)
 					assert.Equal(t, sessionToken, apiKey)
 					return &healthsdk.HealthcheckReport{
@@ -62,7 +63,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel  = context.WithTimeout(context.Background(), testutil.WaitShort)
 			sessionToken string
 			client       = coderdtest.New(t, &coderdtest.Options{
-				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.Progress) *healthsdk.HealthcheckReport {
 					calls.Add(1)
 					assert.Equal(t, sessionToken, apiKey)
 					return &healthsdk.HealthcheckReport{
@@ -94,19 +95,14 @@ func TestDebugHealth(t *testing.T) {
 			// Need to ignore errors due to ctx timeout
 			logger      = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 			ctx, cancel = context.WithTimeout(context.Background(), testutil.WaitShort)
+			done        = make(chan struct{})
 			client      = coderdtest.New(t, &coderdtest.Options{
 				Logger:             &logger,
-				HealthcheckTimeout: time.Microsecond,
-				HealthcheckFunc: func(context.Context, string, *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
-					t := time.NewTimer(time.Second)
-					defer t.Stop()
-
-					select {
-					case <-ctx.Done():
-						return &healthsdk.HealthcheckReport{}
-					case <-t.C:
-						return &healthsdk.HealthcheckReport{}
-					}
+				HealthcheckTimeout: time.Second,
+				HealthcheckFunc: func(_ context.Context, _ string, progress *healthcheck.Progress) *healthsdk.HealthcheckReport {
+					progress.Start("test")
+					<-done
+					return &healthsdk.HealthcheckReport{}
 				},
 			})
 			_ = coderdtest.CreateFirstUser(t, client)
@@ -116,8 +112,14 @@ func TestDebugHealth(t *testing.T) {
 		res, err := client.Request(ctx, "GET", "/api/v2/debug/health", nil)
 		require.NoError(t, err)
 		defer res.Body.Close()
-		_, _ = io.ReadAll(res.Body)
+		close(done)
+		bs, err := io.ReadAll(res.Body)
+		require.NoError(t, err, "reading body")
 		require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+		var sdkResp codersdk.Response
+		require.NoError(t, json.Unmarshal(bs, &sdkResp), "unmarshaling sdk response")
+		require.Equal(t, "Healthcheck timed out.", sdkResp.Message)
+		require.Contains(t, sdkResp.Detail, "Still running: test (elapsed:")
 	})
 
 	t.Run("Refresh", func(t *testing.T) {
@@ -129,7 +131,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel = context.WithTimeout(context.Background(), testutil.WaitShort)
 			client      = coderdtest.New(t, &coderdtest.Options{
 				HealthcheckRefresh: time.Microsecond,
-				HealthcheckFunc: func(context.Context, string, *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(context.Context, string, *healthcheck.Progress) *healthsdk.HealthcheckReport {
 					calls <- struct{}{}
 					return &healthsdk.HealthcheckReport{}
 				},
@@ -174,7 +176,7 @@ func TestDebugHealth(t *testing.T) {
 			client      = coderdtest.New(t, &coderdtest.Options{
 				HealthcheckRefresh: time.Hour,
 				HealthcheckTimeout: time.Hour,
-				HealthcheckFunc: func(context.Context, string, *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(context.Context, string, *healthcheck.Progress) *healthsdk.HealthcheckReport {
 					calls++
 					return &healthsdk.HealthcheckReport{
 						Time: time.Now(),
@@ -208,7 +210,7 @@ func TestDebugHealth(t *testing.T) {
 			ctx, cancel  = context.WithTimeout(context.Background(), testutil.WaitShort)
 			sessionToken string
 			client       = coderdtest.New(t, &coderdtest.Options{
-				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.CheckProgress) *healthsdk.HealthcheckReport {
+				HealthcheckFunc: func(_ context.Context, apiKey string, _ *healthcheck.Progress) *healthsdk.HealthcheckReport {
 					assert.Equal(t, sessionToken, apiKey)
 					return &healthsdk.HealthcheckReport{
 						Time:    time.Now(),


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/272

This flake has been persisting for a while, and unfortunately there's no detail on which healthcheck in particular is holding things up.

This PR adds a concurrency-safe `healthcheck.Progress` and wires it through `healthcheck.Run`. If the healthcheck times out, it will provide information on which healthchecks are completed / running, and how long they took / are still taking. 

🤖 Claude Opus 4.5 completed the first round of this implementation, which I then refactored.