### PR TITLE
test: fix race condition in TestAPI/Delete/OK_with_container_and_subagent

### DIFF
--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -1477,14 +1477,6 @@ func TestAPI(t *testing.T) {
 					)
 				}
 
-				api := agentcontainers.NewAPI(logger, apiOpts...)
-
-				api.Start()
-				defer api.Close()
-
-				r := chi.NewRouter()
-				r.Mount("/", api.Routes())
-
 				var (
 					agentRunningCh chan struct{}
 					stopAgentCh    chan struct{}
@@ -1500,6 +1492,14 @@ func TestAPI(t *testing.T) {
 						requireDevcontainerExec(ctx, t, tt.devcontainerCLI, agentRunningCh, stopAgentCh)
 					}
 				}
+
+				api := agentcontainers.NewAPI(logger, apiOpts...)
+
+				api.Start()
+				defer api.Close()
+
+				r := chi.NewRouter()
+				r.Mount("/", api.Routes())
 
 				tickerTrap.MustWait(ctx).MustRelease(ctx)
 				tickerTrap.Close()


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1345#event-22592902899 <-- **This report is wrong, look at the failed logs to see the real failure**


To be honest, I do not fully understand this fix. But if you add this sleep, it breaks in the same way CI broke (add to [here](https://github.com/coder/coder/blob/a31e4766232b9c51b9033b1e69b8687e6d591629/agent/agentcontainers/api_test.go#L1497))

```golang
allowSubAgentCreate(ctx, t, fakeSAC)
// BUG DEMO: Sleep AFTER allowSubAgentCreate to let the
// async code proceed to call Exec() before we set up
// the blocking handler. This proves the race condition.
time.Sleep(100 * time.Millisecond)
```

After the fix, adding the sleep does not break the test.

# AI summary

## Fix race condition in TestAPI/Delete/OK_with_container_and_subagent

### Problem

The test was flaky due to a race condition in the test setup order. The test called `api.Start()` before setting up the blocking exec handler via `requireDevcontainerExec()`.

When `api.Start()` ran, it triggered an initial container update which called `fakeDevcontainerCLI.Exec()`. Since `execErrC` wasn't set up yet, `Exec()` returned immediately, causing the subagent process to finish instantly. When `api.RefreshContainers()` was later called, it detected the finished process (`proc.ctx.Err() != nil`) and attempted to reinject, calling `DetectArchitecture` a second time - but the mock only expected one call.

### Solution

Move the channel setup and `requireDevcontainerExec()` call **before** `api.Start()` so the blocking exec handler is ready before any async code can call `Exec()`.

```go
// Before (buggy):
api.Start()                    // Exec() called here, returns immediately
...
requireDevcontainerExec(...)   // Too late!

// After (fixed):
requireDevcontainerExec(...)   // Set up blocking handler first
api.Start()                    // Now Exec() blocks properly
```

### Testing

The race can be reproduced by adding a sleep after `allowSubAgentCreate()` but before `requireDevcontainerExec()` - this gives the async code time to call `Exec()` before the blocking handler is set up.