### PR TITLE
fix: remove mui components from `<TagInput/>`

### DIFF
--- a/site/src/components/TagInput/TagInput.tsx
+++ b/site/src/components/TagInput/TagInput.tsx
@@ -1,5 +1,6 @@
-import Chip from "@mui/material/Chip";
-import FormHelperText from "@mui/material/FormHelperText";
+import { Badge } from "components/Badge/Badge";
+import { Button } from "components/Button/Button";
+import { X } from "lucide-react";
 import { type FC, useId, useMemo } from "react";
 
 type TagInputProps = {
@@ -31,15 +32,20 @@ export const TagInput: FC<TagInputProps> = ({
 				focus-within:border-content-link focus-within:border-2 focus-within:-top-px focus-within:-left-px"
 			>
 				{values.map((value, index) => (
-					<Chip
-						key={itemIds[index]}
-						className="rounded-md bg-surface-secondary text-content-secondary h-7"
-						label={value}
-						size="small"
-						onDelete={() => {
-							onChange(values.filter((oldValue) => oldValue !== value));
-						}}
-					/>
+					<Badge key={itemIds[index]} size="sm" className="gap-1 pr-1">
+						{value}
+						<Button
+							type="button"
+							variant="subtle"
+							className="p-0 min-w-0 h-auto [&_svg]:pr-0 rounded-full"
+							onClick={() => {
+								onChange(values.filter((oldValue) => oldValue !== value));
+							}}
+							aria-label={`Remove ${value}`}
+						>
+							<X className="size-3" />
+						</Button>
+					</Badge>
 				))}
 				<input
 					id={id}
@@ -76,9 +82,9 @@ export const TagInput: FC<TagInputProps> = ({
 				/>
 			</label>
 
-			<FormHelperText className="text-content-secondary text-xs">
+			<p className="text-content-secondary text-xs mt-1 mx-3.5">
 				{'Type "," to separate the values'}
-			</FormHelperText>
+			</p>
 		</div>
 	);
 };

--- a/site/src/components/TagInput/TagInput.tsx
+++ b/site/src/components/TagInput/TagInput.tsx
@@ -27,12 +27,12 @@ export const TagInput: FC<TagInputProps> = ({
 
 	return (
 		<div>
-			<label
+			<div
 				className="flex flex-wrap min-h-10 px-1.5 py-1.5 gap-2 border border-border border-solid relative rounded-md
 				focus-within:border-content-link focus-within:border-2 focus-within:-top-px focus-within:-left-px"
 			>
 				{values.map((value, index) => (
-					<Badge key={itemIds[index]} size="sm" className="gap-1 pr-1">
+					<Badge key={itemIds[index]} size="md" className="gap-1 pr-1">
 						{value}
 						<Button
 							type="button"
@@ -80,9 +80,9 @@ export const TagInput: FC<TagInputProps> = ({
 						}
 					}}
 				/>
-			</label>
+			</div>
 
-			<p className="text-content-secondary text-xs mt-1 mx-3.5">
+			<p className="text-content-secondary text-xs mt-1">
 				{'Type "," to separate the values'}
 			</p>
 		</div>

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.jest.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.jest.tsx
@@ -444,10 +444,8 @@ describe("DynamicParameter", () => {
 				/>,
 			);
 
-			const deleteButtons = screen.getAllByTestId("CancelIcon");
-			await waitFor(async () => {
-				await userEvent.click(deleteButtons[0]);
-			});
+			const deleteButton = screen.getByRole("button", { name: "Remove tag1" });
+			await userEvent.click(deleteButton);
 
 			expect(mockOnChange).toHaveBeenCalledWith('["tag2"]');
 		});

--- a/site/src/theme/mui.ts
+++ b/site/src/theme/mui.ts
@@ -93,13 +93,6 @@ export const components = {
 			},
 		},
 	},
-	MuiChip: {
-		styleOverrides: {
-			root: {
-				backgroundColor: tw.zinc[600],
-			},
-		},
-	},
 	MuiMenu: {
 		defaultProps: {
 			anchorOrigin: {

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -137,7 +137,6 @@ export default defineConfig({
 			"@mui/material/CardActionArea",
 			"@mui/material/CardContent",
 			"@mui/material/Checkbox",
-			"@mui/material/Chip",
 			"@mui/material/CircularProgress",
 			"@mui/material/Collapse",
 			"@mui/material/CssBaseline",


### PR DESCRIPTION
This pull-request removes the last instance of `@mui/material/Chip` from the codebase. And removes it from our `vite.config.mts` so we no longer have to cache it 🙂 