### PR TITLE
fix: handle boundary usage across snapshots and prevent race (cherry-pick)

### DIFF
--- a/coderd/boundaryusage/doc.go
+++ b/coderd/boundaryusage/doc.go
@@ -40,8 +40,10 @@
 // counters. When boundary logs are reported, Track() adds the IDs to the sets
 // and increments request counters.
 //
-// FlushToDB() writes stats to the database, replacing all values with the current
-// in-memory state. Stats accumulate in memory throughout the telemetry period.
+// FlushToDB() writes stats to the database only when there's been new activity
+// since the last flush. This prevents stale data from being written after a
+// telemetry reset when no new usage occurred. Stats accumulate in memory
+// throughout the telemetry period.
 //
 // A new period is detected when the upsert results in an INSERT (meaning
 // telemetry deleted the replica's row). At that point, all in-memory stats are

--- a/coderd/boundaryusage/tracker.go
+++ b/coderd/boundaryusage/tracker.go
@@ -14,21 +14,40 @@ import (
 
 // Tracker tracks boundary usage for telemetry reporting.
 //
-// All stats accumulate in memory throughout a telemetry period and are only
-// reset when a new period begins.
+// Unique user/workspace counts are tracked both cumulatively and as deltas since
+// the last flush. The delta is needed because when a new telemetry period starts
+// (the DB row is deleted), we must only insert data accumulated since the last
+// flush. If we used cumulative values, stale data from the previous period would
+// be written to the new row and then lost when subsequent updates overwrite it.
+//
+// Request counts are tracked as deltas and accumulated in the database.
 type Tracker struct {
-	mu              sync.Mutex
-	workspaces      map[uuid.UUID]struct{}
-	users           map[uuid.UUID]struct{}
+	mu sync.Mutex
+
+	// Cumulative unique counts for the current period (used on UPDATE to
+	// replace the DB value with accurate totals).
+	workspaces map[uuid.UUID]struct{}
+	users      map[uuid.UUID]struct{}
+
+	// Delta unique counts since last flush (used on INSERT to avoid writing
+	// stale data from the previous period).
+	workspacesDelta map[uuid.UUID]struct{}
+	usersDelta      map[uuid.UUID]struct{}
+
+	// Request deltas (always reset when flushing, accumulated in DB).
 	allowedRequests int64
 	deniedRequests  int64
+
+	usageSinceLastFlush bool
 }
 
 // NewTracker creates a new boundary usage tracker.
 func NewTracker() *Tracker {
 	return &Tracker{
-		workspaces: make(map[uuid.UUID]struct{}),
-		users:      make(map[uuid.UUID]struct{}),
+		workspaces:      make(map[uuid.UUID]struct{}),
+		users:           make(map[uuid.UUID]struct{}),
+		workspacesDelta: make(map[uuid.UUID]struct{}),
+		usersDelta:      make(map[uuid.UUID]struct{}),
 	}
 }
 
@@ -39,50 +58,68 @@ func (t *Tracker) Track(workspaceID, ownerID uuid.UUID, allowed, denied int64) {
 
 	t.workspaces[workspaceID] = struct{}{}
 	t.users[ownerID] = struct{}{}
+	t.workspacesDelta[workspaceID] = struct{}{}
+	t.usersDelta[ownerID] = struct{}{}
 	t.allowedRequests += allowed
 	t.deniedRequests += denied
+	t.usageSinceLastFlush = true
 }
 
-// FlushToDB writes the accumulated stats to the database. All values are
-// replaced in the database (they represent the current in-memory state). If the
-// database row was deleted (new telemetry period), all in-memory stats are reset.
+// FlushToDB writes stats to the database. For unique counts, cumulative values
+// are used on UPDATE (replacing the DB value) while delta values are used on
+// INSERT (starting fresh). Request counts are always deltas, accumulated in DB.
+// All deltas are reset immediately after snapshot so Track() calls during the
+// DB operation are preserved for the next flush.
 func (t *Tracker) FlushToDB(ctx context.Context, db database.Store, replicaID uuid.UUID) error {
 	t.mu.Lock()
-	workspaceCount := int64(len(t.workspaces))
-	userCount := int64(len(t.users))
-	allowed := t.allowedRequests
-	denied := t.deniedRequests
-	t.mu.Unlock()
-
-	// Don't flush if there's no activity.
-	if workspaceCount == 0 && userCount == 0 && allowed == 0 && denied == 0 {
+	if !t.usageSinceLastFlush {
+		t.mu.Unlock()
 		return nil
 	}
 
+	// Snapshot all values.
+	workspaceCount := int64(len(t.workspaces))      // cumulative, for UPDATE
+	userCount := int64(len(t.users))                // cumulative, for UPDATE
+	workspaceDelta := int64(len(t.workspacesDelta)) // delta, for INSERT
+	userDelta := int64(len(t.usersDelta))           // delta, for INSERT
+	allowed := t.allowedRequests                    // delta, accumulated in DB
+	denied := t.deniedRequests                      // delta, accumulated in DB
+
+	// Reset all deltas immediately so Track() calls during the DB operation
+	// below are preserved for the next flush.
+	t.workspacesDelta = make(map[uuid.UUID]struct{})
+	t.usersDelta = make(map[uuid.UUID]struct{})
+	t.allowedRequests = 0
+	t.deniedRequests = 0
+	t.usageSinceLastFlush = false
+	t.mu.Unlock()
+
 	//nolint:gocritic // This is the actual package doing boundary usage tracking.
-	newPeriod, err := db.UpsertBoundaryUsageStats(dbauthz.AsBoundaryUsageTracker(ctx), database.UpsertBoundaryUsageStatsParams{
+	_, err := db.UpsertBoundaryUsageStats(dbauthz.AsBoundaryUsageTracker(ctx), database.UpsertBoundaryUsageStatsParams{
 		ReplicaID:             replicaID,
-		UniqueWorkspacesCount: workspaceCount,
-		UniqueUsersCount:      userCount,
+		UniqueWorkspacesCount: workspaceCount, // cumulative, for UPDATE
+		UniqueUsersCount:      userCount,      // cumulative, for UPDATE
+		UniqueWorkspacesDelta: workspaceDelta, // delta, for INSERT
+		UniqueUsersDelta:      userDelta,      // delta, for INSERT
 		AllowedRequests:       allowed,
 		DeniedRequests:        denied,
 	})
-	if err != nil {
-		return err
-	}
 
-	// If this was an insert (new period), reset all stats. Any Track() calls
-	// that occurred during the DB operation will be counted in the next period.
-	if newPeriod {
-		t.mu.Lock()
-		t.workspaces = make(map[uuid.UUID]struct{})
-		t.users = make(map[uuid.UUID]struct{})
-		t.allowedRequests = 0
-		t.deniedRequests = 0
-		t.mu.Unlock()
+	// Always reset cumulative counts to prevent unbounded memory growth (e.g.
+	// if the DB is unreachable). Copy delta maps to preserve any Track() calls
+	// that occurred during the DB operation above.
+	t.mu.Lock()
+	t.workspaces = make(map[uuid.UUID]struct{})
+	t.users = make(map[uuid.UUID]struct{})
+	for id := range t.workspacesDelta {
+		t.workspaces[id] = struct{}{}
 	}
+	for id := range t.usersDelta {
+		t.users[id] = struct{}{}
+	}
+	t.mu.Unlock()
 
-	return nil
+	return err
 }
 
 // StartFlushLoop begins the periodic flush loop that writes accumulated stats

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -762,9 +762,10 @@ type sqlcQuerier interface {
 	UpsertAnnouncementBanners(ctx context.Context, value string) error
 	UpsertAppSecurityKey(ctx context.Context, value string) error
 	UpsertApplicationName(ctx context.Context, value string) error
-	// Upserts boundary usage statistics for a replica. All values are replaced with
-	// the current in-memory state. Returns true if this was an insert (new period),
-	// false if update.
+	// Upserts boundary usage statistics for a replica. On INSERT (new period), uses
+	// delta values for unique counts (only data since last flush). On UPDATE, uses
+	// cumulative values for unique counts (accurate period totals). Request counts
+	// are always deltas, accumulated in DB. Returns true if insert, false if update.
 	UpsertBoundaryUsageStats(ctx context.Context, arg UpsertBoundaryUsageStatsParams) (bool, error)
 	UpsertConnectionLog(ctx context.Context, arg UpsertConnectionLogParams) (ConnectionLog, error)
 	UpsertCoordinatorResumeTokenSigningKey(ctx context.Context, value string) error


### PR DESCRIPTION
Previously there were two issues that could cause incorrect telemetry data:

1. Bad handling across snapshot intervals: After telemetry reset deleted the DB row, the next flush would INSERT the stale cumulative data (which included already-reported usage). This would then be overwritten by subsequent UPDATE flushes, causing the delta between the last snapshot and the reset to be lost (under-reporting usage). Additionally, if there was no new usage after the reset, the tracker would carry over all usage from the previous period into the next period (over-reporting usage).

2. Missed usage from a race condition: Track() calls between the first unlock and second lock in FlushToDB() were lost. The data wasn't included in the current flush (already snapshotted) and was wiped by the subsequent reset. Likely low impact to overall usage numbers.

Fix by tracking deltas separately from cumulative values. Deltas are used for INSERT (fresh start after reset), cumulative for UPDATE (accurate unique counts within a period). All counters reset atomically before the DB operation so Track() calls during the operation are preserved for the next flush.

(cherry picked from commit a64dec0b577d3db3aafa90e88181f90bd40193e0)

Original PR #21805. **Why cherry-pick:** boundary is going GA in 2.30 and this change fixes bugs with boundary usage telemetry that cause frequent and significant over/under reporting of actual usage. 1) above is the most impactful problem that drives this cherry-pick. Without this cherry-pick we will have a hard time understanding what boundary usage actually looks like. Related: https://github.com/coder/coder/issues/21806
