### PR TITLE
feat: add `data-[state=open]` modifiers

### DIFF
--- a/site/src/components/Button/Button.tsx
+++ b/site/src/components/Button/Button.tsx
@@ -25,16 +25,16 @@ const buttonVariants = cva(
 			variant: {
 				default: `
 					border-none bg-surface-invert-primary font-semibold text-content-invert
-					hover:bg-surface-invert-secondary
+					hover:bg-surface-invert-secondary data-[state=open]:bg-surface-invert-secondary
 					disabled:bg-surface-secondary
 					`,
 				outline: `
 					border border-border-default bg-transparent text-content-primary
-					hover:bg-surface-secondary
+					hover:bg-surface-secondary data-[state=open]:bg-surface-secondary
 					`,
 				subtle: `
 					border-none bg-transparent text-content-secondary
-					hover:text-content-primary
+					hover:text-content-primary data-[state=open]:text-content-primary data-[state=open]:bg-surface-secondary
 					`,
 				destructive: `
 					border border-border-destructive font-semibold text-content-primary bg-surface-destructive


### PR DESCRIPTION
> [!WARNING]  
> This is an experimental change, it shouldn't be merged until we've decided this is something we'd like to proceed with.

This pull-request enables that when the state of a button has something attached (i.e a `<Dropdown />` or a `<Popover />`) that we would persist the `hover:` state making it clearer to the user the context of which something is open. This is applied to every button but the `destructive` variant, with the `subtle` variant gaining a `surface-secondary` background.

https://github.com/user-attachments/assets/49e7129e-82c2-4f3b-b092-005b6bb2bb67

