### PR TITLE
fix(cli): honor Default option in Select and RichSelect prompts

### DIFF
--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -108,6 +108,13 @@ func Select(inv *serpent.Invocation, opts SelectOptions) (string, error) {
 	// to the IO provided. See:
 	// https://github.com/AlecAivazis/survey/blob/master/terminal/runereader_windows.go#L94
 	if flag.Lookup("test.v") != nil {
+		// Return the default option if it matches a valid option,
+		// otherwise return the first option.
+		for _, opt := range opts.Options {
+			if opt == opts.Default {
+				return opt, nil
+			}
+		}
 		return opts.Options[0], nil
 	}
 
@@ -117,6 +124,14 @@ func Select(inv *serpent.Invocation, opts SelectOptions) (string, error) {
 		options:    opts.Options,
 		height:     opts.Size,
 		message:    opts.Message,
+	}
+
+	// Set initial cursor position to the default option if provided.
+	for i, opt := range opts.Options {
+		if opt == opts.Default {
+			initialModel.cursor = i
+			break
+		}
 	}
 
 	if initialModel.height == 0 {

--- a/cli/cliui/select_test.go
+++ b/cli/cliui/select_test.go
@@ -27,6 +27,21 @@ func TestSelect(t *testing.T) {
 		}()
 		require.Equal(t, "First", <-msgChan)
 	})
+
+	t.Run("DefaultIsSelected", func(t *testing.T) {
+		t.Parallel()
+		ptty := ptytest.New(t)
+		msgChan := make(chan string)
+		go func() {
+			resp, err := newSelect(ptty, cliui.SelectOptions{
+				Options: []string{"First", "Second", "Third"},
+				Default: "Second",
+			})
+			assert.NoError(t, err)
+			msgChan <- resp
+		}()
+		require.Equal(t, "Second", <-msgChan)
+	})
 }
 
 func newSelect(ptty *ptytest.PTY, opts cliui.SelectOptions) (string, error) {
@@ -60,6 +75,25 @@ func TestRichSelect(t *testing.T) {
 			msgChan <- resp
 		}()
 		require.Equal(t, "A-Value", <-msgChan)
+	})
+
+	t.Run("DefaultIsSelected", func(t *testing.T) {
+		t.Parallel()
+		ptty := ptytest.New(t)
+		msgChan := make(chan string)
+		go func() {
+			resp, err := newRichSelect(ptty, cliui.RichSelectOptions{
+				Options: []codersdk.TemplateVersionParameterOption{
+					{Name: "A-Name", Value: "A-Value", Description: "A-Description."},
+					{Name: "B-Name", Value: "B-Value", Description: "B-Description."},
+					{Name: "C-Name", Value: "C-Value", Description: "C-Description."},
+				},
+				Default: "B-Value",
+			})
+			assert.NoError(t, err)
+			msgChan <- resp
+		}()
+		require.Equal(t, "B-Value", <-msgChan)
 	})
 }
 


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/22078

`SelectOptions.Default` was documented as *"Default will be highlighted first
if it's a valid option"* but never implemented. The `Select` function
initialized `selectModel` with `cursor` defaulting to 0, ignoring
`opts.Default` entirely. This caused `--parameter-default` to be ignored for
option (select) parameters in interactive mode.

Set `initialModel.cursor` to the index of the matching default option so the
prompt highlights it. Also updated the test-mode early return path to return
the default option when it matches, rather than always returning the first
option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>