### PR TITLE
fix: upgrade `font-weight` in `<Welcome />` heading

### DIFF
--- a/site/src/components/Welcome/Welcome.tsx
+++ b/site/src/components/Welcome/Welcome.tsx
@@ -13,7 +13,7 @@ export const Welcome: FC<WelcomeProps> = ({ children, className }) => {
 				<CoderIcon className="w-12 h-12" />
 			</div>
 
-			<h1 className="text-3xl font-semibold m-0 flex items-center text-center leading-snug">
+			<h1 className="text-3xl font-semibold m-0 flex justify-center items-center text-center leading-snug">
 				{children || "Welcome to Coder"}
 			</h1>
 		</div>

--- a/site/src/components/Welcome/Welcome.tsx
+++ b/site/src/components/Welcome/Welcome.tsx
@@ -1,14 +1,6 @@
 import type { FC, PropsWithChildren } from "react";
 import { CoderIcon } from "../Icons/CoderIcon";
 
-const Language = {
-	defaultMessage: (
-		<>
-			Welcome to <strong>Coder</strong>
-		</>
-	),
-};
-
 type WelcomeProps = Readonly<
 	PropsWithChildren<{
 		className?: string;
@@ -21,8 +13,8 @@ export const Welcome: FC<WelcomeProps> = ({ children, className }) => {
 				<CoderIcon className="w-12 h-12" />
 			</div>
 
-			<h1 className="text-center text-3xl font-normal m-0 leading-[1.1] pb-4 [&_strong]:font-semibold">
-				{children || Language.defaultMessage}
+			<h1 className="text-3xl font-semibold m-0 flex items-center text-center leading-snug">
+				{children || "Welcome to Coder"}
 			</h1>
 		</div>
 	);


### PR DESCRIPTION
This pull-request ensures we're globally using a similar `font-weight` in the `<Welcome />` component (specifically noticed on `cli-auth`).