### PR TITLE
fix: disable `Activity bump` when `Default autostop` is `0`

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TTLHelperText.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TTLHelperText.tsx
@@ -22,8 +22,20 @@ export const DefaultTTLHelperText = (props: { ttl?: number }) => {
 	);
 };
 
-export const ActivityBumpHelperText = (props: { bump?: number }) => {
-	const { bump = 0 } = props;
+export const ActivityBumpHelperText = (props: {
+	bump?: number;
+	defaultTTL?: number;
+}) => {
+	const { bump = 0, defaultTTL = 0 } = props;
+
+	if (!defaultTTL) {
+		return (
+			<span>
+				Activity bump only applies when a default TTL is configured. Set a
+				default TTL above to enable activity bumping.
+			</span>
+		);
+	}
 
 	// Error will show once field is considered touched
 	if (bump < 0) {

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -201,9 +201,12 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 			default_ttl_ms: form.values.default_ttl_ms
 				? form.values.default_ttl_ms * MS_HOUR_CONVERSION
 				: undefined,
-			activity_bump_ms: form.values.activity_bump_ms
-				? form.values.activity_bump_ms * MS_HOUR_CONVERSION
-				: undefined,
+			// Activity bump has no effect without a default TTL, so
+			// discard any stale value when default autostop is off.
+			activity_bump_ms:
+				form.values.default_ttl_ms && form.values.activity_bump_ms
+					? form.values.activity_bump_ms * MS_HOUR_CONVERSION
+					: undefined,
 			failure_ttl_ms: form.values.failure_ttl_ms,
 			time_til_dormant_ms: form.values.time_til_dormant_ms,
 			time_til_dormant_autodelete_ms:

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -365,7 +365,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						/>
 					</div>
 
-					<div className="flex items-center">
+					<div className="flex items-start">
 						<Checkbox
 							id="allow-user-autostop"
 							disabled={isSubmitting || !allowAdvancedScheduling}
@@ -397,7 +397,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 				description="Allow users to set custom autostart and autostop scheduling options for workspaces created from this template."
 			>
 				<div className="flex flex-col gap-4">
-					<div className="flex items-center">
+					<div className="flex items-start">
 						<Checkbox
 							id="allow_user_autostart"
 							disabled={isSubmitting || !allowAdvancedScheduling}
@@ -442,7 +442,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 				>
 					<FormFields spacing={FORM_FIELDS_SPACING}>
 						<div className="flex flex-col gap-8">
-							<div className="flex items-center">
+							<div className="flex items-start">
 								<Switch
 									id="dormancyThreshold"
 									name="dormancyThreshold"
@@ -472,7 +472,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						</div>
 
 						<div className="flex flex-col gap-8">
-							<div className="flex items-center">
+							<div className="flex items-start">
 								<Switch
 									id="dormancyAutoDeletion"
 									name="dormancyAutoDeletion"
@@ -513,7 +513,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						</div>
 
 						<div className="flex flex-col gap-8">
-							<div className="flex items-center">
+							<div className="flex items-start">
 								<Switch
 									id="failureCleanupEnabled"
 									name="failureCleanupEnabled"

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -334,10 +334,13 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 					<TextField
 						{...getFieldHelpers("activity_bump_ms", {
 							helperText: (
-								<ActivityBumpHelperText bump={form.values.activity_bump_ms} />
+								<ActivityBumpHelperText
+									bump={form.values.activity_bump_ms}
+									defaultTTL={form.values.default_ttl_ms}
+								/>
 							),
 						})}
-						disabled={isSubmitting}
+						disabled={isSubmitting || !form.values.default_ttl_ms}
 						fullWidth
 						inputProps={{ min: 0, step: 1 }}
 						label="Activity bump (hours)"

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -12,7 +12,6 @@ import {
 	HorizontalForm,
 } from "components/Form/Form";
 import { Spinner } from "components/Spinner/Spinner";
-import { Stack } from "components/Stack/Stack";
 import {
 	StackLabel,
 	StackLabelHelperText,
@@ -58,7 +57,6 @@ const DORMANT_AUTODELETION_DEFAULT = 30 * MS_DAY_CONVERSION;
  * increase the space can make it feels lighter.
  */
 const FORM_FIELDS_SPACING = 8;
-const DORMANT_FIELDSET_SPACING = 4;
 
 export interface TemplateScheduleForm {
 	template: Template;
@@ -316,7 +314,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						type="number"
 					/>
 
-					<Stack direction="row" className="w-full">
+					<div className="flex flex-row gap-4 w-full">
 						<TextField
 							{...getFieldHelpers("autostop_requirement_days_of_week", {
 								helperText: (
@@ -365,7 +363,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 							label="Weeks between required stops"
 							type="number"
 						/>
-					</Stack>
+					</div>
 
 					<FormControlLabel
 						control={
@@ -400,7 +398,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 				title="Autostart"
 				description="Allow users to set custom autostart and autostop scheduling options for workspaces created from this template."
 			>
-				<Stack>
+				<div className="flex flex-col gap-4">
 					<FormControlLabel
 						control={
 							<Checkbox
@@ -438,7 +436,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 							}}
 						/>
 					)}
-				</Stack>
+				</div>
 			</FormSection>
 
 			{allowAdvancedScheduling && (
@@ -447,7 +445,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 					description="When enabled, Coder will mark workspaces as dormant after a period of time with no connections. Dormant workspaces can be auto-deleted (see below) or manually reviewed by the workspace owner or admins."
 				>
 					<FormFields spacing={FORM_FIELDS_SPACING}>
-						<Stack spacing={DORMANT_FIELDSET_SPACING}>
+						<div className="flex flex-col gap-8">
 							<FormControlLabel
 								control={
 									<Switch
@@ -474,9 +472,9 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 									isSubmitting || !form.values.inactivity_cleanup_enabled
 								}
 							/>
-						</Stack>
+						</div>
 
-						<Stack spacing={DORMANT_FIELDSET_SPACING}>
+						<div className="flex flex-col gap-8">
 							<FormControlLabel
 								control={
 									<Switch
@@ -516,9 +514,9 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 									!form.values.dormant_autodeletion_cleanup_enabled
 								}
 							/>
-						</Stack>
+						</div>
 
-						<Stack spacing={DORMANT_FIELDSET_SPACING}>
+						<div className="flex flex-col gap-8">
 							<FormControlLabel
 								control={
 									<Switch
@@ -548,7 +546,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 								onChange={(v) => form.setFieldValue("failure_ttl_ms", v)}
 								disabled={isSubmitting || !form.values.failure_cleanup_enabled}
 							/>
-						</Stack>
+						</div>
 					</FormFields>
 				</FormSection>
 			)}

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -1,4 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
 import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";
 import type { Template, UpdateTemplateMeta } from "api/typesGenerated";
@@ -11,6 +10,7 @@ import {
 	FormSection,
 	HorizontalForm,
 } from "components/Form/Form";
+import { Label } from "components/Label/Label";
 import { Spinner } from "components/Spinner/Spinner";
 import {
 	StackLabel,
@@ -365,22 +365,20 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						/>
 					</div>
 
-					<FormControlLabel
-						control={
-							<Checkbox
-								id="allow-user-autostop"
-								disabled={isSubmitting || !allowAdvancedScheduling}
-								onCheckedChange={async (checked) => {
-									await form.setFieldValue(
-										"allow_user_autostop",
-										checked === true,
-									);
-								}}
-								name="allow_user_autostop"
-								checked={form.values.allow_user_autostop}
-							/>
-						}
-						label={
+					<div className="flex items-center">
+						<Checkbox
+							id="allow-user-autostop"
+							disabled={isSubmitting || !allowAdvancedScheduling}
+							onCheckedChange={async (checked) => {
+								await form.setFieldValue(
+									"allow_user_autostop",
+									checked === true,
+								);
+							}}
+							name="allow_user_autostop"
+							checked={form.values.allow_user_autostop}
+						/>
+						<Label htmlFor="allow-user-autostop">
 							<StackLabel>
 								Allow users to customize autostop duration for workspaces.
 								<StackLabelHelperText>
@@ -389,8 +387,8 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 									Autostop timers on their workspaces or turn off the timer.
 								</StackLabelHelperText>
 							</StackLabel>
-						}
-					/>
+						</Label>
+					</div>
 				</FormFields>
 			</FormSection>
 
@@ -399,27 +397,25 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 				description="Allow users to set custom autostart and autostop scheduling options for workspaces created from this template."
 			>
 				<div className="flex flex-col gap-4">
-					<FormControlLabel
-						control={
-							<Checkbox
-								id="allow_user_autostart"
-								disabled={isSubmitting || !allowAdvancedScheduling}
-								onCheckedChange={async (checked) => {
-									await form.setFieldValue(
-										"allow_user_autostart",
-										checked === true,
-									);
-								}}
-								name="allow_user_autostart"
-								checked={form.values.allow_user_autostart}
-							/>
-						}
-						label={
+					<div className="flex items-center">
+						<Checkbox
+							id="allow_user_autostart"
+							disabled={isSubmitting || !allowAdvancedScheduling}
+							onCheckedChange={async (checked) => {
+								await form.setFieldValue(
+									"allow_user_autostart",
+									checked === true,
+								);
+							}}
+							name="allow_user_autostart"
+							checked={form.values.allow_user_autostart}
+						/>
+						<Label htmlFor="allow_user_autostart">
 							<StackLabel>
 								Allow users to automatically start workspaces on a schedule.
 							</StackLabel>
-						}
-					/>
+						</Label>
+					</div>
 
 					{allowAdvancedScheduling && (
 						<TemplateScheduleAutostart
@@ -446,16 +442,17 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 				>
 					<FormFields spacing={FORM_FIELDS_SPACING}>
 						<div className="flex flex-col gap-8">
-							<FormControlLabel
-								control={
-									<Switch
-										name="dormancyThreshold"
-										checked={form.values.inactivity_cleanup_enabled}
-										onCheckedChange={handleToggleInactivityCleanup}
-									/>
-								}
-								label={<StackLabel>Enable Dormancy Threshold</StackLabel>}
-							/>
+							<div className="flex items-center">
+								<Switch
+									id="dormancyThreshold"
+									name="dormancyThreshold"
+									checked={form.values.inactivity_cleanup_enabled}
+									onCheckedChange={handleToggleInactivityCleanup}
+								/>
+								<Label htmlFor="dormancyThreshold">
+									<StackLabel>Enable Dormancy Threshold</StackLabel>
+								</Label>
+							</div>
 
 							<DurationField
 								{...getFieldHelpers("time_til_dormant_ms", {
@@ -475,15 +472,14 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						</div>
 
 						<div className="flex flex-col gap-8">
-							<FormControlLabel
-								control={
-									<Switch
-										name="dormancyAutoDeletion"
-										checked={form.values.dormant_autodeletion_cleanup_enabled}
-										onCheckedChange={handleToggleDormantAutoDeletion}
-									/>
-								}
-								label={
+							<div className="flex items-center">
+								<Switch
+									id="dormancyAutoDeletion"
+									name="dormancyAutoDeletion"
+									checked={form.values.dormant_autodeletion_cleanup_enabled}
+									onCheckedChange={handleToggleDormantAutoDeletion}
+								/>
+								<Label htmlFor="dormancyAutoDeletion">
 									<StackLabel>
 										Enable Dormancy Auto-Deletion
 										<StackLabelHelperText>
@@ -494,8 +490,8 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 											</strong>
 										</StackLabelHelperText>
 									</StackLabel>
-								}
-							/>
+								</Label>
+							</div>
 							<DurationField
 								{...getFieldHelpers("time_til_dormant_autodelete_ms", {
 									helperText: (
@@ -517,15 +513,14 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						</div>
 
 						<div className="flex flex-col gap-8">
-							<FormControlLabel
-								control={
-									<Switch
-										name="failureCleanupEnabled"
-										checked={form.values.failure_cleanup_enabled}
-										onCheckedChange={handleToggleFailureCleanup}
-									/>
-								}
-								label={
+							<div className="flex items-center">
+								<Switch
+									id="failureCleanupEnabled"
+									name="failureCleanupEnabled"
+									checked={form.values.failure_cleanup_enabled}
+									onCheckedChange={handleToggleFailureCleanup}
+								/>
+								<Label htmlFor="failureCleanupEnabled">
 									<StackLabel>
 										Enable Failure Cleanup
 										<StackLabelHelperText>
@@ -533,8 +528,8 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 											are in a failed state after a period of time.
 										</StackLabelHelperText>
 									</StackLabel>
-								}
-							/>
+								</Label>
+							</div>
 							<DurationField
 								{...getFieldHelpers("failure_ttl_ms", {
 									helperText: (

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -1,10 +1,9 @@
-import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import MenuItem from "@mui/material/MenuItem";
-import Switch from "@mui/material/Switch";
 import TextField from "@mui/material/TextField";
 import type { Template, UpdateTemplateMeta } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
+import { Checkbox } from "components/Checkbox/Checkbox";
 import { DurationField } from "components/DurationField/DurationField";
 import {
 	FormFields,
@@ -18,8 +17,9 @@ import {
 	StackLabel,
 	StackLabelHelperText,
 } from "components/StackLabel/StackLabel";
+import { Switch } from "components/Switch/Switch";
 import { type FormikTouched, useFormik } from "formik";
-import { type ChangeEvent, type FC, useEffect, useState } from "react";
+import { type FC, useEffect, useState } from "react";
 import { getFormHelpers } from "utils/formUtils";
 import {
 	calculateAutostopRequirementDaysValue,
@@ -251,61 +251,30 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 		}
 	}, [currentValues, setValues]);
 
-	const handleToggleFailureCleanup = async (e: ChangeEvent) => {
-		form.handleChange(e);
-		if (!form.values.failure_cleanup_enabled) {
-			// fill failure_ttl_ms with defaults
-			await form.setValues({
-				...form.values,
-				failure_cleanup_enabled: true,
-				failure_ttl_ms: FAILURE_CLEANUP_DEFAULT,
-			});
-		} else {
-			// clear failure_ttl_ms
-			await form.setValues({
-				...form.values,
-				failure_cleanup_enabled: false,
-				failure_ttl_ms: 0,
-			});
-		}
+	const handleToggleFailureCleanup = async (checked: boolean) => {
+		await form.setValues({
+			...form.values,
+			failure_cleanup_enabled: checked,
+			failure_ttl_ms: checked ? FAILURE_CLEANUP_DEFAULT : 0,
+		});
 	};
 
-	const handleToggleInactivityCleanup = async (e: ChangeEvent) => {
-		form.handleChange(e);
-		if (!form.values.inactivity_cleanup_enabled) {
-			// fill time_til_dormant_ms with defaults
-			await form.setValues({
-				...form.values,
-				inactivity_cleanup_enabled: true,
-				time_til_dormant_ms: INACTIVITY_CLEANUP_DEFAULT,
-			});
-		} else {
-			// clear time_til_dormant_ms
-			await form.setValues({
-				...form.values,
-				inactivity_cleanup_enabled: false,
-				time_til_dormant_ms: 0,
-			});
-		}
+	const handleToggleInactivityCleanup = async (checked: boolean) => {
+		await form.setValues({
+			...form.values,
+			inactivity_cleanup_enabled: checked,
+			time_til_dormant_ms: checked ? INACTIVITY_CLEANUP_DEFAULT : 0,
+		});
 	};
 
-	const handleToggleDormantAutoDeletion = async (e: ChangeEvent) => {
-		form.handleChange(e);
-		if (!form.values.dormant_autodeletion_cleanup_enabled) {
-			// fill failure_ttl_ms with defaults
-			await form.setValues({
-				...form.values,
-				dormant_autodeletion_cleanup_enabled: true,
-				time_til_dormant_autodelete_ms: DORMANT_AUTODELETION_DEFAULT,
-			});
-		} else {
-			// clear failure_ttl_ms
-			await form.setValues({
-				...form.values,
-				dormant_autodeletion_cleanup_enabled: false,
-				time_til_dormant_autodelete_ms: 0,
-			});
-		}
+	const handleToggleDormantAutoDeletion = async (checked: boolean) => {
+		await form.setValues({
+			...form.values,
+			dormant_autodeletion_cleanup_enabled: checked,
+			time_til_dormant_autodelete_ms: checked
+				? DORMANT_AUTODELETION_DEFAULT
+				: 0,
+		});
 	};
 
 	return (
@@ -347,7 +316,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						type="number"
 					/>
 
-					<Stack direction="row" css={styles.ttlFields}>
+					<Stack direction="row" className="w-full">
 						<TextField
 							{...getFieldHelpers("autostop_requirement_days_of_week", {
 								helperText: (
@@ -402,10 +371,12 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						control={
 							<Checkbox
 								id="allow-user-autostop"
-								size="small"
 								disabled={isSubmitting || !allowAdvancedScheduling}
-								onChange={async (_, checked) => {
-									await form.setFieldValue("allow_user_autostop", checked);
+								onCheckedChange={async (checked) => {
+									await form.setFieldValue(
+										"allow_user_autostop",
+										checked === true,
+									);
 								}}
 								name="allow_user_autostop"
 								checked={form.values.allow_user_autostop}
@@ -434,12 +405,11 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 						control={
 							<Checkbox
 								id="allow_user_autostart"
-								size="small"
 								disabled={isSubmitting || !allowAdvancedScheduling}
-								onChange={async () => {
+								onCheckedChange={async (checked) => {
 									await form.setFieldValue(
 										"allow_user_autostart",
-										!form.values.allow_user_autostart,
+										checked === true,
 									);
 								}}
 								name="allow_user_autostart"
@@ -481,10 +451,9 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 							<FormControlLabel
 								control={
 									<Switch
-										size="small"
 										name="dormancyThreshold"
 										checked={form.values.inactivity_cleanup_enabled}
-										onChange={handleToggleInactivityCleanup}
+										onCheckedChange={handleToggleInactivityCleanup}
 									/>
 								}
 								label={<StackLabel>Enable Dormancy Threshold</StackLabel>}
@@ -511,10 +480,9 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 							<FormControlLabel
 								control={
 									<Switch
-										size="small"
 										name="dormancyAutoDeletion"
 										checked={form.values.dormant_autodeletion_cleanup_enabled}
-										onChange={handleToggleDormantAutoDeletion}
+										onCheckedChange={handleToggleDormantAutoDeletion}
 									/>
 								}
 								label={
@@ -554,10 +522,9 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 							<FormControlLabel
 								control={
 									<Switch
-										size="small"
 										name="failureCleanupEnabled"
 										checked={form.values.failure_cleanup_enabled}
-										onChange={handleToggleFailureCleanup}
+										onCheckedChange={handleToggleFailureCleanup}
 									/>
 								}
 								label={
@@ -648,13 +615,4 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 			</FormFooter>
 		</HorizontalForm>
 	);
-};
-
-const styles = {
-	ttlFields: {
-		width: "100%",
-	},
-	dayButtons: {
-		borderRadius: "0px",
-	},
 };

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -75,27 +75,24 @@ const fillAndSubmitForm = async ({
 	}
 
 	if (failure_ttl_ms) {
-		const failureTtlField = screen.getByRole("checkbox", {
+		const failureTtlField = screen.getByRole("switch", {
 			name: /Failure Cleanup/i,
 		});
-		await user.type(failureTtlField, failure_ttl_ms.toString());
+		await user.click(failureTtlField);
 	}
 
 	if (time_til_dormant_ms) {
-		const inactivityTtlField = screen.getByRole("checkbox", {
+		const inactivityTtlField = screen.getByRole("switch", {
 			name: /Dormancy Threshold/i,
 		});
-		await user.type(inactivityTtlField, time_til_dormant_ms.toString());
+		await user.click(inactivityTtlField);
 	}
 
 	if (time_til_dormant_autodelete_ms) {
-		const dormancyAutoDeletionField = screen.getByRole("checkbox", {
+		const dormancyAutoDeletionField = screen.getByRole("switch", {
 			name: /Dormancy Auto-Deletion/i,
 		});
-		await user.type(
-			dormancyAutoDeletionField,
-			time_til_dormant_autodelete_ms.toString(),
-		);
+		await user.click(dormancyAutoDeletionField);
 	}
 
 	const submitButton = screen.getByRole("button", {

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -352,4 +352,64 @@ describe("TemplateSchedulePage", () => {
 		const validate = () => getValidationSchema().validateSync(values);
 		expect(validate).toThrowError();
 	});
+
+	it("disables activity bump field when default TTL is 0", async () => {
+		await renderTemplateSchedulePage();
+		const user = userEvent.setup();
+
+		const defaultTtlField = await screen.findByLabelText(
+			"Default autostop (hours)",
+		);
+		const activityBumpField = screen.getByLabelText("Activity bump (hours)");
+
+		// Activity bump should be enabled when default TTL is non-zero.
+		expect(activityBumpField).not.toBeDisabled();
+
+		// Set default TTL to 0.
+		await user.clear(defaultTtlField);
+		await user.type(defaultTtlField, "0");
+
+		// Activity bump should now be disabled.
+		expect(activityBumpField).toBeDisabled();
+	});
+
+	it("shows helper text on activity bump when default TTL is 0", async () => {
+		await renderTemplateSchedulePage();
+		const user = userEvent.setup();
+
+		const defaultTtlField = await screen.findByLabelText(
+			"Default autostop (hours)",
+		);
+
+		// Set default TTL to 0.
+		await user.clear(defaultTtlField);
+		await user.type(defaultTtlField, "0");
+
+		// Should show the explanatory helper text.
+		expect(
+			screen.getByText(
+				/activity bump only applies when a default TTL is configured/i,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("re-enables activity bump field when default TTL is set back to non-zero", async () => {
+		await renderTemplateSchedulePage();
+		const user = userEvent.setup();
+
+		const defaultTtlField = await screen.findByLabelText(
+			"Default autostop (hours)",
+		);
+		const activityBumpField = screen.getByLabelText("Activity bump (hours)");
+
+		// Set default TTL to 0.
+		await user.clear(defaultTtlField);
+		await user.type(defaultTtlField, "0");
+		expect(activityBumpField).toBeDisabled();
+
+		// Set default TTL back to a non-zero value.
+		await user.clear(defaultTtlField);
+		await user.type(defaultTtlField, "8");
+		expect(activityBumpField).not.toBeDisabled();
+	});
 });

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePageView.stories.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePageView.stories.tsx
@@ -2,6 +2,7 @@ import { MockTemplate } from "testHelpers/entities";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { action } from "storybook/actions";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { TemplateSchedulePageView } from "./TemplateSchedulePageView";
 
 const queryClient = new QueryClient({
@@ -42,4 +43,42 @@ export const Example: Story = {
 
 export const CantSetMaxTTL: Story = {
 	args: { ...defaultArgs, allowAdvancedScheduling: false },
+};
+
+export const SubmitClearsActivityBumpWhenDefaultTTLIsZero: Story = {
+	args: {
+		...defaultArgs,
+		template: {
+			...MockTemplate,
+			// Start with a non-zero activity bump so we can verify
+			// it gets discarded when default TTL is set to 0.
+			activity_bump_ms: 3 * 60 * 60 * 1000,
+		},
+		onSubmit: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+
+		const defaultTtlField = await canvas.findByLabelText(
+			"Default autostop (hours)",
+		);
+		const activityBumpField = canvas.getByLabelText("Activity bump (hours)");
+
+		await user.clear(defaultTtlField);
+		await user.type(defaultTtlField, "0");
+
+		await expect(activityBumpField).toBeDisabled();
+
+		const submitButton = canvas.getByRole("button", { name: /save/i });
+		await user.click(submitButton);
+
+		await waitFor(() => {
+			expect(args.onSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					activity_bump_ms: undefined,
+				}),
+			);
+		});
+	},
 };


### PR DESCRIPTION
Closes #21703

This doesn't make sense to have an `Activity bump` value when the `Default autostop` is set to `0`. There is nothing to bump if we don't have a timed stopping mechanism on the container. This is already present on the backend and now we're describing this to the user on the frontend.