### PR TITLE
fix(coderd): handle rbac.NotAuthorizedError when deleting template

### DIFF
--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -101,6 +101,10 @@ func (api *API) deleteTemplate(rw http.ResponseWriter, r *http.Request) {
 		Deleted:   true,
 		UpdatedAt: dbtime.Now(),
 	})
+	if dbauthz.IsNotAuthorizedError(err) {
+		httpapi.Forbidden(rw)
+		return
+	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error deleting template.",


### PR DESCRIPTION
Relates to https://github.com/coder/aibridge/pull/143/changes#r2720659638

We previously had been returning the following when attempting to delete failed due to lack of permissions.

```
500 Internal error deleting template: unauthorized: rbac: forbidden
```

This PR updates the handler to return our usual 403 forbidden response.