### PR TITLE
fix(site): preserve autofill values during parameter WebSocket sync

### DIFF
--- a/site/src/modules/hooks/useSyncFormParameters.ts
+++ b/site/src/modules/hooks/useSyncFormParameters.ts
@@ -16,8 +16,9 @@ export function useSyncFormParameters({
 	formValues,
 	setFieldValue,
 }: UseSyncFormParametersProps) {
-	// Form values only needs to be updated when parameters change
-	// Keep track of form values in a ref to avoid unnecessary updates to rich_parameter_values
+	// Form values only needs to be updated when parameters change.
+	// Keep track of form values in a ref to avoid unnecessary
+	// updates to rich_parameter_values.
 	const formValuesRef = useRef(formValues);
 
 	useEffect(() => {
@@ -27,15 +28,27 @@ export function useSyncFormParameters({
 	useEffect(() => {
 		if (!parameters) return;
 		const currentFormValues = formValuesRef.current;
-
-		const newParameterValues = parameters.map((param) => ({
-			name: param.name,
-			value: param.value.valid ? param.value.value : "",
-		}));
-
 		const currentFormValuesMap = new Map(
 			currentFormValues.map((value) => [value.name, value.value]),
 		);
+
+		const newParameterValues = parameters.map((param) => {
+			// When the server has not evaluated this parameter yet
+			// (valid=false), its value is meaningless — preserve
+			// whatever the form already holds (e.g. autofill or
+			// previous build values). When valid=true, the server
+			// has intentionally set this value and we respect it.
+			if (!param.value.valid) {
+				const currentValue = currentFormValuesMap.get(param.name);
+				if (currentValue) {
+					return { name: param.name, value: currentValue };
+				}
+			}
+			return {
+				name: param.name,
+				value: param.value.valid ? param.value.value : "",
+			};
+		});
 
 		const isChanged =
 			currentFormValues.length !== newParameterValues.length ||


### PR DESCRIPTION
Fixes coder/internal#1154

```sh
$ pnpm playwright:test -g "create workspace with default and required parameters" --repeat-each=1000

# ...

[console][warning] Could not create web worker(s). Falling back to loading web worker code in main thread, which might cause UI freezes. Please see https://github.com/microsoft/monaco-editor#faq
[console][warning] You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[response] url=http://localhost:3111/api/v2/users/me status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}
[console][error] Failed to load resource: the server responded with a status of 401 (Unauthorized)
[response] url=http://localhost:3111/api/v2/users/me status=401 body={"message":"You are signed out or your session has expired. Please sign in again to continue.","detail":"Cookie \"coder_session_token\" or query parameter must be provided."}

  1001 passed (28.8m)
```

Created by Mux using Opus 4.6.

## Problem

The e2e test "create workspace with default and required parameters" is flaky — it intermittently sees an empty input where `"12345"` is expected.

The `useSyncFormParameters` hook syncs form values with WebSocket server responses. However, `param.value` from the server only reflects **template defaults**, not values provided by the client (autofill or build parameters). For a required parameter with no template default, `param.value` is always `""`.

This means every WebSocket response overwrites autofilled build values with empty strings, and the form never recovers because the server never echoes input values back in `param.value`.

### Timeline on the workspace parameters settings page:

1. REST API returns last build parameters → form initializes with `"12345"` via autofill ✅
2. WebSocket responds with `param.value = ""` (template default) → hook overwrites form to `""` ❌
3. `sendInitialParameters` sends `"12345"` to WebSocket
4. Server responds again → `param.value` is still `""` → hook keeps form at `""` ❌

## Fix

When the server reports an empty value but the form already holds a non-empty value (from autofill or user input), preserve the form value.

This is safe because:
- The hook is read-only from the server's perspective — it never sends data, only updates local form state
- User edits go through `handleChange` → WebSocket → the next server response carries the validated (non-empty) value
- An empty `param.value` means "I have no value" — it should never silently erase values the form already knows about