### PR TITLE
fix: temporarily hide `prompt` column from table view

### DIFF
--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.tsx
@@ -56,7 +56,6 @@ export const RequestLogsPageView: FC<RequestLogsPageViewProps> = ({
 						<TableRow className="text-xs">
 							<TableHead>Timestamp</TableHead>
 							<TableHead>Initiator</TableHead>
-							<TableHead>Prompt</TableHead>
 							<TableHead>Tokens</TableHead>
 							<TableHead>Model</TableHead>
 							<TableHead>Tool Calls</TableHead>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -107,8 +107,6 @@ export function tokenUsageMetadataMerge(
 export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 	const [isOpen, setIsOpen] = useState(false);
 
-	const [firstPrompt] = interception.user_prompts;
-
 	const inputTokens = interception.token_usages.reduce(
 		(acc, tokenUsage) => acc + tokenUsage.input_tokens,
 		0,
@@ -166,22 +164,6 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 							<div className="font-medium truncate min-w-0 flex-1 overflow-hidden">
 								{interception.initiator.name ?? interception.initiator.username}
 							</div>
-						</div>
-					</div>
-				</TableCell>
-				<TableCell className="min-w-0">
-					{/*
-						This is ensuring that the prompt is truncated and won't escape its bounding
-						container with an `absolute`.
-
-						Alternatively we could use a `table-fixed` table, but that would break worse
-						on mobile with the `min-w-0` column required.
-
-						This is a bit of a hack, but it works.
-					*/}
-					<div className="w-full h-4 min-w-48 relative">
-						<div className="absolute inset-0 leading-none overflow-hidden truncate">
-							{firstPrompt?.prompt}
 						</div>
 					</div>
 				</TableCell>


### PR DESCRIPTION
Closes #21580

This pull-request hides the `prompt` column from the `<RequestLogRow />` parent row. This is as for the time-being we are not able to pull prompts at every stage of the requests coming to AI Bridge. The prompt(s) are still available to be viewed in the overall view.

| Collapsed | Expanded | 
| --- | --- | 
| <img width="3516" height="2390" alt="CleanShot 2026-01-21 at 01 38 36@2x" src="https://github.com/user-attachments/assets/f56b3a54-7329-411c-916b-0f49a57b8c85" /> | <img width="3478" height="2352" alt="CleanShot 2026-01-21 at 01 39 41@2x" src="https://github.com/user-attachments/assets/fdbefe56-656a-4e02-8d61-0e60d629e489" /> |
