### PR TITLE
docs: update AI Governance nav label to AI Governance Add-On

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -987,7 +987,7 @@
 					]
 				},
 				{
-					"title": "AI Governance",
+					"title": "AI Governance Add-On",
 					"description": "Features around managing agents at scale",
 					"path": "./ai-coder/ai-governance.md",
 					"state": ["premium"],


### PR DESCRIPTION
Updates the page title and left navigation for the AI Governance page from "AI Governance" to "AI Governance Add-On"