### PR TITLE
chore(dogfood): capitalize Mux display name

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -373,11 +373,12 @@ module "personalize" {
 }
 
 module "mux" {
-  count     = data.coder_workspace.me.start_count
-  source    = "registry.coder.com/coder/mux/coder"
-  version   = "1.0.7"
-  agent_id  = coder_agent.dev.id
-  subdomain = true
+  count        = data.coder_workspace.me.start_count
+  source       = "registry.coder.com/coder/mux/coder"
+  version      = "1.0.7"
+  agent_id     = coder_agent.dev.id
+  subdomain    = true
+  display_name = "Mux"
 }
 
 module "code-server" {


### PR DESCRIPTION
Capitalizes the Mux display name in the dogfood template to match branding.