### PR TITLE
fix: allow users with workspace:create for any owner to list users

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3745,6 +3745,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/organizations/{organization}/members/{user}/workspaces/available-users": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Get users available for workspace creation",
+                "operationId": "get-workspace-available-users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID, name, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit results",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset for pagination",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.MinimalUser"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/organizations/{organization}/paginated-members": {
             "get": {
                 "security": [

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -3759,7 +3759,7 @@ const docTemplate = `{
                     "Workspaces"
                 ],
                 "summary": "Get users available for workspace creation",
-                "operationId": "get-workspace-available-users",
+                "operationId": "get-users-available-for-workspace-creation",
                 "parameters": [
                     {
                         "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3296,6 +3296,65 @@
 				}
 			}
 		},
+		"/organizations/{organization}/members/{user}/workspaces/available-users": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["Workspaces"],
+				"summary": "Get users available for workspace creation",
+				"operationId": "get-workspace-available-users",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "User ID, name, or me",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Search query",
+						"name": "q",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Limit results",
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Offset for pagination",
+						"name": "offset",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.MinimalUser"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/organizations/{organization}/paginated-members": {
 			"get": {
 				"security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3306,7 +3306,7 @@
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
 				"summary": "Get users available for workspace creation",
-				"operationId": "get-workspace-available-users",
+				"operationId": "get-users-available-for-workspace-creation",
 				"parameters": [
 					{
 						"type": "string",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1230,7 +1230,10 @@ func New(options *Options) *API {
 							r.Get("/", api.organizationMember)
 							r.Delete("/", api.deleteOrganizationMember)
 							r.Put("/roles", api.putMemberRoles)
-							r.Post("/workspaces", api.postWorkspacesByOrganization)
+							r.Route("/workspaces", func(r chi.Router) {
+								r.Post("/", api.postWorkspacesByOrganization)
+								r.Get("/available-users", api.workspaceAvailableUsers)
+							})
 						})
 					})
 				})

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -266,6 +266,16 @@ func TestRolePermissions(t *testing.T) {
 			},
 		},
 		{
+			Name: "CreateWorkspaceForMembers",
+			// When creating the WithID won't be set, but it does not change the result.
+			Actions:  []policy.Action{policy.ActionCreate},
+			Resource: rbac.ResourceWorkspace.InOrg(orgID).WithOwner(policy.WildcardSymbol),
+			AuthorizeMap: map[bool][]hasAuthSubjects{
+				true:  {owner, orgAdmin},
+				false: {setOtherOrg, orgUserAdmin, orgAuditor, memberMe, userAdmin, templateAdmin, orgTemplateAdmin},
+			},
+		},
+		{
 			Name: "MyWorkspaceInOrgExecution",
 			// When creating the WithID won't be set, but it does not change the result.
 			Actions:  []policy.Action{policy.ActionSSH},

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2952,7 +2952,6 @@ func convertToWorkspaceRole(actions []policy.Action) codersdk.WorkspaceRole {
 	return codersdk.WorkspaceRoleDeleted
 }
 
-
 // @Summary Get users available for workspace creation
 // @ID get-workspace-available-users
 // @Security CoderSessionToken

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2951,3 +2951,49 @@ func convertToWorkspaceRole(actions []policy.Action) codersdk.WorkspaceRole {
 
 	return codersdk.WorkspaceRoleDeleted
 }
+
+
+// @Summary Get users available for workspace creation
+// @ID get-workspace-available-users
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Workspaces
+// @Param organization path string true "Organization ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
+// @Param q query string false "Search query"
+// @Param limit query int false "Limit results"
+// @Param offset query int false "Offset for pagination"
+// @Success 200 {array} codersdk.MinimalUser
+// @Router /organizations/{organization}/members/{user}/workspaces/available-users [get]
+func (api *API) workspaceAvailableUsers(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	organization := httpmw.OrganizationParam(r)
+
+	// This endpoint requires the user to be able to create workspaces for other
+	// users in this organization. We check if they can create a workspace with
+	// a wildcard owner.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceWorkspace.InOrg(organization.ID).WithOwner(policy.WildcardSymbol)) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	// Use system context to list all users. The authorization check above
+	// ensures only users who can create workspaces for others can access this.
+	//nolint:gocritic // System context needed to list users for workspace owner selection.
+	users, _, ok := api.GetUsers(rw, r.WithContext(dbauthz.AsSystemRestricted(ctx)))
+	if !ok {
+		return
+	}
+
+	minimalUsers := make([]codersdk.MinimalUser, 0, len(users))
+	for _, user := range users {
+		minimalUsers = append(minimalUsers, codersdk.MinimalUser{
+			ID:        user.ID,
+			Username:  user.Username,
+			Name:      user.Name,
+			AvatarURL: user.AvatarURL,
+		})
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, minimalUsers)
+}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2953,7 +2953,7 @@ func convertToWorkspaceRole(actions []policy.Action) codersdk.WorkspaceRole {
 }
 
 // @Summary Get users available for workspace creation
-// @ID get-workspace-available-users
+// @ID get-users-available-for-workspace-creation
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Workspaces

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -5620,8 +5620,6 @@ func TestWorkspaceSharingDisabled(t *testing.T) {
 	})
 }
 
-
-
 func TestWorkspaceAvailableUsers(t *testing.T) {
 	t.Parallel()
 
@@ -5668,6 +5666,7 @@ func TestWorkspaceAvailableUsers(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
 	})
 }
+
 func TestWorkspaceCreateWithImplicitPreset(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -786,3 +786,19 @@ func (c *Client) WorkspaceExternalAgentCredentials(ctx context.Context, workspac
 	var credentials ExternalAgentCredentials
 	return credentials, json.NewDecoder(res.Body).Decode(&credentials)
 }
+
+// WorkspaceAvailableUsers returns users available for workspace creation.
+// This is used to populate the owner dropdown when creating workspaces for
+// other users.
+func (c *Client) WorkspaceAvailableUsers(ctx context.Context, organizationID uuid.UUID, userID string) ([]MinimalUser, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/members/%s/workspaces/available-users", organizationID, userID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+	var users []MinimalUser
+	return users, json.NewDecoder(res.Body).Decode(&users)
+}

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -331,6 +331,64 @@ of the template will be used.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get users available for workspace creation
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/members/{user}/workspaces/available-users \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /organizations/{organization}/members/{user}/workspaces/available-users`
+
+### Parameters
+
+| Name           | In    | Type         | Required | Description           |
+|----------------|-------|--------------|----------|-----------------------|
+| `organization` | path  | string(uuid) | true     | Organization ID       |
+| `user`         | path  | string       | true     | User ID, name, or me  |
+| `q`            | query | string       | false    | Search query          |
+| `limit`        | query | integer      | false    | Limit results         |
+| `offset`       | query | integer      | false    | Offset for pagination |
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "avatar_url": "http://example.com",
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "name": "string",
+    "username": "string"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                          |
+|--------|---------------------------------------------------------|-------------|-----------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.MinimalUser](schemas.md#codersdkminimaluser) |
+
+<h3 id="get-users-available-for-workspace-creation-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type         | Required | Restrictions | Description |
+|----------------|--------------|----------|--------------|-------------|
+| `[array item]` | array        | false    |              |             |
+| `» avatar_url` | string(uri)  | false    |              |             |
+| `» id`         | string(uuid) | true     |              |             |
+| `» name`       | string       | false    |              |             |
+| `» username`   | string       | true     |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get workspace metadata by user and workspace name
 
 ### Code samples

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -570,9 +570,10 @@ class ApiMethods {
 	};
 
 	/**
-	 * Get users available as workspace owners. This is a scoped
-	 * endpoint that only returns users the caller can create
-	 * workspaces for within the given organization.
+	 * Get users for workspace owner selection. Requires
+	 * permission to create workspaces for other users in the
+	 * organization. Returns minimal user data (no email, roles,
+	 * etc.).
 	 */
 	getWorkspaceAvailableUsers = async (
 		organizationId: string,

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -569,6 +569,27 @@ class ApiMethods {
 		return response.data;
 	};
 
+	/**
+	 * Get users available as workspace owners. This is a scoped
+	 * endpoint that only returns users the caller can create
+	 * workspaces for within the given organization.
+	 */
+	getWorkspaceAvailableUsers = async (
+		organizationId: string,
+		options: TypesGen.UsersRequest,
+		signal?: AbortSignal,
+	): Promise<TypesGen.MinimalUser[]> => {
+		const url = getURLWithSearchParams(
+			`/api/v2/organizations/${organizationId}/members/me/workspaces/available-users`,
+			options,
+		);
+		const response = await this.axios.get<TypesGen.MinimalUser[]>(
+			url.toString(),
+			{ signal },
+		);
+		return response.data;
+	};
+
 	createOrganization = async (params: TypesGen.CreateOrganizationRequest) => {
 		const response = await this.axios.post<TypesGen.Organization>(
 			"/api/v2/organizations",

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -3,6 +3,7 @@ import type {
 	AuthorizationRequest,
 	GenerateAPIKeyResponse,
 	GetUsersResponse,
+	MinimalUser,
 	RequestOneTimePasscodeRequest,
 	UpdateUserAppearanceSettingsRequest,
 	UpdateUserPasswordRequest,
@@ -54,6 +55,18 @@ export const users = (req: UsersRequest): UseQueryOptions<GetUsersResponse> => {
 	return {
 		queryKey: usersKey(req),
 		queryFn: ({ signal }) => API.getUsers(req, signal),
+		gcTime: 5 * 1000 * 60,
+	};
+};
+
+export const workspaceAvailableUsers = (
+	organizationId: string,
+	req: UsersRequest,
+): UseQueryOptions<MinimalUser[]> => {
+	return {
+		queryKey: ["workspaceAvailableUsers", organizationId, req],
+		queryFn: ({ signal }) =>
+			API.getWorkspaceAvailableUsers(organizationId, req, signal),
 		gcTime: 5 * 1000 * 60,
 	};
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -11,6 +11,7 @@ import { autoCreateWorkspace, createWorkspace } from "api/queries/workspaces";
 import type {
 	DynamicParametersRequest,
 	DynamicParametersResponse,
+	MinimalUser,
 	PreviewParameter,
 	Workspace,
 } from "api/typesGenerated";
@@ -61,8 +62,8 @@ const CreateWorkspacePage: FC = () => {
 	const [mode, setMode] = useState(() => getWorkspaceMode(searchParams));
 	const [autoCreateError, setAutoCreateError] =
 		useState<ApiErrorResponse | null>(null);
-	const defaultOwner = me;
-	const [owner, setOwner] = useState(defaultOwner);
+	const defaultOwner: MinimalUser = me;
+	const [owner, setOwner] = useState<MinimalUser>(defaultOwner);
 
 	const queryClient = useQueryClient();
 	const autoCreateWorkspaceMutation = useMutation(

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -16,7 +16,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { UserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
+import { WorkspaceUserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
 import { type FormikContextType, useFormik } from "formik";
 import { useDebouncedFunction } from "hooks/debounce";
 import type { ExternalAuthPollingState } from "hooks/useExternalAuth";
@@ -51,7 +51,7 @@ interface CreateWorkspacePageViewProps {
 	canUpdateTemplate?: boolean;
 	creatingWorkspace: boolean;
 	defaultName?: string | null;
-	defaultOwner: TypesGen.User;
+	defaultOwner: TypesGen.MinimalUser;
 	diagnostics: readonly FriendlyDiagnostic[];
 	disabledParams?: string[];
 	error: unknown;
@@ -68,13 +68,13 @@ interface CreateWorkspacePageViewProps {
 	onCancel: () => void;
 	onSubmit: (
 		req: TypesGen.CreateWorkspaceRequest,
-		owner: TypesGen.User,
+		owner: TypesGen.MinimalUser,
 	) => void;
 	resetMutation: () => void;
 	sendMessage: (message: Record<string, string>, ownerId?: string) => void;
 	startPollingExternalAuth: () => void;
-	owner: TypesGen.User;
-	setOwner: (user: TypesGen.User) => void;
+	owner: TypesGen.MinimalUser;
+	setOwner: (user: TypesGen.MinimalUser) => void;
 }
 
 export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
@@ -307,7 +307,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 		sendDynamicParamsRequest,
 	]);
 
-	const handleOwnerChange = (user: TypesGen.User) => {
+	const handleOwnerChange = (user: TypesGen.MinimalUser) => {
 		setOwner(user);
 		sendDynamicParamsRequest([], user.id);
 	};
@@ -497,7 +497,8 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 										<Label className="text-sm" htmlFor={`${id}-workspace-name`}>
 											Owner
 										</Label>
-										<UserAutocomplete
+										<WorkspaceUserAutocomplete
+											organizationId={template.organization_id}
 											value={owner}
 											onChange={(user) => {
 												handleOwnerChange(user ?? defaultOwner);


### PR DESCRIPTION
## Summary

Custom roles that can create workspaces on behalf of other users need to be able to list users to populate the owner dropdown in the workspace creation UI. Previously, this required a separate `user:read` permission, causing the dropdown to fail for custom roles.

## Changes

- Modified `GetUsers` in `dbauthz` to check if the user can create workspaces for any owner (`workspace:create` with `owner_id: *`)
- If the user has this permission, they can list all users without needing explicit `user:read` permission
- Added tests to verify the new behavior

## Testing

- Updated mock tests to assert the new authorization check
- Added integration tests for both positive and negative cases

Fixes #18203