### PR TITLE
fix: render organization group page full-width

### DIFF
--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -103,11 +103,7 @@ const GroupPage: FC = () => {
 		<>
 			{title}
 
-			<Stack
-				alignItems="baseline"
-				direction="row"
-				justifyContent="space-between"
-			>
+			<div className="flex align-baseline justify-between w-full">
 				<SettingsHeader>
 					<SettingsHeaderTitle>
 						{groupData?.display_name || groupData?.name || "Unknown Group"}
@@ -137,9 +133,9 @@ const GroupPage: FC = () => {
 						</Button>
 					</Stack>
 				)}
-			</Stack>
+			</div>
 
-			<Stack spacing={1}>
+			<div className="flex flex-col w-full gap-1">
 				{canUpdateGroup && groupData && !isEveryoneGroup(groupData) && (
 					<AddGroupMember
 						isLoading={addMemberMutation.isPending}
@@ -212,7 +208,7 @@ const GroupPage: FC = () => {
 						)}
 					</TableBody>
 				</Table>
-			</Stack>
+			</div>
 
 			{groupQuery.data && (
 				<DeleteDialog


### PR DESCRIPTION
Addresses some feedback found in #21553 where the width of this page wasn't meeting its true potential. Now we're expanding the content to the full size of the`/organizations/:organisationId/groups/:groupName` route.

| Previously | Now |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d2c5d527-0fdf-44d5-a27c-5992c2fdf6bc" /> | <img src="https://github.com/user-attachments/assets/75c5f460-4ef2-479d-8ed1-5700945dcfa1" /> |
