### PR TITLE
feat: persist `email` through `<RequestOTP />`

### DIFF
--- a/site/src/pages/LoginPage/PasswordSignInForm.tsx
+++ b/site/src/pages/LoginPage/PasswordSignInForm.tsx
@@ -71,7 +71,11 @@ export const PasswordSignInForm: FC<PasswordSignInFormProps> = ({
 				</Button>
 				<Link
 					component={RouterLink}
-					to="/reset-password"
+					to={
+						form.values.email
+							? `/reset-password?email=${encodeURIComponent(form.values.email)}`
+							: "/reset-password"
+					}
 					css={{
 						fontSize: 12,
 						fontWeight: 500,

--- a/site/src/pages/ResetPasswordPage/RequestOTPPage.tsx
+++ b/site/src/pages/ResetPasswordPage/RequestOTPPage.tsx
@@ -8,13 +8,15 @@ import { Spinner } from "components/Spinner/Spinner";
 import { Stack } from "components/Stack/Stack";
 import type { FC } from "react";
 import { useMutation } from "react-query";
-import { Link as RouterLink } from "react-router";
+import { Link as RouterLink, useSearchParams } from "react-router";
 import { getApplicationName } from "utils/appearance";
 import { pageTitle } from "utils/page";
 
 const RequestOTPPage: FC = () => {
 	const applicationName = getApplicationName();
 	const requestOTPMutation = useMutation(requestOneTimePassword());
+	const [searchParams] = useSearchParams();
+	const initialEmail = searchParams.get("email") ?? "";
 
 	return (
 		<>
@@ -30,6 +32,7 @@ const RequestOTPPage: FC = () => {
 					<RequestOTP
 						error={requestOTPMutation.error}
 						isRequesting={requestOTPMutation.isPending}
+						initialEmail={initialEmail}
 						onRequest={(email) => {
 							requestOTPMutation.mutate({ email });
 						}}
@@ -44,12 +47,14 @@ type RequestOTPProps = {
 	error: unknown;
 	onRequest: (email: string) => void;
 	isRequesting: boolean;
+	initialEmail: string;
 };
 
 const RequestOTP: FC<RequestOTPProps> = ({
 	error,
 	onRequest,
 	isRequesting,
+	initialEmail,
 }) => {
 	return (
 		<div css={styles.container}>
@@ -83,6 +88,7 @@ const RequestOTP: FC<RequestOTPProps> = ({
 								autoFocus
 								required
 								fullWidth
+								defaultValue={initialEmail}
 							/>
 
 							<Stack spacing={1}>


### PR DESCRIPTION
This pull-request implements a super simple change, essentially when we fail to login we'd like to persist the `email` used when attempting to sign-in. This just speeds up the flow rather than having to type the email in again.