### PR TITLE
chore: only count successfully started workspaces towards usage

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2128,7 +2128,9 @@ func (s *server) completeWorkspaceBuildJob(ctx context.Context, job database.Pro
 			}
 		}
 
-		if hasAITask && workspaceBuild.Transition == database.WorkspaceTransitionStart {
+		if hasAITask &&
+			workspaceBuild.Transition == database.WorkspaceTransitionStart &&
+			job.JobStatus == database.ProvisionerJobStatusSucceeded {
 			// Insert usage event for managed agents.
 			usageInserter := s.UsageInserter.Load()
 			if usageInserter != nil {


### PR DESCRIPTION
I don't think this can be triggered because AI tasks are parsed from tf state. We don't parse tf state if the apply failed. We only parse tf state in the graph step, which assumes the apply worked.