### PR TITLE
fix(coderd): return effective automatic_updates value when template requires active version

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2746,7 +2746,7 @@ func convertWorkspace(
 			Healthy:       len(failingAgents) == 0,
 			FailingAgents: failingAgents,
 		},
-		AutomaticUpdates: codersdk.AutomaticUpdates(workspace.AutomaticUpdates),
+		AutomaticUpdates: convertWorkspaceAutomaticUpdates(template.RequireActiveVersion, workspace.AutomaticUpdates),
 		AllowRenames:     allowRenames,
 		Favorite:         requesterFavorite,
 		NextStartAt:      nextStartAt,
@@ -2803,6 +2803,18 @@ func sharedWorkspaceActors(
 	}
 
 	return out
+}
+
+// convertWorkspaceAutomaticUpdates returns "always" when the template
+// requires the active version, regardless of the workspace-level
+// setting. This keeps API responses consistent with the actual
+// enforcement behavior so that all consumers (UI, CLI, etc.) see
+// the effective value.
+func convertWorkspaceAutomaticUpdates(templateRequireActiveVersion bool, ws database.AutomaticUpdates) codersdk.AutomaticUpdates {
+	if templateRequireActiveVersion {
+		return codersdk.AutomaticUpdatesAlways
+	}
+	return codersdk.AutomaticUpdates(ws)
 }
 
 func convertWorkspaceTTLMillis(i sql.NullInt64) *int64 {


### PR DESCRIPTION
## Summary

When a template has `require_active_version` enabled, the workspace API now
returns `automatic_updates: "always"` regardless of the stored database value.

## Problem

The Workspace Settings UI displayed "Always" for Automatic Updates when
`require_active_version` was enabled, but this was only a visual override in
the frontend. The actual API response (and database value) remained `"never"`.
Any code path reading the API—such as the CLI—saw `"never"` and behaved
accordingly, creating an inconsistency between UI display and actual API
state.

## Fix

In `convertWorkspace()`, the `automatic_updates` field is now set to
`"always"` when `template.RequireActiveVersion` is true. This follows the
same pattern already used for TTL, where the template setting overrides the
workspace setting in the API response. All API consumers (UI, CLI, other
integrations) now see a consistent value that reflects the effective
enforcement behavior.

Closes https://github.com/coder/coder/issues/22031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>