### PR TITLE
feat: make `coder task send` resumes paused tasks

### DIFF
--- a/cli/task_logs_test.go
+++ b/cli/task_logs_test.go
@@ -41,11 +41,11 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
-		inv, root := clitest.New(t, "task", "logs", task.Name, "--output", "json")
+		inv, root := clitest.New(t, "task", "logs", setup.task.Name, "--output", "json")
 		output := clitest.Capture(inv)
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
@@ -64,11 +64,11 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
-		inv, root := clitest.New(t, "task", "logs", task.ID.String(), "--output", "json")
+		inv, root := clitest.New(t, "task", "logs", setup.task.ID.String(), "--output", "json")
 		output := clitest.Capture(inv)
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
@@ -87,11 +87,11 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsOK(testMessages))
 
-		inv, root := clitest.New(t, "task", "logs", task.ID.String())
+		inv, root := clitest.New(t, "task", "logs", setup.task.ID.String())
 		output := clitest.Capture(inv)
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
@@ -141,10 +141,10 @@ func Test_TaskLogs_Golden(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsErr(assert.AnError))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskLogsErr(assert.AnError))
 
-		inv, root := clitest.New(t, "task", "logs", task.ID.String())
-		clitest.SetupConfig(t, userClient, root)
+		inv, root := clitest.New(t, "task", "logs", setup.task.ID.String())
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()

--- a/cli/task_pause_test.go
+++ b/cli/task_pause_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
-	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -21,12 +20,12 @@ func TestExpTaskPause(t *testing.T) {
 
 		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
+		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause the task
-		inv, root := clitest.New(t, "task", "pause", task.Name, "--yes")
+		inv, root := clitest.New(t, "task", "pause", setup.task.Name, "--yes")
 		output := clitest.Capture(inv)
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		// Then: Expect the task to be paused
 		ctx := testutil.Context(t, testutil.WaitMedium)
@@ -34,7 +33,7 @@ func TestExpTaskPause(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, output.Stdout(), "has been paused")
 
-		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
+		updated, err := setup.userClient.TaskByIdentifier(ctx, setup.task.Name)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
 	})
@@ -46,13 +45,13 @@ func TestExpTaskPause(t *testing.T) {
 
 		// Given: A different user's running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		adminClient, _, task := setupCLITaskTest(setupCtx, t, nil)
+		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause their task
-		identifier := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
+		identifier := fmt.Sprintf("%s/%s", setup.task.OwnerName, setup.task.Name)
 		inv, root := clitest.New(t, "task", "pause", identifier, "--yes")
 		output := clitest.Capture(inv)
-		clitest.SetupConfig(t, adminClient, root)
+		clitest.SetupConfig(t, setup.ownerClient, root)
 
 		// Then: We expect the task to be paused
 		ctx := testutil.Context(t, testutil.WaitMedium)
@@ -60,7 +59,7 @@ func TestExpTaskPause(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, output.Stdout(), "has been paused")
 
-		updated, err := adminClient.TaskByIdentifier(ctx, identifier)
+		updated, err := setup.ownerClient.TaskByIdentifier(ctx, identifier)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
 	})
@@ -70,11 +69,11 @@ func TestExpTaskPause(t *testing.T) {
 
 		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
+		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause the task
-		inv, root := clitest.New(t, "task", "pause", task.Name)
-		clitest.SetupConfig(t, userClient, root)
+		inv, root := clitest.New(t, "task", "pause", setup.task.Name)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		// And: We confirm we want to pause the task
 		ctx := testutil.Context(t, testutil.WaitMedium)
@@ -88,7 +87,7 @@ func TestExpTaskPause(t *testing.T) {
 		pty.ExpectMatchContext(ctx, "has been paused")
 		require.NoError(t, w.Wait())
 
-		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
+		updated, err := setup.userClient.TaskByIdentifier(ctx, setup.task.Name)
 		require.NoError(t, err)
 		require.Equal(t, codersdk.TaskStatusPaused, updated.Status)
 	})
@@ -98,11 +97,11 @@ func TestExpTaskPause(t *testing.T) {
 
 		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
+		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// When: We attempt to pause the task
-		inv, root := clitest.New(t, "task", "pause", task.Name)
-		clitest.SetupConfig(t, userClient, root)
+		inv, root := clitest.New(t, "task", "pause", setup.task.Name)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		// But: We say no at the confirmation screen
 		ctx := testutil.Context(t, testutil.WaitMedium)
@@ -114,7 +113,7 @@ func TestExpTaskPause(t *testing.T) {
 		require.Error(t, w.Wait())
 
 		// Then: We expect the task to not be paused
-		updated, err := userClient.TaskByIdentifier(ctx, task.Name)
+		updated, err := setup.userClient.TaskByIdentifier(ctx, setup.task.Name)
 		require.NoError(t, err)
 		require.NotEqual(t, codersdk.TaskStatusPaused, updated.Status)
 	})
@@ -124,21 +123,18 @@ func TestExpTaskPause(t *testing.T) {
 
 		// Given: A running task
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, nil)
+		setup := setupCLITaskTest(setupCtx, t, nil)
 
 		// And: We paused the running task
-		ctx := testutil.Context(t, testutil.WaitMedium)
-		resp, err := userClient.PauseTask(ctx, task.OwnerName, task.ID)
-		require.NoError(t, err)
-		require.NotNil(t, resp.WorkspaceBuild)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, resp.WorkspaceBuild.ID)
+		pauseTask(setupCtx, t, setup.userClient, setup.task)
 
 		// When: We attempt to pause the task again
-		inv, root := clitest.New(t, "task", "pause", task.Name, "--yes")
-		clitest.SetupConfig(t, userClient, root)
+		inv, root := clitest.New(t, "task", "pause", setup.task.Name, "--yes")
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		// Then: We expect to get an error that the task is already paused
-		err = inv.WithContext(ctx).Run()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		err := inv.WithContext(ctx).Run()
 		require.ErrorContains(t, err, "is already paused")
 	})
 }

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -22,10 +22,10 @@ func (r *RootCmd) taskSend() *serpent.Command {
 		Short: "Send input to a task",
 		Long: "Send input to a task. If the task is paused, it will be automatically resumed before input is sent. If the task is initializing, it will wait for the task to become ready.\n" +
 			FormatExamples(Example{
-				Description: "Send direct input to a task.",
+				Description: "Send direct input to a task",
 				Command:     "coder task send task1 \"Please also add unit tests\"",
 			}, Example{
-				Description: "Send input from stdin to a task.",
+				Description: "Send input from stdin to a task",
 				Command:     "echo \"Please also add unit tests\" | coder task send task1 --stdin",
 			}),
 		Middleware: serpent.RequireRangeArgs(1, 2),

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -20,13 +20,14 @@ func (r *RootCmd) taskSend() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "send <task> [<input> | --stdin]",
 		Short: "Send input to a task",
-		Long: FormatExamples(Example{
-			Description: "Send direct input to a task.",
-			Command:     "coder task send task1 \"Please also add unit tests\"",
-		}, Example{
-			Description: "Send input from stdin to a task.",
-			Command:     "echo \"Please also add unit tests\" | coder task send task1 --stdin",
-		}),
+		Long: "Send input to a task. If the task is paused, it will be automatically resumed before input is sent. If the task is initializing, it will wait for the task to become ready.\n" +
+			FormatExamples(Example{
+				Description: "Send direct input to a task.",
+				Command:     "coder task send task1 \"Please also add unit tests\"",
+			}, Example{
+				Description: "Send input from stdin to a task.",
+				Command:     "echo \"Please also add unit tests\" | coder task send task1 --stdin",
+			}),
 		Middleware: serpent.RequireRangeArgs(1, 2),
 		Options: serpent.OptionSet{
 			{

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"io"
+	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/serpent"
 )
@@ -64,8 +69,46 @@ func (r *RootCmd) taskSend() *serpent.Command {
 				return xerrors.Errorf("resolve task: %w", err)
 			}
 
-			if err = client.TaskSend(ctx, codersdk.Me, task.ID, codersdk.TaskSendRequest{Input: taskInput}); err != nil {
-				return xerrors.Errorf("send input to task: %w", err)
+			display := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
+
+			// Before attempting to send, check the task status and
+			// handle non-active states.
+			switch task.Status {
+			case codersdk.TaskStatusActive:
+				// Ready to send, fall through.
+
+			case codersdk.TaskStatusPaused:
+				resp, err := client.ResumeTask(ctx, task.OwnerName, task.ID)
+				if err != nil {
+					return xerrors.Errorf("resume task %q: %w", display, err)
+				} else if resp.WorkspaceBuild == nil {
+					return xerrors.Errorf("resume task %q", display)
+				}
+
+				if err = waitForTaskReady(ctx, inv, client, task, resp.WorkspaceBuild.ID); err != nil {
+					return err
+				}
+
+			case codersdk.TaskStatusInitializing:
+				if !task.WorkspaceID.Valid {
+					return xerrors.Errorf("send input to task %q: task has no backing workspace", display)
+				}
+
+				workspace, err := client.Workspace(ctx, task.WorkspaceID.UUID)
+				if err != nil {
+					return xerrors.Errorf("get workspace for task %q: %w", display, err)
+				}
+
+				if err = waitForTaskReady(ctx, inv, client, task, workspace.LatestBuild.ID); err != nil {
+					return err
+				}
+
+			default:
+				return xerrors.Errorf("task %q has status %s and cannot be sent input", display, task.Status)
+			}
+
+			if err := client.TaskSend(ctx, codersdk.Me, task.ID, codersdk.TaskSendRequest{Input: taskInput}); err != nil {
+				return xerrors.Errorf("send input to task %q: %w", display, err)
 			}
 
 			return nil
@@ -73,4 +116,37 @@ func (r *RootCmd) taskSend() *serpent.Command {
 	}
 
 	return cmd
+}
+
+// waitForTaskReady watches the workspace build to completion then polls
+// until the task becomes active.
+func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *codersdk.Client, task codersdk.Task, workspaceBuildID uuid.UUID) error {
+	display := fmt.Sprintf("%s/%s", task.OwnerName, task.Name)
+
+	if err := cliui.WorkspaceBuild(ctx, inv.Stdout, client, workspaceBuildID); err != nil {
+		return xerrors.Errorf("watch workspace build for task %q: %w", display, err)
+	}
+
+	// TODO(DanielleMaywood):
+	// When we have a streaming Task API, this should be converted away from polling.
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			task, err := client.TaskByID(ctx, task.ID)
+			if err != nil {
+				return xerrors.Errorf("get task by id: %w", err)
+			} else if task.Status == codersdk.TaskStatusError || task.Status == codersdk.TaskStatusUnknown {
+				return xerrors.Errorf("entered %s state while waiting for it to become active", task.Status)
+			}
+
+			if task.Status == codersdk.TaskStatusActive {
+				return nil
+			}
+		}
+	}
 }

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -23,10 +23,10 @@ func (r *RootCmd) taskSend() *serpent.Command {
 		Long: "Send input to a task. If the task is paused, it will be automatically resumed before input is sent. If the task is initializing, it will wait for the task to become ready.\n" +
 			FormatExamples(Example{
 				Description: "Send direct input to a task",
-				Command:     "coder task send task1 \"Please also add unit tests\"",
+				Command:     `coder task send task1 "Please also add unit tests"`,
 			}, Example{
 				Description: "Send input from stdin to a task",
-				Command:     "echo \"Please also add unit tests\" | coder task send task1 --stdin",
+				Command:     `echo "Please also add unit tests" | coder task send task1 --stdin`,
 			}),
 		Middleware: serpent.RequireRangeArgs(1, 2),
 		Options: serpent.OptionSet{

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -75,9 +75,11 @@ func (r *RootCmd) taskSend() *serpent.Command {
 
 			// Before attempting to send, check the task status and
 			// handle non-active states.
+			var workspaceBuildID uuid.UUID
+
 			switch task.Status {
 			case codersdk.TaskStatusActive:
-				// Ready to send, fall through.
+				// Already active, no build to watch.
 
 			case codersdk.TaskStatusPaused:
 				resp, err := client.ResumeTask(ctx, task.OwnerName, task.ID)
@@ -87,9 +89,7 @@ func (r *RootCmd) taskSend() *serpent.Command {
 					return xerrors.Errorf("resume task %q", display)
 				}
 
-				if err = waitForTaskReady(ctx, inv, client, task, resp.WorkspaceBuild.ID); err != nil {
-					return xerrors.Errorf("wait for task %q to be ready: %w", display, err)
-				}
+				workspaceBuildID = resp.WorkspaceBuild.ID
 
 			case codersdk.TaskStatusInitializing:
 				if !task.WorkspaceID.Valid {
@@ -101,15 +101,13 @@ func (r *RootCmd) taskSend() *serpent.Command {
 					return xerrors.Errorf("get workspace for task %q: %w", display, err)
 				}
 
-				if err = waitForTaskReady(ctx, inv, client, task, workspace.LatestBuild.ID); err != nil {
-					return xerrors.Errorf("wait for task %q to be ready: %w", display, err)
-				}
+				workspaceBuildID = workspace.LatestBuild.ID
 
 			default:
 				return xerrors.Errorf("task %q has status %s and cannot be sent input", display, task.Status)
 			}
 
-			if err := waitForTaskIdle(ctx, client, task); err != nil {
+			if err := waitForTaskIdle(ctx, inv, client, task, workspaceBuildID); err != nil {
 				return xerrors.Errorf("wait for task %q to be idle: %w", display, err)
 			}
 
@@ -124,66 +122,35 @@ func (r *RootCmd) taskSend() *serpent.Command {
 	return cmd
 }
 
-// waitForTaskIdle polls until the task's app state becomes idle.
-// This ensures the agent is ready to accept input before we send it.
-func waitForTaskIdle(ctx context.Context, client *codersdk.Client, task codersdk.Task) error {
-	// TODO(DanielleMaywood):
-	// When we have a streaming Task API, this should be converted
-	// away from polling.
-
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			task, err := client.TaskByID(ctx, task.ID)
-			if err != nil {
-				return xerrors.Errorf("get task by id: %w", err)
-			}
-
-			if task.CurrentState == nil {
-				continue
-			}
-
-			switch task.CurrentState.State {
-			case codersdk.TaskStateIdle, codersdk.TaskStateComplete, codersdk.TaskStateFailed:
-				return nil
-			case codersdk.TaskStateWorking:
-				// Still busy, keep polling.
-			default:
-				// If the task enters an unexpected state (e.g. paused
-				// externally), stop waiting and report the problem.
-				return xerrors.Errorf("task entered unexpected app state %q while waiting for it to become idle", task.CurrentState.State)
-			}
+// waitForTaskIdle optionally watches a workspace build to completion,
+// then polls until the task becomes active and its app state is idle.
+// This merges build-watching and idle-polling into a single loop so
+// that status changes (e.g. paused) are never missed between phases.
+func waitForTaskIdle(ctx context.Context, inv *serpent.Invocation, client *codersdk.Client, task codersdk.Task, workspaceBuildID uuid.UUID) error {
+	if workspaceBuildID != uuid.Nil {
+		if err := cliui.WorkspaceBuild(ctx, inv.Stdout, client, workspaceBuildID); err != nil {
+			return xerrors.Errorf("watch workspace build: %w", err)
 		}
-	}
-}
-
-// waitForTaskReady watches the workspace build to completion then polls
-// until the task becomes active.
-func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *codersdk.Client, task codersdk.Task, workspaceBuildID uuid.UUID) error {
-	if err := cliui.WorkspaceBuild(ctx, inv.Stdout, client, workspaceBuildID); err != nil {
-		return xerrors.Errorf("watch workspace build: %w", err)
 	}
 
 	// NOTE(DanielleMaywood):
-	// It has been observed that the `TaskStatusError` state has appeared during
-	// a typical healthy startup [^0]. To combat this, we allow a 5 minute grace
-	// period where we allow `TaskStatusError` to surface without immediately
-	// failing.
+	// It has been observed that the `TaskStatusError` state has
+	// appeared during a typical healthy startup [^0]. To combat
+	// this, we allow a 5 minute grace period where we allow
+	// `TaskStatusError` to surface without immediately failing.
 	//
 	// TODO(DanielleMaywood):
-	// Remove this grace period once the upstream agentapi health check no
-	// longer reports transient error states during normal startup.
+	// Remove this grace period once the upstream agentapi health
+	// check no longer reports transient error states during normal
+	// startup.
 	//
 	// [0]: https://github.com/coder/coder/pull/22203#discussion_r2858002569
 	const errorGracePeriod = 5 * time.Minute
 	gracePeriodDeadline := time.Now().Add(errorGracePeriod)
 
 	// TODO(DanielleMaywood):
-	// When we have a streaming Task API, this should be converted away from polling.
+	// When we have a streaming Task API, this should be converted
+	// away from polling.
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -197,22 +164,34 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 			}
 
 			switch task.Status {
-			case codersdk.TaskStatusInitializing:
+			case codersdk.TaskStatusInitializing,
+				codersdk.TaskStatusPending:
+				// Not yet active, keep polling.
 				continue
 			case codersdk.TaskStatusActive:
-				return nil
+				// Task is active; check app state.
+				if task.CurrentState == nil {
+					continue
+				}
+				switch task.CurrentState.State {
+				case codersdk.TaskStateIdle,
+					codersdk.TaskStateComplete,
+					codersdk.TaskStateFailed:
+					return nil
+				default:
+					// Still working, keep polling.
+					continue
+				}
 			case codersdk.TaskStatusError:
 				if time.Now().After(gracePeriodDeadline) {
-					return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
+					return xerrors.Errorf("task entered %s state while waiting for it to become idle", task.Status)
 				}
 			case codersdk.TaskStatusPaused:
-				return xerrors.Errorf("task was paused while waiting for it to become active")
-			case codersdk.TaskStatusPending:
-				// Task is still pending, keep polling.
+				return xerrors.Errorf("task was paused while waiting for it to become idle")
 			case codersdk.TaskStatusUnknown:
-				return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
+				return xerrors.Errorf("task entered %s state while waiting for it to become idle", task.Status)
 			default:
-				return xerrors.Errorf("task entered unexpected state (%s) while waiting for it to become active", task.Status)
+				return xerrors.Errorf("task entered unexpected state (%s) while waiting for it to become idle", task.Status)
 			}
 		}
 	}

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -147,12 +147,8 @@ func waitForTaskIdle(ctx context.Context, client *codersdk.Client, task codersdk
 			}
 
 			switch task.CurrentState.State {
-			case codersdk.TaskStateIdle:
+			case codersdk.TaskStateIdle, codersdk.TaskStateComplete, codersdk.TaskStateFailed:
 				return nil
-			case codersdk.TaskStateComplete:
-				return xerrors.Errorf("task has completed and cannot be sent input")
-			case codersdk.TaskStateFailed:
-				return xerrors.Errorf("task has failed and cannot be sent input")
 			case codersdk.TaskStateWorking:
 				// Still busy, keep polling.
 			}

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -191,14 +191,18 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 			}
 
 			switch task.Status {
+			case codersdk.TaskStatusInitializing:
+				continue
 			case codersdk.TaskStatusActive:
 				return nil
 			case codersdk.TaskStatusError:
 				if time.Now().After(gracePeriodDeadline) {
 					return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
 				}
-			case codersdk.TaskStatusUnknown:
+			case codersdk.TaskStatusPaused, codersdk.TaskStatusUnknown:
 				return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
+			default:
+				return xerrors.Errorf("task entered unknown state (%s) while waiting for it to become active", task.Status)
 			}
 		}
 	}

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -133,6 +133,8 @@ func waitForTaskIdle(ctx context.Context, inv *serpent.Invocation, client *coder
 		}
 	}
 
+	cliui.Infof(inv.Stdout, "Waiting for task to become idle...")
+
 	// NOTE(DanielleMaywood):
 	// It has been observed that the `TaskStatusError` state has
 	// appeared during a typical healthy startup [^0]. To combat
@@ -147,6 +149,15 @@ func waitForTaskIdle(ctx context.Context, inv *serpent.Invocation, client *coder
 	// [0]: https://github.com/coder/coder/pull/22203#discussion_r2858002569
 	const errorGracePeriod = 5 * time.Minute
 	gracePeriodDeadline := time.Now().Add(errorGracePeriod)
+
+	// NOTE(DanielleMaywood):
+	// On resume the MCP may not report an initial app status,
+	// leaving CurrentState nil indefinitely. To avoid hanging
+	// forever we treat Active with nil CurrentState as idle
+	// after a grace period, giving the MCP time to report
+	// during normal startup.
+	const nilStateGracePeriod = 30 * time.Second
+	var nilStateDeadline time.Time
 
 	// TODO(DanielleMaywood):
 	// When we have a streaming Task API, this should be converted
@@ -171,8 +182,20 @@ func waitForTaskIdle(ctx context.Context, inv *serpent.Invocation, client *coder
 			case codersdk.TaskStatusActive:
 				// Task is active; check app state.
 				if task.CurrentState == nil {
+					// The MCP may not have reported state yet.
+					// Start a grace period on first observation
+					// and treat as idle once it expires.
+					if nilStateDeadline.IsZero() {
+						nilStateDeadline = time.Now().Add(nilStateGracePeriod)
+					}
+					if time.Now().After(nilStateDeadline) {
+						return nil
+					}
 					continue
 				}
+				// Reset nil-state deadline since we got a real
+				// state report.
+				nilStateDeadline = time.Time{}
 				switch task.CurrentState.State {
 				case codersdk.TaskStateIdle,
 					codersdk.TaskStateComplete,

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -20,7 +20,8 @@ func (r *RootCmd) taskSend() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "send <task> [<input> | --stdin]",
 		Short: "Send input to a task",
-		Long: "Send input to a task. If the task is paused, it will be automatically resumed before input is sent. If the task is initializing, it will wait for the task to become ready.\n" +
+		Long: `Send input to a task. If the task is paused, it will be automatically resumed before input is sent. If the task is initializing, it will wait for the task to become ready.
+` +
 			FormatExamples(Example{
 				Description: "Send direct input to a task",
 				Command:     `coder task send task1 "Please also add unit tests"`,
@@ -151,6 +152,10 @@ func waitForTaskIdle(ctx context.Context, client *codersdk.Client, task codersdk
 				return nil
 			case codersdk.TaskStateWorking:
 				// Still busy, keep polling.
+			default:
+				// If the task enters an unexpected state (e.g. paused
+				// externally), stop waiting and report the problem.
+				return xerrors.Errorf("task entered unexpected app state %q while waiting for it to become idle", task.CurrentState.State)
 			}
 		}
 	}
@@ -166,11 +171,12 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 	// NOTE(DanielleMaywood):
 	// It has been observed that the `TaskStatusError` state has appeared during
 	// a typical healthy startup [^0]. To combat this, we allow a 5 minute grace
-	// period where we allow `TaskStatusError` and `TaskStatusUnknown` to surface.
+	// period where we allow `TaskStatusError` to surface without immediately
+	// failing.
 	//
 	// TODO(DanielleMaywood):
-	// When/If the upstream API handles this scenario better, we should remove the
-	// grace period.
+	// Remove this grace period once the upstream agentapi health check no
+	// longer reports transient error states during normal startup.
 	//
 	// [0]: https://github.com/coder/coder/pull/22203#discussion_r2858002569
 	const errorGracePeriod = 5 * time.Minute
@@ -199,10 +205,14 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 				if time.Now().After(gracePeriodDeadline) {
 					return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
 				}
-			case codersdk.TaskStatusPaused, codersdk.TaskStatusUnknown:
+			case codersdk.TaskStatusPaused:
+				return xerrors.Errorf("task was paused while waiting for it to become active")
+			case codersdk.TaskStatusPending:
+				// Task is still pending, keep polling.
+			case codersdk.TaskStatusUnknown:
 				return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
 			default:
-				return xerrors.Errorf("task entered unknown state (%s) while waiting for it to become active", task.Status)
+				return xerrors.Errorf("task entered unexpected state (%s) while waiting for it to become active", task.Status)
 			}
 		}
 	}

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -166,6 +166,15 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 	// TODO(DanielleMaywood):
 	// When we have a streaming Task API, this should be converted away from polling.
 
+	// TODO(DanielleMaywood):
+	// It has been observed that the `TaskStausError` state has appeared during
+	// a typical healthy startup [^0]. To combat this, we allow a 5 minute grace
+	// period where we allow `TaskStatusError` and `TaskStatusUnknown` to surface.
+	//
+	// [0]: https://github.com/coder/coder/pull/22203#discussion_r2858002569
+	const errorGracePeriod = 5 * time.Minute
+	gracePeriodDeadline := time.Now().Add(errorGracePeriod)
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -176,12 +185,17 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 			task, err := client.TaskByID(ctx, task.ID)
 			if err != nil {
 				return xerrors.Errorf("get task by id: %w", err)
-			} else if task.Status == codersdk.TaskStatusError || task.Status == codersdk.TaskStatusUnknown {
-				return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
 			}
 
-			if task.Status == codersdk.TaskStatusActive {
+			switch task.Status {
+			case codersdk.TaskStatusActive:
 				return nil
+			case codersdk.TaskStatusError:
+				if time.Now().After(gracePeriodDeadline) {
+					return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
+				}
+			case codersdk.TaskStatusUnknown:
+				return xerrors.Errorf("task entered %s state while waiting for it to become active", task.Status)
 			}
 		}
 	}

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -130,7 +130,7 @@ func waitForTaskIdle(ctx context.Context, client *codersdk.Client, task codersdk
 	// When we have a streaming Task API, this should be converted
 	// away from polling.
 
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
@@ -170,7 +170,7 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 	// TODO(DanielleMaywood):
 	// When we have a streaming Task API, this should be converted away from polling.
 
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -167,7 +167,7 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 	// When we have a streaming Task API, this should be converted away from polling.
 
 	// TODO(DanielleMaywood):
-	// It has been observed that the `TaskStausError` state has appeared during
+	// It has been observed that the `TaskStatusError` state has appeared during
 	// a typical healthy startup [^0]. To combat this, we allow a 5 minute grace
 	// period where we allow `TaskStatusError` and `TaskStatusUnknown` to surface.
 	//

--- a/cli/task_send.go
+++ b/cli/task_send.go
@@ -163,18 +163,21 @@ func waitForTaskReady(ctx context.Context, inv *serpent.Invocation, client *code
 		return xerrors.Errorf("watch workspace build: %w", err)
 	}
 
-	// TODO(DanielleMaywood):
-	// When we have a streaming Task API, this should be converted away from polling.
-
-	// TODO(DanielleMaywood):
+	// NOTE(DanielleMaywood):
 	// It has been observed that the `TaskStatusError` state has appeared during
 	// a typical healthy startup [^0]. To combat this, we allow a 5 minute grace
 	// period where we allow `TaskStatusError` and `TaskStatusUnknown` to surface.
+	//
+	// TODO(DanielleMaywood):
+	// When/If the upstream API handles this scenario better, we should remove the
+	// grace period.
 	//
 	// [0]: https://github.com/coder/coder/pull/22203#discussion_r2858002569
 	const errorGracePeriod = 5 * time.Minute
 	gracePeriodDeadline := time.Now().Add(errorGracePeriod)
 
+	// TODO(DanielleMaywood):
+	// When we have a streaming Task API, this should be converted away from polling.
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {

--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -12,9 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	agentapisdk "github.com/coder/agentapi-sdk-go"
+	"github.com/coder/coder/v2/agent"
+	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -25,12 +30,12 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
-		inv, root := clitest.New(t, "task", "send", task.Name, "carry on with the task")
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "carry on with the task")
 		inv.Stdout = &stdout
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
@@ -41,12 +46,12 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
-		inv, root := clitest.New(t, "task", "send", task.ID.String(), "carry on with the task")
+		inv, root := clitest.New(t, "task", "send", setup.task.ID.String(), "carry on with the task")
 		inv.Stdout = &stdout
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
@@ -57,13 +62,13 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "carry on with the task", "you got it"))
 
 		var stdout strings.Builder
-		inv, root := clitest.New(t, "task", "send", task.Name, "--stdin")
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "--stdin")
 		inv.Stdout = &stdout
 		inv.Stdin = strings.NewReader("carry on with the task")
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
@@ -110,16 +115,107 @@ func Test_TaskSend(t *testing.T) {
 		t.Parallel()
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
-		_, userClient, task := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendErr(t, assert.AnError))
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendErr(assert.AnError))
 
 		var stdout strings.Builder
-		inv, root := clitest.New(t, "task", "send", task.Name, "some task input")
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
 		inv.Stdout = &stdout
-		clitest.SetupConfig(t, userClient, root)
+		clitest.SetupConfig(t, setup.userClient, root)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := inv.WithContext(ctx).Run()
 		require.ErrorContains(t, err, assert.AnError.Error())
+	})
+
+	t.Run("WaitsForInitializingTask", func(t *testing.T) {
+		t.Parallel()
+
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some task input", "some task response"))
+
+		// Close the first agent, pause, then resume the task so the
+		// workspace is started but no agent is connected.
+		// This puts the task in "initializing" state.
+		require.NoError(t, setup.agent.Close())
+		pauseTask(setupCtx, t, setup.userClient, setup.task)
+		resumeTask(setupCtx, t, setup.userClient, setup.task)
+
+		// When: We attempt to send input to the initializing task.
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
+		clitest.SetupConfig(t, setup.userClient, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv = inv.WithContext(ctx)
+
+		// Use a pty so we can wait for the command to produce build
+		// output, confirming it has entered the initializing code
+		// path before we connect the agent.
+		pty := ptytest.New(t).Attach(inv)
+		w := clitest.StartWithWaiter(t, inv)
+
+		// Wait for the command to observe the initializing state and
+		// start watching the workspace build. This ensures the command
+		// has entered the waiting code path.
+		pty.ExpectMatchContext(ctx, "Queued")
+
+		// Connect a new agent so the task can transition to active.
+		agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
+		setup.agent = agenttest.New(t, setup.userClient.URL, setup.agentToken, func(o *agent.Options) {
+			o.Client = agentClient
+		})
+		coderdtest.NewWorkspaceAgentWaiter(t, setup.userClient, setup.task.WorkspaceID.UUID).
+			WaitFor(coderdtest.AgentsReady)
+
+		// Then: The command should complete successfully.
+		require.NoError(t, w.Wait())
+
+		updated, err := setup.userClient.TaskByIdentifier(ctx, setup.task.Name)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.TaskStatusActive, updated.Status)
+	})
+
+	t.Run("ResumesPausedTask", func(t *testing.T) {
+		t.Parallel()
+
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some task input", "some task response"))
+
+		// Close the first agent before pausing so it does not conflict
+		// with the agent we reconnect after the workspace is resumed.
+		require.NoError(t, setup.agent.Close())
+		pauseTask(setupCtx, t, setup.userClient, setup.task)
+
+		// When: We attempt to send input to the paused task.
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
+		clitest.SetupConfig(t, setup.userClient, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv = inv.WithContext(ctx)
+
+		// Use a pty so we can wait for the command to produce build
+		// output, confirming it has entered the paused code path and
+		// triggered a resume before we connect the agent.
+		pty := ptytest.New(t).Attach(inv)
+		w := clitest.StartWithWaiter(t, inv)
+
+		// Wait for the command to observe the paused state, trigger
+		// a resume, and start watching the workspace build.
+		pty.ExpectMatchContext(ctx, "Queued")
+
+		// Connect a new agent so the task can transition to active.
+		agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
+		setup.agent = agenttest.New(t, setup.userClient.URL, setup.agentToken, func(o *agent.Options) {
+			o.Client = agentClient
+		})
+		coderdtest.NewWorkspaceAgentWaiter(t, setup.userClient, setup.task.WorkspaceID.UUID).
+			WaitFor(coderdtest.AgentsReady)
+
+		// Then: The command should complete successfully.
+		require.NoError(t, w.Wait())
+
+		updated, err := setup.userClient.TaskByIdentifier(ctx, setup.task.Name)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.TaskStatusActive, updated.Status)
 	})
 }
 
@@ -151,7 +247,7 @@ func fakeAgentAPITaskSendOK(t *testing.T, expectMessage, returnMessage string) m
 	}
 }
 
-func fakeAgentAPITaskSendErr(t *testing.T, returnErr error) map[string]http.HandlerFunc {
+func fakeAgentAPITaskSendErr(returnErr error) map[string]http.HandlerFunc {
 	return map[string]http.HandlerFunc{
 		"/status": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -232,48 +232,34 @@ func Test_TaskSend(t *testing.T) {
 		require.Equal(t, codersdk.TaskStatusActive, updated.Status)
 	})
 
-	t.Run("RejectsCompletedTask", func(t *testing.T) {
+	t.Run("SendToNonIdleAppState", func(t *testing.T) {
 		t.Parallel()
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
-		setup := setupCLITaskTest(setupCtx, t, nil)
+		for _, appState := range []codersdk.WorkspaceAppStatusState{
+			codersdk.WorkspaceAppStatusStateComplete,
+			codersdk.WorkspaceAppStatusStateFailure,
+		} {
+			t.Run(string(appState), func(t *testing.T) {
+				t.Parallel()
 
-		agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
-		require.NoError(t, agentClient.PatchAppStatus(setupCtx, agentsdk.PatchAppStatus{
-			AppSlug: "task-sidebar",
-			State:   codersdk.WorkspaceAppStatusStateComplete,
-			Message: "done",
-		}))
+				setupCtx := testutil.Context(t, testutil.WaitLong)
+				setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some input", "some response"))
 
-		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some input")
-		clitest.SetupConfig(t, setup.userClient, root)
+				agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
+				require.NoError(t, agentClient.PatchAppStatus(setupCtx, agentsdk.PatchAppStatus{
+					AppSlug: "task-sidebar",
+					State:   appState,
+					Message: "done",
+				}))
 
-		ctx := testutil.Context(t, testutil.WaitLong)
-		err := inv.WithContext(ctx).Run()
-		require.Error(t, err)
-		require.ErrorContains(t, err, "has completed and cannot be sent input")
-	})
+				inv, root := clitest.New(t, "task", "send", setup.task.Name, "some input")
+				clitest.SetupConfig(t, setup.userClient, root)
 
-	t.Run("RejectsFailedTask", func(t *testing.T) {
-		t.Parallel()
-
-		setupCtx := testutil.Context(t, testutil.WaitLong)
-		setup := setupCLITaskTest(setupCtx, t, nil)
-
-		agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
-		require.NoError(t, agentClient.PatchAppStatus(setupCtx, agentsdk.PatchAppStatus{
-			AppSlug: "task-sidebar",
-			State:   codersdk.WorkspaceAppStatusStateFailure,
-			Message: "something went wrong",
-		}))
-
-		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some input")
-		clitest.SetupConfig(t, setup.userClient, root)
-
-		ctx := testutil.Context(t, testutil.WaitLong)
-		err := inv.WithContext(ctx).Run()
-		require.Error(t, err)
-		require.ErrorContains(t, err, "has failed and cannot be sent input")
+				ctx := testutil.Context(t, testutil.WaitLong)
+				err := inv.WithContext(ctx).Run()
+				require.NoError(t, err)
+			})
+		}
 	})
 }
 

--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -266,7 +266,7 @@ func Test_TaskSend(t *testing.T) {
 		// Then: The command should fail because the task was paused.
 		err := w.Wait()
 		require.Error(t, err)
-		require.ErrorContains(t, err, "was paused while waiting for it to become active")
+		require.ErrorContains(t, err, "was paused while waiting for it to become idle")
 	})
 
 	t.Run("WaitsForWorkingAppState", func(t *testing.T) {

--- a/cli/task_send_test.go
+++ b/cli/task_send_test.go
@@ -232,6 +232,77 @@ func Test_TaskSend(t *testing.T) {
 		require.Equal(t, codersdk.TaskStatusActive, updated.Status)
 	})
 
+	t.Run("PausedDuringWaitForReady", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: An initializing task (workspace running, no agent
+		// connected).
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setup := setupCLITaskTest(setupCtx, t, nil)
+
+		require.NoError(t, setup.agent.Close())
+		pauseTask(setupCtx, t, setup.userClient, setup.task)
+		resumeTask(setupCtx, t, setup.userClient, setup.task)
+
+		// When: We attempt to send input to the initializing task.
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
+		clitest.SetupConfig(t, setup.userClient, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv = inv.WithContext(ctx)
+
+		pty := ptytest.New(t).Attach(inv)
+		w := clitest.StartWithWaiter(t, inv)
+
+		// Wait for the command to enter the build-watching phase
+		// of waitForTaskReady.
+		pty.ExpectMatchContext(ctx, "Queued")
+
+		// Pause the task while waitForTaskReady is polling. Since
+		// no agent is connected, the task stays initializing until
+		// we pause it, at which point the status becomes paused.
+		pauseTask(ctx, t, setup.userClient, setup.task)
+
+		// Then: The command should fail because the task was paused.
+		err := w.Wait()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "was paused while waiting for it to become active")
+	})
+
+	t.Run("WaitsForWorkingAppState", func(t *testing.T) {
+		t.Parallel()
+
+		// Given: An active task whose app is in "working" state.
+		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setup := setupCLITaskTest(setupCtx, t, fakeAgentAPITaskSendOK(t, "some task input", "some task response"))
+
+		// Move the app into "working" state before running the command.
+		agentClient := agentsdk.New(setup.userClient.URL, agentsdk.WithFixedToken(setup.agentToken))
+		require.NoError(t, agentClient.PatchAppStatus(setupCtx, agentsdk.PatchAppStatus{
+			AppSlug: "task-sidebar",
+			State:   codersdk.WorkspaceAppStatusStateWorking,
+			Message: "busy",
+		}))
+
+		// When: We send input while the app is working.
+		inv, root := clitest.New(t, "task", "send", setup.task.Name, "some task input")
+		clitest.SetupConfig(t, setup.userClient, root)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv = inv.WithContext(ctx)
+		w := clitest.StartWithWaiter(t, inv)
+
+		// Transition the app back to idle so waitForTaskIdle proceeds.
+		require.NoError(t, agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
+			AppSlug: "task-sidebar",
+			State:   codersdk.WorkspaceAppStatusStateIdle,
+			Message: "ready",
+		}))
+
+		// Then: The command should complete successfully.
+		require.NoError(t, w.Wait())
+	})
+
 	t.Run("SendToNonIdleAppState", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/task_test.go
+++ b/cli/task_test.go
@@ -272,10 +272,19 @@ func fakeAgentAPIEcho(ctx context.Context, t testing.TB, initMsg agentapisdk.Mes
 // setupCLITaskTest creates a test workspace with an AI task template and agent,
 // with a fake agent API configured with the provided set of handlers.
 // Returns the user client and workspace.
-func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[string]http.HandlerFunc) (ownerClient *codersdk.Client, memberClient *codersdk.Client, task codersdk.Task) {
+// setupCLITaskTestResult holds the return values from setupCLITaskTest.
+type setupCLITaskTestResult struct {
+	ownerClient *codersdk.Client
+	userClient  *codersdk.Client
+	task        codersdk.Task
+	agentToken  string
+	agent       agent.Agent
+}
+
+func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[string]http.HandlerFunc) setupCLITaskTestResult {
 	t.Helper()
 
-	ownerClient = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	ownerClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	owner := coderdtest.CreateFirstUser(t, ownerClient)
 	userClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
 
@@ -292,21 +301,48 @@ func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[st
 	})
 	require.NoError(t, err)
 
-	// Wait for the task's underlying workspace to be built
+	// Wait for the task's underlying workspace to be built.
 	require.True(t, task.WorkspaceID.Valid, "task should have a workspace ID")
 	workspace, err := userClient.Workspace(ctx, task.WorkspaceID.UUID)
 	require.NoError(t, err)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, userClient, workspace.LatestBuild.ID)
 
 	agentClient := agentsdk.New(userClient.URL, agentsdk.WithFixedToken(authToken))
-	_ = agenttest.New(t, userClient.URL, authToken, func(o *agent.Options) {
+	agt := agenttest.New(t, userClient.URL, authToken, func(o *agent.Options) {
 		o.Client = agentClient
 	})
 
 	coderdtest.NewWorkspaceAgentWaiter(t, userClient, workspace.ID).
 		WaitFor(coderdtest.AgentsReady)
 
-	return ownerClient, userClient, task
+	return setupCLITaskTestResult{
+		ownerClient: ownerClient,
+		userClient:  userClient,
+		task:        task,
+		agentToken:  authToken,
+		agent:       agt,
+	}
+}
+
+// pauseTask pauses the task and waits for the stop build to complete.
+func pauseTask(ctx context.Context, t *testing.T, client *codersdk.Client, task codersdk.Task) {
+	t.Helper()
+
+	pauseResp, err := client.PauseTask(ctx, task.OwnerName, task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, pauseResp.WorkspaceBuild)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, pauseResp.WorkspaceBuild.ID)
+}
+
+// resumeTask resumes the task waits for the start build to complete. The task
+// will be in "initializing" state after this returns because no agent is connected.
+func resumeTask(ctx context.Context, t *testing.T, client *codersdk.Client, task codersdk.Task) {
+	t.Helper()
+
+	resumeResp, err := client.ResumeTask(ctx, task.OwnerName, task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, resumeResp.WorkspaceBuild)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, resumeResp.WorkspaceBuild.ID)
 }
 
 // setupCLITaskTestWithSnapshot creates a task in the specified status with a log snapshot.

--- a/cli/task_test.go
+++ b/cli/task_test.go
@@ -88,6 +88,13 @@ func Test_Tasks(t *testing.T) {
 					o.Client = agentClient
 				})
 				coderdtest.NewWorkspaceAgentWaiter(t, userClient, tasks[0].WorkspaceID.UUID).WithContext(ctx).WaitFor(coderdtest.AgentsReady)
+				// Report the task app as idle so that waitForTaskIdle
+				// can proceed during the "send task message" step.
+				require.NoError(t, agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
+					AppSlug: "task-sidebar",
+					State:   codersdk.WorkspaceAppStatusStateIdle,
+					Message: "ready",
+				}))
 			},
 		},
 		{
@@ -314,6 +321,14 @@ func setupCLITaskTest(ctx context.Context, t *testing.T, agentAPIHandlers map[st
 
 	coderdtest.NewWorkspaceAgentWaiter(t, userClient, workspace.ID).
 		WaitFor(coderdtest.AgentsReady)
+
+	// Report the task app as idle so that waitForTaskIdle can proceed.
+	err = agentClient.PatchAppStatus(ctx, agentsdk.PatchAppStatus{
+		AppSlug: "task-sidebar",
+		State:   codersdk.WorkspaceAppStatusStateIdle,
+		Message: "ready",
+	})
+	require.NoError(t, err)
 
 	return setupCLITaskTestResult{
 		ownerClient: ownerClient,

--- a/cli/testdata/coder_task_send_--help.golden
+++ b/cli/testdata/coder_task_send_--help.golden
@@ -5,6 +5,9 @@ USAGE:
 
   Send input to a task
 
+  Send input to a task. If the task is paused, it will be automatically resumed
+  before input is sent. If the task is initializing, it will wait for the task
+  to become ready.
     - Send direct input to a task.:
   
        $ coder task send task1 "Please also add unit tests"

--- a/cli/testdata/coder_task_send_--help.golden
+++ b/cli/testdata/coder_task_send_--help.golden
@@ -8,11 +8,11 @@ USAGE:
   Send input to a task. If the task is paused, it will be automatically resumed
   before input is sent. If the task is initializing, it will wait for the task
   to become ready.
-    - Send direct input to a task.:
+    - Send direct input to a task:
   
        $ coder task send task1 "Please also add unit tests"
   
-    - Send input from stdin to a task.:
+    - Send input from stdin to a task:
   
        $ echo "Please also add unit tests" | coder task send task1 --stdin
 

--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -314,6 +314,18 @@ func taskFromDBTaskAndWorkspace(dbTask database.Task, ws codersdk.Workspace) cod
 	}
 }
 
+// appStatusStateToTaskState converts a WorkspaceAppStatusState to a
+// TaskState. The two enums mostly share values but "failure" in the
+// app status maps to "failed" in the public task API.
+func appStatusStateToTaskState(s codersdk.WorkspaceAppStatusState) codersdk.TaskState {
+	switch s {
+	case codersdk.WorkspaceAppStatusStateFailure:
+		return codersdk.TaskStateFailed
+	default:
+		return codersdk.TaskState(s)
+	}
+}
+
 // deriveTaskCurrentState determines the current state of a task based on the
 // workspace's latest app status and initialization phase.
 // Returns nil if no valid state can be determined.
@@ -333,7 +345,7 @@ func deriveTaskCurrentState(
 		if ws.LatestBuild.Transition != codersdk.WorkspaceTransitionStart || ws.LatestAppStatus.CreatedAt.After(ws.LatestBuild.CreatedAt) {
 			currentState = &codersdk.TaskStateEntry{
 				Timestamp: ws.LatestAppStatus.CreatedAt,
-				State:     codersdk.TaskState(ws.LatestAppStatus.State),
+				State:     appStatusStateToTaskState(ws.LatestAppStatus.State),
 				Message:   ws.LatestAppStatus.Message,
 				URI:       ws.LatestAppStatus.URI,
 			}

--- a/docs/reference/cli/task_send.md
+++ b/docs/reference/cli/task_send.md
@@ -12,11 +12,12 @@ coder task send [flags] <task> [<input> | --stdin]
 ## Description
 
 ```console
-  - Send direct input to a task.:
+Send input to a task. If the task is paused, it will be automatically resumed before input is sent. If the task is initializing, it will wait for the task to become ready.
+  - Send direct input to a task:
 
      $ coder task send task1 "Please also add unit tests"
 
-  - Send input from stdin to a task.:
+  - Send input from stdin to a task:
 
      $ echo "Please also add unit tests" | coder task send task1 --stdin
 ```


### PR DESCRIPTION
Closes COCO-22 / Closes https://github.com/coder/internal/issues/1266

The test for this was a little awkward to write, so a little refactoring was done. Happy to have another go if we think they're a little unwieldy.