### PR TITLE
fix: resolve `interception.model` badge size

### DIFF
--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -197,15 +197,15 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 					<TooltipProvider>
 						<Tooltip>
 							<TooltipTrigger asChild>
-								<div className="w-full min-w-0 overflow-hidden">
-									<Badge className="gap-1.5 w-full">
+								<div className="min-w-0 overflow-hidden">
+									<Badge className="gap-1.5 max-w-full">
 										<div className="flex-shrink-0 flex items-center">
 											<AIBridgeModelIcon
 												model={interception.model}
 												className="size-icon-xs"
 											/>
 										</div>
-										<span className="truncate min-w-0 w-full">
+										<span className="truncate min-w-0">
 											{interception.model}
 										</span>
 									</Badge>


### PR DESCRIPTION
This pull-request ensures that our model badges don't go to an odd width when the content is shorter in subsequent columns. 

| Old | New |
| --- | --- |
| <img width="1352" height="514" alt="REQUEST_LOGS_MODEL_BADGE_OLD" src="https://github.com/user-attachments/assets/8f6108d9-ba55-409b-ad27-859e727ed4e5" /> | <img width="1352" height="514" alt="REQUEST_LOGS_MODEL_BADGE_NEW" src="https://github.com/user-attachments/assets/f8e736e1-846c-4c0e-ac10-082ef5204b69" /> |