### PR TITLE
chore: reword unhealthy agents on workspace page depending on the failure

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -1252,8 +1252,7 @@ func (api *API) convertWorkspaceBuild(
 			statuses := statusesByAgentID[agent.ID]
 			logSources := logSourcesByAgentID[agent.ID]
 			apiAgent, err := db2sdk.WorkspaceAgent(
-				api.DERPMap(), *api.TailnetCoordinator.Load(), agent, db2sdk.Apps(apps, statuses, agent, workspace.OwnerUsername, workspace), convertScripts(scripts), convertLogSources(logSources),
-				time.Duration(agent.ConnectionTimeoutSeconds)*time.Second,
+				api.DERPMap(), *api.TailnetCoordinator.Load(), agent, db2sdk.Apps(apps, statuses, agent, workspace.OwnerUsername, workspace), convertScripts(scripts), convertLogSources(logSources), api.AgentInactiveDisconnectTimeout,
 				api.DeploymentValues.AgentFallbackTroubleshootingURL.String(),
 			)
 			if err != nil {

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -1252,7 +1252,8 @@ func (api *API) convertWorkspaceBuild(
 			statuses := statusesByAgentID[agent.ID]
 			logSources := logSourcesByAgentID[agent.ID]
 			apiAgent, err := db2sdk.WorkspaceAgent(
-				api.DERPMap(), *api.TailnetCoordinator.Load(), agent, db2sdk.Apps(apps, statuses, agent, workspace.OwnerUsername, workspace), convertScripts(scripts), convertLogSources(logSources), api.AgentInactiveDisconnectTimeout,
+				api.DERPMap(), *api.TailnetCoordinator.Load(), agent, db2sdk.Apps(apps, statuses, agent, workspace.OwnerUsername, workspace), convertScripts(scripts), convertLogSources(logSources),
+				time.Duration(agent.ConnectionTimeoutSeconds)*time.Second,
 				api.DeploymentValues.AgentFallbackTroubleshootingURL.String(),
 			)
 			if err != nil {

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -284,7 +284,8 @@ const UnhealthyWorkspaceAlert: FC<UnhealthyWorkspaceAlertProps> = ({
 	});
 
 	var title = "Workspace agents are not connected";
-	var message = "Your workspace cannot be used until an agent connects. Continue to wait and check the log output of your workspace for any errors.";
+	var message =
+		"Your workspace cannot be used until an agent connects. Continue to wait and check the log output of your workspace for any errors.";
 
 	// Disconnected is a more serious failure than timeout, so we can
 	// prioritize handling it first.

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -284,7 +284,7 @@ const UnhealthyWorkspaceAlert: FC<UnhealthyWorkspaceAlertProps> = ({
 	});
 
 	var title = "Workspace agents are not connected";
-	var message = "Your workspace cannot be used until an agent connects.";
+	var message = "Your workspace cannot be used until an agent connects. Continue to wait and check the log output of your workspace for any errors.";
 
 	// Disconnected is a more serious failure than timeout, so we can
 	// prioritize handling it first.

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -292,14 +292,13 @@ const UnhealthyWorkspaceAlert: FC<UnhealthyWorkspaceAlertProps> = ({
 	if (failureSet.has("disconnected")) {
 		title = "Workspace agents are disconnected";
 		message =
-			"Your workspace agents were connected but have since disconnected. If logs are streaming, the agent may still connect if you wait. Otherwise restarting the workspace can be done to try again.";
+			"The agents have disconnected. If logs are streaming, the agent may still connect if you wait. Otherwise restarting the workspace can be done to try again.";
 
 	} else if (failureSet.has("timeout")) {
 		// Handle timeout case
 		title = "Workspace agents have timed out";
 		message =
-			"Your workspace agents have not connected in the expected time. If logs are streaming, the agent may still connect if you wait. Otherwise restarting the workspace can be done to try again.";
-
+			"The agents did not connect within the expected time. If logs are still streaming, they may finish connecting if you wait. Otherwise, restart the workspace to try again.";
 	}
 
 	return (
@@ -308,8 +307,8 @@ const UnhealthyWorkspaceAlert: FC<UnhealthyWorkspaceAlertProps> = ({
 			<AlertDetail>
 				<p>Your workspace is running but{" "}
 					{failingAgentCount > 1
-						? `${failingAgentCount} agents are not connected`
-						: "the agent is not connected"}
+						? `${failingAgentCount} agents have not connected yet.`
+						: "the agent has not connected yet."}
 					.{" "}</p>
 				<p>{message}</p>
 				<p>

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -21,7 +21,6 @@ import {
 	WorkspaceBuildProgress,
 } from "./WorkspaceBuildProgress";
 import { WorkspaceDeletedBanner } from "./WorkspaceDeletedBanner";
-import { NotificationActionButton } from "./WorkspaceNotifications/Notifications";
 import { findTroubleshootingURL } from "./WorkspaceNotifications/WorkspaceNotifications";
 import { WorkspaceTopbar } from "./WorkspaceTopbar";
 
@@ -290,26 +289,27 @@ const UnhealthyWorkspaceAlert: FC<UnhealthyWorkspaceAlertProps> = ({
 	// Disconnected is a more serious failure than timeout, so we can
 	// prioritize handling it first.
 	if (failureSet.has("disconnected")) {
-		title = "Workspace agents are disconnected";
+		title = "Workspace agents have disconnected";
 		message =
-			"The agents have disconnected. If logs are streaming, the agent may still connect if you wait. Otherwise restarting the workspace can be done to try again.";
-
+			"Continue to wait and check the log output of your workspace for any errors. If the agent does not reconnect, restarting the workspace can be used to try again.";
 	} else if (failureSet.has("timeout")) {
 		// Handle timeout case
-		title = "Workspace agents have timed out";
+		title = "Your workspace is starting, but the agent has not yet connected.";
 		message =
-			"The agents did not connect within the expected time. If logs are still streaming, they may finish connecting if you wait. Otherwise, restart the workspace to try again.";
+			"The agent is taking longer than expected to connect. Continue to wait and check the log output of your workspace for any errors. If the agent does not connect, restarting the workspace can be used to try again.";
 	}
 
 	return (
 		<Alert severity="warning" prominent>
 			<AlertTitle>{title}</AlertTitle>
 			<AlertDetail>
-				<p>Your workspace is running but{" "}
+				<p>
+					Your workspace is running but{" "}
 					{failingAgentCount > 1
 						? `${failingAgentCount} agents have not connected yet.`
 						: "the agent has not connected yet."}
-					.{" "}</p>
+					.{" "}
+				</p>
 				<p>{message}</p>
 				<p>
 					{troubleshootingURL && (

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -203,34 +203,12 @@ export const Workspace: FC<WorkspaceProps> = ({
 						)}
 
 						{!workspace.health.healthy && (
-							<Alert severity="warning" prominent>
-								<AlertTitle>Workspace is unhealthy</AlertTitle>
-								<AlertDetail>
-									<p>
-										Your workspace is running but{" "}
-										{workspace.health.failing_agents.length > 1
-											? `${workspace.health.failing_agents.length} agents are unhealthy`
-											: "1 agent is unhealthy"}
-										.{" "}
-										{troubleshootingURL && (
-											<Link href={troubleshootingURL} target="_blank">
-												View docs to troubleshoot
-											</Link>
-										)}
-									</p>
-									{hasActions && (
-										<div className="flex items-center gap-2">
-											{permissions.updateWorkspace && (
-												<NotificationActionButton
-													onClick={() => handleRestart()}
-												>
-													Restart
-												</NotificationActionButton>
-											)}
-										</div>
-									)}
-								</AlertDetail>
-							</Alert>
+							<UnhealthyWorkspaceAlert
+								workspace={workspace}
+								troubleshootingURL={troubleshootingURL}
+								canUpdate={permissions.updateWorkspace}
+								onRestart={() => handleRestart()}
+							/>
 						)}
 
 						{transitionStats !== undefined && (
@@ -287,6 +265,49 @@ export const Workspace: FC<WorkspaceProps> = ({
 				</div>
 			</div>
 		</div>
+	);
+};
+
+interface UnhealthyWorkspaceAlertProps {
+	workspace: TypesGen.Workspace;
+	troubleshootingURL: string | undefined;
+	canUpdate: boolean;
+	onRestart: () => void;
+}
+
+const UnhealthyWorkspaceAlert: FC<UnhealthyWorkspaceAlertProps> = ({
+	workspace,
+	troubleshootingURL,
+	canUpdate,
+	onRestart,
+}) => {
+	const failingAgentCount = workspace.health.failing_agents.length;
+
+	return (
+		<Alert severity="warning" prominent>
+			<AlertTitle>Workspace is unhealthy</AlertTitle>
+			<AlertDetail>
+				<p>
+					Your workspace is running but{" "}
+					{failingAgentCount > 1
+						? `${failingAgentCount} agents are unhealthy`
+						: "1 agent is unhealthy"}
+					.{" "}
+					{troubleshootingURL && (
+						<Link href={troubleshootingURL} target="_blank">
+							View docs to troubleshoot
+						</Link>
+					)}
+				</p>
+				{canUpdate && (
+					<div className="flex items-center gap-2">
+						<NotificationActionButton onClick={onRestart}>
+							Restart
+						</NotificationActionButton>
+					</div>
+				)}
+			</AlertDetail>
+		</Alert>
 	);
 };
 


### PR DESCRIPTION
Also remove the "restart" button. The language is still there, and the restart button is already on this page. That button being present had users clicking it when waiting was the correct solution.

So the "Restart" option is not as pushed.

# Before
<img width="1331" height="169" alt="Screenshot From 2026-01-21 19-44-40" src="https://github.com/user-attachments/assets/06286d44-082a-4db5-8a30-b7f51e4311b2" />

# Why this was done

The previous language resulted in users clicking "restart", which would put them back in the same situation. The new verbiage trys to educate the user and encourage "waiting" as opposed to action.

Action is still available and suggested if "waiting" does not seem like a viable solution.