### PR TITLE
test: don't drop error on blank IP address in report

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -882,7 +882,7 @@ const (
 )
 
 func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_Type, ip string) (disconnected func(code int, reason string)) {
-	// a blank IP can unfortunately happen if the connection is broken in a data race before we get to introspect it. We
+	// A blank IP can unfortunately happen if the connection is broken in a data race before we get to introspect it. We
 	// still report it, and the recipient can handle a blank IP.
 	if ip != "" {
 		// Remove the port from the IP because ports are not supported in coderd.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -882,12 +882,16 @@ const (
 )
 
 func (a *agent) reportConnection(id uuid.UUID, connectionType proto.Connection_Type, ip string) (disconnected func(code int, reason string)) {
-	// Remove the port from the IP because ports are not supported in coderd.
-	if host, _, err := net.SplitHostPort(ip); err != nil {
-		a.logger.Error(a.hardCtx, "split host and port for connection report failed", slog.F("ip", ip), slog.Error(err))
-	} else {
-		// Best effort.
-		ip = host
+	// a blank IP can unfortunately happen if the connection is broken in a data race before we get to introspect it. We
+	// still report it, and the recipient can handle a blank IP.
+	if ip != "" {
+		// Remove the port from the IP because ports are not supported in coderd.
+		if host, _, err := net.SplitHostPort(ip); err != nil {
+			a.logger.Error(a.hardCtx, "split host and port for connection report failed", slog.F("ip", ip), slog.Error(err))
+		} else {
+			// Best effort.
+			ip = host
+		}
 	}
 
 	// If the IP is "localhost" (which it can be in some cases), set it to


### PR DESCRIPTION
fixes https://github.com/coder/internal/issues/1286

We can get blank IP address from the net connection if the client has already disconnected, as was the case in this flake. Fix is to only log error if we get something non-empty we can't parse.