### PR TITLE
test(cli): remove IncludeProvisionerDaemon from task snapshot tests

### DIFF
--- a/cli/task_test.go
+++ b/cli/task_test.go
@@ -276,10 +276,13 @@ func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[st
 }
 
 // setupCLITaskTestWithSnapshot creates a task in the specified status with a log snapshot.
+// Note: We do not use IncludeProvisionerDaemon because these tests use dbfake to directly
+// set up database state and don't need actual provisioning. This also avoids potential
+// interference from the provisioner daemon polling for jobs.
 func setupCLITaskTestWithSnapshot(ctx context.Context, t *testing.T, status codersdk.TaskStatus, messages []agentapisdk.Message) (*codersdk.Client, codersdk.Task) {
 	t.Helper()
 
-	ownerClient, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	ownerClient, db := coderdtest.NewWithDatabase(t, nil)
 	owner := coderdtest.CreateFirstUser(t, ownerClient)
 	userClient, user := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
 
@@ -312,10 +315,13 @@ func setupCLITaskTestWithSnapshot(ctx context.Context, t *testing.T, status code
 }
 
 // setupCLITaskTestWithoutSnapshot creates a task in the specified status without a log snapshot.
+// Note: We do not use IncludeProvisionerDaemon because these tests use dbfake to directly
+// set up database state and don't need actual provisioning. This also avoids potential
+// interference from the provisioner daemon polling for jobs.
 func setupCLITaskTestWithoutSnapshot(t *testing.T, status codersdk.TaskStatus) (*codersdk.Client, codersdk.Task) {
 	t.Helper()
 
-	ownerClient, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	ownerClient, db := coderdtest.NewWithDatabase(t, nil)
 	owner := coderdtest.CreateFirstUser(t, ownerClient)
 	userClient, user := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
 


### PR DESCRIPTION
These tests use dbfake to set up database state directly and don't need a provisioner daemon. Removing it fixes a flaky failure on Windows where the provisioner daemon acquired a job that dbfake had already "completed", causing the task status to be 'error' instead of 'paused'.

Fixes coder/internal#1322
Refs coder/internal#1323