### PR TITLE
fix: reappend `fe0f` to emoji urls

### DIFF
--- a/site/src/components/IconField/IconField.tsx
+++ b/site/src/components/IconField/IconField.tsx
@@ -12,10 +12,6 @@ import {
 import { ChevronDownIcon } from "lucide-react";
 import { type FC, lazy, Suspense, useState } from "react";
 
-// See: https://github.com/missive/emoji-mart/issues/51#issuecomment-287353222
-const urlFromUnifiedCode = (unified: string) =>
-	`/emojis/${unified.replace(/-fe0f$/, "")}.png`;
-
 type IconFieldProps = TextFieldProps & {
 	onPickEmoji: (value: string) => void;
 };
@@ -97,7 +93,7 @@ export const IconField: FC<IconFieldProps> = ({
 					<Suspense fallback={<Loader />}>
 						<EmojiPicker
 							onEmojiSelect={(emoji) => {
-								const value = emoji.src ?? urlFromUnifiedCode(emoji.unified);
+								const value = emoji.src ?? `/emojis/${emoji.unified}.png`;
 								onPickEmoji(value);
 								setOpen(false);
 							}}


### PR DESCRIPTION
Closes #20836

There was previously an issue in `@emoji-mart/react` where-in the files would be stored at `*-fe0f.png` but the frontend would return `*.png`. This behaviour was changed in `v0.4.4` which we have well and truely surpassed.

Some of the broken icons (according to a quick AI chat)...

* **Objects/Symbols**
   Airplane, Alembic, Atom Symbol, Balance Scale, Bed, Bellhop Bell, Biohazard, Candle, Chains, Chess Pawn, Coffin, Comet, Crossed Swords, Dagger, Desktop Computer, Gear, Hammer and Pick, Hammer and Wrench, Hole, Joystick, Keyboard, Shield, World Map, etc.
* **UI-relevant ones**
   Copyright, Check Mark, Information, Label, Linked Paperclips, Fountain Pen, Writing Hand, Eye, Framed Picture, etc.
* **Arrows/Shapes**
   Down Arrow, Left Arrow, Left-Right Arrow, Up-Down Arrow, Black Medium Square, Black Small Square, etc.
* **Weather/Nature**
   Cloud, Cloud with Lightning, Cloud with Rain, Cloud with Snow, Comet, Fog, Hot Pepper, Hot Springs, Snowflake, Star, Sun, Tornado, etc.
* **Hearts** 
   Heart Exclamation, Heart Suit, plus many couple/kiss variants with skin tones.
* **People**
   Detective, Hand with Fingers Splayed, Index Pointing Up, and then the massive set of gendered activity/profession variants with skin tones (Man/Woman Biking, Bouncing Ball, Bowing, Cartwheeling, Climbing, Construction Worker, Detective, Facepalming, Golfing, Guard, Health Worker, Judge, Juggling, Lifting Weights, Pilot, Police Officer, Running, Shrugging, Standing, Superhero, Surfing, Swimming, Vampire, Walking, Wrestling, etc. -- each with 6 skin tone variants).