### PR TITLE
fix: increase retry attempts for builtin postgres port conflicts

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2174,7 +2174,7 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 	// existing database
 	retryPortDiscovery := errors.Is(err, os.ErrNotExist) && testing.Testing()
 	if retryPortDiscovery {
-		maxAttempts = 3
+		maxAttempts = 10
 	}
 
 	var startErr error


### PR DESCRIPTION
## Summary

Fixes flaky `TestServer/BuiltinPostgres` test caused by port conflicts in CI.

## Fix

Increase retry attempts from 3 to 10 for better odds when port conflicts occur.

Fixes https://github.com/coder/internal/issues/1017