### PR TITLE
chore(coderd/database/dbfake): add support for provisioner job timestamp control

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -171,7 +171,7 @@ func (b WorkspaceBuildBuilder) Pending(ts ...time.Time) WorkspaceBuildBuilder {
 }
 
 // Canceled sets the job to canceled status with optional timestamp.
-// If timestamp provided, it's used for CompletedAt.
+// If timestamp provided, it's used for CanceledAt and CompletedAt.
 func (b WorkspaceBuildBuilder) Canceled(ts ...time.Time) WorkspaceBuildBuilder {
 	//nolint: revive // returns modified struct
 	b.jobStatus = database.ProvisionerJobStatusCanceled
@@ -181,9 +181,22 @@ func (b WorkspaceBuildBuilder) Canceled(ts ...time.Time) WorkspaceBuildBuilder {
 	return b
 }
 
+// Succeeded sets the job to succeeded status with optional timestamp.
+// If timestamp provided, it's used for CompletedAt.
+// This is the default status, so calling this is only needed to set a specific
+// completion timestamp.
+func (b WorkspaceBuildBuilder) Succeeded(ts ...time.Time) WorkspaceBuildBuilder {
+	//nolint: revive // returns modified struct
+	b.jobStatus = database.ProvisionerJobStatusSucceeded
+	if len(ts) > 0 {
+		b.jobCompletedAt = ts[0]
+	}
+	return b
+}
+
 // Failed sets the provisioner job to a failed state with the given error
 // message and error code. If error is empty, a default error message is used.
-// If timestamp provided, it's used for CompletedAt.
+// If timestamp provided, it's used for CanceledAt and CompletedAt.
 func (b WorkspaceBuildBuilder) Failed(jobError, jobErrorCode string, ts ...time.Time) WorkspaceBuildBuilder {
 	//nolint: revive // returns modified struct
 	b.jobStatus = database.ProvisionerJobStatusFailed
@@ -204,14 +217,6 @@ func (b WorkspaceBuildBuilder) Failed(jobError, jobErrorCode string, ts ...time.
 func (b WorkspaceBuildBuilder) JobUpdatedAt(t time.Time) WorkspaceBuildBuilder {
 	//nolint: revive // returns modified struct
 	b.jobUpdatedAt = t
-	return b
-}
-
-// JobCompletedAt sets when the provisioner job completed.
-// Only applies when job status is Canceled, Failed, or Succeeded (default).
-func (b WorkspaceBuildBuilder) JobCompletedAt(t time.Time) WorkspaceBuildBuilder {
-	//nolint: revive // returns modified struct
-	b.jobCompletedAt = t
 	return b
 }
 

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -101,6 +101,20 @@ func WithJobCompletedAt(t time.Time) BuilderOption {
 	}
 }
 
+// WithJobError sets the error message for the provisioner job.
+func WithJobError(msg string) BuilderOption {
+	return func(b *WorkspaceBuildBuilder) {
+		b.jobError = msg
+	}
+}
+
+// WithJobErrorCode sets the error code for the provisioner job.
+func WithJobErrorCode(code string) BuilderOption {
+	return func(b *WorkspaceBuildBuilder) {
+		b.jobErrorCode = code
+	}
+}
+
 // WorkspaceBuild generates a workspace build for the provided workspace.
 // Pass a database.Workspace{} with a nil ID to also generate a new workspace.
 // Omitting the template ID on a workspace will also generate a new template
@@ -223,18 +237,17 @@ func (b WorkspaceBuildBuilder) Succeeded(opts ...BuilderOption) WorkspaceBuildBu
 	return b
 }
 
-// Failed sets the provisioner job to a failed state with the given error
-// message and error code. If error is empty, a default error message is used.
-func (b WorkspaceBuildBuilder) Failed(jobError, jobErrorCode string, opts ...BuilderOption) WorkspaceBuildBuilder {
+// Failed sets the provisioner job to a failed state. Use WithJobError and
+// WithJobErrorCode options to set the error message and code. If no error
+// message is provided, "failed" is used as the default.
+func (b WorkspaceBuildBuilder) Failed(opts ...BuilderOption) WorkspaceBuildBuilder {
 	//nolint: revive // returns modified struct
 	b.jobStatus = database.ProvisionerJobStatusFailed
-	if jobError == "" {
-		jobError = "failed"
-	}
-	b.jobError = jobError
-	b.jobErrorCode = jobErrorCode
 	for _, opt := range opts {
 		opt(&b)
+	}
+	if b.jobError == "" {
+		b.jobError = "failed"
 	}
 	return b
 }

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -204,7 +204,7 @@ func (b WorkspaceBuildBuilder) WithJobUpdatedAt(t time.Time) WorkspaceBuildBuild
 }
 
 // WithJobCompletedAt sets when the provisioner job completed.
-// Only applies when job status is Canceled or Succeeded (default).
+// Only applies when job status is Canceled, Failed, or Succeeded (default).
 // If not called, defaults to dbtime.Now().
 func (b WorkspaceBuildBuilder) WithJobCompletedAt(t time.Time) WorkspaceBuildBuilder {
 	//nolint: revive // returns modified struct

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -196,7 +196,7 @@ func (b WorkspaceBuildBuilder) Succeeded(ts ...time.Time) WorkspaceBuildBuilder 
 
 // Failed sets the provisioner job to a failed state with the given error
 // message and error code. If error is empty, a default error message is used.
-// If timestamp provided, it's used for CanceledAt and CompletedAt.
+// If timestamp provided, it's used for CompletedAt and UpdatedAt.
 func (b WorkspaceBuildBuilder) Failed(jobError, jobErrorCode string, ts ...time.Time) WorkspaceBuildBuilder {
 	//nolint: revive // returns modified struct
 	b.jobStatus = database.ProvisionerJobStatusFailed

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -128,14 +128,14 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: twentyMinAgo, Valid: true}}).
+	}).Succeeded(dbfake.WithJobCompletedAt(twentyMinAgo)).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
 	currentBuild := dbfake.WorkspaceBuild(t, db, previousBuild.Workspace).
 		Pubsub(pubsub).
 		Seed(database.WorkspaceBuild{BuildNumber: 2}).
-		Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
+		Starting(dbfake.WithJobStartedAt(tenMinAgo), dbfake.WithJobUpdatedAt(sixMinAgo)).
 		Do()
 
 	t.Log("previous job ID: ", previousBuild.Build.JobID)
@@ -196,7 +196,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
-	}).Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: twentyMinAgo, Valid: true}}).
+	}).Succeeded(dbfake.WithJobCompletedAt(twentyMinAgo)).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
@@ -207,7 +207,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 			BuildNumber:      2,
 			ProvisionerState: expectedWorkspaceBuildState,
 		}).
-		Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
+		Starting(dbfake.WithJobStartedAt(tenMinAgo), dbfake.WithJobUpdatedAt(sixMinAgo)).
 		Do()
 
 	t.Log("previous job ID: ", previousBuild.Build.JobID)
@@ -268,7 +268,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
+	}).Starting(dbfake.WithJobStartedAt(tenMinAgo), dbfake.WithJobUpdatedAt(sixMinAgo)).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)
@@ -327,7 +327,7 @@ func TestDetectorPendingWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testin
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Pending().UpdateJob(database.ProvisionerJob{CreatedAt: thirtyFiveMinAgo, UpdatedAt: thirtyFiveMinAgo}).
+	}).Pending(dbfake.WithJobCreatedAt(thirtyFiveMinAgo), dbfake.WithJobUpdatedAt(thirtyFiveMinAgo)).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)
@@ -400,7 +400,7 @@ func TestDetectorWorkspaceBuildForDormantWorkspace(t *testing.T) {
 		},
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
+	}).Starting(dbfake.WithJobStartedAt(tenMinAgo), dbfake.WithJobUpdatedAt(sixMinAgo)).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/jobreaper"
@@ -113,87 +113,34 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 	)
 
 	var (
-		now          = time.Now()
-		twentyMinAgo = now.Add(-time.Minute * 20)
-		tenMinAgo    = now.Add(-time.Minute * 10)
-		sixMinAgo    = now.Add(-time.Minute * 6)
-		org          = dbgen.Organization(t, db, database.Organization{})
-		user         = dbgen.User(t, db, database.User{})
-		file         = dbgen.File(t, db, database.File{})
-		template     = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-		})
-		templateVersion = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-			OrganizationID: org.ID,
-			TemplateID: uuid.NullUUID{
-				UUID:  template.ID,
-				Valid: true,
-			},
-			CreatedBy: user.ID,
-		})
-		workspace = dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     template.ID,
-		})
-
-		// Previous build.
+		now                         = time.Now()
+		twentyMinAgo                = now.Add(-time.Minute * 20)
+		sixMinAgo                   = now.Add(-time.Minute * 6)
+		org                         = dbgen.Organization(t, db, database.Organization{})
+		user                        = dbgen.User(t, db, database.User{})
 		expectedWorkspaceBuildState = []byte(`{"dean":"cool","colin":"also cool"}`)
-		previousWorkspaceBuildJob   = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: twentyMinAgo,
-			UpdatedAt: twentyMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  twentyMinAgo,
-				Valid: true,
-			},
-			CompletedAt: sql.NullTime{
-				Time:  twentyMinAgo,
-				Valid: true,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       1,
-			ProvisionerState:  expectedWorkspaceBuildState,
-			JobID:             previousWorkspaceBuildJob.ID,
-		})
-
-		// Current build.
-		currentWorkspaceBuildJob = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: tenMinAgo,
-			UpdatedAt: sixMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  tenMinAgo,
-				Valid: true,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		currentWorkspaceBuild = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       2,
-			JobID:             currentWorkspaceBuildJob.ID,
-			// No provisioner state.
-		})
 	)
 
-	t.Log("previous job ID: ", previousWorkspaceBuildJob.ID)
-	t.Log("current job ID: ", currentWorkspaceBuildJob.ID)
+	// Previous build (completed successfully).
+	previousBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
+		ProvisionerState: expectedWorkspaceBuildState,
+	}).WithJobCreatedAt(twentyMinAgo).
+		WithJobCompletedAt(twentyMinAgo).
+		Do()
+
+	// Current build (hung - running job with UpdatedAt > 5 min ago).
+	currentBuild := dbfake.WorkspaceBuild(t, db, previousBuild.Workspace).
+		Pubsub(pubsub).
+		Seed(database.WorkspaceBuild{BuildNumber: 2}).
+		Starting().
+		WithJobStartedAt(sixMinAgo).
+		Do()
+
+	t.Log("previous job ID: ", previousBuild.Build.JobID)
+	t.Log("current job ID: ", currentBuild.Build.JobID)
 
 	detector := jobreaper.New(ctx, wrapDBAuthz(db, log), pubsub, log, tickCh).WithStatsChannel(statsCh)
 	detector.Start()
@@ -202,10 +149,10 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 	stats := <-statsCh
 	require.NoError(t, stats.Error)
 	require.Len(t, stats.TerminatedJobIDs, 1)
-	require.Equal(t, currentWorkspaceBuildJob.ID, stats.TerminatedJobIDs[0])
+	require.Equal(t, currentBuild.Build.JobID, stats.TerminatedJobIDs[0])
 
 	// Check that the current provisioner job was updated.
-	job, err := db.GetProvisionerJobByID(ctx, currentWorkspaceBuildJob.ID)
+	job, err := db.GetProvisionerJobByID(ctx, currentBuild.Build.JobID)
 	require.NoError(t, err)
 	require.WithinDuration(t, now, job.UpdatedAt, 30*time.Second)
 	require.True(t, job.CompletedAt.Valid)
@@ -215,7 +162,7 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 	require.False(t, job.ErrorCode.Valid)
 
 	// Check that the provisioner state was copied.
-	build, err := db.GetWorkspaceBuildByID(ctx, currentWorkspaceBuild.ID)
+	build, err := db.GetWorkspaceBuildByID(ctx, currentBuild.Build.ID)
 	require.NoError(t, err)
 	require.Equal(t, expectedWorkspaceBuildState, build.ProvisionerState)
 
@@ -235,88 +182,38 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 	)
 
 	var (
-		now          = time.Now()
-		twentyMinAgo = now.Add(-time.Minute * 20)
-		tenMinAgo    = now.Add(-time.Minute * 10)
-		sixMinAgo    = now.Add(-time.Minute * 6)
-		org          = dbgen.Organization(t, db, database.Organization{})
-		user         = dbgen.User(t, db, database.User{})
-		file         = dbgen.File(t, db, database.File{})
-		template     = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-		})
-		templateVersion = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-			OrganizationID: org.ID,
-			TemplateID: uuid.NullUUID{
-				UUID:  template.ID,
-				Valid: true,
-			},
-			CreatedBy: user.ID,
-		})
-		workspace = dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     template.ID,
-		})
-
-		// Previous build.
-		previousWorkspaceBuildJob = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: twentyMinAgo,
-			UpdatedAt: twentyMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  twentyMinAgo,
-				Valid: true,
-			},
-			CompletedAt: sql.NullTime{
-				Time:  twentyMinAgo,
-				Valid: true,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       1,
-			ProvisionerState:  []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
-			JobID:             previousWorkspaceBuildJob.ID,
-		})
-
-		// Current build.
+		now                         = time.Now()
+		twentyMinAgo                = now.Add(-time.Minute * 20)
+		sixMinAgo                   = now.Add(-time.Minute * 6)
+		org                         = dbgen.Organization(t, db, database.Organization{})
+		user                        = dbgen.User(t, db, database.User{})
 		expectedWorkspaceBuildState = []byte(`{"dean":"cool","colin":"also cool"}`)
-		currentWorkspaceBuildJob    = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: tenMinAgo,
-			UpdatedAt: sixMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  tenMinAgo,
-				Valid: true,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		currentWorkspaceBuild = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       2,
-			JobID:             currentWorkspaceBuildJob.ID,
-			// Should not be overridden.
-			ProvisionerState: expectedWorkspaceBuildState,
-		})
 	)
 
-	t.Log("previous job ID: ", previousWorkspaceBuildJob.ID)
-	t.Log("current job ID: ", currentWorkspaceBuildJob.ID)
+	// Previous build (completed successfully).
+	previousBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
+		ProvisionerState: []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
+	}).WithJobCreatedAt(twentyMinAgo).
+		WithJobCompletedAt(twentyMinAgo).
+		Do()
+
+	// Current build (hung - running job with UpdatedAt > 5 min ago).
+	// This build already has provisioner state, which should NOT be overridden.
+	currentBuild := dbfake.WorkspaceBuild(t, db, previousBuild.Workspace).
+		Pubsub(pubsub).
+		Seed(database.WorkspaceBuild{
+			BuildNumber:      2,
+			ProvisionerState: expectedWorkspaceBuildState,
+		}).
+		Starting().
+		WithJobStartedAt(sixMinAgo).
+		Do()
+
+	t.Log("previous job ID: ", previousBuild.Build.JobID)
+	t.Log("current job ID: ", currentBuild.Build.JobID)
 
 	detector := jobreaper.New(ctx, wrapDBAuthz(db, log), pubsub, log, tickCh).WithStatsChannel(statsCh)
 	detector.Start()
@@ -325,10 +222,10 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 	stats := <-statsCh
 	require.NoError(t, stats.Error)
 	require.Len(t, stats.TerminatedJobIDs, 1)
-	require.Equal(t, currentWorkspaceBuildJob.ID, stats.TerminatedJobIDs[0])
+	require.Equal(t, currentBuild.Build.JobID, stats.TerminatedJobIDs[0])
 
 	// Check that the current provisioner job was updated.
-	job, err := db.GetProvisionerJobByID(ctx, currentWorkspaceBuildJob.ID)
+	job, err := db.GetProvisionerJobByID(ctx, currentBuild.Build.JobID)
 	require.NoError(t, err)
 	require.WithinDuration(t, now, job.UpdatedAt, 30*time.Second)
 	require.True(t, job.CompletedAt.Valid)
@@ -338,7 +235,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 	require.False(t, job.ErrorCode.Valid)
 
 	// Check that the provisioner state was NOT copied.
-	build, err := db.GetWorkspaceBuildByID(ctx, currentWorkspaceBuild.ID)
+	build, err := db.GetWorkspaceBuildByID(ctx, currentBuild.Build.ID)
 	require.NoError(t, err)
 	require.Equal(t, expectedWorkspaceBuildState, build.ProvisionerState)
 
@@ -358,58 +255,25 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 	)
 
 	var (
-		now       = time.Now()
-		tenMinAgo = now.Add(-time.Minute * 10)
-		sixMinAgo = now.Add(-time.Minute * 6)
-		org       = dbgen.Organization(t, db, database.Organization{})
-		user      = dbgen.User(t, db, database.User{})
-		file      = dbgen.File(t, db, database.File{})
-		template  = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-		})
-		templateVersion = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-			OrganizationID: org.ID,
-			TemplateID: uuid.NullUUID{
-				UUID:  template.ID,
-				Valid: true,
-			},
-			CreatedBy: user.ID,
-		})
-		workspace = dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     template.ID,
-		})
-
-		// First build.
+		now                         = time.Now()
+		sixMinAgo                   = now.Add(-time.Minute * 6)
+		org                         = dbgen.Organization(t, db, database.Organization{})
+		user                        = dbgen.User(t, db, database.User{})
 		expectedWorkspaceBuildState = []byte(`{"dean":"cool","colin":"also cool"}`)
-		currentWorkspaceBuildJob    = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: tenMinAgo,
-			UpdatedAt: sixMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  tenMinAgo,
-				Valid: true,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		currentWorkspaceBuild = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       1,
-			JobID:             currentWorkspaceBuildJob.ID,
-			// Should not be overridden.
-			ProvisionerState: expectedWorkspaceBuildState,
-		})
 	)
 
-	t.Log("current job ID: ", currentWorkspaceBuildJob.ID)
+	// First build (hung - no previous build exists).
+	// This build has provisioner state, which should NOT be overridden.
+	currentBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
+		ProvisionerState: expectedWorkspaceBuildState,
+	}).Starting().
+		WithJobStartedAt(sixMinAgo).
+		Do()
+
+	t.Log("current job ID: ", currentBuild.Build.JobID)
 
 	detector := jobreaper.New(ctx, wrapDBAuthz(db, log), pubsub, log, tickCh).WithStatsChannel(statsCh)
 	detector.Start()
@@ -418,10 +282,10 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 	stats := <-statsCh
 	require.NoError(t, stats.Error)
 	require.Len(t, stats.TerminatedJobIDs, 1)
-	require.Equal(t, currentWorkspaceBuildJob.ID, stats.TerminatedJobIDs[0])
+	require.Equal(t, currentBuild.Build.JobID, stats.TerminatedJobIDs[0])
 
 	// Check that the current provisioner job was updated.
-	job, err := db.GetProvisionerJobByID(ctx, currentWorkspaceBuildJob.ID)
+	job, err := db.GetProvisionerJobByID(ctx, currentBuild.Build.JobID)
 	require.NoError(t, err)
 	require.WithinDuration(t, now, job.UpdatedAt, 30*time.Second)
 	require.True(t, job.CompletedAt.Valid)
@@ -431,7 +295,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 	require.False(t, job.ErrorCode.Valid)
 
 	// Check that the provisioner state was NOT updated.
-	build, err := db.GetWorkspaceBuildByID(ctx, currentWorkspaceBuild.ID)
+	build, err := db.GetWorkspaceBuildByID(ctx, currentBuild.Build.ID)
 	require.NoError(t, err)
 	require.Equal(t, expectedWorkspaceBuildState, build.ProvisionerState)
 
@@ -451,57 +315,25 @@ func TestDetectorPendingWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testin
 	)
 
 	var (
-		now              = time.Now()
-		thirtyFiveMinAgo = now.Add(-time.Minute * 35)
-		org              = dbgen.Organization(t, db, database.Organization{})
-		user             = dbgen.User(t, db, database.User{})
-		file             = dbgen.File(t, db, database.File{})
-		template         = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-		})
-		templateVersion = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-			OrganizationID: org.ID,
-			TemplateID: uuid.NullUUID{
-				UUID:  template.ID,
-				Valid: true,
-			},
-			CreatedBy: user.ID,
-		})
-		workspace = dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     template.ID,
-		})
-
-		// First build.
+		now                         = time.Now()
+		thirtyFiveMinAgo            = now.Add(-time.Minute * 35)
+		org                         = dbgen.Organization(t, db, database.Organization{})
+		user                        = dbgen.User(t, db, database.User{})
 		expectedWorkspaceBuildState = []byte(`{"dean":"cool","colin":"also cool"}`)
-		currentWorkspaceBuildJob    = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: thirtyFiveMinAgo,
-			UpdatedAt: thirtyFiveMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  time.Time{},
-				Valid: false,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		currentWorkspaceBuild = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       1,
-			JobID:             currentWorkspaceBuildJob.ID,
-			// Should not be overridden.
-			ProvisionerState: expectedWorkspaceBuildState,
-		})
 	)
 
-	t.Log("current job ID: ", currentWorkspaceBuildJob.ID)
+	// First build (hung pending - no previous build exists).
+	// This build has provisioner state, which should NOT be overridden.
+	currentBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
+		ProvisionerState: expectedWorkspaceBuildState,
+	}).Pending().
+		WithJobCreatedAt(thirtyFiveMinAgo).
+		Do()
+
+	t.Log("current job ID: ", currentBuild.Build.JobID)
 
 	detector := jobreaper.New(ctx, wrapDBAuthz(db, log), pubsub, log, tickCh).WithStatsChannel(statsCh)
 	detector.Start()
@@ -510,10 +342,10 @@ func TestDetectorPendingWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testin
 	stats := <-statsCh
 	require.NoError(t, stats.Error)
 	require.Len(t, stats.TerminatedJobIDs, 1)
-	require.Equal(t, currentWorkspaceBuildJob.ID, stats.TerminatedJobIDs[0])
+	require.Equal(t, currentBuild.Build.JobID, stats.TerminatedJobIDs[0])
 
 	// Check that the current provisioner job was updated.
-	job, err := db.GetProvisionerJobByID(ctx, currentWorkspaceBuildJob.ID)
+	job, err := db.GetProvisionerJobByID(ctx, currentBuild.Build.JobID)
 	require.NoError(t, err)
 	require.WithinDuration(t, now, job.UpdatedAt, 30*time.Second)
 	require.True(t, job.CompletedAt.Valid)
@@ -525,7 +357,7 @@ func TestDetectorPendingWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testin
 	require.False(t, job.ErrorCode.Valid)
 
 	// Check that the provisioner state was NOT updated.
-	build, err := db.GetWorkspaceBuildByID(ctx, currentWorkspaceBuild.ID)
+	build, err := db.GetWorkspaceBuildByID(ctx, currentBuild.Build.ID)
 	require.NoError(t, err)
 	require.Equal(t, expectedWorkspaceBuildState, build.ProvisionerState)
 
@@ -551,62 +383,39 @@ func TestDetectorWorkspaceBuildForDormantWorkspace(t *testing.T) {
 	)
 
 	var (
-		now       = time.Now()
-		tenMinAgo = now.Add(-time.Minute * 10)
-		sixMinAgo = now.Add(-time.Minute * 6)
-		org       = dbgen.Organization(t, db, database.Organization{})
-		user      = dbgen.User(t, db, database.User{})
-		file      = dbgen.File(t, db, database.File{})
-		template  = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-		})
-		templateVersion = dbgen.TemplateVersion(t, db, database.TemplateVersion{
-			OrganizationID: org.ID,
-			TemplateID: uuid.NullUUID{
-				UUID:  template.ID,
-				Valid: true,
-			},
-			CreatedBy: user.ID,
-		})
-		workspace = dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        user.ID,
-			OrganizationID: org.ID,
-			TemplateID:     template.ID,
-			DormantAt: sql.NullTime{
-				Time:  now.Add(-time.Hour),
-				Valid: true,
-			},
-		})
-
-		// First build.
+		now                         = time.Now()
+		sixMinAgo                   = now.Add(-time.Minute * 6)
+		org                         = dbgen.Organization(t, db, database.Organization{})
+		user                        = dbgen.User(t, db, database.User{})
 		expectedWorkspaceBuildState = []byte(`{"dean":"cool","colin":"also cool"}`)
-		currentWorkspaceBuildJob    = dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
-			CreatedAt: tenMinAgo,
-			UpdatedAt: sixMinAgo,
-			StartedAt: sql.NullTime{
-				Time:  tenMinAgo,
-				Valid: true,
-			},
-			OrganizationID: org.ID,
-			InitiatorID:    user.ID,
-			Provisioner:    database.ProvisionerTypeEcho,
-			StorageMethod:  database.ProvisionerStorageMethodFile,
-			FileID:         file.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			Input:          []byte("{}"),
-		})
-		_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			WorkspaceID:       workspace.ID,
-			TemplateVersionID: templateVersion.ID,
-			BuildNumber:       1,
-			JobID:             currentWorkspaceBuildJob.ID,
-			// Should not be overridden.
-			ProvisionerState: expectedWorkspaceBuildState,
-		})
 	)
 
-	t.Log("current job ID: ", currentWorkspaceBuildJob.ID)
+	// First build (hung - running job with UpdatedAt > 5 min ago).
+	// This build has provisioner state, which should NOT be overridden.
+	currentBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
+		ProvisionerState: expectedWorkspaceBuildState,
+	}).Starting().
+		WithJobStartedAt(sixMinAgo).
+		Do()
+
+	// Mark the workspace as dormant after the build is created.
+	_, err := db.UpdateWorkspaceDormantDeletingAt(ctx, database.UpdateWorkspaceDormantDeletingAtParams{
+		ID: currentBuild.Workspace.ID,
+		DormantAt: sql.NullTime{
+			Time:  now.Add(-time.Hour),
+			Valid: true,
+		},
+	})
+	require.NoError(t, err)
+
+	// Refetch the workspace to get the updated dormant status.
+	workspace, err := db.GetWorkspaceByID(ctx, currentBuild.Workspace.ID)
+	require.NoError(t, err)
+
+	t.Log("current job ID: ", currentBuild.Build.JobID)
 
 	// Ensure the RBAC is the dormant type to ensure we're testing the right
 	// thing.
@@ -619,10 +428,10 @@ func TestDetectorWorkspaceBuildForDormantWorkspace(t *testing.T) {
 	stats := <-statsCh
 	require.NoError(t, stats.Error)
 	require.Len(t, stats.TerminatedJobIDs, 1)
-	require.Equal(t, currentWorkspaceBuildJob.ID, stats.TerminatedJobIDs[0])
+	require.Equal(t, currentBuild.Build.JobID, stats.TerminatedJobIDs[0])
 
 	// Check that the current provisioner job was updated.
-	job, err := db.GetProvisionerJobByID(ctx, currentWorkspaceBuildJob.ID)
+	job, err := db.GetProvisionerJobByID(ctx, currentBuild.Build.JobID)
 	require.NoError(t, err)
 	require.WithinDuration(t, now, job.UpdatedAt, 30*time.Second)
 	require.True(t, job.CompletedAt.Valid)

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -128,17 +128,14 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).WithJobCreatedAt(twentyMinAgo).
-		WithJobCompletedAt(twentyMinAgo).
+	}).WithJobCompletedAt(twentyMinAgo).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
 	currentBuild := dbfake.WorkspaceBuild(t, db, previousBuild.Workspace).
 		Pubsub(pubsub).
 		Seed(database.WorkspaceBuild{BuildNumber: 2}).
-		Starting().
-		WithJobCreatedAt(tenMinAgo).
-		WithJobStartedAt(tenMinAgo).
+		Starting(tenMinAgo).
 		WithJobUpdatedAt(sixMinAgo).
 		Do()
 
@@ -200,8 +197,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
-	}).WithJobCreatedAt(twentyMinAgo).
-		WithJobCompletedAt(twentyMinAgo).
+	}).WithJobCompletedAt(twentyMinAgo).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
@@ -212,9 +208,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 			BuildNumber:      2,
 			ProvisionerState: expectedWorkspaceBuildState,
 		}).
-		Starting().
-		WithJobCreatedAt(tenMinAgo).
-		WithJobStartedAt(tenMinAgo).
+		Starting(tenMinAgo).
 		WithJobUpdatedAt(sixMinAgo).
 		Do()
 
@@ -276,9 +270,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Starting().
-		WithJobCreatedAt(tenMinAgo).
-		WithJobStartedAt(tenMinAgo).
+	}).Starting(tenMinAgo).
 		WithJobUpdatedAt(sixMinAgo).
 		Do()
 
@@ -338,8 +330,7 @@ func TestDetectorPendingWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testin
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Pending().
-		WithJobCreatedAt(thirtyFiveMinAgo).
+	}).Pending(thirtyFiveMinAgo).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)
@@ -412,9 +403,7 @@ func TestDetectorWorkspaceBuildForDormantWorkspace(t *testing.T) {
 		},
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Starting().
-		WithJobCreatedAt(tenMinAgo).
-		WithJobStartedAt(tenMinAgo).
+	}).Starting(tenMinAgo).
 		WithJobUpdatedAt(sixMinAgo).
 		Do()
 

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -128,15 +128,14 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Succeeded(twentyMinAgo).
+	}).Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: twentyMinAgo, Valid: true}}).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
 	currentBuild := dbfake.WorkspaceBuild(t, db, previousBuild.Workspace).
 		Pubsub(pubsub).
 		Seed(database.WorkspaceBuild{BuildNumber: 2}).
-		Starting(tenMinAgo).
-		JobUpdatedAt(sixMinAgo).
+		Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
 		Do()
 
 	t.Log("previous job ID: ", previousBuild.Build.JobID)
@@ -197,7 +196,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
-	}).Succeeded(twentyMinAgo).
+	}).Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: twentyMinAgo, Valid: true}}).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
@@ -208,8 +207,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 			BuildNumber:      2,
 			ProvisionerState: expectedWorkspaceBuildState,
 		}).
-		Starting(tenMinAgo).
-		JobUpdatedAt(sixMinAgo).
+		Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
 		Do()
 
 	t.Log("previous job ID: ", previousBuild.Build.JobID)
@@ -270,8 +268,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Starting(tenMinAgo).
-		JobUpdatedAt(sixMinAgo).
+	}).Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)
@@ -330,7 +327,7 @@ func TestDetectorPendingWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testin
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Pending(thirtyFiveMinAgo).
+	}).Pending().UpdateJob(database.ProvisionerJob{CreatedAt: thirtyFiveMinAgo, UpdatedAt: thirtyFiveMinAgo}).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)
@@ -403,8 +400,7 @@ func TestDetectorWorkspaceBuildForDormantWorkspace(t *testing.T) {
 		},
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).Starting(tenMinAgo).
-		JobUpdatedAt(sixMinAgo).
+	}).Starting().UpdateJob(database.ProvisionerJob{StartedAt: sql.NullTime{Time: tenMinAgo, Valid: true}, UpdatedAt: sixMinAgo}).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -128,7 +128,7 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).WithJobCompletedAt(twentyMinAgo).
+	}).JobCompletedAt(twentyMinAgo).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
@@ -136,7 +136,7 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 		Pubsub(pubsub).
 		Seed(database.WorkspaceBuild{BuildNumber: 2}).
 		Starting(tenMinAgo).
-		WithJobUpdatedAt(sixMinAgo).
+		JobUpdatedAt(sixMinAgo).
 		Do()
 
 	t.Log("previous job ID: ", previousBuild.Build.JobID)
@@ -197,7 +197,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
-	}).WithJobCompletedAt(twentyMinAgo).
+	}).JobCompletedAt(twentyMinAgo).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
@@ -209,7 +209,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 			ProvisionerState: expectedWorkspaceBuildState,
 		}).
 		Starting(tenMinAgo).
-		WithJobUpdatedAt(sixMinAgo).
+		JobUpdatedAt(sixMinAgo).
 		Do()
 
 	t.Log("previous job ID: ", previousBuild.Build.JobID)
@@ -271,7 +271,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideStateIfNoExistingBuild(t *testing.T
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
 	}).Starting(tenMinAgo).
-		WithJobUpdatedAt(sixMinAgo).
+		JobUpdatedAt(sixMinAgo).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)
@@ -404,7 +404,7 @@ func TestDetectorWorkspaceBuildForDormantWorkspace(t *testing.T) {
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
 	}).Starting(tenMinAgo).
-		WithJobUpdatedAt(sixMinAgo).
+		JobUpdatedAt(sixMinAgo).
 		Do()
 
 	t.Log("current job ID: ", currentBuild.Build.JobID)

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -128,7 +128,7 @@ func TestDetectorHungWorkspaceBuild(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: expectedWorkspaceBuildState,
-	}).JobCompletedAt(twentyMinAgo).
+	}).Succeeded(twentyMinAgo).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).
@@ -197,7 +197,7 @@ func TestDetectorHungWorkspaceBuildNoOverrideState(t *testing.T) {
 		OwnerID:        user.ID,
 	}).Pubsub(pubsub).Seed(database.WorkspaceBuild{
 		ProvisionerState: []byte(`{"dean":"NOT cool","colin":"also NOT cool"}`),
-	}).JobCompletedAt(twentyMinAgo).
+	}).Succeeded(twentyMinAgo).
 		Do()
 
 	// Current build (hung - running job with UpdatedAt > 5 min ago).

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -96,7 +96,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-6*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
 			Do()
 
 		// When: first run
@@ -185,50 +185,50 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-6*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(now.Add(-5 * dayDuration)).
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-5 * dayDuration), Valid: true}}).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 3, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-4*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-4 * dayDuration), Valid: true}}).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 4, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(now.Add(-5 * dayDuration)).
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-5 * dayDuration), Valid: true}}).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 5, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-4*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-4 * dayDuration), Valid: true}}).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 6, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-3*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-3 * dayDuration), Valid: true}}).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w3).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 7, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-3*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-3 * dayDuration), Valid: true}}).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 8, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-6*dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 9, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(now.Add(-dayDuration)).
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-dayDuration), Valid: true}}).
 			Do()
 
 		// When
@@ -309,7 +309,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 77, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, now.Add(-dayDuration)).
+			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-dayDuration), Valid: true}}).
 			Do()
 
 		// When
@@ -417,7 +417,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 777, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-24 * time.Hour), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(now.Add(-24 * time.Hour)).
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-24 * time.Hour), Valid: true}}).
 			Do()
 
 		for i := 1; i <= 23; i++ {
@@ -426,13 +426,13 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i), TemplateVersionID: t1v1.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String, at).
+				Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: at, Valid: true}}).
 				Do()
 
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i) + 100, TemplateVersionID: t1v2.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String, at).
+				Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: at, Valid: true}}).
 				Do()
 		}
 
@@ -532,12 +532,12 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(now.Add(-6 * dayDuration)).
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-1 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(now.Add(-5 * dayDuration)).
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-5 * dayDuration), Valid: true}}).
 			Do()
 
 		// When

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -190,7 +190,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5*dayDuration))).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5 * dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
@@ -201,7 +201,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 4, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5*dayDuration))).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5 * dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
@@ -417,7 +417,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 777, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-24 * time.Hour), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(dbfake.WithJobCompletedAt(now.Add(-24*time.Hour))).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-24 * time.Hour))).
 			Do()
 
 		for i := 1; i <= 23; i++ {
@@ -532,12 +532,12 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-6 * dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-1 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5*dayDuration))).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5 * dayDuration))).
 			Do()
 
 		// When

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -96,8 +96,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-6 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-6*dayDuration)).
 			Do()
 
 		// When: first run
@@ -186,8 +185,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-6 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-6*dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
@@ -197,8 +195,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 3, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-4 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-4*dayDuration)).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w2).
@@ -209,28 +206,24 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 5, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-4 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-4*dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 6, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-3 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-3*dayDuration)).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w3).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 7, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-3 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-3*dayDuration)).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 8, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-6 * dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-6*dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
@@ -316,8 +309,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 77, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).
-			WithJobCompletedAt(now.Add(-dayDuration)).
+			Failed(jobError.String, jobErrorCode.String, now.Add(-dayDuration)).
 			Do()
 
 		// When
@@ -434,15 +426,13 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i), TemplateVersionID: t1v1.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String).
-				WithJobCompletedAt(at).
+				Failed(jobError.String, jobErrorCode.String, at).
 				Do()
 
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i) + 100, TemplateVersionID: t1v2.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String).
-				WithJobCompletedAt(at).
+				Failed(jobError.String, jobErrorCode.String, at).
 				Do()
 		}
 

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -190,7 +190,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			WithJobCompletedAt(now.Add(-5 * dayDuration)).
+			JobCompletedAt(now.Add(-5 * dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
@@ -201,7 +201,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 4, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			WithJobCompletedAt(now.Add(-5 * dayDuration)).
+			JobCompletedAt(now.Add(-5 * dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
@@ -228,7 +228,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 9, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			WithJobCompletedAt(now.Add(-dayDuration)).
+			JobCompletedAt(now.Add(-dayDuration)).
 			Do()
 
 		// When
@@ -417,7 +417,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 777, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-24 * time.Hour), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			WithJobCompletedAt(now.Add(-24 * time.Hour)).
+			JobCompletedAt(now.Add(-24 * time.Hour)).
 			Do()
 
 		for i := 1; i <= 23; i++ {
@@ -532,12 +532,12 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			WithJobCompletedAt(now.Add(-6 * dayDuration)).
+			JobCompletedAt(now.Add(-6 * dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-1 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			WithJobCompletedAt(now.Add(-5 * dayDuration)).
+			JobCompletedAt(now.Add(-5 * dayDuration)).
 			Do()
 
 		// When

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -190,7 +190,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			JobCompletedAt(now.Add(-5 * dayDuration)).
+			Succeeded(now.Add(-5 * dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
@@ -201,7 +201,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 4, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			JobCompletedAt(now.Add(-5 * dayDuration)).
+			Succeeded(now.Add(-5 * dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
@@ -228,7 +228,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 9, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			JobCompletedAt(now.Add(-dayDuration)).
+			Succeeded(now.Add(-dayDuration)).
 			Do()
 
 		// When
@@ -417,7 +417,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 777, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-24 * time.Hour), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			JobCompletedAt(now.Add(-24 * time.Hour)).
+			Succeeded(now.Add(-24 * time.Hour)).
 			Do()
 
 		for i := 1; i <= 23; i++ {
@@ -532,12 +532,12 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			JobCompletedAt(now.Add(-6 * dayDuration)).
+			Succeeded(now.Add(-6 * dayDuration)).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-1 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			JobCompletedAt(now.Add(-5 * dayDuration)).
+			Succeeded(now.Add(-5 * dayDuration)).
 			Do()
 
 		// When

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -96,7 +96,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 
 		// When: first run
@@ -185,50 +185,50 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-5 * dayDuration), Valid: true}}).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 3, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-4 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-4*dayDuration))).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 4, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-5 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-5 * dayDuration), Valid: true}}).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 5, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-4 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-4*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 6, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-3 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-3*dayDuration))).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w3).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 7, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-3 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-3*dayDuration))).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 8, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 9, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-dayDuration), Valid: true}}).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-dayDuration))).
 			Do()
 
 		// When
@@ -309,7 +309,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 77, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-dayDuration), Valid: true}}).
+			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-dayDuration))).
 			Do()
 
 		// When
@@ -417,7 +417,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 777, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-24 * time.Hour), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-24 * time.Hour), Valid: true}}).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-24*time.Hour))).
 			Do()
 
 		for i := 1; i <= 23; i++ {
@@ -426,13 +426,13 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i), TemplateVersionID: t1v1.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: at, Valid: true}}).
+				Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(at)).
 				Do()
 
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i) + 100, TemplateVersionID: t1v2.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String).UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: at, Valid: true}}).
+				Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(at)).
 				Do()
 		}
 
@@ -532,12 +532,12 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-6 * dayDuration), Valid: true}}).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 2, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-1 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: now.Add(-5 * dayDuration), Valid: true}}).
+			Succeeded(dbfake.WithJobCompletedAt(now.Add(-5*dayDuration))).
 			Do()
 
 		// When

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -96,7 +96,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-2 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 
 		// When: first run
@@ -185,7 +185,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 1, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
@@ -195,7 +195,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 3, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-4*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-4*dayDuration))).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w2).
@@ -206,24 +206,24 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 5, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-4 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-4*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-4*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w2).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 6, TemplateVersionID: t2v2.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-3*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-3*dayDuration))).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w3).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 7, TemplateVersionID: t1v1.ID, CreatedAt: now.Add(-3 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-3*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-3*dayDuration))).
 			Do()
 
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 8, TemplateVersionID: t2v1.ID, CreatedAt: now.Add(-6 * dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-6*dayDuration))).
 			Do()
 		_ = dbfake.WorkspaceBuild(t, db, w4).
 			Pubsub(ps).
@@ -309,7 +309,7 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		_ = dbfake.WorkspaceBuild(t, db, w1).
 			Pubsub(ps).
 			Seed(database.WorkspaceBuild{BuildNumber: 77, TemplateVersionID: t1v2.ID, CreatedAt: now.Add(-dayDuration), Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}).
-			Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(now.Add(-dayDuration))).
+			Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(now.Add(-dayDuration))).
 			Do()
 
 		// When
@@ -426,13 +426,13 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i), TemplateVersionID: t1v1.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(at)).
+				Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(at)).
 				Do()
 
 			_ = dbfake.WorkspaceBuild(t, db, w1).
 				Pubsub(ps).
 				Seed(database.WorkspaceBuild{BuildNumber: int32(i) + 100, TemplateVersionID: t1v2.ID, CreatedAt: at, Transition: database.WorkspaceTransitionStart, Reason: database.BuildReasonInitiator}). // nolint:gosec
-				Failed(jobError.String, jobErrorCode.String, dbfake.WithJobCompletedAt(at)).
+				Failed(dbfake.WithJobError(jobError.String), dbfake.WithJobErrorCode(jobErrorCode.String), dbfake.WithJobCompletedAt(at)).
 				Do()
 		}
 

--- a/enterprise/coderd/prebuilds/reconcile_test.go
+++ b/enterprise/coderd/prebuilds/reconcile_test.go
@@ -1830,8 +1830,6 @@ func TestExpiredPrebuildsMultipleActions(t *testing.T) {
 					expiredCount++
 				}
 
-				// Use dbfake.WorkspaceBuild directly to control job timestamps for
-				// expiration testing via WithJobCreatedAt.
 				jobCreatedAt := clock.Now().Add(createdAt)
 				resp := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 					OwnerID:        database.PrebuildsSystemUserID,
@@ -1846,14 +1844,13 @@ func TestExpiredPrebuildsMultipleActions(t *testing.T) {
 				}).Params(database.WorkspaceBuildParameter{
 					Name:  "test",
 					Value: "test",
-				}).WithJobCreatedAt(jobCreatedAt).Do()
-				workspace := resp.Workspace
+				}).Do()
 				if isExpired {
-					expiredWorkspaces = append(expiredWorkspaces, workspace)
+					expiredWorkspaces = append(expiredWorkspaces, resp.Workspace)
 				} else {
-					nonExpiredWorkspaces = append(nonExpiredWorkspaces, workspace)
+					nonExpiredWorkspaces = append(nonExpiredWorkspaces, resp.Workspace)
 				}
-				runningWorkspaces[workspace.ID.String()] = workspace
+				runningWorkspaces[resp.Workspace.ID.String()] = resp.Workspace
 			}
 
 			getJobStatusMap := func(workspaces []database.WorkspaceTable) map[database.ProvisionerJobStatus]int {

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -256,21 +256,18 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 				ProvisionerState:  []byte(must(cryptorand.String(64))),
 			}).WithJobCompletedAt(buildTime).Do()
 
-			_ = buildResp.Workspace
-			wsBuild := buildResp.Build
-
 			// Assert test invariant: workspace build state must not be empty
-			require.NotEmpty(t, wsBuild.ProvisionerState, "provisioner state must not be empty")
+			require.NotEmpty(t, buildResp.Build.ProvisionerState, "provisioner state must not be empty")
 
 			err := db.UpdateWorkspaceBuildDeadlineByID(ctx, database.UpdateWorkspaceBuildDeadlineByIDParams{
-				ID:          wsBuild.ID,
+				ID:          buildResp.Build.ID,
 				UpdatedAt:   buildTime,
 				Deadline:    c.deadline,
 				MaxDeadline: c.maxDeadline,
 			})
 			require.NoError(t, err)
 
-			wsBuild, err = db.GetWorkspaceBuildByID(ctx, wsBuild.ID)
+			wsBuild, err := db.GetWorkspaceBuildByID(ctx, buildResp.Build.ID)
 			require.NoError(t, err)
 
 			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -254,7 +254,7 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			}).Seed(database.WorkspaceBuild{
 				TemplateVersionID: templateVersion.ID,
 				ProvisionerState:  []byte(must(cryptorand.String(64))),
-			}).Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: buildTime, Valid: true}}).Do()
+			}).Succeeded(dbfake.WithJobCompletedAt(buildTime)).Do()
 
 			// Assert test invariant: workspace build state must not be empty
 			require.NotEmpty(t, buildResp.Build.ProvisionerState, "provisioner state must not be empty")

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -254,7 +254,7 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			}).Seed(database.WorkspaceBuild{
 				TemplateVersionID: templateVersion.ID,
 				ProvisionerState:  []byte(must(cryptorand.String(64))),
-			}).Succeeded(buildTime).Do()
+			}).Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: buildTime, Valid: true}}).Do()
 
 			// Assert test invariant: workspace build state must not be empty
 			require.NotEmpty(t, buildResp.Build.ProvisionerState, "provisioner state must not be empty")

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -254,7 +254,7 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			}).Seed(database.WorkspaceBuild{
 				TemplateVersionID: templateVersion.ID,
 				ProvisionerState:  []byte(must(cryptorand.String(64))),
-			}).JobCompletedAt(buildTime).Do()
+			}).Succeeded(buildTime).Do()
 
 			// Assert test invariant: workspace build state must not be empty
 			require.NotEmpty(t, buildResp.Build.ProvisionerState, "provisioner state must not be empty")

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -254,7 +254,7 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			}).Seed(database.WorkspaceBuild{
 				TemplateVersionID: templateVersion.ID,
 				ProvisionerState:  []byte(must(cryptorand.String(64))),
-			}).WithJobCompletedAt(buildTime).Do()
+			}).JobCompletedAt(buildTime).Do()
 
 			// Assert test invariant: workspace build state must not be empty
 			require.NotEmpty(t, buildResp.Build.ProvisionerState, "provisioner state must not be empty")

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -242,65 +242,27 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			t.Log("newMaxDeadline", c.newMaxDeadline)
 			t.Log("ttl", c.ttl)
 
-			var (
-				template = dbgen.Template(t, db, database.Template{
-					OrganizationID:  organizationID,
-					ActiveVersionID: templateVersion.ID,
-					CreatedBy:       user.ID,
-				})
-				ws = dbgen.Workspace(t, db, database.WorkspaceTable{
-					OrganizationID: organizationID,
-					OwnerID:        user.ID,
-					TemplateID:     template.ID,
-				})
-				job = dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
-					OrganizationID: organizationID,
-					FileID:         file.ID,
-					InitiatorID:    user.ID,
-					Provisioner:    database.ProvisionerTypeEcho,
-					Tags: database.StringMap{
-						c.name: "yeah",
-					},
-				})
-				wsBuild = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-					WorkspaceID:       ws.ID,
-					BuildNumber:       1,
-					JobID:             job.ID,
-					InitiatorID:       user.ID,
-					TemplateVersionID: templateVersion.ID,
-					ProvisionerState:  []byte(must(cryptorand.String(64))),
-				})
-			)
+			template := dbgen.Template(t, db, database.Template{
+				OrganizationID:  organizationID,
+				ActiveVersionID: templateVersion.ID,
+				CreatedBy:       user.ID,
+			})
+			buildResp := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+				OrganizationID: organizationID,
+				OwnerID:        user.ID,
+				TemplateID:     template.ID,
+			}).Seed(database.WorkspaceBuild{
+				TemplateVersionID: templateVersion.ID,
+				ProvisionerState:  []byte(must(cryptorand.String(64))),
+			}).WithJobCompletedAt(buildTime).Do()
+
+			_ = buildResp.Workspace
+			wsBuild := buildResp.Build
 
 			// Assert test invariant: workspace build state must not be empty
 			require.NotEmpty(t, wsBuild.ProvisionerState, "provisioner state must not be empty")
 
-			acquiredJob, err := db.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-				OrganizationID: job.OrganizationID,
-				StartedAt: sql.NullTime{
-					Time:  buildTime,
-					Valid: true,
-				},
-				WorkerID: uuid.NullUUID{
-					UUID:  uuid.New(),
-					Valid: true,
-				},
-				Types:           []database.ProvisionerType{database.ProvisionerTypeEcho},
-				ProvisionerTags: json.RawMessage(fmt.Sprintf(`{%q: "yeah"}`, c.name)),
-			})
-			require.NoError(t, err)
-			require.Equal(t, job.ID, acquiredJob.ID)
-			err = db.UpdateProvisionerJobWithCompleteByID(ctx, database.UpdateProvisionerJobWithCompleteByIDParams{
-				ID: job.ID,
-				CompletedAt: sql.NullTime{
-					Time:  buildTime,
-					Valid: true,
-				},
-				UpdatedAt: buildTime,
-			})
-			require.NoError(t, err)
-
-			err = db.UpdateWorkspaceBuildDeadlineByID(ctx, database.UpdateWorkspaceBuildDeadlineByIDParams{
+			err := db.UpdateWorkspaceBuildDeadlineByID(ctx, database.UpdateWorkspaceBuildDeadlineByIDParams{
 				ID:          wsBuild.ID,
 				UpdatedAt:   buildTime,
 				Deadline:    c.deadline,

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -380,7 +380,6 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 		}).
 		Do()
 
-	// Create workspace with the first build's timestamp
 	wrk := dbgen.Workspace(t, db, database.WorkspaceTable{
 		OwnerID:        s.usr.ID,
 		OrganizationID: s.org.ID,
@@ -399,15 +398,14 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 				Transition:  b.transition,
 				InitiatorID: s.usr.ID,
 			}).
-			WithJobCreatedAt(b.at).
 			WithJobCompletedAt(b.at)
 
 		// Set job status based on the build args
 		switch b.jobStatus {
 		case database.ProvisionerJobStatusCanceled:
-			builder = builder.Canceled()
+			builder = builder.Canceled(b.at)
 		case database.ProvisionerJobStatusFailed:
-			builder = builder.Failed("fake error", "")
+			builder = builder.Failed("fake error", "", b.at)
 			// default: Succeeded (the builder's default)
 		}
 

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -398,7 +398,7 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 				Transition:  b.transition,
 				InitiatorID: s.usr.ID,
 			}).
-			JobCompletedAt(b.at)
+			Succeeded(b.at)
 
 		// Set job status based on the build args
 		switch b.jobStatus {

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -408,7 +408,7 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 			builder = builder.Canceled()
 		case database.ProvisionerJobStatusFailed:
 			builder = builder.Failed("fake error", "")
-		// default: Succeeded (the builder's default)
+			// default: Succeeded (the builder's default)
 		}
 
 		builder.Do()

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -5,7 +5,6 @@
 package runtimeaudit_test
 
 import (
-	"database/sql"
 	_ "embed"
 	"math"
 	"strings"
@@ -399,14 +398,14 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 				Transition:  b.transition,
 				InitiatorID: s.usr.ID,
 			}).
-			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: b.at, Valid: true}})
+			Succeeded(dbfake.WithJobCompletedAt(b.at))
 
 		// Set job status based on the build args
 		switch b.jobStatus {
 		case database.ProvisionerJobStatusCanceled:
-			builder = builder.Canceled().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: b.at, Valid: true}})
+			builder = builder.Canceled(dbfake.WithJobCompletedAt(b.at))
 		case database.ProvisionerJobStatusFailed:
-			builder = builder.Failed("fake error", "").UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: b.at, Valid: true}})
+			builder = builder.Failed("fake error", "", dbfake.WithJobCompletedAt(b.at))
 			// default: Succeeded (the builder's default)
 		}
 

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -5,6 +5,7 @@
 package runtimeaudit_test
 
 import (
+	"database/sql"
 	_ "embed"
 	"math"
 	"strings"
@@ -398,14 +399,14 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 				Transition:  b.transition,
 				InitiatorID: s.usr.ID,
 			}).
-			Succeeded(b.at)
+			Succeeded().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: b.at, Valid: true}})
 
 		// Set job status based on the build args
 		switch b.jobStatus {
 		case database.ProvisionerJobStatusCanceled:
-			builder = builder.Canceled(b.at)
+			builder = builder.Canceled().UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: b.at, Valid: true}})
 		case database.ProvisionerJobStatusFailed:
-			builder = builder.Failed("fake error", "", b.at)
+			builder = builder.Failed("fake error", "").UpdateJob(database.ProvisionerJob{CompletedAt: sql.NullTime{Time: b.at, Valid: true}})
 			// default: Succeeded (the builder's default)
 		}
 

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -398,7 +398,7 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 				Transition:  b.transition,
 				InitiatorID: s.usr.ID,
 			}).
-			WithJobCompletedAt(b.at)
+			JobCompletedAt(b.at)
 
 		// Set job status based on the build args
 		switch b.jobStatus {

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -5,7 +5,6 @@
 package runtimeaudit_test
 
 import (
-	"database/sql"
 	_ "embed"
 	"math"
 	"strings"
@@ -258,8 +257,8 @@ func TestRuntimeAudit(t *testing.T) {
 			name: "canceled_start_does_not_count_usage",
 			// Only start+succeeded counts; canceled start is ignored.
 			builds: []workspaceBuildArgs{
-				{at: decUTC(8, 9, 0), canceled: true, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusCanceled},
-				{at: decUTC(8, 10, 0), canceled: false, transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(8, 9, 0), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusCanceled},
+				{at: decUTC(8, 10, 0), transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusSucceeded},
 			},
 			expect: func(_ time.Time, _ []workspaceBuildArgs) int { return 0 },
 		},
@@ -267,8 +266,8 @@ func TestRuntimeAudit(t *testing.T) {
 			name: "failed_start_does_not_count_even_if_later_stop_occurs",
 			// Start failed => never turns on => later stop does nothing.
 			builds: []workspaceBuildArgs{
-				{at: decUTC(9, 9, 0), canceled: false, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusFailed},
-				{at: decUTC(9, 12, 0), canceled: false, transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(9, 9, 0), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusFailed},
+				{at: decUTC(9, 12, 0), transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusSucceeded},
 			},
 			expect: func(_ time.Time, _ []workspaceBuildArgs) int { return 0 },
 		},
@@ -276,8 +275,8 @@ func TestRuntimeAudit(t *testing.T) {
 			name: "canceled_stop_still_stops_timer_and_counts_time",
 			// Any non-(start+succeeded) is treated as stop while running, regardless of status/canceled.
 			builds: []workspaceBuildArgs{
-				{at: decUTC(10, 9, 0), canceled: false, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
-				{at: decUTC(10, 9, 40), canceled: true, transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusCanceled},
+				{at: decUTC(10, 9, 0), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(10, 9, 40), transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusCanceled},
 			},
 			expect: func(_ time.Time, in []workspaceBuildArgs) int {
 				return roundUpHours(in[1].at, in[0].at)
@@ -287,8 +286,8 @@ func TestRuntimeAudit(t *testing.T) {
 			name: "failed_stop_still_stops_timer_and_counts_time",
 			// Same as above: stop is stop even if job failed (ELSE path).
 			builds: []workspaceBuildArgs{
-				{at: decUTC(11, 10, 0), canceled: false, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
-				{at: decUTC(11, 10, 10), canceled: false, transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusFailed},
+				{at: decUTC(11, 10, 0), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(11, 10, 10), transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusFailed},
 			},
 			expect: func(_ time.Time, in []workspaceBuildArgs) int {
 				return roundUpHours(in[1].at, in[0].at)
@@ -298,8 +297,8 @@ func TestRuntimeAudit(t *testing.T) {
 			name: "failed_transition_stops_timer_and_counts_time",
 			// A failed *non-stop* transition (e.g. delete) still stops if currently on.
 			builds: []workspaceBuildArgs{
-				{at: decUTC(12, 8, 0), canceled: false, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
-				{at: decUTC(12, 8, 5), canceled: false, transition: database.WorkspaceTransitionDelete, jobStatus: database.ProvisionerJobStatusFailed},
+				{at: decUTC(12, 8, 0), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(12, 8, 5), transition: database.WorkspaceTransitionDelete, jobStatus: database.ProvisionerJobStatusFailed},
 			},
 			expect: func(_ time.Time, in []workspaceBuildArgs) int {
 				return roundUpHours(in[1].at, in[0].at)
@@ -310,11 +309,11 @@ func TestRuntimeAudit(t *testing.T) {
 			// When already on, a subsequent non-(start+succeeded) build triggers stop logic.
 			// This verifies you *do not* treat start+failed as a "start"; it will stop the running timer.
 			builds: []workspaceBuildArgs{
-				{at: decUTC(13, 9, 0), canceled: false, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(13, 9, 0), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusSucceeded},
 				// This goes to ELSE branch (because job_status != succeeded) and will stop the timer.
-				{at: decUTC(13, 9, 30), canceled: false, transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusFailed},
+				{at: decUTC(13, 9, 30), transition: database.WorkspaceTransitionStart, jobStatus: database.ProvisionerJobStatusFailed},
 				// Subsequent stop should not add more time because timer was reset.
-				{at: decUTC(13, 10, 0), canceled: false, transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusSucceeded},
+				{at: decUTC(13, 10, 0), transition: database.WorkspaceTransitionStop, jobStatus: database.ProvisionerJobStatusSucceeded},
 			},
 			expect: func(_ time.Time, in []workspaceBuildArgs) int {
 				// Only counts from first start to failed-start event.
@@ -368,13 +367,12 @@ func initSetup(t *testing.T, db database.Store) *setup {
 
 type workspaceBuildArgs struct {
 	at         time.Time
-	canceled   bool
 	transition database.WorkspaceTransition
 	jobStatus  database.ProvisionerJobStatus
 }
 
 func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []workspaceBuildArgs) database.WorkspaceTable {
-	// Insert the first build
+	// Create template version first
 	tv := dbfake.TemplateVersion(t, db).
 		Seed(database.TemplateVersion{
 			OrganizationID: s.org.ID,
@@ -382,6 +380,7 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 		}).
 		Do()
 
+	// Create workspace with the first build's timestamp
 	wrk := dbgen.Workspace(t, db, database.WorkspaceTable{
 		OwnerID:        s.usr.ID,
 		OrganizationID: s.org.ID,
@@ -390,39 +389,29 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 	})
 
 	for i, b := range builds {
-		job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
-			CreatedAt: b.at,
-			UpdatedAt: b.at,
-			StartedAt: sql.NullTime{
-				Time:  b.at,
-				Valid: true,
-			},
-			CanceledAt: sql.NullTime{
-				Time:  b.at,
-				Valid: b.canceled,
-			},
-			CompletedAt: sql.NullTime{
-				Time:  b.at,
-				Valid: true,
-			},
-			Error:          sql.NullString{},
-			OrganizationID: s.org.ID,
-			InitiatorID:    s.usr.ID,
-			Type:           database.ProvisionerJobTypeWorkspaceBuild,
-			JobStatus:      b.jobStatus,
-		})
+		builder := dbfake.WorkspaceBuild(t, db, wrk).
+			Seed(database.WorkspaceBuild{
+				CreatedAt:         b.at,
+				UpdatedAt:         b.at,
+				TemplateVersionID: tv.TemplateVersion.ID,
+				//nolint:gosec // this will not overflow
+				BuildNumber: int32(i) + 1,
+				Transition:  b.transition,
+				InitiatorID: s.usr.ID,
+			}).
+			WithJobCreatedAt(b.at).
+			WithJobCompletedAt(b.at)
 
-		dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-			CreatedAt:         b.at,
-			UpdatedAt:         b.at,
-			WorkspaceID:       wrk.ID,
-			TemplateVersionID: tv.TemplateVersion.ID,
-			///nolint:gosec // this will not overflow
-			BuildNumber: int32(i) + 1,
-			Transition:  b.transition,
-			InitiatorID: s.usr.ID,
-			JobID:       job.ID,
-		})
+		// Set job status based on the build args
+		switch b.jobStatus {
+		case database.ProvisionerJobStatusCanceled:
+			builder = builder.Canceled()
+		case database.ProvisionerJobStatusFailed:
+			builder = builder.Failed("fake error", "")
+		// default: Succeeded (the builder's default)
+		}
+
+		builder.Do()
 	}
 
 	return wrk

--- a/scripts/workspace-runtime-audit/runtimeaudit_test.go
+++ b/scripts/workspace-runtime-audit/runtimeaudit_test.go
@@ -405,7 +405,7 @@ func (s *setup) createWorkspace(t *testing.T, db database.Store, builds []worksp
 		case database.ProvisionerJobStatusCanceled:
 			builder = builder.Canceled(dbfake.WithJobCompletedAt(b.at))
 		case database.ProvisionerJobStatusFailed:
-			builder = builder.Failed("fake error", "", dbfake.WithJobCompletedAt(b.at))
+			builder = builder.Failed(dbfake.WithJobError("fake error"), dbfake.WithJobCompletedAt(b.at))
 			// default: Succeeded (the builder's default)
 		}
 


### PR DESCRIPTION
Motivation: reduce `dbgen` boilerplate when creating tests that depend on specific pieces of provisioner job timing.

Relates to https://github.com/coder/coder/pull/21922 / https://github.com/coder/internal/issues/1259

<details>
<summary>
Original API design:
</summary>

Extends dbfake.WorkspaceBuildBuilder with timestamp and status control methods
  * Adds an optional timestamp to `Starting()`, which sets the provisioner job start and update time.
  * Adds an optional timestamp to `Pending()`, which sets provisioner job create and update time
  * Adds an optional timestamp to `Canceled()`, which sets provisioner job complete and cancel time
  * Adds method `Failed()` which sets a job to the failed state with a given error message / error code, and optionally allows setting job complete time.
  * Adds method `Succeeded()` which allows setting the completed at time of the job.
</details>

Updated after review feedback:

* Adds `dbfake.BuilderOption func(*WorkspaceBuildBuilder)`
* Adds `BuilderOption` methods for setting various provisioner job related fields on `WorkspaceBuildBuilder`.
* Migrates a number of existing tests that previously dependeded on provisioner job timing to use these updated methods in the following packages:
  * `coderd/jobreaper`
  * `coderd/notifications/reports`
  * `enterprise/coderd/schedule`
  * `enterprise/coderd/prebuilds`
  * `scripts/workspace-runtime-audit` 

🤖 Created using Mux (Opus 4.5)