### PR TITLE
ci: split lint-actions into separate job to reduce flakes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -997,6 +997,7 @@ jobs:
       - changes
       - fmt
       - lint
+      - lint-actions
       - gen
       - test-go-pg
       - test-go-pg-17
@@ -1021,6 +1022,7 @@ jobs:
           echo "- changes: ${{ needs.changes.result }}"
           echo "- fmt: ${{ needs.fmt.result }}"
           echo "- lint: ${{ needs.lint.result }}"
+          echo "- lint-actions: ${{ needs.lint-actions.result }}"
           echo "- gen: ${{ needs.gen.result }}"
           echo "- test-go-pg: ${{ needs.test-go-pg.result }}"
           echo "- test-go-pg-17: ${{ needs.test-go-pg-17.result }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,13 +225,7 @@ jobs:
         run: helm version --short
 
       - name: make lint
-        run: |
-          # zizmor isn't included in the lint target because it takes a while,
-          # but we explicitly want to run it in CI.
-          make --output-sync=line -j lint lint/actions/zizmor
-        env:
-          # Used by zizmor to lint third-party GitHub actions.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make --output-sync=line -j lint
 
       - name: Check workflow files
         run: |
@@ -244,6 +238,30 @@ jobs:
           rm -f ./actionlint ./typos
           ./scripts/check_unstaged.sh
         shell: bash
+
+  lint-actions:
+    needs: changes
+    if: needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: make lint/actions
+        run: make --output-sync=line -j lint/actions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   gen:
     timeout-minutes: 20

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,6 +261,7 @@ jobs:
       - name: make lint/actions
         run: make --output-sync=line -j lint/actions
         env:
+          # Used by zizmor to lint third-party GitHub actions.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   gen:

--- a/Makefile
+++ b/Makefile
@@ -562,9 +562,11 @@ else
 endif
 .PHONY: fmt/markdown
 
-# Note: we don't run zizmor in the lint target because it takes a while. CI
-#       runs it explicitly.
-lint: lint/shellcheck lint/go lint/ts lint/examples lint/helm lint/site-icons lint/markdown lint/actions/actionlint lint/check-scopes lint/migrations
+# Note: we don't run zizmor in the lint target because it takes a while.
+# GitHub Actions linters are run in a separate CI job (lint-actions) that only
+# triggers when workflow files change, so we skip them here when CI=true.
+LINT_ACTIONS_TARGETS := $(if $(CI),,lint/actions/actionlint)
+lint: lint/shellcheck lint/go lint/ts lint/examples lint/helm lint/site-icons lint/markdown lint/check-scopes lint/migrations $(LINT_ACTIONS_TARGETS)
 .PHONY: lint
 
 lint/site-icons:


### PR DESCRIPTION
## Summary

The `lint/actions/zizmor` target flakes in CI due to network connectivity issues when running on depot runners (https://github.com/coder/internal/issues/1233). The zizmor tool needs to reach GitHub's API but intermittently fails with "Connection refused" errors.

## Changes

- Creates a new `lint-actions` CI job that only runs when `.github/**` files are touched (using existing `ci` filter)
- Removes zizmor from the main `lint` job  
- Uses a Makefile conditional to include actionlint in `make lint` locally but skip it in CI (where `lint-actions` handles it)

This reduces unnecessary flake exposure for PRs that don't modify GitHub Actions files.

## Testing

- `actionlint` passes on the modified ci.yaml
- Verified Makefile conditional works: actionlint included locally, skipped when `CI=true`

Fixes https://github.com/coder/internal/issues/1233