### PR TITLE
fix: redirect to new task upon creation

### DIFF
--- a/site/src/modules/navigation.ts
+++ b/site/src/modules/navigation.ts
@@ -30,3 +30,5 @@ export const linkToTemplate =
 		dashboard.showOrganizations
 			? `/templates/${organizationName}/${templateName}`
 			: `/templates/${templateName}`;
+
+export const linkToTask = (taskId: string): string => `/tasks/admin/${taskId}`;

--- a/site/src/modules/navigation.ts
+++ b/site/src/modules/navigation.ts
@@ -31,4 +31,5 @@ export const linkToTemplate =
 			? `/templates/${organizationName}/${templateName}`
 			: `/templates/${templateName}`;
 
-export const linkToTask = (taskId: string): string => `/tasks/admin/${taskId}`;
+export const linkToTask = (ownerName: string, taskId: string): string =>
+	`/tasks/${ownerName}/${taskId}`;

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -28,8 +28,10 @@ import {
 import { useAuthenticated } from "hooks/useAuthenticated";
 import { useExternalAuth } from "hooks/useExternalAuth";
 import { ArrowUpIcon, InfoIcon, RedoIcon, RotateCcwIcon } from "lucide-react";
+import { linkToTask } from "modules/navigation";
 import { type FC, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useNavigate } from "react-router";
 import TextareaAutosize, {
 	type TextareaAutosizeProps,
 } from "react-textarea-autosize";
@@ -48,6 +50,8 @@ export const TaskPrompt: FC<TaskPromptProps> = ({
 	error,
 	onRetry,
 }) => {
+	const navigate = useNavigate();
+
 	if (error) {
 		return <TaskPromptLoadingError error={error} onRetry={onRetry} />;
 	}
@@ -60,8 +64,9 @@ export const TaskPrompt: FC<TaskPromptProps> = ({
 	return (
 		<CreateTaskForm
 			templates={templates}
-			onSuccess={() => {
+			onSuccess={(task) => {
 				displaySuccess("Task created successfully");
+				navigate(linkToTask(task.id));
 			}}
 		/>
 	);

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -66,7 +66,7 @@ export const TaskPrompt: FC<TaskPromptProps> = ({
 			templates={templates}
 			onSuccess={(task) => {
 				displaySuccess("Task created successfully");
-				navigate(linkToTask(task.id));
+				navigate(linkToTask(task.owner_name, task.id));
 			}}
 		/>
 	);


### PR DESCRIPTION
This pull-request addresses an annoyance around task creation. Put simply when creating a Workspace, Template, Group, etc. we always navigate to the created resource after creation. This behaviour was not shared by tasks.