### PR TITLE
fix: resolve small screen layout for `/tasks`

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
+++ b/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
@@ -18,6 +18,7 @@ type PromptSelectTriggerProps = SelectTriggerProps & {
 export const PromptSelectTrigger: FC<PromptSelectTriggerProps> = ({
 	className,
 	tooltip,
+	children,
 	...props
 }) => {
 	return (
@@ -27,12 +28,19 @@ export const PromptSelectTrigger: FC<PromptSelectTriggerProps> = ({
 					<SelectTrigger
 						{...props}
 						className={cn([
-							`w-auto max-w-full overflow-hidden border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-3
-						[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
-						h-8 data-[state=open]:bg-surface-tertiary [&>span]:overflow-hidden [&>span]:min-w-0`,
+							`w-full md:w-auto max-w-full overflow-hidden border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-4 md:px-3
+							[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
+							h-10 md:h-8 data-[state=open]:bg-surface-tertiary`,
 							className,
 						])}
-					/>
+					>
+						<span
+							data-slot="value"
+							className="overflow-hidden min-w-0 flex items-center gap-2"
+						>
+							{children}
+						</span>
+					</SelectTrigger>
 				</TooltipTrigger>
 				<TooltipContent>{tooltip}</TooltipContent>
 			</Tooltip>

--- a/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
+++ b/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
@@ -27,10 +27,10 @@ export const PromptSelectTrigger: FC<PromptSelectTriggerProps> = ({
 					<SelectTrigger
 						{...props}
 						className={cn([
+							`w-auto max-w-full overflow-hidden border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-3
+						[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
+						h-8 data-[state=open]:bg-surface-tertiary [&>span]:overflow-hidden [&>span]:min-w-0`,
 							className,
-							`w-auto border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-3
-							[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
-							h-8 data-[state=open]:bg-surface-tertiary`,
 						])}
 					/>
 				</TooltipTrigger>

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -8,6 +8,7 @@ import type {
 	TemplateVersionExternalAuth,
 } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
@@ -235,7 +236,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 			{externalAuthError && <ErrorAlert error={externalAuthError} />}
 
 			<fieldset
-				className="border border-border border-solid rounded-3xl p-3 bg-surface-secondary"
+				className="border border-border border-solid rounded-3xl p-3 bg-surface-secondary min-w-0"
 				disabled={createTaskMutation.isPending}
 			>
 				<label htmlFor="prompt" className="sr-only">
@@ -248,9 +249,9 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 					isSubmitting={createTaskMutation.isPending}
 					onKeyDown={handleKeyDown}
 				/>
-				<div className="flex items-center justify-between pt-2">
-					<div className="flex items-center gap-1">
-						<div>
+				<div className="flex items-center justify-between pt-2 gap-2">
+					<div className="flex items-center gap-1 flex-1 min-w-0">
+						<div className="min-w-0 max-w-[33%]">
 							<label htmlFor="templateID" className="sr-only">
 								Select template
 							</label>
@@ -292,7 +293,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						</div>
 
 						{permissions.updateTemplates && (
-							<div>
+							<div className="min-w-0 max-w-[33%]">
 								<label htmlFor="versionId" className="sr-only">
 									Template version
 								</label>
@@ -324,7 +325,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 										<PromptSelectTrigger
 											id="presetID"
 											tooltip="Preset"
-											className="w-full max-w-full [&_span]:flex [&_span]:items-center [&_span]:gap-2 [&_span]:min-w-0 [&_span]:overflow-hidden [&_span>span]:truncate [&_svg[data-slot='preset-description']]:hidden"
+											className="max-w-full [&>span]:flex [&>span]:items-center [&>span]:gap-2 [&>span>span]:truncate [&>span>span]:min-w-0 [&_svg[data-slot='preset-description']]:hidden"
 										>
 											<SelectValue placeholder="Select a preset" />
 										</PromptSelectTrigger>
@@ -339,12 +340,17 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 														<img
 															src={preset.Icon}
 															alt={preset.Name}
-															className="size-icon-sm flex-shrink-0"
+															className="size-icon-sm shrink-0"
 														/>
 													)}
-													<span>
-														{preset.Name} {preset.Default && "(Default)"}
+													<span className="truncate min-w-0">
+														{preset.Name}
 													</span>
+													{preset.Default && (
+														<Badge size="xs" className="shrink-0">
+															Default
+														</Badge>
+													)}
 													{preset.Description && (
 														<Tooltip>
 															<TooltipTrigger asChild>

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -325,45 +325,47 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 										<PromptSelectTrigger
 											id="presetID"
 											tooltip="Preset"
-											className="max-w-full [&>span]:flex [&>span]:items-center [&>span]:gap-2 [&>span>span]:truncate [&>span>span]:min-w-0 [&_svg[data-slot='preset-description']]:hidden"
+											className="max-w-full [&_[data-slot=preset-name]]:truncate [&_[data-slot=preset-name]]:min-w-0 [&_[data-slot=preset-description]]:hidden"
 										>
 											<SelectValue placeholder="Select a preset" />
 										</PromptSelectTrigger>
 										<SelectContent>
 											{presets?.toSorted(sortByDefault).map((preset) => (
-												<SelectItem
-													value={preset.ID}
-													key={preset.ID}
-													className="[&_span]:flex [&_span]:items-center [&_span]:gap-2"
-												>
-													{preset.Icon && (
-														<img
-															src={preset.Icon}
-															alt={preset.Name}
-															className="size-icon-sm shrink-0"
-														/>
-													)}
-													<span className="truncate min-w-0">
-														{preset.Name}
-													</span>
-													{preset.Default && (
-														<Badge size="xs" className="shrink-0">
-															Default
-														</Badge>
-													)}
-													{preset.Description && (
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<InfoIcon
-																	className="size-4"
-																	data-slot="preset-description"
-																/>
-															</TooltipTrigger>
-															<TooltipContent>
-																{preset.Description}
-															</TooltipContent>
-														</Tooltip>
-													)}
+												<SelectItem value={preset.ID} key={preset.ID}>
+													<div className="flex items-center gap-2">
+														{preset.Icon && (
+															<img
+																data-slot="preset-icon"
+																src={preset.Icon}
+																alt={preset.Name}
+																className="size-icon-sm shrink-0"
+															/>
+														)}
+														<span
+															data-slot="preset-name"
+															className="truncate min-w-0"
+														>
+															{preset.Name}
+														</span>
+														{preset.Default && (
+															<Badge size="xs" className="shrink-0">
+																Default
+															</Badge>
+														)}
+														{preset.Description && (
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<InfoIcon
+																		className="size-4"
+																		data-slot="preset-description"
+																	/>
+																</TooltipTrigger>
+																<TooltipContent>
+																	{preset.Description}
+																</TooltipContent>
+															</Tooltip>
+														)}
+													</div>
 												</SelectItem>
 											))}
 										</SelectContent>

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -251,7 +251,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 				/>
 				<div className="flex items-center justify-between pt-2 gap-2">
 					<div className="flex items-center gap-1 flex-1 min-w-0">
-						<div className="min-w-0 max-w-[33%]">
+						<div className="min-w-0 max-w-[33.3%]">
 							<label htmlFor="templateID" className="sr-only">
 								Select template
 							</label>
@@ -293,7 +293,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						</div>
 
 						{permissions.updateTemplates && (
-							<div className="min-w-0 max-w-[33%]">
+							<div className="min-w-0 max-w-[33.3%]">
 								<label htmlFor="versionId" className="sr-only">
 									Template version
 								</label>

--- a/site/src/modules/tasks/TaskPrompt/TemplateVersionSelect.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TemplateVersionSelect.tsx
@@ -48,10 +48,10 @@ export const TemplateVersionSelect: FC<TemplateVersionSelectProps> = ({
 				{versions.map((version) => {
 					return (
 						<SelectItem value={version.id} key={version.id}>
-							<span className="flex items-center gap-2">
-								{version.name}
+							<span className="flex items-center gap-2 min-w-0">
+								<span className="truncate">{version.name}</span>
 								{activeVersionId === version.id && (
-									<Badge size="xs" variant="green">
+									<Badge size="xs" variant="green" className="shrink-0">
 										Active
 									</Badge>
 								)}


### PR DESCRIPTION
When discussing the changes needed for #22032 I was complaining about how the `overflow-hidden` didn't work correctly so we could safely remove it.

To continue these changes, I've refactored down how we work on mobile within these triggers and enable full truncating and `max-w-`'s on each of the content. Everything stemmed from the `<fieldset />` having a `width: max-content` causing the content to extend past the bounds of the container with `flex` in-toe. 

Furthermore, the `(Default)` on `Preset` has been turned into a badge so that we get the full truncation effect as we do with  `Template Version`.

Follow-up improvements here might be to wrap the content of this input on smaller displays.

### Preview

Top is the old, bottom is the new.

<img width="924" height="594" alt="preview" src="https://github.com/user-attachments/assets/c1bbf152-03a6-4cad-b925-aad0549536a7" />
