### PR TITLE
fix: resize `!size-icon-lg` in `<ProxyMenu />`

### DIFF
--- a/site/src/modules/dashboard/Navbar/ProxyMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/ProxyMenu.tsx
@@ -96,7 +96,7 @@ export const ProxyMenu: FC<ProxyMenuProps> = ({ proxyContextValue }) => {
 						"Select Proxy"
 					)}
 
-					<ChevronDownIcon className="text-content-primary !size-icon-lg" />
+					<ChevronDownIcon className="text-content-primary !size-icon-sm" />
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="w-80">


### PR DESCRIPTION
This pull-request changes the size of our `▼` / downwards chevron to match that update in #21781 . This was incorrectly changed in #21807.

| Old | New |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a5ea1fbf-ac3e-44f8-8e6b-afd3d0dab28f" /> | <img src="https://github.com/user-attachments/assets/dffe408d-47a5-4c45-ad78-939663327695" /> |
