### PR TITLE
test: bump timeout on TestSSH/StdioExitOnParentDeath

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1126,7 +1126,7 @@ func TestSSH(t *testing.T) {
 	t.Run("StdioExitOnParentDeath", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 		defer cancel()
 
 		// sleepStart -> agentReady -> sessionStarted -> sleepKill -> sleepDone -> cmdDone


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/1289

I was able to reproduce the issue locally -- it appears to sometimes just take 25 seconds to get all of the test dependencies stood up:

```
t.go:111: 2026-01-22 16:39:15.388 [debu]  pubsub: pubsub dialing postgres  network=tcp  address=127.0.0.1:5432  timeout_ms=0 
...
    t.go:111: 2026-01-22 16:39:38.789 [info]  agent.net.tailnet.tcp: accepted connection  src=[fd7a:115c:a1e0:44b1:8901:8f09:e605:d019]:55406  dst=[fd7a:115c:a1e0:4cfd:a892:e4e2:8cad:8534]:1
...
    ssh_test.go:1208: 
                Error Trace:    /Users/cian/src/coder/coder/testutil/chan.go:74
                                                        /Users/cian/src/coder/coder/cli/ssh_test.go:1208
                Error:          SoftTryReceive: context expired
                Test:           TestSSH/StdioExitOnParentDeath
    ssh_test.go:1212: 
```

Hopefully bumping the timeout should fix it. 