### PR TITLE
chore(helm): disable liveness probes by default, allow all probe settings

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -258,15 +258,6 @@ reference, and not all security requirements may apply to your business.
    - Both the control plane and workspaces set resource request/limits by
      default.
 
-7. **All Kubernetes objects must define liveness and readiness probes**
-
-   - Control plane - The control plane Deployment has liveness and readiness
-     probes
-     [configured by default here](https://github.com/coder/coder/blob/f57ce97b5aadd825ddb9a9a129bb823a3725252b/helm/coder/templates/_coder.tpl#L98-L107).
-   - Workspaces - the Kubernetes Deployment template does not configure
-     liveness/readiness probes for the workspace, but this can be added to the
-     Terraform template, and is supported.
-
 ## Load balancing considerations
 
 ### AWS

--- a/helm/coder/templates/_coder.tpl
+++ b/helm/coder/templates/_coder.tpl
@@ -108,16 +108,44 @@ ports:
   {{- end }}
   {{- end }}
   {{- end }}
+{{- if .Values.coder.readinessProbe.enabled }}
 readinessProbe:
   httpGet:
     path: /healthz
     port: "http"
     scheme: "HTTP"
   initialDelaySeconds: {{ .Values.coder.readinessProbe.initialDelaySeconds }}
+  {{- if hasKey .Values.coder.readinessProbe "periodSeconds" }}
+  periodSeconds: {{ .Values.coder.readinessProbe.periodSeconds }}
+  {{- end }}
+  {{- if hasKey .Values.coder.readinessProbe "timeoutSeconds" }}
+  timeoutSeconds: {{ .Values.coder.readinessProbe.timeoutSeconds }}
+  {{- end }}
+  {{- if hasKey .Values.coder.readinessProbe "successThreshold" }}
+  successThreshold: {{ .Values.coder.readinessProbe.successThreshold }}
+  {{- end }}
+  {{- if hasKey .Values.coder.readinessProbe "failureThreshold" }}
+  failureThreshold: {{ .Values.coder.readinessProbe.failureThreshold }}
+  {{- end }}
+{{- end }}
+{{- if .Values.coder.livenessProbe.enabled }}
 livenessProbe:
   httpGet:
     path: /healthz
     port: "http"
     scheme: "HTTP"
   initialDelaySeconds: {{ .Values.coder.livenessProbe.initialDelaySeconds }}
+  {{- if hasKey .Values.coder.livenessProbe "periodSeconds" }}
+  periodSeconds: {{ .Values.coder.livenessProbe.periodSeconds }}
+  {{- end }}
+  {{- if hasKey .Values.coder.livenessProbe "timeoutSeconds" }}
+  timeoutSeconds: {{ .Values.coder.livenessProbe.timeoutSeconds }}
+  {{- end }}
+  {{- if hasKey .Values.coder.livenessProbe "successThreshold" }}
+  successThreshold: {{ .Values.coder.livenessProbe.successThreshold }}
+  {{- end }}
+  {{- if hasKey .Values.coder.livenessProbe "failureThreshold" }}
+  failureThreshold: {{ .Values.coder.livenessProbe.failureThreshold }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/coder/tests/chart_test.go
+++ b/helm/coder/tests/chart_test.go
@@ -137,6 +137,14 @@ var testCases = []testCase{
 		name:          "priority_class_name",
 		expectedError: "",
 	},
+	{
+		name:          "probes_custom",
+		expectedError: "",
+	},
+	{
+		name:          "probes_disabled",
+		expectedError: "",
+	},
 }
 
 type testCase struct {

--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -169,12 +169,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/auto_access_url_1_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1_coder.golden
@@ -169,12 +169,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -169,12 +169,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/auto_access_url_2_coder.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2_coder.golden
@@ -169,12 +169,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -168,12 +168,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/command_args_coder.golden
+++ b/helm/coder/tests/testdata/command_args_coder.golden
@@ -168,12 +168,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/command_coder.golden
+++ b/helm/coder/tests/testdata/command_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/custom_resources.golden
+++ b/helm/coder/tests/testdata/custom_resources.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/custom_resources_coder.golden
+++ b/helm/coder/tests/testdata/custom_resources_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/default_values_coder.golden
+++ b/helm/coder/tests/testdata/default_values_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -179,12 +179,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/env_from_coder.golden
+++ b/helm/coder/tests/testdata/env_from_coder.golden
@@ -179,12 +179,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -176,12 +176,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/extra_templates_coder.golden
+++ b/helm/coder/tests/testdata/extra_templates_coder.golden
@@ -176,12 +176,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -175,12 +175,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/labels_annotations_coder.golden
+++ b/helm/coder/tests/testdata/labels_annotations_coder.golden
@@ -175,12 +175,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/namespace_rbac.golden
+++ b/helm/coder/tests/testdata/namespace_rbac.golden
@@ -357,12 +357,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/namespace_rbac_coder.golden
+++ b/helm/coder/tests/testdata/namespace_rbac_coder.golden
@@ -357,12 +357,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/partial_resources.golden
+++ b/helm/coder/tests/testdata/partial_resources.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/partial_resources_coder.golden
+++ b/helm/coder/tests/testdata/partial_resources_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/pod_securitycontext.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/pod_securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/pod_securitycontext_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/priority_class_name.golden
+++ b/helm/coder/tests/testdata/priority_class_name.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/priority_class_name_coder.golden
+++ b/helm/coder/tests/testdata/priority_class_name_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/probes_custom.golden
+++ b/helm/coder/tests/testdata/probes_custom.golden
@@ -12,14 +12,14 @@ metadata:
     app.kubernetes.io/version: 0.1.0
     helm.sh/chart: coder-0.1.0
   name: coder
-  namespace: coder
+  namespace: default
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: coder-workspace-perms
-  namespace: coder
+  namespace: default
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -62,7 +62,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "coder"
-  namespace: coder
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: "coder"
@@ -76,7 +76,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: coder
-  namespace: coder
+  namespace: default
   labels:
     helm.sh/chart: coder-0.1.0
     app.kubernetes.io/name: coder
@@ -113,7 +113,7 @@ metadata:
     app.kubernetes.io/version: 0.1.0
     helm.sh/chart: coder-0.1.0
   name: coder
-  namespace: coder
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -156,28 +156,42 @@ spec:
           value: 0.0.0.0:2112
         - name: CODER_PPROF_ADDRESS
           value: 0.0.0.0:6060
+        - name: CODER_ACCESS_URL
+          value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
-        - name: SOME_ENV
-          value: some value
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
         name: coder
         ports:
         - containerPort: 8080
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 6
           httpGet:
             path: /healthz
             port: http
             scheme: HTTP
-          initialDelaySeconds: 0
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          successThreshold: 2
+          timeoutSeconds: 5
         resources:
           limits:
             cpu: 2000m

--- a/helm/coder/tests/testdata/probes_custom.yaml
+++ b/helm/coder/tests/testdata/probes_custom.yaml
@@ -1,0 +1,17 @@
+coder:
+  image:
+    tag: latest
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 5
+    successThreshold: 2
+    failureThreshold: 6
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3

--- a/helm/coder/tests/testdata/probes_custom_coder.golden
+++ b/helm/coder/tests/testdata/probes_custom_coder.golden
@@ -156,28 +156,42 @@ spec:
           value: 0.0.0.0:2112
         - name: CODER_PPROF_ADDRESS
           value: 0.0.0.0:6060
+        - name: CODER_ACCESS_URL
+          value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
-        - name: SOME_ENV
-          value: some value
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
         name: coder
         ports:
         - containerPort: 8080
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 6
           httpGet:
             path: /healthz
             port: http
             scheme: HTTP
-          initialDelaySeconds: 0
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          successThreshold: 2
+          timeoutSeconds: 5
         resources:
           limits:
             cpu: 2000m

--- a/helm/coder/tests/testdata/probes_disabled.golden
+++ b/helm/coder/tests/testdata/probes_disabled.golden
@@ -12,14 +12,14 @@ metadata:
     app.kubernetes.io/version: 0.1.0
     helm.sh/chart: coder-0.1.0
   name: coder
-  namespace: coder
+  namespace: default
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: coder-workspace-perms
-  namespace: coder
+  namespace: default
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -62,7 +62,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "coder"
-  namespace: coder
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: "coder"
@@ -76,7 +76,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: coder
-  namespace: coder
+  namespace: default
   labels:
     helm.sh/chart: coder-0.1.0
     app.kubernetes.io/name: coder
@@ -113,7 +113,7 @@ metadata:
     app.kubernetes.io/version: 0.1.0
     helm.sh/chart: coder-0.1.0
   name: coder
-  namespace: coder
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -156,14 +156,14 @@ spec:
           value: 0.0.0.0:2112
         - name: CODER_PPROF_ADDRESS
           value: 0.0.0.0:6060
+        - name: CODER_ACCESS_URL
+          value: http://coder.default.svc.cluster.local
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
-        - name: SOME_ENV
-          value: some value
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
@@ -172,12 +172,6 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         resources:
           limits:
             cpu: 2000m

--- a/helm/coder/tests/testdata/probes_disabled.yaml
+++ b/helm/coder/tests/testdata/probes_disabled.yaml
@@ -1,0 +1,7 @@
+coder:
+  image:
+    tag: latest
+  readinessProbe:
+    enabled: false
+  livenessProbe:
+    enabled: false

--- a/helm/coder/tests/testdata/probes_disabled_coder.golden
+++ b/helm/coder/tests/testdata/probes_disabled_coder.golden
@@ -156,14 +156,14 @@ spec:
           value: 0.0.0.0:2112
         - name: CODER_PPROF_ADDRESS
           value: 0.0.0.0:6060
+        - name: CODER_ACCESS_URL
+          value: http://coder.coder.svc.cluster.local
         - name: KUBE_POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
         - name: CODER_DERP_SERVER_RELAY_URL
           value: http://$(KUBE_POD_IP):8080
-        - name: SOME_ENV
-          value: some value
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
@@ -172,12 +172,6 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         resources:
           limits:
             cpu: 2000m

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -168,12 +168,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/prometheus_coder.golden
+++ b/helm/coder/tests/testdata/prometheus_coder.golden
@@ -168,12 +168,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -172,12 +172,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/provisionerd_psk_coder.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk_coder.golden
@@ -172,12 +172,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -169,12 +169,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/sa_coder.golden
+++ b/helm/coder/tests/testdata/sa_coder.golden
@@ -169,12 +169,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/sa_disabled.golden
+++ b/helm/coder/tests/testdata/sa_disabled.golden
@@ -153,12 +153,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/sa_disabled_coder.golden
+++ b/helm/coder/tests/testdata/sa_disabled_coder.golden
@@ -153,12 +153,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -180,12 +180,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/sa_extra_rules_coder.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules_coder.golden
@@ -180,12 +180,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/securitycontext.golden
+++ b/helm/coder/tests/testdata/securitycontext.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/securitycontext_coder.golden
+++ b/helm/coder/tests/testdata/securitycontext_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/svc_loadbalancer.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/svc_loadbalancer_class.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class.golden
@@ -168,12 +168,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_class_coder.golden
@@ -168,12 +168,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
+++ b/helm/coder/tests/testdata/svc_loadbalancer_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/svc_nodeport.golden
+++ b/helm/coder/tests/testdata/svc_nodeport.golden
@@ -166,12 +166,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/svc_nodeport_coder.golden
+++ b/helm/coder/tests/testdata/svc_nodeport_coder.golden
@@ -166,12 +166,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -180,12 +180,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/tls_coder.golden
+++ b/helm/coder/tests/testdata/tls_coder.golden
@@ -180,12 +180,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/topology.golden
+++ b/helm/coder/tests/testdata/topology.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/topology_coder.golden
+++ b/helm/coder/tests/testdata/topology_coder.golden
@@ -167,12 +167,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -175,12 +175,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/tests/testdata/workspace_proxy_coder.golden
+++ b/helm/coder/tests/testdata/workspace_proxy_coder.golden
@@ -175,12 +175,6 @@ spec:
         image: ghcr.io/coder/coder:latest
         imagePullPolicy: IfNotPresent
         lifecycle: {}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 0
         name: coder
         ports:
         - containerPort: 8080

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -266,16 +266,44 @@ coder:
     #  memory: 4096Mi
 
   # coder.readinessProbe -- Readiness probe configuration for the Coder container.
+  # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+  # for default values.
   readinessProbe:
+    # coder.readinessProbe.enabled -- Whether to enable the readiness probe.
+    enabled: true
     # coder.readinessProbe.initialDelaySeconds -- Number of seconds after the container
     # has started before readiness probes are initiated.
     initialDelaySeconds: 0
+    # coder.readinessProbe.periodSeconds -- How often (in seconds) to perform the probe.
+    # periodSeconds: 10
+    # coder.readinessProbe.timeoutSeconds -- Number of seconds after which the probe times out.
+    # timeoutSeconds: 1
+    # coder.readinessProbe.successThreshold -- Minimum consecutive successes for the probe
+    # to be considered successful after having failed.
+    # successThreshold: 1
+    # coder.readinessProbe.failureThreshold -- Minimum consecutive failures for the probe
+    # to be considered failed after having succeeded.
+    # failureThreshold: 3
 
   # coder.livenessProbe -- Liveness probe configuration for the Coder container.
+  # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+  # for default values.
   livenessProbe:
+    # coder.livenessProbe.enabled -- Whether to enable the liveness probe.
+    enabled: false
     # coder.livenessProbe.initialDelaySeconds -- Number of seconds after the container
     # has started before liveness probes are initiated.
     initialDelaySeconds: 0
+    # coder.livenessProbe.periodSeconds -- How often (in seconds) to perform the probe.
+    # periodSeconds: 10
+    # coder.livenessProbe.timeoutSeconds -- Number of seconds after which the probe times out.
+    # timeoutSeconds: 1
+    # coder.livenessProbe.successThreshold -- Minimum consecutive successes for the probe
+    # to be considered successful after having failed.
+    # successThreshold: 1
+    # coder.livenessProbe.failureThreshold -- Minimum consecutive failures for the probe
+    # to be considered failed after having succeeded.
+    # failureThreshold: 3
 
   # coder.certs -- CA bundles to mount inside the Coder pod.
   certs:


### PR DESCRIPTION
Liveness checks are currently causing pods to be killed during long-running migrations.

They are generally not advisable for our workloads; if a pod becomes unresponsive we _need_ to know about it (due to a deadlock, etc) and not paper over the issue by killing the pod.

I've also made all probe settings configurable.