### PR TITLE
feat: auto-reconnect websocket for dynamic parameters and reduce timeout

### DIFF
--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -128,7 +128,7 @@ func (*API) handleParameterEvaluate(rw http.ResponseWriter, r *http.Request, ini
 }
 
 func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request, initial codersdk.DynamicParametersRequest, render dynamicparameters.Renderer) {
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Minute)
 	defer cancel()
 
 	conn, err := websocket.Accept(rw, r, nil)


### PR DESCRIPTION
This PR implements the changes requested in issue #20846.

## Changes

1. **Reduced websocket timeout from 30 minutes to 3 minutes** - Updated the backend context timeout in `coderd/parameters.go:131` to prevent long-lived idle connections that could timeout unexpectedly.

2. **Auto-reconnect on page focus** - Added logic in `CreateWorkspacePage.tsx` to automatically reconnect the websocket when the create workspace page regains focus after a websocket error or timeout. This provides a better user experience for users who leave the page and return later.

## Implementation Details

The auto-reconnect mechanism works as follows:
- When the websocket closes or encounters an error, the component marks that a reconnect is needed
- A visibility change listener detects when the page regains focus
- When the page becomes visible and a websocket error exists, it triggers a reconnection by incrementing the `reconnectTrigger` state
- The websocket effect re-runs, creating a new connection and resetting the error state

The error message shown to users has been updated from "Refresh the page to reset the form" to "The connection will automatically reconnect when you focus this page" to reflect the new behavior.

Closes https://github.com/coder/coder/issues/20846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>