### PR TITLE
feat(site): show task log preview in paused and failed states

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2777,6 +2777,16 @@ class ApiMethods {
 		await this.axios.delete(`/api/v2/tasks/${user}/${id}`);
 	};
 
+	getTaskLogs = async (
+		user: string,
+		id: string,
+	): Promise<TypesGen.TaskLogsResponse> => {
+		const response = await this.axios.get<TypesGen.TaskLogsResponse>(
+			`/api/v2/tasks/${user}/${id}/logs`,
+		);
+		return response.data;
+	};
+
 	updateTaskInput = async (
 		user: string,
 		id: string,

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2777,16 +2777,6 @@ class ApiMethods {
 		await this.axios.delete(`/api/v2/tasks/${user}/${id}`);
 	};
 
-	getTaskLogs = async (
-		user: string,
-		id: string,
-	): Promise<TypesGen.TaskLogsResponse> => {
-		const response = await this.axios.get<TypesGen.TaskLogsResponse>(
-			`/api/v2/tasks/${user}/${id}/logs`,
-		);
-		return response.data;
-	};
-
 	updateTaskInput = async (
 		user: string,
 		id: string,

--- a/site/src/api/queries/tasks.ts
+++ b/site/src/api/queries/tasks.ts
@@ -2,6 +2,11 @@ import { API } from "api/api";
 import type { Task } from "api/typesGenerated";
 import type { QueryClient } from "react-query";
 
+export const taskLogs = (user: string, taskId: string) => ({
+	queryKey: ["tasks", user, taskId, "logs"],
+	queryFn: () => API.getTaskLogs(user, taskId),
+});
+
 export const pauseTask = (task: Task, queryClient: QueryClient) => {
 	return {
 		mutationFn: async () => {

--- a/site/src/api/queries/tasks.ts
+++ b/site/src/api/queries/tasks.ts
@@ -2,8 +2,15 @@ import { API } from "api/api";
 import type { Task } from "api/typesGenerated";
 import type { QueryClient } from "react-query";
 
+export const taskLogsKey = (user: string, taskId: string) => [
+	"tasks",
+	user,
+	taskId,
+	"logs",
+];
+
 export const taskLogs = (user: string, taskId: string) => ({
-	queryKey: ["tasks", user, taskId, "logs"],
+	queryKey: taskLogsKey(user, taskId),
 	queryFn: () => API.getTaskLogs(user, taskId),
 });
 

--- a/site/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/site/src/components/InfoTooltip/InfoTooltip.tsx
@@ -12,7 +12,7 @@ import { cn } from "utils/cn";
 
 interface InfoTooltipProps {
 	type?: ThemeRole;
-	title: ReactNode;
+	title?: ReactNode;
 	message: ReactNode;
 }
 
@@ -39,7 +39,7 @@ export const InfoTooltip: FC<InfoTooltipProps> = ({
 				<HelpTooltipIcon className={cn(tooltipColorClasses[type])} />
 			</HelpTooltipIconTrigger>
 			<HelpTooltipContent>
-				<HelpTooltipTitle>{title}</HelpTooltipTitle>
+				{title && <HelpTooltipTitle>{title}</HelpTooltipTitle>}
 				<HelpTooltipText>{message}</HelpTooltipText>
 			</HelpTooltipContent>
 		</HelpTooltip>

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -310,6 +310,23 @@ export const TaskPausedNoSnapshot: Story = {
 	},
 };
 
+export const TaskPausedEmptySnapshot: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTask").mockResolvedValue({
+			...MockTask,
+			status: "paused",
+		});
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			MockStoppedWorkspace,
+		);
+		spyOn(API, "getTaskLogs").mockResolvedValue({
+			snapshot: true,
+			snapshot_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+			logs: [],
+		});
+	},
+};
+
 export const TaskPausedSingleMessage: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTask").mockResolvedValue({

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -31,6 +31,7 @@ import {
 } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
+import { taskLogsKey } from "api/queries/tasks";
 import type {
 	Task,
 	TaskLogsResponse,
@@ -225,6 +226,19 @@ export const FailedBuild: Story = {
 	},
 };
 
+export const FailedBuildNoSnapshot: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTask").mockResolvedValue(MockTask);
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			MockFailedWorkspace,
+		);
+		spyOn(API, "getTaskLogs").mockResolvedValue({
+			snapshot: true,
+			logs: [],
+		});
+	},
+};
+
 export const TerminatedBuild: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTask").mockResolvedValue(MockTask);
@@ -277,6 +291,39 @@ export const TaskPaused: Story = {
 			MockStoppedWorkspace,
 		);
 		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
+	},
+};
+
+export const TaskPausedNoSnapshot: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTask").mockResolvedValue({
+			...MockTask,
+			status: "paused",
+		});
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			MockStoppedWorkspace,
+		);
+		spyOn(API, "getTaskLogs").mockResolvedValue({
+			snapshot: true,
+			logs: [],
+		});
+	},
+};
+
+export const TaskPausedSingleMessage: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTask").mockResolvedValue({
+			...MockTask,
+			status: "paused",
+		});
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			MockStoppedWorkspace,
+		);
+		spyOn(API, "getTaskLogs").mockResolvedValue({
+			snapshot: true,
+			snapshot_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+			logs: [MockTaskLogsResponse.logs[0]],
+		});
 	},
 };
 
@@ -610,7 +657,7 @@ export const TaskPausedOutdated: Story = {
 				data: [],
 			},
 			{
-				key: ["tasks", MockTask.owner_name, MockTask.id, "logs"],
+				key: taskLogsKey(MockTask.owner_name, MockTask.id),
 				data: MockTaskLogsResponse,
 			},
 		],

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -31,7 +31,12 @@ import {
 } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
-import type { Task, Workspace, WorkspaceApp } from "api/typesGenerated";
+import type {
+	Task,
+	TaskLogsResponse,
+	Workspace,
+	WorkspaceApp,
+} from "api/typesGenerated";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import TaskPage from "./TaskPage";
@@ -66,6 +71,48 @@ const MockVSCodeApp: WorkspaceApp = {
 	display_name: "VS Code Web",
 	icon: "/icon/code.svg",
 	health: "healthy",
+};
+
+const MockTaskLogsResponse: TaskLogsResponse = {
+	logs: [
+		{
+			id: 1,
+			content:
+				"I'll help you implement the authentication system. Let me start by examining the existing code structure.",
+			type: "output",
+			time: "2024-01-01T12:00:00Z",
+		},
+		{
+			id: 2,
+			content:
+				"Looking at the codebase, I can see the following relevant files:\n- src/auth/login.ts\n- src/auth/middleware.ts\n- src/models/user.ts",
+			type: "output",
+			time: "2024-01-01T12:00:05Z",
+		},
+		{
+			id: 3,
+			content:
+				"I'll now create the JWT token validation middleware. This will intercept all protected routes and verify the bearer token.",
+			type: "output",
+			time: "2024-01-01T12:00:10Z",
+		},
+		{
+			id: 4,
+			content:
+				"Successfully updated src/auth/middleware.ts with the new token validation logic.\nRunning tests to verify the changes...",
+			type: "output",
+			time: "2024-01-01T12:00:15Z",
+		},
+		{
+			id: 5,
+			content:
+				"All 12 tests passed. The authentication middleware is working correctly.\n\nNext, I'll add the refresh token rotation endpoint to prevent token reuse attacks.",
+			type: "output",
+			time: "2024-01-01T12:00:20Z",
+		},
+	],
+	snapshot: true,
+	snapshot_at: new Date().toISOString(),
 };
 
 const meta: Meta<typeof TaskPage> = {
@@ -154,6 +201,7 @@ export const FailedBuild: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockFailedWorkspace,
 		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 };
 
@@ -163,6 +211,7 @@ export const TerminatedBuild: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 };
 
@@ -173,6 +222,7 @@ export const TerminatedBuildWithStatus: Story = {
 			...MockStoppedWorkspace,
 			latest_app_status: MockWorkspaceAppStatus,
 		});
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 };
 
@@ -206,6 +256,7 @@ export const TaskPaused: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 };
 
@@ -223,6 +274,7 @@ export const TaskPausedTimeout: Story = {
 				reason: "task_auto_pause",
 			},
 		});
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 };
 
@@ -235,6 +287,7 @@ export const TaskCanceled: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockCanceledWorkspace,
 		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 };
 
@@ -511,6 +564,10 @@ export const TaskPausedOutdated: Story = {
 				],
 				data: [],
 			},
+			{
+				key: ["tasks", MockTask.owner_name, MockTask.id, "logs"],
+				data: MockTaskLogsResponse,
+			},
 		],
 	},
 	// Then: a tooltip should be displayed prompting the user to update the workspace.
@@ -576,6 +633,7 @@ export const TaskResuming: Story = {
 		spyOn(API, "startWorkspace").mockResolvedValue(
 			MockStartingWorkspace.latest_build,
 		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -617,6 +675,7 @@ export const TaskResumeFailure: Story = {
 		spyOn(API, "startWorkspace").mockRejectedValue(
 			new Error("Some unexpected error"),
 		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({
@@ -659,6 +718,7 @@ export const TaskResumeFailureWithDialog: Story = {
 			}),
 			code: "ERR_BAD_REQUEST",
 		});
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 	parameters: {
 		reactRouter: reactRouterParameters({

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -37,7 +37,14 @@ import type {
 	Workspace,
 	WorkspaceApp,
 } from "api/typesGenerated";
-import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import {
+	expect,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import TaskPage from "./TaskPage";
 
@@ -77,34 +84,47 @@ const MockTaskLogsResponse: TaskLogsResponse = {
 	logs: [
 		{
 			id: 1,
+			content: "Implement JWT authentication with refresh token rotation.",
+			type: "input",
+			time: "2024-01-01T11:59:55Z",
+		},
+		{
+			id: 2,
 			content:
 				"I'll help you implement the authentication system. Let me start by examining the existing code structure.",
 			type: "output",
 			time: "2024-01-01T12:00:00Z",
 		},
 		{
-			id: 2,
+			id: 3,
 			content:
 				"Looking at the codebase, I can see the following relevant files:\n- src/auth/login.ts\n- src/auth/middleware.ts\n- src/models/user.ts",
 			type: "output",
 			time: "2024-01-01T12:00:05Z",
 		},
 		{
-			id: 3,
+			id: 4,
 			content:
 				"I'll now create the JWT token validation middleware. This will intercept all protected routes and verify the bearer token.",
 			type: "output",
 			time: "2024-01-01T12:00:10Z",
 		},
 		{
-			id: 4,
+			id: 5,
+			content:
+				"Looks good so far. Also add rate limiting to the token endpoint.",
+			type: "input",
+			time: "2024-01-01T12:00:12Z",
+		},
+		{
+			id: 6,
 			content:
 				"Successfully updated src/auth/middleware.ts with the new token validation logic.\nRunning tests to verify the changes...",
 			type: "output",
 			time: "2024-01-01T12:00:15Z",
 		},
 		{
-			id: 5,
+			id: 7,
 			content:
 				"All 12 tests passed. The authentication middleware is working correctly.\n\nNext, I'll add the refresh token rotation endpoint to prevent token reuse attacks.",
 			type: "output",
@@ -112,7 +132,7 @@ const MockTaskLogsResponse: TaskLogsResponse = {
 		},
 	],
 	snapshot: true,
-	snapshot_at: new Date().toISOString(),
+	snapshot_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
 };
 
 const meta: Meta<typeof TaskPage> = {
@@ -257,6 +277,31 @@ export const TaskPaused: Story = {
 			MockStoppedWorkspace,
 		);
 		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
+	},
+};
+
+export const TaskPausedSnapshotTooltip: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTask").mockResolvedValue({
+			...MockTask,
+			status: "paused",
+		});
+		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
+			MockStoppedWorkspace,
+		);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const tooltipTrigger = await canvas.findByRole("button", {
+			name: /info/i,
+		});
+		await userEvent.hover(tooltipTrigger);
+		await waitFor(() =>
+			expect(screen.getByRole("tooltip")).toHaveTextContent(
+				/This log snapshot was taken/,
+			),
+		);
 	},
 };
 

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -324,8 +324,6 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 	headerAction,
 	snapshotAt,
 }) => {
-	const hasLogs = logs.length > 0;
-
 	// Scroll to the bottom on mount since snapshot logs are static.
 	const scrollToBottom = useCallback((el: HTMLDivElement | null) => {
 		if (!isChromatic() && el) {
@@ -348,37 +346,43 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 					</span>
 					{headerAction}
 				</div>
-				{hasLogs ? (
-					<ScrollArea className="h-96">
-						<div
-							ref={scrollToBottom}
-							className="p-4 font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap break-words"
-						>
-							{logs.map((entry, index) => {
-								const prev = index === 0 ? undefined : logs[index - 1];
-								const isNewGroup = !prev || prev.type !== entry.type;
-								return (
-									<div
-										key={entry.id}
-										className={cn(
-											"pl-3 border-0 border-l-2 border-solid",
-											entry.type === "input"
-												? "border-l-border-pending"
-												: "border-l-border-purple",
-											isNewGroup && index > 0 && "mt-4",
-										)}
-									>
-										{isNewGroup && (
-											<div className="text-content-primary font-semibold mb-1">
-												{entry.type === "input" ? "[user]" : "[agent]"}
-											</div>
-										)}
-										{entry.content || "\u00A0"}
-									</div>
-								);
-							})}
-						</div>
-					</ScrollArea>
+				{snapshotAt ? (
+					logs.length > 0 ? (
+						<ScrollArea className="h-96">
+							<div
+								ref={scrollToBottom}
+								className="p-4 font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap break-words"
+							>
+								{logs.map((entry, index) => {
+									const prev = index === 0 ? undefined : logs[index - 1];
+									const isNewGroup = !prev || prev.type !== entry.type;
+									return (
+										<div
+											key={entry.id}
+											className={cn(
+												"pl-3 border-0 border-l-2 border-solid",
+												entry.type === "input"
+													? "border-l-border-pending"
+													: "border-l-border-purple",
+												isNewGroup && index > 0 && "mt-4",
+											)}
+										>
+											{isNewGroup && (
+												<div className="text-content-primary font-semibold mb-1">
+													{entry.type === "input" ? "[user]" : "[agent]"}
+												</div>
+											)}
+											{entry.content || "\u00A0"}
+										</div>
+									);
+								})}
+							</div>
+						</ScrollArea>
+					) : (
+						<p className="px-4 py-3 text-sm text-content-secondary m-0">
+							No log messages in this snapshot.
+						</p>
+					)
 				) : (
 					<p className="px-4 py-3 text-sm text-content-secondary m-0">
 						No log snapshot available. Resume your task to view logs.

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -338,21 +338,20 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 	const scrollAreaRef = useScrollAreaAutoScroll([visibleLogs]);
 
 	return (
-		<div className="w-full max-w-screen-lg flex flex-col gap-2">
-			<div className="flex items-center justify-between text-sm text-content-secondary px-1">
-				<span>Last {maxMessages} messages of AI chat logs</span>
-				{headerAction}
-			</div>
-			<ScrollArea
-				ref={scrollAreaRef}
-				className="h-96 border border-solid border-border rounded-lg"
-			>
-				<div className="p-4 font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap break-words">
-					{visibleLogs.map((entry) => (
-						<div key={entry.id}>{entry.content || "\u00A0"}</div>
-					))}
+		<div className="w-full max-w-screen-lg mx-auto px-16">
+			<div className="border border-solid border-border rounded-lg overflow-hidden">
+				<div className="flex items-center justify-between px-4 py-2 border-b border-solid border-border bg-surface-secondary text-sm text-content-secondary">
+					<span>Last {maxMessages} messages of AI chat logs</span>
+					{headerAction}
 				</div>
-			</ScrollArea>
+				<ScrollArea ref={scrollAreaRef} className="h-96">
+					<div className="p-4 font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap break-words">
+						{visibleLogs.map((entry) => (
+							<div key={entry.id}>{entry.content || "\u00A0"}</div>
+						))}
+					</div>
+				</ScrollArea>
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -320,12 +320,10 @@ function logPreviewLabel(count: number): string {
 
 const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 	logs,
-	maxMessages = 30,
 	headerAction,
 	snapshotAt,
 }) => {
-	const visibleLogs = logs.slice(-maxMessages);
-	const hasLogs = visibleLogs.length > 0;
+	const hasLogs = logs.length > 0;
 
 	// Scroll to the bottom on mount since snapshot logs are static.
 	const scrollToBottom = useRef((el: HTMLDivElement | null) => {
@@ -339,7 +337,7 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 			<div className="border border-solid border-border rounded-lg overflow-hidden">
 				<div className="flex items-center justify-between px-4 py-2 border-0 border-b border-solid border-border bg-surface-secondary text-sm text-content-secondary">
 					<span className="flex items-center gap-1.5">
-						{logPreviewLabel(visibleLogs.length)}
+						{logPreviewLabel(logs.length)}
 						{snapshotAt && (
 							<InfoTooltip
 								type="info"
@@ -355,8 +353,8 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 							ref={scrollToBottom}
 							className="p-4 font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap break-words"
 						>
-							{visibleLogs.map((entry, index) => {
-								const prev = visibleLogs[index - 1];
+							{logs.map((entry, index) => {
+								const prev = index === 0 ? undefined : logs[index - 1];
 								const isNewGroup = !prev || prev.type !== entry.type;
 								return (
 									<div

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -37,6 +37,7 @@ import {
 	type FC,
 	type PropsWithChildren,
 	type ReactNode,
+	useCallback,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -326,11 +327,11 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 	const hasLogs = logs.length > 0;
 
 	// Scroll to the bottom on mount since snapshot logs are static.
-	const scrollToBottom = useRef((el: HTMLDivElement | null) => {
+	const scrollToBottom = useCallback((el: HTMLDivElement | null) => {
 		if (!isChromatic() && el) {
 			el.scrollIntoView({ block: "end" });
 		}
-	}).current;
+	}, []);
 
 	return (
 		<div className="w-full max-w-screen-lg mx-auto px-16">

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -325,23 +325,22 @@ function useScrollAreaAutoScroll(deps: DependencyList) {
 
 type TaskLogPreviewProps = {
 	logs: readonly TaskLogEntry[];
-	maxLines?: number;
+	maxMessages?: number;
 	headerAction?: ReactNode;
 };
 
 const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 	logs,
-	maxLines = 30,
+	maxMessages = 30,
 	headerAction,
 }) => {
-	const lines = logs.flatMap((entry) => entry.content.split("\n"));
-	const visibleLines = lines.slice(-maxLines);
-	const scrollAreaRef = useScrollAreaAutoScroll([visibleLines]);
+	const visibleLogs = logs.slice(-maxMessages);
+	const scrollAreaRef = useScrollAreaAutoScroll([visibleLogs]);
 
 	return (
 		<div className="w-full max-w-screen-lg flex flex-col gap-2">
 			<div className="flex items-center justify-between text-sm text-content-secondary px-1">
-				<span>Last {maxLines} lines of AI chat logs</span>
+				<span>Last {maxMessages} messages of AI chat logs</span>
 				{headerAction}
 			</div>
 			<ScrollArea
@@ -349,8 +348,8 @@ const TaskLogPreview: FC<TaskLogPreviewProps> = ({
 				className="h-96 border border-solid border-border rounded-lg"
 			>
 				<div className="p-4 font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap break-words">
-					{visibleLines.map((line, i) => (
-						<div key={i}>{line || "\u00A0"}</div>
+					{visibleLogs.map((entry) => (
+						<div key={entry.id}>{entry.content || "\u00A0"}</div>
 					))}
 				</div>
 			</ScrollArea>


### PR DESCRIPTION
Shows a preview of the last 30 AI chat log messages when a task is paused or its build has failed, giving users context about what happened before the task stopped.

- Add `TaskLogPreview` component with auto-scroll, `[user]`/`[agent]` group labels, and a left border on each log line
- Show a snapshot timestamp tooltip in the log header when logs come from a point-in-time snapshot
- Make `InfoTooltip` `title` prop optional
- Extract `useScrollAreaAutoScroll` hook shared with `BuildingWorkspace`

Closes coder/internal#1268