### PR TITLE
feat: archive modules in size order until limit is hit

### DIFF
--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -83,8 +83,9 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/modules/main.tf")
 		require.NoError(t, err)
 
-		modulesArchive, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
+		modulesArchive, skipped, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
 		require.NoError(t, err)
+		require.Len(t, skipped, 0)
 
 		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
 			provisionerDaemonVersion: provProto.CurrentVersion.String(),
@@ -198,8 +199,9 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/modules/main.tf")
 		require.NoError(t, err)
 
-		modulesArchive, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
+		modulesArchive, skipped, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
 		require.NoError(t, err)
+		require.Len(t, skipped, 0)
 
 		c := atomic.NewInt32(0)
 		reject := &dbRejectGitSSHKey{Store: db, hook: func(d *dbRejectGitSSHKey) {
@@ -232,8 +234,9 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/modules/main.tf")
 		require.NoError(t, err)
 
-		modulesArchive, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
+		modulesArchive, skipped, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
 		require.NoError(t, err)
+		require.Len(t, skipped, 0)
 
 		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
 			provisionerDaemonVersion: provProto.CurrentVersion.String(),
@@ -318,8 +321,9 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/modules/main.tf")
 		require.NoError(t, err)
 
-		modulesArchive, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
+		modulesArchive, skipped, err := terraform.GetModulesArchive(os.DirFS("testdata/parameters/modules"))
 		require.NoError(t, err)
+		require.Len(t, skipped, 0)
 
 		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
 			provisionerDaemonVersion: provProto.CurrentVersion.String(),

--- a/coderd/util/xio/limitwriter.go
+++ b/coderd/util/xio/limitwriter.go
@@ -41,3 +41,7 @@ func (l *LimitWriter) Write(p []byte) (int, error) {
 	l.N += int64(n)
 	return n, err
 }
+
+func (l *LimitWriter) Remaining() int64 {
+	return l.Limit - l.N
+}

--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -833,7 +833,11 @@ In the meantime, you can safely convert existing templates and build new paramet
 
 ### "Module not loaded" errors when using Dynamic Parameters
 
-One possible cause is exceeding the size limit for module archiving. If your template uses modules that exceed the limit, you may see warnings in the provisioner logs:
+Dynamic Parameters require Terraform modules to be archived and stored in the database. Coder limits module archives to **20MB total** to prevent database bloat. If your template uses modules that exceed this limit, some modules will be unavailable for parameter declarations.
+
+**Symptoms:**
+
+You may see warnings in the provisioner logs:
 
 ```text
 [API] 2026-01-29 22:00:22.691 [warn]  provisionerd-nixos-0.executor: some (or all) terraform modules were not archived, template will have reduced function  skipped_modules=large:git::https://github.com/coder/large-module.git

--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -830,3 +830,14 @@ Unless explicitly mentioned, no registry modules require Dynamic Parameters.
 Later in 2025, more registry modules will be converted to Dynamic Parameters to improve their UX.
 
 In the meantime, you can safely convert existing templates and build new parameters on top of the functionality provided in the registry.
+
+
+### "Module not loaded" errors when using Dynamic Parameters
+
+One possible cause is exceeding the size limit for module archiving. If your template uses modules that exceed the limit, you may see warnings in the provisioner logs:
+
+```text
+[API] 2026-01-29 22:00:22.691 [warn]  provisionerd-nixos-0.executor: some (or all) terraform modules were not archived, template will have reduced function  skipped_modules=large:git::https://github.com/coder/large-module.git
+```
+
+If encountered, reduce the size of the module by removing unnecessary files.

--- a/docs/admin/templates/extending-templates/dynamic-parameters.md
+++ b/docs/admin/templates/extending-templates/dynamic-parameters.md
@@ -831,7 +831,6 @@ Later in 2025, more registry modules will be converted to Dynamic Parameters to 
 
 In the meantime, you can safely convert existing templates and build new parameters on top of the functionality provided in the registry.
 
-
 ### "Module not loaded" errors when using Dynamic Parameters
 
 One possible cause is exceeding the size limit for module archiving. If your template uses modules that exceed the limit, you may see warnings in the provisioner logs:

--- a/provisioner/terraform/modules.go
+++ b/provisioner/terraform/modules.go
@@ -211,7 +211,7 @@ func GetModulesArchiveWithLimit(root fs.FS, maxArchiveSize int64) ([]byte, []str
 // directory to a tar archive.
 func estimateModuleSize(root fs.FS, moduleDir string) (int64, error) {
 	size := int64(0)
-	err := fs.WalkDir(root, moduleDir, func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(root, moduleDir, func(_ string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/provisioner/terraform/modules.go
+++ b/provisioner/terraform/modules.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -136,9 +135,8 @@ func GetModulesArchiveWithLimit(root fs.FS, maxArchiveSize int64) ([]byte, []str
 			continue
 		}
 
-		r := lw.Remaining()
-		fmt.Println(r)
-		if it.EstimatedSize > lw.Remaining() {
+		// Leave 1024 bytes for the footer
+		if it.EstimatedSize > lw.Remaining()-1024 {
 			skippedModules = append(skippedModules, fmt.Sprintf("%s:%s", it.Key, it.Source))
 			continue
 		}

--- a/provisioner/terraform/modules.go
+++ b/provisioner/terraform/modules.go
@@ -4,9 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,6 +36,11 @@ type module struct {
 	Version string `json:"Version"`
 	Key     string `json:"Key"`
 	Dir     string `json:"Dir"`
+}
+
+type moduleWithEstimatedSize struct {
+	*module
+	EstimatedSize int64
 }
 
 type modulesFile struct {
@@ -78,30 +86,60 @@ func getModules(files tfpath.Layout) ([]*proto.Module, error) {
 	return filteredModules, nil
 }
 
-func GetModulesArchive(root fs.FS) ([]byte, error) {
+func GetModulesArchive(root fs.FS) ([]byte, []string, error) {
+	return GetModulesArchiveWithLimit(root, MaximumModuleArchiveSize)
+}
+
+// GetModulesArchiveWithLimit returns the tar archive, the skipped modules, and an error if any.
+func GetModulesArchiveWithLimit(root fs.FS, maxArchiveSize int64) ([]byte, []string, error) {
 	modulesFileContent, err := fs.ReadFile(root, ".terraform/modules/modules.json")
 	if err != nil {
 		if xerrors.Is(err, fs.ErrNotExist) {
-			return []byte{}, nil
+			return []byte{}, []string{}, nil
 		}
-		return nil, xerrors.Errorf("failed to read modules.json: %w", err)
+		return nil, []string{}, xerrors.Errorf("failed to read modules.json: %w", err)
 	}
 	var m modulesFile
 	if err := json.Unmarshal(modulesFileContent, &m); err != nil {
-		return nil, xerrors.Errorf("failed to parse modules.json: %w", err)
+		return nil, []string{}, xerrors.Errorf("failed to parse modules.json: %w", err)
 	}
 
 	empty := true
 	var b bytes.Buffer
 
-	lw := xio.NewLimitWriter(&b, MaximumModuleArchiveSize)
+	lw := xio.NewLimitWriter(&b, maxArchiveSize)
 	w := tar.NewWriter(lw)
 
+	sized := make([]*moduleWithEstimatedSize, 0, len(m.Modules))
 	for _, it := range m.Modules {
+		sz, err := estimateModuleSize(root, it.Dir)
+		if err != nil {
+			return nil, []string{}, xerrors.Errorf("failed to estimate module size for %q: %w", it.Dir, err)
+		}
+		sized = append(sized, &moduleWithEstimatedSize{
+			module:        it,
+			EstimatedSize: sz,
+		})
+	}
+
+	// Sort modules by estimated size descending so that we skip the largest
+	slices.SortFunc(sized, func(a, b *moduleWithEstimatedSize) int {
+		return int(a.EstimatedSize - b.EstimatedSize)
+	})
+	skippedModules := []string{}
+
+	for _, it := range sized {
 		// Check to make sure that the module is a remote module fetched by
 		// Terraform. Any module that doesn't start with this path is already local,
 		// and should be part of the template files already.
 		if !strings.HasPrefix(it.Dir, ".terraform/modules/") {
+			continue
+		}
+
+		r := lw.Remaining()
+		fmt.Println(r)
+		if it.EstimatedSize > lw.Remaining() {
+			skippedModules = append(skippedModules, fmt.Sprintf("%s:%s", it.Key, it.Source))
 			continue
 		}
 
@@ -149,26 +187,67 @@ func GetModulesArchive(root fs.FS) ([]byte, error) {
 			return nil
 		})
 		if err != nil {
-			return nil, err
+			return nil, skippedModules, err
 		}
 	}
 
 	err = w.WriteHeader(defaultFileHeader(".terraform/modules/modules.json", len(modulesFileContent)))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to write modules.json to archive: %w", err)
+		return nil, skippedModules, xerrors.Errorf("failed to write modules.json to archive: %w", err)
 	}
 	if _, err := w.Write(modulesFileContent); err != nil {
-		return nil, xerrors.Errorf("failed to write modules.json to archive: %w", err)
+		return nil, skippedModules, xerrors.Errorf("failed to write modules.json to archive: %w", err)
 	}
 
 	if err := w.Close(); err != nil {
-		return nil, xerrors.Errorf("failed to close module files archive: %w", err)
+		return nil, skippedModules, xerrors.Errorf("failed to close module files archive: %w", err)
 	}
 	// Don't persist empty tar files in the database
 	if empty {
-		return []byte{}, nil
+		return []byte{}, skippedModules, nil
 	}
-	return b.Bytes(), nil
+	return b.Bytes(), skippedModules, nil
+}
+
+// estimateModuleSize estimates the size impact of adding the specified module
+// directory to a tar archive.
+func estimateModuleSize(root fs.FS, moduleDir string) (int64, error) {
+	size := int64(0)
+	err := fs.WalkDir(root, moduleDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		fileMode := d.Type()
+		if !fileMode.IsRegular() && !fileMode.IsDir() {
+			return nil
+		}
+
+		// .git directories are not needed in the archive and only cause
+		// hash differences for identical modules.
+		if fileMode.IsDir() && d.Name() == ".git" {
+			return fs.SkipDir
+		}
+
+		fileInfo, err := d.Info()
+		if err != nil {
+			return xerrors.Errorf("file info: %w", err)
+		}
+
+		size += 512 // tar header size
+		if !fileMode.IsRegular() {
+			return nil // Dirs have no content size
+		}
+
+		fileSize := fileInfo.Size()
+		size += fileSize
+		// Pad to 512 bytes
+		size += 512 - (fileSize % 512)
+		return nil
+	})
+	if err != nil {
+		return -1, err
+	}
+	return size, err
 }
 
 func fileHeader(filePath string, fileMode fs.FileMode, fileInfo fs.FileInfo) (*tar.Header, error) {

--- a/provisioner/terraform/modules_internal_test.go
+++ b/provisioner/terraform/modules_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -93,9 +92,150 @@ func TestGetModulesArchive(t *testing.T) {
 		archive, skipped, err := GetModulesArchiveWithLimit(memFS, 5000)
 		require.NoError(t, err)
 		require.Len(t, skipped, 1)
-		require.Equal(t, skipped[0], "large:large")
+		require.Equal(t, "large:large", skipped[0])
 
-		fmt.Println(archive)
+		// Verify small module is in the archive
+		tarfs := archivefs.FromTarReader(bytes.NewBuffer(archive))
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/small/payload")
+		require.NoError(t, err, "small module should be included")
+	})
+
+	// TestModulePackingPrioritizesSmallest verifies that when space is limited,
+	// smaller modules are included first to maximize the number of modules archived.
+	t.Run("PackingPrioritizesSmallest", func(t *testing.T) {
+		t.Parallel()
+
+		// Create modules of varying sizes. With a limit that can fit
+		// small + medium but not large, we should see small and medium included.
+		memFS := moduleArchiveFS(t, map[string]moduleDef{
+			"small": {
+				payload: bytes.Repeat([]byte("S"), 500),
+			},
+			"medium": {
+				payload: bytes.Repeat([]byte("M"), 1500),
+			},
+			"large": {
+				payload: bytes.Repeat([]byte("L"), 5000),
+			},
+		})
+
+		// Estimate: each module needs ~512 (dir) + 512 (file header) + content + padding
+		// small: ~1536 bytes, medium: ~2560 bytes, large: ~6144 bytes
+		// Plus modules.json overhead (~1024) and tar end blocks (1024).
+		// Set limit to fit small + medium + overhead but not large.
+		archive, skipped, err := GetModulesArchiveWithLimit(memFS, 8000)
+		require.NoError(t, err)
+
+		require.Len(t, skipped, 1, "only the large module should be skipped")
+		require.Equal(t, "large:large", skipped[0])
+
+		// Verify correct modules are in archive
+		tarfs := archivefs.FromTarReader(bytes.NewBuffer(archive))
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/small/payload")
+		require.NoError(t, err, "small module should be included")
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/medium/payload")
+		require.NoError(t, err, "medium module should be included")
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/large/payload")
+		require.Error(t, err, "large module should NOT be included")
+	})
+
+	// TestModulePackingAllFit verifies all modules are included when under budget.
+	t.Run("PackingAllFit", func(t *testing.T) {
+		t.Parallel()
+
+		memFS := moduleArchiveFS(t, map[string]moduleDef{
+			"mod1": {payload: []byte("module one")},
+			"mod2": {payload: []byte("module two")},
+			"mod3": {payload: []byte("module three")},
+		})
+
+		// Large limit - everything should fit
+		archive, skipped, err := GetModulesArchiveWithLimit(memFS, 100000)
+		require.NoError(t, err)
+		require.Empty(t, skipped, "no modules should be skipped")
+
+		tarfs := archivefs.FromTarReader(bytes.NewBuffer(archive))
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/mod1/payload")
+		require.NoError(t, err)
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/mod2/payload")
+		require.NoError(t, err)
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/mod3/payload")
+		require.NoError(t, err)
+	})
+
+	// TestModulePackingNoneFit verifies behavior when no modules fit.
+	t.Run("PackingNoneFit", func(t *testing.T) {
+		t.Parallel()
+
+		memFS := moduleArchiveFS(t, map[string]moduleDef{
+			"mod1": {payload: bytes.Repeat([]byte("X"), 2000)},
+			"mod2": {payload: bytes.Repeat([]byte("Y"), 3000)},
+		})
+
+		// Set limit that's enough for modules.json but not for the modules themselves
+		// modules.json needs ~512 header + content + padding + 1024 end blocks
+		archive, skipped, err := GetModulesArchiveWithLimit(memFS, 2500)
+		require.NoError(t, err)
+		require.Len(t, skipped, 2, "both modules should be skipped")
+
+		// Archive should just contain modules.json (empty means no module content)
+		require.True(t, len(archive) == 0 || len(archive) < 2500,
+			"archive should be empty or minimal when no modules fit")
+	})
+
+	// TestModulePackingEdgeCaseExactFit tests when a module exactly fits the remaining space.
+	// The second module should be skipped, because the first module is perfect.
+	t.Run("PackingEdgeCaseExactFit", func(t *testing.T) {
+		t.Parallel()
+
+		originalDef := map[string]moduleDef{
+			"exact": {payload: bytes.Repeat([]byte("E"), 1000)},
+		}
+		// Create a single module and measure its actual archive size
+		memFS := moduleArchiveFS(t, originalDef)
+
+		// First, get the actual size with no limit
+		archive, skipped, err := GetModulesArchiveWithLimit(memFS, 100000)
+		require.NoError(t, err)
+		require.Empty(t, skipped)
+		actualSize := int64(len(archive))
+
+		originalDef["extra"] = moduleDef{payload: bytes.Repeat([]byte("X"), 1001)}
+		memFS = moduleArchiveFS(t, originalDef)
+
+		// Now test with exact size - should just fit
+		archive, skipped, err = GetModulesArchiveWithLimit(memFS, actualSize)
+		require.NoError(t, err)
+		require.Len(t, skipped, 1)
+		require.Equal(t, skipped[0], "extra:extra", "extra module should be skipped")
+		require.Equal(t, actualSize, int64(len(archive)))
+	})
+
+	// TestModulePackingMultipleSkipped verifies correct behavior when multiple
+	// large modules must be skipped.
+	t.Run("PackingMultipleSkipped", func(t *testing.T) {
+		t.Parallel()
+
+		memFS := moduleArchiveFS(t, map[string]moduleDef{
+			"tiny":   {payload: []byte("t")},
+			"small":  {payload: bytes.Repeat([]byte("S"), 200)},
+			"large1": {payload: bytes.Repeat([]byte("L"), 5000)},
+			"large2": {payload: bytes.Repeat([]byte("L"), 6000)},
+			"large3": {payload: bytes.Repeat([]byte("L"), 7000)},
+		})
+
+		// Set limit to fit tiny + small + overhead but not the large ones
+		// tiny: ~1536, small: ~1536, overhead (modules.json + tar end): ~3072
+		archive, skipped, err := GetModulesArchiveWithLimit(memFS, 7000)
+		require.NoError(t, err)
+
+		require.Len(t, skipped, 3, "all three large modules should be skipped")
+
+		tarfs := archivefs.FromTarReader(bytes.NewBuffer(archive))
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/tiny/payload")
+		require.NoError(t, err, "tiny module should be included")
+		_, err = fs.ReadFile(tarfs, ".terraform/modules/small/payload")
+		require.NoError(t, err, "small module should be included")
 	})
 }
 


### PR DESCRIPTION
When archiving modules, used for dynamic parameters, a hard limit is set on the size. Before when this size was hit, the entire payload was discarded.

Now modules are sorted by size order, and when the limit is hit, the remaining modules are omitted. Leaving the workspace with reduced functionality, but more then if all the modules were discarded.

_I think there still exists a case this can fail_, but it's probably not going to actually happen. It would be if there exists just enough room for the next module, but not enough for the next module + extra tar bytes (which we estimate). We would hit the limit writer, and trip an error. We use `lw.Remaining()`, so if the estimate is wrong, errors in estimation do not accumulate. Ideally `LimitWriter` would have a hard and soft limit or something.

# Why do this?

This solves a very niche error case that was thought about when dynamic parameters came about. 

Dynamic parameters requires downloading modules to the database. A maximum size was set: https://github.com/coder/coder/blob/1d87ce2a5e86c628df48d14a1bcae11c2796a137/provisioner/terraform/modules.go#L30-L30

If this limit is reached, all modules fail to load.

<img width="794" height="1025" alt="Screenshot From 2026-01-29 13-22-01" src="https://github.com/user-attachments/assets/68c949cd-2e83-41ad-a61c-52e34b782859" />


This new code sorts the modules in size order and attempts to load as many as it can to provide a less reduced experience. An error still occurs, but more of the template is usable.

<img width="794" height="1025" alt="Screenshot From 2026-01-29 13-23-43" src="https://github.com/user-attachments/assets/42aeda3e-22d4-4acb-b768-603e260a85bb" />

# Inspiration to do this now

This issue might be caused by this: https://github.com/coder/coder/issues/19754?notification_referrer_id=NT_kwHOAFMamtoAJVJlcG9zaXRvcnk7NDQwNzUyMDg2O0lzc3VlOzM0MDA2NTAzMTc#issuecomment-3818961913

1 large module can be taking down the rest.


# Database size concerns (not relevant to this PR)

These files do add bloat to the coder database as purging does not occur. However, all template versions with the same modules re-use the same downloaded archive. So if 10 template versions are made with 0 changes to the modules, only 1 archive lives in the code database
