### PR TITLE
feat(cli): show snapshots in task logs

### DIFF
--- a/cli/clitest/golden.go
+++ b/cli/clitest/golden.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -93,6 +94,76 @@ ExtractCommandPathsLoop:
 			TestGoldenFile(t, tt.Name, outBuf.Bytes(), replacements)
 		})
 	}
+}
+
+// Output captures stdout and stderr from an invocation and formats them with
+// prefixes for golden file testing, preserving their interleaved order.
+type Output struct {
+	mu       sync.Mutex
+	stdout   bytes.Buffer
+	stderr   bytes.Buffer
+	combined bytes.Buffer
+}
+
+// prefixWriter wraps a buffer and prefixes each line with a given prefix.
+type prefixWriter struct {
+	mu       *sync.Mutex
+	prefix   string
+	raw      *bytes.Buffer
+	combined *bytes.Buffer
+	line     bytes.Buffer // buffer for incomplete lines
+}
+
+// Write implements io.Writer, adding a prefix to each complete line.
+func (w *prefixWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Write unprefixed to raw buffer.
+	_, _ = w.raw.Write(p)
+
+	// Append to line buffer.
+	_, _ = w.line.Write(p)
+
+	// Split on newlines.
+	lines := bytes.Split(w.line.Bytes(), []byte{'\n'})
+
+	// Write all complete lines (all but the last, which may be incomplete).
+	for i := 0; i < len(lines)-1; i++ {
+		_, _ = w.combined.WriteString(w.prefix)
+		_, _ = w.combined.Write(lines[i])
+		_ = w.combined.WriteByte('\n')
+	}
+
+	// Keep the last line (incomplete) in the buffer.
+	w.line.Reset()
+	_, _ = w.line.Write(lines[len(lines)-1])
+
+	return len(p), nil
+}
+
+// Capture sets up stdout and stderr writers on the invocation that prefix each
+// line with "out: " or "err: " while preserving their order.
+func Capture(inv *serpent.Invocation) *Output {
+	output := &Output{}
+	inv.Stdout = &prefixWriter{mu: &output.mu, prefix: "out: ", raw: &output.stdout, combined: &output.combined}
+	inv.Stderr = &prefixWriter{mu: &output.mu, prefix: "err: ", raw: &output.stderr, combined: &output.combined}
+	return output
+}
+
+// Golden returns the formatted output with lines prefixed by "err: " or "out: ".
+func (o *Output) Golden() []byte {
+	return o.combined.Bytes()
+}
+
+// Stdout returns the unprefixed stdout content for parsing (e.g., JSON).
+func (o *Output) Stdout() string {
+	return o.stdout.String()
+}
+
+// Stderr returns the unprefixed stderr content.
+func (o *Output) Stderr() string {
+	return o.stderr.String()
 }
 
 // TestGoldenFile will test the given bytes slice input against the

--- a/cli/task_logs_test.go
+++ b/cli/task_logs_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func Test_TaskLogs(t *testing.T) {
+func Test_TaskLogs_Golden(t *testing.T) {
 	t.Parallel()
 
 	testMessages := []agentapisdk.Message{
@@ -44,23 +44,20 @@ func Test_TaskLogs(t *testing.T) {
 		client, task := setupCLITaskTest(ctx, t, fakeAgentAPITaskLogsOK(testMessages))
 		userClient := client // user already has access to their own workspace
 
-		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "logs", task.Name, "--output", "json")
-		inv.Stdout = &stdout
+		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
+		// Verify JSON is valid.
 		var logs []codersdk.TaskLogEntry
-		err = json.NewDecoder(strings.NewReader(stdout.String())).Decode(&logs)
+		err = json.NewDecoder(strings.NewReader(output.Stdout())).Decode(&logs)
 		require.NoError(t, err)
 
-		require.Len(t, logs, 2)
-		require.Equal(t, "What is 1 + 1?", logs[0].Content)
-		require.Equal(t, codersdk.TaskLogTypeInput, logs[0].Type)
-		require.Equal(t, "2", logs[1].Content)
-		require.Equal(t, codersdk.TaskLogTypeOutput, logs[1].Type)
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
 	})
 
 	t.Run("ByTaskID_JSON", func(t *testing.T) {
@@ -70,23 +67,20 @@ func Test_TaskLogs(t *testing.T) {
 		client, task := setupCLITaskTest(ctx, t, fakeAgentAPITaskLogsOK(testMessages))
 		userClient := client
 
-		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "logs", task.ID.String(), "--output", "json")
-		inv.Stdout = &stdout
+		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
+		// Verify JSON is valid.
 		var logs []codersdk.TaskLogEntry
-		err = json.NewDecoder(strings.NewReader(stdout.String())).Decode(&logs)
+		err = json.NewDecoder(strings.NewReader(output.Stdout())).Decode(&logs)
 		require.NoError(t, err)
 
-		require.Len(t, logs, 2)
-		require.Equal(t, "What is 1 + 1?", logs[0].Content)
-		require.Equal(t, codersdk.TaskLogTypeInput, logs[0].Type)
-		require.Equal(t, "2", logs[1].Content)
-		require.Equal(t, codersdk.TaskLogTypeOutput, logs[1].Type)
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
 	})
 
 	t.Run("ByTaskID_Table", func(t *testing.T) {
@@ -96,19 +90,15 @@ func Test_TaskLogs(t *testing.T) {
 		client, task := setupCLITaskTest(ctx, t, fakeAgentAPITaskLogsOK(testMessages))
 		userClient := client
 
-		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "logs", task.ID.String())
-		inv.Stdout = &stdout
+		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, userClient, root)
 
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
-		output := stdout.String()
-		require.Contains(t, output, "What is 1 + 1?")
-		require.Contains(t, output, "2")
-		require.Contains(t, output, "input")
-		require.Contains(t, output, "output")
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
 	})
 
 	t.Run("TaskNotFound_ByName", func(t *testing.T) {
@@ -159,6 +149,128 @@ func Test_TaskLogs(t *testing.T) {
 
 		err := inv.WithContext(ctx).Run()
 		require.ErrorContains(t, err, assert.AnError.Error())
+	})
+
+	t.Run("SnapshotWithLogs_Table", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client, task := setupCLITaskTestWithSnapshot(ctx, t, codersdk.TaskStatusPaused, testMessages)
+		userClient := client
+
+		inv, root := clitest.New(t, "task", "logs", task.Name)
+		output := clitest.Capture(inv)
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
+	})
+
+	t.Run("SnapshotWithLogs_JSON", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client, task := setupCLITaskTestWithSnapshot(ctx, t, codersdk.TaskStatusPaused, testMessages)
+		userClient := client
+
+		inv, root := clitest.New(t, "task", "logs", task.Name, "--output", "json")
+		output := clitest.Capture(inv)
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// Verify JSON is valid.
+		var logs []codersdk.TaskLogEntry
+		err = json.NewDecoder(strings.NewReader(output.Stdout())).Decode(&logs)
+		require.NoError(t, err)
+
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
+	})
+
+	t.Run("SnapshotWithoutLogs_NoSnapshotCaptured", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client, task := setupCLITaskTestWithoutSnapshot(t, codersdk.TaskStatusPaused)
+		userClient := client
+
+		inv, root := clitest.New(t, "task", "logs", task.Name)
+		output := clitest.Capture(inv)
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
+	})
+
+	t.Run("SnapshotWithSingleMessage", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		singleMessage := []agentapisdk.Message{
+			{
+				Id:      0,
+				Role:    agentapisdk.RoleUser,
+				Content: "Single message",
+				Time:    time.Now(),
+			},
+		}
+
+		client, task := setupCLITaskTestWithSnapshot(ctx, t, codersdk.TaskStatusPending, singleMessage)
+		userClient := client
+
+		inv, root := clitest.New(t, "task", "logs", task.Name)
+		output := clitest.Capture(inv)
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
+	})
+
+	t.Run("SnapshotEmptyLogs", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client, task := setupCLITaskTestWithSnapshot(ctx, t, codersdk.TaskStatusInitializing, []agentapisdk.Message{})
+		userClient := client
+
+		inv, root := clitest.New(t, "task", "logs", task.Name)
+		output := clitest.Capture(inv)
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
+	})
+
+	t.Run("InitializingTaskSnapshot", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client, task := setupCLITaskTestWithSnapshot(ctx, t, codersdk.TaskStatusInitializing, testMessages)
+		userClient := client
+
+		inv, root := clitest.New(t, "task", "logs", task.Name)
+		output := clitest.Capture(inv)
+		clitest.SetupConfig(t, userClient, root)
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// Verify output format with golden file.
+		clitest.TestGoldenFile(t, t.Name(), output.Golden(), nil)
 	})
 }
 

--- a/cli/testdata/Test_TaskLogs_Golden/ByTaskID_JSON.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/ByTaskID_JSON.golden
@@ -1,0 +1,14 @@
+out: [
+out:   {
+out:     "id": 0,
+out:     "content": "What is 1 + 1?",
+out:     "type": "input",
+out:     "time": "====[timestamp]====="
+out:   },
+out:   {
+out:     "id": 1,
+out:     "content": "2",
+out:     "type": "output",
+out:     "time": "====[timestamp]====="
+out:   }
+out: ]

--- a/cli/testdata/Test_TaskLogs_Golden/ByTaskID_Table.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/ByTaskID_Table.golden
@@ -1,0 +1,3 @@
+out: TYPE    CONTENT         
+out: input   What is 1 + 1?  
+out: output  2               

--- a/cli/testdata/Test_TaskLogs_Golden/ByTaskName_JSON.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/ByTaskName_JSON.golden
@@ -1,0 +1,14 @@
+out: [
+out:   {
+out:     "id": 0,
+out:     "content": "What is 1 + 1?",
+out:     "type": "input",
+out:     "time": "====[timestamp]====="
+out:   },
+out:   {
+out:     "id": 1,
+out:     "content": "2",
+out:     "type": "output",
+out:     "time": "====[timestamp]====="
+out:   }
+out: ]

--- a/cli/testdata/Test_TaskLogs_Golden/InitializingTaskSnapshot.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/InitializingTaskSnapshot.golden
@@ -1,0 +1,5 @@
+err: WARN: Task is initializing. Showing last 2 messages from snapshot.
+err: 
+out: TYPE    CONTENT         
+out: input   What is 1 + 1?  
+out: output  2               

--- a/cli/testdata/Test_TaskLogs_Golden/SnapshotEmptyLogs.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/SnapshotEmptyLogs.golden
@@ -1,0 +1,1 @@
+err: No task logs found.

--- a/cli/testdata/Test_TaskLogs_Golden/SnapshotWithLogs_JSON.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/SnapshotWithLogs_JSON.golden
@@ -1,0 +1,16 @@
+err: WARN: Task is paused. Showing last 2 messages from snapshot.
+err: 
+out: [
+out:   {
+out:     "id": 0,
+out:     "content": "What is 1 + 1?",
+out:     "type": "input",
+out:     "time": "====[timestamp]====="
+out:   },
+out:   {
+out:     "id": 1,
+out:     "content": "2",
+out:     "type": "output",
+out:     "time": "====[timestamp]====="
+out:   }
+out: ]

--- a/cli/testdata/Test_TaskLogs_Golden/SnapshotWithLogs_Table.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/SnapshotWithLogs_Table.golden
@@ -1,0 +1,5 @@
+err: WARN: Task is paused. Showing last 2 messages from snapshot.
+err: 
+out: TYPE    CONTENT         
+out: input   What is 1 + 1?  
+out: output  2               

--- a/cli/testdata/Test_TaskLogs_Golden/SnapshotWithSingleMessage.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/SnapshotWithSingleMessage.golden
@@ -1,0 +1,4 @@
+err: WARN: Task is initializing. Showing last 1 message from snapshot.
+err: 
+out: TYPE   CONTENT         
+out: input  Single message  

--- a/cli/testdata/Test_TaskLogs_Golden/SnapshotWithoutLogs_NoSnapshotCaptured.golden
+++ b/cli/testdata/Test_TaskLogs_Golden/SnapshotWithoutLogs_NoSnapshotCaptured.golden
@@ -1,0 +1,3 @@
+err: WARN: Task is paused. No snapshot available (snapshot may have failed during pause, resume your task to view logs).
+err: 
+err: No task logs found.


### PR DESCRIPTION
The CLI displays warnings when showing snapshot data with task status
and message count, detects missing snapshots via SnapshotAt nullability,
and provides actionable guidance when no snapshot is available.

Closes coder/internal#1255
