### PR TITLE
chore: refactor bin handler to be struct

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -104,7 +104,7 @@ func New(opts *Options) *Handler {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/bin/", binHandler(opts.BinFS, newBinMetadataCache(opts.BinFS, opts.BinHashes)))
+	mux.Handle("/bin/", newBinHandler(opts))
 	mux.Handle("/", http.FileServer(
 		http.FS(
 			// OnlyFiles is a wrapper around the file system that prevents directory


### PR DESCRIPTION
relates to: https://github.com/coder/internal/issues/1300

Refactors the bin handler to be a `struct` instead of a handlerfunc. The reason we want this is because we are going to introduce a cache of compressed files, so we need somewhere to put this cache.
