### PR TITLE
fix(site): use native thin scrollbar style for admin bar

### DIFF
--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -104,7 +104,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 		<div
 			className="sticky bottom-0 z-[1] flex h-9 w-full items-center gap-8
 		 		overflow-x-auto whitespace-nowrap border-0 border-t border-solid border-border
-				bg-surface-primary pr-4 font-mono text-xs leading-none"
+				bg-surface-primary pr-4 font-mono text-xs leading-none [scrollbar-width:thin]"
 		>
 			<TooltipProvider delayDuration={100}>
 				<Tooltip>


### PR DESCRIPTION
## Summary

The bottom admin bar (DeploymentBannerView) was showing a thick scrollbar when content overflowed horizontally. This change applies the native thin scrollbar style instead.

## Changes

- Added `[scrollbar-width:thin]` Tailwind CSS arbitrary value to the deployment banner container

This uses the native CSS `scrollbar-width: thin` property which is supported in modern browsers (Firefox, Chrome, Edge, Safari) and provides a less obtrusive scrollbar when horizontal scrolling is needed.

## Testing

- The change is purely CSS and was verified with lint and format checks passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a CSS styling tweak with no behavioral, data, or security impact; risk is limited to minor cross-browser appearance differences.
> 
> **Overview**
> Updates the dashboard `DeploymentBannerView` bottom admin bar styling to use the native CSS `scrollbar-width: thin` via Tailwind (`[scrollbar-width:thin]`), reducing scrollbar thickness when the banner overflows horizontally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba36e48d66eb5a2cfcdfe53eb8acebdfafbe3be4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->