### PR TITLE
fix: resolve rounding on `<TasksPage />` control

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -180,7 +180,7 @@ const TasksPage: FC = () => {
 										className="mt-6 flex justify-between"
 										aria-label="Controls"
 									>
-										<div className="flex items-center bg-surface-secondary rounded p-1">
+										<div className="flex items-center bg-surface-secondary rounded-lg p-1">
 											<PillButton
 												active={tab.value === "all"}
 												onClick={() => {


### PR DESCRIPTION
This pull-request resolves a really annoying issue with the `<TasksPage />` switcher control. Essentially every time I navigated to this page my eyes were drawn to this button that felt out of place. I finally figured out why and its that its breaking the first rules of nested rounded corners.

We should be using the following math to calculate the roundedness. 

```
outerRadius - gap = innerRadius
```

<img width="852" height="596" alt="button-rounding" src="https://github.com/user-attachments/assets/89de5d98-0891-4c9d-a5aa-66f722796630" />

