### PR TITLE
fix: extend app test timeout

### DIFF
--- a/site/e2e/tests/app.spec.ts
+++ b/site/e2e/tests/app.spec.ts
@@ -62,7 +62,7 @@ test("app", async ({ context, page }) => {
 	const agent = await startAgent(page, token);
 
 	// Wait for the web terminal to open in a new tab
-	const pagePromise = context.waitForEvent("page");
+	const pagePromise = context.waitForEvent("page", { timeout: 10_000 });
 	await page.getByText(appName).click({ timeout: 10_000 });
 	const app = await pagePromise;
 	await app.waitForLoadState("domcontentloaded");


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

Closes https://github.com/coder/internal/issues/577

Hopefully this reduces the flakiness. This is all I can think of that might possibly help alleviate it. The test is pretty straight forward, the thousands of lines of logs don't provide any helpful details, and I really don't know what we could do to make it more reliable other than maybe trying to just rewrite it from scratch.