### PR TITLE
chore: move agent's file API into separate package

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -40,6 +40,7 @@ import (
 	"github.com/coder/clistat"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/agent/agentscripts"
 	"github.com/coder/coder/v2/agent/agentsocket"
 	"github.com/coder/coder/v2/agent/agentssh"
@@ -295,6 +296,8 @@ type agent struct {
 	containerAPIOptions []agentcontainers.Option
 	containerAPI        *agentcontainers.API
 
+	filesAPI *agentfiles.API
+
 	socketServerEnabled bool
 	socketPath          string
 	socketServer        *agentsocket.Server
@@ -364,6 +367,8 @@ func (a *agent) init() {
 	containerAPIOpts = append(containerAPIOpts, a.containerAPIOptions...)
 
 	a.containerAPI = agentcontainers.NewAPI(a.logger.Named("containers"), containerAPIOpts...)
+
+	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem)
 
 	a.reconnectingPTYServer = reconnectingpty.NewServer(
 		a.logger.Named("reconnecting-pty"),

--- a/agent/agentfiles/api.go
+++ b/agent/agentfiles/api.go
@@ -1,0 +1,36 @@
+package agentfiles
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/spf13/afero"
+
+	"cdr.dev/slog/v3"
+)
+
+// API exposes file-related operations performed through the agent.
+type API struct {
+	logger     slog.Logger
+	filesystem afero.Fs
+}
+
+func NewAPI(logger slog.Logger, filesystem afero.Fs) *API {
+	api := &API{
+		logger:     logger,
+		filesystem: filesystem,
+	}
+	return api
+}
+
+// Routes returns the HTTP handler for file-related routes.
+func (api *API) Routes() http.Handler {
+	r := chi.NewRouter()
+
+	r.Post("/list-directory", api.HandleLS)
+	r.Get("/read-file", api.HandleReadFile)
+	r.Post("/write-file", api.HandleWriteFile)
+	r.Post("/edit-files", api.HandleEditFiles)
+
+	return r
+}

--- a/agent/agentfiles/ls.go
+++ b/agent/agentfiles/ls.go
@@ -1,4 +1,4 @@
-package agent
+package agentfiles
 
 import (
 	"errors"
@@ -21,7 +21,7 @@ import (
 
 var WindowsDriveRegex = regexp.MustCompile(`^[a-zA-Z]:\\$`)
 
-func (a *agent) HandleLS(rw http.ResponseWriter, r *http.Request) {
+func (api *API) HandleLS(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// An absolute path may be optionally provided, otherwise a path split into an
@@ -43,7 +43,7 @@ func (a *agent) HandleLS(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := listFiles(a.filesystem, path, req)
+	resp, err := listFiles(api.filesystem, path, req)
 	if err != nil {
 		status := http.StatusInternalServerError
 		switch {

--- a/agent/agentfiles/ls_internal_test.go
+++ b/agent/agentfiles/ls_internal_test.go
@@ -1,4 +1,4 @@
-package agent
+package agentfiles
 
 import (
 	"os"

--- a/agent/api.go
+++ b/agent/api.go
@@ -27,6 +27,8 @@ func (a *agent) apiHandler() http.Handler {
 		})
 	})
 
+	r.Mount("/api/v0", a.filesAPI.Routes())
+
 	if a.devcontainers {
 		r.Mount("/api/v0/containers", a.containerAPI.Routes())
 	} else if manifest := a.manifest.Load(); manifest != nil && manifest.ParentID != uuid.Nil {
@@ -49,10 +51,6 @@ func (a *agent) apiHandler() http.Handler {
 
 	r.Get("/api/v0/listening-ports", a.listeningPortsHandler.handler)
 	r.Get("/api/v0/netcheck", a.HandleNetcheck)
-	r.Post("/api/v0/list-directory", a.HandleLS)
-	r.Get("/api/v0/read-file", a.HandleReadFile)
-	r.Post("/api/v0/write-file", a.HandleWriteFile)
-	r.Post("/api/v0/edit-files", a.HandleEditFiles)
 	r.Get("/debug/logs", a.HandleHTTPDebugLogs)
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)


### PR DESCRIPTION
This makes it so we can test it directly without having to go through Tailnet, which appears to be causing flakes in CI where the requests time out and never make it to the agent.

Takes inspiration from the container-related API endpoints.

Would probably make sense to refactor the ls tests to also go through the API (rather than be internal tests like they are currently) but I left those alone for now to keep the diff minimal.

Closes https://github.com/coder/internal/issues/1059
Closes https://github.com/coder/internal/issues/1124