### PR TITLE
fix: backport fix for managed agent tracking (#21696)

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -2932,7 +2932,7 @@ func TestCompleteJob(t *testing.T) {
 					isTask:           true,
 					expectTaskStatus: database.TaskStatusInitializing,
 					expectHasAiTask:  false,
-					expectUsageEvent: false,
+					expectUsageEvent: true,
 				},
 				{
 					name:       "has_ai_task is set to true, but transition is not start",

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -64,6 +63,8 @@ type Builder struct {
 	initiator               uuid.UUID
 	reason                  database.BuildReason
 	templateVersionPresetID uuid.UUID
+	task                    *database.Task
+	hasTask                 *bool // A workspace without a task will have a nil `task` and false `hasTask`.
 
 	// used during build, makes function arguments less verbose
 	ctx       context.Context
@@ -93,7 +94,7 @@ type Builder struct {
 }
 
 type UsageChecker interface {
-	CheckBuildUsage(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, transition database.WorkspaceTransition) (UsageCheckResponse, error)
+	CheckBuildUsage(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, task *database.Task, transition database.WorkspaceTransition) (UsageCheckResponse, error)
 }
 
 type UsageCheckResponse struct {
@@ -105,7 +106,7 @@ type NoopUsageChecker struct{}
 
 var _ UsageChecker = NoopUsageChecker{}
 
-func (NoopUsageChecker) CheckBuildUsage(_ context.Context, _ database.Store, _ *database.TemplateVersion, _ database.WorkspaceTransition) (UsageCheckResponse, error) {
+func (NoopUsageChecker) CheckBuildUsage(_ context.Context, _ database.Store, _ *database.TemplateVersion, _ *database.Task, _ database.WorkspaceTransition) (UsageCheckResponse, error) {
 	return UsageCheckResponse{
 		Permitted: true,
 	}, nil
@@ -489,8 +490,13 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 			return BuildError{code, "insert workspace build", err}
 		}
 
+		task, err := b.getWorkspaceTask()
+		if err != nil {
+			return BuildError{http.StatusInternalServerError, "get task by workspace id", err}
+		}
+
 		// If this is a task workspace, link it to the latest workspace build.
-		if task, err := store.GetTaskByWorkspaceID(b.ctx, b.workspace.ID); err == nil {
+		if task != nil {
 			_, err = store.UpsertTaskWorkspaceApp(b.ctx, database.UpsertTaskWorkspaceAppParams{
 				TaskID:               task.ID,
 				WorkspaceBuildNumber: buildNum,
@@ -500,8 +506,6 @@ func (b *Builder) buildTx(authFunc func(action policy.Action, object rbac.Object
 			if err != nil {
 				return BuildError{http.StatusInternalServerError, "upsert task workspace app", err}
 			}
-		} else if !errors.Is(err, sql.ErrNoRows) {
-			return BuildError{http.StatusInternalServerError, "get task by workspace id", err}
 		}
 
 		err = store.InsertWorkspaceBuildParameters(b.ctx, database.InsertWorkspaceBuildParametersParams{
@@ -632,6 +636,27 @@ func (b *Builder) getTemplateVersionID() (uuid.UUID, error) {
 		return uuid.Nil, xerrors.Errorf("get last build so we can get version: %w", err)
 	}
 	return bld.TemplateVersionID, nil
+}
+
+// getWorkspaceTask returns the task associated with the workspace, if any.
+// If no task exists, it returns (nil, nil).
+func (b *Builder) getWorkspaceTask() (*database.Task, error) {
+	if b.hasTask != nil {
+		return b.task, nil
+	}
+	t, err := b.store.GetTaskByWorkspaceID(b.ctx, b.workspace.ID)
+	if err != nil {
+		if xerrors.Is(err, sql.ErrNoRows) {
+			b.hasTask = ptr.Ref(false)
+			//nolint:nilnil // No task exists.
+			return nil, nil
+		}
+		return nil, xerrors.Errorf("get task: %w", err)
+	}
+
+	b.task = &t
+	b.hasTask = ptr.Ref(true)
+	return b.task, nil
 }
 
 func (b *Builder) getTemplateTerraformValues() (*database.TemplateVersionTerraformValue, error) {
@@ -1307,7 +1332,12 @@ func (b *Builder) checkUsage() error {
 		return BuildError{http.StatusInternalServerError, "Failed to fetch template version", err}
 	}
 
-	resp, err := b.usageChecker.CheckBuildUsage(b.ctx, b.store, templateVersion, b.trans)
+	task, err := b.getWorkspaceTask()
+	if err != nil {
+		return BuildError{http.StatusInternalServerError, "Failed to fetch workspace task", err}
+	}
+
+	resp, err := b.usageChecker.CheckBuildUsage(b.ctx, b.store, templateVersion, task, b.trans)
 	if err != nil {
 		return BuildError{http.StatusInternalServerError, "Failed to check build usage", err}
 	}

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -571,6 +571,7 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			// Inputs
 			withTemplate,
 			withInactiveVersionNoParams(),
+			withNoTask,
 			withLastBuildFound,
 			withTemplateVersionVariables(inactiveVersionID, nil),
 			withParameterSchemas(inactiveJobID, schemas),
@@ -604,6 +605,7 @@ func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 			// Inputs
 			withTemplate,
 			withInactiveVersion(richParameters),
+			withNoTask,
 			withLastBuildFound,
 			withTemplateVersionVariables(inactiveVersionID, nil),
 			withRichParameters(initialBuildParameters),
@@ -1049,7 +1051,7 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 
 		var calls int64
 		fakeUsageChecker := &fakeUsageChecker{
-			checkBuildUsageFunc: func(_ context.Context, _ database.Store, templateVersion *database.TemplateVersion, _ database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
+			checkBuildUsageFunc: func(_ context.Context, _ database.Store, templateVersion *database.TemplateVersion, _ *database.Task, _ database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
 				atomic.AddInt64(&calls, 1)
 				return wsbuilder.UsageCheckResponse{Permitted: true}, nil
 			},
@@ -1126,7 +1128,7 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 
 			var calls int64
 			fakeUsageChecker := &fakeUsageChecker{
-				checkBuildUsageFunc: func(_ context.Context, _ database.Store, templateVersion *database.TemplateVersion, _ database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
+				checkBuildUsageFunc: func(_ context.Context, _ database.Store, templateVersion *database.TemplateVersion, _ *database.Task, _ database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
 					atomic.AddInt64(&calls, 1)
 					return c.response, c.responseErr
 				},
@@ -1134,6 +1136,7 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 
 			mDB := expectDB(t,
 				withTemplate,
+				withNoTask,
 				withInactiveVersionNoParams(),
 			)
 			fc := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
@@ -1577,11 +1580,11 @@ func expectFindMatchingPresetID(id uuid.UUID, err error) func(mTx *dbmock.MockSt
 }
 
 type fakeUsageChecker struct {
-	checkBuildUsageFunc func(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, transition database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error)
+	checkBuildUsageFunc func(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, task *database.Task, transition database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error)
 }
 
-func (f *fakeUsageChecker) CheckBuildUsage(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, transition database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
-	return f.checkBuildUsageFunc(ctx, store, templateVersion, transition)
+func (f *fakeUsageChecker) CheckBuildUsage(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, task *database.Task, transition database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
+	return f.checkBuildUsageFunc(ctx, store, templateVersion, task, transition)
 }
 
 func withNoTask(mTx *dbmock.MockStore) {

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -626,7 +626,7 @@ func TestManagedAgentLimit(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 
-	cli, _ := coderdenttest.New(t, &coderdenttest.Options{
+	cli, owner := coderdenttest.New(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 		},
@@ -711,19 +711,30 @@ func TestManagedAgentLimit(t *testing.T) {
 	noAiTemplate := coderdtest.CreateTemplate(t, cli, uuid.Nil, noAiVersion.ID)
 
 	// Create one AI workspace, which should succeed.
-	workspace := coderdtest.CreateWorkspace(t, cli, aiTemplate.ID)
+	// Create one AI workspace, which should succeed.
+	task, err := codersdk.NewExperimentalClient(cli).CreateTask(ctx, owner.UserID.String(), codersdk.CreateTaskRequest{
+		Name:                    "test-task-1",
+		TemplateVersionID:       aiTemplate.ActiveVersionID,
+		TemplateVersionPresetID: uuid.Nil,
+		Input:                   "hi",
+	})
+	require.NoError(t, err, "creating task for AI workspace must succeed")
+	workspace, err := cli.Workspace(ctx, task.WorkspaceID.UUID)
+	require.NoError(t, err, "fetching AI workspace must succeed")
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, cli, workspace.LatestBuild.ID)
 
-	// Create a second AI workspace, which should fail. This needs to be done
-	// manually because coderdtest.CreateWorkspace expects it to succeed.
-	_, err = cli.CreateUserWorkspace(ctx, codersdk.Me, codersdk.CreateWorkspaceRequest{ //nolint:gocritic // owners must still be subject to the limit
-		TemplateID:       aiTemplate.ID,
-		Name:             coderdtest.RandomUsername(t),
-		AutomaticUpdates: codersdk.AutomaticUpdatesNever,
+	// Create a second AI task, which should fail due to breaching the limit.
+	_, err = codersdk.NewExperimentalClient(cli).CreateTask(ctx, owner.UserID.String(), codersdk.CreateTaskRequest{
+		Name:              "test-task-2",
+		TemplateVersionID: aiTemplate.ActiveVersionID,
 	})
 	require.ErrorContains(t, err, "You have breached the managed agent limit in your license")
 
-	// Create a third non-AI workspace, which should succeed.
+	// Create a third workspace using the same template, which should succeed.
+	workspace = coderdtest.CreateWorkspace(t, cli, aiTemplate.ID)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, cli, workspace.LatestBuild.ID)
+
+	// Create a fourth non-AI workspace, which should also succeed.
 	workspace = coderdtest.CreateWorkspace(t, cli, noAiTemplate.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, cli, workspace.LatestBuild.ID)
 }
@@ -765,6 +776,10 @@ func TestCheckBuildUsage_SkipsAIForNonStartTransitions(t *testing.T) {
 		HasExternalAgent: sql.NullBool{Valid: true, Bool: false},
 	}
 
+	task := database.Task{
+		TemplateVersionID: tv.ID,
+	}
+
 	// Mock DB: expect exactly one count call for the "start" transition.
 	mDB := dbmock.NewMockStore(ctrl)
 	mDB.EXPECT().
@@ -775,18 +790,18 @@ func TestCheckBuildUsage_SkipsAIForNonStartTransitions(t *testing.T) {
 	ctx := context.Background()
 
 	// Start transition: should be not permitted due to limit breach.
-	startResp, err := eapi.CheckBuildUsage(ctx, mDB, tv, database.WorkspaceTransitionStart)
+	startResp, err := eapi.CheckBuildUsage(ctx, mDB, tv, &task, database.WorkspaceTransitionStart)
 	require.NoError(t, err)
 	require.False(t, startResp.Permitted)
 	require.Contains(t, startResp.Message, "breached the managed agent limit")
 
 	// Stop transition: should be permitted and must not trigger additional DB calls.
-	stopResp, err := eapi.CheckBuildUsage(ctx, mDB, tv, database.WorkspaceTransitionStop)
+	stopResp, err := eapi.CheckBuildUsage(ctx, mDB, tv, &task, database.WorkspaceTransitionStop)
 	require.NoError(t, err)
 	require.True(t, stopResp.Permitted)
 
 	// Delete transition: should be permitted and must not trigger additional DB calls.
-	deleteResp, err := eapi.CheckBuildUsage(ctx, mDB, tv, database.WorkspaceTransitionDelete)
+	deleteResp, err := eapi.CheckBuildUsage(ctx, mDB, tv, &task, database.WorkspaceTransitionDelete)
 	require.NoError(t, err)
 	require.True(t, deleteResp.Permitted)
 }


### PR DESCRIPTION
Depends on https://github.com/coder/coder/pull/21724/

Backports the following:
* https://github.com/coder/coder/pull/21696
* https://github.com/coder/coder/pull/21689
* https://github.com/coder/coder/pull/21731 (for verification)

Note: This PR does not change the semantics of `has_ai_task` but simply fixes the incorrect usage insertion.