### PR TITLE
chore: add active field to template versions json output

### DIFF
--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -139,6 +139,7 @@ func (r *RootCmd) templateVersionsList() *serpent.Command {
 type templateVersionRow struct {
 	// For json format:
 	TemplateVersion codersdk.TemplateVersion `table:"-"`
+	ActiveJSON      bool                     `json:"active" table:"-"`
 
 	// For table format:
 	ID        string    `json:"-" table:"id"`
@@ -167,6 +168,7 @@ func templateVersionsToRows(activeVersionID uuid.UUID, templateVersions ...coder
 
 		rows[i] = templateVersionRow{
 			TemplateVersion: templateVersion,
+			ActiveJSON:      templateVersion.ID == activeVersionID,
 			ID:              templateVersion.ID.String(),
 			Name:            templateVersion.Name,
 			CreatedAt:       templateVersion.CreatedAt,


### PR DESCRIPTION
`coder templates version list` makes a call to determine the `active` version:

```
➜  ~ coder templates version list aws-linux-dynamic 
NAME                 CREATED AT                 CREATED BY  STATUS     ACTIVE  
infallible_feistel2  2025-10-10T10:34:02+11:00  rowansmith  Succeeded  Active  
mystifying_almeida1  2025-10-10T10:32:38+11:00  rowansmith  Succeeded      
```

but this is not carried across to the `-ojson` output version, so this PR implements that in order to support programattic addressing.

It is added a top level entry. If it should be nested under `TemplateVersion` let me know.

```
➜  ~ ./Downloads/coder-cli-templateversions-json-active templates version list aws-linux-dynamic -ojson | jq '.[] | select(.active == true) | { active, id: .TemplateVersion.id }'      

{
  "active": true,
  "id": "38f66eae-ec63-49b7-a9d2-cdb79c379d19"
}

➜  ~ ./Downloads/coder-cli-templateversions-json-active templates version list aws-linux-dynamic -ojson |jq '.[] | select(.active == true)'
{
  "TemplateVersion": {
    "id": "38f66eae-ec63-49b7-a9d2-cdb79c379d19",
    "template_id": "1a84ce78-06a6-41ad-99e4-8ea5d9b91e89",
    "organization_id": "35f75f20-890e-4095-95f1-bb8f2ba02e79",
    "created_at": "2025-10-10T10:34:02.254357+11:00",
    "updated_at": "2025-10-10T10:34:46.594032+11:00",
    "name": "infallible_feistel2",
    "message": "Uploaded from the CLI",
    "job": {
      "id": "8afd05ca-b4be-48d5-a6b9-82dcfd12c960",
      "created_at": "2025-10-10T10:34:02.251234+11:00",
      "started_at": "2025-10-10T10:34:02.257301+11:00",
      "completed_at": "2025-10-10T10:34:46.594032+11:00",
      "status": "succeeded",
      "worker_id": "a0940ade-ecdd-47c2-98c6-f2a4e5eb0733",
      "file_id": "05fd653c-3a3f-4e5c-856b-29407732e1b1",
      "tags": {
        "owner": "",
        "scope": "organization"
      },
      "queue_position": 0,
      "queue_size": 0,
      "organization_id": "35f75f20-890e-4095-95f1-bb8f2ba02e79",
      "initiator_id": "d20c05ff-ecf3-4521-a99d-516c8befbaa6",
      "input": {
        "template_version_id": "38f66eae-ec63-49b7-a9d2-cdb79c379d19"
      },
      "type": "template_version_import",
      "metadata": {
        "template_version_name": "",
        "template_id": "00000000-0000-0000-0000-000000000000",
        "template_name": "",
        "template_display_name": "",
        "template_icon": ""
      },
      "logs_overflowed": false
    },
    "readme": "---\ndxxxxx,
    "created_by": {
      "id": "d20c05ff-ecf3-4521-a99d-516c8befbaa6",
      "username": "rowansmith",
      "name": "rowan smith"
    },
    "archived": false,
    "has_external_agent": false
  },
  "active": true
}
```