### PR TITLE
feat: refactor `<Dialog />`

### DIFF
--- a/site/src/components/Combobox/Combobox.tsx
+++ b/site/src/components/Combobox/Combobox.tsx
@@ -81,7 +81,10 @@ export const ComboboxButton = ({
 }: ComboboxButtonProps) => {
 	return (
 		<Button
-			className="flex items-center justify-between shrink-0 grow gap-2 pr-1.5"
+			className={cn(
+				"flex items-center justify-between shrink-0 grow gap-2 pr-1.5",
+				className,
+			)}
 			style={{ flexBasis: width }}
 			variant="outline"
 			ref={ref}

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -32,13 +32,15 @@ const DialogOverlay: React.FC<
 
 const dialogVariants = cva(
 	`fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg gap-6
-	border border-solid bg-surface-primary p-8 shadow-lg duration-200 sm:rounded-lg
+	border border-solid bg-surface-primary p-6 shadow-lg duration-200 sm:rounded-lg
 	translate-x-[-50%] translate-y-[-50%]
 	data-[state=open]:animate-in data-[state=closed]:animate-out
 	data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
 	data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95
-	data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]
-	data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]`,
+	data-[state=closed]:slide-out-to-left-1/2
+	data-[state=closed]:slide-out-to-top-[48%]
+	data-[state=open]:slide-in-from-left-1/2
+	data-[state=open]:slide-in-from-top-[48%]`,
 	{
 		variants: {
 			variant: {
@@ -83,7 +85,7 @@ export const DialogHeader: React.FC<React.ComponentPropsWithRef<"div">> = ({
 	return (
 		<div
 			className={cn(
-				"flex flex-col space-y-5 text-center sm:text-left",
+				"flex flex-col space-y-4 text-center sm:text-left",
 				className,
 			)}
 			{...props}
@@ -125,7 +127,7 @@ export const DialogDescription: React.FC<
 > = ({ className, ...props }) => {
 	return (
 		<DialogPrimitive.Description
-			className={cn("text-sm text-content-secondary font-medium", className)}
+			className={cn("text-sm text-content-secondary", className)}
 			{...props}
 		/>
 	);

--- a/site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.tsx
@@ -1,11 +1,13 @@
-import type { Interpolation, Theme } from "@emotion/react";
-import DialogActions from "@mui/material/DialogActions";
-import type { FC, ReactNode } from "react";
 import {
 	Dialog,
-	DialogActionButtons,
-	type DialogActionButtonsProps,
-} from "../Dialog";
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
+import type { FC, ReactNode } from "react";
+import { DialogActionButtons, type DialogActionButtonsProps } from "../Dialog";
 import type { ConfirmDialogType } from "../types";
 
 interface ConfirmDialogTypeConfig {
@@ -52,48 +54,6 @@ export interface ConfirmDialogProps
 	readonly title: string;
 }
 
-const styles = {
-	dialogWrapper: (theme) => ({
-		"& .MuiPaper-root": {
-			background: theme.palette.background.paper,
-			border: `1px solid ${theme.palette.divider}`,
-			width: "100%",
-			maxWidth: 440,
-		},
-		"& .MuiDialogActions-spacing": {
-			padding: "0 40px 40px",
-		},
-	}),
-	dialogContent: (theme) => ({
-		color: theme.palette.text.secondary,
-		padding: "40px 40px 20px",
-	}),
-	dialogTitle: (theme) => ({
-		margin: 0,
-		marginBottom: 16,
-		color: theme.palette.text.primary,
-		fontWeight: 400,
-		fontSize: 20,
-	}),
-	dialogDescription: (theme) => ({
-		color: theme.palette.text.secondary,
-		lineHeight: "160%",
-		fontSize: 16,
-
-		"& strong": {
-			color: theme.palette.text.primary,
-		},
-
-		"& p:not(.MuiFormHelperText-root)": {
-			margin: 0,
-		},
-
-		"& > p": {
-			margin: "8px 0",
-		},
-	}),
-} satisfies Record<string, Interpolation<Theme>>;
-
 /**
  * Quick-use version of the Dialog component with slightly alternative styles,
  * great to use for dialogs that don't have any interaction beyond yes / no.
@@ -119,27 +79,38 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 
 	return (
 		<Dialog
-			css={styles.dialogWrapper}
-			onClose={onClose}
 			open={open}
-			data-testid="dialog"
+			onOpenChange={(isOpen) => {
+				if (!isOpen) onClose();
+			}}
 		>
-			<div css={styles.dialogContent}>
-				<h3 css={styles.dialogTitle}>{title}</h3>
-				{description && <div css={styles.dialogDescription}>{description}</div>}
-			</div>
-
-			<DialogActions>
-				<DialogActionButtons
-					cancelText={cancelText}
-					confirmLoading={confirmLoading}
-					confirmText={confirmText || defaults.confirmText}
-					disabled={disabled}
-					onCancel={!hideCancel ? onClose : undefined}
-					onConfirm={onConfirm || onClose}
-					type={type}
-				/>
-			</DialogActions>
+			<DialogContent
+				variant={type === "delete" ? "destructive" : "default"}
+				className="max-w-[440px]"
+				data-testid="dialog"
+			>
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+					{description && (
+						<DialogDescription asChild>
+							<div className="[&_strong]:text-content-primary [&_p]:my-2">
+								{description}
+							</div>
+						</DialogDescription>
+					)}
+				</DialogHeader>
+				<DialogFooter>
+					<DialogActionButtons
+						cancelText={cancelText}
+						confirmLoading={confirmLoading}
+						confirmText={confirmText || defaults.confirmText}
+						disabled={disabled}
+						onCancel={!hideCancel ? onClose : undefined}
+						onConfirm={onConfirm || onClose}
+						type={type}
+					/>
+				</DialogFooter>
+			</DialogContent>
 		</Dialog>
 	);
 };

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -1,7 +1,7 @@
-import type { Interpolation, Theme } from "@emotion/react";
-import TextField from "@mui/material/TextField";
+import { Input } from "components/Input/Input";
+import { Label } from "components/Label/Label";
 import { type FC, type FormEvent, useId, useState } from "react";
-import { Stack } from "../../Stack/Stack";
+import { cn } from "utils/cn";
 import { ConfirmDialog } from "../ConfirmDialog/ConfirmDialog";
 
 interface DeleteDialogProps {
@@ -47,7 +47,7 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 
 	const hasError = !deletionConfirmed && userConfirmationText.length > 0;
 	const displayErrorMessage = hasError && !isFocused;
-	const inputColor = hasError ? "error" : "primary";
+	const inputId = `${hookId}-confirm`;
 
 	return (
 		<ConfirmDialog
@@ -62,56 +62,56 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 			confirmText={confirmText}
 			description={
 				<>
-					<Stack spacing={1.5}>
+					<div className="flex flex-col gap-3">
 						<p>
 							{verb ?? "Deleting"} this {entity} is irreversible!
 						</p>
 
-						{Boolean(info) && <div css={styles.callout}>{info}</div>}
+						{Boolean(info) && (
+							<div className="rounded-md border border-solid border-border-destructive bg-surface-destructive px-4 py-2 text-content-destructive">
+								{info}
+							</div>
+						)}
 
 						<p>
 							Type <strong>{name}</strong> below to confirm.
 						</p>
-					</Stack>
+					</div>
 
-					<form onSubmit={onSubmit}>
-						<TextField
-							fullWidth
-							autoFocus
-							css={{ marginTop: 24 }}
-							name="confirmation"
-							autoComplete="off"
-							id={`${hookId}-confirm`}
-							placeholder={name}
-							value={userConfirmationText}
-							onChange={(event) => setUserConfirmationText(event.target.value)}
-							onFocus={() => setIsFocused(true)}
-							onBlur={() => setIsFocused(false)}
-							label={label ?? `Name of the ${entity} to delete`}
-							color={inputColor}
-							error={displayErrorMessage}
-							helperText={
-								displayErrorMessage &&
-								`${userConfirmationText} does not match the name of this ${entity}`
-							}
-							InputProps={{ color: inputColor }}
-							inputProps={{
-								"data-testid": "delete-dialog-name-confirmation",
-							}}
-						/>
+					<form onSubmit={onSubmit} className="mt-6">
+						<div className="flex flex-col gap-1">
+							<Label htmlFor={inputId}>
+								{label ?? `Name of the ${entity} to delete`}
+							</Label>
+							<Input
+								id={inputId}
+								name="confirmation"
+								autoFocus
+								autoComplete="off"
+								placeholder={name}
+								value={userConfirmationText}
+								onChange={(event) =>
+									setUserConfirmationText(event.target.value)
+								}
+								onFocus={() => setIsFocused(true)}
+								onBlur={() => setIsFocused(false)}
+								aria-invalid={displayErrorMessage}
+								className={cn(
+									displayErrorMessage &&
+										"border-border-destructive focus-visible:ring-border-destructive",
+								)}
+								data-testid="delete-dialog-name-confirmation"
+							/>
+							{displayErrorMessage && (
+								<p className="text-xs text-content-destructive mt-1">
+									{userConfirmationText} does not match the name of this{" "}
+									{entity}
+								</p>
+							)}
+						</div>
 					</form>
 				</>
 			}
 		/>
 	);
 };
-
-const styles = {
-	callout: (theme) => ({
-		backgroundColor: theme.roles.danger.background,
-		border: `1px solid ${theme.roles.danger.outline}`,
-		borderRadius: theme.shape.borderRadius,
-		color: theme.roles.danger.text,
-		padding: "8px 16px",
-	}),
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/components/Popover/Popover.tsx
+++ b/site/src/components/Popover/Popover.tsx
@@ -14,10 +14,12 @@ export const Popover = PopoverPrimitive.Root;
 export const PopoverTrigger = PopoverPrimitive.Trigger;
 
 export const PopoverContent: React.FC<
-	React.ComponentPropsWithRef<typeof PopoverPrimitive.Content>
-> = ({ className, align = "center", sideOffset = 4, ...props }) => {
+	React.ComponentPropsWithRef<typeof PopoverPrimitive.Content> & {
+		container?: HTMLElement | null;
+	}
+> = ({ className, align = "center", sideOffset = 4, container, ...props }) => {
 	return (
-		<PopoverPrimitive.Portal>
+		<PopoverPrimitive.Portal container={container ?? undefined}>
 			<PopoverPrimitive.Content
 				align={align}
 				sideOffset={sideOffset}

--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
@@ -1,18 +1,23 @@
-import Autocomplete from "@mui/material/Autocomplete";
-import TextField from "@mui/material/TextField";
 import { templateVersions } from "api/queries/templates";
 import type { TemplateVersion, Workspace } from "api/typesGenerated";
-import { Alert, AlertTitle } from "components/Alert/Alert";
 import { Avatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/Avatar/AvatarData";
+import { Badge } from "components/Badge/Badge";
+import { Button } from "components/Button/Button";
+import {
+	Combobox,
+	ComboboxContent,
+	ComboboxEmpty,
+	ComboboxInput,
+	ComboboxItem,
+	ComboboxList,
+	ComboboxTrigger,
+} from "components/Combobox/Combobox";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
-import { FormFields } from "components/Form/Form";
 import { Loader } from "components/Loader/Loader";
-import { Pill } from "components/Pill/Pill";
-import { Spinner } from "components/Spinner/Spinner";
-import { InfoIcon } from "lucide-react";
+import { ChevronDownIcon, InfoIcon, UserIcon } from "lucide-react";
 import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
-import { type FC, useState } from "react";
+import { type FC, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import { createDayString } from "utils/createDayString";
 
@@ -30,13 +35,13 @@ export const ChangeWorkspaceVersionDialog: FC<
 		...templateVersions(workspace.template_id),
 		select: (data) => [...data].reverse(),
 	});
-	const [isAutocompleteOpen, setIsAutocompleteOpen] = useState(false);
 	const currentVersion = versions?.find(
 		(v) => workspace.latest_build.template_version_id === v.id,
 	);
 	const [newVersion, setNewVersion] = useState<TemplateVersion>();
 	const validVersions = versions?.filter((v) => v.job.status === "succeeded");
 	const selectedVersion = newVersion || currentVersion;
+	const popoverContainerRef = useRef<HTMLDivElement>(null);
 
 	return (
 		<ConfirmDialog
@@ -57,74 +62,101 @@ export const ChangeWorkspaceVersionDialog: FC<
 					<p>You are about to change the version of this workspace.</p>
 					{validVersions ? (
 						<>
-							<FormFields>
-								<Autocomplete
-									disableClearable
-									options={validVersions}
-									defaultValue={selectedVersion}
-									id="template-version-autocomplete"
-									open={isAutocompleteOpen}
-									onChange={(_, newTemplateVersion) => {
-										setNewVersion(newTemplateVersion);
+							<div ref={popoverContainerRef}>
+								<Combobox
+									value={selectedVersion?.id}
+									onValueChange={(id) => {
+										const version = validVersions.find((v) => v.id === id);
+										if (version) {
+											setNewVersion(version);
+										}
 									}}
-									onOpen={() => {
-										setIsAutocompleteOpen(true);
-									}}
-									onClose={() => {
-										setIsAutocompleteOpen(false);
-									}}
-									isOptionEqualToValue={(
-										option: TemplateVersion,
-										value: TemplateVersion,
-									) => option.id === value.id}
-									getOptionLabel={(option) => option.name}
-									renderOption={(props, option: TemplateVersion) => (
-										<li {...props}>
-											<AvatarData
-												avatar={
-													<Avatar
-														src={option.created_by.avatar_url}
-														fallback={option.name}
+								>
+									<ComboboxTrigger asChild>
+										<Button
+											variant="outline"
+											className="h-16 w-full justify-between"
+										>
+											{newVersion ? (
+												<div className="text-left justify-between flex-1">
+													<AvatarData
+														avatar={
+															<Avatar
+																src={newVersion.created_by.avatar_url}
+																fallback={newVersion.name}
+															/>
+														}
+														title={
+															<div className="flex flex-row justify-between w-full gap-2">
+																<div className="flex flex-row items-center gap-2">
+																	{newVersion.name}
+																	{newVersion.message && (
+																		<InfoIcon
+																			aria-hidden="true"
+																			className="size-icon-xs"
+																		/>
+																	)}
+																</div>
+																{workspace.template_active_version_id ===
+																	newVersion.id && (
+																	<Badge variant="green">Active</Badge>
+																)}
+															</div>
+														}
+														subtitle={createDayString(newVersion.created_at)}
 													/>
-												}
-												title={
-													<div className="flex flex-row justify-between w-full">
-														<div className="flex flex-row items-center gap-2">
-															{option.name}
-															{option.message && (
-																<InfoIcon
-																	aria-hidden="true"
-																	className="size-icon-xs"
-																/>
-															)}
-														</div>
-														{workspace.template_active_version_id ===
-															option.id && <Pill type="success">Active</Pill>}
-													</div>
-												}
-												subtitle={createDayString(option.created_at)}
-											/>
-										</li>
-									)}
-									renderInput={(params) => (
-										<TextField
-											{...params}
-											fullWidth
-											placeholder="Template version name"
-											InputProps={{
-												...params.InputProps,
-												endAdornment: (
-													<>
-														{!versions && <Spinner loading size="sm" />}
-														{params.InputProps.endAdornment}
-													</>
-												),
-												sx: { pl: "14px !important" },
-											}}
-										/>
-									)}
-								/>
-							</FormFields>
+												</div>
+											) : (
+												<span>Select a version</span>
+											)}
+											<ChevronDownIcon />
+										</Button>
+									</ComboboxTrigger>
+									<ComboboxContent
+										className="w-[var(--radix-popper-anchor-width)]"
+										container={popoverContainerRef.current}
+									>
+										<ComboboxInput placeholder="Search versions..." />
+										<ComboboxList>
+											{validVersions.map((version) => (
+												<ComboboxItem
+													key={version.id}
+													value={version.id}
+													keywords={[version.name]}
+												>
+													<AvatarData
+														avatar={
+															<Avatar
+																src={version.created_by.avatar_url}
+																fallback={version.name}
+															/>
+														}
+														title={
+															<div className="flex flex-row justify-between w-full gap-2">
+																<div className="flex flex-row items-center gap-2">
+																	{version.name}
+																	{version.message && (
+																		<InfoIcon
+																			aria-hidden="true"
+																			className="size-icon-xs"
+																		/>
+																	)}
+																</div>
+																{workspace.template_active_version_id ===
+																	version.id && (
+																	<Badge variant="green">Active</Badge>
+																)}
+															</div>
+														}
+														subtitle={createDayString(version.created_at)}
+													/>
+												</ComboboxItem>
+											))}
+										</ComboboxList>
+										<ComboboxEmpty>No versions found</ComboboxEmpty>
+									</ComboboxContent>
+								</Combobox>
+							</div>
 							{selectedVersion && (
 								<>
 									{selectedVersion.message && (
@@ -132,11 +164,12 @@ export const ChangeWorkspaceVersionDialog: FC<
 											{selectedVersion.message}
 										</TemplateUpdateMessage>
 									)}
-									<Alert severity="info">
-										<AlertTitle>
+									<div className="flex items-center gap-1 font-normal text-sm">
+										<UserIcon className="size-icon-sm" />
+										<span>
 											Published by {selectedVersion.created_by.username}
-										</AlertTitle>
-									</Alert>
+										</span>
+									</div>
 								</>
 							)}
 						</>

--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
@@ -77,20 +77,20 @@ export const ChangeWorkspaceVersionDialog: FC<
 											variant="outline"
 											className="h-16 w-full justify-between"
 										>
-											{newVersion ? (
+											{selectedVersion ? (
 												<div className="text-left justify-between flex-1">
 													<AvatarData
 														avatar={
 															<Avatar
-																src={newVersion.created_by.avatar_url}
-																fallback={newVersion.name}
+																src={selectedVersion.created_by.avatar_url}
+																fallback={selectedVersion.name}
 															/>
 														}
 														title={
 															<div className="flex flex-row justify-between w-full gap-2">
 																<div className="flex flex-row items-center gap-2">
-																	{newVersion.name}
-																	{newVersion.message && (
+																	{selectedVersion.name}
+																	{selectedVersion.message && (
 																		<InfoIcon
 																			aria-hidden="true"
 																			className="size-icon-xs"
@@ -98,17 +98,17 @@ export const ChangeWorkspaceVersionDialog: FC<
 																	)}
 																</div>
 																{workspace.template_active_version_id ===
-																	newVersion.id && (
+																	selectedVersion.id && (
 																	<Badge variant="green">Active</Badge>
 																)}
 															</div>
 														}
-														subtitle={createDayString(newVersion.created_at)}
+														subtitle={createDayString(
+															selectedVersion.created_at,
+														)}
 													/>
 												</div>
-											) : (
-												<span>Select a version</span>
-											)}
+											) : null}
 											<ChevronDownIcon />
 										</Button>
 									</ComboboxTrigger>

--- a/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/ChangeWorkspaceVersionDialog.tsx
@@ -1,6 +1,4 @@
-import { css } from "@emotion/css";
 import Autocomplete from "@mui/material/Autocomplete";
-import CircularProgress from "@mui/material/CircularProgress";
 import TextField from "@mui/material/TextField";
 import { templateVersions } from "api/queries/templates";
 import type { TemplateVersion, Workspace } from "api/typesGenerated";
@@ -8,18 +6,18 @@ import { Alert, AlertTitle } from "components/Alert/Alert";
 import { Avatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/Avatar/AvatarData";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
-import type { DialogProps } from "components/Dialogs/Dialog";
 import { FormFields } from "components/Form/Form";
 import { Loader } from "components/Loader/Loader";
 import { Pill } from "components/Pill/Pill";
-import { Stack } from "components/Stack/Stack";
+import { Spinner } from "components/Spinner/Spinner";
 import { InfoIcon } from "lucide-react";
 import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
 import { type FC, useState } from "react";
 import { useQuery } from "react-query";
 import { createDayString } from "utils/createDayString";
 
-type ChangeWorkspaceVersionDialogProps = DialogProps & {
+type ChangeWorkspaceVersionDialogProps = {
+	open: boolean;
 	workspace: Workspace;
 	onClose: () => void;
 	onConfirm: (version: TemplateVersion) => void;
@@ -27,7 +25,7 @@ type ChangeWorkspaceVersionDialogProps = DialogProps & {
 
 export const ChangeWorkspaceVersionDialog: FC<
 	ChangeWorkspaceVersionDialogProps
-> = ({ workspace, onClose, onConfirm, ...dialogProps }) => {
+> = ({ workspace, onClose, onConfirm, open }) => {
 	const { data: versions } = useQuery({
 		...templateVersions(workspace.template_id),
 		select: (data) => [...data].reverse(),
@@ -42,7 +40,7 @@ export const ChangeWorkspaceVersionDialog: FC<
 
 	return (
 		<ConfirmDialog
-			{...dialogProps}
+			open={open}
 			onClose={onClose}
 			onConfirm={() => {
 				if (newVersion) {
@@ -55,7 +53,7 @@ export const ChangeWorkspaceVersionDialog: FC<
 			confirmText="Change"
 			title="Change version"
 			description={
-				<Stack>
+				<div className="flex flex-col gap-4">
 					<p>You are about to change the version of this workspace.</p>
 					{validVersions ? (
 						<>
@@ -90,16 +88,8 @@ export const ChangeWorkspaceVersionDialog: FC<
 													/>
 												}
 												title={
-													<Stack
-														direction="row"
-														justifyContent="space-between"
-														style={{ width: "100%" }}
-													>
-														<Stack
-															direction="row"
-															alignItems="center"
-															spacing={1}
-														>
+													<div className="flex flex-row justify-between w-full">
+														<div className="flex flex-row items-center gap-2">
 															{option.name}
 															{option.message && (
 																<InfoIcon
@@ -107,33 +97,31 @@ export const ChangeWorkspaceVersionDialog: FC<
 																	className="size-icon-xs"
 																/>
 															)}
-														</Stack>
+														</div>
 														{workspace.template_active_version_id ===
 															option.id && <Pill type="success">Active</Pill>}
-													</Stack>
+													</div>
 												}
 												subtitle={createDayString(option.created_at)}
 											/>
 										</li>
 									)}
 									renderInput={(params) => (
-										<>
-											<TextField
-												{...params}
-												fullWidth
-												placeholder="Template version name"
-												InputProps={{
-													...params.InputProps,
-													endAdornment: (
-														<>
-															{!versions && <CircularProgress size={16} />}
-															{params.InputProps.endAdornment}
-														</>
-													),
-													classes: { root: classNames.root },
-												}}
-											/>
-										</>
+										<TextField
+											{...params}
+											fullWidth
+											placeholder="Template version name"
+											InputProps={{
+												...params.InputProps,
+												endAdornment: (
+													<>
+														{!versions && <Spinner loading size="sm" />}
+														{params.InputProps.endAdornment}
+													</>
+												),
+												sx: { pl: "14px !important" },
+											}}
+										/>
 									)}
 								/>
 							</FormFields>
@@ -155,15 +143,8 @@ export const ChangeWorkspaceVersionDialog: FC<
 					) : (
 						<Loader />
 					)}
-				</Stack>
+				</div>
 			}
 		/>
 	);
-};
-
-const classNames = {
-	// Same `padding-left` as input
-	root: css`
-    padding-left: 14px !important;
-  `,
 };

--- a/site/src/modules/workspaces/WorkspaceMoreActions/UpdateBuildParametersDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/UpdateBuildParametersDialog.tsx
@@ -1,16 +1,16 @@
-import { css } from "@emotion/css";
-import type { Interpolation, Theme } from "@emotion/react";
-import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText";
-import DialogTitle from "@mui/material/DialogTitle";
 import type {
 	TemplateVersionParameter,
 	WorkspaceBuildParameter,
 } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
-import type { DialogProps } from "components/Dialogs/Dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
 import { FormFields, VerticalForm } from "components/Form/Form";
 import { RichParameterInput } from "components/RichParameterInput/RichParameterInput";
 import { useFormik } from "formik";
@@ -22,7 +22,8 @@ import {
 } from "utils/richParameters";
 import * as Yup from "yup";
 
-type UpdateBuildParametersDialogProps = DialogProps & {
+type UpdateBuildParametersDialogProps = {
+	open: boolean;
 	onClose: () => void;
 	onUpdate: (buildParameters: WorkspaceBuildParameter[]) => void;
 	missedParameters: TemplateVersionParameter[];
@@ -30,7 +31,7 @@ type UpdateBuildParametersDialogProps = DialogProps & {
 
 export const UpdateBuildParametersDialog: FC<
 	UpdateBuildParametersDialogProps
-> = ({ missedParameters, onUpdate, ...dialogProps }) => {
+> = ({ missedParameters, onUpdate, open, onClose }) => {
 	const form = useFormik({
 		initialValues: {
 			rich_parameter_values: getInitialRichParameterValues(missedParameters),
@@ -48,28 +49,21 @@ export const UpdateBuildParametersDialog: FC<
 
 	return (
 		<Dialog
-			{...dialogProps}
-			scroll="body"
-			aria-labelledby="update-build-parameters-title"
-			maxWidth="xs"
-			data-testid="dialog"
+			open={open}
+			onOpenChange={(isOpen) => {
+				if (!isOpen) onClose();
+			}}
 		>
-			<DialogTitle
-				id="update-build-parameters-title"
-				classes={{ root: classNames.root }}
-			>
-				Workspace parameters
-			</DialogTitle>
-			<DialogContent css={styles.content}>
-				<DialogContentText css={{ margin: 0 }}>
-					This template has new parameters that must be configured to complete
-					the update
-				</DialogContentText>
-				<VerticalForm
-					css={styles.form}
-					onSubmit={form.handleSubmit}
-					id="updateParameters"
-				>
+			<DialogContent className="max-w-sm" data-testid="dialog">
+				<DialogHeader>
+					<DialogTitle>Workspace parameters</DialogTitle>
+					<DialogDescription>
+						This template has new parameters that must be configured to complete
+						the update
+					</DialogDescription>
+				</DialogHeader>
+
+				<VerticalForm onSubmit={form.handleSubmit} id="updateParameters">
 					{missedParameters && (
 						<FormFields>
 							{missedParameters.map((parameter, index) => {
@@ -95,47 +89,21 @@ export const UpdateBuildParametersDialog: FC<
 						</FormFields>
 					)}
 				</VerticalForm>
+
+				<DialogFooter className="flex-col gap-2">
+					<Button
+						variant="outline"
+						className="w-full"
+						type="button"
+						onClick={onClose}
+					>
+						Cancel
+					</Button>
+					<Button className="w-full" type="submit" form="updateParameters">
+						Update parameters
+					</Button>
+				</DialogFooter>
 			</DialogContent>
-			<DialogActions disableSpacing css={styles.dialogActions}>
-				<Button
-					variant="outline"
-					className="w-full"
-					type="button"
-					onClick={dialogProps.onClose}
-				>
-					Cancel
-				</Button>
-				<Button className="w-full" type="submit" form="updateParameters">
-					Update parameters
-				</Button>
-			</DialogActions>
 		</Dialog>
 	);
 };
-
-const classNames = {
-	root: css`
-    padding: 24px 40px;
-
-    & h2 {
-      font-size: 20px;
-      font-weight: 400;
-    }
-  `,
-};
-
-const styles = {
-	content: {
-		padding: "0 40px",
-	},
-
-	form: {
-		paddingTop: 32,
-	},
-
-	dialogActions: {
-		padding: 40,
-		flexDirection: "column",
-		gap: 8,
-	},
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -1,14 +1,14 @@
-import type { Interpolation, Theme } from "@emotion/react";
-import Checkbox from "@mui/material/Checkbox";
-import Link from "@mui/material/Link";
-import TextField from "@mui/material/TextField";
 import type {
 	CreateWorkspaceBuildRequest,
 	Workspace,
 } from "api/typesGenerated";
+import { Checkbox } from "components/Checkbox/Checkbox";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
+import { Input } from "components/Input/Input";
+import { Label } from "components/Label/Label";
 import dayjs from "dayjs";
 import { type FC, type FormEvent, useId, useState } from "react";
+import { cn } from "utils/cn";
 import { docs } from "utils/docs";
 
 interface WorkspaceDeleteDialogProps {
@@ -42,7 +42,6 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 
 	const hasError = !deletionConfirmed && userConfirmationText.length > 0;
 	const displayErrorMessage = hasError && !isFocused;
-	const inputColor = hasError ? "error" : "primary";
 	// Orphaning is sort of a "last resort" that should really only
 	// be used under the following circumstances:
 	// a) Terraform is failing to apply while deleting, which
@@ -69,14 +68,18 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 			disabled={!deletionConfirmed}
 			description={
 				<>
-					<div css={styles.workspaceInfo}>
+					<div className="flex justify-between rounded-md p-4 mb-5 leading-snug border border-solid border-border">
 						<div>
-							<p className="name">{workspace.name}</p>
-							<p className="label">workspace</p>
+							<p className="text-base font-semibold text-content-primary m-0">
+								{workspace.name}
+							</p>
+							<p className="text-xs text-content-secondary m-0">workspace</p>
 						</div>
-						<div css={{ textAlign: "right" }}>
-							<p className="info">{dayjs(workspace.created_at).fromNow()}</p>
-							<p className="label">created</p>
+						<div className="text-right">
+							<p className="text-xs font-medium text-content-primary m-0">
+								{dayjs(workspace.created_at).fromNow()}
+							</p>
+							<p className="text-xs text-content-secondary m-0">created</p>
 						</div>
 					</div>
 
@@ -87,77 +90,86 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 					</p>
 
 					<form onSubmit={onSubmit}>
-						<TextField
-							fullWidth
-							autoFocus
-							css={{ marginTop: 32 }}
-							name="confirmation"
-							autoComplete="off"
-							id={`${hookId}-confirm`}
-							placeholder={workspace.name}
-							value={userConfirmationText}
-							onChange={(event) => setUserConfirmationText(event.target.value)}
-							onFocus={() => setIsFocused(true)}
-							onBlur={() => setIsFocused(false)}
-							label="Workspace name"
-							color={inputColor}
-							error={displayErrorMessage}
-							helperText={
-								displayErrorMessage &&
-								`${userConfirmationText} does not match the name of this workspace`
-							}
-							InputProps={{ color: inputColor }}
-							inputProps={{
-								"data-testid": "delete-dialog-name-confirmation",
-							}}
-						/>
+						<div className="mt-8 flex flex-col gap-2">
+							<Label htmlFor={`${hookId}-confirm`}>Workspace name</Label>
+							<Input
+								autoFocus
+								name="confirmation"
+								autoComplete="off"
+								id={`${hookId}-confirm`}
+								placeholder={workspace.name}
+								value={userConfirmationText}
+								onChange={(event) =>
+									setUserConfirmationText(event.target.value)
+								}
+								onFocus={() => setIsFocused(true)}
+								onBlur={() => setIsFocused(false)}
+								aria-invalid={displayErrorMessage || undefined}
+								data-testid="delete-dialog-name-confirmation"
+							/>
+							{displayErrorMessage && (
+								<p className="text-xs text-content-destructive m-0">
+									{userConfirmationText} does not match the name of this
+									workspace
+								</p>
+							)}
+						</div>
 						{hasTask && (
-							<div css={styles.warnContainer}>
-								<div css={{ flexDirection: "column" }}>
-									<p className="info">This workspace is related to a task</p>
-									<span css={{ fontSize: 12, marginTop: 4, display: "block" }}>
+							<div className="mt-6 flex bg-surface-destructive border border-solid border-border-destructive rounded-lg p-3 gap-2 leading-[18px]">
+								<div className="flex flex-col">
+									<p className="text-sm font-semibold text-content-destructive m-0">
+										This workspace is related to a task
+									</p>
+									<span className="text-xs mt-1 block">
 										Deleting this workspace will also delete{" "}
-										<Link
+										<a
 											href={`/tasks/${workspace.owner_name}/${workspace.task_id}`}
+											className="text-content-link hover:underline"
 										>
 											this task
-										</Link>
+										</a>
 										.
 									</span>
 								</div>
 							</div>
 						)}
 						{canOrphan && (
-							<div css={styles.warnContainer}>
-								<div css={{ flexDirection: "column" }}>
+							<div className="mt-6 flex bg-surface-destructive border border-solid border-border-destructive rounded-lg p-3 gap-2 leading-[18px]">
+								<div className="flex flex-col items-start pt-0.5">
 									<Checkbox
 										id="orphan_resources"
-										size="small"
-										color="warning"
-										onChange={() => {
-											setOrphanWorkspace(!orphanWorkspace);
+										checked={orphanWorkspace || false}
+										onCheckedChange={(checked) => {
+											setOrphanWorkspace(checked === true);
 										}}
-										className="option"
-										name="orphan_resources"
-										checked={orphanWorkspace}
+										className={cn(
+											"border-content-destructive",
+											"data-[state=checked]:bg-content-destructive data-[state=checked]:text-white",
+										)}
 										data-testid="orphan-checkbox"
 									/>
 								</div>
-								<div css={{ flexDirection: "column" }}>
-									<p className="info">Orphan Resources</p>
-									<span css={{ fontSize: 12, marginTop: 4, display: "block" }}>
+								<div className="flex flex-col">
+									<label
+										htmlFor="orphan_resources"
+										className="text-sm font-semibold text-content-destructive cursor-pointer"
+									>
+										Orphan Resources
+									</label>
+									<span className="text-xs mt-1 block">
 										As a Template Admin, you may skip resource cleanup to delete
 										a failed workspace. Resources such as volumes and virtual
 										machines will not be destroyed.&nbsp;
-										<Link
+										<a
 											href={docs(
 												"/user-guides/workspace-management#workspace-resources",
 											)}
 											target="_blank"
 											rel="noreferrer"
+											className="text-content-link hover:underline"
 										>
 											Learn more...
-										</Link>
+										</a>
 									</span>
 								</div>
 							</div>
@@ -168,56 +180,3 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 		/>
 	);
 };
-
-const styles = {
-	workspaceInfo: (theme) => ({
-		display: "flex",
-		justifyContent: "space-between",
-		borderRadius: 6,
-		padding: 16,
-		marginBottom: 20,
-		lineHeight: "1.3em",
-		border: `1px solid ${theme.palette.divider}`,
-
-		"& .name": {
-			fontSize: 16,
-			fontWeight: 600,
-			color: theme.palette.text.primary,
-		},
-
-		"& .label": {
-			fontSize: 12,
-			color: theme.palette.text.secondary,
-		},
-
-		"& .info": {
-			fontSize: 12,
-			fontWeight: 500,
-			color: theme.palette.text.primary,
-		},
-	}),
-	warnContainer: (theme) => ({
-		marginTop: 24,
-		display: "flex",
-		backgroundColor: theme.roles.danger.background,
-		justifyContent: "space-between",
-		border: `1px solid ${theme.roles.danger.outline}`,
-		borderRadius: 8,
-		padding: 12,
-		gap: 8,
-		lineHeight: "18px",
-
-		"& .option": {
-			color: theme.roles.danger.fill.solid,
-			"&.Mui-checked": {
-				color: theme.roles.danger.fill.solid,
-			},
-		},
-
-		"& .info": {
-			fontSize: 14,
-			fontWeight: 600,
-			color: theme.roles.danger.text,
-		},
-	}),
-} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -172,7 +172,7 @@ export const Workspace: FC<WorkspaceProps> = ({
 					{selectedResource && (
 						<ResourceMetadata
 							resource={selectedResource}
-							className="-mx-6 -mt-6 mb-6"
+							className="-mx-8 -mt-8 mb-6"
 						/>
 					)}
 					<div className="flex flex-col gap-6 max-w-[1200px] m-auto">

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -172,7 +172,7 @@ export const Workspace: FC<WorkspaceProps> = ({
 					{selectedResource && (
 						<ResourceMetadata
 							resource={selectedResource}
-							className="-mx-8 -mt-8 mb-6"
+							className="-mx-6 -mt-6 mb-6"
 						/>
 					)}
 					<div className="flex flex-col gap-6 max-w-[1200px] m-auto">

--- a/site/src/pages/WorkspacePage/WorkspacePage.jest.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.jest.tsx
@@ -155,9 +155,7 @@ describe("WorkspacePage", () => {
 		await user.type(textField, MockFailedWorkspace.name);
 
 		// check orphan option
-		const orphanCheckbox = within(
-			screen.getByTestId("orphan-checkbox"),
-		).getByRole("checkbox");
+		const orphanCheckbox = screen.getByTestId("orphan-checkbox");
 
 		await user.click(orphanCheckbox);
 

--- a/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateModalForm.tsx
@@ -244,7 +244,7 @@ const ContainerBody: FC<ContainerBodyProps> = ({
 		// Have to subtract parent padding via margin values and then add it
 		// back as child padding so that there's no risk of the scrollbar
 		// covering up content when the container gets tall enough to overflow
-		<div className="overflow-y-auto flex flex-col gap-3 -mx-8 -mt-8 p-8">
+		<div className="overflow-y-auto flex flex-col gap-3 -mx-6 -mt-6 p-8">
 			<div className="flex flex-col gap-3">
 				<DialogTitle asChild>
 					<h3 className="text-3xl font-semibold m-0 leading-tight">
@@ -276,7 +276,7 @@ const ContainerFooter: FC<ContainerFooterProps> = ({ children, className }) => {
 				// Also have to subtract padding here to make sure footer is
 				// full-bleed, and there's no risk of the border getting
 				// confused for the outline of one of the panels
-				"border-0 border-t border-solid border-t-border pt-8 -mx-8 px-8",
+				"border-0 border-t border-solid border-t-border pt-6 -mx-6 px-6",
 				className,
 			)}
 		>
@@ -299,7 +299,7 @@ const WorkspacesListSection: FC<WorkspacesListSectionProps> = ({
 	return (
 		<section className="flex flex-col gap-3.5">
 			<div className="max-w-prose">
-				<h4 className="m-0">{headerText}</h4>
+				<h4 className="font-semibold m-0">{headerText}</h4>
 				<p className="m-0 text-sm leading-snug text-content-secondary">
 					{description}
 				</p>


### PR DESCRIPTION
This pull-request moves our dialogs to using the internal `<Dialog />` rather than making a mixture use of both `@mui/*` and `@emotion/css` imports. Things are now inline with Figma (even though this component is a WIP.)