### PR TITLE
ci: add retry logic for Go module operations

### DIFF
--- a/.github/actions/setup-go-tools/action.yaml
+++ b/.github/actions/setup-go-tools/action.yaml
@@ -7,6 +7,6 @@ runs:
     - name: go install tools
       shell: bash
       run: |
-          go install tool
+          ./.github/scripts/retry.sh 3 go install tool
           # NOTE: protoc-gen-go cannot be installed with `go get`
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
+          ./.github/scripts/retry.sh 3 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -22,14 +22,14 @@ runs:
 
     - name: Install gotestsum
       shell: bash
-      run: go install gotest.tools/gotestsum@0d9599e513d70e5792bb9334869f82f6e8b53d4d # main as of 2025-05-15
+      run: ./.github/scripts/retry.sh 3 go install gotest.tools/gotestsum@0d9599e513d70e5792bb9334869f82f6e8b53d4d # main as of 2025-05-15
 
     - name: Install mtimehash
       shell: bash
-      run: go install github.com/slsyy/mtimehash/cmd/mtimehash@a6b5da4ed2c4a40e7b805534b004e9fde7b53ce0 # v1.0.0
+      run: ./.github/scripts/retry.sh 3 go install github.com/slsyy/mtimehash/cmd/mtimehash@a6b5da4ed2c4a40e7b805534b004e9fde7b53ce0 # v1.0.0
 
     # It isn't necessary that we ever do this, but it helps
     # separate the "setup" from the "run" times.
     - name: go mod download
       shell: bash
-      run: go mod download -x
+      run: ./.github/scripts/retry.sh 3 go mod download -x

--- a/.github/actions/setup-sqlc/action.yaml
+++ b/.github/actions/setup-sqlc/action.yaml
@@ -14,4 +14,4 @@ runs:
       # - https://github.com/sqlc-dev/sqlc/pull/4159
       shell: bash
       run: |
-        CGO_ENABLED=1 go install github.com/coder/sqlc/cmd/sqlc@aab4e865a51df0c43e1839f81a9d349b41d14f05
+        ./.github/scripts/retry.sh 3 env CGO_ENABLED=1 go install github.com/coder/sqlc/cmd/sqlc@aab4e865a51df0c43e1839f81a9d349b41d14f05

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Retry a command with exponential backoff.
+# Usage: retry.sh <max_attempts> <command...>
+#
+# Example:
+#   retry.sh 3 go install gotest.tools/gotestsum@latest
+#
+# This will retry the command up to 3 times with exponential backoff
+# (2s, 4s, 8s delays between attempts).
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+	echo "Usage: retry.sh <max_attempts> <command...>" >&2
+	exit 1
+fi
+
+max_attempts=$1
+shift
+
+attempt=1
+until "$@"; do
+	if ((attempt >= max_attempts)); then
+		echo "Command failed after $max_attempts attempts: $*" >&2
+		exit 1
+	fi
+	delay=$((2 ** attempt))
+	echo "Attempt $attempt/$max_attempts failed, retrying in ${delay}s..." >&2
+	sleep "$delay"
+	((attempt++))
+done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,7 +176,7 @@ jobs:
       - name: Get golangci-lint cache dir
         run: |
           linter_ver=$(grep -Eo 'GOLANGCI_LINT_VERSION=\S+' dogfood/coder/Dockerfile | cut -d '=' -f 2)
-          go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v$linter_ver"
+          ./.github/scripts/retry.sh 3 go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v$linter_ver"
           dir=$(golangci-lint cache status | awk '/Dir/ { print $2 }')
           echo "LINT_CACHE_DIR=$dir" >> "$GITHUB_ENV"
 
@@ -329,7 +329,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install shfmt
-        run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0
+        run: ./.github/scripts/retry.sh 3 go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0
 
       - name: make fmt
         timeout-minutes: 7
@@ -1068,7 +1068,7 @@ jobs:
       - name: Build dylibs
         run: |
           set -euxo pipefail
-          go mod download
+          ./.github/scripts/retry.sh 3 go mod download
 
           make gen/mark-fresh
           make build/coder-dylib
@@ -1117,10 +1117,10 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Install go-winres
-        run: go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
+        run: ./.github/scripts/retry.sh 3 go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
 
       - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1
+        run: ./.github/scripts/retry.sh 3 go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1
 
       - name: Install zstd
         run: sudo apt-get install -y zstd
@@ -1128,7 +1128,7 @@ jobs:
       - name: Build
         run: |
           set -euxo pipefail
-          go mod download
+          ./.github/scripts/retry.sh 3 go mod download
           make gen/mark-fresh
           make build
 
@@ -1207,10 +1207,10 @@ jobs:
           java-version: "11.0"
 
       - name: Install go-winres
-        run: go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
+        run: ./.github/scripts/retry.sh 3 go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
 
       - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1
+        run: ./.github/scripts/retry.sh 3 go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1
 
       - name: Install zstd
         run: sudo apt-get install -y zstd
@@ -1258,7 +1258,7 @@ jobs:
       - name: Build
         run: |
           set -euxo pipefail
-          go mod download
+          ./.github/scripts/retry.sh 3 go mod download
 
           version="$(./scripts/version.sh)"
           tag="main-${version//+/-}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Build dylibs
         run: |
           set -euxo pipefail
-          go mod download
+          ./.github/scripts/retry.sh 3 go mod download
 
           make gen/mark-fresh
           make build/coder-dylib
@@ -259,7 +259,7 @@ jobs:
           java-version: "11.0"
 
       - name: Install go-winres
-        run: go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
+        run: ./.github/scripts/retry.sh 3 go install github.com/tc-hib/go-winres@d743268d7ea168077ddd443c4240562d4f5e8c3e # v0.3.3
 
       - name: Install nsis and zstd
         run: sudo apt-get install -y nsis zstd
@@ -341,7 +341,7 @@ jobs:
       - name: Build binaries
         run: |
           set -euo pipefail
-          go mod download
+          ./.github/scripts/retry.sh 3 go mod download
 
           version="$(./scripts/version.sh)"
           make gen/mark-fresh

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -97,11 +97,11 @@ jobs:
       - name: Install yq
         run: go run github.com/mikefarah/yq/v4@v4.44.3
       - name: Install mockgen
-        run: go install go.uber.org/mock/mockgen@v0.5.0
+        run: ./.github/scripts/retry.sh 3 go install go.uber.org/mock/mockgen@v0.5.0
       - name: Install protoc-gen-go
-        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
+        run: ./.github/scripts/retry.sh 3 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
       - name: Install protoc-gen-go-drpc
-        run: go install storj.io/drpc/cmd/protoc-gen-go-drpc@v0.0.34
+        run: ./.github/scripts/retry.sh 3 go install storj.io/drpc/cmd/protoc-gen-go-drpc@v0.0.34
       - name: Install Protoc
         run: |
           # protoc must be in lockstep with our dogfood Dockerfile or the


### PR DESCRIPTION
## Description

Add exponential backoff retries to all `go install` and `go mod download` commands across CI workflows and actions.

## Why

Fixes [coder/internal#1276](https://github.com/coder/internal/issues/1276) - CI fails when `sum.golang.org` returns 500 errors during Go module verification. This is an infrastructure-level flake that can't be controlled.

## Changes

- Created `.github/scripts/retry.sh` - reusable retry helper with exponential backoff (2s, 4s, 8s delays, max 3 attempts)
- Wrapped all `go install` and `go mod download` commands with retry in:
  - `.github/actions/setup-go/action.yaml`
  - `.github/actions/setup-sqlc/action.yaml`
  - `.github/actions/setup-go-tools/action.yaml`
  - `.github/workflows/ci.yaml`
  - `.github/workflows/release.yaml`
  - `.github/workflows/security.yaml`

## Testing

The retry script has been tested locally. CI will validate the changes work in practice.

---

Follows the same pattern as the helm fallback added in #21268.