### PR TITLE
test: drop windows for TestGetModulesArchive due to flakiness

### DIFF
--- a/provisioner/terraform/modules_internal_test.go
+++ b/provisioner/terraform/modules_internal_test.go
@@ -23,6 +23,9 @@ import (
 // platform specific.
 func TestGetModulesArchive(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows path separators and newline handling make this test unreliable.")
+	}
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Coder is run in a linux container almost always anyway

Closes https://github.com/coder/internal/issues/1325