### PR TITLE
fix: revert automatically set 'host-prefix-cookie' in https deployments"

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2916,9 +2916,9 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Flag:        "host-prefix-cookie",
 			Env:         "CODER_HOST_PREFIX_COOKIE",
 			Value:       serpent.BoolOf(&c.HTTPCookies.EnableHostPrefix),
-			DefaultFn: func() string {
-				return strconv.FormatBool(c.AccessURL.Scheme == "https")
-			},
+			// Ideally this is true, however any frontend interactions with the coder api would be broken.
+			// So for compatibility reasons, this is set to false.
+			Default:     "false",
 			Group:       &deploymentGroupNetworking,
 			YAML:        "hostPrefixCookie",
 			Annotations: serpent.Annotations{}.Mark(annotationExternalProxies, "true"),

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1065,6 +1065,7 @@ Controls the 'SameSite' property is set on browser session cookies.
 | Type        | <code>bool</code>                        |
 | Environment | <code>$CODER_HOST_PREFIX_COOKIE</code>   |
 | YAML        | <code>networking.hostPrefixCookie</code> |
+| Default     | <code>false</code>                       |
 
 Recommended to be enabled. Enables `__Host-` prefix for cookies to guarantee they are only set by the right domain.
 


### PR DESCRIPTION
Reverts coder/coder#22224

https://codercom.slack.com/archives/C06T78M7X7H/p1771610993750189?thread_ts=1771610966.160879&cid=C06T78M7X7H