### PR TITLE
chore: remove dbmem comment references

### DIFF
--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -93,7 +93,6 @@ type TxOptions struct {
 
 // IncrementExecutionCount is a helper function for external packages
 // to increment the unexported count.
-// Mainly for `dbmem`.
 func IncrementExecutionCount(opts *TxOptions) {
 	opts.executionCount++
 }

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -262,8 +262,6 @@ func TestWebhookDispatch(t *testing.T) {
 	// This is not strictly necessary for this test, but it's testing some side logic which is too small for its own test.
 	require.Equal(t, payload.Payload.UserName, name)
 	require.Equal(t, payload.Payload.UserUsername, username)
-	// Right now we don't have a way to query notification templates by ID in dbmem, and it's not necessary to add this
-	// just to satisfy this test. We can safely assume that as long as this value is not empty that the given value was delivered.
 	require.NotEmpty(t, payload.Payload.NotificationName)
 }
 


### PR DESCRIPTION
👻 The ghost of dbmem managed to live on... until now.