### PR TITLE
fix(coderd/oauth2provider): support client_secret_basic client auth

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -503,6 +503,12 @@ func OneWayWebSocketEventSender(log slog.Logger) func(rw http.ResponseWriter, r 
 // WriteOAuth2Error writes an OAuth2-compliant error response per RFC 6749.
 // This should be used for all OAuth2 endpoints (/oauth2/*) to ensure compliance.
 func WriteOAuth2Error(ctx context.Context, rw http.ResponseWriter, status int, errorCode codersdk.OAuth2ErrorCode, description string) {
+	// RFC 6749 §5.2: invalid_client SHOULD use 401 and MUST include a
+	// WWW-Authenticate response header.
+	if status == http.StatusUnauthorized && errorCode == codersdk.OAuth2ErrorCodeInvalidClient {
+		rw.Header().Set("WWW-Authenticate", `Basic realm="coder"`)
+	}
+
 	Write(ctx, rw, status, codersdk.OAuth2Error{
 		Error:            errorCode,
 		ErrorDescription: description,

--- a/coderd/httpmw/oauth2.go
+++ b/coderd/httpmw/oauth2.go
@@ -330,6 +330,13 @@ func extractOAuth2ProviderAppBase(db database.Store, errWriter errorWriter) func
 					}
 				}
 				if paramAppID == "" {
+					// RFC 6749 §2.3.1: confidential clients may authenticate via
+					// HTTP Basic where the username is the client_id.
+					if user, _, ok := r.BasicAuth(); ok && user != "" {
+						paramAppID = user
+					}
+				}
+				if paramAppID == "" {
 					errWriter.writeMissingClientID(ctx, rw)
 					return
 				}

--- a/coderd/oauth2provider/metadata.go
+++ b/coderd/oauth2provider/metadata.go
@@ -23,7 +23,7 @@ func GetAuthorizationServerMetadata(accessURL *url.URL) http.HandlerFunc {
 			GrantTypesSupported:               []codersdk.OAuth2ProviderGrantType{codersdk.OAuth2ProviderGrantTypeAuthorizationCode, codersdk.OAuth2ProviderGrantTypeRefreshToken},
 			CodeChallengeMethodsSupported:     []codersdk.OAuth2PKCECodeChallengeMethod{codersdk.OAuth2PKCECodeChallengeMethodS256},
 			ScopesSupported:                   rbac.ExternalScopeNames(),
-			TokenEndpointAuthMethodsSupported: []codersdk.OAuth2TokenEndpointAuthMethod{codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost},
+			TokenEndpointAuthMethodsSupported: []codersdk.OAuth2TokenEndpointAuthMethod{codersdk.OAuth2TokenEndpointAuthMethodClientSecretBasic, codersdk.OAuth2TokenEndpointAuthMethodClientSecretPost},
 		}
 		httpapi.Write(ctx, rw, http.StatusOK, metadata)
 	}

--- a/coderd/oauth2provider/oauth2providertest/oauth2_test.go
+++ b/coderd/oauth2provider/oauth2providertest/oauth2_test.go
@@ -1,13 +1,20 @@
 package oauth2providertest_test
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/oauth2provider/oauth2providertest"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestOAuth2AuthorizationServerMetadata(t *testing.T) {
@@ -41,6 +48,12 @@ func TestOAuth2AuthorizationServerMetadata(t *testing.T) {
 	challengeMethods, ok := metadata["code_challenge_methods_supported"].([]any)
 	require.True(t, ok, "code_challenge_methods_supported should be an array")
 	require.Contains(t, challengeMethods, "S256", "should support S256 PKCE method")
+
+	// Verify token endpoint auth methods
+	authMethods, ok := metadata["token_endpoint_auth_methods_supported"].([]any)
+	require.True(t, ok, "token_endpoint_auth_methods_supported should be an array")
+	require.Contains(t, authMethods, "client_secret_basic", "should support client_secret_basic token auth")
+	require.Contains(t, authMethods, "client_secret_post", "should support client_secret_post token auth")
 
 	// Verify endpoints are proper URLs
 	authEndpoint, ok := metadata["authorization_endpoint"].(string)
@@ -184,6 +197,109 @@ func TestOAuth2WithoutPKCE(t *testing.T) {
 	token := oauth2providertest.ExchangeCodeForToken(t, client.URL.String(), tokenParams)
 	require.NotEmpty(t, token.AccessToken, "should receive access token")
 	require.NotEmpty(t, token.RefreshToken, "should receive refresh token")
+}
+
+func TestOAuth2TokenExchangeClientSecretBasic(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: false,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	app, clientSecret := oauth2providertest.CreateTestOAuth2App(t, client)
+	t.Cleanup(func() {
+		oauth2providertest.CleanupOAuth2App(t, client, app.ID)
+	})
+
+	state := oauth2providertest.GenerateState(t)
+
+	authParams := oauth2providertest.AuthorizeParams{
+		ClientID:     app.ID.String(),
+		ResponseType: "code",
+		RedirectURI:  oauth2providertest.TestRedirectURI,
+		State:        state,
+	}
+
+	code := oauth2providertest.AuthorizeOAuth2App(t, client, client.URL.String(), authParams)
+	require.NotEmpty(t, code, "should receive authorization code")
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", oauth2providertest.TestRedirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", client.URL.String()+"/oauth2/tokens", strings.NewReader(data.Encode()))
+	require.NoError(t, err, "failed to create token request")
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(app.ID.String(), clientSecret)
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err, "failed to perform token request")
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code")
+
+	var tokenResp oauth2.Token
+	err = json.NewDecoder(resp.Body).Decode(&tokenResp)
+	require.NoError(t, err, "failed to decode token response")
+
+	require.NotEmpty(t, tokenResp.AccessToken, "missing access token")
+	require.NotEmpty(t, tokenResp.RefreshToken, "missing refresh token")
+	require.Equal(t, "Bearer", tokenResp.TokenType, "unexpected token type")
+}
+
+func TestOAuth2TokenExchangeClientSecretBasicInvalidSecret(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: false,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	app, clientSecret := oauth2providertest.CreateTestOAuth2App(t, client)
+	t.Cleanup(func() {
+		oauth2providertest.CleanupOAuth2App(t, client, app.ID)
+	})
+
+	state := oauth2providertest.GenerateState(t)
+
+	authParams := oauth2providertest.AuthorizeParams{
+		ClientID:     app.ID.String(),
+		ResponseType: "code",
+		RedirectURI:  oauth2providertest.TestRedirectURI,
+		State:        state,
+	}
+
+	code := oauth2providertest.AuthorizeOAuth2App(t, client, client.URL.String(), authParams)
+	require.NotEmpty(t, code, "should receive authorization code")
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", oauth2providertest.TestRedirectURI)
+
+	wrongSecret := clientSecret + "x"
+
+	req, err := http.NewRequestWithContext(ctx, "POST", client.URL.String()+"/oauth2/tokens", strings.NewReader(data.Encode()))
+	require.NoError(t, err, "failed to create token request")
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(app.ID.String(), wrongSecret)
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err, "failed to perform token request")
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "expected 401 status code")
+	require.Equal(t, `Basic realm="coder"`, resp.Header.Get("WWW-Authenticate"), "missing WWW-Authenticate header")
+
+	oauth2providertest.RequireOAuth2Error(t, resp, oauth2providertest.OAuth2ErrorTypes.InvalidClient)
 }
 
 func TestOAuth2PKCEPlainMethodRejected(t *testing.T) {

--- a/coderd/oauth2provider/tokens.go
+++ b/coderd/oauth2provider/tokens.go
@@ -88,13 +88,13 @@ func extractTokenRequest(r *http.Request, callbackURL *url.URL) (codersdk.OAuth2
 		if req.ClientID == "" {
 			p.Errors = append(p.Errors, codersdk.ValidationError{
 				Field:  "client_id",
-				Detail: "Query param \"client_id\" is required and cannot be empty",
+				Detail: "Parameter \"client_id\" is required and cannot be empty",
 			})
 		}
 		if req.ClientSecret == "" {
 			p.Errors = append(p.Errors, codersdk.ValidationError{
 				Field:  "client_secret",
-				Detail: "Query param \"client_secret\" is required and cannot be empty",
+				Detail: "Parameter \"client_secret\" is required and cannot be empty",
 			})
 		}
 	}

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -78,7 +78,7 @@ Coder supports the following OAuth2 client authentication methods at the token e
 
 Coder supports both methods for compatibility; existing integrations using `client_secret_post` do not need to change.
 
-If you use Dynamic Client Registration (RFC 7591) and omit `token_endpoint_auth_method`, clients default to `client_secret_basic`.
+If you use Dynamic Client Registration (RFC 7591) and omit `token_endpoint_auth_method`, clients default to `client_secret_basic`. To request `client_secret_post`, set `token_endpoint_auth_method` to `client_secret_post` in the registration request.
 
 If client authentication fails, the token endpoint returns **HTTP 401** with an OAuth2 `invalid_client` error and a `WWW-Authenticate: Basic realm="coder"` response header.
 

--- a/docs/admin/integrations/oauth2-provider.md
+++ b/docs/admin/integrations/oauth2-provider.md
@@ -69,6 +69,19 @@ curl -X POST \
 
 ## Integration Patterns
 
+### Client Authentication Methods
+
+Coder supports the following OAuth2 client authentication methods at the token endpoint (`/oauth2/tokens`):
+
+- `client_secret_basic` (recommended): HTTP Basic authentication (RFC 6749 §2.3.1). The username is `client_id` and the password is `client_secret`.
+- `client_secret_post`: Form-based authentication where `client_id` and `client_secret` are sent in the request body.
+
+Coder supports both methods for compatibility; existing integrations using `client_secret_post` do not need to change.
+
+If you use Dynamic Client Registration (RFC 7591) and omit `token_endpoint_auth_method`, clients default to `client_secret_basic`.
+
+If client authentication fails, the token endpoint returns **HTTP 401** with an OAuth2 `invalid_client` error and a `WWW-Authenticate: Basic realm="coder"` response header.
+
 ### Standard OAuth2 Flow
 
 1. **Authorization Request**: Redirect users to Coder's authorization endpoint:
@@ -81,7 +94,21 @@ curl -X POST \
      state=random-string
    ```
 
-2. **Token Exchange**: Exchange the authorization code for an access token:
+2. **Token Exchange**: Exchange the authorization code for an access token.
+
+   **Option A: HTTP Basic authentication (`client_secret_basic`, recommended)**
+
+   ```bash
+   curl -X POST \
+     -u "$CLIENT_ID:$CLIENT_SECRET" \
+     -H "Content-Type: application/x-www-form-urlencoded" \
+     -d "grant_type=authorization_code" \
+     -d "code=$AUTH_CODE" \
+     -d "redirect_uri=https://yourapp.example.com/callback" \
+     "$CODER_URL/oauth2/tokens"
+   ```
+
+   **Option B: Form parameters (`client_secret_post`)**
 
    ```bash
    curl -X POST \
@@ -101,9 +128,9 @@ curl -X POST \
      "$CODER_URL/api/v2/users/me"
    ```
 
-### PKCE Flow (Public Clients)
+### PKCE Flow (Recommended)
 
-For mobile apps and single-page applications, use PKCE for enhanced security:
+Use PKCE for enhanced security (recommended for both public and confidential clients):
 
 1. Generate a code verifier and challenge:
 
@@ -123,14 +150,16 @@ For mobile apps and single-page applications, use PKCE for enhanced security:
      redirect_uri=https://yourapp.example.com/callback
    ```
 
-3. Include the code verifier in the token exchange:
+3. Include the code verifier in the token exchange (see [Client Authentication Methods](#client-authentication-methods)):
 
    ```bash
    curl -X POST \
+     -u "$CLIENT_ID:$CLIENT_SECRET" \
+     -H "Content-Type: application/x-www-form-urlencoded" \
      -d "grant_type=authorization_code" \
      -d "code=$AUTH_CODE" \
-     -d "client_id=$CLIENT_ID" \
      -d "code_verifier=$CODE_VERIFIER" \
+     -d "redirect_uri=https://yourapp.example.com/callback" \
      "$CODER_URL/oauth2/tokens"
    ```
 
@@ -147,7 +176,20 @@ These endpoints return server capabilities and endpoint URLs according to [RFC 8
 
 ### Refresh Tokens
 
-Refresh an expired access token:
+Refresh an expired access token.
+
+**Option A: HTTP Basic authentication (`client_secret_basic`)**
+
+```bash
+curl -X POST \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=$REFRESH_TOKEN" \
+  "$CODER_URL/oauth2/tokens"
+```
+
+**Option B: Form parameters (`client_secret_post`)**
 
 ```bash
 curl -X POST \


### PR DESCRIPTION
Adds RFC 6749 §2.3.1 `client_secret_basic` support to Coder's OAuth2 provider.

- Accept `client_id` from HTTP Basic auth for OAuth2 app lookup middleware.
- Allow `/oauth2/tokens` to authenticate clients via `Authorization: Basic`.
  - If both body creds and header creds are provided and conflict, return
    `invalid_request`.
- Advertise `client_secret_basic` + `client_secret_post` in discovery metadata.
- Add `WWW-Authenticate` header for `401 invalid_client` responses.
- Add regression tests for Basic auth token exchange + metadata.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Add OAuth2 `client_secret_basic` (HTTP Basic auth) support

## Context / why
`codex mcp add` is failing during the OAuth2 token exchange with:

- `invalid_request: Missing client_id parameter`

Coder’s OAuth2 provider currently identifies the client (`client_id`) and authenticates it (`client_secret`) **only via query/form parameters**, but RFC 6749 §2.3.1 requires supporting **HTTP Basic authentication** for confidential clients. This is especially important because Dynamic Client Registration (RFC 7591) defaults `token_endpoint_auth_method` to `client_secret_basic`.

## Evidence (what we verified)
- `coderd/httpmw/oauth2.go`: `extractOAuth2ProviderAppBase` checks `client_id` only in query + form body and returns `Missing client_id parameter` otherwise.
- `coderd/oauth2provider/tokens.go`: `extractTokenRequest` requires `client_id` and `client_secret` as **form fields** for `authorization_code` grant.
- `coderd/oauth2provider/metadata.go`: discovery metadata advertises only `client_secret_post` today.
- User-provided `curl` shows `/oauth2/tokens` correctly parses form bodies (returns `unsupported_grant_type` when only `client_id` is supplied), so the failure is specifically “client_id not found where Coder looks for it”.

## Goals
- Support OAuth2 client authentication via **HTTP Basic** on `/oauth2/tokens` (and other OAuth2 endpoints that expect client auth).
- Keep existing `client_secret_post` behavior working.
- Make discovery metadata match reality: advertise both `client_secret_basic` and `client_secret_post`.
- Improve RFC compliance for error responses: `invalid_client` with HTTP 401 should include `WWW-Authenticate`.

## Non-goals
- Adding new OAuth2 grant types.
- Changing `client_id` format (it remains the app UUID).
- Reworking public-client (`token_endpoint_auth_method=none`) behavior beyond what’s needed for Basic auth.

## Implementation plan

### 1) Parse `client_id` from HTTP Basic in the OAuth2 app lookup middleware
**File:** `coderd/httpmw/oauth2.go`

**Target:** `extractOAuth2ProviderAppBase`

**Change:** when `client_id` is not present in URL param, query string, or form body, fall back to HTTP Basic username.

```go
paramAppID := r.URL.Query().Get("client_id")
if paramAppID == "" {
	if r.ParseForm() == nil {
		paramAppID = r.Form.Get("client_id")
	}
}
if paramAppID == "" {
	// RFC 6749 §2.3.1: support HTTP Basic client authentication.
	if user, _, ok := r.BasicAuth(); ok && user != "" {
		paramAppID = user
	}
}
if paramAppID == "" {
	errWriter.writeMissingClientID(ctx, rw)
	return
}
```

### 2) Support `client_secret_basic` during token exchange
**File:** `coderd/oauth2provider/tokens.go`

**Targets:** `extractTokenRequest`, and its callsite in `Tokens()`.

**Change:** after parsing the form, merge credentials from form + Basic auth:

- `basicUser/basicPass := r.BasicAuth()`
- `formClientID := vals.Get("client_id")`, `formClientSecret := vals.Get("client_secret")`
- If Basic auth is present:
  - Prefer Basic auth values.
  - If both Basic and form provide a value and they **conflict**, return `invalid_request` (defensive + avoids ambiguous auth).
- Validate required fields based on `grant_type`, but validate the **merged** `client_id`/`client_secret` instead of requiring they exist in the form.

<details>
<summary>Sketch of the intended logic</summary>

```go
user, pass, basicOK := r.BasicAuth()
clientID := vals.Get("client_id")
clientSecret := vals.Get("client_secret")

if basicOK {
	if clientID != "" && clientID != user {
		// invalid_request: conflicting client_id
	}
	if clientSecret != "" && clientSecret != pass {
		// invalid_request: conflicting client_secret
	}
	clientID = user
	clientSecret = pass
}

// Now do grant-type-specific required checks:
// - authorization_code: require code + clientID + clientSecret
// - refresh_token: keep existing behavior unless we decide to tighten it
```

</details>

### 3) Update discovery metadata to advertise Basic auth support
**File:** `coderd/oauth2provider/metadata.go`

**Change:**

- Today: `TokenEndpointAuthMethodsSupported: [client_secret_post]`
- After: `TokenEndpointAuthMethodsSupported: [client_secret_basic, client_secret_post]`

### 4) Add RFC-required `WWW-Authenticate` header for `invalid_client`
**File:** `coderd/httpapi/httpapi.go`

**Target:** `WriteOAuth2Error`

**Change:** When writing an OAuth2 error with `status==401` and `error==invalid_client`, set:

```go
rw.Header().Set("WWW-Authenticate", `Basic realm=\"coder\"`)
```

This aligns with RFC 6749 §5.2 (“MUST include WWW-Authenticate when using 401”).

### 5) Tests
Add/extend tests to prevent regressions:

1. **Token endpoint accepts Basic auth**
   - Create OAuth2 app + secret.
   - Complete authorization-code issuance (existing test patterns already do this).
   - Exchange code at `/oauth2/tokens` while:
     - Setting `req.SetBasicAuth(clientID, clientSecret)`
     - Omitting `client_id` + `client_secret` from the form body
   - Expect HTTP 200.

2. **Invalid secret via Basic returns `invalid_client` and includes `WWW-Authenticate`**
   - Same setup, but send wrong password.
   - Expect HTTP 401, OAuth2 error `invalid_client`, and `WWW-Authenticate: Basic realm="coder"`.

3. **Metadata advertises both auth methods**
   - Update `coderd/oauth2provider/metadata_test.go` to assert
     `TokenEndpointAuthMethodsSupported` contains both `client_secret_basic` and `client_secret_post`.

## Acceptance criteria
- `codex mcp add ...` succeeds end-to-end against a Coder instance with OAuth2 provider enabled.
- `/oauth2/tokens` works for both:
  - `client_secret_post` (existing behavior)
  - `client_secret_basic` (new behavior)
- `.well-known/oauth-authorization-server` includes `token_endpoint_auth_methods_supported` with `client_secret_basic`.
- `invalid_client` responses return 401 + a `WWW-Authenticate` header.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
