### PR TITLE
chore!: remove `api.ts` unnecessary calls

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5468,6 +5468,9 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/codersdk.TemplateVersion"
                         }
+                    },
+                    "204": {
+                        "description": "No Content"
                     }
                 },
                 "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4853,6 +4853,9 @@
 						"schema": {
 							"$ref": "#/definitions/codersdk.TemplateVersion"
 						}
+					},
+					"204": {
+						"description": "No Content"
 					}
 				},
 				"security": [

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1074,6 +1074,7 @@ func (api *API) templateVersionByOrganizationTemplateAndName(rw http.ResponseWri
 // @Param templatename path string true "Template name"
 // @Param templateversionname path string true "Template version name"
 // @Success 200 {object} codersdk.TemplateVersion
+// @Success 204
 // @Router /organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous [get]
 func (api *API) previousTemplateVersionByOrganizationTemplateAndName(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -1126,9 +1127,7 @@ func (api *API) previousTemplateVersionByOrganizationTemplateAndName(rw http.Res
 	})
 	if err != nil {
 		if httpapi.Is404Error(err) {
-			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
-				Message: fmt.Sprintf("No previous template version found for %q.", templateVersionName),
-			})
+			rw.WriteHeader(http.StatusNoContent)
 			return
 		}
 

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1980,8 +1980,8 @@ func TestPreviousTemplateVersion(t *testing.T) {
 		templateAVersion1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.CreateTemplate(t, client, user.OrganizationID, templateAVersion1.ID)
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, templateAVersion1.ID)
-		// Create two versions for the template B to be sure if we try to get the
-		// previous version of the first version it will returns a 404
+		// Create two versions for template B so we can verify that requesting
+		// the previous version of the first version returns nil.
 		templateBVersion1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		templateB := coderdtest.CreateTemplate(t, client, user.OrganizationID, templateBVersion1.ID)
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, templateBVersion1.ID)
@@ -1992,9 +1992,7 @@ func TestPreviousTemplateVersion(t *testing.T) {
 		defer cancel()
 
 		_, err := client.PreviousTemplateVersion(ctx, user.OrganizationID, templateB.Name, templateBVersion1.Name)
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
+		require.ErrorIs(t, err, codersdk.ErrNoPreviousVersion)
 	})
 
 	t.Run("Previous version found", func(t *testing.T) {

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 )
 
 type TemplateVersionWarning string
@@ -280,12 +281,19 @@ func (c *Client) CancelTemplateVersionDryRun(ctx context.Context, version, job u
 	return nil
 }
 
+// ErrNoPreviousVersion is returned when no previous template version
+// exists (the server responds with 204 No Content).
+var ErrNoPreviousVersion = xerrors.New("no previous template version")
+
 func (c *Client) PreviousTemplateVersion(ctx context.Context, organization uuid.UUID, templateName, versionName string) (TemplateVersion, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s/templates/%s/versions/%s/previous", organization, templateName, versionName), nil)
 	if err != nil {
 		return TemplateVersion{}, err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusNoContent {
+		return TemplateVersion{}, ErrNoPreviousVersion
+	}
 	if res.StatusCode != http.StatusOK {
 		return TemplateVersion{}, ReadBodyAsError(res)
 	}

--- a/docs/reference/api/templates.md
+++ b/docs/reference/api/templates.md
@@ -632,9 +632,10 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                         |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.TemplateVersion](schemas.md#codersdktemplateversion) |
+| Status | Meaning                                                         | Description | Schema                                                         |
+|--------|-----------------------------------------------------------------|-------------|----------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)         | OK          | [codersdk.TemplateVersion](schemas.md#codersdktemplateversion) |
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |                                                                |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1106,25 +1106,17 @@ class ApiMethods {
 		templateName: string,
 		versionName: string,
 	) => {
-		try {
-			const response = await this.axios.get<TypesGen.TemplateVersion>(
-				`/api/v2/organizations/${organization}/templates/${templateName}/versions/${versionName}/previous`,
-			);
+		const response = await this.axios.get<TypesGen.TemplateVersion>(
+			`/api/v2/organizations/${organization}/templates/${templateName}/versions/${versionName}/previous`,
+		);
 
-			return response.data;
-		} catch (error) {
-			// When there is no previous version, like the first version of a
-			// template, the API returns 404 so in this case we can safely return
-			// undefined
-			const is404 =
-				isAxiosError(error) && error.response && error.response.status === 404;
-
-			if (is404) {
-				return undefined;
-			}
-
-			throw error;
+		// The API returns 204 No Content when there is no previous version
+		// (e.g. the first version of a template).
+		if (response.status === 204) {
+			return undefined;
 		}
+
+		return response.data;
 	};
 
 	/**

--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBanner.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBanner.tsx
@@ -18,7 +18,10 @@ const HIDE_DEPLOYMENT_BANNER_PATHS = [
 
 export const DeploymentBanner: FC = () => {
 	const { permissions } = useAuthenticated();
-	const deploymentStatsQuery = useQuery(deploymentStats());
+	const deploymentStatsQuery = useQuery({
+		...deploymentStats(),
+		enabled: permissions.viewDeploymentStats,
+	});
 	const healthQuery = useQuery({
 		...health(),
 		enabled: permissions.viewDeploymentConfig,

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -259,7 +259,7 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 
 	const { data: provisioners } = useQuery({
 		...provisionerDaemons(selectedOrg?.id ?? ""),
-		enabled: showOrganizationPicker && Boolean(selectedOrg),
+		enabled: Boolean(showOrganizationPicker) && Boolean(selectedOrg),
 	});
 
 	// TODO: Ideally, we would have a backend endpoint that could notify the

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionerKeysPage/OrganizationProvisionerKeysPage.tsx
@@ -17,6 +17,7 @@ const OrganizationProvisionerKeysPage: FC = () => {
 	const { entitlements } = useDashboard();
 	const provisionerKeyDaemonsQuery = useQuery({
 		...provisionerDaemonGroups(organizationName),
+		enabled: !!organization,
 		select: (data) =>
 			[...data].sort((a, b) => b.daemons.length - a.daemons.length),
 	});

--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPage.tsx
@@ -30,6 +30,7 @@ const OrganizationProvisionersPage: FC = () => {
 			...queryParams,
 			limit: 100,
 		}),
+		enabled: !!organization,
 	});
 
 	if (!organization) {

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -96,9 +96,7 @@ export const TasksTable: FC<TasksTableProps> = ({
 							<Checkbox
 								disabled={!tasks || tasks.length === 0}
 								checked={
-									tasks &&
-									tasks.length > 0 &&
-									checkedTaskIds.size === tasks.length
+									Boolean(tasks) && checkedTaskIds.size === tasks?.length
 								}
 								onCheckedChange={(checked) => {
 									if (!tasks || !onCheckChange) {


### PR DESCRIPTION
> [!WARNING]  
> The change of the status code from `404` to `204` could break peoples code downstream. Adding this as a breaking change incase.

Theres a whole ton of noise around failed requests, these are all unrelated to the actual thing that is broken at hand (and are confusing). 

* Change `/api/v2/organizations/.../templates/.../versions/.../previous` to return `204` instead of `404` (actually makes more sense because the content doesn't exist, but the route is found.
* Remove unnecessary calls to `/api/v2/users/me/appearance` when the user isn't logged in.
* Remove unnecessary calls to `/api/v2/deployment/stats` when the deployment stats aren't allowed to be seen.
* Various changes to `workspace-sharing` so we don't make unnecessary calls.

Whats left:

* `/api/v2/users/me` still `401`s on the login page. This persists as when the user is logged in but tries to reach the sign-in page they should be redirected to the app, not sign in again.
* `monaco-editor` is still upset... we theoretically could inject an environment that can serve workers... but eh.

#### Old

```sh
% pnpm playwright:test -g "create workspace with default and required parameters"

> coder-v2@ playwright:test /home/coder/coder/site
> playwright test --config=e2e/playwright.config.ts -g 'create workspace with default and required parameters'

...

Running 2 tests using 1 worker

  ✓  1 …e/setup/addUsersAndLicense.spec.ts:7:5 › setup deployment (8.2s)
     2 ….ts:79:5 › create workspace with default and required parameters
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[response] url=http://localhost:3111/api/v2/users/me/appearance status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[response] url=http://localhost:3111/api/v2/users/me status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[console][error] Failed to load resource: the server responded with a status of 403 (Forbidden)
[response] url=http://localhost:3111/api/v2/deployment/stats status=403 body={"message":"Forbidden.","detail":"You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials."}
[console][error] Failed to load resource: the server responded with a status of 403 (Forbidden)
[response] url=http://localhost:3111/api/v2/deployment/stats status=403 body={"message":"Forbidden.","detail":"You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials."}
[console][error] Failed to load resource: the server responded with a status of 404 (Not Found)
[response] url=http://localhost:3111/api/v2/organizations//provisionerdaemons status=404 body={"message":"Resource not found or you do not have access to this resource"}
[console][error] Failed to load resource: the server responded with a status of 404 (Not Found)
[response] url=http://localhost:3111/api/v2/organizations/default/templates/a4e8096d/versions/agreeable_glenn33/previous status=404 body={"message":"No previous template version found for \"agreeable_glenn33\"."}
[console][warning] Could not create web worker(s). Falling back to loading web worker code in main thread, which might cause UI freezes. Please see https://github.com/microsoft/monaco-editor#faq
[console][warning] You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[response] url=http://localhost:3111/api/v2/users/me/appearance status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[response] url=http://localhost:3111/api/v2/users/me status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[console][error] Failed to load resource: the server responded with a status of 403 (Forbidden)
[response] url=http://localhost:3111/api/v2/deployment/stats status=403 body={"message":"Forbidden.","detail":"You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials."}
  ✓  2 …5 › create workspace with default and required parameters (7.0s)atus of 403 (Forbidden)
[response] url=http://localhost:3111/api/v2/deployment/stats status=403 body={"message":"Forbidden.","detail":"You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials."}
[console][error] Failed to load resource: the server responded with a status of 403 (Forbidden)
[response] url=http://localhost:3111/api/v2/deployment/stats status=403 body={"message":"Forbidden.","detail":"You don't have permission to view this content. If you believe this is a mistake, please contact your administrator or try signing in with different credentials."}

  2 passed (56.1s)
```

`23 LOL` (Lines of logs)

#### New

```sh
% pnpm playwright:test -g "create workspace with default and required parameters"

> coder-v2@ playwright:test /home/coder/coder/site
> playwright test --config=e2e/playwright.config.ts -g 'create workspace with default and required parameters'

...

Running 2 tests using 1 worker

  ✓  1 …e/setup/addUsersAndLicense.spec.ts:7:5 › setup deployment (8.7s)
     2 ….ts:79:5 › create workspace with default and required parameters
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[response] url=http://localhost:3111/api/v2/users/me/appearance status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[response] url=http://localhost:3111/api/v2/users/me status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[console][warning] Could not create web worker(s). Falling back to loading web worker code in main thread, which might cause UI freezes. Please see https://github.com/microsoft/monaco-editor#faq
[console][warning] You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker
  ✓  2 …5 › create workspace with default and required parameters (7.1s)atus of 401 (Unauthorized)
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[response] url=http://localhost:3111/api/v2/users/me/appearance status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[response] url=http://localhost:3111/api/v2/users/me status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}

  2 passed (32.0s)
```

`9 LOL` (Lines of logs)