### PR TITLE
feat: support aibridge filtering by multiple `client`s

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -84,6 +84,34 @@ const docTemplate = `{
                 }
             }
         },
+        "/aibridge/clients": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AI Bridge"
+                ],
+                "summary": "List AI Bridge clients",
+                "operationId": "list-ai-bridge-clients",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/aibridge/interceptions": {
             "get": {
                 "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -65,6 +65,30 @@
 				}
 			}
 		},
+		"/aibridge/clients": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["AI Bridge"],
+				"summary": "List AI Bridge clients",
+				"operationId": "list-ai-bridge-clients",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/aibridge/interceptions": {
 			"get": {
 				"security": [

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -4799,6 +4799,14 @@ func (q *querier) ListAIBridgeModels(ctx context.Context, arg database.ListAIBri
 	return q.db.ListAuthorizedAIBridgeModels(ctx, arg, prep)
 }
 
+func (q *querier) ListAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams) ([]string, error) {
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceAibridgeInterception.Type)
+	if err != nil {
+		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
+	}
+	return q.db.ListAuthorizedAIBridgeClients(ctx, arg, prep)
+}
+
 func (q *querier) ListAIBridgeTokenUsagesByInterceptionIDs(ctx context.Context, interceptionIDs []uuid.UUID) ([]database.AIBridgeTokenUsage, error) {
 	// This function is a system function until we implement a join for aibridge interceptions.
 	// Matches the behavior of the workspaces listing endpoint.
@@ -6366,4 +6374,12 @@ func (q *querier) ListAuthorizedAIBridgeModels(ctx context.Context, arg database
 	// This cannot be deleted for now because it's included in the
 	// database.Store interface, so dbauthz needs to implement it.
 	return q.ListAIBridgeModels(ctx, arg)
+}
+
+func (q *querier) ListAuthorizedAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams, _ rbac.PreparedAuthorized) ([]string, error) {
+	// TODO: Delete this function, all ListAIBridgeClients should be
+	// authorized. For now just call ListAIBridgeClients on the authz
+	// querier. This cannot be deleted for now because it's included in
+	// the database.Store interface, so dbauthz needs to implement it.
+	return q.ListAIBridgeClients(ctx, arg)
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -4776,6 +4776,14 @@ func (q *querier) InsertWorkspaceResourceMetadata(ctx context.Context, arg datab
 	return q.db.InsertWorkspaceResourceMetadata(ctx, arg)
 }
 
+func (q *querier) ListAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams) ([]string, error) {
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceAibridgeInterception.Type)
+	if err != nil {
+		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
+	}
+	return q.db.ListAuthorizedAIBridgeClients(ctx, arg, prep)
+}
+
 func (q *querier) ListAIBridgeInterceptions(ctx context.Context, arg database.ListAIBridgeInterceptionsParams) ([]database.ListAIBridgeInterceptionsRow, error) {
 	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceAibridgeInterception.Type)
 	if err != nil {
@@ -4797,14 +4805,6 @@ func (q *querier) ListAIBridgeModels(ctx context.Context, arg database.ListAIBri
 		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
 	}
 	return q.db.ListAuthorizedAIBridgeModels(ctx, arg, prep)
-}
-
-func (q *querier) ListAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams) ([]string, error) {
-	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceAibridgeInterception.Type)
-	if err != nil {
-		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
-	}
-	return q.db.ListAuthorizedAIBridgeClients(ctx, arg, prep)
 }
 
 func (q *querier) ListAIBridgeTokenUsagesByInterceptionIDs(ctx context.Context, interceptionIDs []uuid.UUID) ([]database.AIBridgeTokenUsage, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -4774,6 +4774,20 @@ func (s *MethodTestSuite) TestAIBridge() {
 		check.Args(params, emptyPreparedAuthorized{}).Asserts()
 	}))
 
+	s.Run("ListAIBridgeClients", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		params := database.ListAIBridgeClientsParams{}
+		db.EXPECT().ListAuthorizedAIBridgeClients(gomock.Any(), params, gomock.Any()).Return([]string{}, nil).AnyTimes()
+		// No asserts here because SQLFilter.
+		check.Args(params).Asserts()
+	}))
+
+	s.Run("ListAuthorizedAIBridgeClients", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		params := database.ListAIBridgeClientsParams{}
+		db.EXPECT().ListAuthorizedAIBridgeClients(gomock.Any(), params, gomock.Any()).Return([]string{}, nil).AnyTimes()
+		// No asserts here because SQLFilter.
+		check.Args(params, emptyPreparedAuthorized{}).Asserts()
+	}))
+
 	s.Run("ListAIBridgeTokenUsagesByInterceptionIDs", s.Mocked(func(db *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		ids := []uuid.UUID{{1}}
 		db.EXPECT().ListAIBridgeTokenUsagesByInterceptionIDs(gomock.Any(), ids).Return([]database.AIBridgeTokenUsage{}, nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3198,6 +3198,14 @@ func (m queryMetricsStore) InsertWorkspaceResourceMetadata(ctx context.Context, 
 	return r0, r1
 }
 
+func (m queryMetricsStore) ListAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams) ([]string, error) {
+	start := time.Now()
+	r0, r1 := m.s.ListAIBridgeClients(ctx, arg)
+	m.queryLatencies.WithLabelValues("ListAIBridgeClients").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "ListAIBridgeClients").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) ListAIBridgeInterceptions(ctx context.Context, arg database.ListAIBridgeInterceptionsParams) ([]database.ListAIBridgeInterceptionsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.ListAIBridgeInterceptions(ctx, arg)
@@ -4442,5 +4450,13 @@ func (m queryMetricsStore) ListAuthorizedAIBridgeModels(ctx context.Context, arg
 	r0, r1 := m.s.ListAuthorizedAIBridgeModels(ctx, arg, prepared)
 	m.queryLatencies.WithLabelValues("ListAuthorizedAIBridgeModels").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "ListAuthorizedAIBridgeModels").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) ListAuthorizedAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams, prepared rbac.PreparedAuthorized) ([]string, error) {
+	start := time.Now()
+	r0, r1 := m.s.ListAuthorizedAIBridgeClients(ctx, arg, prepared)
+	m.queryLatencies.WithLabelValues("ListAuthorizedAIBridgeClients").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "ListAuthorizedAIBridgeClients").Inc()
 	return r0, r1
 }

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6087,6 +6087,21 @@ func (mr *MockStoreMockRecorder) ListAIBridgeUserPromptsByInterceptionIDs(ctx, i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAIBridgeUserPromptsByInterceptionIDs", reflect.TypeOf((*MockStore)(nil).ListAIBridgeUserPromptsByInterceptionIDs), ctx, interceptionIds)
 }
 
+// ListAuthorizedAIBridgeClients mocks base method.
+func (m *MockStore) ListAuthorizedAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams, prepared rbac.PreparedAuthorized) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAuthorizedAIBridgeClients", ctx, arg, prepared)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAuthorizedAIBridgeClients indicates an expected call of ListAuthorizedAIBridgeClients.
+func (mr *MockStoreMockRecorder) ListAuthorizedAIBridgeClients(ctx, arg, prepared any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthorizedAIBridgeClients", reflect.TypeOf((*MockStore)(nil).ListAuthorizedAIBridgeClients), ctx, arg, prepared)
+}
+
 // ListAuthorizedAIBridgeInterceptions mocks base method.
 func (m *MockStore) ListAuthorizedAIBridgeInterceptions(ctx context.Context, arg database.ListAIBridgeInterceptionsParams, prepared rbac.PreparedAuthorized) ([]database.ListAIBridgeInterceptionsRow, error) {
 	m.ctrl.T.Helper()
@@ -6115,21 +6130,6 @@ func (m *MockStore) ListAuthorizedAIBridgeModels(ctx context.Context, arg databa
 func (mr *MockStoreMockRecorder) ListAuthorizedAIBridgeModels(ctx, arg, prepared any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthorizedAIBridgeModels", reflect.TypeOf((*MockStore)(nil).ListAuthorizedAIBridgeModels), ctx, arg, prepared)
-}
-
-// ListAuthorizedAIBridgeClients mocks base method.
-func (m *MockStore) ListAuthorizedAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams, prepared rbac.PreparedAuthorized) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuthorizedAIBridgeClients", ctx, arg, prepared)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAuthorizedAIBridgeClients indicates an expected call of ListAuthorizedAIBridgeClients.
-func (mr *MockStoreMockRecorder) ListAuthorizedAIBridgeClients(ctx, arg, prepared any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthorizedAIBridgeClients", reflect.TypeOf((*MockStore)(nil).ListAuthorizedAIBridgeClients), ctx, arg, prepared)
 }
 
 // ListProvisionerKeysByOrganization mocks base method.

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -5982,6 +5982,21 @@ func (mr *MockStoreMockRecorder) InsertWorkspaceResourceMetadata(ctx, arg any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkspaceResourceMetadata", reflect.TypeOf((*MockStore)(nil).InsertWorkspaceResourceMetadata), ctx, arg)
 }
 
+// ListAIBridgeClients mocks base method.
+func (m *MockStore) ListAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAIBridgeClients", ctx, arg)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAIBridgeClients indicates an expected call of ListAIBridgeClients.
+func (mr *MockStoreMockRecorder) ListAIBridgeClients(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAIBridgeClients", reflect.TypeOf((*MockStore)(nil).ListAIBridgeClients), ctx, arg)
+}
+
 // ListAIBridgeInterceptions mocks base method.
 func (m *MockStore) ListAIBridgeInterceptions(ctx context.Context, arg database.ListAIBridgeInterceptionsParams) ([]database.ListAIBridgeInterceptionsRow, error) {
 	m.ctrl.T.Helper()
@@ -6100,6 +6115,21 @@ func (m *MockStore) ListAuthorizedAIBridgeModels(ctx context.Context, arg databa
 func (mr *MockStoreMockRecorder) ListAuthorizedAIBridgeModels(ctx, arg, prepared any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthorizedAIBridgeModels", reflect.TypeOf((*MockStore)(nil).ListAuthorizedAIBridgeModels), ctx, arg, prepared)
+}
+
+// ListAuthorizedAIBridgeClients mocks base method.
+func (m *MockStore) ListAuthorizedAIBridgeClients(ctx context.Context, arg database.ListAIBridgeClientsParams, prepared rbac.PreparedAuthorized) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAuthorizedAIBridgeClients", ctx, arg, prepared)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAuthorizedAIBridgeClients indicates an expected call of ListAuthorizedAIBridgeClients.
+func (mr *MockStoreMockRecorder) ListAuthorizedAIBridgeClients(ctx, arg, prepared any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthorizedAIBridgeClients", reflect.TypeOf((*MockStore)(nil).ListAuthorizedAIBridgeClients), ctx, arg, prepared)
 }
 
 // ListProvisionerKeysByOrganization mocks base method.

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -770,6 +770,7 @@ type aibridgeQuerier interface {
 	ListAuthorizedAIBridgeInterceptions(ctx context.Context, arg ListAIBridgeInterceptionsParams, prepared rbac.PreparedAuthorized) ([]ListAIBridgeInterceptionsRow, error)
 	CountAuthorizedAIBridgeInterceptions(ctx context.Context, arg CountAIBridgeInterceptionsParams, prepared rbac.PreparedAuthorized) (int64, error)
 	ListAuthorizedAIBridgeModels(ctx context.Context, arg ListAIBridgeModelsParams, prepared rbac.PreparedAuthorized) ([]string, error)
+	ListAuthorizedAIBridgeClients(ctx context.Context, arg ListAIBridgeClientsParams, prepared rbac.PreparedAuthorized) ([]string, error)
 }
 
 func (q *sqlQuerier) ListAuthorizedAIBridgeInterceptions(ctx context.Context, arg ListAIBridgeInterceptionsParams, prepared rbac.PreparedAuthorized) ([]ListAIBridgeInterceptionsRow, error) {
@@ -896,6 +897,35 @@ func (q *sqlQuerier) ListAuthorizedAIBridgeModels(ctx context.Context, arg ListA
 			return nil, err
 		}
 		items = append(items, model)
+	}
+	return items, nil
+}
+
+func (q *sqlQuerier) ListAuthorizedAIBridgeClients(ctx context.Context, arg ListAIBridgeClientsParams, prepared rbac.PreparedAuthorized) ([]string, error) {
+	authorizedFilter, err := prepared.CompileToSQL(ctx, regosql.ConvertConfig{
+		VariableConverter: regosql.AIBridgeInterceptionConverter(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("compile authorized filter: %w", err)
+	}
+	filtered, err := insertAuthorizedFilter(listAIBridgeClients, fmt.Sprintf(" AND %s", authorizedFilter))
+	if err != nil {
+		return nil, xerrors.Errorf("insert authorized filter: %w", err)
+	}
+
+	query := fmt.Sprintf("-- name: ListAIBridgeClients :many\n%s", filtered)
+	rows, err := q.db.QueryContext(ctx, query, arg.Client, arg.Offset, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var client string
+		if err := rows.Scan(&client); err != nil {
+			return nil, err
+		}
+		items = append(items, client)
 	}
 	return items, nil
 }

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -792,7 +792,7 @@ func (q *sqlQuerier) ListAuthorizedAIBridgeInterceptions(ctx context.Context, ar
 		arg.InitiatorID,
 		arg.Provider,
 		arg.Model,
-		arg.Client,
+		pq.Array(arg.Clients),
 		arg.AfterID,
 		arg.Offset,
 		arg.Limit,
@@ -851,7 +851,7 @@ func (q *sqlQuerier) CountAuthorizedAIBridgeInterceptions(ctx context.Context, a
 		arg.InitiatorID,
 		arg.Provider,
 		arg.Model,
-		arg.Client,
+		pq.Array(arg.Clients),
 	)
 	if err != nil {
 		return 0, err

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -649,6 +649,7 @@ type sqlcQuerier interface {
 	InsertWorkspaceProxy(ctx context.Context, arg InsertWorkspaceProxyParams) (WorkspaceProxy, error)
 	InsertWorkspaceResource(ctx context.Context, arg InsertWorkspaceResourceParams) (WorkspaceResource, error)
 	InsertWorkspaceResourceMetadata(ctx context.Context, arg InsertWorkspaceResourceMetadataParams) ([]WorkspaceResourceMetadatum, error)
+	ListAIBridgeClients(ctx context.Context, arg ListAIBridgeClientsParams) ([]string, error)
 	ListAIBridgeInterceptions(ctx context.Context, arg ListAIBridgeInterceptionsParams) ([]ListAIBridgeInterceptionsRow, error)
 	// Finds all unique AI Bridge interception telemetry summaries combinations
 	// (provider, model, client) in the given timeframe for telemetry reporting.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -749,6 +749,58 @@ func (q *sqlQuerier) InsertAIBridgeUserPrompt(ctx context.Context, arg InsertAIB
 	return i, err
 }
 
+const listAIBridgeClients = `-- name: ListAIBridgeClients :many
+SELECT
+	COALESCE(client, 'Unknown') AS client
+FROM
+	aibridge_interceptions
+WHERE
+	ended_at IS NOT NULL
+	-- Filter client (prefix match to allow B-tree index usage).
+	AND CASE
+		WHEN $1::text != '' THEN COALESCE(aibridge_interceptions.client, 'Unknown') LIKE $1::text || '%'
+		ELSE true
+	END
+	-- We use an ` + "`" + `@authorize_filter` + "`" + ` as we are attempting to list clients
+	-- that are relevant to the user and what they are allowed to see.
+	-- Authorize Filter clause will be injected below in
+	-- ListAIBridgeClientsAuthorized.
+	-- @authorize_filter
+GROUP BY
+	client
+LIMIT COALESCE(NULLIF($3::integer, 0), 100)
+OFFSET $2
+`
+
+type ListAIBridgeClientsParams struct {
+	Client string `db:"client" json:"client"`
+	Offset int32  `db:"offset_" json:"offset_"`
+	Limit  int32  `db:"limit_" json:"limit_"`
+}
+
+func (q *sqlQuerier) ListAIBridgeClients(ctx context.Context, arg ListAIBridgeClientsParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listAIBridgeClients, arg.Client, arg.Offset, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var client string
+		if err := rows.Scan(&client); err != nil {
+			return nil, err
+		}
+		items = append(items, client)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAIBridgeInterceptions = `-- name: ListAIBridgeInterceptions :many
 SELECT
 	aibridge_interceptions.id, aibridge_interceptions.initiator_id, aibridge_interceptions.provider, aibridge_interceptions.model, aibridge_interceptions.started_at, aibridge_interceptions.metadata, aibridge_interceptions.ended_at, aibridge_interceptions.api_key_id, aibridge_interceptions.client,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -938,7 +938,7 @@ WHERE
 	aibridge_interceptions.ended_at IS NOT NULL
 	-- Filter model
 	AND CASE
-		WHEN $1::text != '' THEN aibridge_interceptions.model ILIKE '%' || $1::text || '%'
+		WHEN $1::text != '' THEN aibridge_interceptions.model LIKE $1::text || '%'
 		ELSE true
 	END
 	-- We use an ` + "`" + `@authorize_filter` + "`" + ` as we are attempting to list models that are relevant

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -938,7 +938,7 @@ WHERE
 	aibridge_interceptions.ended_at IS NOT NULL
 	-- Filter model
 	AND CASE
-		WHEN $1::text != '' THEN aibridge_interceptions.model LIKE $1::text || '%'
+		WHEN $1::text != '' THEN aibridge_interceptions.model ILIKE '%' || $1::text || '%'
 		ELSE true
 	END
 	-- We use an ` + "`" + `@authorize_filter` + "`" + ` as we are attempting to list models that are relevant

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -115,9 +115,9 @@ WHERE
 		WHEN @model::text != '' THEN aibridge_interceptions.model = @model::text
 		ELSE true
 	END
-	-- Filter client
+	-- Filter client(s)
 	AND CASE
-		WHEN @client::text != '' THEN COALESCE(aibridge_interceptions.client, 'Unknown') = @client::text
+		WHEN cardinality(@clients :: text[]) > 0 THEN COALESCE(aibridge_interceptions.client, 'Unknown') = ANY(@clients :: text[])
 		ELSE true
 	END
 	-- Authorize Filter clause will be injected below in ListAuthorizedAIBridgeInterceptions
@@ -159,9 +159,9 @@ WHERE
 		WHEN @model::text != '' THEN aibridge_interceptions.model = @model::text
 		ELSE true
 	END
-	-- Filter client
+	-- Filter client(s)
 	AND CASE
-		WHEN @client::text != '' THEN COALESCE(aibridge_interceptions.client, 'Unknown') = @client::text
+		WHEN cardinality(@clients :: text[]) > 0 THEN COALESCE(aibridge_interceptions.client, 'Unknown') = ANY(@clients :: text[])
 		ELSE true
 	END
 	-- Cursor pagination

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -385,7 +385,7 @@ WHERE
 	aibridge_interceptions.ended_at IS NOT NULL
 	-- Filter model
 	AND CASE
-		WHEN @model::text != '' THEN aibridge_interceptions.model LIKE @model::text || '%'
+		WHEN @model::text != '' THEN aibridge_interceptions.model ILIKE '%' || @model::text || '%'
 		ELSE true
 	END
 	-- We use an `@authorize_filter` as we are attempting to list models that are relevant

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -385,7 +385,7 @@ WHERE
 	aibridge_interceptions.ended_at IS NOT NULL
 	-- Filter model
 	AND CASE
-		WHEN @model::text != '' THEN aibridge_interceptions.model ILIKE '%' || @model::text || '%'
+		WHEN @model::text != '' THEN aibridge_interceptions.model LIKE @model::text || '%'
 		ELSE true
 	END
 	-- We use an `@authorize_filter` as we are attempting to list models that are relevant

--- a/coderd/database/queries/aibridge.sql
+++ b/coderd/database/queries/aibridge.sql
@@ -399,3 +399,26 @@ ORDER BY
 LIMIT COALESCE(NULLIF(@limit_::integer, 0), 100)
 OFFSET @offset_
 ;
+
+-- name: ListAIBridgeClients :many
+SELECT
+	COALESCE(client, 'Unknown') AS client
+FROM
+	aibridge_interceptions
+WHERE
+	ended_at IS NOT NULL
+	-- Filter client (prefix match to allow B-tree index usage).
+	AND CASE
+		WHEN @client::text != '' THEN COALESCE(aibridge_interceptions.client, 'Unknown') LIKE @client::text || '%'
+		ELSE true
+	END
+	-- We use an `@authorize_filter` as we are attempting to list clients
+	-- that are relevant to the user and what they are allowed to see.
+	-- Authorize Filter clause will be injected below in
+	-- ListAIBridgeClientsAuthorized.
+	-- @authorize_filter
+GROUP BY
+	client
+LIMIT COALESCE(NULLIF(@limit_::integer, 0), 100)
+OFFSET @offset_
+;

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -430,6 +430,34 @@ func AIBridgeModels(query string, page codersdk.Pagination) (database.ListAIBrid
 	return filter, parser.Errors
 }
 
+func AIBridgeClients(query string, page codersdk.Pagination) (database.ListAIBridgeClientsParams, []codersdk.ValidationError) {
+	// nolint:exhaustruct // Empty values just means "don't filter by that field".
+	filter := database.ListAIBridgeClientsParams{
+		// #nosec G115 - Safe conversion for pagination offset which is expected to be within int32 range
+		Offset: int32(page.Offset),
+		// #nosec G115 - Safe conversion for pagination limit which is expected to be within int32 range
+		Limit: int32(page.Limit),
+	}
+
+	if query == "" {
+		return filter, nil
+	}
+
+	values, errors := searchTerms(query, func(term string, values url.Values) error {
+		values.Add("client", term)
+		return nil
+	})
+	if len(errors) > 0 {
+		return filter, errors
+	}
+
+	parser := httpapi.NewQueryParamParser()
+	filter.Client = parser.String(values, "", "client")
+
+	parser.ErrorExcessParams(values)
+	return filter, parser.Errors
+}
+
 // Tasks parses a search query for tasks.
 //
 // Supported query parameters:

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -385,7 +385,7 @@ func AIBridgeInterceptions(ctx context.Context, db database.Store, query string,
 	filter.InitiatorID = parseUser(ctx, db, parser, values, "initiator", actorID)
 	filter.Provider = parser.String(values, "", "provider")
 	filter.Model = parser.String(values, "", "model")
-	filter.Client = parser.String(values, "", "client")
+	filter.Clients = parser.Strings(values, nil, "client")
 
 	// Time must be between started_after and started_before.
 	filter.StartedAfter = parser.Time3339Nano(values, time.Time{}, "started_after")

--- a/docs/reference/api/aibridge.md
+++ b/docs/reference/api/aibridge.md
@@ -1,5 +1,38 @@
 # AI Bridge
 
+## List AI Bridge clients
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/aibridge/clients \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /aibridge/clients`
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  "string"
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema          |
+|--------|---------------------------------------------------------|-------------|-----------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of string |
+
+<h3 id="list-ai-bridge-clients-responseschema">Response Schema</h3>
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## List AI Bridge interceptions
 
 ### Code samples

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -141,7 +141,7 @@ func (api *API) aiBridgeListInterceptions(rw http.ResponseWriter, r *http.Reques
 			InitiatorID:   filter.InitiatorID,
 			Provider:      filter.Provider,
 			Model:         filter.Model,
-			Client:        filter.Client,
+			Clients:       filter.Clients,
 		})
 		if err != nil {
 			return xerrors.Errorf("count authorized aibridge interceptions: %w", err)

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2871,6 +2871,13 @@ class ApiMethods {
 		const response = await this.axios.get<string[]>(url);
 		return response.data;
 	};
+
+	getAIBridgeClients = async (options: SearchParamOptions) => {
+		const url = getURLWithSearchParams("/api/v2/aibridge/clients", options);
+
+		const response = await this.axios.get<string[]>(url);
+		return response.data;
+	};
 }
 
 export type TaskFeedbackRating = "good" | "okay" | "bad";

--- a/site/src/components/Combobox/Combobox.tsx
+++ b/site/src/components/Combobox/Combobox.tsx
@@ -21,7 +21,7 @@ import { cn } from "utils/cn";
 type ComboboxContextProps = {
 	open: boolean;
 	setOpen: (open: boolean) => void;
-	value: string | undefined;
+	value: string | Set<string> | undefined;
 	onValueChange: ((value: string | undefined) => void) | undefined;
 };
 
@@ -36,7 +36,7 @@ function useCombobox() {
 }
 
 interface ComboboxProps extends React.ComponentProps<typeof Popover> {
-	value?: string;
+	value?: string | Set<string>;
 	onValueChange?: (value: string | undefined) => void;
 }
 
@@ -50,7 +50,6 @@ export const Combobox = ({
 }: ComboboxProps) => {
 	const [internalOpen, setInternalOpen] = useState(false);
 
-	// Use controlled state if provided, otherwise use internal state
 	const open = controlledOpen ?? internalOpen;
 	const setOpen = controlledOnOpenChange ?? setInternalOpen;
 
@@ -128,17 +127,22 @@ export const ComboboxItem = ({
 	...props
 }: React.ComponentPropsWithRef<typeof CommandItem>) => {
 	const { setOpen, value: selectedValue, onValueChange } = useCombobox();
-	const isSelected = value === selectedValue;
+	const isMultiple = selectedValue instanceof Set;
+	const isSelected = isMultiple
+		? selectedValue.has(value ?? "")
+		: value === selectedValue;
 
 	return (
 		<CommandItem
 			value={value}
 			className={cn(className, "rounded-none")}
 			onSelect={(itemValue) => {
-				setOpen(false);
-				// Toggle behavior: selecting the same value deselects it.
-				const newValue = itemValue === selectedValue ? undefined : itemValue;
-				onValueChange?.(newValue);
+				if (!isMultiple) {
+					setOpen(false);
+				}
+				onValueChange?.(
+					!isMultiple && itemValue === selectedValue ? undefined : itemValue,
+				);
 				onSelect?.(itemValue);
 			}}
 			{...props}

--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -101,15 +101,13 @@ const parseFilterQuery = (filterQuery: string): FilterValues => {
 		return {};
 	}
 
-	const pairs = filterQuery.split(" ");
 	const result: FilterValues = {};
+	const keyValuePair = /(\w+):"([^"]+)"|(\w+):(\S+)/g;
 
-	for (const pair of pairs) {
-		const [key, value] = pair.split(":") as [
-			keyof FilterValues,
-			string | undefined,
-		];
-		if (value) {
+	for (const match of filterQuery.matchAll(keyValuePair)) {
+		const key = match[1] ?? match[3];
+		const value = match[2] ?? match[4];
+		if (key && value) {
 			result[key] = value;
 		}
 	}
@@ -123,7 +121,8 @@ const stringifyFilter = (filterValue: FilterValues): string => {
 	for (const key in filterValue) {
 		const value = filterValue[key];
 		if (value) {
-			result += `${key}:${value} `;
+			const needsQuotes = value.includes(" ");
+			result += needsQuotes ? `${key}:"${value}" ` : `${key}:${value} `;
 		}
 	}
 

--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -105,7 +105,7 @@ const parseFilterQuery = (filterQuery: string): FilterValues => {
 	// Matches key:value pairs where the value is either a quoted string
 	// or unquoted (no spaces). Repeated keys (e.g. client:A client:"B C")
 	// are merged into a comma-separated value.
-	const keyValuePair = /(\w+):("([^"]*)"|[^\s]+)/g;
+	const keyValuePair = /([\w-]+):("([^"]*)"|[^\s]+)/g;
 
 	for (const match of filterQuery.matchAll(keyValuePair)) {
 		const key = match[1];

--- a/site/src/components/Filter/SelectFilter.tsx
+++ b/site/src/components/Filter/SelectFilter.tsx
@@ -21,16 +21,15 @@ export type SelectFilterOption = {
 
 type SelectFilterProps = {
 	options: SelectFilterOption[] | undefined;
+	// For single-select, pass the currently selected option.
 	selectedOption?: SelectFilterOption;
-	// Used to add a accessibility label to the select
+	// For multi-select, pass a Set of selected values.
+	value?: Set<string>;
 	label: string;
-	// Used when there is no option selected
 	placeholder: string;
-	// Used to customize the empty state message
 	emptyText?: string;
 	onSelect: (option: SelectFilterOption | undefined) => void;
 	width?: number;
-	// SelectFilterSearch element
 	selectFilterSearch?: ReactNode;
 };
 
@@ -38,22 +37,32 @@ export const SelectFilter: FC<SelectFilterProps> = ({
 	label,
 	options,
 	selectedOption,
+	value,
 	onSelect,
 	placeholder,
 	emptyText = "No options found",
 	width = BASE_WIDTH,
 	selectFilterSearch,
 }) => {
+	const isMultiple = value instanceof Set;
+	const comboboxValue = isMultiple ? value : selectedOption?.value;
+
+	const displayOption = isMultiple
+		? value.size > 1
+			? { label: `${value.size} selected`, value: "" }
+			: value.size === 1
+				? options?.find((o) => value.has(o.value))
+				: undefined
+		: selectedOption;
+
 	return (
 		<Combobox
-			value={selectedOption?.value}
-			onValueChange={(value) =>
-				onSelect(options?.find((opt) => opt.value === value))
-			}
+			value={comboboxValue}
+			onValueChange={(v) => onSelect(options?.find((opt) => opt.value === v))}
 		>
 			<ComboboxTrigger asChild>
 				<ComboboxButton
-					selectedOption={selectedOption}
+					selectedOption={displayOption}
 					placeholder={placeholder}
 					className="flex-shrink-0 grow"
 					style={{ flexBasis: width }}
@@ -61,12 +70,7 @@ export const SelectFilter: FC<SelectFilterProps> = ({
 				/>
 			</ComboboxTrigger>
 			<ComboboxContent
-				className={cn([
-					// When including selectFilterSearch, we aim for the width to be as
-					// wide as possible.
-					selectFilterSearch && "w-full",
-					"max-w-[260px]",
-				])}
+				className={cn([selectFilterSearch && "w-full", "max-w-[260px]"])}
 				style={{
 					minWidth: width,
 				}}

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ClientFilter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ClientFilter.tsx
@@ -1,0 +1,72 @@
+import { API } from "api/api";
+import { ComboboxInput } from "components/Combobox/Combobox";
+import {
+	type UseFilterMenuOptions,
+	useFilterMenu,
+} from "components/Filter/menu";
+import { SelectFilter } from "components/Filter/SelectFilter";
+
+export const useClientFilterMenu = ({
+	value,
+	onChange,
+	enabled,
+}: Pick<UseFilterMenuOptions, "value" | "onChange" | "enabled">) => {
+	return useFilterMenu({
+		id: "client",
+		getSelectedOption: async () => {
+			const clientsRes = await API.getAIBridgeClients({
+				q: value,
+				limit: 1,
+			});
+			const firstClient = clientsRes.at(0);
+
+			if (firstClient) {
+				return {
+					label: firstClient,
+					value: firstClient,
+				};
+			}
+
+			return null;
+		},
+		getOptions: async (query) => {
+			const clientsRes = await API.getAIBridgeClients({
+				q: query,
+				limit: 25,
+			});
+			return clientsRes.map((client) => ({
+				label: client,
+				value: client,
+			}));
+		},
+		value,
+		onChange,
+		enabled,
+	});
+};
+
+export type ClientFilterMenu = ReturnType<typeof useClientFilterMenu>;
+
+interface ClientFilterProps {
+	menu: ClientFilterMenu;
+}
+
+export const ClientFilter: React.FC<ClientFilterProps> = ({ menu }) => {
+	return (
+		<SelectFilter
+			label="Select client"
+			placeholder="All clients"
+			emptyText="No clients found"
+			options={menu.searchOptions}
+			onSelect={(option) => menu.selectOption(option)}
+			selectedOption={menu.selectedOption ?? undefined}
+			selectFilterSearch={
+				<ComboboxInput
+					placeholder="Search client..."
+					value={menu.query}
+					onValueChange={menu.setQuery}
+				/>
+			}
+		/>
+	);
+};

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ClientFilter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ClientFilter.tsx
@@ -5,6 +5,7 @@ import {
 	useFilterMenu,
 } from "components/Filter/menu";
 import { SelectFilter } from "components/Filter/SelectFilter";
+import { AIBridgeClientIcon } from "../icons/AIBridgeClientIcon";
 
 export const useClientFilterMenu = ({
 	value,
@@ -24,6 +25,9 @@ export const useClientFilterMenu = ({
 				return {
 					label: firstClient,
 					value: firstClient,
+					startIcon: (
+						<AIBridgeClientIcon client={firstClient} className="size-icon-sm" />
+					),
 				};
 			}
 
@@ -37,6 +41,9 @@ export const useClientFilterMenu = ({
 			return clientsRes.map((client) => ({
 				label: client,
 				value: client,
+				startIcon: (
+					<AIBridgeClientIcon client={client} className="size-icon-sm" />
+				),
 			}));
 		},
 		value,

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ModelFilter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ModelFilter.tsx
@@ -1,10 +1,12 @@
 import { API } from "api/api";
-import { ComboboxInput } from "components/Combobox/Combobox";
 import {
 	type UseFilterMenuOptions,
 	useFilterMenu,
 } from "components/Filter/menu";
-import { SelectFilter } from "components/Filter/SelectFilter";
+import {
+	SelectFilter,
+	SelectFilterSearch,
+} from "components/Filter/SelectFilter";
 import type { FC } from "react";
 import { AIBridgeModelIcon } from "../icons/AIBridgeModelIcon";
 
@@ -67,10 +69,11 @@ export const ModelFilter: FC<ModelFilterProps> = ({ menu }) => {
 			onSelect={(option) => menu.selectOption(option)}
 			selectedOption={menu.selectedOption ?? undefined}
 			selectFilterSearch={
-				<ComboboxInput
+				<SelectFilterSearch
+					inputProps={{ "aria-label": "Search model" }}
 					placeholder="Search model..."
 					value={menu.query}
-					onValueChange={menu.setQuery}
+					onChange={menu.setQuery}
 				/>
 			}
 		/>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ModelFilter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/ModelFilter.tsx
@@ -1,12 +1,10 @@
 import { API } from "api/api";
+import { ComboboxInput } from "components/Combobox/Combobox";
 import {
 	type UseFilterMenuOptions,
 	useFilterMenu,
 } from "components/Filter/menu";
-import {
-	SelectFilter,
-	SelectFilterSearch,
-} from "components/Filter/SelectFilter";
+import { SelectFilter } from "components/Filter/SelectFilter";
 import type { FC } from "react";
 import { AIBridgeModelIcon } from "../icons/AIBridgeModelIcon";
 
@@ -69,11 +67,10 @@ export const ModelFilter: FC<ModelFilterProps> = ({ menu }) => {
 			onSelect={(option) => menu.selectOption(option)}
 			selectedOption={menu.selectedOption ?? undefined}
 			selectFilterSearch={
-				<SelectFilterSearch
-					inputProps={{ "aria-label": "Search model" }}
+				<ComboboxInput
 					placeholder="Search model..."
 					value={menu.query}
-					onChange={menu.setQuery}
+					onValueChange={menu.setQuery}
 				/>
 			}
 		/>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/RequestLogsFilter.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsFilter/RequestLogsFilter.tsx
@@ -1,6 +1,6 @@
 import { Filter, MenuSkeleton, type useFilter } from "components/Filter/Filter";
 import { type UserFilterMenu, UserMenu } from "components/Filter/UserFilter";
-import type { FC } from "react";
+import { ClientFilter, type ClientFilterMenu } from "./ClientFilter";
 import { ModelFilter, type ModelFilterMenu } from "./ModelFilter";
 import { ProviderFilter, type ProviderFilterMenu } from "./ProviderFilter";
 
@@ -11,10 +11,11 @@ interface RequestLogsFilterProps {
 		user: UserFilterMenu;
 		provider: ProviderFilterMenu;
 		model: ModelFilterMenu;
+		client: ClientFilterMenu;
 	};
 }
 
-export const RequestLogsFilter: FC<RequestLogsFilterProps> = ({
+export const RequestLogsFilter: React.FC<RequestLogsFilterProps> = ({
 	filter,
 	error,
 	menus,
@@ -40,6 +41,7 @@ export const RequestLogsFilter: FC<RequestLogsFilterProps> = ({
 					<UserMenu menu={menus.user} placeholder="All initiators" />
 					<ProviderFilter menu={menus.provider} />
 					<ModelFilter menu={menus.model} />
+					<ClientFilter menu={menus.client} />
 				</>
 			}
 		/>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
@@ -65,10 +65,10 @@ const RequestLogsPage: FC = () => {
 
 	const clientMenu = useClientFilterMenu({
 		value: filter.values.client,
-		onChange: (option) =>
+		onChange: (value) =>
 			filter.update({
 				...filter.values,
-				client: option?.value,
+				client: value,
 			}),
 	});
 

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPage.tsx
@@ -8,6 +8,7 @@ import { RequirePermission } from "modules/permissions/RequirePermission";
 import type { FC } from "react";
 import { useSearchParams } from "react-router";
 import { pageTitle } from "utils/page";
+import { useClientFilterMenu } from "./RequestLogsFilter/ClientFilter";
 import { useModelFilterMenu } from "./RequestLogsFilter/ModelFilter";
 import { useProviderFilterMenu } from "./RequestLogsFilter/ProviderFilter";
 import { RequestLogsPageView } from "./RequestLogsPageView";
@@ -62,6 +63,15 @@ const RequestLogsPage: FC = () => {
 			}),
 	});
 
+	const clientMenu = useClientFilterMenu({
+		value: filter.values.client,
+		onChange: (option) =>
+			filter.update({
+				...filter.values,
+				client: option?.value,
+			}),
+	});
+
 	return (
 		<RequirePermission isFeatureVisible={hasPermission}>
 			<title>{pageTitle("Request Logs", "AI Bridge")}</title>
@@ -78,6 +88,7 @@ const RequestLogsPage: FC = () => {
 						user: userMenu,
 						provider: providerMenu,
 						model: modelMenu,
+						client: clientMenu,
 					},
 				}}
 			/>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.stories.tsx
@@ -13,21 +13,9 @@ import {
 	mockSuccessResult,
 } from "components/PaginationWidget/PaginationContainer.mocks";
 import type { ComponentProps } from "react";
-import { action } from "storybook/actions";
-import type { ClientFilterMenu } from "./RequestLogsFilter/ClientFilter";
 import { RequestLogsPageView } from "./RequestLogsPageView";
 
 type FilterProps = ComponentProps<typeof RequestLogsPageView>["filterProps"];
-
-const MockClientMenu: ClientFilterMenu = {
-	query: "",
-	setQuery: action("setClientQuery"),
-	searchOptions: [],
-	selectedClients: new Set<string>(),
-	toggleOption: action("toggleClientOption"),
-	isInitializing: false,
-	isSearching: false,
-};
 
 const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 	query: "owner:me",
@@ -39,7 +27,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 		user: MockMenu,
 		provider: MockMenu,
 		model: MockMenu,
-		client: MockClientMenu as unknown as typeof MockMenu,
+		client: MockMenu,
 	},
 });
 

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.stories.tsx
@@ -13,9 +13,21 @@ import {
 	mockSuccessResult,
 } from "components/PaginationWidget/PaginationContainer.mocks";
 import type { ComponentProps } from "react";
+import { action } from "storybook/actions";
+import type { ClientFilterMenu } from "./RequestLogsFilter/ClientFilter";
 import { RequestLogsPageView } from "./RequestLogsPageView";
 
 type FilterProps = ComponentProps<typeof RequestLogsPageView>["filterProps"];
+
+const MockClientMenu: ClientFilterMenu = {
+	query: "",
+	setQuery: action("setClientQuery"),
+	searchOptions: [],
+	selectedClients: new Set<string>(),
+	toggleOption: action("toggleClientOption"),
+	isInitializing: false,
+	isSearching: false,
+};
 
 const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 	query: "owner:me",
@@ -27,7 +39,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 		user: MockMenu,
 		provider: MockMenu,
 		model: MockMenu,
-		client: MockMenu,
+		client: MockClientMenu as unknown as typeof MockMenu,
 	},
 });
 

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.stories.tsx
@@ -27,6 +27,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 		user: MockMenu,
 		provider: MockMenu,
 		model: MockMenu,
+		client: MockMenu,
 	},
 });
 

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -220,28 +220,6 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 								<TooltipTrigger asChild>
 									<Badge className="gap-1.5 max-w-full">
 										<div className="flex-shrink-0 flex items-center">
-											<AIBridgeClientIcon
-												client={interception.client}
-												className="size-icon-xs"
-											/>
-										</div>
-										<span className="truncate min-w-0">
-											{interception.client ?? "Unknown"}
-										</span>
-									</Badge>
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>{interception.client}</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-				</TableCell>
-				<TableCell className="w-40 max-w-40">
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="min-w-0 overflow-hidden">
-									<Badge className="gap-1.5 max-w-full">
-										<div className="flex-shrink-0 flex items-center">
 											<AIBridgeModelIcon
 												model={interception.model}
 												className="size-icon-xs"

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -220,6 +220,28 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 								<TooltipTrigger asChild>
 									<Badge className="gap-1.5 max-w-full">
 										<div className="flex-shrink-0 flex items-center">
+											<AIBridgeClientIcon
+												client={interception.client}
+												className="size-icon-xs"
+											/>
+										</div>
+										<span className="truncate min-w-0">
+											{interception.client}
+										</span>
+									</Badge>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent>{interception.client}</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</TableCell>
+				<TableCell className="w-40 max-w-40">
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div className="min-w-0 overflow-hidden">
+									<Badge className="gap-1.5 max-w-full">
+										<div className="flex-shrink-0 flex items-center">
 											<AIBridgeModelIcon
 												model={interception.model}
 												className="size-icon-xs"

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -226,7 +226,7 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 											/>
 										</div>
 										<span className="truncate min-w-0">
-											{interception.client}
+											{interception.client ?? "Unknown"}
 										</span>
 									</Badge>
 								</div>


### PR DESCRIPTION
Adds a new `/aibridge/clients` GET endpoint to list AI Bridge clients with filtering and pagination support.

- Added `GET /aibridge/clients` endpoint with authentication and pagination
- Implemented `ListAIBridgeClients` query with authorization support and prefix-based client filtering
- Added client filter component with search functionality to the Request Logs page
- Updated filter parsing to handle quoted values containing spaces
