### PR TITLE
chore: deprecate CODER_SSH_HOSTNAME_PREFIX in favor of CODER_WORKSPACE_HOSTNAME_SUFFIX

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -215,9 +215,6 @@ Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
           commas.Using this incorrectly can break SSH to your deployment, use
           cautiously.
 
-      --ssh-hostname-prefix string, $CODER_SSH_HOSTNAME_PREFIX (default: coder.)
-          The SSH deployment prefix is used in the Host of the ssh config.
-
       --web-terminal-renderer string, $CODER_WEB_TERMINAL_RENDERER (default: canvas)
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -523,7 +523,8 @@ disableWorkspaceSharing: false
 # These options change the behavior of how clients interact with the Coder.
 # Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 client:
-  # The SSH deployment prefix is used in the Host of the ssh config.
+  # Deprecated: use workspace-hostname-suffix instead. The SSH deployment prefix is
+  # used in the Host of the ssh config.
   # (default: coder., type: string)
   sshHostnamePrefix: coder.
   # Workspace hostnames use this suffix in SSH config and Coder Connect on Coder

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1549,6 +1549,17 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		Group:       &deploymentGroupTelemetry,
 		YAML:        "enable",
 	}
+	workspaceHostnameSuffix := serpent.Option{
+		Name:        "Workspace Hostname Suffix",
+		Description: "Workspace hostnames use this suffix in SSH config and Coder Connect on Coder Desktop. By default it is coder, resulting in names like myworkspace.coder.",
+		Flag:        "workspace-hostname-suffix",
+		Env:         "CODER_WORKSPACE_HOSTNAME_SUFFIX",
+		YAML:        "workspaceHostnameSuffix",
+		Group:       &deploymentGroupClient,
+		Value:       &c.WorkspaceHostnameSuffix,
+		Hidden:      false,
+		Default:     "coder",
+	}
 	opts := serpent.OptionSet{
 		{
 			Name:        "Access URL",
@@ -2973,26 +2984,17 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "SSH Host Prefix",
-			Description: "The SSH deployment prefix is used in the Host of the ssh config.",
+			Description: "Deprecated: use workspace-hostname-suffix instead. The SSH deployment prefix is used in the Host of the ssh config.",
 			Flag:        "ssh-hostname-prefix",
 			Env:         "CODER_SSH_HOSTNAME_PREFIX",
 			YAML:        "sshHostnamePrefix",
 			Group:       &deploymentGroupClient,
 			Value:       &c.SSHConfig.DeploymentName,
-			Hidden:      false,
+			Hidden:      true,
 			Default:     "coder.",
+			UseInstead:  serpent.OptionSet{workspaceHostnameSuffix},
 		},
-		{
-			Name:        "Workspace Hostname Suffix",
-			Description: "Workspace hostnames use this suffix in SSH config and Coder Connect on Coder Desktop. By default it is coder, resulting in names like myworkspace.coder.",
-			Flag:        "workspace-hostname-suffix",
-			Env:         "CODER_WORKSPACE_HOSTNAME_SUFFIX",
-			YAML:        "workspaceHostnameSuffix",
-			Group:       &deploymentGroupClient,
-			Value:       &c.WorkspaceHostnameSuffix,
-			Hidden:      false,
-			Default:     "coder",
-		},
+		workspaceHostnameSuffix,
 		{
 			Name: "SSH Config Options",
 			Description: "These SSH config options will override the default SSH config options. " +

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1198,17 +1198,6 @@ Disable password authentication. This is recommended for security purposes in pr
 
 Specify a YAML file to load configuration from.
 
-### --ssh-hostname-prefix
-
-|             |                                         |
-|-------------|-----------------------------------------|
-| Type        | <code>string</code>                     |
-| Environment | <code>$CODER_SSH_HOSTNAME_PREFIX</code> |
-| YAML        | <code>client.sshHostnamePrefix</code>   |
-| Default     | <code>coder.</code>                     |
-
-The SSH deployment prefix is used in the Host of the ssh config.
-
 ### --workspace-hostname-suffix
 
 |             |                                               |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -216,9 +216,6 @@ Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
           commas.Using this incorrectly can break SSH to your deployment, use
           cautiously.
 
-      --ssh-hostname-prefix string, $CODER_SSH_HOSTNAME_PREFIX (default: coder.)
-          The SSH deployment prefix is used in the Host of the ssh config.
-
       --web-terminal-renderer string, $CODER_WEB_TERMINAL_RENDERER (default: canvas)
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.


### PR DESCRIPTION
## Description

Mark `--ssh-hostname-prefix` flag and `CODER_SSH_HOSTNAME_PREFIX` env variable as deprecated, recommending users to use `--workspace-hostname-suffix` / `CODER_WORKSPACE_HOSTNAME_SUFFIX` instead for consistency with Coder Desktop.

The deprecated option is now hidden from help output and docs but remains functional for backward compatibility. When used, it will show a deprecation warning pointing to the recommended alternative.

## Changes

- Added `UseInstead` pointing to `workspace-hostname-suffix` option (triggers deprecation warning)
- Set `Hidden: true` to hide from CLI help and documentation
- Updated description to mention deprecation
- Regenerated docs and help files via `make gen`

Closes #18156

---

_Originally requested by @matifali in https://github.com/coder/coder/pull/18085#discussion_r2115594447_