### PR TITLE
chore: disallow `forwardRef`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,11 +3,11 @@
 		"enabled": true,
 		"clientKind": "git",
 		"useIgnoreFile": true,
-		"defaultBranch": "main"
+		"defaultBranch": "main",
 	},
 	"files": {
 		"includes": ["**", "!**/pnpm-lock.yaml"],
-		"ignoreUnknown": true
+		"ignoreUnknown": true,
 	},
 	"linter": {
 		"rules": {
@@ -15,18 +15,18 @@
 				"noSvgWithoutTitle": "off",
 				"useButtonType": "off",
 				"useSemanticElements": "off",
-				"noStaticElementInteractions": "off"
+				"noStaticElementInteractions": "off",
 			},
-		"correctness": {
-			"noUnusedImports": "warn",
+			"correctness": {
+				"noUnusedImports": "warn",
 				"useUniqueElementIds": "off", // TODO: This is new but we want to fix it
 				"noNestedComponentDefinitions": "off", // TODO: Investigate, since it is used by shadcn components
-			"noUnusedVariables": {
-				"level": "warn",
+				"noUnusedVariables": {
+					"level": "warn",
 					"options": {
-						"ignoreRestSiblings": true
-					}
-				}
+						"ignoreRestSiblings": true,
+					},
+				},
 			},
 			"style": {
 				"noNonNullAssertion": "off",
@@ -45,6 +45,10 @@
 					"level": "error",
 					"options": {
 						"paths": {
+							"react": {
+								"message": "React 19 no longer requires forwardRef. Use ref as a prop instead.",
+								"importNames": ["forwardRef"],
+							},
 							// "@mui/material/Alert": "Use components/Alert/Alert instead.",
 							// "@mui/material/AlertTitle": "Use components/Alert/Alert instead.",
 							// "@mui/material/Autocomplete": "Use shadcn/ui Combobox instead.",
@@ -111,10 +115,10 @@
 							"@emotion/styled": "Use Tailwind CSS instead.",
 							// "@emotion/cache": "Use Tailwind CSS instead.",
 							// "components/Stack/Stack": "Use Tailwind flex utilities instead (e.g., <div className='flex flex-col gap-4'>).",
-							"lodash": "Use lodash/<name> instead."
-						}
-					}
-				}
+							"lodash": "Use lodash/<name> instead.",
+						},
+					},
+				},
 			},
 			"suspicious": {
 				"noArrayIndexKey": "off",
@@ -125,14 +129,14 @@
 				"noConsole": {
 					"level": "error",
 					"options": {
-						"allow": ["error", "info", "warn"]
-					}
-				}
+						"allow": ["error", "info", "warn"],
+					},
+				},
 			},
 			"complexity": {
-				"noImportantStyles": "off" // TODO: check and fix !important styles
-			}
-		}
+				"noImportantStyles": "off", // TODO: check and fix !important styles
+			},
+		},
 	},
-	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 }

--- a/site/src/components/Chart/Chart.tsx
+++ b/site/src/components/Chart/Chart.tsx
@@ -2,7 +2,14 @@
  * Copied from shadc/ui on 01/13/2025
  * @see {@link https://ui.shadcn.com/docs/components/chart}
  */
-import * as React from "react";
+import {
+	type CSSProperties,
+	createContext,
+	type Ref,
+	useContext,
+	useId,
+	useMemo,
+} from "react";
 import * as RechartsPrimitive from "recharts";
 import { cn } from "utils/cn";
 
@@ -23,10 +30,10 @@ type ChartContextProps = {
 	config: ChartConfig;
 };
 
-const ChartContext = React.createContext<ChartContextProps | null>(null);
+const ChartContext = createContext<ChartContextProps | null>(null);
 
 function useChart() {
-	const context = React.useContext(ChartContext);
+	const context = useContext(ChartContext);
 
 	if (!context) {
 		throw new Error("useChart must be used within a <ChartContainer />");
@@ -35,23 +42,31 @@ function useChart() {
 	return context;
 }
 
-export const ChartContainer = React.forwardRef<
-	HTMLDivElement,
-	React.ComponentProps<"div"> & {
+type ChartContainerProps = Omit<
+	React.ComponentPropsWithRef<"div">,
+	"children"
+> &
+	Pick<
+		React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>,
+		"children"
+	> & {
 		config: ChartConfig;
-		children: React.ComponentProps<
-			typeof RechartsPrimitive.ResponsiveContainer
-		>["children"];
-	}
->(({ id, className, children, config, ...props }, ref) => {
-	const uniqueId = React.useId();
+	};
+
+export const ChartContainer: React.FC<ChartContainerProps> = ({
+	id,
+	className,
+	children,
+	config,
+	...props
+}) => {
+	const uniqueId = useId();
 	const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
 
 	return (
 		<ChartContext.Provider value={{ config }}>
 			<div
 				data-chart={chartId}
-				ref={ref}
 				className={cn(
 					"flex aspect-video justify-center text-xs",
 					"[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground",
@@ -79,8 +94,7 @@ export const ChartContainer = React.forwardRef<
 			</div>
 		</ChartContext.Provider>
 	);
-});
-ChartContainer.displayName = "Chart";
+};
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 	const colorConfig = Object.entries(config).filter(
@@ -117,219 +131,157 @@ ${colorConfig
 
 export const ChartTooltip = RechartsPrimitive.Tooltip;
 
-export const ChartTooltipContent = React.forwardRef<
-	HTMLDivElement,
-	React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-		React.ComponentProps<"div"> & {
-			hideLabel?: boolean;
-			hideIndicator?: boolean;
-			indicator?: "line" | "dot" | "dashed";
-			nameKey?: string;
-			labelKey?: string;
-		}
->(
-	(
-		{
-			active,
-			payload,
-			className,
-			indicator = "dot",
-			hideLabel = false,
-			hideIndicator = false,
-			label,
-			labelFormatter,
-			labelClassName,
-			formatter,
-			color,
-			nameKey,
-			labelKey,
-		},
-		ref,
-	) => {
-		const { config } = useChart();
+type ChartTooltipContentProps = React.ComponentProps<
+	typeof RechartsPrimitive.Tooltip
+> & {
+	className?: string;
+	color?: string;
+	hideLabel?: boolean;
+	hideIndicator?: boolean;
+	indicator?: "line" | "dot" | "dashed";
+	nameKey?: string;
+	labelKey?: string;
+	ref?: Ref<HTMLDivElement>;
+};
 
-		const tooltipLabel = React.useMemo(() => {
-			if (hideLabel || !payload?.length) {
-				return null;
-			}
+export const ChartTooltipContent: React.FC<ChartTooltipContentProps> = ({
+	active,
+	payload,
+	formatter,
+	className,
+	color,
+	hideLabel = false,
+	hideIndicator = false,
+	indicator = "dot",
+	nameKey,
+	labelKey,
+	label,
+	labelFormatter,
+	labelClassName,
+	ref,
+}) => {
+	const { config } = useChart();
 
-			const [item] = payload;
-			const key = `${labelKey || item.dataKey || item.name || "value"}`;
-			const itemConfig = getPayloadConfigFromPayload(config, item, key);
-			const value =
-				!labelKey && typeof label === "string"
-					? config[label as keyof typeof config]?.label || label
-					: itemConfig?.label;
-
-			if (labelFormatter) {
-				return (
-					<div className={cn("font-medium", labelClassName)}>
-						{labelFormatter(value, payload)}
-					</div>
-				);
-			}
-
-			if (!value) {
-				return null;
-			}
-
-			return <div className={cn("font-medium", labelClassName)}>{value}</div>;
-		}, [
-			label,
-			labelFormatter,
-			payload,
-			hideLabel,
-			labelClassName,
-			config,
-			labelKey,
-		]);
-
-		if (!active || !payload?.length) {
+	const tooltipLabel = useMemo(() => {
+		if (hideLabel || !payload?.length) {
 			return null;
 		}
 
-		const nestLabel = payload.length === 1 && indicator !== "dot";
+		const [item] = payload;
+		const key = `${labelKey || item.dataKey || item.name || "value"}`;
+		const itemConfig = getPayloadConfigFromPayload(config, item, key);
+		const value =
+			!labelKey && typeof label === "string"
+				? config[label as keyof typeof config]?.label || label
+				: itemConfig?.label;
 
-		return (
-			<div
-				ref={ref}
-				className={cn(
-					"grid min-w-[8rem] items-start gap-1 rounded-lg border border-solid border-border bg-surface-primary px-3 py-2 text-xs shadow-xl",
-					className,
-				)}
-			>
-				{!nestLabel ? tooltipLabel : null}
-				<div className="grid gap-1.5">
-					{payload.map((item, index) => {
-						const key = `${nameKey || item.name || item.dataKey || "value"}`;
-						const itemConfig = getPayloadConfigFromPayload(config, item, key);
-						const indicatorColor = color || item.payload.fill || item.color;
-
-						return (
-							<div
-								key={item.dataKey}
-								className={cn(
-									"flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-									indicator === "dot" && "items-center",
-								)}
-							>
-								{formatter && item?.value !== undefined && item.name ? (
-									formatter(item.value, item.name, item, index, item.payload)
-								) : (
-									<>
-										{itemConfig?.icon ? (
-											<itemConfig.icon />
-										) : (
-											!hideIndicator && (
-												<div
-													className={cn(
-														"shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
-														{
-															"h-2.5 w-2.5": indicator === "dot",
-															"w-1": indicator === "line",
-															"w-0 border-[1.5px] border-dashed bg-transparent":
-																indicator === "dashed",
-															"my-0.5": nestLabel && indicator === "dashed",
-														},
-													)}
-													style={
-														{
-															"--color-bg": indicatorColor,
-															"--color-border": indicatorColor,
-														} as React.CSSProperties
-													}
-												/>
-											)
-										)}
-										<div
-											className={cn(
-												"flex flex-1 justify-between leading-none",
-												nestLabel ? "items-end" : "items-center",
-											)}
-										>
-											<div className="grid gap-1.5">
-												{nestLabel ? tooltipLabel : null}
-												<span className="text-muted-foreground">
-													{itemConfig?.label || item.name}
-												</span>
-											</div>
-											{item.value && (
-												<span className="font-mono font-medium tabular-nums text-foreground">
-													{item.value.toLocaleString()}
-												</span>
-											)}
-										</div>
-									</>
-								)}
-							</div>
-						);
-					})}
+		if (labelFormatter) {
+			return (
+				<div className={cn("font-medium", labelClassName)}>
+					{labelFormatter(value, payload)}
 				</div>
-			</div>
-		);
-	},
-);
-ChartTooltipContent.displayName = "ChartTooltip";
-
-const _ChartLegend = RechartsPrimitive.Legend;
-
-const ChartLegendContent = React.forwardRef<
-	HTMLDivElement,
-	React.ComponentProps<"div"> &
-		Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-			hideIcon?: boolean;
-			nameKey?: string;
+			);
 		}
->(
-	(
-		{ className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
-		ref,
-	) => {
-		const { config } = useChart();
 
-		if (!payload?.length) {
+		if (!value) {
 			return null;
 		}
 
-		return (
-			<div
-				ref={ref}
-				className={cn(
-					"flex items-center justify-center gap-4",
-					verticalAlign === "top" ? "pb-3" : "pt-3",
-					className,
-				)}
-			>
-				{payload.map((item) => {
-					const key = `${nameKey || item.dataKey || "value"}`;
+		return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+	}, [
+		label,
+		labelFormatter,
+		payload,
+		hideLabel,
+		labelClassName,
+		config,
+		labelKey,
+	]);
+
+	if (!active || !payload?.length) {
+		return null;
+	}
+
+	const nestLabel = payload.length === 1 && indicator !== "dot";
+
+	return (
+		<div
+			ref={ref}
+			className={cn(
+				"grid min-w-[8rem] items-start gap-1 rounded-lg border border-solid border-border bg-surface-primary px-3 py-2 text-xs shadow-xl",
+				className,
+			)}
+		>
+			{!nestLabel ? tooltipLabel : null}
+			<div className="grid gap-1.5">
+				{payload.map((item, index) => {
+					const key = `${nameKey || item.name || item.dataKey || "value"}`;
 					const itemConfig = getPayloadConfigFromPayload(config, item, key);
+					const indicatorColor = color || item.payload.fill || item.color;
 
 					return (
 						<div
-							key={item.value}
+							key={item.dataKey}
 							className={cn(
-								"flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
+								"flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+								indicator === "dot" && "items-center",
 							)}
 						>
-							{itemConfig?.icon && !hideIcon ? (
-								<itemConfig.icon />
+							{formatter && item?.value !== undefined && item.name ? (
+								formatter(item.value, item.name, item, index, item.payload)
 							) : (
-								<div
-									className="h-2 w-2 shrink-0 rounded-[2px]"
-									style={{
-										backgroundColor: item.color,
-									}}
-								/>
+								<>
+									{itemConfig?.icon ? (
+										<itemConfig.icon />
+									) : (
+										!hideIndicator && (
+											<div
+												className={cn(
+													"shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+													{
+														"h-2.5 w-2.5": indicator === "dot",
+														"w-1": indicator === "line",
+														"w-0 border-[1.5px] border-dashed bg-transparent":
+															indicator === "dashed",
+														"my-0.5": nestLabel && indicator === "dashed",
+													},
+												)}
+												style={
+													{
+														"--color-bg": indicatorColor,
+														"--color-border": indicatorColor,
+													} as CSSProperties
+												}
+											/>
+										)
+									)}
+									<div
+										className={cn(
+											"flex flex-1 justify-between leading-none",
+											nestLabel ? "items-end" : "items-center",
+										)}
+									>
+										<div className="grid gap-1.5">
+											{nestLabel ? tooltipLabel : null}
+											<span className="text-muted-foreground">
+												{itemConfig?.label || item.name}
+											</span>
+										</div>
+										{item.value && (
+											<span className="font-mono font-medium tabular-nums text-foreground">
+												{item.value.toLocaleString()}
+											</span>
+										)}
+									</div>
+								</>
 							)}
-							{itemConfig?.label}
 						</div>
 					);
 				})}
 			</div>
-		);
-	},
-);
-ChartLegendContent.displayName = "ChartLegend";
+		</div>
+	);
+};
 
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(

--- a/site/src/components/Command/Command.tsx
+++ b/site/src/components/Command/Command.tsx
@@ -1,145 +1,102 @@
-/**
- * Copied from shadc/ui on 11/13/2024
- * @see {@link https://ui.shadcn.com/docs/components/command}
- */
-import type { DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
-import { Dialog, DialogContent } from "components/Dialog/Dialog";
 import { Search } from "lucide-react";
-import { type FC, forwardRef } from "react";
 import { cn } from "utils/cn";
 
-export const Command = forwardRef<
-	React.ElementRef<typeof CommandPrimitive>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
-	<CommandPrimitive
-		ref={ref}
-		className={cn(
-			"flex h-full w-full flex-col overflow-hidden rounded-md bg-surface-primary text-content-primary",
-			className,
-		)}
-		{...props}
-	/>
-));
-
-const _CommandDialog: FC<DialogProps> = ({ children, ...props }) => {
+export const Command: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive>
+> = ({ className, ...props }) => {
 	return (
-		<Dialog {...props}>
-			<DialogContent className="overflow-hidden p-0">
-				<Command
-					className={`
-						[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-content-disabled
-						[&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0
-						[&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5
-						[&_[cmdk-input]]:h-12
-						[&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3
-						[&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5
-					`}
-				>
-					{children}
-				</Command>
-			</DialogContent>
-		</Dialog>
-	);
-};
-
-export const CommandInput = forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Input>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-	<div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-		<Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-		<CommandPrimitive.Input
-			ref={ref}
+		<CommandPrimitive
 			className={cn(
-				`flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none border-none
-				placeholder:text-content-secondary text-content-primary
-				disabled:cursor-not-allowed disabled:opacity-50`,
+				"flex h-full w-full flex-col overflow-hidden rounded-md bg-surface-primary text-content-primary",
 				className,
 			)}
 			{...props}
 		/>
-	</div>
-));
+	);
+};
 
-export const CommandList = forwardRef<
-	React.ElementRef<typeof CommandPrimitive.List>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
-	<CommandPrimitive.List
-		ref={ref}
-		className={cn(
-			"max-h-96 overflow-y-auto overflow-x-hidden border-0 border-t border-solid border-border",
-			className,
-		)}
-		{...props}
-	/>
-));
+export const CommandInput: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.Input>
+> = ({ className, ...props }) => {
+	return (
+		<div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+			<Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+			<CommandPrimitive.Input
+				className={cn(
+					`flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none border-none
+				placeholder:text-content-secondary text-content-primary
+				disabled:cursor-not-allowed disabled:opacity-50`,
+					className,
+				)}
+				{...props}
+			/>
+		</div>
+	);
+};
 
-export const CommandEmpty = forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Empty>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-	<CommandPrimitive.Empty
-		ref={ref}
-		className="py-6 text-center text-sm"
-		{...props}
-	/>
-));
+export const CommandList: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.List>
+> = ({ className, ...props }) => {
+	return (
+		<CommandPrimitive.List
+			className={cn(
+				"max-h-96 overflow-y-auto overflow-x-hidden border-0 border-t border-solid border-border",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
-export const CommandGroup = forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Group>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
-	<CommandPrimitive.Group
-		ref={ref}
-		className={cn(
-			`overflow-hidden p-2 text-content-primary
+export const CommandEmpty: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.Empty>
+> = ({ className, ...props }) => {
+	return (
+		<CommandPrimitive.Empty
+			className={cn("py-6 text-center text-sm", className)}
+			{...props}
+		/>
+	);
+};
+
+export const CommandGroup: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.Group>
+> = ({ className, ...props }) => {
+	return (
+		<CommandPrimitive.Group
+			className={cn(
+				`overflow-hidden p-2 text-content-primary
 			[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs
 			[&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-content-secondary`,
-			className,
-		)}
-		{...props}
-	/>
-));
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
-export const CommandSeparator = forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Separator>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
-	<CommandPrimitive.Separator
-		ref={ref}
-		className={cn("-mx-1 h-px bg-border", className)}
-		{...props}
-	/>
-));
+export const CommandSeparator: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.Separator>
+> = ({ className, ...props }) => {
+	return (
+		<CommandPrimitive.Separator
+			className={cn("-mx-1 h-px bg-border", className)}
+			{...props}
+		/>
+	);
+};
 
-export const CommandItem = forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Item>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
-	<CommandPrimitive.Item
-		ref={ref}
-		className={cn(
-			`relative flex cursor-default gap-2 select-none text-content-secondary items-center rounded-sm px-2 py-2 text-sm font-medium outline-none
+export const CommandItem: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.Item>
+> = ({ className, ...props }) => {
+	return (
+		<CommandPrimitive.Item
+			className={cn(
+				`relative flex cursor-default gap-2 select-none text-content-secondary items-center rounded-sm px-2 py-2 text-sm font-medium outline-none
 			data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50
 			data-[selected=true]:bg-surface-secondary data-[selected=true]:text-content-primary
 			[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0`,
-			className,
-		)}
-		{...props}
-	/>
-));
-
-const _CommandShortcut = ({
-	className,
-	...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-	return (
-		<span
-			className={cn(
-				"ml-auto text-xs tracking-widest text-content-disabled",
 				className,
 			)}
 			{...props}

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -4,13 +4,6 @@
  */
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cva, type VariantProps } from "class-variance-authority";
-import {
-	type ComponentPropsWithoutRef,
-	type ElementRef,
-	type FC,
-	forwardRef,
-	type HTMLAttributes,
-} from "react";
 import { cn } from "utils/cn";
 
 export const Dialog = DialogPrimitive.Root;
@@ -21,21 +14,21 @@ const DialogPortal = DialogPrimitive.Portal;
 
 export const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = forwardRef<
-	ElementRef<typeof DialogPrimitive.Overlay>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-	<DialogPrimitive.Overlay
-		ref={ref}
-		className={cn(
-			`fixed inset-0 z-50 bg-overlay
+const DialogOverlay: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Overlay>
+> = ({ className, ...props }) => {
+	return (
+		<DialogPrimitive.Overlay
+			className={cn(
+				`fixed inset-0 z-50 bg-overlay
 			data-[state=open]:animate-in data-[state=closed]:animate-out
 			data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
-			className,
-		)}
-		{...props}
-	/>
-));
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
 const dialogVariants = cva(
 	`fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg gap-6
@@ -59,73 +52,81 @@ const dialogVariants = cva(
 	},
 );
 
-interface DialogContentProps
-	extends ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
-		VariantProps<typeof dialogVariants> {}
+type DialogContentProps = React.ComponentPropsWithRef<
+	typeof DialogPrimitive.Content
+> &
+	VariantProps<typeof dialogVariants>;
 
-export const DialogContent = forwardRef<
-	ElementRef<typeof DialogPrimitive.Content>,
-	DialogContentProps
->(({ className, variant, children, ...props }, ref) => (
-	<DialogPortal>
-		<DialogOverlay />
-		<DialogPrimitive.Content
-			ref={ref}
-			className={cn(dialogVariants({ variant }), className)}
+export const DialogContent: React.FC<DialogContentProps> = ({
+	className,
+	variant,
+	children,
+	...props
+}) => {
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				className={cn(dialogVariants({ variant }), className)}
+				{...props}
+			>
+				{children}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+};
+
+export const DialogHeader: React.FC<React.ComponentPropsWithRef<"div">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div
+			className={cn(
+				"flex flex-col space-y-5 text-center sm:text-left",
+				className,
+			)}
 			{...props}
-		>
-			{children}
-		</DialogPrimitive.Content>
-	</DialogPortal>
-));
+		/>
+	);
+};
 
-export const DialogHeader: FC<HTMLAttributes<HTMLDivElement>> = ({
+export const DialogFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
 	className,
 	...props
-}) => (
-	<div
-		className={cn(
-			"flex flex-col space-y-5 text-center sm:text-left",
-			className,
-		)}
-		{...props}
-	/>
-);
+}) => {
+	return (
+		<div
+			className={cn(
+				"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
-export const DialogFooter: FC<HTMLAttributes<HTMLDivElement>> = ({
-	className,
-	...props
-}) => (
-	<div
-		className={cn(
-			"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-			className,
-		)}
-		{...props}
-	/>
-);
+export const DialogTitle: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Title>
+> = ({ className, ...props }) => {
+	return (
+		<DialogPrimitive.Title
+			className={cn(
+				"text-xl m-0 text-content-primary font-semibold leading-none tracking-tight",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
-export const DialogTitle = forwardRef<
-	ElementRef<typeof DialogPrimitive.Title>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-	<DialogPrimitive.Title
-		ref={ref}
-		className={cn(
-			"text-xl m-0 text-content-primary font-semibold leading-none tracking-tight",
-			className,
-		)}
-		{...props}
-	/>
-));
-
-export const DialogDescription = forwardRef<
-	ElementRef<typeof DialogPrimitive.Description>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-	<DialogPrimitive.Description
-		ref={ref}
-		className={cn("text-sm text-content-secondary font-medium", className)}
-		{...props}
-	/>
-));
+export const DialogDescription: React.FC<
+	React.ComponentPropsWithRef<typeof DialogPrimitive.Description>
+> = ({ className, ...props }) => {
+	return (
+		<DialogPrimitive.Description
+			className={cn("text-sm text-content-secondary font-medium", className)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/site/src/components/DropdownMenu/DropdownMenu.tsx
@@ -7,13 +7,7 @@
  */
 
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { Check, ChevronRight } from "lucide-react";
-import {
-	type ComponentPropsWithoutRef,
-	type ElementRef,
-	forwardRef,
-	type HTMLAttributes,
-} from "react";
+import { Check } from "lucide-react";
 import { cn } from "utils/cn";
 
 export const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -22,93 +16,43 @@ export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
 export const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
-const _DropdownMenuPortal = DropdownMenuPrimitive.Portal;
-
-const _DropdownMenuSub = DropdownMenuPrimitive.Sub;
-
 export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-const DropdownMenuSubTrigger = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-		inset?: boolean;
-	}
->(({ className, inset, children, ...props }, ref) => (
-	<DropdownMenuPrimitive.SubTrigger
-		ref={ref}
-		className={cn(
-			[
-				"flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-surface-secondary",
-				"data-[state=open]:bg-surface-secondary [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-				inset && "pl-8",
-			],
-			className,
-		)}
-		{...props}
-	>
-		{children}
-		<ChevronRight className="ml-auto" />
-	</DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName =
-	DropdownMenuPrimitive.SubTrigger.displayName;
-
-const DropdownMenuSubContent = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-	<DropdownMenuPrimitive.SubContent
-		ref={ref}
-		className={cn(
-			[
-				"z-50 min-w-[8rem] overflow-hidden rounded-md border border-solid bg-surface-primary p-1 text-content-secondary shadow-lg",
-				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-				"data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-				"data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
-				"data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-			],
-			className,
-		)}
-		{...props}
-	/>
-));
-DropdownMenuSubContent.displayName =
-	DropdownMenuPrimitive.SubContent.displayName;
-
-export const DropdownMenuContent = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Content>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-	<DropdownMenuPrimitive.Portal>
-		<DropdownMenuPrimitive.Content
-			ref={ref}
-			sideOffset={sideOffset}
-			className={cn(
-				[
+export const DropdownMenuContent: React.FC<
+	React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Content>
+> = ({ className, sideOffset = 4, ...props }) => {
+	return (
+		<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Content
+				sideOffset={sideOffset}
+				className={cn(
 					"z-50 min-w-48 overflow-hidden rounded-md border border-solid bg-surface-primary p-2 text-content-secondary shadow-md",
 					"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
 					"data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
 					"data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
 					"data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-				],
-				className,
-			)}
-			{...props}
-		/>
-	</DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+					className,
+				)}
+				{...props}
+			/>
+		</DropdownMenuPrimitive.Portal>
+	);
+};
 
-export const DropdownMenuItem = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Item>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-		inset?: boolean;
-	}
->(({ className, inset, ...props }, ref) => (
-	<DropdownMenuPrimitive.Item
-		ref={ref}
-		className={cn(
-			[
+type DropdownMenuItemProps = React.ComponentPropsWithRef<
+	typeof DropdownMenuPrimitive.Item
+> & {
+	inset?: boolean;
+};
+
+export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({
+	className,
+	inset,
+	...props
+}) => {
+	return (
+		<DropdownMenuPrimitive.Item
+			className={cn(
 				`
 				relative flex cursor-default select-none items-center gap-2 rounded-sm
 				px-2 py-1.5 text-sm text-content-secondary font-medium outline-none
@@ -119,106 +63,44 @@ export const DropdownMenuItem = forwardRef<
 				[&_img]:size-icon-sm [&>img]:shrink-0
 				`,
 				inset && "pl-8",
-			],
-			className,
-		)}
-		{...props}
-	/>
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
-
-const DropdownMenuCheckboxItem = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-	<DropdownMenuPrimitive.CheckboxItem
-		ref={ref}
-		className={cn(
-			[
-				"relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
-				"focus:bg-surface-secondary focus:text-content-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-			],
-			className,
-		)}
-		checked={checked}
-		{...props}
-	>
-		<span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-			<DropdownMenuPrimitive.ItemIndicator>
-				<Check className="h-4 w-4" />
-			</DropdownMenuPrimitive.ItemIndicator>
-		</span>
-		{children}
-	</DropdownMenuPrimitive.CheckboxItem>
-));
-DropdownMenuCheckboxItem.displayName =
-	DropdownMenuPrimitive.CheckboxItem.displayName;
-
-export const DropdownMenuRadioItem = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-	<DropdownMenuPrimitive.RadioItem
-		ref={ref}
-		className={cn(
-			[
-				"relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none transition-colors",
-				"focus:bg-surface-secondary focus:text-content-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-				"data-[state=checked]:bg-surface-secondary data-[state=checked]:text-content-primary",
-				"font-medium",
-			],
-			className,
-		)}
-		{...props}
-	>
-		{children}
-		<span className="absolute top-3.5 right-2 flex h-3.5 w-3.5 items-center justify-center">
-			<DropdownMenuPrimitive.ItemIndicator>
-				<Check className="h-4 w-4" />
-			</DropdownMenuPrimitive.ItemIndicator>
-		</span>
-	</DropdownMenuPrimitive.RadioItem>
-));
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
-
-const DropdownMenuLabel = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Label>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-		inset?: boolean;
-	}
->(({ className, inset, ...props }, ref) => (
-	<DropdownMenuPrimitive.Label
-		ref={ref}
-		className={cn(
-			["px-2 py-1.5 text-sm font-semibold", inset && "pl-8"],
-			className,
-		)}
-		{...props}
-	/>
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
-
-export const DropdownMenuSeparator = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Separator>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-	<DropdownMenuPrimitive.Separator
-		ref={ref}
-		className={cn(["-mx-1 my-2 h-px bg-border"], className)}
-		{...props}
-	/>
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
-
-const DropdownMenuShortcut = ({
-	className,
-	...props
-}: HTMLAttributes<HTMLSpanElement>) => {
-	return (
-		<span
-			className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+				className,
+			)}
 			{...props}
 		/>
 	);
 };
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export const DropdownMenuRadioItem: React.FC<
+	React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.RadioItem>
+> = ({ className, children, ...props }) => {
+	return (
+		<DropdownMenuPrimitive.RadioItem
+			className={cn(
+				"relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none transition-colors",
+				"focus:bg-surface-secondary focus:text-content-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+				"data-[state=checked]:bg-surface-secondary data-[state=checked]:text-content-primary",
+				"font-medium",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<span className="absolute top-3.5 right-2 flex h-3.5 w-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<Check className="h-4 w-4" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+		</DropdownMenuPrimitive.RadioItem>
+	);
+};
+
+export const DropdownMenuSeparator: React.FC<
+	React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Separator>
+> = ({ className, ...props }) => {
+	return (
+		<DropdownMenuPrimitive.Separator
+			className={cn(["-mx-1 my-2 h-px bg-border"], className)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/components/FullPageLayout/Topbar.tsx
+++ b/site/src/components/FullPageLayout/Topbar.tsx
@@ -5,10 +5,9 @@ import { Button, type ButtonProps } from "components/Button/Button";
 import {
 	cloneElement,
 	type FC,
-	type ForwardedRef,
-	forwardRef,
 	type HTMLAttributes,
 	type ReactElement,
+	type Ref,
 } from "react";
 import { cn } from "utils/cn";
 
@@ -27,33 +26,27 @@ export const Topbar: FC<HTMLAttributes<HTMLElement>> = ({
 	);
 };
 
-export const TopbarIconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-	({ className, ...props }, ref) => {
-		return (
-			<IconButton
-				ref={ref}
-				{...props}
-				size="small"
-				className={cn(
-					"p-0 rounded-none size-12 [&_svg]:size-icon-sm",
-					className,
-				)}
-			/>
-		);
-	},
-) as typeof IconButton;
+export const TopbarIconButton = (({ className, ...props }: IconButtonProps) => {
+	return (
+		<IconButton
+			{...props}
+			size="small"
+			className={cn("p-0 rounded-none size-12 [&_svg]:size-icon-sm", className)}
+		/>
+	);
+}) as typeof IconButton;
 
-export const TopbarButton = forwardRef<HTMLButtonElement, ButtonProps>(
-	(props: ButtonProps, ref) => {
-		return <Button ref={ref} variant="outline" size="sm" {...props} />;
-	},
-);
+export const TopbarButton: React.FC<ButtonProps> = ({ ...props }) => {
+	return <Button variant="outline" size="sm" {...props} />;
+};
 
 export const TopbarData: FC<HTMLAttributes<HTMLDivElement>> = (props) => {
 	return <div {...props} className="flex gap-2 items-center justify-center" />;
 };
 
-export const TopbarDivider: FC<HTMLAttributes<HTMLSpanElement>> = (props) => {
+export const TopbarDivider: FC<
+	Omit<HTMLAttributes<HTMLSpanElement>, "children">
+> = (props) => {
 	const theme = useTheme();
 	return (
 		<span {...props} css={{ color: theme.palette.divider }}>
@@ -66,23 +59,19 @@ export const TopbarAvatar: FC<AvatarProps> = (props) => {
 	return <Avatar {...props} variant="icon" size="md" />;
 };
 
-type TopbarIconProps = HTMLAttributes<HTMLOrSVGElement>;
+type TopbarIconProps = HTMLAttributes<HTMLOrSVGElement> & {
+	ref?: Ref<HTMLOrSVGElement>;
+};
 
-export const TopbarIcon = forwardRef<HTMLOrSVGElement, TopbarIconProps>(
-	(props: TopbarIconProps, ref) => {
-		const { children, className, ...restProps } = props;
-
-		return cloneElement(
-			children as ReactElement<
-				HTMLAttributes<HTMLOrSVGElement> & {
-					ref: ForwardedRef<HTMLOrSVGElement>;
-				}
-			>,
-			{
-				...restProps,
-				ref,
-				className: "text-base text-content-disabled size-icon-sm",
-			},
-		);
-	},
-);
+export const TopbarIcon: React.FC<TopbarIconProps> = ({
+	ref,
+	children,
+	className,
+	...restProps
+}) => {
+	return cloneElement(children as ReactElement<TopbarIconProps>, {
+		...restProps,
+		ref,
+		className: "text-base text-content-disabled size-icon-sm",
+	});
+};

--- a/site/src/components/HelpTooltip/HelpTooltip.tsx
+++ b/site/src/components/HelpTooltip/HelpTooltip.tsx
@@ -6,13 +6,7 @@ import {
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
 import { CircleHelpIcon, ExternalLinkIcon } from "lucide-react";
-import {
-	type FC,
-	forwardRef,
-	type HTMLAttributes,
-	type PropsWithChildren,
-	type ReactNode,
-} from "react";
+import type { FC, HTMLAttributes, PropsWithChildren, ReactNode } from "react";
 import { cn } from "utils/cn";
 
 type Icon = typeof CircleHelpIcon;
@@ -45,29 +39,23 @@ export const HelpTooltipContent: FC<TooltipContentProps> = ({
 	);
 };
 
-type HelpTooltipIconTriggerProps = HTMLAttributes<HTMLButtonElement> & {
+type HelpTooltipIconTriggerProps = React.ComponentPropsWithRef<"button"> & {
 	size?: Size;
 	hoverEffect?: boolean;
 };
 
-export const HelpTooltipIconTrigger = forwardRef<
-	HTMLButtonElement,
-	HelpTooltipIconTriggerProps
->((props, ref) => {
-	const {
-		size = "medium",
-		children = <HelpTooltipIcon />,
-		hoverEffect = true,
-		className,
-		...buttonProps
-	} = props;
-
+export const HelpTooltipIconTrigger: React.FC<HelpTooltipIconTriggerProps> = ({
+	size = "medium",
+	children = <HelpTooltipIcon />,
+	hoverEffect = true,
+	className,
+	...buttonProps
+}) => {
 	return (
 		<HelpTooltipTrigger asChild>
 			<button
 				{...buttonProps}
 				aria-label="More info"
-				ref={ref}
 				className={cn(
 					"flex items-center justify-center px-0 py-1",
 					"border-0 border-none bg-transparent cursor-pointer text-inherit",
@@ -80,7 +68,7 @@ export const HelpTooltipIconTrigger = forwardRef<
 			</button>
 		</HelpTooltipTrigger>
 	);
-});
+};
 
 export const HelpTooltipTitle: FC<HTMLAttributes<HTMLHeadingElement>> = ({
 	children,

--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -19,11 +19,10 @@ import {
 import { useDebouncedValue } from "hooks/debounce";
 import { ChevronDown, Info, X } from "lucide-react";
 import {
-	type ComponentProps,
 	type ComponentPropsWithoutRef,
-	forwardRef,
 	type KeyboardEvent,
 	type ReactNode,
+	type Ref,
 	useCallback,
 	useEffect,
 	useImperativeHandle,
@@ -105,6 +104,7 @@ interface MultiSelectComboboxProps {
 	hideClearAllButton?: boolean;
 	/** Test ID for testing purposes */
 	"data-testid"?: string;
+	ref?: Ref<MultiSelectComboboxRef>;
 }
 
 interface MultiSelectComboboxRef {
@@ -158,562 +158,540 @@ function isOptionsExist(groupOption: GroupOption, targetOption: Option[]) {
  *
  * @reference: https://github.com/hsuanyi-chou/shadcn-ui-expansions/issues/34#issuecomment-1949561607
  **/
-const CommandEmpty = forwardRef<
-	HTMLDivElement,
-	ComponentProps<typeof CommandPrimitive.Empty>
->(({ className, ...props }, forwardedRef) => {
+const CommandEmpty: React.FC<
+	React.ComponentPropsWithRef<typeof CommandPrimitive.Empty>
+> = ({ className, ...props }) => {
 	const render = useCommandState((state) => state.filtered.count === 0);
 
 	if (!render) return null;
 
 	return (
 		<div
-			ref={forwardedRef}
 			className={cn("py-6 text-center text-sm", className)}
 			cmdk-empty=""
 			role="presentation"
 			{...props}
 		/>
 	);
-});
+};
 
-export const MultiSelectCombobox = forwardRef<
-	MultiSelectComboboxRef,
-	MultiSelectComboboxProps
->(
-	(
-		{
-			value,
-			onChange,
-			placeholder,
-			defaultOptions: arrayDefaultOptions = [],
-			options: arrayOptions,
-			delay,
-			onSearch,
-			onSearchSync,
-			loadingIndicator,
-			emptyIndicator,
-			maxSelected = Number.MAX_SAFE_INTEGER,
-			onMaxSelected,
-			hidePlaceholderWhenSelected,
-			disabled,
-			groupBy,
-			className,
-			badgeClassName,
-			selectFirstItem = true,
-			creatable = false,
-			triggerSearchOnFocus = false,
-			commandProps,
-			inputProps,
-			hideClearAllButton = false,
-			"data-testid": dataTestId,
-		}: MultiSelectComboboxProps,
+export const MultiSelectCombobox: React.FC<MultiSelectComboboxProps> = ({
+	value,
+	onChange,
+	placeholder,
+	defaultOptions: arrayDefaultOptions = [],
+	options: arrayOptions,
+	delay,
+	onSearch,
+	onSearchSync,
+	loadingIndicator,
+	emptyIndicator,
+	maxSelected = Number.MAX_SAFE_INTEGER,
+	onMaxSelected,
+	hidePlaceholderWhenSelected,
+	disabled,
+	groupBy,
+	className,
+	badgeClassName,
+	selectFirstItem = true,
+	creatable = false,
+	triggerSearchOnFocus = false,
+	commandProps,
+	inputProps,
+	hideClearAllButton = false,
+	"data-testid": dataTestId,
+	ref,
+}) => {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [open, setOpen] = useState(false);
+	const [onScrollbar, setOnScrollbar] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const dropdownRef = useRef<HTMLDivElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	const [selected, setSelected] = useState<Option[]>(arrayDefaultOptions ?? []);
+	const [options, setOptions] = useState<GroupOption>(
+		transitionToGroupOption(arrayDefaultOptions, groupBy),
+	);
+	const [inputValue, setInputValue] = useState("");
+	const debouncedSearchTerm = useDebouncedValue(inputValue, delay || 500);
+
+	const [previousValue, setPreviousValue] = useState<Option[]>(value || []);
+	if (value && value !== previousValue) {
+		setPreviousValue(value);
+		setSelected(value);
+	}
+
+	useImperativeHandle(
 		ref,
-	) => {
-		const inputRef = useRef<HTMLInputElement>(null);
-		const [open, setOpen] = useState(false);
-		const [onScrollbar, setOnScrollbar] = useState(false);
-		const [isLoading, setIsLoading] = useState(false);
-		const dropdownRef = useRef<HTMLDivElement>(null);
-		const listRef = useRef<HTMLDivElement>(null);
+		() => ({
+			selectedValue: [...selected],
+			input: inputRef.current as HTMLInputElement,
+			focus: () => inputRef?.current?.focus(),
+			reset: () => setSelected([]),
+		}),
+		[selected],
+	);
 
-		const [selected, setSelected] = useState<Option[]>(
-			arrayDefaultOptions ?? [],
-		);
-		const [options, setOptions] = useState<GroupOption>(
-			transitionToGroupOption(arrayDefaultOptions, groupBy),
-		);
-		const [inputValue, setInputValue] = useState("");
-		const debouncedSearchTerm = useDebouncedValue(inputValue, delay || 500);
+	const handleUnselect = useCallback(
+		(option: Option) => {
+			const newOptions = selected.filter((s) => s.value !== option.value);
+			setSelected(newOptions);
+			onChange?.(newOptions);
+		},
+		[onChange, selected],
+	);
 
-		const [previousValue, setPreviousValue] = useState<Option[]>(value || []);
-		if (value && value !== previousValue) {
-			setPreviousValue(value);
-			setSelected(value);
-		}
-
-		useImperativeHandle(
-			ref,
-			() => ({
-				selectedValue: [...selected],
-				input: inputRef.current as HTMLInputElement,
-				focus: () => inputRef?.current?.focus(),
-				reset: () => setSelected([]),
-			}),
-			[selected],
-		);
-
-		const handleUnselect = useCallback(
-			(option: Option) => {
-				const newOptions = selected.filter((s) => s.value !== option.value);
-				setSelected(newOptions);
-				onChange?.(newOptions);
-			},
-			[onChange, selected],
-		);
-
-		const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-			const input = inputRef.current;
-			if (input) {
-				if (e.key === "Delete" || e.key === "Backspace") {
-					if (input.value === "" && selected.length > 0) {
-						const lastSelectOption = selected[selected.length - 1];
-						// If last item is fixed, we should not remove it.
-						if (!lastSelectOption.fixed) {
-							handleUnselect(selected[selected.length - 1]);
-						}
+	const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+		const input = inputRef.current;
+		if (input) {
+			if (e.key === "Delete" || e.key === "Backspace") {
+				if (input.value === "" && selected.length > 0) {
+					const lastSelectOption = selected[selected.length - 1];
+					// If last item is fixed, we should not remove it.
+					if (!lastSelectOption.fixed) {
+						handleUnselect(selected[selected.length - 1]);
 					}
 				}
-				// This is not a default behavior of the <input /> field
-				if (e.key === "Escape") {
-					input.blur();
-				}
 			}
-		};
-
-		useEffect(() => {
-			if (!open) {
-				return;
+			// This is not a default behavior of the <input /> field
+			if (e.key === "Escape") {
+				input.blur();
 			}
+		}
+	};
 
-			const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-				if (
-					dropdownRef.current &&
-					!dropdownRef.current.contains(event.target as Node) &&
-					inputRef.current &&
-					!inputRef.current.contains(event.target as Node)
-				) {
-					setOpen(false);
-					inputRef.current.blur();
-				}
-			};
-
-			if (open) {
-				document.addEventListener("mousedown", handleClickOutside);
-				document.addEventListener("touchend", handleClickOutside);
-			}
-
-			return () => {
-				document.removeEventListener("mousedown", handleClickOutside);
-				document.removeEventListener("touchend", handleClickOutside);
-			};
-		}, [open]);
-
-		useEffect(() => {
-			/** If `onSearch` is provided, do not trigger options updated. */
-			if (!arrayOptions || onSearch) {
-				return;
-			}
-			const newOption = transitionToGroupOption(arrayOptions || [], groupBy);
-			if (JSON.stringify(newOption) !== JSON.stringify(options)) {
-				setOptions(newOption);
-			}
-		}, [arrayOptions, groupBy, onSearch, options]);
-
-		useEffect(() => {
-			/** sync search */
-
-			const doSearchSync = () => {
-				const res = onSearchSync?.(debouncedSearchTerm);
-				setOptions(transitionToGroupOption(res || [], groupBy));
-			};
-
-			const exec = () => {
-				if (!onSearchSync || !open) return;
-
-				if (triggerSearchOnFocus) {
-					doSearchSync();
-				}
-
-				if (debouncedSearchTerm) {
-					doSearchSync();
-				}
-			};
-
-			void exec();
-		}, [
-			debouncedSearchTerm,
-			groupBy,
-			open,
-			triggerSearchOnFocus,
-			onSearchSync,
-		]);
-
-		useEffect(() => {
-			/** async search */
-
-			const doSearch = async () => {
-				setIsLoading(true);
-				const res = await onSearch?.(debouncedSearchTerm);
-				setOptions(transitionToGroupOption(res || [], groupBy));
-				setIsLoading(false);
-			};
-
-			const exec = async () => {
-				if (!onSearch || !open) return;
-
-				if (triggerSearchOnFocus) {
-					await doSearch();
-				}
-
-				if (debouncedSearchTerm) {
-					await doSearch();
-				}
-			};
-
-			void exec();
-		}, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus, onSearch]);
-
-		// Scroll dropdown into view on open
-		useEffect(() => {
-			if (!open || !listRef.current) {
-				return;
-			}
-
-			listRef.current.scrollIntoView({ behavior: "smooth" });
-		}, [open]);
-
-		const CreatableItem = () => {
-			if (!creatable) {
-				return undefined;
-			}
-			if (
-				isOptionsExist(options, [{ value: inputValue, label: inputValue }]) ||
-				selected.find((s) => s.value === inputValue)
-			) {
-				return undefined;
-			}
-
-			const Item = (
-				<CommandItem
-					value={inputValue}
-					className="cursor-pointer"
-					onMouseDown={(e) => {
-						e.preventDefault();
-						e.stopPropagation();
-					}}
-					onSelect={(value: string) => {
-						if (selected.length >= maxSelected) {
-							onMaxSelected?.(selected.length);
-							return;
-						}
-						setInputValue("");
-						const newOptions = [...selected, { value, label: value }];
-						setSelected(newOptions);
-						onChange?.(newOptions);
-					}}
-				>
-					Create "{inputValue}"
-				</CommandItem>
-			);
-
-			// For normal creatable
-			if (!onSearch && inputValue.length > 0) {
-				return Item;
-			}
-
-			// For async search creatable. avoid showing creatable item before loading at first.
-			if (onSearch && debouncedSearchTerm.length > 0 && !isLoading) {
-				return Item;
-			}
-
-			return undefined;
-		};
-
-		const EmptyItem = useCallback(() => {
-			if (!emptyIndicator) return undefined;
-
-			// For async search that showing emptyIndicator
-			if (onSearch && !creatable && Object.keys(options).length === 0) {
-				return (
-					<CommandItem value="-" disabled>
-						{emptyIndicator}
-					</CommandItem>
-				);
-			}
-
-			return <CommandEmpty>{emptyIndicator}</CommandEmpty>;
-		}, [creatable, emptyIndicator, onSearch, options]);
-
-		const selectables = useMemo<GroupOption>(
-			() => removePickedOption(options, selected),
-			[options, selected],
-		);
-
-		/** Avoid Creatable Selector freezing or lagging when paste a long string. */
-		const commandFilter = () => {
-			if (commandProps?.filter) {
-				return commandProps.filter;
-			}
-
-			if (creatable) {
-				return (value: string, search: string) => {
-					return value.toLowerCase().includes(search.toLowerCase()) ? 1 : -1;
-				};
-			}
-			// Using default filter in `cmdk`. We don't have to provide it.
-			return undefined;
-		};
-
-		if (inputRef.current && inputProps?.id) {
-			inputRef.current.id = inputProps?.id;
+	useEffect(() => {
+		if (!open) {
+			return;
 		}
 
-		const fixedOptions = selected.filter((s) => s.fixed);
-		const showIcons = arrayOptions?.some((it) => it.icon);
+		const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+			if (
+				dropdownRef.current &&
+				!dropdownRef.current.contains(event.target as Node) &&
+				inputRef.current &&
+				!inputRef.current.contains(event.target as Node)
+			) {
+				setOpen(false);
+				inputRef.current.blur();
+			}
+		};
 
-		return (
-			<Command
-				ref={dropdownRef}
-				{...commandProps}
-				data-testid={dataTestId}
-				onKeyDown={(e) => {
-					handleKeyDown(e);
-					commandProps?.onKeyDown?.(e);
+		if (open) {
+			document.addEventListener("mousedown", handleClickOutside);
+			document.addEventListener("touchend", handleClickOutside);
+		}
+
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+			document.removeEventListener("touchend", handleClickOutside);
+		};
+	}, [open]);
+
+	useEffect(() => {
+		/** If `onSearch` is provided, do not trigger options updated. */
+		if (!arrayOptions || onSearch) {
+			return;
+		}
+		const newOption = transitionToGroupOption(arrayOptions || [], groupBy);
+		if (JSON.stringify(newOption) !== JSON.stringify(options)) {
+			setOptions(newOption);
+		}
+	}, [arrayOptions, groupBy, onSearch, options]);
+
+	useEffect(() => {
+		/** sync search */
+
+		const doSearchSync = () => {
+			const res = onSearchSync?.(debouncedSearchTerm);
+			setOptions(transitionToGroupOption(res || [], groupBy));
+		};
+
+		const exec = () => {
+			if (!onSearchSync || !open) return;
+
+			if (triggerSearchOnFocus) {
+				doSearchSync();
+			}
+
+			if (debouncedSearchTerm) {
+				doSearchSync();
+			}
+		};
+
+		void exec();
+	}, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus, onSearchSync]);
+
+	useEffect(() => {
+		/** async search */
+
+		const doSearch = async () => {
+			setIsLoading(true);
+			const res = await onSearch?.(debouncedSearchTerm);
+			setOptions(transitionToGroupOption(res || [], groupBy));
+			setIsLoading(false);
+		};
+
+		const exec = async () => {
+			if (!onSearch || !open) return;
+
+			if (triggerSearchOnFocus) {
+				await doSearch();
+			}
+
+			if (debouncedSearchTerm) {
+				await doSearch();
+			}
+		};
+
+		void exec();
+	}, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus, onSearch]);
+
+	// Scroll dropdown into view on open
+	useEffect(() => {
+		if (!open || !listRef.current) {
+			return;
+		}
+
+		listRef.current.scrollIntoView({ behavior: "smooth" });
+	}, [open]);
+
+	const CreatableItem = () => {
+		if (!creatable) {
+			return undefined;
+		}
+		if (
+			isOptionsExist(options, [{ value: inputValue, label: inputValue }]) ||
+			selected.find((s) => s.value === inputValue)
+		) {
+			return undefined;
+		}
+
+		const Item = (
+			<CommandItem
+				value={inputValue}
+				className="cursor-pointer"
+				onMouseDown={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
 				}}
-				className={cn(
-					"h-auto overflow-visible bg-transparent",
-					commandProps?.className,
-				)}
-				shouldFilter={
-					commandProps?.shouldFilter !== undefined
-						? commandProps.shouldFilter
-						: !onSearch
-				} // When onSearch is provided, we don't want to filter the options. You can still override it.
-				filter={commandFilter()}
+				onSelect={(value: string) => {
+					if (selected.length >= maxSelected) {
+						onMaxSelected?.(selected.length);
+						return;
+					}
+					setInputValue("");
+					const newOptions = [...selected, { value, label: value }];
+					setSelected(newOptions);
+					onChange?.(newOptions);
+				}}
 			>
-				{/* biome-ignore lint/a11y/useKeyWithClickEvents: onKeyDown is not needed here */}
-				<div
-					className={cn(
-						`min-h-10 rounded-md border border-solid border-border text-sm pr-3
+				Create "{inputValue}"
+			</CommandItem>
+		);
+
+		// For normal creatable
+		if (!onSearch && inputValue.length > 0) {
+			return Item;
+		}
+
+		// For async search creatable. avoid showing creatable item before loading at first.
+		if (onSearch && debouncedSearchTerm.length > 0 && !isLoading) {
+			return Item;
+		}
+
+		return undefined;
+	};
+
+	const EmptyItem = useCallback(() => {
+		if (!emptyIndicator) return undefined;
+
+		// For async search that showing emptyIndicator
+		if (onSearch && !creatable && Object.keys(options).length === 0) {
+			return (
+				<CommandItem value="-" disabled>
+					{emptyIndicator}
+				</CommandItem>
+			);
+		}
+
+		return <CommandEmpty>{emptyIndicator}</CommandEmpty>;
+	}, [creatable, emptyIndicator, onSearch, options]);
+
+	const selectables = useMemo<GroupOption>(
+		() => removePickedOption(options, selected),
+		[options, selected],
+	);
+
+	/** Avoid Creatable Selector freezing or lagging when paste a long string. */
+	const commandFilter = () => {
+		if (commandProps?.filter) {
+			return commandProps.filter;
+		}
+
+		if (creatable) {
+			return (value: string, search: string) => {
+				return value.toLowerCase().includes(search.toLowerCase()) ? 1 : -1;
+			};
+		}
+		// Using default filter in `cmdk`. We don't have to provide it.
+		return undefined;
+	};
+
+	if (inputRef.current && inputProps?.id) {
+		inputRef.current.id = inputProps?.id;
+	}
+
+	const fixedOptions = selected.filter((s) => s.fixed);
+	const showIcons = arrayOptions?.some((it) => it.icon);
+
+	return (
+		<Command
+			ref={dropdownRef}
+			{...commandProps}
+			data-testid={dataTestId}
+			onKeyDown={(e) => {
+				handleKeyDown(e);
+				commandProps?.onKeyDown?.(e);
+			}}
+			className={cn(
+				"h-auto overflow-visible bg-transparent",
+				commandProps?.className,
+			)}
+			shouldFilter={
+				commandProps?.shouldFilter !== undefined
+					? commandProps.shouldFilter
+					: !onSearch
+			} // When onSearch is provided, we don't want to filter the options. You can still override it.
+			filter={commandFilter()}
+		>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: onKeyDown is not needed here */}
+			<div
+				className={cn(
+					`min-h-10 rounded-md border border-solid border-border text-sm pr-3
 						focus-within:ring-2 focus-within:ring-content-link [&>svg]:p-0.5`,
-						{
-							"pl-3 py-1": selected.length !== 0,
-							"cursor-text": !disabled && selected.length !== 0,
-						},
-						className,
-					)}
-					onClick={() => {
-						if (disabled) return;
-						inputRef?.current?.focus();
-					}}
-				>
-					<div className="flex justify-between items-center">
-						<div className="relative flex flex-wrap gap-1">
-							{selected.map((option) => {
-								return (
-									<Badge
-										key={option.value}
-										className={cn(
-											"data-[disabled]:bg-content-disabled data-[disabled]:text-surface-tertiary data-[disabled]:hover:bg-content-disabled",
-											"data-[fixed]:bg-content-disabled data-[fixed]:text-surface-tertiary data-[fixed]:hover:bg-surface-secondary",
-											badgeClassName,
+					{
+						"pl-3 py-1": selected.length !== 0,
+						"cursor-text": !disabled && selected.length !== 0,
+					},
+					className,
+				)}
+				onClick={() => {
+					if (disabled) return;
+					inputRef?.current?.focus();
+				}}
+			>
+				<div className="flex justify-between items-center">
+					<div className="relative flex flex-wrap gap-1">
+						{selected.map((option) => {
+							return (
+								<Badge
+									key={option.value}
+									className={cn(
+										"data-[disabled]:bg-content-disabled data-[disabled]:text-surface-tertiary data-[disabled]:hover:bg-content-disabled",
+										"data-[fixed]:bg-content-disabled data-[fixed]:text-surface-tertiary data-[fixed]:hover:bg-surface-secondary",
+										badgeClassName,
+									)}
+									data-fixed={option.fixed}
+									data-disabled={disabled || undefined}
+								>
+									<div className="flex items-center gap-1">
+										{option.icon && (
+											<Avatar
+												size="sm"
+												src={option.icon}
+												fallback={option.label}
+											/>
 										)}
-										data-fixed={option.fixed}
-										data-disabled={disabled || undefined}
-									>
-										<div className="flex items-center gap-1">
-											{option.icon && (
-												<Avatar
-													size="sm"
-													src={option.icon}
-													fallback={option.label}
-												/>
-											)}
-											{option.label}
-										</div>
-										<button
-											type="button"
-											data-testid="clear-option-button"
-											className={cn(
-												`ml-1 pr-0 rounded-sm bg-transparent border-none outline-none
+										{option.label}
+									</div>
+									<button
+										type="button"
+										data-testid="clear-option-button"
+										className={cn(
+											`ml-1 pr-0 rounded-sm bg-transparent border-none outline-none
 												focus:ring-2 focus:ring-content-link focus:ml-2.5 focus:pl-0 cursor-pointer`,
-												(disabled || option.fixed) && "hidden",
-											)}
-											onKeyDown={(e) => {
-												if (e.key === "Enter") {
-													handleUnselect(option);
-												}
-											}}
-											onMouseDown={(e) => {
-												e.preventDefault();
-												e.stopPropagation();
-											}}
-											onClick={() => handleUnselect(option)}
-										>
-											<X className="h-4 w-4 text-content-secondary hover:text-content-primary align-text-bottom" />
-										</button>
-									</Badge>
-								);
-							})}
-							{/* Avoid having the "Search" Icon */}
-							<CommandPrimitive.Input
-								{...inputProps}
-								ref={inputRef}
-								value={inputValue}
-								disabled={disabled}
-								onValueChange={(value) => {
-									setInputValue(value);
-									inputProps?.onValueChange?.(value);
-								}}
-								onBlur={(event) => {
-									if (!onScrollbar) {
-										setOpen(false);
-									}
-									inputProps?.onBlur?.(event);
-								}}
-								onFocus={(event) => {
-									setOpen(true);
-									triggerSearchOnFocus && onSearch?.(debouncedSearchTerm);
-									inputProps?.onFocus?.(event);
-								}}
-								placeholder={
-									hidePlaceholderWhenSelected && selected.length !== 0
-										? ""
-										: placeholder
+											(disabled || option.fixed) && "hidden",
+										)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter") {
+												handleUnselect(option);
+											}
+										}}
+										onMouseDown={(e) => {
+											e.preventDefault();
+											e.stopPropagation();
+										}}
+										onClick={() => handleUnselect(option)}
+									>
+										<X className="h-4 w-4 text-content-secondary hover:text-content-primary align-text-bottom" />
+									</button>
+								</Badge>
+							);
+						})}
+						{/* Avoid having the "Search" Icon */}
+						<CommandPrimitive.Input
+							{...inputProps}
+							ref={inputRef}
+							value={inputValue}
+							disabled={disabled}
+							onValueChange={(value) => {
+								setInputValue(value);
+								inputProps?.onValueChange?.(value);
+							}}
+							onBlur={(event) => {
+								if (!onScrollbar) {
+									setOpen(false);
 								}
-								className={cn(
-									"flex-1 border-none outline-none bg-transparent placeholder:text-content-secondary",
-									{
-										"w-full": hidePlaceholderWhenSelected,
-										"px-3 py-2.5": selected.length === 0,
-										"ml-1": selected.length !== 0,
-									},
-									inputProps?.className,
-								)}
-							/>
-						</div>
-						<div className="flex items-center justify-between">
-							<button
-								type="button"
-								data-testid="clear-all-button"
-								onClick={() => {
+								inputProps?.onBlur?.(event);
+							}}
+							onFocus={(event) => {
+								setOpen(true);
+								triggerSearchOnFocus && onSearch?.(debouncedSearchTerm);
+								inputProps?.onFocus?.(event);
+							}}
+							placeholder={
+								hidePlaceholderWhenSelected && selected.length !== 0
+									? ""
+									: placeholder
+							}
+							className={cn(
+								"flex-1 border-none outline-none bg-transparent placeholder:text-content-secondary",
+								{
+									"w-full": hidePlaceholderWhenSelected,
+									"px-3 py-2.5": selected.length === 0,
+									"ml-1": selected.length !== 0,
+								},
+								inputProps?.className,
+							)}
+						/>
+					</div>
+					<div className="flex items-center justify-between">
+						<button
+							type="button"
+							data-testid="clear-all-button"
+							onClick={() => {
+								setSelected(fixedOptions);
+								onChange?.(fixedOptions);
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
 									setSelected(fixedOptions);
 									onChange?.(fixedOptions);
-								}}
-								onKeyDown={(e) => {
-									if (e.key === "Enter") {
-										setSelected(fixedOptions);
-										onChange?.(fixedOptions);
-									}
-								}}
-								className={cn(
-									"bg-transparent mt-1 border-none rounded-sm",
-									"cursor-pointer text-content-secondary hover:text-content-primary",
-									"outline-none focus:ring-2 focus:ring-content-link [&>svg]:p-0.5",
-									(hideClearAllButton ||
-										disabled ||
-										selected.length < 1 ||
-										fixedOptions.length === selected.length) &&
-										"hidden",
-								)}
-							>
-								<X className="h-5 w-5" />
-							</button>
-							<ChevronDown className="cursor-pointer text-content-secondary hover:text-content-primary p-0.5" />
-						</div>
+								}
+							}}
+							className={cn(
+								"bg-transparent mt-1 border-none rounded-sm",
+								"cursor-pointer text-content-secondary hover:text-content-primary",
+								"outline-none focus:ring-2 focus:ring-content-link [&>svg]:p-0.5",
+								(hideClearAllButton ||
+									disabled ||
+									selected.length < 1 ||
+									fixedOptions.length === selected.length) &&
+									"hidden",
+							)}
+						>
+							<X className="h-5 w-5" />
+						</button>
+						<ChevronDown className="cursor-pointer text-content-secondary hover:text-content-primary p-0.5" />
 					</div>
 				</div>
-				<div className="relative" ref={listRef}>
-					{open && (
-						<CommandList
-							className={`absolute top-1 z-10 w-full rounded-md
+			</div>
+			<div className="relative" ref={listRef}>
+				{open && (
+					<CommandList
+						className={`absolute top-1 z-10 w-full rounded-md
 								border border-solid border-border
 								bg-surface-primary text-content-primary shadow-md outline-none
 								animate-in`}
-							onPointerLeave={() => {
-								setOnScrollbar(false);
-							}}
-							onPointerEnter={() => {
-								setOnScrollbar(true);
-							}}
-							onMouseUp={() => {
-								inputRef?.current?.focus();
-							}}
-						>
-							{isLoading ? (
-								loadingIndicator
-							) : (
-								<>
-									{EmptyItem()}
-									{CreatableItem()}
-									{!selectFirstItem && (
-										<CommandItem value="-" className="hidden" />
-									)}
-									{Object.entries(selectables).map(([key, dropdowns]) => (
-										<CommandGroup
-											key={key}
-											heading={key}
-											className="h-full overflow-auto"
-										>
-											{/* biome-ignore lint/complexity/noUselessFragments: A parent element is
+						onPointerLeave={() => {
+							setOnScrollbar(false);
+						}}
+						onPointerEnter={() => {
+							setOnScrollbar(true);
+						}}
+						onMouseUp={() => {
+							inputRef?.current?.focus();
+						}}
+					>
+						{isLoading ? (
+							loadingIndicator
+						) : (
+							<>
+								{EmptyItem()}
+								{CreatableItem()}
+								{!selectFirstItem && (
+									<CommandItem value="-" className="hidden" />
+								)}
+								{Object.entries(selectables).map(([key, dropdowns]) => (
+									<CommandGroup
+										key={key}
+										heading={key}
+										className="h-full overflow-auto"
+									>
+										{/* biome-ignore lint/complexity/noUselessFragments: A parent element is
 											    needed for multiple dropdown items */}
-											<>
-												{dropdowns.map((option) => {
-													return (
-														<CommandItem
-															key={option.value}
-															value={option.value}
-															disabled={option.disable}
-															onMouseDown={(e) => {
-																e.preventDefault();
-																e.stopPropagation();
-															}}
-															onSelect={() => {
-																if (selected.length >= maxSelected) {
-																	onMaxSelected?.(selected.length);
-																	return;
-																}
-																setInputValue("");
-																const newOptions = [...selected, option];
-																setSelected(newOptions);
-																onChange?.(newOptions);
-															}}
-															className={cn(
-																"cursor-pointer",
-																option.disable &&
-																	"cursor-default text-content-disabled",
+										<>
+											{dropdowns.map((option) => {
+												return (
+													<CommandItem
+														key={option.value}
+														value={option.value}
+														disabled={option.disable}
+														onMouseDown={(e) => {
+															e.preventDefault();
+															e.stopPropagation();
+														}}
+														onSelect={() => {
+															if (selected.length >= maxSelected) {
+																onMaxSelected?.(selected.length);
+																return;
+															}
+															setInputValue("");
+															const newOptions = [...selected, option];
+															setSelected(newOptions);
+															onChange?.(newOptions);
+														}}
+														className={cn(
+															"cursor-pointer",
+															option.disable &&
+																"cursor-default text-content-disabled",
+														)}
+													>
+														<div className="flex items-center gap-2">
+															{showIcons && (
+																<Avatar
+																	size="sm"
+																	src={option.icon}
+																	fallback={option.label}
+																/>
 															)}
-														>
-															<div className="flex items-center gap-2">
-																{showIcons && (
-																	<Avatar
-																		size="sm"
-																		src={option.icon}
-																		fallback={option.label}
-																	/>
-																)}
-																{option.label}
-																{option.description && (
-																	<Tooltip>
-																		<TooltipTrigger asChild>
-																			<span className="flex items-center pointer-events-auto">
-																				<Info className="!w-3.5 !h-3.5 text-content-secondary" />
-																			</span>
-																		</TooltipTrigger>
-																		<TooltipContent
-																			side="right"
-																			sideOffset={10}
-																		>
-																			{option.description}
-																		</TooltipContent>
-																	</Tooltip>
-																)}
-															</div>
-														</CommandItem>
-													);
-												})}
-											</>
-										</CommandGroup>
-									))}
-								</>
-							)}
-						</CommandList>
-					)}
-				</div>
-			</Command>
-		);
-	},
-);
-
-MultiSelectCombobox.displayName = "MultiSelectCombobox";
+															{option.label}
+															{option.description && (
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<span className="flex items-center pointer-events-auto">
+																			<Info className="!w-3.5 !h-3.5 text-content-secondary" />
+																		</span>
+																	</TooltipTrigger>
+																	<TooltipContent side="right" sideOffset={10}>
+																		{option.description}
+																	</TooltipContent>
+																</Tooltip>
+															)}
+														</div>
+													</CommandItem>
+												);
+											})}
+										</>
+									</CommandGroup>
+								))}
+							</>
+						)}
+					</CommandList>
+				)}
+			</div>
+		</Command>
+	);
+};

--- a/site/src/components/SearchField/SearchField.tsx
+++ b/site/src/components/SearchField/SearchField.tsx
@@ -11,7 +11,7 @@ import {
 } from "components/Tooltip/Tooltip";
 import { useEffectEvent } from "hooks/hookPolyfills";
 import { SearchIcon, XIcon } from "lucide-react";
-import { forwardRef, useLayoutEffect, useRef } from "react";
+import { type Ref, useLayoutEffect, useRef } from "react";
 
 export type SearchFieldProps = {
 	value: string;
@@ -20,82 +20,79 @@ export type SearchFieldProps = {
 	placeholder?: string;
 	className?: string;
 	autoFocus?: boolean;
+	onBlur?: () => void;
+	ref?: Ref<HTMLInputElement>;
 	"aria-label"?: string;
 	"aria-invalid"?: boolean;
-	onBlur?: () => void;
 };
 
-export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
-	(
-		{
-			onChange,
-			onClear,
-			value = "",
-			placeholder = "Search...",
-			className,
-			autoFocus = false,
-			onBlur,
-			...ariaProps
-		},
-		forwardedRef,
-	) => {
-		const internalRef = useRef<HTMLInputElement | null>(null);
-		const focusOnMount = useEffectEvent((): void => {
-			if (autoFocus) {
-				internalRef.current?.focus();
-			}
-		});
-		useLayoutEffect(() => {
-			focusOnMount();
-		}, [focusOnMount]);
+export const SearchField: React.FC<SearchFieldProps> = ({
+	value = "",
+	onChange,
+	onClear,
+	placeholder = "Search...",
+	className,
+	autoFocus = false,
+	onBlur,
+	ref,
+	...ariaProps
+}) => {
+	const internalRef = useRef<HTMLInputElement | null>(null);
+	const focusOnMount = useEffectEvent((): void => {
+		if (autoFocus) {
+			internalRef.current?.focus();
+		}
+	});
+	useLayoutEffect(() => {
+		focusOnMount();
+	}, [focusOnMount]);
 
-		const handleClear = () => {
-			if (onClear) {
-				onClear();
-			} else {
-				onChange("");
-			}
-		};
+	const handleClear = () => {
+		if (onClear) {
+			onClear();
+		} else {
+			onChange("");
+		}
+	};
 
-		const setRefs = (el: HTMLInputElement | null) => {
-			internalRef.current = el;
-			if (typeof forwardedRef === "function") {
-				forwardedRef(el);
-			} else if (forwardedRef) {
-				forwardedRef.current = el;
-			}
-		};
+	const setRefs = (el: HTMLInputElement | null) => {
+		internalRef.current = el;
+		if (typeof ref === "function") {
+			ref(el);
+		} else if (ref) {
+			ref.current = el;
+		}
+	};
 
-		return (
-			<InputGroup className={className}>
-				<InputGroupAddon>
-					<SearchIcon className="size-icon-sm" />
+	return (
+		<InputGroup className={className}>
+			<InputGroupAddon>
+				<SearchIcon className="size-icon-sm" />
+			</InputGroupAddon>
+			<InputGroupInput
+				ref={setRefs}
+				className="flex-1 h-10"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				onBlur={onBlur}
+				placeholder={placeholder}
+				{...ariaProps}
+			/>
+			{value !== "" && (
+				<InputGroupAddon align="inline-end">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<InputGroupButton onClick={handleClear} size="icon">
+								<XIcon />
+								<span className="sr-only">Clear search</span>
+							</InputGroupButton>
+						</TooltipTrigger>
+						<TooltipContent align="end" sideOffset={8} alignOffset={-8}>
+							Clear search
+						</TooltipContent>
+					</Tooltip>
 				</InputGroupAddon>
-				<InputGroupInput
-					ref={setRefs}
-					className="flex-1 h-10"
-					value={value}
-					onChange={(e) => onChange(e.target.value)}
-					onBlur={onBlur}
-					placeholder={placeholder}
-					{...ariaProps}
-				/>
-				{value !== "" && (
-					<InputGroupAddon align="inline-end">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<InputGroupButton onClick={handleClear} size="icon">
-									<XIcon />
-									<span className="sr-only">Clear search</span>
-								</InputGroupButton>
-							</TooltipTrigger>
-							<TooltipContent align="end" sideOffset={8} alignOffset={-8}>
-								Clear search
-							</TooltipContent>
-						</Tooltip>
-					</InputGroupAddon>
-				)}
-			</InputGroup>
-		);
-	},
-);
+			)}
+		</InputGroup>
+	);
+};

--- a/site/src/components/Table/Table.tsx
+++ b/site/src/components/Table/Table.tsx
@@ -2,64 +2,65 @@
  * Copied from shadc/ui on 02/03/2025
  * @see {@link https://ui.shadcn.com/docs/components/table}
  */
-
 import { cva, type VariantProps } from "class-variance-authority";
-import * as React from "react";
 import { cn } from "utils/cn";
 
-export const Table = React.forwardRef<
-	HTMLTableElement,
-	React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-	<div className="relative w-full overflow-auto">
-		<table
-			ref={ref}
+export const Table: React.FC<React.ComponentPropsWithRef<"table">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<div className="relative w-full overflow-auto">
+			<table
+				className={cn(
+					"w-full caption-bottom text-xs font-medium text-content-secondary border-separate border-spacing-0",
+					className,
+				)}
+				{...props}
+			/>
+		</div>
+	);
+};
+
+export const TableHeader: React.FC<React.ComponentPropsWithRef<"thead">> = ({
+	className,
+	...props
+}) => {
+	return <thead className={cn("[&_td]:border-none", className)} {...props} />;
+};
+
+export const TableBody: React.FC<React.ComponentPropsWithRef<"tbody">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<tbody
 			className={cn(
-				"w-full caption-bottom text-xs font-medium text-content-secondary border-separate border-spacing-0",
+				"[&>tr:first-of-type>td]:border-t [&>tr>td:first-of-type]:border-l",
+				"[&>tr:last-child>td]:border-b [&>tr>td:last-child]:border-r",
+				"[&>tr:first-of-type>td:first-of-type]:rounded-tl-md [&>tr:first-of-type>td:last-child]:rounded-tr-md",
+				"[&>tr:last-child>td:first-of-type]:rounded-bl-md [&>tr:last-child>td:last-child]:rounded-br-md",
 				className,
 			)}
 			{...props}
 		/>
-	</div>
-));
+	);
+};
 
-export const TableHeader = React.forwardRef<
-	HTMLTableSectionElement,
-	React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-	<thead ref={ref} className={cn("[&_td]:border-none", className)} {...props} />
-));
-
-export const TableBody = React.forwardRef<
-	HTMLTableSectionElement,
-	React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-	<tbody
-		ref={ref}
-		className={cn(
-			"[&>tr:first-of-type>td]:border-t [&>tr>td:first-of-type]:border-l",
-			"[&>tr:last-child>td]:border-b [&>tr>td:last-child]:border-r",
-			"[&>tr:first-of-type>td:first-of-type]:rounded-tl-md [&>tr:first-of-type>td:last-child]:rounded-tr-md",
-			"[&>tr:last-child>td:first-of-type]:rounded-bl-md [&>tr:last-child>td:last-child]:rounded-br-md",
-			className,
-		)}
-		{...props}
-	/>
-));
-
-export const TableFooter = React.forwardRef<
-	HTMLTableSectionElement,
-	React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-	<tfoot
-		ref={ref}
-		className={cn(
-			"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-			className,
-		)}
-		{...props}
-	/>
-));
+export const TableFooter: React.FC<React.ComponentPropsWithRef<"tfoot">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<tfoot
+			className={cn(
+				"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
 const tableRowVariants = cva(
 	[
@@ -70,10 +71,10 @@ const tableRowVariants = cva(
 		variants: {
 			hover: {
 				false: null,
-				true: cn([
+				true: cn(
 					"cursor-pointer hover:outline focus:outline outline-1 -outline-offset-1 outline-border-hover",
 					"first:rounded-t-md last:rounded-b-md",
-				]),
+				),
 			},
 		},
 		defaultVariants: {
@@ -85,10 +86,13 @@ const tableRowVariants = cva(
 export type TableRowProps = React.HTMLAttributes<HTMLTableRowElement> &
 	VariantProps<typeof tableRowVariants>;
 
-export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
-	({ className, hover, ...props }, ref) => (
+export const TableRow: React.FC<TableRowProps> = ({
+	className,
+	hover,
+	...props
+}) => {
+	return (
 		<tr
-			ref={ref}
 			className={cn(
 				"border-0 border-b border-solid border-border transition-colors",
 				"data-[state=selected]:bg-muted",
@@ -97,46 +101,37 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
 			)}
 			{...props}
 		/>
-	),
-);
+	);
+};
 
-export const TableHead = React.forwardRef<
-	HTMLTableCellElement,
-	React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-	<th
-		ref={ref}
-		className={cn(
-			"p-3 text-left align-middle font-semibold",
-			"[&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-			className,
-		)}
-		{...props}
-	/>
-));
+export const TableHead: React.FC<React.ComponentPropsWithRef<"th">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<th
+			className={cn(
+				"p-3 text-left align-middle font-semibold",
+				"[&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
-export const TableCell = React.forwardRef<
-	HTMLTableCellElement,
-	React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-	<td
-		ref={ref}
-		className={cn(
-			"border-0 border-t border-border border-solid",
-			"p-3 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-			className,
-		)}
-		{...props}
-	/>
-));
-
-const _TableCaption = React.forwardRef<
-	HTMLTableCaptionElement,
-	React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
-	<caption
-		ref={ref}
-		className={cn("mt-4 text-sm text-muted-foreground", className)}
-		{...props}
-	/>
-));
+export const TableCell: React.FC<React.ComponentPropsWithRef<"td">> = ({
+	className,
+	...props
+}) => {
+	return (
+		<td
+			className={cn(
+				"border-0 border-t border-border border-solid",
+				"p-3 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/modules/resources/AgentLogs/AgentLogs.tsx
+++ b/site/src/modules/resources/AgentLogs/AgentLogs.tsx
@@ -6,7 +6,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { type ComponentProps, forwardRef, type JSX } from "react";
+import type { JSX } from "react";
 import { FixedSizeList as List } from "react-window";
 import { cn } from "utils/cn";
 import { AGENT_LOG_LINE_HEIGHT, AgentLogLine } from "./AgentLogLine";
@@ -23,7 +23,7 @@ const fallbackLog: WorkspaceAgentLogSource = {
 };
 
 type AgentLogsProps = Omit<
-	ComponentProps<typeof List>,
+	React.ComponentPropsWithRef<typeof List>,
 	"children" | "itemSize" | "itemCount" | "itemKey"
 > & {
 	logs: readonly Line[];
@@ -31,148 +31,151 @@ type AgentLogsProps = Omit<
 	overflowed: boolean;
 };
 
-export const AgentLogs = forwardRef<List, AgentLogsProps>(
-	({ logs, sources, overflowed, className, ...listProps }, ref) => {
-		const logSourceById = Object.fromEntries(sources.map((s) => [s.id, s]));
-		const getLogSource = (id: string) => logSourceById[id] || fallbackLog;
+export const AgentLogs: React.FC<AgentLogsProps> = ({
+	logs,
+	sources,
+	overflowed,
+	className,
+	...listProps
+}) => {
+	const logSourceById = Object.fromEntries(sources.map((s) => [s.id, s]));
+	const getLogSource = (id: string) => logSourceById[id] || fallbackLog;
 
-		return (
-			<div className="bg-surface-secondary relative">
-				<List
-					{...listProps}
-					ref={ref}
-					itemCount={logs.length}
-					itemSize={AGENT_LOG_LINE_HEIGHT}
-					itemKey={(index) => logs[index]?.id || index}
-					// We need the div selector to be able to apply the padding
-					// top from startupLogs
-					className={cn(
-						"pt-4 [&>div]:relative bg-surface-secondary",
-						// Add extra padding so that overflow indicator can't
-						// fully cover up lines of text
-						overflowed && "pb-10",
-						className,
-					)}
-				>
-					{({ index, style }) => {
-						const log = logs[index];
-						const logSource = getLogSource(log.sourceId);
+	return (
+		<div className="bg-surface-secondary relative">
+			<List
+				{...listProps}
+				itemCount={logs.length}
+				itemSize={AGENT_LOG_LINE_HEIGHT}
+				itemKey={(index) => logs[index]?.id || index}
+				// We need the div selector to be able to apply the padding
+				// top from startupLogs
+				className={cn(
+					"pt-4 [&>div]:relative bg-surface-secondary",
+					// Add extra padding so that overflow indicator can't
+					// fully cover up lines of text
+					overflowed && "pb-10",
+					className,
+				)}
+			>
+				{({ index, style }) => {
+					const log = logs[index];
+					const logSource = getLogSource(log.sourceId);
 
-						let assignedIcon = false;
-						let icon: JSX.Element;
-						// If no icon is specified, we show a deterministic
-						// colored circle to identify unique scripts.
-						if (logSource.icon) {
-							icon = (
-								<img
-									src={logSource.icon}
-									alt=""
-									className="size-3.5 mr-2 shrink-0"
-								/>
-							);
-						} else {
-							icon = (
-								<div
-									role="presentation"
-									className="size-3.5 mr-2 shrink-0 rounded-full"
-									style={{
-										background: determineScriptDisplayColor(
-											logSource.display_name,
-										),
-									}}
-								/>
-							);
-							assignedIcon = true;
-						}
-
-						const doesNextLineHaveDifferentSource =
-							index < logs.length - 1 &&
-							getLogSource(logs[index + 1].sourceId).id !== log.sourceId;
-
-						// We don't want every line to repeat the icon, because
-						// that is ugly and repetitive. This removes the icon
-						// for subsequent lines of the same source and shows a
-						// line instead, visually indicating they are from the
-						// same source.
-						const shouldHideSource =
-							index > 0 &&
-							getLogSource(logs[index - 1].sourceId).id === log.sourceId;
-						if (shouldHideSource) {
-							icon = (
-								<div className="size-3.5 mr-2 flex justify-center relative shrink-0">
-									<div
-										// dashed-line class comes from AgentLogLine component
-										className={cn(
-											"dashed-line w-0.5 rounded-[2px] bg-surface-tertiary h-full",
-											doesNextLineHaveDifferentSource && "h-1/2",
-										)}
-									/>
-									{doesNextLineHaveDifferentSource && (
-										<div
-											role="presentation"
-											className="dashed-line h-[2px] w-1/2 top-[calc(50%-2px)] left-[calc(50%-1px)] rounded-[2px] absolute bg-surface-tertiary"
-										/>
-									)}
-								</div>
-							);
-						}
-
-						return (
-							<AgentLogLine
-								line={log}
-								number={index + 1}
-								maxLineNumber={logs.length}
-								style={style}
-								sourceIcon={
-									<Tooltip>
-										<TooltipTrigger asChild>{icon}</TooltipTrigger>
-										<TooltipContent side="bottom">
-											{logSource.display_name}
-											{assignedIcon && (
-												<i>
-													<br />
-													No icon specified!
-												</i>
-											)}
-										</TooltipContent>
-									</Tooltip>
-								}
+					let assignedIcon = false;
+					let icon: JSX.Element;
+					// If no icon is specified, we show a deterministic
+					// colored circle to identify unique scripts.
+					if (logSource.icon) {
+						icon = (
+							<img
+								src={logSource.icon}
+								alt=""
+								className="size-3.5 mr-2 shrink-0"
 							/>
 						);
-					}}
-				</List>
+					} else {
+						icon = (
+							<div
+								role="presentation"
+								className="size-3.5 mr-2 shrink-0 rounded-full"
+								style={{
+									background: determineScriptDisplayColor(
+										logSource.display_name,
+									),
+								}}
+							/>
+						);
+						assignedIcon = true;
+					}
 
-				{overflowed && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Badge
-								asChild
-								className="max-w-fit py-1.5 px-3 absolute bottom-3 left-1/2 -translate-x-1/2"
-							>
-								<span>Logs overflowed</span>
-							</Badge>
-						</TooltipTrigger>
-						<TooltipContent
+					const doesNextLineHaveDifferentSource =
+						index < logs.length - 1 &&
+						getLogSource(logs[index + 1].sourceId).id !== log.sourceId;
+
+					// We don't want every line to repeat the icon, because
+					// that is ugly and repetitive. This removes the icon
+					// for subsequent lines of the same source and shows a
+					// line instead, visually indicating they are from the
+					// same source.
+					const shouldHideSource =
+						index > 0 &&
+						getLogSource(logs[index - 1].sourceId).id === log.sourceId;
+					if (shouldHideSource) {
+						icon = (
+							<div className="size-3.5 mr-2 flex justify-center relative shrink-0">
+								<div
+									// dashed-line class comes from AgentLogLine component
+									className={cn(
+										"dashed-line w-0.5 rounded-[2px] bg-surface-tertiary h-full",
+										doesNextLineHaveDifferentSource && "h-1/2",
+									)}
+								/>
+								{doesNextLineHaveDifferentSource && (
+									<div
+										role="presentation"
+										className="dashed-line h-[2px] w-1/2 top-[calc(50%-2px)] left-[calc(50%-1px)] rounded-[2px] absolute bg-surface-tertiary"
+									/>
+								)}
+							</div>
+						);
+					}
+
+					return (
+						<AgentLogLine
+							line={log}
+							number={index + 1}
+							maxLineNumber={logs.length}
+							style={style}
+							sourceIcon={
+								<Tooltip>
+									<TooltipTrigger asChild>{icon}</TooltipTrigger>
+									<TooltipContent side="bottom">
+										{logSource.display_name}
+										{assignedIcon && (
+											<i>
+												<br />
+												No icon specified!
+											</i>
+										)}
+									</TooltipContent>
+								</Tooltip>
+							}
+						/>
+					);
+				}}
+			</List>
+
+			{overflowed && (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Badge
 							asChild
-							className="w-full text-sm text-content-secondary bg-surface-primary max-w-prose leading-relaxed m-0 p-4"
+							className="max-w-fit py-1.5 px-3 absolute bottom-3 left-1/2 -translate-x-1/2"
 						>
-							<p>
-								Startup logs exceeded the max size of{" "}
-								<span className="tracking-wide font-mono">1MB</span>, and will
-								not continue to be written to the database. Logs will continue
-								to be written to the{" "}
-								<span className="font-mono bg-surface-tertiary rounded-md px-1.5 py-0.5">
-									/tmp/coder-startup-script.log
-								</span>{" "}
-								file in the workspace.
-							</p>
-						</TooltipContent>
-					</Tooltip>
-				)}
-			</div>
-		);
-	},
-);
+							<span>Logs overflowed</span>
+						</Badge>
+					</TooltipTrigger>
+					<TooltipContent
+						asChild
+						className="w-full text-sm text-content-secondary bg-surface-primary max-w-prose leading-relaxed m-0 p-4"
+					>
+						<p>
+							Startup logs exceeded the max size of{" "}
+							<span className="tracking-wide font-mono">1MB</span>, and will not
+							continue to be written to the database. Logs will continue to be
+							written to the{" "}
+							<span className="font-mono bg-surface-tertiary rounded-md px-1.5 py-0.5">
+								/tmp/coder-startup-script.log
+							</span>{" "}
+							file in the workspace.
+						</p>
+					</TooltipContent>
+				</Tooltip>
+			)}
+		</div>
+	);
+};
 
 // These colors were picked at random. Feel free to add more, adjust, or change!
 // Users will not depend on these colors.

--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/Bar.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/Bar.tsx
@@ -1,5 +1,4 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import { type ButtonHTMLAttributes, forwardRef, type HTMLProps } from "react";
 export type BarColors = {
 	stroke: string;
 	fill: string;
@@ -22,34 +21,35 @@ type BaseBarProps<T> = Omit<T, "size" | "color"> & {
 	colors?: BarColors;
 };
 
-type BarProps = BaseBarProps<HTMLProps<HTMLDivElement>>;
+type BarProps = BaseBarProps<React.ComponentPropsWithRef<"div">>;
 
-export const Bar = forwardRef<HTMLDivElement, BarProps>(
-	({ colors, scale, value, offset, ...htmlProps }, ref) => {
-		return (
-			<div
-				css={barCSS({ colors, scale, value, offset })}
-				{...htmlProps}
-				ref={ref}
-			/>
-		);
-	},
-);
+export const Bar: React.FC<BarProps> = ({
+	colors,
+	scale,
+	value,
+	offset,
+	...htmlProps
+}) => {
+	return <div css={barCSS({ colors, scale, value, offset })} {...htmlProps} />;
+};
 
-type ClickableBarProps = BaseBarProps<ButtonHTMLAttributes<HTMLButtonElement>>;
+type ClickableBarProps = BaseBarProps<React.ComponentPropsWithRef<"button">>;
 
-export const ClickableBar = forwardRef<HTMLButtonElement, ClickableBarProps>(
-	({ colors, scale, value, offset, ...htmlProps }, ref) => {
-		return (
-			<button
-				type="button"
-				css={[...barCSS({ colors, scale, value, offset }), styles.clickable]}
-				{...htmlProps}
-				ref={ref}
-			/>
-		);
-	},
-);
+export const ClickableBar: React.FC<ClickableBarProps> = ({
+	colors,
+	scale,
+	value,
+	offset,
+	...htmlProps
+}) => {
+	return (
+		<button
+			type="button"
+			css={[...barCSS({ colors, scale, value, offset }), styles.clickable]}
+			{...htmlProps}
+		/>
+	);
+};
 
 const barCSS = ({ scale, value, colors, offset }: BaseBarProps<unknown>) => {
 	return [

--- a/site/src/pages/WorkspacePage/WorkspaceScheduleControls.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceScheduleControls.tsx
@@ -18,7 +18,7 @@ import dayjs, { type Dayjs } from "dayjs";
 import { useTime } from "hooks/useTime";
 import { ClockIcon, MinusIcon, PlusIcon } from "lucide-react";
 import { getWorkspaceActivityStatus } from "modules/workspaces/activity";
-import { type FC, forwardRef, type ReactNode, useRef, useState } from "react";
+import { type FC, type ReactNode, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
 import { Link as RouterLink } from "react-router";
 import {
@@ -265,24 +265,21 @@ const AutostopDisplay: FC<AutostopDisplayProps> = ({
 	);
 };
 
-const ScheduleSettingsLink = forwardRef<HTMLAnchorElement, LinkProps>(
-	(props, ref) => {
-		return (
-			<Link
-				ref={ref}
-				component={RouterLink}
-				to="settings/schedule"
-				css={{
-					color: "inherit",
-					"&:first-letter": {
-						textTransform: "uppercase",
-					},
-				}}
-				{...props}
-			/>
-		);
-	},
-);
+const ScheduleSettingsLink: React.FC<LinkProps> = ({ ...props }) => {
+	return (
+		<Link
+			component={RouterLink}
+			to="settings/schedule"
+			css={{
+				color: "inherit",
+				"&:first-letter": {
+					textTransform: "uppercase",
+				},
+			}}
+			{...props}
+		/>
+	);
+};
 
 const hasDeadline = (workspace: Workspace): boolean => {
 	return Boolean(workspace.latest_build.deadline);


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

`forwardRef` has always been a bad API, and in React 19 it's finally been deprecated. we use React 19! we should quit using `forwardRef`!