### PR TITLE
test(site): add tests for OAuth2 app form query parameter autofill

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/CreateOAuth2AppPage.test.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/CreateOAuth2AppPage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { vi } from "vitest";
+import CreateOAuth2AppPage from "./CreateOAuth2AppPage";
+
+// Mock the GlobalSnackbar utils to prevent side effects
+vi.mock("components/GlobalSnackbar/utils", () => ({
+	displayError: vi.fn(),
+	displaySuccess: vi.fn(),
+}));
+
+describe("CreateOAuth2AppPage", () => {
+	const renderWithRouter = (initialEntry: string) => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+
+		const router = createMemoryRouter(
+			[
+				{
+					path: "/deployment/oauth2-provider/apps/add",
+					element: <CreateOAuth2AppPage />,
+				},
+			],
+			{
+				initialEntries: [initialEntry],
+			},
+		);
+
+		return render(
+			<QueryClientProvider client={queryClient}>
+				<RouterProvider router={router} />
+			</QueryClientProvider>,
+		);
+	};
+
+	it("pre-fills form fields from URL query parameters", async () => {
+		renderWithRouter(
+			"/deployment/oauth2-provider/apps/add?name=TestApp&callback_url=https://test.com/callback&icon=/icon/test.svg",
+		);
+
+		await waitFor(() => {
+			const nameInput = screen.getByLabelText("Application name");
+			expect(nameInput).toHaveValue("TestApp");
+		});
+
+		const callbackInput = screen.getByLabelText("Callback URL");
+		const iconInput = screen.getByLabelText("Application icon");
+
+		expect(callbackInput).toHaveValue("https://test.com/callback");
+		expect(iconInput).toHaveValue("/icon/test.svg");
+	});
+
+	it("renders with empty fields when no query parameters provided", async () => {
+		renderWithRouter("/deployment/oauth2-provider/apps/add");
+
+		await waitFor(() => {
+			const nameInput = screen.getByLabelText("Application name");
+			expect(nameInput).toHaveValue("");
+		});
+
+		const callbackInput = screen.getByLabelText("Callback URL");
+		const iconInput = screen.getByLabelText("Application icon");
+
+		expect(callbackInput).toHaveValue("");
+		expect(iconInput).toHaveValue("");
+	});
+
+	it("handles URL-encoded callback URLs correctly", async () => {
+		const encodedCallbackUrl = encodeURIComponent(
+			"https://example.com/callback?state=123",
+		);
+		renderWithRouter(
+			`/deployment/oauth2-provider/apps/add?name=MyApp&callback_url=${encodedCallbackUrl}`,
+		);
+
+		await waitFor(() => {
+			const nameInput = screen.getByLabelText("Application name");
+			expect(nameInput).toHaveValue("MyApp");
+		});
+
+		const callbackInput = screen.getByLabelText("Callback URL");
+		expect(callbackInput).toHaveValue("https://example.com/callback?state=123");
+	});
+});

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppForm.test.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppForm.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { OAuth2AppForm } from "./OAuth2AppForm";
+
+describe("OAuth2AppForm", () => {
+	it("renders with empty fields when no props provided", () => {
+		render(<OAuth2AppForm onSubmit={() => {}} isUpdating={false} />);
+
+		const nameInput = screen.getByLabelText("Application name");
+		const callbackInput = screen.getByLabelText("Callback URL");
+		const iconInput = screen.getByLabelText("Application icon");
+
+		expect(nameInput).toHaveValue("");
+		expect(callbackInput).toHaveValue("");
+		expect(iconInput).toHaveValue("");
+	});
+
+	it("renders with defaultValues when provided", () => {
+		const defaultValues = {
+			name: "Test App",
+			callback_url: "https://example.com/callback",
+			icon: "/icon/test.svg",
+		};
+
+		render(
+			<OAuth2AppForm
+				onSubmit={() => {}}
+				isUpdating={false}
+				defaultValues={defaultValues}
+			/>,
+		);
+
+		const nameInput = screen.getByLabelText("Application name");
+		const callbackInput = screen.getByLabelText("Callback URL");
+		const iconInput = screen.getByLabelText("Application icon");
+
+		expect(nameInput).toHaveValue("Test App");
+		expect(callbackInput).toHaveValue("https://example.com/callback");
+		expect(iconInput).toHaveValue("/icon/test.svg");
+	});
+
+	it("prefers app values over defaultValues when both provided", () => {
+		const app = {
+			id: "test-id",
+			name: "App Name",
+			callback_url: "https://app.com/callback",
+			icon: "/icon/app.svg",
+			endpoints: {
+				authorization: "",
+				token: "",
+				device_authorization: "",
+			},
+		};
+
+		const defaultValues = {
+			name: "Default Name",
+			callback_url: "https://default.com/callback",
+			icon: "/icon/default.svg",
+		};
+
+		render(
+			<OAuth2AppForm
+				app={app}
+				onSubmit={() => {}}
+				isUpdating={false}
+				defaultValues={defaultValues}
+			/>,
+		);
+
+		const nameInput = screen.getByLabelText("Application name");
+		const callbackInput = screen.getByLabelText("Callback URL");
+		const iconInput = screen.getByLabelText("Application icon");
+
+		// Should use app values, not default values
+		expect(nameInput).toHaveValue("App Name");
+		expect(callbackInput).toHaveValue("https://app.com/callback");
+		expect(iconInput).toHaveValue("/icon/app.svg");
+	});
+});


### PR DESCRIPTION
## Summary

Adds tests to verify the query parameter autofill functionality works correctly for the OAuth2 app creation page.

## Changes

- **OAuth2AppForm.test.tsx**: Tests that the form component correctly handles:
  - Empty fields when no props provided
  - Pre-filled fields when `defaultValues` prop is provided
  - Preference for `app` values over `defaultValues` when both are provided

- **CreateOAuth2AppPage.test.tsx**: Tests that the page component correctly:
  - Reads query parameters from the URL (`name`, `callback_url`, `icon`)
  - Pre-fills the form fields with query parameter values
  - Handles URL-encoded callback URLs correctly

## Testing

All 6 tests pass:
```
✓ src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppForm.test.tsx (3 tests)
✓ src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/CreateOAuth2AppPage.test.tsx (3 tests)
```

These tests verify that the feature added in #21821 works correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new frontend unit tests only; no production logic changes, with low risk limited to potential test flakiness due to routing/query-client setup.
> 
> **Overview**
> Adds new unit tests covering OAuth2 app creation form autofill behavior.
> 
> `CreateOAuth2AppPage.test.tsx` verifies `name`, `callback_url`, and `icon` are pre-populated from URL query params (including URL-encoded callback URLs) and remain empty when params are absent, with `GlobalSnackbar` mocked to avoid side effects. `OAuth2AppForm.test.tsx` validates default rendering, use of `defaultValues`, and that `app` props take precedence over `defaultValues`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 055a6b2788233858a4b4bae7bfff9b5a77e5f96a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->