### PR TITLE
feat: add time window fields to telemetry boundary usage (cherry-pick)

### DIFF
--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -880,6 +880,8 @@ func TestTelemetry_BoundaryUsageSummary(t *testing.T) {
 		require.Equal(t, int64(2), snapshot.BoundaryUsageSummary.UniqueUsers)
 		require.Equal(t, int64(10+5+3), snapshot.BoundaryUsageSummary.AllowedRequests)
 		require.Equal(t, int64(2+1+0), snapshot.BoundaryUsageSummary.DeniedRequests)
+		require.Equal(t, clock.Now().Add(-telemetry.DefaultSnapshotFrequency), snapshot.BoundaryUsageSummary.PeriodStart)
+		require.Equal(t, int64(telemetry.DefaultSnapshotFrequency/time.Millisecond), snapshot.BoundaryUsageSummary.PeriodDurationMilliseconds)
 	})
 
 	t.Run("ResetAfterCollection", func(t *testing.T) {


### PR DESCRIPTION
Add PeriodStart and PeriodDurationMilliseconds fields to BoundaryUsageSummary so consumers of telemetry data can understand usage within a particular time window.

(cherry picked from commit ad4363ce528b90a743553d12503b620686206ba9)

Original PR #21772 . **Why cherry-pick**: because boundary is going GA in 2.30 and without these time windows included in the boundary usage telemetry emitted by coder deployments, we will have a hard time making sense of the usage telemetry on the server side.