### PR TITLE
fix: stop workspace on failed starts prior to retrying start

### DIFF
--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -586,4 +586,3 @@ func TestStart_FailedStartCleansUp(t *testing.T) {
 
 	_ = testutil.TryReceive(ctx, t, doneChan)
 }
-

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -345,6 +345,7 @@ type SearchParamOptions = TypesGen.Pagination & {
 type RestartWorkspaceParameters = Readonly<{
 	workspace: TypesGen.Workspace;
 	buildParameters?: TypesGen.WorkspaceBuildParameter[];
+	logLevel?: TypesGen.ProvisionerLogLevel;
 }>;
 
 export type DeleteWorkspaceOptions = Pick<
@@ -1385,8 +1386,9 @@ class ApiMethods {
 	restartWorkspace = async ({
 		workspace,
 		buildParameters,
+		logLevel,
 	}: RestartWorkspaceParameters): Promise<void> => {
-		const stopBuild = await this.stopWorkspace(workspace.id);
+		const stopBuild = await this.stopWorkspace(workspace.id, logLevel);
 		const awaitedStopBuild = await this.waitForBuild(stopBuild);
 
 		// If the restart is canceled halfway through, make sure we bail
@@ -1397,7 +1399,7 @@ class ApiMethods {
 		const startBuild = await this.startWorkspace(
 			workspace.id,
 			workspace.latest_build.template_version_id,
-			undefined,
+			logLevel,
 			buildParameters,
 		);
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2236,8 +2236,14 @@ class ApiMethods {
 
 	updateWorkspaceVersion = async (
 		workspace: TypesGen.Workspace,
-	): Promise<TypesGen.WorkspaceBuild> => {
+	): Promise<TypesGen.WorkspaceBuild | void> => {
 		const template = await this.getTemplate(workspace.template_id);
+		if (
+			workspace.latest_build.status === "failed" &&
+			workspace.latest_build.transition === "start"
+		) {
+			return this.restartWorkspace({ workspace });
+		}
 		return this.startWorkspace(workspace.id, template.active_version_id);
 	};
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1387,13 +1387,15 @@ class ApiMethods {
 		workspace,
 		buildParameters,
 		logLevel,
-	}: RestartWorkspaceParameters): Promise<void> => {
+	}: RestartWorkspaceParameters): Promise<
+		TypesGen.WorkspaceBuild | undefined
+	> => {
 		const stopBuild = await this.stopWorkspace(workspace.id, logLevel);
 		const awaitedStopBuild = await this.waitForBuild(stopBuild);
 
 		// If the restart is canceled halfway through, make sure we bail
 		if (awaitedStopBuild?.status === "canceled") {
-			return;
+			return undefined;
 		}
 
 		const startBuild = await this.startWorkspace(
@@ -1404,6 +1406,7 @@ class ApiMethods {
 		);
 
 		await this.waitForBuild(startBuild);
+		return startBuild;
 	};
 
 	cancelTemplateVersionBuild = async (
@@ -2236,7 +2239,7 @@ class ApiMethods {
 
 	updateWorkspaceVersion = async (
 		workspace: TypesGen.Workspace,
-	): Promise<TypesGen.WorkspaceBuild | void> => {
+	): Promise<TypesGen.WorkspaceBuild | undefined> => {
 		const template = await this.getTemplate(workspace.template_id);
 		if (
 			workspace.latest_build.status === "failed" &&

--- a/site/src/api/queries/tasks.ts
+++ b/site/src/api/queries/tasks.ts
@@ -22,6 +22,10 @@ export const resumeTask = (task: Task, queryClient: QueryClient) => {
 			if (!task.workspace_id) {
 				throw new Error("Task has no workspace");
 			}
+			// TODO: #22043 - If the task's workspace has a failed start,
+			// we should call restartWorkspace to clean up before starting.
+			// Currently we lack the full Workspace object needed to check
+			// latest_build.status and latest_build.transition.
 			return API.startWorkspace(
 				task.workspace_id,
 				task.template_version_id,

--- a/site/src/api/queries/workspaces.ts
+++ b/site/src/api/queries/workspaces.ts
@@ -318,12 +318,11 @@ export const startWorkspace = (
 				workspace.latest_build.transition === "start" &&
 				workspace.latest_build.status === "failed"
 			) {
-				await API.restartWorkspace({
+				return API.restartWorkspace({
 					workspace,
 					buildParameters,
 					logLevel,
 				});
-				return undefined;
 			}
 			return API.startWorkspace(
 				workspace.id,

--- a/site/src/pages/WorkspacePage/WorkspacePage.jest.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.jest.tsx
@@ -421,7 +421,9 @@ describe("WorkspacePage", () => {
 		const retryDebugButtonRe = /^Debug$/i;
 
 		describe("Retries a failed 'Start' transition", () => {
-			const mockStart = jest.spyOn(API, "startWorkspace");
+			const mockRestart = jest
+				.spyOn(API, "restartWorkspace")
+				.mockResolvedValue(undefined);
 			const failedStart: Workspace = {
 				...MockFailedWorkspace,
 				latest_build: {
@@ -431,25 +433,23 @@ describe("WorkspacePage", () => {
 			};
 
 			test("Retry with no debug", async () => {
-				await testButton(failedStart, retryButtonRe, mockStart);
+				await testButton(failedStart, retryButtonRe, mockRestart);
 
-				expect(mockStart).toBeCalledWith(
-					failedStart.id,
-					failedStart.latest_build.template_version_id,
-					undefined,
-					undefined,
-				);
+				expect(mockRestart).toBeCalledWith({
+					workspace: failedStart,
+					buildParameters: undefined,
+					logLevel: undefined,
+				});
 			});
 
 			test("Retry with debug logs", async () => {
-				await testButton(failedStart, retryDebugButtonRe, mockStart);
+				await testButton(failedStart, retryDebugButtonRe, mockRestart);
 
-				expect(mockStart).toBeCalledWith(
-					failedStart.id,
-					failedStart.latest_build.template_version_id,
-					"debug",
-					undefined,
-				);
+				expect(mockRestart).toBeCalledWith({
+					workspace: failedStart,
+					buildParameters: undefined,
+					logLevel: "debug",
+				});
 			});
 		});
 
@@ -522,7 +522,9 @@ describe("WorkspacePage", () => {
 				return HttpResponse.json([parameter]);
 			}),
 		);
-		const startWorkspaceSpy = jest.spyOn(API, "startWorkspace");
+		const restartWorkspaceSpy = jest
+			.spyOn(API, "restartWorkspace")
+			.mockResolvedValue(undefined);
 
 		await renderWorkspacePage(workspace);
 		const retryWithBuildParametersButton = await screen.findByRole("button", {
@@ -539,12 +541,11 @@ describe("WorkspacePage", () => {
 		await user.click(submitButton);
 
 		await waitFor(() => {
-			expect(startWorkspaceSpy).toBeCalledWith(
-				workspace.id,
-				workspace.latest_build.template_version_id,
-				undefined,
-				[{ name: parameter.name, value: "some-value" }],
-			);
+			expect(restartWorkspaceSpy).toBeCalledWith({
+				workspace,
+				buildParameters: [{ name: parameter.name, value: "some-value" }],
+				logLevel: undefined,
+			});
 		});
 	});
 
@@ -568,7 +569,9 @@ describe("WorkspacePage", () => {
 				return HttpResponse.json([parameter]);
 			}),
 		);
-		const startWorkspaceSpy = jest.spyOn(API, "startWorkspace");
+		const restartWorkspaceSpy = jest
+			.spyOn(API, "restartWorkspace")
+			.mockResolvedValue(undefined);
 
 		await renderWorkspacePage(workspace);
 		const retryWithBuildParametersButton = await screen.findByRole("button", {
@@ -585,12 +588,11 @@ describe("WorkspacePage", () => {
 		await user.click(submitButton);
 
 		await waitFor(() => {
-			expect(startWorkspaceSpy).toBeCalledWith(
-				workspace.id,
-				workspace.latest_build.template_version_id,
-				"debug",
-				[{ name: parameter.name, value: "some-value" }],
-			);
+			expect(restartWorkspaceSpy).toBeCalledWith({
+				workspace,
+				buildParameters: [{ name: parameter.name, value: "some-value" }],
+				logLevel: "debug",
+			});
 		});
 	});
 

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -235,10 +235,20 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 		} else {
 			switch (workspace.latest_build.transition) {
 				case "start":
-					startWorkspaceMutation.mutate({
-						logLevel,
-						buildParameters,
-					});
+					// If the last build was a failed start, clean up
+					// before retrying by running a stop→start sequence.
+					if (workspace.latest_build.status === "failed") {
+						mutateRestartWorkspace({
+							workspace,
+							buildParameters,
+							logLevel,
+						});
+					} else {
+						startWorkspaceMutation.mutate({
+							logLevel,
+							buildParameters,
+						});
+					}
 					break;
 				case "stop":
 					stopWorkspaceMutation.mutate({ logLevel });

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -71,8 +71,19 @@ const WorkspaceSchedulePage: FC = () => {
 
 	const [isConfirmingApply, setIsConfirmingApply] = useState(false);
 	const { mutate: updateWorkspace } = useMutation({
-		mutationFn: () =>
-			API.startWorkspace(workspace.id, workspace.template_active_version_id),
+		mutationFn: async () => {
+			if (
+				workspace.latest_build.status === "failed" &&
+				workspace.latest_build.transition === "start"
+			) {
+				await API.restartWorkspace({ workspace });
+				return;
+			}
+			await API.startWorkspace(
+				workspace.id,
+				workspace.template_active_version_id,
+			);
+		},
 	});
 
 	return (


### PR DESCRIPTION
Updates the `Retry` action to attempt a stop prior to re-running a start. This is a best attempt at putting the workspace in a "fresh" state before retrying. 