### PR TITLE
chore: bump claude code module version

### DIFF
--- a/docs/ai-coder/boundary/agent-boundary.md
+++ b/docs/ai-coder/boundary/agent-boundary.md
@@ -21,6 +21,9 @@ The easiest way to use Agent Boundaries is through existing Coder modules, such 
 
 ## Configuration
 
+> [!NOTE]
+> For information about version requirements and compatibility, see the [Version Requirements](./version.md) documentation.
+
 Boundary is configured using a `config.yaml` file. This allows you to maintain allow lists and share detailed policies with teammates.
 
 In your Terraform module, enable Boundary with minimal configuration:

--- a/docs/ai-coder/boundary/agent-boundary.md
+++ b/docs/ai-coder/boundary/agent-boundary.md
@@ -28,9 +28,8 @@ In your Terraform module, enable Boundary with minimal configuration:
 ```tf
 module "claude-code" {
   source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "4.3.0"
+  version             = "4.7.0"
   enable_boundary     = true
-  boundary_version    = "v0.5.2"
 }
 ```
 

--- a/docs/ai-coder/boundary/agent-boundary.md
+++ b/docs/ai-coder/boundary/agent-boundary.md
@@ -118,7 +118,7 @@ The choice of jail type depends on your security requirements, available Linux c
 
 Agent Boundaries stream audit logs to the Coder control plane, providing centralized
 visibility into HTTP requests made within workspaces—whether from AI agents or ad-hoc
-commands run with `boundary-run`.
+commands run with `boundary`.
 
 Audit logs are independent of application logs:
 

--- a/docs/ai-coder/boundary/version.md
+++ b/docs/ai-coder/boundary/version.md
@@ -1,0 +1,55 @@
+# Version Requirements
+
+## Recommended Versions
+
+It's recommended to use **Coder v2.30.0 or newer** and **Claude Code module v4.7.0 or newer**.
+
+### Coder v2.30.0+
+
+Since Coder v2.30.0, Boundary is embedded inside the Coder binary, and you don't need to install it separately. The `coder boundary` subcommand is available directly from the Coder CLI.
+
+### Claude Code Module v4.7.0+
+
+Since Claude Code module v4.7.0, the embedded Coder Boundary subcommand is used by default. This means you don't need to set `boundary_version`; the boundary version is tied to your Coder version.
+
+## Compatibility with Older Versions
+
+### Using Coder Before v2.30.0 with Claude Code Module v4.7.0+
+
+If you're using Coder before v2.30.0 with Claude Code module v4.7.0 or newer, the `coder boundary` subcommand isn't available in your Coder installation. In this case, you need to:
+
+1. Set `use_boundary_directly = true` in your Terraform module configuration
+2. Explicitly set `boundary_version` to specify which Boundary version to install
+
+Example configuration:
+
+```tf
+module "claude-code" {
+  source              = "dev.registry.coder.com/coder/claude-code/coder"
+  version             = "4.7.0"
+  enable_boundary     = true
+  use_boundary_directly = true
+  boundary_version    = "0.6.0"
+}
+```
+
+### Using Claude Code Module Before v4.7.0
+
+If you're using Claude Code module before v4.7.0, the module expects to use Boundary directly. You need to explicitly set `boundary_version` in your Terraform configuration:
+
+```tf
+module "claude-code" {
+  source              = "dev.registry.coder.com/coder/claude-code/coder"
+  version             = "4.6.0"
+  enable_boundary     = true
+  boundary_version    = "0.6.0"
+}
+```
+
+## Summary
+
+| Coder Version | Claude Code Module Version | Configuration Required                                |
+|---------------|----------------------------|-------------------------------------------------------|
+| v2.30.0+      | v4.7.0+                    | No additional configuration needed                    |
+| < v2.30.0     | v4.7.0+                    | `use_boundary_directly = true` and `boundary_version` |
+| Any           | < v4.7.0                   | `boundary_version`                                    |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -999,17 +999,12 @@
 							"state": ["beta"],
 							"children": [
 								{
-									"title": "Version",
-									"description": "Version requirements and compatibility information",
-									"path": "./ai-coder/boundary/version.md"
-								},
-								{
-									"title": "nsjail",
+									"title": "NS Jail",
 									"description": "Documentation for Namespace Jail",
 									"path": "./ai-coder/boundary/nsjail.md"
 								},
 								{
-									"title": "landjail",
+									"title": "LandJail",
 									"description": "Documentation for LandJail",
 									"path": "./ai-coder/boundary/landjail.md"
 								},
@@ -1017,6 +1012,11 @@
 									"title": "Rules Engine",
 									"description": "Documentation for the Boundary rules engine",
 									"path": "./ai-coder/boundary/rules-engine.md"
+								},
+								{
+									"title": "Version Compatibility",
+									"description": "Version requirements and compatibility information",
+									"path": "./ai-coder/boundary/version.md"
 								}
 							]
 						},

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -996,7 +996,7 @@
 							"title": "Agent Boundaries",
 							"description": "Understanding Agent Boundaries in Coder Tasks",
 							"path": "./ai-coder/boundary/agent-boundary.md",
-							"state": ["beta"],
+							"state": ["premium", "beta"],
 							"children": [
 								{
 									"title": "NS Jail",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -999,6 +999,11 @@
 							"state": ["beta"],
 							"children": [
 								{
+									"title": "Version",
+									"description": "Version requirements and compatibility information",
+									"path": "./ai-coder/boundary/version.md"
+								},
+								{
 									"title": "nsjail",
 									"description": "Documentation for Namespace Jail",
 									"path": "./ai-coder/boundary/nsjail.md"

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -855,9 +855,8 @@ resource "coder_script" "boundary_config_setup" {
 module "claude-code" {
   count               = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   source              = "dev.registry.coder.com/coder/claude-code/coder"
-  version             = "4.4.2"
+  version             = "4.7.0"
   enable_boundary     = true
-  boundary_version    = "v0.6.0"
   agent_id            = coder_agent.dev.id
   workdir             = local.repo_dir
   claude_code_version = "latest"


### PR DESCRIPTION
Changes:
- bump claude-code module version
- add docs for version compatibility (for customers using older version of coder or claude-code module; before GA)