### PR TITLE
feat(database): convert tailnet tables to UNLOGGED for improved write performance

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1803,35 +1803,35 @@ CREATE TABLE site_configs (
     value text NOT NULL
 );
 
-CREATE TABLE tailnet_agents (
+CREATE UNLOGGED TABLE tailnet_agents (
     id uuid NOT NULL,
     coordinator_id uuid NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     node jsonb NOT NULL
 );
 
-CREATE TABLE tailnet_client_subscriptions (
+CREATE UNLOGGED TABLE tailnet_client_subscriptions (
     client_id uuid NOT NULL,
     coordinator_id uuid NOT NULL,
     agent_id uuid NOT NULL,
     updated_at timestamp with time zone NOT NULL
 );
 
-CREATE TABLE tailnet_clients (
+CREATE UNLOGGED TABLE tailnet_clients (
     id uuid NOT NULL,
     coordinator_id uuid NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     node jsonb NOT NULL
 );
 
-CREATE TABLE tailnet_coordinators (
+CREATE UNLOGGED TABLE tailnet_coordinators (
     id uuid NOT NULL,
     heartbeat_at timestamp with time zone NOT NULL
 );
 
 COMMENT ON TABLE tailnet_coordinators IS 'We keep this separate from replicas in case we need to break the coordinator out into its own service';
 
-CREATE TABLE tailnet_peers (
+CREATE UNLOGGED TABLE tailnet_peers (
     id uuid NOT NULL,
     coordinator_id uuid NOT NULL,
     updated_at timestamp with time zone NOT NULL,
@@ -1839,7 +1839,7 @@ CREATE TABLE tailnet_peers (
     status tailnet_status DEFAULT 'ok'::tailnet_status NOT NULL
 );
 
-CREATE TABLE tailnet_tunnels (
+CREATE UNLOGGED TABLE tailnet_tunnels (
     coordinator_id uuid NOT NULL,
     src_id uuid NOT NULL,
     dst_id uuid NOT NULL,

--- a/coderd/database/migrations/000409_tailnet_tables_unlogged.down.sql
+++ b/coderd/database/migrations/000409_tailnet_tables_unlogged.down.sql
@@ -1,0 +1,13 @@
+-- Revert tailnet tables to LOGGED (standard WAL-enabled tables).
+-- WARNING: This requires a full table rewrite with WAL generation,
+-- which can be slow for large tables.
+
+-- Convert parent table first (before children, reverse of up migration)
+ALTER TABLE tailnet_coordinators SET LOGGED;
+
+-- Convert child tables after parent
+ALTER TABLE tailnet_peers SET LOGGED;
+ALTER TABLE tailnet_tunnels SET LOGGED;
+ALTER TABLE tailnet_agents SET LOGGED;
+ALTER TABLE tailnet_clients SET LOGGED;
+ALTER TABLE tailnet_client_subscriptions SET LOGGED;

--- a/coderd/database/migrations/000409_tailnet_tables_unlogged.up.sql
+++ b/coderd/database/migrations/000409_tailnet_tables_unlogged.up.sql
@@ -1,0 +1,23 @@
+-- Convert all tailnet coordination tables to UNLOGGED for improved write performance.
+-- These tables contain ephemeral coordination data that can be safely reconstructed
+-- after a crash. UNLOGGED tables skip WAL writes, significantly improving performance
+-- for high-frequency updates like coordinator heartbeats and peer state changes.
+--
+-- IMPORTANT: UNLOGGED tables are truncated on crash recovery and are not replicated
+-- to standby servers. This is acceptable because:
+-- 1. Coordinators re-register on startup
+-- 2. Peers re-establish connections on reconnect
+-- 3. Tunnels are re-created based on current peer state
+
+-- Convert child tables first (they have FK references to tailnet_coordinators).
+-- UNLOGGED child tables can reference LOGGED parent tables, but LOGGED child
+-- tables cannot reference UNLOGGED parent tables. So we must convert children
+-- before converting the parent.
+ALTER TABLE tailnet_client_subscriptions SET UNLOGGED;
+ALTER TABLE tailnet_clients SET UNLOGGED;
+ALTER TABLE tailnet_agents SET UNLOGGED;
+ALTER TABLE tailnet_tunnels SET UNLOGGED;
+ALTER TABLE tailnet_peers SET UNLOGGED;
+
+-- Convert parent table last (after all children are unlogged)
+ALTER TABLE tailnet_coordinators SET UNLOGGED;


### PR DESCRIPTION
## Summary

This migration converts all 6 tailnet coordination tables to UNLOGGED for improved write performance.

**Tables converted:**
- `tailnet_coordinators` - Coordinator instance heartbeats
- `tailnet_peers` - Peer node data (v2 API)
- `tailnet_tunnels` - Tunnel relationships between peers (v2 API)
- `tailnet_agents` - Workspace agent nodes (v1 API, legacy)
- `tailnet_clients` - Client connections (v1 API, legacy)
- `tailnet_client_subscriptions` - Client-to-agent subscriptions (v1 API, legacy)

## Why UNLOGGED?

UNLOGGED tables skip Write-Ahead Log (WAL) writes, providing significant write performance improvements for high-frequency updates like:
- Coordinator heartbeats
- Peer state changes
- Tunnel creation/deletion

## Trade-offs

UNLOGGED tables:
- Are **truncated on crash recovery** (data is lost)
- Are **not replicated** to standby servers

This is acceptable for these tables because the data is ephemeral:
1. Coordinators re-register on startup
2. Peers re-establish connections on reconnect  
3. Tunnels are re-created based on current peer state

## Migration Details

The migration order respects foreign key constraints:
- **Up migration**: Child tables first, then parent (`tailnet_coordinators`) last
- **Down migration**: Parent table first, then children

This is required because UNLOGGED child tables can reference LOGGED parent tables, but LOGGED child tables cannot reference UNLOGGED parent tables.

Fixes #21333