### PR TITLE
fix: propagate correct agent exit code 

### DIFF
--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -7,6 +7,6 @@ func IsInitProcess() bool {
 	return false
 }
 
-func ForkReap(_ ...Option) error {
-	return nil
+func ForkReap(_ ...Option) (int, error) {
+	return 0, nil
 }

--- a/agent/reaper/reaper_unix.go
+++ b/agent/reaper/reaper_unix.go
@@ -40,7 +40,10 @@ func catchSignals(pid int, sigs []os.Signal) {
 // the reaper and an exec.Command waiting for its process to complete.
 // The provided 'pids' channel may be nil if the caller does not care about the
 // reaped children PIDs.
-func ForkReap(opt ...Option) error {
+//
+// Returns the child's exit code (using 128+signal for signal termination)
+// and any error from Wait4.
+func ForkReap(opt ...Option) (int, error) {
 	opts := &options{
 		ExecArgs: os.Args,
 	}
@@ -53,7 +56,7 @@ func ForkReap(opt ...Option) error {
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		return xerrors.Errorf("get wd: %w", err)
+		return 1, xerrors.Errorf("get wd: %w", err)
 	}
 
 	pattrs := &syscall.ProcAttr{
@@ -72,7 +75,7 @@ func ForkReap(opt ...Option) error {
 	//#nosec G204
 	pid, err := syscall.ForkExec(opts.ExecArgs[0], opts.ExecArgs, pattrs)
 	if err != nil {
-		return xerrors.Errorf("fork exec: %w", err)
+		return 1, xerrors.Errorf("fork exec: %w", err)
 	}
 
 	go catchSignals(pid, opts.CatchSignals)
@@ -82,5 +85,18 @@ func ForkReap(opt ...Option) error {
 	for xerrors.Is(err, syscall.EINTR) {
 		_, err = syscall.Wait4(pid, &wstatus, 0, nil)
 	}
-	return err
+
+	// Convert wait status to exit code using standard Unix conventions:
+	// - Normal exit: use the exit code
+	// - Signal termination: use 128 + signal number
+	var exitCode int
+	switch {
+	case wstatus.Exited():
+		exitCode = wstatus.ExitStatus()
+	case wstatus.Signaled():
+		exitCode = 128 + int(wstatus.Signal())
+	default:
+		exitCode = 1
+	}
+	return exitCode, err
 }

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -145,13 +145,7 @@ func workspaceAgent() *serpent.Command {
 					return xerrors.Errorf("fork reap: %w", err)
 				}
 
-				if exitCode != 0 {
-					logger.Warn(ctx, "reaper: child process exited with non-zero status",
-						slog.F("exit_code", exitCode),
-					)
-				} else {
-					logger.Info(ctx, "reaper: child process exited successfully")
-				}
+				logger.Info(ctx, "reaper child process exited", slog.F("exit_code", exitCode))
 				return ExitError(exitCode, nil)
 			}
 

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -136,7 +136,7 @@ func workspaceAgent() *serpent.Command {
 				// to do this else we fork bomb ourselves.
 				//nolint:gocritic
 				args := append(os.Args, "--no-reap")
-				err := reaper.ForkReap(
+				exitCode, err := reaper.ForkReap(
 					reaper.WithExecArgs(args...),
 					reaper.WithCatchSignals(StopSignals...),
 				)
@@ -145,8 +145,14 @@ func workspaceAgent() *serpent.Command {
 					return xerrors.Errorf("fork reap: %w", err)
 				}
 
-				logger.Info(ctx, "reaper process exiting")
-				return nil
+				if exitCode != 0 {
+					logger.Warn(ctx, "reaper: child process exited with non-zero status",
+						slog.F("exit_code", exitCode),
+					)
+				} else {
+					logger.Info(ctx, "reaper: child process exited successfully")
+				}
+				return ExitError(exitCode, nil)
 			}
 
 			// Handle interrupt signals to allow for graceful shutdown,


### PR DESCRIPTION
The reaper (PID 1) now returns the child's exit code instead of always exiting 0. Signal termination uses the standard Unix convention of 128 + signal number. 

fixes #21661
