### PR TITLE
chore: log the OS signal prior to exiting in agent

### DIFF
--- a/agent/reaper/reaper.go
+++ b/agent/reaper/reaper.go
@@ -4,6 +4,8 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-reap"
+
+	"cdr.dev/slog/v3"
 )
 
 type Option func(o *options)
@@ -34,8 +36,15 @@ func WithCatchSignals(sigs ...os.Signal) Option {
 	}
 }
 
+func WithLogger(logger slog.Logger) Option {
+	return func(o *options) {
+		o.Logger = logger
+	}
+}
+
 type options struct {
 	ExecArgs     []string
 	PIDs         reap.PidCh
 	CatchSignals []os.Signal
+	Logger       slog.Logger
 }

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -581,7 +581,6 @@ func logSignalNotifyContext(parent context.Context, logger slog.Logger, signals 
 			cancel()
 		case <-ctx.Done():
 		}
-		signal.Stop(c)
 	}()
 
 	return ctx, func() {

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -569,8 +569,8 @@ func urlPort(u string) (int, error) {
 
 // logSignalNotifyContext is like signal.NotifyContext but logs the received
 // signal before canceling the context.
-func logSignalNotifyContext(ctx context.Context, logger slog.Logger, signals ...os.Signal) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(ctx)
+func logSignalNotifyContext(parent context.Context, logger slog.Logger, signals ...os.Signal) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, signals...)
 


### PR DESCRIPTION
Adds additional logs for determining what signal the agent receives prior to shut down. Also helps distinguish whether the signal originated at the agent or reaper.