### PR TITLE
feat: add an endpoint to manually pause a coder task

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -1255,9 +1255,11 @@ func (api *API) postWorkspaceAgentTaskLogSnapshot(rw http.ResponseWriter, r *htt
 // @Success 202 {object} codersdk.WorkspaceBuild
 // @Router /tasks/{user}/{task}/pause [post]
 func (api *API) pauseTask(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	task := httpmw.TaskParam(r)
-	apiKey := httpmw.APIKey(r)
+	var (
+		ctx    = r.Context()
+		apiKey = httpmw.APIKey(r)
+		task   = httpmw.TaskParam(r)
+	)
 
 	if !task.WorkspaceID.Valid {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -1273,7 +1275,7 @@ func (api *API) pauseTask(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching task workspace before pausing task.",
+			Message: "Internal error fetching task workspace.",
 			Detail:  err.Error(),
 		})
 		return

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -1301,6 +1301,6 @@ func (api *API) pauseTask(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	httpapi.Write(ctx, rw, http.StatusAccepted, codersdk.PauseTaskResponse{
-		WorkspaceBuildID: build.ID,
+		WorkspaceBuild: &build,
 	})
 }

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -1252,7 +1252,7 @@ func (api *API) postWorkspaceAgentTaskLogSnapshot(rw http.ResponseWriter, r *htt
 // @Tags Tasks
 // @Param user path string true "Username, user ID, or 'me' for the authenticated user"
 // @Param task path string true "Task ID" format(uuid)
-// @Success 202 {object} codersdk.WorkspaceBuild
+// @Success 202 {object} codersdk.PauseTaskResponse
 // @Router /tasks/{user}/{task}/pause [post]
 func (api *API) pauseTask(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -1300,5 +1300,7 @@ func (api *API) pauseTask(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusAccepted, build)
+	httpapi.Write(ctx, rw, http.StatusAccepted, codersdk.PauseTaskResponse{
+		WorkspaceBuildID: build.ID,
+	})
 }

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -2511,7 +2511,9 @@ func TestPauseTask(t *testing.T) {
 		require.NoError(t, err)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
-		build, err := client.PauseTask(ctx, codersdk.Me, task.ID)
+		resp, err := client.PauseTask(ctx, codersdk.Me, task.ID)
+		require.NoError(t, err)
+		build, err := client.WorkspaceBuild(ctx, resp.WorkspaceBuildID)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.WorkspaceTransitionStop, build.Transition)
 		require.Equal(t, task.WorkspaceID.UUID, build.WorkspaceID)

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -2467,6 +2467,15 @@ func TestPauseTask(t *testing.T) {
 
 	t.Run("Task not found", func(t *testing.T) {
 		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.PauseTask(ctx, codersdk.Me, uuid.New())
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
 	})
 
 	t.Run("Task lookup forbidden", func(t *testing.T) {

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	agentapisdk "github.com/coder/agentapi-sdk-go"
 	"github.com/coder/coder/v2/agent"
@@ -2643,7 +2643,7 @@ func TestPauseTask(t *testing.T) {
 			Store: db,
 			getWorkspaceByID: func(ctx context.Context, id uuid.UUID) (database.Workspace, error) {
 				if id == workspaceID && id != uuid.Nil {
-					return database.Workspace{}, errors.New("boom")
+					return database.Workspace{}, xerrors.New("boom")
 				}
 				return db.GetWorkspaceByID(ctx, id)
 			},
@@ -2711,7 +2711,7 @@ func TestPauseTask(t *testing.T) {
 		wrapped := storeWrapper{
 			Store: db,
 			insertWorkspaceBuild: func(ctx context.Context, arg database.InsertWorkspaceBuildParams) error {
-				return errors.New("insert failed")
+				return xerrors.New("insert failed")
 			},
 		}
 		client := setupClient(t, wrapped, ps, nil)

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -2518,8 +2518,7 @@ func TestPauseTask(t *testing.T) {
 		require.Equal(t, codersdk.WorkspaceTransitionStop, build.Transition)
 		require.Equal(t, task.WorkspaceID.UUID, build.WorkspaceID)
 		require.Equal(t, workspace.LatestBuild.BuildNumber+1, build.BuildNumber)
-		// TODO: verify whether the assertion below is a requirement
-		// require.Equal(t, codersdk.BuildReason(codersdk.CreateWorkspaceBuildReasonTaskManualPause), build.Reason)
+		require.Equal(t, string(codersdk.CreateWorkspaceBuildReasonTaskManualPause), string(build.Reason))
 	})
 
 	t.Run("Non-owner role access", func(t *testing.T) {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14187,7 +14187,8 @@ const docTemplate = `{
                         "cli",
                         "ssh_connection",
                         "vscode_connection",
-                        "jetbrains_connection"
+                        "jetbrains_connection",
+                        "task_manual_pause"
                     ],
                     "allOf": [
                         {
@@ -17061,9 +17062,8 @@ const docTemplate = `{
         "codersdk.PauseTaskResponse": {
             "type": "object",
             "properties": {
-                "workspace_build_id": {
-                    "type": "string",
-                    "format": "uuid"
+                "workspace_build": {
+                    "$ref": "#/definitions/codersdk.WorkspaceBuild"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5824,6 +5824,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/tasks/{user}/{task}/pause": {
+            "post": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tasks"
+                ],
+                "summary": "Pause task",
+                "operationId": "pause-task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username, user ID, or 'me' for the authenticated user",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Task ID",
+                        "name": "task",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceBuild"
+                        }
+                    }
+                }
+            }
+        },
         "/tasks/{user}/{task}/send": {
             "post": {
                 "security": [
@@ -14102,14 +14144,16 @@ const docTemplate = `{
                 "cli",
                 "ssh_connection",
                 "vscode_connection",
-                "jetbrains_connection"
+                "jetbrains_connection",
+                "task_manual_pause"
             ],
             "x-enum-varnames": [
                 "CreateWorkspaceBuildReasonDashboard",
                 "CreateWorkspaceBuildReasonCLI",
                 "CreateWorkspaceBuildReasonSSHConnection",
                 "CreateWorkspaceBuildReasonVSCodeConnection",
-                "CreateWorkspaceBuildReasonJetbrainsConnection"
+                "CreateWorkspaceBuildReasonJetbrainsConnection",
+                "CreateWorkspaceBuildReasonTaskManualPause"
             ]
         },
         "codersdk.CreateWorkspaceBuildRequest": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5860,7 +5860,7 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/codersdk.WorkspaceBuild"
+                            "$ref": "#/definitions/codersdk.PauseTaskResponse"
                         }
                     }
                 }
@@ -17055,6 +17055,15 @@ const docTemplate = `{
                 },
                 "regenerate_token": {
                     "type": "boolean"
+                }
+            }
+        },
+        "codersdk.PauseTaskResponse": {
+            "type": "object",
+            "properties": {
+                "workspace_build_id": {
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12739,7 +12739,8 @@
 						"cli",
 						"ssh_connection",
 						"vscode_connection",
-						"jetbrains_connection"
+						"jetbrains_connection",
+						"task_manual_pause"
 					],
 					"allOf": [
 						{
@@ -15520,9 +15521,8 @@
 		"codersdk.PauseTaskResponse": {
 			"type": "object",
 			"properties": {
-				"workspace_build_id": {
-					"type": "string",
-					"format": "uuid"
+				"workspace_build": {
+					"$ref": "#/definitions/codersdk.WorkspaceBuild"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5147,6 +5147,44 @@
 				}
 			}
 		},
+		"/tasks/{user}/{task}/pause": {
+			"post": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"consumes": ["application/json"],
+				"tags": ["Tasks"],
+				"summary": "Pause task",
+				"operationId": "pause-task",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Username, user ID, or 'me' for the authenticated user",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Task ID",
+						"name": "task",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"202": {
+						"description": "Accepted",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceBuild"
+						}
+					}
+				}
+			}
+		},
 		"/tasks/{user}/{task}/send": {
 			"post": {
 				"security": [
@@ -12662,14 +12700,16 @@
 				"cli",
 				"ssh_connection",
 				"vscode_connection",
-				"jetbrains_connection"
+				"jetbrains_connection",
+				"task_manual_pause"
 			],
 			"x-enum-varnames": [
 				"CreateWorkspaceBuildReasonDashboard",
 				"CreateWorkspaceBuildReasonCLI",
 				"CreateWorkspaceBuildReasonSSHConnection",
 				"CreateWorkspaceBuildReasonVSCodeConnection",
-				"CreateWorkspaceBuildReasonJetbrainsConnection"
+				"CreateWorkspaceBuildReasonJetbrainsConnection",
+				"CreateWorkspaceBuildReasonTaskManualPause"
 			]
 		},
 		"codersdk.CreateWorkspaceBuildRequest": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5179,7 +5179,7 @@
 					"202": {
 						"description": "Accepted",
 						"schema": {
-							"$ref": "#/definitions/codersdk.WorkspaceBuild"
+							"$ref": "#/definitions/codersdk.PauseTaskResponse"
 						}
 					}
 				}
@@ -15514,6 +15514,15 @@
 				},
 				"regenerate_token": {
 					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.PauseTaskResponse": {
+			"type": "object",
+			"properties": {
+				"workspace_build_id": {
+					"type": "string",
+					"format": "uuid"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1076,6 +1076,7 @@ func New(options *Options) *API {
 					r.Patch("/input", api.taskUpdateInput)
 					r.Post("/send", api.taskSend)
 					r.Get("/logs", api.taskLogs)
+					r.Post("/pause", api.pauseTask)
 				})
 			})
 		})

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -384,7 +384,7 @@ func (api *API) postWorkspaceBuildsInternal(
 		Experiments(api.Experiments).
 		TemplateVersionPresetID(createBuild.TemplateVersionPresetID)
 
-	if transition == database.WorkspaceTransitionStart && createBuild.Reason != "" {
+	if (transition == database.WorkspaceTransitionStart || transition == database.WorkspaceTransitionStop) && createBuild.Reason != "" {
 		builder = builder.Reason(database.BuildReason(createBuild.Reason))
 	}
 

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -329,24 +329,29 @@ func (c *Client) UpdateTaskInput(ctx context.Context, user string, id uuid.UUID,
 	return nil
 }
 
+// PauseTaskResponse represents the response from pausing a task.
+type PauseTaskResponse struct {
+	WorkspaceBuildID uuid.UUID `json:"workspace_build_id" format:"uuid"`
+}
+
 // PauseTask pauses a task by stopping its workspace.
 // Experimental: uses the /api/experimental endpoint.
-func (c *Client) PauseTask(ctx context.Context, user string, id uuid.UUID) (WorkspaceBuild, error) {
+func (c *Client) PauseTask(ctx context.Context, user string, id uuid.UUID) (PauseTaskResponse, error) {
 	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/tasks/%s/%s/pause", user, id.String()), nil)
 	if err != nil {
-		return WorkspaceBuild{}, err
+		return PauseTaskResponse{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusAccepted {
-		return WorkspaceBuild{}, ReadBodyAsError(res)
+		return PauseTaskResponse{}, ReadBodyAsError(res)
 	}
 
-	var build WorkspaceBuild
-	if err := json.NewDecoder(res.Body).Decode(&build); err != nil {
-		return WorkspaceBuild{}, err
+	var resp PauseTaskResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return PauseTaskResponse{}, err
 	}
 
-	return build, nil
+	return resp, nil
 }
 
 // TaskLogType indicates the source of a task log entry.

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -331,7 +331,7 @@ func (c *Client) UpdateTaskInput(ctx context.Context, user string, id uuid.UUID,
 
 // PauseTaskResponse represents the response from pausing a task.
 type PauseTaskResponse struct {
-	WorkspaceBuildID uuid.UUID `json:"workspace_build_id" format:"uuid"`
+	WorkspaceBuild *WorkspaceBuild `json:"workspace_build"`
 }
 
 // PauseTask pauses a task by stopping its workspace.

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -329,6 +329,26 @@ func (c *Client) UpdateTaskInput(ctx context.Context, user string, id uuid.UUID,
 	return nil
 }
 
+// PauseTask pauses a task by stopping its workspace.
+// Experimental: uses the /api/experimental endpoint.
+func (c *Client) PauseTask(ctx context.Context, user string, id uuid.UUID) (WorkspaceBuild, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/tasks/%s/%s/pause", user, id.String()), nil)
+	if err != nil {
+		return WorkspaceBuild{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusAccepted {
+		return WorkspaceBuild{}, ReadBodyAsError(res)
+	}
+
+	var build WorkspaceBuild
+	if err := json.NewDecoder(res.Body).Decode(&build); err != nil {
+		return WorkspaceBuild{}, err
+	}
+
+	return build, nil
+}
+
 // TaskLogType indicates the source of a task log entry.
 type TaskLogType string
 

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -109,6 +109,7 @@ const (
 	CreateWorkspaceBuildReasonSSHConnection       CreateWorkspaceBuildReason = "ssh_connection"
 	CreateWorkspaceBuildReasonVSCodeConnection    CreateWorkspaceBuildReason = "vscode_connection"
 	CreateWorkspaceBuildReasonJetbrainsConnection CreateWorkspaceBuildReason = "jetbrains_connection"
+	CreateWorkspaceBuildReasonTaskManualPause     CreateWorkspaceBuildReason = "task_manual_pause"
 )
 
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -130,7 +130,7 @@ type CreateWorkspaceBuildRequest struct {
 	// TemplateVersionPresetID is the ID of the template version preset to use for the build.
 	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty" format:"uuid"`
 	// Reason sets the reason for the workspace build.
-	Reason CreateWorkspaceBuildReason `json:"reason,omitempty" validate:"omitempty,oneof=dashboard cli ssh_connection vscode_connection jetbrains_connection"`
+	Reason CreateWorkspaceBuildReason `json:"reason,omitempty" validate:"omitempty,oneof=dashboard cli ssh_connection vscode_connection jetbrains_connection task_manual_pause"`
 }
 
 type WorkspaceOptions struct {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2227,11 +2227,11 @@ This is required on creation to enable a user-flow of validating a template work
 
 #### Enumerated Values
 
-| Property     | Value(s)                                                                          |
-|--------------|-----------------------------------------------------------------------------------|
-| `log_level`  | `debug`                                                                           |
-| `reason`     | `cli`, `dashboard`, `jetbrains_connection`, `ssh_connection`, `vscode_connection` |
-| `transition` | `delete`, `start`, `stop`                                                         |
+| Property     | Value(s)                                                                                               |
+|--------------|--------------------------------------------------------------------------------------------------------|
+| `log_level`  | `debug`                                                                                                |
+| `reason`     | `cli`, `dashboard`, `jetbrains_connection`, `ssh_connection`, `task_manual_pause`, `vscode_connection` |
+| `transition` | `delete`, `start`, `stop`                                                                              |
 
 ## codersdk.CreateWorkspaceProxyRequest
 
@@ -6182,15 +6182,220 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ```json
 {
-  "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+  "workspace_build": {
+    "build_number": 0,
+    "created_at": "2019-08-24T14:15:22Z",
+    "daily_cost": 0,
+    "deadline": "2019-08-24T14:15:22Z",
+    "has_ai_task": true,
+    "has_external_agent": true,
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+    "initiator_name": "string",
+    "job": {
+      "available_workers": [
+        "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+      ],
+      "canceled_at": "2019-08-24T14:15:22Z",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "created_at": "2019-08-24T14:15:22Z",
+      "error": "string",
+      "error_code": "REQUIRED_TEMPLATE_VARIABLES",
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+      "input": {
+        "error": "string",
+        "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+        "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+      },
+      "logs_overflowed": true,
+      "metadata": {
+        "template_display_name": "string",
+        "template_icon": "string",
+        "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
+        "template_name": "string",
+        "template_version_name": "string",
+        "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+        "workspace_name": "string"
+      },
+      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+      "queue_position": 0,
+      "queue_size": 0,
+      "started_at": "2019-08-24T14:15:22Z",
+      "status": "pending",
+      "tags": {
+        "property1": "string",
+        "property2": "string"
+      },
+      "type": "template_version_import",
+      "worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b",
+      "worker_name": "string"
+    },
+    "matched_provisioners": {
+      "available": 0,
+      "count": 0,
+      "most_recently_seen": "2019-08-24T14:15:22Z"
+    },
+    "max_deadline": "2019-08-24T14:15:22Z",
+    "reason": "initiator",
+    "resources": [
+      {
+        "agents": [
+          {
+            "api_version": "string",
+            "apps": [
+              {
+                "command": "string",
+                "display_name": "string",
+                "external": true,
+                "group": "string",
+                "health": "disabled",
+                "healthcheck": {
+                  "interval": 0,
+                  "threshold": 0,
+                  "url": "string"
+                },
+                "hidden": true,
+                "icon": "string",
+                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                "open_in": "slim-window",
+                "sharing_level": "owner",
+                "slug": "string",
+                "statuses": [
+                  {
+                    "agent_id": "2b1e3b65-2c04-4fa2-a2d7-467901e98978",
+                    "app_id": "affd1d10-9538-4fc8-9e0b-4594a28c1335",
+                    "created_at": "2019-08-24T14:15:22Z",
+                    "icon": "string",
+                    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                    "message": "string",
+                    "needs_user_attention": true,
+                    "state": "working",
+                    "uri": "string",
+                    "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9"
+                  }
+                ],
+                "subdomain": true,
+                "subdomain_name": "string",
+                "tooltip": "string",
+                "url": "string"
+              }
+            ],
+            "architecture": "string",
+            "connection_timeout_seconds": 0,
+            "created_at": "2019-08-24T14:15:22Z",
+            "directory": "string",
+            "disconnected_at": "2019-08-24T14:15:22Z",
+            "display_apps": [
+              "vscode"
+            ],
+            "environment_variables": {
+              "property1": "string",
+              "property2": "string"
+            },
+            "expanded_directory": "string",
+            "first_connected_at": "2019-08-24T14:15:22Z",
+            "health": {
+              "healthy": false,
+              "reason": "agent has lost connection"
+            },
+            "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "instance_id": "string",
+            "last_connected_at": "2019-08-24T14:15:22Z",
+            "latency": {
+              "property1": {
+                "latency_ms": 0,
+                "preferred": true
+              },
+              "property2": {
+                "latency_ms": 0,
+                "preferred": true
+              }
+            },
+            "lifecycle_state": "created",
+            "log_sources": [
+              {
+                "created_at": "2019-08-24T14:15:22Z",
+                "display_name": "string",
+                "icon": "string",
+                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                "workspace_agent_id": "7ad2e618-fea7-4c1a-b70a-f501566a72f1"
+              }
+            ],
+            "logs_length": 0,
+            "logs_overflowed": true,
+            "name": "string",
+            "operating_system": "string",
+            "parent_id": {
+              "uuid": "string",
+              "valid": true
+            },
+            "ready_at": "2019-08-24T14:15:22Z",
+            "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
+            "scripts": [
+              {
+                "cron": "string",
+                "display_name": "string",
+                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                "log_path": "string",
+                "log_source_id": "4197ab25-95cf-4b91-9c78-f7f2af5d353a",
+                "run_on_start": true,
+                "run_on_stop": true,
+                "script": "string",
+                "start_blocks_login": true,
+                "timeout": 0
+              }
+            ],
+            "started_at": "2019-08-24T14:15:22Z",
+            "startup_script_behavior": "blocking",
+            "status": "connecting",
+            "subsystems": [
+              "envbox"
+            ],
+            "troubleshooting_url": "string",
+            "updated_at": "2019-08-24T14:15:22Z",
+            "version": "string"
+          }
+        ],
+        "created_at": "2019-08-24T14:15:22Z",
+        "daily_cost": 0,
+        "hide": true,
+        "icon": "string",
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "job_id": "453bd7d7-5355-4d6d-a38e-d9e7eb218c3f",
+        "metadata": [
+          {
+            "key": "string",
+            "sensitive": true,
+            "value": "string"
+          }
+        ],
+        "name": "string",
+        "type": "string",
+        "workspace_transition": "start"
+      }
+    ],
+    "status": "pending",
+    "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+    "template_version_name": "string",
+    "template_version_preset_id": "512a53a7-30da-446e-a1fc-713c630baff1",
+    "transition": "start",
+    "updated_at": "2019-08-24T14:15:22Z",
+    "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+    "workspace_name": "string",
+    "workspace_owner_avatar_url": "string",
+    "workspace_owner_id": "e7078695-5279-4c86-8774-3ac2367a2fc7",
+    "workspace_owner_name": "string"
+  }
 }
 ```
 
 ### Properties
 
-| Name                 | Type   | Required | Restrictions | Description |
-|----------------------|--------|----------|--------------|-------------|
-| `workspace_build_id` | string | false    |              |             |
+| Name              | Type                                               | Required | Restrictions | Description |
+|-------------------|----------------------------------------------------|----------|--------------|-------------|
+| `workspace_build` | [codersdk.WorkspaceBuild](#codersdkworkspacebuild) | false    |              |             |
 
 ## codersdk.Permission
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -6178,6 +6178,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `name`             | string  | true     |              |             |
 | `regenerate_token` | boolean | false    |              |             |
 
+## codersdk.PauseTaskResponse
+
+```json
+{
+  "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+}
+```
+
+### Properties
+
+| Name                 | Type   | Required | Restrictions | Description |
+|----------------------|--------|----------|--------------|-------------|
+| `workspace_build_id` | string | false    |              |             |
+
 ## codersdk.Permission
 
 ```json

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2184,9 +2184,9 @@ This is required on creation to enable a user-flow of validating a template work
 
 #### Enumerated Values
 
-| Value(s)                                                                          |
-|-----------------------------------------------------------------------------------|
-| `cli`, `dashboard`, `jetbrains_connection`, `ssh_connection`, `vscode_connection` |
+| Value(s)                                                                                               |
+|--------------------------------------------------------------------------------------------------------|
+| `cli`, `dashboard`, `jetbrains_connection`, `ssh_connection`, `task_manual_pause`, `vscode_connection` |
 
 ## codersdk.CreateWorkspaceBuildRequest
 

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -391,9 +391,9 @@ curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/pause \
 
 ### Responses
 
-| Status | Meaning                                                       | Description | Schema                                                       |
-|--------|---------------------------------------------------------------|-------------|--------------------------------------------------------------|
-| 202    | [Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3) | Accepted    | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
+| Status | Meaning                                                       | Description | Schema                                                             |
+|--------|---------------------------------------------------------------|-------------|--------------------------------------------------------------------|
+| 202    | [Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3) | Accepted    | [codersdk.PauseTaskResponse](schemas.md#codersdkpausetaskresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -365,6 +365,38 @@ curl -X GET http://coder-server:8080/api/v2/tasks/{user}/{task}/logs \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Pause task
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/pause \
+  -H 'Accept: */*' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /tasks/{user}/{task}/pause`
+
+### Parameters
+
+| Name   | In   | Type         | Required | Description                                           |
+|--------|------|--------------|----------|-------------------------------------------------------|
+| `user` | path | string       | true     | Username, user ID, or 'me' for the authenticated user |
+| `task` | path | string(uuid) | true     | Task ID                                               |
+
+### Example responses
+
+> 202 Response
+
+### Responses
+
+| Status | Meaning                                                       | Description | Schema                                                       |
+|--------|---------------------------------------------------------------|-------------|--------------------------------------------------------------|
+| 202    | [Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3) | Accepted    | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Send input to AI task
 
 ### Code samples

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1425,6 +1425,7 @@ export type CreateWorkspaceBuildReason =
 	| "dashboard"
 	| "jetbrains_connection"
 	| "ssh_connection"
+	| "task_manual_pause"
 	| "vscode_connection";
 
 export const CreateWorkspaceBuildReasons: CreateWorkspaceBuildReason[] = [
@@ -1432,6 +1433,7 @@ export const CreateWorkspaceBuildReasons: CreateWorkspaceBuildReason[] = [
 	"dashboard",
 	"jetbrains_connection",
 	"ssh_connection",
+	"task_manual_pause",
 	"vscode_connection",
 ];
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3585,6 +3585,14 @@ export interface PatchWorkspaceProxy {
  */
 export const PathAppSessionTokenCookie = "coder_path_app_session_token";
 
+// From codersdk/aitasks.go
+/**
+ * PauseTaskResponse represents the response from pausing a task.
+ */
+export interface PauseTaskResponse {
+	readonly workspace_build_id: string;
+}
+
 // From codersdk/roles.go
 /**
  * Permission is the format passed into the rego.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3590,7 +3590,7 @@ export const PathAppSessionTokenCookie = "coder_path_app_session_token";
  * PauseTaskResponse represents the response from pausing a task.
  */
 export interface PauseTaskResponse {
-	readonly workspace_build_id: string;
+	readonly workspace_build: WorkspaceBuild | null;
 }
 
 // From codersdk/roles.go


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1261.

This pull request adds an endpoint to pause coder tasks by stopping the underlying workspace.
* Instead of `POST /api/v2/tasks/{user}/{task}/pause`, the endpoint is currently experimental.