### PR TITLE
feat: use coder specific header for aibridge authentication from AI proxy

### DIFF
--- a/coderd/aibridge/aibridge.go
+++ b/coderd/aibridge/aibridge.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 )
 
-// HeaderCoderSessionAuth is an internal header used to pass the Coder session
-// token from AI Proxy to AI Bridge for authentication. This header is
-// stripped by AI Bridge before forwarding requests to upstream providers.
-const HeaderCoderSessionAuth = "X-Coder-Session-Token"
+// HeaderCoderAuth is an internal header used to pass the Coder token
+// from AI Proxy to AI Bridge for authentication. This header is stripped
+// by AI Bridge before forwarding requests to upstream providers.
+const HeaderCoderAuth = "X-Coder-Token"
 
 // ExtractAuthToken extracts an authorization token from HTTP headers.
-// It checks X-Coder-Session-Token first (set by AI Proxy), then falls back
+// It checks X-Coder-Token first (set by AI Proxy), then falls back
 // to Authorization header (Bearer token) and X-Api-Key header, which represent
 // the different ways clients authenticate against AI providers.
 // If none are present, an empty string is returned.
 func ExtractAuthToken(header http.Header) string {
-	if token := strings.TrimSpace(header.Get(HeaderCoderSessionAuth)); token != "" {
+	if token := strings.TrimSpace(header.Get(HeaderCoderAuth)); token != "" {
 		return token
 	}
 	if auth := strings.TrimSpace(header.Get("Authorization")); auth != "" {

--- a/coderd/aibridge/aibridge.go
+++ b/coderd/aibridge/aibridge.go
@@ -6,11 +6,20 @@ import (
 	"strings"
 )
 
+// HeaderCoderSessionAuth is an internal header used to pass the Coder session
+// token from AI Proxy to AI Bridge for authentication. This header is
+// stripped by AI Bridge before forwarding requests to upstream providers.
+const HeaderCoderSessionAuth = "X-Coder-Session-Token"
+
 // ExtractAuthToken extracts an authorization token from HTTP headers.
-// It checks the Authorization header (Bearer token) and X-Api-Key header,
-// which represent the different ways clients authenticate against AI providers.
-// If neither are present, an empty string is returned.
+// It checks X-Coder-Session-Token first (set by AI Proxy), then falls back
+// to Authorization header (Bearer token) and X-Api-Key header, which represent
+// the different ways clients authenticate against AI providers.
+// If none are present, an empty string is returned.
 func ExtractAuthToken(header http.Header) string {
+	if token := strings.TrimSpace(header.Get(HeaderCoderSessionAuth)); token != "" {
+		return token
+	}
 	if auth := strings.TrimSpace(header.Get("Authorization")); auth != "" {
 		fields := strings.Fields(auth)
 		if len(fields) == 2 && strings.EqualFold(fields[0], "Bearer") {

--- a/enterprise/aibridged/aibridged_test.go
+++ b/enterprise/aibridged/aibridged_test.go
@@ -173,7 +173,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 	}
 }
 
-func TestServeHTTP_CoderSessionTokenRemoved(t *testing.T) {
+func TestServeHTTP_CoderTokenRemoved(t *testing.T) {
 	t.Parallel()
 
 	mockHandler := &mockHandler{}
@@ -191,9 +191,9 @@ func TestServeHTTP_CoderSessionTokenRemoved(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, httpSrv.URL+"/openai/v1/chat/completions", nil)
 	require.NoError(t, err)
 
-	// X-Coder-Session-Token is used for authentication and should be stripped.
+	// X-Coder-Token is used for authentication and should be stripped.
 	// Other authorization headers should be preserved.
-	req.Header.Set(agplaibridge.HeaderCoderSessionAuth, "coder-session-token")
+	req.Header.Set(agplaibridge.HeaderCoderAuth, "coder-token")
 	req.Header.Set("Authorization", "Bearer some-token")
 	req.Header.Set("X-Api-Key", "some-api-key")
 
@@ -203,10 +203,10 @@ func TestServeHTTP_CoderSessionTokenRemoved(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// Verify X-Coder-Session-Token was removed before forwarding to handler.
+	// Verify X-Coder-Token was removed before forwarding to handler.
 	require.NotNil(t, mockHandler.headersReceived)
-	require.Empty(t, mockHandler.headersReceived.Get(agplaibridge.HeaderCoderSessionAuth),
-		"X-Coder-Session-Token should be removed before forwarding to handler")
+	require.Empty(t, mockHandler.headersReceived.Get(agplaibridge.HeaderCoderAuth),
+		"X-Coder-Token should be removed before forwarding to handler")
 
 	// Verify other headers were preserved.
 	require.Equal(t, "Bearer some-token", mockHandler.headersReceived.Get("Authorization"))
@@ -225,27 +225,27 @@ func TestExtractAuthToken(t *testing.T) {
 			name: "none",
 		},
 		{
-			name:    "x-coder-session-token/empty",
-			headers: map[string]string{agplaibridge.HeaderCoderSessionAuth: ""},
+			name:    "x-coder-token/empty",
+			headers: map[string]string{agplaibridge.HeaderCoderAuth: ""},
 		},
 		{
-			name:        "x-coder-session-token/ok",
-			headers:     map[string]string{agplaibridge.HeaderCoderSessionAuth: "coder-token"},
+			name:        "x-coder-token/ok",
+			headers:     map[string]string{agplaibridge.HeaderCoderAuth: "coder-token"},
 			expectedKey: "coder-token",
 		},
 		{
-			name: "x-coder-session-token/priority over authorization",
+			name: "x-coder-token/priority over authorization",
 			headers: map[string]string{
-				agplaibridge.HeaderCoderSessionAuth: "coder-token",
-				"Authorization":                     "Bearer other-token",
+				agplaibridge.HeaderCoderAuth: "coder-token",
+				"Authorization":              "Bearer other-token",
 			},
 			expectedKey: "coder-token",
 		},
 		{
-			name: "x-coder-session-token/priority over x-api-key",
+			name: "x-coder-token/priority over x-api-key",
 			headers: map[string]string{
-				agplaibridge.HeaderCoderSessionAuth: "coder-token",
-				"X-Api-Key":                         "api-key",
+				agplaibridge.HeaderCoderAuth: "coder-token",
+				"X-Api-Key":                  "api-key",
 			},
 			expectedKey: "coder-token",
 		},

--- a/enterprise/aibridged/http.go
+++ b/enterprise/aibridged/http.go
@@ -43,6 +43,9 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Remove the Coder session token header so it's not forwarded to upstream providers.
+	r.Header.Del(agplaibridge.HeaderCoderSessionAuth)
+
 	client, err := s.Client()
 	if err != nil {
 		logger.Warn(ctx, "failed to connect to coderd", slog.Error(err))

--- a/enterprise/aibridged/http.go
+++ b/enterprise/aibridged/http.go
@@ -43,8 +43,8 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove the Coder session token header so it's not forwarded to upstream providers.
-	r.Header.Del(agplaibridge.HeaderCoderSessionAuth)
+	// Remove the Coder token header so it's not forwarded to upstream providers.
+	r.Header.Del(agplaibridge.HeaderCoderAuth)
 
 	client, err := s.Client()
 	if err != nil {

--- a/enterprise/aibridgeproxyd/aibridgeproxyd.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd.go
@@ -238,7 +238,7 @@ func New(ctx context.Context, logger slog.Logger, opts Options) (*Server, error)
 		// All other requests will be tunneled directly to their destination.
 		goproxy.ReqHostIs(mitmHosts...),
 	).HandleConnectFunc(
-		// Extract Coder session token from proxy authentication to forward to aibridged.
+		// Extract Coder token from proxy authentication to forward to aibridged.
 		srv.authMiddleware,
 	)
 
@@ -393,8 +393,8 @@ func convertDomainsToHosts(domains []string, allowedPorts []string) ([]string, e
 	return hosts, nil
 }
 
-// authMiddleware is a CONNECT middleware that extracts the Coder session token
-// from the Proxy-Authorization header and stores it in ctx.UserData for use by
+// authMiddleware is a CONNECT middleware that extracts the Coder token from
+// the Proxy-Authorization header and stores it in ctx.UserData for use by
 // downstream request handlers.
 // Requests without valid credentials are rejected.
 //
@@ -425,7 +425,7 @@ func (s *Server) authMiddleware(host string, ctx *goproxy.ProxyCtx) (*goproxy.Co
 	return goproxy.MitmConnect, host
 }
 
-// extractCoderTokenFromProxyAuth extracts the Coder session token from the
+// extractCoderTokenFromProxyAuth extracts the Coder token from the
 // Proxy-Authorization header. The token is expected to be in the password
 // field of basic auth: "Basic base64(username:token)".
 //
@@ -473,8 +473,8 @@ func defaultAIBridgeProvider(host string) string {
 }
 
 // handleRequest intercepts HTTP requests after MITM decryption.
-//   - Requests to known AI providers are rewritten to aibridged, with the Coder session token
-//     (from ctx.UserData, set during CONNECT) set in the X-Coder-Session-Token header.
+//   - Requests to known AI providers are rewritten to aibridged, with the Coder token
+//     (from ctx.UserData, set during CONNECT) set in the X-Coder-Token header.
 //   - Unknown hosts are passed through to the original upstream.
 func (s *Server) handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	originalPath := req.URL.Path
@@ -495,7 +495,7 @@ func (s *Server) handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.
 		return req, nil
 	}
 
-	// Get the Coder session token stored during CONNECT.
+	// Get the Coder token stored during CONNECT.
 	coderToken, _ := ctx.UserData.(string)
 
 	// Reject unauthenticated requests to AI providers.
@@ -534,10 +534,10 @@ func (s *Server) handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.
 	req.URL = aiBridgeParsedURL
 	req.Host = aiBridgeParsedURL.Host
 
-	// Set Coder session token header for aibridged authentication.
+	// Set X-Coder-Token header for aibridged authentication.
 	// Using a separate header preserves the original request headers,
 	// which are forwarded to upstream providers.
-	req.Header.Set(agplaibridge.HeaderCoderSessionAuth, coderToken)
+	req.Header.Set(agplaibridge.HeaderCoderAuth, coderToken)
 
 	s.logger.Debug(s.ctx, "routing request to aibridged",
 		slog.F("provider", provider),


### PR DESCRIPTION
## Description

Introduces a new `X-Coder-Token` header for authenticating requests from AI Proxy to AI Bridge. Previously, the proxy overwrote the `Authorization` header with the Coder token, which prevented the original authentication headers from flowing through to upstream providers.

With this change, AI Proxy sets the Coder token in a separate header, preserving the original `Authorization` and `X-Api-Key` headers. AI Bridge uses this header for authentication and removes it before forwarding requests to upstream providers. For requests that don't come through AI Proxy, AI Bridge continues to use `Authorization` and `X-Api-Key` for authentication.

## Changes

* Add `HeaderCoderAuth` constant and update `ExtractAuthToken` to check headers in the following order: `X-Coder-Token` > `Authorization` > `X-Api-Key`
* Update AI Proxy to set `X-Coder-Token` instead of overwriting `Authorization`
* Remove `X-Coder-Token` in AI Bridge before forwarding to upstream providers
* Add tests for header handling and token extraction priority

Related to: https://github.com/coder/internal/issues/1235