### PR TITLE
feat(enterprise/coderd): add soft warning for AI Bridge GA transition

### DIFF
--- a/enterprise/cli/aibridge_test.go
+++ b/enterprise/cli/aibridge_test.go
@@ -27,6 +27,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = true
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -77,6 +78,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = true
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -162,6 +164,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = true
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,

--- a/enterprise/coderd/aibridge_test.go
+++ b/enterprise/coderd/aibridge_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/serpent"
 )
 
 func TestAIBridgeListInterceptions(t *testing.T) {
@@ -51,6 +52,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Run("EmptyDB", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -71,6 +73,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -189,6 +192,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -304,6 +308,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Run("InflightInterceptions", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -337,6 +342,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Run("Authorized", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		adminClient, db, firstUser := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -381,6 +387,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Run("Filter", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, db, firstUser := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -561,6 +568,7 @@ func TestAIBridgeListInterceptions(t *testing.T) {
 	t.Run("FilterErrors", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -643,6 +651,7 @@ func TestAIBridgeRouting(t *testing.T) {
 	t.Parallel()
 
 	dv := coderdtest.DeploymentValues(t)
+	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 	client, closer, api, _ := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{
 			DeploymentValues: dv,
@@ -703,6 +712,7 @@ func TestAIBridgeRateLimiting(t *testing.T) {
 	t.Parallel()
 
 	dv := coderdtest.DeploymentValues(t)
+	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 	// Set a low rate limit for testing.
 	dv.AI.BridgeConfig.RateLimit = 2
 
@@ -758,6 +768,7 @@ func TestAIBridgeConcurrencyLimiting(t *testing.T) {
 	t.Parallel()
 
 	dv := coderdtest.DeploymentValues(t)
+	dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 	// Set a low concurrency limit for testing.
 	dv.AI.BridgeConfig.MaxConcurrency = 1
 

--- a/enterprise/coderd/aibridgeproxy_test.go
+++ b/enterprise/coderd/aibridgeproxy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/serpent"
 )
 
 func TestAIBridgeProxyCertificateRetrieval(t *testing.T) {
@@ -20,6 +21,7 @@ func TestAIBridgeProxyCertificateRetrieval(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		// Proxy is disabled by default, so we don't need to set it explicitly.
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -50,6 +52,7 @@ func TestAIBridgeProxyCertificateRetrieval(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
@@ -78,6 +81,7 @@ func TestAIBridgeProxyCertificateRetrieval(t *testing.T) {
 		t.Parallel()
 
 		dv := coderdtest.DeploymentValues(t)
+		dv.AI.BridgeConfig.Enabled = serpent.Bool(true)
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -769,7 +769,7 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 				codersdk.FeatureUserRoleManagement:         true,
 				codersdk.FeatureAccessControl:              true,
 				codersdk.FeatureControlSharedPorts:         true,
-				codersdk.FeatureAIBridge:                   true,
+				codersdk.FeatureAIBridge:                   api.DeploymentValues.AI.BridgeConfig.Enabled.Value(),
 			})
 		if err != nil {
 			return codersdk.Entitlements{}, err

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -167,6 +167,12 @@ func LicensesEntitlements(
 	keys map[string]ed25519.PublicKey,
 	featureArguments FeatureArguments,
 ) (codersdk.Entitlements, error) {
+	// TODO: Remove this tracking once AI Bridge is enforced as an add-on license.
+	// Track if AI Bridge was explicitly granted via license Features (add-on)
+	// vs inherited from FeatureSet (Premium). Only explicit grants should
+	// suppress the soft warning for AI Bridge GA.
+	hasExplicitAIBridgeEntitlement := false
+
 	// Default all entitlements to be disabled.
 	entitlements := codersdk.Entitlements{
 		Features: map[codersdk.FeatureName]codersdk.Feature{
@@ -333,6 +339,12 @@ func LicensesEntitlements(
 			if featureValue < 0 {
 				// We currently don't use negative values for features.
 				continue
+			}
+
+			// TODO: Remove this tracking once AI Bridge is enforced as an add-on license.
+			// Track explicit AI Bridge entitlement (add-on license).
+			if featureName == codersdk.FeatureAIBridge && featureValue > 0 {
+				hasExplicitAIBridgeEntitlement = true
 			}
 
 			// Special handling for grouped (e.g. usage period) features.
@@ -582,6 +594,17 @@ func LicensesEntitlements(
 					fmt.Sprintf("%s is enabled but your license for this feature is expired.", niceName))
 			default:
 			}
+		}
+
+		// TODO: Remove this soft warning block once AI Bridge is enforced as an add-on license.
+		// AI Bridge soft warning: Show warning when AI Bridge is enabled and
+		// entitled via Premium FeatureSet but not via explicit add-on license.
+		// This is a transitional warning as AI Bridge moves to GA and will
+		// require a separate add-on license in future versions.
+		aiBridgeFeature := entitlements.Features[codersdk.FeatureAIBridge]
+		if aiBridgeFeature.Enabled && aiBridgeFeature.Entitlement.Entitled() && !hasExplicitAIBridgeEntitlement {
+			entitlements.Warnings = append(entitlements.Warnings,
+				"AI Bridge is now Generally Available in v2.30. In a future Coder version, your deployment will require the AI Governance Add-On to continue using this feature. Please reach out to your account team or sales@coder.com to learn more.")
 		}
 	}
 


### PR DESCRIPTION
## Summary

AI Bridge is moving to General Availability in v2.30 and will require the AI Governance Add-On license in future versions. This adds a soft warning for deployments using AI Bridge via Premium/Enterprise FeatureSet without an explicit AI Bridge add-on license.

Relates to: https://github.com/coder/internal/issues/1226

## Changes

- Track whether AI Bridge was explicitly granted via license Features (add-on) vs inherited from FeatureSet
- Show soft warning when AI Bridge is enabled and entitled via FeatureSet but not via explicit add-on
- Changed AI Bridge enablement from hardcoded `true` to check `CODER_AIBRIDGE_ENABLED` deployment config

## Behavior Change

AI Bridge is now only marked as "enabled" in entitlements when `CODER_AIBRIDGE_ENABLED=true` is set in the deployment config. Previously, it was always enabled for Premium/Enterprise licenses regardless of the config setting.

This change ensures that users who do not use AI Bridge will not see the soft warning about the upcoming license requirement.

## Warning Message

> AI Bridge is now Generally Available in v2.30. In a future Coder version, your deployment will require the AI Governance Add-On to continue using this feature. Please reach out to your account team or sales@coder.com to learn more.

## Behavior

| Condition | Warning Shown |
|-----------|---------------|
| AI Bridge disabled | ❌ No |
| AI Bridge enabled + explicit add-on license | ❌ No |
| AI Bridge enabled + Premium/Enterprise FeatureSet (no add-on) | ✅ Yes |

## Screenshots

### 1. No license
<img width="1708" height="577" alt="image" src="https://github.com/user-attachments/assets/cbdbfd4d-55de-4d70-8abf-2665f458e96f" />

### 2. No license + CODER_AIBRIDGE_ENABLED=true
<img width="1716" height="513" alt="image" src="https://github.com/user-attachments/assets/344aae76-7703-485f-b568-1f13a1efa48f" />

### 3. Premium license + CODER_AIBRIDGE_ENABLED=false
<img width="1687" height="389" alt="image" src="https://github.com/user-attachments/assets/c2be12b0-1c0f-438d-a293-f9ec9fe6a736" />

### 4. Premium license + CODER_AIBRIDGE_ENABLED=true
<img width="1707" height="525" alt="image" src="https://github.com/user-attachments/assets/1a4640e1-e656-4f9b-bed0-9390cb5d6a84" />

## Notes

- TODO comments added to mark code that should be removed when AI Bridge enforcement is added
- Feature continues to work - this is just a transitional warning (soft enforcement)
