### PR TITLE
fix: remove `fullscreen` from `<ExternalAuthPageView />` `<Loading />`

### DIFF
--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -59,7 +59,7 @@ export const ExternalAuthPageView: FC<ExternalAuthPageViewProps> = ({
 	}
 
 	if (isLoading || !auths) {
-		return <Loader fullscreen />;
+		return <Loader />;
 	}
 
 	return (


### PR DESCRIPTION
This pull-request addresses an annoyance I found when navigating through the User Settings routes. Essentially when the content is unloaded here we're flashing the `<Loader />` across the whole screen. This is unlike any other page we use within User Settings and causes the sidebar to hide momentarily whilst covered by the `<Loader />`

The simple fix is just to remove the `fullscreen` prop from `<Loader />`

https://github.com/user-attachments/assets/fc019935-a17a-4fe9-9919-635c5e026f91