### PR TITLE
feat: add `organization_icon` to `<TemplatesPageView />`

### DIFF
--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -132,7 +132,7 @@ const TemplateRow: FC<TemplateRowProps> = ({
 				{showOrganizations ? (
 					<AvatarData
 						title={template.organization_display_name}
-						subtitle={Language.developerCount(template.active_user_count)}
+						subtitle={`Used by ${Language.developerCount(template.active_user_count)}`}
 						avatar={<Avatar variant="icon" src={template.organization_icon} />}
 					/>
 				) : (

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -130,19 +130,11 @@ const TemplateRow: FC<TemplateRowProps> = ({
 
 			<TableCell css={styles.secondary}>
 				{showOrganizations ? (
-					<Stack
-						spacing={0}
-						css={{
-							width: "100%",
-						}}
-					>
-						<span css={styles.cellPrimaryLine}>
-							{template.organization_display_name}
-						</span>
-						<span css={styles.cellSecondaryLine}>
-							Used by {Language.developerCount(template.active_user_count)}
-						</span>
-					</Stack>
+					<AvatarData
+						title={template.organization_display_name}
+						subtitle={Language.developerCount(template.active_user_count)}
+						avatar={<Avatar variant="icon" src={template.organization_icon} />}
+					/>
 				) : (
 					Language.developerCount(template.active_user_count)
 				)}


### PR DESCRIPTION
This pull-request adds the `organization_icon` to the `<TemplatesPageView />` table. This is inline with how we tend to render organisations elsewhere (such as breadcrumbs, organization switcher, etc).

<img src="https://github.com/user-attachments/assets/e6c3cec4-5afc-42ae-a289-8346e2835073" />

| Old | New |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f64b4d49-16b0-43b5-9bb0-21eb3c5cf8f0" /> | <img src="https://github.com/user-attachments/assets/7d79d4e2-3d00-4472-a832-14bbbd011245" /> |
