### PR TITLE
docs: add Mux client configuration

### DIFF
--- a/docs/ai-coder/ai-bridge/clients/index.md
+++ b/docs/ai-coder/ai-bridge/clients/index.md
@@ -46,6 +46,7 @@ The table below shows tested AI clients and their compatibility with AI Bridge.
 |----------------------------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Claude Code](./claude-code.md)  | -      | ✅         |                                                                                                                                                        |
 | [Codex CLI](./codex.md)          | ✅      | -         |                                                                                                                                                        |
+| [Mux](./mux.md)                  | ✅      | ✅         |                                                                                                                                                        |
 | [OpenCode](./opencode.md)        | ✅      | ✅         |                                                                                                                                                        |
 | [Factory](./factory.md)          | ✅      | ✅         |                                                                                                                                                        |
 | [Cline](./cline.md)              | ✅      | ✅         |                                                                                                                                                        |

--- a/docs/ai-coder/ai-bridge/clients/index.md
+++ b/docs/ai-coder/ai-bridge/clients/index.md
@@ -44,9 +44,9 @@ The table below shows tested AI clients and their compatibility with AI Bridge.
 
 | Client                           | OpenAI | Anthropic | Notes                                                                                                                                                  |
 |----------------------------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Mux](./mux.md)                  | ✅      | ✅         |                                                                                                                                                        |
 | [Claude Code](./claude-code.md)  | -      | ✅         |                                                                                                                                                        |
 | [Codex CLI](./codex.md)          | ✅      | -         |                                                                                                                                                        |
-| [Mux](./mux.md)                  | ✅      | ✅         |                                                                                                                                                        |
 | [OpenCode](./opencode.md)        | ✅      | ✅         |                                                                                                                                                        |
 | [Factory](./factory.md)          | ✅      | ✅         |                                                                                                                                                        |
 | [Cline](./cline.md)              | ✅      | ✅         |                                                                                                                                                        |

--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -50,6 +50,32 @@ export ANTHROPIC_API_KEY="<your-coder-session-token>"
 export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
 ```
 
+## Running Mux in a Coder workspace
+
+If you want to run Mux inside a Coder workspace (for example, as a Coder app), you can install it with the [Mux module](https://registry.coder.com/modules/coder/mux) and pre-configure AI Bridge via environment variables on the agent:
+
+```tf
+data "coder_workspace" "me" {}
+
+data "coder_workspace_owner" "me" {}
+
+resource "coder_agent" "main" {
+  # ... other agent configuration
+  env = {
+    OPENAI_API_KEY     = data.coder_workspace_owner.me.session_token
+    OPENAI_BASE_URL    = "${data.coder_workspace.me.access_url}/api/v2/aibridge/openai/v1"
+    ANTHROPIC_API_KEY  = data.coder_workspace_owner.me.session_token
+    ANTHROPIC_BASE_URL = "${data.coder_workspace.me.access_url}/api/v2/aibridge/anthropic"
+  }
+}
+
+module "mux" {
+  source   = "registry.coder.com/coder/mux/coder"
+  version  = "~> 1.0" # See the module page for the latest version.
+  agent_id = coder_agent.main.id
+}
+```
+
 ## Advanced: providers.jsonc
 
 If you prefer a file-based config, edit `~/.mux/providers.jsonc`:

--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -1,5 +1,7 @@
 # Mux
 
+Mux makes it easy to run parallel coding agents, each with its own isolated workspace, from your browser or desktop; it is open source and provider-agnostic. For more background on Mux, see [Coder Research](https://coder.com/docs/coder-research#mux).
+
 Mux can be configured to route OpenAI- and Anthropic-compatible traffic through AI Bridge by setting a custom provider base URL and using a Coder-issued token for authentication.
 
 ## Prerequisites

--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -1,6 +1,6 @@
 # Mux
 
-Mux makes it easy to run parallel coding agents, each with its own isolated workspace, from your browser or desktop; it is open source and provider-agnostic. For more background on Mux, see [Coder Research](https://coder.com/docs/coder-research#mux).
+Mux makes it easy to run parallel coding agents, each with its own isolated workspace, from your browser or desktop; it is open source and provider-agnostic. For more background on Mux, see [Coder Research](../../../coder-research.md#mux).
 
 Mux can be configured to route OpenAI- and Anthropic-compatible traffic through AI Bridge by setting a custom provider base URL and using a Coder-issued token for authentication.
 

--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -11,14 +11,14 @@ Mux can be configured to route OpenAI- and Anthropic-compatible traffic through 
 
 <div class="tabs">
 
-### OpenAI (GPT / Codex)
+### OpenAI
 
 1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
 2. Go to **Providers** → **OpenAI**.
 3. Set **API Key** to your Coder session token.
 4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/openai/v1`.
 
-### Anthropic (Claude)
+### Anthropic
 
 1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
 2. Go to **Providers** → **Anthropic**.

--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -1,0 +1,68 @@
+# Mux
+
+Mux can be configured to route OpenAI- and Anthropic-compatible traffic through AI Bridge by setting a custom provider base URL and using a Coder-issued token for authentication.
+
+## Prerequisites
+
+- AI Bridge is enabled on your Coder deployment.
+- A **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** or long-lived API key.
+
+## Configuration
+
+<div class="tabs">
+
+### OpenAI (GPT / Codex)
+
+1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
+2. Go to **Providers** → **OpenAI**.
+3. Set **API Key** to your Coder session token.
+4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/openai/v1`.
+
+### Anthropic (Claude)
+
+1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
+2. Go to **Providers** → **Anthropic**.
+3. Set **API Key** to your Coder session token.
+4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/anthropic`.
+
+</div>
+
+_Replace `coder.example.com` with your Coder deployment URL._
+
+## Environment variables
+
+Mux reads provider configuration from its settings UI and also from environment variables.
+Environment variables are useful in CI or when running Mux inside a Coder workspace.
+
+> [!NOTE]
+> Mux treats environment variables as a fallback when a provider is not configured in settings.
+> If you have already configured a provider in the UI, clear it (or update it) for env vars to take effect.
+
+```sh
+# OpenAI-compatible traffic (GPT, Codex, etc.)
+export OPENAI_API_KEY="<your-coder-session-token>"
+export OPENAI_BASE_URL="https://coder.example.com/api/v2/aibridge/openai/v1"
+
+# Anthropic-compatible traffic (Claude, etc.)
+export ANTHROPIC_API_KEY="<your-coder-session-token>"
+export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
+```
+
+## Advanced: providers.jsonc
+
+If you prefer a file-based config, edit `~/.mux/providers.jsonc`:
+
+```jsonc
+{
+  "openai": {
+    "apiKey": "<your-coder-session-token>",
+    "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1"
+  },
+  "anthropic": {
+    "apiKey": "<your-coder-session-token>",
+    "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic"
+  }
+}
+```
+
+**References:** [Mux provider environment variables](https://mux.coder.com/config/providers#environment-variables)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1048,6 +1048,11 @@
 											"path": "./ai-coder/ai-bridge/clients/codex.md"
 										},
 										{
+											"title": "Mux",
+											"description": "Configure Mux to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/mux.md"
+										},
+										{
 											"title": "OpenCode",
 											"description": "Configure OpenCode to use AI Bridge",
 											"path": "./ai-coder/ai-bridge/clients/opencode.md"


### PR DESCRIPTION
Adds a new AI Bridge client configuration page for **Mux** and lists it in the client compatibility table.

- Add `docs/ai-coder/ai-bridge/clients/mux.md` with a short intro, UI + env var + `~/.mux/providers.jsonc` examples
- Add Mux to the AI Bridge client compatibility table
- Add the new page to `docs/manifest.json`

Refs: https://mux.coder.com/config/providers#environment-variables