### PR TITLE
fix(cli/cliui): apply defaults when rendering select prompts

### DIFF
--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -123,6 +123,10 @@ func Select(inv *serpent.Invocation, opts SelectOptions) (string, error) {
 		initialModel.height = defaultSelectModelHeight
 	}
 
+	if idx := slices.Index(opts.Options, opts.Default); idx >= 0 {
+		initialModel.cursor = idx
+	}
+
 	initialModel.search.Prompt = ""
 	initialModel.search.Focus()
 

--- a/cli/exp_prompts.go
+++ b/cli/exp_prompts.go
@@ -109,13 +109,13 @@ func (RootCmd) promptExample() *serpent.Command {
 					Options: []string{
 						"Blue", "Green", "Yellow", "Red", "Something else",
 					},
-					Default:    "",
+					Default:    "Green",
 					Message:    "Select your favorite color:",
 					Size:       5,
 					HideSearch: !useSearch,
 				})
 				if value == "Something else" {
-					_, _ = fmt.Fprint(inv.Stdout, "I would have picked blue.\n")
+					_, _ = fmt.Fprint(inv.Stdout, "I would have picked green.\n")
 				} else {
 					_, _ = fmt.Fprintf(inv.Stdout, "%s is a nice color.\n", value)
 				}
@@ -128,7 +128,7 @@ func (RootCmd) promptExample() *serpent.Command {
 					Options: []string{
 						"Car", "Bike", "Plane", "Boat", "Train",
 					},
-					Default: "Car",
+					Default: "Bike",
 				})
 				if err != nil {
 					return err


### PR DESCRIPTION
Related to: https://github.com/coder/coder/issues/22078

We don't test `cliui.Select()` due to Windows, so no tests :man_shrugging: 