### PR TITLE
fix: solid background on mobile navigation

### DIFF
--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -63,7 +63,7 @@ export const MobileMenu: FC<MobileMenuProps> = ({
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			{open && (
-				<div className="fixed inset-0 top-[72px] backdrop-blur-sm z-10 bg-surface-primary/50" />
+				<div className="fixed inset-0 top-[72px] z-10 bg-surface-primary" />
 			)}
 			<DropdownMenuTrigger asChild>
 				<Button


### PR DESCRIPTION
Closes #16010 

This pull-request ensures that the background on the mobile navigation is a solid full colour (`bg-surface-primary`).

<img width="357" height="397" alt="image" src="https://github.com/user-attachments/assets/78d60cdc-5689-4e20-b48c-b5f9056d77e6" />
