### PR TITLE
fix(site): remove overflow-hidden

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -473,6 +473,23 @@ export const CheckExternalAuthOnChangingVersions: Story = {
 	},
 };
 
+export const PresetSelectorFocused: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplateVersionPresets").mockResolvedValue(
+			MockPresets.map((preset, i) => ({
+				...preset,
+				Icon: i === 0 ? "/icon/code.svg" : i === 1 ? "/icon/database.svg" : "",
+				Description: i === 0 ? "For everyday development work" : "",
+			})),
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const presetSelect = await canvas.findByLabelText(/preset/i);
+		presetSelect.focus();
+	},
+};
+
 export const CheckPresetsWhenChangingTemplate: Story = {
 	args: {
 		templates: [

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -473,6 +473,11 @@ export const CheckExternalAuthOnChangingVersions: Story = {
 	},
 };
 
+// Regression test introduced in https://github.com/coder/coder/pull/22032
+// A change was introduced that cause the focused selector to be mostly
+// hidden due to an introduced `overflow-hidden`. The change wasn't spotted
+// in the PR it was introduced as no stories triggered that behavior, so we
+// have added one to ensure the behavior doesn't regress.
 export const PresetSelectorFocused: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplateVersionPresets").mockResolvedValue(

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -305,7 +305,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 							</div>
 						)}
 
-						<div className="flex-1 overflow-hidden min-w-0">
+						<div className="flex-1 min-w-0">
 							<label htmlFor="presetID" className="sr-only">
 								Preset
 							</label>


### PR DESCRIPTION
Fixes an issue where the outline on the tasks page preset selector was obscured by `overflow-hidden`.