### PR TITLE
fix(oauth2): RFC compliance for MCP client authentication

### DIFF
--- a/coderd/oauth2provider/tokens_internal_test.go
+++ b/coderd/oauth2provider/tokens_internal_test.go
@@ -123,7 +123,7 @@ func TestExtractTokenParams_Scopes(t *testing.T) {
 			}
 
 			// Extract token request
-			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+			tokenReq, validationErrs, err := extractTokenRequest(req, []*url.URL{callbackURL})
 
 			// Verify no errors occurred
 			require.NoError(t, err, "extractTokenRequest should not return error for: %s", tc.description)
@@ -186,7 +186,7 @@ func TestExtractTokenParams_ScopesURLEncoded(t *testing.T) {
 			}
 
 			// Extract token request
-			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+			tokenReq, validationErrs, err := extractTokenRequest(req, []*url.URL{callbackURL})
 
 			// Verify no errors
 			require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestExtractTokenParams_ScopesEdgeCases(t *testing.T) {
 				Form:     form,
 			}
 
-			tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+			tokenReq, validationErrs, err := extractTokenRequest(req, []*url.URL{callbackURL})
 
 			require.NoError(t, err, "extractTokenRequest should not error for: %s", tc.description)
 			require.Empty(t, validationErrs)
@@ -332,7 +332,7 @@ func TestExtractAuthorizeParams_Scopes(t *testing.T) {
 			}
 
 			// Extract authorize params
-			params, validationErrs, err := extractAuthorizeParams(req, callbackURL)
+			params, validationErrs, err := extractAuthorizeParams(req, []*url.URL{callbackURL}, callbackURL)
 
 			require.NoError(t, err)
 			require.Empty(t, validationErrs)
@@ -361,7 +361,7 @@ func TestRefreshTokenGrant_Scopes(t *testing.T) {
 		Form:     form,
 	}
 
-	tokenReq, validationErrs, err := extractTokenRequest(req, callbackURL)
+	tokenReq, validationErrs, err := extractTokenRequest(req, []*url.URL{callbackURL})
 
 	require.NoError(t, err)
 	require.Empty(t, validationErrs)


### PR DESCRIPTION
## Summary

This PR fixes two OAuth2 RFC compliance issues that block VS Code MCP client from authenticating with Coder's MCP server.

## Issue 1: RFC 9728 Resource Identifier Mismatch

VS Code MCP client expects the `resource` field in protected resource metadata to match the exact URL of the protected resource being accessed.

**Error observed:**
```
Error: Protected Resource Metadata 'resource' property value
"https://dev.coder.com/" does not match expected value
"https://dev.coder.com/api/experimental/mcp/http"
```

**Fix:** The `GetProtectedResourceMetadata` handler now extracts the resource path from the request URL. Requests to `/.well-known/oauth-protected-resource/api/experimental/mcp/http` now return metadata with the `resource` field set to the full path.

## Issue 2: RFC 6749 Redirect URI Validation

OAuth2 clients registered via Dynamic Client Registration (RFC 7591) can specify multiple redirect URIs. However, Coder only validated against the first registered URI, causing authorization failures.

**Error observed:**
```
400: Query param "redirect_uri" must be a subset of
https://insiders.vscode.dev/redirect
```

**Fix:** Added `RedirectURLWithList()` method to validate `redirect_uri` against all registered URIs. Updated `authorize.go` and `tokens.go` to use the new validation that checks `app.RedirectUris` array.

## Changes

| File | Change |
|------|--------|
| `coderd/oauth2provider/metadata.go` | Use request path for resource identifier |
| `coderd/oauth2provider/authorize.go` | Validate redirect_uri against all registered URIs |
| `coderd/oauth2provider/tokens.go` | Same redirect_uri fix for token exchange |
| `coderd/httpapi/queryparams.go` | Add `RedirectURLWithList()` validation method |
| Tests | Add comprehensive coverage for both fixes |

## Testing

- Added `TestOAuth2ProtectedResourceMetadataWithPath` to verify RFC 9728 compliance
- Added `TestRedirectURLWithList` to cover multi-URI validation scenarios
- All existing tests pass

## Verification

After this fix, VS Code MCP client should:
1. Successfully fetch protected resource metadata
2. Complete DCR and authorization flow
3. Connect to Coder MCP server

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `low`_
