### PR TITLE
fix: separate SMTP envelope and header addresses

### DIFF
--- a/coderd/notifications/dispatch/smtp_internal_test.go
+++ b/coderd/notifications/dispatch/smtp_internal_test.go
@@ -1,0 +1,81 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateFromAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		input              string
+		expectedEnvelope   string
+		expectedHeader     string
+		expectedErrContain string
+	}{
+		{
+			name:             "bare email address",
+			input:            "system@coder.com",
+			expectedEnvelope: "system@coder.com",
+			expectedHeader:   "system@coder.com",
+		},
+		{
+			name:             "email with display name",
+			input:            "Coder System <system@coder.com>",
+			expectedEnvelope: "system@coder.com",
+			expectedHeader:   "Coder System <system@coder.com>",
+		},
+		{
+			name:             "email with quoted display name",
+			input:            `"Coder Notifications" <notifications@coder.com>`,
+			expectedEnvelope: "notifications@coder.com",
+			expectedHeader:   `"Coder Notifications" <notifications@coder.com>`,
+		},
+		{
+			name:             "email with special characters in display name",
+			input:            `"O'Brien, John" <john@example.com>`,
+			expectedEnvelope: "john@example.com",
+			expectedHeader:   `"O'Brien, John" <john@example.com>`,
+		},
+		{
+			name:               "invalid email address",
+			input:              "not-an-email",
+			expectedErrContain: "parse 'from' address",
+		},
+		{
+			name:               "empty string",
+			input:              "",
+			expectedErrContain: "parse 'from' address",
+		},
+		{
+			name:               "multiple addresses",
+			input:              "a@example.com, b@example.com",
+			expectedErrContain: "'from' address not defined",
+		},
+	}
+
+	handler := &SMTPHandler{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			envelope, header, err := handler.validateFromAddr(tc.input)
+
+			if tc.expectedErrContain != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedErrContain)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedEnvelope, envelope,
+				"envelope address should be the bare email")
+			require.Equal(t, tc.expectedHeader, header,
+				"header address should preserve the original input")
+		})
+	}
+}

--- a/docs/admin/monitoring/notifications/index.md
+++ b/docs/admin/monitoring/notifications/index.md
@@ -109,11 +109,11 @@ existing one.
 
 **Server Settings:**
 
-| Required | CLI                 | Env                     | Type     | Description                                               | Default   |
-|:--------:|---------------------|-------------------------|----------|-----------------------------------------------------------|-----------|
+| Required | CLI                 | Env                     | Type     | Description                                                       | Default   |
+|:--------:|---------------------|-------------------------|----------|-------------------------------------------------------------------|-----------|
 |    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use (e.g. `"Coder <coder@example.com>"`). |           |
-|    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages (format: `hostname:port`) |           |
-|    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server.                 | localhost |
+|    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages (format: `hostname:port`)         |           |
+|    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server.                         | localhost |
 
 **Authentication Settings:**
 

--- a/docs/admin/monitoring/notifications/index.md
+++ b/docs/admin/monitoring/notifications/index.md
@@ -111,7 +111,7 @@ existing one.
 
 | Required | CLI                 | Env                     | Type     | Description                                               | Default   |
 |:--------:|---------------------|-------------------------|----------|-----------------------------------------------------------|-----------|
-|    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use.                              |           |
+|    ✔️    | `--email-from`      | `CODER_EMAIL_FROM`      | `string` | The sender's address to use (e.g. `"Coder <coder@example.com>"`). |           |
 |    ✔️    | `--email-smarthost` | `CODER_EMAIL_SMARTHOST` | `string` | The SMTP relay to send messages (format: `hostname:port`) |           |
 |    ✔️    | `--email-hello`     | `CODER_EMAIL_HELLO`     | `string` | The hostname identifying the SMTP server.                 | localhost |
 


### PR DESCRIPTION
## Description

When configuring a From address with a display name (e.g., `Coder System <system@coder.com>`), the SMTP `MAIL FROM` command was incorrectly receiving the full address string instead of just the bare email address, causing `501 Invalid MAIL argument` errors on some SMTP servers.

## Changes

- Updated `validateFromAddr` to return both:
  - `envelopeFrom`: bare email for SMTP `MAIL FROM` command (RFC 5321)
  - `headerFrom`: original address with display name for email header (RFC 5322)

Fixes #20727