### PR TITLE
chore: remove unnecessary loop variable captures

### DIFF
--- a/coderd/agentapi/subagent_test.go
+++ b/coderd/agentapi/subagent_test.go
@@ -1320,7 +1320,6 @@ func TestSubAgentAPI(t *testing.T) {
 		}
 
 		for _, tc := range tests {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -2567,7 +2567,6 @@ func TestPauseTask(t *testing.T) {
 		}
 
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				task, _ := setupWorkspaceTask(t, db, owner)
 				userClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, tc.roles...)

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -138,7 +138,6 @@ func TestCheckLatestVersion(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		i, tc := i, tc
 		t.Run(fmt.Sprintf("entry %d", i), func(t *testing.T) {
 			t.Parallel()
 

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -6646,7 +6646,6 @@ func TestUserSecretsAuthorization(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
@@ -7460,7 +7459,6 @@ func TestGetTaskByWorkspaceID(t *testing.T) {
 	db, _ := dbtestutil.NewDB(t)
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -8000,7 +7998,6 @@ func TestUpdateTaskWorkspaceID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/coderd/devtunnel/servers.go
+++ b/coderd/devtunnel/servers.go
@@ -86,7 +86,6 @@ func FindClosestNode(nodes []Node) (Node, error) {
 		eg      = errgroup.Group{}
 	)
 	for i, node := range nodes {
-		i, node := i, node
 		eg.Go(func() error {
 			pinger, err := ping.NewPinger(node.HostnameHTTPS)
 			if err != nil {

--- a/coderd/httpmw/httpmw_internal_test.go
+++ b/coderd/httpmw/httpmw_internal_test.go
@@ -106,7 +106,6 @@ func TestNormalizeAudienceURI(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := normalizeAudienceURI(tc.input)
@@ -157,7 +156,6 @@ func TestNormalizeHost(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := normalizeHost(tc.input)
@@ -203,7 +201,6 @@ func TestNormalizePathSegments(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := normalizePathSegments(tc.input)
@@ -247,7 +244,6 @@ func TestExtractExpectedAudience(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			var req *http.Request

--- a/coderd/oauth2provider/pkce_test.go
+++ b/coderd/oauth2provider/pkce_test.go
@@ -53,7 +53,6 @@ func TestVerifyPKCE(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := oauth2provider.VerifyPKCE(tt.challenge, tt.verifier)

--- a/coderd/oauth2provider/provider_test.go
+++ b/coderd/oauth2provider/provider_test.go
@@ -217,7 +217,6 @@ func TestOAuth2ClientRegistrationValidation(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/coderd/prebuilds/parameters_test.go
+++ b/coderd/prebuilds/parameters_test.go
@@ -128,7 +128,6 @@ func TestFindMatchingPresetID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/coderd/prebuilds/preset_snapshot_test.go
+++ b/coderd/prebuilds/preset_snapshot_test.go
@@ -1193,7 +1193,6 @@ func TestMatchesCron(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1518,7 +1517,6 @@ func TestCalculateDesiredInstances(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			desiredInstances := tc.snapshot.CalculateDesiredInstances(tc.at)

--- a/coderd/presets_test.go
+++ b/coderd/presets_test.go
@@ -190,7 +190,6 @@ func TestTemplateVersionPresetsDefault(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitShort)

--- a/coderd/schedule/cron/cron_test.go
+++ b/coderd/schedule/cron/cron_test.go
@@ -253,7 +253,6 @@ func TestIsWithinRange(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			sched, err := cron.Weekly(testCase.spec)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -606,7 +606,6 @@ func TestWorkspaceAgentAppStatus_ActivityBump(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1920,7 +1919,6 @@ func TestWorkspaceAgentDeleteDevcontainer(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -747,7 +747,6 @@ func TestRetentionConfigParsing(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/enterprise/cli/prebuilds_test.go
+++ b/enterprise/cli/prebuilds_test.go
@@ -390,7 +390,6 @@ func TestSchedulePrebuilds(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/enterprise/coderd/prebuilds/membership_test.go
+++ b/enterprise/coderd/prebuilds/membership_test.go
@@ -60,14 +60,10 @@ func TestReconcileAll(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		includePreset := tc.includePreset
 		for _, preExistingOrgMembership := range tc.preExistingOrgMembership {
-			preExistingOrgMembership := preExistingOrgMembership
 			for _, preExistingGroup := range tc.preExistingGroup {
-				preExistingGroup := preExistingGroup
 				for _, preExistingGroupMembership := range tc.preExistingGroupMembership {
-					preExistingGroupMembership := preExistingGroupMembership
 					t.Run(tc.name, func(t *testing.T) {
 						t.Parallel()
 

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -1268,7 +1268,6 @@ func TestTemplateUpdatePrebuilds(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -2750,7 +2750,6 @@ func TestPrebuildUpdateLifecycleParams(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -525,7 +525,6 @@ func TestDERPMesh(t *testing.T) {
 	require.Len(t, cases, (len(proxies)*(len(proxies)+1))/2) // triangle number
 
 	for i, c := range cases {
-		i, c := i, c
 		t.Run(fmt.Sprintf("Proxy%d", i), func(t *testing.T) {
 			t.Parallel()
 

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -1472,7 +1472,6 @@ func TestDefaultPresets(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, logger := ctxAndLogger(t)

--- a/scaletest/agentconn/run.go
+++ b/scaletest/agentconn/run.go
@@ -297,7 +297,6 @@ func holdConnection(ctx context.Context, logs io.Writer, conn workspacesdk.Agent
 		_, _ = fmt.Fprintln(logs, "\nStarting connection loops...")
 	}
 	for i, connSpec := range specs {
-		i, connSpec := i, connSpec
 		if connSpec.Interval <= 0 {
 			continue
 		}

--- a/scaletest/dynamicparameters/template_internal_test.go
+++ b/scaletest/dynamicparameters/template_internal_test.go
@@ -46,7 +46,6 @@ func TestPartitionEvaluations(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := partitionEvaluations(tc.input)

--- a/scaletest/harness/strategies.go
+++ b/scaletest/harness/strategies.go
@@ -89,8 +89,6 @@ func (p ParallelExecutionStrategy) Run(ctx context.Context, fns []TestFn) ([]err
 	defer close(sem)
 
 	for i, fn := range fns {
-		i, fn := i, fn
-
 		wg.Add(1)
 		go func() {
 			defer func() {

--- a/scaletest/taskstatus/run_internal_test.go
+++ b/scaletest/taskstatus/run_internal_test.go
@@ -637,7 +637,6 @@ func TestParseStatusMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			gotNum, gotOk := parseStatusMessage(tt.message)

--- a/support/support.go
+++ b/support/support.go
@@ -715,7 +715,6 @@ func PprofInfo(ctx context.Context, client *codersdk.Client, log slog.Logger) *P
 	}
 
 	for endpoint, setter := range endpoints {
-		endpoint, setter := endpoint, setter
 		eg.Go(func() error {
 			timeout := 10 * time.Second
 			if strings.Contains(endpoint, "seconds=30") {
@@ -822,7 +821,6 @@ func PprofInfoFromAgent(ctx context.Context, conn workspacesdk.AgentConn, log sl
 
 	// Collect each endpoint in parallel
 	for endpoint, setter := range endpoints {
-		endpoint, setter := endpoint, setter // capture loop variables
 		eg.Go(func() error {
 			// Set longer timeout for profile and trace endpoints (they take 30 seconds)
 			timeout := 10 * time.Second


### PR DESCRIPTION
Since Go 1.22, the loop variable capture issue is resolved. Variables declared by for loops are now per-iteration rather than per-loop, making the 'v := v' pattern unnecessary.
