### PR TITLE
test: use explicit names in TestStartAutoUpdate to prevent flake

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -139,12 +139,15 @@ func TestCreate(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, client)
 		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, completeWithAgent())
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, completeWithAgent(), func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.Name = "v1"
+		})
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
 		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
 
 		// Create a new version
 		version2 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, completeWithAgent(), func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.Name = "v2"
 			ctvr.TemplateID = template.ID
 		})
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version2.ID)
@@ -516,6 +519,7 @@ func TestCreateWithRichParameters(t *testing.T) {
 				version2 := coderdtest.CreateTemplateVersion(t, tctx.client, tctx.owner.OrganizationID, prepareEchoResponses([]*proto.RichParameter{
 					{Name: "another_parameter", Type: "string", DefaultValue: "not-relevant"},
 				}), func(ctvr *codersdk.CreateTemplateVersionRequest) {
+					ctvr.Name = "v2"
 					ctvr.TemplateID = tctx.template.ID
 				})
 				coderdtest.AwaitTemplateVersionJobCompleted(t, tctx.client, version2.ID)

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -367,7 +367,9 @@ func TestStartAutoUpdate(t *testing.T) {
 			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			owner := coderdtest.CreateFirstUser(t, client)
 			member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-			version1 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+			version1 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+				ctvr.Name = "v1"
+			})
 			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version1.ID)
 			template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version1.ID)
 			workspace := coderdtest.CreateWorkspace(t, member, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -379,6 +381,7 @@ func TestStartAutoUpdate(t *testing.T) {
 				coderdtest.MustTransitionWorkspace(t, member, workspace.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
 			}
 			version2 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, prepareEchoResponses(stringRichParameters), func(ctvr *codersdk.CreateTemplateVersionRequest) {
+				ctvr.Name = "v2"
 				ctvr.TemplateID = template.ID
 			})
 			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version2.ID)

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1977,10 +1977,13 @@ func TestTemplateVersionPatch(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.Name = "v1"
+		})
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version1.ID)
 
 		version2 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.Name = "v2"
 			ctvr.TemplateID = template.ID
 		})
 

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1486,7 +1486,9 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a template version1 that passes to get a functioning workspace.
-		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.Name = "v1"
+		})
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version1.ID)
 
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version1.ID)
@@ -1502,6 +1504,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// Create a new version so that we can assert we don't update
 		// to the latest by default.
 		version2 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.Name = "v2"
 			ctvr.TemplateID = template.ID
 		})
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version2.ID)


### PR DESCRIPTION
The test was creating two template versions without explicit names, relying on `namesgenerator.NameDigitWith()` which can produce collisions. When both versions got the same random name, the test failed with a 409 Conflict error.

Fix by giving each version an explicit name (`v1`, `v2`).

Closes https://github.com/coder/internal/issues/1309

---

*Generated by [mux](https://mux.coder.com)*