### PR TITLE
fix(site): scroll page to top on sidebar navigation

### DIFF
--- a/site/src/modules/management/DeploymentSettingsLayout.tsx
+++ b/site/src/modules/management/DeploymentSettingsLayout.tsx
@@ -9,13 +9,21 @@ import { Loader } from "components/Loader/Loader";
 import { useAuthenticated } from "hooks";
 import { canViewDeploymentSettings } from "modules/permissions";
 import { RequirePermission } from "modules/permissions/RequirePermission";
-import { type FC, Suspense } from "react";
+import { type FC, Suspense, useEffect, useRef } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
 import { DeploymentSidebar } from "./DeploymentSidebar";
 
 const DeploymentSettingsLayout: FC = () => {
 	const { permissions } = useAuthenticated();
 	const location = useLocation();
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// Reset scroll position when navigating between sub-pages.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on pathname change
+	useEffect(() => {
+		// Scroll the nearest scrollable parent to the top.
+		containerRef.current?.closest(".overflow-y-auto")?.scrollTo(0, 0);
+	}, [location.pathname]);
 
 	if (location.pathname === "/deployment") {
 		return (
@@ -36,7 +44,7 @@ const DeploymentSettingsLayout: FC = () => {
 
 	return (
 		<RequirePermission isFeatureVisible={canViewDeploymentSettingsPage}>
-			<div>
+			<div ref={containerRef}>
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem>

--- a/site/src/modules/management/OrganizationSidebarLayout.tsx
+++ b/site/src/modules/management/OrganizationSidebarLayout.tsx
@@ -1,13 +1,25 @@
 import { Loader } from "components/Loader/Loader";
-import { type FC, Suspense } from "react";
-import { Outlet } from "react-router";
+import { type FC, Suspense, useEffect, useRef } from "react";
+import { Outlet, useLocation } from "react-router";
 import { OrganizationSidebar } from "./OrganizationSidebar";
 
 const OrganizationSidebarLayout: FC = () => {
+	const location = useLocation();
+	const mainRef = useRef<HTMLElement>(null);
+
+	// Reset scroll position when navigating between sub-pages.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on pathname change
+	useEffect(() => {
+		mainRef.current?.scrollTo(0, 0);
+	}, [location.pathname]);
+
 	return (
 		<div className="flex flex-row flex-1 min-h-0 w-full">
 			<OrganizationSidebar />
-			<main className="flex flex-col items-center flex-1 min-h-0 h-full overflow-y-auto w-full px-10 pt-10">
+			<main
+				ref={mainRef}
+				className="flex flex-col items-center flex-1 min-h-0 h-full overflow-y-auto w-full px-10 pt-10"
+			>
 				<Suspense fallback={<Loader />}>
 					<Outlet />
 				</Suspense>

--- a/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
@@ -2,7 +2,7 @@ import type { Interpolation, Theme } from "@emotion/react";
 import type { TemplateExample } from "api/typesGenerated";
 import { Stack } from "components/Stack/Stack";
 import { TemplateExampleCard } from "modules/templates/TemplateExampleCard/TemplateExampleCard";
-import type { FC } from "react";
+import { type FC, useEffect, useRef } from "react";
 import { Link, useSearchParams } from "react-router";
 import type { StarterTemplatesByTag } from "utils/starterTemplates";
 
@@ -55,6 +55,7 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 	starterTemplatesByTag,
 }) => {
 	const [urlParams] = useSearchParams();
+	const containerRef = useRef<HTMLDivElement>(null);
 	const tags = starterTemplatesByTag
 		? selectTags(starterTemplatesByTag)
 		: undefined;
@@ -63,8 +64,19 @@ export const StarterTemplates: FC<StarterTemplatesProps> = ({
 		? sortVisibleTemplates(starterTemplatesByTag[activeTag])
 		: undefined;
 
+	// Reset scroll position when changing filter tags.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on tag change
+	useEffect(() => {
+		containerRef.current?.closest(".overflow-y-auto")?.scrollTo(0, 0);
+	}, [activeTag]);
+
 	return (
-		<Stack direction="row" spacing={4} alignItems="flex-start">
+		<Stack
+			ref={containerRef}
+			direction="row"
+			spacing={4}
+			alignItems="flex-start"
+		>
 			{starterTemplatesByTag && tags && (
 				<Stack css={{ width: 202, flexShrink: 0, position: "sticky" }}>
 					<h2 css={styles.sectionTitle}>Choose a starter template</h2>


### PR DESCRIPTION
When navigating between sub-pages using the sidebar in /organizations, /deployment, and /starter-templates, the page now scrolls to the top instead of maintaining the previous scroll position.

## Problem

Navigating between sub-pages or clicking filter links in the sidebar areas didn't reset the scroll position. When users scrolled down on one page and clicked a sidebar link to navigate to another page or filter, the new content would appear at the same scroll position rather than at the top.

## Fix

Added scroll restoration logic to the affected layouts and components:

- **OrganizationSidebarLayout**: Uses a ref to the scrollable `<main>` element (which has `overflow-y-auto`) and scrolls it to top when the pathname changes.
- **DeploymentSettingsLayout**: Uses a ref to find the nearest scrollable parent (the `overflow-y-auto` container from DashboardLayout) and scrolls it to top when the pathname changes.
- **StarterTemplates**: Uses a ref to find the nearest scrollable parent and scrolls it to top when the active filter tag changes.

All implementations use `useEffect` with the relevant dependency (pathname or filter tag) to trigger the scroll reset on navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)