### PR TITLE
feat: implement icon to `template` in `/tasks`

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -270,9 +270,18 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 									{templates.map((template) => {
 										return (
 											<SelectItem value={template.id} key={template.id}>
-												<span className="overflow-hidden text-ellipsis block">
-													{template.display_name || template.name}
-												</span>
+												<div className="flex items-center gap-2">
+													{template.icon && (
+														<img
+															src={template.icon}
+															alt={template.name}
+															className="size-icon-sm flex-shrink-0"
+														/>
+													)}
+													<span className="overflow-hidden text-ellipsis block">
+														{template.display_name || template.name}
+													</span>
+												</div>
 											</SelectItem>
 										);
 									})}


### PR DESCRIPTION
This pull-request adds the icon to the templates for `/tasks` in a similar fashion to #21694.

<img width="1326" height="868" alt="CleanShot 2026-02-05 at 05 14 16@2x" src="https://github.com/user-attachments/assets/2686344a-146d-43c9-ac91-3c8ed5774b00" />
