### PR TITLE
feat: add agentutil.Go() and lint rule for panic recovery

### DIFF
--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -22,6 +22,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentssh"
+	"github.com/coder/coder/v2/agent/agentutil"
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
@@ -473,10 +474,10 @@ func (r *Runner) trackCommandGoroutine(fn func()) error {
 		return xerrors.New("track command goroutine: closed")
 	}
 	r.cmdCloseWait.Add(1)
-	go func() {
+	agentutil.Go(r.cronCtx, r.Logger, func() {
 		defer r.cmdCloseWait.Done()
 		fn()
-	}()
+	})
 	return nil
 }
 

--- a/agent/agentsocket/server.go
+++ b/agent/agentsocket/server.go
@@ -12,6 +12,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/agentsocket/proto"
+	"github.com/coder/coder/v2/agent/agentutil"
 	"github.com/coder/coder/v2/agent/unit"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 )
@@ -79,10 +80,10 @@ func NewServer(logger slog.Logger, opts ...Option) (*Server, error) {
 	server.logger.Info(server.ctx, "agent socket server started", slog.F("path", server.path))
 
 	server.wg.Add(1)
-	go func() {
+	agentutil.Go(server.ctx, server.logger, func() {
 		defer server.wg.Done()
 		server.acceptConnections()
-	}()
+	})
 
 	return server, nil
 }

--- a/agent/agentssh/bicopy.go
+++ b/agent/agentssh/bicopy.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"io"
 	"sync"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/agent/agentutil"
 )
 
 // Bicopy copies all of the data between the two connections and will close them
@@ -35,10 +38,10 @@ func Bicopy(ctx context.Context, c1, c2 io.ReadWriteCloser) {
 
 	// Convert waitgroup to a channel so we can also wait on the context.
 	done := make(chan struct{})
-	go func() {
+	agentutil.Go(ctx, slog.Logger{}, func() {
 		defer close(done)
 		wg.Wait()
-	}()
+	})
 
 	select {
 	case <-ctx.Done():

--- a/agent/agentssh/x11.go
+++ b/agent/agentssh/x11.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/agent/agentutil"
 )
 
 const (
@@ -122,10 +123,10 @@ func (x *x11Forwarder) x11Handler(sshCtx ssh.Context, sshSession ssh.Session) (d
 	}
 
 	// clean up the X11 session if the SSH session completes.
-	go func() {
+	agentutil.Go(ctx, x.logger, func() {
 		<-ctx.Done()
 		x.closeAndRemoveSession(x11session)
-	}()
+	})
 
 	go x.listenForConnections(ctx, x11session, serverConn, x11)
 	x.logger.Debug(ctx, "X11 forwarding started", slog.F("display", x11session.display))
@@ -206,10 +207,10 @@ func (x *x11Forwarder) listenForConnections(
 			_ = conn.Close()
 			continue
 		}
-		go func() {
+		agentutil.Go(ctx, x.logger, func() {
 			defer x.trackConn(conn, false)
 			Bicopy(ctx, conn, channel)
-		}()
+		})
 	}
 }
 

--- a/agent/agentutil/agentutil.go
+++ b/agent/agentutil/agentutil.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"runtime/debug"
 
-	"cdr.dev/slog"
+	"cdr.dev/slog/v3"
 )
 
-// Go runs fn in a goroutine, logging any panic before re-panicking.
+// Go runs the provided function in a goroutine, recovering from panics and
+// logging them before re-panicking.
 func Go(ctx context.Context, log slog.Logger, fn func()) {
 	go func() {
 		defer func() {

--- a/agent/agentutil/agentutil.go
+++ b/agent/agentutil/agentutil.go
@@ -1,0 +1,24 @@
+package agentutil
+
+import (
+	"context"
+	"runtime/debug"
+
+	"cdr.dev/slog"
+)
+
+// Go runs fn in a goroutine, logging any panic before re-panicking.
+func Go(ctx context.Context, log slog.Logger, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Critical(ctx, "panic in goroutine",
+					slog.F("panic", r),
+					slog.F("stack", string(debug.Stack())),
+				)
+				panic(r)
+			}
+		}()
+		fn()
+	}()
+}

--- a/agent/apphealth.go
+++ b/agent/apphealth.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/agent/agentutil"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/quartz"
@@ -69,7 +70,7 @@ func NewAppHealthReporterWithClock(
 				continue
 			}
 			app := nextApp
-			go func() {
+			agentutil.Go(ctx, logger, func() {
 				_ = clk.TickerFunc(ctx, time.Duration(app.Healthcheck.Interval)*time.Second, func() error {
 					// We time out at the healthcheck interval to prevent getting too backed up, but
 					// set it 1ms early so that it's not simultaneous with the next tick in testing,
@@ -133,7 +134,7 @@ func NewAppHealthReporterWithClock(
 					}
 					return nil
 				}, "healthcheck", app.Slug)
-			}()
+			})
 		}
 
 		mu.Lock()

--- a/agent/boundarylogproxy/proxy.go
+++ b/agent/boundarylogproxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/agent/agentutil"
 	"github.com/coder/coder/v2/agent/boundarylogproxy/codec"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 )
@@ -133,11 +134,11 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 	defer cancel()
 
 	s.wg.Add(1)
-	go func() {
+	agentutil.Go(ctx, s.logger, func() {
 		defer s.wg.Done()
 		<-ctx.Done()
 		_ = conn.Close()
-	}()
+	})
 
 	// This is intended to be a sane starting point for the read buffer size. It may be
 	// grown by codec.ReadFrame if necessary.

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -10,6 +10,7 @@ import (
 	"tailscale.com/types/netlogtype"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/agent/agentutil"
 	"github.com/coder/coder/v2/agent/proto"
 )
 
@@ -86,13 +87,13 @@ func (s *statsReporter) reportLoop(ctx context.Context, dest statsDest) error {
 	// use a separate goroutine to monitor the context so that we notice immediately, rather than
 	// waiting for the next callback (which might never come if we are closing!)
 	ctxDone := false
-	go func() {
+	agentutil.Go(ctx, s.logger, func() {
 		<-ctx.Done()
 		s.L.Lock()
 		defer s.L.Unlock()
 		ctxDone = true
 		s.Broadcast()
-	}()
+	})
 	defer s.logger.Debug(ctx, "reportLoop exiting")
 
 	s.L.Lock()

--- a/go.mod
+++ b/go.mod
@@ -470,6 +470,7 @@ require (
 )
 
 require (
+	cdr.dev/slog v1.6.2-0.20251120224544-40ff19937ff2
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cdr.dev/slog v1.6.2-0.20251120224544-40ff19937ff2 h1:M4Z9eTbnHPdZI4GpBUNCae0lSgUucY+aW5j7+zB8lCk=
+cdr.dev/slog v1.6.2-0.20251120224544-40ff19937ff2/go.mod h1:NaoTA7KwopCrnaSb0JXTC0PTp/O/Y83Lndnq0OEV3ZQ=
 cdr.dev/slog/v3 v3.0.0-rc1 h1:EN7Zim6GvTpAeHQjI0ERDEfqKbTyXRvgH4UhlzLpvWM=
 cdr.dev/slog/v3 v3.0.0-rc1/go.mod h1:iO/OALX1VxlI03mkodCGdVP7pXzd2bRMvu3ePvlJ9ak=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -104,6 +104,17 @@ func testingWithOwnerUser(m dsl.Matcher) {
 		Report(`This client is operating as the owner user, which has unrestricted permissions. Consider creating a different user.`)
 }
 
+// doNotUseRawGoInAgent detects raw `go func()` in agent package.
+// Use agentutil.Go() instead for panic recovery.
+//
+//nolint:unused,deadcode,varnamelen
+func doNotUseRawGoInAgent(m dsl.Matcher) {
+	m.Match(`go func() { $*_ }()`, `go func($*_) { $*_ }($*_)`).
+		Where(m.File().PkgPath.Matches(`github\.com/coder/coder/v2/agent(/.*)?`) &&
+			!m.File().Name.Matches(`_test\.go$`)).
+		Report("Use agentutil.Go() instead of raw go func() for panic recovery")
+}
+
 // Use xerrors everywhere! It provides additional stacktrace info!
 //
 //nolint:unused,deadcode,varnamelen


### PR DESCRIPTION
- Currently we do not have any sort of `recover` handling for our goroutines in the agent. This makes it difficult to understand why the agent crashed if logging to `stderr` is not enabled. Unfortunately there's nothing we can do about panics in third party dependencies but we can at least ensure that we log appropriate from our own goroutines.
- Adds a linting rule to ensure any goroutines added to `agent` subpkgs call the `agentutil.Go` function intead.