### PR TITLE
fix(coderd): use BuildReasonTaskAutoPause for task workspaces

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13502,7 +13502,8 @@ const docTemplate = `{
                 "cli",
                 "ssh_connection",
                 "vscode_connection",
-                "jetbrains_connection"
+                "jetbrains_connection",
+                "task_auto_pause"
             ],
             "x-enum-varnames": [
                 "BuildReasonInitiator",
@@ -13513,7 +13514,8 @@ const docTemplate = `{
                 "BuildReasonCLI",
                 "BuildReasonSSHConnection",
                 "BuildReasonVSCodeConnection",
-                "BuildReasonJetbrainsConnection"
+                "BuildReasonJetbrainsConnection",
+                "BuildReasonTaskAutoPause"
             ]
         },
         "codersdk.CORSBehavior": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13503,7 +13503,9 @@ const docTemplate = `{
                 "ssh_connection",
                 "vscode_connection",
                 "jetbrains_connection",
-                "task_auto_pause"
+                "task_auto_pause",
+                "task_manual_pause",
+                "task_resume"
             ],
             "x-enum-varnames": [
                 "BuildReasonInitiator",
@@ -13515,7 +13517,9 @@ const docTemplate = `{
                 "BuildReasonSSHConnection",
                 "BuildReasonVSCodeConnection",
                 "BuildReasonJetbrainsConnection",
-                "BuildReasonTaskAutoPause"
+                "BuildReasonTaskAutoPause",
+                "BuildReasonTaskManualPause",
+                "BuildReasonTaskResume"
             ]
         },
         "codersdk.CORSBehavior": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12099,7 +12099,8 @@
 				"cli",
 				"ssh_connection",
 				"vscode_connection",
-				"jetbrains_connection"
+				"jetbrains_connection",
+				"task_auto_pause"
 			],
 			"x-enum-varnames": [
 				"BuildReasonInitiator",
@@ -12110,7 +12111,8 @@
 				"BuildReasonCLI",
 				"BuildReasonSSHConnection",
 				"BuildReasonVSCodeConnection",
-				"BuildReasonJetbrainsConnection"
+				"BuildReasonJetbrainsConnection",
+				"BuildReasonTaskAutoPause"
 			]
 		},
 		"codersdk.CORSBehavior": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12100,7 +12100,9 @@
 				"ssh_connection",
 				"vscode_connection",
 				"jetbrains_connection",
-				"task_auto_pause"
+				"task_auto_pause",
+				"task_manual_pause",
+				"task_resume"
 			],
 			"x-enum-varnames": [
 				"BuildReasonInitiator",
@@ -12112,7 +12114,9 @@
 				"BuildReasonSSHConnection",
 				"BuildReasonVSCodeConnection",
 				"BuildReasonJetbrainsConnection",
-				"BuildReasonTaskAutoPause"
+				"BuildReasonTaskAutoPause",
+				"BuildReasonTaskManualPause",
+				"BuildReasonTaskResume"
 			]
 		},
 		"codersdk.CORSBehavior": {

--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -525,10 +525,18 @@ func getNextTransition(
 ) {
 	switch {
 	case isEligibleForAutostop(user, ws, latestBuild, latestJob, currentTick):
+		// Use task-specific reason for AI task workspaces.
+		if ws.TaskID.Valid {
+			return database.WorkspaceTransitionStop, database.BuildReasonTaskAutoPause, nil
+		}
 		return database.WorkspaceTransitionStop, database.BuildReasonAutostop, nil
 	case isEligibleForAutostart(user, ws, latestBuild, latestJob, templateSchedule, currentTick):
 		return database.WorkspaceTransitionStart, database.BuildReasonAutostart, nil
 	case isEligibleForFailedStop(latestBuild, latestJob, templateSchedule, currentTick):
+		// Use task-specific reason for AI task workspaces.
+		if ws.TaskID.Valid {
+			return database.WorkspaceTransitionStop, database.BuildReasonTaskAutoPause, nil
+		}
 		return database.WorkspaceTransitionStop, database.BuildReasonAutostop, nil
 	case isEligibleForDormantStop(ws, templateSchedule, currentTick):
 		// Only stop started workspaces.

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -2019,5 +2019,11 @@ func TestExecutorTaskWorkspace(t *testing.T) {
 		assert.Contains(t, stats.Transitions, workspace.ID, "task workspace should be in transitions")
 		assert.Equal(t, database.WorkspaceTransitionStop, stats.Transitions[workspace.ID], "should autostop the workspace")
 		require.Empty(t, stats.Errors, "should have no errors when managing task workspaces")
+
+		// Then: The build reason should be TaskAutoPause (not regular Autostop)
+		workspace = coderdtest.MustWorkspace(t, client, workspace.ID)
+		_ = coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+		workspace = coderdtest.MustWorkspace(t, client, workspace.ID)
+		assert.Equal(t, codersdk.BuildReasonTaskAutoPause, workspace.LatestBuild.Reason, "task workspace should use TaskAutoPause build reason")
 	})
 }

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -59,6 +59,9 @@ const (
 	BuildReasonVSCodeConnection BuildReason = "vscode_connection"
 	// BuildReasonJetbrainsConnection "jetbrains_connection" is used when a build to start a workspace is triggered by a JetBrains connection.
 	BuildReasonJetbrainsConnection BuildReason = "jetbrains_connection"
+	// BuildReasonTaskAutoPause "task_auto_pause" is used when a build to stop
+	// a task workspace is triggered by the lifecycle executor.
+	BuildReasonTaskAutoPause BuildReason = "task_auto_pause"
 )
 
 // WorkspaceBuild is an at-point representation of a workspace state.

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -62,6 +62,12 @@ const (
 	// BuildReasonTaskAutoPause "task_auto_pause" is used when a build to stop
 	// a task workspace is triggered by the lifecycle executor.
 	BuildReasonTaskAutoPause BuildReason = "task_auto_pause"
+	// BuildReasonTaskManualPause "task_manual_pause" is used when a build to
+	// stop a task workspace is triggered by a user.
+	BuildReasonTaskManualPause BuildReason = "task_manual_pause"
+	// BuildReasonTaskResume "task_resume" is used when a build to
+	// start a task workspace is triggered by a user.
+	BuildReasonTaskResume BuildReason = "task_resume"
 )
 
 // WorkspaceBuild is an at-point representation of a workspace state.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1508,9 +1508,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                            |
-|-------------------------------------------------------------------------------------------------------------------------------------|
-| `autostart`, `autostop`, `cli`, `dashboard`, `dormancy`, `initiator`, `jetbrains_connection`, `ssh_connection`, `vscode_connection` |
+| Value(s)                                                                                                                                               |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `autostart`, `autostop`, `cli`, `dashboard`, `dormancy`, `initiator`, `jetbrains_connection`, `ssh_connection`, `task_auto_pause`, `vscode_connection` |
 
 ## codersdk.CORSBehavior
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1508,9 +1508,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                               |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `autostart`, `autostop`, `cli`, `dashboard`, `dormancy`, `initiator`, `jetbrains_connection`, `ssh_connection`, `task_auto_pause`, `vscode_connection` |
+| Value(s)                                                                                                                                                                                   |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `autostart`, `autostop`, `cli`, `dashboard`, `dormancy`, `initiator`, `jetbrains_connection`, `ssh_connection`, `task_auto_pause`, `task_manual_pause`, `task_resume`, `vscode_connection` |
 
 ## codersdk.CORSBehavior
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -963,6 +963,8 @@ export type BuildReason =
 	| "jetbrains_connection"
 	| "ssh_connection"
 	| "task_auto_pause"
+	| "task_manual_pause"
+	| "task_resume"
 	| "vscode_connection";
 
 export const BuildReasons: BuildReason[] = [
@@ -975,6 +977,8 @@ export const BuildReasons: BuildReason[] = [
 	"jetbrains_connection",
 	"ssh_connection",
 	"task_auto_pause",
+	"task_manual_pause",
+	"task_resume",
 	"vscode_connection",
 ];
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -962,6 +962,7 @@ export type BuildReason =
 	| "initiator"
 	| "jetbrains_connection"
 	| "ssh_connection"
+	| "task_auto_pause"
 	| "vscode_connection";
 
 export const BuildReasons: BuildReason[] = [
@@ -973,6 +974,7 @@ export const BuildReasons: BuildReason[] = [
 	"initiator",
 	"jetbrains_connection",
 	"ssh_connection",
+	"task_auto_pause",
 	"vscode_connection",
 ];
 

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -220,7 +220,7 @@ export const TaskPausedTimeout: Story = {
 			latest_build: {
 				...MockWorkspaceBuildStop,
 				status: "stopped",
-				reason: "autostop",
+				reason: "task_auto_pause",
 			},
 		});
 	},

--- a/site/src/utils/workspace.test.ts
+++ b/site/src/utils/workspace.test.ts
@@ -93,6 +93,13 @@ describe("util > workspace", () => {
 				},
 				"Coder",
 			],
+			[
+				{
+					...Mocks.MockWorkspaceBuild,
+					reason: "task_auto_pause",
+				},
+				"Coder",
+			],
 		])(
 			"getDisplayWorkspaceBuildInitiatedBy(%p) returns %p",
 			(build, initiatedBy) => {

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -87,6 +87,8 @@ export const getDisplayWorkspaceBuildInitiatedBy = (
 		case "ssh_connection":
 		case "vscode_connection":
 		case "jetbrains_connection":
+		case "task_manual_pause":
+		case "task_resume":
 			return build.initiator_name;
 		case "autostart":
 		case "autostop":
@@ -102,6 +104,8 @@ export const systemBuildReasons = [
 	"autostop",
 	"dormancy",
 	"task_auto_pause",
+	"task_manual_pause",
+	"task_resume",
 ];
 
 export const buildReasonLabels: Record<TypesGen.BuildReason, string> = {
@@ -118,6 +122,8 @@ export const buildReasonLabels: Record<TypesGen.BuildReason, string> = {
 	autostop: "Autostop",
 	dormancy: "Dormancy",
 	task_auto_pause: "Task Auto-Pause",
+	task_manual_pause: "Task Manual Pause",
+	task_resume: "Task Resume",
 };
 
 const getWorkspaceBuildDurationInSeconds = (

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -91,6 +91,7 @@ export const getDisplayWorkspaceBuildInitiatedBy = (
 		case "autostart":
 		case "autostop":
 		case "dormancy":
+		case "task_auto_pause":
 			return "Coder";
 	}
 	return undefined;

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -96,7 +96,12 @@ export const getDisplayWorkspaceBuildInitiatedBy = (
 	return undefined;
 };
 
-export const systemBuildReasons = ["autostart", "autostop", "dormancy"];
+export const systemBuildReasons = [
+	"autostart",
+	"autostop",
+	"dormancy",
+	"task_auto_pause",
+];
 
 export const buildReasonLabels: Record<TypesGen.BuildReason, string> = {
 	// User build reasons
@@ -111,6 +116,7 @@ export const buildReasonLabels: Record<TypesGen.BuildReason, string> = {
 	autostart: "Autostart",
 	autostop: "Autostop",
 	dormancy: "Dormancy",
+	task_auto_pause: "Task Auto-Pause",
 };
 
 const getWorkspaceBuildDurationInSeconds = (


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/1252

When a workspace with a TaskID hits its deadline, use BuildReasonTaskAutoPause instead of BuildReasonAutostop. This allows downstream systems to distinguish between regular autostop and task workspace pauses.

Created by Mux using Opus 4.5.
