### PR TITLE
fix(site): disable app buttons when agent is not connected

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -68,6 +68,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const shouldDisplayAgentApps =
 		(agent.status === "connected" && hasAppsToDisplay) ||
 		(agent.status === "connecting" && !isExternalAgent);
+	const agentAppsDisabled = agent.status !== "connected";
 	const hasVSCodeApp =
 		agent.display_apps.includes("vscode") ||
 		agent.display_apps.includes("vscode_insiders");
@@ -239,6 +240,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 										agentName={agent.name}
 										folderPath={agent.expanded_directory}
 										displayApps={agent.display_apps}
+										disabled={agentAppsDisabled}
 									/>
 								)}
 								{appSections.map((section, i) => (
@@ -257,6 +259,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 								workspaceName={workspace.name}
 								agentName={agent.name}
 								userName={workspace.owner_name}
+								disabled={agentAppsDisabled}
 							/>
 						)}
 					</section>

--- a/site/src/modules/resources/AppLink/AppLink.jest.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.jest.tsx
@@ -1,0 +1,78 @@
+import {
+	MockProxyLatencies,
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+} from "testHelpers/entities";
+import { render } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import type { ProxyContextValue } from "contexts/ProxyContext";
+import { getPreferredProxy, ProxyContext } from "contexts/ProxyContext";
+import { AppLink } from "./AppLink";
+
+function renderAppLink(
+	agentOverrides: Partial<typeof MockWorkspaceAgent> = {},
+	appOverrides: Partial<typeof MockWorkspaceApp> = {},
+) {
+	const agent = { ...MockWorkspaceAgent, ...agentOverrides };
+	const app = { ...MockWorkspaceApp, ...appOverrides };
+
+	const proxyContextValue: ProxyContextValue = {
+		latenciesLoaded: true,
+		proxyLatencies: MockProxyLatencies,
+		proxy: getPreferredProxy([], undefined),
+		proxies: [],
+		isLoading: false,
+		isFetched: true,
+		setProxy: () => {},
+		clearProxy: () => {},
+		refetchProxyLatencies: () => new Date(),
+	};
+
+	return render(
+		<ProxyContext.Provider value={proxyContextValue}>
+			<AppLink workspace={MockWorkspace} app={app} agent={agent} />
+		</ProxyContext.Provider>,
+	);
+}
+
+describe("AppLink", () => {
+	it("is clickable when agent is connected", () => {
+		renderAppLink({ status: "connected" });
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href");
+	});
+
+	it("is not clickable when agent is connecting", () => {
+		renderAppLink({ status: "connecting" });
+
+		const link = screen.getByText(MockWorkspaceApp.display_name!);
+		expect(link.closest("a")).not.toHaveAttribute("href");
+	});
+
+	it("is not clickable when agent is disconnected", () => {
+		renderAppLink({ status: "disconnected" });
+
+		const link = screen.getByText(MockWorkspaceApp.display_name!);
+		expect(link.closest("a")).not.toHaveAttribute("href");
+	});
+
+	it("is not clickable when agent has timed out", () => {
+		renderAppLink({ status: "timeout" });
+
+		const link = screen.getByText(MockWorkspaceApp.display_name!);
+		expect(link.closest("a")).not.toHaveAttribute("href");
+	});
+
+	it("is not clickable when agent has blocking startup script running", () => {
+		renderAppLink({
+			status: "connected",
+			lifecycle_state: "starting",
+			startup_script_behavior: "blocking",
+		});
+
+		const link = screen.getByText(MockWorkspaceApp.display_name!);
+		expect(link.closest("a")).not.toHaveAttribute("href");
+	});
+});

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -109,6 +109,10 @@ export const AppLink: FC<AppLinkProps> = ({
 		);
 	}
 
+	if (agent.status !== "connected") {
+		canClick = false;
+	}
+
 	if (isExternalApp(app) && needsSessionToken(app) && !link.hasToken) {
 		canClick = false;
 	}

--- a/site/src/modules/resources/TerminalLink/TerminalLink.tsx
+++ b/site/src/modules/resources/TerminalLink/TerminalLink.tsx
@@ -9,6 +9,7 @@ interface TerminalLinkProps {
 	agentName?: string;
 	userName?: string;
 	containerName?: string;
+	disabled?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export const TerminalLink: FC<TerminalLinkProps> = ({
 	userName = "me",
 	workspaceName,
 	containerName,
+	disabled,
 }) => {
 	const href = getTerminalHref({
 		username: userName,
@@ -34,8 +36,11 @@ export const TerminalLink: FC<TerminalLinkProps> = ({
 	return (
 		<AgentButton asChild>
 			<a
-				href={href}
+				href={disabled ? undefined : href}
 				onClick={(event: MouseEvent<HTMLElement>) => {
+					if (disabled) {
+						return;
+					}
 					event.preventDefault();
 					openAppInNewWindow(href);
 				}}

--- a/site/src/modules/resources/VSCodeDesktopButton/VSCodeDesktopButton.tsx
+++ b/site/src/modules/resources/VSCodeDesktopButton/VSCodeDesktopButton.tsx
@@ -16,6 +16,7 @@ interface VSCodeDesktopButtonProps {
 	agentName?: string;
 	folderPath?: string;
 	displayApps: readonly DisplayApp[];
+	disabled?: boolean;
 }
 
 type VSCodeVariant = "vscode" | "vscode-insiders";
@@ -109,12 +110,13 @@ const VSCodeButton: FC<VSCodeDesktopButtonProps> = ({
 	workspaceName,
 	agentName,
 	folderPath,
+	disabled,
 }) => {
 	const [loading, setLoading] = useState(false);
 
 	return (
 		<AgentButton
-			disabled={loading}
+			disabled={loading || disabled}
 			onClick={() => {
 				setLoading(true);
 				API.getApiKey()
@@ -146,12 +148,13 @@ const VSCodeInsidersButton: FC<VSCodeDesktopButtonProps> = ({
 	workspaceName,
 	agentName,
 	folderPath,
+	disabled,
 }) => {
 	const [loading, setLoading] = useState(false);
 
 	return (
 		<AgentButton
-			disabled={loading}
+			disabled={loading || disabled}
 			onClick={() => {
 				setLoading(true);
 				API.getApiKey()


### PR DESCRIPTION
## Summary

App buttons (VS Code, Terminal, custom apps) were clickable during the agent
"connecting" state, causing failed connections when clicked. The `canClick`
logic in `AppLink` only checked `agent.lifecycle_state` but not `agent.status`.

## Fix

- **AppLink.tsx**: Added check for `agent.status !== "connected"` to disable
  clicks when the agent hasn't established its connection yet.
- **TerminalLink.tsx**: Added `disabled` prop that removes the href and blocks
  onClick when the agent is not connected.
- **VSCodeDesktopButton.tsx**: Added `disabled` prop that disables the button
  when the agent is not connected.
- **AgentRow.tsx**: Passes `disabled={agentAppsDisabled}` to VSCodeDesktopButton
  and TerminalLink when `agent.status !== "connected"`.

The existing CSS rule `[&:is(a):not([href])]:pointer-events-none [&:is(a):not([href])]:text-content-disabled`
on the Button component automatically greys out anchor-based buttons when their
href is removed.

Closes https://github.com/coder/coder/issues/21954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>