### PR TITLE
fix(site): respect meta user appearance preference as theme fallback

### DIFF
--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -58,9 +58,12 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 	}, [themeQuery]);
 
 	// We might not be logged in yet, or the `theme_preference` could be an empty string.
+	// Prefer JS-fetched value, fall back to server-rendered meta tag, then default.
 	const themePreference =
-		appearanceSettingsQuery.data?.theme_preference || DEFAULT_THEME;
-	// The janky casting here is find because of the much more type safe fallback
+		appearanceSettingsQuery.data?.theme_preference ||
+		metadata.userAppearance?.value?.theme_preference ||
+		DEFAULT_THEME;
+	// The janky casting here is fine because of the much more type safe fallback
 	// We need to support `themePreference` being wrong anyway because the database
 	// value could be anything, like an empty string.
 


### PR DESCRIPTION
Use the server-rendered meta tag value as an intermediate fallback for theme preference, between the JS-fetched value and the default theme. This ensures the correct theme is applied before the API response loads.

Fixes #20050