### PR TITLE
feat: remove duplicate `Cancel` from `<CreateTemplatePage />`

### DIFF
--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -235,7 +235,7 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 	const showProvisionerWarning = provisioners ? provisioners.length < 1 : false;
 
 	return (
-		<HorizontalForm onSubmit={form.handleSubmit}>
+		<HorizontalForm onSubmit={form.handleSubmit} className="pb-12">
 			{/* General info */}
 			<FormSection
 				title="General"

--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.tsx
@@ -21,10 +21,6 @@ const CreateTemplatePage: FC = () => {
 	const createTemplateMutation = useMutation(createTemplate());
 	const variablesSectionRef = useRef<HTMLDivElement>(null);
 
-	const onCancel = () => {
-		navigate(-1);
-	};
-
 	const pageViewProps: CreateTemplatePageViewProps = {
 		onCreateTemplate: async (options) => {
 			setIsBuildLogsOpen(true);
@@ -47,7 +43,7 @@ const CreateTemplatePage: FC = () => {
 		<>
 			<title>{pageTitle("Create Template")}</title>
 
-			<FullPageHorizontalForm title="Create Template" onCancel={onCancel}>
+			<FullPageHorizontalForm title="Create Template">
 				{searchParams.has("fromTemplate") ? (
 					<DuplicateTemplateView {...pageViewProps} />
 				) : searchParams.has("exampleId") ? (


### PR DESCRIPTION
Closes #14851 

Removes duplicate `Cancel` button from the top-right of the `Create Template` page. This was dependant on #11275 but as that is now merged we should have the green-light to remove this. 

| Old | New |
| --- | --- |
| <img width="1109" height="656" alt="image" src="https://github.com/user-attachments/assets/a1043093-def2-4596-8369-e8e46e8d6932" /> | <img width="1112" height="390" alt="image" src="https://github.com/user-attachments/assets/9e5fb5ab-17af-47a1-ac84-d5a92cff5334" /> |