### PR TITLE
fix(site): render username with content-primary, not white

### DIFF
--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -50,7 +50,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 			>
 				<Link to="/settings/account">
 					<div className="flex flex-col">
-						<span className="text-white">{user.username}</span>
+						<span className="text-content-primary">{user.username}</span>
 						<span className="text-xs font-semibold">{user.email}</span>
 					</div>
 				</Link>


### PR DESCRIPTION
In https://github.com/coder/coder/pull/21809 we wrongly set the text as `text-white`, this made it unreadable on light themes

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
