### PR TITLE
fix: user status change chart accommodates DST

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1748,6 +1748,13 @@ const docTemplate = `{
                 "operationId": "get-insights-about-user-status-counts",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "IANA timezone name (e.g. America/St_Johns)",
+                        "name": "timezone",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "type": "integer",
                         "description": "Time-zone offset (e.g. -2)",
                         "name": "tz_offset",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1751,15 +1751,13 @@ const docTemplate = `{
                         "type": "string",
                         "description": "IANA timezone name (e.g. America/St_Johns)",
                         "name": "timezone",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Time-zone offset (e.g. -2)",
+                        "description": "Deprecated: Time-zone offset (e.g. -2). Use timezone instead.",
                         "name": "tz_offset",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1528,6 +1528,13 @@
 				"operationId": "get-insights-about-user-status-counts",
 				"parameters": [
 					{
+						"type": "string",
+						"description": "IANA timezone name (e.g. America/St_Johns)",
+						"name": "timezone",
+						"in": "query",
+						"required": true
+					},
+					{
 						"type": "integer",
 						"description": "Time-zone offset (e.g. -2)",
 						"name": "tz_offset",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1531,15 +1531,13 @@
 						"type": "string",
 						"description": "IANA timezone name (e.g. America/St_Johns)",
 						"name": "timezone",
-						"in": "query",
-						"required": true
+						"in": "query"
 					},
 					{
 						"type": "integer",
-						"description": "Time-zone offset (e.g. -2)",
+						"description": "Deprecated: Time-zone offset (e.g. -2). Use timezone instead.",
 						"name": "tz_offset",
-						"in": "query",
-						"required": true
+						"in": "query"
 					}
 				],
 				"responses": {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1691,7 +1691,7 @@ func (s *MethodTestSuite) TestUser() {
 		)
 	}))
 	s.Run("GetUserStatusCounts", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		arg := database.GetUserStatusCountsParams{StartTime: time.Now().Add(-time.Hour * 24 * 30), EndTime: time.Now(), Interval: int32((time.Hour * 24).Seconds())}
+		arg := database.GetUserStatusCountsParams{StartTime: time.Now().Add(-time.Hour * 24 * 30), EndTime: time.Now(), Tz: "America/St_Johns"}
 		dbm.EXPECT().GetUserStatusCounts(gomock.Any(), arg).Return([]database.GetUserStatusCountsRow{}, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceUser, policy.ActionRead)
 	}))

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -447,16 +447,6 @@ type sqlcQuerier interface {
 	GetUserSecretByUserIDAndName(ctx context.Context, arg GetUserSecretByUserIDAndNameParams) (UserSecret, error)
 	// GetUserStatusCounts returns the count of users in each status over time.
 	// The time range is inclusively defined by the start_time and end_time parameters.
-	//
-	// Bucketing:
-	// Between the start_time and end_time, we include each timestamp where a user's status changed or they were deleted.
-	// We do not bucket these results by day or some other time unit. This is because such bucketing would hide potentially
-	// important patterns. If a user was active for 23 hours and 59 minutes, and then suspended, a daily bucket would hide this.
-	// A daily bucket would also have required us to carefully manage the timezone of the bucket based on the timezone of the user.
-	//
-	// Accumulation:
-	// We do not start counting from 0 at the start_time. We check the last status change before the start_time for each user. As such,
-	// the result shows the total number of users in each status on any particular day.
 	GetUserStatusCounts(ctx context.Context, arg GetUserStatusCountsParams) ([]GetUserStatusCountsRow, error)
 	GetUserTaskNotificationAlertDismissed(ctx context.Context, userID uuid.UUID) (bool, error)
 	GetUserTerminalFont(ctx context.Context, userID uuid.UUID) (string, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -4291,7 +4291,6 @@ func TestGroupRemovalTrigger(t *testing.T) {
 
 func TestGetUserStatusCounts(t *testing.T) {
 	t.Parallel()
-	t.Skip("https://github.com/coder/internal/issues/464")
 
 	timezones := []string{
 		"America/St_Johns",

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5095,6 +5095,7 @@ latest_status_before_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
+	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
@@ -5114,6 +5115,7 @@ status_changes_during_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
+	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5076,18 +5076,17 @@ func (q *sqlQuerier) GetUserLatencyInsights(ctx context.Context, arg GetUserLate
 
 const getUserStatusCounts = `-- name: GetUserStatusCounts :many
 WITH
-	-- dates_of_interest defines all points in time that are relevant to the query.
-	-- It includes the start_time, all status changes, all deletions, and the end_time.
+	-- dates_of_interest generates the dates that will represent the horizontal axis of the chart.
 dates_of_interest AS (
-	SELECT date FROM generate_series(
-		$1::timestamptz,
-		$2::timestamptz,
-		(CASE WHEN $3::int <= 0 THEN 3600 * 24 ELSE $3::int END || ' seconds')::interval
-	) AS date
+  SELECT timezone($1::text, gs_local) AS date
+  FROM generate_series(
+    timezone($1::text, $2::timestamptz),
+    timezone($1::text, $3::timestamptz),
+    interval '1 day'
+  ) AS gs_local
 ),
-	-- latest_status_before_range defines the status of each user before the start_time.
-	-- We do not include users who were deleted before the start_time. We use this to ensure that
-	-- we correctly count users prior to the start_time for a complete graph.
+	-- latest_status_before_range selects the last status of each user before the start_time.
+	-- This represents the status of all users at the start of the time range.
 latest_status_before_range AS (
     SELECT
         DISTINCT usc.user_id,
@@ -5099,15 +5098,12 @@ latest_status_before_range AS (
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
-		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < $1)
+		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < $2)
 	) AS ud ON true
-    WHERE usc.changed_at < $1::timestamptz
+    WHERE usc.changed_at < $2::timestamptz
     ORDER BY usc.user_id, usc.changed_at DESC
 ),
-	-- status_changes_during_range defines the status of each user during the start_time and end_time.
-	-- If a user is deleted during the time range, we count status changes between the start_time and the deletion date.
-	-- Theoretically, it should probably not be possible to update the status of a deleted user, but we
-	-- need to ensure that this is enforced, so that a change in business logic later does not break this graph.
+	-- status_changes_during_range selects the statuses of each user during the start_time and end_time.
 status_changes_during_range AS (
     SELECT
         usc.user_id,
@@ -5121,18 +5117,16 @@ status_changes_during_range AS (
 		FROM user_deleted ud
 		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
 	) AS ud ON true
-    WHERE usc.changed_at >= $1::timestamptz
-        AND usc.changed_at <= $2::timestamptz
+    WHERE usc.changed_at >= $2::timestamptz
+        AND usc.changed_at <= $3::timestamptz
 ),
-	-- relevant_status_changes defines the status of each user at any point in time.
-	-- It includes the status of each user before the start_time, and the status of each user during the start_time and end_time.
 relevant_status_changes AS (
     SELECT
         user_id,
         new_status,
         changed_at
     FROM latest_status_before_range
-    WHERE NOT deleted
+    WHERE NOT deleted -- TODO(sasswart): move this clause to the CTE above.
 
     UNION ALL
 
@@ -5141,16 +5135,15 @@ relevant_status_changes AS (
         new_status,
         changed_at
     FROM status_changes_during_range
-    WHERE NOT deleted
+    WHERE NOT deleted -- TODO(sasswart): move this clause to the CTE above.
 ),
-	-- statuses defines all the distinct statuses that were present just before and during the time range.
-	-- This is used to ensure that we have a series for every relevant status.
+	-- statuses selects all the distinct statuses that were present just before and during the time range.
+	-- Each status will have a series on the chart.
 statuses AS (
 	SELECT DISTINCT new_status FROM relevant_status_changes
 ),
-	-- We only want to count the latest status change for each user on each date and then filter them by the relevant status.
-	-- We use the row_number function to ensure that we only count the latest status change for each user on each date.
-	-- We then filter the status changes by the relevant status in the final select statement below.
+	-- ranked_status_change_per_user_per_date selects the latest status change for each user on each date.
+	-- The last status for a user on every given date will be counted.
 ranked_status_change_per_user_per_date AS (
 	SELECT
 	d.date,
@@ -5183,9 +5176,9 @@ ORDER BY rscpupd.date
 `
 
 type GetUserStatusCountsParams struct {
+	Tz        string    `db:"tz" json:"tz"`
 	StartTime time.Time `db:"start_time" json:"start_time"`
 	EndTime   time.Time `db:"end_time" json:"end_time"`
-	Interval  int32     `db:"interval" json:"interval"`
 }
 
 type GetUserStatusCountsRow struct {
@@ -5196,18 +5189,8 @@ type GetUserStatusCountsRow struct {
 
 // GetUserStatusCounts returns the count of users in each status over time.
 // The time range is inclusively defined by the start_time and end_time parameters.
-//
-// Bucketing:
-// Between the start_time and end_time, we include each timestamp where a user's status changed or they were deleted.
-// We do not bucket these results by day or some other time unit. This is because such bucketing would hide potentially
-// important patterns. If a user was active for 23 hours and 59 minutes, and then suspended, a daily bucket would hide this.
-// A daily bucket would also have required us to carefully manage the timezone of the bucket based on the timezone of the user.
-//
-// Accumulation:
-// We do not start counting from 0 at the start_time. We check the last status change before the start_time for each user. As such,
-// the result shows the total number of users in each status on any particular day.
 func (q *sqlQuerier) GetUserStatusCounts(ctx context.Context, arg GetUserStatusCountsParams) ([]GetUserStatusCountsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getUserStatusCounts, arg.StartTime, arg.EndTime, arg.Interval)
+	rows, err := q.db.QueryContext(ctx, getUserStatusCounts, arg.Tz, arg.StartTime, arg.EndTime)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5076,6 +5076,9 @@ func (q *sqlQuerier) GetUserLatencyInsights(ctx context.Context, arg GetUserLate
 
 const getUserStatusCounts = `-- name: GetUserStatusCounts :many
 WITH
+system_users AS (
+    SELECT id FROM users WHERE is_system = TRUE
+),
 	-- dates_of_interest generates the dates that will represent the horizontal axis of the chart.
 dates_of_interest AS (
   SELECT timezone($1::text, gs_local) AS date
@@ -5094,13 +5097,13 @@ latest_status_before_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
-	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
 		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < $2)
 	) AS ud ON true
-    WHERE usc.changed_at < $2::timestamptz
+    WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND usc.changed_at < $2::timestamptz
     ORDER BY usc.user_id, usc.changed_at DESC
 ),
 	-- status_changes_during_range selects the statuses of each user during the start_time and end_time.
@@ -5111,13 +5114,13 @@ status_changes_during_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
-	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
 		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
 	) AS ud ON true
-    WHERE usc.changed_at >= $2::timestamptz
+    WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND usc.changed_at >= $2::timestamptz
         AND usc.changed_at <= $3::timestamptz
 ),
 relevant_status_changes AS (

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5094,8 +5094,7 @@ latest_status_before_range AS (
     SELECT
         DISTINCT usc.user_id,
         usc.new_status,
-        usc.changed_at,
-        ud.deleted
+        usc.changed_at
     FROM user_status_changes usc
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
@@ -5103,6 +5102,7 @@ latest_status_before_range AS (
 		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < $2)
 	) AS ud ON true
     WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND NOT ud.deleted
         AND usc.changed_at < $2::timestamptz
     ORDER BY usc.user_id, usc.changed_at DESC
 ),
@@ -5111,8 +5111,7 @@ status_changes_during_range AS (
     SELECT
         usc.user_id,
         usc.new_status,
-        usc.changed_at,
-        ud.deleted
+        usc.changed_at
     FROM user_status_changes usc
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
@@ -5120,25 +5119,18 @@ status_changes_during_range AS (
 		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
 	) AS ud ON true
     WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND NOT ud.deleted
         AND usc.changed_at >= $2::timestamptz
         AND usc.changed_at <= $3::timestamptz
 ),
 relevant_status_changes AS (
-    SELECT
-        user_id,
-        new_status,
-        changed_at
+    SELECT user_id, new_status, changed_at
     FROM latest_status_before_range
-    WHERE NOT deleted -- TODO(sasswart): move this clause to the CTE above.
 
     UNION ALL
 
-    SELECT
-        user_id,
-        new_status,
-        changed_at
+    SELECT user_id, new_status, changed_at
     FROM status_changes_during_range
-    WHERE NOT deleted -- TODO(sasswart): move this clause to the CTE above.
 ),
 	-- statuses selects all the distinct statuses that were present just before and during the time range.
 	-- Each status will have a series on the chart.

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -835,6 +835,7 @@ latest_status_before_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
+	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
@@ -854,6 +855,7 @@ status_changes_during_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
+	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -806,6 +806,9 @@ GROUP BY utp.num, utp.template_ids, utp.name, utp.type, utp.display_name, utp.de
 -- GetUserStatusCounts returns the count of users in each status over time.
 -- The time range is inclusively defined by the start_time and end_time parameters.
 WITH
+system_users AS (
+    SELECT id FROM users WHERE is_system = TRUE
+),
 	-- dates_of_interest generates the dates that will represent the horizontal axis of the chart.
 dates_of_interest AS (
   SELECT timezone(@tz::text, gs_local) AS date
@@ -824,13 +827,13 @@ latest_status_before_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
-	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
 		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < @start_time)
 	) AS ud ON true
-    WHERE usc.changed_at < @start_time::timestamptz
+    WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND usc.changed_at < @start_time::timestamptz
     ORDER BY usc.user_id, usc.changed_at DESC
 ),
 	-- status_changes_during_range selects the statuses of each user during the start_time and end_time.
@@ -841,13 +844,13 @@ status_changes_during_range AS (
         usc.changed_at,
         ud.deleted
     FROM user_status_changes usc
-	INNER JOIN users u ON u.id = usc.user_id AND NOT u.is_system
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
 		FROM user_deleted ud
 		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
 	) AS ud ON true
-    WHERE usc.changed_at >= @start_time::timestamptz
+    WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND usc.changed_at >= @start_time::timestamptz
         AND usc.changed_at <= @end_time::timestamptz
 ),
 relevant_status_changes AS (

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -824,8 +824,7 @@ latest_status_before_range AS (
     SELECT
         DISTINCT usc.user_id,
         usc.new_status,
-        usc.changed_at,
-        ud.deleted
+        usc.changed_at
     FROM user_status_changes usc
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
@@ -833,6 +832,7 @@ latest_status_before_range AS (
 		WHERE ud.user_id = usc.user_id AND (ud.deleted_at < usc.changed_at OR ud.deleted_at < @start_time)
 	) AS ud ON true
     WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND NOT ud.deleted
         AND usc.changed_at < @start_time::timestamptz
     ORDER BY usc.user_id, usc.changed_at DESC
 ),
@@ -841,8 +841,7 @@ status_changes_during_range AS (
     SELECT
         usc.user_id,
         usc.new_status,
-        usc.changed_at,
-        ud.deleted
+        usc.changed_at
     FROM user_status_changes usc
 	LEFT JOIN LATERAL (
 		SELECT COUNT(*) > 0 AS deleted
@@ -850,25 +849,18 @@ status_changes_during_range AS (
 		WHERE ud.user_id = usc.user_id AND ud.deleted_at < usc.changed_at
 	) AS ud ON true
     WHERE usc.user_id NOT IN (SELECT id FROM system_users)
+        AND NOT ud.deleted
         AND usc.changed_at >= @start_time::timestamptz
         AND usc.changed_at <= @end_time::timestamptz
 ),
 relevant_status_changes AS (
-    SELECT
-        user_id,
-        new_status,
-        changed_at
+    SELECT user_id, new_status, changed_at
     FROM latest_status_before_range
-    WHERE NOT deleted -- TODO(sasswart): move this clause to the CTE above.
 
     UNION ALL
 
-    SELECT
-        user_id,
-        new_status,
-        changed_at
+    SELECT user_id, new_status, changed_at
     FROM status_changes_during_range
-    WHERE NOT deleted -- TODO(sasswart): move this clause to the CTE above.
 ),
 	-- statuses selects all the distinct statuses that were present just before and during the time range.
 	-- Each status will have a series on the chart.

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -298,8 +298,8 @@ func (api *API) insightsUserLatency(rw http.ResponseWriter, r *http.Request) {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Insights
-// @Param timezone query string true "IANA timezone name (e.g. America/St_Johns)"
-// @Param tz_offset query int true "Time-zone offset (e.g. -2)"
+// @Param timezone query string false "IANA timezone name (e.g. America/St_Johns)"
+// @Param tz_offset query int false "Deprecated: Time-zone offset (e.g. -2). Use timezone instead."
 // @Success 200 {object} codersdk.GetUserStatusCountsResponse
 // @Router /insights/user-status-counts [get]
 func (api *API) insightsUserStatusCounts(rw http.ResponseWriter, r *http.Request) {
@@ -309,12 +309,20 @@ func (api *API) insightsUserStatusCounts(rw http.ResponseWriter, r *http.Request
 	vals := r.URL.Query()
 	timezone := p.String(vals, "", "timezone")
 	tzOffset := p.Int(vals, 0, "tz_offset")
+	_ = p.Int(vals, 0, "interval") // Deprecated: ignored, kept for backward compatibility.
 	p.ErrorExcessParams(vals)
 
 	if len(p.Errors) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message:     "Query parameters have invalid values.",
 			Validations: p.Errors,
+		})
+		return
+	}
+
+	if timezone != "" && tzOffset != 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Provide either \"timezone\" or \"tz_offset\", not both.",
 		})
 		return
 	}
@@ -344,7 +352,11 @@ func (api *API) insightsUserStatusCounts(rw http.ResponseWriter, r *http.Request
 	queryParams := database.GetUserStatusCountsParams{
 		StartTime: sixtyDaysAgo,
 		EndTime:   nextHourInLoc,
-		Tz:        loc.String(),
+		// loc.String() returns an IANA timezone name (e.g. "America/New_York").
+		// Both Go and PostgreSQL use the IANA Time Zone Database, so names are
+		// compatible. The Etc/GMT±N names used for offset fallback are also valid
+		// in both systems.
+		Tz: loc.String(),
 	}
 	rows, err := api.Database.GetUserStatusCounts(ctx, queryParams)
 	if err != nil {

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -2443,7 +2443,8 @@ func TestGenericInsights_Disabled(t *testing.T) {
 			name: "UserStatusCounts",
 			fn: func(ctx context.Context) error {
 				_, err := client.GetUserStatusCounts(ctx, codersdk.GetUserStatusCountsRequest{
-					Offset: 0,
+					Timezone: "America/St_Johns",
+					Offset:   -2,
 				})
 				return err
 			},

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -294,14 +294,14 @@ type UserStatusChangeCount struct {
 }
 
 type GetUserStatusCountsRequest struct {
-	// Timezone offset in hours. Use 0 for UTC, and TimezoneOffsetHour(time.Local)
-	// for the local timezone.
-	Offset int `json:"offset"`
+	Timezone string `json:"timezone" example:"America/St_Johns"`
+	Offset   int    `json:"offset" example:"-2"`
 }
 
 func (c *Client) GetUserStatusCounts(ctx context.Context, req GetUserStatusCountsRequest) (GetUserStatusCountsResponse, error) {
 	qp := url.Values{}
 	qp.Add("tz_offset", strconv.Itoa(req.Offset))
+	qp.Add("timezone", req.Timezone)
 
 	reqURL := fmt.Sprintf("/api/v2/insights/user-status-counts?%s", qp.Encode())
 	resp, err := c.Request(ctx, http.MethodGet, reqURL, nil)

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -295,13 +295,17 @@ type UserStatusChangeCount struct {
 
 type GetUserStatusCountsRequest struct {
 	Timezone string `json:"timezone" example:"America/St_Johns"`
-	Offset   int    `json:"offset" example:"-2"`
+	// Deprecated: Use Timezone instead. Offset is ignored when Timezone is provided.
+	Offset int `json:"offset,omitempty" example:"-2"`
 }
 
 func (c *Client) GetUserStatusCounts(ctx context.Context, req GetUserStatusCountsRequest) (GetUserStatusCountsResponse, error) {
 	qp := url.Values{}
-	qp.Add("tz_offset", strconv.Itoa(req.Offset))
-	qp.Add("timezone", req.Timezone)
+	if req.Timezone != "" {
+		qp.Add("timezone", req.Timezone)
+	} else {
+		qp.Add("tz_offset", strconv.Itoa(req.Offset))
+	}
 
 	reqURL := fmt.Sprintf("/api/v2/insights/user-status-counts?%s", qp.Encode())
 	resp, err := c.Request(ctx, http.MethodGet, reqURL, nil)

--- a/docs/reference/api/insights.md
+++ b/docs/reference/api/insights.md
@@ -266,7 +266,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts?tz_offset=0 \
+curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts?timezone=string&tz_offset=0 \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
@@ -275,9 +275,10 @@ curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts?tz_offse
 
 ### Parameters
 
-| Name        | In    | Type    | Required | Description                |
-|-------------|-------|---------|----------|----------------------------|
-| `tz_offset` | query | integer | true     | Time-zone offset (e.g. -2) |
+| Name        | In    | Type    | Required | Description                                |
+|-------------|-------|---------|----------|--------------------------------------------|
+| `timezone`  | query | string  | true     | IANA timezone name (e.g. America/St_Johns) |
+| `tz_offset` | query | integer | true     | Time-zone offset (e.g. -2)                 |
 
 ### Example responses
 

--- a/docs/reference/api/insights.md
+++ b/docs/reference/api/insights.md
@@ -266,7 +266,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts?timezone=string&tz_offset=0 \
+curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
@@ -275,10 +275,10 @@ curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts?timezone
 
 ### Parameters
 
-| Name        | In    | Type    | Required | Description                                |
-|-------------|-------|---------|----------|--------------------------------------------|
-| `timezone`  | query | string  | true     | IANA timezone name (e.g. America/St_Johns) |
-| `tz_offset` | query | integer | true     | Time-zone offset (e.g. -2)                 |
+| Name        | In    | Type    | Required | Description                                                   |
+|-------------|-------|---------|----------|---------------------------------------------------------------|
+| `timezone`  | query | string  | false    | IANA timezone name (e.g. America/St_Johns)                    |
+| `tz_offset` | query | integer | false    | Deprecated: Time-zone offset (e.g. -2). Use timezone instead. |
 
 ### Example responses
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2468,9 +2468,11 @@ class ApiMethods {
 	};
 
 	getInsightsUserStatusCounts = async (
+		timezone = Intl.DateTimeFormat().resolvedOptions().timeZone,
 		offset = Math.trunc(new Date().getTimezoneOffset() / 60),
 	): Promise<TypesGen.GetUserStatusCountsResponse> => {
 		const searchParams = new URLSearchParams({
+			timezone,
 			tz_offset: offset.toString(),
 		});
 		const response = await this.axios.get(

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2467,13 +2467,14 @@ class ApiMethods {
 		return response.data;
 	};
 
+	// Intl.DateTimeFormat().resolvedOptions().timeZone returns an IANA timezone
+	// name (e.g. "America/New_York") per ECMA-402. Go's time.LoadLocation and
+	// PostgreSQL's timezone() both accept IANA names, so these are compatible.
 	getInsightsUserStatusCounts = async (
 		timezone = Intl.DateTimeFormat().resolvedOptions().timeZone,
-		offset = Math.trunc(new Date().getTimezoneOffset() / 60),
 	): Promise<TypesGen.GetUserStatusCountsResponse> => {
 		const searchParams = new URLSearchParams({
 			timezone,
-			tz_offset: offset.toString(),
 		});
 		const response = await this.axios.get(
 			`/api/v2/insights/user-status-counts?${searchParams}`,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2226,10 +2226,7 @@ export interface GetInboxNotificationResponse {
 
 // From codersdk/insights.go
 export interface GetUserStatusCountsRequest {
-	/**
-	 * Timezone offset in hours. Use 0 for UTC, and TimezoneOffsetHour(time.Local)
-	 * for the local timezone.
-	 */
+	readonly timezone: string;
 	readonly offset: number;
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2227,7 +2227,10 @@ export interface GetInboxNotificationResponse {
 // From codersdk/insights.go
 export interface GetUserStatusCountsRequest {
 	readonly timezone: string;
-	readonly offset: number;
+	/**
+	 * Deprecated: Use Timezone instead. Offset is ignored when Timezone is provided.
+	 */
+	readonly offset?: number;
 }
 
 // From codersdk/insights.go


### PR DESCRIPTION
closes https://github.com/coder/internal/issues/464

# Summary

This PR resolves a flaky test that was sensitive to DST transitions in various time zones. The root of the flake was:
* a bug; the query and its tests assume 24 hours per day
* the tests used local system time, which resulted in failures for dates proximal to DST transitions

# Changes

Query:

The original query assumed 24 hour intervals between each day, which is not a valid assumption. It now increments `1 day` at a time.

Database tests:

Database level tests for the query all assumed 24 hour days. They now increment in DST-aware days instead. Instead of using time.Now() as a base for testing, the test uses a series of dates over the course of an entire year, to ensure that DST transition dates are present in every test run.

# API Endpoint

The endpoint that delivers the user status chart now accepts an IANA timezone name as a parameter and passes it, keeping the existing offset as a fallback, to the database query.

API level tests were added to ensure the correct response form and error behaviour. Correctness of content is tested at the database level.