### PR TITLE
feat: add an endpoint to manually resume a coder task

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -1388,6 +1388,6 @@ func (api *API) resumeTask(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpapi.Write(ctx, rw, http.StatusAccepted, codersdk.ResumeTaskResponse{
-		WorkspaceBuildID: build.ID,
+		WorkspaceBuild: &build,
 	})
 }

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -2781,3 +2781,47 @@ func TestPauseTask(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, apiErr.StatusCode())
 	})
 }
+
+func TestResumeTask(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Task not found", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Task lookup forbidden", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Workspace lookup forbidden", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("No Workspace for Task", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Workspace not found", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Workspace lookup internal error", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Build Forbidden", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Job already in progress", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	t.Run("Build Internal Error", func(t *testing.T) {
+		t.Parallel()
+	})
+}

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -3034,7 +3034,11 @@ func TestResumeTask(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 		task, _ := setupWorkspaceTask(t, db, user)
 
-		_, err := client.ResumeTask(ctx, codersdk.Me, task.ID)
+		pauseResp, err := client.PauseTask(ctx, codersdk.Me, task.ID)
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, pauseResp.WorkspaceBuild.ID)
+
+		_, err = client.ResumeTask(ctx, codersdk.Me, task.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5866,6 +5866,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/tasks/{user}/{task}/resume": {
+            "post": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tasks"
+                ],
+                "summary": "Resume task",
+                "operationId": "resume-task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username, user ID, or 'me' for the authenticated user",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Task ID",
+                        "name": "task",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ResumeTaskResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/tasks/{user}/{task}/send": {
             "post": {
                 "security": [
@@ -14145,7 +14187,8 @@ const docTemplate = `{
                 "ssh_connection",
                 "vscode_connection",
                 "jetbrains_connection",
-                "task_manual_pause"
+                "task_manual_pause",
+                "task_resume"
             ],
             "x-enum-varnames": [
                 "CreateWorkspaceBuildReasonDashboard",
@@ -14153,7 +14196,8 @@ const docTemplate = `{
                 "CreateWorkspaceBuildReasonSSHConnection",
                 "CreateWorkspaceBuildReasonVSCodeConnection",
                 "CreateWorkspaceBuildReasonJetbrainsConnection",
-                "CreateWorkspaceBuildReasonTaskManualPause"
+                "CreateWorkspaceBuildReasonTaskManualPause",
+                "CreateWorkspaceBuildReasonTaskResume"
             ]
         },
         "codersdk.CreateWorkspaceBuildRequest": {
@@ -18232,6 +18276,15 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.ValidationError"
                     }
+                }
+            }
+        },
+        "codersdk.ResumeTaskResponse": {
+            "type": "object",
+            "properties": {
+                "workspace_build_id": {
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18282,9 +18282,8 @@ const docTemplate = `{
         "codersdk.ResumeTaskResponse": {
             "type": "object",
             "properties": {
-                "workspace_build_id": {
-                    "type": "string",
-                    "format": "uuid"
+                "workspace_build": {
+                    "$ref": "#/definitions/codersdk.WorkspaceBuild"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5185,6 +5185,44 @@
 				}
 			}
 		},
+		"/tasks/{user}/{task}/resume": {
+			"post": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"consumes": ["application/json"],
+				"tags": ["Tasks"],
+				"summary": "Resume task",
+				"operationId": "resume-task",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Username, user ID, or 'me' for the authenticated user",
+						"name": "user",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Task ID",
+						"name": "task",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"202": {
+						"description": "Accepted",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ResumeTaskResponse"
+						}
+					}
+				}
+			}
+		},
 		"/tasks/{user}/{task}/send": {
 			"post": {
 				"security": [
@@ -12701,7 +12739,8 @@
 				"ssh_connection",
 				"vscode_connection",
 				"jetbrains_connection",
-				"task_manual_pause"
+				"task_manual_pause",
+				"task_resume"
 			],
 			"x-enum-varnames": [
 				"CreateWorkspaceBuildReasonDashboard",
@@ -12709,7 +12748,8 @@
 				"CreateWorkspaceBuildReasonSSHConnection",
 				"CreateWorkspaceBuildReasonVSCodeConnection",
 				"CreateWorkspaceBuildReasonJetbrainsConnection",
-				"CreateWorkspaceBuildReasonTaskManualPause"
+				"CreateWorkspaceBuildReasonTaskManualPause",
+				"CreateWorkspaceBuildReasonTaskResume"
 			]
 		},
 		"codersdk.CreateWorkspaceBuildRequest": {
@@ -16644,6 +16684,15 @@
 					"items": {
 						"$ref": "#/definitions/codersdk.ValidationError"
 					}
+				}
+			}
+		},
+		"codersdk.ResumeTaskResponse": {
+			"type": "object",
+			"properties": {
+				"workspace_build_id": {
+					"type": "string",
+					"format": "uuid"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16690,9 +16690,8 @@
 		"codersdk.ResumeTaskResponse": {
 			"type": "object",
 			"properties": {
-				"workspace_build_id": {
-					"type": "string",
-					"format": "uuid"
+				"workspace_build": {
+					"$ref": "#/definitions/codersdk.WorkspaceBuild"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1079,6 +1079,7 @@ func New(options *Options) *API {
 					r.Post("/send", api.taskSend)
 					r.Get("/logs", api.taskLogs)
 					r.Post("/pause", api.pauseTask)
+					r.Post("/resume", api.resumeTask)
 				})
 			})
 		})

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -354,6 +354,29 @@ func (c *Client) PauseTask(ctx context.Context, user string, id uuid.UUID) (Paus
 	return resp, nil
 }
 
+// ResumeTaskResponse represents the response from resuming a task.
+type ResumeTaskResponse struct {
+	WorkspaceBuildID uuid.UUID `json:"workspace_build_id" format:"uuid"`
+}
+
+func (c *Client) ResumeTask(ctx context.Context, user string, id uuid.UUID) (ResumeTaskResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/tasks/%s/%s/resume", user, id.String()), nil)
+	if err != nil {
+		return ResumeTaskResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusAccepted {
+		return ResumeTaskResponse{}, ReadBodyAsError(res)
+	}
+
+	var resp ResumeTaskResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return ResumeTaskResponse{}, err
+	}
+
+	return resp, nil
+}
+
 // TaskLogType indicates the source of a task log entry.
 type TaskLogType string
 

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -356,7 +356,7 @@ func (c *Client) PauseTask(ctx context.Context, user string, id uuid.UUID) (Paus
 
 // ResumeTaskResponse represents the response from resuming a task.
 type ResumeTaskResponse struct {
-	WorkspaceBuildID uuid.UUID `json:"workspace_build_id" format:"uuid"`
+	WorkspaceBuild *WorkspaceBuild `json:"workspace_build"`
 }
 
 func (c *Client) ResumeTask(ctx context.Context, user string, id uuid.UUID) (ResumeTaskResponse, error) {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -110,7 +110,7 @@ const (
 	CreateWorkspaceBuildReasonVSCodeConnection    CreateWorkspaceBuildReason = "vscode_connection"
 	CreateWorkspaceBuildReasonJetbrainsConnection CreateWorkspaceBuildReason = "jetbrains_connection"
 	CreateWorkspaceBuildReasonTaskManualPause     CreateWorkspaceBuildReason = "task_manual_pause"
-	CreateWorkspaceBuildReasonTaskManualResume    CreateWorkspaceBuildReason = "task_manual_resume"
+	CreateWorkspaceBuildReasonTaskResume          CreateWorkspaceBuildReason = "task_resume"
 )
 
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -110,6 +110,7 @@ const (
 	CreateWorkspaceBuildReasonVSCodeConnection    CreateWorkspaceBuildReason = "vscode_connection"
 	CreateWorkspaceBuildReasonJetbrainsConnection CreateWorkspaceBuildReason = "jetbrains_connection"
 	CreateWorkspaceBuildReasonTaskManualPause     CreateWorkspaceBuildReason = "task_manual_pause"
+	CreateWorkspaceBuildReasonTaskManualResume    CreateWorkspaceBuildReason = "task_manual_resume"
 )
 
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -7526,15 +7526,220 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ```json
 {
-  "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+  "workspace_build": {
+    "build_number": 0,
+    "created_at": "2019-08-24T14:15:22Z",
+    "daily_cost": 0,
+    "deadline": "2019-08-24T14:15:22Z",
+    "has_ai_task": true,
+    "has_external_agent": true,
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+    "initiator_name": "string",
+    "job": {
+      "available_workers": [
+        "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+      ],
+      "canceled_at": "2019-08-24T14:15:22Z",
+      "completed_at": "2019-08-24T14:15:22Z",
+      "created_at": "2019-08-24T14:15:22Z",
+      "error": "string",
+      "error_code": "REQUIRED_TEMPLATE_VARIABLES",
+      "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+      "input": {
+        "error": "string",
+        "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+        "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+      },
+      "logs_overflowed": true,
+      "metadata": {
+        "template_display_name": "string",
+        "template_icon": "string",
+        "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
+        "template_name": "string",
+        "template_version_name": "string",
+        "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+        "workspace_name": "string"
+      },
+      "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+      "queue_position": 0,
+      "queue_size": 0,
+      "started_at": "2019-08-24T14:15:22Z",
+      "status": "pending",
+      "tags": {
+        "property1": "string",
+        "property2": "string"
+      },
+      "type": "template_version_import",
+      "worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b",
+      "worker_name": "string"
+    },
+    "matched_provisioners": {
+      "available": 0,
+      "count": 0,
+      "most_recently_seen": "2019-08-24T14:15:22Z"
+    },
+    "max_deadline": "2019-08-24T14:15:22Z",
+    "reason": "initiator",
+    "resources": [
+      {
+        "agents": [
+          {
+            "api_version": "string",
+            "apps": [
+              {
+                "command": "string",
+                "display_name": "string",
+                "external": true,
+                "group": "string",
+                "health": "disabled",
+                "healthcheck": {
+                  "interval": 0,
+                  "threshold": 0,
+                  "url": "string"
+                },
+                "hidden": true,
+                "icon": "string",
+                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                "open_in": "slim-window",
+                "sharing_level": "owner",
+                "slug": "string",
+                "statuses": [
+                  {
+                    "agent_id": "2b1e3b65-2c04-4fa2-a2d7-467901e98978",
+                    "app_id": "affd1d10-9538-4fc8-9e0b-4594a28c1335",
+                    "created_at": "2019-08-24T14:15:22Z",
+                    "icon": "string",
+                    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                    "message": "string",
+                    "needs_user_attention": true,
+                    "state": "working",
+                    "uri": "string",
+                    "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9"
+                  }
+                ],
+                "subdomain": true,
+                "subdomain_name": "string",
+                "tooltip": "string",
+                "url": "string"
+              }
+            ],
+            "architecture": "string",
+            "connection_timeout_seconds": 0,
+            "created_at": "2019-08-24T14:15:22Z",
+            "directory": "string",
+            "disconnected_at": "2019-08-24T14:15:22Z",
+            "display_apps": [
+              "vscode"
+            ],
+            "environment_variables": {
+              "property1": "string",
+              "property2": "string"
+            },
+            "expanded_directory": "string",
+            "first_connected_at": "2019-08-24T14:15:22Z",
+            "health": {
+              "healthy": false,
+              "reason": "agent has lost connection"
+            },
+            "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "instance_id": "string",
+            "last_connected_at": "2019-08-24T14:15:22Z",
+            "latency": {
+              "property1": {
+                "latency_ms": 0,
+                "preferred": true
+              },
+              "property2": {
+                "latency_ms": 0,
+                "preferred": true
+              }
+            },
+            "lifecycle_state": "created",
+            "log_sources": [
+              {
+                "created_at": "2019-08-24T14:15:22Z",
+                "display_name": "string",
+                "icon": "string",
+                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                "workspace_agent_id": "7ad2e618-fea7-4c1a-b70a-f501566a72f1"
+              }
+            ],
+            "logs_length": 0,
+            "logs_overflowed": true,
+            "name": "string",
+            "operating_system": "string",
+            "parent_id": {
+              "uuid": "string",
+              "valid": true
+            },
+            "ready_at": "2019-08-24T14:15:22Z",
+            "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
+            "scripts": [
+              {
+                "cron": "string",
+                "display_name": "string",
+                "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                "log_path": "string",
+                "log_source_id": "4197ab25-95cf-4b91-9c78-f7f2af5d353a",
+                "run_on_start": true,
+                "run_on_stop": true,
+                "script": "string",
+                "start_blocks_login": true,
+                "timeout": 0
+              }
+            ],
+            "started_at": "2019-08-24T14:15:22Z",
+            "startup_script_behavior": "blocking",
+            "status": "connecting",
+            "subsystems": [
+              "envbox"
+            ],
+            "troubleshooting_url": "string",
+            "updated_at": "2019-08-24T14:15:22Z",
+            "version": "string"
+          }
+        ],
+        "created_at": "2019-08-24T14:15:22Z",
+        "daily_cost": 0,
+        "hide": true,
+        "icon": "string",
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "job_id": "453bd7d7-5355-4d6d-a38e-d9e7eb218c3f",
+        "metadata": [
+          {
+            "key": "string",
+            "sensitive": true,
+            "value": "string"
+          }
+        ],
+        "name": "string",
+        "type": "string",
+        "workspace_transition": "start"
+      }
+    ],
+    "status": "pending",
+    "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+    "template_version_name": "string",
+    "template_version_preset_id": "512a53a7-30da-446e-a1fc-713c630baff1",
+    "transition": "start",
+    "updated_at": "2019-08-24T14:15:22Z",
+    "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+    "workspace_name": "string",
+    "workspace_owner_avatar_url": "string",
+    "workspace_owner_id": "e7078695-5279-4c86-8774-3ac2367a2fc7",
+    "workspace_owner_name": "string"
+  }
 }
 ```
 
 ### Properties
 
-| Name                 | Type   | Required | Restrictions | Description |
-|----------------------|--------|----------|--------------|-------------|
-| `workspace_build_id` | string | false    |              |             |
+| Name              | Type                                               | Required | Restrictions | Description |
+|-------------------|----------------------------------------------------|----------|--------------|-------------|
+| `workspace_build` | [codersdk.WorkspaceBuild](#codersdkworkspacebuild) | false    |              |             |
 
 ## codersdk.RetentionConfig
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2184,9 +2184,9 @@ This is required on creation to enable a user-flow of validating a template work
 
 #### Enumerated Values
 
-| Value(s)                                                                                               |
-|--------------------------------------------------------------------------------------------------------|
-| `cli`, `dashboard`, `jetbrains_connection`, `ssh_connection`, `task_manual_pause`, `vscode_connection` |
+| Value(s)                                                                                                              |
+|-----------------------------------------------------------------------------------------------------------------------|
+| `cli`, `dashboard`, `jetbrains_connection`, `ssh_connection`, `task_manual_pause`, `task_resume`, `vscode_connection` |
 
 ## codersdk.CreateWorkspaceBuildRequest
 
@@ -7521,6 +7521,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `detail`      | string                                                        | false    |              | Detail is a debug message that provides further insight into why the action failed. This information can be technical and a regular golang err.Error() text. - "database: too many open connections" - "stat: too many open files" |
 | `message`     | string                                                        | false    |              | Message is an actionable message that depicts actions the request took. These messages should be fully formed sentences with proper punctuation. Examples: - "A user has been created." - "Failed to create a user."               |
 | `validations` | array of [codersdk.ValidationError](#codersdkvalidationerror) | false    |              | Validations are form field-specific friendly error messages. They will be shown on a form field in the UI. These can also be used to add additional context if there is a set of errors in the primary 'Message'.                  |
+
+## codersdk.ResumeTaskResponse
+
+```json
+{
+  "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+}
+```
+
+### Properties
+
+| Name                 | Type   | Required | Restrictions | Description |
+|----------------------|--------|----------|--------------|-------------|
+| `workspace_build_id` | string | false    |              |             |
 
 ## codersdk.RetentionConfig
 

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -397,6 +397,38 @@ curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/pause \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Resume task
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/resume \
+  -H 'Accept: */*' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /tasks/{user}/{task}/resume`
+
+### Parameters
+
+| Name   | In   | Type         | Required | Description                                           |
+|--------|------|--------------|----------|-------------------------------------------------------|
+| `user` | path | string       | true     | Username, user ID, or 'me' for the authenticated user |
+| `task` | path | string(uuid) | true     | Task ID                                               |
+
+### Example responses
+
+> 202 Response
+
+### Responses
+
+| Status | Meaning                                                       | Description | Schema                                                               |
+|--------|---------------------------------------------------------------|-------------|----------------------------------------------------------------------|
+| 202    | [Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3) | Accepted    | [codersdk.ResumeTaskResponse](schemas.md#codersdkresumetaskresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Send input to AI task
 
 ### Code samples

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1426,6 +1426,7 @@ export type CreateWorkspaceBuildReason =
 	| "jetbrains_connection"
 	| "ssh_connection"
 	| "task_manual_pause"
+	| "task_resume"
 	| "vscode_connection";
 
 export const CreateWorkspaceBuildReasons: CreateWorkspaceBuildReason[] = [
@@ -1434,6 +1435,7 @@ export const CreateWorkspaceBuildReasons: CreateWorkspaceBuildReason[] = [
 	"jetbrains_connection",
 	"ssh_connection",
 	"task_manual_pause",
+	"task_resume",
 	"vscode_connection",
 ];
 
@@ -4353,6 +4355,14 @@ export interface Response {
 	 * context if there is a set of errors in the primary 'Message'.
 	 */
 	readonly validations?: readonly ValidationError[];
+}
+
+// From codersdk/aitasks.go
+/**
+ * ResumeTaskResponse represents the response from resuming a task.
+ */
+export interface ResumeTaskResponse {
+	readonly workspace_build_id: string;
 }
 
 // From codersdk/deployment.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4362,7 +4362,7 @@ export interface Response {
  * ResumeTaskResponse represents the response from resuming a task.
  */
 export interface ResumeTaskResponse {
-	readonly workspace_build_id: string;
+	readonly workspace_build: WorkspaceBuild | null;
 }
 
 // From codersdk/deployment.go


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1262.

This PR adds:
* the `POST /api/experimental/tasks/{user}/{task}/resume` endpoint
* follows conventions from https://github.com/coder/internal/issues/1261
* sets the build reason to `task_resume`
* a task that is not paused (ie. is already running), cannot be resumed.