### PR TITLE
chore: manually add entitlement to `aibridge` for March release in Premium tier

### DIFF
--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -289,6 +290,23 @@ func LicensesEntitlements(
 					Start:    defaultManagedAgentsStart,
 					End:      defaultManagedAgentsEnd,
 				},
+			})
+		}
+
+		// Temporary: revert this in March 2026 release.
+		// Give people access to AI Bridge for this release if they are entitled to Premium.
+		// We're going to enforce license restrictions in March 2026 release.
+		if !slices.Contains(claims.Addons, codersdk.AddonAIGovernance) &&
+			claims.FeatureSet == codersdk.FeatureSetPremium {
+			entitlements.Warnings = append(entitlements.Warnings,
+				fmt.Sprintf(
+					"%s has reached General Availability and your Coder deployment is not entitled to run this feature. Contact your account team for information around getting a license with %s.",
+					codersdk.FeatureAIBridge.Humanize(),
+					codersdk.AddonAIGovernance.Humanize()),
+			)
+			entitlements.AddFeature(codersdk.FeatureAIBridge, codersdk.Feature{
+				Enabled:     true,
+				Entitlement: entitlement,
 			})
 		}
 


### PR DESCRIPTION
Related to #21499 

Closes #1226

> [!NOTE]
I've kept this as a seperate PR for easier merging, we can simply revert this pull-request after the Feburary release.

This PR temporarily enables AI Bridge for Premium license holders until March 2026. While Premium users will have access to the feature, they'll see a warning that their deployment isn't entitled to run AI Bridge and should contact their account team for information about getting a license with AI Governance.

![preview-general-availability-bridge.jpg](https://app.graphite.com/user-attachments/assets/7bde7e69-b874-40e8-bd87-5e8394d457be.jpg)

