### PR TITLE
chore: add ready_for_review trigger and disable auto-commenting to doc-check worfklow

### DIFF
--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -6,6 +6,7 @@
 #   - New PR opened: Initial documentation review
 #   - PR updated (synchronize): Re-review after changes
 #   - Label "doc-check" added: Manual trigger for review
+#   - PR marked ready for review: Review when draft is promoted
 #   - Workflow dispatch: Manual run with PR URL
 #
 # Note: This workflow requires access to secrets and will be skipped for:
@@ -20,6 +21,7 @@ on:
       - opened
       - synchronize
       - labeled
+      - ready_for_review
   workflow_dispatch:
     inputs:
       pr_url:
@@ -36,13 +38,14 @@ jobs:
   doc-check:
     name: Analyze PR for Documentation Updates Needed
     runs-on: ubuntu-latest
-    # Run on: opened, synchronize, labeled (with doc-check label), or workflow_dispatch
+    # Run on: opened, synchronize, labeled (with doc-check label), ready_for_review, or workflow_dispatch
     # Skip draft PRs unless manually triggered
     if: |
       (
         github.event.action == 'opened' ||
         github.event.action == 'synchronize' ||
         github.event.label.name == 'doc-check' ||
+        github.event.action == 'ready_for_review' ||
         github.event_name == 'workflow_dispatch'
       ) &&
       (github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch')
@@ -132,6 +135,9 @@ jobs:
               labeled)
                 echo "trigger_type=label_requested" >> "${GITHUB_OUTPUT}"
                 ;;
+              ready_for_review)
+                echo "trigger_type=ready_for_review" >> "${GITHUB_OUTPUT}"
+                ;;
               *)
                 echo "trigger_type=unknown" >> "${GITHUB_OUTPUT}"
                 ;;
@@ -161,6 +167,9 @@ jobs:
               ;;
             label_requested)
               CONTEXT="A documentation review was REQUESTED via label. Perform a thorough documentation review."
+              ;;
+            ready_for_review)
+              CONTEXT="This PR was marked READY FOR REVIEW (converted from draft). Perform a thorough documentation review."
               ;;
             manual)
               CONTEXT="This is a MANUAL review request. Perform a thorough documentation review."
@@ -232,7 +241,7 @@ jobs:
           coder-username: doc-check-bot
           github-token: ${{ github.token }}
           github-issue-url: ${{ steps.determine-context.outputs.pr_url }}
-          comment-on-issue: true
+          comment-on-issue: false
 
       - name: Write Task Info
         if: steps.check-secrets.outputs.skip != 'true'


### PR DESCRIPTION
This pull request updates the `.github/workflows/doc-check.yaml` workflow to improve how documentation reviews are triggered and handled, particularly for pull requests that are converted from draft to ready for review. The changes ensure that documentation checks are performed at the appropriate times and clarify the workflow's behavior.

**Workflow trigger and logic enhancements:**

* Added support for triggering the documentation check when a pull request is marked as "ready for review" (converted from draft), both in the workflow triggers and in the workflow logic. [[1]](diffhunk://#diff-46e6065a312f35e5d294476e7865089afd10e6072fed80ac77b257e090def149R9) [[2]](diffhunk://#diff-46e6065a312f35e5d294476e7865089afd10e6072fed80ac77b257e090def149R24) [[3]](diffhunk://#diff-46e6065a312f35e5d294476e7865089afd10e6072fed80ac77b257e090def149L39-R48)
* Updated the internal context and trigger type handling to recognize and describe the "ready_for_review" event, providing more accurate context for the agent. [[1]](diffhunk://#diff-46e6065a312f35e5d294476e7865089afd10e6072fed80ac77b257e090def149R138-R140) [[2]](diffhunk://#diff-46e6065a312f35e5d294476e7865089afd10e6072fed80ac77b257e090def149R171-R173)

**Workflow behavior adjustment:**

* Changed the `comment-on-issue` setting to `false`, so the workflow will no longer automatically comment on the PR issue when running which was creating unnecessary noise.