### PR TITLE
fix(site): add optional label to dynamic parameters

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -137,6 +137,21 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 							<span className="text-content-destructive">*</span>
 						)}
 					</span>
+					{!parameter.required && (
+						<TooltipProvider delayDuration={100}>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span className="text-sm font-medium text-content-disabled">
+										(optional)
+									</span>
+								</TooltipTrigger>
+								<TooltipContent className="max-w-xs">
+									If no value is specified, the system will default to the value
+									set by the administrator.
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					)}
 					{!parameter.mutable && (
 						<TooltipProvider delayDuration={100}>
 							<Tooltip>


### PR DESCRIPTION
## Summary

Dynamic parameters were missing the "(optional)" label that legacy parameters
displayed for non-required fields. This adds the same label with a tooltip to
the dynamic parameter UI, matching the legacy behavior.

Fixes https://github.com/coder/coder/issues/22045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>