### PR TITLE
fix(coderd): authorize workspace start/stop/delete by transition action

### DIFF
--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -969,7 +969,6 @@ func OrgMemberPermissions(workspaceSharingDisabled bool) (
 				policy.ActionDelete,
 				policy.ActionCreate,
 				policy.ActionUpdate,
-				policy.ActionWorkspaceStart,
 				policy.ActionWorkspaceStop,
 				policy.ActionCreateAgent,
 				policy.ActionDeleteAgent,

--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -969,6 +969,7 @@ func OrgMemberPermissions(workspaceSharingDisabled bool) (
 				policy.ActionDelete,
 				policy.ActionCreate,
 				policy.ActionUpdate,
+				policy.ActionWorkspaceStart,
 				policy.ActionWorkspaceStop,
 				policy.ActionCreateAgent,
 				policy.ActionDeleteAgent,

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -1175,8 +1175,10 @@ func (b *Builder) authorize(authFunc func(action policy.Action, object rbac.Obje
 	switch b.trans {
 	case database.WorkspaceTransitionDelete:
 		action = policy.ActionDelete
-	case database.WorkspaceTransitionStart, database.WorkspaceTransitionStop:
-		action = policy.ActionUpdate
+	case database.WorkspaceTransitionStart:
+		action = policy.ActionWorkspaceStart
+	case database.WorkspaceTransitionStop:
+		action = policy.ActionWorkspaceStop
 	default:
 		msg := fmt.Sprintf("Transition %q not supported.", b.trans)
 		return BuildError{http.StatusBadRequest, msg, xerrors.New(msg)}

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -1177,6 +1177,12 @@ func (b *Builder) authorize(authFunc func(action policy.Action, object rbac.Obje
 		action = policy.ActionDelete
 	case database.WorkspaceTransitionStart:
 		action = policy.ActionWorkspaceStart
+		if b.workspace.DormantAt.Valid {
+			// Dormant workspaces can't be started directly; they are
+			// "woken" by unsetting dormancy, which makes the
+			// workspace.start permission apply.
+			action = policy.ActionUpdate
+		}
 	case database.WorkspaceTransitionStop:
 		action = policy.ActionWorkspaceStop
 	default:

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -1179,7 +1179,7 @@ func (b *Builder) authorize(authFunc func(action policy.Action, object rbac.Obje
 		action = policy.ActionWorkspaceStart
 		if b.workspace.DormantAt.Valid {
 			// Dormant workspaces can't be started directly; they are
-			// "woken" by unsetting dormancy, which makes the
+			// first "woken" by unsetting dormancy, which makes the
 			// workspace.start permission apply.
 			action = policy.ActionUpdate
 		}


### PR DESCRIPTION
Use transition-specific actions when authorizing workspace build parameter inserts in the database layer so start/stop/delete do not require workspace.update.

Related to: https://github.com/coder/internal/issues/1299