### PR TITLE
test: fix failnow in goroutine in TestServer_TelemetryDisabled_FinalReport

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/acarl005/stripansi"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/pty"
@@ -78,7 +79,7 @@ func newExpecter(t *testing.T, r io.Reader, name string) outExpecter {
 	ex := outExpecter{
 		t:    t,
 		out:  out,
-		name: name,
+		name: atomic.NewString(name),
 
 		runeReader: bufio.NewReaderSize(out, utf8.UTFMax),
 	}
@@ -140,7 +141,7 @@ type outExpecter struct {
 	t     *testing.T
 	close func(reason string) error
 	out   *stdbuf
-	name  string
+	name  *atomic.String
 
 	runeReader *bufio.Reader
 }
@@ -361,7 +362,7 @@ func (e *outExpecter) logf(format string, args ...interface{}) {
 
 	// Match regular logger timestamp format, we seem to be logging in
 	// UTC in other places as well, so match here.
-	e.t.Logf("%s: %s: %s", time.Now().UTC().Format("2006-01-02 15:04:05.000"), e.name, fmt.Sprintf(format, args...))
+	e.t.Logf("%s: %s: %s", time.Now().UTC().Format("2006-01-02 15:04:05.000"), e.name.Load(), fmt.Sprintf(format, args...))
 }
 
 func (e *outExpecter) fatalf(reason string, format string, args ...interface{}) {
@@ -428,6 +429,15 @@ func (p *PTY) WriteLine(str string) {
 	p.logf("stdin: %q", str+string(newline))
 	_, err := p.Input().Write(append([]byte(str), newline...))
 	require.NoError(p.t, err, "write line failed")
+}
+
+// Named sets the PTY name in the logs. Defaults to "cmd". Make sure you set this before anything starts writing to the
+// pty, or it may not be named consistently. E.g.
+//
+// p := New(t).Named("myCmd")
+func (p *PTY) Named(name string) *PTY {
+	p.name.Store(name)
+	return p
 }
 
 type PTYCmd struct {


### PR DESCRIPTION
closes: https://github.com/coder/internal/issues/1331

Fixes up an issue in the test where we end up calling `FailNow` outside the main test goroutine. Also adds the ability to name a `ptytest.PTY` for cases like this one where we start multiple commands. This will help debugging if we see the issue again.

This doesn't address the root cause of the failure, but I think we should close the flake issue. I think we'd need like a stacktrace of all goroutines at the point of failing the test, but that's way too much effort unless we see this again.