### PR TITLE
fix: resolve mobile layout entirely on `/tasks`

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/PromptField.tsx
+++ b/site/src/modules/tasks/TaskPrompt/PromptField.tsx
@@ -1,0 +1,32 @@
+import type { ComponentProps, FC } from "react";
+import { cn } from "utils/cn";
+
+const PromptField: FC<ComponentProps<"div">> = ({ className, ...props }) => {
+	return (
+		<div
+			className={cn(
+				"min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+const PromptFieldLabel: FC<ComponentProps<"label">> = ({
+	className,
+	...props
+}) => {
+	return (
+		// biome-ignore lint/a11y/noLabelWithoutControl: htmlFor is passed via props
+		<label
+			className={cn(
+				"text-xs font-medium text-content-secondary pl-4 md:sr-only",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
+
+export { PromptField, PromptFieldLabel };

--- a/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
+++ b/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
@@ -27,9 +27,9 @@ export const PromptSelectTrigger: FC<PromptSelectTriggerProps> = ({
 					<SelectTrigger
 						{...props}
 						className={cn([
-							`w-auto max-w-full overflow-hidden border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-3
+							`w-full md:w-auto max-w-full overflow-hidden border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-4 md:px-3
 						[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
-						h-8 data-[state=open]:bg-surface-tertiary [&>span]:overflow-hidden [&>span]:min-w-0`,
+						h-10 md:h-8 data-[state=open]:bg-surface-tertiary [&>span]:overflow-hidden [&>span]:min-w-0`,
 							className,
 						])}
 					/>

--- a/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
+++ b/site/src/modules/tasks/TaskPrompt/PromptSelectTrigger.tsx
@@ -27,10 +27,10 @@ export const PromptSelectTrigger: FC<PromptSelectTriggerProps> = ({
 					<SelectTrigger
 						{...props}
 						className={cn([
+							`w-auto max-w-full overflow-hidden border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-3
+						[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
+						h-8 data-[state=open]:bg-surface-tertiary [&>span]:overflow-hidden [&>span]:min-w-0`,
 							className,
-							`w-auto border-0 bg-surface-secondary text-sm text-content-primary gap-2 px-3
-							[&_svg]:text-inherit cursor-pointer hover:bg-surface-quaternary rounded-full
-							h-8 data-[state=open]:bg-surface-tertiary`,
 						])}
 					/>
 				</TooltipTrigger>

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -249,11 +249,14 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 					isSubmitting={createTaskMutation.isPending}
 					onKeyDown={handleKeyDown}
 				/>
-				<div className="flex items-center justify-between pt-2 gap-2">
-					<div className="flex items-center gap-1 flex-1 min-w-0">
-						<div className="min-w-0 max-w-[33%]">
-							<label htmlFor="templateID" className="sr-only">
-								Select template
+				<div className="flex flex-col md:flex-row md:items-center justify-between pt-2 gap-6 md:gap-2">
+					<div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-1 flex-1 min-w-0">
+						<div className="min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0">
+							<label
+								htmlFor="templateID"
+								className="text-xs font-medium text-content-secondary pl-4 md:sr-only"
+							>
+								Template
 							</label>
 							<Select
 								name="templateID"
@@ -293,8 +296,11 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						</div>
 
 						{permissions.updateTemplates && (
-							<div className="min-w-0 max-w-[33%]">
-								<label htmlFor="versionId" className="sr-only">
+							<div className="min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0">
+								<label
+									htmlFor="versionId"
+									className="text-xs font-medium text-content-secondary pl-4 md:sr-only"
+								>
 									Template version
 								</label>
 								<TemplateVersionSelect
@@ -306,8 +312,11 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 							</div>
 						)}
 
-						<div className="flex-1 min-w-0">
-							<label htmlFor="presetID" className="sr-only">
+						<div className="min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0">
+							<label
+								htmlFor="presetID"
+								className="text-xs font-medium text-content-secondary pl-4 md:sr-only"
+							>
 								Preset
 							</label>
 							{isLoadingPresets ? (
@@ -373,7 +382,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						</div>
 					</div>
 
-					<div className="flex items-center gap-2">
+					<div className="flex items-center gap-2 md:shrink-0">
 						{missedExternalAuth && (
 							<ExternalAuthButtons
 								versionId={selectedVersionId}
@@ -384,11 +393,11 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<Button
-									size="icon"
 									type="submit"
 									disabled={prompt.trim().length === 0 || isMissingExternalAuth}
-									className="rounded-full disabled:bg-surface-invert-primary disabled:opacity-70"
+									className="w-full md:w-auto rounded-full disabled:bg-surface-invert-primary disabled:opacity-70 md:size-8 md:min-w-[auto]"
 								>
+									<span className="md:hidden">Run task</span>
 									<Spinner
 										loading={
 											isLoadingExternalAuth ||
@@ -396,9 +405,8 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 											createTaskMutation.isPending
 										}
 									>
-										<ArrowUpIcon />
+										<ArrowUpIcon className="!size-icon-sm" />
 									</Spinner>
-									<span className="sr-only">Run task</span>
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent align="end">

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -37,6 +37,7 @@ import TextareaAutosize, {
 } from "react-textarea-autosize";
 import { docs } from "utils/docs";
 import { getOSKey } from "utils/platform";
+import { PromptField, PromptFieldLabel } from "./PromptField";
 import { PromptSelectTrigger } from "./PromptSelectTrigger";
 import { TemplateVersionSelect } from "./TemplateVersionSelect";
 
@@ -251,13 +252,8 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 				/>
 				<div className="flex flex-col md:flex-row md:items-center justify-between pt-2 gap-6 md:gap-2">
 					<div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-1 flex-1 min-w-0">
-						<div className="min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0">
-							<label
-								htmlFor="templateID"
-								className="text-xs font-medium text-content-secondary pl-4 md:sr-only"
-							>
-								Template
-							</label>
+						<PromptField>
+							<PromptFieldLabel htmlFor="templateID">Template</PromptFieldLabel>
 							<Select
 								name="templateID"
 								onValueChange={(value) => {
@@ -293,32 +289,24 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 									})}
 								</SelectContent>
 							</Select>
-						</div>
+						</PromptField>
 
 						{permissions.updateTemplates && (
-							<div className="min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0">
-								<label
-									htmlFor="versionId"
-									className="text-xs font-medium text-content-secondary pl-4 md:sr-only"
-								>
+							<PromptField>
+								<PromptFieldLabel htmlFor="versionId">
 									Template version
-								</label>
+								</PromptFieldLabel>
 								<TemplateVersionSelect
 									templateId={selectedTemplateId}
 									activeVersionId={selectedTemplate.active_version_id}
 									value={selectedVersionId}
 									onValueChange={setSelectedVersionId}
 								/>
-							</div>
+							</PromptField>
 						)}
 
-						<div className="min-w-0 w-full md:w-auto md:max-w-[33%] flex flex-col gap-2 md:gap-0">
-							<label
-								htmlFor="presetID"
-								className="text-xs font-medium text-content-secondary pl-4 md:sr-only"
-							>
-								Preset
-							</label>
+						<PromptField>
+							<PromptFieldLabel htmlFor="presetID">Preset</PromptFieldLabel>
 							{isLoadingPresets ? (
 								<Skeleton className="w-[140px] h-8 rounded-full" />
 							) : (
@@ -379,7 +367,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 									</Select>
 								)
 							)}
-						</div>
+						</PromptField>
 					</div>
 
 					<div className="flex items-center gap-2 md:shrink-0">

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -8,6 +8,7 @@ import type {
 	TemplateVersionExternalAuth,
 } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
@@ -235,7 +236,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 			{externalAuthError && <ErrorAlert error={externalAuthError} />}
 
 			<fieldset
-				className="border border-border border-solid rounded-3xl p-3 bg-surface-secondary"
+				className="border border-border border-solid rounded-3xl p-3 bg-surface-secondary min-w-0"
 				disabled={createTaskMutation.isPending}
 			>
 				<label htmlFor="prompt" className="sr-only">
@@ -248,9 +249,9 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 					isSubmitting={createTaskMutation.isPending}
 					onKeyDown={handleKeyDown}
 				/>
-				<div className="flex items-center justify-between pt-2">
-					<div className="flex items-center gap-1">
-						<div>
+				<div className="flex items-center justify-between pt-2 gap-2">
+					<div className="flex items-center gap-1 flex-1 min-w-0">
+						<div className="min-w-0 max-w-[33%]">
 							<label htmlFor="templateID" className="sr-only">
 								Select template
 							</label>
@@ -292,7 +293,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 						</div>
 
 						{permissions.updateTemplates && (
-							<div>
+							<div className="min-w-0 max-w-[33%]">
 								<label htmlFor="versionId" className="sr-only">
 									Template version
 								</label>
@@ -324,7 +325,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 										<PromptSelectTrigger
 											id="presetID"
 											tooltip="Preset"
-											className="w-full max-w-full [&_span]:flex [&_span]:items-center [&_span]:gap-2 [&_span]:min-w-0 [&_span]:overflow-hidden [&_span>span]:truncate [&_svg[data-slot='preset-description']]:hidden"
+											className="max-w-full [&>span]:flex [&>span]:items-center [&>span]:gap-2 [&>span>span]:truncate [&>span>span]:min-w-0 [&_svg[data-slot='preset-description']]:hidden"
 										>
 											<SelectValue placeholder="Select a preset" />
 										</PromptSelectTrigger>
@@ -339,12 +340,17 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 														<img
 															src={preset.Icon}
 															alt={preset.Name}
-															className="size-icon-sm flex-shrink-0"
+															className="size-icon-sm shrink-0"
 														/>
 													)}
-													<span>
-														{preset.Name} {preset.Default && "(Default)"}
+													<span className="truncate min-w-0">
+														{preset.Name}
 													</span>
+													{preset.Default && (
+														<Badge size="xs" className="shrink-0">
+															Default
+														</Badge>
+													)}
 													{preset.Description && (
 														<Tooltip>
 															<TooltipTrigger asChild>

--- a/site/src/modules/tasks/TaskPrompt/TemplateVersionSelect.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TemplateVersionSelect.tsx
@@ -48,10 +48,10 @@ export const TemplateVersionSelect: FC<TemplateVersionSelectProps> = ({
 				{versions.map((version) => {
 					return (
 						<SelectItem value={version.id} key={version.id}>
-							<span className="flex items-center gap-2">
-								{version.name}
+							<span className="flex items-center gap-2 min-w-0">
+								<span className="truncate">{version.name}</span>
 								{activeVersionId === version.id && (
-									<Badge size="xs" variant="green">
+									<Badge size="xs" variant="green" className="shrink-0">
 										Active
 									</Badge>
 								)}

--- a/site/src/pages/TasksPage/TasksPage.tsx
+++ b/site/src/pages/TasksPage/TasksPage.tsx
@@ -177,10 +177,10 @@ const TasksPage: FC = () => {
 							<section className="py-8">
 								{permissions.viewDeploymentConfig && (
 									<section
-										className="mt-6 flex justify-between"
+										className="mt-6 flex justify-between gap-2 min-w-0"
 										aria-label="Controls"
 									>
-										<div className="flex items-center bg-surface-secondary rounded-lg p-1">
+										<div className="flex items-center bg-surface-secondary rounded-lg p-1 shrink-0">
 											<PillButton
 												active={tab.value === "all"}
 												onClick={() => {

--- a/site/src/pages/TasksPage/UsersCombobox.tsx
+++ b/site/src/pages/TasksPage/UsersCombobox.tsx
@@ -60,7 +60,7 @@ export const UsersCombobox: FC<UsersComboboxProps> = ({
 					variant="outline"
 					role="combobox"
 					aria-expanded={open}
-					className="w-[280px] justify-between"
+					className="w-[280px] shrink min-w-0 overflow-hidden justify-between"
 				>
 					{options ? (
 						selectedOption ? (
@@ -123,9 +123,13 @@ type UserItemProps = {
 
 const UserItem: FC<UserItemProps> = ({ option, className }) => {
 	return (
-		<div className={cn("flex flex-1 items-center gap-2", className)}>
-			<Avatar src={option.avatarUrl} fallback={option.label} />
-			{option.label}
+		<div className={cn("flex flex-1 items-center gap-2 min-w-0", className)}>
+			<Avatar
+				src={option.avatarUrl}
+				fallback={option.label}
+				className="shrink-0"
+			/>
+			<span className="truncate">{option.label}</span>
 		</div>
 	);
 };


### PR DESCRIPTION
Follow-up #22036

This pull-request implements a proper layout with content on mobile displays. This will let us more effectively target mobile users within `/tasks` with various layout improvements.

- Vertical dropdown groups.
- Larger hit targets on dropdown groups.
- Larger `create task` button.
- Resolution to tabs + user dropdown offscreen overflow.

| Old | New |
| --- | --- |
| <img width="432" height="689" alt="TASKS_MOBILE_OLD" src="https://github.com/user-attachments/assets/ceec90ad-9b96-47e0-ad7b-0d0bc2906a44" /> | <img width="432" height="689" alt="TASKS_MOBILE_NEW" src="https://github.com/user-attachments/assets/85e6dc6c-a420-4937-9c11-9c40518eb5d5" /> |
