### PR TITLE
feat: implement `<NotificationsInbox />` tabs

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2703,10 +2703,16 @@ class ApiMethods {
 		return res.data;
 	};
 
-	getInboxNotifications = async (startingBeforeId?: string) => {
+	getInboxNotifications = async (
+		startingBeforeId?: string,
+		readStatus?: "read" | "unread" | "all",
+	) => {
 		const params = new URLSearchParams();
 		if (startingBeforeId) {
 			params.append("starting_before", startingBeforeId);
+		}
+		if (readStatus) {
+			params.append("read_status", readStatus);
 		}
 		const res = await this.axios.get<TypesGen.ListInboxNotificationsResponse>(
 			`/api/v2/notifications/inbox?${params.toString()}`,

--- a/site/src/components/EmptyState/EmptyState.tsx
+++ b/site/src/components/EmptyState/EmptyState.tsx
@@ -1,7 +1,9 @@
+import type { LucideIcon } from "lucide-react";
 import type { FC, HTMLAttributes, ReactNode } from "react";
 import { cn } from "utils/cn";
 
 export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
+	icon?: LucideIcon;
 	/** Text Message to display, placed inside Typography component */
 	message: string;
 	/** Longer optional description to display below the message */
@@ -17,6 +19,7 @@ export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
  * or to add an item that they currently have none of.
  */
 export const EmptyState: FC<EmptyStateProps> = ({
+	icon: Icon,
 	message,
 	description,
 	cta,
@@ -28,17 +31,16 @@ export const EmptyState: FC<EmptyStateProps> = ({
 	return (
 		<div
 			className={cn(
-				"overflow-hidden flex flex-col justify-center items-center text-center min-h-96 py-20 px-10 relative",
+				"overflow-hidden flex flex-col gap-2 justify-center items-center text-center min-h-96 py-20 px-10 relative",
 				isCompact && "min-h-44 py-2.5",
 				className,
 			)}
 			{...attrs}
 		>
-			<h5 className="text-2xl font-medium m-0">{message}</h5>
+			{Icon && <Icon className="size-icon-lg" />}
+			<h5 className="text-xl font-medium m-0">{message}</h5>
 			{description && (
-				<p className="mt-4 line-height-[140%] max-w-md text-content-secondary">
-					{description}
-				</p>
+				<p className="m-0 max-w-md text-content-secondary">{description}</p>
 			)}
 			{cta && <div className="mt-6">{cta}</div>}
 			{image}

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,11 @@
-import { createContext, type FC, type HTMLAttributes, useContext } from "react";
+import type { Button } from "components/Button/Button";
+import {
+	type ComponentProps,
+	createContext,
+	type FC,
+	type HTMLAttributes,
+	useContext,
+} from "react";
 import { Link, type LinkProps } from "react-router";
 import { cn } from "utils/cn";
 
@@ -70,6 +77,42 @@ export const TabLink: FC<TabLinkProps> = ({
 				},
 				className,
 			)}
+		/>
+	);
+};
+
+type TabButtonProps = ComponentProps<"button"> & {
+	value: string;
+};
+
+export const TabButton: FC<TabButtonProps> = ({
+	className,
+	value,
+	...props
+}) => {
+	const tabsContext = useContext(TabsContext);
+	if (!tabsContext) {
+		throw new Error("Tab only can be used inside of Tabs");
+	}
+
+	const isActive = tabsContext.active === value;
+
+	return (
+		<button
+			type="button"
+			role="tab"
+			className={cn(
+				"bg-transparent border-none",
+				`text-sm text-content-secondary no-underline font-medium py-3 px-1 hover:text-content-primary rounded-md
+		focus-visible:ring-offset-1 focus-visible:ring-offset-surface-primary
+		focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:rounded-sm`,
+				{
+					"text-content-primary relative before:absolute before:bg-surface-invert-primary before:left-0 before:w-full before:h-px before:-bottom-px before:content-['']":
+						isActive,
+				},
+				className,
+			)}
+			{...props}
 		/>
 	);
 };

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.stories.tsx
@@ -8,6 +8,8 @@ const meta: Meta<typeof InboxPopover> = {
 	component: InboxPopover,
 	args: {
 		defaultOpen: true,
+		activeTab: "unread",
+		onTabChange: fn(),
 	},
 	render: (args) => {
 		return (

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.tsx
@@ -1,5 +1,6 @@
 import type { InboxNotification } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
+import { EmptyState } from "components/EmptyState/EmptyState";
 import {
 	Popover,
 	PopoverContent,
@@ -7,7 +8,8 @@ import {
 } from "components/Popover/Popover";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import { Spinner } from "components/Spinner/Spinner";
-import { RefreshCwIcon, SettingsIcon } from "lucide-react";
+import { TabButton, Tabs, TabsList } from "components/Tabs/Tabs";
+import { CheckIcon, RefreshCwIcon, SettingsIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import { cn } from "utils/cn";
@@ -15,12 +17,16 @@ import { InboxButton } from "./InboxButton";
 import { InboxItem } from "./InboxItem";
 import { UnreadBadge } from "./UnreadBadge";
 
+export type ReadStatus = "read" | "unread" | "all";
+
 type InboxPopoverProps = {
 	notifications: readonly InboxNotification[] | undefined;
 	unreadCount: number;
 	error: unknown;
 	isLoadingMoreNotifications: boolean;
 	hasMoreNotifications: boolean;
+	activeTab: ReadStatus;
+	onTabChange: (tab: ReadStatus) => void;
 	onRetry: () => void;
 	onMarkAllAsRead: () => void;
 	onMarkNotificationAsRead: (notificationId: string) => void;
@@ -35,6 +41,8 @@ export const InboxPopover: FC<InboxPopoverProps> = ({
 	error,
 	isLoadingMoreNotifications,
 	hasMoreNotifications,
+	activeTab,
+	onTabChange,
 	onRetry,
 	onMarkAllAsRead,
 	onMarkNotificationAsRead,
@@ -50,6 +58,8 @@ export const InboxPopover: FC<InboxPopoverProps> = ({
 			<PopoverContent
 				className="w-[var(--radix-popper-available-width)] max-w-[466px]"
 				align="end"
+				sideOffset={8}
+				alignOffset={-16}
 			>
 				{/*
 				 * data-radix-scroll-area-viewport is used to set the max-height of the ScrollArea
@@ -64,12 +74,12 @@ export const InboxPopover: FC<InboxPopoverProps> = ({
 				>
 					<div
 						className={cn([
-							"flex items-center justify-between p-3 border-0 border-b border-solid border-border",
+							"flex items-center justify-between py-3 px-5 border-0 border-b border-solid border-border",
 							"sticky top-0 bg-surface-primary z-10 rounded-t",
 						])}
 					>
 						<div className="flex items-center gap-2">
-							<span className="text-xl font-semibold">Inbox</span>
+							<span className="text-lg font-semibold">Inbox</span>
 							{unreadCount > 0 && <UnreadBadge count={unreadCount} />}
 						</div>
 
@@ -93,6 +103,17 @@ export const InboxPopover: FC<InboxPopoverProps> = ({
 							</Button>
 						</div>
 					</div>
+
+					<Tabs active={activeTab} className="px-4">
+						<TabsList>
+							<TabButton value="unread" onClick={() => onTabChange("unread")}>
+								Unread
+							</TabButton>
+							<TabButton value="all" onClick={() => onTabChange("all")}>
+								All
+							</TabButton>
+						</TabsList>
+					</Tabs>
 
 					{notifications ? (
 						notifications.length > 0 ? (
@@ -123,19 +144,26 @@ export const InboxPopover: FC<InboxPopoverProps> = ({
 								)}
 							</div>
 						) : (
-							<div className="p-6 flex items-center justify-center min-h-48">
-								<div className="text-sm text-center flex flex-col">
-									<span className="font-medium">No notifications</span>
-									<span className="text-xs text-content-secondary">
-										New notifications will be displayed here.
-									</span>
-								</div>
-							</div>
+							<EmptyState
+								icon={CheckIcon}
+								message="No new notifications"
+								description="You're all caught up!"
+								cta={
+									activeTab === "unread" ? (
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => onTabChange("all")}
+										>
+											View all notifications
+										</Button>
+									) : null
+								}
+							/>
 						)
 					) : error === undefined ? (
 						<div className="p-6 flex items-center justify-center min-h-48">
 							<Spinner loading />
-							<span className="sr-only">Loading notifications...</span>
 						</div>
 					) : (
 						<div className="p-6 flex items-center justify-center min-h-48">


### PR DESCRIPTION
> [!WARNING]  
> This is an experimental change, it shouldn't be merged until we've decided this is something we'd like to proceed with.

This pull-request enables being able to filtered by "New" notifications and "All" notifications. This reduces mental-load as to what you're actually looking at whilst still being able to go back and find previous items (if you need them).

https://github.com/user-attachments/assets/290de108-45c1-42b4-9371-69b15673a37c

