### PR TITLE
fix: make metric registration resilient to duplicate registration

### DIFF
--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -151,7 +151,6 @@ func registerOnce[T prometheus.Collector](logger slog.Logger, registerer prometh
 	if errors.As(err, &alreadyRegistered) {
 		logger.Debug(context.Background(), "reusing already registered prometheus collector",
 			slog.F("collector_type", fmt.Sprintf("%T", alreadyRegistered.ExistingCollector)),
-			slog.F("collector_desc", describeCollector(alreadyRegistered.ExistingCollector)),
 		)
 		//nolint:forcetypeassert // The type must match since the descriptor is identical.
 		return alreadyRegistered.ExistingCollector.(T)
@@ -162,21 +161,6 @@ func registerOnce[T prometheus.Collector](logger slog.Logger, registerer prometh
 	return collector
 }
 
-
-// describeCollector returns the fqNames of all metric descriptors
-// exposed by a prometheus.Collector, for use in debug logging.
-func describeCollector(c prometheus.Collector) []string {
-	ch := make(chan *prometheus.Desc, 16)
-	go func() {
-		c.Describe(ch)
-		close(ch)
-	}()
-	var names []string
-	for desc := range ch {
-		names = append(names, desc.String())
-	}
-	return names
-}
 
 // calculateReconciliationConcurrency determines the number of concurrent
 // goroutines for preset reconciliation. Each preset may perform multiple

--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -133,7 +133,6 @@ func NewStoreReconciler(store database.Store,
 	return reconciler
 }
 
-
 // registerOnce attempts to register a prometheus collector. If the
 // collector is already registered (e.g. from a previous reconciler
 // that wasn't properly stopped), it reuses the existing one instead
@@ -160,7 +159,6 @@ func registerOnce[T prometheus.Collector](logger slog.Logger, registerer prometh
 	// be scraped by Prometheus).
 	return collector
 }
-
 
 // calculateReconciliationConcurrency determines the number of concurrent
 // goroutines for preset reconciliation. Each preset may perform multiple


### PR DESCRIPTION
Fixes #21803

Replace `promauto` (panics via `MustRegister`) with a `registerOnce` helper that calls `Register()` and reuses the existing collector on `AlreadyRegisteredError`. This prevents the panic when a license is re-added and `NewStoreReconciler` re-registers metrics before the previous reconciler's `Stop()` completes.

Added `TestMetricsRegistrationLifecycle` covering normal stop-then-recreate, recreate-without-stop (the panic scenario), and double-stop safety.