### PR TITLE
chore: add Go module domains to boundary allowlist

### DIFF
--- a/dogfood/coder/boundary-config.yaml
+++ b/dogfood/coder/boundary-config.yaml
@@ -121,8 +121,31 @@ allowlist:
   - domain=index.golang.org
   - domain=golang.org
   - domain=www.golang.org
+  - domain=go.dev
+  - domain=dl.google.com
   - domain=goproxy.io
   - domain=pkg.go.dev
+
+  # Go Module Domains (from go.mod)
+  - domain=cdr.dev
+  - domain=cel.dev
+  - domain=dario.cat
+  - domain=git.sr.ht
+  - domain=go.mozilla.org
+  - domain=go.nhat.io
+  - domain=go.opentelemetry.io
+  - domain=go.uber.org
+  - domain=go.yaml.in
+  - domain=go4.org
+  - domain=golang.zx2c4.com
+  - domain=gonum.org
+  - domain=gopkg.in
+  - domain=gvisor.dev
+  - domain=howett.net
+  - domain=kernel.org
+  - domain=mvdan.cc
+  - domain=sigs.k8s.io
+  - domain=storj.io
 
   # Package Managers - JVM
   - domain=maven.org


### PR DESCRIPTION
Add 21 domains to the boundary allowlist to support Go module downloads in the dogfood environment.

When running `go mod download` with `GOPROXY=direct`, Go fetches modules directly from their source domains. Several dependencies in `go.mod` use non-standard import paths that were being blocked by boundary with `403 Forbidden` errors.

**Added domains:**

| Domain | Purpose |
|--------|---------|
| `go.dev`, `dl.google.com` | Go toolchain downloads |
| `cdr.dev` | cdr.dev/slog (Coder logging) |
| `cel.dev` | cel.dev/expr |
| `dario.cat` | dario.cat/mergo |
| `git.sr.ht` | git.sr.ht/~jackmordaunt/go-toast |
| `go.mozilla.org` | go.mozilla.org/pkcs7 |
| `go.nhat.io` | go.nhat.io/otelsql |
| `go.opentelemetry.io` | OpenTelemetry packages |
| `go.uber.org` | go.uber.org/atomic, etc. |
| `go.yaml.in` | go.yaml.in/yaml |
| `go4.org` | go4.org/netipx |
| `golang.zx2c4.com` | WireGuard Go packages |
| `gonum.org` | gonum.org/v1/gonum |
| `gopkg.in` | gopkg.in/yaml.v3, etc. |
| `gvisor.dev` | gvisor.dev/gvisor |
| `howett.net` | howett.net/plist |
| `kernel.org` | libcap packages |
| `mvdan.cc` | mvdan.cc/gofumpt |
| `sigs.k8s.io` | sigs.k8s.io/yaml |
| `storj.io` | storj.io/drpc |

**Tested:** All domains verified working through boundary in a Linux container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)