### PR TITLE
fix(coderd/telemetry): only include tasks created in time range

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -1476,9 +1476,10 @@ func TestTasksCreate(t *testing.T) {
 
 		// Verify the bidirectional relationship works by looking up the task
 		// via workspace ID.
-		dbTaskByWs, err := db.GetTaskByWorkspaceID(dbCtx, ws.ID)
+		dbTasksByWs, err := db.GetTasksByWorkspaceIDs(dbCtx, []uuid.UUID{ws.ID})
 		require.NoError(t, err)
-		assert.Equal(t, dbTask.ID, dbTaskByWs.ID)
+		require.Len(t, dbTasksByWs, 1)
+		assert.Equal(t, dbTask.ID, dbTasksByWs[0].ID)
 	})
 
 	t.Run("TaskWithCustomName", func(t *testing.T) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3111,10 +3111,6 @@ func (q *querier) GetTaskByOwnerIDAndName(ctx context.Context, arg database.GetT
 	return fetch(q.log, q.auth, q.db.GetTaskByOwnerIDAndName)(ctx, arg)
 }
 
-func (q *querier) GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (database.Task, error) {
-	return fetch(q.log, q.auth, q.db.GetTaskByWorkspaceID)(ctx, workspaceID)
-}
-
 func (q *querier) GetTaskSnapshot(ctx context.Context, taskID uuid.UUID) (database.TaskSnapshot, error) {
 	// Fetch task to build RBAC object for authorization.
 	task, err := q.GetTaskByID(ctx, taskID)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2573,11 +2573,11 @@ func (s *MethodTestSuite) TestTasks() {
 
 		check.Args(arg).Asserts(task, policy.ActionUpdate).Returns(updatedTask.TaskTable())
 	}))
-	s.Run("GetTaskByWorkspaceID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+	s.Run("GetTasksByWorkspaceIDs", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		task := testutil.Fake(s.T(), faker, database.Task{})
 		task.WorkspaceID = uuid.NullUUID{UUID: uuid.New(), Valid: true}
-		dbm.EXPECT().GetTaskByWorkspaceID(gomock.Any(), task.WorkspaceID.UUID).Return(task, nil).AnyTimes()
-		check.Args(task.WorkspaceID.UUID).Asserts(task, policy.ActionRead).Returns(task)
+		dbm.EXPECT().GetTasksByWorkspaceIDs(gomock.Any(), []uuid.UUID{task.WorkspaceID.UUID}).Return([]database.Task{task}, nil).AnyTimes()
+		check.Args([]uuid.UUID{task.WorkspaceID.UUID}).Asserts(task, policy.ActionRead).Returns([]database.Task{task})
 	}))
 	s.Run("ListTasks", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		u1 := testutil.Fake(s.T(), faker, database.User{})

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -351,12 +351,13 @@ func (b WorkspaceBuildBuilder) doInTX() WorkspaceResponse {
 		slog.F("build_number", resp.Build.BuildNumber))
 
 	// If this is a task workspace, link it to the workspace build.
-	task, err := b.db.GetTaskByWorkspaceID(ownerCtx, resp.Workspace.ID)
+	tasks, err := b.db.GetTasksByWorkspaceIDs(ownerCtx, []uuid.UUID{resp.Workspace.ID})
 	if err != nil {
 		if b.taskAppID != uuid.Nil {
-			require.Fail(b.t, "task app configured but failed to get task by workspace id", err)
+			require.Fail(b.t, "task app configured but failed to get tasks by workspace id", err)
 		}
-	} else {
+	} else if len(tasks) > 0 {
+		task := tasks[0]
 		if b.taskAppID == uuid.Nil {
 			require.Fail(b.t, "task app not configured but workspace is a task workspace")
 		}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1182,6 +1182,14 @@ func (m queryMetricsStore) GetLastUpdateCheck(ctx context.Context) (string, erro
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetLastWorkingAppStatusesBeforeTimeBatch(ctx context.Context, arg database.GetLastWorkingAppStatusesBeforeTimeBatchParams) ([]database.GetLastWorkingAppStatusesBeforeTimeBatchRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetLastWorkingAppStatusesBeforeTimeBatch(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetLastWorkingAppStatusesBeforeTimeBatch").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetLastWorkingAppStatusesBeforeTimeBatch").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetLatestCryptoKeyByFeature(ctx, feature)
@@ -1779,6 +1787,14 @@ func (m queryMetricsStore) GetTaskSnapshot(ctx context.Context, taskID uuid.UUID
 	r0, r1 := m.s.GetTaskSnapshot(ctx, taskID)
 	m.queryLatencies.WithLabelValues("GetTaskSnapshot").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTaskSnapshot").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetTasksByWorkspaceIDs(ctx context.Context, workspaceIds []uuid.UUID) ([]database.Task, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetTasksByWorkspaceIDs(ctx, workspaceIds)
+	m.queryLatencies.WithLabelValues("GetTasksByWorkspaceIDs").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTasksByWorkspaceIDs").Inc()
 	return r0, r1
 }
 

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1774,14 +1774,6 @@ func (m queryMetricsStore) GetTaskByOwnerIDAndName(ctx context.Context, arg data
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (database.Task, error) {
-	start := time.Now()
-	r0, r1 := m.s.GetTaskByWorkspaceID(ctx, workspaceID)
-	m.queryLatencies.WithLabelValues("GetTaskByWorkspaceID").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTaskByWorkspaceID").Inc()
-	return r0, r1
-}
-
 func (m queryMetricsStore) GetTaskSnapshot(ctx context.Context, taskID uuid.UUID) (database.TaskSnapshot, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetTaskSnapshot(ctx, taskID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2173,6 +2173,21 @@ func (mr *MockStoreMockRecorder) GetLastUpdateCheck(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastUpdateCheck", reflect.TypeOf((*MockStore)(nil).GetLastUpdateCheck), ctx)
 }
 
+// GetLastWorkingAppStatusesBeforeTimeBatch mocks base method.
+func (m *MockStore) GetLastWorkingAppStatusesBeforeTimeBatch(ctx context.Context, arg database.GetLastWorkingAppStatusesBeforeTimeBatchParams) ([]database.GetLastWorkingAppStatusesBeforeTimeBatchRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLastWorkingAppStatusesBeforeTimeBatch", ctx, arg)
+	ret0, _ := ret[0].([]database.GetLastWorkingAppStatusesBeforeTimeBatchRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLastWorkingAppStatusesBeforeTimeBatch indicates an expected call of GetLastWorkingAppStatusesBeforeTimeBatch.
+func (mr *MockStoreMockRecorder) GetLastWorkingAppStatusesBeforeTimeBatch(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastWorkingAppStatusesBeforeTimeBatch", reflect.TypeOf((*MockStore)(nil).GetLastWorkingAppStatusesBeforeTimeBatch), ctx, arg)
+}
+
 // GetLatestCryptoKeyByFeature mocks base method.
 func (m *MockStore) GetLatestCryptoKeyByFeature(ctx context.Context, feature database.CryptoKeyFeature) (database.CryptoKey, error) {
 	m.ctrl.T.Helper()
@@ -3296,6 +3311,21 @@ func (m *MockStore) GetTaskSnapshot(ctx context.Context, taskID uuid.UUID) (data
 func (mr *MockStoreMockRecorder) GetTaskSnapshot(ctx, taskID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskSnapshot", reflect.TypeOf((*MockStore)(nil).GetTaskSnapshot), ctx, taskID)
+}
+
+// GetTasksByWorkspaceIDs mocks base method.
+func (m *MockStore) GetTasksByWorkspaceIDs(ctx context.Context, workspaceIds []uuid.UUID) ([]database.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTasksByWorkspaceIDs", ctx, workspaceIds)
+	ret0, _ := ret[0].([]database.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTasksByWorkspaceIDs indicates an expected call of GetTasksByWorkspaceIDs.
+func (mr *MockStoreMockRecorder) GetTasksByWorkspaceIDs(ctx, workspaceIds any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasksByWorkspaceIDs", reflect.TypeOf((*MockStore)(nil).GetTasksByWorkspaceIDs), ctx, workspaceIds)
 }
 
 // GetTelemetryItem mocks base method.

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3283,21 +3283,6 @@ func (mr *MockStoreMockRecorder) GetTaskByOwnerIDAndName(ctx, arg any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskByOwnerIDAndName", reflect.TypeOf((*MockStore)(nil).GetTaskByOwnerIDAndName), ctx, arg)
 }
 
-// GetTaskByWorkspaceID mocks base method.
-func (m *MockStore) GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (database.Task, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTaskByWorkspaceID", ctx, workspaceID)
-	ret0, _ := ret[0].(database.Task)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTaskByWorkspaceID indicates an expected call of GetTaskByWorkspaceID.
-func (mr *MockStoreMockRecorder) GetTaskByWorkspaceID(ctx, workspaceID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskByWorkspaceID", reflect.TypeOf((*MockStore)(nil).GetTaskByWorkspaceID), ctx, workspaceID)
-}
-
 // GetTaskSnapshot mocks base method.
 func (m *MockStore) GetTaskSnapshot(ctx context.Context, taskID uuid.UUID) (database.TaskSnapshot, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -364,7 +364,6 @@ type sqlcQuerier interface {
 	GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerIDsRow, error)
 	GetTaskByID(ctx context.Context, id uuid.UUID) (Task, error)
 	GetTaskByOwnerIDAndName(ctx context.Context, arg GetTaskByOwnerIDAndNameParams) (Task, error)
-	GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (Task, error)
 	GetTaskSnapshot(ctx context.Context, taskID uuid.UUID) (TaskSnapshot, error)
 	// Batch fetch tasks by workspace IDs from the tasks_with_status view.
 	// Used for telemetry to efficiently fetch tasks for workspaces with activity.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -250,6 +250,12 @@ type sqlcQuerier interface {
 	// param limit_opt: The limit of notifications to fetch. If the limit is not specified, it defaults to 25
 	GetInboxNotificationsByUserID(ctx context.Context, arg GetInboxNotificationsByUserIDParams) ([]InboxNotification, error)
 	GetLastUpdateCheck(ctx context.Context) (string, error)
+	// Get the last "working" app status for multiple apps before a specific time.
+	// Used for task telemetry to determine when a task was last actively working
+	// before being paused (to calculate idle duration).
+	//
+	// Returns at most one row per app_id (the most recent "working" status).
+	GetLastWorkingAppStatusesBeforeTimeBatch(ctx context.Context, arg GetLastWorkingAppStatusesBeforeTimeBatchParams) ([]GetLastWorkingAppStatusesBeforeTimeBatchRow, error)
 	GetLatestCryptoKeyByFeature(ctx context.Context, feature CryptoKeyFeature) (CryptoKey, error)
 	GetLatestWorkspaceAppStatusByAppID(ctx context.Context, appID uuid.UUID) (WorkspaceAppStatus, error)
 	GetLatestWorkspaceAppStatusesByWorkspaceIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAppStatus, error)
@@ -360,6 +366,9 @@ type sqlcQuerier interface {
 	GetTaskByOwnerIDAndName(ctx context.Context, arg GetTaskByOwnerIDAndNameParams) (Task, error)
 	GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (Task, error)
 	GetTaskSnapshot(ctx context.Context, taskID uuid.UUID) (TaskSnapshot, error)
+	// Batch fetch tasks by workspace IDs from the tasks_with_status view.
+	// Used for telemetry to efficiently fetch tasks for workspaces with activity.
+	GetTasksByWorkspaceIDs(ctx context.Context, workspaceIds []uuid.UUID) ([]Task, error)
 	GetTelemetryItem(ctx context.Context, key string) (TelemetryItem, error)
 	GetTelemetryItems(ctx context.Context) ([]TelemetryItem, error)
 	// GetTemplateAppInsights returns the aggregate usage of each app in a given

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -13259,39 +13259,6 @@ func (q *sqlQuerier) GetTaskByOwnerIDAndName(ctx context.Context, arg GetTaskByO
 	return i, err
 }
 
-const getTaskByWorkspaceID = `-- name: GetTaskByWorkspaceID :one
-SELECT id, organization_id, owner_id, name, workspace_id, template_version_id, template_parameters, prompt, created_at, deleted_at, display_name, status, status_debug, workspace_build_number, workspace_agent_id, workspace_app_id, workspace_agent_lifecycle_state, workspace_app_health, owner_username, owner_name, owner_avatar_url FROM tasks_with_status WHERE workspace_id = $1::uuid
-`
-
-func (q *sqlQuerier) GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (Task, error) {
-	row := q.db.QueryRowContext(ctx, getTaskByWorkspaceID, workspaceID)
-	var i Task
-	err := row.Scan(
-		&i.ID,
-		&i.OrganizationID,
-		&i.OwnerID,
-		&i.Name,
-		&i.WorkspaceID,
-		&i.TemplateVersionID,
-		&i.TemplateParameters,
-		&i.Prompt,
-		&i.CreatedAt,
-		&i.DeletedAt,
-		&i.DisplayName,
-		&i.Status,
-		&i.StatusDebug,
-		&i.WorkspaceBuildNumber,
-		&i.WorkspaceAgentID,
-		&i.WorkspaceAppID,
-		&i.WorkspaceAgentLifecycleState,
-		&i.WorkspaceAppHealth,
-		&i.OwnerUsername,
-		&i.OwnerName,
-		&i.OwnerAvatarUrl,
-	)
-	return i, err
-}
-
 const getTaskSnapshot = `-- name: GetTaskSnapshot :one
 SELECT
 	task_id, log_snapshot, log_snapshot_created_at

--- a/coderd/database/queries/tasks.sql
+++ b/coderd/database/queries/tasks.sql
@@ -38,9 +38,6 @@ RETURNING *;
 -- name: GetTaskByID :one
 SELECT * FROM tasks_with_status WHERE id = @id::uuid;
 
--- name: GetTaskByWorkspaceID :one
-SELECT * FROM tasks_with_status WHERE workspace_id = @workspace_id::uuid;
-
 -- name: GetTasksByWorkspaceIDs :many
 -- Batch fetch tasks by workspace IDs from the tasks_with_status view.
 -- Used for telemetry to efficiently fetch tasks for workspaces with activity.

--- a/coderd/database/queries/tasks.sql
+++ b/coderd/database/queries/tasks.sql
@@ -41,6 +41,13 @@ SELECT * FROM tasks_with_status WHERE id = @id::uuid;
 -- name: GetTaskByWorkspaceID :one
 SELECT * FROM tasks_with_status WHERE workspace_id = @workspace_id::uuid;
 
+-- name: GetTasksByWorkspaceIDs :many
+-- Batch fetch tasks by workspace IDs from the tasks_with_status view.
+-- Used for telemetry to efficiently fetch tasks for workspaces with activity.
+SELECT * FROM tasks_with_status
+WHERE workspace_id = ANY(@workspace_ids::uuid[])
+ORDER BY created_at DESC;
+
 -- name: GetTaskByOwnerIDAndName :one
 SELECT * FROM tasks_with_status
 WHERE

--- a/coderd/database/queries/tasks.sql
+++ b/coderd/database/queries/tasks.sql
@@ -51,6 +51,7 @@ WHERE
 -- name: ListTasks :many
 SELECT * FROM tasks_with_status tws
 WHERE tws.deleted_at IS NULL
+AND CASE WHEN sqlc.narg('created_after')::timestamptz IS NOT NULL THEN tws.created_at > sqlc.narg('created_after')::timestamptz ELSE TRUE END
 AND CASE WHEN @owner_id::UUID != '00000000-0000-0000-0000-000000000000' THEN tws.owner_id = @owner_id::UUID ELSE TRUE END
 AND CASE WHEN @organization_id::UUID != '00000000-0000-0000-0000-000000000000' THEN tws.organization_id = @organization_id::UUID ELSE TRUE END
 AND CASE WHEN @status::text != '' THEN tws.status = @status::task_status ELSE TRUE END

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -399,6 +399,7 @@ func AIBridgeInterceptions(ctx context.Context, db database.Store, query string,
 //   - status: string (pending, initializing, active, paused, error, unknown)
 func Tasks(ctx context.Context, db database.Store, query string, actorID uuid.UUID) (database.ListTasksParams, []codersdk.ValidationError) {
 	filter := database.ListTasksParams{
+		CreatedAfter:   sql.NullTime{},
 		OwnerID:        uuid.Nil,
 		OrganizationID: uuid.Nil,
 		Status:         "",

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -744,9 +744,10 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 			OwnerID:        uuid.Nil,
 			OrganizationID: uuid.Nil,
 			Status:         "",
+			CreatedAfter:   sql.NullTime{Time: createdAfter, Valid: true},
 		})
 		if err != nil {
-			return err
+			return xerrors.Errorf("get tasks: %w", err)
 		}
 		for _, dbTask := range dbTasks {
 			snapshot.Tasks = append(snapshot.Tasks, ConvertTask(dbTask))

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -154,6 +154,15 @@ func TestTelemetry(t *testing.T) {
 			JobID:             taskJob.ID,
 			HasAITask:         sql.NullBool{Valid: true, Bool: true},
 		})
+		// Create an old task that should be filtered out by created_after.
+		_ = dbgen.Task(t, db, database.TaskTable{
+			OwnerID:            user.ID,
+			OrganizationID:     org.ID,
+			TemplateVersionID:  taskTV.ID,
+			Prompt:             "old task prompt",
+			TemplateParameters: json.RawMessage(`{"old": "task"}`),
+			CreatedAt:          now.Add(-2 * time.Hour),
+		})
 		task := dbgen.Task(t, db, database.TaskTable{
 			OwnerID:            user.ID,
 			OrganizationID:     org.ID,

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -641,17 +641,17 @@ func (b *Builder) getWorkspaceTask() (*database.Task, error) {
 	if b.hasTask != nil {
 		return b.task, nil
 	}
-	t, err := b.store.GetTaskByWorkspaceID(b.ctx, b.workspace.ID)
+	tasks, err := b.store.GetTasksByWorkspaceIDs(b.ctx, []uuid.UUID{b.workspace.ID})
 	if err != nil {
-		if xerrors.Is(err, sql.ErrNoRows) {
-			b.hasTask = ptr.Ref(false)
-			//nolint:nilnil // No task exists.
-			return nil, nil
-		}
 		return nil, xerrors.Errorf("get task: %w", err)
 	}
+	if len(tasks) == 0 {
+		b.hasTask = ptr.Ref(false)
+		//nolint:nilnil // No task exists.
+		return nil, nil
+	}
 
-	b.task = &t
+	b.task = &tasks[0]
 	b.hasTask = ptr.Ref(true)
 	return b.task, nil
 }

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -1588,17 +1588,17 @@ func (f *fakeUsageChecker) CheckBuildUsage(ctx context.Context, store database.S
 }
 
 func withNoTask(mTx *dbmock.MockStore) {
-	mTx.EXPECT().GetTaskByWorkspaceID(gomock.Any(), gomock.Any()).Times(1).
-		DoAndReturn(func(ctx context.Context, id uuid.UUID) (database.Task, error) {
-			return database.Task{}, sql.ErrNoRows
+	mTx.EXPECT().GetTasksByWorkspaceIDs(gomock.Any(), gomock.Any()).Times(1).
+		DoAndReturn(func(ctx context.Context, ids []uuid.UUID) ([]database.Task, error) {
+			return []database.Task{}, nil
 		})
 }
 
 func withTask(task database.Task) func(mTx *dbmock.MockStore) {
 	return func(mTx *dbmock.MockStore) {
-		mTx.EXPECT().GetTaskByWorkspaceID(gomock.Any(), gomock.Any()).Times(1).
-			DoAndReturn(func(ctx context.Context, id uuid.UUID) (database.Task, error) {
-				return task, nil
+		mTx.EXPECT().GetTasksByWorkspaceIDs(gomock.Any(), gomock.Any()).Times(1).
+			DoAndReturn(func(ctx context.Context, ids []uuid.UUID) ([]database.Task, error) {
+				return []database.Task{task}, nil
 			})
 	}
 }


### PR DESCRIPTION
Fixes coder/internal#1313

* Adds `CreatedAfter` to `ListTasksParams`
* Updates `remoteReporter.createSnapshot()` to query for tasks created within the same time window
* Updates existing tests

🤖 Generated by Claude Opus 4.5, reviewed by me.
