### PR TITLE
chore: update agent metadata in WCOC template

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -502,61 +502,27 @@ resource "coder_agent" "dev" {
   }
 
   metadata {
-    display_name = "CPU Usage (Host)"
-    key          = "cpu_usage_host"
+    display_name = "/home Usage"
+    key          = "home_usage"
     order        = 2
-    script       = "coder stat cpu --host"
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "RAM Usage (Host)"
-    key          = "ram_usage_host"
-    order        = 3
-    script       = "coder stat mem --host"
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "Swap Usage (Host)"
-    key          = "swap_usage_host"
-    order        = 4
-    script       = <<EOT
-      #!/usr/bin/env bash
-      echo "$(free -b | awk '/^Swap/ { printf("%.1f/%.1f", $3/1024.0/1024.0/1024.0, $2/1024.0/1024.0/1024.0) }') GiB"
-    EOT
-    interval     = 10
-    timeout      = 1
-  }
-
-  metadata {
-    display_name = "Load Average (Host)"
-    key          = "load_host"
-    order        = 5
-    # get load avg scaled by number of cores
-    script   = <<EOT
-      #!/usr/bin/env bash
-      echo "`cat /proc/loadavg | awk '{ print $1 }'` `nproc`" | awk '{ printf "%0.2f", $1/$2 }'
-    EOT
-    interval = 60
-    timeout  = 1
-  }
-
-  metadata {
-    display_name = "Disk Usage (Host)"
-    key          = "disk_host"
-    order        = 6
-    script       = "coder stat disk --path /"
+    script       = "sudo du -sh /home/coder | awk '{print $1}'"
     interval     = 600
-    timeout      = 10
+    timeout      = 600
+  }
+
+  metadata {
+    display_name = "/var/lib/docker Usage"
+    key          = "var_lib_docker_usage"
+    order        = 3
+    script       = "sudo du -sh /var/lib/docker | awk '{print $1}'"
+    interval     = 600
+    timeout      = 600
   }
 
   metadata {
     display_name = "Word of the Day"
     key          = "word"
-    order        = 7
+    order        = 4
     script       = <<EOT
       #!/usr/bin/env bash
       curl -o - --silent https://www.merriam-webster.com/word-of-the-day 2>&1 | awk ' $0 ~ "Word of the Day: [A-z]+" { print $5; exit }'


### PR DESCRIPTION
This PR:
- Removes the host-related agent metadata. It's not particularly useful and the hosts have dedicated monitoring via Netdata.
- Adds two metdata blocks to expose the sizes of `/home/coder` and `/var/lib/docker` 