### PR TITLE
fix(site): filter build timeline events by agent ID

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/StagesChart.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/StagesChart.tsx
@@ -42,6 +42,11 @@ export type Stage = {
 	 */
 	section: string;
 	/**
+	 * The agent ID for agent-related stages. Used to filter timings correctly
+	 * when multiple agents exist.
+	 */
+	agentId?: string;
+	/**
 	 * The tooltip is used to provide additional information about the stage.
 	 */
 	tooltip: {
@@ -268,12 +273,13 @@ export const provisioningStages: Stage[] = [
 	},
 ];
 
-export const agentStages = (section: string): Stage[] => {
+export const agentStages = (section: string, agentId: string): Stage[] => {
 	return [
 		{
 			name: "connect",
 			label: "connect",
 			section,
+			agentId,
 			tooltip: {
 				heading: "Connect",
 				description: "Establish an RPC connection with the control plane.",
@@ -283,6 +289,7 @@ export const agentStages = (section: string): Stage[] => {
 			name: "start",
 			label: "run startup scripts",
 			section,
+			agentId,
 			tooltip: {
 				heading: "Run startup scripts",
 				description: "Execute each agent startup script.",

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -285,7 +285,7 @@ export const InvalidTimeRange: Story = {
 export const MultipleAgents: Story = {
 	decorators: [
 		(Story) => (
-			<div css={{ "--collapse-body-height": "600px" }}>
+			<div style={{ "--collapse-body-height": "600px" } as React.CSSProperties}>
 				<Story />
 			</div>
 		),

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -278,6 +278,133 @@ export const InvalidTimeRange: Story = {
 	},
 };
 
+// Test case for multiple agents (e.g., main + devcontainer) where each agent
+// should only show its own timings, not duplicated across all agents.
+export const MultipleAgents: Story = {
+	decorators: [
+		(Story) => (
+			<div css={{ "--collapse-body-height": "600px" }}>
+				<Story />
+			</div>
+		),
+	],
+	args: {
+		provisionerTimings: [
+			{
+				job_id: "fb0a0941-5052-4f8b-8046-64da139220cd",
+				started_at: "2026-02-02T08:34:16.067798Z",
+				ended_at: "2026-02-02T08:34:16.626888Z",
+				stage: "init",
+				source: "coder",
+				action: "terraform",
+				resource: "coder_stage_init",
+			},
+			{
+				job_id: "fb0a0941-5052-4f8b-8046-64da139220cd",
+				started_at: "2026-02-02T08:34:16.649547Z",
+				ended_at: "2026-02-02T08:34:18.65871Z",
+				stage: "plan",
+				source: "coder",
+				action: "terraform",
+				resource: "coder_stage_plan",
+			},
+			{
+				job_id: "fb0a0941-5052-4f8b-8046-64da139220cd",
+				started_at: "2026-02-02T08:34:18.722631Z",
+				ended_at: "2026-02-02T08:34:21.332458Z",
+				stage: "apply",
+				source: "coder",
+				action: "terraform",
+				resource: "coder_stage_apply",
+			},
+			{
+				job_id: "fb0a0941-5052-4f8b-8046-64da139220cd",
+				started_at: "2026-02-02T08:34:21.698283Z",
+				ended_at: "2026-02-02T08:34:22.014735Z",
+				stage: "graph",
+				source: "coder",
+				action: "terraform",
+				resource: "coder_stage_graph",
+			},
+		],
+		agentConnectionTimings: [
+			{
+				started_at: "2026-02-02T08:34:22.092544Z",
+				ended_at: "2026-02-02T08:34:23.090936Z",
+				stage: "connect",
+				workspace_agent_id: "a1d50955-a671-4e6c-8e0e-6bc938e931bf",
+				workspace_agent_name: "dev",
+			},
+			{
+				started_at: "2026-02-02T08:34:50.171921Z",
+				ended_at: "2026-02-02T08:34:51.36274Z",
+				stage: "connect",
+				workspace_agent_id: "afbdd368-b7b8-453e-af5a-02b13bc45553",
+				workspace_agent_name: "coder",
+			},
+		],
+		agentScriptTimings: [
+			{
+				started_at: "2026-02-02T08:34:23.745887Z",
+				ended_at: "2026-02-02T08:34:25.23973Z",
+				exit_code: 0,
+				stage: "start",
+				status: "ok",
+				display_name: "Installing Dependencies",
+				workspace_agent_id: "a1d50955-a671-4e6c-8e0e-6bc938e931bf",
+				workspace_agent_name: "dev",
+			},
+			{
+				started_at: "2026-02-02T08:34:23.743853Z",
+				ended_at: "2026-02-02T08:34:23.809943Z",
+				exit_code: 0,
+				stage: "start",
+				status: "ok",
+				display_name: "Git Clone",
+				workspace_agent_id: "a1d50955-a671-4e6c-8e0e-6bc938e931bf",
+				workspace_agent_name: "dev",
+			},
+			{
+				started_at: "2026-02-02T08:34:23.74382Z",
+				ended_at: "2026-02-02T08:34:40.822488Z",
+				exit_code: 0,
+				stage: "start",
+				status: "ok",
+				display_name: "code-server",
+				workspace_agent_id: "a1d50955-a671-4e6c-8e0e-6bc938e931bf",
+				workspace_agent_name: "dev",
+			},
+			// Same display_name as dev agent to test dedup scoping by agent ID.
+			{
+				started_at: "2026-02-02T08:34:51.5Z",
+				ended_at: "2026-02-02T08:34:53.2Z",
+				exit_code: 0,
+				stage: "start",
+				status: "ok",
+				display_name: "Installing Dependencies",
+				workspace_agent_id: "afbdd368-b7b8-453e-af5a-02b13bc45553",
+				workspace_agent_name: "coder",
+			},
+			{
+				started_at: "2026-02-02T08:34:53.3Z",
+				ended_at: "2026-02-02T08:34:55.1Z",
+				exit_code: 0,
+				stage: "start",
+				status: "ok",
+				display_name: "Personalize",
+				workspace_agent_id: "afbdd368-b7b8-453e-af5a-02b13bc45553",
+				workspace_agent_name: "coder",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Verify both agents are shown
+		await canvas.findByText("agent (dev)");
+		await canvas.findByText("agent (coder)");
+	},
+};
+
 // A template with no agent scripts.
 export const NoAgentScripts: Story = {
 	args: {

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -273,6 +273,8 @@ export const InvalidTimeRange: Story = {
 				display_name: "Startup Script 1",
 				started_at: "0001-01-01T00:00:00Z",
 				ended_at: "2025-01-01T00:10:00Z",
+				workspace_agent_id: "67e37a9d-ccac-497e-8f48-4093bcc4f3e7",
+				workspace_agent_name: "main",
 			},
 		],
 	},

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -285,7 +285,7 @@ export const InvalidTimeRange: Story = {
 export const MultipleAgents: Story = {
 	decorators: [
 		(Story) => (
-			<div style={{ "--collapse-body-height": "600px" } as React.CSSProperties}>
+			<div css={{ "--collapse-body-height": "600px" }}>
 				<Story />
 			</div>
 		),

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -1,4 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
 import Collapse from "@mui/material/Collapse";
 import Skeleton from "@mui/material/Skeleton";
 import type {
@@ -6,7 +5,6 @@ import type {
 	AgentScriptTiming,
 	ProvisionerTiming,
 } from "api/typesGenerated";
-import { Button } from "components/Button/Button";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
@@ -100,35 +98,30 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 	};
 
 	return (
-		<div css={styles.collapse}>
-			<Button
+		<div className="rounded-lg border border-border bg-surface-primary">
+			<button
+				type="button"
 				disabled={isLoading}
-				variant="subtle"
-				css={styles.collapseTrigger}
+				className="flex items-center p-4 w-full bg-transparent border-0 text-content-secondary text-sm leading-none font-medium cursor-pointer"
 				onClick={() => setIsOpen((o) => !o)}
 			>
 				{isOpen ? (
-					<ChevronUpIcon css={{ width: 16, height: 16, marginRight: 16 }} />
+					<ChevronUpIcon className="size-4 mr-4" />
 				) : (
-					<ChevronDownIcon css={{ width: 16, height: 16, marginRight: 16 }} />
+					<ChevronDownIcon className="size-4 mr-4" />
 				)}
 				<span>Build timeline</span>
-				<span
-					css={(theme) => ({
-						marginLeft: "auto",
-						color: theme.palette.text.secondary,
-					})}
-				>
+				<span className="ml-auto">
 					{isLoading ? (
 						<Skeleton variant="text" width={40} height={16} />
 					) : (
 						displayProvisioningTime()
 					)}
 				</span>
-			</Button>
+			</button>
 			{!isLoading && (
 				<Collapse in={isOpen}>
-					<div css={styles.collapseBody}>
+					<div className="border-t border-border flex flex-col h-[var(--collapse-body-height,420px)]">
 						{view.name === "default" && (
 							<StagesChart
 								timings={stages.map((s) => {
@@ -255,30 +248,3 @@ const _humanizeDuration = (durationMs: number): string => {
 
 	return `${seconds.toLocaleString()}s`;
 };
-
-const styles = {
-	collapse: (theme) => ({
-		borderRadius: 8,
-		border: `1px solid ${theme.palette.divider}`,
-		backgroundColor: theme.palette.background.default,
-	}),
-	collapseTrigger: {
-		background: "none",
-		border: 0,
-		padding: 16,
-		color: "inherit",
-		width: "100%",
-		display: "flex",
-		alignItems: "center",
-		height: 57,
-		fontSize: 14,
-		fontWeight: 500,
-		cursor: "pointer",
-	},
-	collapseBody: (theme) => ({
-		borderTop: `1px solid ${theme.palette.divider}`,
-		display: "flex",
-		flexDirection: "column",
-		height: "var(--collapse-body-height, 420px)",
-	}),
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -1,3 +1,4 @@
+import type { Interpolation, Theme } from "@emotion/react";
 import Collapse from "@mui/material/Collapse";
 import Skeleton from "@mui/material/Skeleton";
 import type {
@@ -5,6 +6,7 @@ import type {
 	AgentScriptTiming,
 	ProvisionerTiming,
 } from "api/typesGenerated";
+import { Button } from "components/Button/Button";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
@@ -98,30 +100,35 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 	};
 
 	return (
-		<div className="rounded-lg border border-border bg-surface-primary">
-			<button
-				type="button"
+		<div css={styles.collapse}>
+			<Button
 				disabled={isLoading}
-				className="flex items-center p-4 w-full bg-transparent border-0 text-content-secondary text-sm leading-none font-medium cursor-pointer"
+				variant="subtle"
+				css={styles.collapseTrigger}
 				onClick={() => setIsOpen((o) => !o)}
 			>
 				{isOpen ? (
-					<ChevronUpIcon className="size-4 mr-4" />
+					<ChevronUpIcon css={{ width: 16, height: 16, marginRight: 16 }} />
 				) : (
-					<ChevronDownIcon className="size-4 mr-4" />
+					<ChevronDownIcon css={{ width: 16, height: 16, marginRight: 16 }} />
 				)}
 				<span>Build timeline</span>
-				<span className="ml-auto">
+				<span
+					css={(theme) => ({
+						marginLeft: "auto",
+						color: theme.palette.text.secondary,
+					})}
+				>
 					{isLoading ? (
 						<Skeleton variant="text" width={40} height={16} />
 					) : (
 						displayProvisioningTime()
 					)}
 				</span>
-			</button>
+			</Button>
 			{!isLoading && (
 				<Collapse in={isOpen}>
-					<div className="border-t border-border flex flex-col h-[var(--collapse-body-height,420px)]">
+					<div css={styles.collapseBody}>
 						{view.name === "default" && (
 							<StagesChart
 								timings={stages.map((s) => {
@@ -248,3 +255,30 @@ const _humanizeDuration = (durationMs: number): string => {
 
 	return `${seconds.toLocaleString()}s`;
 };
+
+const styles = {
+	collapse: (theme) => ({
+		borderRadius: 8,
+		border: `1px solid ${theme.palette.divider}`,
+		backgroundColor: theme.palette.background.default,
+	}),
+	collapseTrigger: {
+		background: "none",
+		border: 0,
+		padding: 16,
+		color: "inherit",
+		width: "100%",
+		display: "flex",
+		alignItems: "center",
+		height: 57,
+		fontSize: 14,
+		fontWeight: 500,
+		cursor: "pointer",
+	},
+	collapseBody: (theme) => ({
+		borderTop: `1px solid ${theme.palette.divider}`,
+		display: "flex",
+		flexDirection: "column",
+		height: "var(--collapse-body-height, 420px)",
+	}),
+} satisfies Record<string, Interpolation<Theme>>;


### PR DESCRIPTION
When a workspace has multiple agents (e.g., main + devcontainer), the
build timeline was showing all events duplicated under each agent
instead of filtering by the agent they belong to.

Added agentId to the Stage type and filter timings by workspace_agent_id
so each agent section only shows its own events.

Fixes #18002

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-5` • Cost: ~`$11.48`~ `$21.48`_