### PR TITLE
chore: modernize for loops to use range over integers

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -857,7 +857,7 @@ func TestAgent_Session_TTY_FastCommandHasOutput(t *testing.T) {
 	// not increase test times needlessly).
 	// Limit GOMAXPROCS (e.g. `export GOMAXPROCS=1`) to further increase
 	// chance of failure. Also -race helps.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		func() {
 			stdout.Reset()
 
@@ -906,7 +906,7 @@ func TestAgent_Session_TTY_HugeOutputIsNotLost(t *testing.T) {
 	// not increase test times needlessly). Run with -race and do not
 	// limit parallelism (`export GOMAXPROCS=10`) to increase the chance
 	// of failure.
-	for i := 0; i < 1; i++ {
+	for range 1 {
 		func() {
 			stdout.Reset()
 

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -175,7 +175,7 @@ func TestNewServer_CloseActiveConnections(t *testing.T) {
 			assert.Error(t, err) // Server is closed.
 		}()
 
-		for i := 0; i < len(waitConns); i++ {
+		for i := range waitConns {
 			waitConns[i] = make(chan struct{})
 			go func(ch chan struct{}) {
 				defer wg.Done()

--- a/agent/apphealth_test.go
+++ b/agent/apphealth_test.go
@@ -76,7 +76,7 @@ func TestAppHealth_Healthy(t *testing.T) {
 	fakeAPI, closeFn := setupAppReporter(ctx, t, slices.Clone(apps), handlers, mClock)
 	defer closeFn()
 	healthchecksStarted := make([]string, 2)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		c := healthcheckTrap.MustWait(ctx)
 		c.MustRelease(ctx)
 		healthchecksStarted[i] = c.Tags[1]

--- a/agent/immortalstreams/backedpipe/backed_pipe_test.go
+++ b/agent/immortalstreams/backedpipe/backed_pipe_test.go
@@ -755,7 +755,7 @@ func TestBackedPipe_DuplicateReconnectionPrevention(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Start all goroutines
-	for i := 0; i < numConcurrent; i++ {
+	for i := range numConcurrent {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -778,7 +778,7 @@ func TestBackedPipe_DuplicateReconnectionPrevention(t *testing.T) {
 	}
 
 	// Wait for all ForceReconnect calls to join the singleflight operation.
-	for i := 0; i < numConcurrent; i++ {
+	for range numConcurrent {
 		testutil.RequireReceive(testCtx, t, enteredSignals)
 	}
 

--- a/agent/immortalstreams/backedpipe/backed_reader_test.go
+++ b/agent/immortalstreams/backedpipe/backed_reader_test.go
@@ -435,7 +435,7 @@ func TestBackedReader_PartialReads(t *testing.T) {
 
 	// Read multiple times
 	buf := make([]byte, 10)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		n, err := br.Read(buf)
 		require.NoError(t, err)
 		require.Equal(t, 1, n)

--- a/agent/immortalstreams/backedpipe/backed_writer_test.go
+++ b/agent/immortalstreams/backedpipe/backed_writer_test.go
@@ -882,7 +882,7 @@ func TestBackedWriter_MultipleWritesDuringReconnect(t *testing.T) {
 	writeResults := make([]error, numWriters)
 	writesStarted := make(chan struct{}, numWriters)
 
-	for i := 0; i < numWriters; i++ {
+	for i := range numWriters {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -895,7 +895,7 @@ func TestBackedWriter_MultipleWritesDuringReconnect(t *testing.T) {
 
 	// Wait for all writes to start
 	ctx := testutil.Context(t, testutil.WaitLong)
-	for i := 0; i < numWriters; i++ {
+	for range numWriters {
 		testutil.RequireReceive(ctx, t, writesStarted)
 	}
 
@@ -980,7 +980,7 @@ func BenchmarkBackedWriter_Reconnect(b *testing.B) {
 
 	// Fill buffer with data
 	data := bytes.Repeat([]byte("x"), 1024)
-	for i := 0; i < 32; i++ {
+	for range 32 {
 		bw.Write(data)
 	}
 

--- a/agent/immortalstreams/backedpipe/ring_buffer_internal_test.go
+++ b/agent/immortalstreams/backedpipe/ring_buffer_internal_test.go
@@ -247,7 +247,7 @@ func BenchmarkRingBuffer_Write(b *testing.B) {
 func BenchmarkRingBuffer_ReadLast(b *testing.B) {
 	rb := newRingBuffer(64 * 1024 * 1024) // 64MB for benchmarks
 	// Fill buffer with test data
-	for i := 0; i < 64; i++ {
+	for range 64 {
 		rb.Write(bytes.Repeat([]byte("x"), 1024))
 	}
 

--- a/agent/unit/graph_test.go
+++ b/agent/unit/graph_test.go
@@ -243,12 +243,12 @@ func TestGraphThreadSafety(t *testing.T) {
 
 		barrier := make(chan struct{})
 		// Launch writers
-		for i := 0; i < numWriters; i++ {
+		for i := range numWriters {
 			wg.Add(1)
 			go func(writerID int) {
 				defer wg.Done()
 				<-barrier
-				for j := 0; j < operationsPerWriter; j++ {
+				for j := range operationsPerWriter {
 					from := &testGraphVertex{Name: fmt.Sprintf("writer-%d-%d", writerID, j)}
 					to := &testGraphVertex{Name: fmt.Sprintf("writer-%d-%d", writerID, j+1)}
 					graph.AddEdge(from, to, testEdgeCompleted)
@@ -262,7 +262,7 @@ func TestGraphThreadSafety(t *testing.T) {
 			readCount int
 		}, numReaders)
 
-		for i := 0; i < numReaders; i++ {
+		for i := range numReaders {
 			wg.Add(1)
 			go func(readerID int) {
 				defer wg.Done()
@@ -274,7 +274,7 @@ func TestGraphThreadSafety(t *testing.T) {
 				}()
 
 				readCount := 0
-				for j := 0; j < operationsPerReader; j++ {
+				for j := range operationsPerReader {
 					// Create a test vertex and read
 					testUnit := &testGraphVertex{Name: fmt.Sprintf("test-reader-%d-%d", readerID, j)}
 					forwardEdges := graph.GetForwardAdjacentVertices(testUnit)
@@ -323,7 +323,7 @@ func TestGraphThreadSafety(t *testing.T) {
 		cycleErrors := make([]error, numGoroutines)
 
 		// Launch goroutines trying to add D→A (creates cycle)
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(goroutineID int) {
 				defer wg.Done()
@@ -354,7 +354,7 @@ func TestGraphThreadSafety(t *testing.T) {
 		graph := &testGraph{}
 
 		// Pre-populate graph
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			from := &testGraphVertex{Name: fmt.Sprintf("dot-unit-%d", i)}
 			to := &testGraphVertex{Name: fmt.Sprintf("dot-unit-%d", i+1)}
 			err := graph.AddEdge(from, to, testEdgeCompleted)
@@ -369,7 +369,7 @@ func TestGraphThreadSafety(t *testing.T) {
 
 		// Launch readers calling ToDOT
 		dotErrors := make([]error, numReaders)
-		for i := 0; i < numReaders; i++ {
+		for i := range numReaders {
 			wg.Add(1)
 			go func(readerID int) {
 				defer wg.Done()
@@ -383,7 +383,7 @@ func TestGraphThreadSafety(t *testing.T) {
 		}
 
 		// Launch writers adding edges
-		for i := 0; i < numWriters; i++ {
+		for i := range numWriters {
 			wg.Add(1)
 			go func(writerID int) {
 				defer wg.Done()
@@ -417,7 +417,7 @@ func BenchmarkGraph_ConcurrentMixedOperations(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Launch goroutines performing random operations
-		for j := 0; j < numGoroutines; j++ {
+		for j := range numGoroutines {
 			wg.Add(1)
 			go func(goroutineID int) {
 				defer wg.Done()

--- a/cli/cliutil/queue_test.go
+++ b/cli/cliutil/queue_test.go
@@ -18,7 +18,7 @@ func TestQueue(t *testing.T) {
 		q := cliutil.NewQueue[int](10)
 		require.Equal(t, 0, q.Len())
 
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			err := q.Push(i)
 			require.NoError(t, err)
 			if i < 10 {
@@ -38,13 +38,13 @@ func TestQueue(t *testing.T) {
 		t.Parallel()
 
 		q := cliutil.NewQueue[int](10)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			err := q.Push(i)
 			require.NoError(t, err)
 		}
 
 		// No blocking, should pop immediately.
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			val, ok := q.Pop()
 			require.True(t, ok)
 			require.Equal(t, i, val)
@@ -94,13 +94,13 @@ func TestQueue(t *testing.T) {
 			return n + 1, true
 		})
 
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			err := q.Push(i)
 			require.NoError(t, err)
 		}
 
 		got := []int{}
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			val, ok := q.Pop()
 			require.True(t, ok)
 			got = append(got, val)

--- a/cmd/cliui/main.go
+++ b/cmd/cliui/main.go
@@ -235,7 +235,7 @@ func main() {
 					agent.LifecycleState = codersdk.WorkspaceAgentLifecycleStarting
 					startingAt := time.Now()
 					agent.StartedAt = &startingAt
-					for i := 0; i < 10; i++ {
+					for i := range 10 {
 						level := codersdk.LogLevelInfo
 						if rand.Float64() > 0.75 { //nolint:gosec
 							level = codersdk.LogLevelError

--- a/coderd/agentapi/metadata_test.go
+++ b/coderd/agentapi/metadata_test.go
@@ -2,6 +2,7 @@ package agentapi_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -119,7 +120,7 @@ func TestBatchUpdateMetadata(t *testing.T) {
 
 		now := dbtime.Now()
 		almostLongValue := ""
-		for i := 0; i < 2048; i++ {
+		for range 2048 {
 			almostLongValue += "a"
 		}
 		req := &agentproto.BatchUpdateMetadataRequest{
@@ -206,11 +207,12 @@ func TestBatchUpdateMetadata(t *testing.T) {
 				},
 				{
 					Key: func() string {
-						key := "key 3 "
-						for i := 0; i < (6144 - len("key 1") - len("key 2") - len("key 3") - 1); i++ {
-							key += "a"
+						var key strings.Builder
+						key.WriteString("key 3 ")
+						for range 6144 - len("key 1") - len("key 2") - len("key 3") - 1 {
+							key.WriteString("a")
 						}
-						return key
+						return key.String()
 					}(),
 					Result: &agentproto.WorkspaceAgentMetadata_Result{
 						Value: "value 3",

--- a/coderd/coderdtest/authorize_test.go
+++ b/coderd/coderdtest/authorize_test.go
@@ -106,7 +106,7 @@ func fuzzAuthzPrep(t *testing.T, prep rbac.PreparedAuthorized, n int, action pol
 	t.Helper()
 	pairs := make([]coderdtest.ActionObjectPair, 0, n)
 
-	for i := 0; i < n; i++ {
+	for range n {
 		obj := coderdtest.RandomRBACObject()
 		obj.Type = objectType
 		p := coderdtest.ActionObjectPair{Action: action, Object: obj}
@@ -120,7 +120,7 @@ func fuzzAuthz(t *testing.T, sub rbac.Subject, rec rbac.Authorizer, n int) []cod
 	t.Helper()
 	pairs := make([]coderdtest.ActionObjectPair, 0, n)
 
-	for i := 0; i < n; i++ {
+	for range n {
 		p := coderdtest.ActionObjectPair{Action: coderdtest.RandomRBACAction(), Object: coderdtest.RandomRBACObject()}
 		_ = rec.Authorize(context.Background(), sub, p.Action, p.Object)
 		pairs = append(pairs, p)

--- a/coderd/database/dbauthz/groupsauth_test.go
+++ b/coderd/database/dbauthz/groupsauth_test.go
@@ -41,7 +41,7 @@ func TestGroupsAuth(t *testing.T) {
 	})
 
 	var users []database.User
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		user := dbgen.User(t, db, database.User{})
 		users = append(users, user)
 		err := db.InsertGroupMember(ownerCtx, database.InsertGroupMemberParams{

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -802,7 +802,7 @@ func TestDeleteOldAuditLogConnectionEventsLimit(t *testing.T) {
 	now := dbtime.Now()
 	threshold := now.Add(-90 * 24 * time.Hour)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		dbgen.AuditLog(t, db, database.AuditLog{
 			UserID:         user.ID,
 			OrganizationID: org.ID,

--- a/coderd/database/dbtestutil/postgres_test.go
+++ b/coderd/database/dbtestutil/postgres_test.go
@@ -80,7 +80,7 @@ func TestOpen_ValidDBFrom(t *testing.T) {
 	require.NoError(t, rows.Close())
 	require.NoError(t, db.Close())
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		db, err := sql.Open("postgres", dsn)
 		require.NoError(t, err)
 		require.NoError(t, db.Ping())

--- a/coderd/database/pubsub/watchdog_test.go
+++ b/coderd/database/pubsub/watchdog_test.go
@@ -41,7 +41,7 @@ func TestWatchdog_NoTimeout(t *testing.T) {
 	require.Equal(t, pubsub.EventPubsubWatchdog, sub.event)
 
 	// 5 min / 15 sec = 20, so do 21 ticks
-	for i := 0; i < 21; i++ {
+	for range 21 {
 		d, w := mClock.AdvanceNext()
 		w.MustWait(ctx)
 		require.LessOrEqual(t, d, 15*time.Second)
@@ -97,7 +97,7 @@ func TestWatchdog_Timeout(t *testing.T) {
 	require.Equal(t, pubsub.EventPubsubWatchdog, sub.event)
 
 	// 5 min / 15 sec = 20, so do 19 ticks without timing out
-	for i := 0; i < 19; i++ {
+	for range 19 {
 		d, w := mClock.AdvanceNext()
 		w.MustWait(ctx)
 		require.LessOrEqual(t, d, 15*time.Second)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -1478,7 +1478,7 @@ func TestQueuePosition(t *testing.T) {
 	jobCount := 10
 	jobs := []database.ProvisionerJob{}
 	jobIDs := []uuid.UUID{}
-	for i := 0; i < jobCount; i++ {
+	for range jobCount {
 		job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
 			OrganizationID: org.ID,
 			Tags:           database.StringMap{},
@@ -1931,7 +1931,7 @@ func TestAuditLogDefaultLimit(t *testing.T) {
 	require.NoError(t, err)
 	db := database.New(sqlDB)
 
-	for i := 0; i < 110; i++ {
+	for range 110 {
 		dbgen.AuditLog(t, db, database.AuditLog{})
 	}
 
@@ -2074,7 +2074,7 @@ func TestReadCustomRoles(t *testing.T) {
 	allRoles := make([]database.CustomRole, 0)
 	siteRoles := make([]database.CustomRole, 0)
 	orgRoles := make([]database.CustomRole, 0)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		orgID := uuid.NullUUID{
 			UUID:  orgIDs[i%len(orgIDs)],
 			Valid: true,
@@ -2829,7 +2829,7 @@ func TestCountConnectionLogs(t *testing.T) {
 	wsB := dbgen.Workspace(t, db, database.WorkspaceTable{OwnerID: userB.ID, OrganizationID: orgB.Org.ID, TemplateID: tplB.ID})
 
 	// Create logs for two different orgs.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
 			OrganizationID:   wsA.OrganizationID,
 			WorkspaceOwnerID: wsA.OwnerID,
@@ -2837,7 +2837,7 @@ func TestCountConnectionLogs(t *testing.T) {
 			Type:             database.ConnectionTypeSsh,
 		})
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		dbgen.ConnectionLog(t, db, database.UpsertConnectionLogParams{
 			OrganizationID:   wsB.OrganizationID,
 			WorkspaceOwnerID: wsB.OwnerID,

--- a/coderd/database/tx.go
+++ b/coderd/database/tx.go
@@ -32,7 +32,7 @@ const maxRetries = 5
 func ReadModifyUpdate(db Store, f func(tx Store) error,
 ) error {
 	var err error
-	for retries := 0; retries < maxRetries; retries++ {
+	for range maxRetries {
 		err = db.InTx(f, &TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 		})

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -44,7 +44,7 @@ func TestDebugHealth(t *testing.T) {
 		defer cancel()
 
 		sessionToken = client.SessionToken()
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			res, err := client.Request(ctx, "GET", "/api/v2/debug/health", nil)
 			require.NoError(t, err)
 			_, _ = io.ReadAll(res.Body)
@@ -77,7 +77,7 @@ func TestDebugHealth(t *testing.T) {
 		defer cancel()
 
 		sessionToken = client.SessionToken()
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			res, err := client.Request(ctx, "GET", "/api/v2/debug/health?force=true", nil)
 			require.NoError(t, err)
 			_, _ = io.ReadAll(res.Body)

--- a/coderd/devtunnel/tunnel_test.go
+++ b/coderd/devtunnel/tunnel_test.go
@@ -199,7 +199,7 @@ func newTunnelServer(t *testing.T) *tunnelServer {
 	// passed an active listener (because wireguard needs to make the listener),
 	// so we may need to try a few times to get a free port.
 	var td *tunneld.API
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wireguardPort := freeUDPPort(t)
 		options := &tunneld.Options{
 			BaseURL:                baseURLParsed,

--- a/coderd/gitsshkey/ed25519.go
+++ b/coderd/gitsshkey/ed25519.go
@@ -101,7 +101,7 @@ func MarshalED25519PrivateKey(key ed25519.PrivateKey) ([]byte, error) {
 	pk1.Pad = make([]byte, padLen)
 
 	// Padding is a sequence of bytes like: 1, 2, 3...
-	for i := 0; i < padLen; i++ {
+	for i := range padLen {
 		pk1.Pad[i] = byte(i + 1)
 	}
 

--- a/coderd/healthcheck/database.go
+++ b/coderd/healthcheck/database.go
@@ -38,7 +38,7 @@ func (r *DatabaseReport) Run(ctx context.Context, opts *DatabaseReportOptions) {
 	pingCount := 5
 	pings := make([]time.Duration, 0, pingCount)
 	// Ping 5 times and average the latency.
-	for i := 0; i < pingCount; i++ {
+	for range pingCount {
 		pong, err := opts.DB.Ping(ctx)
 		if err != nil {
 			r.Error = health.Errorf(health.CodeDatabasePingFailed, "ping database: %s", err)

--- a/coderd/httpmw/authorize_test.go
+++ b/coderd/httpmw/authorize_test.go
@@ -76,7 +76,7 @@ func TestExtractUserRoles(t *testing.T) {
 				expected := []rbac.RoleIdentifier{}
 				user, token := addUser(t, db)
 				expected = append(expected, rbac.RoleMember())
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					organization, err := db.InsertOrganization(context.Background(), database.InsertOrganizationParams{
 						ID:          uuid.New(),
 						Name:        fmt.Sprintf("testorg%d", i),

--- a/coderd/jobreaper/detector_test.go
+++ b/coderd/jobreaper/detector_test.go
@@ -71,7 +71,7 @@ func TestDetectorNoHungJobs(t *testing.T) {
 	org := dbgen.Organization(t, db, database.Organization{})
 	user := dbgen.User(t, db, database.User{})
 	file := dbgen.File(t, db, database.File{})
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
 			CreatedAt: now.Add(-time.Minute * 5),
 			UpdatedAt: now.Add(-time.Minute * time.Duration(i)),
@@ -884,7 +884,7 @@ func TestDetectorMaxJobsPerRun(t *testing.T) {
 
 	// Create MaxJobsPerRun + 1 hung jobs.
 	now := time.Now()
-	for i := 0; i < jobreaper.MaxJobsPerRun+1; i++ {
+	for range jobreaper.MaxJobsPerRun + 1 {
 		pj := dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
 			CreatedAt: now.Add(-time.Hour),
 			UpdatedAt: now.Add(-time.Hour),

--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -269,12 +269,12 @@ func (m *Manager) syncUpdates(ctx context.Context) {
 	// If more items are added to the success or failure channels between measuring their lengths and now, those items
 	// will be processed on the next bulk update.
 
-	for i := 0; i < nSuccess; i++ {
+	for range nSuccess {
 		res := <-m.success
 		successParams.IDs = append(successParams.IDs, res.msg)
 		successParams.SentAts = append(successParams.SentAts, res.ts)
 	}
-	for i := 0; i < nFailure; i++ {
+	for range nFailure {
 		res := <-m.failure
 
 		var (

--- a/coderd/notifications/metrics_test.go
+++ b/coderd/notifications/metrics_test.go
@@ -353,7 +353,7 @@ func TestInflightDispatchesMetric(t *testing.T) {
 	user := createSampleUser(t, store)
 
 	// WHEN: notifications are enqueued which will succeed (and be delayed during dispatch)
-	for i := 0; i < msgCount; i++ {
+	for i := range msgCount {
 		_, err = enq.Enqueue(ctx, user.ID, tmpl, map[string]string{"type": "success", "i": strconv.Itoa(i)}, "test")
 		require.NoError(t, err)
 	}
@@ -366,7 +366,7 @@ func TestInflightDispatchesMetric(t *testing.T) {
 		return promtest.ToFloat64(metrics.InflightDispatches.WithLabelValues(string(method), tmpl.String())) == msgCount
 	}, testutil.WaitShort, testutil.IntervalFast)
 
-	for i := 0; i < msgCount; i++ {
+	for range msgCount {
 		barrier.wg.Done()
 	}
 

--- a/coderd/oauth2_metadata_validation_test.go
+++ b/coderd/oauth2_metadata_validation_test.go
@@ -715,7 +715,7 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 
 		// Test with many redirect URIs
 		redirectURIs := make([]string, 20)
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			redirectURIs[i] = fmt.Sprintf("https://example%d.com/callback", i)
 		}
 

--- a/coderd/oauth2_security_test.go
+++ b/coderd/oauth2_security_test.go
@@ -421,7 +421,7 @@ func TestOAuth2ConcurrentSecurityOperations(t *testing.T) {
 		errors := make([]error, numGoroutines)
 
 		// Launch concurrent attempts to access the client configuration
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(index int) {
 				defer wg.Done()
@@ -448,7 +448,7 @@ func TestOAuth2ConcurrentSecurityOperations(t *testing.T) {
 		statusCodes := make([]int, numGoroutines)
 
 		// Launch concurrent attempts with invalid tokens
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(index int) {
 				defer wg.Done()
@@ -494,7 +494,7 @@ func TestOAuth2ConcurrentSecurityOperations(t *testing.T) {
 		deleteResults := make([]error, numGoroutines)
 
 		// Launch concurrent deletion attempts
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(index int) {
 				defer wg.Done()

--- a/coderd/oauth2_test.go
+++ b/coderd/oauth2_test.go
@@ -109,7 +109,7 @@ func TestOAuth2ProviderAppSecrets(t *testing.T) {
 		require.Len(t, secrets, 0)
 
 		// Should be able to create secrets.
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			//nolint:gocritic // OAauth2 app management requires owner permission.
 			secret, err := client.PostOAuth2ProviderAppSecret(ctx, apps.Default.ID)
 			require.NoError(t, err)

--- a/coderd/oauth2provider/validation_test.go
+++ b/coderd/oauth2provider/validation_test.go
@@ -715,7 +715,7 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 
 		// Test with many redirect URIs
 		redirectURIs := make([]string, 20)
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			redirectURIs[i] = fmt.Sprintf("https://example%d.com/callback", i)
 		}
 

--- a/coderd/oauthpki/okidcpki_test.go
+++ b/coderd/oauthpki/okidcpki_test.go
@@ -177,7 +177,7 @@ func TestAzureAKPKIWithCoderd(t *testing.T) {
 	user, _ := helper.Login(t, claims)
 
 	// Try refreshing the token more than once.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		helper.ForceRefresh(t, api.Database, user, claims)
 	}
 }

--- a/coderd/prometheusmetrics/aggregator_test.go
+++ b/coderd/prometheusmetrics/aggregator_test.go
@@ -676,7 +676,7 @@ func benchmarkRunner(b *testing.B, aggregateByLabels []string) {
 		b.StopTimer()
 		b.Logf("N=%d generating %d metrics", b.N, numMetrics)
 		metrics := make([]*agentproto.Stats_Metric, 0, numMetrics)
-		for i := 0; i < numMetrics; i++ {
+		for range numMetrics {
 			metrics = append(metrics, genAgentMetric(b))
 		}
 
@@ -684,7 +684,7 @@ func benchmarkRunner(b *testing.B, aggregateByLabels []string) {
 		var nGot atomic.Int64
 		b.StartTimer()
 		metricsAggregator.Update(ctx, testLabels, metrics)
-		for i := 0; i < numMetrics; i++ {
+		for range numMetrics {
 			select {
 			case <-ctx.Done():
 				b.FailNow()

--- a/coderd/prometheusmetrics/collector_test.go
+++ b/coderd/prometheusmetrics/collector_test.go
@@ -122,7 +122,7 @@ func collectAndSortMetrics(t *testing.T, collector prometheus.Collector, count i
 	var metrics []*dto.Metric
 
 	collector.Collect(ch)
-	for i := 0; i < count; i++ {
+	for range count {
 		m := <-ch
 
 		var metric dto.Metric

--- a/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_internal_test.go
@@ -53,7 +53,7 @@ func benchAsPrometheus(b *testing.B, base []string, extraN int) {
 		templateName:      "tmpl",
 		aggregateByLabels: base,
 	}
-	for i := 0; i < extraN; i++ {
+	for i := range extraN {
 		am.Labels[i] = &agentproto.Stats_Metric_Label{Name: fmt.Sprintf("l%d", i), Value: "v"}
 	}
 

--- a/coderd/provisionerdserver/acquirer_test.go
+++ b/coderd/provisionerdserver/acquirer_test.go
@@ -84,21 +84,21 @@ func TestAcquirer_MultipleSameDomain(t *testing.T) {
 	tags := provisionerdserver.Tags{
 		"environment": "on-prem",
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wID := uuid.New()
 		workerIDs[wID] = true
 		a := newTestAcquiree(t, orgID, wID, pt, tags)
 		acquirees = append(acquirees, a)
 		a.startAcquire(ctx, uut)
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		jobID := uuid.New()
 		jobIDs[jobID] = true
 		err := fs.sendCtx(ctx, database.ProvisionerJob{ID: jobID}, nil)
 		require.NoError(t, err)
 	}
 	gotJobIDs := make(map[uuid.UUID]bool)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		j := acquirees[i].success(ctx)
 		gotJobIDs[j.ID] = true
 	}
@@ -310,7 +310,7 @@ func TestAcquirer_UnblockOnCancel(t *testing.T) {
 
 	// queue up 2 responses --- we may not need both, since acquiree0 will
 	// usually cancel before calling, but cancel is async, so it might call.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		err := fs.sendCtx(ctx, database.ProvisionerJob{ID: jobID}, nil)
 		require.NoError(t, err)
 	}

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -134,7 +134,7 @@ func TestHeartbeat(t *testing.T) {
 		heartbeatInterval: testutil.IntervalFast,
 	})
 
-	for i := 0; i < numBeats; i++ {
+	for range numBeats {
 		testutil.TryReceive(ctx, t, heartbeatChan)
 	}
 	// goleak.VerifyTestMain ensures that the heartbeat goroutine does not leak

--- a/coderd/tailnet_test.go
+++ b/coderd/tailnet_test.go
@@ -228,7 +228,7 @@ func TestServerTailnet_ReverseProxy(t *testing.T) {
 
 		rp := serverTailnet.ReverseProxy(u, u, a.id, appurl.ApplicationURL{}, "")
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(
 				http.MethodGet,
@@ -442,7 +442,7 @@ func setupServerTailnetAgent(t *testing.T, agentNum int, opts ...tailnettest.DER
 
 	agents := []agentWithID{}
 
-	for i := 0; i < agentNum; i++ {
+	for range agentNum {
 		manifest := agentsdk.Manifest{
 			AgentID: uuid.New(),
 			DERPMap: derpMap,

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -767,7 +767,7 @@ func TestRecordTelemetryStatus(t *testing.T) {
 				require.Nil(t, snapshot1)
 			}
 
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				// Whatever happens, subsequent calls should not report if telemetryEnabled didn't change
 				snapshot2, err := telemetry.RecordTelemetryStatus(ctx, logger, db, testCase.telemetryEnabled)
 				require.NoError(t, err)

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1689,7 +1689,7 @@ func TestPaginatedTemplateVersions(t *testing.T) {
 	require.NoError(t, err)
 	file, err := client.Upload(egCtx, codersdk.ContentTypeTar, bytes.NewReader(data))
 	require.NoError(t, err)
-	for i := 0; i < total; i++ {
+	for i := range total {
 		eg.Go(func() error {
 			templateVersion, err := client.CreateTemplateVersion(egCtx, user.OrganizationID, codersdk.CreateTemplateVersionRequest{
 				Name:          uuid.NewString(),
@@ -2340,7 +2340,7 @@ func TestTemplateArchiveVersions(t *testing.T) {
 	allFailed := make([]uuid.UUID, 0)
 	expArchived := make([]uuid.UUID, 0)
 	// create some failed versions
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		failed := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, &echo.Responses{
 			Parse:          echo.ParseComplete,
 			ProvisionPlan:  echo.PlanFailed,
@@ -2354,7 +2354,7 @@ func TestTemplateArchiveVersions(t *testing.T) {
 	}
 
 	// Create some unused versions
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		unused := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil, func(req *codersdk.CreateTemplateVersionRequest) {
 			req.TemplateID = template.ID
 		})
@@ -2363,7 +2363,7 @@ func TestTemplateArchiveVersions(t *testing.T) {
 	}
 
 	// Create some used template versions
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		used := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil, func(req *codersdk.CreateTemplateVersionRequest) {
 			req.TemplateID = template.ID
 		})

--- a/coderd/updatecheck/updatecheck_test.go
+++ b/coderd/updatecheck/updatecheck_test.go
@@ -66,7 +66,7 @@ func TestChecker_Notify(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 
-	for i := 0; i < len(wantVersion); i++ {
+	for i := range wantVersion {
 		select {
 		case <-ctx.Done():
 			t.Error("timed out waiting for notification")

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1601,7 +1601,7 @@ func TestUsersFilter(t *testing.T) {
 	lastSeenNow := time.Date(2023, 1, 18, 12, 0, 0, 0, time.UTC)
 	users := make([]codersdk.User, 0)
 	users = append(users, firstUser)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		roles := []rbac.RoleIdentifier{}
 		if i%2 == 0 {
 			roles = append(roles, rbac.RoleTemplateAdmin(), rbac.RoleUserAdmin())
@@ -1637,7 +1637,7 @@ func TestUsersFilter(t *testing.T) {
 	}
 
 	// Add users with different creation dates for testing date filters
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		user1, err := api.Database.InsertUser(dbauthz.AsSystemRestricted(ctx), database.InsertUserParams{
 			ID:        uuid.New(),
 			Email:     fmt.Sprintf("before%d@coder.com", i),
@@ -2543,7 +2543,7 @@ func TestSuspendedPagination(t *testing.T) {
 	total := 10
 	users := make([]codersdk.User, 0, total)
 	// Create users
-	for i := 0; i < total; i++ {
+	for i := range total {
 		email := fmt.Sprintf("%d@coder.com", i)
 		username := fmt.Sprintf("user%d", i)
 		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
@@ -2719,7 +2719,7 @@ func TestPaginatedUsers(t *testing.T) {
 
 	eg, _ := errgroup.WithContext(ctx)
 	// Create users
-	for i := 0; i < total; i++ {
+	for i := range total {
 		eg.Go(func() error {
 			email := fmt.Sprintf("%d@coder.com", i)
 			username := fmt.Sprintf("user%d", i)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -2846,7 +2846,7 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 		}()
 
 		// Send off 10 ticks to cause 10 validate calls
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			ticks <- time.Now()
 		}
 		cancel()

--- a/coderd/workspaceapps/stats_test.go
+++ b/coderd/workspaceapps/stats_test.go
@@ -369,7 +369,7 @@ func TestStatsCollector_backlog(t *testing.T) {
 	// The first collected stat is "rolled up" and moved into the
 	// backlog during the first flush. On the second flush nothing is
 	// rolled up due to being unable to report the backlog.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		collector.Collect(workspaceapps.StatsReport{
 			SessionID:        uuid.New(),
 			SessionStartedAt: start,

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1715,7 +1715,7 @@ func TestWorkspaceFilter(t *testing.T) {
 	t.Cleanup(cancel)
 
 	users := make([]coderUser, 0)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, rbac.RoleOwner())
 
 		if i%3 == 0 {

--- a/coderd/workspacestats/activitybump_test.go
+++ b/coderd/workspacestats/activitybump_test.go
@@ -220,7 +220,7 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 
 				var buildNumber int32 = 1
 				// Insert a number of previous workspace builds.
-				for i := 0; i < 5; i++ {
+				for range 5 {
 					insertPrevWorkspaceBuild(t, db, org.ID, templateVersion.ID, ws.ID, database.WorkspaceTransitionStart, buildNumber)
 					buildNumber++
 					insertPrevWorkspaceBuild(t, db, org.ID, templateVersion.ID, ws.ID, database.WorkspaceTransitionStop, buildNumber)

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -84,7 +84,7 @@ func TestBatchStats(t *testing.T) {
 	go func() {
 		defer close(done)
 		t.Logf("inserting %d stats", defaultBufferSize)
-		for i := 0; i < defaultBufferSize; i++ {
+		for i := range defaultBufferSize {
 			if i%2 == 0 {
 				b.Add(t3.Add(time.Millisecond), deps1.Agent.ID, deps1.User.ID, deps1.Template.ID, deps1.Workspace.ID, randStats(t), false)
 			} else {

--- a/codersdk/agentsdk/logs_internal_test.go
+++ b/codersdk/agentsdk/logs_internal_test.go
@@ -285,7 +285,7 @@ func TestLogSender_Batch(t *testing.T) {
 	t0 := dbtime.Now()
 	ls1 := uuid.UUID{0x11}
 	var logs []Log
-	for i := 0; i < 60000; i++ {
+	for range 60000 {
 		logs = append(logs, Log{
 			CreatedAt: t0,
 			Output:    "r",
@@ -340,7 +340,7 @@ func TestLogSender_MaxQueuedLogs(t *testing.T) {
 		hugeLog[i] = 'q'
 	}
 	var logs []Log
-	for i := 0; i < n; i++ {
+	for range n {
 		logs = append(logs, Log{
 			CreatedAt: t0,
 			Output:    string(hugeLog),
@@ -366,7 +366,7 @@ func TestLogSender_MaxQueuedLogs(t *testing.T) {
 	// limit. These come over a total of 3 updates, because due to overhead, the n logs from source
 	// #1 come in 2 updates, plus 1 update for source #2.
 	logsBySource := make(map[uuid.UUID]int)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		req := testutil.TryReceive(ctx, t, fDest.reqs)
 		require.NotNil(t, req)
 		srcID, err := uuid.FromBytes(req.LogSourceId)

--- a/codersdk/name_test.go
+++ b/codersdk/name_test.go
@@ -165,7 +165,7 @@ func TestTemplateVersionNameValid(t *testing.T) {
 func TestGeneratedTemplateVersionNameValid(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		name := testutil.GetRandomName(t)
 		err := codersdk.TemplateVersionNameValid(name)
 		require.NoError(t, err, "invalid template version name: %s", name)

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -103,7 +103,7 @@ func WeekdaysToBitmap(days []string) (uint8, error) {
 // the schedule package's rules (see above).
 func BitmapToWeekdays(bitmap uint8) []string {
 	days := []string{}
-	for i := 0; i < 7; i++ {
+	for i := range 7 {
 		if bitmap&(1<<i) != 0 {
 			switch i {
 			case 0:

--- a/cryptorand/numbers_test.go
+++ b/cryptorand/numbers_test.go
@@ -11,7 +11,7 @@ import (
 func TestInt63(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		v, err := cryptorand.Int63()
 		require.NoError(t, err, "unexpected error from Int63")
 		t.Logf("value: %v <- random?", v)
@@ -22,7 +22,7 @@ func TestInt63(t *testing.T) {
 func TestInt63n(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		v, err := cryptorand.Int63n(100)
 		require.NoError(t, err, "unexpected error from Int63n")
 		t.Logf("value: %v <- random?", v)
@@ -43,7 +43,7 @@ func TestInt63n(t *testing.T) {
 func TestIntn(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		v, err := cryptorand.Intn(100)
 		require.NoError(t, err, "unexpected error from Intn")
 		t.Logf("value: %v <- random?", v)
@@ -64,7 +64,7 @@ func TestIntn(t *testing.T) {
 func TestFloat64(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		v, err := cryptorand.Float64()
 		require.NoError(t, err, "unexpected error from Float64")
 		t.Logf("value: %v <- random?", v)

--- a/cryptorand/slices_test.go
+++ b/cryptorand/slices_test.go
@@ -41,7 +41,7 @@ func TestRandomElement(t *testing.T) {
 		}
 
 		// Get a random value from each 20 times.
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			iv, err := cryptorand.Element(ints)
 			require.NoError(t, err, "unexpected error from Element(ints)")
 			t.Logf("random int slice element: %v", iv)

--- a/cryptorand/strings.go
+++ b/cryptorand/strings.go
@@ -92,7 +92,7 @@ func StringCharset(charSetStr string, size int) (string, error) {
 	var buf strings.Builder
 	buf.Grow(size)
 
-	for i := 0; i < size; i++ {
+	for range size {
 		r := binary.BigEndian.Uint32(entropy[:4])
 		entropy = entropy[4:]
 

--- a/cryptorand/strings_test.go
+++ b/cryptorand/strings_test.go
@@ -16,7 +16,7 @@ import (
 func TestString(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		rs, err := cryptorand.String(10)
 		require.NoError(t, err, "unexpected error from String")
 		t.Logf("value: %v <- random?", rs)
@@ -95,7 +95,7 @@ func TestStringCharset(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				rs, err := cryptorand.StringCharset(test.Charset, test.Length)
 				require.NoError(t, err, "unexpected error from StringCharset")
 				require.Equal(t, test.Length, utf8.RuneCountInString(rs), "expected RuneCountInString to match requested")
@@ -109,7 +109,7 @@ func TestStringCharset(t *testing.T) {
 			t.Run(test.Name+"HelperFunc", func(t *testing.T) {
 				t.Parallel()
 
-				for i := 0; i < 5; i++ {
+				for i := range 5 {
 					rs, err := test.HelperFunc(test.Length)
 					require.NoError(t, err, "unexpected error from HelperFunc")
 					require.Equal(t, test.Length, utf8.RuneCountInString(rs), "expected RuneCountInString to match requested")
@@ -125,7 +125,7 @@ func TestStringCharset(t *testing.T) {
 func TestSha1String(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		rs, err := cryptorand.Sha1String()
 		require.NoError(t, err, "unexpected error from String")
 		require.Equal(t, 40, utf8.RuneCountInString(rs), "expected RuneCountInString to match requested")
@@ -157,7 +157,7 @@ func BenchmarkStringUnsafe20(b *testing.B) {
 		var buf strings.Builder
 		buf.Grow(size)
 
-		for i := 0; i < size; i++ {
+		for i := range size {
 			n := binary.BigEndian.Uint32(ibuf[i*4 : (i+1)*4])
 			_, _ = buf.WriteRune(charSet[n%uint32(len(charSet))]) // #nosec G115 - Safe conversion as len(charSet) will be reasonably small for character sets
 		}
@@ -180,7 +180,7 @@ func BenchmarkStringBigint20(b *testing.B) {
 		buf.Grow(size)
 
 		bi := big.NewInt(int64(size))
-		for i := 0; i < size; i++ {
+		for range size {
 			num, err := rand.Int(rand.Reader, bi)
 			if err != nil {
 				return "", err

--- a/enterprise/aibridged/aibridged_integration_test.go
+++ b/enterprise/aibridged/aibridged_integration_test.go
@@ -514,7 +514,7 @@ func TestIntegrationCircuitBreaker(t *testing.T) {
 
 	// Test OpenAI circuit breaker.
 	openaiRequestBody := `{"messages":[{"role":"user","content":"test"}],"model":"gpt-4"}`
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/openai/v1/chat/completions", bytes.NewBufferString(openaiRequestBody))
 		require.NoError(t, err)
 		req.Header.Add("Authorization", "Bearer "+apiKey.Key)
@@ -527,7 +527,7 @@ func TestIntegrationCircuitBreaker(t *testing.T) {
 
 	// Test Anthropic circuit breaker.
 	anthropicRequestBody := `{"messages":[{"role":"user","content":"test"}],"model":"claude-3-5-sonnet-20241022","max_tokens":100}`
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/anthropic/v1/messages", bytes.NewBufferString(anthropicRequestBody))
 		require.NoError(t, err)
 		req.Header.Add("Authorization", "Bearer "+apiKey.Key)

--- a/enterprise/audit/table_internal_test.go
+++ b/enterprise/audit/table_internal_test.go
@@ -47,9 +47,9 @@ func TestAuditableResources(t *testing.T) {
 	found := make(map[string]bool)
 	expectedList := make([]string, 0)
 	// Now we check we have all the resources in the AuditableResources
-	for i := 0; i < unionType.Len(); i++ {
+	for term := range unionType.Terms() {
 		// All types come across like 'github.com/coder/coder/v2/coderd/database.<type>'
-		typeName := unionType.Term(i).Type().String()
+		typeName := term.Type().String()
 		_, ok := AuditableResources[typeName]
 		assert.True(t, ok, "missing resource %q from AuditableResources", typeName)
 		found[typeName] = true
@@ -121,8 +121,7 @@ func findSwitchTypes(f *types.Func) []string {
 
 func returnSwitchBlocks(sc *types.Scope) []*types.Scope {
 	switches := make([]*types.Scope, 0)
-	for i := 0; i < sc.NumChildren(); i++ {
-		child := sc.Child(i)
+	for child := range sc.Children() {
 		cStr := child.String()
 		// This is the easiest way to tell if it is a switch statement.
 		if strings.Contains(cStr, "type switch scope") {
@@ -136,8 +135,7 @@ func returnSwitchBlocks(sc *types.Scope) []*types.Scope {
 // the "Default:" case.
 func findCaseTypes(sc *types.Scope) []string {
 	caseTypes := make([]string, 0)
-	for i := 0; i < sc.NumChildren(); i++ {
-		child := sc.Child(i)
+	for child := range sc.Children() {
 		for _, name := range child.Names() {
 			obj := child.Lookup(name).Type()
 			typeName := obj.String()

--- a/enterprise/coderd/prebuilds/metricscollector_test.go
+++ b/enterprise/coderd/prebuilds/metricscollector_test.go
@@ -223,7 +223,7 @@ func TestMetricsCollector(t *testing.T) {
 									registry.Register(collector)
 
 									numTemplates := 2
-									for i := 0; i < numTemplates; i++ {
+									for range numTemplates {
 										org, template := setupTestDBTemplate(t, db, ownerID, templateDeleted)
 										templateVersionID := setupTestDBTemplateVersion(ctx, t, clock, db, pubsub, org.ID, ownerID, template.ID)
 										preset := setupTestDBPreset(t, db, templateVersionID, 1, uuid.New().String())

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -317,7 +317,7 @@ func TestScim(t *testing.T) {
 			})
 
 			sUser := makeScimUser(t)
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				res, err := client.Request(ctx, "POST", "/scim/v2/Users", sUser, setScimAuth(scimAPIKey))
 				require.NoError(t, err)
 				_ = res.Body.Close()

--- a/enterprise/coderd/usage/publisher_test.go
+++ b/enterprise/coderd/usage/publisher_test.go
@@ -76,7 +76,7 @@ func TestIntegration(t *testing.T) {
 
 	// Insert the events we expect to be published.
 	clock.Set(now.Add(1 * time.Second))
-	for i := 0; i < eventCount; i++ {
+	for i := range eventCount {
 		clock.Advance(time.Second)
 		err := inserter.InsertDiscreteUsageEvent(ctx, db, usagetypes.DCManagedAgentsV1{
 			Count: uint64(i + 1), // nolint:gosec // these numbers are tiny and will not overflow

--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -752,7 +752,7 @@ func TestUserOIDC(t *testing.T) {
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 
 			// Refresh multiple times.
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				runner.ForceRefresh(t, client, claims)
 			}
 		})

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -574,9 +574,9 @@ func TestProxyRegisterDeregister(t *testing.T) {
 
 		proxyClient := wsproxysdk.New(client.URL, createRes.ProxyToken)
 
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			ok := false
-			for j := 0; j < 2; j++ {
+			for range 2 {
 				registerRes, err := proxyClient.RegisterWorkspaceProxy(ctx, wsproxysdk.RegisterWorkspaceProxyRequest{
 					AccessURL:           "https://proxy.coder.test",
 					WildcardHostname:    "*.proxy.coder.test",

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -957,7 +957,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
 
 		workspaces := make([]codersdk.Workspace, 0, numWorkspaces)
-		for i := 0; i < numWorkspaces; i++ {
+		for range numWorkspaces {
 			ws := coderdtest.CreateWorkspace(t, client, template.ID)
 			build := coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
 			require.Equal(t, codersdk.WorkspaceStatusRunning, build.Status)

--- a/enterprise/dbcrypt/dbcrypt.go
+++ b/enterprise/dbcrypt/dbcrypt.go
@@ -410,7 +410,7 @@ func (db *dbCrypt) decryptField(field *string, digest sql.NullString) error {
 
 func (db *dbCrypt) ensureEncryptedWithRetry(ctx context.Context) error {
 	var err error
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		err = db.ensureEncrypted(ctx)
 		if err == nil {
 			return nil

--- a/enterprise/derpmesh/derpmesh_test.go
+++ b/enterprise/derpmesh/derpmesh_test.go
@@ -137,7 +137,7 @@ func TestDERPMesh(t *testing.T) {
 		t.Parallel()
 		meshes := make([]*derpmesh.Mesh, 0, 20)
 		serverURLs := make([]string, 0, 20)
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			server, url := startDERP(t, tlsConfig)
 			mesh := derpmesh.New(testutil.Logger(t).Named("mesh"), server, tlsConfig)
 			t.Cleanup(func() {

--- a/enterprise/provisionerd/remoteprovisioners_test.go
+++ b/enterprise/provisionerd/remoteprovisioners_test.go
@@ -356,7 +356,7 @@ func (e *fuzzExecutor) Execute(
 			}
 			// replace newlines so the Connector doesn't think we are done
 			// with the JobID
-			for i := 0; i < len(rb); i++ {
+			for i := range rb {
 				if rb[i] == '\n' || rb[i] == '\r' {
 					rb[i] = 'A'
 				}

--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -295,7 +295,7 @@ func (m *Manager) syncReplicas(ctx context.Context) error {
 	}
 
 	replicaErrs := make([]string, 0, len(peers))
-	for i := 0; i < len(peers); i++ {
+	for range peers {
 		err := <-errs
 		if err != nil {
 			replicaErrs = append(replicaErrs, err.Error())

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -606,7 +606,7 @@ func TestPGCoordinator_Unhealthy(t *testing.T) {
 	}()
 	agent1 := agpltest.NewAgent(ctx, t, uut, "agent1")
 	defer agent1.Close(ctx)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		select {
 		case <-ctx.Done():
 			t.Fatalf("timeout waiting for call %d", i+1)
@@ -623,7 +623,7 @@ func TestPGCoordinator_Unhealthy(t *testing.T) {
 	agent2.AssertEventuallyResponsesClosed(tailnet.CloseErrUnhealthy)
 
 	// next heartbeats succeed, so we are healthy
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-ctx.Done():
 			t.Fatal("timeout")

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -545,7 +545,7 @@ func pingSiblingReplicas(ctx context.Context, logger slog.Logger, sf *singleflig
 		}
 
 		replicaErrs := make([]string, 0, len(replicas))
-		for i := 0; i < len(replicas); i++ {
+		for range replicas {
 			err := <-errs
 			if err != nil {
 				replicaErrs = append(replicaErrs, err.Error())
@@ -568,7 +568,7 @@ func pingSiblingReplicas(ctx context.Context, logger slog.Logger, sf *singleflig
 func pingReplica(ctx context.Context, client http.Client, replica codersdk.Replica) error {
 	const attempts = 2
 	var err error
-	for i := 0; i < attempts; i++ {
+	for i := range attempts {
 		err = replicasync.PingPeerReplica(ctx, client, replica.RelayAddress)
 		if err == nil {
 			return nil

--- a/provisioner/terraform/internal/timings_test_utils.go
+++ b/provisioner/terraform/internal/timings_test_utils.go
@@ -51,7 +51,7 @@ func TimingsAreEqual(t *testing.T, expected []*proto.Timing, actual []*proto.Tim
 	}
 
 	// Compare each element; both are expected to be sorted in a stable manner.
-	for i := 0; i < len(expected); i++ {
+	for i := range expected {
 		ex := expected[i]
 		ac := actual[i]
 		if !protobuf.Equal(ex, ac) {

--- a/provisionersdk/proto/dataupload_test.go
+++ b/provisionersdk/proto/dataupload_test.go
@@ -52,7 +52,7 @@ func FuzzBytesToDataUpload(f *testing.F) {
 func TestBytesToDataUpload(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		// Generate random data
 		//nolint:gosec // Just a unit test
 		chunkCount := 1 + rand.Intn(3)

--- a/provisionersdk/tfpath/tfpath.go
+++ b/provisionersdk/tfpath/tfpath.go
@@ -188,7 +188,7 @@ func (l Layout) Cleanup(ctx context.Context, logger slog.Logger, fs afero.Fs) {
 	var err error
 	path := l.WorkDirectory()
 
-	for attempt := 0; attempt < 5; attempt++ {
+	for range 5 {
 		err := fs.RemoveAll(path)
 		if err != nil {
 			// On Windows, open files cannot be removed.

--- a/scaletest/agentconn/run.go
+++ b/scaletest/agentconn/run.go
@@ -140,7 +140,7 @@ func waitForDisco(ctx context.Context, logs io.Writer, conn workspacesdk.AgentCo
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	for i := 0; i < pingAttempts; i++ {
+	for i := range pingAttempts {
 		_, _ = fmt.Fprintf(logs, "\tDisco ping attempt %d/%d...\n", i+1, pingAttempts)
 		pingCtx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
 		_, p2p, _, err := conn.Ping(pingCtx)
@@ -172,7 +172,7 @@ func waitForDirectConnection(ctx context.Context, logs io.Writer, conn workspace
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	for i := 0; i < directConnectionAttempts; i++ {
+	for i := range directConnectionAttempts {
 		_, _ = fmt.Fprintf(logs, "\tDirect connection check %d/%d...\n", i+1, directConnectionAttempts)
 		status := conn.TailnetConn().Status()
 
@@ -215,7 +215,7 @@ func verifyConnection(ctx context.Context, logs io.Writer, conn workspacesdk.Age
 	defer span.End()
 
 	client := agentHTTPClient(conn)
-	for i := 0; i < verifyConnectionAttempts; i++ {
+	for i := range verifyConnectionAttempts {
 		_, _ = fmt.Fprintf(logs, "\tVerify connection attempt %d/%d...\n", i+1, verifyConnectionAttempts)
 		verifyCtx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
 

--- a/scaletest/harness/strategies_test.go
+++ b/scaletest/harness/strategies_test.go
@@ -185,7 +185,7 @@ func strategyTestData(count int, runFn func(ctx context.Context, i int, logs io.
 		runs = make([]*harness.TestRun, count)
 		fns  = make([]harness.TestFn, count)
 	)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		runs[i] = harness.NewTestRun("test", strconv.Itoa(i), testFns{
 			RunFn: func(ctx context.Context, id string, logs io.Writer) error {
 				if runFn != nil {

--- a/scaletest/notifications/run_test.go
+++ b/scaletest/notifications/run_test.go
@@ -115,7 +115,7 @@ func TestRun(t *testing.T) {
 		// Wait for all runners to connect
 		dialBarrier.Wait()
 
-		for i := 0; i < numReceivingUsers; i++ {
+		for i := range numReceivingUsers {
 			err := sendInboxNotification(runCtx, t, db, inboxHandler, "receiving-user-"+strconv.Itoa(i), notificationsLib.TemplateUserAccountCreated)
 			require.NoError(t, err)
 			err = sendInboxNotification(runCtx, t, db, inboxHandler, "receiving-user-"+strconv.Itoa(i), notificationsLib.TemplateUserAccountDeleted)
@@ -272,11 +272,11 @@ func TestRunWithSMTP(t *testing.T) {
 		// Wait for all runners to connect
 		dialBarrier.Wait()
 
-		for i := 0; i < numReceivingUsers; i++ {
+		for range numReceivingUsers {
 			smtpTrap.MustWait(runCtx).MustRelease(runCtx)
 		}
 
-		for i := 0; i < numReceivingUsers; i++ {
+		for i := range numReceivingUsers {
 			err := sendInboxNotification(runCtx, t, db, inboxHandler, "receiving-user-"+strconv.Itoa(i), notificationsLib.TemplateUserAccountCreated)
 			require.NoError(t, err)
 			err = sendInboxNotification(runCtx, t, db, inboxHandler, "receiving-user-"+strconv.Itoa(i), notificationsLib.TemplateUserAccountDeleted)

--- a/scaletest/taskstatus/run_internal_test.go
+++ b/scaletest/taskstatus/run_internal_test.go
@@ -228,7 +228,7 @@ func TestRunner_Run(t *testing.T) {
 	require.Equal(t, testAgentToken, fPatcher.agentToken)
 
 	updateDelay := time.Duration(0)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		tickWaiter := mClock.Advance((10 * time.Second) - updateDelay)
 
 		patchCall := testutil.RequireReceive(ctx, t, fPatcher.patchStatusCalls)
@@ -347,7 +347,7 @@ func TestRunner_RunMissedUpdate(t *testing.T) {
 	tickerTrap.MustWait(testCtx).MustRelease(testCtx)
 
 	updateDelay := time.Duration(0)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		tickWaiter := mClock.Advance((10 * time.Second) - updateDelay)
 		patchCall := testutil.RequireReceive(testCtx, t, fPatcher.patchStatusCalls)
 		require.Equal(t, appSlug, patchCall.AppSlug)
@@ -465,7 +465,7 @@ func TestRunner_Run_WithErrors(t *testing.T) {
 	// Wait for the initial TickerFunc call before advancing time, otherwise our ticks will be off.
 	tickerTrap.MustWait(testCtx).MustRelease(testCtx)
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		tickWaiter := mClock.Advance(10 * time.Second)
 		testutil.RequireSend(testCtx, t, fPatcher.patchStatusErrors, xerrors.New("a bad thing happened"))
 		_ = testutil.RequireReceive(testCtx, t, fPatcher.patchStatusCalls)


### PR DESCRIPTION
Go 1.22 introduced range over integers, allowing 'for range N' and 'for i := range N' instead of 'for i := 0; i < N; i++'.
