### PR TITLE
fix: update `<RequestLogsPage />` permissions check

### DIFF
--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
@@ -17,9 +17,11 @@ const RequestLogsPage: FC = () => {
 
 	// Users are allowed to view their own request logs via the API,
 	// but this page is only visible if the feature is enabled and the user
-	// has the necessary permission (as its found in the Admin settings dropdown).
-	const canViewRequestLogs =
-		Boolean(feats.aibridge) && permissions.viewAnyAIBridgeInterception;
+	// has the `viewAnyAIBridgeInterception` permission.
+	// (as its defined in the Admin settings dropdown).
+	const isEntitled = Boolean(feats.aibridge);
+	const hasPermission = permissions.viewAnyAIBridgeInterception;
+	const canViewRequestLogs = isEntitled && hasPermission;
 
 	const [searchParams, setSearchParams] = useSearchParams();
 	const interceptionsQuery = usePaginatedQuery({
@@ -51,12 +53,12 @@ const RequestLogsPage: FC = () => {
 	});
 
 	return (
-		<RequirePermission isFeatureVisible={canViewRequestLogs}>
+		<RequirePermission isFeatureVisible={hasPermission}>
 			<title>{pageTitle("Request Logs", "AI Bridge")}</title>
 
 			<RequestLogsPageView
 				isLoading={interceptionsQuery.isLoading}
-				isRequestLogsVisible={canViewRequestLogs}
+				isRequestLogsVisible={isEntitled}
 				interceptions={interceptionsQuery.data?.results}
 				interceptionsQuery={interceptionsQuery}
 				filterProps={{


### PR DESCRIPTION
Closes #20965 

This pull-request enables a quick permission check that the user is allowed to view the `<RequestLogsPage />` under the admin panel. Previously, users would be able to view this page and browse their own logs if they had this permission (which was fine), however now we've decided as this is an admin page, they should only be able to do this via the API/CLI not from the main admin panel.