### PR TITLE
chore: add id to template version output columns

### DIFF
--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -141,6 +141,7 @@ type templateVersionRow struct {
 	TemplateVersion codersdk.TemplateVersion `table:"-"`
 
 	// For table format:
+	ID        string    `json:"-" table:"id"`
 	Name      string    `json:"-" table:"name,default_sort"`
 	CreatedAt time.Time `json:"-" table:"created at"`
 	CreatedBy string    `json:"-" table:"created by"`
@@ -166,6 +167,7 @@ func templateVersionsToRows(activeVersionID uuid.UUID, templateVersions ...coder
 
 		rows[i] = templateVersionRow{
 			TemplateVersion: templateVersion,
+			ID:              templateVersion.ID.String(),
 			Name:            templateVersion.Name,
 			CreatedAt:       templateVersion.CreatedAt,
 			CreatedBy:       templateVersion.CreatedBy.Username,

--- a/cli/testdata/coder_templates_versions_list_--help.golden
+++ b/cli/testdata/coder_templates_versions_list_--help.golden
@@ -9,7 +9,7 @@ OPTIONS:
   -O, --org string, $CODER_ORGANIZATION
           Select which organization (uuid or name) to use.
 
-  -c, --column [name|created at|created by|status|active|archived] (default: name,created at,created by,status,active)
+  -c, --column [id|name|created at|created by|status|active|archived] (default: name,created at,created by,status,active)
           Columns to display in table output.
 
       --include-archived bool

--- a/docs/reference/cli/templates_versions_list.md
+++ b/docs/reference/cli/templates_versions_list.md
@@ -30,10 +30,10 @@ Select which organization (uuid or name) to use.
 
 ### -c, --column
 
-|         |                                                                       |
-|---------|-----------------------------------------------------------------------|
-| Type    | <code>[name\|created at\|created by\|status\|active\|archived]</code> |
-| Default | <code>name,created at,created by,status,active</code>                 |
+|         |                                                                           |
+|---------|---------------------------------------------------------------------------|
+| Type    | <code>[id\|name\|created at\|created by\|status\|active\|archived]</code> |
+| Default | <code>name,created at,created by,status,active</code>                     |
 
 Columns to display in table output.
 


### PR DESCRIPTION
At present it is not possible to obtain the `id` of the template version in the table output:

```
➜  ~ coder templates version list -h                
coder v2.30.1+16408b1

USAGE:
  coder templates versions list [flags] <template>

  List all the versions of the specified template

OPTIONS:
  -O, --org string, $CODER_ORGANIZATION
          Select which organization (uuid or name) to use.

  -c, --column [name|created at|created by|status|active|archived] (default: name,created at,created by,status,active)
          Columns to display in table output.

➜  ~ coder templates version list aws-linux-dynamic 
NAME                 CREATED AT                 CREATED BY  STATUS     ACTIVE  
infallible_feistel2  2025-10-10T10:34:02+11:00  rowansmith  Succeeded  Active  
mystifying_almeida1  2025-10-10T10:32:38+11:00  rowansmith  Succeeded         
```

Adding this because it is useful when wanting to programatically retrieve the details of the latest template version, and `-ojson` does not include `active` details in it's output.

```
➜  Downloads ./coder-cli-templateversions-list-id templates version list -h                
coder v2.30.1-devel+bab99db9e7

USAGE:
  coder templates versions list [flags] <template>

  List all the versions of the specified template

OPTIONS:
  -O, --org string, $CODER_ORGANIZATION
          Select which organization (uuid or name) to use.

  -c, --column [id|name|created at|created by|status|active|archived] (default: name,created at,created by,status,active)
          Columns to display in table output.

      --include-archived bool
          Include archived versions in the result list.

  -o, --output table|json (default: table)
          Output format.

———
Run `coder --help` for a list of global options.

➜  Downloads ./coder-cli-templateversions-list-id templates version list aws-linux-dynamic -c id,name,'created at','created by',status,active
ID                                    NAME                 CREATED AT                 CREATED BY  STATUS     ACTIVE  
38f66eae-ec63-49b7-a9d2-cdb79c379d19  infallible_feistel2  2025-10-10T10:34:02+11:00  rowansmith  Succeeded  Active  
aa797ea5-4221-461b-80b0-90c5164f8dc0  mystifying_almeida1  2025-10-10T10:32:38+11:00  rowansmith  Succeeded
```
