### PR TITLE
fix: disable task sharing

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2353,6 +2353,17 @@ func (api *API) patchWorkspaceACL(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Don't allow adding new groups or users to a workspace associated with a
+	// task. Sharing a task workspace without sharing the task itself is a broken
+	// half measure that we don't want to support right now. To be fixed!
+	if workspace.TaskID.Valid {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Task workspaces cannot be shared.",
+			Detail:  "This workspace is managed by a task. Task sharing has not yet been implemented.",
+		})
+		return
+	}
+
 	apiKey := httpmw.APIKey(r)
 	if _, ok := req.UserRoles[apiKey.UserID.String()]; ok {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
+++ b/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
@@ -7,7 +7,6 @@ import {
 	DropdownMenuContent,
 	DropdownMenuGroup,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
 import { CoderIcon } from "components/Icons/CoderIcon";
@@ -22,13 +21,7 @@ import {
 } from "components/Tooltip/Tooltip";
 import { useAuthenticated } from "hooks";
 import { useSearchParamsKey } from "hooks/useSearchParamsKey";
-import {
-	EditIcon,
-	EllipsisIcon,
-	PanelLeftIcon,
-	Share2Icon,
-	TrashIcon,
-} from "lucide-react";
+import { EditIcon, EllipsisIcon, PanelLeftIcon, TrashIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { useQuery } from "react-query";
 import { Link as RouterLink, useNavigate, useParams } from "react-router";
@@ -234,15 +227,6 @@ const TaskSidebarMenuItem: FC<TaskSidebarMenuItemProps> = ({ task }) => {
 
 						<DropdownMenuContent align="end">
 							<DropdownMenuGroup>
-								<DropdownMenuItem asChild>
-									<RouterLink
-										to={`/@${task.owner_name}/${task.workspace_name}/settings/sharing`}
-									>
-										<Share2Icon />
-										Share
-									</RouterLink>
-								</DropdownMenuItem>
-								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="text-content-destructive focus:text-content-destructive"
 									onClick={(e) => {

--- a/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
@@ -141,6 +141,7 @@ export const RoleSelectField: FC<RoleSelectFieldProps> = ({
 interface WorkspaceSharingFormProps {
 	workspaceACL: WorkspaceACL | undefined;
 	canUpdatePermissions: boolean;
+	isTaskWorkspace: boolean;
 	error: unknown;
 	onUpdateUser: (user: WorkspaceUser, role: WorkspaceRole) => void;
 	updatingUserId: WorkspaceUser["id"] | undefined;
@@ -156,6 +157,7 @@ interface WorkspaceSharingFormProps {
 export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 	workspaceACL,
 	canUpdatePermissions,
+	isTaskWorkspace,
 	error,
 	updatingUserId,
 	onUpdateUser,
@@ -185,7 +187,17 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 
 	const tableBody = (
 		<TableBody>
-			{!workspaceACL ? (
+			{isTaskWorkspace ? (
+				<TableRow>
+					<TableCell colSpan={999}>
+						<EmptyState
+							message="Task workspaces cannot be shared"
+							description="This workspace is managed by a task. Task sharing has not yet been implemented."
+							isCompact={isCompact}
+						/>
+					</TableCell>
+				</TableRow>
+			) : !workspaceACL ? (
 				<TableLoader />
 			) : isEmpty ? (
 				<TableRow>

--- a/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
@@ -204,7 +204,7 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 					<TableCell colSpan={999}>
 						<EmptyState
 							message="No shared members or groups yet"
-							description="Add a member or group using the controls above"
+							description="Add a member or group using the controls above."
 							isCompact={isCompact}
 						/>
 					</TableCell>

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -5,7 +5,6 @@ import { workspaceBuildParameters } from "api/queries/workspaceBuilds";
 import {
 	startWorkspace,
 	workspaceByOwnerAndName,
-	workspacePermissions,
 } from "api/queries/workspaces";
 import type {
 	Workspace,
@@ -79,7 +78,6 @@ const TaskPage = () => {
 			return state.error ? false : 5_000;
 		},
 	});
-	const { data: permissions } = useQuery(workspacePermissions(workspace));
 	const refetch = taskQuery.error ? taskQuery.refetch : workspaceQuery.refetch;
 	const error = taskQuery.error ?? workspaceQuery.error;
 	const waitingStatuses: WorkspaceStatus[] = ["starting", "pending"];
@@ -200,11 +198,7 @@ const TaskPage = () => {
 		<TaskPageLayout>
 			<title>{pageTitle(task.display_name)}</title>
 
-			<TaskTopbar
-				task={task}
-				workspace={workspace}
-				canUpdatePermissions={permissions?.updateWorkspace ?? false}
-			/>
+			<TaskTopbar task={task} workspace={workspace} />
 			{content}
 
 			<ModifyPromptDialog

--- a/site/src/pages/TaskPage/TaskTopbar.tsx
+++ b/site/src/pages/TaskPage/TaskTopbar.tsx
@@ -11,8 +11,8 @@ import {
 	ArrowLeftIcon,
 	CheckIcon,
 	CopyIcon,
-	LaptopMinimalIcon,
-	TerminalIcon,
+	LayoutPanelTopIcon,
+	SquareTerminalIcon,
 } from "lucide-react";
 import type { FC } from "react";
 import { Link as RouterLink } from "react-router";
@@ -57,8 +57,8 @@ export const TaskTopbar: FC<TaskTopbarProps> = ({ task, workspace }) => {
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<Button variant="outline" size="sm">
-								<TerminalIcon />
-								Prompt
+								<SquareTerminalIcon />
+								View Prompt
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent className="max-w-xs bg-surface-secondary p-4">
@@ -72,8 +72,8 @@ export const TaskTopbar: FC<TaskTopbarProps> = ({ task, workspace }) => {
 
 				<Button asChild variant="outline" size="sm">
 					<RouterLink to={`/@${workspace.owner_name}/${workspace.name}`}>
-						<LaptopMinimalIcon />
-						Workspace
+						<LayoutPanelTopIcon />
+						Go to workspace
 					</RouterLink>
 				</Button>
 			</div>

--- a/site/src/pages/TaskPage/TaskTopbar.tsx
+++ b/site/src/pages/TaskPage/TaskTopbar.tsx
@@ -11,26 +11,17 @@ import {
 	ArrowLeftIcon,
 	CheckIcon,
 	CopyIcon,
-	LayoutPanelTopIcon,
-	SquareTerminalIcon,
+	LaptopMinimalIcon,
+	TerminalIcon,
 } from "lucide-react";
 import type { FC } from "react";
 import { Link as RouterLink } from "react-router";
-import { ShareButton } from "../WorkspacePage/WorkspaceActions/ShareButton";
 import { TaskStartupWarningButton } from "./TaskStartupWarningButton";
 import { TaskStatusLink } from "./TaskStatusLink";
 
-type TaskTopbarProps = {
-	task: Task;
-	workspace: Workspace;
-	canUpdatePermissions: boolean;
-};
+type TaskTopbarProps = { task: Task; workspace: Workspace };
 
-export const TaskTopbar: FC<TaskTopbarProps> = ({
-	task,
-	workspace,
-	canUpdatePermissions,
-}) => {
+export const TaskTopbar: FC<TaskTopbarProps> = ({ task, workspace }) => {
 	return (
 		<header className="flex flex-shrink-0 items-center gap-2 p-3 border-solid border-border border-0 border-b">
 			<TooltipProvider>
@@ -66,8 +57,8 @@ export const TaskTopbar: FC<TaskTopbarProps> = ({
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<Button variant="outline" size="sm">
-								<SquareTerminalIcon />
-								View Prompt
+								<TerminalIcon />
+								Prompt
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent className="max-w-xs bg-surface-secondary p-4">
@@ -79,15 +70,10 @@ export const TaskTopbar: FC<TaskTopbarProps> = ({
 					</Tooltip>
 				</TooltipProvider>
 
-				<ShareButton
-					workspace={workspace}
-					canUpdatePermissions={canUpdatePermissions}
-				/>
-
 				<Button asChild variant="outline" size="sm">
 					<RouterLink to={`/@${workspace.owner_name}/${workspace.name}`}>
-						<LayoutPanelTopIcon />
-						Go to workspace
+						<LaptopMinimalIcon />
+						Workspace
 					</RouterLink>
 				</Button>
 			</div>

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -16,7 +16,15 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
 import { getTemplatesQueryKey } from "api/queries/templates";
 import { MockUsers } from "pages/UsersPage/storybookData/users";
-import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import {
+	expect,
+	fireEvent,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 import TasksPage from "./TasksPage";
 
 const meta: Meta<typeof TasksPage> = {
@@ -232,6 +240,20 @@ export const NonAdmin: Story = {
 	},
 };
 
+export const OpenKebabMenu: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
+		spyOn(API, "getTasks").mockResolvedValue(MockTasks);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const kebabButtons = await canvas.findAllByRole("button", {
+			name: /show task actions/i,
+		});
+		await userEvent.click(kebabButtons[0]);
+	},
+};
+
 export const OpenDeleteDialog: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
@@ -239,10 +261,15 @@ export const OpenDeleteDialog: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const deleteButtons = await canvas.findAllByRole("button", {
-			name: /delete task/i,
+		const kebabButtons = await canvas.findAllByRole("button", {
+			name: /show task actions/i,
 		});
-		await userEvent.click(deleteButtons[0]);
+		await userEvent.click(kebabButtons[0]);
+
+		const deleteMenuItem = await screen.findByRole("menuitem", {
+			name: /delete/i,
+		});
+		fireEvent.click(deleteMenuItem);
 	},
 };
 

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -16,15 +16,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
 import { getTemplatesQueryKey } from "api/queries/templates";
 import { MockUsers } from "pages/UsersPage/storybookData/users";
-import {
-	expect,
-	fireEvent,
-	screen,
-	spyOn,
-	userEvent,
-	waitFor,
-	within,
-} from "storybook/test";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import TasksPage from "./TasksPage";
 
 const meta: Meta<typeof TasksPage> = {
@@ -240,20 +232,6 @@ export const NonAdmin: Story = {
 	},
 };
 
-export const OpenKebabMenu: Story = {
-	beforeEach: () => {
-		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
-		spyOn(API, "getTasks").mockResolvedValue(MockTasks);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const kebabButtons = await canvas.findAllByRole("button", {
-			name: /open task actions/i,
-		});
-		await userEvent.click(kebabButtons[0]);
-	},
-};
-
 export const OpenDeleteDialog: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
@@ -261,15 +239,10 @@ export const OpenDeleteDialog: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const kebabButtons = await canvas.findAllByRole("button", {
-			name: /open task actions/i,
+		const deleteButtons = await canvas.findAllByRole("button", {
+			name: /delete task/i,
 		});
-		await userEvent.click(kebabButtons[0]);
-
-		const deleteMenuItem = await screen.findByRole("menuitem", {
-			name: /delete/i,
-		});
-		fireEvent.click(deleteMenuItem);
+		await userEvent.click(deleteButtons[0]);
 	},
 };
 

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -25,7 +25,7 @@ import {
 	TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
 import { useClickableTableRow } from "hooks";
-import { RotateCcwIcon, TrashIcon } from "lucide-react";
+import { EllipsisVertical, RotateCcwIcon, TrashIcon } from "lucide-react";
 import { TaskDeleteDialog } from "modules/tasks/TaskDeleteDialog/TaskDeleteDialog";
 import { TaskStatus } from "modules/tasks/TaskStatus/TaskStatus";
 import { type FC, type ReactNode, useState } from "react";

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -9,7 +9,6 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
 import { Skeleton } from "components/Skeleton/Skeleton";
@@ -26,12 +25,7 @@ import {
 	TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
 import { useClickableTableRow } from "hooks";
-import {
-	EllipsisVertical,
-	RotateCcwIcon,
-	Share2Icon,
-	TrashIcon,
-} from "lucide-react";
+import { RotateCcwIcon, TrashIcon } from "lucide-react";
 import { TaskDeleteDialog } from "modules/tasks/TaskDeleteDialog/TaskDeleteDialog";
 import { TaskStatus } from "modules/tasks/TaskStatus/TaskStatus";
 import { type FC, type ReactNode, useState } from "react";
@@ -266,22 +260,10 @@ const TaskRow: FC<TaskRowProps> = ({
 								onClick={(e) => e.stopPropagation()}
 							>
 								<EllipsisVertical aria-hidden="true" />
-								<span className="sr-only">Open task actions</span>
+								<span className="sr-only">Show task actions</span>
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
-							<DropdownMenuItem
-								onClick={(e) => {
-									e.stopPropagation();
-									navigate(
-										`/@${task.owner_name}/${task.workspace_name}/settings/sharing`,
-									);
-								}}
-							>
-								<Share2Icon />
-								Share
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
 							<DropdownMenuItem
 								className="text-content-destructive focus:text-content-destructive"
 								onClick={(e) => {

--- a/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
@@ -35,6 +35,7 @@ export const ShareButton: FC<ShareButtonProps> = ({
 				<WorkspaceSharingForm
 					workspaceACL={sharing.workspaceACL}
 					canUpdatePermissions={canUpdatePermissions}
+					isTaskWorkspace={workspace.task_id !== null}
 					error={sharing.error ?? sharing.mutationError}
 					updatingUserId={sharing.updatingUserId}
 					onUpdateUser={sharing.updateUser}

--- a/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
@@ -35,7 +35,7 @@ export const ShareButton: FC<ShareButtonProps> = ({
 				<WorkspaceSharingForm
 					workspaceACL={sharing.workspaceACL}
 					canUpdatePermissions={canUpdatePermissions}
-					isTaskWorkspace={workspace.task_id !== null}
+					isTaskWorkspace={Boolean(workspace.task_id)}
 					error={sharing.error ?? sharing.mutationError}
 					updatingUserId={sharing.updatingUserId}
 					onUpdateUser={sharing.updateUser}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
@@ -54,7 +54,7 @@ export const WorkspaceSharingPageView: FC<WorkspaceSharingPageViewProps> = ({
 		<WorkspaceSharingForm
 			workspaceACL={workspaceACL}
 			canUpdatePermissions={canUpdatePermissions}
-			isTaskWorkspace={workspace.task_id !== null}
+			isTaskWorkspace={Boolean(workspace.task_id)}
 			error={error}
 			updatingUserId={updatingUserId}
 			onUpdateUser={onUpdateUser}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
@@ -54,6 +54,7 @@ export const WorkspaceSharingPageView: FC<WorkspaceSharingPageViewProps> = ({
 		<WorkspaceSharingForm
 			workspaceACL={workspaceACL}
 			canUpdatePermissions={canUpdatePermissions}
+			isTaskWorkspace={workspace.task_id !== null}
 			error={error}
 			updatingUserId={updatingUserId}
 			onUpdateUser={onUpdateUser}


### PR DESCRIPTION
This reverts commit e1156b050fecfe93807ab79bbee309944dbbc090.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

Tasks are a distinct resource type and making them sharable will require a much larger effort than just adding a button that shares the underlying workspace. Sharing the workspace is only half of a solution.

An actual fix will require database changes, probably some rego changes, and some architectural decisions. There's not really time for all of that in a day so instead we're just removing the buttons, since they're currently very broken.
