### PR TITLE
chore(dogfood): add project to mux module

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -379,6 +379,7 @@ module "mux" {
   agent_id     = coder_agent.dev.id
   subdomain    = true
   display_name = "Mux"
+  add-project  = local.repo_dir
 }
 
 module "code-server" {


### PR DESCRIPTION
Adds `add-project` to the `mux` module in the dogfood Coder template so Mux opens the cloned repo by default.

- Uses `local.repo_dir` (defaults to `/home/coder/coder`) so it stays correct if the repo base dir parameter changes.

Testing:
- `terraform fmt -check dogfood/coder/main.tf`