### PR TITLE
fix: revert "fix: apply `overflow-y: scroll` to `<html />` (#21988)"

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -100,10 +100,6 @@
 		@apply border-border;
 	}
 
-	html {
-		overflow-y: scroll;
-	}
-
 	/*
 	By default, Radix adds a margin to the `body` element when a dropdown is displayed,
 	causing some shifting when the dropdown has a full-width size, as is the case with the mobile menu.
@@ -114,7 +110,12 @@
 	 */
 	html body[data-scroll-locked] {
 		--removed-body-scroll-bar-size: 0;
-		margin-right: 0 !important;
+		margin-right: 0;
+	}
+
+	/* Prevent layout shift when modals open by maintaining scrollbar width */
+	html {
+		scrollbar-gutter: stable;
 	}
 
 	/*


### PR DESCRIPTION
This reverts commit 5224387c5a807ec5bad66106db69375ee93a5e6e.

This is causing layout shifts to `0,0` when attempting to open dropdowns. Something more battle-tested is needed unfortunately, Radix + Scrollgutters is really annoying.