### PR TITLE
docs: add a joke to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ We are always happy to see new contributors to Coder. If you are new to the Code
 [a guide on how to get started](https://coder.com/docs/CONTRIBUTING). We'd love to see your
 contributions!
 
+## Joke of the Day
+
+> Why do programmers prefer dark mode?
+>
+> Because light attracts bugs. 🪲
+
 ## Hiring
 
 Apply [here](https://jobs.ashbyhq.com/coder?utm_source=github&utm_medium=readme&utm_campaign=unknown) if you're interested in joining our team.


### PR DESCRIPTION
Adds a programmer joke to the README, right before the Hiring section.

> Why do programmers prefer dark mode?
>
> Because light attracts bugs. 🪲

This is a fun, lighthearted addition to make the README a bit more enjoyable to read.