### PR TITLE
feat: add link for viewing raw build logs in workspace and template build jobs

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6722,6 +6722,16 @@ const docTemplate = `{
                         "description": "Follow log stream",
                         "name": "follow",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "json",
+                            "text"
+                        ],
+                        "type": "string",
+                        "description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+                        "name": "format",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6980,6 +6990,16 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Follow log stream",
                         "name": "follow",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "json",
+                            "text"
+                        ],
+                        "type": "string",
+                        "description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+                        "name": "format",
                         "in": "query"
                     }
                 ],
@@ -9944,6 +9964,16 @@ const docTemplate = `{
                         "description": "Disable compression for WebSocket connection",
                         "name": "no_compression",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "json",
+                            "text"
+                        ],
+                        "type": "string",
+                        "description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+                        "name": "format",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -10238,6 +10268,16 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Follow log stream",
                         "name": "follow",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "json",
+                            "text"
+                        ],
+                        "type": "string",
+                        "description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+                        "name": "format",
                         "in": "query"
                     }
                 ],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5945,6 +5945,13 @@
 						"description": "Follow log stream",
 						"name": "follow",
 						"in": "query"
+					},
+					{
+						"enum": ["json", "text"],
+						"type": "string",
+						"description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+						"name": "format",
+						"in": "query"
 					}
 				],
 				"responses": {
@@ -6179,6 +6186,13 @@
 						"type": "boolean",
 						"description": "Follow log stream",
 						"name": "follow",
+						"in": "query"
+					},
+					{
+						"enum": ["json", "text"],
+						"type": "string",
+						"description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+						"name": "format",
 						"in": "query"
 					}
 				],
@@ -8799,6 +8813,13 @@
 						"description": "Disable compression for WebSocket connection",
 						"name": "no_compression",
 						"in": "query"
+					},
+					{
+						"enum": ["json", "text"],
+						"type": "string",
+						"description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+						"name": "format",
+						"in": "query"
 					}
 				],
 				"responses": {
@@ -9066,6 +9087,13 @@
 						"type": "boolean",
 						"description": "Follow log stream",
 						"name": "follow",
+						"in": "query"
+					},
+					{
+						"enum": ["json", "text"],
+						"type": "string",
+						"description": "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true.",
+						"name": "format",
 						"in": "query"
 					}
 				],

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -623,6 +623,27 @@ func WorkspaceAppStatus(status database.WorkspaceAppStatus) codersdk.WorkspaceAp
 	}
 }
 
+func ProvisionerJobLog(log database.ProvisionerJobLog) codersdk.ProvisionerJobLog {
+	return codersdk.ProvisionerJobLog{
+		ID:        log.ID,
+		CreatedAt: log.CreatedAt,
+		Source:    codersdk.LogSource(log.Source),
+		Level:     codersdk.LogLevel(log.Level),
+		Stage:     log.Stage,
+		Output:    log.Output,
+	}
+}
+
+func WorkspaceAgentLog(log database.WorkspaceAgentLog) codersdk.WorkspaceAgentLog {
+	return codersdk.WorkspaceAgentLog{
+		ID:        log.ID,
+		CreatedAt: log.CreatedAt,
+		Output:    log.Output,
+		Level:     codersdk.LogLevel(log.Level),
+		SourceID:  log.LogSourceID,
+	}
+}
+
 func ProvisionerDaemon(dbDaemon database.ProvisionerDaemon) codersdk.ProvisionerDaemon {
 	result := codersdk.ProvisionerDaemon{
 		ID:             dbDaemon.ID,

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -157,7 +157,29 @@ func (api *API) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 		logger   = api.Logger.With(slog.F("job_id", job.ID))
 		follow   = r.URL.Query().Has("follow")
 		afterRaw = r.URL.Query().Get("after")
+		format   = r.URL.Query().Get("format")
 	)
+
+	// Validate format parameter.
+	if format == "" {
+		format = "json"
+	}
+	if format != "json" && format != "text" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid format parameter.",
+			Detail:  "Allowed values are \"json\" and \"text\".",
+		})
+		return
+	}
+
+	// Text format is not supported with streaming.
+	if format == "text" && follow {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Text format is not supported with follow mode.",
+			Detail:  "Use format=json or omit the follow parameter.",
+		})
+		return
+	}
 
 	var after int64
 	// Only fetch logs created after the time provided.
@@ -176,7 +198,7 @@ func (api *API) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 	}
 
 	if !follow {
-		fetchAndWriteLogs(ctx, api.Database, job.ID, after, rw)
+		fetchAndWriteLogs(ctx, api.Database, job.ID, after, rw, format)
 		return
 	}
 
@@ -416,7 +438,7 @@ func convertProvisionerJobWithQueuePosition(pj database.GetProvisionerJobsByOrga
 	return job
 }
 
-func fetchAndWriteLogs(ctx context.Context, db database.Store, jobID uuid.UUID, after int64, rw http.ResponseWriter) {
+func fetchAndWriteLogs(ctx context.Context, db database.Store, jobID uuid.UUID, after int64, rw http.ResponseWriter, format string) {
 	logs, err := db.GetProvisionerLogsAfterID(ctx, database.GetProvisionerLogsAfterIDParams{
 		JobID:        jobID,
 		CreatedAfter: after,
@@ -430,6 +452,16 @@ func fetchAndWriteLogs(ctx context.Context, db database.Store, jobID uuid.UUID, 
 	}
 	if logs == nil {
 		logs = []database.ProvisionerJobLog{}
+	}
+
+	if format == "text" {
+		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		rw.WriteHeader(http.StatusOK)
+		for _, log := range logs {
+			_, _ = rw.Write([]byte(db2sdk.ProvisionerJobLog(log).Text()))
+			_, _ = rw.Write([]byte("\n"))
+		}
+		return
 	}
 	httpapi.Write(ctx, rw, http.StatusOK, convertProvisionerJobLogs(logs))
 }

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -656,6 +656,7 @@ func (api *API) templateVersionDryRunResources(rw http.ResponseWriter, r *http.R
 // @Param before query int false "Before Unix timestamp"
 // @Param after query int false "After Unix timestamp"
 // @Param follow query bool false "Follow log stream"
+// @Param format query string false "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true." Enums(json,text)
 // @Success 200 {array} codersdk.ProvisionerJobLog
 // @Router /templateversions/{templateversion}/dry-run/{jobID}/logs [get]
 func (api *API) templateVersionDryRunLogs(rw http.ResponseWriter, r *http.Request) {
@@ -1928,6 +1929,7 @@ func (api *API) templateVersionResources(rw http.ResponseWriter, r *http.Request
 // @Param before query int false "Before log id"
 // @Param after query int false "After log id"
 // @Param follow query bool false "Follow log stream"
+// @Param format query string false "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true." Enums(json,text)
 // @Success 200 {array} codersdk.ProvisionerJobLog
 // @Router /templateversions/{templateversion}/logs [get]
 func (api *API) templateVersionLogs(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1039,7 +1039,7 @@ func TestTemplateVersionLogsFormat(t *testing.T) {
 			expectedStatus:      http.StatusOK,
 			expectedContentType: "application/json",
 			checkBody: func(t *testing.T, body string) {
-				assert.NotEmpty(t, body) // This is checked more thoroughly in the case above.
+				assert.NotEmpty(t, body) // This is checked more thoroughly in TestTemplateVersionLogs above.
 			},
 		},
 		{

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -3,6 +3,9 @@ package coderd_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -16,9 +19,13 @@ import (
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/externalauth"
+	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
@@ -996,6 +1003,103 @@ func TestTemplateVersionLogs(t *testing.T) {
 	}
 }
 
+func TestTemplateVersionLogsFormat(t *testing.T) {
+	t.Parallel()
+
+	// Setup: Create template version with logs using dbfake.
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	tv := dbfake.TemplateVersion(t, db).
+		Seed(database.TemplateVersion{
+			OrganizationID: user.OrganizationID,
+			CreatedBy:      user.UserID,
+		}).
+		Do()
+
+	// Insert test log directly into database.
+	jl := dbgen.ProvisionerJobLog(t, db, database.ProvisionerJobLog{
+		JobID:  tv.TemplateVersion.JobID,
+		Stage:  "Planning",
+		Source: database.LogSourceProvisioner,
+		Level:  database.LogLevelInfo,
+		Output: "test log output",
+	})
+
+	tests := []struct {
+		name                string
+		queryParams         string
+		expectedStatus      int
+		expectedContentType string
+		checkBody           func(t *testing.T, body string)
+	}{
+		{
+			name:                "JSON",
+			queryParams:         "",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "application/json",
+			checkBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body) // This is checked more thoroughly in the case above.
+			},
+		},
+		{
+			name:                "Text",
+			queryParams:         "?format=text",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "text/plain",
+			checkBody: func(t *testing.T, body string) {
+				expected := db2sdk.ProvisionerJobLog(jl).Text()
+				assert.Contains(t, body, expected)
+			},
+		},
+		{
+			name:           "InvalidFormat",
+			queryParams:    "?format=invalid",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body string) {
+				t.Log(body)
+				var sdkErr codersdk.Error
+				assert.NoError(t, json.NewDecoder(strings.NewReader(body)).Decode(&sdkErr))
+				assert.Equal(t, "Invalid format parameter.", sdkErr.Message)
+			},
+		},
+		{
+			name:           "TextWithFollowFails",
+			queryParams:    "?format=text&follow",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body string) {
+				t.Log(body)
+				var sdkErr codersdk.Error
+				assert.NoError(t, json.NewDecoder(strings.NewReader(body)).Decode(&sdkErr))
+				assert.Equal(t, "Text format is not supported with follow mode.", sdkErr.Message)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			urlPath := fmt.Sprintf("/api/v2/templateversions/%s/logs%s", tv.TemplateVersion.ID, tt.queryParams)
+
+			res, err := client.Request(ctx, http.MethodGet, urlPath, nil)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, tt.expectedStatus, res.StatusCode)
+			if tt.expectedContentType != "" {
+				require.Contains(t, res.Header.Get("Content-Type"), tt.expectedContentType)
+			}
+			if assert.NotNil(t, tt.checkBody) {
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+				tt.checkBody(t, string(body))
+			}
+		})
+	}
+}
+
 func TestTemplateVersionsByTemplate(t *testing.T) {
 	t.Parallel()
 	t.Run("Get", func(t *testing.T) {
@@ -1459,6 +1563,111 @@ func TestTemplateVersionDryRun(t *testing.T) {
 		require.Equal(t, 0, matched.Available)
 		require.Zero(t, matched.MostRecentlySeen.Time)
 	})
+}
+
+func TestTemplateVersionDryRunLogsFormat(t *testing.T) {
+	t.Parallel()
+
+	// Setup: Create template version and dry-run job with logs using dbfake.
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	tv := dbfake.TemplateVersion(t, db).
+		Seed(database.TemplateVersion{
+			OrganizationID: user.OrganizationID,
+			CreatedBy:      user.UserID,
+		}).
+		Do()
+
+	// Create a dry-run provisioner job.
+	dryRunInput, err := json.Marshal(provisionerdserver.TemplateVersionDryRunJob{
+		TemplateVersionID: tv.TemplateVersion.ID,
+	})
+	require.NoError(t, err)
+
+	dryRunJob := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		OrganizationID: user.OrganizationID,
+		InitiatorID:    user.UserID,
+		Type:           database.ProvisionerJobTypeTemplateVersionDryRun,
+		Input:          dryRunInput,
+	})
+
+	// Insert test log directly into database.
+	jl := dbgen.ProvisionerJobLog(t, db, database.ProvisionerJobLog{
+		JobID:  dryRunJob.ID,
+		Stage:  "Planning",
+		Source: database.LogSourceProvisioner,
+		Level:  database.LogLevelInfo,
+		Output: "test dry-run log output",
+	})
+
+	tests := []struct {
+		name                string
+		queryParams         string
+		expectedStatus      int
+		expectedContentType string
+		checkBody           func(t *testing.T, body string)
+	}{
+		{
+			name:                "JSON",
+			queryParams:         "",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "application/json",
+			checkBody: func(t *testing.T, body string) {
+				assert.NotEmpty(t, body)
+			},
+		},
+		{
+			name:                "Text",
+			queryParams:         "?format=text",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "text/plain",
+			checkBody: func(t *testing.T, body string) {
+				expected := db2sdk.ProvisionerJobLog(jl).Text()
+				assert.Contains(t, body, expected)
+			},
+		},
+		{
+			name:           "InvalidFormat",
+			queryParams:    "?format=invalid",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body string) {
+				assert.Contains(t, body, "Invalid format")
+			},
+		},
+		{
+			name:           "TextWithFollowFails",
+			queryParams:    "?format=text&follow",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body string) {
+				assert.Contains(t, body, "not supported with follow mode")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			urlPath := fmt.Sprintf("/api/v2/templateversions/%s/dry-run/%s/logs%s", tv.TemplateVersion.ID, dryRunJob.ID, tt.queryParams)
+
+			res, err := client.Request(ctx, http.MethodGet, urlPath, nil)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, tt.expectedStatus, res.StatusCode)
+			if tt.expectedContentType != "" {
+				require.Contains(t, res.Header.Get("Content-Type"), tt.expectedContentType)
+			}
+
+			if assert.NotNil(t, tt.checkBody) {
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+				tt.checkBody(t, string(body))
+			}
+		})
+	}
 }
 
 // TestPaginatedTemplateVersions creates a list of template versions and paginate.

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -615,7 +615,7 @@ func (api *API) workspaceAgentLogs(rw http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			lsids := make(map[uuid.UUID]string, 0)
+			lsids := make(map[uuid.UUID]string, len(sids))
 			for _, sid := range sids {
 				lsids[sid.ID] = sid.DisplayName
 			}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -615,7 +615,7 @@ func (api *API) workspaceAgentLogs(rw http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			lsids := make(map[uuid.UUID]string)
+			lsids := make(map[uuid.UUID]string, 0)
 			for _, sid := range sids {
 				lsids[sid.ID] = sid.DisplayName
 			}

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"os"
@@ -39,6 +40,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -335,6 +337,97 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestWorkspaceAgentLogsFormat(t *testing.T) {
+	t.Parallel()
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent().Do()
+
+	workspaceAgent := r.Agents[0]
+	logSource := dbgen.WorkspaceAgentLogSource(t, db, database.WorkspaceAgentLogSource{
+		WorkspaceAgentID: workspaceAgent.ID,
+		DisplayName:      "startup_script",
+	})
+	agentLog := dbgen.WorkspaceAgentLog(t, db, database.WorkspaceAgentLog{
+		AgentID:     workspaceAgent.ID,
+		LogSourceID: logSource.ID,
+		Output:      "test log output",
+		Level:       database.LogLevelInfo,
+	})
+
+	tests := []struct {
+		name                string
+		queryParams         string
+		expectedStatus      int
+		expectedContentType string
+		checkBody           func(string)
+	}{
+		{
+			name:                "JSON",
+			queryParams:         "",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "application/json",
+			checkBody: func(body string) {
+				assert.NotEmpty(t, body)
+			},
+		},
+		{
+			name:                "Text",
+			queryParams:         "?format=text",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "text/plain",
+			checkBody: func(body string) {
+				expected := db2sdk.WorkspaceAgentLog(agentLog).Text(workspaceAgent.Name, logSource.DisplayName)
+				assert.Contains(t, body, expected)
+			},
+		},
+		{
+			name:           "InvalidFormat",
+			queryParams:    "?format=invalid",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(body string) {
+				assert.Contains(t, body, "Invalid format")
+			},
+		},
+		{
+			name:           "TextWithFollowFails",
+			queryParams:    "?format=text&follow",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(body string) {
+				assert.Contains(t, body, "not supported with follow mode")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			urlPath := fmt.Sprintf("/api/v2/workspaceagents/%s/logs%s", workspaceAgent.ID, tt.queryParams)
+
+			res, err := client.Request(ctx, http.MethodGet, urlPath, nil)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, tt.expectedStatus, res.StatusCode)
+			if tt.expectedContentType != "" {
+				require.Contains(t, res.Header.Get("Content-Type"), tt.expectedContentType)
+			}
+
+			if assert.NotNil(t, tt.checkBody) {
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+				tt.checkBody(string(body))
+			}
+		})
+	}
 }
 
 func TestWorkspaceAgentAppStatus(t *testing.T) {

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -826,6 +826,7 @@ func (api *API) workspaceBuildParameters(rw http.ResponseWriter, r *http.Request
 // @Param before query int false "Before log id"
 // @Param after query int false "After log id"
 // @Param follow query bool false "Follow log stream"
+// @Param format query string false "Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true." Enums(json,text)
 // @Success 200 {array} codersdk.ProvisionerJobLog
 // @Router /workspacebuilds/{workspacebuild}/logs [get]
 func (api *API) workspaceBuildLogs(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"slices"
 	"strconv"
@@ -25,6 +26,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -1090,6 +1092,96 @@ func TestWorkspaceBuildLogs(t *testing.T) {
 		}
 	}
 	require.Fail(t, "example message never happened")
+}
+
+func TestWorkspaceBuildLogsFormat(t *testing.T) {
+	t.Parallel()
+
+	// Setup: Create workspace build with logs using dbfake.
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).Do()
+
+	// Insert test log directly into database.
+	jl := dbgen.ProvisionerJobLog(t, db, database.ProvisionerJobLog{
+		JobID:  r.Build.JobID,
+		Stage:  "Planning",
+		Source: database.LogSourceProvisioner,
+		Level:  database.LogLevelInfo,
+		Output: "test log output",
+	})
+
+	tests := []struct {
+		name                string
+		queryParams         string
+		expectedStatus      int
+		expectedContentType string
+		checkBody           func(t *testing.T, body string)
+	}{
+		{
+			name:                "JSON",
+			queryParams:         "",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "application/json",
+			checkBody: func(t *testing.T, body string) {
+				require.NotEmpty(t, body)
+			},
+		},
+		{
+			name:                "Text",
+			queryParams:         "?format=text",
+			expectedStatus:      http.StatusOK,
+			expectedContentType: "text/plain",
+			checkBody: func(t *testing.T, body string) {
+				expected := db2sdk.ProvisionerJobLog(jl).Text()
+				require.Contains(t, body, expected)
+			},
+		},
+		{
+			name:           "InvalidFormat",
+			queryParams:    "?format=invalid",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body string) {
+				require.Contains(t, body, "Invalid format")
+			},
+		},
+		{
+			name:           "TextWithFollowFails",
+			queryParams:    "?format=text&follow",
+			expectedStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body string) {
+				require.Contains(t, body, "not supported with follow mode")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.Context(t, testutil.WaitLong)
+
+			urlPath := fmt.Sprintf("/api/v2/workspacebuilds/%s/logs%s", r.Build.ID, tt.queryParams)
+
+			res, err := client.Request(ctx, http.MethodGet, urlPath, nil)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, tt.expectedStatus, res.StatusCode)
+			if tt.expectedContentType != "" {
+				require.Contains(t, res.Header.Get("Content-Type"), tt.expectedContentType)
+			}
+
+			if assert.NotNil(t, tt.checkBody) {
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+				tt.checkBody(t, string(body))
+			}
+		})
+	}
 }
 
 func TestWorkspaceBuildState(t *testing.T) {

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -216,6 +216,19 @@ type ProvisionerJobLog struct {
 	Output    string    `json:"output"`
 }
 
+// Text formats the log entry as human-readable text.
+func (l ProvisionerJobLog) Text() string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(l.CreatedAt.Format(time.RFC3339))
+	_, _ = sb.WriteString(" [")
+	_, _ = sb.WriteString(string(l.Level))
+	_, _ = sb.WriteString("] [provisioner|")
+	_, _ = sb.WriteString(l.Stage)
+	_, _ = sb.WriteString("] ")
+	_, _ = sb.WriteString(l.Output)
+	return sb.String()
+}
+
 // provisionerJobLogsAfter streams logs that occurred after a specific time.
 func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after int64) (<-chan ProvisionerJobLog, io.Closer, error) {
 	afterQuery := ""

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -217,6 +217,26 @@ type WorkspaceAgentLog struct {
 	SourceID  uuid.UUID `json:"source_id" format:"uuid"`
 }
 
+// Text formats the log entry as human-readable text.
+func (l WorkspaceAgentLog) Text(agentName, sourceName string) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(l.CreatedAt.Format(time.RFC3339))
+	_, _ = sb.WriteString(" [")
+	_, _ = sb.WriteString(string(l.Level))
+	_, _ = sb.WriteString("] [agent")
+	if agentName != "" {
+		_, _ = sb.WriteString(".")
+		_, _ = sb.WriteString(agentName)
+	}
+	if sourceName != "" {
+		_, _ = sb.WriteString("|")
+		_, _ = sb.WriteString(sourceName)
+	}
+	_, _ = sb.WriteString("] ")
+	_, _ = sb.WriteString(l.Output)
+	return sb.String()
+}
+
 type AgentSubsystem string
 
 const (

--- a/codersdk/workspaceagents_test.go
+++ b/codersdk/workspaceagents_test.go
@@ -1,0 +1,112 @@
+package codersdk_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestProvisionerJobLogText(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.ProvisionerJobLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelInfo,
+		Source:    codersdk.LogSourceProvisioner,
+		Stage:     "Planning",
+		Output:    "Terraform init complete",
+	}
+	result := log.Text()
+	require.Equal(t, "2024-01-28T10:30:00Z [info] [provisioner|Planning] Terraform init complete", result)
+}
+
+func TestProvisionerJobLogTextEmptyOutput(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.ProvisionerJobLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelInfo,
+		Source:    codersdk.LogSourceProvisioner,
+		Stage:     "Planning",
+		Output:    "",
+	}
+	result := log.Text()
+	require.Equal(t, "2024-01-28T10:30:00Z [info] [provisioner|Planning] ", result)
+}
+
+func TestProvisionerJobLogTextSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.ProvisionerJobLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelInfo,
+		Source:    codersdk.LogSourceProvisioner,
+		Stage:     "Applying",
+		Output:    "\033[32mSuccess!\033[0m Unicode: 你好世界",
+	}
+	result := log.Text()
+	require.Equal(t, "2024-01-28T10:30:00Z [info] [provisioner|Applying] \033[32mSuccess!\033[0m Unicode: 你好世界", result)
+}
+
+func TestWorkspaceAgentLogText(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.WorkspaceAgentLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelInfo,
+		Output:    "Agent started successfully",
+		SourceID:  uuid.New(),
+	}
+	result := log.Text("main", "startup_script")
+	require.Equal(t, "2024-01-28T10:30:00Z [info] [agent.main|startup_script] Agent started successfully", result)
+}
+
+func TestWorkspaceAgentLogTextEmptySourceAndAgent(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.WorkspaceAgentLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelWarn,
+		Output:    "Warning message",
+		SourceID:  uuid.New(),
+	}
+	result := log.Text("", "")
+	require.Equal(t, "2024-01-28T10:30:00Z [warn] [agent] Warning message", result)
+}
+
+func TestWorkspaceAgentLogTextMultiline(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.WorkspaceAgentLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelInfo,
+		Output:    "Line 1\nLine 2\nLine 3",
+		SourceID:  uuid.New(),
+	}
+	result := log.Text("main", "startup_script")
+	require.Equal(t, "2024-01-28T10:30:00Z [info] [agent.main|startup_script] Line 1\nLine 2\nLine 3", result)
+}
+
+func TestWorkspaceAgentLogTextSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 28, 10, 30, 0, 0, time.UTC)
+	log := codersdk.WorkspaceAgentLog{
+		CreatedAt: ts,
+		Level:     codersdk.LogLevelDebug,
+		Output:    "\033[31mError!\033[0m 🚀 Unicode: 日本語",
+		SourceID:  uuid.New(),
+	}
+	result := log.Text("main", "startup_script")
+	require.Equal(t, "2024-01-28T10:30:00Z [debug] [agent.main|startup_script] \033[31mError!\033[0m 🚀 Unicode: 日本語", result)
+}

--- a/docs/reference/api/agents.md
+++ b/docs/reference/api/agents.md
@@ -1116,13 +1116,20 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/log
 
 ### Parameters
 
-| Name             | In    | Type         | Required | Description                                  |
-|------------------|-------|--------------|----------|----------------------------------------------|
-| `workspaceagent` | path  | string(uuid) | true     | Workspace agent ID                           |
-| `before`         | query | integer      | false    | Before log id                                |
-| `after`          | query | integer      | false    | After log id                                 |
-| `follow`         | query | boolean      | false    | Follow log stream                            |
-| `no_compression` | query | boolean      | false    | Disable compression for WebSocket connection |
+| Name             | In    | Type         | Required | Description                                                                                                                                 |
+|------------------|-------|--------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `workspaceagent` | path  | string(uuid) | true     | Workspace agent ID                                                                                                                          |
+| `before`         | query | integer      | false    | Before log id                                                                                                                               |
+| `after`          | query | integer      | false    | After log id                                                                                                                                |
+| `follow`         | query | boolean      | false    | Follow log stream                                                                                                                           |
+| `no_compression` | query | boolean      | false    | Disable compression for WebSocket connection                                                                                                |
+| `format`         | query | string       | false    | Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true. |
+
+#### Enumerated Values
+
+| Parameter | Value(s)       |
+|-----------|----------------|
+| `format`  | `json`, `text` |
 
 ### Example responses
 

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -548,12 +548,19 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/log
 
 ### Parameters
 
-| Name             | In    | Type    | Required | Description        |
-|------------------|-------|---------|----------|--------------------|
-| `workspacebuild` | path  | string  | true     | Workspace build ID |
-| `before`         | query | integer | false    | Before log id      |
-| `after`          | query | integer | false    | After log id       |
-| `follow`         | query | boolean | false    | Follow log stream  |
+| Name             | In    | Type    | Required | Description                                                                                                                                 |
+|------------------|-------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `workspacebuild` | path  | string  | true     | Workspace build ID                                                                                                                          |
+| `before`         | query | integer | false    | Before log id                                                                                                                               |
+| `after`          | query | integer | false    | After log id                                                                                                                                |
+| `follow`         | query | boolean | false    | Follow log stream                                                                                                                           |
+| `format`         | query | string  | false    | Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true. |
+
+#### Enumerated Values
+
+| Parameter | Value(s)       |
+|-----------|----------------|
+| `format`  | `json`, `text` |
 
 ### Example responses
 

--- a/docs/reference/api/templates.md
+++ b/docs/reference/api/templates.md
@@ -2239,13 +2239,20 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
 
 ### Parameters
 
-| Name              | In    | Type         | Required | Description           |
-|-------------------|-------|--------------|----------|-----------------------|
-| `templateversion` | path  | string(uuid) | true     | Template version ID   |
-| `jobID`           | path  | string(uuid) | true     | Job ID                |
-| `before`          | query | integer      | false    | Before Unix timestamp |
-| `after`           | query | integer      | false    | After Unix timestamp  |
-| `follow`          | query | boolean      | false    | Follow log stream     |
+| Name              | In    | Type         | Required | Description                                                                                                                                 |
+|-------------------|-------|--------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `templateversion` | path  | string(uuid) | true     | Template version ID                                                                                                                         |
+| `jobID`           | path  | string(uuid) | true     | Job ID                                                                                                                                      |
+| `before`          | query | integer      | false    | Before Unix timestamp                                                                                                                       |
+| `after`           | query | integer      | false    | After Unix timestamp                                                                                                                        |
+| `follow`          | query | boolean      | false    | Follow log stream                                                                                                                           |
+| `format`          | query | string       | false    | Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true. |
+
+#### Enumerated Values
+
+| Parameter | Value(s)       |
+|-----------|----------------|
+| `format`  | `json`, `text` |
 
 ### Example responses
 
@@ -2847,12 +2854,19 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/l
 
 ### Parameters
 
-| Name              | In    | Type         | Required | Description         |
-|-------------------|-------|--------------|----------|---------------------|
-| `templateversion` | path  | string(uuid) | true     | Template version ID |
-| `before`          | query | integer      | false    | Before log id       |
-| `after`           | query | integer      | false    | After log id        |
-| `follow`          | query | boolean      | false    | Follow log stream   |
+| Name              | In    | Type         | Required | Description                                                                                                                                 |
+|-------------------|-------|--------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `templateversion` | path  | string(uuid) | true     | Template version ID                                                                                                                         |
+| `before`          | query | integer      | false    | Before log id                                                                                                                               |
+| `after`           | query | integer      | false    | After log id                                                                                                                                |
+| `follow`          | query | boolean      | false    | Follow log stream                                                                                                                           |
+| `format`          | query | string       | false    | Log output format. Accepted: 'json' (default), 'text' (plain text with RFC3339 timestamps and ANSI colors). Not supported with follow=true. |
+
+#### Enumerated Values
+
+| Parameter | Value(s)       |
+|-----------|----------------|
+| `format`  | `json`, `text` |
 
 ### Example responses
 

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -582,13 +582,28 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 									</button>
 								</div>
 
+								{selectedTab === "logs" && gotBuildLogs && (
+									<a
+										href={`/api/v2/templateversions/${templateVersion.id}/logs?format=text`}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="flex items-center gap-1 px-3 text-xs text-content-secondary hover:text-content-primary"
+									>
+										View raw logs
+										<ExternalLinkIcon className="size-3" />
+									</a>
+								)}
+
 								{selectedTab && (
 									<IconButton
 										onClick={() => {
 											setSelectedTab(undefined);
 										}}
 										css={{
-											marginLeft: "auto",
+											marginLeft:
+												selectedTab !== "logs" || !gotBuildLogs
+													? "auto"
+													: undefined,
 											width: 36,
 											height: 36,
 											borderRadius: 0,

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
@@ -10,7 +10,7 @@ import {
 } from "components/PageHeader/PageHeader";
 import { Stack } from "components/Stack/Stack";
 import { Stats, StatsItem } from "components/Stats/Stats";
-import { EditIcon, PlusIcon } from "lucide-react";
+import { EditIcon, ExternalLinkIcon, PlusIcon } from "lucide-react";
 import { linkToTemplate, useLinks } from "modules/navigation";
 import { TemplateFiles } from "modules/templates/TemplateFiles/TemplateFiles";
 import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
@@ -80,21 +80,32 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
 				)}
 				{currentVersion && currentFiles && (
 					<>
-						<Stats>
-							<StatsItem
-								label="Template"
-								value={
-									<RouterLink to={templateLink}>{templateName}</RouterLink>
-								}
-							/>
-							<StatsItem
-								label="Created by"
-								value={currentVersion.created_by.username}
-							/>
-							<StatsItem
-								label="Created"
-								value={createDayString(currentVersion.created_at)}
-							/>
+						<Stats className="justify-between">
+							<div className="flex flex-wrap items-center">
+								<StatsItem
+									label="Template"
+									value={
+										<RouterLink to={templateLink}>{templateName}</RouterLink>
+									}
+								/>
+								<StatsItem
+									label="Created by"
+									value={currentVersion.created_by.username}
+								/>
+								<StatsItem
+									label="Created"
+									value={createDayString(currentVersion.created_at)}
+								/>
+							</div>
+							<a
+								href={`/api/v2/templateversions/${currentVersion.id}/logs?format=text`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-1 p-2 text-xs text-content-secondary underline hover:text-content-primary md:py-3.5 md:px-4"
+							>
+								View raw logs
+								<ExternalLinkIcon className="size-3" />
+							</a>
 						</Stats>
 
 						<TemplateFiles

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -16,6 +16,7 @@ import { Stack } from "components/Stack/Stack";
 import { Stats, StatsItem } from "components/Stats/Stats";
 import { TAB_PADDING_X, TabLink, Tabs, TabsList } from "components/Tabs/Tabs";
 import { useSearchParamsKey } from "hooks/useSearchParamsKey";
+import { ExternalLinkIcon } from "lucide-react";
 import { BuildAvatar } from "modules/builds/BuildAvatar/BuildAvatar";
 import { DashboardFullPage } from "modules/dashboard/DashboardLayout";
 import { AgentLogs } from "modules/resources/AgentLogs/AgentLogs";
@@ -150,28 +151,52 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 				</Sidebar>
 
 				<ScrollArea>
-					<Tabs active={tabState.value}>
-						<TabsList className="gap-0">
-							<TabLink
-								to={`?${LOGS_TAB_KEY}=build`}
-								value="build"
-								className="px-6 pb-2"
-							>
-								Build
-							</TabLink>
-
-							{agents.map((a) => (
+					<div className="flex items-center justify-between border-b border-solid border-border">
+						<Tabs active={tabState.value}>
+							<TabsList className="gap-0">
 								<TabLink
+									to={`?${LOGS_TAB_KEY}=build`}
+									value="build"
 									className="px-6 pb-2"
-									to={`?${LOGS_TAB_KEY}=${a.id}`}
-									value={a.id}
-									key={a.id}
 								>
-									coder_agent.{a.name}
+									Build
 								</TabLink>
-							))}
-						</TabsList>
-					</Tabs>
+
+								{agents.map((a) => (
+									<TabLink
+										className="px-6 pb-2"
+										to={`?${LOGS_TAB_KEY}=${a.id}`}
+										value={a.id}
+										key={a.id}
+									>
+										coder_agent.{a.name}
+									</TabLink>
+								))}
+							</TabsList>
+						</Tabs>
+						{tabState.value === "build" && (
+							<a
+								href={`/api/v2/workspacebuilds/${build.id}/logs?format=text`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-1 px-4 pb-2 text-xs text-content-secondary hover:text-content-primary"
+							>
+								View raw logs
+								<ExternalLinkIcon className="size-3" />
+							</a>
+						)}
+						{tabState.value !== "build" && selectedAgent && (
+							<a
+								href={`/api/v2/workspaceagents/${selectedAgent.id}/logs?format=text`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-1 px-4 pb-2 text-xs text-content-secondary hover:text-content-primary"
+							>
+								View raw logs
+								<ExternalLinkIcon className="size-3" />
+							</a>
+						)}
+					</div>
 					{build.transition === "delete" && build.job.status === "failed" && (
 						<Alert
 							severity="error"


### PR DESCRIPTION
This addresses a long-standing peeve of mine: it's not easy to link someone to just the logs for a single provisioner job or workspace agent.

You can now add `?format=text` to the following API routes:

* `/api/v2/workspaceagents/:id/logs`
* `/api/v2/workspacebuilds/:id/logs`
* `/api/v2/templateversions/:id/logs` 
* `/api/v2/templateversions/:id/dry-run/:id/logs` 

**Note:** `format=text` is not supported with websocket streaming (`follow`). Specifying both will return 400 Bad Request.

In addition, added links to the raw logs on the following pages:
* Workspace build page

<img width="1463" height="275" alt="image" src="https://github.com/user-attachments/assets/2c297637-ba10-41c5-ab8c-bfbb530c2348" />

* Template editor page

<img width="897" height="386" alt="image" src="https://github.com/user-attachments/assets/2b4fc1de-149b-490d-8c32-0541bf110eb6" />


* Template version page

<img width="1457" height="358" alt="image" src="https://github.com/user-attachments/assets/4403ca38-6395-4b7c-98bc-83b45f628aa0" />


As a side-effect, refactored the existing log formatting in `cli/logs.go` to live in `codersdk`.

🤖 Generated with Claude Opus 4.5, reviewed by me.