### PR TITLE
perf: improve memory use and cpu usage for OpenAI requests handled by bridge

### DIFF
--- a/cli/exp_scaletest_bridge.go
+++ b/cli/exp_scaletest_bridge.go
@@ -49,6 +49,9 @@ Examples:
   # Test OpenAI API through bridge
   coder scaletest bridge --mode bridge --provider openai --concurrent-users 10 --request-count 5 --num-messages 10
 
+  # Test OpenAI Responses API through bridge
+  coder scaletest bridge --mode bridge --provider responses --concurrent-users 10 --request-count 5 --num-messages 10
+
   # Test Anthropic API through bridge
   coder scaletest bridge --mode bridge --provider anthropic --concurrent-users 10 --request-count 5 --num-messages 10
 
@@ -219,9 +222,9 @@ Examples:
 		{
 			Flag:        "provider",
 			Env:         "CODER_SCALETEST_BRIDGE_PROVIDER",
-			Default:     "openai",
+			Required:    true,
 			Description: "API provider to use.",
-			Value:       serpent.EnumOf(&provider, "openai", "anthropic"),
+			Value:       serpent.EnumOf(&provider, "completions", "messages", "responses"),
 		},
 		{
 			Flag:        "request-count",

--- a/cli/exp_scaletest_llmmock.go
+++ b/cli/exp_scaletest_llmmock.go
@@ -62,6 +62,7 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 
 			_, _ = fmt.Fprintf(inv.Stdout, "Mock LLM API server started on %s\n", srv.APIAddress())
 			_, _ = fmt.Fprintf(inv.Stdout, "  OpenAI endpoint: %s/v1/chat/completions\n", srv.APIAddress())
+			_, _ = fmt.Fprintf(inv.Stdout, "  OpenAI responses endpoint: %s/v1/responses\n", srv.APIAddress())
 			_, _ = fmt.Fprintf(inv.Stdout, "  Anthropic endpoint: %s/v1/messages\n", srv.APIAddress())
 
 			<-ctx.Done()

--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b
+	github.com/coder/aibridge v1.0.1-0.20260202135542-9e2857aaac8f
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.6.0
 	github.com/coder/preview v1.0.4

--- a/go.mod
+++ b/go.mod
@@ -594,7 +594,3 @@ tool (
 replace github.com/anthropics/anthropic-sdk-go v1.19.0 => github.com/dannykopping/anthropic-sdk-go v0.0.0-20251230111224-88a4315810bd
 
 replace github.com/openai/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250
-
-// replace github.com/openai/openai-go/v3 => ../openai-go
-
-// replace github.com/coder/aibridge => ../aibridge

--- a/go.mod
+++ b/go.mod
@@ -592,3 +592,5 @@ tool (
 )
 
 replace github.com/anthropics/anthropic-sdk-go v1.19.0 => github.com/dannykopping/anthropic-sdk-go v0.0.0-20251230111224-88a4315810bd
+
+replace github.com/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250

--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.0.0
+	github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.6.0
 	github.com/coder/preview v1.0.4

--- a/go.mod
+++ b/go.mod
@@ -593,4 +593,4 @@ tool (
 
 replace github.com/anthropics/anthropic-sdk-go v1.19.0 => github.com/dannykopping/anthropic-sdk-go v0.0.0-20251230111224-88a4315810bd
 
-replace github.com/openai/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250
+replace github.com/openai/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260202093810-72af3b857f95

--- a/go.mod
+++ b/go.mod
@@ -591,6 +591,9 @@ tool (
 	storj.io/drpc/cmd/protoc-gen-go-drpc
 )
 
+// Replace sdks with our own optimized forks until relevant upstream PRs are merged.
+// https://github.com/anthropics/anthropic-sdk-go/pull/262
 replace github.com/anthropics/anthropic-sdk-go v1.19.0 => github.com/dannykopping/anthropic-sdk-go v0.0.0-20251230111224-88a4315810bd
 
+// https://github.com/openai/openai-go/pull/602
 replace github.com/openai/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260202093810-72af3b857f95

--- a/go.mod
+++ b/go.mod
@@ -593,4 +593,8 @@ tool (
 
 replace github.com/anthropics/anthropic-sdk-go v1.19.0 => github.com/dannykopping/anthropic-sdk-go v0.0.0-20251230111224-88a4315810bd
 
-replace github.com/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250
+replace github.com/openai/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250
+
+// replace github.com/openai/openai-go/v3 => ../openai-go
+
+// replace github.com/coder/aibridge => ../aibridge

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,6 @@ github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.0 h1:gQYJ8Q83tnfWKqObu9DR4mNFTh4uTwq1rkRtuqO3x20=
-github.com/coder/aibridge v1.0.0/go.mod h1:NzO3dgxVXosV3a405QdhfGjisGW44tffhYDVTiV9KJ8=
 github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b h1:wgmyZ//tfJ8JvBcJeLpyrDDqsuhP4ptWMyhV3Gb5kL8=
 github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b/go.mod h1:NCGqNaHHEk9cGqGVSPL6EoOutXKm6k7L3bWxEPuK9n8=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=

--- a/go.sum
+++ b/go.sum
@@ -929,6 +929,8 @@ github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JR
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
 github.com/coder/aibridge v1.0.0 h1:gQYJ8Q83tnfWKqObu9DR4mNFTh4uTwq1rkRtuqO3x20=
 github.com/coder/aibridge v1.0.0/go.mod h1:NzO3dgxVXosV3a405QdhfGjisGW44tffhYDVTiV9KJ8=
+github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b h1:wgmyZ//tfJ8JvBcJeLpyrDDqsuhP4ptWMyhV3Gb5kL8=
+github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b/go.mod h1:NCGqNaHHEk9cGqGVSPL6EoOutXKm6k7L3bWxEPuK9n8=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.6.0 h1:DfYVBIH8/6EBfg9I0qz7rX2jo+4blUx4P4amd13nib8=

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
-github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250 h1:PXoP9IYh0eCdThmwibgFaZY6IcmKERafO9MpJnorSJI=
-github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
+github.com/SasSwart/openai-go/v3 v3.0.0-20260202093810-72af3b857f95 h1:HVJp3FanNaeFAlwg0/lkdkSnwFemHnwwjXBM8KRj540=
+github.com/SasSwart/openai-go/v3 v3.0.0-20260202093810-72af3b857f95/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b h1:wgmyZ//tfJ8JvBcJeLpyrDDqsuhP4ptWMyhV3Gb5kL8=
-github.com/coder/aibridge v1.0.1-0.20260202111350-1943e48bcd8b/go.mod h1:NCGqNaHHEk9cGqGVSPL6EoOutXKm6k7L3bWxEPuK9n8=
+github.com/coder/aibridge v1.0.1-0.20260202135542-9e2857aaac8f h1:DaSKB6p/CgDN3RXHESvFbvsT2P9XRZm0th2+MiFImwE=
+github.com/coder/aibridge v1.0.1-0.20260202135542-9e2857aaac8f/go.mod h1:M1aoiK6qmybTjD2nzcTCRPXzA/I0Ned+MAxUmz4Ju+k=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.6.0 h1:DfYVBIH8/6EBfg9I0qz7rX2jo+4blUx4P4amd13nib8=

--- a/go.sum
+++ b/go.sum
@@ -693,6 +693,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
+github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250 h1:PXoP9IYh0eCdThmwibgFaZY6IcmKERafO9MpJnorSJI=
+github.com/SasSwart/openai-go/v3 v3.0.0-20260130120340-7f5aceda0250/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -1685,8 +1687,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisti
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.120.1/go.mod h1:Z/S1brD5gU2Ntht/bHxBVnGxXKTvZDr0dNv/riUzPmY=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
-github.com/openai/openai-go/v3 v3.15.0 h1:hk99rM7YPz+M99/5B/zOQcVwFRLLMdprVGx1vaZ8XMo=
-github.com/openai/openai-go/v3 v3.15.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/scaletest/bridge/config.go
+++ b/scaletest/bridge/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	// Only used in direct mode.
 	UpstreamURL string `json:"upstream_url"`
 
-	// Provider is the API provider to use: "openai" or "anthropic".
+	// Provider is the API provider to use: "completions", "messages", or "responses".
 	Provider string `json:"provider"`
 
 	// RequestCount is the number of requests to make per runner.
@@ -77,8 +77,8 @@ func (c Config) Validate() error {
 	}
 
 	// Validate provider
-	if c.Provider != "openai" && c.Provider != "anthropic" {
-		return xerrors.New("provider must be either 'openai' or 'anthropic'")
+	if c.Provider != "completions" && c.Provider != "messages" && c.Provider != "responses" {
+		return xerrors.New("provider must be 'completions', 'messages', or 'responses'")
 	}
 
 	if c.Mode == RequestModeDirect {

--- a/scaletest/bridge/run.go
+++ b/scaletest/bridge/run.go
@@ -331,7 +331,7 @@ func (r *Runner) handleResponsesResponse(ctx context.Context, logger slog.Logger
 			if content.Type != "output_text" {
 				continue
 			}
-			contentBuilder.WriteString(content.Text)
+			_, _ = contentBuilder.WriteString(content.Text)
 		}
 	}
 	assistantContent = contentBuilder.String()

--- a/scaletest/bridge/strategy.go
+++ b/scaletest/bridge/strategy.go
@@ -64,9 +64,12 @@ func (s *bridgeStrategy) Setup(ctx context.Context, id string, logs io.Writer) (
 		slog.F("user_id", newUser.ID.String()),
 	)
 
-	if s.provider == "anthropic" {
+	switch s.provider {
+	case "messages":
 		requestURL = fmt.Sprintf("%s/api/v2/aibridge/anthropic/v1/messages", s.client.URL)
-	} else {
+	case "responses":
+		requestURL = fmt.Sprintf("%s/api/v2/aibridge/openai/v1/responses", s.client.URL)
+	case "completions":
 		requestURL = fmt.Sprintf("%s/api/v2/aibridge/openai/v1/chat/completions", s.client.URL)
 	}
 	logger.Info(ctx, "bridge runner in bridge mode",


### PR DESCRIPTION
Apply optimizations:
* https://github.com/openai/openai-go/pull/602
* https://github.com/coder/aibridge/pull/160

These reduce CPU time and allocation count for OpenAI `chat/completions` and `responses` APIs, making the use of OpenAI chat models through AI Bridge more performant.

In order to test these changes, we add scaletesting support for the responses API.