### PR TITLE
feat: improve SSH disconnect reasons diagnostics

### DIFF
--- a/enterprise/coderd/diagnostic_internal_test.go
+++ b/enterprise/coderd/diagnostic_internal_test.go
@@ -1,0 +1,105 @@
+package coderd
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestClassifySessionStatusUnexpectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	status := classifySessionStatus(
+		"connection ended unexpectedly: session closed without explicit reason (exit code: 1)",
+		true,
+		false,
+	)
+	assert.Equal(t, codersdk.ConnectionStatusControlLost, status)
+}
+
+func TestClassifySessionStatusProcessExitMinusOne(t *testing.T) {
+	t.Parallel()
+
+	status := classifySessionStatus(
+		"process exited with error status: -1",
+		true,
+		false,
+	)
+	assert.Equal(t, codersdk.ConnectionStatusControlLost, status)
+}
+
+func TestGenerateExplanationUnexpectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	explanation := generateExplanation(
+		"connection ended unexpectedly: session closed without explicit reason (exit code: 1)",
+		false,
+	)
+	assert.Equal(t, "Connection lost unexpectedly.", explanation)
+}
+
+func TestGenerateExplanationProcessExitMinusOne(t *testing.T) {
+	t.Parallel()
+
+	explanation := generateExplanation(
+		"process exited with error status: -1",
+		false,
+	)
+	assert.Equal(t, "Connection lost unexpectedly.", explanation)
+}
+
+func TestConvertSessionConnectionUnexpectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	conn := convertSessionConnection(database.ConnectionLog{
+		ID:   uuid.New(),
+		Type: database.ConnectionTypeSsh,
+		DisconnectTime: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+		DisconnectReason: sql.NullString{
+			String: "connection ended unexpectedly: session closed without explicit reason (exit code: 1)",
+			Valid:  true,
+		},
+	})
+
+	assert.Equal(t, codersdk.ConnectionStatusControlLost, conn.Status)
+	assert.Equal(t, "Connection lost unexpectedly.", conn.Explanation)
+}
+
+func TestBuildTimelineIncludesDisconnectCodeForUnexpectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	events := buildTimeline([]database.ConnectionLog{{
+		ID:          uuid.New(),
+		ConnectTime: now,
+		Type:        database.ConnectionTypeSsh,
+		Code: sql.NullInt32{
+			Int32: 1,
+			Valid: true,
+		},
+		DisconnectTime: sql.NullTime{
+			Time:  now.Add(time.Minute),
+			Valid: true,
+		},
+		DisconnectReason: sql.NullString{
+			String: "connection ended unexpectedly: session closed without explicit reason (exit code: 1)",
+			Valid:  true,
+		},
+	}})
+
+	assert.Len(t, events, 2)
+
+	closeEvent := events[1]
+	assert.Equal(t, codersdk.DiagnosticTimelineEventConnectionClosed, closeEvent.Kind)
+	assert.Equal(t, codersdk.ConnectionDiagnosticSeverityError, closeEvent.Severity)
+	assert.Equal(t, int32(1), closeEvent.Metadata["disconnect_code"])
+}

--- a/site/src/pages/WorkspaceSessionsPage/ConnectionDetailDialog.tsx
+++ b/site/src/pages/WorkspaceSessionsPage/ConnectionDetailDialog.tsx
@@ -1,4 +1,4 @@
-import type { WorkspaceConnection } from "api/typesGenerated";
+import type { DiagnosticTimelineEvent, WorkspaceConnection } from "api/typesGenerated";
 import {
 	Dialog,
 	DialogContent,
@@ -18,6 +18,10 @@ interface ConnectionDetailDialogProps {
 	connection: WorkspaceConnection | null;
 	open: boolean;
 	onClose: () => void;
+	timeline?: readonly DiagnosticTimelineEvent[];
+	timelineLoading?: boolean;
+	timelineError?: unknown;
+	showTimeline?: boolean;
 }
 
 function formatDuration(startISO: string, endISO: string): string {
@@ -57,6 +61,10 @@ export const ConnectionDetailDialog: FC<ConnectionDetailDialogProps> = ({
 	connection,
 	open,
 	onClose,
+	timeline = [],
+	timelineLoading = false,
+	timelineError,
+	showTimeline = false,
 }) => {
 	if (!connection) {
 		return null;
@@ -147,6 +155,55 @@ export const ConnectionDetailDialog: FC<ConnectionDetailDialogProps> = ({
 						<DetailRow label="Home DERP" value={connection.home_derp.name} />
 					)}
 				</div>
+
+				{showTimeline && (
+					<div className="mt-4">
+						<h3 className="text-sm font-semibold mb-2">Timeline</h3>
+						{timelineLoading ? (
+							<p className="text-xs text-content-secondary">
+								Loading timeline…
+							</p>
+						) : timelineError ? (
+							<p className="text-xs text-content-destructive">
+								Unable to load timeline for this session.
+							</p>
+						) : timeline.length === 0 ? (
+							<p className="text-xs text-content-secondary italic">
+								No timeline data for this session.
+							</p>
+						) : (
+							<ol className="max-h-56 overflow-y-auto border border-border rounded p-3 space-y-2">
+								{timeline.map((event, idx) => (
+									<li
+										key={`${event.timestamp}-${idx}`}
+										className="flex items-start gap-2"
+									>
+										<span
+											className={`mt-1.5 inline-block size-2 rounded-full shrink-0 ${
+												event.severity === "error"
+													? "bg-content-destructive"
+													: event.severity === "warning"
+														? "bg-content-warning"
+														: "bg-highlight-sky"
+											}`}
+										/>
+										<span className="text-xs text-content-secondary font-mono shrink-0 w-16">
+											{new Date(event.timestamp).toLocaleTimeString([], {
+												hour: "2-digit",
+												minute: "2-digit",
+												second: "2-digit",
+												hour12: false,
+											})}
+										</span>
+										<span className="text-xs text-content-primary">
+											{event.description}
+										</span>
+									</li>
+								))}
+							</ol>
+						)}
+					</div>
+				)}
 			</DialogContent>
 		</Dialog>
 	);


### PR DESCRIPTION
## Summary
- add SSH agent fallback disconnect reason when a session closes with non-zero code but no explicit reason
- classify additional unexpected SSH disconnect patterns as lost/control-loss in diagnostics (including `process exited with error status: -1`)
- include `disconnect_code` in connection-closed timeline metadata
- add targeted tests for fallback reason behavior and diagnostic classification/timeline severity

## Validation
- go test ./agent/agentssh -run 'TestFallbackDisconnectReason' -count=1
- go test ./enterprise/coderd -run 'TestClassifySessionStatusUnexpectedDisconnect|TestClassifySessionStatusProcessExitMinusOne|TestGenerateExplanationUnexpectedDisconnect|TestGenerateExplanationProcessExitMinusOne|TestConvertSessionConnectionUnexpectedDisconnect|TestBuildTimelineIncludesDisconnectCodeForUnexpectedDisconnect' -count=1

## Context
This improves diagnostics for cases where SSH drops unexpectedly (for example client sleep/network interruption), which previously appeared as clean disconnects.