### PR TITLE
chore: optionally prefix authentication related cookies

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -97,7 +97,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-AI BRIDGE OPTIONS: 
+AI BRIDGE OPTIONS:
       --aibridge-anthropic-base-url string, $CODER_AIBRIDGE_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           The base URL of the Anthropic API.
 
@@ -172,7 +172,7 @@ AI BRIDGE OPTIONS:
           Emit structured logs for AI Bridge interception records. Use this for
           exporting these records to external SIEM or observability systems.
 
-AI BRIDGE PROXY OPTIONS: 
+AI BRIDGE PROXY OPTIONS:
       --aibridge-proxy-cert-file string, $CODER_AIBRIDGE_PROXY_CERT_FILE
           Path to the CA certificate file for AI Bridge Proxy.
 
@@ -197,7 +197,7 @@ AI BRIDGE PROXY OPTIONS:
           certificates not trusted by the system. If not provided, the system
           certificate pool is used.
 
-CLIENT OPTIONS: 
+CLIENT OPTIONS:
 These options change the behavior of how clients interact with the Coder.
 Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 
@@ -224,17 +224,17 @@ Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
           Coder Desktop. By default it is coder, resulting in names like
           myworkspace.coder.
 
-CONFIG OPTIONS: 
+CONFIG OPTIONS:
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-          
+
           Write out the current server config as YAML to stdout.
 
-EMAIL OPTIONS: 
+EMAIL OPTIONS:
 Configure how emails are sent.
 
       --email-force-tls bool, $CODER_EMAIL_FORCE_TLS (default: false)
@@ -249,7 +249,7 @@ Configure how emails are sent.
       --email-smarthost string, $CODER_EMAIL_SMARTHOST
           The intermediary SMTP host through which emails are sent.
 
-EMAIL / EMAIL AUTHENTICATION OPTIONS: 
+EMAIL / EMAIL AUTHENTICATION OPTIONS:
 Configure SMTP authentication options.
 
       --email-auth-identity string, $CODER_EMAIL_AUTH_IDENTITY
@@ -265,7 +265,7 @@ Configure SMTP authentication options.
       --email-auth-username string, $CODER_EMAIL_AUTH_USERNAME
           Username to use with PLAIN/LOGIN authentication.
 
-EMAIL / EMAIL TLS OPTIONS: 
+EMAIL / EMAIL TLS OPTIONS:
 Configure TLS for your SMTP server target.
 
       --email-tls-ca-cert-file string, $CODER_EMAIL_TLS_CACERTFILE
@@ -286,7 +286,7 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
-INTROSPECTION / HEALTH CHECK OPTIONS: 
+INTROSPECTION / HEALTH CHECK OPTIONS:
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -295,7 +295,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS: 
+INTROSPECTION / LOGGING OPTIONS:
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -312,7 +312,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS: 
+INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -332,7 +332,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS: 
+INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
       --stats-collection-usage-stats-enable bool, $CODER_STATS_COLLECTION_USAGE_STATS_ENABLE (default: true)
           Enable the collection of application and workspace usage along with
           the associated API endpoints and the template insights page. Disabling
@@ -340,7 +340,7 @@ INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
           deployment stats shown to admins in the bottom bar of the Coder UI,
           and will prevent Prometheus collection of these values.
 
-INTROSPECTION / TRACING OPTIONS: 
+INTROSPECTION / TRACING OPTIONS:
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -354,14 +354,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS: 
+INTROSPECTION / PPROF OPTIONS:
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS: 
+NETWORKING OPTIONS:
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -391,10 +391,10 @@ NETWORKING OPTIONS:
           the form "*.example.com".
 
       --host-prefix-cookie bool, $CODER_HOST_PREFIX_COOKIE (default: false)
-          Recommended to be enabled. Enables `__HOST-` prefix for cookies to
+          Recommended to be enabled. Enables `__Host-` prefix for cookies to
           guarantee they are only set by the right domain.
 
-NETWORKING / DERP OPTIONS: 
+NETWORKING / DERP OPTIONS:
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -436,7 +436,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS: 
+NETWORKING / HTTP OPTIONS:
       --additional-csp-policy string-array, $CODER_ADDITIONAL_CSP_POLICY
           Coder configures a Content Security Policy (CSP) to protect against
           XSS attacks. This setting allows you to add additional CSP directives,
@@ -478,7 +478,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS: 
+NETWORKING / TLS OPTIONS:
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -540,7 +540,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-NOTIFICATIONS OPTIONS: 
+NOTIFICATIONS OPTIONS:
 Configure how notifications are processed and delivered.
 
       --notifications-dispatch-timeout duration, $CODER_NOTIFICATIONS_DISPATCH_TIMEOUT (default: 1m0s)
@@ -552,7 +552,7 @@ Configure how notifications are processed and delivered.
       --notifications-method string, $CODER_NOTIFICATIONS_METHOD (default: smtp)
           Which delivery method to use (available options: 'smtp', 'webhook').
 
-NOTIFICATIONS / EMAIL OPTIONS: 
+NOTIFICATIONS / EMAIL OPTIONS:
 Configure how email notifications are sent.
 
       --notifications-email-force-tls bool, $CODER_NOTIFICATIONS_EMAIL_FORCE_TLS
@@ -571,7 +571,7 @@ Configure how email notifications are sent.
           The intermediary SMTP host through which emails are sent.
           DEPRECATED: Use --email-smarthost instead.
 
-NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS: 
+NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS:
 Configure SMTP authentication options.
 
       --notifications-email-auth-identity string, $CODER_NOTIFICATIONS_EMAIL_AUTH_IDENTITY
@@ -591,7 +591,7 @@ Configure SMTP authentication options.
           Username to use with PLAIN/LOGIN authentication.
           DEPRECATED: Use --email-auth-username instead.
 
-NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS: 
+NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS:
 Configure TLS for your SMTP server target.
 
       --notifications-email-tls-ca-cert-file string, $CODER_NOTIFICATIONS_EMAIL_TLS_CACERTFILE
@@ -618,15 +618,15 @@ Configure TLS for your SMTP server target.
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
           DEPRECATED: Use --email-tls-starttls instead.
 
-NOTIFICATIONS / INBOX OPTIONS: 
+NOTIFICATIONS / INBOX OPTIONS:
       --notifications-inbox-enabled bool, $CODER_NOTIFICATIONS_INBOX_ENABLED (default: true)
           Enable Coder Inbox.
 
-NOTIFICATIONS / WEBHOOK OPTIONS: 
+NOTIFICATIONS / WEBHOOK OPTIONS:
       --notifications-webhook-endpoint url, $CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT
           The endpoint to which to send webhooks.
 
-OAUTH2 / GITHUB OPTIONS: 
+OAUTH2 / GITHUB OPTIONS:
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -657,7 +657,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS: 
+OIDC OPTIONS:
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -757,7 +757,7 @@ OIDC OPTIONS:
           requirement, and can lead to an insecure OIDC configuration. It is not
           recommended to use this flag.
 
-PROVISIONING OPTIONS: 
+PROVISIONING OPTIONS:
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -778,7 +778,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-RETENTION OPTIONS: 
+RETENTION OPTIONS:
 Configure data retention policies for various database tables. Retention
 policies automatically purge old data to reduce database size and improve
 performance. Setting a retention duration to 0 disables automatic purging for
@@ -805,7 +805,7 @@ that data type.
           Logs from the latest build are always retained. Set to 0 to disable
           automatic deletion.
 
-TELEMETRY OPTIONS: 
+TELEMETRY OPTIONS:
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry
 when required by your organization's security policy.
@@ -814,7 +814,7 @@ when required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS: 
+USER QUIET HOURS SCHEDULE OPTIONS:
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template scheduling.
 
@@ -834,13 +834,13 @@ workspaces stopping during the day due to template scheduling.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-WORKSPACE PREBUILDS OPTIONS: 
+WORKSPACE PREBUILDS OPTIONS:
 Configure how workspace prebuilds behave.
 
       --workspace-prebuilds-reconciliation-interval duration, $CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL (default: 1m0s)
           How often to reconcile workspace prebuilds state.
 
-⚠️ DANGEROUS OPTIONS: 
+⚠️ DANGEROUS OPTIONS:
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -857,7 +857,7 @@ Configure how workspace prebuilds behave.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS: 
+ENTERPRISE OPTIONS:
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -97,7 +97,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-AI BRIDGE OPTIONS:
+AI BRIDGE OPTIONS: 
       --aibridge-anthropic-base-url string, $CODER_AIBRIDGE_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           The base URL of the Anthropic API.
 
@@ -172,7 +172,7 @@ AI BRIDGE OPTIONS:
           Emit structured logs for AI Bridge interception records. Use this for
           exporting these records to external SIEM or observability systems.
 
-AI BRIDGE PROXY OPTIONS:
+AI BRIDGE PROXY OPTIONS: 
       --aibridge-proxy-cert-file string, $CODER_AIBRIDGE_PROXY_CERT_FILE
           Path to the CA certificate file for AI Bridge Proxy.
 
@@ -197,7 +197,7 @@ AI BRIDGE PROXY OPTIONS:
           certificates not trusted by the system. If not provided, the system
           certificate pool is used.
 
-CLIENT OPTIONS:
+CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
 Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 
@@ -224,17 +224,17 @@ Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
           Coder Desktop. By default it is coder, resulting in names like
           myworkspace.coder.
 
-CONFIG OPTIONS:
+CONFIG OPTIONS: 
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-
+          
           Write out the current server config as YAML to stdout.
 
-EMAIL OPTIONS:
+EMAIL OPTIONS: 
 Configure how emails are sent.
 
       --email-force-tls bool, $CODER_EMAIL_FORCE_TLS (default: false)
@@ -249,7 +249,7 @@ Configure how emails are sent.
       --email-smarthost string, $CODER_EMAIL_SMARTHOST
           The intermediary SMTP host through which emails are sent.
 
-EMAIL / EMAIL AUTHENTICATION OPTIONS:
+EMAIL / EMAIL AUTHENTICATION OPTIONS: 
 Configure SMTP authentication options.
 
       --email-auth-identity string, $CODER_EMAIL_AUTH_IDENTITY
@@ -265,7 +265,7 @@ Configure SMTP authentication options.
       --email-auth-username string, $CODER_EMAIL_AUTH_USERNAME
           Username to use with PLAIN/LOGIN authentication.
 
-EMAIL / EMAIL TLS OPTIONS:
+EMAIL / EMAIL TLS OPTIONS: 
 Configure TLS for your SMTP server target.
 
       --email-tls-ca-cert-file string, $CODER_EMAIL_TLS_CACERTFILE
@@ -286,7 +286,7 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
-INTROSPECTION / HEALTH CHECK OPTIONS:
+INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -295,7 +295,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS:
+INTROSPECTION / LOGGING OPTIONS: 
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -312,7 +312,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS:
+INTROSPECTION / PROMETHEUS OPTIONS: 
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -332,7 +332,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
+INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS: 
       --stats-collection-usage-stats-enable bool, $CODER_STATS_COLLECTION_USAGE_STATS_ENABLE (default: true)
           Enable the collection of application and workspace usage along with
           the associated API endpoints and the template insights page. Disabling
@@ -340,7 +340,7 @@ INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
           deployment stats shown to admins in the bottom bar of the Coder UI,
           and will prevent Prometheus collection of these values.
 
-INTROSPECTION / TRACING OPTIONS:
+INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -354,14 +354,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS:
+INTROSPECTION / PPROF OPTIONS: 
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS:
+NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -394,7 +394,7 @@ NETWORKING OPTIONS:
           Recommended to be enabled. Enables `__Host-` prefix for cookies to
           guarantee they are only set by the right domain.
 
-NETWORKING / DERP OPTIONS:
+NETWORKING / DERP OPTIONS: 
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -436,7 +436,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS:
+NETWORKING / HTTP OPTIONS: 
       --additional-csp-policy string-array, $CODER_ADDITIONAL_CSP_POLICY
           Coder configures a Content Security Policy (CSP) to protect against
           XSS attacks. This setting allows you to add additional CSP directives,
@@ -478,7 +478,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS:
+NETWORKING / TLS OPTIONS: 
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -540,7 +540,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-NOTIFICATIONS OPTIONS:
+NOTIFICATIONS OPTIONS: 
 Configure how notifications are processed and delivered.
 
       --notifications-dispatch-timeout duration, $CODER_NOTIFICATIONS_DISPATCH_TIMEOUT (default: 1m0s)
@@ -552,7 +552,7 @@ Configure how notifications are processed and delivered.
       --notifications-method string, $CODER_NOTIFICATIONS_METHOD (default: smtp)
           Which delivery method to use (available options: 'smtp', 'webhook').
 
-NOTIFICATIONS / EMAIL OPTIONS:
+NOTIFICATIONS / EMAIL OPTIONS: 
 Configure how email notifications are sent.
 
       --notifications-email-force-tls bool, $CODER_NOTIFICATIONS_EMAIL_FORCE_TLS
@@ -571,7 +571,7 @@ Configure how email notifications are sent.
           The intermediary SMTP host through which emails are sent.
           DEPRECATED: Use --email-smarthost instead.
 
-NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS:
+NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS: 
 Configure SMTP authentication options.
 
       --notifications-email-auth-identity string, $CODER_NOTIFICATIONS_EMAIL_AUTH_IDENTITY
@@ -591,7 +591,7 @@ Configure SMTP authentication options.
           Username to use with PLAIN/LOGIN authentication.
           DEPRECATED: Use --email-auth-username instead.
 
-NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS:
+NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS: 
 Configure TLS for your SMTP server target.
 
       --notifications-email-tls-ca-cert-file string, $CODER_NOTIFICATIONS_EMAIL_TLS_CACERTFILE
@@ -618,15 +618,15 @@ Configure TLS for your SMTP server target.
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
           DEPRECATED: Use --email-tls-starttls instead.
 
-NOTIFICATIONS / INBOX OPTIONS:
+NOTIFICATIONS / INBOX OPTIONS: 
       --notifications-inbox-enabled bool, $CODER_NOTIFICATIONS_INBOX_ENABLED (default: true)
           Enable Coder Inbox.
 
-NOTIFICATIONS / WEBHOOK OPTIONS:
+NOTIFICATIONS / WEBHOOK OPTIONS: 
       --notifications-webhook-endpoint url, $CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT
           The endpoint to which to send webhooks.
 
-OAUTH2 / GITHUB OPTIONS:
+OAUTH2 / GITHUB OPTIONS: 
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -657,7 +657,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS:
+OIDC OPTIONS: 
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -757,7 +757,7 @@ OIDC OPTIONS:
           requirement, and can lead to an insecure OIDC configuration. It is not
           recommended to use this flag.
 
-PROVISIONING OPTIONS:
+PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -778,7 +778,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-RETENTION OPTIONS:
+RETENTION OPTIONS: 
 Configure data retention policies for various database tables. Retention
 policies automatically purge old data to reduce database size and improve
 performance. Setting a retention duration to 0 disables automatic purging for
@@ -805,7 +805,7 @@ that data type.
           Logs from the latest build are always retained. Set to 0 to disable
           automatic deletion.
 
-TELEMETRY OPTIONS:
+TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry
 when required by your organization's security policy.
@@ -814,7 +814,7 @@ when required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS:
+USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template scheduling.
 
@@ -834,13 +834,13 @@ workspaces stopping during the day due to template scheduling.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-WORKSPACE PREBUILDS OPTIONS:
+WORKSPACE PREBUILDS OPTIONS: 
 Configure how workspace prebuilds behave.
 
       --workspace-prebuilds-reconciliation-interval duration, $CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL (default: 1m0s)
           How often to reconcile workspace prebuilds state.
 
-⚠️ DANGEROUS OPTIONS:
+⚠️ DANGEROUS OPTIONS: 
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -857,7 +857,7 @@ Configure how workspace prebuilds behave.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS:
+ENTERPRISE OPTIONS: 
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -390,6 +390,10 @@ NETWORKING OPTIONS:
           Specifies the wildcard hostname to use for workspace applications in
           the form "*.example.com".
 
+      --host-prefix-cookie bool, $CODER_HOST_PREFIX_COOKIE (default: false)
+          Reccomended to be enabled. Enables `__HOST-` prefix for cookies to
+          guarantee they are only set by the right domain.
+
 NETWORKING / DERP OPTIONS: 
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -391,7 +391,7 @@ NETWORKING OPTIONS:
           the form "*.example.com".
 
       --host-prefix-cookie bool, $CODER_HOST_PREFIX_COOKIE (default: false)
-          Reccomended to be enabled. Enables `__HOST-` prefix for cookies to
+          Recommended to be enabled. Enables `__HOST-` prefix for cookies to
           guarantee they are only set by the right domain.
 
 NETWORKING / DERP OPTIONS: 

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -181,7 +181,7 @@ networking:
   # Controls the 'SameSite' property is set on browser session cookies.
   # (default: lax, type: enum[lax\|none])
   sameSiteAuthCookie: lax
-  # Reccomended to be enabled. Enables `__HOST-` prefix for cookies to guarantee
+  # Recommended to be enabled. Enables `__HOST-` prefix for cookies to guarantee
   # they are only set by the right domain.
   # (default: false, type: bool)
   hostPrefixCookie: false

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -181,6 +181,10 @@ networking:
   # Controls the 'SameSite' property is set on browser session cookies.
   # (default: lax, type: enum[lax\|none])
   sameSiteAuthCookie: lax
+  # Reccomended to be enabled. Enables `__HOST-` prefix for cookies to guarantee
+  # they are only set by the right domain.
+  # (default: false, type: bool)
+  hostPrefixCookie: false
   # Whether Coder only allows connections to workspaces via the browser.
   # (default: <unset>, type: bool)
   browserOnly: false

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -181,7 +181,7 @@ networking:
   # Controls the 'SameSite' property is set on browser session cookies.
   # (default: lax, type: enum[lax\|none])
   sameSiteAuthCookie: lax
-  # Recommended to be enabled. Enables `__HOST-` prefix for cookies to guarantee
+  # Recommended to be enabled. Enables `__Host-` prefix for cookies to guarantee
   # they are only set by the right domain.
   # (default: false, type: bool)
   hostPrefixCookie: false

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15512,6 +15512,9 @@ const docTemplate = `{
         "codersdk.HTTPCookieConfig": {
             "type": "object",
             "properties": {
+                "host_prefix": {
+                    "type": "boolean"
+                },
                 "same_site": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14037,6 +14037,9 @@
 		"codersdk.HTTPCookieConfig": {
 			"type": "object",
 			"properties": {
+				"host_prefix": {
+					"type": "boolean"
+				},
 				"same_site": {
 					"type": "string"
 				},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -900,6 +900,7 @@ func New(options *Options) *API {
 		sharedhttpmw.Recover(api.Logger),
 		httpmw.WithProfilingLabels,
 		tracing.StatusWriterMiddleware,
+		options.DeploymentValues.HTTPCookies.Middleware,
 		tracing.Middleware(api.TracerProvider),
 		httpmw.AttachRequestID,
 		httpmw.ExtractRealIP(api.RealIPConfig),
@@ -908,7 +909,6 @@ func New(options *Options) *API {
 		rolestore.CustomRoleMW,
 		httpmw.HTTPRoute, // NB: prometheusMW depends on this middleware.
 		prometheusMW,
-		options.DeploymentValues.HTTPCookies.Middleware,
 		// Build-Version is helpful for debugging.
 		func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -908,6 +908,7 @@ func New(options *Options) *API {
 		rolestore.CustomRoleMW,
 		httpmw.HTTPRoute, // NB: prometheusMW depends on this middleware.
 		prometheusMW,
+		options.DeploymentValues.HTTPCookies.Middleware,
 		// Build-Version is helpful for debugging.
 		func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -704,7 +704,7 @@ func (api *API) postLogout(rw http.ResponseWriter, r *http.Request) {
 		Name:   codersdk.SessionTokenCookie,
 		Path:   "/",
 	}
-	http.SetCookie(rw, cookie)
+	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(cookie))
 
 	// Delete the session token from database.
 	apiKey := httpmw.APIKey(r)

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1905,10 +1905,13 @@ func TestUserLogout(t *testing.T) {
 	// Create a custom database so it's easier to make scoped tokens for
 	// testing.
 	db, pubSub := dbtestutil.NewDB(t)
+	dv := coderdtest.DeploymentValues(t)
+	dv.HTTPCookies.EnableHostPrefix = true
 
 	client := coderdtest.New(t, &coderdtest.Options{
-		Database: db,
-		Pubsub:   pubSub,
+		DeploymentValues: dv,
+		Database:         db,
+		Pubsub:           pubSub,
 	})
 	firstUser := coderdtest.CreateFirstUser(t, client)
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -852,7 +852,7 @@ type TraceConfig struct {
 	DataDog         serpent.Bool   `json:"data_dog" typescript:",notnull"`
 }
 
-const cookieHostPrefix = "__HOST-"
+const cookieHostPrefix = "__Host-"
 
 type HTTPCookieConfig struct {
 	Secure           serpent.Bool `json:"secure_auth_cookie,omitempty" typescript:",notnull"`
@@ -2894,8 +2894,8 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Annotations: serpent.Annotations{}.Mark(annotationExternalProxies, "true"),
 		},
 		{
-			Name:        "__HOST Prefix Cookies",
-			Description: "Recommended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.",
+			Name:        "__Host Prefix Cookies",
+			Description: "Recommended to be enabled. Enables `__Host-` prefix for cookies to guarantee they are only set by the right domain.",
 			Flag:        "host-prefix-cookie",
 			Env:         "CODER_HOST_PREFIX_COOKIE",
 			Value:       serpent.BoolOf(&c.HTTPCookies.EnableHostPrefix),

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -892,12 +892,11 @@ func (cfg *HTTPCookieConfig) Middleware(next http.Handler) http.Handler {
 		// feature.
 		//
 		// This code also handles any unprefixed cookies that are now invalid.
-		cookies := r.Cookies() // r.Cookies() returns a parsed copy of the cookies
+		cookies := r.Cookies()
 		for i, c := range cookies {
 			// If any cookies that should be prefixed are found without the prefix, remove
 			// them from the client and the request. This is usually from a migration where
-			// the prefix was just turned on. In the ignorant or malicious scenario, these
-			// cookies MUST be dropped.
+			// the prefix was just turned on. In any case, these cookies MUST be dropped
 			if _, ok := cookiesToPrefix[c.Name]; ok {
 				// Remove the cookie from the client to prevent any future requests from sending it.
 				http.SetCookie(rw, &http.Cookie{
@@ -909,7 +908,7 @@ func (cfg *HTTPCookieConfig) Middleware(next http.Handler) http.Handler {
 				cookies[i] = nil
 			}
 
-			// Only strip from the cookies we care about. Let other `__HOST-` cookies be.
+			// Only strip prefix's from the cookies we care about. Let other `__HOST-` cookies be
 			if _, ok := prefixed[c.Name]; ok {
 				c.Name = strings.TrimPrefix(c.Name, cookieHostPrefix)
 			}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -924,7 +924,6 @@ func (cfg *HTTPCookieConfig) Middleware(next http.Handler) http.Handler {
 		}
 
 		next.ServeHTTP(rw, r)
-		return
 	})
 }
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2897,7 +2897,7 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 		},
 		{
 			Name:        "__HOST Prefix Cookies",
-			Description: "Reccomended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.",
+			Description: "Recommended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.",
 			Flag:        "host-prefix-cookie",
 			Env:         "CODER_HOST_PREFIX_COOKIE",
 			Value:       serpent.BoolOf(&c.HTTPCookies.EnableHostPrefix),

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -878,14 +878,14 @@ func (cfg *HTTPCookieConfig) Middleware(next http.Handler) http.Handler {
 	}
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if !cfg.EnableHostPrefix {
-			// If a deployment has this config on, then turned it off. Then some old __HOST-
+			// If a deployment has this config on, then turned it off. Then some old __Host-
 			// cookies could exist on the browsers of the clients. These cookies have no
 			// impact, so we are going to ignore them if they exist (niche scenario)
 			next.ServeHTTP(rw, r)
 			return
 		}
 
-		// When 'EnableHostPrefix', some cookies are set with a `__HOST-` prefix. This
+		// When 'EnableHostPrefix', some cookies are set with a `__Host-` prefix. This
 		// middleware will strip any prefixes, so the backend is unaware of this security
 		// feature.
 		//
@@ -906,7 +906,7 @@ func (cfg *HTTPCookieConfig) Middleware(next http.Handler) http.Handler {
 				cookies[i] = nil
 			}
 
-			// Only strip prefix's from the cookies we care about. Let other `__HOST-` cookies be
+			// Only strip prefix's from the cookies we care about. Let other `__Host-` cookies be
 			if _, ok := prefixed[c.Name]; ok {
 				c.Name = strings.TrimPrefix(c.Name, cookieHostPrefix)
 			}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -863,9 +863,7 @@ type HTTPCookieConfig struct {
 // cookiesToPrefix is the set of cookies that should be prefixed with the host prefix if EnableHostPrefix is true.
 // This is a constant, do not ever mutate it.
 var cookiesToPrefix = map[string]struct{}{
-	SessionTokenCookie:             {},
-	PathAppSessionTokenCookie:      {},
-	SubdomainAppSessionTokenCookie: {},
+	SessionTokenCookie: {},
 }
 
 // Middleware handles some cookie mutation the requests.

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -971,10 +971,12 @@ func TestHTTPCookieConfigMiddleware(t *testing.T) {
 			extraCookies: []*http.Cookie{
 				{Name: "custom_cookie", Value: "custom-value"},
 				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "session"},
+				{Name: "__HOST-foobar", Value: "do-not-change-me"},
 			},
 			expectedCookies: map[string]string{
 				"custom_cookie":             "custom-value",
 				codersdk.SessionTokenCookie: "session",
+				"__HOST-foobar":             "do-not-change-me",
 			},
 		},
 	}
@@ -1074,6 +1076,14 @@ func BenchmarkHTTPCookieConfigMiddleware(b *testing.B) {
 				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
 				{Name: "__HOST-" + codersdk.PathAppSessionTokenCookie, Value: "xyz123"},
 				{Name: "__HOST-" + codersdk.SubdomainAppSessionTokenCookie, Value: "abc456"},
+				{Name: "__HOST-" + "foobar", Value: "do-not-change-me"},
+			},
+		},
+		{
+			name: "Enabled_NonSessionPrefixedCookies",
+			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
+			extraCookies: []*http.Cookie{
+				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
 			},
 		},
 	}

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -918,7 +918,7 @@ func TestHTTPCookieConfigMiddleware(t *testing.T) {
 			name: "Enabled_StripsPrefixFromCookie",
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "token123"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "token123"},
 			},
 			expectedCookies: map[string]string{
 				codersdk.SessionTokenCookie: "token123",
@@ -944,7 +944,7 @@ func TestHTTPCookieConfigMiddleware(t *testing.T) {
 				{Name: codersdk.SessionTokenCookie, Value: "unprefixed-token"},
 				{Name: codersdk.PathAppSessionTokenCookie, Value: "unprefixed-token"},
 				{Name: codersdk.SubdomainAppSessionTokenCookie, Value: "unprefixed-token"},
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "prefixed-token"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "prefixed-token"},
 			},
 			expectedCookies: map[string]string{
 				codersdk.SessionTokenCookie: "prefixed-token", // Prefixed wins.
@@ -955,9 +955,9 @@ func TestHTTPCookieConfigMiddleware(t *testing.T) {
 			name: "Enabled_MultiplePrefixedCookies",
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "session"},
-				{Name: "__HOST-" + codersdk.PathAppSessionTokenCookie, Value: "path-app"},
-				{Name: "__HOST-" + codersdk.SubdomainAppSessionTokenCookie, Value: "subdomain-app"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "session"},
+				{Name: "__Host-" + codersdk.PathAppSessionTokenCookie, Value: "path-app"},
+				{Name: "__Host-" + codersdk.SubdomainAppSessionTokenCookie, Value: "subdomain-app"},
 			},
 			expectedCookies: map[string]string{
 				codersdk.SessionTokenCookie:             "session",
@@ -970,13 +970,13 @@ func TestHTTPCookieConfigMiddleware(t *testing.T) {
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
 				{Name: "custom_cookie", Value: "custom-value"},
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "session"},
-				{Name: "__HOST-foobar", Value: "do-not-change-me"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "session"},
+				{Name: "__Host-foobar", Value: "do-not-change-me"},
 			},
 			expectedCookies: map[string]string{
 				"custom_cookie":             "custom-value",
 				codersdk.SessionTokenCookie: "session",
-				"__HOST-foobar":             "do-not-change-me",
+				"__Host-foobar":             "do-not-change-me",
 			},
 		},
 	}
@@ -1066,24 +1066,24 @@ func BenchmarkHTTPCookieConfigMiddleware(b *testing.B) {
 			name: "Enabled_WithPrefixedCookie",
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
 			},
 		},
 		{
 			name: "Enabled_MultiplePrefixedCookies",
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
-				{Name: "__HOST-" + codersdk.PathAppSessionTokenCookie, Value: "xyz123"},
-				{Name: "__HOST-" + codersdk.SubdomainAppSessionTokenCookie, Value: "abc456"},
-				{Name: "__HOST-" + "foobar", Value: "do-not-change-me"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
+				{Name: "__Host-" + codersdk.PathAppSessionTokenCookie, Value: "xyz123"},
+				{Name: "__Host-" + codersdk.SubdomainAppSessionTokenCookie, Value: "abc456"},
+				{Name: "__Host-" + "foobar", Value: "do-not-change-me"},
 			},
 		},
 		{
 			name: "Enabled_NonSessionPrefixedCookies",
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
-				{Name: "__HOST-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
+				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "KybJV9fNul-u11vlll9wiF6eLQDxBVucD"},
 			},
 		},
 	}

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -1093,9 +1093,10 @@ func BenchmarkHTTPCookieConfigMiddleware(b *testing.B) {
 			handler := tc.cfg.Middleware(noop)
 			rw := httptest.NewRecorder()
 
-			allCookies := make([]*http.Cookie, 0, len(baseCookies)+len(tc.extraCookies))
+			allCookies := make([]*http.Cookie, 1, len(baseCookies))
+			copy(allCookies, baseCookies)
 			// Combine base cookies with test-specific cookies.
-			allCookies = append(baseCookies, tc.extraCookies...)
+			allCookies = append(allCookies, tc.extraCookies...)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -942,27 +942,25 @@ func TestHTTPCookieConfigMiddleware(t *testing.T) {
 			extraCookies: []*http.Cookie{
 				// Browser might send both during migration.
 				{Name: codersdk.SessionTokenCookie, Value: "unprefixed-token"},
-				{Name: codersdk.PathAppSessionTokenCookie, Value: "unprefixed-token"},
-				{Name: codersdk.SubdomainAppSessionTokenCookie, Value: "unprefixed-token"},
 				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "prefixed-token"},
 			},
 			expectedCookies: map[string]string{
 				codersdk.SessionTokenCookie: "prefixed-token", // Prefixed wins.
 			},
-			expectedDeleted: []string{codersdk.SessionTokenCookie, codersdk.PathAppSessionTokenCookie, codersdk.SubdomainAppSessionTokenCookie},
+			expectedDeleted: []string{codersdk.SessionTokenCookie},
 		},
 		{
 			name: "Enabled_MultiplePrefixedCookies",
 			cfg:  codersdk.HTTPCookieConfig{EnableHostPrefix: true},
 			extraCookies: []*http.Cookie{
 				{Name: "__Host-" + codersdk.SessionTokenCookie, Value: "session"},
-				{Name: "__Host-" + codersdk.PathAppSessionTokenCookie, Value: "path-app"},
-				{Name: "__Host-" + codersdk.SubdomainAppSessionTokenCookie, Value: "subdomain-app"},
+				{Name: "__Host-SomeOtherCookie", Value: "other-cookie"},
+				{Name: "__Host-Santa", Value: "santa"},
 			},
 			expectedCookies: map[string]string{
-				codersdk.SessionTokenCookie:             "session",
-				codersdk.PathAppSessionTokenCookie:      "path-app",
-				codersdk.SubdomainAppSessionTokenCookie: "subdomain-app",
+				codersdk.SessionTokenCookie: "session",
+				"__Host-SomeOtherCookie":    "other-cookie",
+				"__Host-Santa":              "santa",
 			},
 		},
 		{

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -1093,8 +1093,9 @@ func BenchmarkHTTPCookieConfigMiddleware(b *testing.B) {
 			handler := tc.cfg.Middleware(noop)
 			rw := httptest.NewRecorder()
 
+			allCookies := make([]*http.Cookie, 0, len(baseCookies)+len(tc.extraCookies))
 			// Combine base cookies with test-specific cookies.
-			allCookies := append(baseCookies, tc.extraCookies...)
+			allCookies = append(baseCookies, tc.extraCookies...)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -314,6 +314,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "hide_ai_tasks": true,
     "http_address": "string",
     "http_cookies": {
+      "host_prefix": true,
       "same_site": "string",
       "secure_auth_cookie": true
     },

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2815,6 +2815,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "hide_ai_tasks": true,
     "http_address": "string",
     "http_cookies": {
+      "host_prefix": true,
       "same_site": "string",
       "secure_auth_cookie": true
     },
@@ -3369,6 +3370,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "hide_ai_tasks": true,
   "http_address": "string",
   "http_cookies": {
+    "host_prefix": true,
     "same_site": "string",
     "secure_auth_cookie": true
   },
@@ -4492,6 +4494,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ```json
 {
+  "host_prefix": true,
   "same_site": "string",
   "secure_auth_cookie": true
 }
@@ -4501,6 +4504,7 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 | Name                 | Type    | Required | Restrictions | Description |
 |----------------------|---------|----------|--------------|-------------|
+| `host_prefix`        | boolean | false    |              |             |
 | `same_site`          | string  | false    |              |             |
 | `secure_auth_cookie` | boolean | false    |              |             |
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1067,7 +1067,7 @@ Controls the 'SameSite' property is set on browser session cookies.
 | YAML        | <code>networking.hostPrefixCookie</code> |
 | Default     | <code>false</code>                       |
 
-Reccomended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.
+Recommended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.
 
 ### --terms-of-service-url
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1067,7 +1067,7 @@ Controls the 'SameSite' property is set on browser session cookies.
 | YAML        | <code>networking.hostPrefixCookie</code> |
 | Default     | <code>false</code>                       |
 
-Recommended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.
+Recommended to be enabled. Enables `__Host-` prefix for cookies to guarantee they are only set by the right domain.
 
 ### --terms-of-service-url
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1058,6 +1058,17 @@ Controls if the 'Secure' property is set on browser session cookies.
 
 Controls the 'SameSite' property is set on browser session cookies.
 
+### --host-prefix-cookie
+
+|             |                                          |
+|-------------|------------------------------------------|
+| Type        | <code>bool</code>                        |
+| Environment | <code>$CODER_HOST_PREFIX_COOKIE</code>   |
+| YAML        | <code>networking.hostPrefixCookie</code> |
+| Default     | <code>false</code>                       |
+
+Reccomended to be enabled. Enables `__HOST-` prefix for cookies to guarantee they are only set by the right domain.
+
 ### --terms-of-service-url
 
 |             |                                          |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -98,7 +98,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-AI BRIDGE OPTIONS: 
+AI BRIDGE OPTIONS:
       --aibridge-anthropic-base-url string, $CODER_AIBRIDGE_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           The base URL of the Anthropic API.
 
@@ -173,7 +173,7 @@ AI BRIDGE OPTIONS:
           Emit structured logs for AI Bridge interception records. Use this for
           exporting these records to external SIEM or observability systems.
 
-AI BRIDGE PROXY OPTIONS: 
+AI BRIDGE PROXY OPTIONS:
       --aibridge-proxy-cert-file string, $CODER_AIBRIDGE_PROXY_CERT_FILE
           Path to the CA certificate file for AI Bridge Proxy.
 
@@ -198,7 +198,7 @@ AI BRIDGE PROXY OPTIONS:
           certificates not trusted by the system. If not provided, the system
           certificate pool is used.
 
-CLIENT OPTIONS: 
+CLIENT OPTIONS:
 These options change the behavior of how clients interact with the Coder.
 Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 
@@ -225,17 +225,17 @@ Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
           Coder Desktop. By default it is coder, resulting in names like
           myworkspace.coder.
 
-CONFIG OPTIONS: 
+CONFIG OPTIONS:
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-          
+
           Write out the current server config as YAML to stdout.
 
-EMAIL OPTIONS: 
+EMAIL OPTIONS:
 Configure how emails are sent.
 
       --email-force-tls bool, $CODER_EMAIL_FORCE_TLS (default: false)
@@ -250,7 +250,7 @@ Configure how emails are sent.
       --email-smarthost string, $CODER_EMAIL_SMARTHOST
           The intermediary SMTP host through which emails are sent.
 
-EMAIL / EMAIL AUTHENTICATION OPTIONS: 
+EMAIL / EMAIL AUTHENTICATION OPTIONS:
 Configure SMTP authentication options.
 
       --email-auth-identity string, $CODER_EMAIL_AUTH_IDENTITY
@@ -266,7 +266,7 @@ Configure SMTP authentication options.
       --email-auth-username string, $CODER_EMAIL_AUTH_USERNAME
           Username to use with PLAIN/LOGIN authentication.
 
-EMAIL / EMAIL TLS OPTIONS: 
+EMAIL / EMAIL TLS OPTIONS:
 Configure TLS for your SMTP server target.
 
       --email-tls-ca-cert-file string, $CODER_EMAIL_TLS_CACERTFILE
@@ -287,7 +287,7 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
-INTROSPECTION / HEALTH CHECK OPTIONS: 
+INTROSPECTION / HEALTH CHECK OPTIONS:
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -296,7 +296,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS: 
+INTROSPECTION / LOGGING OPTIONS:
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -313,7 +313,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS: 
+INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -333,7 +333,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS: 
+INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
       --stats-collection-usage-stats-enable bool, $CODER_STATS_COLLECTION_USAGE_STATS_ENABLE (default: true)
           Enable the collection of application and workspace usage along with
           the associated API endpoints and the template insights page. Disabling
@@ -341,7 +341,7 @@ INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
           deployment stats shown to admins in the bottom bar of the Coder UI,
           and will prevent Prometheus collection of these values.
 
-INTROSPECTION / TRACING OPTIONS: 
+INTROSPECTION / TRACING OPTIONS:
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -355,14 +355,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS: 
+INTROSPECTION / PPROF OPTIONS:
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS: 
+NETWORKING OPTIONS:
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -392,10 +392,10 @@ NETWORKING OPTIONS:
           the form "*.example.com".
 
       --host-prefix-cookie bool, $CODER_HOST_PREFIX_COOKIE (default: false)
-          Recommended to be enabled. Enables `__HOST-` prefix for cookies to
+          Recommended to be enabled. Enables `__Host-` prefix for cookies to
           guarantee they are only set by the right domain.
 
-NETWORKING / DERP OPTIONS: 
+NETWORKING / DERP OPTIONS:
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -437,7 +437,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS: 
+NETWORKING / HTTP OPTIONS:
       --additional-csp-policy string-array, $CODER_ADDITIONAL_CSP_POLICY
           Coder configures a Content Security Policy (CSP) to protect against
           XSS attacks. This setting allows you to add additional CSP directives,
@@ -479,7 +479,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS: 
+NETWORKING / TLS OPTIONS:
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -541,7 +541,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-NOTIFICATIONS OPTIONS: 
+NOTIFICATIONS OPTIONS:
 Configure how notifications are processed and delivered.
 
       --notifications-dispatch-timeout duration, $CODER_NOTIFICATIONS_DISPATCH_TIMEOUT (default: 1m0s)
@@ -553,7 +553,7 @@ Configure how notifications are processed and delivered.
       --notifications-method string, $CODER_NOTIFICATIONS_METHOD (default: smtp)
           Which delivery method to use (available options: 'smtp', 'webhook').
 
-NOTIFICATIONS / EMAIL OPTIONS: 
+NOTIFICATIONS / EMAIL OPTIONS:
 Configure how email notifications are sent.
 
       --notifications-email-force-tls bool, $CODER_NOTIFICATIONS_EMAIL_FORCE_TLS
@@ -572,7 +572,7 @@ Configure how email notifications are sent.
           The intermediary SMTP host through which emails are sent.
           DEPRECATED: Use --email-smarthost instead.
 
-NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS: 
+NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS:
 Configure SMTP authentication options.
 
       --notifications-email-auth-identity string, $CODER_NOTIFICATIONS_EMAIL_AUTH_IDENTITY
@@ -592,7 +592,7 @@ Configure SMTP authentication options.
           Username to use with PLAIN/LOGIN authentication.
           DEPRECATED: Use --email-auth-username instead.
 
-NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS: 
+NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS:
 Configure TLS for your SMTP server target.
 
       --notifications-email-tls-ca-cert-file string, $CODER_NOTIFICATIONS_EMAIL_TLS_CACERTFILE
@@ -619,15 +619,15 @@ Configure TLS for your SMTP server target.
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
           DEPRECATED: Use --email-tls-starttls instead.
 
-NOTIFICATIONS / INBOX OPTIONS: 
+NOTIFICATIONS / INBOX OPTIONS:
       --notifications-inbox-enabled bool, $CODER_NOTIFICATIONS_INBOX_ENABLED (default: true)
           Enable Coder Inbox.
 
-NOTIFICATIONS / WEBHOOK OPTIONS: 
+NOTIFICATIONS / WEBHOOK OPTIONS:
       --notifications-webhook-endpoint url, $CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT
           The endpoint to which to send webhooks.
 
-OAUTH2 / GITHUB OPTIONS: 
+OAUTH2 / GITHUB OPTIONS:
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -658,7 +658,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS: 
+OIDC OPTIONS:
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -758,7 +758,7 @@ OIDC OPTIONS:
           requirement, and can lead to an insecure OIDC configuration. It is not
           recommended to use this flag.
 
-PROVISIONING OPTIONS: 
+PROVISIONING OPTIONS:
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -779,7 +779,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-RETENTION OPTIONS: 
+RETENTION OPTIONS:
 Configure data retention policies for various database tables. Retention
 policies automatically purge old data to reduce database size and improve
 performance. Setting a retention duration to 0 disables automatic purging for
@@ -806,7 +806,7 @@ that data type.
           Logs from the latest build are always retained. Set to 0 to disable
           automatic deletion.
 
-TELEMETRY OPTIONS: 
+TELEMETRY OPTIONS:
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry
 when required by your organization's security policy.
@@ -815,7 +815,7 @@ when required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS: 
+USER QUIET HOURS SCHEDULE OPTIONS:
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template scheduling.
 
@@ -835,13 +835,13 @@ workspaces stopping during the day due to template scheduling.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-WORKSPACE PREBUILDS OPTIONS: 
+WORKSPACE PREBUILDS OPTIONS:
 Configure how workspace prebuilds behave.
 
       --workspace-prebuilds-reconciliation-interval duration, $CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL (default: 1m0s)
           How often to reconcile workspace prebuilds state.
 
-⚠️ DANGEROUS OPTIONS: 
+⚠️ DANGEROUS OPTIONS:
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -858,7 +858,7 @@ Configure how workspace prebuilds behave.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS: 
+ENTERPRISE OPTIONS:
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -98,7 +98,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-AI BRIDGE OPTIONS:
+AI BRIDGE OPTIONS: 
       --aibridge-anthropic-base-url string, $CODER_AIBRIDGE_ANTHROPIC_BASE_URL (default: https://api.anthropic.com/)
           The base URL of the Anthropic API.
 
@@ -173,7 +173,7 @@ AI BRIDGE OPTIONS:
           Emit structured logs for AI Bridge interception records. Use this for
           exporting these records to external SIEM or observability systems.
 
-AI BRIDGE PROXY OPTIONS:
+AI BRIDGE PROXY OPTIONS: 
       --aibridge-proxy-cert-file string, $CODER_AIBRIDGE_PROXY_CERT_FILE
           Path to the CA certificate file for AI Bridge Proxy.
 
@@ -198,7 +198,7 @@ AI BRIDGE PROXY OPTIONS:
           certificates not trusted by the system. If not provided, the system
           certificate pool is used.
 
-CLIENT OPTIONS:
+CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
 Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
 
@@ -225,17 +225,17 @@ Clients include the Coder CLI, Coder Desktop, IDE extensions, and the web UI.
           Coder Desktop. By default it is coder, resulting in names like
           myworkspace.coder.
 
-CONFIG OPTIONS:
+CONFIG OPTIONS: 
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-
+          
           Write out the current server config as YAML to stdout.
 
-EMAIL OPTIONS:
+EMAIL OPTIONS: 
 Configure how emails are sent.
 
       --email-force-tls bool, $CODER_EMAIL_FORCE_TLS (default: false)
@@ -250,7 +250,7 @@ Configure how emails are sent.
       --email-smarthost string, $CODER_EMAIL_SMARTHOST
           The intermediary SMTP host through which emails are sent.
 
-EMAIL / EMAIL AUTHENTICATION OPTIONS:
+EMAIL / EMAIL AUTHENTICATION OPTIONS: 
 Configure SMTP authentication options.
 
       --email-auth-identity string, $CODER_EMAIL_AUTH_IDENTITY
@@ -266,7 +266,7 @@ Configure SMTP authentication options.
       --email-auth-username string, $CODER_EMAIL_AUTH_USERNAME
           Username to use with PLAIN/LOGIN authentication.
 
-EMAIL / EMAIL TLS OPTIONS:
+EMAIL / EMAIL TLS OPTIONS: 
 Configure TLS for your SMTP server target.
 
       --email-tls-ca-cert-file string, $CODER_EMAIL_TLS_CACERTFILE
@@ -287,7 +287,7 @@ Configure TLS for your SMTP server target.
       --email-tls-starttls bool, $CODER_EMAIL_TLS_STARTTLS
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
 
-INTROSPECTION / HEALTH CHECK OPTIONS:
+INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -296,7 +296,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS:
+INTROSPECTION / LOGGING OPTIONS: 
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -313,7 +313,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS:
+INTROSPECTION / PROMETHEUS OPTIONS: 
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -333,7 +333,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
+INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS: 
       --stats-collection-usage-stats-enable bool, $CODER_STATS_COLLECTION_USAGE_STATS_ENABLE (default: true)
           Enable the collection of application and workspace usage along with
           the associated API endpoints and the template insights page. Disabling
@@ -341,7 +341,7 @@ INTROSPECTION / STATS COLLECTION / USAGE STATS OPTIONS:
           deployment stats shown to admins in the bottom bar of the Coder UI,
           and will prevent Prometheus collection of these values.
 
-INTROSPECTION / TRACING OPTIONS:
+INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -355,14 +355,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS:
+INTROSPECTION / PPROF OPTIONS: 
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS:
+NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -395,7 +395,7 @@ NETWORKING OPTIONS:
           Recommended to be enabled. Enables `__Host-` prefix for cookies to
           guarantee they are only set by the right domain.
 
-NETWORKING / DERP OPTIONS:
+NETWORKING / DERP OPTIONS: 
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -437,7 +437,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS:
+NETWORKING / HTTP OPTIONS: 
       --additional-csp-policy string-array, $CODER_ADDITIONAL_CSP_POLICY
           Coder configures a Content Security Policy (CSP) to protect against
           XSS attacks. This setting allows you to add additional CSP directives,
@@ -479,7 +479,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS:
+NETWORKING / TLS OPTIONS: 
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -541,7 +541,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-NOTIFICATIONS OPTIONS:
+NOTIFICATIONS OPTIONS: 
 Configure how notifications are processed and delivered.
 
       --notifications-dispatch-timeout duration, $CODER_NOTIFICATIONS_DISPATCH_TIMEOUT (default: 1m0s)
@@ -553,7 +553,7 @@ Configure how notifications are processed and delivered.
       --notifications-method string, $CODER_NOTIFICATIONS_METHOD (default: smtp)
           Which delivery method to use (available options: 'smtp', 'webhook').
 
-NOTIFICATIONS / EMAIL OPTIONS:
+NOTIFICATIONS / EMAIL OPTIONS: 
 Configure how email notifications are sent.
 
       --notifications-email-force-tls bool, $CODER_NOTIFICATIONS_EMAIL_FORCE_TLS
@@ -572,7 +572,7 @@ Configure how email notifications are sent.
           The intermediary SMTP host through which emails are sent.
           DEPRECATED: Use --email-smarthost instead.
 
-NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS:
+NOTIFICATIONS / EMAIL / EMAIL AUTHENTICATION OPTIONS: 
 Configure SMTP authentication options.
 
       --notifications-email-auth-identity string, $CODER_NOTIFICATIONS_EMAIL_AUTH_IDENTITY
@@ -592,7 +592,7 @@ Configure SMTP authentication options.
           Username to use with PLAIN/LOGIN authentication.
           DEPRECATED: Use --email-auth-username instead.
 
-NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS:
+NOTIFICATIONS / EMAIL / EMAIL TLS OPTIONS: 
 Configure TLS for your SMTP server target.
 
       --notifications-email-tls-ca-cert-file string, $CODER_NOTIFICATIONS_EMAIL_TLS_CACERTFILE
@@ -619,15 +619,15 @@ Configure TLS for your SMTP server target.
           Enable STARTTLS to upgrade insecure SMTP connections using TLS.
           DEPRECATED: Use --email-tls-starttls instead.
 
-NOTIFICATIONS / INBOX OPTIONS:
+NOTIFICATIONS / INBOX OPTIONS: 
       --notifications-inbox-enabled bool, $CODER_NOTIFICATIONS_INBOX_ENABLED (default: true)
           Enable Coder Inbox.
 
-NOTIFICATIONS / WEBHOOK OPTIONS:
+NOTIFICATIONS / WEBHOOK OPTIONS: 
       --notifications-webhook-endpoint url, $CODER_NOTIFICATIONS_WEBHOOK_ENDPOINT
           The endpoint to which to send webhooks.
 
-OAUTH2 / GITHUB OPTIONS:
+OAUTH2 / GITHUB OPTIONS: 
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -658,7 +658,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS:
+OIDC OPTIONS: 
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -758,7 +758,7 @@ OIDC OPTIONS:
           requirement, and can lead to an insecure OIDC configuration. It is not
           recommended to use this flag.
 
-PROVISIONING OPTIONS:
+PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -779,7 +779,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-RETENTION OPTIONS:
+RETENTION OPTIONS: 
 Configure data retention policies for various database tables. Retention
 policies automatically purge old data to reduce database size and improve
 performance. Setting a retention duration to 0 disables automatic purging for
@@ -806,7 +806,7 @@ that data type.
           Logs from the latest build are always retained. Set to 0 to disable
           automatic deletion.
 
-TELEMETRY OPTIONS:
+TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all personal
 information before sending data to our servers. Please only disable telemetry
 when required by your organization's security policy.
@@ -815,7 +815,7 @@ when required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS:
+USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template scheduling.
 
@@ -835,13 +835,13 @@ workspaces stopping during the day due to template scheduling.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-WORKSPACE PREBUILDS OPTIONS:
+WORKSPACE PREBUILDS OPTIONS: 
 Configure how workspace prebuilds behave.
 
       --workspace-prebuilds-reconciliation-interval duration, $CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL (default: 1m0s)
           How often to reconcile workspace prebuilds state.
 
-⚠️ DANGEROUS OPTIONS:
+⚠️ DANGEROUS OPTIONS: 
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -858,7 +858,7 @@ Configure how workspace prebuilds behave.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS:
+ENTERPRISE OPTIONS: 
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -392,7 +392,7 @@ NETWORKING OPTIONS:
           the form "*.example.com".
 
       --host-prefix-cookie bool, $CODER_HOST_PREFIX_COOKIE (default: false)
-          Reccomended to be enabled. Enables `__HOST-` prefix for cookies to
+          Recommended to be enabled. Enables `__HOST-` prefix for cookies to
           guarantee they are only set by the right domain.
 
 NETWORKING / DERP OPTIONS: 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -391,6 +391,10 @@ NETWORKING OPTIONS:
           Specifies the wildcard hostname to use for workspace applications in
           the form "*.example.com".
 
+      --host-prefix-cookie bool, $CODER_HOST_PREFIX_COOKIE (default: false)
+          Reccomended to be enabled. Enables `__HOST-` prefix for cookies to
+          guarantee they are only set by the right domain.
+
 NETWORKING / DERP OPTIONS: 
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -332,12 +332,12 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 		sharedhttpmw.Recover(s.Logger),
 		httpmw.WithProfilingLabels,
 		tracing.StatusWriterMiddleware,
+		opts.CookieConfig.Middleware,
 		tracing.Middleware(s.TracerProvider),
 		httpmw.AttachRequestID,
 		httpmw.ExtractRealIP(s.Options.RealIPConfig),
 		loggermw.Logger(s.Logger),
 		prometheusMW,
-		opts.CookieConfig.Middleware,
 
 		// HandleSubdomain is a middleware that handles all requests to the
 		// subdomain-based workspace apps.

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -337,6 +337,7 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 		httpmw.ExtractRealIP(s.Options.RealIPConfig),
 		loggermw.Logger(s.Logger),
 		prometheusMW,
+		opts.CookieConfig.Middleware,
 
 		// HandleSubdomain is a middleware that handles all requests to the
 		// subdomain-based workspace apps.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2341,6 +2341,7 @@ export interface GroupSyncSettings {
 export interface HTTPCookieConfig {
 	readonly secure_auth_cookie?: boolean;
 	readonly same_site?: string;
+	readonly host_prefix?: boolean;
 }
 
 // From health/model.go


### PR DESCRIPTION
# What this does

When the deployment option is enabled auth cookies are prefixed with `__HOST-` ([info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie)).

This is all done in a middleware that intercepts all requests and strips the prefix on incoming request cookies.

For setting cookies the `.Apply(` methods intercepts all `Set-Cookie`.


# Implementation

I did consider avoiding the looping behavior of this PR, but upon benchmarking the performance impact is negligible 

```
BenchmarkHTTPCookieConfigMiddleware
BenchmarkHTTPCookieConfigMiddleware/Disabled
BenchmarkHTTPCookieConfigMiddleware/Disabled-16         	  397396	      2744 ns/op
BenchmarkHTTPCookieConfigMiddleware/Enabled_NoPrefixedCookies
BenchmarkHTTPCookieConfigMiddleware/Enabled_NoPrefixedCookies-16         	  316842	      3797 ns/op
BenchmarkHTTPCookieConfigMiddleware/Enabled_WithPrefixedCookie
BenchmarkHTTPCookieConfigMiddleware/Enabled_WithPrefixedCookie-16        	  314773	      3833 ns/op
BenchmarkHTTPCookieConfigMiddleware/Enabled_MultiplePrefixedCookies
BenchmarkHTTPCookieConfigMiddleware/Enabled_MultiplePrefixedCookies-16   	  207536	      6409 ns/op
BenchmarkHTTPCookieConfigMiddleware/Enabled_NonSessionPrefixedCookies
BenchmarkHTTPCookieConfigMiddleware/Enabled_NonSessionPrefixedCookies-16 	  207328	      5851 ns/op
```


## Other considerations

I did consider implementing this code in `ExtractAPIKey` middleware and similar authentication spots. Instead of finding all the places that we use auth tokens, this middleware handles it all. The codebase does not have to deal with the possible prefixs.

This is also beneficial when handling unprefix'd cookies in a standardized way
