### PR TITLE
fix: resolve selectors for `<NotificationsPage />` storybook

### DIFF
--- a/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.stories.tsx
+++ b/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.stories.tsx
@@ -60,13 +60,13 @@ export const Default: Story = {
 
 		await Promise.all([
 			// System notification templates
-			canvas.findByRole("checkbox", { name: "Task Events" }),
-			canvas.findByRole("checkbox", { name: "Template Events" }),
-			canvas.findByRole("checkbox", { name: "User Events" }),
-			canvas.findByRole("checkbox", { name: "Workspace Events" }),
+			canvas.findByRole("switch", { name: "Task Events" }),
+			canvas.findByRole("switch", { name: "Template Events" }),
+			canvas.findByRole("switch", { name: "User Events" }),
+			canvas.findByRole("switch", { name: "Workspace Events" }),
 
 			// Custom notification template
-			canvas.findByRole("checkbox", { name: "Custom Events" }),
+			canvas.findByRole("switch", { name: "Custom Events" }),
 		]);
 	},
 };

--- a/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -160,7 +160,9 @@ const NotificationsPage: FC = () => {
 													}}
 												/>
 											</div>
-											<div className="font-medium text-sm">{group}</div>
+											<label htmlFor={group} className="font-medium text-sm">
+												{group}
+											</label>
 										</header>
 										{templates.map((tmpl) => {
 											const method = castNotificationMethod(


### PR DESCRIPTION
This pull-request resolves the selectors for Storybook within `<NotificationsPage />`. It appears I broke this when refactoring within #21937.