### PR TITLE
chore: helm - tolerations - change format from object to array

### DIFF
--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -175,7 +175,7 @@ coder:
   # coder.tolerations -- Tolerations for tainted nodes.
   # See: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations:
-    {}
+    []
     # - key: "key"
     #   operator: "Equal"
     #   value: "value"


### PR DESCRIPTION
`tolerations` is a list/array, not a map and should be represented using `[]` instead of `{}`

closes #22179