### PR TITLE
chore: update the dependency on aibridge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae
+	github.com/coder/aibridge v0.3.1-0.20260120123323-c997d7bed20e
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.0.1-alpha
 	github.com/coder/preview v1.0.4

--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v0.3.1-0.20260105111716-7535a71e91a1
+	github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.0.1-alpha
 	github.com/coder/preview v1.0.4
@@ -545,7 +545,7 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/openai/openai-go v1.12.0 // indirect
-	github.com/openai/openai-go/v2 v2.7.0 // indirect
+	github.com/openai/openai-go/v3 v3.15.0 // indirect
 	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
@@ -554,6 +554,7 @@ require (
 	github.com/samber/lo v1.51.0 // indirect
 	github.com/sergeymakinen/go-bmp v1.0.0 // indirect
 	github.com/sergeymakinen/go-ico v1.0.0-beta.0 // indirect
+	github.com/sony/gobreaker/v2 v2.3.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v0.3.1-0.20260105111716-7535a71e91a1 h1:cr2K36NgU1fHKtjzfOCMVH1QBhW7AGUg4lq+GjvJ41I=
-github.com/coder/aibridge v0.3.1-0.20260105111716-7535a71e91a1/go.mod h1:5Ztcl+9HF0tog85iEEuFdaBkBe8EkxJe5XjbMOFviQs=
+github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae h1:C5AOlFWjZvurag+W2nhdizkl0CEUgeI6jLVToDCFuQ0=
+github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae/go.mod h1:wYy+8VtBU0DKWGadNQhG6zI90XT9LeXVJ7sYnms6Oks=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.0.1-alpha h1:6shUQ2zkrWrfbgVcqWvpV2ibljOQvPvYqTctWBkKoUA=
@@ -1683,8 +1683,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisti
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.120.1/go.mod h1:Z/S1brD5gU2Ntht/bHxBVnGxXKTvZDr0dNv/riUzPmY=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
-github.com/openai/openai-go/v2 v2.7.0 h1:/8MSFCXcasin7AyuWQ2au6FraXL71gzAs+VfbMv+J3k=
-github.com/openai/openai-go/v2 v2.7.0/go.mod h1:jrJs23apqJKKbT+pqtFgNKpRju/KP9zpUTZhz3GElQE=
+github.com/openai/openai-go/v3 v3.15.0 h1:hk99rM7YPz+M99/5B/zOQcVwFRLLMdprVGx1vaZ8XMo=
+github.com/openai/openai-go/v3 v3.15.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -1804,6 +1804,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/sony/gobreaker/v2 v2.3.0 h1:7VYxZ69QXRQ2Q4eEawHn6eU4FiuwovzJwsUMA03Lu4I=
+github.com/sony/gobreaker/v2 v2.3.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/sosedoff/gitkit v0.4.0 h1:opyQJ/h9xMRLsz2ca/2CRXtstePcpldiZN8DpLLF8Os=
 github.com/sosedoff/gitkit v0.4.0/go.mod h1:V3EpGZ0nvCBhXerPsbDeqtyReNb48cwP9KtkUYTKT5I=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/go.sum
+++ b/go.sum
@@ -929,6 +929,10 @@ github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JR
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
 github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae h1:C5AOlFWjZvurag+W2nhdizkl0CEUgeI6jLVToDCFuQ0=
 github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae/go.mod h1:wYy+8VtBU0DKWGadNQhG6zI90XT9LeXVJ7sYnms6Oks=
+github.com/coder/aibridge v0.3.1-0.20260119093643-5dc19fcc01ac h1:gpeBTvH0ReG0CjkWDNSCWgGoGzYH8/rhlk9vecxH9ic=
+github.com/coder/aibridge v0.3.1-0.20260119093643-5dc19fcc01ac/go.mod h1:wYy+8VtBU0DKWGadNQhG6zI90XT9LeXVJ7sYnms6Oks=
+github.com/coder/aibridge v0.3.1-0.20260120123323-c997d7bed20e h1:FcXw+6MXWFTrRYKaYuao6IRLdt/aqfonFfSDh0wFTa8=
+github.com/coder/aibridge v0.3.1-0.20260120123323-c997d7bed20e/go.mod h1:x45BE/NNDesDN1eWy4bsg81QsL6ou7xXPIeQr0ePETQ=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.0.1-alpha h1:6shUQ2zkrWrfbgVcqWvpV2ibljOQvPvYqTctWBkKoUA=

--- a/go.sum
+++ b/go.sum
@@ -927,10 +927,6 @@ github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae h1:C5AOlFWjZvurag+W2nhdizkl0CEUgeI6jLVToDCFuQ0=
-github.com/coder/aibridge v0.3.1-0.20260119083322-b8b4a7dee7ae/go.mod h1:wYy+8VtBU0DKWGadNQhG6zI90XT9LeXVJ7sYnms6Oks=
-github.com/coder/aibridge v0.3.1-0.20260119093643-5dc19fcc01ac h1:gpeBTvH0ReG0CjkWDNSCWgGoGzYH8/rhlk9vecxH9ic=
-github.com/coder/aibridge v0.3.1-0.20260119093643-5dc19fcc01ac/go.mod h1:wYy+8VtBU0DKWGadNQhG6zI90XT9LeXVJ7sYnms6Oks=
 github.com/coder/aibridge v0.3.1-0.20260120123323-c997d7bed20e h1:FcXw+6MXWFTrRYKaYuao6IRLdt/aqfonFfSDh0wFTa8=
 github.com/coder/aibridge v0.3.1-0.20260120123323-c997d7bed20e/go.mod h1:x45BE/NNDesDN1eWy4bsg81QsL6ou7xXPIeQr0ePETQ=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=


### PR DESCRIPTION
Update our dependency on coder/aibridge. This allows us to benefit from the following additions to bridge:

feat: inner agentic loop for openai responses requests (blocking only) (coder/aibridge#127)
feat: req/resp logging middleware (coder/aibridge#105)
perf: eliminate unnecessary json marshalling for anthropic requests to bridge (coder/aibridge#102)
feat: add token usage recording for responses streaming interceptor (coder/aibridge#125)
feat: add token usage recording for responses blocking interceptor (coder/aibridge#124)
feat: add tool usage recording to streaming responses interceptor (coder/aibridge#123)
feat: add tool usage recording for blocking responses interceptor (coder/aibridge#122)
Extend circuit breaker functionality to support per-model isolation (coder/aibridge#111)
feat: add circuit breaker for upstream provider overload protection (coder/aibridge#75)
chore: change blocking request timeouts to 10m (coder/aibridge#118)
feat: add prompt recording for responses API (coder/aibridge#109)
feat: add basic responses API interceptor  (coder/aibridge#107)
