### PR TITLE
fix(cli): ignore space in custom input mode

### DIFF
--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -491,6 +491,11 @@ func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case tea.KeySpace:
 			options := m.filteredOptions()
+
+			if m.enableCustomInput && m.cursor == len(options) {
+				return m, nil
+			}
+
 			if len(options) != 0 {
 				options[m.cursor].chosen = !options[m.cursor].chosen
 			}

--- a/cli/exp_prompts.go
+++ b/cli/exp_prompts.go
@@ -174,6 +174,19 @@ func (RootCmd) promptExample() *serpent.Command {
 				_, _ = fmt.Fprintf(inv.Stdout, "%q are nice choices.\n", strings.Join(multiSelectValues, ", "))
 				return multiSelectError
 			}, useThingsOption, enableCustomInputOption),
+			promptCmd("multi-select-no-defaults", func(inv *serpent.Invocation) error {
+				if len(multiSelectValues) == 0 {
+					multiSelectValues, multiSelectError = cliui.MultiSelect(inv, cliui.MultiSelectOptions{
+						Message: "Select some things:",
+						Options: []string{
+							"Code", "Chairs", "Whale",
+						},
+						EnableCustomInput: enableCustomInput,
+					})
+				}
+				_, _ = fmt.Fprintf(inv.Stdout, "%q are nice choices.\n", strings.Join(multiSelectValues, ", "))
+				return multiSelectError
+			}, useThingsOption, enableCustomInputOption),
 			promptCmd("rich-multi-select", func(inv *serpent.Invocation) error {
 				if len(multiSelectValues) == 0 {
 					multiSelectValues, multiSelectError = cliui.MultiSelect(inv, cliui.MultiSelectOptions{


### PR DESCRIPTION
Fixes: https://github.com/coder/internal/issues/560

"Select" CLI UI component should ignore "space" when `+Add custom value` is highlighted. Otherwise it interprets that as a potential option... and panics.

Testing:

```
go run ./cmd/coder exp prompt-example multi-select-no-defaults  --enable-custom-input
```