### PR TITLE
fix(site): prevent workspace sharing button from causing forbidden error

### DIFF
--- a/site/src/modules/workspaces/WorkspaceSharingForm/useWorkspaceSharing.ts
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/useWorkspaceSharing.ts
@@ -11,6 +11,7 @@ import type {
 	WorkspaceUser,
 } from "api/typesGenerated";
 import { displaySuccess } from "components/GlobalSnackbar/utils";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 /**
@@ -20,8 +21,12 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
  */
 export function useWorkspaceSharing(workspace: Workspace) {
 	const queryClient = useQueryClient();
+	const { experiments } = useDashboard();
 
-	const workspaceACLQuery = useQuery(workspaceACL(workspace.id));
+	const workspaceACLQuery = useQuery({
+		...workspaceACL(workspace.id),
+		enabled: experiments.includes("workspace-sharing"),
+	});
 
 	const addUserMutation = useMutation(setWorkspaceUserRole(queryClient));
 	const updateUserMutation = useMutation(setWorkspaceUserRole(queryClient));

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -1,6 +1,7 @@
 import { deploymentConfig } from "api/queries/deployment";
 import type { Workspace, WorkspaceBuildParameter } from "api/typesGenerated";
 import { useAuthenticated } from "hooks/useAuthenticated";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import {
 	type ActionType,
 	abilitiesByWorkspaceStatus,
@@ -58,6 +59,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
 	handleDormantActivate,
 }) => {
 	const { user } = useAuthenticated();
+	const { experiments } = useDashboard();
 	const { data: deployment } = useQuery({
 		...deploymentConfig(),
 		enabled: permissions.deploymentConfig,
@@ -191,7 +193,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
 				onToggle={handleToggleFavorite}
 			/>
 
-			{!sharingDisabled && (
+			{!sharingDisabled && experiments.includes("workspace-sharing") && (
 				<ShareButton
 					workspace={workspace}
 					canUpdatePermissions={permissions.updateWorkspace}


### PR DESCRIPTION
## Summary

Fixes the workspace sharing button causing a "forbidden" error and infinite loading state when the `workspace-sharing` experiment is not enabled.

## Problem

When viewing any workspace page, if the `workspace-sharing` experiment was not enabled, the workspace sharing button would still be rendered and would attempt to fetch workspace ACL data from the backend. Since the `/api/v2/workspaces/{workspace}/acl` endpoint requires the experiment to be enabled (enforced by middleware), the request would fail with a "forbidden" error, causing an error message to appear in the UI and an infinite loading state.

This issue was particularly noticeable for users without the experiment enabled, but could theoretically affect any workspace regardless of its status.

## Fix

This PR adds two layers of protection:

1. **Frontend rendering check**: The `ShareButton` component is now only rendered when the `workspace-sharing` experiment is enabled. This prevents the button from appearing at all when the feature is unavailable.

2. **Query guard**: The `workspaceACL` query in `useWorkspaceSharing` is now disabled (`enabled: false`) when the experiment is not enabled. This ensures that even if the component is somehow rendered, it won't make the failing API request.

## Testing

- Verified TypeScript compilation passes (`pnpm check`)
- Verified code formatting is correct (`pnpm format`)
- All existing tests continue to pass

To manually test:
1. Start Coder without the `workspace-sharing` experiment enabled
2. Navigate to any workspace page
3. Verify the sharing button does not appear
4. Verify no "forbidden" error appears in the console or UI

Closes https://github.com/coder/coder/issues/21508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>