### PR TITLE
chore: increase du interval to 1h in dogfood/coder template

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -506,7 +506,7 @@ resource "coder_agent" "dev" {
     key          = "home_usage"
     order        = 2
     script       = "sudo du -sh /home/coder | awk '{print $1}'"
-    interval     = 600
+    interval     = 3600
     timeout      = 600
   }
 
@@ -515,7 +515,7 @@ resource "coder_agent" "dev" {
     key          = "var_lib_docker_usage"
     order        = 3
     script       = "sudo du -sh /var/lib/docker | awk '{print $1}'"
-    interval     = 600
+    interval     = 3600
     timeout      = 600
   }
 

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -506,8 +506,8 @@ resource "coder_agent" "dev" {
     key          = "home_usage"
     order        = 2
     script       = "sudo du -sh /home/coder | awk '{print $1}'"
-    interval     = 3600
-    timeout      = 600
+    interval     = 3600 # 1h to avoid thrashing disk
+    timeout      = 60   # Longer than this is likely problematic
   }
 
   metadata {
@@ -515,8 +515,8 @@ resource "coder_agent" "dev" {
     key          = "var_lib_docker_usage"
     order        = 3
     script       = "sudo du -sh /var/lib/docker | awk '{print $1}'"
-    interval     = 3600
-    timeout      = 600
+    interval     = 3600 # 1h to avoid thrashing disk
+    timeout      = 60   # Longer than this is likely problematic
   }
 
   metadata {


### PR DESCRIPTION
Increases the interval of running `du` on `/home/coder` and `/var/lib/docker` to 1h.
Also decreases the timout to 1m; having `du` run for longer is likely not great. 