### PR TITLE
fix: implement debounce `<WorkspaceParametersPageViewExperimental />`

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -100,6 +100,13 @@ const WorkspaceParametersPageExperimental: FC = () => {
 			sendInitialParameters();
 		}
 
+		// Skip stale responses. If we've already sent a newer request,
+		// this response contains outdated parameter values that would
+		// overwrite the user's more recent input.
+		if (response.id < wsResponseId.current) {
+			return;
+		}
+
 		setLatestResponse(response);
 	});
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -96,10 +96,6 @@ const WorkspaceParametersPageExperimental: FC = () => {
 			return;
 		}
 
-		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
-			sendInitialParameters();
-		}
-
 		// Skip stale responses. If we've already sent a newer request,
 		// this response contains outdated parameter values that would
 		// overwrite the user's more recent input.
@@ -108,6 +104,10 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		}
 
 		setLatestResponse(response);
+
+		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
+			sendInitialParameters();
+		}
 	});
 
 	useEffect(() => {
@@ -204,7 +204,7 @@ const WorkspaceParametersPageExperimental: FC = () => {
 
 	if (
 		latestBuildParametersLoading ||
-		!latestResponse ||
+		(!latestResponse && !wsError) ||
 		(ws.current && ws.current.readyState === WebSocket.CONNECTING)
 	) {
 		return <Loader />;
@@ -251,7 +251,7 @@ const WorkspaceParametersPageExperimental: FC = () => {
 					autofillParameters={autofillParameters}
 					canChangeVersions={canChangeVersions}
 					parameters={sortedParams}
-					diagnostics={latestResponse.diagnostics}
+					diagnostics={latestResponse?.diagnostics ?? []}
 					isSubmitting={updateParameters.isPending}
 					onSubmit={handleSubmit}
 					onCancel={() =>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -104,6 +104,21 @@ export const WorkspaceParametersPageViewExperimental: FC<
 		setFieldValue: form.setFieldValue,
 	});
 
+	// True when the form holds values the backend hasn't evaluated
+	// yet (debounce pending or WS round-trip in flight).
+	const hasUnsyncedParameters = (form.values.rich_parameter_values ?? []).some(
+		(formParam) => {
+			const responseParam = parameters.find((p) => p.name === formParam.name);
+			if (!responseParam) {
+				return true;
+			}
+			const responseValue = responseParam.value.valid
+				? responseParam.value.value
+				: "";
+			return formParam.value !== responseValue;
+		},
+	);
+
 	const hasIncompatibleParameters = parameters.some((parameter) => {
 		if (!parameter.mutable && parameter.diagnostics.length > 0) {
 			return true;
@@ -250,6 +265,7 @@ export const WorkspaceParametersPageViewExperimental: FC<
 						disabled={
 							isSubmitting ||
 							disabled ||
+							hasUnsyncedParameters ||
 							diagnostics.some(
 								(diagnostic) => diagnostic.severity === "error",
 							) ||


### PR DESCRIPTION
Closes #22028

This pull-request simply takes debounces the message sent to our web-socket backend and debounces it to ensure we're not overwriting the users input as they type. As an added bonus this will debounce message spam if people are going crazy on Radio Items or similar.

An extra flavour bit of flavour with resolving a good use-case for `cn()` in diagnostic errors 🙂 