### PR TITLE
feat(cli): add `coder task pause` command

### DIFF
--- a/cli/task.go
+++ b/cli/task.go
@@ -17,6 +17,7 @@ func (r *RootCmd) tasksCommand() *serpent.Command {
 			r.taskDelete(),
 			r.taskList(),
 			r.taskLogs(),
+			r.taskPause(),
 			r.taskSend(),
 			r.taskStatus(),
 		},

--- a/cli/task_logs_test.go
+++ b/cli/task_logs_test.go
@@ -41,8 +41,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
-		userClient := client // user already has access to their own workspace
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
 		inv, root := clitest.New(t, "task", "logs", task.Name, "--output", "json")
 		output := clitest.Capture(inv)
@@ -65,8 +64,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
-		userClient := client
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
 		inv, root := clitest.New(t, "task", "logs", task.ID.String(), "--output", "json")
 		output := clitest.Capture(inv)
@@ -89,8 +87,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
-		userClient := client
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
 		inv, root := clitest.New(t, "task", "logs", task.ID.String())
 		output := clitest.Capture(inv)
@@ -144,8 +141,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsErr(assert.AnError))
-		userClient := client
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsErr(assert.AnError))
 
 		inv, root := clitest.New(t, "task", "logs", task.ID.String())
 		clitest.SetupConfig(t, userClient, root)
@@ -201,8 +197,7 @@ func Test_TaskLogs_Golden(t *testing.T) {
 	t.Run("SnapshotWithoutLogs_NoSnapshotCaptured", func(t *testing.T) {
 		t.Parallel()
 
-		client, task := setupCLITaskTestWithoutSnapshot(t, codersdk.TaskStatusPaused)
-		userClient := client
+		userClient, task := setupCLITaskTestWithoutSnapshot(t, codersdk.TaskStatusPaused)
 
 		inv, root := clitest.New(t, "task", "logs", task.Name)
 		output := clitest.Capture(inv)

--- a/cli/task_pause.go
+++ b/cli/task_pause.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/pretty"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) taskPause() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "pause <task>",
+		Short: "Pause a task",
+		Long: FormatExamples(
+			Example{
+				Description: "Pause a task by name.",
+				Command:     "coder task pause my-task",
+			},
+			Example{
+				Description: "Pause a task without confirmation.",
+				Command:     "coder task pause my-task --yes",
+			},
+		),
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(1),
+		),
+		Options: serpent.OptionSet{
+			cliui.SkipPromptOption(),
+		},
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+
+			task, err := client.TaskByIdentifier(ctx, inv.Args[0])
+			if err != nil {
+				return xerrors.Errorf("resolve task %q: %w", inv.Args[0], err)
+			}
+
+			display := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
+
+			_, err = cliui.Prompt(inv, cliui.PromptOptions{
+				Text:      fmt.Sprintf("Pause task %s?", pretty.Sprint(cliui.DefaultStyles.Code, display)),
+				IsConfirm: true,
+				Default:   cliui.ConfirmNo,
+			})
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.PauseTask(ctx, task.OwnerName, task.ID)
+			if err != nil {
+				return xerrors.Errorf("pause task %q: %w", display, err)
+			}
+
+			if resp.WorkspaceBuild != nil {
+				err = cliui.WorkspaceBuild(ctx, inv.Stdout, client, resp.WorkspaceBuild.ID)
+				if err != nil {
+					return xerrors.Errorf("watch pause build for task %q: %w", display, err)
+				}
+			} else {
+				cliui.Warn(inv.Stderr,
+					"Pause was accepted but no workspace build was returned.",
+					"The task may not be fully paused yet.",
+				)
+			}
+
+			_, _ = fmt.Fprintf(
+				inv.Stdout,
+				"\nThe %s task has been paused at %s!\n",
+				cliui.Keyword(task.Name),
+				cliui.Timestamp(time.Now()),
+			)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cli/task_pause.go
+++ b/cli/task_pause.go
@@ -21,6 +21,10 @@ func (r *RootCmd) taskPause() *serpent.Command {
 				Command:     "coder task pause my-task",
 			},
 			Example{
+				Description: "Pause another user's task",
+				Command:     "coder task pause alice/my-task",
+			},
+			Example{
 				Description: "Pause a task without confirmation",
 				Command:     "coder task pause my-task --yes",
 			},

--- a/cli/task_pause.go
+++ b/cli/task_pause.go
@@ -68,6 +68,10 @@ func (r *RootCmd) taskPause() *serpent.Command {
 				return xerrors.Errorf("pause task %q: %w", display, err)
 			}
 
+			if resp.WorkspaceBuild == nil {
+				return xerrors.Errorf("pause task %q: no workspace build returned", display)
+			}
+
 			err = cliui.WorkspaceBuild(ctx, inv.Stdout, client, resp.WorkspaceBuild.ID)
 			if err != nil {
 				return xerrors.Errorf("watch pause build for task %q: %w", display, err)

--- a/cli/task_pause.go
+++ b/cli/task_pause.go
@@ -17,11 +17,11 @@ func (r *RootCmd) taskPause() *serpent.Command {
 		Short: "Pause a task",
 		Long: FormatExamples(
 			Example{
-				Description: "Pause a task by name.",
+				Description: "Pause a task by name",
 				Command:     "coder task pause my-task",
 			},
 			Example{
-				Description: "Pause a task without confirmation.",
+				Description: "Pause a task without confirmation",
 				Command:     "coder task pause my-task --yes",
 			},
 		),
@@ -59,16 +59,9 @@ func (r *RootCmd) taskPause() *serpent.Command {
 				return xerrors.Errorf("pause task %q: %w", display, err)
 			}
 
-			if resp.WorkspaceBuild != nil {
-				err = cliui.WorkspaceBuild(ctx, inv.Stdout, client, resp.WorkspaceBuild.ID)
-				if err != nil {
-					return xerrors.Errorf("watch pause build for task %q: %w", display, err)
-				}
-			} else {
-				cliui.Warn(inv.Stderr,
-					"Pause was accepted but no workspace build was returned.",
-					"The task may not be fully paused yet.",
-				)
+			err = cliui.WorkspaceBuild(ctx, inv.Stdout, client, resp.WorkspaceBuild.ID)
+			if err != nil {
+				return xerrors.Errorf("watch pause build for task %q: %w", display, err)
 			}
 
 			_, _ = fmt.Fprintf(

--- a/cli/task_pause.go
+++ b/cli/task_pause.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 )
@@ -48,6 +49,10 @@ func (r *RootCmd) taskPause() *serpent.Command {
 			}
 
 			display := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
+
+			if task.Status == codersdk.TaskStatusPaused {
+				return xerrors.Errorf("task %q is already paused", display)
+			}
 
 			_, err = cliui.Prompt(inv, cliui.PromptOptions{
 				Text:      fmt.Sprintf("Pause task %s?", pretty.Sprint(cliui.DefaultStyles.Code, display)),

--- a/cli/task_pause_test.go
+++ b/cli/task_pause_test.go
@@ -1,0 +1,223 @@
+package cli_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestExpTaskPause(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name          string
+		args          []string
+		promptYes     bool
+		promptNo      bool
+		wantErr       string
+		wantPausedMsg bool
+		buildHandler  func() http.HandlerFunc
+	}
+
+	const (
+		id1 = "11111111-1111-1111-1111-111111111111"
+		id2 = "22222222-2222-2222-2222-222222222222"
+		id3 = "33333333-3333-3333-3333-333333333333"
+	)
+
+	cases := []testCase{
+		{
+			name:      "OK_ByName",
+			args:      []string{"my-task"},
+			promptYes: true,
+			buildHandler: func() http.HandlerFunc {
+				taskID := uuid.MustParse(id1)
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/my-task":
+						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
+							ID:        taskID,
+							Name:      "my-task",
+							OwnerName: "me",
+						})
+					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id1+"/pause":
+						httpapi.Write(r.Context(), w, http.StatusAccepted, codersdk.PauseTaskResponse{})
+					default:
+						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
+					}
+				}
+			},
+			wantPausedMsg: true,
+		},
+		{
+			name:      "OK_ByUUID",
+			args:      []string{id2},
+			promptYes: true,
+			buildHandler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/"+id2:
+						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
+							ID:        uuid.MustParse(id2),
+							OwnerName: "me",
+							Name:      "uuid-task",
+						})
+					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id2+"/pause":
+						httpapi.Write(r.Context(), w, http.StatusAccepted, codersdk.PauseTaskResponse{})
+					default:
+						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
+					}
+				}
+			},
+			wantPausedMsg: true,
+		},
+		{
+			name: "YesFlag",
+			args: []string{"--yes", "my-task"},
+			buildHandler: func() http.HandlerFunc {
+				taskID := uuid.MustParse(id3)
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/my-task":
+						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
+							ID:        taskID,
+							Name:      "my-task",
+							OwnerName: "me",
+						})
+					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id3+"/pause":
+						httpapi.Write(r.Context(), w, http.StatusAccepted, codersdk.PauseTaskResponse{})
+					default:
+						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
+					}
+				}
+			},
+			wantPausedMsg: true,
+		},
+		{
+			name:    "ResolveError",
+			args:    []string{"doesnotexist"},
+			wantErr: "resolve task",
+			buildHandler: func() http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/doesnotexist":
+						httpapi.Write(r.Context(), w, http.StatusNotFound, codersdk.Response{
+							Message: "Task not found.",
+						})
+					default:
+						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
+					}
+				}
+			},
+		},
+		{
+			name:      "PauseError",
+			args:      []string{"bad-task"},
+			promptYes: true,
+			wantErr:   "pause task",
+			buildHandler: func() http.HandlerFunc {
+				taskID := uuid.MustParse(id1)
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/bad-task":
+						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
+							ID:        taskID,
+							Name:      "bad-task",
+							OwnerName: "me",
+						})
+					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id1+"/pause":
+						httpapi.Write(r.Context(), w, http.StatusInternalServerError, codersdk.Response{
+							Message: "Internal error.",
+							Detail:  "boom",
+						})
+					default:
+						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
+					}
+				}
+			},
+		},
+		{
+			name:     "PromptDeclined",
+			args:     []string{"my-task"},
+			promptNo: true,
+			wantErr:  "canceled",
+			buildHandler: func() http.HandlerFunc {
+				taskID := uuid.MustParse(id1)
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/my-task":
+						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
+							ID:        taskID,
+							Name:      "my-task",
+							OwnerName: "me",
+						})
+					default:
+						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+
+			srv := httptest.NewServer(tc.buildHandler())
+			t.Cleanup(srv.Close)
+
+			client := codersdk.New(testutil.MustURL(t, srv.URL))
+
+			args := append([]string{"task", "pause"}, tc.args...)
+			inv, root := clitest.New(t, args...)
+			inv = inv.WithContext(ctx)
+			clitest.SetupConfig(t, client, root)
+
+			var runErr error
+			var outBuf bytes.Buffer
+			if tc.promptYes || tc.promptNo {
+				pty := ptytest.New(t).Attach(inv)
+				w := clitest.StartWithWaiter(t, inv)
+				pty.ExpectMatchContext(ctx, "Pause task")
+				if tc.promptYes {
+					pty.WriteLine("yes")
+				} else {
+					pty.WriteLine("no")
+				}
+				if tc.wantPausedMsg {
+					pty.ExpectMatchContext(ctx, "has been paused")
+				}
+				runErr = w.Wait()
+			} else {
+				inv.Stdout = &outBuf
+				inv.Stderr = &outBuf
+				runErr = inv.Run()
+			}
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, runErr, tc.wantErr)
+			} else {
+				require.NoError(t, runErr)
+			}
+
+			// For non-PTY tests, verify output from the buffer.
+			if tc.wantPausedMsg && !tc.promptYes && !tc.promptNo {
+				output := outBuf.String()
+				require.Contains(t, output, "has been paused")
+			}
+		})
+	}
+}

--- a/cli/task_pause_test.go
+++ b/cli/task_pause_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -18,20 +19,22 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("WithYesFlag", func(t *testing.T) {
 		t.Parallel()
 
+		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, client, task := setupCLITaskTest(setupCtx, t, nil)
+		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
 
+		// When: We attempt to pause the task
 		inv, root := clitest.New(t, "task", "pause", task.Name, "--yes")
 		output := clitest.Capture(inv)
-		clitest.SetupConfig(t, client, root)
+		clitest.SetupConfig(t, userClient, root)
 
+		// Then: Expect the task to be paused
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 		require.Contains(t, output.Stdout(), "has been paused")
 
-		// Verify the task is actually paused on the server.
-		updated, err := client.TaskByIdentifier(ctx, task.Name)
+		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
 	})
@@ -41,21 +44,22 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("OtherUserTask", func(t *testing.T) {
 		t.Parallel()
 
+		// Given: A different user's running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
 		adminClient, _, task := setupCLITaskTest(setupCtx, t, nil)
 
+		// When: We attempt to pause their task
 		identifier := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
-
 		inv, root := clitest.New(t, "task", "pause", identifier, "--yes")
 		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, adminClient, root)
 
+		// Then: We expect the task to be paused
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 		require.Contains(t, output.Stdout(), "has been paused")
 
-		// Verify the task is actually paused on the server.
 		updated, err := adminClient.TaskByIdentifier(ctx, identifier)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
@@ -64,22 +68,26 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("PromptConfirm", func(t *testing.T) {
 		t.Parallel()
 
+		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
 		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
 
+		// When: We attempt to pause the task
 		inv, root := clitest.New(t, "task", "pause", task.Name)
 		clitest.SetupConfig(t, userClient, root)
 
+		// And: We confirm we want to pause the task
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		inv = inv.WithContext(ctx)
 		pty := ptytest.New(t).Attach(inv)
 		w := clitest.StartWithWaiter(t, inv)
 		pty.ExpectMatchContext(ctx, "Pause task")
 		pty.WriteLine("yes")
+
+		// Then: We expect the task to be paused
 		pty.ExpectMatchContext(ctx, "has been paused")
 		require.NoError(t, w.Wait())
 
-		// Verify the task is actually paused on the server.
 		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
@@ -88,12 +96,15 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("PromptDecline", func(t *testing.T) {
 		t.Parallel()
 
+		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
 		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
 
+		// When: We attempt to pause the task
 		inv, root := clitest.New(t, "task", "pause", task.Name)
 		clitest.SetupConfig(t, userClient, root)
 
+		// But: We say no at the confirmation screen
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		inv = inv.WithContext(ctx)
 		pty := ptytest.New(t).Attach(inv)
@@ -102,9 +113,32 @@ func TestExpTaskPause(t *testing.T) {
 		pty.WriteLine("no")
 		require.Error(t, w.Wait())
 
-		// Verify the task was not paused.
+		// Then: We expect the task to not be paused
 		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
 		require.NoError(t, err)
 		require.NotEqual(t, codersdk.TaskStatusPaused, updated.Status)
+	})
+
+	t.Run("TaskAlreadyPaused", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: A running task
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
+
+		// And: We paused the running task
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		resp, err := userClient.PauseTask(ctx, task.OwnerName, task.ID)
+		require.NoError(t, err)
+		require.NotNil(t, resp.WorkspaceBuild)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, resp.WorkspaceBuild.ID)
+
+		// When: We attempt to pause the task again
+		inv, root := clitest.New(t, "task", "pause", task.Name, "--yes")
+		clitest.SetupConfig(t, userClient, root)
+
+		// Then: We expect to get an error that the task is already paused
+		err = inv.WithContext(ctx).Run()
+		require.ErrorContains(t, err, "is already paused")
 	})
 }

--- a/cli/task_pause_test.go
+++ b/cli/task_pause_test.go
@@ -2,16 +2,12 @@ package cli_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
-	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/provisioner/echo"
-	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -19,58 +15,20 @@ import (
 func TestExpTaskPause(t *testing.T) {
 	t.Parallel()
 
-	// setup creates an AI task with a completed workspace build, ready
-	// to be paused. Follows the pattern from TestPauseTask in
-	// coderd/aitasks_test.go. Returns the admin client, the member
-	// client that owns the task, and the task itself.
-	setup := func(t *testing.T) (adminClient *codersdk.Client, memberClient *codersdk.Client, task codersdk.Task) {
-		t.Helper()
-
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
-		owner := coderdtest.CreateFirstUser(t, client)
-		userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-
-		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, &echo.Responses{
-			Parse:          echo.ParseComplete,
-			ProvisionApply: echo.ApplyComplete,
-			ProvisionGraph: []*proto.Response{
-				{Type: &proto.Response_Graph{Graph: &proto.GraphComplete{
-					HasAiTasks: true,
-				}}},
-			},
-		})
-		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-		tpl := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
-
-		ctx := testutil.Context(t, testutil.WaitMedium)
-		task, err := userClient.CreateTask(ctx, codersdk.Me, codersdk.CreateTaskRequest{
-			TemplateVersionID: tpl.ActiveVersionID,
-			Input:             "test task for pause",
-		})
-		require.NoError(t, err)
-		require.True(t, task.WorkspaceID.Valid)
-
-		ws, err := userClient.Workspace(ctx, task.WorkspaceID.UUID)
-		require.NoError(t, err)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
-
-		return client, userClient, task
-	}
-
 	t.Run("WithYesFlag", func(t *testing.T) {
 		t.Parallel()
 
-		_, client, task := setup(t)
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		_, client, task := setupCLITaskTest(setupCtx, t, nil)
 
-		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "pause", task.Name, "--yes")
-		inv.Stdout = &stdout
+		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, client, root)
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
-		require.Contains(t, stdout.String(), "has been paused")
+		require.Contains(t, output.Stdout(), "has been paused")
 
 		// Verify the task is actually paused on the server.
 		updated, err := client.TaskByIdentifier(ctx, task.Name)
@@ -83,19 +41,19 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("OtherUserTask", func(t *testing.T) {
 		t.Parallel()
 
-		adminClient, _, task := setup(t)
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		adminClient, _, task := setupCLITaskTest(setupCtx, t, nil)
 
 		identifier := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
 
-		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "pause", identifier, "--yes")
-		inv.Stdout = &stdout
+		output := clitest.Capture(inv)
 		clitest.SetupConfig(t, adminClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
-		require.Contains(t, stdout.String(), "has been paused")
+		require.Contains(t, output.Stdout(), "has been paused")
 
 		// Verify the task is actually paused on the server.
 		updated, err := adminClient.TaskByIdentifier(ctx, identifier)
@@ -106,10 +64,11 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("PromptConfirm", func(t *testing.T) {
 		t.Parallel()
 
-		_, client, task := setup(t)
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
 
 		inv, root := clitest.New(t, "task", "pause", task.Name)
-		clitest.SetupConfig(t, client, root)
+		clitest.SetupConfig(t, userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		inv = inv.WithContext(ctx)
@@ -121,7 +80,7 @@ func TestExpTaskPause(t *testing.T) {
 		require.NoError(t, w.Wait())
 
 		// Verify the task is actually paused on the server.
-		updated, err := client.TaskByIdentifier(ctx, task.Name)
+		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
 	})
@@ -129,10 +88,11 @@ func TestExpTaskPause(t *testing.T) {
 	t.Run("PromptDecline", func(t *testing.T) {
 		t.Parallel()
 
-		_, client, task := setup(t)
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
 
 		inv, root := clitest.New(t, "task", "pause", task.Name)
-		clitest.SetupConfig(t, client, root)
+		clitest.SetupConfig(t, userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		inv = inv.WithContext(ctx)
@@ -143,7 +103,7 @@ func TestExpTaskPause(t *testing.T) {
 		require.Error(t, w.Wait())
 
 		// Verify the task was not paused.
-		updated, err := client.TaskByIdentifier(ctx, task.Name)
+		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
 		require.NoError(t, err)
 		require.NotEqual(t, codersdk.TaskStatusPaused, updated.Status)
 	})

--- a/cli/task_pause_test.go
+++ b/cli/task_pause_test.go
@@ -1,18 +1,16 @@
 package cli_test
 
 import (
-	"bytes"
-	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/cli/clitest"
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -20,204 +18,91 @@ import (
 func TestExpTaskPause(t *testing.T) {
 	t.Parallel()
 
-	type testCase struct {
-		name          string
-		args          []string
-		promptYes     bool
-		promptNo      bool
-		wantErr       string
-		wantPausedMsg bool
-		buildHandler  func() http.HandlerFunc
-	}
+	// setup creates an AI task with a completed workspace build, ready
+	// to be paused. Follows the pattern from TestPauseTask in
+	// coderd/aitasks_test.go.
+	setup := func(t *testing.T) (*codersdk.Client, codersdk.Task) {
+		t.Helper()
+		ctx := testutil.Context(t, testutil.WaitLong)
 
-	const (
-		id1 = "11111111-1111-1111-1111-111111111111"
-		id2 = "22222222-2222-2222-2222-222222222222"
-		id3 = "33333333-3333-3333-3333-333333333333"
-	)
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 
-	cases := []testCase{
-		{
-			name:      "OK_ByName",
-			args:      []string{"my-task"},
-			promptYes: true,
-			buildHandler: func() http.HandlerFunc {
-				taskID := uuid.MustParse(id1)
-				return func(w http.ResponseWriter, r *http.Request) {
-					switch {
-					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/my-task":
-						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
-							ID:        taskID,
-							Name:      "my-task",
-							OwnerName: "me",
-						})
-					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id1+"/pause":
-						httpapi.Write(r.Context(), w, http.StatusAccepted, codersdk.PauseTaskResponse{})
-					default:
-						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
-					}
-				}
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionApply: echo.ApplyComplete,
+			ProvisionGraph: []*proto.Response{
+				{Type: &proto.Response_Graph{Graph: &proto.GraphComplete{
+					HasAiTasks: true,
+				}}},
 			},
-			wantPausedMsg: true,
-		},
-		{
-			name:      "OK_ByUUID",
-			args:      []string{id2},
-			promptYes: true,
-			buildHandler: func() http.HandlerFunc {
-				return func(w http.ResponseWriter, r *http.Request) {
-					switch {
-					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/"+id2:
-						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
-							ID:        uuid.MustParse(id2),
-							OwnerName: "me",
-							Name:      "uuid-task",
-						})
-					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id2+"/pause":
-						httpapi.Write(r.Context(), w, http.StatusAccepted, codersdk.PauseTaskResponse{})
-					default:
-						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
-					}
-				}
-			},
-			wantPausedMsg: true,
-		},
-		{
-			name: "YesFlag",
-			args: []string{"--yes", "my-task"},
-			buildHandler: func() http.HandlerFunc {
-				taskID := uuid.MustParse(id3)
-				return func(w http.ResponseWriter, r *http.Request) {
-					switch {
-					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/my-task":
-						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
-							ID:        taskID,
-							Name:      "my-task",
-							OwnerName: "me",
-						})
-					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id3+"/pause":
-						httpapi.Write(r.Context(), w, http.StatusAccepted, codersdk.PauseTaskResponse{})
-					default:
-						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
-					}
-				}
-			},
-			wantPausedMsg: true,
-		},
-		{
-			name:    "ResolveError",
-			args:    []string{"doesnotexist"},
-			wantErr: "resolve task",
-			buildHandler: func() http.HandlerFunc {
-				return func(w http.ResponseWriter, r *http.Request) {
-					switch {
-					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/doesnotexist":
-						httpapi.Write(r.Context(), w, http.StatusNotFound, codersdk.Response{
-							Message: "Task not found.",
-						})
-					default:
-						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
-					}
-				}
-			},
-		},
-		{
-			name:      "PauseError",
-			args:      []string{"bad-task"},
-			promptYes: true,
-			wantErr:   "pause task",
-			buildHandler: func() http.HandlerFunc {
-				taskID := uuid.MustParse(id1)
-				return func(w http.ResponseWriter, r *http.Request) {
-					switch {
-					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/bad-task":
-						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
-							ID:        taskID,
-							Name:      "bad-task",
-							OwnerName: "me",
-						})
-					case r.Method == http.MethodPost && r.URL.Path == "/api/experimental/tasks/me/"+id1+"/pause":
-						httpapi.Write(r.Context(), w, http.StatusInternalServerError, codersdk.Response{
-							Message: "Internal error.",
-							Detail:  "boom",
-						})
-					default:
-						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
-					}
-				}
-			},
-		},
-		{
-			name:     "PromptDeclined",
-			args:     []string{"my-task"},
-			promptNo: true,
-			wantErr:  "canceled",
-			buildHandler: func() http.HandlerFunc {
-				taskID := uuid.MustParse(id1)
-				return func(w http.ResponseWriter, r *http.Request) {
-					switch {
-					case r.Method == http.MethodGet && r.URL.Path == "/api/v2/tasks/me/my-task":
-						httpapi.Write(r.Context(), w, http.StatusOK, codersdk.Task{
-							ID:        taskID,
-							Name:      "my-task",
-							OwnerName: "me",
-						})
-					default:
-						httpapi.InternalServerError(w, xerrors.New("unwanted path: "+r.Method+" "+r.URL.Path))
-					}
-				}
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ctx := testutil.Context(t, testutil.WaitMedium)
-
-			srv := httptest.NewServer(tc.buildHandler())
-			t.Cleanup(srv.Close)
-
-			client := codersdk.New(testutil.MustURL(t, srv.URL))
-
-			args := append([]string{"task", "pause"}, tc.args...)
-			inv, root := clitest.New(t, args...)
-			inv = inv.WithContext(ctx)
-			clitest.SetupConfig(t, client, root)
-
-			var runErr error
-			var outBuf bytes.Buffer
-			if tc.promptYes || tc.promptNo {
-				pty := ptytest.New(t).Attach(inv)
-				w := clitest.StartWithWaiter(t, inv)
-				pty.ExpectMatchContext(ctx, "Pause task")
-				if tc.promptYes {
-					pty.WriteLine("yes")
-				} else {
-					pty.WriteLine("no")
-				}
-				if tc.wantPausedMsg {
-					pty.ExpectMatchContext(ctx, "has been paused")
-				}
-				runErr = w.Wait()
-			} else {
-				inv.Stdout = &outBuf
-				inv.Stderr = &outBuf
-				runErr = inv.Run()
-			}
-
-			if tc.wantErr != "" {
-				require.ErrorContains(t, runErr, tc.wantErr)
-			} else {
-				require.NoError(t, runErr)
-			}
-
-			// For non-PTY tests, verify output from the buffer.
-			if tc.wantPausedMsg && !tc.promptYes && !tc.promptNo {
-				output := outBuf.String()
-				require.Contains(t, output, "has been paused")
-			}
 		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		tpl := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		task, err := userClient.CreateTask(ctx, codersdk.Me, codersdk.CreateTaskRequest{
+			TemplateVersionID: tpl.ActiveVersionID,
+			Input:             "test task for pause",
+		})
+		require.NoError(t, err)
+		require.True(t, task.WorkspaceID.Valid)
+
+		ws, err := userClient.Workspace(ctx, task.WorkspaceID.UUID)
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
+
+		return userClient, task
 	}
+
+	t.Run("WithYesFlag", func(t *testing.T) {
+		t.Parallel()
+
+		client, task := setup(t)
+
+		var stdout strings.Builder
+		inv, root := clitest.New(t, "task", "pause", task.Name, "--yes")
+		inv.Stdout = &stdout
+		clitest.SetupConfig(t, client, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Contains(t, stdout.String(), "has been paused")
+	})
+
+	t.Run("PromptConfirm", func(t *testing.T) {
+		t.Parallel()
+
+		client, task := setup(t)
+
+		inv, root := clitest.New(t, "task", "pause", task.Name)
+		clitest.SetupConfig(t, client, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv = inv.WithContext(ctx)
+		pty := ptytest.New(t).Attach(inv)
+		w := clitest.StartWithWaiter(t, inv)
+		pty.ExpectMatchContext(ctx, "Pause task")
+		pty.WriteLine("yes")
+		pty.ExpectMatchContext(ctx, "has been paused")
+		require.NoError(t, w.Wait())
+	})
+
+	t.Run("PromptDecline", func(t *testing.T) {
+		t.Parallel()
+
+		client, task := setup(t)
+
+		inv, root := clitest.New(t, "task", "pause", task.Name)
+		clitest.SetupConfig(t, client, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv = inv.WithContext(ctx)
+		pty := ptytest.New(t).Attach(inv)
+		w := clitest.StartWithWaiter(t, inv)
+		pty.ExpectMatchContext(ctx, "Pause task")
+		pty.WriteLine("no")
+		require.Error(t, w.Wait())
+	})
 }

--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -25,8 +25,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
-		userClient := client
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "send", task.Name, "carry on with the task")
@@ -42,8 +41,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
-		userClient := client
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "send", task.ID.String(), "carry on with the task")
@@ -59,8 +57,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		client, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
-		userClient := client
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "send", task.Name, "--stdin")
@@ -113,7 +110,7 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendErr(t, assert.AnError))
+		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendErr(t, assert.AnError))
 
 		var stdout strings.Builder
 		inv, root := clitest.New(t, "task", "send", task.Name, "some task input")

--- a/cli/task_test.go
+++ b/cli/task_test.go
@@ -121,6 +121,23 @@ func Test_Tasks(t *testing.T) {
 			},
 		},
 		{
+			name:    "pause task",
+			cmdArgs: []string{"task", "pause", taskName, "--yes"},
+			assertFn: func(stdout string, userClient *codersdk.Client) {
+				require.Contains(t, stdout, "has been paused", "pause output should confirm task was paused")
+			},
+		},
+		{
+			name:    "get task status after pause",
+			cmdArgs: []string{"task", "status", taskName, "--output", "json"},
+			assertFn: func(stdout string, userClient *codersdk.Client) {
+				var task codersdk.Task
+				require.NoError(t, json.NewDecoder(strings.NewReader(stdout)).Decode(&task), "should unmarshal task status")
+				require.Equal(t, taskName, task.Name, "task name should match")
+				require.Equal(t, codersdk.TaskStatusPaused, task.Status, "task should be paused")
+			},
+		},
+		{
 			name:    "delete task",
 			cmdArgs: []string{"task", "delete", taskName, "--yes"},
 			assertFn: func(stdout string, userClient *codersdk.Client) {

--- a/cli/testdata/coder_task_--help.golden
+++ b/cli/testdata/coder_task_--help.golden
@@ -12,6 +12,7 @@ SUBCOMMANDS:
     delete    Delete tasks
     list      List tasks
     logs      Show a task's logs
+    pause     Pause a task
     send      Send input to a task
     status    Show the status of a task.
 

--- a/cli/testdata/coder_task_pause_--help.golden
+++ b/cli/testdata/coder_task_pause_--help.golden
@@ -5,11 +5,11 @@ USAGE:
 
   Pause a task
 
-    - Pause a task by name.:
+    - Pause a task by name:
   
        $ coder task pause my-task
   
-    - Pause a task without confirmation.:
+    - Pause a task without confirmation:
   
        $ coder task pause my-task --yes
 

--- a/cli/testdata/coder_task_pause_--help.golden
+++ b/cli/testdata/coder_task_pause_--help.golden
@@ -9,6 +9,10 @@ USAGE:
   
        $ coder task pause my-task
   
+    - Pause another user's task:
+  
+       $ coder task pause alice/my-task
+  
     - Pause a task without confirmation:
   
        $ coder task pause my-task --yes

--- a/cli/testdata/coder_task_pause_--help.golden
+++ b/cli/testdata/coder_task_pause_--help.golden
@@ -1,0 +1,21 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder task pause [flags] <task>
+
+  Pause a task
+
+    - Pause a task by name.:
+  
+       $ coder task pause my-task
+  
+    - Pause a task without confirmation.:
+  
+       $ coder task pause my-task --yes
+
+OPTIONS:
+  -y, --yes bool
+          Bypass confirmation prompts.
+
+———
+Run `coder --help` for a list of global options.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2010,6 +2010,11 @@
 							"path": "reference/cli/task_logs.md"
 						},
 						{
+							"title": "task pause",
+							"description": "Pause a task",
+							"path": "reference/cli/task_pause.md"
+						},
+						{
 							"title": "task send",
 							"description": "Send input to a task",
 							"path": "reference/cli/task_send.md"

--- a/docs/reference/cli/task.md
+++ b/docs/reference/cli/task.md
@@ -21,5 +21,6 @@ coder task
 | [<code>delete</code>](./task_delete.md) | Delete tasks               |
 | [<code>list</code>](./task_list.md)     | List tasks                 |
 | [<code>logs</code>](./task_logs.md)     | Show a task's logs         |
+| [<code>pause</code>](./task_pause.md)   | Pause a task               |
 | [<code>send</code>](./task_send.md)     | Send input to a task       |
 | [<code>status</code>](./task_status.md) | Show the status of a task. |

--- a/docs/reference/cli/task_pause.md
+++ b/docs/reference/cli/task_pause.md
@@ -1,32 +1,34 @@
 <!-- DO NOT EDIT | GENERATED CONTENT -->
 # task pause
 
+
 Pause a task
 
-## Usage
 
+
+
+## Usage
 ```console
 coder task pause [flags] <task>
 ```
 
 ## Description
-
 ```console
-  - Pause a task by name.:
+  - Pause a task by name:
 
      $ coder task pause my-task
 
-  - Pause a task without confirmation.:
+  - Pause a task without confirmation:
 
      $ coder task pause my-task --yes
 ```
 
+
 ## Options
-
 ### -y, --yes
-
-|      |                   |
-|------|-------------------|
+ 
+| | |
+| --- | --- |
 | Type | <code>bool</code> |
 
 Bypass confirmation prompts.

--- a/docs/reference/cli/task_pause.md
+++ b/docs/reference/cli/task_pause.md
@@ -1,0 +1,32 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+# task pause
+
+Pause a task
+
+## Usage
+
+```console
+coder task pause [flags] <task>
+```
+
+## Description
+
+```console
+  - Pause a task by name.:
+
+     $ coder task pause my-task
+
+  - Pause a task without confirmation.:
+
+     $ coder task pause my-task --yes
+```
+
+## Options
+
+### -y, --yes
+
+|      |                   |
+|------|-------------------|
+| Type | <code>bool</code> |
+
+Bypass confirmation prompts.

--- a/docs/reference/cli/task_pause.md
+++ b/docs/reference/cli/task_pause.md
@@ -27,8 +27,8 @@ coder task pause [flags] <task>
 ## Options
 ### -y, --yes
  
-| | |
-| --- | --- |
+|      |                   |
+|------|-------------------|
 | Type | <code>bool</code> |
 
 Bypass confirmation prompts.

--- a/docs/reference/cli/task_pause.md
+++ b/docs/reference/cli/task_pause.md
@@ -1,32 +1,34 @@
 <!-- DO NOT EDIT | GENERATED CONTENT -->
 # task pause
 
-
 Pause a task
 
-
-
-
 ## Usage
+
 ```console
 coder task pause [flags] <task>
 ```
 
 ## Description
+
 ```console
   - Pause a task by name:
 
      $ coder task pause my-task
+
+  - Pause another user's task:
+
+     $ coder task pause alice/my-task
 
   - Pause a task without confirmation:
 
      $ coder task pause my-task --yes
 ```
 
-
 ## Options
+
 ### -y, --yes
- 
+
 |      |                   |
 |------|-------------------|
 | Type | <code>bool</code> |


### PR DESCRIPTION
## Summary

Add a new `coder task pause` CLI command that pauses a running task by triggering a workspace build transition to stop.

### Features

- Accepts task identifier as UUID, name, or `owner/name` format
- Supports pausing another user's task (e.g. `coder task pause alice/my-task`)
- Interactive confirmation prompt with `--yes` flag to bypass
- Streams workspace build progress after triggering the pause
- Consistent with existing task commands (create, delete, etc.)

### Testing

Integration tests with a real coderd instance and echo provisioner (4 cases):
- **WithYesFlag**: Pauses via `--yes`, verifies output and server-side task status
- **OtherUserTask**: Admin pauses a task owned by another user via `owner/name` identifier
- **PromptConfirm**: Interactive prompt answered "yes", verifies pause and server-side status
- **PromptDecline**: Interactive prompt answered "no", verifies command errors and task is not paused

Closes coder/internal#1263 (Closes COCO-2)

---

Generated by [Coder Mux](https://mux.coder.com/)