### PR TITLE
feat(coderd): return log snapshot for paused tasks

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -786,6 +786,30 @@ func (api *API) taskSend(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusNoContent)
 }
 
+// convertAgentAPIMessagesToLogEntries converts AgentAPI messages to
+// TaskLogEntry format.
+func convertAgentAPIMessagesToLogEntries(messages []agentapisdk.Message) ([]codersdk.TaskLogEntry, error) {
+	logs := make([]codersdk.TaskLogEntry, 0, len(messages))
+	for _, m := range messages {
+		var typ codersdk.TaskLogType
+		switch m.Role {
+		case agentapisdk.RoleUser:
+			typ = codersdk.TaskLogTypeInput
+		case agentapisdk.RoleAgent:
+			typ = codersdk.TaskLogTypeOutput
+		default:
+			return nil, xerrors.Errorf("invalid agentapi message role %q", m.Role)
+		}
+		logs = append(logs, codersdk.TaskLogEntry{
+			ID:      int(m.Id),
+			Content: m.Content,
+			Type:    typ,
+			Time:    m.Time,
+		})
+	}
+	return logs, nil
+}
+
 // @Summary Get AI task logs
 // @ID get-ai-task-logs
 // @Security CoderSessionToken
@@ -799,53 +823,134 @@ func (api *API) taskLogs(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	task := httpmw.TaskParam(r)
 
-	var out codersdk.TaskLogsResponse
-	if err := api.authAndDoWithTaskAppClient(r, task, func(ctx context.Context, client *http.Client, appURL *url.URL) error {
-		agentAPIClient, err := agentapisdk.NewClient(appURL.String(), agentapisdk.WithHTTPClient(client))
-		if err != nil {
-			return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
-				Message: "Failed to create agentapi client.",
-				Detail:  err.Error(),
-			})
-		}
-
-		messagesResp, err := agentAPIClient.GetMessages(ctx)
-		if err != nil {
-			return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
-				Message: "Failed to get messages from task app.",
-				Detail:  err.Error(),
-			})
-		}
-
-		logs := make([]codersdk.TaskLogEntry, 0, len(messagesResp.Messages))
-		for _, m := range messagesResp.Messages {
-			var typ codersdk.TaskLogType
-			switch m.Role {
-			case agentapisdk.RoleUser:
-				typ = codersdk.TaskLogTypeInput
-			case agentapisdk.RoleAgent:
-				typ = codersdk.TaskLogTypeOutput
-			default:
+	switch task.Status {
+	case database.TaskStatusActive:
+		// Active tasks: fetch live logs from AgentAPI.
+		var out codersdk.TaskLogsResponse
+		if err := api.authAndDoWithTaskAppClient(r, task, func(ctx context.Context, client *http.Client, appURL *url.URL) error {
+			agentAPIClient, err := agentapisdk.NewClient(appURL.String(), agentapisdk.WithHTTPClient(client))
+			if err != nil {
 				return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
-					Message: "Invalid task app response message role.",
-					Detail:  fmt.Sprintf(`Expected "user" or "agent", got %q.`, m.Role),
+					Message: "Failed to create agentapi client.",
+					Detail:  err.Error(),
 				})
 			}
-			logs = append(logs, codersdk.TaskLogEntry{
-				ID:      int(m.Id),
-				Content: m.Content,
-				Type:    typ,
-				Time:    m.Time,
-			})
-		}
-		out = codersdk.TaskLogsResponse{Logs: logs}
-		return nil
-	}); err != nil {
-		httperror.WriteResponseError(ctx, rw, err)
-		return
-	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, out)
+			messagesResp, err := agentAPIClient.GetMessages(ctx)
+			if err != nil {
+				return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
+					Message: "Failed to get messages from task app.",
+					Detail:  err.Error(),
+				})
+			}
+
+			logs, err := convertAgentAPIMessagesToLogEntries(messagesResp.Messages)
+			if err != nil {
+				return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
+					Message: "Invalid task app response.",
+					Detail:  err.Error(),
+				})
+			}
+
+			out = codersdk.TaskLogsResponse{
+				Count: len(logs),
+				Logs:  logs,
+			}
+			return nil
+		}); err != nil {
+			httperror.WriteResponseError(ctx, rw, err)
+			return
+		}
+
+		httpapi.Write(ctx, rw, http.StatusOK, out)
+
+	case database.TaskStatusPaused, database.TaskStatusPending, database.TaskStatusInitializing:
+		// In pause, pending and initializing states, we attempt to the fetch
+		// snapshot from database to provide continuity.
+		snapshot, err := api.Database.GetTaskSnapshot(ctx, task.ID)
+		if err != nil {
+			if httpapi.IsUnauthorizedError(err) {
+				httpapi.ResourceNotFound(rw)
+				return
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				// No snapshot exists yet, return empty logs. Snapshot is true
+				// because this field indicates whether the data is from the
+				// live task app (false) or not (true). Since the task is
+				// paused/initializing/pending, we cannot fetch live logs, so
+				// snapshot must be true even with no snapshot data.
+				httpapi.Write(ctx, rw, http.StatusOK, codersdk.TaskLogsResponse{
+					Count:    0,
+					Logs:     []codersdk.TaskLogEntry{},
+					Snapshot: true,
+				})
+				return
+			}
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error fetching task snapshot.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+
+		// Unmarshal envelope with pre-populated data field to decode once.
+		envelope := TaskLogSnapshotEnvelope{
+			Data: &agentapisdk.GetMessagesResponse{},
+		}
+		if err := json.Unmarshal(snapshot.LogSnapshot, &envelope); err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error decoding task snapshot.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+
+		// Validate snapshot format.
+		if envelope.Format != "agentapi" {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Unsupported task snapshot format.",
+				Detail:  fmt.Sprintf("Expected format %q, got %q.", "agentapi", envelope.Format),
+			})
+			return
+		}
+
+		// Extract agentapi data from envelope (already decoded into the correct type).
+		messagesResp, ok := envelope.Data.(*agentapisdk.GetMessagesResponse)
+		if !ok {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error decoding snapshot data.",
+				Detail:  "Unexpected data type in envelope.",
+			})
+			return
+		}
+
+		// Convert agentapi messages to log entries.
+		logs, err := convertAgentAPIMessagesToLogEntries(messagesResp.Messages)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Invalid snapshot data.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+
+		out := codersdk.TaskLogsResponse{
+			Count:      len(logs),
+			Logs:       logs,
+			Snapshot:   true,
+			SnapshotAt: ptr.Ref(snapshot.LogSnapshotCreatedAt),
+		}
+		httpapi.Write(ctx, rw, http.StatusOK, out)
+
+	default:
+		// Cases: database.TaskStatusError, database.TaskStatusUnknown.
+		// - Error: snapshot would be stale from previous pause.
+		// - Unknown: cannot determine reliable state.
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+			Message: "Cannot fetch logs for task in current state.",
+			Detail:  fmt.Sprintf("Task status is %q.", task.Status),
+		})
+	}
 }
 
 // authAndDoWithTaskAppClient centralizes the shared logic to:

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -884,8 +884,7 @@ func (api *API) fetchLiveTaskLogs(r *http.Request, task database.Task) (codersdk
 		}
 
 		out = codersdk.TaskLogsResponse{
-			Count: len(logs),
-			Logs:  logs,
+			Logs: logs,
 		}
 		return nil
 	})
@@ -907,7 +906,6 @@ func (api *API) fetchSnapshotTaskLogs(ctx context.Context, taskID uuid.UUID) (co
 			// paused/initializing/pending, we cannot fetch live logs, so
 			// snapshot must be true even with no snapshot data.
 			return codersdk.TaskLogsResponse{
-				Count:    0,
 				Logs:     []codersdk.TaskLogEntry{},
 				Snapshot: true,
 			}, nil
@@ -956,7 +954,6 @@ func (api *API) fetchSnapshotTaskLogs(ctx context.Context, taskID uuid.UUID) (co
 	}
 
 	return codersdk.TaskLogsResponse{
-		Count:      len(logs),
 		Logs:       logs,
 		Snapshot:   true,
 		SnapshotAt: ptr.Ref(snapshot.LogSnapshotCreatedAt),

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -827,7 +827,6 @@ func TestTasks(t *testing.T) {
 		verifySnapshotLogs := func(t *testing.T, got codersdk.TaskLogsResponse) {
 			t.Helper()
 			want := codersdk.TaskLogsResponse{
-				Count:      2,
 				Snapshot:   true,
 				SnapshotAt: &snapshotTime,
 				Logs: []codersdk.TaskLogEntry{
@@ -915,8 +914,7 @@ func TestTasks(t *testing.T) {
 
 			assert.True(t, logsResp.Snapshot)
 			assert.Nil(t, logsResp.SnapshotAt)
-			assert.Equal(t, 0, logsResp.Count)
-			assert.Empty(t, logsResp.Logs)
+			assert.Len(t, logsResp.Logs, 0)
 		})
 
 		t.Run("InvalidSnapshotFormat", func(t *testing.T) {

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -723,6 +723,257 @@ func TestTasks(t *testing.T) {
 		})
 	})
 
+	t.Run("LogsWithSnapshot", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+		owner := coderdtest.CreateFirstUser(t, client)
+
+		ownerUser, err := client.User(testutil.Context(t, testutil.WaitMedium), owner.UserID.String())
+		require.NoError(t, err)
+		ownerSubject := coderdtest.AuthzUserSubject(ownerUser)
+
+		// Helper to create a task in the desired state.
+		createTaskInState := func(ctx context.Context, t *testing.T, status database.TaskStatus) uuid.UUID {
+			ctx = dbauthz.As(ctx, ownerSubject)
+
+			builder := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OrganizationID: owner.OrganizationID,
+				OwnerID:        owner.UserID,
+			}).
+				WithTask(database.TaskTable{
+					OrganizationID: owner.OrganizationID,
+					OwnerID:        owner.UserID,
+				}, nil)
+
+			switch status {
+			case database.TaskStatusPending:
+				builder = builder.Pending()
+			case database.TaskStatusInitializing:
+				builder = builder.Starting()
+			case database.TaskStatusPaused:
+				builder = builder.Seed(database.WorkspaceBuild{
+					Transition: database.WorkspaceTransitionStop,
+				})
+			case database.TaskStatusError:
+				// For error state, create a completed build then manipulate app health.
+			default:
+				require.Fail(t, "unsupported task status in test helper", "status: %s", status)
+			}
+
+			resp := builder.Do()
+			taskID := resp.Task.ID
+
+			// Post-process by manipulating agent and app state.
+			if status == database.TaskStatusError {
+				// First, set agent to ready state so agent_status returns 'active'.
+				// This ensures the cascade reaches app_status.
+				err := db.UpdateWorkspaceAgentLifecycleStateByID(ctx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{
+					ID:             resp.Agents[0].ID,
+					LifecycleState: database.WorkspaceAgentLifecycleStateReady,
+				})
+				require.NoError(t, err)
+
+				// Then set workspace app health to unhealthy to trigger error state.
+				apps, err := db.GetWorkspaceAppsByAgentID(ctx, resp.Agents[0].ID)
+				require.NoError(t, err)
+				require.Len(t, apps, 1, "expected exactly one app for task")
+
+				err = db.UpdateWorkspaceAppHealthByID(ctx, database.UpdateWorkspaceAppHealthByIDParams{
+					ID:     apps[0].ID,
+					Health: database.WorkspaceAppHealthUnhealthy,
+				})
+				require.NoError(t, err)
+			}
+
+			return taskID
+		}
+
+		// Prepare snapshot data used across tests.
+		snapshotMessages := []agentapisdk.Message{
+			{
+				Id:      0,
+				Content: "First message",
+				Role:    agentapisdk.RoleAgent,
+				Time:    time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC),
+			},
+			{
+				Id:      1,
+				Content: "Second message",
+				Role:    agentapisdk.RoleUser,
+				Time:    time.Date(2025, 1, 1, 10, 1, 0, 0, time.UTC),
+			},
+		}
+
+		snapshotData := agentapisdk.GetMessagesResponse{
+			Messages: snapshotMessages,
+		}
+
+		envelope := coderd.TaskLogSnapshotEnvelope{
+			Format: "agentapi",
+			Data:   snapshotData,
+		}
+
+		snapshotJSON, err := json.Marshal(envelope)
+		require.NoError(t, err)
+
+		snapshotTime := time.Date(2025, 1, 1, 10, 5, 0, 0, time.UTC)
+
+		// Helper to verify snapshot logs content.
+		verifySnapshotLogs := func(t *testing.T, resp codersdk.TaskLogsResponse) {
+			t.Helper()
+			assert.True(t, resp.Snapshot)
+			require.NotNil(t, resp.SnapshotAt)
+			assert.True(t, snapshotTime.Equal(*resp.SnapshotAt))
+			assert.Equal(t, 2, resp.Count)
+			require.Len(t, resp.Logs, 2)
+			assert.Equal(t, 0, resp.Logs[0].ID)
+			assert.Equal(t, codersdk.TaskLogTypeOutput, resp.Logs[0].Type)
+			assert.Equal(t, "First message", resp.Logs[0].Content)
+			assert.Equal(t, snapshotMessages[0].Time, resp.Logs[0].Time)
+
+			assert.Equal(t, 1, resp.Logs[1].ID)
+			assert.Equal(t, codersdk.TaskLogTypeInput, resp.Logs[1].Type)
+			assert.Equal(t, "Second message", resp.Logs[1].Content)
+			assert.Equal(t, snapshotMessages[1].Time, resp.Logs[1].Time)
+		}
+
+		t.Run("PendingTaskReturnsSnapshot", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusPending)
+
+			err := db.UpsertTaskSnapshot(dbauthz.As(ctx, ownerSubject), database.UpsertTaskSnapshotParams{
+				TaskID:               taskID,
+				LogSnapshot:          json.RawMessage(snapshotJSON),
+				LogSnapshotCreatedAt: snapshotTime,
+			})
+			require.NoError(t, err)
+
+			logsResp, err := client.TaskLogs(ctx, "me", taskID)
+			require.NoError(t, err)
+			verifySnapshotLogs(t, logsResp)
+		})
+
+		t.Run("InitializingTaskReturnsSnapshot", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusInitializing)
+
+			err := db.UpsertTaskSnapshot(dbauthz.As(ctx, ownerSubject), database.UpsertTaskSnapshotParams{
+				TaskID:               taskID,
+				LogSnapshot:          json.RawMessage(snapshotJSON),
+				LogSnapshotCreatedAt: snapshotTime,
+			})
+			require.NoError(t, err)
+
+			logsResp, err := client.TaskLogs(ctx, "me", taskID)
+			require.NoError(t, err)
+			verifySnapshotLogs(t, logsResp)
+		})
+
+		t.Run("PausedTaskReturnsSnapshot", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusPaused)
+
+			err := db.UpsertTaskSnapshot(dbauthz.As(ctx, ownerSubject), database.UpsertTaskSnapshotParams{
+				TaskID:               taskID,
+				LogSnapshot:          json.RawMessage(snapshotJSON),
+				LogSnapshotCreatedAt: snapshotTime,
+			})
+			require.NoError(t, err)
+
+			logsResp, err := client.TaskLogs(ctx, "me", taskID)
+			require.NoError(t, err)
+			verifySnapshotLogs(t, logsResp)
+		})
+
+		t.Run("NoSnapshotReturnsEmpty", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusPending)
+
+			logsResp, err := client.TaskLogs(ctx, "me", taskID)
+			require.NoError(t, err)
+
+			assert.True(t, logsResp.Snapshot)
+			assert.Nil(t, logsResp.SnapshotAt)
+			assert.Equal(t, 0, logsResp.Count)
+			assert.Empty(t, logsResp.Logs)
+		})
+
+		t.Run("InvalidSnapshotFormat", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusPending)
+
+			invalidEnvelope := coderd.TaskLogSnapshotEnvelope{
+				Format: "unknown-format",
+				Data:   map[string]any{},
+			}
+			invalidJSON, err := json.Marshal(invalidEnvelope)
+			require.NoError(t, err)
+
+			err = db.UpsertTaskSnapshot(dbauthz.As(ctx, ownerSubject), database.UpsertTaskSnapshotParams{
+				TaskID:               taskID,
+				LogSnapshot:          json.RawMessage(invalidJSON),
+				LogSnapshotCreatedAt: snapshotTime,
+			})
+			require.NoError(t, err)
+
+			_, err = client.TaskLogs(ctx, "me", taskID)
+			require.Error(t, err)
+
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			assert.Equal(t, http.StatusInternalServerError, sdkErr.StatusCode())
+			assert.Contains(t, sdkErr.Message, "Unsupported task snapshot format")
+		})
+
+		t.Run("MalformedSnapshotData", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusPending)
+
+			err := db.UpsertTaskSnapshot(dbauthz.As(ctx, ownerSubject), database.UpsertTaskSnapshotParams{
+				TaskID:               taskID,
+				LogSnapshot:          json.RawMessage(`{"format":"agentapi","data":"not an object"}`),
+				LogSnapshotCreatedAt: snapshotTime,
+			})
+			require.NoError(t, err)
+
+			_, err = client.TaskLogs(ctx, "me", taskID)
+			require.Error(t, err)
+
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			assert.Equal(t, http.StatusInternalServerError, sdkErr.StatusCode())
+		})
+
+		t.Run("ErrorStateReturnsError", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			taskID := createTaskInState(ctx, t, database.TaskStatusError)
+
+			_, err := client.TaskLogs(ctx, "me", taskID)
+			require.Error(t, err)
+
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			assert.Equal(t, http.StatusConflict, sdkErr.StatusCode())
+			assert.Contains(t, sdkErr.Message, "Cannot fetch logs for task in current state")
+			assert.Contains(t, sdkErr.Detail, "error")
+		})
+	})
+
 	t.Run("UpdateInput", func(t *testing.T) {
 		tests := []struct {
 			name               string

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18562,9 +18562,6 @@ const docTemplate = `{
         "codersdk.TaskLogsResponse": {
             "type": "object",
             "properties": {
-                "count": {
-                    "type": "integer"
-                },
                 "logs": {
                     "type": "array",
                     "items": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18562,11 +18562,20 @@ const docTemplate = `{
         "codersdk.TaskLogsResponse": {
             "type": "object",
             "properties": {
+                "count": {
+                    "type": "integer"
+                },
                 "logs": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.TaskLogEntry"
                     }
+                },
+                "snapshot": {
+                    "type": "boolean"
+                },
+                "snapshot_at": {
+                    "type": "string"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16978,9 +16978,6 @@
 		"codersdk.TaskLogsResponse": {
 			"type": "object",
 			"properties": {
-				"count": {
-					"type": "integer"
-				},
 				"logs": {
 					"type": "array",
 					"items": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16978,11 +16978,20 @@
 		"codersdk.TaskLogsResponse": {
 			"type": "object",
 			"properties": {
+				"count": {
+					"type": "integer"
+				},
 				"logs": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/codersdk.TaskLogEntry"
 					}
+				},
+				"snapshot": {
+					"type": "boolean"
+				},
+				"snapshot_at": {
+					"type": "string"
 				}
 			}
 		},

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -350,7 +350,6 @@ type TaskLogEntry struct {
 // logs are fetched live from the task app. When snapshot is true, logs are
 // fetched from a stored snapshot captured during pause.
 type TaskLogsResponse struct {
-	Count      int            `json:"count"`
 	Logs       []TaskLogEntry `json:"logs"`
 	Snapshot   bool           `json:"snapshot,omitempty"`
 	SnapshotAt *time.Time     `json:"snapshot_at,omitempty"`

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -346,9 +346,14 @@ type TaskLogEntry struct {
 	Time    time.Time   `json:"time" format:"date-time" table:"time,default_sort"`
 }
 
-// TaskLogsResponse contains the logs for a task.
+// TaskLogsResponse contains task logs and metadata. When snapshot is false,
+// logs are fetched live from the task app. When snapshot is true, logs are
+// fetched from a stored snapshot captured during pause.
 type TaskLogsResponse struct {
-	Logs []TaskLogEntry `json:"logs"`
+	Count      int            `json:"count"`
+	Logs       []TaskLogEntry `json:"logs"`
+	Snapshot   bool           `json:"snapshot,omitempty"`
+	SnapshotAt *time.Time     `json:"snapshot_at,omitempty"`
 }
 
 // TaskLogs retrieves logs from the task app.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7795,7 +7795,6 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ```json
 {
-  "count": 0,
   "logs": [
     {
       "content": "string",
@@ -7813,7 +7812,6 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 | Name          | Type                                                    | Required | Restrictions | Description |
 |---------------|---------------------------------------------------------|----------|--------------|-------------|
-| `count`       | integer                                                 | false    |              |             |
 | `logs`        | array of [codersdk.TaskLogEntry](#codersdktasklogentry) | false    |              |             |
 | `snapshot`    | boolean                                                 | false    |              |             |
 | `snapshot_at` | string                                                  | false    |              |             |

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7795,6 +7795,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ```json
 {
+  "count": 0,
   "logs": [
     {
       "content": "string",
@@ -7802,15 +7803,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
       "time": "2019-08-24T14:15:22Z",
       "type": "input"
     }
-  ]
+  ],
+  "snapshot": true,
+  "snapshot_at": "string"
 }
 ```
 
 ### Properties
 
-| Name   | Type                                                    | Required | Restrictions | Description |
-|--------|---------------------------------------------------------|----------|--------------|-------------|
-| `logs` | array of [codersdk.TaskLogEntry](#codersdktasklogentry) | false    |              |             |
+| Name          | Type                                                    | Required | Restrictions | Description |
+|---------------|---------------------------------------------------------|----------|--------------|-------------|
+| `count`       | integer                                                 | false    |              |             |
+| `logs`        | array of [codersdk.TaskLogEntry](#codersdktasklogentry) | false    |              |             |
+| `snapshot`    | boolean                                                 | false    |              |             |
+| `snapshot_at` | string                                                  | false    |              |             |
 
 ## codersdk.TaskSendRequest
 

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -344,6 +344,7 @@ curl -X GET http://coder-server:8080/api/v2/tasks/{user}/{task}/logs \
 
 ```json
 {
+  "count": 0,
   "logs": [
     {
       "content": "string",
@@ -351,7 +352,9 @@ curl -X GET http://coder-server:8080/api/v2/tasks/{user}/{task}/logs \
       "time": "2019-08-24T14:15:22Z",
       "type": "input"
     }
-  ]
+  ],
+  "snapshot": true,
+  "snapshot_at": "string"
 }
 ```
 

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -344,7 +344,6 @@ curl -X GET http://coder-server:8080/api/v2/tasks/{user}/{task}/logs \
 
 ```json
 {
-  "count": 0,
   "logs": [
     {
       "content": "string",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5008,10 +5008,15 @@ export const TaskLogTypes: TaskLogType[] = ["input", "output"];
 
 // From codersdk/aitasks.go
 /**
- * TaskLogsResponse contains the logs for a task.
+ * TaskLogsResponse contains task logs and metadata. When snapshot is false,
+ * logs are fetched live from the task app. When snapshot is true, logs are
+ * fetched from a stored snapshot captured during pause.
  */
 export interface TaskLogsResponse {
+	readonly count: number;
 	readonly logs: readonly TaskLogEntry[];
+	readonly snapshot?: boolean;
+	readonly snapshot_at?: string;
 }
 
 // From codersdk/aitasks.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5013,7 +5013,6 @@ export const TaskLogTypes: TaskLogType[] = ["input", "output"];
  * fetched from a stored snapshot captured during pause.
  */
 export interface TaskLogsResponse {
-	readonly count: number;
 	readonly logs: readonly TaskLogEntry[];
 	readonly snapshot?: boolean;
 	readonly snapshot_at?: string;


### PR DESCRIPTION
Previously the task logs endpoint only worked when the workspace was
running, leaving users unable to view task history after pausing.

This change adds snapshot retrieval with state-based branching: active
tasks fetch live logs from AgentAPI, paused/initializing/pending tasks
return stored snapshots (providing continuity during pause/resume), and
error/unknown states return HTTP 409 Conflict.

The response includes snapshot metadata (snapshot, snapshot_at) to
indicate whether logs are live or historical.

Closes coder/internal#1254
