### PR TITLE
fix: marshal `OAuth2ProviderApp` into `[]` not `null`

### DIFF
--- a/coderd/oauth2provider/apps.go
+++ b/coderd/oauth2provider/apps.go
@@ -50,7 +50,7 @@ func ListApps(db database.Store, accessURL *url.URL) http.HandlerFunc {
 			return
 		}
 
-		var sdkApps []codersdk.OAuth2ProviderApp
+		sdkApps := make([]codersdk.OAuth2ProviderApp, 0, len(userApps))
 		for _, app := range userApps {
 			sdkApps = append(sdkApps, db2sdk.OAuth2ProviderApp(accessURL, app.OAuth2ProviderApp))
 		}


### PR DESCRIPTION
This pull-request makes it so that when we `json.Marshal` an empty set of responses from `ListApps(...)` we return an empty array (`[]`) instead of `null`. This ensures that the array is non-nil 🙂 

| Old | New |
| --- | --- |
| <img width="839" height="177" alt="OAUTH2_APPS_BORKED" src="https://github.com/user-attachments/assets/c264be1a-6260-405a-bf07-50a533e48ed5" /> | <img width="839" height="177" alt="OAUTH2_APPS_WORKING" src="https://github.com/user-attachments/assets/483a46b1-f5fd-496e-bfcb-4193a3ca8ec3" /> |
