### PR TITLE
feat: add time window fields to telemetry boundary usage

### DIFF
--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -880,6 +880,8 @@ func TestTelemetry_BoundaryUsageSummary(t *testing.T) {
 		require.Equal(t, int64(2), snapshot.BoundaryUsageSummary.UniqueUsers)
 		require.Equal(t, int64(10+5+3), snapshot.BoundaryUsageSummary.AllowedRequests)
 		require.Equal(t, int64(2+1+0), snapshot.BoundaryUsageSummary.DeniedRequests)
+		require.Equal(t, clock.Now().Add(-telemetry.DefaultSnapshotFrequency), snapshot.BoundaryUsageSummary.PeriodStart)
+		require.Equal(t, int64(telemetry.DefaultSnapshotFrequency/time.Millisecond), snapshot.BoundaryUsageSummary.PeriodDurationMilliseconds)
 	})
 
 	t.Run("ResetAfterCollection", func(t *testing.T) {


### PR DESCRIPTION
Add PeriodStart and PeriodDurationMilliseconds fields to BoundaryUsageSummary so consumers of telemetry data can understand usage within a particular time window. This was identified in the PR adding the bigquery table for the new boundary usage telemetry data: https://redirect.github.com/coder/coder-telemetry-server/pull/36#issuecomment-3816970252
