### PR TITLE
feat: restore `aibridge` premium entitlement

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -227,6 +227,8 @@ func (set FeatureSet) Features() []FeatureName {
 		copy(premiumFeatures, FeatureNames)
 		// Remove the selection
 		premiumFeatures = slices.DeleteFunc(premiumFeatures, func(f FeatureName) bool {
+			// TODO: Remove AI Bridge once it's moved to a separate add-on and we begin
+			// TODO: license entitlement enforcement.
 			return f.UsesLimit()
 		})
 		return premiumFeatures

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -225,9 +225,9 @@ func (set FeatureSet) Features() []FeatureName {
 	case FeatureSetPremium:
 		premiumFeatures := make([]FeatureName, len(FeatureNames))
 		copy(premiumFeatures, FeatureNames)
-		// Remove features that use limits and AI Bridge (now a separate add-on).
+		// Remove the selection
 		premiumFeatures = slices.DeleteFunc(premiumFeatures, func(f FeatureName) bool {
-			return f.UsesLimit() || f == FeatureAIBridge
+			return f.UsesLimit()
 		})
 		return premiumFeatures
 	}

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -623,10 +623,10 @@ func TestPremiumSuperSet(t *testing.T) {
 	// Premium ⊃ Enterprise
 	require.Subset(t, premium.Features(), enterprise.Features(), "premium should be a superset of enterprise. If this fails, update the premium feature set to include all enterprise features.")
 
-	// Premium = All Features EXCEPT usage limit features and AI Bridge (add-on).
+	// Premium = All Features EXCEPT usage limit features.
 	expectedPremiumFeatures := []codersdk.FeatureName{}
 	for _, feature := range codersdk.FeatureNames {
-		if feature.UsesLimit() || feature == codersdk.FeatureAIBridge {
+		if feature.UsesLimit() {
 			continue
 		}
 		expectedPremiumFeatures = append(expectedPremiumFeatures, feature)

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -113,7 +113,8 @@ func TestEntitlements(t *testing.T) {
 		assert.True(t, al.Enabled)
 		assert.Nil(t, al.Limit)
 		assert.Nil(t, al.Actual)
-		assert.Empty(t, res.Warnings)
+		assert.Len(t, res.Warnings, 1)
+		assert.Contains(t, res.Warnings[0], "AI Bridge has reached General Availability and your Coder deployment is not entitled to run this feature. Contact your account team (https://coder.com/contact) for information around getting a license with AI Bridge.")
 	})
 	t.Run("FullLicenseToNone", func(t *testing.T) {
 		t.Parallel()

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -550,6 +550,8 @@ func LicensesEntitlements(
 
 		// AI Bridge has a custom warning message as it moved to a separate add-on.
 		aiBridge := entitlements.Features[codersdk.FeatureAIBridge]
+		// TODO: Only add this warning if the addon isn't present.
+		// TODO: This is reliant on #21532 being merged.
 		if aiBridge.Enabled {
 			entitlements.Warnings = append(entitlements.Warnings,
 				"AI Bridge has reached General Availability and your Coder deployment is not entitled "+

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -550,7 +550,7 @@ func LicensesEntitlements(
 
 		// AI Bridge has a custom warning message as it moved to a separate add-on.
 		aiBridge := entitlements.Features[codersdk.FeatureAIBridge]
-		if aiBridge.Enabled && aiBridge.Entitlement != codersdk.EntitlementEntitled {
+		if aiBridge.Enabled {
 			entitlements.Warnings = append(entitlements.Warnings,
 				"AI Bridge has reached General Availability and your Coder deployment is not entitled "+
 					"to run this feature. Contact your account team (https://coder.com/contact) for "+

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -552,7 +552,7 @@ func LicensesEntitlements(
 		aiBridge := entitlements.Features[codersdk.FeatureAIBridge]
 		// TODO: Only add this warning if the addon isn't present.
 		// TODO: This is reliant on #21532 being merged.
-		if aiBridge.Enabled {
+		if aiBridge.Enabled && aiBridge.Entitlement != codersdk.EntitlementEntitled {
 			entitlements.Warnings = append(entitlements.Warnings,
 				"AI Bridge has reached General Availability and your Coder deployment is not entitled "+
 					"to run this feature. Contact your account team (https://coder.com/contact) for "+

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -552,7 +552,7 @@ func LicensesEntitlements(
 		aiBridge := entitlements.Features[codersdk.FeatureAIBridge]
 		// TODO: Only add this warning if the addon isn't present.
 		// TODO: This is reliant on #21532 being merged.
-		if aiBridge.Enabled && aiBridge.Entitlement != codersdk.EntitlementEntitled {
+		if aiBridge.Enabled {
 			entitlements.Warnings = append(entitlements.Warnings,
 				"AI Bridge has reached General Availability and your Coder deployment is not entitled "+
 					"to run this feature. Contact your account team (https://coder.com/contact) for "+

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -571,6 +571,13 @@ func TestEntitlements(t *testing.T) {
 				continue
 			}
 
+			if featureName == codersdk.FeatureAIBridge {
+				// AI Bridge is entitled but not auto-enabled (requires CODER_AIBRIDGE_ENABLED=true)
+				require.False(t, entitlements.Features[featureName].Enabled, featureName)
+				require.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[featureName].Entitlement)
+				continue
+			}
+
 			if slices.Contains(enterpriseFeatures, featureName) {
 				require.True(t, entitlements.Features[featureName].Enabled, featureName)
 				require.Equal(t, codersdk.EntitlementEntitled, entitlements.Features[featureName].Entitlement)

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -815,8 +815,8 @@ func TestEntitlements(t *testing.T) {
 		db.InsertLicense(context.Background(), database.InsertLicenseParams{
 			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
 				FeatureSet: codersdk.FeatureSetPremium,
-				GraceAt:    time.Now().Add(time.Hour * 24 * 60),
-				ExpiresAt:  time.Now().Add(time.Hour * 24 * 90),
+				GraceAt:    time.Now().Add(time.Hour * 24 * 30),
+				ExpiresAt:  time.Now().Add(time.Hour * 24 * 60),
 			}),
 			Exp: time.Now().Add(time.Hour * 24 * 90),
 		})


### PR DESCRIPTION
This pull-request ensures that we're still able to use AI Bridge whilst we're on a premium license. However, as we haven't closed out #21499 we have no way to see if the `addon` is actually present. For the time-being we're going to show just this error message to all users who have a premium license. 