### PR TITLE
fix: apply `overflow-y: scroll` to `<html />`

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -101,7 +101,7 @@
 	}
 
 	html {
-		overflow-y: scroll !important;
+		overflow-y: scroll;
 	}
 
 	/*

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -100,6 +100,10 @@
 		@apply border-border;
 	}
 
+	html {
+		overflow-y: scroll !important;
+	}
+
 	/*
 	By default, Radix adds a margin to the `body` element when a dropdown is displayed,
 	causing some shifting when the dropdown has a full-width size, as is the case with the mobile menu.
@@ -108,10 +112,6 @@
 	There’s a related issue on GitHub: Radix UI Primitives Issue #3251
 	https://github.com/radix-ui/primitives/issues/3251
 	 */
-	html {
-		overflow-y: scroll !important;
-	}
-
 	html body[data-scroll-locked] {
 		--removed-body-scroll-bar-size: 0;
 		margin-right: 0 !important;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -108,14 +108,13 @@
 	There’s a related issue on GitHub: Radix UI Primitives Issue #3251
 	https://github.com/radix-ui/primitives/issues/3251
 	 */
-	html body[data-scroll-locked] {
-		--removed-body-scroll-bar-size: 0;
-		margin-right: 0;
+	html {
+		overflow-y: scroll !important;
 	}
 
-	/* Prevent layout shift when modals open by maintaining scrollbar width */
-	html {
-		scrollbar-gutter: stable;
+	html body[data-scroll-locked] {
+		--removed-body-scroll-bar-size: 0;
+		margin-right: 0 !important;
 	}
 
 	/*


### PR DESCRIPTION
Now that the changes in #21823 exist, we're able to address this properly. 

Previously when you ran MacOS with the sidebars always shown you would see a layout shift when things that locked the scroll with `[data-scroll-locked]` were enabled. This change ensures that scrollbars are always shown (even on pages that don't require them) so we achieve a uniform layout.

<img width="299" height="117" alt="SCROLLBARS_ALWAYS" src="https://github.com/user-attachments/assets/898426ab-f762-4928-94db-6821222e12e4" />

<img width="299" height="117" alt="SCROLLBARS_AUTOMATIC" src="https://github.com/user-attachments/assets/c7532245-9721-4d9b-9a51-4d1983a99681" />


| Old | New |
| --- | --- |
| [Video Preview](https://github.com/user-attachments/assets/3e6e1ed0-48a2-490d-a781-dc73badd031b) | [Video Preview](https://github.com/user-attachments/assets/94def4a6-9f85-4781-a9b9-3ef0dd6fe46b) |

This may be a odd choice but its the same fix employed by sites like [X](https://x.com/) and [Facebook](https://facebook.com/).