### PR TITLE
test(mcp): deflake template version waits in CI

### DIFF
--- a/coderd/mcp/mcp_e2e_test.go
+++ b/coderd/mcp/mcp_e2e_test.go
@@ -1366,14 +1366,19 @@ func awaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, ver
 	t.Helper()
 
 	timeout := testutil.WaitLong
+	timeoutKind := "standard"
 	if testutil.InCI() {
 		timeout = testutil.WaitSuperLong
+		timeoutKind = "CI"
+		t.Logf("detected CI environment; using extended template version job timeout: %s", timeout)
+	} else {
+		t.Logf("using standard template version job timeout: %s", timeout)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	t.Logf("waiting for template version %s build job to complete (timeout: %s)", versionID.String(), timeout)
+	t.Logf("waiting for template version %s build job to complete (%s timeout)", versionID.String(), timeoutKind)
 
 	var (
 		templateVersion codersdk.TemplateVersion
@@ -1397,8 +1402,8 @@ func awaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, ver
 
 		return templateVersion.Job.CompletedAt != nil
 	}, timeout, testutil.IntervalMedium,
-		"template version %s build job did not complete within %s (lastStatus=%s lastErr=%v); make sure you set `IncludeProvisionerDaemon`!",
-		versionID.String(), timeout, lastStatus, lastErr,
+		"template version %s build job did not complete within %s (%s timeout, lastStatus=%s lastErr=%v); make sure you set `IncludeProvisionerDaemon`!",
+		versionID.String(), timeout, timeoutKind, lastStatus, lastErr,
 	)
 
 	t.Logf("template version %s job has completed", versionID.String())


### PR DESCRIPTION
Deflake `coderd/mcp` E2E tests by reducing contention and making template-version
job waits CI-tolerant.

## What changed
- Add a `coderd/mcp`-local `awaitTemplateVersionJobCompleted` helper that uses a
  longer timeout when `CI` is set.
- Use the new helper in the two provisioner/template-version E2E tests.
- Remove `t.Parallel()` from the two heaviest E2E tests to lower within-package
  parallelism.
- Stop starting a provisioner daemon in tests that don’t create template
  versions/workspaces.

## Testing
- `go test ./coderd/mcp -run ^$ -count=1` (compile-only; full E2E runs in CI)

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Deflake `coderd/mcp` CI failures (internal issue #1016)

## Context / why
CI occasionally fails the Go test job (`test-go-pg-17`) in package `coderd/mcp`, and the flake report (internal issue #1016, opened 2025-09-23) indicates **2 test failures** with **no race/panic/crash**.

This package’s E2E tests start full `coderdtest.NewWithAPI` instances (DB + HTTP server, sometimes provisioner daemons) and run them **in parallel**, which increases resource contention. Two tests also depend on provisioner/template-version jobs and use timeouts that are likely too tight for CI.

**Goal:** Make the `coderd/mcp` tests reliably pass in CI (especially PG17) without masking real failures, while keeping runtime reasonable.

## Evidence (what we inspected)
- `coderd/mcp/mcp_e2e_test.go`
  - Every top-level E2E test calls `t.Parallel()`.
  - `TestMCPHTTP_E2E_ToolWithWorkspace` and `TestMCPHTTP_E2E_ChatGPTEndpoint` both do:
    - `coderdtest.CreateTemplateVersion(...)`
    - `coderdtest.AwaitTemplateVersionJobCompleted(...)`
- `coderd/coderdtest/coderdtest.go`:
  - `AwaitTemplateVersionJobCompleted` hard-codes `testutil.WaitLong` for both context timeout and `require.Eventually`.
- `testutil/duration.go`:
  - `WaitLong = 25s`, `WaitSuperLong = 60s`.
- `coderd/mcp/mcp_http.go` and `coderd/mcp/mcp.go`:
  - MCP server is created per request and tools are re-registered per request. This is extra overhead but not the primary suspected flake cause.

## Working hypothesis (most likely flake mechanism)
1. **Provisioner/template-version job completion sometimes exceeds 25s** under CI load (PG17 job + parallel tests), causing `AwaitTemplateVersionJobCompleted` to time out.
2. Because **two** tests do this provisioner-dependent work, the job summary can show **two failures**, matching the flake report.
3. High within-package parallelism (many `coderdtest.NewWithAPI` instances at once) makes #1 more likely.

<details>
<summary>Other plausible contributors (lower confidence)</summary>

- `TestMCPHTTP_E2E_OAuth2_EndToEnd` runs several `t.Run(...); t.Parallel()` subtests against the same in-memory coderd instance, increasing contention and making failures harder to attribute.
- Some MCP E2E tests start a provisioner daemon even when they don’t create template versions/workspaces; this adds background load.

</details>

## Implementation plan (recommended)

### 1) Make template-version waits tolerant (CI-aware) in **this test package**
**Preferred (narrow scope):** add a local helper in `coderd/mcp/mcp_e2e_test.go` that waits for template-version completion with a longer timeout **only in CI**, then switch the two provisioner-dependent tests to use it.

- **Files:**
  - `coderd/mcp/mcp_e2e_test.go`

- **Edits:**
  1. Add helper near the bottom of the file:

     ```go
     func awaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, versionID uuid.UUID) codersdk.TemplateVersion {
       t.Helper()

       timeout := testutil.WaitLong
       if testutil.InCI() {
         timeout = testutil.WaitSuperLong
       }

       ctx, cancel := context.WithTimeout(context.Background(), timeout)
       defer cancel()

       var (
         tv codersdk.TemplateVersion
         lastErr error
       )

       require.Eventually(t, func() bool {
         var err error
         tv, err = client.TemplateVersion(ctx, versionID)
         if err != nil {
           lastErr = err
           return false
         }
         return tv.Job.CompletedAt != nil
       }, timeout, testutil.IntervalMedium,
         "template version job %s did not complete within %s (lastStatus=%s lastErr=%v)",
         versionID, timeout, tv.Job.Status, lastErr,
       )

       return tv
     }
     ```

  2. Replace these calls:
     - In `TestMCPHTTP_E2E_ToolWithWorkspace`:
       - `coderdtest.AwaitTemplateVersionJobCompleted(...)` → `awaitTemplateVersionJobCompleted(...)`
     - In `TestMCPHTTP_E2E_ChatGPTEndpoint`:
       - `coderdtest.AwaitTemplateVersionJobCompleted(...)` → `awaitTemplateVersionJobCompleted(...)`

**Why this is preferred:** it keeps the behavior change scoped to the flaky package and avoids globally increasing timeouts for unrelated test suites.

### 2) Don’t start a provisioner daemon when the test doesn’t need it
Some MCP E2E tests set `IncludeProvisionerDaemon: true` but never create template versions/workspaces.

- **Files:** `coderd/mcp/mcp_e2e_test.go`
- **Edits:**
  - Change `coderdtest.NewWithAPI(t, &coderdtest.Options{ IncludeProvisionerDaemon: true })` → `coderdtest.NewWithAPI(t, nil)` in:
    - `TestMCPHTTP_E2E_ErrorHandling`
    - `TestMCPHTTP_E2E_ConcurrentRequests`

This reduces background work (daemon update loop, extra goroutines, extra DB traffic) and lowers the chance of timeouts.

### 3) Reduce within-package parallelism for the heaviest flows
Keep parallelism for cheap unit tests, but reduce it for the two tests that:
- start provisioner daemons, and
- run template version jobs.

- **Files:** `coderd/mcp/mcp_e2e_test.go`
- **Edits:** remove `t.Parallel()` from:
  - `TestMCPHTTP_E2E_ToolWithWorkspace`
  - `TestMCPHTTP_E2E_ChatGPTEndpoint`

<details>
<summary>Optional follow-up if flakes continue</summary>

- Remove `t.Parallel()` from `TestMCPHTTP_E2E_OAuth2_EndToEnd` and/or its parallel subtests to avoid many concurrent OAuth2 calls against a single coderd instance.

</details>

## Alternative plan (broader scope)
If the flake persists in other packages that use `coderdtest.AwaitTemplateVersionJobCompleted`, update that helper to use a CI-aware timeout:

- In `coderd/coderdtest/coderdtest.go:AwaitTemplateVersionJobCompleted`:
  - use `testutil.WaitSuperLong` when `testutil.InCI()` is true, otherwise keep `testutil.WaitLong`.

This is broader (affects many tests) and increases worst-case failure time, so it’s a second choice.

## Verification plan
1. Run the MCP package repeatedly:
   - `go test ./coderd/mcp -count=10`
2. Stress the two provisioner-dependent tests:
   - `go test ./coderd/mcp -run TestMCPHTTP_E2E_ToolWithWorkspace -count=25 -v`
   - `go test ./coderd/mcp -run TestMCPHTTP_E2E_ChatGPTEndpoint -count=25 -v`
3. Re-run the CI workflow / job that flakes (`test-go-pg-17`) multiple times.

## Acceptance criteria
- `coderd/mcp` package tests pass reliably across repeated runs in CI (PG17 job), with no intermittent timeout failures.
- Runtime impact is minimal (only affects timeout ceilings and reduces parallelism for two heavy tests).

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: openai:gpt-5.2 • Thinking: xhigh_
