### PR TITLE
feat: animate `<TerminalAlerts />` when `isRefreshing`

### DIFF
--- a/site/src/pages/TerminalPage/TerminalAlerts.tsx
+++ b/site/src/pages/TerminalPage/TerminalAlerts.tsx
@@ -206,7 +206,7 @@ const RefreshSessionButton: FC = () => {
 				window.location.reload();
 			}}
 		>
-			<RefreshCwIcon className={cn(isRefreshing && "animate-spin")}  />
+			<RefreshCwIcon className={cn(isRefreshing && "animate-spin")} />
 			{isRefreshing ? "Refreshing session..." : "Refresh session"}
 		</Button>
 	);

--- a/site/src/pages/TerminalPage/TerminalAlerts.tsx
+++ b/site/src/pages/TerminalPage/TerminalAlerts.tsx
@@ -6,7 +6,7 @@ import {
 } from "components/Alert/Alert";
 import { Button } from "components/Button/Button";
 import { Link } from "components/Link/Link";
-import { RefreshCcwIcon } from "lucide-react";
+import { RefreshCwIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
 import { cn } from "utils/cn";
 import { docs } from "utils/docs";
@@ -206,7 +206,7 @@ const RefreshSessionButton: FC = () => {
 				window.location.reload();
 			}}
 		>
-			<RefreshCcwIcon />
+			<RefreshCwIcon className={cn(isRefreshing && "animate-spin")}  />
 			{isRefreshing ? "Refreshing session..." : "Refresh session"}
 		</Button>
 	);


### PR DESCRIPTION
Follow up to #22004

This pull-request adds a bit of flavour to the frontend. I noticed in another use case we were actually animating this icon and it was using the `<RefreshCwIcon />` instead of `<RefreshCcwIcon />`.