### PR TITLE
fix(coderd/database): log critical error on nested tx isolation mismatch

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -774,7 +774,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				options.PrometheusRegistry.MustRegister(collectors.NewDBStatsCollector(sqlDB, ""))
 			}
 
-			options.Database = database.New(sqlDB)
+			options.Database = database.New(sqlDB, database.WithLogger(logger.Named("database")))
 			ps, err := pubsub.New(ctx, logger.Named("pubsub"), sqlDB, dbURL)
 			if err != nil {
 				return xerrors.Errorf("create pubsub: %w", err)


### PR DESCRIPTION
When a nested transaction requests a stricter isolation level than the
outer transaction, the inner level is silently ignored. This can cause
correctness issues when deeper call stack functions need serializable
isolation but the outer transaction runs at a weaker level.

Add detection in `runTx`: if the nested transaction's requested isolation
level is stricter than the current transaction's level, emit a
`log.Critical` to alert operators. The `sqlQuerier` struct now tracks
`currentIsolation` and accepts an optional `slog.Logger` via
`WithLogger`.

Three test cases verify the behavior:
- Critical log emitted when inner requests stricter isolation
- No log when isolation levels match
- No log when inner requests weaker isolation

Fixes #21939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>