### PR TITLE
fix(coderd/database): prevent AcquireProvisionerJob from grabbing canceled jobs

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -314,14 +314,15 @@ func (b WorkspaceBuildBuilder) doInTX() WorkspaceResponse {
 	case database.ProvisionerJobStatusCanceled:
 		// Set provisioner job status to 'canceled'
 		b.logger.Debug(context.Background(), "canceling the provisioner job")
+		now := dbtime.Now()
 		err = b.db.UpdateProvisionerJobWithCancelByID(ownerCtx, database.UpdateProvisionerJobWithCancelByIDParams{
 			ID: jobID,
 			CanceledAt: sql.NullTime{
-				Time:  dbtime.Now(),
+				Time:  now,
 				Valid: true,
 			},
 			CompletedAt: sql.NullTime{
-				Time:  dbtime.Now(),
+				Time:  now,
 				Valid: true,
 			},
 		})
@@ -696,12 +697,16 @@ func (b JobCompleteBuilder) Pubsub(ps pubsub.Pubsub) JobCompleteBuilder {
 
 func (b JobCompleteBuilder) Do() JobCompleteResponse {
 	r := JobCompleteResponse{CompletedAt: dbtime.Now()}
-	err := b.db.UpdateProvisionerJobWithCompleteByID(ownerCtx, database.UpdateProvisionerJobWithCompleteByIDParams{
+	err := b.db.UpdateProvisionerJobWithCompleteWithStartedAtByID(ownerCtx, database.UpdateProvisionerJobWithCompleteWithStartedAtByIDParams{
 		ID:        b.jobID,
 		UpdatedAt: r.CompletedAt,
 		Error:     sql.NullString{},
 		ErrorCode: sql.NullString{},
 		CompletedAt: sql.NullTime{
+			Time:  r.CompletedAt,
+			Valid: true,
+		},
+		StartedAt: sql.NullTime{
 			Time:  r.CompletedAt,
 			Valid: true,
 		},

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10251,6 +10251,7 @@ WHERE
 			provisioner_jobs AS potential_job
 		WHERE
 			potential_job.started_at IS NULL
+			AND potential_job.completed_at IS NULL
 			AND potential_job.organization_id = $3
 			-- Ensure the caller has the correct provisioner.
 			AND potential_job.provisioner = ANY($4 :: provisioner_type [ ])

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -19,6 +19,7 @@ WHERE
 			provisioner_jobs AS potential_job
 		WHERE
 			potential_job.started_at IS NULL
+			AND potential_job.completed_at IS NULL
 			AND potential_job.organization_id = @organization_id
 			-- Ensure the caller has the correct provisioner.
 			AND potential_job.provisioner = ANY(@types :: provisioner_type [ ])


### PR DESCRIPTION
The `AcquireProvisionerJob` query only checked `started_at IS NULL`, allowing it to acquire jobs that were canceled while pending (which have `completed_at` set but `started_at` still NULL).

Added `completed_at IS NULL` check to the query to prevent this.

Also fixed `JobCompleteBuilder.Do()` in dbfake to set `started_at` when completing jobs, ensuring test provisioner daemons don't attempt to acquire already-completed fake jobs.

Fixes coder/internal#1323