### PR TITLE
fix: resolve mobile menu navigation

### DIFF
--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -63,7 +63,7 @@ export const MobileMenu: FC<MobileMenuProps> = ({
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			{open && (
-				<div className="fixed inset-0 top-[72px] backdrop-blur-sm z-10 bg-surface-primary/50" />
+				<div className="fixed inset-0 backdrop-blur-sm z-10 bg-surface-primary/50" />
 			)}
 			<DropdownMenuTrigger asChild>
 				<Button

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -70,7 +70,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 				)}
 			</NavLink>
 
-			<NavItems className="ml-4" user={user} />
+			<NavItems className="flex-1 overflow-y-auto px-4" user={user} />
 
 			<div className="flex items-center gap-3 ml-auto">
 				{supportLinks.filter(isNavbarLink).map((link) => (


### PR DESCRIPTION
This pull-request resolves the header navigation on mobile, meaning things won't go off the screen if we have too much content (i.e by adding tasks or other menu items). Furthermore, resolved another issue where the hamburger menu would be too far from the top of the screen.


https://github.com/user-attachments/assets/7daa97c6-62d4-40d5-9478-5eda01ce3a2f

