### PR TITLE
fix(site): use total_member_count for group subtitles when sharing

### DIFF
--- a/site/src/modules/groups.ts
+++ b/site/src/modules/groups.ts
@@ -41,13 +41,11 @@ export const getGroupSubtitle = (group: Group): string => {
 		return "All users";
 	}
 
-	if (!group.members) {
-		return "0 members";
-	}
+	const total = group.total_member_count ?? group.members?.length ?? 0;
 
-	if (group.members.length === 1) {
+	if (total === 1) {
 		return "1 member";
 	}
 
-	return `${group.members.length} members`;
+	return `${total} members`;
 };


### PR DESCRIPTION
Justification:

  - Populating `members` is authorized with `group_member.read` which is not required to be able to share a workspace

  - Populating `total_member_count` is authorized with `group.read` which is required to be able to share

  - The updated helper is only used in template/workspace sharing UIs, so other pages that might need counts of readable members are unaffected

Related to: https://github.com/coder/internal/issues/1302

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
