### PR TITLE
test(agent): stabilize TestAgent_Stats_SSH

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -176,8 +176,15 @@ func TestAgent_Stats_SSH(t *testing.T) {
 				echoErr string
 			}
 
+			type lastStats struct {
+				ConnectionCount int64
+				RxBytes         int64
+				TxBytes         int64
+				SessionCountSSH int64
+			}
+
 			var (
-				last  proto.Stats
+				last  lastStats
 				seen  seenStats
 				write writeState
 			)
@@ -199,8 +206,15 @@ func TestAgent_Stats_SSH(t *testing.T) {
 					if !ok {
 						return false
 					}
-					if s != nil {
-						last = *s
+					if s == nil {
+						write.echoErr = "received nil stats"
+						return false
+					}
+					last = lastStats{
+						ConnectionCount: s.ConnectionCount,
+						RxBytes:         s.RxBytes,
+						TxBytes:         s.TxBytes,
+						SessionCountSSH: s.SessionCountSsh,
 					}
 					if last.ConnectionCount > 0 {
 						seen.connectionCount = true
@@ -211,7 +225,7 @@ func TestAgent_Stats_SSH(t *testing.T) {
 					if last.TxBytes > 0 {
 						seen.txBytes = true
 					}
-					if last.SessionCountSsh == 1 {
+					if last.SessionCountSSH == 1 {
 						seen.sessionCountSSH = true
 					}
 


### PR DESCRIPTION
Fixes flakes in `TestAgent_Stats_SSH` (internal issue #505) by making the test deterministic with respect to the agent stats reporter lifecycle.

### What changed
- Wait for the first stats report before opening an SSH session (ensures the stats reporter has negotiated an interval and installed the tailnet connstats callback).
- Generate SSH traffic (`echo mux-stats-test`) and re-issue while waiting so `ConnectionCount/RxBytes/TxBytes` reliably become non-zero.
- Avoid blocking reads inside `Eventuallyf` and improve timeout diagnostics (`last`, `seen`, and echo write errors).

### Tests
- `go test ./agent -run TestAgent_Stats_SSH -count=50`
- `go test -race ./agent -run TestAgent_Stats_SSH -count=20`
- `go test ./agent`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Fix flake in `TestAgent_Stats_SSH` (internal issue #505)

## Context / Why
CI intermittently fails `TestAgent_Stats_SSH` with `Condition never satisfied` while waiting for the agent to report:
- `ConnectionCount > 0`
- `RxBytes > 0`
- `TxBytes > 0`
- `SessionCountSsh == 1`

The flake is timing-dependent: the agent’s stats reporter only starts counting tailnet traffic **after** it negotiates a report interval and registers a `SetConnStatsCallback`. If the SSH handshake happens before that callback is installed, and the SSH session stays mostly idle, later stats reports can legitimately contain **zero** bytes/connCount forever.

Goal: make the test deterministic by (1) waiting until the stats reporter is definitely running, and (2) generating reliable bi-directional SSH traffic while the session is open.

## Evidence (what we verified)
- `agent/agent_test.go`: `TestAgent_Stats_SSH` opens an SSH shell and then waits on stats from a channel (no traffic is forced until after the assertion passes).
- `agent/stats.go`: `statsReporter.reportLoop` sends reports **only** when the tailnet connstats callback fires (after registration).
- `tailnet/conn.go`: `SetConnStatsCallback(maxPeriod=500ms)` flushes periodically but can flush **empty** maps if no packets were observed.
- `agent/agent.go:Collect`: `ConnectionCount/RxBytes/TxBytes` come from the tailnet connstats window (traffic-based; idle connections may appear as 0).
- `agent/agentssh/agentssh.go`: `SessionCountSsh` is derived from an atomic session counter.
- `agent/agenttest/client.go`: `FakeAgentAPI.UpdateStats` pushes only non-nil stats to a buffered channel; no drops.

These are sufficient to explain: “SSH happened before connstats started, then went quiet ⇒ bytes/connCount never observed >0”.

---

## Implementation plan (test-only, minimal product risk)

### 1) Make `TestAgent_Stats_SSH` wait for the stats reporter to be active *before* opening SSH
**Edit:** `agent/agent_test.go`, function `TestAgent_Stats_SSH`.

Add a small pre-step right after `setupAgent(...)`:
- wait until we receive the **first** stats report from `statsCh` (drain one message)
- this implies the stats reporter has negotiated the interval *and* the connstats callback is registered and firing

**Shape:**
```go
// After setupAgent(...)
require.Eventually(t, func() bool {
    select {
    case s := <-stats:
        if s != nil {
            last = *s // for debugging
        }
        return true
    default:
        return false
    }
}, testutil.WaitLong, testutil.IntervalFast, "timed out waiting for initial stats report")
```

Why this helps:
- It removes the race where the SSH handshake occurs before the connstats collector exists.

### 2) Force deterministic bi-directional SSH traffic while waiting for stats
Still in `TestAgent_Stats_SSH`:
- keep the SSH session open
- write an `echo` command *before* the `Eventually` loop, and (optionally) re-issue it if bytes/connCount still haven’t been observed

**Shape (robust approach, no sleeps):**
```go
_, err := stdin.Write([]byte("echo mux-stats-test\n"))
require.NoError(t, err)

require.Eventuallyf(t, func() bool {
    select {
    case s, ok := <-stats:
        if !ok {
            return false
        }
        last = *s

        // If we still haven't observed traffic, cause more.
        if !seen.rxBytes || !seen.txBytes || !seen.connectionCount {
            _, _ = stdin.Write([]byte("echo mux-stats-test\n"))
        }

        if s.ConnectionCount > 0 { seen.connectionCount = true }
        if s.RxBytes > 0 { seen.rxBytes = true }
        if s.TxBytes > 0 { seen.txBytes = true }
        if s.SessionCountSsh == 1 { seen.sessionCountSSH = true }
        return seen.connectionCount && seen.rxBytes && seen.txBytes && seen.sessionCountSSH

    case <-ctx.Done():
        return false
    }
}, testutil.WaitLong, testutil.IntervalFast,
   "never saw all stats: last=%+v seen=%+v", &last, &seen,
)
```

Notes:
- `echo` is intentionally chosen because it’s broadly available across shells/OSes.
- We avoid `time.Sleep`; traffic generation is driven by stats arrivals.

### 3) Fix misleading failure output in `Eventuallyf`
Today, the test passes `s`/bools as `Eventuallyf` args; those args are evaluated once (often printing `<nil>`/`false` even if stats were later seen).

Instead:
- track `last proto.Stats` (value) and `seen` as a small struct
- pass pointers (`&last`, `&seen`) so the final failure message reflects the latest values.

### 4) (Optional hardening) Avoid blocking forever on `<-stats` inside `Eventually`
Even though the reported CI failure times out, the current pattern can block longer than the `Eventually` timeout if stats stop flowing.

The snippet above uses `select { case <-stats ...; case <-ctx.Done(): ... }` so we always unblock.

---

## Validation plan
1. Run the single test repeatedly to shake out flakes:
   - `go test ./agent -run TestAgent_Stats_SSH -count=50`
2. Run under race (matches one of the failing CI jobs):
   - `go test -race ./agent -run TestAgent_Stats_SSH -count=20`
3. Run the package tests once to ensure no collateral issues:
   - `go test ./agent`

## Rollout / risk
- Scope is limited to tests (`agent/agent_test.go`), so it should not affect production behavior.
- The change makes the test assert what it actually needs: the agent can report stats when there is SSH activity, not “some bytes must have been counted during an arbitrary startup race window.”

<details>
<summary>Alternative considered (not recommended initially): change product stats reporter to always tick</summary>

We could change `agent/stats.go` to emit reports on a fixed ticker independent of connstats callback activity. That’s higher risk (behavior change in production) and still doesn’t guarantee `RxBytes/TxBytes > 0` without traffic. A test-only fix is the lowest-risk first step.

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
