### PR TITLE
fix: use  2 characters on `<Avatar />` fallback

### DIFF
--- a/site/src/components/Avatar/Avatar.tsx
+++ b/site/src/components/Avatar/Avatar.tsx
@@ -83,7 +83,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 			/>
 			{fallback && (
 				<AvatarPrimitive.Fallback className="flex h-full w-full items-center justify-center rounded-full">
-					{fallback.charAt(0).toUpperCase()}
+					{fallback.slice(0, 2).toUpperCase()}
 				</AvatarPrimitive.Fallback>
 			)}
 			{children}


### PR DESCRIPTION
Closes #15944 

This pull-request moves to using 2 characters for the fallback of content instead of just a single character.

- `Jane Doe` → `JA`
- `J` → `J`
