### PR TITLE
fix: permissions check on `<TemplateInsightsPage />`

### DIFF
--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -40,8 +40,8 @@ import {
 	CircleXIcon,
 	SquareArrowOutUpRightIcon,
 } from "lucide-react";
-import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
 import { RequirePermission } from "modules/permissions/RequirePermission";
+import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
 import {
 	type FC,
 	Fragment,

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -41,6 +41,7 @@ import {
 	SquareArrowOutUpRightIcon,
 } from "lucide-react";
 import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
+import { RequirePermission } from "modules/permissions/RequirePermission";
 import {
 	type FC,
 	Fragment,
@@ -69,7 +70,7 @@ import { numberOfWeeksOptions, WeekPicker } from "./WeekPicker";
 const DEFAULT_NUMBER_OF_WEEKS = numberOfWeeksOptions[0];
 
 export default function TemplateInsightsPage() {
-	const { template } = useTemplateLayoutContext();
+	const { template, permissions } = useTemplateLayoutContext();
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	const defaultInterval = getDefaultInterval(template);
@@ -92,13 +93,25 @@ export default function TemplateInsightsPage() {
 		end_time: toISOLocal(dateRange.endDate, baseOffset),
 	};
 
+	const canViewInsights =
+		permissions.canUpdateTemplate || permissions.canReadInsights;
+
 	const insightsFilter = { ...commonFilters, interval };
-	const templateInsights = useQuery(insightsTemplate(insightsFilter));
-	const userLatency = useQuery(insightsUserLatency(commonFilters));
-	const userActivity = useQuery(insightsUserActivity(commonFilters));
+	const templateInsights = useQuery({
+		...insightsTemplate(insightsFilter),
+		enabled: canViewInsights,
+	});
+	const userLatency = useQuery({
+		...insightsUserLatency(commonFilters),
+		enabled: canViewInsights,
+	});
+	const userActivity = useQuery({
+		...insightsUserActivity(commonFilters),
+		enabled: canViewInsights,
+	});
 
 	return (
-		<>
+		<RequirePermission isFeatureVisible={canViewInsights}>
 			<title>{getTemplatePageTitle("Insights", template)}</title>
 
 			<TemplateInsightsPageView
@@ -116,7 +129,7 @@ export default function TemplateInsightsPage() {
 				userActivity={userActivity}
 				interval={interval}
 			/>
-		</>
+		</RequirePermission>
 	);
 }
 


### PR DESCRIPTION
Closes #20859 

This page previously wasn't rendered to the user, however, there is a possibility that they can navigate to this page and things will end up in `<Spinner />`s until the requests ultimately fail. We can mitigate this problem by showing them the `<RequirePermission />` modal. 

<img width="1456" height="861" alt="image" src="https://github.com/user-attachments/assets/57195643-ad55-4340-9c97-f8247b05a13b" />
