### PR TITLE
fix(site): use valid status enum in connection log preset

### DIFF
--- a/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
@@ -1,8 +1,8 @@
 import {
-	ConnectionLogStatuses,
-	ConnectionTypes,
 	type ConnectionLogStatus,
+	ConnectionLogStatuses,
 	type ConnectionType,
+	ConnectionTypes,
 } from "api/typesGenerated";
 import { Filter, MenuSkeleton, type useFilter } from "components/Filter/Filter";
 import {
@@ -34,7 +34,9 @@ type ConnectionLogFilterValues = {
 	organization?: string;
 };
 
-const buildConnectionLogFilterQuery = (v: ConnectionLogFilterValues): string => {
+const buildConnectionLogFilterQuery = (
+	v: ConnectionLogFilterValues,
+): string => {
 	const parts: string[] = [];
 	if (v.status) parts.push(`status:${v.status}`);
 	if (v.type) parts.push(`type:${v.type}`);

--- a/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogFilter.tsx
@@ -1,4 +1,9 @@
-import { ConnectionLogStatuses, ConnectionTypes } from "api/typesGenerated";
+import {
+	ConnectionLogStatuses,
+	ConnectionTypes,
+	type ConnectionLogStatus,
+	type ConnectionType,
+} from "api/typesGenerated";
 import { Filter, MenuSkeleton, type useFilter } from "components/Filter/Filter";
 import {
 	type UseFilterMenuOptions,
@@ -22,12 +27,28 @@ import type { FC } from "react";
 import { connectionTypeToFriendlyName } from "utils/connection";
 import { docs } from "utils/docs";
 
-const PRESET_FILTERS = [
+type ConnectionLogFilterValues = {
+	status?: ConnectionLogStatus;
+	type?: ConnectionType;
+	workspace_owner?: string;
+	organization?: string;
+};
+
+const buildConnectionLogFilterQuery = (v: ConnectionLogFilterValues): string => {
+	const parts: string[] = [];
+	if (v.status) parts.push(`status:${v.status}`);
+	if (v.type) parts.push(`type:${v.type}`);
+	if (v.workspace_owner) parts.push(`workspace_owner:${v.workspace_owner}`);
+	if (v.organization) parts.push(`organization:${v.organization}`);
+	return parts.join(" ");
+};
+
+const CONNECTION_LOG_PRESET_FILTERS = [
 	{
-		query: "status:connected type:ssh",
+		query: buildConnectionLogFilterQuery({ status: "ongoing", type: "ssh" }),
 		name: "Active SSH connections",
 	},
-];
+] satisfies { name: string; query: string }[];
 
 interface ConnectionLogFilterProps {
 	filter: ReturnType<typeof useFilter>;
@@ -52,7 +73,7 @@ export const ConnectionLogFilter: FC<ConnectionLogFilterProps> = ({
 			learnMoreLink={docs(
 				"/admin/monitoring/connection-logs#how-to-filter-connection-logs",
 			)}
-			presets={PRESET_FILTERS}
+			presets={CONNECTION_LOG_PRESET_FILTERS}
 			isLoading={menus.user.isInitializing}
 			filter={filter}
 			error={error}

--- a/site/src/pages/ConnectionLogPage/ConnectionLogPage.test.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogPage.test.tsx
@@ -97,7 +97,7 @@ describe("ConnectionLogPage", () => {
 					count: 1,
 				});
 
-			const query = "type:ssh status:connected";
+			const query = "type:ssh status:ongoing";
 			await renderPage({ filter: query });
 
 			expect(getConnectionLogsSpy).toHaveBeenCalledWith({
@@ -114,7 +114,7 @@ describe("ConnectionLogPage", () => {
 			getConnectionLogsSpy.mockClear();
 
 			const filterField = screen.getByLabelText("Filter");
-			const query = "type:ssh status:connected";
+			const query = "type:ssh status:ongoing";
 			await userEvent.type(filterField, query);
 
 			await waitFor(() =>


### PR DESCRIPTION
The Connection Log page has a preset filter "Active SSH connections" that was using `status:connected`, but the only valid status enum values are `completed` and `ongoing`. This caused the preset to generate an invalid query.

This changes the preset to use `status:ongoing type:ssh` and adds a typed helper function so that invalid enum values will be caught at compile time.

---
PR generated by [mux](https://mux.coder.com), but reviewed by a human.