### PR TITLE
fix: set content-primary text color instead of hardcoding white text

### DIFF
--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -342,7 +342,7 @@ const MarkdownGfmAlert: FC<MarkdownGfmAlertProps> = ({
 			<aside
 				{...delegatedProps}
 				className={cn(
-					"border-0 border-l-4 border-solid border-border p-4 text-white",
+					"border-0 border-l-4 border-solid border-border p-4 text-content-primary",
 					"[&_p]:m-0 [&_p]:mb-2",
 
 					alertType === "important" &&

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -408,7 +408,7 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 		return (
 			<div className="flex items-center gap-2" key={auth.id}>
 				<Button
-					className="bg-surface-tertiary hover:bg-surface-quaternary rounded-full text-white"
+					className="bg-surface-tertiary hover:bg-surface-quaternary rounded-full text-content-primary"
 					size="sm"
 					disabled={isPollingExternalAuth || auth.authenticated}
 					onClick={() => {

--- a/site/src/pages/UsersPage/UsersTable/UserGroupsCell.tsx
+++ b/site/src/pages/UsersPage/UsersTable/UserGroupsCell.tsx
@@ -59,7 +59,7 @@ export const UserGroupsCell: FC<GroupsCellProps> = ({ userGroups }) => {
 							</button>
 						</TooltipTrigger>
 
-						<TooltipContent className="p-0 bg-surface-secondary border-surface-quaternary text-white">
+						<TooltipContent className="p-0 bg-surface-secondary border-surface-quaternary text-content-primary">
 							<OverflowY maxHeight={400}>
 								<List
 									component="ul"

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
@@ -51,7 +51,7 @@ export const Notifications: FC<NotificationsProps> = ({
 				<TooltipContent
 					align="end"
 					collisionPadding={16}
-					className="max-w-[400px] p-0 bg-surface-secondary border-surface-quaternary text-sm  text-white"
+					className="max-w-[400px] p-0 bg-surface-secondary border-surface-quaternary text-sm text-content-primary"
 					style={{
 						borderColor: theme.roles[severity].outline,
 					}}


### PR DESCRIPTION
fixes #21735 

Removes all instances of `.text-white` from the codebase.

Storybook stories where I verified these fixes:

component | story
---|---
Markdown.tsx: `MarkdownGfmAlert` | http://localhost:6006/?path=/story/components-markdown--gfm-alerts&globals=theme:light
TaskPrompt.tsx: `ExternalAuthButtons` | http://localhost:6006/?path=/story/modules-tasks-taskprompt--missing-external-auth&globals=theme:light
`UserGroupsCell` | http://localhost:6006/?path=/story/pages-userspage--loaded&globals=theme:light
`Notifications`| http://localhost:6006/?path=/story/pages-workspacepage-workspacenotifications--outdated&globals=theme:light