### PR TITLE
feat: change task `view prompt` `<Dropdown />` into a `<Popover />`

### DIFF
--- a/site/src/pages/TaskPage/TaskTopbar.tsx
+++ b/site/src/pages/TaskPage/TaskTopbar.tsx
@@ -1,6 +1,11 @@
 import type { Task, Workspace } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "components/Popover/Popover";
+import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
@@ -53,22 +58,28 @@ export const TaskTopbar: FC<TaskTopbarProps> = ({ task, workspace }) => {
 					lifecycleState={task.workspace_agent_lifecycle}
 				/>
 
-				<TooltipProvider delayDuration={250}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button variant="outline" size="sm">
-								<SquareTerminalIcon />
-								View Prompt
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent className="max-w-xs bg-surface-secondary p-4">
-							<p className="m-0 mb-2 select-all text-sm font-normal text-content-primary leading-snug">
+				<Popover>
+					<PopoverTrigger asChild>
+						<Button variant="outline" size="sm">
+							<SquareTerminalIcon />
+							View Prompt
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent
+						className="w-[402px] p-4 bg-surface-secondary text-content-secondary text-sm flex flex-col gap-3"
+						align="end"
+					>
+						<div className="text-sm font-semibold text-content-primary">
+							Prompt
+						</div>
+						<div className="m-0 mb-2 select-all leading-snug p-4 border border-solid rounded-lg font-mono">
+							<pre className="m-0 whitespace-pre-wrap break-words">
 								{task.initial_prompt}
-							</p>
-							<CopyPromptButton prompt={task.initial_prompt} />
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
+							</pre>
+						</div>
+						<CopyPromptButton prompt={task.initial_prompt} />
+					</PopoverContent>
+				</Popover>
 
 				<Button asChild variant="outline" size="sm">
 					<RouterLink to={`/@${workspace.owner_name}/${workspace.name}`}>
@@ -90,8 +101,8 @@ const CopyPromptButton: FC<CopyPromptButtonProps> = ({ prompt }) => {
 			disabled={showCopiedSuccess}
 			onClick={() => copyToClipboard(prompt)}
 			size="sm"
-			variant="subtle"
-			className="p-0 min-w-0"
+			variant="outline"
+			className="p-0 min-w-0 w-full"
 		>
 			{showCopiedSuccess ? (
 				<>


### PR DESCRIPTION
Closes #21651 

This pull-request implements a new and improved `View Prompt` button in Tasks. We've moved from using a `<Tooltip />` over to a `<Popover />` which toggles upon clicking the `View Prompt` button. We've improved the rendering here using a `<pre />` with word breaking too. 

| Old | New |
| --- | --- |
| <img width="422" height="369" alt="OLD_BASIC_PROMPT" src="https://github.com/user-attachments/assets/aea2c642-8e92-4897-9923-060c24206211" /> | <img width="422" height="369" alt="NEW_BASIC_PROMPT" src="https://github.com/user-attachments/assets/473cbe83-78cc-4a1d-8a53-2be4de2ef02d" /> |
| <img width="422" height="369" alt="OLD_LONG_INPUT" src="https://github.com/user-attachments/assets/70ef1364-9548-4551-b249-9241fafbc997" /> | <img width="422" height="369" alt="NEW_LONG_INPUT" src="https://github.com/user-attachments/assets/3ba81e29-fa5d-4099-aebc-2a024365bd39" /> |
| <img width="422" height="369" alt="OLD_RICH_INPUT" src="https://github.com/user-attachments/assets/f5b5b60f-27ba-48b0-abbc-e8ec21f19674" /> | <img width="422" height="369" alt="NEW_RICH_INPUT" src="https://github.com/user-attachments/assets/225cd760-f295-4a6f-a078-6b39f1719d57" /> |