### PR TITLE
fix(coderd/rbac): make workspace ACL disabled flag atomic

### DIFF
--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -239,16 +240,16 @@ func (z Object) WithGroupACL(groups map[string][]policy.Action) Object {
 
 // TODO(geokat): similar to builtInRoles, this should ideally be
 // scoped to a coderd rather than a global.
-var workspaceACLDisabled bool
+var workspaceACLDisabled atomic.Bool
 
 // SetWorkspaceACLDisabled disables/enables workspace sharing for the
 // deployment.
 func SetWorkspaceACLDisabled(v bool) {
-	workspaceACLDisabled = v
+	workspaceACLDisabled.Store(v)
 }
 
 // WorkspaceACLDisabled returns true if workspace sharing is disabled
 // for the deployment.
 func WorkspaceACLDisabled() bool {
-	return workspaceACLDisabled
+	return workspaceACLDisabled.Load()
 }


### PR DESCRIPTION
The flag is a package-global that was only meant to be set once on startup. This was a bad assumption since the lack of sync caused test flakes.

Related to:
https://github.com/coder/internal/issues/1317
https://github.com/coder/internal/issues/1318
