### PR TITLE
chore: undeprecate the workspace rename flag and clarify potential issues

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -15,9 +15,11 @@ SUBCOMMANDS:
 
 OPTIONS:
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
-          DEPRECATED: Allow users to rename their workspaces. Use only for
-          temporary compatibility reasons, this will be removed in a future
-          release.
+          Allow users to rename their workspaces. WARNING: Renaming a workspace
+          can cause Terraform resources that depend on the workspace name to be
+          destroyed and recreated, potentially causing data loss. Only enable
+          this if your templates do not use workspace names in resource
+          identifiers, or if you understand the risks.
 
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -575,8 +575,10 @@ userQuietHoursSchedule:
   # change their quiet hours schedule and the site default is always used.
   # (default: true, type: bool)
   allowCustomQuietHours: true
-# DEPRECATED: Allow users to rename their workspaces. Use only for temporary
-# compatibility reasons, this will be removed in a future release.
+# Allow users to rename their workspaces. WARNING: Renaming a workspace can cause
+# Terraform resources that depend on the workspace name to be destroyed and
+# recreated, potentially causing data loss. Only enable this if your templates do
+# not use workspace names in resource identifiers, or if you understand the risks.
 # (default: false, type: bool)
 allowWorkspaceRenames: false
 # Configure how emails are sent.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2969,16 +2969,16 @@ Write out the current server config as YAML to stdout.`,
 			YAML:        "webTerminalRenderer",
 		},
 		{
-			Name:        "Allow Workspace Renames",
+			Name: "Allow Workspace Renames",
 			Description: "Allow users to rename their workspaces. " +
 				"WARNING: Renaming a workspace can cause Terraform resources that depend on the " +
 				"workspace name to be destroyed and recreated, potentially causing data loss. " +
 				"Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.",
-			Flag:        "allow-workspace-renames",
-			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
-			Default:     "false",
-			Value:       &c.AllowWorkspaceRenames,
-			YAML:        "allowWorkspaceRenames",
+			Flag:    "allow-workspace-renames",
+			Env:     "CODER_ALLOW_WORKSPACE_RENAMES",
+			Default: "false",
+			Value:   &c.AllowWorkspaceRenames,
+			YAML:    "allowWorkspaceRenames",
 		},
 		// Healthcheck Options
 		{

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2970,7 +2970,10 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Allow Workspace Renames",
-			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this will be removed in a future release.",
+			Description: "Allow users to rename their workspaces. " +
+				"WARNING: Renaming a workspace can cause Terraform resources that depend on the " +
+				"workspace name to be destroyed and recreated, potentially causing data loss. " +
+				"Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.",
 			Flag:        "allow-workspace-renames",
 			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
 			Default:     "false",

--- a/docs/admin/templates/extending-templates/resource-persistence.md
+++ b/docs/admin/templates/extending-templates/resource-persistence.md
@@ -57,7 +57,7 @@ To prevent this, use immutable IDs:
 - `coder_workspace.me.owner_id`
 - `coder_workspace.me.id`
 
-You should also avoid using `coder_workspace.me.name` if your deployment allows workspace renaming via `allow-workspace-renames`.
+You should also avoid using `coder_workspace.me.name` if your deployment allows workspace renaming via `CODER_ALLOW_WORKSPACE_RENAMES` or `--allow-workspace-renames`.
 
 ```tf
 data "coder_workspace" "me" {

--- a/docs/admin/templates/extending-templates/resource-persistence.md
+++ b/docs/admin/templates/extending-templates/resource-persistence.md
@@ -57,6 +57,8 @@ To prevent this, use immutable IDs:
 - `coder_workspace.me.owner_id`
 - `coder_workspace.me.id`
 
+You should also avoid using `coder_workspace.me.name` if your deployment allows workspace renaming via `allow-workspace-renames`.
+
 ```tf
 data "coder_workspace" "me" {
 }

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1311,7 +1311,7 @@ The renderer to use when opening a web terminal. Valid values are 'canvas', 'web
 | YAML        | <code>allowWorkspaceRenames</code>          |
 | Default     | <code>false</code>                          |
 
-DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this will be removed in a future release.
+Allow users to rename their workspaces. WARNING: Renaming a workspace can cause Terraform resources that depend on the workspace name to be destroyed and recreated, potentially causing data loss. Only enable this if your templates do not use workspace names in resource identifiers, or if you understand the risks.
 
 ### --health-check-refresh
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -16,9 +16,11 @@ SUBCOMMANDS:
 
 OPTIONS:
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
-          DEPRECATED: Allow users to rename their workspaces. Use only for
-          temporary compatibility reasons, this will be removed in a future
-          release.
+          Allow users to rename their workspaces. WARNING: Renaming a workspace
+          can cause Terraform resources that depend on the workspace name to be
+          destroyed and recreated, potentially causing data loss. Only enable
+          this if your templates do not use workspace names in resource
+          identifiers, or if you understand the risks.
 
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and


### PR DESCRIPTION
This undeprecates the `allow-workspace-renames` flag. IIUC, the 'danger' with using this flag is that the workspace name might have been used in the definition of some other terraform resources within template code, so a rename could cause problems such as with persistent disks.

for https://github.com/coder/coder/issues/21628