### PR TITLE
feat: refactor `<NotificationsPage />`

### DIFF
--- a/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -217,9 +217,12 @@ const NotificationsPage: FC = () => {
 																	}
 																}}
 															/>
-															<div className="font-medium text-sm">
+															<label
+																htmlFor={tmpl.id}
+																className="font-medium text-sm"
+															>
 																{tmpl.name}
-															</div>
+															</label>
 														</div>
 
 														<Tooltip>


### PR DESCRIPTION
This pull-request refactors MUI-based components out of `<NotificationsPage />`. Furthermore a mild improvement where if the notifications fail to apply we toast with an error message. 

| Old | New |
| --- | --- |
| <img width="3516" height="2390" src="https://github.com/user-attachments/assets/470b98c7-04a4-47ce-aa25-0bf132f6949e" /> | <img width="3516" height="2390" src="https://github.com/user-attachments/assets/efb7d5db-8cbe-4d1e-971a-3540b60d4bb1" />
