### PR TITLE
feat: improve aibridgeproxyd logging

### DIFF
--- a/enterprise/aibridgeproxyd/aibridgeproxyd.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd.go
@@ -361,9 +361,8 @@ func (s *Server) portMiddleware(allowedPorts []string) func(host string, ctx *go
 		allowed[p] = true
 	}
 
-	return func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+	return func(host string, _ *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 		logger := s.logger.With(
-			slog.F("connect_id", ctx.Session),
 			slog.F("host", host),
 		)
 
@@ -385,8 +384,6 @@ func (s *Server) portMiddleware(allowedPorts []string) func(host string, ctx *go
 			logger.Warn(s.ctx, "rejecting CONNECT to non-allowed port")
 			return goproxy.RejectConnect, host
 		}
-
-		logger.Debug(s.ctx, "request CONNECT port allowed")
 
 		return nil, ""
 	}
@@ -442,7 +439,7 @@ func (s *Server) authMiddleware(host string, ctx *goproxy.ProxyCtx) (*goproxy.Co
 	coderToken := extractCoderTokenFromProxyAuth(proxyAuth)
 
 	logger := s.logger.With(
-		slog.F("connect_id", ctx.Session),
+		slog.F("connect_id", connectSessionID),
 		slog.F("host", host),
 	)
 
@@ -526,7 +523,6 @@ func (s *Server) handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.
 	reqCtx, _ := ctx.UserData.(*requestContext)
 	if reqCtx == nil {
 		s.logger.Warn(s.ctx, "rejecting request with missing context",
-			slog.F("request_id", ctx.Session),
 			slog.F("host", req.Host),
 			slog.F("method", req.Method),
 			slog.F("path", originalPath),

--- a/enterprise/aibridgeproxyd/aibridgeproxyd.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd.go
@@ -622,17 +622,17 @@ func (s *Server) handleResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *htt
 	}
 
 	reqCtx, _ := ctx.UserData.(*requestContext)
-	connecSessiontID := uuid.Nil
+	connectSessionID := uuid.Nil
 	requestID := uuid.Nil
 	provider := ""
 	if reqCtx != nil {
-		connecSessiontID = reqCtx.ConnectSessionID
+		connectSessionID = reqCtx.ConnectSessionID
 		requestID = reqCtx.RequestID
 		provider = reqCtx.Provider
 	}
 
 	s.logger.Debug(s.ctx, "received response from aibridged",
-		slog.F("connect_id", connecSessiontID.String()),
+		slog.F("connect_id", connectSessionID.String()),
 		slog.F("request_id", requestID.String()),
 		slog.F("status", resp.StatusCode),
 		slog.F("provider", provider),

--- a/enterprise/aibridgeproxyd/aibridgeproxyd_test.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	agplaibridge "github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/enterprise/aibridgeproxyd"
@@ -171,7 +172,7 @@ func newTestProxy(t *testing.T, opts ...testProxyOption) *aibridgeproxyd.Server 
 	}
 
 	certFile, keyFile := getSharedTestCA(t)
-	logger := slogtest.Make(t, nil)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 	aibridgeOpts := aibridgeproxyd.Options{
 		ListenAddr:               cfg.listenAddr,


### PR DESCRIPTION
## Description

Improves logging in `aibridgeproxyd` to provide better observability for proxy requests. Adds structured logging with request correlation IDs and propagates request context through the proxy chain.

## Changes

* Add `requestContext` struct to propagate metadata (token, provider, session ID) through the proxy request/response chain
* ~Add `handleTunnelRequest` to log passthrough requests for non-allowlisted domains at debug level~ (removed due to verbosity)
* Add `handleResponse` to log responses from `aibridged`
* Log MITM requests routed to `aibridged` at info level, tunneled requests at debug level

Related to: https://github.com/coder/internal/issues/1185