### PR TITLE
feat: animate between `<TabLink />`s

### DIFF
--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,13 @@
-import { createContext, type FC, type HTMLAttributes, useContext } from "react";
+import {
+	createContext,
+	type FC,
+	type HTMLAttributes,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { Link, type LinkProps } from "react-router";
 import { cn } from "utils/cn";
 
@@ -32,12 +41,72 @@ export const Tabs: FC<TabsProps> = ({ className, active, ...htmlProps }) => {
 type TabsListProps = HTMLAttributes<HTMLDivElement>;
 
 export const TabsList: FC<TabsListProps> = ({ className, ...props }) => {
+	const listRef = useRef<HTMLDivElement | null>(null);
+	const [indicatorStyle, setIndicatorStyle] = useState({
+		left: 0,
+		width: 0,
+	});
+	const [hasActiveTab, setHasActiveTab] = useState(false);
+
+	const updateIndicator = useCallback(() => {
+		if (!listRef.current) return;
+
+		const activeTab = listRef.current.querySelector<HTMLElement>(
+			"[data-active='true']",
+		);
+		if (!activeTab) {
+			setHasActiveTab(false);
+			return;
+		}
+
+		const listRect = listRef.current.getBoundingClientRect();
+		const activeRect = activeTab.getBoundingClientRect();
+
+		requestAnimationFrame(() => {
+			setIndicatorStyle({
+				left: activeRect.left - listRect.left,
+				width: activeRect.width,
+			});
+			setHasActiveTab(true);
+		});
+	}, []);
+
+	useEffect(() => {
+		const timeoutId = setTimeout(updateIndicator, 0);
+
+		window.addEventListener("resize", updateIndicator);
+		const observer = new MutationObserver(updateIndicator);
+
+		if (listRef.current) {
+			observer.observe(listRef.current, {
+				attributes: true,
+				childList: true,
+				subtree: true,
+			});
+		}
+
+		return () => {
+			clearTimeout(timeoutId);
+			window.removeEventListener("resize", updateIndicator);
+			observer.disconnect();
+		};
+	}, [updateIndicator]);
+
 	return (
-		<div
-			role="tablist"
-			className={cn("flex items-baseline gap-6", className)}
-			{...props}
-		/>
+		<div ref={listRef} className="relative">
+			<div
+				role="tablist"
+				className={cn("flex items-baseline gap-6", className)}
+				{...props}
+			/>
+			<div
+				className={cn(
+					"absolute bottom-0 h-px bg-surface-invert-primary transition-all duration-200 ease-in-out",
+					!hasActiveTab && "opacity-0",
+				)}
+				style={indicatorStyle}
+			/>
+		</div>
 	);
 };
 
@@ -59,15 +128,13 @@ export const TabLink: FC<TabLinkProps> = ({
 
 	return (
 		<Link
+			data-active={isActive}
 			{...linkProps}
 			className={cn(
-				`text-sm text-content-secondary no-underline font-medium py-3 px-1 hover:text-content-primary rounded-md
-				focus-visible:ring-offset-1 focus-visible:ring-offset-surface-primary
-				focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:rounded-sm`,
-				{
-					"text-content-primary relative before:absolute before:bg-surface-invert-primary before:left-0 before:w-full before:h-px before:-bottom-px before:content-['']":
-						isActive,
-				},
+				"text-sm text-content-secondary no-underline font-medium py-3 px-1 hover:text-content-primary rounded-md",
+				"focus-visible:ring-offset-1 focus-visible:ring-offset-surface-primary",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:rounded-sm",
+				isActive ? "text-content-primary" : "",
 				className,
 			)}
 		/>

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -47,6 +47,10 @@ export const TabsList: FC<TabsListProps> = ({ className, ...props }) => {
 		width: 0,
 	});
 	const [hasActiveTab, setHasActiveTab] = useState(false);
+	// Track whether we've done the initial placement so we can
+	// skip the transition on first render and avoid the "slide in"
+	// effect on page load.
+	const hasInitialized = useRef(false);
 
 	const updateIndicator = useCallback(() => {
 		if (!listRef.current) return;
@@ -68,6 +72,13 @@ export const TabsList: FC<TabsListProps> = ({ className, ...props }) => {
 				width: activeRect.width,
 			});
 			setHasActiveTab(true);
+			// Mark as initialized after the first position is set so
+			// subsequent updates will animate.
+			if (!hasInitialized.current) {
+				requestAnimationFrame(() => {
+					hasInitialized.current = true;
+				});
+			}
 		});
 	}, []);
 
@@ -101,7 +112,10 @@ export const TabsList: FC<TabsListProps> = ({ className, ...props }) => {
 			/>
 			<div
 				className={cn(
-					"absolute bottom-0 h-px bg-surface-invert-primary transition-all duration-200 ease-in-out",
+					"absolute bottom-0 h-px bg-surface-invert-primary ease-in-out",
+					hasInitialized.current
+						? "transition-all duration-300"
+						: "transition-none",
 					!hasActiveTab && "opacity-0",
 				)}
 				style={indicatorStyle}


### PR DESCRIPTION
This pull-request implements a tiny little animation between our `<Tabs />` items (`<TabLinks />`), this provides feedback to the user while they're navigating the website.

https://github.com/user-attachments/assets/6e97f5da-3c5d-4703-b39c-cd1ad7ab479e