### PR TITLE
fix: resolve overflow on `<TemplateInsightsPage />` `Parameters usage`

### DIFF
--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
@@ -187,6 +187,29 @@ export const Loaded: Story = {
 						{
 							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
 							display_name: "",
+							name: "GitHub Dotfiles",
+							type: "string",
+							description: "This string is optional",
+							values: [
+								{
+									value:
+										"https://github.com/jakehwll/my-comprehensive-dotfiles-with-neovim-tmux-zsh-and-alacritty-configurations",
+									count: 1,
+								},
+								{
+									value: "https://github.com/aslilac/dotfiles",
+									count: 1000000000,
+								},
+								{
+									value:
+										"https://github.com/jaaydenh/dotfiles-and-shell-scripts",
+									count: 3,
+								},
+							],
+						},
+						{
+							template_ids: ["7dd1d090-3e23-4ada-8894-3945affcad42"],
+							display_name: "",
 							name: "Region",
 							type: "string",
 							description: "These are options.",

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -35,10 +35,15 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { CircleCheck as CircleCheckIcon, CircleXIcon } from "lucide-react";
+import {
+	CircleCheck as CircleCheckIcon,
+	CircleXIcon,
+	SquareArrowOutUpRightIcon,
+} from "lucide-react";
 import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
 import {
 	type FC,
+	Fragment,
 	type HTMLAttributes,
 	type PropsWithChildren,
 	type ReactNode,
@@ -505,29 +510,38 @@ const TemplateParametersUsagePanel: FC<TemplateParametersUsagePanelProps> = ({
 									{parameter.description}
 								</p>
 							</div>
-							<div className="flex-1 text-[14px]" style={{ flexGrow: 2 }}>
-								<ParameterUsageRow className="font-medium text-[13px] cursor-default text-content-secondary">
-									<div>Value</div>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<div>Count</div>
-										</TooltipTrigger>
-										<TooltipContent>
-											The number of workspaces using this value
-										</TooltipContent>
-									</Tooltip>
-								</ParameterUsageRow>
+							<div
+								className="flex-1 text-sm grid grid-cols-[1fr_auto] gap-x-4 items-baseline"
+								style={{ flexGrow: 2 }}
+							>
+								<div className="font-medium text-[13px] text-content-secondary py-1">
+									Value
+								</div>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="font-medium text-[13px] text-content-secondary text-right py-1 cursor-default">
+											Count
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>
+										The number of workspaces using this value
+									</TooltipContent>
+								</Tooltip>
 								{[...parameter.values]
 									.sort((a, b) => b.count - a.count)
 									.filter((usage) => filterOrphanValues(usage, parameter))
 									.map((usage, usageIndex) => (
-										<ParameterUsageRow key={`${parameterIndex}-${usageIndex}`}>
-											<ParameterUsageLabel
-												usage={usage}
-												parameter={parameter}
-											/>
-											<div className="text-right">{usage.count}</div>
-										</ParameterUsageRow>
+										<Fragment key={`${parameterIndex}-${usageIndex}`}>
+											<div className="min-w-0 py-1">
+												<ParameterUsageLabel
+													usage={usage}
+													parameter={parameter}
+												/>
+											</div>
+											<div className="text-right py-1">
+												{usage.count.toLocaleString()}
+											</div>
+										</Fragment>
 									))}
 							</div>
 						</div>
@@ -546,21 +560,6 @@ const filterOrphanValues = (
 		return parameter.options.some((o) => o.value === usage.value);
 	}
 	return true;
-};
-
-const ParameterUsageRow: FC<HTMLAttributes<HTMLDivElement>> = ({
-	children,
-	className,
-	...attrs
-}) => {
-	return (
-		<div
-			{...attrs}
-			className={cn("flex items-baseline justify-between py-1", className)}
-		>
-			{children}
-		</div>
-	);
 };
 
 interface ParameterUsageLabelProps {
@@ -598,9 +597,23 @@ const ParameterUsageLabel: FC<ParameterUsageLabelProps> = ({
 
 	if (usage.value.startsWith("http")) {
 		return (
-			<Link href={usage.value} target="_blank" rel="noreferrer">
-				<TextValue>{usage.value}</TextValue>
-			</Link>
+			<span className="break-all">
+				<span className="mr-0.5 text-content-secondary">&quot;</span>
+				<Link
+					href={usage.value}
+					target="_blank"
+					rel="noreferrer"
+					showExternalIcon={false}
+					// We're using a manual underline because `inline`
+					// removes it from the first line of the text when it wraps.
+					className="inline hover:underline after:hover:content-none"
+				>
+					{usage.value}
+				</Link>
+				{/* Manual icon because we want to support multi-line. */}
+				<SquareArrowOutUpRightIcon className="inline-flex align-text-bottom size-icon-sm p-0.5 text-content-link" />
+				<span className="ml-0.5 text-content-secondary">&quot;</span>
+			</span>
 		);
 	}
 
@@ -720,7 +733,7 @@ const NoDataAvailable: FC<NoDataAvailableProps> = ({ error, ...props }) => {
 
 const TextValue: FC<PropsWithChildren> = ({ children }) => {
 	return (
-		<span>
+		<span className="break-all">
 			<span className="mr-0.5 text-content-secondary">&quot;</span>
 			{children}
 			<span className="ml-0.5 text-content-secondary">&quot;</span>

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -510,9 +510,7 @@ const TemplateParametersUsagePanel: FC<TemplateParametersUsagePanelProps> = ({
 									{parameter.description}
 								</p>
 							</div>
-							<div
-								className="flex-1 grow-2 text-sm grid grid-cols-[1fr_auto] gap-x-4 items-baseline"
-							>
+							<div className="flex-1 grow-2 text-sm grid grid-cols-[1fr_auto] gap-x-4 items-baseline">
 								<div className="font-medium text-[13px] text-content-secondary py-1">
 									Value
 								</div>

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -511,8 +511,7 @@ const TemplateParametersUsagePanel: FC<TemplateParametersUsagePanelProps> = ({
 								</p>
 							</div>
 							<div
-								className="flex-1 text-sm grid grid-cols-[1fr_auto] gap-x-4 items-baseline"
-								style={{ flexGrow: 2 }}
+								className="flex-1 grow-2 text-sm grid grid-cols-[1fr_auto] gap-x-4 items-baseline"
 							>
 								<div className="font-medium text-[13px] text-content-secondary py-1">
 									Value


### PR DESCRIPTION
Closes #19954 

This pull-request ensures content doesn't overflow the screen when looking at `Parameters usage` in `<TemplateInsightsPage />`. 

| Old | New |
| --- | --- | 
| <img width="1120" height="211" alt="TEMPLATE_ANALYTICS_OLD" src="https://github.com/user-attachments/assets/88f35aef-6ade-425c-ae03-7e43d9da192a" /> | <img width="1121" height="211" alt="TEMPLATE_ANALYTICS_NEW" src="https://github.com/user-attachments/assets/7cde6baa-ea0e-4a94-9246-a5fdf3c9c081" /> |
