### PR TITLE
fix: correct https://github.com/coder/internal/issues/1167 behaviour

### DIFF
--- a/enterprise/aibridged/aibridged_integration_test.go
+++ b/enterprise/aibridged/aibridged_integration_test.go
@@ -249,7 +249,7 @@ func TestIntegration(t *testing.T) {
 	require.Equal(t, "openai", intc0.Provider)
 	require.Equal(t, "gpt-4.1", intc0.Model)
 	require.True(t, intc0.EndedAt.Valid)
-	require.True(t, intc0.StartedAt.Before(intc0.EndedAt.Time))
+	require.False(t, intc0.EndedAt.Time.Before(intc0.StartedAt), "EndedAt should not be before StartedAt")
 	require.Less(t, intc0.EndedAt.Time.Sub(intc0.StartedAt), 5*time.Second)
 
 	prompts, err := db.GetAIBridgeUserPromptsByInterceptionID(ctx, interceptions[0].ID)


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1167

Previously we were checking that start != end time; this was flaking on Windows.

On Windows, `time.Now()` has limited resolution (~1ms with Go runtime's `timeBeginPeriod`, or ~15.6ms in default system resolution). When two `time.Now()` calls execute within the same clock tick, they return identical timestamps, causing `StartedAt.Before(EndedAt)` to return `false`.                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
  **References:**                                                                                                                                                                                                                                                               
  - [Go issue #8687](https://github.com/golang/go/issues/8687) - Windows system clock resolution issue                                                                                                                                                                          
  - [Go issue #67066](https://github.com/golang/go/issues/67066) - time.Now precision on Windows (still open)  

Instead, we're changing the assertion to (the more semantically correct) "end not before start".

A possible future enhancement could be to plumb coder/quartz through the recording mechanism, but it's unnecessary for now.