### PR TITLE
fix(.devcontainer): make post_start.sh idempotent

### DIFF
--- a/.devcontainer/scripts/post_start.sh
+++ b/.devcontainer/scripts/post_start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Start Docker service if not already running.
-sudo service docker start
+sudo service docker status >/dev/null 2>&1 || sudo service docker start


### PR DESCRIPTION
When running multiple instances of the coder/coder devcontainer, the `postStartCommand` fails with exit code 1:

```
postStartCommand from devcontainer.json failed with exit code 1
Command failed: ./.devcontainer/scripts/post_start.sh
```

`service docker start` returns exit code 1 when Docker is already running:

| Docker State | Exit Code |
|--------------|-----------|
| Not running | 0 |
| Already running | **1** |

## Fix

Check if Docker is already running before attempting to start it:

```bash
sudo service docker status >/dev/null 2>&1 || sudo service docker start
```

---

*This PR and description were generated by [Mux](https://mux.coder.com).*