### PR TITLE
ci: add setup-gnu-tools action for macOS runners

### DIFF
--- a/.github/actions/setup-gnu-tools/action.yaml
+++ b/.github/actions/setup-gnu-tools/action.yaml
@@ -1,0 +1,18 @@
+name: "Setup GNU tools (macOS)"
+description: |
+  Installs GNU versions of bash, getopt, and make on macOS runners.
+  Required because lib.sh needs bash 4+, GNU getopt, and make 4+.
+  This is a no-op on non-macOS runners.
+runs:
+  using: "composite"
+  steps:
+    - name: Setup GNU tools (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew install bash gnu-getopt make
+        {
+          echo "$(brew --prefix bash)/bin"
+          echo "$(brew --prefix gnu-getopt)/bin"
+          echo "$(brew --prefix make)/libexec/gnubin"
+        } >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,17 +414,8 @@ jobs:
         id: go-paths
         uses: ./.github/actions/setup-go-paths
 
-      # macOS default bash and coreutils are too old for our scripts
-      # (lib.sh requires bash 4+, GNU getopt, make 4+).
       - name: Setup GNU tools (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install bash gnu-getopt make
-          {
-            echo "$(brew --prefix bash)/bin"
-            echo "$(brew --prefix gnu-getopt)/bin"
-            echo "$(brew --prefix make)/libexec/gnubin"
-          } >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-gnu-tools
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -1056,14 +1047,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup build tools
-        run: |
-          brew install bash gnu-getopt make
-          {
-            echo "$(brew --prefix bash)/bin"
-            echo "$(brew --prefix gnu-getopt)/bin"
-            echo "$(brew --prefix make)/libexec/gnubin"
-          } >> "$GITHUB_PATH"
+      - name: Setup GNU tools (macOS)
+        uses: ./.github/actions/setup-gnu-tools
 
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -59,6 +59,9 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Setup GNU tools (macOS)
+        uses: ./.github/actions/setup-gnu-tools
+
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,14 +78,8 @@ jobs:
       - name: Fetch git tags
         run: git fetch --tags --force
 
-      - name: Setup build tools
-        run: |
-          brew install bash gnu-getopt make
-          {
-            echo "$(brew --prefix bash)/bin"
-            echo "$(brew --prefix gnu-getopt)/bin"
-            echo "$(brew --prefix make)/libexec/gnubin"
-          } >> "$GITHUB_PATH"
+      - name: Setup GNU tools (macOS)
+        uses: ./.github/actions/setup-gnu-tools
 
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0


### PR DESCRIPTION
macOS runners lack GNU toolchain dependencies (bash 4+, GNU getopt, make 4+) required by `scripts/lib.sh`. When any script sources `lib.sh`, it checks for these dependencies and fails if they're missing.

This caused consistent failures in the `test-go-pg (macos-latest)` job in `nightly-gauntlet.yaml`, which didn't have the GNU tools setup that `ci.yaml` had. Commit 9a417df ("ci: add retry logic for Go module operations") added a macOS GNU tools step to `ci.yaml`, but `nightly-gauntlet.yaml` was not updated.

This PR adds a reusable `setup-gnu-tools` action and uses it consistently across all workflows with macOS jobs, replacing the inline brew install steps.

Closes https://github.com/coder/internal/issues/1133