### PR TITLE
fix: drop `<SettingsHeaderTitle />` `font-weight`

### DIFF
--- a/site/src/components/SettingsHeader/SettingsHeader.tsx
+++ b/site/src/components/SettingsHeader/SettingsHeader.tsx
@@ -53,7 +53,7 @@ export const SettingsHeaderDocsLink: FC<SettingsHeaderDocsLinkProps> = ({
 const titleVariants = cva("m-0 flex items-center gap-2 leading-tight", {
 	variants: {
 		hierarchy: {
-			primary: "text-3xl font-bold",
+			primary: "text-3xl font-semibold",
 			secondary: "text-2xl font-medium",
 		},
 	},


### PR DESCRIPTION
We attempted to unify these previously in #21914 however it appears I missed dropping this a `font-weight` level. This pull-request makes this very simple change, its now inline with the Figma design!