### PR TITLE
chore: fix pty-max-limit flake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -489,6 +489,14 @@ jobs:
           # macOS will output "The default interactive shell is now zsh" intermittently in CI.
           touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
 
+      - name: Increase PTY limit (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # Increase PTY limit to avoid exhaustion during tests.
+          # Default is 511; 999 is the maximum value on CI runner.
+          sudo sysctl -w kern.tty.ptmx_max=999
+
       - name: Test with PostgreSQL Database (Linux)
         if: runner.os == 'Linux'
         uses: ./.github/actions/test-go-pg


### PR DESCRIPTION
### Notes
- Closes https://github.com/coder/internal/issues/558
- I closed previous attempt with `ptySemaphore`: https://github.com/coder/coder/pull/21981
- We can consider implementing the retries proposed by Spike in: https://github.com/coder/coder/pull/21981#pullrequestreview-3783200423, if increasing the limit isn’t enough.
- I looked into Datadog — this particular test doesn’t seem very flaky right now. It failed once in the Nightly gauntlet (3 weeks ago), but it hasn’t failed again in the last 3 months (at least I couldn’t find any other failures in Datadog).

## Fix PTY exhaustion flake on macOS CI

### Problem
macOS CI runners were experiencing PTY exhaustion during test runs, causing flakes. The default PTY limit on macOS is 511, which can be insufficient when running parallel tests.

### Solution
Added a CI step to increase the PTY limit on macOS runners from the default 511 to the maximum allowed value of 999 before running tests.

### Changes
- Added `Increase PTY limit (macOS)` step in `.github/workflows/ci.yaml`
- Sets `kern.tty.ptmx_max=999` using `sysctl` (maximum value on our CI runners)
- Runs only on macOS runners before the test-go-pg action