### PR TITLE
test: fix flakiness around tar block size in test

### DIFF
--- a/provisioner/terraform/modules_internal_test.go
+++ b/provisioner/terraform/modules_internal_test.go
@@ -200,7 +200,7 @@ func TestGetModulesArchive(t *testing.T) {
 		require.Empty(t, skipped)
 		actualSize := int64(len(archive))
 
-		originalDef["extra"] = moduleDef{payload: bytes.Repeat([]byte("X"), 1001)}
+		originalDef["extra"] = moduleDef{payload: bytes.Repeat([]byte("X"), 2000)}
 		memFS = moduleArchiveFS(t, originalDef)
 
 		// Now test with exact size - should just fit


### PR DESCRIPTION
So 1000 bytes and 1001 bytes is both 1024 bytes

Closes https://github.com/coder/internal/issues/1324#issuecomment-3836984358