### PR TITLE
feat: add non-interactive flag to create command

### DIFF
--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -20,6 +20,10 @@ OPTIONS:
       --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
 
+      --non-interactive bool, $CODER_NON_INTERACTIVE
+          Automatically accept all defaults and error when there is no default
+          for a required input.
+
       --parameter string-array, $CODER_RICH_PARAMETER
           Rich parameter value in the format "name=value".
 

--- a/docs/reference/cli/create.md
+++ b/docs/reference/cli/create.md
@@ -92,6 +92,15 @@ Specify the source workspace name to copy parameters from.
 
 Automatically accept parameter defaults when no value is provided.
 
+### --non-interactive
+
+|             |                                     |
+|-------------|-------------------------------------|
+| Type        | <code>bool</code>                   |
+| Environment | <code>$CODER_NON_INTERACTIVE</code> |
+
+Automatically accept all defaults and error when there is no default for a required input.
+
 ### -y, --yes
 
 |      |                   |

--- a/docs/reference/cli/external-workspaces_create.md
+++ b/docs/reference/cli/external-workspaces_create.md
@@ -92,6 +92,15 @@ Specify the source workspace name to copy parameters from.
 
 Automatically accept parameter defaults when no value is provided.
 
+### --non-interactive
+
+|             |                                     |
+|-------------|-------------------------------------|
+| Type        | <code>bool</code>                   |
+| Environment | <code>$CODER_NON_INTERACTIVE</code> |
+
+Automatically accept all defaults and error when there is no default for a required input.
+
 ### -y, --yes
 
 |      |                   |

--- a/enterprise/cli/testdata/coder_external-workspaces_create_--help.golden
+++ b/enterprise/cli/testdata/coder_external-workspaces_create_--help.golden
@@ -20,6 +20,10 @@ OPTIONS:
       --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
 
+      --non-interactive bool, $CODER_NON_INTERACTIVE
+          Automatically accept all defaults and error when there is no default
+          for a required input.
+
       --parameter string-array, $CODER_RICH_PARAMETER
           Rich parameter value in the format "name=value".
 


### PR DESCRIPTION
This will automatically select the template if there is only one, skip the preset prompt (the default will still be applied if there is one), and use parameter defaults.

If there are multiple templates or required parameters that have no defaults, the command will error.

I poked around the docs to see if there was a place that made sense to add info about this and `--use-parameter-defaults` but I am not really sure where it could go.  I thought maybe I could add it in `workspace-management.md` under `Creating workspaces` but as I was writing it I realized I was just duplicating the info already found in`--help` and the CLI flag references so I decided to hold off.

Maybe a FAQ entry would make the most sense, something like "how do I non-interactively create workspaces" or something, although it does seem like it would also just be duplicating the help info so I held off on that too.