### PR TITLE
feat: remove emojimart external call to `jsdelivr`

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -32,7 +32,7 @@
 		"test:watch": "vitest",
 		"test:watch-jest": "jest --watch",
 		"stats": "STATS=true pnpm build && npx http-server ./stats -p 8081 -c-1",
-		"update-emojis": "cp -rf ./node_modules/emoji-datasource-apple/img/apple/64/* ./static/emojis"
+		"update-emojis": "cp -rf ./node_modules/emoji-datasource-apple/img/apple/64/* ./static/emojis && cp -f ./node_modules/emoji-datasource-apple/img/apple/sheets-256/64.png ./static/emojis/spritesheet.png"
 	},
 	"dependencies": {
 		"@emoji-mart/data": "1.2.1",

--- a/site/src/@types/emoji-mart.d.ts
+++ b/site/src/@types/emoji-mart.d.ts
@@ -36,6 +36,7 @@ declare module "@emoji-mart/react" {
 		emojiButtonSize?: number;
 		emojiSize?: number;
 		emojiVersion?: string;
+		getSpritesheetURL?: (set: string) => string;
 		onEmojiSelect: (emoji: EmojiData) => void;
 	}
 

--- a/site/src/components/IconField/EmojiPicker.tsx
+++ b/site/src/components/IconField/EmojiPicker.tsx
@@ -25,7 +25,7 @@ const custom = [
 
 type EmojiPickerProps = Omit<
 	ComponentProps<typeof EmojiMart>,
-	"custom" | "data" | "set" | "theme"
+	"custom" | "data" | "set" | "theme" | "getSpritesheetURL"
 >;
 
 const EmojiPicker: FC<EmojiPickerProps> = (props) => {
@@ -53,6 +53,7 @@ const EmojiPicker: FC<EmojiPickerProps> = (props) => {
 			emojiVersion="15"
 			data={data}
 			custom={custom}
+			getSpritesheetURL={() => "/emojis/spritesheet.png"}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
This pull-request ensures we don't have any reason to call out externally to `jsdelivr`. Nobody has complained about this yet, but in an [air-gapped environment](https://coder.com/docs/install/airgap) I foresaw an issue where this might try to reach-out and fail to load the image. 

New behaviour for the spritesheet.

```diff
- https://cdn.jsdelivr.net/npm/emoji-datasource-apple@15.0.1/img/apple/sheets-256/64.png
+ /emojis/spritesheet.png
```