### PR TITLE
fix(site): stop workspace before template version change with dynamic parameters

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2297,6 +2297,24 @@ class ApiMethods {
 		}));
 	};
 
+	/**
+	 * Stop a running workspace and wait for the stop to complete.
+	 * Returns true if the workspace was stopped (or was already stopped),
+	 * false if the stop was canceled.
+	 */
+	private stopWorkspaceIfRunning = async (
+		workspace: TypesGen.Workspace,
+	): Promise<boolean> => {
+		if (workspace.latest_build.status !== "running") {
+			return true;
+		}
+		const stopBuild = await this.stopWorkspace(workspace.id);
+		const awaitedStopBuild = await this.waitForBuild(stopBuild);
+		// If the stop is canceled halfway through, we bail.
+		// This is the same behavior as restartWorkspace.
+		return awaitedStopBuild?.status !== "canceled";
+	};
+
 	/** Steps to change the workspace version
 	 * - Get the latest template to access the latest active version
 	 * - Get the current build parameters
@@ -2304,6 +2322,7 @@ class ApiMethods {
 	 * - Update the build parameters and check if there are missed parameters for
 	 *   the new version
 	 *   - If there are missing parameters raise an error
+	 * - Stop the workspace if it is already running
 	 * - Create a build with the version and updated build parameters
 	 */
 	changeWorkspaceVersion = async (
@@ -2338,6 +2357,13 @@ class ApiMethods {
 			throw new MissingBuildParameters(missingParameters, templateVersionId);
 		}
 
+		const stopped = await this.stopWorkspaceIfRunning(workspace);
+		if (!stopped) {
+			throw new Error(
+				"Workspace stop was canceled, not proceeding with version change.",
+			);
+		}
+
 		return this.postWorkspaceBuild(workspace.id, {
 			transition: "start",
 			template_version_id: templateVersionId,
@@ -2368,6 +2394,13 @@ class ApiMethods {
 		const activeVersionId = template.active_version_id;
 
 		if (isDynamicParametersEnabled) {
+			const stopped = await this.stopWorkspaceIfRunning(workspace);
+			if (!stopped) {
+				throw new Error(
+					"Workspace stop was canceled, not proceeding with update.",
+				);
+			}
+
 			try {
 				return await this.postWorkspaceBuild(workspace.id, {
 					transition: "start",
@@ -2405,17 +2438,11 @@ class ApiMethods {
 			throw new MissingBuildParameters(missingParameters, activeVersionId);
 		}
 
-		// Stop the workspace if it is already running.
-		if (workspace.latest_build.status === "running") {
-			const stopBuild = await this.stopWorkspace(workspace.id);
-			const awaitedStopBuild = await this.waitForBuild(stopBuild);
-			// If the stop is canceled halfway through, we bail.
-			// This is the same behaviour as restartWorkspace.
-			if (awaitedStopBuild?.status === "canceled") {
-				return Promise.reject(
-					new Error("Workspace stop was canceled, not proceeding with update."),
-				);
-			}
+		const stopped = await this.stopWorkspaceIfRunning(workspace);
+		if (!stopped) {
+			throw new Error(
+				"Workspace stop was canceled, not proceeding with update.",
+			);
 		}
 
 		return this.postWorkspaceBuild(workspace.id, {


### PR DESCRIPTION
## Summary

Fixes the regression where workspace template updates bypass stop-before-start
logic when dynamic parameters are enabled, causing agent reconnection failures.

Two code paths were affected:

- `updateWorkspace` dynamic parameters branch directly started a build without
  stopping the running workspace first.
- `changeWorkspaceVersion` never had stop-before-start logic at all.

Extracts a `stopWorkspaceIfRunning` private helper (matching the existing
`restartWorkspace` pattern) and applies it to both paths.

Fixes #20333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>