### PR TITLE
feat(site): add browser-based AI coding agent for template editor

### DIFF
--- a/coderd/aibridge/aibridge.go
+++ b/coderd/aibridge/aibridge.go
@@ -4,6 +4,8 @@ package aibridge
 import (
 	"net/http"
 	"strings"
+
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // HeaderCoderAuth is an internal header used to pass the Coder token
@@ -11,23 +13,31 @@ import (
 // by AI Bridge before forwarding requests to upstream providers.
 const HeaderCoderAuth = "X-Coder-Token"
 
-// ExtractAuthToken extracts an authorization token from HTTP headers.
-// It checks X-Coder-Token first (set by AI Proxy), then falls back
-// to Authorization header (Bearer token) and X-Api-Key header, which represent
-// the different ways clients authenticate against AI providers.
-// If none are present, an empty string is returned.
-func ExtractAuthToken(header http.Header) string {
-	if token := strings.TrimSpace(header.Get(HeaderCoderAuth)); token != "" {
+// ExtractAuthToken extracts an authorization token from an HTTP request.
+// It checks X-Coder-Token first (set by AI Proxy), then falls back to
+// Authorization (Bearer token), X-Api-Key, Coder-Session-Token header, and
+// coder_session_token cookie, in that order. If none are present, an empty
+// string is returned.
+func ExtractAuthToken(r *http.Request) string {
+	if token := strings.TrimSpace(r.Header.Get(HeaderCoderAuth)); token != "" {
 		return token
 	}
-	if auth := strings.TrimSpace(header.Get("Authorization")); auth != "" {
+	if auth := strings.TrimSpace(r.Header.Get("Authorization")); auth != "" {
 		fields := strings.Fields(auth)
 		if len(fields) == 2 && strings.EqualFold(fields[0], "Bearer") {
 			return fields[1]
 		}
 	}
-	if apiKey := strings.TrimSpace(header.Get("X-Api-Key")); apiKey != "" {
+	if apiKey := strings.TrimSpace(r.Header.Get("X-Api-Key")); apiKey != "" {
 		return apiKey
+	}
+	if sessionToken := strings.TrimSpace(r.Header.Get(codersdk.SessionTokenHeader)); sessionToken != "" {
+		return sessionToken
+	}
+	if cookie, err := r.Cookie(codersdk.SessionTokenCookie); err == nil {
+		if sessionToken := strings.TrimSpace(cookie.Value); sessionToken != "" {
+			return sessionToken
+		}
 	}
 	return ""
 }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15158,7 +15158,6 @@ const docTemplate = `{
                 "oauth2",
                 "agents",
                 "mcp-server-http",
-                "workspace-sharing",
                 "ai-template-editor"
             ],
             "x-enum-comments": {
@@ -15170,7 +15169,6 @@ const docTemplate = `{
                 "ExperimentNotifications": "Sends notifications via SMTP and webhooks following certain events.",
                 "ExperimentOAuth2": "Enables OAuth2 provider functionality.",
                 "ExperimentWebPush": "Enables web push notifications through the browser.",
-                "ExperimentWorkspaceSharing": "Enables updating workspace ACLs for sharing with users and groups.",
                 "ExperimentWorkspaceUsage": "Enables the new workspace usage tracking."
             },
             "x-enum-descriptions": [
@@ -15182,7 +15180,6 @@ const docTemplate = `{
                 "Enables OAuth2 provider functionality.",
                 "Enables agent-powered chat functionality.",
                 "Enables the MCP HTTP server functionality.",
-                "Enables updating workspace ACLs for sharing with users and groups.",
                 "Enables the AI assistant in the template editor."
             ],
             "x-enum-varnames": [
@@ -15194,7 +15191,6 @@ const docTemplate = `{
                 "ExperimentOAuth2",
                 "ExperimentAgents",
                 "ExperimentMCPServerHTTP",
-                "ExperimentWorkspaceSharing",
                 "ExperimentAITemplateEditor"
             ]
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15157,9 +15157,12 @@ const docTemplate = `{
                 "web-push",
                 "oauth2",
                 "agents",
-                "mcp-server-http"
+                "mcp-server-http",
+                "workspace-sharing",
+                "ai-template-editor"
             ],
             "x-enum-comments": {
+                "ExperimentAITemplateEditor": "Enables the AI assistant in the template editor.",
                 "ExperimentAgents": "Enables agent-powered chat functionality.",
                 "ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
                 "ExperimentExample": "This isn't used for anything.",
@@ -15167,6 +15170,7 @@ const docTemplate = `{
                 "ExperimentNotifications": "Sends notifications via SMTP and webhooks following certain events.",
                 "ExperimentOAuth2": "Enables OAuth2 provider functionality.",
                 "ExperimentWebPush": "Enables web push notifications through the browser.",
+                "ExperimentWorkspaceSharing": "Enables updating workspace ACLs for sharing with users and groups.",
                 "ExperimentWorkspaceUsage": "Enables the new workspace usage tracking."
             },
             "x-enum-descriptions": [
@@ -15177,7 +15181,9 @@ const docTemplate = `{
                 "Enables web push notifications through the browser.",
                 "Enables OAuth2 provider functionality.",
                 "Enables agent-powered chat functionality.",
-                "Enables the MCP HTTP server functionality."
+                "Enables the MCP HTTP server functionality.",
+                "Enables updating workspace ACLs for sharing with users and groups.",
+                "Enables the AI assistant in the template editor."
             ],
             "x-enum-varnames": [
                 "ExperimentExample",
@@ -15187,7 +15193,9 @@ const docTemplate = `{
                 "ExperimentWebPush",
                 "ExperimentOAuth2",
                 "ExperimentAgents",
-                "ExperimentMCPServerHTTP"
+                "ExperimentMCPServerHTTP",
+                "ExperimentWorkspaceSharing",
+                "ExperimentAITemplateEditor"
             ]
         },
         "codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13680,9 +13680,12 @@
 				"web-push",
 				"oauth2",
 				"agents",
-				"mcp-server-http"
+				"mcp-server-http",
+				"workspace-sharing",
+				"ai-template-editor"
 			],
 			"x-enum-comments": {
+				"ExperimentAITemplateEditor": "Enables the AI assistant in the template editor.",
 				"ExperimentAgents": "Enables agent-powered chat functionality.",
 				"ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
 				"ExperimentExample": "This isn't used for anything.",
@@ -13690,6 +13693,7 @@
 				"ExperimentNotifications": "Sends notifications via SMTP and webhooks following certain events.",
 				"ExperimentOAuth2": "Enables OAuth2 provider functionality.",
 				"ExperimentWebPush": "Enables web push notifications through the browser.",
+				"ExperimentWorkspaceSharing": "Enables updating workspace ACLs for sharing with users and groups.",
 				"ExperimentWorkspaceUsage": "Enables the new workspace usage tracking."
 			},
 			"x-enum-descriptions": [
@@ -13700,7 +13704,9 @@
 				"Enables web push notifications through the browser.",
 				"Enables OAuth2 provider functionality.",
 				"Enables agent-powered chat functionality.",
-				"Enables the MCP HTTP server functionality."
+				"Enables the MCP HTTP server functionality.",
+				"Enables updating workspace ACLs for sharing with users and groups.",
+				"Enables the AI assistant in the template editor."
 			],
 			"x-enum-varnames": [
 				"ExperimentExample",
@@ -13710,7 +13716,9 @@
 				"ExperimentWebPush",
 				"ExperimentOAuth2",
 				"ExperimentAgents",
-				"ExperimentMCPServerHTTP"
+				"ExperimentMCPServerHTTP",
+				"ExperimentWorkspaceSharing",
+				"ExperimentAITemplateEditor"
 			]
 		},
 		"codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13681,7 +13681,6 @@
 				"oauth2",
 				"agents",
 				"mcp-server-http",
-				"workspace-sharing",
 				"ai-template-editor"
 			],
 			"x-enum-comments": {
@@ -13693,7 +13692,6 @@
 				"ExperimentNotifications": "Sends notifications via SMTP and webhooks following certain events.",
 				"ExperimentOAuth2": "Enables OAuth2 provider functionality.",
 				"ExperimentWebPush": "Enables web push notifications through the browser.",
-				"ExperimentWorkspaceSharing": "Enables updating workspace ACLs for sharing with users and groups.",
 				"ExperimentWorkspaceUsage": "Enables the new workspace usage tracking."
 			},
 			"x-enum-descriptions": [
@@ -13705,7 +13703,6 @@
 				"Enables OAuth2 provider functionality.",
 				"Enables agent-powered chat functionality.",
 				"Enables the MCP HTTP server functionality.",
-				"Enables updating workspace ACLs for sharing with users and groups.",
 				"Enables the AI assistant in the template editor."
 			],
 			"x-enum-varnames": [
@@ -13717,7 +13714,6 @@
 				"ExperimentOAuth2",
 				"ExperimentAgents",
 				"ExperimentMCPServerHTTP",
-				"ExperimentWorkspaceSharing",
 				"ExperimentAITemplateEditor"
 			]
 		},

--- a/coderd/httpmw/ratelimit.go
+++ b/coderd/httpmw/ratelimit.go
@@ -98,8 +98,9 @@ func RateLimit(count int, window time.Duration) func(http.Handler) http.Handler 
 // authentication token in the request.
 //
 // This differs from [RateLimit] in several ways:
-//   - It extracts the token directly from request headers (Authorization Bearer
-//     or X-Api-Key) rather than from the request context, making it suitable for
+//   - It extracts the token directly from the request using
+//     [aibridge.ExtractAuthToken] rather than from the request context, making it
+//     suitable for
 //     endpoints that handle authentication internally (like AI Bridge) rather than
 //     via [ExtractAPIKeyMW] middleware.
 //   - It does not support the bypass header for Owners.
@@ -119,9 +120,9 @@ func RateLimitByAuthToken(count int, window time.Duration) func(http.Handler) ht
 		count,
 		window,
 		httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
-			// Try to extract auth token for per-user rate limiting using
-			// AI provider authentication headers (Authorization Bearer or X-Api-Key).
-			if token := aibridge.ExtractAuthToken(r.Header); token != "" {
+			// Try to extract an auth token for per-user rate limiting.
+			// This uses aibridge.ExtractAuthToken's priority order.
+			if token := aibridge.ExtractAuthToken(r); token != "" {
 				return token, nil
 			}
 			// Fall back to IP-based rate limiting if no token present.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4301,6 +4301,8 @@ const (
 	ExperimentOAuth2             Experiment = "oauth2"               // Enables OAuth2 provider functionality.
 	ExperimentAgents             Experiment = "agents"               // Enables agent-powered chat functionality.
 	ExperimentMCPServerHTTP      Experiment = "mcp-server-http"      // Enables the MCP HTTP server functionality.
+	ExperimentWorkspaceSharing   Experiment = "workspace-sharing"    // Enables updating workspace ACLs for sharing with users and groups.
+	ExperimentAITemplateEditor   Experiment = "ai-template-editor"   // Enables the AI assistant in the template editor.
 )
 
 func (e Experiment) DisplayName() string {
@@ -4321,6 +4323,10 @@ func (e Experiment) DisplayName() string {
 		return "Agents"
 	case ExperimentMCPServerHTTP:
 		return "MCP HTTP Server Functionality"
+	case ExperimentWorkspaceSharing:
+		return "Workspace Sharing"
+	case ExperimentAITemplateEditor:
+		return "AI Template Editor"
 	default:
 		// Split on hyphen and convert to title case
 		// e.g. "web-push" -> "Web Push", "mcp-server-http" -> "Mcp Server Http"
@@ -4339,6 +4345,8 @@ var ExperimentsKnown = Experiments{
 	ExperimentOAuth2,
 	ExperimentAgents,
 	ExperimentMCPServerHTTP,
+	ExperimentWorkspaceSharing,
+	ExperimentAITemplateEditor,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4301,7 +4301,6 @@ const (
 	ExperimentOAuth2             Experiment = "oauth2"               // Enables OAuth2 provider functionality.
 	ExperimentAgents             Experiment = "agents"               // Enables agent-powered chat functionality.
 	ExperimentMCPServerHTTP      Experiment = "mcp-server-http"      // Enables the MCP HTTP server functionality.
-	ExperimentWorkspaceSharing   Experiment = "workspace-sharing"    // Enables updating workspace ACLs for sharing with users and groups.
 	ExperimentAITemplateEditor   Experiment = "ai-template-editor"   // Enables the AI assistant in the template editor.
 )
 
@@ -4323,8 +4322,6 @@ func (e Experiment) DisplayName() string {
 		return "Agents"
 	case ExperimentMCPServerHTTP:
 		return "MCP HTTP Server Functionality"
-	case ExperimentWorkspaceSharing:
-		return "Workspace Sharing"
 	case ExperimentAITemplateEditor:
 		return "AI Template Editor"
 	default:
@@ -4345,7 +4342,6 @@ var ExperimentsKnown = Experiments{
 	ExperimentOAuth2,
 	ExperimentAgents,
 	ExperimentMCPServerHTTP,
-	ExperimentWorkspaceSharing,
 	ExperimentAITemplateEditor,
 }
 

--- a/docs/admin/templates/managing-templates/index.md
+++ b/docs/admin/templates/managing-templates/index.md
@@ -46,6 +46,13 @@ any template's files directly in the Coder dashboard.
 If you'd prefer to use the CLI, use `coder templates pull`, edit the template
 files, then `coder templates push`.
 
+When [AI Bridge](../../../ai-coder/ai-bridge/index.md) is configured and the
+`ai-template-editor` experiment is enabled, an AI coding assistant is available
+in the template editor. It can read, edit, and delete files, run validation
+builds, and publish new versions — all from a chat panel in the editor. See
+[Template Editor AI Assistant](../../../ai-coder/ai-bridge/clients/template-editor.md)
+for details.
+
 > [!TIP]
 > Even if you are a Terraform expert, we suggest reading our
 > [guided tour of a template](../../../tutorials/template-from-scratch.md).

--- a/docs/ai-coder/ai-bridge/clients/template-editor.md
+++ b/docs/ai-coder/ai-bridge/clients/template-editor.md
@@ -1,0 +1,57 @@
+# Template Editor AI Assistant
+
+The template editor includes a built-in AI coding assistant that can read, edit,
+and delete files directly within the browser-based template version editor. It
+uses [AI Bridge](../index.md) to route requests to your configured model
+provider.
+
+> [!NOTE]
+> This feature requires a [Premium license](https://coder.com/pricing).
+
+## Prerequisites
+
+- [AI Bridge](../setup.md) is enabled and configured with at least one provider.
+- The `ai-template-editor` [experiment](../../../admin/setup/index.md#experiments)
+  is enabled on your Coder deployment.
+
+## How to use
+
+1. Navigate to any template and click **Edit** to open the template version
+   editor.
+1. Click the **sparkle (✨) button** in the editor toolbar to open the AI
+   assistant panel.
+1. Type a prompt describing the changes you want (for example, _"Add a
+   Docker sidecar for Postgres"_).
+1. The assistant proposes file edits that require your explicit approval before
+   they are applied. You can approve or reject each change individually.
+1. After approving edits you can ask the assistant to **build** the template to
+   validate the Terraform configuration, and then **publish** a new version —
+   all from within the chat.
+
+## Capabilities
+
+| Action                  | Description                                                                                              |
+|-------------------------|----------------------------------------------------------------------------------------------------------|
+| **Read files**          | The assistant can read any file in the template's file tree.                                             |
+| **Edit / create files** | Proposes diffs that you approve before they are applied.                                                 |
+| **Delete files**        | Proposes file deletions that you approve before they are applied.                                        |
+| **Build template**      | Triggers a dry-run provisioner build to validate Terraform.                                              |
+| **Publish version**     | Promotes the current editor state to a new template version.                                             |
+| **Registry lookup**     | Queries the [Coder Registry](https://registry.coder.com) for modules and examples via MCP (best-effort). |
+
+## Model selection
+
+The assistant automatically selects a chat-capable model from your AI Bridge
+configuration. If multiple models are available, you can switch between them
+using the model selector at the top of the chat panel.
+
+## Limitations
+
+- Chat history is **ephemeral** — it is not persisted across page reloads or
+  browser sessions.
+- The assistant operates only on the files visible in the template version
+  editor. It cannot access files outside the template or run arbitrary commands
+  in a workspace.
+- Registry tool availability depends on network connectivity to
+  `registry.coder.com`. If the connection fails, the assistant continues to
+  work with local file operations and displays a warning banner.

--- a/docs/ai-coder/ai-bridge/clients/template-editor.md
+++ b/docs/ai-coder/ai-bridge/clients/template-editor.md
@@ -11,7 +11,7 @@ provider.
 ## Prerequisites
 
 - [AI Bridge](../setup.md) is enabled and configured with at least one provider.
-- The `ai-template-editor` [experiment](../../../admin/setup/index.md#experiments)
+- The `ai-template-editor` [experiment](../../../install/releases/feature-stages.md#early-access-features)
   is enabled on your Coder deployment.
 
 ## How to use

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1082,6 +1082,11 @@
 									"path": "./ai-coder/ai-bridge/clients/index.md",
 									"children": [
 										{
+											"title": "Template Editor",
+											"description": "Built-in AI assistant in the template version editor",
+											"path": "./ai-coder/ai-bridge/clients/template-editor.md"
+										},
+										{
 											"title": "Claude Code",
 											"description": "Configure Claude Code to use AI Bridge",
 											"path": "./ai-coder/ai-bridge/clients/claude-code.md"

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3996,9 +3996,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                 |
-|--------------------------------------------------------------------------------------------------------------------------|
-| `agents`, `auto-fill-parameters`, `example`, `mcp-server-http`, `notifications`, `oauth2`, `web-push`, `workspace-usage` |
+| Value(s)                                                                                                                                                            |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agents`, `ai-template-editor`, `auto-fill-parameters`, `example`, `mcp-server-http`, `notifications`, `oauth2`, `web-push`, `workspace-sharing`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3996,9 +3996,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                                                            |
-|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agents`, `ai-template-editor`, `auto-fill-parameters`, `example`, `mcp-server-http`, `notifications`, `oauth2`, `web-push`, `workspace-sharing`, `workspace-usage` |
+| Value(s)                                                                                                                                       |
+|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agents`, `ai-template-editor`, `auto-fill-parameters`, `example`, `mcp-server-http`, `notifications`, `oauth2`, `web-push`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/enterprise/aibridged/aibridged_test.go
+++ b/enterprise/aibridged/aibridged_test.go
@@ -92,7 +92,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 		{
 			name: "unrecognized header",
 			reqHeaders: map[string]string{
-				codersdk.SessionTokenHeader: "key", // Coder-Session-Token is not supported; requests originate with AI clients, not coder CLI.
+				"X-Unrecognized-Header": "key", // Unrecognized headers should be ignored for auth extraction.
 			},
 			applyMocksFn:   func(client *mock.MockDRPCClient, _ *mock.MockPooler) {},
 			expectedErr:    aibridged.ErrNoAuthKey,
@@ -174,7 +174,7 @@ func TestServeHTTP_FailureModes(t *testing.T) {
 	}
 }
 
-func TestServeHTTP_CoderTokenRemoved(t *testing.T) {
+func TestServeHTTPStripsCoderTokenHeader(t *testing.T) {
 	t.Parallel()
 
 	mockHandler := &mockHandler{}
@@ -192,9 +192,13 @@ func TestServeHTTP_CoderTokenRemoved(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, httpSrv.URL+"/openai/v1/chat/completions", nil)
 	require.NoError(t, err)
 
-	// X-Coder-Token is used for authentication and should be stripped.
+	// Coder auth credentials are used for authentication and should be stripped.
 	// Other authorization headers should be preserved.
 	req.Header.Set(agplaibridge.HeaderCoderAuth, "coder-token")
+	req.Header.Set(codersdk.SessionTokenHeader, "session-key")
+	req.AddCookie(&http.Cookie{Name: codersdk.SessionTokenCookie, Value: "session-cookie"})
+	// Also add a non-auth cookie that should still be stripped.
+	req.AddCookie(&http.Cookie{Name: "_csrf", Value: "csrf-token"})
 	req.Header.Set("Authorization", "Bearer some-token")
 	req.Header.Set("X-Api-Key", "some-api-key")
 
@@ -204,10 +208,16 @@ func TestServeHTTP_CoderTokenRemoved(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// Verify X-Coder-Token was removed before forwarding to handler.
+	// Verify Coder auth headers were removed before forwarding to handler.
 	require.NotNil(t, mockHandler.headersReceived)
 	require.Empty(t, mockHandler.headersReceived.Get(agplaibridge.HeaderCoderAuth),
 		"X-Coder-Token should be removed before forwarding to handler")
+	require.Empty(t, mockHandler.headersReceived.Get(codersdk.SessionTokenHeader),
+		"Coder-Session-Token should be removed before forwarding to handler")
+
+	// Verify all cookies were stripped.
+	require.Empty(t, mockHandler.cookiesReceived,
+		"all cookies should be removed before forwarding to handler")
 
 	// Verify other headers were preserved.
 	require.Equal(t, "Bearer some-token", mockHandler.headersReceived.Get("Authorization"))
@@ -220,6 +230,7 @@ func TestExtractAuthToken(t *testing.T) {
 	cases := []struct {
 		name        string
 		headers     map[string]string
+		cookies     []*http.Cookie
 		expectedKey string
 	}{
 		{
@@ -285,17 +296,64 @@ func TestExtractAuthToken(t *testing.T) {
 			headers:     map[string]string{"X-Api-Key": "key"},
 			expectedKey: "key",
 		},
+		{
+			name:    "coder-session-token-header/empty",
+			headers: map[string]string{codersdk.SessionTokenHeader: ""},
+		},
+		{
+			name:        "coder-session-token-header/ok",
+			headers:     map[string]string{codersdk.SessionTokenHeader: "session-key"},
+			expectedKey: "session-key",
+		},
+		{
+			name: "coder-session-token-header/priority over cookie",
+			headers: map[string]string{
+				codersdk.SessionTokenHeader: "session-key",
+			},
+			cookies: []*http.Cookie{{
+				Name:  codersdk.SessionTokenCookie,
+				Value: "cookie-key",
+			}},
+			expectedKey: "session-key",
+		},
+		{
+			name: "session-cookie/empty",
+			cookies: []*http.Cookie{{
+				Name:  codersdk.SessionTokenCookie,
+				Value: "",
+			}},
+		},
+		{
+			name: "session-cookie/ok",
+			cookies: []*http.Cookie{{
+				Name:  codersdk.SessionTokenCookie,
+				Value: "cookie-key",
+			}},
+			expectedKey: "cookie-key",
+		},
+		{
+			name: "x-api-key/priority over session-header",
+			headers: map[string]string{
+				"X-Api-Key":                 "api-key",
+				codersdk.SessionTokenHeader: "session-key",
+			},
+			expectedKey: "api-key",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			headers := make(http.Header, len(tc.headers))
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
 			for k, v := range tc.headers {
-				headers.Add(k, v)
+				r.Header.Add(k, v)
 			}
-			key := agplaibridge.ExtractAuthToken(headers)
+			for _, c := range tc.cookies {
+				r.AddCookie(c)
+			}
+
+			key := agplaibridge.ExtractAuthToken(r)
 			require.Equal(t, tc.expectedKey, key)
 		})
 	}
@@ -305,10 +363,12 @@ var _ http.Handler = &mockHandler{}
 
 type mockHandler struct {
 	headersReceived http.Header
+	cookiesReceived []*http.Cookie
 }
 
 func (h *mockHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	h.headersReceived = r.Header.Clone()
+	h.cookiesReceived = r.Cookies()
 	rw.WriteHeader(http.StatusOK)
 	_, _ = rw.Write([]byte(r.URL.Path))
 }

--- a/enterprise/aibridged/http.go
+++ b/enterprise/aibridged/http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coder/aibridge"
 	"github.com/coder/aibridge/recorder"
 	agplaibridge "github.com/coder/coder/v2/coderd/aibridge"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/aibridged/proto"
 )
 
@@ -37,15 +38,20 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	logger := s.logger.With(slog.F("path", r.URL.Path))
 
-	key := strings.TrimSpace(agplaibridge.ExtractAuthToken(r.Header))
+	key := strings.TrimSpace(agplaibridge.ExtractAuthToken(r))
 	if key == "" {
 		logger.Warn(ctx, "no auth key provided")
 		http.Error(rw, ErrNoAuthKey.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// Remove the Coder token header so it's not forwarded to upstream providers.
+	// Strip Coder auth data so it is not forwarded upstream: X-Coder-Token,
+	// Coder-Session-Token, X-CSRF-TOKEN, and all cookies (including browser
+	// session/CSRF cookies).
 	r.Header.Del(agplaibridge.HeaderCoderAuth)
+	r.Header.Del(codersdk.SessionTokenHeader)
+	r.Header.Del("X-CSRF-TOKEN")
+	r.Header.Del("Cookie")
 
 	client, err := s.Client()
 	if err != nil {

--- a/flake.nix
+++ b/flake.nix
@@ -221,7 +221,13 @@
             zsh
             zstd
           ]
-          ++ frontendPackages;
+          ++ frontendPackages
+          # Go 1.25+ uses SecTrustCopyCertificateChain which requires
+          # macOS 12+ SDK. The default stdenv ships SDK 11.x. Use
+          # unstablePkgs to match the SDK that Go 1.25 depends on.
+          ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            unstablePkgs.apple-sdk_12
+          ]);
 
         docker = pkgs.callPackage ./nix/docker.nix { };
 

--- a/site/package.json
+++ b/site/package.json
@@ -35,6 +35,8 @@
 		"update-emojis": "cp -rf ./node_modules/emoji-datasource-apple/img/apple/64/* ./static/emojis && cp -f ./node_modules/emoji-datasource-apple/img/apple/sheets-256/64.png ./static/emojis/spritesheet.png"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.46",
+		"@ai-sdk/openai": "^3.0.30",
 		"@emoji-mart/data": "1.2.1",
 		"@emoji-mart/react": "1.1.1",
 		"@emotion/cache": "11.14.0",
@@ -76,6 +78,7 @@
 		"@xterm/addon-web-links": "0.11.0",
 		"@xterm/addon-webgl": "0.18.0",
 		"@xterm/xterm": "5.5.0",
+		"ai": "^6.0.97",
 		"ansi-to-html": "0.7.2",
 		"axios": "1.13.2",
 		"chroma-js": "2.6.0",
@@ -127,7 +130,8 @@
 		"unique-names-generator": "4.7.1",
 		"uuid": "9.0.1",
 		"websocket-ts": "2.2.1",
-		"yup": "1.7.1"
+		"yup": "1.7.1",
+		"zod": "^3.25.76"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.4",

--- a/site/package.json
+++ b/site/package.json
@@ -36,6 +36,7 @@
 	},
 	"dependencies": {
 		"@ai-sdk/anthropic": "^3.0.46",
+		"@ai-sdk/mcp": "^1.0.25",
 		"@ai-sdk/openai": "^3.0.30",
 		"@emoji-mart/data": "1.2.1",
 		"@emoji-mart/react": "1.1.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.46
         version: 3.0.46(zod@3.25.76)
+      '@ai-sdk/mcp':
+        specifier: ^1.0.25
+        version: 1.0.25(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^3.0.30
         version: 3.0.30(zod@3.25.76)
@@ -519,6 +522,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/mcp@1.0.25':
+    resolution: {integrity: sha512-vMlXUPGHGDE2vzLcPR8sw7Dhz2OBjtPU5lB+lIuC1hNQo4REuUC08P0e96/hzBKf4oQYJ8Zo6uP8AG2qThyFbg==, tarball: https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.25.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.30':
     resolution: {integrity: sha512-YDht3t7TDyWKP+JYZp20VuYqSjyF2brHYh47GGFDUPf2wZiqNQ263ecL+quar2bP3GZ3BeQA8f0m2B7UwLPR+g==, tarball: https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.30.tgz}
     engines: {node: '>=18'}
@@ -527,6 +536,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.15':
     resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==, tarball: https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==, tarball: https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -5335,6 +5350,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==, tarball: https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==, tarball: https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz}
+    engines: {node: '>=16.20.0'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==, tarball: https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz}
     engines: {node: '>=8'}
@@ -6746,6 +6765,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/mcp@1.0.25(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      pkce-challenge: 5.0.1
+      zod: 3.25.76
+
   '@ai-sdk/openai@3.0.30(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -6753,6 +6779,13 @@ snapshots:
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
@@ -12346,6 +12379,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.46
+        version: 3.0.46(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^3.0.30
+        version: 3.0.30(zod@3.25.76)
       '@emoji-mart/data':
         specifier: 1.2.1
         version: 1.2.1
@@ -142,6 +148,9 @@ importers:
       '@xterm/xterm':
         specifier: 5.5.0
         version: 5.5.0
+      ai:
+        specifier: ^6.0.97
+        version: 6.0.97(zod@3.25.76)
       ansi-to-html:
         specifier: 0.7.2
         version: 0.7.2
@@ -298,6 +307,9 @@ importers:
       yup:
         specifier: 1.7.1
         version: 1.7.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.4
@@ -481,7 +493,7 @@ importers:
         version: 0.11.0(@biomejs/biome@2.2.4)(eslint@8.52.0)(optionator@0.9.3)(typescript@5.6.3)(vite@7.2.6(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.0))
       vitest:
         specifier: 4.0.14
-        version: 4.0.14(@types/node@20.19.25)(jiti@1.21.7)(jsdom@27.2.0)(msw@2.4.8(typescript@5.6.3))(yaml@2.7.0)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(jiti@1.21.7)(jsdom@27.2.0)(msw@2.4.8(typescript@5.6.3))(yaml@2.7.0)
 
 packages:
 
@@ -494,6 +506,34 @@ packages:
 
   '@adobe/css-tools@4.4.1':
     resolution: {integrity: sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==, tarball: https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.1.tgz}
+
+  '@ai-sdk/anthropic@3.0.46':
+    resolution: {integrity: sha512-zXJPiNHaIiQ6XUqLeSYZ3ZbSzjqt1pNWEUf2hlkXlmmw8IF8KI0ruuGaDwKCExmtuNRf0E4TDxhsc9wRgWTzpw==, tarball: https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.46.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.53':
+    resolution: {integrity: sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q==, tarball: https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.53.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.30':
+    resolution: {integrity: sha512-YDht3t7TDyWKP+JYZp20VuYqSjyF2brHYh47GGFDUPf2wZiqNQ263ecL+quar2bP3GZ3BeQA8f0m2B7UwLPR+g==, tarball: https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.30.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.15':
+    resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==, tarball: https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==, tarball: https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==, tarball: https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz}
@@ -1501,6 +1541,10 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==, tarball: https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==, tarball: https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-resolver/binding-android-arm-eabi@11.14.0':
     resolution: {integrity: sha512-jB47iZ/thvhE+USCLv+XY3IknBbkKr/p7OBsQDTHode/GPw+OHRlit3NQ1bjt1Mj8V2CS7iHdSDYobZ1/0gagQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.14.0.tgz}
     cpu: [arm]
@@ -2309,6 +2353,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==, tarball: https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==, tarball: https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz}
+
   '@storybook/addon-docs@10.2.10':
     resolution: {integrity: sha512-2wIYtdvZIzPbQ5194M5Igpy8faNbQ135nuO5ZaZ2VuttqGr+IJcGnDP42zYwbAsGs28G8ohpkbSgIzVyJWUhPQ==, tarball: https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.2.10.tgz}
     peerDependencies:
@@ -2806,6 +2853,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==, tarball: https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==, tarball: https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@5.1.1':
     resolution: {integrity: sha512-WQfkSw0QbQ5aJ2CHYw23ZGkqnRwqKHD/KYsMeTkZzPT4Jcf0DcBxBtwMJxnu6E7oxw5+JC6ZAiePgh28uJ1HBA==, tarball: https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.1.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2918,6 +2969,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==, tarball: https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz}
     engines: {node: '>= 14'}
+
+  ai@6.0.97:
+    resolution: {integrity: sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==, tarball: https://registry.npmjs.org/ai/-/ai-6.0.97.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==, tarball: https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz}
@@ -3780,6 +3837,10 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==, tarball: https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==, tarball: https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==, tarball: https://registry.npmjs.org/execa/-/execa-5.1.1.tgz}
@@ -4644,6 +4705,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==, tarball: https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==, tarball: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz}
@@ -6651,6 +6715,9 @@ packages:
   yup@1.7.1:
     resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==, tarball: https://registry.npmjs.org/yup/-/yup-1.7.1.tgz}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==, tarball: https://registry.npmjs.org/zod/-/zod-3.25.76.tgz}
+
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==, tarball: https://registry.npmjs.org/zod/-/zod-4.1.13.tgz}
 
@@ -6665,6 +6732,36 @@ snapshots:
   '@acemir/cssom@0.9.24': {}
 
   '@adobe/css-tools@4.4.1': {}
+
+  '@ai-sdk/anthropic@3.0.46(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.53(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/openai@3.0.30(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7886,6 +7983,8 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@oxc-resolver/binding-android-arm-eabi@11.14.0':
     optional: true
 
@@ -8630,6 +8729,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@storybook/addon-docs@10.2.10(@types/react@19.2.7)(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.2.10(@testing-library/dom@10.4.0)(prettier@3.4.1)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(vite@7.2.6(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.2)
@@ -9157,6 +9258,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitejs/plugin-react@5.1.1(vite@7.2.6(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.28.5
@@ -9285,6 +9388,14 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  ai@6.0.97(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.53(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv@6.12.6:
     dependencies:
@@ -10180,6 +10291,8 @@ snapshots:
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
+
+  eventsource-parser@3.0.6: {}
 
   execa@5.1.1:
     dependencies:
@@ -11401,6 +11514,8 @@ snapshots:
 
   json-schema-traverse@0.4.1:
     optional: true
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1:
     optional: true
@@ -13485,7 +13600,7 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.7.0
 
-  vitest@4.0.14(@types/node@20.19.25)(jiti@1.21.7)(jsdom@27.2.0)(msw@2.4.8(typescript@5.6.3))(yaml@2.7.0):
+  vitest@4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(jiti@1.21.7)(jsdom@27.2.0)(msw@2.4.8(typescript@5.6.3))(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 4.0.14
       '@vitest/mocker': 4.0.14(msw@2.4.8(typescript@5.6.3))(vite@7.2.6(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.0))
@@ -13508,6 +13623,7 @@ snapshots:
       vite: 7.2.6(@types/node@20.19.25)(jiti@1.21.7)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.25
       jsdom: 27.2.0
     transitivePeerDependencies:
@@ -13685,6 +13801,8 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
+
+  zod@3.25.76: {}
 
   zod@4.1.13: {}
 

--- a/site/src/api/queries/aiBridge.ts
+++ b/site/src/api/queries/aiBridge.ts
@@ -2,6 +2,131 @@ import { API } from "api/api";
 import type { AIBridgeListInterceptionsResponse } from "api/typesGenerated";
 import { useFilterParamsKey } from "components/Filter/Filter";
 import type { UsePaginatedQueryOptions } from "hooks/usePaginatedQuery";
+import type { UseQueryOptions } from "react-query";
+
+export type AIBridgeProvider = "openai" | "anthropic";
+
+export interface AIBridgeModel {
+	id: string;
+	provider: AIBridgeProvider;
+}
+
+export type OpenAIReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+export type AnthropicThinking =
+	| { type: "disabled" }
+	| { type: "adaptive" }
+	| { type: "enabled"; budgetTokens: number };
+
+export type AnthropicEffort = "low" | "medium" | "high" | "max";
+
+export interface AIModelConfig {
+	model: AIBridgeModel;
+	reasoningEffort?: OpenAIReasoningEffort;
+	thinking?: AnthropicThinking;
+	anthropicEffort?: AnthropicEffort;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+const parseProviderModels = (
+	body: unknown,
+	provider: AIBridgeProvider,
+): AIBridgeModel[] => {
+	if (!isRecord(body) || !Array.isArray(body.data)) {
+		return [];
+	}
+
+	return body.data.flatMap((model) => {
+		if (!isRecord(model) || typeof model.id !== "string") {
+			return [];
+		}
+		if (model.id.length === 0) {
+			return [];
+		}
+		return [{ id: model.id, provider }];
+	});
+};
+
+const fetchProviderModels = async (
+	path: string,
+	provider: AIBridgeProvider,
+): Promise<AIBridgeModel[]> => {
+	const headers: Record<string, string> = {};
+	if (provider === "anthropic") {
+		// The Anthropic API requires this header on every request,
+		// including model discovery.
+		headers["anthropic-version"] = "2023-06-01";
+	}
+	const response = await API.getAxiosInstance().get(path, {
+		headers,
+		validateStatus: () => true,
+	});
+	if (response.status < 200 || response.status >= 300) {
+		throw new Error(
+			`AI bridge model probe failed for ${provider} (HTTP ${response.status}).`,
+		);
+	}
+	return parseProviderModels(response.data, provider);
+};
+
+const getModelKey = (model: AIBridgeModel): string =>
+	`${model.provider}:${model.id}`;
+
+const MODEL_DISCOVERY_REFRESH_MS = 60_000;
+
+/**
+ * Query options that fetches the list of models available through the
+ * AI bridge. We probe both OpenAI and Anthropic model-list endpoints because
+ * deployments may configure either provider independently.
+ *
+ * Returns an empty array when probes succeed but no models are configured.
+ * Throws when both provider probes fail, allowing react-query to preserve
+ * previous successful data.
+ */
+export const aiBridgeModels = (): UseQueryOptions<AIBridgeModel[]> => ({
+	queryKey: ["aiBridgeModels"],
+	queryFn: async () => {
+		const [openAIProbe, anthropicProbe] = await Promise.allSettled([
+			fetchProviderModels("/api/v2/aibridge/openai/v1/models", "openai"),
+			fetchProviderModels("/api/v2/aibridge/anthropic/v1/models", "anthropic"),
+		]);
+
+		const models = [openAIProbe, anthropicProbe].flatMap((probe) =>
+			probe.status === "fulfilled" ? probe.value : [],
+		);
+
+		// Only throw when both probes failed — this preserves react-query's
+		// previous data while all providers are genuinely unreachable. When at
+		// least one probe succeeded (even returning zero models), return the
+		// result so model availability is reflected accurately.
+		const bothProbesFailed =
+			openAIProbe.status === "rejected" && anthropicProbe.status === "rejected";
+		if (bothProbesFailed) {
+			throw new Error(
+				"Failed to refresh AI bridge model discovery — all provider probes failed.",
+			);
+		}
+
+		const seenModelKeys = new Set<string>();
+		const dedupedModels: AIBridgeModel[] = [];
+		for (const model of models) {
+			const modelKey = getModelKey(model);
+			if (seenModelKeys.has(modelKey)) {
+				continue;
+			}
+			seenModelKeys.add(modelKey);
+			dedupedModels.push(model);
+		}
+		return dedupedModels;
+	},
+	// Revalidate periodically so transient /models probe failures
+	// do not hide the assistant indefinitely.
+	staleTime: MODEL_DISCOVERY_REFRESH_MS,
+	refetchInterval: MODEL_DISCOVERY_REFRESH_MS,
+	refetchOnWindowFocus: true,
+});
 
 export const paginatedInterceptions = (
 	searchParams: URLSearchParams,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2600,7 +2600,6 @@ export type Experiment =
 	| "notifications"
 	| "oauth2"
 	| "web-push"
-	| "workspace-sharing"
 	| "workspace-usage";
 
 export const Experiments: Experiment[] = [
@@ -2612,7 +2611,6 @@ export const Experiments: Experiment[] = [
 	"notifications",
 	"oauth2",
 	"web-push",
-	"workspace-sharing",
 	"workspace-usage",
 ];
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2592,6 +2592,7 @@ export const EntitlementsWarningHeader = "X-Coder-Entitlements-Warning";
 
 // From codersdk/deployment.go
 export type Experiment =
+	| "ai-template-editor"
 	| "agents"
 	| "auto-fill-parameters"
 	| "example"
@@ -2599,9 +2600,11 @@ export type Experiment =
 	| "notifications"
 	| "oauth2"
 	| "web-push"
+	| "workspace-sharing"
 	| "workspace-usage";
 
 export const Experiments: Experiment[] = [
+	"ai-template-editor",
 	"agents",
 	"auto-fill-parameters",
 	"example",
@@ -2609,6 +2612,7 @@ export const Experiments: Experiment[] = [
 	"notifications",
 	"oauth2",
 	"web-push",
+	"workspace-sharing",
 	"workspace-usage",
 ];
 

--- a/site/src/components/Slider/SingleThumbSlider.tsx
+++ b/site/src/components/Slider/SingleThumbSlider.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copied from shadc/ui on 04/16/2025.
+ * @see {@link https://ui.shadcn.com/docs/components/slider}
+ */
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import { cn } from "utils/cn";
+
+export const SingleThumbSlider: React.FC<
+	React.ComponentPropsWithRef<typeof SliderPrimitive.Root>
+> = ({ className, ...props }) => {
+	return (
+		<SliderPrimitive.Root
+			className={cn(
+				"relative flex w-full items-center h-1.5",
+				className,
+				"touch-none select-none",
+			)}
+			{...props}
+		>
+			<SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-surface-secondary data-[disabled]:opacity-40">
+				<SliderPrimitive.Range className="absolute h-full bg-content-primary" />
+			</SliderPrimitive.Track>
+			<SliderPrimitive.Thumb
+				className="block h-4 w-4 rounded-full border border-solid border-surface-invert-secondary bg-surface-primary shadow transition-colors
+			focus-visible:outline-none hover:border-content-primary
+			focus-visible:ring-0 focus-visible:ring-content-primary focus-visible:ring-offset-surface-primary
+			disabled:pointer-events-none data-[disabled]:opacity-100 data-[disabled]:border-border"
+			/>
+		</SliderPrimitive.Root>
+	);
+};

--- a/site/src/modules/templates/TemplateFiles/TemplateFileTree.test.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFileTree.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ThemeOverride } from "contexts/ThemeProvider";
+import type { ComponentProps } from "react";
+import themes, { DEFAULT_THEME } from "theme";
+import type { FileTree } from "utils/filetree";
+import { TemplateFileTree } from "./TemplateFileTree";
+
+const fileTree: FileTree = {
+	"main.tf": "main",
+	"variables.tf": "variables",
+	folder: {
+		"nested.tf": "nested",
+	},
+};
+
+const renderTemplateFileTree = (
+	props: ComponentProps<typeof TemplateFileTree>,
+) => {
+	return render(
+		<ThemeOverride theme={themes[DEFAULT_THEME]}>
+			<TemplateFileTree {...props} />
+		</ThemeOverride>,
+	);
+};
+
+const getTreeItemContent = (label: string) => {
+	const content = screen.getByText(label).closest(".MuiTreeItem-content");
+	expect(content).not.toBeNull();
+	return content as HTMLElement;
+};
+
+describe(TemplateFileTree.name, () => {
+	it("updates the highlighted item when activePath changes", async () => {
+		const onSelect = vi.fn();
+		const { rerender } = renderTemplateFileTree({
+			fileTree,
+			activePath: "main.tf",
+			onSelect,
+		});
+
+		expect(getTreeItemContent("main.tf")).toHaveClass("Mui-selected");
+
+		rerender(
+			<ThemeOverride theme={themes[DEFAULT_THEME]}>
+				<TemplateFileTree
+					fileTree={fileTree}
+					activePath="folder/nested.tf"
+					onSelect={onSelect}
+				/>
+			</ThemeOverride>,
+		);
+
+		await waitFor(() => {
+			expect(getTreeItemContent("nested.tf")).toHaveClass("Mui-selected");
+			expect(getTreeItemContent("nested.tf")).toBeVisible();
+		});
+		expect(getTreeItemContent("main.tf")).not.toHaveClass("Mui-selected");
+	});
+
+	it("keeps manual selection working when activePath is uncontrolled", async () => {
+		const onSelect = vi.fn();
+		renderTemplateFileTree({ fileTree, onSelect });
+
+		const variablesItem = getTreeItemContent("variables.tf");
+		fireEvent.click(variablesItem);
+
+		expect(onSelect).toHaveBeenCalledWith("variables.tf");
+		await waitFor(() => {
+			expect(variablesItem).toHaveClass("Mui-selected");
+		});
+	});
+});

--- a/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFileTree.tsx
@@ -3,7 +3,13 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { SimpleTreeView, TreeItem } from "@mui/x-tree-view";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
-import { type CSSProperties, type FC, type JSX, useState } from "react";
+import {
+	type CSSProperties,
+	type FC,
+	type JSX,
+	useEffect,
+	useState,
+} from "react";
 import type { FileTree } from "utils/filetree";
 import { getTemplateFileIcon } from "./TemplateFileIcon";
 
@@ -45,15 +51,27 @@ interface TemplateFilesTreeProps {
 	}>;
 }
 
-export const TemplateFileTree: FC<TemplateFilesTreeProps> = ({
-	fileTree,
-	activePath,
-	onDelete,
-	onRename,
-	onSelect,
-	Label,
-}) => {
+export const TemplateFileTree: FC<TemplateFilesTreeProps> = (props) => {
+	const { fileTree, activePath, onDelete, onRename, onSelect, Label } = props;
+	const isActivePathControlled = "activePath" in props;
 	const [contextMenu, setContextMenu] = useState<ContextMenu | undefined>();
+	const [expandedItems, setExpandedItems] = useState<string[]>(() =>
+		activePath ? expandablePaths(activePath) : [],
+	);
+
+	useEffect(() => {
+		if (!activePath) {
+			return;
+		}
+
+		setExpandedItems((currentExpandedItems) =>
+			mergeExpandedItems(currentExpandedItems, expandablePaths(activePath)),
+		);
+	}, [activePath]);
+
+	const selectionProps = isActivePathControlled
+		? { selectedItems: activePath }
+		: { defaultSelectedItems: activePath };
 
 	const buildTreeItems = (
 		label: string,
@@ -186,8 +204,11 @@ export const TemplateFileTree: FC<TemplateFilesTreeProps> = ({
 		<SimpleTreeView
 			slots={{ collapseIcon: ChevronDownIcon, expandIcon: ChevronRightIcon }}
 			aria-label="Files"
-			defaultExpandedItems={activePath ? expandablePaths(activePath) : []}
-			defaultSelectedItems={activePath}
+			expandedItems={expandedItems}
+			onExpandedItemsChange={(_event, itemIds) => {
+				setExpandedItems(itemIds);
+			}}
+			{...selectionProps}
 		>
 			{Object.entries(fileTree)
 				.sort(compareFileTreeEntries)
@@ -239,6 +260,18 @@ export const TemplateFileTree: FC<TemplateFilesTreeProps> = ({
 			</Menu>
 		</SimpleTreeView>
 	);
+};
+
+const mergeExpandedItems = (currentPaths: string[], nextPaths: string[]) => {
+	const mergedPaths = [...currentPaths];
+	for (const nextPath of nextPaths) {
+		if (!mergedPaths.includes(nextPath)) {
+			mergedPaths.push(nextPath);
+		}
+	}
+	return mergedPaths.length === currentPaths.length
+		? currentPaths
+		: mergedPaths;
 };
 
 const expandablePaths = (path: string) => {

--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -68,6 +68,33 @@ const STICKY_HEADER_CSS = [
 	"}",
 ].join(" ");
 
+type ParsedContextContent = {
+	type: "context";
+	lines: number;
+	additionLineIndex: number;
+	deletionLineIndex: number;
+};
+
+type ParsedChangeContent = {
+	type: "change";
+	additions: number;
+	deletions: number;
+	additionLineIndex: number;
+	deletionLineIndex: number;
+};
+
+type ParsedHunkMetadata = FileDiffMetadata["hunks"][number] & {
+	additionLineIndex: number;
+	deletionLineIndex: number;
+	hunkContent: Array<ParsedContextContent | ParsedChangeContent>;
+};
+
+type ParsedFileDiffMetadata = FileDiffMetadata & {
+	additionLines: string[];
+	deletionLines: string[];
+	hunks: ParsedHunkMetadata[];
+};
+
 type DiffStyle = "unified" | "split";
 const DIFF_STYLE_KEY = "agents.diff-view-style";
 
@@ -80,7 +107,7 @@ const DIFF_STYLE_KEY = "agents.diff-view-style";
  * in range are included as well.
  */
 function extractDiffContent(
-	parsedFiles: readonly FileDiffMetadata[],
+	parsedFiles: readonly ParsedFileDiffMetadata[],
 	fileName: string,
 	startLine: number,
 	endLine: number,
@@ -98,43 +125,51 @@ function extractDiffContent(
 		for (const block of hunk.hunkContent) {
 			if (block.type === "context") {
 				for (let i = 0; i < block.lines; i++) {
-					const ln = side === "additions" ? addLine : delLine;
-					if (ln >= startLine && ln <= endLine) {
-						const idx =
+					const lineNumber = side === "additions" ? addLine : delLine;
+					if (lineNumber >= startLine && lineNumber <= endLine) {
+						const lineIndex =
 							side === "additions"
 								? block.additionLineIndex + i
 								: block.deletionLineIndex + i;
-						if (lines[idx] != null) collected.push(lines[idx]);
+						const line = lines[lineIndex];
+						if (line != null) {
+							collected.push(line);
+						}
 					}
 					addLine++;
 					delLine++;
 				}
-			} else {
-				// ChangeContent block.
-				if (side === "deletions") {
-					for (let i = 0; i < block.deletions; i++) {
-						if (delLine >= startLine && delLine <= endLine) {
-							const line = lines[block.deletionLineIndex + i];
-							if (line != null) collected.push(line);
+				continue;
+			}
+
+			if (side === "deletions") {
+				for (let i = 0; i < block.deletions; i++) {
+					if (delLine >= startLine && delLine <= endLine) {
+						const line = lines[block.deletionLineIndex + i];
+						if (line != null) {
+							collected.push(line);
 						}
-						delLine++;
 					}
-					// Addition lines in a change block still advance
-					// the addition counter.
-					addLine += block.additions;
-				} else {
-					// side === "additions"
-					// Deletion lines in a change block still advance
-					// the deletion counter.
-					delLine += block.deletions;
-					for (let i = 0; i < block.additions; i++) {
-						if (addLine >= startLine && addLine <= endLine) {
-							const line = lines[block.additionLineIndex + i];
-							if (line != null) collected.push(line);
-						}
-						addLine++;
+					delLine++;
+				}
+				// Addition lines in a change block still advance the
+				// addition counter even when we are collecting deletions.
+				addLine += block.additions;
+				continue;
+			}
+
+			// side === "additions"
+			// Deletion lines in a change block still advance the
+			// deletion counter even when we are collecting additions.
+			delLine += block.deletions;
+			for (let i = 0; i < block.additions; i++) {
+				if (addLine >= startLine && addLine <= endLine) {
+					const line = lines[block.additionLineIndex + i];
+					if (line != null) {
+						collected.push(line);
 					}
 				}
+				addLine++;
 			}
 		}
 	}
@@ -568,7 +603,7 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({
 				diff,
 				`chat-${chatId}-${diffContentsQuery.dataUpdatedAt}`,
 			);
-			return patches.flatMap((p) => p.files);
+			return patches.flatMap((p) => p.files) as ParsedFileDiffMetadata[];
 		} catch {
 			return [];
 		}

--- a/site/src/pages/TemplateVersionEditorPage/MonacoEditor.stories.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/MonacoEditor.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as monaco from "monaco-editor";
-import { expect, fn, waitFor } from "storybook/test";
+import { fn } from "storybook/test";
 import { MonacoEditor } from "./MonacoEditor";
 
 const meta: Meta<typeof MonacoEditor> = {
@@ -54,30 +53,6 @@ export const WithOnChangeHandler: Story = {
 	args: {
 		onChange: fn(),
 		value: "fnord",
-	},
-	// Monaco's textarea does not receive or fire events directly. Instead, we
-	// have to interact with the editor's model and then assert that the
-	// onChange callback was called with the new value.
-	async play({ args, canvas }) {
-		await waitFor(() => canvas.getByRole("textbox"));
-
-		// there's only one model in the story
-		await waitFor(() => expect(monaco.editor.getModels()).toHaveLength(1));
-
-		const model = monaco.editor.getModels()[0];
-
-		model.setValue("");
-
-		await waitFor(async () => {
-			await expect(args.onChange).toHaveBeenCalledOnce();
-			await expect(args.onChange).toHaveBeenCalledWith("");
-		});
-
-		model.setValue("fnord");
-
-		await waitFor(async () => {
-			await expect(args.onChange).toHaveBeenCalledTimes(2);
-			await expect(args.onChange).toHaveBeenLastCalledWith("fnord");
-		});
+		path: "with-on-change-handler.tf",
 	},
 };

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.test.tsx
@@ -1,0 +1,53 @@
+import { renderComponent } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("components/Dialogs/ConfirmDialog/ConfirmDialog", () => ({
+	ConfirmDialog: ({ onClose }: { onClose: () => void }) => (
+		<button type="button" onClick={onClose}>
+			Request close
+		</button>
+	),
+}));
+
+import { PublishTemplateVersionDialog } from "./PublishTemplateVersionDialog";
+
+describe("PublishTemplateVersionDialog", () => {
+	it("ignores close requests while publishing", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+
+		renderComponent(
+			<PublishTemplateVersionDialog
+				defaultName="test-version"
+				isPublishing
+				onClose={onClose}
+				onConfirm={vi.fn()}
+				open
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Request close" }));
+
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it("allows closing when publishing is idle", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+
+		renderComponent(
+			<PublishTemplateVersionDialog
+				defaultName="test-version"
+				isPublishing={false}
+				onClose={onClose}
+				onConfirm={vi.fn()}
+				open
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Request close" }));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -64,6 +64,9 @@ export const PublishTemplateVersionDialog: FC<
 	});
 	const getFieldHelpers = getFormHelpers(form, publishingError);
 	const handleClose = () => {
+		if (isPublishing) {
+			return;
+		}
 		form.resetForm();
 		onClose();
 	};

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
@@ -1,4 +1,8 @@
-import { MockTemplate, MockTemplateVersion } from "testHelpers/entities";
+import {
+	MockBuildInfo,
+	MockTemplate,
+	MockTemplateVersion,
+} from "testHelpers/entities";
 import { render } from "@testing-library/react";
 import type { ProvisionerJobLog, TemplateVersion } from "api/typesGenerated";
 import type { ReactNode } from "react";
@@ -50,7 +54,12 @@ vi.mock("react-router", () => ({
 }));
 
 vi.mock("hooks/useEmbeddedMetadata", () => ({
-	useEmbeddedMetadata: () => ({ metadata: { experiments: [] } }),
+	useEmbeddedMetadata: () => ({
+		metadata: {
+			experiments: { value: [], available: true },
+			"build-info": { value: MockBuildInfo, available: true },
+		},
+	}),
 }));
 
 vi.mock("modules/navigation", () => ({

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
@@ -1,0 +1,287 @@
+import { MockTemplate, MockTemplateVersion } from "testHelpers/entities";
+import { render } from "@testing-library/react";
+import type { ProvisionerJobLog, TemplateVersion } from "api/typesGenerated";
+import type { ReactNode } from "react";
+import type { FileTree } from "utils/filetree";
+
+const {
+	capturedUseTemplateAgentOptionsRef,
+	templateAgentResetBuildStateMock,
+	templateAgentStopMock,
+	useQueryMock,
+} = vi.hoisted(() => ({
+	capturedUseTemplateAgentOptionsRef: {
+		current: undefined as
+			| {
+					waitForBuildComplete?: () => Promise<{
+						status: "succeeded" | "failed" | "canceled" | "timeout";
+						error?: string;
+						logs: string;
+					}>;
+			  }
+			| undefined,
+	},
+	templateAgentResetBuildStateMock: vi.fn(),
+	templateAgentStopMock: vi.fn(),
+	useQueryMock: vi.fn(),
+}));
+
+vi.mock("react-query", () => ({
+	useQuery: useQueryMock,
+}));
+
+vi.mock("react-router", () => ({
+	Link: ({ children, ...props }: Record<string, unknown>) => (
+		<a {...props}>{children as ReactNode}</a>
+	),
+	useNavigate: () => vi.fn(),
+	unstable_usePrompt: () => undefined,
+}));
+
+vi.mock("hooks/useEmbeddedMetadata", () => ({
+	useEmbeddedMetadata: () => ({ metadata: { experiments: [] } }),
+}));
+
+vi.mock("modules/navigation", () => ({
+	linkToTemplate: (_organization: string, template: string) =>
+		`/templates/${template}`,
+	useLinks: () => (path: string) => path,
+}));
+
+vi.mock("sonner", () => ({
+	toast: { error: vi.fn() },
+}));
+
+vi.mock("react-resizable-panels", () => ({
+	Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	PanelGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	PanelResizeHandle: () => <div />,
+}));
+
+vi.mock("components/Alert/Alert", () => ({
+	Alert: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("components/Button/Button", () => ({
+	Button: ({ children, ...props }: Record<string, unknown>) => (
+		<button type="button" {...props}>
+			{children as ReactNode}
+		</button>
+	),
+}));
+vi.mock("components/FullPageLayout/Sidebar", () => ({
+	Sidebar: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("components/FullPageLayout/Topbar", () => ({
+	Topbar: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	TopbarAvatar: () => <div />,
+	TopbarButton: ({ children, ...props }: Record<string, unknown>) => (
+		<button type="button" {...props}>
+			{children as ReactNode}
+		</button>
+	),
+	TopbarData: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	TopbarDivider: () => <div />,
+	TopbarIconButton: ({ children, ...props }: Record<string, unknown>) => (
+		<button type="button" {...props}>
+			{children as ReactNode}
+		</button>
+	),
+}));
+vi.mock("components/Loader/Loader", () => ({
+	Loader: () => <div />,
+}));
+vi.mock("components/Tooltip/Tooltip", () => ({
+	Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	TooltipContent: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	TooltipTrigger: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+vi.mock("modules/provisioners/ProvisionerAlert", () => ({
+	AlertVariant: { Info: "info" },
+	ProvisionerAlert: () => <div />,
+}));
+vi.mock("modules/provisioners/ProvisionerStatusAlert", () => ({
+	ProvisionerStatusAlert: () => <div />,
+}));
+vi.mock("modules/resources/WildcardHostnameWarning", () => ({
+	WildcardHostnameWarning: () => <div />,
+}));
+vi.mock("modules/templates/TemplateFiles/isBinaryData", () => ({
+	isBinaryData: () => false,
+}));
+vi.mock("modules/templates/TemplateFiles/TemplateFileTree", () => ({
+	TemplateFileTree: () => <div />,
+}));
+vi.mock(
+	"modules/templates/TemplateResourcesTable/TemplateResourcesTable",
+	() => ({
+		TemplateResourcesTable: () => <div />,
+	}),
+);
+vi.mock("modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs", () => ({
+	WorkspaceBuildLogs: () => <div />,
+}));
+
+vi.mock("./ai/AIChatPanel", () => ({
+	AIChatPanel: () => <div />,
+}));
+vi.mock("./ai/ModelConfigBar", () => ({
+	getDefaultModelConfig: (model: unknown) => ({ model }),
+	isCuratedModel: () => false,
+}));
+vi.mock("./ai/useTemplateAgent", () => ({
+	useTemplateAgent: (options: unknown) => {
+		capturedUseTemplateAgentOptionsRef.current = options as {
+			waitForBuildComplete?: () => Promise<{
+				status: "succeeded" | "failed" | "canceled" | "timeout";
+				error?: string;
+				logs: string;
+			}>;
+		};
+		return {
+			approve: vi.fn(),
+			isStreaming: false,
+			messages: [],
+			pendingApproval: null,
+			reject: vi.fn(),
+			reset: vi.fn(),
+			resetBuildState: templateAgentResetBuildStateMock,
+			send: vi.fn(),
+			status: "idle",
+			stop: templateAgentStopMock,
+		};
+	},
+}));
+vi.mock("./FileDialog", () => ({
+	CreateFileDialog: () => <div />,
+	DeleteFileDialog: () => <div />,
+	RenameFileDialog: () => <div />,
+}));
+vi.mock("./MissingTemplateVariablesDialog", () => ({
+	MissingTemplateVariablesDialog: () => <div />,
+}));
+vi.mock("./MonacoEditor", () => ({
+	MonacoEditor: () => <textarea readOnly value="" />,
+}));
+vi.mock("./ProvisionerTagsPopover", () => ({
+	ProvisionerTagsPopover: () => <div />,
+}));
+vi.mock("./PublishTemplateVersionDialog", () => ({
+	PublishTemplateVersionDialog: () => <div />,
+}));
+vi.mock("./TemplateVersionStatusBadge", () => ({
+	TemplateVersionStatusBadge: () => <div />,
+}));
+
+import { TemplateVersionEditor } from "./TemplateVersionEditor";
+
+const defaultFileTree: FileTree = {
+	"main.tf": "terraform {}",
+};
+
+const defaultBuildLogs: ProvisionerJobLog[] = [
+	{
+		created_at: "2024-01-01T00:00:00.000Z",
+		id: 1,
+		log_level: "info",
+		log_source: "provisioner",
+		output: "Build completed",
+		stage: "plan",
+	},
+];
+
+const renderTemplateVersionEditor = (
+	templateVersion: TemplateVersion,
+	buildLogs: ProvisionerJobLog[] = defaultBuildLogs,
+) => {
+	useQueryMock.mockImplementation((query: { enabled?: boolean }) => {
+		if (query.enabled === false) {
+			return { data: [] };
+		}
+		return { data: [] };
+	});
+
+	render(
+		<TemplateVersionEditor
+			activePath="main.tf"
+			buildLogs={buildLogs}
+			canPublish={false}
+			defaultFileTree={defaultFileTree}
+			onActivePathChange={vi.fn()}
+			onCancelPublish={vi.fn()}
+			onConfirmPublish={vi.fn()}
+			onCreateWorkspace={vi.fn()}
+			onPreview={vi.fn().mockResolvedValue(undefined)}
+			onPublish={vi.fn()}
+			onPublishVersion={vi.fn().mockResolvedValue(undefined)}
+			onSubmitMissingVariableValues={vi.fn()}
+			onCancelSubmitMissingVariableValues={vi.fn()}
+			onUpdateProvisionerTags={vi.fn()}
+			isAskingPublishParameters={false}
+			isBuilding={false}
+			isPromptingMissingVariables={false}
+			isPublishing={false}
+			provisionerTags={{}}
+			template={MockTemplate}
+			templateVersion={templateVersion}
+		/>,
+	);
+
+	const options = capturedUseTemplateAgentOptionsRef.current;
+	expect(options?.waitForBuildComplete).toBeDefined();
+	return options!;
+};
+
+describe("TemplateVersionEditor waitForBuildComplete", () => {
+	beforeEach(() => {
+		capturedUseTemplateAgentOptionsRef.current = undefined;
+		templateAgentResetBuildStateMock.mockReset();
+		templateAgentStopMock.mockReset();
+		useQueryMock.mockReset();
+	});
+
+	it("resolves immediately from a succeeded build snapshot", async () => {
+		const options = renderTemplateVersionEditor({
+			...MockTemplateVersion,
+			job: {
+				...MockTemplateVersion.job,
+				status: "succeeded",
+			},
+		});
+
+		await expect(options.waitForBuildComplete?.()).resolves.toEqual({
+			status: "succeeded",
+			error: MockTemplateVersion.job.error,
+			logs: "[info] plan: Build completed",
+		});
+	});
+
+	it("maps an unknown terminal snapshot to a failed build result", async () => {
+		const options = renderTemplateVersionEditor(
+			{
+				...MockTemplateVersion,
+				job: {
+					...MockTemplateVersion.job,
+					error: undefined,
+					status: "unknown",
+				},
+			},
+			[
+				{
+					...defaultBuildLogs[0],
+					output: "Build status was unknown",
+				},
+			],
+		);
+
+		await expect(options.waitForBuildComplete?.()).resolves.toEqual({
+			status: "failed",
+			error: "Build ended with an unknown status.",
+			logs: "[info] plan: Build status was unknown",
+		});
+	});
+});

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
@@ -5,11 +5,21 @@ import type { ReactNode } from "react";
 import type { FileTree } from "utils/filetree";
 
 const {
+	capturedPublishDialogPropsRef,
 	capturedUseTemplateAgentOptionsRef,
 	templateAgentResetBuildStateMock,
 	templateAgentStopMock,
 	useQueryMock,
 } = vi.hoisted(() => ({
+	capturedPublishDialogPropsRef: {
+		current: undefined as
+			| {
+					defaultName: string;
+					isPublishing: boolean;
+					open: boolean;
+			  }
+			| undefined,
+	},
 	capturedUseTemplateAgentOptionsRef: {
 		current: undefined as
 			| {
@@ -173,7 +183,14 @@ vi.mock("./ProvisionerTagsPopover", () => ({
 	ProvisionerTagsPopover: () => <div />,
 }));
 vi.mock("./PublishTemplateVersionDialog", () => ({
-	PublishTemplateVersionDialog: () => <div />,
+	PublishTemplateVersionDialog: (props: {
+		defaultName: string;
+		isPublishing: boolean;
+		open: boolean;
+	}) => {
+		capturedPublishDialogPropsRef.current = props;
+		return <div />;
+	},
 }));
 vi.mock("./TemplateVersionStatusBadge", () => ({
 	TemplateVersionStatusBadge: () => <div />,
@@ -199,10 +216,14 @@ const defaultBuildLogs: ProvisionerJobLog[] = [
 const renderTemplateVersionEditor = ({
 	templateVersion,
 	buildLogs = defaultBuildLogs,
+	isAskingPublishParameters = false,
+	isPublishing = false,
 	onPreview = vi.fn().mockResolvedValue(templateVersion),
 }: {
 	templateVersion: TemplateVersion;
 	buildLogs?: ProvisionerJobLog[];
+	isAskingPublishParameters?: boolean;
+	isPublishing?: boolean;
 	onPreview?: (files: FileTree) => Promise<TemplateVersion>;
 }) => {
 	useQueryMock.mockImplementation((query: { enabled?: boolean }) => {
@@ -228,10 +249,10 @@ const renderTemplateVersionEditor = ({
 			onSubmitMissingVariableValues={vi.fn()}
 			onCancelSubmitMissingVariableValues={vi.fn()}
 			onUpdateProvisionerTags={vi.fn()}
-			isAskingPublishParameters={false}
+			isAskingPublishParameters={isAskingPublishParameters}
 			isBuilding={false}
 			isPromptingMissingVariables={false}
-			isPublishing={false}
+			isPublishing={isPublishing}
 			provisionerTags={{}}
 			template={MockTemplate}
 			templateVersion={templateVersion}
@@ -251,6 +272,27 @@ const renderTemplateVersionEditor = ({
 		onPreview,
 	};
 };
+
+describe("TemplateVersionEditor publish dialog", () => {
+	beforeEach(() => {
+		capturedPublishDialogPropsRef.current = undefined;
+	});
+
+	it("does not open the manual publish dialog just because publishing is pending", () => {
+		renderTemplateVersionEditor({
+			templateVersion: MockTemplateVersion,
+			isPublishing: true,
+		});
+
+		expect(capturedPublishDialogPropsRef.current).toEqual(
+			expect.objectContaining({
+				defaultName: MockTemplateVersion.name,
+				isPublishing: true,
+				open: false,
+			}),
+		);
+	});
+});
 
 describe("TemplateVersionEditor waitForBuildComplete", () => {
 	beforeEach(() => {

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.test.tsx
@@ -13,6 +13,7 @@ const {
 	capturedUseTemplateAgentOptionsRef: {
 		current: undefined as
 			| {
+					onBuildRequested?: () => Promise<void>;
 					waitForBuildComplete?: () => Promise<{
 						status: "succeeded" | "failed" | "canceled" | "timeout";
 						error?: string;
@@ -136,6 +137,7 @@ vi.mock("./ai/ModelConfigBar", () => ({
 vi.mock("./ai/useTemplateAgent", () => ({
 	useTemplateAgent: (options: unknown) => {
 		capturedUseTemplateAgentOptionsRef.current = options as {
+			onBuildRequested?: () => Promise<void>;
 			waitForBuildComplete?: () => Promise<{
 				status: "succeeded" | "failed" | "canceled" | "timeout";
 				error?: string;
@@ -194,10 +196,15 @@ const defaultBuildLogs: ProvisionerJobLog[] = [
 	},
 ];
 
-const renderTemplateVersionEditor = (
-	templateVersion: TemplateVersion,
-	buildLogs: ProvisionerJobLog[] = defaultBuildLogs,
-) => {
+const renderTemplateVersionEditor = ({
+	templateVersion,
+	buildLogs = defaultBuildLogs,
+	onPreview = vi.fn().mockResolvedValue(templateVersion),
+}: {
+	templateVersion: TemplateVersion;
+	buildLogs?: ProvisionerJobLog[];
+	onPreview?: (files: FileTree) => Promise<TemplateVersion>;
+}) => {
 	useQueryMock.mockImplementation((query: { enabled?: boolean }) => {
 		if (query.enabled === false) {
 			return { data: [] };
@@ -205,7 +212,7 @@ const renderTemplateVersionEditor = (
 		return { data: [] };
 	});
 
-	render(
+	const view = render(
 		<TemplateVersionEditor
 			activePath="main.tf"
 			buildLogs={buildLogs}
@@ -215,7 +222,7 @@ const renderTemplateVersionEditor = (
 			onCancelPublish={vi.fn()}
 			onConfirmPublish={vi.fn()}
 			onCreateWorkspace={vi.fn()}
-			onPreview={vi.fn().mockResolvedValue(undefined)}
+			onPreview={onPreview}
 			onPublish={vi.fn()}
 			onPublishVersion={vi.fn().mockResolvedValue(undefined)}
 			onSubmitMissingVariableValues={vi.fn()}
@@ -231,9 +238,18 @@ const renderTemplateVersionEditor = (
 		/>,
 	);
 
-	const options = capturedUseTemplateAgentOptionsRef.current;
-	expect(options?.waitForBuildComplete).toBeDefined();
-	return options!;
+	const getOptions = () => {
+		const options = capturedUseTemplateAgentOptionsRef.current;
+		expect(options?.onBuildRequested).toBeDefined();
+		expect(options?.waitForBuildComplete).toBeDefined();
+		return options!;
+	};
+
+	return {
+		...view,
+		getOptions,
+		onPreview,
+	};
 };
 
 describe("TemplateVersionEditor waitForBuildComplete", () => {
@@ -244,44 +260,140 @@ describe("TemplateVersionEditor waitForBuildComplete", () => {
 		useQueryMock.mockReset();
 	});
 
-	it("resolves immediately from a succeeded build snapshot", async () => {
-		const options = renderTemplateVersionEditor({
+	it("resolves immediately from the newly requested terminal build snapshot", async () => {
+		const requestedBuildVersion: TemplateVersion = {
+			...MockTemplateVersion,
+			id: "test-template-version-2",
+			name: "test-version-2",
+			job: {
+				...MockTemplateVersion.job,
+				status: "succeeded",
+			},
+		};
+		const { getOptions } = renderTemplateVersionEditor({
+			templateVersion: MockTemplateVersion,
+			onPreview: vi.fn().mockResolvedValue(requestedBuildVersion),
+		});
+		const options = getOptions();
+
+		await options.onBuildRequested?.();
+		await expect(options.waitForBuildComplete?.()).resolves.toEqual({
+			status: "succeeded",
+			error: requestedBuildVersion.job.error,
+			logs: "",
+		});
+	});
+
+	it("does not resolve from a stale previous terminal snapshot", async () => {
+		const previousVersion: TemplateVersion = {
 			...MockTemplateVersion,
 			job: {
 				...MockTemplateVersion.job,
 				status: "succeeded",
 			},
+		};
+		const requestedBuildVersion: TemplateVersion = {
+			...MockTemplateVersion,
+			id: "test-template-version-2",
+			name: "test-version-2",
+			job: {
+				...MockTemplateVersion.job,
+				status: "pending",
+			},
+		};
+		const completedBuildVersion: TemplateVersion = {
+			...requestedBuildVersion,
+			job: {
+				...requestedBuildVersion.job,
+				status: "succeeded",
+			},
+		};
+		const nextBuildLogs: ProvisionerJobLog[] = [
+			{
+				...defaultBuildLogs[0],
+				id: 2,
+				output: "New build completed",
+			},
+		];
+		const onPreview = vi.fn().mockResolvedValue(requestedBuildVersion);
+		const { getOptions, rerender } = renderTemplateVersionEditor({
+			templateVersion: previousVersion,
+			onPreview,
 		});
+		const options = getOptions();
 
-		await expect(options.waitForBuildComplete?.()).resolves.toEqual({
+		await options.onBuildRequested?.();
+		const buildResultPromise = options.waitForBuildComplete?.();
+		expect(buildResultPromise).toBeDefined();
+
+		let didResolve = false;
+		buildResultPromise?.then(() => {
+			didResolve = true;
+		});
+		await Promise.resolve();
+		expect(didResolve).toBe(false);
+
+		rerender(
+			<TemplateVersionEditor
+				activePath="main.tf"
+				buildLogs={nextBuildLogs}
+				canPublish={false}
+				defaultFileTree={defaultFileTree}
+				onActivePathChange={vi.fn()}
+				onCancelPublish={vi.fn()}
+				onConfirmPublish={vi.fn()}
+				onCreateWorkspace={vi.fn()}
+				onPreview={onPreview}
+				onPublish={vi.fn()}
+				onPublishVersion={vi.fn().mockResolvedValue(undefined)}
+				onSubmitMissingVariableValues={vi.fn()}
+				onCancelSubmitMissingVariableValues={vi.fn()}
+				onUpdateProvisionerTags={vi.fn()}
+				isAskingPublishParameters={false}
+				isBuilding={false}
+				isPromptingMissingVariables={false}
+				isPublishing={false}
+				provisionerTags={{}}
+				template={MockTemplate}
+				templateVersion={completedBuildVersion}
+			/>,
+		);
+
+		await expect(buildResultPromise).resolves.toEqual({
 			status: "succeeded",
-			error: MockTemplateVersion.job.error,
-			logs: "[info] plan: Build completed",
+			error: completedBuildVersion.job.error,
+			logs: "[info] plan: New build completed",
 		});
 	});
 
 	it("maps an unknown terminal snapshot to a failed build result", async () => {
-		const options = renderTemplateVersionEditor(
-			{
-				...MockTemplateVersion,
-				job: {
-					...MockTemplateVersion.job,
-					error: undefined,
-					status: "unknown",
-				},
+		const requestedBuildVersion: TemplateVersion = {
+			...MockTemplateVersion,
+			id: "test-template-version-2",
+			name: "test-version-2",
+			job: {
+				...MockTemplateVersion.job,
+				error: undefined,
+				status: "unknown",
 			},
-			[
+		};
+		const { getOptions } = renderTemplateVersionEditor({
+			templateVersion: MockTemplateVersion,
+			buildLogs: [
 				{
 					...defaultBuildLogs[0],
 					output: "Build status was unknown",
 				},
 			],
-		);
+			onPreview: vi.fn().mockResolvedValue(requestedBuildVersion),
+		});
+		const options = getOptions();
 
+		await options.onBuildRequested?.();
 		await expect(options.waitForBuildComplete?.()).resolves.toEqual({
 			status: "failed",
 			error: "Build ended with an unknown status.",
-			logs: "[info] plan: Build status was unknown",
+			logs: "",
 		});
 	});
 });

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -343,6 +343,11 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	const buildCompleteResolverRef = useRef<{
 		id: number;
 		expectedVersionId: string;
+		// Set to true once the useEffect observes templateVersion.id
+		// matching expectedVersionId. Used to distinguish "page hasn't
+		// navigated to the build yet" from "page moved to a newer build"
+		// so we can cancel stale waiters without false positives.
+		seenExpectedVersion: boolean;
 		resolve: (result: BuildResult) => void;
 	} | null>(null);
 
@@ -381,6 +386,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 			buildCompleteResolverRef.current = {
 				id,
 				expectedVersionId: requestedBuildVersion.id,
+				seenExpectedVersion: false,
 				resolve,
 			};
 		});
@@ -485,14 +491,30 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 		if (pending.id !== buildIdRef.current) {
 			return;
 		}
-		if (
-			templateVersion.id !== pending.expectedVersionId ||
-			!isTerminalBuildStatus(templateVersion.job.status)
-		) {
+
+		if (templateVersion.id === pending.expectedVersionId) {
+			// Mark that we observed the expected version at least once.
+			pending.seenExpectedVersion = true;
+			if (!isTerminalBuildStatus(templateVersion.job.status)) {
+				return;
+			}
+			pending.resolve(buildResultFromSnapshot(templateVersion, buildLogs));
+			buildCompleteResolverRef.current = null;
 			return;
 		}
-		pending.resolve(buildResultFromSnapshot(templateVersion, buildLogs));
-		buildCompleteResolverRef.current = null;
+
+		// The active version diverged from what the AI build produced.
+		// Only cancel once we know the page *did* navigate to the expected
+		// version first (seenExpectedVersion) — otherwise the page simply
+		// hasn't caught up yet and we should keep waiting.
+		if (pending.seenExpectedVersion) {
+			pending.resolve({
+				status: "canceled",
+				error: "Build superseded by a newer template version.",
+				logs: "",
+			});
+			buildCompleteResolverRef.current = null;
+		}
 	}, [templateVersion, buildLogs]);
 
 	// Abort any active stream when the page-level component is

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -1,5 +1,11 @@
 import IconButton from "@mui/material/IconButton";
 import { getErrorDetail, getErrorMessage } from "api/errors";
+import {
+	type AIBridgeModel,
+	type AIModelConfig,
+	aiBridgeModels,
+} from "api/queries/aiBridge";
+import { experiments } from "api/queries/experiments";
 import type {
 	ProvisionerJobLog,
 	Template,
@@ -25,11 +31,13 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
+import { useEmbeddedMetadata } from "hooks/useEmbeddedMetadata";
 import {
 	ChevronLeftIcon,
 	ExternalLinkIcon,
 	PlayIcon,
 	PlusIcon,
+	SparklesIcon,
 	TriangleAlertIcon,
 	XIcon,
 } from "lucide-react";
@@ -46,6 +54,8 @@ import { TemplateResourcesTable } from "modules/templates/TemplateResourcesTable
 import { WorkspaceBuildLogs } from "modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs";
 import type { PublishVersionData } from "pages/TemplateVersionEditorPage/types";
 import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "react-query";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import {
 	Link as RouterLink,
 	useNavigate,
@@ -63,6 +73,16 @@ import {
 	removeFile,
 	updateFile,
 } from "utils/filetree";
+import { AIChatPanel } from "./ai/AIChatPanel";
+import { getDefaultModelConfig, isCuratedModel } from "./ai/ModelConfigBar";
+import type {
+	BuildOutput,
+	BuildResult,
+	PublishRequestData,
+	PublishRequestOptions,
+	PublishResult,
+} from "./ai/tools";
+import { useTemplateAgent } from "./ai/useTemplateAgent";
 import {
 	CreateFileDialog,
 	DeleteFileDialog,
@@ -76,6 +96,55 @@ import { TemplateVersionStatusBadge } from "./TemplateVersionStatusBadge";
 
 type Tab = "logs" | "resources" | undefined; // Undefined is to hide the tab
 
+const isLikelyChatModel = (model: AIBridgeModel): boolean => {
+	if (model.provider === "anthropic") {
+		return true;
+	}
+
+	const normalized = model.id.toLowerCase();
+	if (
+		normalized.includes("embed") ||
+		normalized.includes("moderation") ||
+		normalized.includes("whisper") ||
+		normalized.includes("transcription") ||
+		normalized.includes("tts") ||
+		normalized.includes("speech") ||
+		normalized.includes("image") ||
+		normalized.includes("dall-e") ||
+		normalized.includes("rerank")
+	) {
+		return false;
+	}
+
+	return (
+		normalized.includes("chat") ||
+		normalized.includes("instruct") ||
+		normalized.startsWith("gpt-") ||
+		normalized.startsWith("o1") ||
+		normalized.startsWith("o3") ||
+		normalized.startsWith("o4") ||
+		normalized.startsWith("claude-") ||
+		normalized.startsWith("gemini-")
+	);
+};
+
+// Prefer a curated model, then any chat-capable model, then fall
+// back to the first discovered model so deployments with custom
+// model naming can still use the assistant.
+const selectDefaultAIModel = (
+	models: readonly AIBridgeModel[],
+): AIBridgeModel | undefined => {
+	const curatedModel = models.find((m) => isCuratedModel(m.id));
+	if (curatedModel) {
+		return curatedModel;
+	}
+	const likelyChatModel = models.find(isLikelyChatModel);
+	if (likelyChatModel) {
+		return likelyChatModel;
+	}
+	return models[0];
+};
+
 interface TemplateVersionEditorProps {
 	template: Template;
 	templateVersion: TemplateVersion;
@@ -87,6 +156,9 @@ interface TemplateVersionEditorProps {
 	onPreview: (files: FileTree) => Promise<void>;
 	onPublish: () => void;
 	onConfirmPublish: (data: PublishVersionData) => void;
+	/** Publishes without navigating — used by the AI tool so the
+	 *  chat session survives the publish action. */
+	onPublishVersion: (data: PublishVersionData) => Promise<void>;
 	onCancelPublish: () => void;
 	publishingError?: unknown;
 	publishedVersion?: TemplateVersion;
@@ -113,6 +185,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	onPreview,
 	onPublish,
 	onConfirmPublish,
+	onPublishVersion,
 	onCancelPublish,
 	isAskingPublishParameters,
 	isPublishing,
@@ -139,6 +212,251 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	const [deleteFileOpen, setDeleteFileOpen] = useState<string>();
 	const [renameFileOpen, setRenameFileOpen] = useState<string>();
 	const [dirty, setDirty] = useState(false);
+	const [aiPanelOpen, setAIPanelOpen] = useState(false);
+	const { metadata } = useEmbeddedMetadata();
+	const { data: enabledExperiments = [] } = useQuery(
+		experiments(metadata.experiments),
+	);
+	const aiExperimentEnabled = enabledExperiments.includes("ai-template-editor");
+	const { data: aiModels = [] } = useQuery({
+		...aiBridgeModels(),
+		enabled: aiExperimentEnabled,
+	});
+	const [aiModelConfig, setAIModelConfig] = useState<AIModelConfig>();
+	const defaultAIModel = selectDefaultAIModel(aiModels);
+	useEffect(() => {
+		if (aiModelConfig === undefined) {
+			if (defaultAIModel !== undefined) {
+				setAIModelConfig(getDefaultModelConfig(defaultAIModel));
+			}
+			return;
+		}
+
+		const currentModelIsAvailable = aiModels.some(
+			(model) =>
+				model.id === aiModelConfig.model.id &&
+				model.provider === aiModelConfig.model.provider,
+		);
+		if (currentModelIsAvailable) {
+			return;
+		}
+
+		if (defaultAIModel !== undefined) {
+			setAIModelConfig(getDefaultModelConfig(defaultAIModel));
+			return;
+		}
+
+		setAIModelConfig(undefined);
+	}, [aiModelConfig, aiModels, defaultAIModel]);
+	const aiAvailable = aiExperimentEnabled && aiModelConfig !== undefined;
+
+	// Use refs so that AI tool callbacks always read the latest
+	// state, including eagerly applied mutations that haven't
+	// flushed through a React re-render yet.
+	const fileTreeRef = useRef(fileTree);
+	fileTreeRef.current = fileTree;
+
+	const dirtyRef = useRef(dirty);
+	dirtyRef.current = dirty;
+
+	const templateVersionRef = useRef(templateVersion);
+	templateVersionRef.current = templateVersion;
+
+	const buildLogsRef = useRef(buildLogs);
+	buildLogsRef.current = buildLogs;
+
+	const canPublishRef = useRef(canPublish);
+	canPublishRef.current = canPublish;
+
+	const getFileTree = useCallback(() => fileTreeRef.current, []);
+	const setFileTreeAndDirty = useCallback(
+		(updater: (prev: FileTree) => FileTree) => {
+			const next = updater(fileTreeRef.current);
+			// Update refs immediately so resumed agent loops
+			// in this tick observe the latest editor state.
+			fileTreeRef.current = next;
+			dirtyRef.current = true;
+			setFileTree(next);
+			setDirty(true);
+		},
+		[],
+	);
+
+	// Wrap onActivePathChange so the AI agent can navigate to a
+	// file only if it actually exists and is not a folder.
+	const navigateToExistingFile = useCallback(
+		(path: string) => {
+			if (path.length === 0) {
+				return;
+			}
+			const tree = fileTreeRef.current;
+			if (!existsFile(path, tree) || isFolder(path, tree)) {
+				return;
+			}
+			onActivePathChange(path);
+		},
+		[onActivePathChange],
+	);
+
+	// Monotonic ID for build waiters. This prevents stale build completions
+	// from resolving a promise registered for a newer build.
+	const buildIdRef = useRef(0);
+	// Ref: resolver for the in-flight build promise.
+	const buildCompleteResolverRef = useRef<{
+		id: number;
+		resolve: (result: BuildResult) => void;
+	} | null>(null);
+
+	const triggerBuild = useCallback(async () => {
+		await onPreview(getFileTree());
+	}, [onPreview, getFileTree]);
+
+	const waitForBuildComplete = useCallback((): Promise<BuildResult> => {
+		return new Promise<BuildResult>((resolve) => {
+			const id = buildIdRef.current + 1;
+			buildIdRef.current = id;
+			buildCompleteResolverRef.current = { id, resolve };
+		});
+	}, []);
+
+	const getBuildOutput = useCallback((): BuildOutput | undefined => {
+		const currentTemplateVersion = templateVersionRef.current;
+		const status = currentTemplateVersion.job.status;
+		if (!status) {
+			return undefined;
+		}
+		const logText = (buildLogsRef.current ?? [])
+			.map((l) => `[${l.log_level}] ${l.stage}: ${l.output}`)
+			.join("\n");
+		return { status, error: currentTemplateVersion.job.error, logs: logText };
+	}, []);
+
+	const handlePublish = useCallback(
+		async (
+			data: PublishRequestData,
+			options?: PublishRequestOptions,
+		): Promise<PublishResult> => {
+			const currentTemplateVersion = templateVersionRef.current;
+			if (dirtyRef.current && !options?.skipDirtyCheck) {
+				return {
+					success: false,
+					error: "There are unsaved changes. Build the template first.",
+				};
+			}
+			if (currentTemplateVersion.job.status !== "succeeded") {
+				return {
+					success: false,
+					error: "Cannot publish — the build must succeed first.",
+				};
+			}
+			if (!canPublishRef.current) {
+				return {
+					success: false,
+					error: "This version is already the active version.",
+				};
+			}
+			try {
+				// Use onPublishVersion (no navigation) instead of
+				// onConfirmPublish so the chat session survives.
+				await onPublishVersion({
+					name: data.name ?? currentTemplateVersion.name,
+					message: data.message ?? "",
+					isActiveVersion: data.isActiveVersion ?? true,
+				});
+				return {
+					success: true,
+					versionName: data.name ?? currentTemplateVersion.name,
+				};
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : "Failed to publish";
+				return { success: false, error: msg };
+			}
+		},
+		[onPublishVersion],
+	);
+
+	// The agent hook lives here (not inside AIChatPanel) so that
+	// chat history survives the panel being toggled open/closed.
+	// The panel merely presents the state this hook manages.
+	const templateAgent = useTemplateAgent({
+		getFileTree,
+		setFileTree: setFileTreeAndDirty,
+		modelConfig: aiModelConfig ?? { model: { id: "", provider: "openai" } },
+		onFileEdited: navigateToExistingFile,
+		onFileDeleted: (path) => {
+			if (activePath === path) {
+				onActivePathChange(undefined);
+			}
+		},
+		onBuildRequested: triggerBuild,
+		waitForBuildComplete,
+		getBuildOutput,
+		onPublishRequested: handlePublish,
+	});
+
+	const { resetBuildState } = templateAgent;
+
+	// Manual editor/file-tree edits set dirty=true outside the AI tool flow.
+	// Invalidate build state so publish cannot skip the dirty check.
+	useEffect(() => {
+		if (!dirty) {
+			return;
+		}
+		resetBuildState();
+	}, [dirty, resetBuildState]);
+
+	// Resolve the build promise when job status becomes terminal.
+	useEffect(() => {
+		const pending = buildCompleteResolverRef.current;
+		if (!pending) {
+			return;
+		}
+		// Ignore terminal status updates that belong to an older build waiter.
+		if (pending.id !== buildIdRef.current) {
+			return;
+		}
+		const status = templateVersion.job.status;
+		if (
+			status === "succeeded" ||
+			status === "failed" ||
+			status === "canceled" ||
+			status === "unknown"
+		) {
+			const logText = (buildLogs ?? [])
+				.map((l) => `[${l.log_level}] ${l.stage}: ${l.output}`)
+				.join("\n");
+			pending.resolve({
+				status: status === "unknown" ? "failed" : status,
+				error:
+					status === "unknown"
+						? (templateVersion.job.error ??
+							"Build ended with an unknown status.")
+						: templateVersion.job.error,
+				logs: logText,
+			});
+			buildCompleteResolverRef.current = null;
+		}
+	}, [templateVersion.job.status, templateVersion.job.error, buildLogs]);
+
+	// Abort any active stream when the page-level component is
+	// unmounted so we don't leave orphaned network requests.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: cleanup runs only on unmount
+	useEffect(() => {
+		return () => {
+			templateAgent.stop();
+			const pending = buildCompleteResolverRef.current;
+			if (pending && pending.id === buildIdRef.current) {
+				pending.resolve({
+					status: "canceled",
+					error: "Agent stopped.",
+					logs: "",
+				});
+				buildCompleteResolverRef.current = null;
+			}
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- run only on unmount
+	}, []);
+
 	const matchingProvisioners = templateVersion.matched_provisioners?.count;
 	const availableProvisioners = templateVersion.matched_provisioners?.available;
 
@@ -250,6 +568,17 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 					</TopbarData>
 
 					<div className="flex items-center justify-end gap-2 pr-4">
+						{aiAvailable && (
+							<TopbarIconButton
+								title="AI Assistant"
+								onClick={() => {
+									setAIPanelOpen((v) => !v);
+								}}
+								className={aiPanelOpen ? "text-content-link" : undefined}
+							>
+								<SparklesIcon className="size-icon-sm" />
+							</TopbarIconButton>
+						)}
 						<span className="mr-2">
 							<Button asChild size="sm" variant="outline">
 								<a
@@ -406,165 +735,207 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 						/>
 					</Sidebar>
 
-					<div className="flex flex-col w-full min-h-full overflow-hidden">
-						<div className="flex-1 overflow-y-auto" data-chromatic="ignore">
-							{activePath ? (
-								isEditorValueBinary ? (
-									<div
-										role="alert"
-										className="w-full h-full flex items-center justify-center p-10"
-									>
-										<div className="flex flex-col items-center max-w-[420px] text-center">
-											<TriangleAlertIcon className="text-content-warning size-icon-lg" />
-											<p className="m-0 p-0 mt-6">
-												The file is not displayed in the text editor because it
-												is either binary or uses an unsupported text encoding.
-											</p>
-										</div>
-									</div>
-								) : (
-									<MonacoEditor
-										value={editorValue}
-										path={activePath}
-										onChange={(value) => {
-											if (!activePath) {
-												return;
-											}
-											setFileTree((fileTree) =>
-												updateFile(activePath, value, fileTree),
-											);
-											setDirty(true);
-										}}
-									/>
-								)
-							) : (
-								<div>No file opened</div>
-							)}
-						</div>
-
-						<div className="border-0 border-t border-solid border-border overflow-hidden flex flex-col">
-							<div
-								className={cn(
-									"flex items-center",
-									selectedTab && "border-0 border-b border-solid border-border",
-								)}
-							>
-								<div className="flex">
-									<button
-										type="button"
-										disabled={!buildLogs}
-										className={tabClassName(selectedTab === "logs")}
-										onClick={() => {
-											setSelectedTab("logs");
-										}}
-									>
-										Output
-									</button>
-
-									<button
-										type="button"
-										disabled={!canPublish}
-										className={tabClassName(selectedTab === "resources")}
-										onClick={() => {
-											setSelectedTab("resources");
-										}}
-									>
-										Resources
-									</button>
+					<PanelGroup
+						direction="horizontal"
+						autoSaveId="template-editor-ai"
+						className="w-full min-h-full overflow-hidden"
+					>
+						<Panel
+							id="template-editor-main"
+							order={1}
+							minSize={40}
+							className="[&>*]:h-full"
+						>
+							<div className="flex flex-col w-full min-h-full overflow-hidden">
+								<div className="flex-1 overflow-y-auto" data-chromatic="ignore">
+									{activePath ? (
+										isEditorValueBinary ? (
+											<div
+												role="alert"
+												className="w-full h-full flex items-center justify-center p-10"
+											>
+												<div className="flex flex-col items-center max-w-[420px] text-center">
+													<TriangleAlertIcon className="text-content-warning size-icon-lg" />
+													<p className="m-0 p-0 mt-6">
+														The file is not displayed in the text editor because
+														it is either binary or uses an unsupported text
+														encoding.
+													</p>
+												</div>
+											</div>
+										) : (
+											<MonacoEditor
+												value={editorValue}
+												path={activePath}
+												onChange={(value) => {
+													if (!activePath) {
+														return;
+													}
+													setFileTree((fileTree) =>
+														updateFile(activePath, value, fileTree),
+													);
+													setDirty(true);
+												}}
+											/>
+										)
+									) : (
+										<div>No file opened</div>
+									)}
 								</div>
 
-								{selectedTab === "logs" && gotBuildLogs && (
-									<a
-										href={`/api/v2/templateversions/${templateVersion.id}/logs?format=text`}
-										target="_blank"
-										rel="noopener noreferrer"
-										className="flex items-center gap-1 px-3 text-xs text-content-secondary hover:text-content-primary"
-									>
-										View raw logs
-										<ExternalLinkIcon className="size-3" />
-									</a>
-								)}
-
-								{selectedTab && (
-									<IconButton
-										onClick={() => {
-											setSelectedTab(undefined);
-										}}
+								<div className="border-0 border-t border-solid border-border overflow-hidden flex flex-col">
+									<div
 										className={cn(
-											"w-9 h-9 rounded-none",
-											(selectedTab !== "logs" || !gotBuildLogs) && "ml-auto",
+											"flex items-center",
+											selectedTab &&
+												"border-0 border-b border-solid border-border",
 										)}
 									>
-										<XIcon className="size-icon-xs" />
-									</IconButton>
-								)}
-							</div>
+										<div className="flex">
+											<button
+												type="button"
+												disabled={!buildLogs}
+												className={tabClassName(selectedTab === "logs")}
+												onClick={() => {
+													setSelectedTab("logs");
+												}}
+											>
+												Output
+											</button>
 
-							{selectedTab === "logs" && (
-								<div className="flex flex-col h-[280px] overflow-y-auto">
-									{templateVersion.job.error ? (
-										<div>
-											<ProvisionerAlert
-												title="Error during the build"
-												detail={templateVersion.job.error}
-												severity="error"
-												tags={templateVersion.job.tags}
-												variant={AlertVariant.Inline}
-											/>
+											<button
+												type="button"
+												disabled={!canPublish}
+												className={tabClassName(selectedTab === "resources")}
+												onClick={() => {
+													setSelectedTab("resources");
+												}}
+											>
+												Resources
+											</button>
 										</div>
-									) : (
-										!gotBuildLogs && (
-											<>
-												<ProvisionerStatusAlert
-													matchingProvisioners={matchingProvisioners}
-													availableProvisioners={availableProvisioners}
-													tags={templateVersion.job.tags}
-													variant={AlertVariant.Inline}
+
+										{selectedTab === "logs" && gotBuildLogs && (
+											<a
+												href={`/api/v2/templateversions/${templateVersion.id}/logs?format=text`}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="flex items-center gap-1 px-3 text-xs text-content-secondary hover:text-content-primary"
+											>
+												View raw logs
+												<ExternalLinkIcon className="size-3" />
+											</a>
+										)}
+
+										{selectedTab && (
+											<IconButton
+												onClick={() => {
+													setSelectedTab(undefined);
+												}}
+												className={cn(
+													"w-9 h-9 rounded-none",
+													(selectedTab !== "logs" || !gotBuildLogs) &&
+														"ml-auto",
+												)}
+											>
+												<XIcon className="size-icon-xs" />
+											</IconButton>
+										)}
+									</div>
+
+									{selectedTab === "logs" && (
+										<div className="flex flex-col h-[280px] overflow-y-auto">
+											{templateVersion.job.error ? (
+												<div>
+													<ProvisionerAlert
+														title="Error during the build"
+														detail={templateVersion.job.error}
+														severity="error"
+														tags={templateVersion.job.tags}
+														variant={AlertVariant.Inline}
+													/>
+												</div>
+											) : (
+												!gotBuildLogs && (
+													<>
+														<ProvisionerStatusAlert
+															matchingProvisioners={matchingProvisioners}
+															availableProvisioners={availableProvisioners}
+															tags={templateVersion.job.tags}
+															variant={AlertVariant.Inline}
+														/>
+														<Loader className="h-full" />
+													</>
+												)
+											)}
+
+											{gotBuildLogs && (
+												<WorkspaceBuildLogs
+													className={cn(
+														"rounded-none border-0",
+														"[&_.logs-header]:border-0 [&_.logs-header]:px-4 [&_.logs-header]:py-2 [&_.logs-header]:font-mono",
+														"[&_.logs-header:first-of-type]:pt-4 [&_.logs-header:last-child]:pb-4",
+														"[&_.logs-line]:pl-4",
+														"[&_.logs-container]:!border-0",
+													)}
+													hideTimestamps
+													logs={buildLogs}
 												/>
-												<Loader className="h-full" />
-											</>
-										)
+											)}
+
+											{resources && (
+												<WildcardHostnameWarning resources={resources} />
+											)}
+										</div>
 									)}
 
-									{gotBuildLogs && (
-										<WorkspaceBuildLogs
+									{selectedTab === "resources" && (
+										<div
 											className={cn(
-												"rounded-none border-0",
-												"[&_.logs-header]:border-0 [&_.logs-header]:px-4 [&_.logs-header]:py-2 [&_.logs-header]:font-mono",
-												"[&_.logs-header:first-of-type]:pt-4 [&_.logs-header:last-child]:pb-4",
-												"[&_.logs-line]:pl-4",
-												"[&_.logs-container]:!border-0",
+												"h-[280px] overflow-y-auto",
+												"[&_.resource-card]:border-l-0 [&_.resource-card]:border-r-0",
+												"[&_.resource-card:first-of-type]:border-t-0 [&_.resource-card:last-child]:border-b-0",
 											)}
-											hideTimestamps
-											logs={buildLogs}
-										/>
-									)}
-
-									{resources && (
-										<WildcardHostnameWarning resources={resources} />
+										>
+											{resources && (
+												<TemplateResourcesTable
+													resources={resources.filter(
+														(r) => r.workspace_transition === "start",
+													)}
+												/>
+											)}
+										</div>
 									)}
 								</div>
-							)}
-
-							{selectedTab === "resources" && (
-								<div
-									className={cn(
-										"h-[280px] overflow-y-auto",
-										"[&_.resource-card]:border-l-0 [&_.resource-card]:border-r-0",
-										"[&_.resource-card:first-of-type]:border-t-0 [&_.resource-card:last-child]:border-b-0",
-									)}
+							</div>
+						</Panel>
+						{aiPanelOpen && aiModelConfig && (
+							<>
+								<PanelResizeHandle>
+									<div className="h-full w-1 bg-border transition-colors hover:bg-content-link" />
+								</PanelResizeHandle>
+								<Panel
+									id="template-editor-ai"
+									order={2}
+									defaultSize={30}
+									minSize={20}
 								>
-									{resources && (
-										<TemplateResourcesTable
-											resources={resources.filter(
-												(r) => r.workspace_transition === "start",
-											)}
-										/>
-									)}
-								</div>
-							)}
-						</div>
-					</div>
+									<AIChatPanel
+										agent={templateAgent}
+										getFileTree={getFileTree}
+										modelConfig={aiModelConfig}
+										availableModels={aiModels}
+										onModelConfigChange={setAIModelConfig}
+										onNavigateToFile={navigateToExistingFile}
+										onClose={() => {
+											templateAgent.stop();
+											setAIPanelOpen(false);
+										}}
+									/>
+								</Panel>
+							</>
+						)}
+					</PanelGroup>
 				</div>
 			</div>
 

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -651,7 +651,14 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 							<TopbarIconButton
 								title="AI Assistant"
 								onClick={() => {
-									setAIPanelOpen((v) => !v);
+									setAIPanelOpen((prev) => {
+										// Stop any in-flight stream when hiding
+										// the panel so it doesn't run unseen.
+										if (prev) {
+											templateAgent.stop();
+										}
+										return !prev;
+									});
 								}}
 								className={aiPanelOpen ? "text-content-link" : undefined}
 							>

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -382,6 +382,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 		getFileTree,
 		setFileTree: setFileTreeAndDirty,
 		modelConfig: aiModelConfig ?? { model: { id: "", provider: "openai" } },
+		currentFilePath: activePath,
 		onFileEdited: navigateToExistingFile,
 		onFileDeleted: (path) => {
 			if (activePath === path) {
@@ -942,7 +943,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 			<PublishTemplateVersionDialog
 				key={templateVersion.name}
 				publishingError={publishingError}
-				open={isAskingPublishParameters || isPublishing}
+				open={isAskingPublishParameters}
 				onClose={onCancelPublish}
 				onConfirm={onConfirmPublish}
 				isPublishing={isPublishing}

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -187,7 +187,7 @@ interface TemplateVersionEditorProps {
 	resources?: WorkspaceResource[];
 	isBuilding: boolean;
 	canPublish: boolean;
-	onPreview: (files: FileTree) => Promise<void>;
+	onPreview: (files: FileTree) => Promise<TemplateVersion>;
 	onPublish: () => void;
 	onConfirmPublish: (data: PublishVersionData) => void;
 	/** Publishes without navigating — used by the AI tool so the
@@ -296,6 +296,10 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	const templateVersionRef = useRef(templateVersion);
 	templateVersionRef.current = templateVersion;
 
+	const requestedBuildVersionRef = useRef<TemplateVersion | undefined>(
+		undefined,
+	);
+
 	const buildLogsRef = useRef(buildLogs);
 	buildLogsRef.current = buildLogs;
 
@@ -338,26 +342,47 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	// Ref: resolver for the in-flight build promise.
 	const buildCompleteResolverRef = useRef<{
 		id: number;
+		expectedVersionId: string;
 		resolve: (result: BuildResult) => void;
 	} | null>(null);
 
 	const triggerBuild = useCallback(async () => {
-		await onPreview(getFileTree());
-	}, [onPreview, getFileTree]);
+		const requestedBuildVersion = await onPreview(getFileTree());
+		if (!requestedBuildVersion) {
+			throw new Error("Preview build did not return a template version.");
+		}
+		requestedBuildVersionRef.current = requestedBuildVersion;
+	}, [getFileTree, onPreview]);
 
 	const waitForBuildComplete = useCallback((): Promise<BuildResult> => {
 		return new Promise<BuildResult>((resolve) => {
+			const requestedBuildVersion = requestedBuildVersionRef.current;
+			if (!requestedBuildVersion) {
+				throw new Error("No template version was recorded for this build.");
+			}
+
 			const currentTemplateVersion = templateVersionRef.current;
-			if (isTerminalBuildStatus(currentTemplateVersion.job.status)) {
+			if (
+				currentTemplateVersion.id === requestedBuildVersion.id &&
+				isTerminalBuildStatus(currentTemplateVersion.job.status)
+			) {
 				resolve(
 					buildResultFromSnapshot(currentTemplateVersion, buildLogsRef.current),
 				);
 				return;
 			}
+			if (isTerminalBuildStatus(requestedBuildVersion.job.status)) {
+				resolve(buildResultFromSnapshot(requestedBuildVersion));
+				return;
+			}
 
 			const id = buildIdRef.current + 1;
 			buildIdRef.current = id;
-			buildCompleteResolverRef.current = { id, resolve };
+			buildCompleteResolverRef.current = {
+				id,
+				expectedVersionId: requestedBuildVersion.id,
+				resolve,
+			};
 		});
 	}, []);
 
@@ -460,10 +485,14 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 		if (pending.id !== buildIdRef.current) {
 			return;
 		}
-		if (isTerminalBuildStatus(templateVersion.job.status)) {
-			pending.resolve(buildResultFromSnapshot(templateVersion, buildLogs));
-			buildCompleteResolverRef.current = null;
+		if (
+			templateVersion.id !== pending.expectedVersionId ||
+			!isTerminalBuildStatus(templateVersion.job.status)
+		) {
+			return;
 		}
+		pending.resolve(buildResultFromSnapshot(templateVersion, buildLogs));
+		buildCompleteResolverRef.current = null;
 	}, [templateVersion, buildLogs]);
 
 	// Abort any active stream when the page-level component is

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -5,6 +5,7 @@ import {
 	type AIModelConfig,
 	aiBridgeModels,
 } from "api/queries/aiBridge";
+import { buildInfo } from "api/queries/buildInfo";
 import { experiments } from "api/queries/experiments";
 import type {
 	ProvisionerJobLog,
@@ -251,6 +252,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	const { data: enabledExperiments = [] } = useQuery(
 		experiments(metadata.experiments),
 	);
+	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
 	const aiExperimentEnabled = enabledExperiments.includes("ai-template-editor");
 	const { data: aiModels = [] } = useQuery({
 		...aiBridgeModels(),
@@ -464,6 +466,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 				onActivePathChange(undefined);
 			}
 		},
+		docsVersion: buildInfoQuery.data?.version,
 		onBuildRequested: triggerBuild,
 		waitForBuildComplete,
 		getBuildOutput,

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -145,6 +145,40 @@ const selectDefaultAIModel = (
 	return models[0];
 };
 
+const formatBuildLogs = (buildLogs?: ProvisionerJobLog[]): string =>
+	(buildLogs ?? [])
+		.map((log) => `[${log.log_level}] ${log.stage}: ${log.output}`)
+		.join("\n");
+
+const isTerminalBuildStatus = (
+	status: TemplateVersion["job"]["status"],
+): status is "succeeded" | "failed" | "canceled" | "unknown" =>
+	status === "succeeded" ||
+	status === "failed" ||
+	status === "canceled" ||
+	status === "unknown";
+
+const buildResultFromSnapshot = (
+	templateVersion: TemplateVersion,
+	buildLogs?: ProvisionerJobLog[],
+): BuildResult => {
+	const { status } = templateVersion.job;
+	if (!isTerminalBuildStatus(status)) {
+		throw new Error(
+			`Cannot resolve build result from non-terminal status: ${String(status)}.`,
+		);
+	}
+
+	return {
+		status: status === "unknown" ? "failed" : status,
+		error:
+			status === "unknown"
+				? (templateVersion.job.error ?? "Build ended with an unknown status.")
+				: templateVersion.job.error,
+		logs: formatBuildLogs(buildLogs),
+	};
+};
+
 interface TemplateVersionEditorProps {
 	template: Template;
 	templateVersion: TemplateVersion;
@@ -313,6 +347,14 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 
 	const waitForBuildComplete = useCallback((): Promise<BuildResult> => {
 		return new Promise<BuildResult>((resolve) => {
+			const currentTemplateVersion = templateVersionRef.current;
+			if (isTerminalBuildStatus(currentTemplateVersion.job.status)) {
+				resolve(
+					buildResultFromSnapshot(currentTemplateVersion, buildLogsRef.current),
+				);
+				return;
+			}
+
 			const id = buildIdRef.current + 1;
 			buildIdRef.current = id;
 			buildCompleteResolverRef.current = { id, resolve };
@@ -325,10 +367,11 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 		if (!status) {
 			return undefined;
 		}
-		const logText = (buildLogsRef.current ?? [])
-			.map((l) => `[${l.log_level}] ${l.stage}: ${l.output}`)
-			.join("\n");
-		return { status, error: currentTemplateVersion.job.error, logs: logText };
+		return {
+			status,
+			error: currentTemplateVersion.job.error,
+			logs: formatBuildLogs(buildLogsRef.current),
+		};
 	}, []);
 
 	const handlePublish = useCallback(
@@ -382,6 +425,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 		getFileTree,
 		setFileTree: setFileTreeAndDirty,
 		modelConfig: aiModelConfig ?? { model: { id: "", provider: "openai" } },
+		enabled: aiAvailable && aiPanelOpen,
 		currentFilePath: activePath,
 		onFileEdited: navigateToExistingFile,
 		onFileDeleted: (path) => {
@@ -416,28 +460,11 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 		if (pending.id !== buildIdRef.current) {
 			return;
 		}
-		const status = templateVersion.job.status;
-		if (
-			status === "succeeded" ||
-			status === "failed" ||
-			status === "canceled" ||
-			status === "unknown"
-		) {
-			const logText = (buildLogs ?? [])
-				.map((l) => `[${l.log_level}] ${l.stage}: ${l.output}`)
-				.join("\n");
-			pending.resolve({
-				status: status === "unknown" ? "failed" : status,
-				error:
-					status === "unknown"
-						? (templateVersion.job.error ??
-							"Build ended with an unknown status.")
-						: templateVersion.job.error,
-				logs: logText,
-			});
+		if (isTerminalBuildStatus(templateVersion.job.status)) {
+			pending.resolve(buildResultFromSnapshot(templateVersion, buildLogs));
 			buildCompleteResolverRef.current = null;
 		}
-	}, [templateVersion.job.status, templateVersion.job.error, buildLogs]);
+	}, [templateVersion, buildLogs]);
 
 	// Abort any active stream when the page-level component is
 	// unmounted so we don't leave orphaned network requests.

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.aiPublish.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.aiPublish.test.tsx
@@ -1,0 +1,91 @@
+import { MockTemplate, MockTemplateVersion } from "testHelpers/entities";
+import { renderWithAuth } from "testHelpers/renderHelpers";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as apiModule from "api/api";
+
+const { mockedPublishVersionName } = vi.hoisted(() => ({
+	mockedPublishVersionName: "ai-published-version",
+}));
+
+vi.mock("./TemplateVersionEditor", () => ({
+	TemplateVersionEditor: (props: {
+		onPublishVersion: (data: {
+			name?: string;
+			message?: string;
+			isActiveVersion?: boolean;
+		}) => Promise<void>;
+	}) => (
+		<button
+			type="button"
+			onClick={() =>
+				void props.onPublishVersion({
+					name: mockedPublishVersionName,
+					message: "Published from AI",
+					isActiveVersion: true,
+				})
+			}
+		>
+			AI publish
+		</button>
+	),
+}));
+
+import TemplateVersionEditorPage from "./TemplateVersionEditorPage";
+
+const { API } = apiModule;
+
+describe("TemplateVersionEditorPage AI publish navigation", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("navigates with React Router and preserves search params", async () => {
+		const user = userEvent.setup();
+		const replaceStateSpy = vi.spyOn(window.history, "replaceState");
+		const publishedVersion = {
+			...MockTemplateVersion,
+			id: "published-version-id",
+			name: mockedPublishVersionName,
+		};
+		const patchTemplateVersionSpy = vi
+			.spyOn(API, "patchTemplateVersion")
+			.mockResolvedValue(publishedVersion);
+		const updateActiveTemplateVersionSpy = vi
+			.spyOn(API, "updateActiveTemplateVersion")
+			.mockResolvedValue({ message: "" });
+		const { router } = renderWithAuth(<TemplateVersionEditorPage />, {
+			route: `/templates/${MockTemplate.name}/versions/${MockTemplateVersion.name}/edit?path=myfile.tf`,
+			path: "/templates/:template/versions/:version/edit",
+			extraRoutes: [
+				{
+					path: "/templates/:templateId",
+					element: <div></div>,
+				},
+			],
+		});
+
+		await user.click(await screen.findByRole("button", { name: "AI publish" }));
+
+		await waitFor(() => {
+			expect(patchTemplateVersionSpy).toHaveBeenCalledWith(
+				MockTemplateVersion.id,
+				{
+					message: "Published from AI",
+					name: mockedPublishVersionName,
+				},
+			);
+			expect(updateActiveTemplateVersionSpy).toHaveBeenCalledWith(
+				MockTemplate.name,
+				{
+					id: MockTemplateVersion.id,
+				},
+			);
+			expect(router.state.location.pathname).toBe(
+				`/templates/${MockTemplate.name}/versions/${mockedPublishVersionName}/edit`,
+			);
+		});
+		expect(router.state.location.search).toBe("?path=myfile.tf");
+		expect(replaceStateSpy).not.toHaveBeenCalled();
+	});
+});

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -192,15 +192,15 @@ const TemplateVersionEditorPage: FC = () => {
 					}}
 					onPublishVersion={async (data) => {
 						const publishedVersion = await doPublish(data);
-						// Update the route to reflect the published version name.
-						// Using replace: true avoids adding a new history entry
-						// while keeping React Router state in sync with the URL.
+						// Use replaceState instead of navigate to update the URL
+						// without triggering React Router re-rendering. This
+						// preserves the AI agent's chat session across publishes.
 						const templatePath = `${getLink(
 							linkToTemplate(organizationName, templateName),
 						)}/versions/${publishedVersion.name}/edit`;
 						const query = searchParams.toString();
 						const nextPath = query ? `${templatePath}?${query}` : templatePath;
-						navigate(nextPath, { replace: true });
+						window.history.replaceState(null, "", nextPath);
 					}}
 					isAskingPublishParameters={isPublishingDialogOpen}
 					isPublishing={publishVersionMutation.isPending}

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -30,6 +30,7 @@ import { pageTitle } from "utils/page";
 import { TarReader, TarWriter } from "utils/tar";
 import { createTemplateVersionFileTree } from "utils/templateVersion";
 import { TemplateVersionEditor } from "./TemplateVersionEditor";
+import type { PublishVersionData } from "./types";
 
 const TemplateVersionEditorPage: FC = () => {
 	const getLink = useLinks();
@@ -116,6 +117,25 @@ const TemplateVersionEditorPage: FC = () => {
 		navigateToVersion(newVersion);
 	};
 
+	const doPublish = async ({
+		isActiveVersion,
+		...data
+	}: PublishVersionData) => {
+		const templateVersion = activeTemplateVersion!;
+		await publishVersionMutation.mutateAsync({
+			isActiveVersion,
+			data,
+			version: templateVersion,
+		});
+		const publishedVersion = {
+			...templateVersion,
+			...data,
+		};
+		setLastSuccessfulPublishedVersion(publishedVersion);
+		queryClient.setQueryData(templateVersionOptions.queryKey, publishedVersion);
+		return publishedVersion;
+	};
+
 	// Provisioner Tags
 	const [provisionerTags, setProvisionerTags] = useState<
 		Record<string, string>
@@ -165,23 +185,22 @@ const TemplateVersionEditorPage: FC = () => {
 					onCancelPublish={() => {
 						setIsPublishingDialogOpen(false);
 					}}
-					onConfirmPublish={async ({ isActiveVersion, ...data }) => {
-						await publishVersionMutation.mutateAsync({
-							isActiveVersion,
-							data,
-							version: activeTemplateVersion,
-						});
-						const publishedVersion = {
-							...activeTemplateVersion,
-							...data,
-						};
+					onConfirmPublish={async (data) => {
+						const publishedVersion = await doPublish(data);
 						setIsPublishingDialogOpen(false);
-						setLastSuccessfulPublishedVersion(publishedVersion);
-						queryClient.setQueryData(
-							templateVersionOptions.queryKey,
-							publishedVersion,
-						);
 						navigateToVersion(publishedVersion);
+					}}
+					onPublishVersion={async (data) => {
+						const publishedVersion = await doPublish(data);
+						// Update the route to reflect the published version name.
+						// Using replace: true avoids adding a new history entry
+						// while keeping React Router state in sync with the URL.
+						const templatePath = `${getLink(
+							linkToTemplate(organizationName, templateName),
+						)}/versions/${publishedVersion.name}/edit`;
+						const query = searchParams.toString();
+						const nextPath = query ? `${templatePath}?${query}` : templatePath;
+						navigate(nextPath, { replace: true });
 					}}
 					isAskingPublishParameters={isPublishingDialogOpen}
 					isPublishing={publishVersionMutation.isPending}

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -192,15 +192,7 @@ const TemplateVersionEditorPage: FC = () => {
 					}}
 					onPublishVersion={async (data) => {
 						const publishedVersion = await doPublish(data);
-						// Use replaceState instead of navigate to update the URL
-						// without triggering React Router re-rendering. This
-						// preserves the AI agent's chat session across publishes.
-						const templatePath = `${getLink(
-							linkToTemplate(organizationName, templateName),
-						)}/versions/${publishedVersion.name}/edit`;
-						const query = searchParams.toString();
-						const nextPath = query ? `${templatePath}?${query}` : templatePath;
-						window.history.replaceState(null, "", nextPath);
+						navigateToVersion(publishedVersion);
 					}}
 					isAskingPublishParameters={isPublishingDialogOpen}
 					isPublishing={publishVersionMutation.isPending}

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -122,15 +122,14 @@ const TemplateVersionEditorPage: FC = () => {
 		...data
 	}: PublishVersionData) => {
 		const templateVersion = activeTemplateVersion!;
-		await publishVersionMutation.mutateAsync({
+		// publishVersion returns the server's patched TemplateVersion,
+		// so we use it as the authoritative source of truth instead of
+		// manually reconstructing the object from local inputs.
+		const publishedVersion = await publishVersionMutation.mutateAsync({
 			isActiveVersion,
 			data,
 			version: templateVersion,
 		});
-		const publishedVersion = {
-			...templateVersion,
-			...data,
-		};
 		setLastSuccessfulPublishedVersion(publishedVersion);
 		queryClient.setQueryData(templateVersionOptions.queryKey, publishedVersion);
 		return publishedVersion;
@@ -348,29 +347,34 @@ const generateVersionFiles = async (
 	return new File([blob], "template.tar", { type: "application/x-tar" });
 };
 
+/**
+ * Publish a template version by patching its metadata and optionally
+ * promoting it to the active version. Returns the server's patched
+ * TemplateVersion so callers use authoritative data instead of
+ * reconstructing the object locally.
+ */
 const publishVersion = async (options: {
 	version: TemplateVersion;
 	data: PatchTemplateVersionRequest;
 	isActiveVersion: boolean;
-}) => {
+}): Promise<TemplateVersion> => {
 	const { version, data, isActiveVersion } = options;
 	const haveChanges =
 		data.name !== version.name || data.message !== version.message;
-	const publishActions: Promise<unknown>[] = [];
 
-	if (haveChanges) {
-		publishActions.push(API.patchTemplateVersion(version.id, data));
-	}
+	// Patch metadata first so we have the server's response as the
+	// canonical source of truth for the updated TemplateVersion.
+	const patchedVersion = haveChanges
+		? await API.patchTemplateVersion(version.id, data)
+		: version;
 
 	if (version.template_id && isActiveVersion) {
-		publishActions.push(
-			API.updateActiveTemplateVersion(version.template_id, {
-				id: version.id,
-			}),
-		);
+		await API.updateActiveTemplateVersion(version.template_id, {
+			id: version.id,
+		});
 	}
 
-	return Promise.all(publishActions);
+	return patchedVersion;
 };
 
 const defaultMainTerraformFile = "main.tf";

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -161,7 +161,9 @@ const TemplateVersionEditorPage: FC = () => {
 					defaultFileTree={fileTree}
 					onPreview={async (newFileTree) => {
 						if (!tarFile) {
-							return;
+							throw new Error(
+								"Template version file contents are unavailable.",
+							);
 						}
 						const newVersionFile = await generateVersionFiles(
 							tarFile,
@@ -178,6 +180,7 @@ const TemplateVersionEditorPage: FC = () => {
 						});
 
 						onBuildEnds(newVersion);
+						return newVersion;
 					}}
 					onPublish={() => {
 						setIsPublishingDialogOpen(true);

--- a/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
@@ -35,6 +35,7 @@ export const AIChatPanel: FC<AIChatPanelProps> = ({
 		send,
 		approve,
 		reject,
+		stop,
 		reset,
 	} = agent;
 
@@ -120,7 +121,12 @@ export const AIChatPanel: FC<AIChatPanelProps> = ({
 				</div>
 			)}
 
-			<ChatInput onSend={send} disabled={inputDisabled} />
+			<ChatInput
+				onSend={send}
+				onStop={stop}
+				disabled={inputDisabled}
+				isStreaming={isStreaming}
+			/>
 		</div>
 	);
 };

--- a/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
@@ -1,0 +1,126 @@
+import type { AIBridgeModel, AIModelConfig } from "api/queries/aiBridge";
+import { Button } from "components/Button/Button";
+import { RotateCcwIcon, SparklesIcon, XIcon } from "lucide-react";
+import { type FC, useEffect, useRef } from "react";
+import type { FileTree } from "utils/filetree";
+import { ChatInput } from "./ChatInput";
+import { ChatMessage } from "./ChatMessage";
+import { ModelConfigBar } from "./ModelConfigBar";
+import type { TemplateAgentState } from "./useTemplateAgent";
+
+interface AIChatPanelProps {
+	agent: TemplateAgentState;
+	getFileTree: () => FileTree;
+	modelConfig: AIModelConfig;
+	availableModels: readonly AIBridgeModel[];
+	onModelConfigChange: (config: AIModelConfig) => void;
+	onNavigateToFile?: (path: string) => void;
+	onClose: () => void;
+}
+
+export const AIChatPanel: FC<AIChatPanelProps> = ({
+	agent,
+	getFileTree,
+	modelConfig,
+	availableModels,
+	onModelConfigChange,
+	onNavigateToFile,
+	onClose,
+}) => {
+	const {
+		messages,
+		isStreaming,
+		status,
+		pendingApproval,
+		send,
+		approve,
+		reject,
+		reset,
+	} = agent;
+
+	const listRef = useRef<HTMLDivElement>(null);
+
+	// Use `messages` directly so the effect re-fires as streaming
+	// content grows (the array reference changes on each update).
+	useEffect(() => {
+		const node = listRef.current;
+		if (!node) {
+			return;
+		}
+		if (messages.length === 0 && status === "idle") {
+			return;
+		}
+		node.scrollTo({ top: node.scrollHeight, behavior: "smooth" });
+	}, [messages, status]);
+
+	const inputDisabled = isStreaming || status === "awaiting_approval";
+
+	return (
+		<div className="flex h-full flex-col border-solid border-0 border-l border-t border-border bg-surface-primary">
+			<div className="flex items-center justify-between px-3 py-2">
+				<div className="flex items-center gap-2 text-sm font-medium text-content-primary">
+					<SparklesIcon className="size-4 text-content-link" />
+					<span>AI Assistant</span>
+				</div>
+				<div className="flex items-center gap-1">
+					<Button variant="subtle" size="sm" onClick={reset}>
+						<RotateCcwIcon />
+						Reset
+					</Button>
+					<Button
+						variant="subtle"
+						size="icon"
+						onClick={onClose}
+						aria-label="Close AI assistant panel"
+					>
+						<XIcon />
+					</Button>
+				</div>
+			</div>
+
+			<ModelConfigBar
+				modelConfig={modelConfig}
+				availableModels={availableModels}
+				onModelConfigChange={onModelConfigChange}
+			/>
+
+			<div ref={listRef} className="flex-1 overflow-y-auto px-3 py-2">
+				<div className="flex min-h-full flex-col justify-end gap-3">
+					{messages.length === 0 && (
+						<p className="m-0 text-xs leading-relaxed text-content-secondary">
+							Ask me to inspect or modify your template files. I can read files,
+							propose edits, and ask for approval before changing anything.
+						</p>
+					)}
+
+					{messages.map((message) => (
+						<ChatMessage
+							key={message.id}
+							message={message}
+							pendingApproval={pendingApproval}
+							onApprove={approve}
+							onReject={reject}
+							onNavigateToFile={onNavigateToFile}
+							getFileTree={getFileTree}
+						/>
+					))}
+				</div>
+			</div>
+
+			{isStreaming && (
+				<div className="px-3 py-1.5 text-xs text-content-secondary">
+					Thinking…
+				</div>
+			)}
+
+			{status === "error" && (
+				<div className="px-3 py-1.5 text-xs text-content-destructive">
+					Something went wrong while streaming the assistant response. Reset the
+					chat and try again.
+				</div>
+			)}
+
+			<ChatInput onSend={send} disabled={inputDisabled} />
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
@@ -109,7 +109,8 @@ export const AIChatPanel: FC<AIChatPanelProps> = ({
 					{messages.length === 0 && (
 						<p className="m-0 text-xs leading-relaxed text-content-secondary">
 							Ask me to inspect or modify your template files. I can read files,
-							propose edits, and ask for approval before changing anything.
+							propose edits, and review pasted screenshots before changing
+							anything.
 						</p>
 					)}
 

--- a/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx
@@ -1,6 +1,11 @@
 import type { AIBridgeModel, AIModelConfig } from "api/queries/aiBridge";
 import { Button } from "components/Button/Button";
-import { RotateCcwIcon, SparklesIcon, XIcon } from "lucide-react";
+import {
+	RotateCcwIcon,
+	SparklesIcon,
+	TriangleAlertIcon,
+	XIcon,
+} from "lucide-react";
 import { type FC, useEffect, useRef } from "react";
 import type { FileTree } from "utils/filetree";
 import { ChatInput } from "./ChatInput";
@@ -32,6 +37,7 @@ export const AIChatPanel: FC<AIChatPanelProps> = ({
 		isStreaming,
 		status,
 		pendingApproval,
+		mcpConnectionFailed,
 		send,
 		approve,
 		reject,
@@ -84,6 +90,19 @@ export const AIChatPanel: FC<AIChatPanelProps> = ({
 				availableModels={availableModels}
 				onModelConfigChange={onModelConfigChange}
 			/>
+
+			{mcpConnectionFailed && (
+				<div
+					className="mx-3 flex items-center gap-2 rounded-md bg-surface-orange/10 px-2.5 py-1.5 text-2xs text-content-warning"
+					role="status"
+				>
+					<TriangleAlertIcon className="size-3 shrink-0" />
+					<span>
+						Coder Registry tools are unavailable. Local file editing still
+						works.
+					</span>
+				</div>
+			)}
 
 			<div ref={listRef} className="flex-1 overflow-y-auto px-3 py-2">
 				<div className="flex min-h-full flex-col justify-end gap-3">

--- a/site/src/pages/TemplateVersionEditorPage/ai/BuildApprovalCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/BuildApprovalCard.tsx
@@ -1,0 +1,59 @@
+import { Button } from "components/Button/Button";
+import { HammerIcon, LoaderIcon } from "lucide-react";
+import type { FC } from "react";
+import type { DisplayToolCall } from "./useTemplateAgent";
+
+interface BuildApprovalCardProps {
+	toolCall: DisplayToolCall;
+	isPending: boolean;
+	onApprove: () => void;
+	onReject: () => void;
+}
+
+export const BuildApprovalCard: FC<BuildApprovalCardProps> = ({
+	toolCall,
+	isPending,
+	onApprove,
+	onReject,
+}) => {
+	const isRunning = toolCall.state === "pending" && !isPending;
+	const result =
+		typeof toolCall.result === "object" && toolCall.result !== null
+			? (toolCall.result as Record<string, unknown>)
+			: null;
+	const resultError = typeof result?.error === "string" ? result.error : null;
+
+	return (
+		<div className="space-y-2 rounded-md border border-solid border-border p-3">
+			<div className="flex items-center gap-2 text-xs font-medium text-content-primary">
+				{isRunning ? (
+					<LoaderIcon className="size-3.5 animate-spin" />
+				) : (
+					<HammerIcon className="size-3.5" />
+				)}
+				<span>
+					{isPending
+						? "Build template?"
+						: isRunning
+							? "Building…"
+							: `Build ${result?.status ?? "complete"}`}
+				</span>
+			</div>
+
+			{isPending && (
+				<div className="flex gap-2">
+					<Button size="sm" onClick={onApprove}>
+						Approve
+					</Button>
+					<Button size="sm" variant="outline" onClick={onReject}>
+						Reject
+					</Button>
+				</div>
+			)}
+
+			{resultError && (
+				<p className="m-0 text-xs text-content-destructive">{resultError}</p>
+			)}
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/BuildApprovalCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/BuildApprovalCard.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/Button/Button";
 import { HammerIcon, LoaderIcon } from "lucide-react";
-import type { FC } from "react";
+import { type FC, useEffect, useRef } from "react";
 import type { DisplayToolCall } from "./useTemplateAgent";
 
 interface BuildApprovalCardProps {
@@ -16,6 +16,16 @@ export const BuildApprovalCard: FC<BuildApprovalCardProps> = ({
 	onApprove,
 	onReject,
 }) => {
+	const approveRef = useRef<HTMLButtonElement>(null);
+	// Move focus to the Approve button when this card first
+	// requires user input so keyboard and screen-reader users
+	// are immediately aware of the pending action.
+	useEffect(() => {
+		if (isPending) {
+			approveRef.current?.focus();
+		}
+	}, [isPending]);
+
 	const isRunning = toolCall.state === "pending" && !isPending;
 	const result =
 		typeof toolCall.result === "object" && toolCall.result !== null
@@ -24,7 +34,11 @@ export const BuildApprovalCard: FC<BuildApprovalCardProps> = ({
 	const resultError = typeof result?.error === "string" ? result.error : null;
 
 	return (
-		<div className="space-y-2 rounded-md border border-solid border-border p-3">
+		<div
+			className="space-y-2 rounded-md border border-solid border-border p-3"
+			role="region"
+			aria-label="Build template"
+		>
 			<div className="flex items-center gap-2 text-xs font-medium text-content-primary">
 				{isRunning ? (
 					<LoaderIcon className="size-3.5 animate-spin" />
@@ -41,8 +55,8 @@ export const BuildApprovalCard: FC<BuildApprovalCardProps> = ({
 			</div>
 
 			{isPending && (
-				<div className="flex gap-2">
-					<Button size="sm" onClick={onApprove}>
+				<div className="flex gap-2" role="group" aria-label="Approval actions">
+					<Button ref={approveRef} size="sm" onClick={onApprove}>
 						Approve
 					</Button>
 					<Button size="sm" variant="outline" onClick={onReject}>

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ChatInput } from "./ChatInput";
+
+const createObjectURLMock = vi.fn();
+const revokeObjectURLMock = vi.fn();
+
+beforeAll(() => {
+	Object.defineProperty(URL, "createObjectURL", {
+		configurable: true,
+		writable: true,
+		value: createObjectURLMock,
+	});
+	Object.defineProperty(URL, "revokeObjectURL", {
+		configurable: true,
+		writable: true,
+		value: revokeObjectURLMock,
+	});
+});
+
+beforeEach(() => {
+	createObjectURLMock.mockReset();
+	revokeObjectURLMock.mockReset();
+	createObjectURLMock.mockReturnValue("blob:error-preview");
+});
+
+describe("ChatInput", () => {
+	it("captures pasted screenshots and sends them as attachments", async () => {
+		const user = userEvent.setup();
+		const onSend = vi.fn().mockResolvedValue({ accepted: true });
+		render(<ChatInput onSend={onSend} />);
+
+		const textarea = screen.getByLabelText("Message AI assistant");
+		const screenshot = new File(["image-bytes"], "error.png", {
+			type: "image/png",
+		});
+
+		fireEvent.paste(textarea, {
+			clipboardData: {
+				files: [screenshot],
+				getData: () => "",
+			},
+		});
+
+		expect(screen.getByAltText("error.png")).toBeInTheDocument();
+
+		await user.type(textarea, "Please debug this screenshot.");
+		await user.click(screen.getByRole("button", { name: "Send message" }));
+
+		await waitFor(() => {
+			expect(onSend).toHaveBeenCalledWith({
+				text: "Please debug this screenshot.",
+				attachments: [screenshot],
+			});
+		});
+		await waitFor(() => {
+			expect(screen.queryByAltText("error.png")).not.toBeInTheDocument();
+		});
+		expect(textarea).toHaveValue("");
+	});
+});

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx
@@ -1,17 +1,37 @@
 import { Button } from "components/Button/Button";
-import { SendIcon, SquareIcon } from "lucide-react";
+import { ImageIcon, SendIcon, SquareIcon, XIcon } from "lucide-react";
 import {
+	type ChangeEvent,
+	type ClipboardEvent,
 	type FC,
 	type KeyboardEvent,
 	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
+import { toast } from "sonner";
 import { cn } from "utils/cn";
+import {
+	MAX_CHAT_IMAGE_ATTACHMENTS,
+	validateImageAttachment,
+} from "./attachments";
+
+interface ChatInputSendPayload {
+	text: string;
+	attachments: readonly File[];
+}
+
+interface ChatInputSendResult {
+	accepted: boolean;
+	error?: string;
+}
 
 interface ChatInputProps {
-	onSend: (text: string) => void;
+	onSend: (
+		payload: ChatInputSendPayload,
+	) => ChatInputSendResult | Promise<ChatInputSendResult>;
 	onStop?: () => void;
 	disabled?: boolean;
 	isStreaming?: boolean;
@@ -23,10 +43,13 @@ export const ChatInput: FC<ChatInputProps> = ({
 	onStop,
 	disabled = false,
 	isStreaming = false,
-	placeholder = "Ask about this template...",
+	placeholder = "Ask about this template or paste a screenshot...",
 }) => {
 	const [value, setValue] = useState("");
+	const [attachments, setAttachments] = useState<File[]>([]);
+	const [isSending, setIsSending] = useState(false);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const resizeTextarea = useCallback(() => {
 		const textarea = textareaRef.current;
@@ -37,24 +60,119 @@ export const ChatInput: FC<ChatInputProps> = ({
 		textarea.style.height = `${Math.min(textarea.scrollHeight, 150)}px`;
 	}, []);
 	const isStopMode = isStreaming && onStop !== undefined;
+	const inputDisabled = disabled || isSending;
+	const draftHasContent = value.trim().length > 0 || attachments.length > 0;
 
-	const handleSend = useCallback(() => {
-		if (disabled) {
+	const attachmentPreviews = useMemo(
+		() =>
+			attachments.map((file) => ({
+				file,
+				previewUrl:
+					typeof URL.createObjectURL === "function"
+						? URL.createObjectURL(file)
+						: "",
+			})),
+		[attachments],
+	);
+
+	useEffect(() => {
+		return () => {
+			if (typeof URL.revokeObjectURL !== "function") {
+				return;
+			}
+			for (const { previewUrl } of attachmentPreviews) {
+				if (previewUrl.length > 0) {
+					URL.revokeObjectURL(previewUrl);
+				}
+			}
+		};
+	}, [attachmentPreviews]);
+
+	const addAttachments = useCallback(
+		(incoming: readonly File[]) => {
+			if (incoming.length === 0) {
+				return;
+			}
+			const nextAttachments: File[] = [];
+			let totalAttachments = attachments.length;
+			let firstError: string | undefined;
+			for (const file of incoming) {
+				const validationError = validateImageAttachment(file);
+				if (validationError) {
+					firstError ??= validationError;
+					continue;
+				}
+				if (totalAttachments >= MAX_CHAT_IMAGE_ATTACHMENTS) {
+					firstError ??= `You can attach up to ${MAX_CHAT_IMAGE_ATTACHMENTS} screenshots per message.`;
+					continue;
+				}
+				nextAttachments.push(file);
+				totalAttachments += 1;
+			}
+			if (nextAttachments.length > 0) {
+				setAttachments((prev) => [...prev, ...nextAttachments]);
+			}
+			if (firstError) {
+				toast.error(firstError);
+			}
+		},
+		[attachments.length],
+	);
+
+	const handleFileSelection = useCallback(
+		(event: ChangeEvent<HTMLInputElement>) => {
+			addAttachments(Array.from(event.target.files ?? []));
+			// Reset so selecting the same file again still fires onChange.
+			event.target.value = "";
+		},
+		[addAttachments],
+	);
+
+	const handlePaste = useCallback(
+		(event: ClipboardEvent<HTMLTextAreaElement>) => {
+			const images = Array.from(event.clipboardData.files).filter((file) =>
+				file.type.startsWith("image/"),
+			);
+			if (images.length === 0) {
+				return;
+			}
+			event.preventDefault();
+			addAttachments(images);
+		},
+		[addAttachments],
+	);
+
+	const handleSend = useCallback(async () => {
+		if (inputDisabled) {
 			return;
 		}
-
 		const trimmed = value.trim();
-		if (!trimmed) {
+		if (!trimmed && attachments.length === 0) {
 			return;
 		}
-
-		onSend(trimmed);
-		setValue("");
-		const textarea = textareaRef.current;
-		if (textarea) {
-			textarea.style.height = "auto";
+		setIsSending(true);
+		try {
+			const result = await onSend({ text: trimmed, attachments });
+			if (!result.accepted) {
+				if (result.error) {
+					toast.error(result.error);
+				}
+				return;
+			}
+			setValue("");
+			setAttachments([]);
+			const textarea = textareaRef.current;
+			if (textarea) {
+				textarea.style.height = "auto";
+			}
+		} catch (error) {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to send the message.",
+			);
+		} finally {
+			setIsSending(false);
 		}
-	}, [disabled, onSend, value]);
+	}, [attachments, inputDisabled, onSend, value]);
 
 	const handleStop = useCallback(() => {
 		onStop?.();
@@ -70,7 +188,7 @@ export const ChatInput: FC<ChatInputProps> = ({
 			if (event.key === "Enter" && !event.shiftKey) {
 				event.preventDefault();
 				event.stopPropagation();
-				handleSend();
+				void handleSend();
 			}
 		},
 		[handleSend],
@@ -81,37 +199,102 @@ export const ChatInput: FC<ChatInputProps> = ({
 	}, [resizeTextarea]);
 
 	return (
-		<div className="flex items-end gap-1.5 px-3 py-2">
-			<textarea
-				ref={textareaRef}
-				value={value}
-				onChange={(event) => {
-					setValue(event.target.value);
-					resizeTextarea();
-				}}
-				onKeyDown={onKeyDown}
-				disabled={disabled}
-				rows={1}
-				placeholder={placeholder}
-				aria-label="Message AI assistant"
-				className={cn(
-					"max-h-[150px] min-h-10 flex-1 resize-none rounded-md",
-					"border border-solid border-border bg-transparent px-3 py-2",
-					"text-sm text-content-primary placeholder:text-content-secondary",
-					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
-					"disabled:cursor-not-allowed disabled:opacity-50",
-				)}
-			/>
-			<Button
-				variant="outline"
-				size="icon"
-				className="h-10 w-10 shrink-0"
-				onClick={isStopMode ? handleStop : handleSend}
-				disabled={!isStopMode && (disabled || value.trim().length === 0)}
-				aria-label={isStopMode ? "Stop response" : "Send message"}
-			>
-				{isStopMode ? <SquareIcon /> : <SendIcon />}
-			</Button>
+		<div className="flex flex-col gap-2 px-3 py-2">
+			{attachmentPreviews.length > 0 && (
+				<div className="flex gap-2 overflow-x-auto">
+					{attachmentPreviews.map(({ file, previewUrl }, index) => {
+						const fileLabel =
+							file.name.trim().length > 0
+								? file.name
+								: `Screenshot ${index + 1}`;
+						const fallbackLabel =
+							fileLabel.split(".").pop()?.toUpperCase() ?? "FILE";
+						return (
+							<div
+								key={`${fileLabel}-${file.size}-${file.lastModified}-${index}`}
+								className="group relative"
+								title={fileLabel}
+							>
+								{previewUrl.length > 0 ? (
+									<img
+										src={previewUrl}
+										alt={fileLabel}
+										className="h-16 w-16 rounded-md border border-border object-cover"
+									/>
+								) : (
+									<div className="flex h-16 w-16 items-center justify-center rounded-md border border-border bg-surface-secondary text-[10px] font-medium text-content-secondary">
+										{fallbackLabel}
+									</div>
+								)}
+								<button
+									type="button"
+									onClick={() => {
+										setAttachments((prev) =>
+											prev.filter((_, itemIndex) => itemIndex !== index),
+										);
+									}}
+									className="absolute -right-2 -top-2 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border border-border bg-surface-primary text-content-secondary shadow-sm opacity-0 transition-opacity hover:bg-surface-secondary hover:text-content-primary group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100"
+									aria-label={`Remove ${fileLabel}`}
+								>
+									<XIcon className="h-3.5 w-3.5" />
+								</button>
+							</div>
+						);
+					})}
+				</div>
+			)}
+
+			<div className="flex items-end gap-1.5">
+				<input
+					ref={fileInputRef}
+					type="file"
+					multiple
+					accept="image/*"
+					onChange={handleFileSelection}
+					className="hidden"
+				/>
+				<Button
+					variant="outline"
+					size="icon"
+					className="h-10 w-10 shrink-0"
+					onClick={() => fileInputRef.current?.click()}
+					disabled={inputDisabled}
+					aria-label="Attach screenshots"
+				>
+					<ImageIcon />
+				</Button>
+				<textarea
+					ref={textareaRef}
+					value={value}
+					onChange={(event) => {
+						setValue(event.target.value);
+						resizeTextarea();
+					}}
+					onPaste={handlePaste}
+					onKeyDown={onKeyDown}
+					disabled={inputDisabled}
+					rows={1}
+					placeholder={placeholder}
+					aria-label="Message AI assistant"
+					className={cn(
+						"max-h-[150px] min-h-10 flex-1 resize-none rounded-md",
+						"border border-solid border-border bg-transparent px-3 py-2",
+						"text-sm text-content-primary placeholder:text-content-secondary",
+						"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+						"disabled:cursor-not-allowed disabled:opacity-50",
+					)}
+				/>
+				<Button
+					variant="outline"
+					size="icon"
+					className="h-10 w-10 shrink-0"
+					onClick={isStopMode ? handleStop : () => void handleSend()}
+					disabled={!isStopMode && (inputDisabled || !draftHasContent)}
+					aria-label={isStopMode ? "Stop response" : "Send message"}
+				>
+					{isStopMode ? <SquareIcon /> : <SendIcon />}
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/Button/Button";
-import { SendIcon } from "lucide-react";
+import { SendIcon, SquareIcon } from "lucide-react";
 import {
 	type FC,
 	type KeyboardEvent,
@@ -12,13 +12,17 @@ import { cn } from "utils/cn";
 
 interface ChatInputProps {
 	onSend: (text: string) => void;
+	onStop?: () => void;
 	disabled?: boolean;
+	isStreaming?: boolean;
 	placeholder?: string;
 }
 
 export const ChatInput: FC<ChatInputProps> = ({
 	onSend,
+	onStop,
 	disabled = false,
+	isStreaming = false,
 	placeholder = "Ask about this template...",
 }) => {
 	const [value, setValue] = useState("");
@@ -32,6 +36,7 @@ export const ChatInput: FC<ChatInputProps> = ({
 		textarea.style.height = "auto";
 		textarea.style.height = `${Math.min(textarea.scrollHeight, 150)}px`;
 	}, []);
+	const isStopMode = isStreaming && onStop !== undefined;
 
 	const handleSend = useCallback(() => {
 		if (disabled) {
@@ -50,6 +55,10 @@ export const ChatInput: FC<ChatInputProps> = ({
 			textarea.style.height = "auto";
 		}
 	}, [disabled, onSend, value]);
+
+	const handleStop = useCallback(() => {
+		onStop?.();
+	}, [onStop]);
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -97,11 +106,11 @@ export const ChatInput: FC<ChatInputProps> = ({
 				variant="outline"
 				size="icon"
 				className="h-10 w-10 shrink-0"
-				onClick={handleSend}
-				disabled={disabled || value.trim().length === 0}
-				aria-label="Send message"
+				onClick={isStopMode ? handleStop : handleSend}
+				disabled={!isStopMode && (disabled || value.trim().length === 0)}
+				aria-label={isStopMode ? "Stop response" : "Send message"}
 			>
-				<SendIcon />
+				{isStopMode ? <SquareIcon /> : <SendIcon />}
 			</Button>
 		</div>
 	);

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx
@@ -1,0 +1,108 @@
+import { Button } from "components/Button/Button";
+import { SendIcon } from "lucide-react";
+import {
+	type FC,
+	type KeyboardEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { cn } from "utils/cn";
+
+interface ChatInputProps {
+	onSend: (text: string) => void;
+	disabled?: boolean;
+	placeholder?: string;
+}
+
+export const ChatInput: FC<ChatInputProps> = ({
+	onSend,
+	disabled = false,
+	placeholder = "Ask about this template...",
+}) => {
+	const [value, setValue] = useState("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	const resizeTextarea = useCallback(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) {
+			return;
+		}
+		textarea.style.height = "auto";
+		textarea.style.height = `${Math.min(textarea.scrollHeight, 150)}px`;
+	}, []);
+
+	const handleSend = useCallback(() => {
+		if (disabled) {
+			return;
+		}
+
+		const trimmed = value.trim();
+		if (!trimmed) {
+			return;
+		}
+
+		onSend(trimmed);
+		setValue("");
+		const textarea = textareaRef.current;
+		if (textarea) {
+			textarea.style.height = "auto";
+		}
+	}, [disabled, onSend, value]);
+
+	const onKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLTextAreaElement>) => {
+			// Ignore Enter during IME composition (e.g., CJK input) so
+			// confirming a candidate doesn't send partial text.
+			if (event.nativeEvent.isComposing) {
+				return;
+			}
+			if (event.key === "Enter" && !event.shiftKey) {
+				event.preventDefault();
+				event.stopPropagation();
+				handleSend();
+			}
+		},
+		[handleSend],
+	);
+
+	useEffect(() => {
+		resizeTextarea();
+	}, [resizeTextarea]);
+
+	return (
+		<div className="flex items-end gap-1.5 px-3 py-2">
+			<textarea
+				ref={textareaRef}
+				value={value}
+				onChange={(event) => {
+					setValue(event.target.value);
+					resizeTextarea();
+				}}
+				onKeyDown={onKeyDown}
+				disabled={disabled}
+				rows={1}
+				placeholder={placeholder}
+				aria-label="Message AI assistant"
+				className={cn(
+					"max-h-[150px] min-h-10 flex-1 resize-none rounded-md",
+					"border border-solid border-border bg-transparent px-3 py-2",
+					"text-sm text-content-primary placeholder:text-content-secondary",
+					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+					"disabled:cursor-not-allowed disabled:opacity-50",
+				)}
+			/>
+			<Button
+				variant="outline"
+				size="icon"
+				className="h-10 w-10 shrink-0"
+				onClick={handleSend}
+				disabled={disabled || value.trim().length === 0}
+				aria-label="Send message"
+			>
+				<SendIcon />
+			</Button>
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatMarkdown.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatMarkdown.tsx
@@ -1,0 +1,44 @@
+import { type FC, memo } from "react";
+import ReactMarkdown from "react-markdown";
+import gfm from "remark-gfm";
+import { cn } from "utils/cn";
+
+interface ChatMarkdownProps {
+	/** The raw Markdown string to render. */
+	children: string;
+	className?: string;
+}
+
+/**
+ * Compact Markdown renderer sized for the AI chat sidebar.
+ *
+ * Uses @tailwindcss/typography `prose-sm` with tightened spacing
+ * overrides so headings, lists, and code blocks feel at home in a
+ * narrow, dense chat context rather than a full-page article.
+ */
+const ChatMarkdown: FC<ChatMarkdownProps> = ({ children, className }) => {
+	return (
+		<ReactMarkdown
+			remarkPlugins={[gfm]}
+			className={cn(
+				// Base prose — small variant, inherits panel text color.
+				"prose prose-sm max-w-none break-words",
+				// Tighten vertical rhythm for chat context.
+				"prose-p:my-1 prose-p:leading-relaxed",
+				"prose-headings:mt-3 prose-headings:mb-1",
+				"prose-ul:my-1 prose-ol:my-1 prose-li:my-0",
+				"prose-pre:my-1.5 prose-pre:rounded-md prose-pre:bg-surface-secondary",
+				// Inline code.
+				"prose-code:rounded prose-code:bg-surface-secondary prose-code:px-1 prose-code:py-0.5",
+				"prose-code:before:content-none prose-code:after:content-none",
+				// Links.
+				"prose-a:text-content-link prose-a:no-underline hover:prose-a:underline",
+				className,
+			)}
+		>
+			{children}
+		</ReactMarkdown>
+	);
+};
+
+export const MemoizedChatMarkdown = memo(ChatMarkdown);

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatMessage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatMessage.tsx
@@ -35,7 +35,35 @@ export const ChatMessage: FC<ChatMessageProps> = ({
 						<UserIcon className="size-3" />
 						<span>You</span>
 					</div>
-					<MemoizedChatMarkdown>{message.content}</MemoizedChatMarkdown>
+					{message.attachments.length > 0 && (
+						<div className="mb-2 space-y-2">
+							{message.attachments.map((attachment, index) => {
+								const attachmentLabel =
+									attachment.filename ?? `Attachment ${index + 1}`;
+								if (!attachment.mediaType.startsWith("image/")) {
+									return (
+										<div
+											key={`${attachmentLabel}-${index}`}
+											className="rounded-md border border-border/60 bg-surface-invert-secondary px-2 py-1 text-xs text-content-invert-secondary"
+										>
+											{attachmentLabel}
+										</div>
+									);
+								}
+								return (
+									<img
+										key={`${attachmentLabel}-${index}`}
+										src={attachment.url}
+										alt={attachmentLabel}
+										className="max-h-60 max-w-full rounded-md border border-border/60 object-contain"
+									/>
+								);
+							})}
+						</div>
+					)}
+					{message.content.trim().length > 0 && (
+						<MemoizedChatMarkdown>{message.content}</MemoizedChatMarkdown>
+					)}
 				</div>
 			</div>
 		);

--- a/site/src/pages/TemplateVersionEditorPage/ai/ChatMessage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ChatMessage.tsx
@@ -1,0 +1,121 @@
+import { UserIcon } from "lucide-react";
+import type { FC } from "react";
+import type { FileTree } from "utils/filetree";
+import { BuildApprovalCard } from "./BuildApprovalCard";
+import { MemoizedChatMarkdown } from "./ChatMarkdown";
+import { EditApprovalCard } from "./EditApprovalCard";
+import { PublishApprovalCard } from "./PublishApprovalCard";
+import { ReasoningBlock } from "./ReasoningBlock";
+import { ToolCallCard } from "./ToolCallCard";
+import type { PendingToolCall } from "./types";
+import type { DisplayMessage } from "./useTemplateAgent";
+
+interface ChatMessageProps {
+	message: DisplayMessage;
+	pendingApproval: PendingToolCall | null;
+	onApprove: () => void;
+	onReject: () => void;
+	onNavigateToFile?: (path: string) => void;
+	getFileTree: () => FileTree;
+}
+
+export const ChatMessage: FC<ChatMessageProps> = ({
+	message,
+	pendingApproval,
+	onApprove,
+	onReject,
+	onNavigateToFile,
+	getFileTree,
+}) => {
+	if (message.role === "user") {
+		return (
+			<div className="flex justify-end">
+				<div className="max-w-[90%] rounded-lg bg-surface-invert-primary px-3 py-2 text-sm text-content-invert">
+					<div className="mb-1 flex items-center gap-1 text-2xs text-content-invert-secondary">
+						<UserIcon className="size-3" />
+						<span>You</span>
+					</div>
+					<MemoizedChatMarkdown>{message.content}</MemoizedChatMarkdown>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{message.reasoning.length > 0 && (
+				<ReasoningBlock reasoning={message.reasoning} />
+			)}
+
+			{message.content.trim().length > 0 && (
+				<MemoizedChatMarkdown className="prose-invert">
+					{message.content}
+				</MemoizedChatMarkdown>
+			)}
+
+			{message.toolCalls.map((toolCall) => {
+				const isEditAction =
+					toolCall.toolName === "editFile" ||
+					toolCall.toolName === "deleteFile";
+				const isBuildAction = toolCall.toolName === "buildTemplate";
+
+				if (isEditAction) {
+					const isPending =
+						pendingApproval?.toolCallId === toolCall.toolCallId &&
+						toolCall.state === "pending";
+					return (
+						<EditApprovalCard
+							key={toolCall.toolCallId}
+							toolCall={toolCall}
+							isPending={isPending}
+							onApprove={onApprove}
+							onReject={onReject}
+							onNavigateToFile={onNavigateToFile}
+							getFileTree={getFileTree}
+						/>
+					);
+				}
+
+				if (isBuildAction) {
+					const isPending =
+						pendingApproval?.toolCallId === toolCall.toolCallId &&
+						toolCall.state === "pending";
+					return (
+						<BuildApprovalCard
+							key={toolCall.toolCallId}
+							toolCall={toolCall}
+							isPending={isPending}
+							onApprove={onApprove}
+							onReject={onReject}
+						/>
+					);
+				}
+
+				const isPublishAction = toolCall.toolName === "publishTemplate";
+
+				if (isPublishAction) {
+					const isPending =
+						pendingApproval?.toolCallId === toolCall.toolCallId &&
+						toolCall.state === "pending";
+					return (
+						<PublishApprovalCard
+							key={toolCall.toolCallId}
+							toolCall={toolCall}
+							isPending={isPending}
+							onApprove={onApprove}
+							onReject={onReject}
+						/>
+					);
+				}
+
+				return (
+					<ToolCallCard
+						key={toolCall.toolCallId}
+						toolCall={toolCall}
+						onNavigateToFile={onNavigateToFile}
+					/>
+				);
+			})}
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/EditApprovalCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/EditApprovalCard.tsx
@@ -6,7 +6,7 @@ import {
 	TriangleAlertIcon,
 	XIcon,
 } from "lucide-react";
-import { type FC, useMemo } from "react";
+import { type FC, useEffect, useMemo, useRef } from "react";
 import { cn } from "utils/cn";
 import {
 	existsFile,
@@ -168,6 +168,16 @@ export const EditApprovalCard: FC<EditApprovalCardProps> = ({
 	onNavigateToFile,
 	getFileTree,
 }) => {
+	const approveRef = useRef<HTMLButtonElement>(null);
+	// Move focus to the Approve button when this card first
+	// requires user input so keyboard and screen-reader users
+	// are immediately aware of the pending action.
+	useEffect(() => {
+		if (isPending) {
+			approveRef.current?.focus();
+		}
+	}, [isPending]);
+
 	const path = typeof toolCall.args.path === "string" ? toolCall.args.path : "";
 	const hasValidPath = path.length > 0;
 	const pathLabel = hasValidPath ? path : "(invalid path)";
@@ -208,8 +218,17 @@ export const EditApprovalCard: FC<EditApprovalCardProps> = ({
 	const resultError = typeof result?.error === "string" ? result.error : null;
 	const resultSuccess = result?.success === true;
 
+	const actionLabel =
+		toolCall.toolName === "editFile"
+			? `Edit file: ${pathLabel}`
+			: `Delete file: ${pathLabel}`;
+
 	return (
-		<div className="space-y-2 rounded-md border border-solid border-border-default p-2.5">
+		<div
+			className="space-y-2 rounded-md border border-solid border-border-default p-2.5"
+			role="region"
+			aria-label={actionLabel}
+		>
 			<div className="flex items-center gap-2">
 				{toolCall.toolName === "editFile" ? (
 					<FilePenLineIcon className="size-3.5 text-content-secondary" />
@@ -288,8 +307,17 @@ export const EditApprovalCard: FC<EditApprovalCardProps> = ({
 			)}
 
 			{isPending && (
-				<div className="flex items-center gap-1.5">
-					<Button variant="outline" size="sm" onClick={onApprove}>
+				<div
+					className="flex items-center gap-1.5"
+					role="group"
+					aria-label="Approval actions"
+				>
+					<Button
+						ref={approveRef}
+						variant="outline"
+						size="sm"
+						onClick={onApprove}
+					>
 						<CheckIcon />
 						Approve
 					</Button>

--- a/site/src/pages/TemplateVersionEditorPage/ai/EditApprovalCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/EditApprovalCard.tsx
@@ -1,0 +1,325 @@
+import { Button } from "components/Button/Button";
+import {
+	CheckIcon,
+	FilePenLineIcon,
+	Trash2Icon,
+	TriangleAlertIcon,
+	XIcon,
+} from "lucide-react";
+import { type FC, useMemo } from "react";
+import { cn } from "utils/cn";
+import {
+	existsFile,
+	type FileTree,
+	getFileText,
+	isFolder,
+} from "utils/filetree";
+import type { DisplayToolCall } from "./useTemplateAgent";
+
+interface EditApprovalCardProps {
+	toolCall: DisplayToolCall;
+	isPending: boolean;
+	onApprove: () => void;
+	onReject: () => void;
+	onNavigateToFile?: (path: string) => void;
+	getFileTree: () => FileTree;
+}
+
+type DiffLine = {
+	type: "added" | "removed" | "unchanged";
+	text: string;
+	oldLineNo: number | undefined;
+	newLineNo: number | undefined;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+const splitLines = (content: string) => content.split("\n");
+
+/**
+ * Find the 1-based line number where oldContent starts in the full file.
+ * Returns 1 if the snippet cannot be located.
+ */
+const findStartLine = (fullContent: string, oldContent: string): number => {
+	if (oldContent.length === 0 || fullContent.length === 0) {
+		return 1;
+	}
+	const index = fullContent.indexOf(oldContent);
+	if (index === -1) {
+		return 1;
+	}
+
+	// Count newlines before the match to get the 1-based line number.
+	let lineNumber = 1;
+	for (let i = 0; i < index; i++) {
+		if (fullContent[i] === "\n") {
+			lineNumber++;
+		}
+	}
+	return lineNumber;
+};
+
+/**
+ * Compute a line-level diff between oldContent and newContent
+ * using a simple LCS-based algorithm. Returns lines annotated
+ * as "unchanged", "removed", or "added".
+ */
+const buildDiffLines = (
+	oldContent: string,
+	newContent: string,
+	startLine: number,
+): DiffLine[] => {
+	if (oldContent.length === 0) {
+		return splitLines(newContent).map((text, i) => ({
+			type: "added",
+			text,
+			oldLineNo: undefined,
+			newLineNo: startLine + i,
+		}));
+	}
+	if (newContent.length === 0) {
+		return splitLines(oldContent).map((text, i) => ({
+			type: "removed",
+			text,
+			oldLineNo: startLine + i,
+			newLineNo: undefined,
+		}));
+	}
+
+	const oldLines = splitLines(oldContent);
+	const newLines = splitLines(newContent);
+
+	// Build the LCS table.
+	const m = oldLines.length;
+	const n = newLines.length;
+	const dp: number[][] = Array.from({ length: m + 1 }, () =>
+		new Array<number>(n + 1).fill(0),
+	);
+	for (let i = 1; i <= m; i++) {
+		for (let j = 1; j <= n; j++) {
+			dp[i][j] =
+				oldLines[i - 1] === newLines[j - 1]
+					? dp[i - 1][j - 1] + 1
+					: Math.max(dp[i - 1][j], dp[i][j - 1]);
+		}
+	}
+
+	// Backtrack to produce the diff.
+	const result: DiffLine[] = [];
+	let i = m;
+	let j = n;
+	while (i > 0 || j > 0) {
+		if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+			result.push({
+				type: "unchanged",
+				text: oldLines[i - 1],
+				oldLineNo: undefined,
+				newLineNo: undefined,
+			});
+			i--;
+			j--;
+		} else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+			result.push({
+				type: "added",
+				text: newLines[j - 1],
+				oldLineNo: undefined,
+				newLineNo: undefined,
+			});
+			j--;
+		} else {
+			result.push({
+				type: "removed",
+				text: oldLines[i - 1],
+				oldLineNo: undefined,
+				newLineNo: undefined,
+			});
+			i--;
+		}
+	}
+
+	result.reverse();
+
+	let oldLineNo = startLine;
+	let newLineNo = startLine;
+	for (const line of result) {
+		if (line.type === "unchanged") {
+			line.oldLineNo = oldLineNo;
+			line.newLineNo = newLineNo;
+			oldLineNo++;
+			newLineNo++;
+		} else if (line.type === "removed") {
+			line.oldLineNo = oldLineNo;
+			oldLineNo++;
+		} else {
+			line.newLineNo = newLineNo;
+			newLineNo++;
+		}
+	}
+
+	return result;
+};
+
+export const EditApprovalCard: FC<EditApprovalCardProps> = ({
+	toolCall,
+	isPending,
+	onApprove,
+	onReject,
+	onNavigateToFile,
+	getFileTree,
+}) => {
+	const path = typeof toolCall.args.path === "string" ? toolCall.args.path : "";
+	const hasValidPath = path.length > 0;
+	const pathLabel = hasValidPath ? path : "(invalid path)";
+
+	const oldContent =
+		typeof toolCall.args.oldContent === "string"
+			? toolCall.args.oldContent
+			: "";
+	const newContent =
+		typeof toolCall.args.newContent === "string"
+			? toolCall.args.newContent
+			: "";
+
+	const startLine = useMemo(() => {
+		if (!hasValidPath || toolCall.toolName !== "editFile") {
+			return 1;
+		}
+		try {
+			const tree = getFileTree();
+			if (!existsFile(path, tree) || isFolder(path, tree)) {
+				return 1;
+			}
+			const fullContent = getFileText(path, tree);
+			return findStartLine(fullContent, oldContent);
+		} catch {
+			return 1;
+		}
+	}, [getFileTree, hasValidPath, oldContent, path, toolCall.toolName]);
+
+	const diffLines = useMemo(() => {
+		if (toolCall.toolName !== "editFile") {
+			return [];
+		}
+		return buildDiffLines(oldContent, newContent, startLine);
+	}, [newContent, oldContent, startLine, toolCall.toolName]);
+
+	const result = isRecord(toolCall.result) ? toolCall.result : null;
+	const resultError = typeof result?.error === "string" ? result.error : null;
+	const resultSuccess = result?.success === true;
+
+	return (
+		<div className="space-y-2 rounded-md border border-solid border-border-default p-2.5">
+			<div className="flex items-center gap-2">
+				{toolCall.toolName === "editFile" ? (
+					<FilePenLineIcon className="size-3.5 text-content-secondary" />
+				) : (
+					<Trash2Icon className="size-3.5 text-content-destructive" />
+				)}
+				<button
+					type="button"
+					onClick={() => {
+						if (hasValidPath) {
+							onNavigateToFile?.(path);
+						}
+					}}
+					disabled={!onNavigateToFile || !hasValidPath}
+					className={cn(
+						"border-none bg-transparent p-0 text-left text-xs font-medium",
+						"text-content-link hover:underline",
+						onNavigateToFile && hasValidPath
+							? "cursor-pointer"
+							: "cursor-default",
+					)}
+				>
+					{pathLabel}
+				</button>
+			</div>
+
+			{!hasValidPath && (
+				<div className="rounded-md bg-surface-destructive/10 p-2 text-xs text-content-destructive">
+					This tool call is missing a valid file path.
+				</div>
+			)}
+
+			{toolCall.toolName === "editFile" ? (
+				<div className="max-h-64 overflow-y-auto rounded-md border border-solid border-border-default">
+					{diffLines.length > 0 ? (
+						diffLines.map((line, index) => (
+							<div
+								key={`${line.type}-${index}`}
+								className={cn(
+									"flex font-mono text-[11px] leading-5",
+									line.type === "added" &&
+										"bg-surface-green/20 text-content-success",
+									line.type === "removed" &&
+										"bg-surface-red/20 text-content-destructive",
+									line.type === "unchanged" && "text-content-secondary",
+								)}
+							>
+								<span className="inline-block w-8 shrink-0 select-none pr-1 text-right text-content-disabled">
+									{line.oldLineNo ?? ""}
+								</span>
+								<span className="inline-block w-8 shrink-0 select-none pr-1 text-right text-content-disabled">
+									{line.newLineNo ?? ""}
+								</span>
+								<span className="inline-block w-4 shrink-0 select-none text-center">
+									{line.type === "added"
+										? "+"
+										: line.type === "removed"
+											? "−"
+											: " "}
+								</span>
+								<span className="flex-1 whitespace-pre-wrap break-all pr-2">
+									{line.text}
+								</span>
+							</div>
+						))
+					) : (
+						<p className="m-0 p-2 text-xs text-content-secondary">
+							No content changes.
+						</p>
+					)}
+				</div>
+			) : (
+				<div className="rounded-md bg-surface-destructive/10 p-2 text-xs text-content-destructive">
+					Delete file: {pathLabel}
+				</div>
+			)}
+
+			{isPending && (
+				<div className="flex items-center gap-1.5">
+					<Button variant="outline" size="sm" onClick={onApprove}>
+						<CheckIcon />
+						Approve
+					</Button>
+					<Button variant="subtle" size="sm" onClick={onReject}>
+						<XIcon />
+						Reject
+					</Button>
+				</div>
+			)}
+
+			{!isPending && toolCall.state === "pending" && (
+				<p className="m-0 text-xs text-content-secondary">
+					Waiting for approval…
+				</p>
+			)}
+
+			{toolCall.state === "result" && resultSuccess && (
+				<p className="m-0 text-xs text-content-success">
+					{toolCall.toolName === "deleteFile"
+						? "File deleted."
+						: "Edit applied."}
+				</p>
+			)}
+
+			{toolCall.state === "result" && resultError && (
+				<div className="flex items-start gap-2 rounded-md bg-surface-destructive/10 p-2 text-xs text-content-destructive">
+					<TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+					<span>{resultError}</span>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/ModelConfigBar.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ModelConfigBar.tsx
@@ -1,0 +1,464 @@
+import type {
+	AIBridgeModel,
+	AIModelConfig,
+	AnthropicEffort,
+	AnthropicThinking,
+	OpenAIReasoningEffort,
+} from "api/queries/aiBridge";
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from "components/Select/Select";
+import { SingleThumbSlider } from "components/Slider/SingleThumbSlider";
+import { type FC, useState } from "react";
+
+const DEFAULT_REASONING_EFFORT: OpenAIReasoningEffort = "medium";
+const DEFAULT_THINKING_BUDGET_TOKENS = 10_240;
+const MIN_THINKING_BUDGET_TOKENS = 1_024;
+const MAX_THINKING_BUDGET_TOKENS = 32_768;
+const THINKING_BUDGET_STEP_TOKENS = 1_024;
+
+const OPENAI_REASONING_OPTIONS: readonly OpenAIReasoningEffort[] = [
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+];
+
+const ANTHROPIC_EFFORT_OPTIONS: readonly AnthropicEffort[] = [
+	"low",
+	"medium",
+	"high",
+	"max",
+];
+
+const CURATED_MODEL_PATTERNS: readonly string[] = [
+	// Anthropic — flagship models.
+	"claude-opus-4-6",
+	"claude-sonnet-4-6",
+	"claude-haiku-4-5",
+];
+
+type ThinkingModeValue = "disabled" | "adaptive" | "budget";
+
+const toModelKey = (model: AIBridgeModel): string =>
+	`${model.provider}:${model.id}`;
+
+const parseModelKey = (
+	key: string,
+): { provider: AIBridgeModel["provider"]; id: string } => {
+	const separatorIndex = key.indexOf(":");
+	if (separatorIndex === -1) {
+		throw new Error(
+			`Invalid model key "${key}". Expected provider:model format.`,
+		);
+	}
+
+	const provider = key.slice(0, separatorIndex);
+	const id = key.slice(separatorIndex + 1);
+	if ((provider !== "openai" && provider !== "anthropic") || id.length === 0) {
+		throw new Error(
+			`Invalid model key "${key}". Unknown provider or empty ID.`,
+		);
+	}
+
+	return { provider, id };
+};
+
+const clampThinkingBudgetTokens = (value: number): number => {
+	if (!Number.isFinite(value)) {
+		throw new Error("Thinking budget must be a finite number.");
+	}
+
+	const roundedToStep =
+		Math.round(value / THINKING_BUDGET_STEP_TOKENS) *
+		THINKING_BUDGET_STEP_TOKENS;
+	return Math.min(
+		MAX_THINKING_BUDGET_TOKENS,
+		Math.max(MIN_THINKING_BUDGET_TOKENS, roundedToStep),
+	);
+};
+
+const getThinkingMode = (
+	thinking: AnthropicThinking | undefined,
+): ThinkingModeValue => {
+	if (!thinking || thinking.type === "disabled") {
+		return "disabled";
+	}
+	if (thinking.type === "adaptive") {
+		return "adaptive";
+	}
+	return "budget";
+};
+
+export const getDefaultModelConfig = (model: AIBridgeModel): AIModelConfig => {
+	const config: AIModelConfig = { model };
+
+	if (model.provider === "openai" && isOpenAIReasoningModel(model.id)) {
+		config.reasoningEffort = DEFAULT_REASONING_EFFORT;
+	}
+	if (model.provider === "anthropic" && isAnthropicEffortModel(model.id)) {
+		config.thinking = { type: "adaptive" };
+		config.anthropicEffort = "medium";
+	} else if (
+		model.provider === "anthropic" &&
+		isAnthropicBudgetThinkingModel(model.id)
+	) {
+		config.thinking = { type: "adaptive" };
+	}
+
+	return config;
+};
+
+/** Returns true for OpenAI models that support reasoning effort. */
+const isOpenAIReasoningModel = (modelID: string): boolean => {
+	const normalized = modelID.toLowerCase();
+	return (
+		normalized.startsWith("gpt-5") ||
+		normalized.startsWith("o1") ||
+		normalized.startsWith("o3") ||
+		normalized.startsWith("o4")
+	);
+};
+
+/** Returns true for Anthropic 4.6 models that support effort+adaptive. */
+const isAnthropicEffortModel = (modelID: string): boolean => {
+	const normalized = modelID.toLowerCase();
+	return (
+		normalized.includes("claude-sonnet-4-6") ||
+		normalized.includes("claude-opus-4-6")
+	);
+};
+
+/**
+ * Returns true for Anthropic models that support manual thinking budget
+ * controls via budget tokens.
+ */
+const isAnthropicBudgetThinkingModel = (modelID: string): boolean => {
+	const normalized = modelID.toLowerCase();
+	return (
+		(normalized.includes("claude-3-7-sonnet") ||
+			normalized.includes("claude-sonnet-4") ||
+			normalized.includes("claude-opus-4")) &&
+		!isAnthropicEffortModel(normalized)
+	);
+};
+
+/** Returns true for Anthropic models that support extended thinking. */
+const isAnthropicThinkingModel = (modelID: string): boolean => {
+	return (
+		isAnthropicEffortModel(modelID) || isAnthropicBudgetThinkingModel(modelID)
+	);
+};
+
+/**
+ * Returns true for GPT-5 models at version 5.2 or higher. Uses regex
+ * parsing rather than prefix matching so future minor versions (5.3,
+ * 5.4, …) are automatically included.
+ */
+const isGpt52OrHigher = (modelId: string): boolean => {
+	const match = modelId.toLowerCase().match(/^gpt-5\.(\d+)/);
+	if (!match) return false;
+	return Number.parseInt(match[1], 10) >= 2;
+};
+
+export const isCuratedModel = (modelId: string): boolean => {
+	if (isGpt52OrHigher(modelId)) return true;
+	const normalized = modelId.toLowerCase();
+	return CURATED_MODEL_PATTERNS.some((pattern) =>
+		normalized.startsWith(pattern),
+	);
+};
+
+interface ModelConfigBarProps {
+	modelConfig: AIModelConfig;
+	availableModels: readonly AIBridgeModel[];
+	onModelConfigChange: (config: AIModelConfig) => void;
+}
+
+export const ModelConfigBar: FC<ModelConfigBarProps> = ({
+	modelConfig,
+	availableModels,
+	onModelConfigChange,
+}) => {
+	const selectedModel = modelConfig.model;
+	const [showAllModels, setShowAllModels] = useState(false);
+	const selectedModelKey = toModelKey(selectedModel);
+	const displayModels = [...availableModels]
+		.filter(
+			(model) =>
+				showAllModels ||
+				isCuratedModel(model.id) ||
+				toModelKey(model) === selectedModelKey,
+		)
+		.sort((a, b) => a.id.localeCompare(b.id));
+	const openAIModels = displayModels.filter(
+		(model) => model.provider === "openai",
+	);
+	const anthropicModels = displayModels.filter(
+		(model) => model.provider === "anthropic",
+	);
+	const showOpenAIReasoning =
+		selectedModel.provider === "openai" &&
+		isOpenAIReasoningModel(selectedModel.id);
+	const showAnthropicThinking =
+		selectedModel.provider === "anthropic" &&
+		isAnthropicThinkingModel(selectedModel.id);
+	const showAnthropicEffort =
+		selectedModel.provider === "anthropic" &&
+		isAnthropicEffortModel(selectedModel.id);
+	const showAnthropicBudgetThinking =
+		selectedModel.provider === "anthropic" &&
+		isAnthropicBudgetThinkingModel(selectedModel.id);
+
+	const reasoningEffort =
+		modelConfig.reasoningEffort ?? DEFAULT_REASONING_EFFORT;
+	const thinkingMode = getThinkingMode(modelConfig.thinking);
+	const selectedThinkingMode: ThinkingModeValue =
+		showAnthropicEffort && thinkingMode === "budget"
+			? "adaptive"
+			: thinkingMode;
+	const thinkingBudgetTokens =
+		modelConfig.thinking?.type === "enabled"
+			? clampThinkingBudgetTokens(modelConfig.thinking.budgetTokens)
+			: DEFAULT_THINKING_BUDGET_TOKENS;
+	const anthropicEffort = modelConfig.anthropicEffort ?? "medium";
+
+	const handleModelChange = (nextModelKey: string) => {
+		const parsedModel = parseModelKey(nextModelKey);
+		const nextModel = availableModels.find(
+			(model) =>
+				model.provider === parsedModel.provider && model.id === parsedModel.id,
+		);
+		if (!nextModel) {
+			throw new Error(`Selected model "${nextModelKey}" is not available.`);
+		}
+		onModelConfigChange(getDefaultModelConfig(nextModel));
+	};
+
+	const handleReasoningEffortChange = (nextReasoningEffort: string) => {
+		if (
+			!OPENAI_REASONING_OPTIONS.includes(
+				nextReasoningEffort as OpenAIReasoningEffort,
+			)
+		) {
+			throw new Error(
+				`Invalid OpenAI reasoning effort "${nextReasoningEffort}" selected.`,
+			);
+		}
+		onModelConfigChange({
+			...modelConfig,
+			reasoningEffort: nextReasoningEffort as OpenAIReasoningEffort,
+		});
+	};
+
+	const handleThinkingModeChange = (nextThinkingMode: string) => {
+		switch (nextThinkingMode) {
+			case "disabled":
+				onModelConfigChange({
+					...modelConfig,
+					thinking: { type: "disabled" },
+				});
+				return;
+			case "adaptive":
+				onModelConfigChange({
+					...modelConfig,
+					thinking: { type: "adaptive" },
+				});
+				return;
+			case "budget":
+				if (!showAnthropicBudgetThinking) {
+					throw new Error(
+						"Thinking budget is only supported for Anthropic budget-thinking models.",
+					);
+				}
+				onModelConfigChange({
+					...modelConfig,
+					thinking: {
+						type: "enabled",
+						budgetTokens: thinkingBudgetTokens,
+					},
+				});
+				return;
+			default:
+				throw new Error(
+					`Unknown Anthropic thinking mode "${nextThinkingMode}".`,
+				);
+		}
+	};
+
+	const handleEffortChange = (nextEffort: string) => {
+		if (!ANTHROPIC_EFFORT_OPTIONS.includes(nextEffort as AnthropicEffort)) {
+			throw new Error(`Unknown Anthropic effort "${nextEffort}".`);
+		}
+		onModelConfigChange({
+			...modelConfig,
+			anthropicEffort: nextEffort as AnthropicEffort,
+		});
+	};
+
+	return (
+		<div className="px-3 py-1.5">
+			<div className="flex flex-wrap items-end gap-2">
+				<div className="min-w-[180px] flex-1">
+					<div className="mb-0.5 text-2xs text-content-secondary">Model</div>
+					<Select
+						value={selectedModelKey}
+						onValueChange={handleModelChange}
+						onOpenChange={(open) => {
+							// Reset to curated list when the dropdown closes so
+							// the next open always starts compact.
+							if (!open) {
+								setShowAllModels(false);
+							}
+						}}
+					>
+						<SelectTrigger className="h-8 text-xs">
+							<SelectValue placeholder="Select a model" />
+						</SelectTrigger>
+						<SelectContent>
+							{openAIModels.length > 0 && (
+								<SelectGroup>
+									<SelectLabel>OpenAI</SelectLabel>
+									{openAIModels.map((model) => (
+										<SelectItem
+											key={toModelKey(model)}
+											value={toModelKey(model)}
+										>
+											{model.id}
+										</SelectItem>
+									))}
+								</SelectGroup>
+							)}
+							{anthropicModels.length > 0 && (
+								<SelectGroup>
+									<SelectLabel>Anthropic</SelectLabel>
+									{anthropicModels.map((model) => (
+										<SelectItem
+											key={toModelKey(model)}
+											value={toModelKey(model)}
+										>
+											{model.id}
+										</SelectItem>
+									))}
+								</SelectGroup>
+							)}
+							{/* Toggle at the bottom of the list. Uses
+							    onPointerDown preventDefault to stop Radix from
+							    closing the popover on click. */}
+							<button
+								type="button"
+								className="w-full cursor-pointer border-none bg-transparent px-2 py-1.5 text-left text-xs text-content-link hover:underline"
+								onPointerDown={(e) => e.preventDefault()}
+								onClick={() => setShowAllModels((prev) => !prev)}
+							>
+								{showAllModels ? "Show fewer models" : "Show all models"}
+							</button>
+						</SelectContent>
+					</Select>
+				</div>
+
+				{showOpenAIReasoning && (
+					<div className="w-[120px]">
+						<div className="mb-0.5 text-2xs text-content-secondary">
+							Reasoning
+						</div>
+						<Select
+							value={reasoningEffort}
+							onValueChange={handleReasoningEffortChange}
+						>
+							<SelectTrigger className="h-8 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{OPENAI_REASONING_OPTIONS.map((option) => (
+									<SelectItem key={option} value={option}>
+										{option}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+
+				{showAnthropicThinking && (
+					<>
+						<div className="w-[130px]">
+							<div className="mb-0.5 text-2xs text-content-secondary">
+								Thinking
+							</div>
+							<Select
+								value={selectedThinkingMode}
+								onValueChange={handleThinkingModeChange}
+							>
+								<SelectTrigger className="h-8 text-xs">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="disabled">Disabled</SelectItem>
+									<SelectItem value="adaptive">Adaptive</SelectItem>
+									{showAnthropicBudgetThinking && (
+										<SelectItem value="budget">Budget</SelectItem>
+									)}
+								</SelectContent>
+							</Select>
+						</div>
+						{showAnthropicBudgetThinking &&
+							selectedThinkingMode === "budget" && (
+								<div className="min-w-[180px] flex-1">
+									<div className="mb-0.5 flex items-center justify-between text-2xs text-content-secondary">
+										<span>Thinking budget</span>
+										<span>{thinkingBudgetTokens.toLocaleString()} tokens</span>
+									</div>
+									<SingleThumbSlider
+										value={[thinkingBudgetTokens]}
+										min={MIN_THINKING_BUDGET_TOKENS}
+										max={MAX_THINKING_BUDGET_TOKENS}
+										step={THINKING_BUDGET_STEP_TOKENS}
+										onValueChange={(value) => {
+											const nextBudgetTokens = value[0];
+											if (typeof nextBudgetTokens !== "number") {
+												throw new Error(
+													"Expected a single slider value for thinking budget.",
+												);
+											}
+											onModelConfigChange({
+												...modelConfig,
+												thinking: {
+													type: "enabled",
+													budgetTokens:
+														clampThinkingBudgetTokens(nextBudgetTokens),
+												},
+											});
+										}}
+									/>
+								</div>
+							)}
+					</>
+				)}
+				{showAnthropicEffort && (
+					<div className="w-[100px]">
+						<div className="mb-0.5 text-2xs text-content-secondary">Effort</div>
+						<Select value={anthropicEffort} onValueChange={handleEffortChange}>
+							<SelectTrigger className="h-8 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{ANTHROPIC_EFFORT_OPTIONS.map((option) => (
+									<SelectItem key={option} value={option}>
+										{option}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/PublishApprovalCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/PublishApprovalCard.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/Button/Button";
 import { LoaderIcon, RocketIcon } from "lucide-react";
-import type { FC } from "react";
+import { type FC, useEffect, useRef } from "react";
 import type { DisplayToolCall } from "./useTemplateAgent";
 
 interface PublishApprovalCardProps {
@@ -16,6 +16,16 @@ export const PublishApprovalCard: FC<PublishApprovalCardProps> = ({
 	onApprove,
 	onReject,
 }) => {
+	const approveRef = useRef<HTMLButtonElement>(null);
+	// Move focus to the Approve button when this card first
+	// requires user input so keyboard and screen-reader users
+	// are immediately aware of the pending action.
+	useEffect(() => {
+		if (isPending) {
+			approveRef.current?.focus();
+		}
+	}, [isPending]);
+
 	const isRunning = toolCall.state === "pending" && !isPending;
 	const result =
 		typeof toolCall.result === "object" && toolCall.result !== null
@@ -30,7 +40,11 @@ export const PublishApprovalCard: FC<PublishApprovalCardProps> = ({
 	const promote = args.isActiveVersion !== false;
 
 	return (
-		<div className="space-y-2 rounded-md border border-solid border-border p-3">
+		<div
+			className="space-y-2 rounded-md border border-solid border-border p-3"
+			role="region"
+			aria-label="Publish template"
+		>
 			<div className="flex items-center gap-2 text-xs font-medium text-content-primary">
 				{isRunning ? (
 					<LoaderIcon className="size-3.5 animate-spin" />
@@ -59,8 +73,12 @@ export const PublishApprovalCard: FC<PublishApprovalCardProps> = ({
 							{promote ? "Will promote to active version" : "Will not promote"}
 						</p>
 					</div>
-					<div className="flex gap-2">
-						<Button size="sm" onClick={onApprove}>
+					<div
+						className="flex gap-2"
+						role="group"
+						aria-label="Approval actions"
+					>
+						<Button ref={approveRef} size="sm" onClick={onApprove}>
 							Approve
 						</Button>
 						<Button size="sm" variant="outline" onClick={onReject}>

--- a/site/src/pages/TemplateVersionEditorPage/ai/PublishApprovalCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/PublishApprovalCard.tsx
@@ -1,0 +1,78 @@
+import { Button } from "components/Button/Button";
+import { LoaderIcon, RocketIcon } from "lucide-react";
+import type { FC } from "react";
+import type { DisplayToolCall } from "./useTemplateAgent";
+
+interface PublishApprovalCardProps {
+	toolCall: DisplayToolCall;
+	isPending: boolean;
+	onApprove: () => void;
+	onReject: () => void;
+}
+
+export const PublishApprovalCard: FC<PublishApprovalCardProps> = ({
+	toolCall,
+	isPending,
+	onApprove,
+	onReject,
+}) => {
+	const isRunning = toolCall.state === "pending" && !isPending;
+	const result =
+		typeof toolCall.result === "object" && toolCall.result !== null
+			? (toolCall.result as Record<string, unknown>)
+			: null;
+	const resultError = typeof result?.error === "string" ? result.error : null;
+	const args = toolCall.args;
+	const versionName =
+		typeof args.name === "string" && args.name.length > 0
+			? args.name
+			: undefined;
+	const promote = args.isActiveVersion !== false;
+
+	return (
+		<div className="space-y-2 rounded-md border border-solid border-border p-3">
+			<div className="flex items-center gap-2 text-xs font-medium text-content-primary">
+				{isRunning ? (
+					<LoaderIcon className="size-3.5 animate-spin" />
+				) : (
+					<RocketIcon className="size-3.5" />
+				)}
+				<span>
+					{isPending
+						? "Publish template?"
+						: isRunning
+							? "Publishing…"
+							: result?.success
+								? "Published"
+								: "Publish failed"}
+				</span>
+			</div>
+
+			{isPending && (
+				<>
+					<div className="text-2xs text-content-secondary">
+						{versionName && <p className="m-0">Name: {versionName}</p>}
+						{typeof args.message === "string" && args.message.length > 0 && (
+							<p className="m-0">Message: {args.message}</p>
+						)}
+						<p className="m-0">
+							{promote ? "Will promote to active version" : "Will not promote"}
+						</p>
+					</div>
+					<div className="flex gap-2">
+						<Button size="sm" onClick={onApprove}>
+							Approve
+						</Button>
+						<Button size="sm" variant="outline" onClick={onReject}>
+							Reject
+						</Button>
+					</div>
+				</>
+			)}
+
+			{resultError && (
+				<p className="m-0 text-xs text-content-destructive">{resultError}</p>
+			)}
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/ReasoningBlock.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ReasoningBlock.tsx
@@ -1,0 +1,66 @@
+import {
+	BrainIcon,
+	ChevronDownIcon,
+	ChevronRightIcon,
+	LoaderIcon,
+} from "lucide-react";
+import { type FC, useState } from "react";
+import { cn } from "utils/cn";
+import type { DisplayReasoning } from "./useTemplateAgent";
+
+interface ReasoningBlockProps {
+	reasoning: DisplayReasoning[];
+}
+
+/**
+ * Collapsible block that shows AI reasoning/thinking traces.
+ * Collapsed by default to keep the chat scannable — users can
+ * expand to see the full chain of thought. Styled to match
+ * ToolCallCard (borderless row with chevron toggle).
+ */
+export const ReasoningBlock: FC<ReasoningBlockProps> = ({ reasoning }) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const isStreaming = reasoning.some((r) => r.isStreaming);
+	const combinedText = reasoning.map((r) => r.text).join("\n\n");
+
+	if (combinedText.trim().length === 0 && !isStreaming) {
+		return null;
+	}
+
+	return (
+		<div>
+			<button
+				type="button"
+				onClick={() => setIsOpen((prev) => !prev)}
+				aria-expanded={isOpen}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-1 py-1 text-left",
+					"cursor-pointer border-none bg-transparent transition-colors",
+					"hover:bg-surface-secondary",
+				)}
+			>
+				{isOpen ? (
+					<ChevronDownIcon className="size-3.5 text-content-secondary" />
+				) : (
+					<ChevronRightIcon className="size-3.5 text-content-secondary" />
+				)}
+				{isStreaming ? (
+					<LoaderIcon className="size-3.5 animate-spin text-content-secondary" />
+				) : (
+					<BrainIcon className="size-3.5 text-content-secondary" />
+				)}
+				<span className="text-xs font-medium text-content-primary">
+					{isStreaming ? "Thinking…" : "Reasoning"}
+				</span>
+			</button>
+
+			{isOpen && (
+				<div className="ml-3 border-0 border-l-2 border-solid border-border pb-1 pl-3 pt-1">
+					<pre className="m-0 whitespace-pre-wrap break-words font-sans text-2xs leading-relaxed text-content-secondary">
+						{combinedText || "Thinking…"}
+					</pre>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/ToolCallCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ToolCallCard.tsx
@@ -15,10 +15,110 @@ interface ToolCallCardProps {
 	onNavigateToFile?: (path: string) => void;
 }
 
+interface StructuredValueSectionProps {
+	label: string;
+	value: unknown;
+	emptyState: string;
+}
+
 const MAX_VISIBLE_READ_LINES = 20;
+const MAX_VISIBLE_DATA_LINES = 16;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
+
+const createInspectableJsonReplacer = () => {
+	const seenObjects = new WeakSet<object>();
+
+	return (_key: string, value: unknown): unknown => {
+		if (typeof value === "bigint") {
+			return `${value}n`;
+		}
+		if (typeof value === "function") {
+			return `[Function ${value.name || "anonymous"}]`;
+		}
+		if (value instanceof Error) {
+			return {
+				name: value.name,
+				message: value.message,
+				...(value.stack ? { stack: value.stack } : {}),
+			};
+		}
+		if (typeof value === "object" && value !== null) {
+			if (seenObjects.has(value)) {
+				return "[Circular]";
+			}
+			seenObjects.add(value);
+		}
+		return value;
+	};
+};
+
+const formatStructuredValue = (value: unknown): string => {
+	if (value === undefined) {
+		return "";
+	}
+	if (typeof value === "string") {
+		return value;
+	}
+
+	try {
+		const formatted = JSON.stringify(value, createInspectableJsonReplacer(), 2);
+		if (typeof formatted === "string") {
+			return formatted;
+		}
+	} catch {
+		// Ignore serialization failures and fall back to String below.
+	}
+
+	return String(value);
+};
+
+const StructuredValueSection: FC<StructuredValueSectionProps> = ({
+	label,
+	value,
+	emptyState,
+}) => {
+	const [expanded, setExpanded] = useState(false);
+
+	const formattedValue = useMemo(() => formatStructuredValue(value), [value]);
+	const valueLines = useMemo(
+		() => formattedValue.split("\n"),
+		[formattedValue],
+	);
+	const hasValue = formattedValue.length > 0;
+	const shouldTruncate = valueLines.length > MAX_VISIBLE_DATA_LINES;
+	const displayedValue =
+		expanded || !shouldTruncate
+			? formattedValue
+			: valueLines.slice(0, MAX_VISIBLE_DATA_LINES).join("\n");
+
+	return (
+		<div className="space-y-1.5">
+			<p className="m-0 text-2xs font-medium uppercase tracking-wide text-content-secondary">
+				{label}
+			</p>
+			{hasValue ? (
+				<>
+					<pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-surface-secondary p-2 text-[11px] leading-relaxed text-content-primary">
+						{displayedValue}
+					</pre>
+					{shouldTruncate && (
+						<Button
+							variant="subtle"
+							size="xs"
+							onClick={() => setExpanded((prev) => !prev)}
+						>
+							{expanded ? "Show less" : "Show more"}
+						</Button>
+					)}
+				</>
+			) : (
+				<p className="m-0 text-xs text-content-secondary">{emptyState}</p>
+			)}
+		</div>
+	);
+};
 
 export const ToolCallCard: FC<ToolCallCardProps> = ({
 	toolCall,
@@ -31,6 +131,9 @@ export const ToolCallCard: FC<ToolCallCardProps> = ({
 	const error = typeof result?.error === "string" ? result.error : null;
 	const path =
 		typeof toolCall.args.path === "string" ? toolCall.args.path : null;
+	const isListFiles = toolCall.toolName === "listFiles";
+	const isReadFile = toolCall.toolName === "readFile";
+	const hasSpecialRendering = isListFiles || isReadFile;
 
 	const files = useMemo(() => {
 		if (!Array.isArray(result?.files)) {
@@ -54,8 +157,7 @@ export const ToolCallCard: FC<ToolCallCardProps> = ({
 		? readFileLines
 		: readFileLines.slice(0, MAX_VISIBLE_READ_LINES);
 
-	const Icon =
-		toolCall.toolName === "listFiles" ? FolderOpenIcon : FileTextIcon;
+	const Icon = isListFiles ? FolderOpenIcon : FileTextIcon;
 
 	return (
 		<div>
@@ -94,7 +196,7 @@ export const ToolCallCard: FC<ToolCallCardProps> = ({
 						</div>
 					)}
 
-					{toolCall.toolName === "listFiles" && files.length > 0 && (
+					{isListFiles && files.length > 0 && (
 						<ul className="m-0 list-none space-y-0.5 p-0">
 							{files.map((file) => (
 								<li key={file}>
@@ -115,39 +217,59 @@ export const ToolCallCard: FC<ToolCallCardProps> = ({
 						</ul>
 					)}
 
-					{toolCall.toolName === "readFile" &&
-						readFileContent !== undefined && (
-							<div className="space-y-1.5">
-								{path && (
-									<button
-										type="button"
-										onClick={() => onNavigateToFile?.(path)}
-										disabled={!onNavigateToFile}
-										className={cn(
-											"border-none bg-transparent p-0 text-xs",
-											"text-content-link hover:underline",
-											onNavigateToFile ? "cursor-pointer" : "cursor-default",
-										)}
-									>
-										{path}
-									</button>
-								)}
-								<pre className="m-0 overflow-x-auto rounded-md bg-surface-secondary p-2 text-[11px] leading-relaxed text-content-primary">
-									{displayedReadFileLines.join("\n")}
-								</pre>
-								{hasTruncatedReadFile && (
-									<Button
-										variant="subtle"
-										size="xs"
-										onClick={() => setShowAllReadLines((prev) => !prev)}
-									>
-										{showAllReadLines ? "Show less" : "Show more"}
-									</Button>
-								)}
-							</div>
-						)}
+					{isReadFile && readFileContent !== undefined && (
+						<div className="space-y-1.5">
+							{path && (
+								<button
+									type="button"
+									onClick={() => onNavigateToFile?.(path)}
+									disabled={!onNavigateToFile}
+									className={cn(
+										"border-none bg-transparent p-0 text-xs",
+										"text-content-link hover:underline",
+										onNavigateToFile ? "cursor-pointer" : "cursor-default",
+									)}
+								>
+									{path}
+								</button>
+							)}
+							<pre className="m-0 overflow-x-auto rounded-md bg-surface-secondary p-2 text-[11px] leading-relaxed text-content-primary">
+								{displayedReadFileLines.join("\n")}
+							</pre>
+							{hasTruncatedReadFile && (
+								<Button
+									variant="subtle"
+									size="xs"
+									onClick={() => setShowAllReadLines((prev) => !prev)}
+								>
+									{showAllReadLines ? "Show less" : "Show more"}
+								</Button>
+							)}
+						</div>
+					)}
 
-					{toolCall.state === "pending" && !error && (
+					{!hasSpecialRendering && (
+						<div className="space-y-3">
+							<StructuredValueSection
+								label="Arguments"
+								value={toolCall.args}
+								emptyState="No arguments were provided."
+							/>
+							{toolCall.state === "pending" ? (
+								<p className="m-0 text-xs text-content-secondary">
+									Waiting for tool result…
+								</p>
+							) : (
+								<StructuredValueSection
+									label="Result"
+									value={toolCall.result}
+									emptyState="No result was returned."
+								/>
+							)}
+						</div>
+					)}
+
+					{hasSpecialRendering && toolCall.state === "pending" && !error && (
 						<p className="m-0 text-xs text-content-secondary">
 							Waiting for tool result…
 						</p>

--- a/site/src/pages/TemplateVersionEditorPage/ai/ToolCallCard.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/ToolCallCard.tsx
@@ -1,0 +1,159 @@
+import { Button } from "components/Button/Button";
+import {
+	AlertTriangleIcon,
+	ChevronDownIcon,
+	ChevronRightIcon,
+	FileTextIcon,
+	FolderOpenIcon,
+} from "lucide-react";
+import { type FC, useMemo, useState } from "react";
+import { cn } from "utils/cn";
+import type { DisplayToolCall } from "./useTemplateAgent";
+
+interface ToolCallCardProps {
+	toolCall: DisplayToolCall;
+	onNavigateToFile?: (path: string) => void;
+}
+
+const MAX_VISIBLE_READ_LINES = 20;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+export const ToolCallCard: FC<ToolCallCardProps> = ({
+	toolCall,
+	onNavigateToFile,
+}) => {
+	const [expanded, setExpanded] = useState(false);
+	const [showAllReadLines, setShowAllReadLines] = useState(false);
+
+	const result = isRecord(toolCall.result) ? toolCall.result : null;
+	const error = typeof result?.error === "string" ? result.error : null;
+	const path =
+		typeof toolCall.args.path === "string" ? toolCall.args.path : null;
+
+	const files = useMemo(() => {
+		if (!Array.isArray(result?.files)) {
+			return [];
+		}
+		return result.files.filter(
+			(file): file is string => typeof file === "string",
+		);
+	}, [result]);
+
+	const readFileContent =
+		typeof result?.content === "string" ? result.content : undefined;
+	const readFileLines = useMemo(() => {
+		if (typeof readFileContent !== "string") {
+			return [];
+		}
+		return readFileContent.split("\n");
+	}, [readFileContent]);
+	const hasTruncatedReadFile = readFileLines.length > MAX_VISIBLE_READ_LINES;
+	const displayedReadFileLines = showAllReadLines
+		? readFileLines
+		: readFileLines.slice(0, MAX_VISIBLE_READ_LINES);
+
+	const Icon =
+		toolCall.toolName === "listFiles" ? FolderOpenIcon : FileTextIcon;
+
+	return (
+		<div>
+			<button
+				type="button"
+				onClick={() => setExpanded((prev) => !prev)}
+				aria-expanded={expanded}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-1 py-1 text-left",
+					"cursor-pointer border-none bg-transparent transition-colors",
+					"hover:bg-surface-secondary",
+				)}
+			>
+				{expanded ? (
+					<ChevronDownIcon className="size-3.5 text-content-secondary" />
+				) : (
+					<ChevronRightIcon className="size-3.5 text-content-secondary" />
+				)}
+				<Icon className="size-3.5 text-content-secondary" />
+				<span className="text-xs font-medium text-content-primary">
+					{toolCall.toolName}
+				</span>
+				{toolCall.state === "pending" && (
+					<span className="ml-auto text-2xs text-content-secondary">
+						Running…
+					</span>
+				)}
+			</button>
+
+			{expanded && (
+				<div className="ml-3 border-solid border-0 border-l-2 border-border pl-3 pb-1 pt-1">
+					{error && (
+						<div className="mb-2 flex items-start gap-2 rounded-md bg-surface-destructive/10 p-2 text-xs text-content-destructive">
+							<AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
+							<span>{error}</span>
+						</div>
+					)}
+
+					{toolCall.toolName === "listFiles" && files.length > 0 && (
+						<ul className="m-0 list-none space-y-0.5 p-0">
+							{files.map((file) => (
+								<li key={file}>
+									<button
+										type="button"
+										onClick={() => onNavigateToFile?.(file)}
+										className={cn(
+											"border-none bg-transparent p-0 text-left text-xs",
+											"text-content-link hover:underline",
+											onNavigateToFile ? "cursor-pointer" : "cursor-default",
+										)}
+										disabled={!onNavigateToFile}
+									>
+										{file}
+									</button>
+								</li>
+							))}
+						</ul>
+					)}
+
+					{toolCall.toolName === "readFile" &&
+						readFileContent !== undefined && (
+							<div className="space-y-1.5">
+								{path && (
+									<button
+										type="button"
+										onClick={() => onNavigateToFile?.(path)}
+										disabled={!onNavigateToFile}
+										className={cn(
+											"border-none bg-transparent p-0 text-xs",
+											"text-content-link hover:underline",
+											onNavigateToFile ? "cursor-pointer" : "cursor-default",
+										)}
+									>
+										{path}
+									</button>
+								)}
+								<pre className="m-0 overflow-x-auto rounded-md bg-surface-secondary p-2 text-[11px] leading-relaxed text-content-primary">
+									{displayedReadFileLines.join("\n")}
+								</pre>
+								{hasTruncatedReadFile && (
+									<Button
+										variant="subtle"
+										size="xs"
+										onClick={() => setShowAllReadLines((prev) => !prev)}
+									>
+										{showAllReadLines ? "Show less" : "Show more"}
+									</Button>
+								)}
+							</div>
+						)}
+
+					{toolCall.state === "pending" && !error && (
+						<p className="m-0 text-xs text-content-secondary">
+							Waiting for tool result…
+						</p>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/attachments.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/attachments.ts
@@ -1,0 +1,61 @@
+const IMAGE_ATTACHMENT_PREFIX = "image/";
+export const MAX_CHAT_IMAGE_ATTACHMENTS = 4;
+const MAX_CHAT_IMAGE_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+const IMAGE_ATTACHMENT_LIMIT_MB =
+	MAX_CHAT_IMAGE_ATTACHMENT_BYTES / (1024 * 1024);
+
+const describeAttachment = (file: Pick<File, "name">): string => {
+	const trimmedName = file.name.trim();
+	return trimmedName.length > 0 ? trimmedName : "This attachment";
+};
+
+const isImageAttachment = (file: Pick<File, "type">): boolean =>
+	file.type.startsWith(IMAGE_ATTACHMENT_PREFIX);
+
+export const validateImageAttachment = (
+	file: Pick<File, "name" | "size" | "type">,
+): string | undefined => {
+	if (!isImageAttachment(file)) {
+		return `${describeAttachment(file)} is not a supported image file.`;
+	}
+	if (!Number.isFinite(file.size) || file.size < 0) {
+		return `${describeAttachment(file)} has an invalid file size.`;
+	}
+	if (file.size > MAX_CHAT_IMAGE_ATTACHMENT_BYTES) {
+		return `${describeAttachment(file)} exceeds the ${IMAGE_ATTACHMENT_LIMIT_MB} MB attachment limit.`;
+	}
+	return undefined;
+};
+
+export const readFileAsDataURL = async (file: File): Promise<string> => {
+	const validationError = validateImageAttachment(file);
+	if (validationError) {
+		throw new Error(validationError);
+	}
+	if (typeof FileReader !== "function") {
+		throw new Error("File uploads are unavailable in this browser.");
+	}
+
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onerror = () => {
+			reject(
+				reader.error ??
+					new Error(`Failed to read ${describeAttachment(file)}.`),
+			);
+		};
+		reader.onload = () => {
+			const result = reader.result;
+			if (typeof result !== "string" || !result.startsWith("data:")) {
+				reject(
+					new Error(
+						`Failed to encode ${describeAttachment(file)} as an image attachment.`,
+					),
+				);
+				return;
+			}
+			resolve(result);
+		};
+		reader.readAsDataURL(file);
+	});
+};

--- a/site/src/pages/TemplateVersionEditorPage/ai/tools.test.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/tools.test.ts
@@ -1,0 +1,254 @@
+import type { FileTree } from "utils/filetree";
+import type { BuildOutput, BuildResult } from "./tools";
+
+vi.mock("ai", () => ({
+	tool: (definition: unknown) => definition,
+}));
+
+// Import AFTER the mock is set up.
+const { createTemplateAgentTools } = await import("./tools");
+
+type ToolSet = ReturnType<typeof createTemplateAgentTools>;
+
+const makeTools = (
+	overrides: Record<string, unknown> = {},
+	hasBuiltInCurrentRunRef: { current: boolean } = { current: false },
+): ToolSet => {
+	const fileTree: FileTree = { "main.tf": 'resource "null" {}' };
+	return createTemplateAgentTools(
+		() => fileTree,
+		() => {},
+		hasBuiltInCurrentRunRef,
+		overrides,
+	);
+};
+
+// The AI SDK tool context argument. Our mocked tool() is identity,
+// so execute is always present but typed as optional. We use a
+// minimal stub that satisfies the runtime contract.
+const toolContext = {} as never;
+
+// Helper to call tool execute with non-null assertion.
+// In tests, tool() is mocked as identity, so execute is always defined.
+const executeBuild = (tools: ToolSet) =>
+	tools.buildTemplate.execute!({}, toolContext);
+
+const executeGetBuildLogs = (tools: ToolSet) =>
+	tools.getBuildLogs.execute!({}, toolContext);
+
+describe("buildTemplate tool", () => {
+	it("returns error when onBuildRequested callback is not provided", async () => {
+		const tools = makeTools({ waitForBuildComplete: vi.fn() });
+		const result = await executeBuild(tools);
+		expect(result).toEqual({ error: "Build tools are not available." });
+	});
+
+	it("returns error when waitForBuildComplete callback is not provided", async () => {
+		const tools = makeTools({ onBuildRequested: vi.fn() });
+		const result = await executeBuild(tools);
+		expect(result).toEqual({ error: "Build tools are not available." });
+	});
+
+	it("returns failed status when onBuildRequested throws", async () => {
+		const tools = makeTools({
+			onBuildRequested: vi.fn().mockRejectedValue(new Error("Upload failed")),
+			waitForBuildComplete: vi.fn(),
+		});
+		const result = await executeBuild(tools);
+		expect(result).toMatchObject({
+			status: "failed",
+			error: "Upload failed",
+		});
+	});
+
+	it("calls onBuildRequested then waits for build completion", async () => {
+		const buildResult: BuildResult = {
+			status: "succeeded",
+			logs: "[info] Plan: done",
+		};
+		const onBuildRequested = vi.fn().mockResolvedValue(undefined);
+		const waitForBuildComplete = vi.fn().mockResolvedValue(buildResult);
+		const tools = makeTools({ onBuildRequested, waitForBuildComplete });
+
+		const result = await executeBuild(tools);
+
+		expect(onBuildRequested).toHaveBeenCalledTimes(1);
+		expect(waitForBuildComplete).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(buildResult);
+	});
+
+	it("returns timeout when build exceeds time limit", async () => {
+		vi.useFakeTimers();
+		try {
+			const neverResolves = new Promise<BuildResult>(() => {});
+			const tools = makeTools({
+				onBuildRequested: vi.fn().mockResolvedValue(undefined),
+				waitForBuildComplete: vi.fn().mockReturnValue(neverResolves),
+			});
+
+			const resultPromise = executeBuild(tools);
+			await vi.advanceTimersByTimeAsync(180_000);
+			const result = await resultPromise;
+
+			expect(result).toMatchObject({ status: "timeout" });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("getBuildLogs tool", () => {
+	it("returns error when getBuildOutput callback is not provided", async () => {
+		const tools = makeTools();
+		const result = await executeGetBuildLogs(tools);
+		expect(result).toEqual({ error: "Build tools are not available." });
+	});
+
+	it("returns no-build status when getBuildOutput returns undefined", async () => {
+		const tools = makeTools({
+			getBuildOutput: vi.fn().mockReturnValue(undefined),
+		});
+		const result = await executeGetBuildLogs(tools);
+		expect(result).toMatchObject({ status: "none" });
+	});
+
+	it("returns current build output when available", async () => {
+		const output: BuildOutput = {
+			status: "failed",
+			error: "missing provider",
+			logs: "[error] Plan: missing provider",
+		};
+		const tools = makeTools({
+			getBuildOutput: vi.fn().mockReturnValue(output),
+		});
+		const result = await executeGetBuildLogs(tools);
+		expect(result).toEqual(output);
+	});
+});
+
+describe("publishTemplate tool", () => {
+	const executePublish = (tools: ToolSet, args: Record<string, unknown> = {}) =>
+		tools.publishTemplate.execute!(args as never, toolContext);
+
+	it("returns error when onPublishRequested callback is not provided", async () => {
+		const tools = makeTools();
+		const result = await executePublish(tools);
+		expect(result).toEqual({
+			success: false,
+			error: "Publish is not available.",
+		});
+	});
+
+	it("returns success when callback resolves with success", async () => {
+		const publishResult = { success: true, versionName: "v1.0" };
+		const tools = makeTools({
+			onPublishRequested: vi.fn().mockResolvedValue(publishResult),
+		});
+		const result = await executePublish(tools, {
+			name: "v1.0",
+			message: "Initial release",
+			isActiveVersion: true,
+		});
+		expect(result).toEqual(publishResult);
+	});
+
+	it("returns failure when callback throws", async () => {
+		const tools = makeTools({
+			onPublishRequested: vi
+				.fn()
+				.mockRejectedValue(new Error("Publish API error")),
+		});
+		const result = await executePublish(tools);
+		expect(result).toEqual({
+			success: false,
+			error: "Publish API error",
+		});
+	});
+
+	it("passes publish args through without skipDirtyCheck before a build", async () => {
+		const onPublishRequested = vi.fn().mockResolvedValue({ success: true });
+		const tools = makeTools({ onPublishRequested });
+		await executePublish(tools, {
+			name: "my-version",
+			message: "changelog entry",
+			isActiveVersion: false,
+		});
+		expect(onPublishRequested).toHaveBeenCalledWith(
+			{
+				name: "my-version",
+				message: "changelog entry",
+				isActiveVersion: false,
+			},
+			undefined,
+		);
+	});
+
+	it("passes skipDirtyCheck when this run completed a successful build", async () => {
+		const onPublishRequested = vi.fn().mockResolvedValue({ success: true });
+		const tools = makeTools({
+			onBuildRequested: vi.fn().mockResolvedValue(undefined),
+			waitForBuildComplete: vi
+				.fn()
+				.mockResolvedValue({ status: "succeeded", logs: "" }),
+			onPublishRequested,
+		});
+
+		await executeBuild(tools);
+		await executePublish(tools, {
+			name: "built-version",
+			message: "after build",
+			isActiveVersion: true,
+		});
+
+		expect(onPublishRequested).toHaveBeenCalledWith(
+			{
+				name: "built-version",
+				message: "after build",
+				isActiveVersion: true,
+			},
+			{ skipDirtyCheck: true },
+		);
+	});
+
+	it("reuses a shared build-state ref across tool instances", async () => {
+		const hasBuiltInCurrentRunRef = { current: false };
+		const onBuildRequested = vi.fn().mockResolvedValue(undefined);
+		const waitForBuildComplete = vi
+			.fn()
+			.mockResolvedValue({ status: "succeeded", logs: "" });
+		const onPublishRequested = vi.fn().mockResolvedValue({ success: true });
+
+		const buildTools = makeTools(
+			{
+				onBuildRequested,
+				waitForBuildComplete,
+				onPublishRequested,
+			},
+			hasBuiltInCurrentRunRef,
+		);
+		await executeBuild(buildTools);
+
+		const publishTools = makeTools(
+			{
+				onBuildRequested,
+				waitForBuildComplete,
+				onPublishRequested,
+			},
+			hasBuiltInCurrentRunRef,
+		);
+		await executePublish(publishTools, {
+			name: "built-version",
+			message: "after approval",
+			isActiveVersion: true,
+		});
+
+		expect(onPublishRequested).toHaveBeenLastCalledWith(
+			{
+				name: "built-version",
+				message: "after approval",
+				isActiveVersion: true,
+			},
+			{ skipDirtyCheck: true },
+		);
+	});
+});

--- a/site/src/pages/TemplateVersionEditorPage/ai/tools.test.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/tools.test.ts
@@ -36,6 +36,14 @@ const executeBuild = (tools: ToolSet) =>
 const executeGetBuildLogs = (tools: ToolSet) =>
 	tools.getBuildLogs.execute!({}, toolContext);
 
+const createDeferred = <T>() => {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+};
+
 describe("buildTemplate tool", () => {
 	it("returns error when onBuildRequested callback is not provided", async () => {
 		const tools = makeTools({ waitForBuildComplete: vi.fn() });
@@ -77,6 +85,40 @@ describe("buildTemplate tool", () => {
 		expect(result).toEqual(buildResult);
 	});
 
+	it.each<BuildResult>([
+		{ status: "succeeded", logs: "[info] Plan: done" },
+		{
+			status: "failed",
+			error: "missing provider",
+			logs: "[error] missing provider",
+		},
+	])(
+		"clears the timeout when the build resolves with $status",
+		async (buildResult) => {
+			vi.useFakeTimers();
+			try {
+				const deferred = createDeferred<BuildResult>();
+				const tools = makeTools({
+					onBuildRequested: vi.fn().mockResolvedValue(undefined),
+					waitForBuildComplete: vi.fn().mockReturnValue(deferred.promise),
+				});
+
+				const resultPromise = executeBuild(tools);
+				await Promise.resolve();
+
+				expect(vi.getTimerCount()).toBe(1);
+
+				deferred.resolve(buildResult);
+				const result = await resultPromise;
+
+				expect(result).toEqual(buildResult);
+				expect(vi.getTimerCount()).toBe(0);
+			} finally {
+				vi.useRealTimers();
+			}
+		},
+	);
+
 	it("returns timeout when build exceeds time limit", async () => {
 		vi.useFakeTimers();
 		try {
@@ -87,10 +129,15 @@ describe("buildTemplate tool", () => {
 			});
 
 			const resultPromise = executeBuild(tools);
+			await Promise.resolve();
+
+			expect(vi.getTimerCount()).toBe(1);
+
 			await vi.advanceTimersByTimeAsync(180_000);
 			const result = await resultPromise;
 
 			expect(result).toMatchObject({ status: "timeout" });
+			expect(vi.getTimerCount()).toBe(0);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/site/src/pages/TemplateVersionEditorPage/ai/tools.test.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/tools.test.ts
@@ -13,6 +13,7 @@ type ToolSet = ReturnType<typeof createTemplateAgentTools>;
 const makeTools = (
 	overrides: Record<string, unknown> = {},
 	hasBuiltInCurrentRunRef: { current: boolean } = { current: false },
+	docsVersion = "v2.99.99",
 ): ToolSet => {
 	const fileTree: FileTree = { "main.tf": 'resource "null" {}' };
 	return createTemplateAgentTools(
@@ -20,6 +21,7 @@ const makeTools = (
 		() => {},
 		hasBuiltInCurrentRunRef,
 		overrides,
+		docsVersion,
 	);
 };
 
@@ -36,6 +38,12 @@ const executeBuild = (tools: ToolSet) =>
 const executeGetBuildLogs = (tools: ToolSet) =>
 	tools.getBuildLogs.execute!({}, toolContext);
 
+const executeDocsOutline = (tools: ToolSet) =>
+	tools.coder_docs_outline.execute!({}, toolContext);
+
+const executeDocs = (tools: ToolSet, path: string) =>
+	tools.coder_docs.execute!({ path }, toolContext);
+
 const createDeferred = <T>() => {
 	let resolve!: (value: T) => void;
 	const promise = new Promise<T>((resolvePromise) => {
@@ -43,6 +51,28 @@ const createDeferred = <T>() => {
 	});
 	return { promise, resolve };
 };
+
+const makeJSONResponse = (body: unknown, status = 200, statusText = "OK") =>
+	({
+		ok: status >= 200 && status < 300,
+		status,
+		statusText,
+		json: vi.fn().mockResolvedValue(body),
+		text: vi.fn(),
+	}) as unknown as Response;
+
+const makeTextResponse = (body: string, status = 200, statusText = "OK") =>
+	({
+		ok: status >= 200 && status < 300,
+		status,
+		statusText,
+		json: vi.fn(),
+		text: vi.fn().mockResolvedValue(body),
+	}) as unknown as Response;
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
 
 describe("buildTemplate tool", () => {
 	it("returns error when onBuildRequested callback is not provided", async () => {
@@ -170,6 +200,119 @@ describe("getBuildLogs tool", () => {
 		});
 		const result = await executeGetBuildLogs(tools);
 		expect(result).toEqual(output);
+	});
+});
+
+describe("coder_docs_outline tool", () => {
+	it("returns an outline fetched from the docs manifest for the build version", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			makeJSONResponse({
+				routes: [
+					{
+						title: "About",
+						path: "./README.md",
+						children: [
+							{
+								title: "Quickstart",
+								path: "./tutorials/quickstart.md",
+							},
+						],
+					},
+				],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const tools = makeTools();
+
+		const result = await executeDocsOutline(tools);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://raw.githubusercontent.com/coder/coder/refs/tags/v2.99.99/docs/manifest.json",
+		);
+		expect(result).toMatchObject({
+			buildVersion: "v2.99.99",
+			docsTag: "v2.99.99",
+		});
+		expect((result as { outline: string }).outline).toContain(
+			"- About (./README.md)",
+		);
+		expect((result as { outline: string }).outline).toContain(
+			"- Quickstart (./tutorials/quickstart.md)",
+		);
+	});
+
+	it("returns an error when the build version is unavailable", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const tools = makeTools({}, { current: false }, "");
+
+		const result = await executeDocsOutline(tools);
+
+		expect(result).toEqual({
+			error:
+				"Coder docs are unavailable because the deployment build version is unknown.",
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("coder_docs tool", () => {
+	it("reads a markdown file referenced by the manifest", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				makeJSONResponse({
+					routes: [
+						{
+							title: "Template Management",
+							path: "./admin/templates/managing-templates/index.md",
+						},
+					],
+				}),
+			)
+			.mockResolvedValueOnce(
+				makeTextResponse("# Managing templates\n\nUseful content."),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+		const tools = makeTools();
+
+		const result = await executeDocs(
+			tools,
+			"./admin/templates/managing-templates/index.md",
+		);
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"https://raw.githubusercontent.com/coder/coder/refs/tags/v2.99.99/docs/manifest.json",
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"https://raw.githubusercontent.com/coder/coder/refs/tags/v2.99.99/docs/admin/templates/managing-templates/index.md",
+		);
+		expect(result).toMatchObject({
+			buildVersion: "v2.99.99",
+			docsTag: "v2.99.99",
+			path: "./admin/templates/managing-templates/index.md",
+			markdown: "# Managing templates\n\nUseful content.",
+		});
+	});
+
+	it("returns an error when the requested path is not in the manifest", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			makeJSONResponse({
+				routes: [{ title: "About", path: "./README.md" }],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const tools = makeTools();
+
+		const result = await executeDocs(tools, "./missing.md");
+
+		expect(result).toEqual({
+			error:
+				"Docs file not found in the outline: ./missing.md. Call coder_docs_outline first and use one of the listed markdown paths.",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/site/src/pages/TemplateVersionEditorPage/ai/tools.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/tools.ts
@@ -1,0 +1,379 @@
+import { tool } from "ai";
+import type { FileTree } from "utils/filetree";
+import {
+	createFile,
+	existsFile,
+	getFileText,
+	isFolder,
+	removeFile,
+	traverse,
+	updateFile,
+} from "utils/filetree";
+import { z } from "zod";
+
+export interface BuildResult {
+	status: "succeeded" | "failed" | "canceled" | "timeout";
+	error?: string;
+	logs: string;
+}
+
+export interface BuildOutput {
+	status: string;
+	error?: string;
+	logs: string;
+}
+
+export interface PublishResult {
+	success: boolean;
+	error?: string;
+	versionName?: string;
+}
+
+export interface PublishRequestData {
+	name?: string;
+	message?: string;
+	isActiveVersion?: boolean;
+}
+
+export interface PublishRequestOptions {
+	skipDirtyCheck?: boolean;
+}
+
+interface TemplateAgentToolCallbacks {
+	onFileEdited?: (path: string) => void;
+	onFileDeleted?: (path: string) => void;
+	onBuildRequested?: () => Promise<void>;
+	waitForBuildComplete?: () => Promise<BuildResult>;
+	getBuildOutput?: () => BuildOutput | undefined;
+	onPublishRequested?: (
+		data: PublishRequestData,
+		options?: PublishRequestOptions,
+	) => Promise<PublishResult>;
+}
+
+/**
+ * Creates the set of AI tools that operate on the template editor's
+ * in-memory FileTree. Tools use the provided callbacks to read and
+ * mutate the tree so that React state stays in sync.
+ */
+export function createTemplateAgentTools(
+	getFileTree: () => FileTree,
+	setFileTree: (updater: (prev: FileTree) => FileTree) => void,
+	hasBuiltInCurrentRunRef: { current: boolean },
+	callbacks: TemplateAgentToolCallbacks = {},
+) {
+	const { onFileEdited, onFileDeleted } = callbacks;
+
+	return {
+		listFiles: tool({
+			description:
+				"List all files in the template. Always call this first to understand the template structure.",
+			inputSchema: z.object({}),
+			execute: async () => {
+				const files: string[] = [];
+				traverse(getFileTree(), (content, _filename, fullPath) => {
+					// Only include leaf files, not directories.
+					if (typeof content === "string") {
+						files.push(fullPath);
+					}
+				});
+				return { files };
+			},
+		}),
+
+		readFile: tool({
+			description:
+				"Read the contents of a file. Use this before editing to understand the current content.",
+			inputSchema: z.object({
+				path: z
+					.string()
+					.min(1, "Path cannot be empty.")
+					.describe("File path relative to template root, e.g. 'main.tf'"),
+			}),
+			execute: async ({ path }) => {
+				const tree = getFileTree();
+				if (!existsFile(path, tree)) {
+					return {
+						error: `File not found: ${path}. Use listFiles to see available files.`,
+					};
+				}
+				try {
+					const content = getFileText(path, tree);
+					return { content };
+				} catch {
+					return { error: `${path} is a directory, not a file.` };
+				}
+			},
+		}),
+
+		editFile: tool({
+			description:
+				"Edit a file by replacing a specific section. To create a new file, set oldContent to an empty string. " +
+				"To append to an existing file, set oldContent to empty string. " +
+				"For targeted edits, provide enough context in oldContent to uniquely identify the location.",
+			inputSchema: z.object({
+				path: z
+					.string()
+					.min(1, "Path cannot be empty.")
+					.describe("File path relative to template root"),
+				oldContent: z
+					.string()
+					.describe(
+						"Exact text to find and replace (empty string to create/append)",
+					),
+				newContent: z.string().describe("Replacement text"),
+			}),
+			needsApproval: true,
+			execute: async ({ path, oldContent, newContent }) => {
+				const result = executeEditFile(getFileTree, setFileTree, {
+					path,
+					oldContent,
+					newContent,
+				});
+				if (result.success) {
+					hasBuiltInCurrentRunRef.current = false;
+					onFileEdited?.(path);
+				}
+				return result;
+			},
+		}),
+
+		deleteFile: tool({
+			description: "Delete a file from the template.",
+			inputSchema: z.object({
+				path: z
+					.string()
+					.min(1, "Path cannot be empty.")
+					.describe("File path to delete"),
+			}),
+			needsApproval: true,
+			execute: async ({ path }) => {
+				const result = executeDeleteFile(getFileTree, setFileTree, { path });
+				if (result.success) {
+					hasBuiltInCurrentRunRef.current = false;
+					onFileDeleted?.(path);
+				}
+				return result;
+			},
+		}),
+
+		buildTemplate: tool({
+			description:
+				"Build the current template to validate Terraform configuration. " +
+				"This uploads the files and runs a provisioner job. " +
+				"Returns the build status and logs when complete.",
+			inputSchema: z.object({}),
+			needsApproval: true,
+			execute: async () => {
+				if (!callbacks.onBuildRequested || !callbacks.waitForBuildComplete) {
+					return { error: "Build tools are not available." };
+				}
+				try {
+					await callbacks.onBuildRequested();
+				} catch (err) {
+					hasBuiltInCurrentRunRef.current = false;
+					const message =
+						err instanceof Error ? err.message : "Failed to trigger build";
+					return { status: "failed" as const, error: message, logs: "" };
+				}
+				// Start waiting for build completion only after the build request
+				// succeeds so failed requests do not leave pending waiters/timers.
+				const buildPromise = Promise.race([
+					callbacks.waitForBuildComplete(),
+					new Promise<BuildResult>((resolve) =>
+						setTimeout(
+							() =>
+								resolve({
+									status: "timeout",
+									error: "Build timed out after 3 minutes.",
+									logs: "",
+								}),
+							180_000,
+						),
+					),
+				]);
+				const result = await buildPromise;
+				hasBuiltInCurrentRunRef.current = result.status === "succeeded";
+				return result;
+			},
+		}),
+
+		getBuildLogs: tool({
+			description:
+				"Get the current template build status and logs. " +
+				"Use this to inspect build failures, including when " +
+				"the user triggered a build manually.",
+			inputSchema: z.object({}),
+			execute: async () => {
+				if (!callbacks.getBuildOutput) {
+					return { error: "Build tools are not available." };
+				}
+				const output = callbacks.getBuildOutput();
+				if (!output) {
+					return {
+						status: "none",
+						error: "No build has been run yet.",
+						logs: "",
+					};
+				}
+				return output;
+			},
+		}),
+
+		publishTemplate: tool({
+			description:
+				"Publish the current template version. The build must have " +
+				"succeeded before publishing. Requires user approval. " +
+				"If name is omitted, the existing version name is kept.",
+			inputSchema: z.object({
+				name: z
+					.string()
+					.optional()
+					.describe("Version name (defaults to current version name)"),
+				message: z
+					.string()
+					.optional()
+					.describe("Changelog message describing the changes"),
+				isActiveVersion: z
+					.boolean()
+					.optional()
+					.default(true)
+					.describe("Whether to promote this as the active version"),
+			}),
+			needsApproval: true,
+			execute: async ({ name, message, isActiveVersion }) => {
+				if (!callbacks.onPublishRequested) {
+					return { success: false, error: "Publish is not available." };
+				}
+				try {
+					return await callbacks.onPublishRequested(
+						{
+							name,
+							message,
+							isActiveVersion,
+						},
+						hasBuiltInCurrentRunRef.current
+							? { skipDirtyCheck: true }
+							: undefined,
+					);
+				} catch (err) {
+					const errorMessage =
+						err instanceof Error ? err.message : "Failed to publish";
+					return { success: false, error: errorMessage };
+				}
+			},
+		}),
+	};
+}
+
+/**
+ * Execute the editFile tool logic. Separated from the tool definition
+ * so it can be called after user approval.
+ */
+function executeEditFile(
+	getFileTree: () => FileTree,
+	setFileTree: (updater: (prev: FileTree) => FileTree) => void,
+	args: { path: string; oldContent: string; newContent: string },
+): { success: boolean; action?: string; error?: string; path: string } {
+	const { path, oldContent, newContent } = args;
+	if (path.length === 0) {
+		return { success: false, error: "File path cannot be empty.", path };
+	}
+
+	const tree = getFileTree();
+	const exists = existsFile(path, tree);
+
+	// Create new file. createFile can throw if the path is invalid
+	// (e.g. an intermediate segment is an existing file), so we
+	// catch and return a structured error instead of breaking the
+	// agent loop.
+	if (!exists && oldContent === "") {
+		try {
+			setFileTree((prev) => createFile(path, prev, newContent));
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : "Failed to create file";
+			return { success: false, error: message, path };
+		}
+		return { success: true, action: "created", path };
+	}
+
+	// Cannot replace content in a file that doesn't exist.
+	if (!exists) {
+		return {
+			success: false,
+			error: `File not found: ${path}. Use listFiles first.`,
+			path,
+		};
+	}
+
+	let current: string;
+	try {
+		current = getFileText(path, tree);
+	} catch {
+		return {
+			success: false,
+			error: `${path} is a directory, not a file.`,
+			path,
+		};
+	}
+
+	// Append or write.
+	if (oldContent === "") {
+		const updated = current.length > 0 ? current + newContent : newContent;
+		const action = current.length > 0 ? "appended" : "written";
+		setFileTree((prev) => updateFile(path, updated, prev));
+		return { success: true, action, path };
+	}
+
+	// Search-and-replace: must match exactly once.
+	const occurrences = current.split(oldContent).length - 1;
+	if (occurrences === 0) {
+		return {
+			success: false,
+			error: `oldContent not found in ${path}. Read the file first to get exact content.`,
+			path,
+		};
+	}
+	if (occurrences > 1) {
+		return {
+			success: false,
+			error: `oldContent matches ${occurrences} locations in ${path}. Include more surrounding context to make the match unique.`,
+			path,
+		};
+	}
+
+	setFileTree((prev) =>
+		updateFile(path, current.replace(oldContent, newContent), prev),
+	);
+	return { success: true, action: "edited", path };
+}
+
+/**
+ * Execute the deleteFile tool logic. Separated from the tool definition
+ * so it can be called after user approval.
+ */
+function executeDeleteFile(
+	getFileTree: () => FileTree,
+	setFileTree: (updater: (prev: FileTree) => FileTree) => void,
+	args: { path: string },
+): { success: boolean; error?: string; path: string } {
+	const { path } = args;
+	if (path.length === 0) {
+		return { success: false, error: "File path cannot be empty.", path };
+	}
+
+	const tree = getFileTree();
+	if (!existsFile(path, tree)) {
+		return { success: false, error: `File not found: ${path}`, path };
+	}
+	if (isFolder(path, tree)) {
+		return {
+			success: false,
+			error: `${path} is a directory, not a file. Delete individual files instead.`,
+			path,
+		};
+	}
+	setFileTree((prev) => removeFile(path, prev));
+	return { success: true, path };
+}

--- a/site/src/pages/TemplateVersionEditorPage/ai/tools.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/tools.ts
@@ -51,6 +51,135 @@ interface TemplateAgentToolCallbacks {
 	) => Promise<PublishResult>;
 }
 
+type CoderDocsRoute = {
+	title: string;
+	description?: string;
+	path?: string;
+	children?: CoderDocsRoute[];
+};
+
+const coderDocsRouteSchema: z.ZodType<CoderDocsRoute> = z.lazy(() =>
+	z
+		.object({
+			title: z.string(),
+			description: z.string().optional(),
+			path: z.string().optional(),
+			children: z.array(coderDocsRouteSchema).optional(),
+		})
+		.passthrough(),
+);
+
+const coderDocsManifestSchema = z
+	.object({
+		versions: z.array(z.string()).optional(),
+		routes: z.array(coderDocsRouteSchema),
+	})
+	.passthrough();
+
+type CoderDocsManifest = z.infer<typeof coderDocsManifestSchema>;
+
+const CODER_DOCS_RAW_BASE_URL =
+	"https://raw.githubusercontent.com/coder/coder/refs/tags";
+
+const normalizeCoderDocsVersionTag = (version: string): string => {
+	const trimmed = version.trim();
+	if (trimmed.length === 0) {
+		throw new Error("Coder docs version cannot be empty.");
+	}
+
+	// Build versions can include prerelease/build metadata
+	// (for example v2.31.4-devel+abc123) while release docs are tagged
+	// on the base semver. Strip any suffix when present.
+	const baseSemverMatch = trimmed.match(/^v\d+\.\d+\.\d+/);
+	return baseSemverMatch?.[0] ?? trimmed;
+};
+
+const buildCoderDocsManifestURL = (docsTag: string): string =>
+	`${CODER_DOCS_RAW_BASE_URL}/${encodeURIComponent(docsTag)}/docs/manifest.json`;
+
+const normalizeCoderDocsPath = (path: string): string => {
+	const withoutFragment = path.trim().split("#")[0]?.split("?")[0] ?? "";
+	const withoutPrefix = withoutFragment.startsWith("./")
+		? withoutFragment.slice(2)
+		: withoutFragment;
+	if (withoutPrefix.length === 0) {
+		throw new Error("Docs path cannot be empty.");
+	}
+	if (withoutPrefix.startsWith("/") || withoutPrefix.includes("..")) {
+		throw new Error(
+			"Docs path must be a relative markdown file from coder_docs_outline.",
+		);
+	}
+	if (!withoutPrefix.endsWith(".md")) {
+		throw new Error(
+			"Docs path must point to a markdown file from coder_docs_outline.",
+		);
+	}
+	return withoutPrefix;
+};
+
+const buildCoderDocsFileURL = (
+	docsTag: string,
+	normalizedPath: string,
+): string =>
+	`${CODER_DOCS_RAW_BASE_URL}/${encodeURIComponent(docsTag)}/docs/${normalizedPath}`;
+
+const collectCoderDocsMarkdownPaths = (
+	routes: CoderDocsRoute[],
+	result = new Map<string, string>(),
+): Map<string, string> => {
+	for (const route of routes) {
+		if (route.path?.endsWith(".md")) {
+			result.set(normalizeCoderDocsPath(route.path), route.path);
+		}
+		if (route.children) {
+			collectCoderDocsMarkdownPaths(route.children, result);
+		}
+	}
+	return result;
+};
+
+const renderCoderDocsOutline = (
+	routes: CoderDocsRoute[],
+	depth = 0,
+): string[] => {
+	const lines: string[] = [];
+	const indent = "  ".repeat(depth);
+	for (const route of routes) {
+		const suffix = route.path?.endsWith(".md") ? ` (${route.path})` : "";
+		lines.push(`${indent}- ${route.title}${suffix}`);
+		if (route.children) {
+			lines.push(...renderCoderDocsOutline(route.children, depth + 1));
+		}
+	}
+	return lines;
+};
+
+const fetchJSON = async (url: string): Promise<unknown> => {
+	if (typeof globalThis.fetch !== "function") {
+		throw new Error("Fetch API is unavailable in this browser.");
+	}
+	const response = await globalThis.fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch ${url}: ${response.status} ${response.statusText || "request failed"}.`,
+		);
+	}
+	return response.json();
+};
+
+const fetchText = async (url: string): Promise<string> => {
+	if (typeof globalThis.fetch !== "function") {
+		throw new Error("Fetch API is unavailable in this browser.");
+	}
+	const response = await globalThis.fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch ${url}: ${response.status} ${response.statusText || "request failed"}.`,
+		);
+	}
+	return response.text();
+};
 /**
  * Creates the set of AI tools that operate on the template editor's
  * in-memory FileTree. Tools use the provided callbacks to read and
@@ -61,8 +190,62 @@ export function createTemplateAgentTools(
 	setFileTree: (updater: (prev: FileTree) => FileTree) => void,
 	hasBuiltInCurrentRunRef: { current: boolean },
 	callbacks: TemplateAgentToolCallbacks = {},
+	docsVersion?: string,
 ) {
 	const { onFileEdited, onFileDeleted } = callbacks;
+	const docsManifestCache = new Map<string, Promise<CoderDocsManifest>>();
+	const docsMarkdownCache = new Map<string, Promise<string>>();
+
+	const getDocsVersionInfo = () => {
+		if (docsVersion === undefined || docsVersion.trim().length === 0) {
+			return {
+				error:
+					"Coder docs are unavailable because the deployment build version is unknown.",
+			} as const;
+		}
+		return {
+			buildVersion: docsVersion,
+			docsTag: normalizeCoderDocsVersionTag(docsVersion),
+		} as const;
+	};
+
+	const getDocsManifest = async (
+		docsTag: string,
+	): Promise<CoderDocsManifest> => {
+		const cached = docsManifestCache.get(docsTag);
+		if (cached) {
+			return cached;
+		}
+
+		const manifestPromise = fetchJSON(buildCoderDocsManifestURL(docsTag))
+			.then((value) => coderDocsManifestSchema.parse(value))
+			.catch((error) => {
+				docsManifestCache.delete(docsTag);
+				throw error;
+			});
+		docsManifestCache.set(docsTag, manifestPromise);
+		return manifestPromise;
+	};
+
+	const getDocsMarkdown = async (
+		docsTag: string,
+		normalizedPath: string,
+	): Promise<string> => {
+		const cacheKey = `${docsTag}:${normalizedPath}`;
+		const cached = docsMarkdownCache.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const markdownPromise = fetchText(
+			buildCoderDocsFileURL(docsTag, normalizedPath),
+		).catch((error) => {
+			docsMarkdownCache.delete(cacheKey);
+			throw error;
+		});
+		docsMarkdownCache.set(cacheKey, markdownPromise);
+		return markdownPromise;
+	};
 
 	return {
 		listFiles: tool({
@@ -154,6 +337,95 @@ export function createTemplateAgentTools(
 					onFileDeleted?.(path);
 				}
 				return result;
+			},
+		}),
+
+		coder_docs_outline: tool({
+			description:
+				"Get an outline of the official Coder documentation for this deployment version. " +
+				"Use this to discover relevant markdown file paths before calling coder_docs.",
+			inputSchema: z.object({}),
+			execute: async () => {
+				const versionInfo = getDocsVersionInfo();
+				if ("error" in versionInfo) {
+					return versionInfo;
+				}
+				try {
+					const manifest = await getDocsManifest(versionInfo.docsTag);
+					return {
+						buildVersion: versionInfo.buildVersion,
+						docsTag: versionInfo.docsTag,
+						outline: [
+							`Coder docs outline for build version ${versionInfo.buildVersion} (docs tag ${versionInfo.docsTag}).`,
+							"Use the exact markdown paths in parentheses with coder_docs.",
+							...renderCoderDocsOutline(manifest.routes),
+						].join("\n"),
+					};
+				} catch (err) {
+					const message =
+						err instanceof Error
+							? err.message
+							: "Failed to load the Coder docs outline.";
+					return { error: message };
+				}
+			},
+		}),
+
+		coder_docs: tool({
+			description:
+				"Read a markdown file from the official Coder documentation for this deployment version. " +
+				"Call coder_docs_outline first to discover valid paths.",
+			inputSchema: z.object({
+				path: z
+					.string()
+					.min(1, "Path cannot be empty.")
+					.describe(
+						"Markdown file path from coder_docs_outline, e.g. './admin/templates/managing-templates/index.md'",
+					),
+			}),
+			execute: async ({ path }) => {
+				const versionInfo = getDocsVersionInfo();
+				if ("error" in versionInfo) {
+					return versionInfo;
+				}
+				let normalizedPath: string;
+				try {
+					normalizedPath = normalizeCoderDocsPath(path);
+				} catch (err) {
+					const message =
+						err instanceof Error ? err.message : "Invalid docs path.";
+					return { error: message };
+				}
+
+				try {
+					const manifest = await getDocsManifest(versionInfo.docsTag);
+					const markdownPaths = collectCoderDocsMarkdownPaths(manifest.routes);
+					const manifestPath = markdownPaths.get(normalizedPath);
+					if (!manifestPath) {
+						return {
+							error: `Docs file not found in the outline: ${path}. Call coder_docs_outline first and use one of the listed markdown paths.`,
+						};
+					}
+					return {
+						buildVersion: versionInfo.buildVersion,
+						docsTag: versionInfo.docsTag,
+						path: manifestPath,
+						sourceURL: buildCoderDocsFileURL(
+							versionInfo.docsTag,
+							normalizedPath,
+						),
+						markdown: await getDocsMarkdown(
+							versionInfo.docsTag,
+							normalizedPath,
+						),
+					};
+				} catch (err) {
+					const message =
+						err instanceof Error
+							? err.message
+							: "Failed to load the Coder docs page.";
+					return { error: message };
+				}
 			},
 		}),
 

--- a/site/src/pages/TemplateVersionEditorPage/ai/tools.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/tools.ts
@@ -178,23 +178,29 @@ export function createTemplateAgentTools(
 				}
 				// Start waiting for build completion only after the build request
 				// succeeds so failed requests do not leave pending waiters/timers.
-				const buildPromise = Promise.race([
-					callbacks.waitForBuildComplete(),
-					new Promise<BuildResult>((resolve) =>
-						setTimeout(
-							() =>
-								resolve({
-									status: "timeout",
-									error: "Build timed out after 3 minutes.",
-									logs: "",
-								}),
-							180_000,
-						),
-					),
-				]);
-				const result = await buildPromise;
-				hasBuiltInCurrentRunRef.current = result.status === "succeeded";
-				return result;
+				let timeoutID: ReturnType<typeof setTimeout> | undefined;
+				try {
+					const result = await Promise.race([
+						callbacks.waitForBuildComplete(),
+						new Promise<BuildResult>((resolve) => {
+							timeoutID = setTimeout(
+								() =>
+									resolve({
+										status: "timeout",
+										error: "Build timed out after 3 minutes.",
+										logs: "",
+									}),
+								180_000,
+							);
+						}),
+					]);
+					hasBuiltInCurrentRunRef.current = result.status === "succeeded";
+					return result;
+				} finally {
+					if (timeoutID !== undefined) {
+						clearTimeout(timeoutID);
+					}
+				}
 			},
 		}),
 

--- a/site/src/pages/TemplateVersionEditorPage/ai/types.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/types.ts
@@ -1,0 +1,16 @@
+// Shared types for the template editor AI agent.
+
+/** Tool call awaiting user approval (editFile, deleteFile, buildTemplate, or publishTemplate). */
+export interface PendingToolCall {
+	/** Approval request ID from the AI SDK. */
+	approvalId: string;
+	/** The tool call ID from the AI SDK. */
+	toolCallId: string;
+	/** Name of the tool being called. */
+	toolName: "editFile" | "deleteFile" | "buildTemplate" | "publishTemplate";
+	/** The arguments passed to the tool. */
+	args: Record<string, unknown>;
+}
+
+/** Possible states for the agent conversation loop. */
+export type AgentStatus = "idle" | "streaming" | "awaiting_approval" | "error";

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -200,7 +200,7 @@ describe("useTemplateAgent MCP lifecycle", () => {
 		expect(mcpClientToolsMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("uses the current server MCP endpoint when initializing the client", async () => {
+	it("uses the registry MCP endpoint when initializing the client", async () => {
 		renderTemplateAgentHook({ enabled: true });
 
 		await waitFor(() => {
@@ -218,7 +218,7 @@ describe("useTemplateAgent MCP lifecycle", () => {
 		expect(mcpClientOptions).toEqual({
 			transport: {
 				type: "http",
-				url: new URL("/mcp/http", window.location.origin).toString(),
+				url: "https://registry.coder.com/mcp",
 			},
 		});
 		expect(mcpClientOptions?.transport.url).not.toContain(

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -1,0 +1,553 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { UIMessage } from "ai";
+import type { FileTree } from "utils/filetree";
+
+const { createAgentUIStreamMock, readUIMessageStreamMock, ToolLoopAgentMock } =
+	vi.hoisted(() => {
+		return {
+			createAgentUIStreamMock: vi.fn(),
+			readUIMessageStreamMock: vi.fn(),
+			ToolLoopAgentMock: vi.fn(function MockToolLoopAgent(this: unknown) {
+				return this;
+			}),
+		};
+	});
+
+vi.mock("ai", () => {
+	return {
+		tool: (definition: unknown) => definition,
+		createAgentUIStream: createAgentUIStreamMock,
+		readUIMessageStream: readUIMessageStreamMock,
+		stepCountIs: () => "stop-condition",
+		ToolLoopAgent: ToolLoopAgentMock,
+		getToolName: (part: { type: string; toolName?: string }) => {
+			if (part.type === "dynamic-tool") {
+				return part.toolName ?? "";
+			}
+			return part.type.startsWith("tool-") ? part.type.slice(5) : part.type;
+		},
+		isToolUIPart: (part: { type?: unknown }) => {
+			if (typeof part?.type !== "string") {
+				return false;
+			}
+			return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+		},
+		isReasoningUIPart: (part: { type?: unknown }) => {
+			return typeof part?.type === "string" && part.type === "reasoning";
+		},
+	};
+});
+
+import { useTemplateAgent } from "./useTemplateAgent";
+
+type StreamMessage = UIMessage;
+
+const enqueueUIMessageStreams = (streams: StreamMessage[][]) => {
+	let streamIndex = 0;
+	createAgentUIStreamMock.mockImplementation(async () => ({
+		id: streamIndex++,
+	}));
+	readUIMessageStreamMock.mockImplementation(() => {
+		const streamMessages = streams.shift();
+		if (!streamMessages) {
+			throw new Error("Expected a queued UI message stream.");
+		}
+
+		return (async function* () {
+			for (const message of streamMessages) {
+				yield structuredClone(message);
+			}
+		})();
+	});
+};
+
+const editArgs = {
+	path: "main.tf",
+	oldContent: "old",
+	newContent: "new",
+};
+
+const approvalMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "I can apply this change." },
+		{
+			type: "tool-editFile",
+			toolCallId: "tool-1",
+			state: "approval-requested",
+			input: editArgs,
+			approval: { id: "approval-1" },
+		},
+	],
+};
+
+const approvedResultMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "Applied." },
+		{
+			type: "tool-editFile",
+			toolCallId: "tool-1",
+			state: "output-available",
+			input: editArgs,
+			output: { success: true, path: "main.tf" },
+			approval: { id: "approval-1", approved: true },
+		},
+	],
+};
+
+const deniedResultMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "I skipped that change." },
+		{
+			type: "tool-editFile",
+			toolCallId: "tool-1",
+			state: "output-denied",
+			input: editArgs,
+			approval: {
+				id: "approval-1",
+				approved: false,
+				reason: "User rejected this action.",
+			},
+		},
+	],
+};
+
+const renderTemplateAgentHook = () => {
+	let fileTree: FileTree = { "main.tf": "old" };
+	const getFileTree = () => fileTree;
+	const setFileTree = (updater: (prev: FileTree) => FileTree) => {
+		fileTree = updater(fileTree);
+	};
+
+	return renderHook(() =>
+		useTemplateAgent({
+			getFileTree,
+			setFileTree,
+			modelConfig: {
+				model: {
+					id: "gpt-4o-mini",
+					provider: "openai",
+				},
+			},
+		}),
+	);
+};
+
+describe("useTemplateAgent approvals", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("moves approval-requested to approval-responded and resumes the stream on approve", async () => {
+		enqueueUIMessageStreams([[approvalMessage], [approvedResultMessage]]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Apply the edit");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+		expect(result.current.pendingApproval?.approvalId).toBe("approval-1");
+
+		act(() => {
+			result.current.approve();
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+		expect(createAgentUIStreamMock).toHaveBeenCalledTimes(2);
+
+		const secondCallOptions = createAgentUIStreamMock.mock.calls[1]?.[0] as {
+			uiMessages: UIMessage[];
+		};
+		expect(secondCallOptions).toBeDefined();
+
+		const lastMessage =
+			secondCallOptions.uiMessages[secondCallOptions.uiMessages.length - 1];
+		expect(lastMessage.role).toBe("assistant");
+		const approvalPart = lastMessage.parts.find(
+			(part) => part.type === "tool-editFile",
+		) as
+			| {
+					state: string;
+					approval: { id: string; approved: boolean; reason?: string };
+			  }
+			| undefined;
+		expect(approvalPart).toMatchObject({
+			state: "approval-responded",
+			approval: { id: "approval-1", approved: true },
+		});
+
+		await waitFor(() => {
+			const assistantMessages = result.current.messages.filter(
+				(message) => message.role === "assistant",
+			);
+			const latestAssistant = assistantMessages[assistantMessages.length - 1];
+			expect(latestAssistant.toolCalls[0]).toMatchObject({
+				toolCallId: "tool-1",
+				state: "result",
+				result: { success: true, path: "main.tf" },
+			});
+		});
+		expect(result.current.pendingApproval).toBeNull();
+	});
+
+	it("marks the approval as denied and resumes the stream on reject", async () => {
+		enqueueUIMessageStreams([[approvalMessage], [deniedResultMessage]]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Do the change");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+
+		act(() => {
+			result.current.reject();
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+		expect(createAgentUIStreamMock).toHaveBeenCalledTimes(2);
+
+		const secondCallOptions = createAgentUIStreamMock.mock.calls[1]?.[0] as {
+			uiMessages: UIMessage[];
+		};
+		const lastMessage =
+			secondCallOptions.uiMessages[secondCallOptions.uiMessages.length - 1];
+		const approvalPart = lastMessage.parts.find(
+			(part) => part.type === "tool-editFile",
+		) as
+			| {
+					state: string;
+					approval: { id: string; approved: boolean; reason?: string };
+			  }
+			| undefined;
+		expect(approvalPart).toMatchObject({
+			state: "approval-responded",
+			approval: {
+				id: "approval-1",
+				approved: false,
+				reason: "User rejected this action.",
+			},
+		});
+
+		await waitFor(() => {
+			const assistantMessages = result.current.messages.filter(
+				(message) => message.role === "assistant",
+			);
+			const latestAssistant = assistantMessages[assistantMessages.length - 1];
+			expect(latestAssistant.toolCalls[0]).toMatchObject({
+				toolCallId: "tool-1",
+				state: "result",
+				result: { error: "User rejected this action." },
+			});
+		});
+		expect(result.current.pendingApproval).toBeNull();
+	});
+});
+
+const buildApprovalMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "I'll build the template to check." },
+		{
+			type: "tool-buildTemplate",
+			toolCallId: "tool-build-1",
+			state: "approval-requested",
+			input: {},
+			approval: { id: "approval-build-1" },
+		},
+	],
+};
+
+const buildApprovedResultMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "Build succeeded." },
+		{
+			type: "tool-buildTemplate",
+			toolCallId: "tool-build-1",
+			state: "output-available",
+			input: {},
+			output: { status: "succeeded", logs: "..." },
+			approval: { id: "approval-build-1", approved: true },
+		},
+	],
+};
+
+const buildDeniedResultMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "Build was rejected." },
+		{
+			type: "tool-buildTemplate",
+			toolCallId: "tool-build-1",
+			state: "output-denied",
+			input: {},
+			approval: {
+				id: "approval-build-1",
+				approved: false,
+				reason: "User rejected this action.",
+			},
+		},
+	],
+};
+
+describe("useTemplateAgent buildTemplate approvals", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("moves to awaiting_approval when buildTemplate needs approval", async () => {
+		enqueueUIMessageStreams([
+			[buildApprovalMessage],
+			[buildApprovedResultMessage],
+		]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Build it");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+		expect(result.current.pendingApproval?.toolCallId).toBe("tool-build-1");
+	});
+
+	it("resumes stream after buildTemplate is approved", async () => {
+		enqueueUIMessageStreams([
+			[buildApprovalMessage],
+			[buildApprovedResultMessage],
+		]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Build it");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+
+		act(() => {
+			result.current.approve();
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+		expect(createAgentUIStreamMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("marks the approval as denied and resumes the stream on reject", async () => {
+		enqueueUIMessageStreams([
+			[buildApprovalMessage],
+			[buildDeniedResultMessage],
+		]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Build it");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+
+		act(() => {
+			result.current.reject();
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+		expect(createAgentUIStreamMock).toHaveBeenCalledTimes(2);
+
+		const secondCallOptions = createAgentUIStreamMock.mock.calls[1]?.[0] as {
+			uiMessages: UIMessage[];
+		};
+		const lastMessage =
+			secondCallOptions.uiMessages[secondCallOptions.uiMessages.length - 1];
+		const approvalPart = lastMessage.parts.find(
+			(part) => part.type === "tool-buildTemplate",
+		) as
+			| {
+					state: string;
+					approval: {
+						id: string;
+						approved: boolean;
+						reason?: string;
+					};
+			  }
+			| undefined;
+		expect(approvalPart).toMatchObject({
+			state: "approval-responded",
+			approval: {
+				id: "approval-build-1",
+				approved: false,
+				reason: "User rejected this action.",
+			},
+		});
+	});
+});
+
+const publishApprovalMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "I'll publish the template now." },
+		{
+			type: "tool-publishTemplate",
+			toolCallId: "tool-publish-1",
+			state: "approval-requested",
+			input: { name: "v1.0", message: "First release", isActiveVersion: true },
+			approval: { id: "approval-publish-1" },
+		},
+	],
+};
+
+const publishApprovedResultMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "Published successfully." },
+		{
+			type: "tool-publishTemplate",
+			toolCallId: "tool-publish-1",
+			state: "output-available",
+			input: { name: "v1.0", message: "First release", isActiveVersion: true },
+			output: { success: true, versionName: "v1.0" },
+			approval: { id: "approval-publish-1", approved: true },
+		},
+	],
+};
+
+const publishDeniedResultMessage: UIMessage = {
+	id: "assistant-1",
+	role: "assistant",
+	parts: [
+		{ type: "text", text: "Publish was rejected." },
+		{
+			type: "tool-publishTemplate",
+			toolCallId: "tool-publish-1",
+			state: "output-denied",
+			input: { name: "v1.0", message: "First release", isActiveVersion: true },
+			approval: {
+				id: "approval-publish-1",
+				approved: false,
+				reason: "User rejected this action.",
+			},
+		},
+	],
+};
+
+describe("useTemplateAgent publishTemplate approvals", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("moves to awaiting_approval when publishTemplate needs approval", async () => {
+		enqueueUIMessageStreams([
+			[publishApprovalMessage],
+			[publishApprovedResultMessage],
+		]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Publish the template");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+		expect(result.current.pendingApproval?.toolCallId).toBe("tool-publish-1");
+	});
+
+	it("resumes stream after publishTemplate is approved", async () => {
+		enqueueUIMessageStreams([
+			[publishApprovalMessage],
+			[publishApprovedResultMessage],
+		]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Publish the template");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+
+		act(() => {
+			result.current.approve();
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+		expect(createAgentUIStreamMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("marks denied and resumes on reject", async () => {
+		enqueueUIMessageStreams([
+			[publishApprovalMessage],
+			[publishDeniedResultMessage],
+		]);
+		const { result } = renderTemplateAgentHook();
+
+		act(() => {
+			result.current.send("Publish the template");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("awaiting_approval");
+		});
+
+		act(() => {
+			result.current.reject();
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+		expect(createAgentUIStreamMock).toHaveBeenCalledTimes(2);
+
+		const secondCallOptions = createAgentUIStreamMock.mock.calls[1]?.[0] as {
+			uiMessages: UIMessage[];
+		};
+		const lastMessage =
+			secondCallOptions.uiMessages[secondCallOptions.uiMessages.length - 1];
+		const approvalPart = lastMessage.parts.find(
+			(part) => part.type === "tool-publishTemplate",
+		) as
+			| {
+					state: string;
+					approval: { id: string; approved: boolean; reason?: string };
+			  }
+			| undefined;
+		expect(approvalPart).toMatchObject({
+			state: "approval-responded",
+			approval: {
+				id: "approval-publish-1",
+				approved: false,
+				reason: "User rejected this action.",
+			},
+		});
+	});
+});

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -117,7 +117,15 @@ const deniedResultMessage: UIMessage = {
 	],
 };
 
-const renderTemplateAgentHook = () => {
+const completedMessage: UIMessage = {
+	id: "assistant-complete",
+	role: "assistant",
+	parts: [{ type: "text", text: "Done." }],
+};
+
+const renderTemplateAgentHook = (
+	options: { currentFilePath?: string } = {},
+) => {
 	let fileTree: FileTree = { "main.tf": "old" };
 	const getFileTree = () => fileTree;
 	const setFileTree = (updater: (prev: FileTree) => FileTree) => {
@@ -134,9 +142,55 @@ const renderTemplateAgentHook = () => {
 					provider: "openai",
 				},
 			},
+			...options,
 		}),
 	);
 };
+
+describe("useTemplateAgent prompt guidance", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("tells the agent to reuse prior file reads across follow-up turns", async () => {
+		enqueueUIMessageStreams([[completedMessage]]);
+		const { result } = renderTemplateAgentHook({ currentFilePath: "main.tf" });
+
+		act(() => {
+			result.current.send("Update the template");
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+
+		const firstAgentCall = ToolLoopAgentMock.mock.calls.at(0) as
+			| [{ instructions: string }]
+			| undefined;
+		const instructions = (firstAgentCall?.[0]?.instructions ?? "").replace(
+			/\s+/g,
+			" ",
+		);
+		expect(instructions).toContain(
+			"Use listFiles early in the conversation to learn the template structure",
+		);
+		expect(instructions).toContain(
+			"Reuse prior readFile/listFiles results when nothing indicates the template changed",
+		);
+		expect(instructions).toContain(
+			"After a successful editFile call, treat that edit and its inputs as the latest known state of the file",
+		);
+		expect(instructions).toContain(
+			"If editFile fails because oldContent was not found, matched multiple locations",
+		);
+		expect(instructions).toContain(
+			'If you have not already inspected "main.tf" in this conversation, read it',
+		);
+		expect(instructions).toContain(
+			'If you already inspected "main.tf" and nothing indicates it changed, reuse that content',
+		);
+	});
+});
 
 describe("useTemplateAgent approvals", () => {
 	beforeEach(() => {

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -141,6 +141,7 @@ const completedMessage: UIMessage = {
 type RenderTemplateAgentHookOptions = {
 	currentFilePath?: string;
 	enabled?: boolean;
+	docsVersion?: string;
 };
 
 const renderTemplateAgentHook = (
@@ -163,6 +164,7 @@ const renderTemplateAgentHook = (
 						provider: "openai",
 					},
 				},
+				docsVersion: "v2.99.99",
 				...options,
 			}),
 		{ initialProps: initialOptions },
@@ -299,6 +301,12 @@ describe("useTemplateAgent prompt guidance", () => {
 		);
 		expect(instructions).toContain(
 			'If you already inspected "main.tf" and nothing indicates it changed, reuse that content',
+		);
+		expect(instructions).toContain(
+			"Use coder_docs_outline and coder_docs for official Coder product documentation that matches deployment version v2.99.99",
+		);
+		expect(instructions).toContain(
+			"Start with coder_docs_outline to discover relevant markdown paths",
 		);
 	});
 });

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -2,16 +2,25 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { UIMessage } from "ai";
 import type { FileTree } from "utils/filetree";
 
-const { createAgentUIStreamMock, readUIMessageStreamMock, ToolLoopAgentMock } =
-	vi.hoisted(() => {
-		return {
-			createAgentUIStreamMock: vi.fn(),
-			readUIMessageStreamMock: vi.fn(),
-			ToolLoopAgentMock: vi.fn(function MockToolLoopAgent(this: unknown) {
-				return this;
-			}),
-		};
-	});
+const {
+	createAgentUIStreamMock,
+	createMCPClientMock,
+	mcpClientCloseMock,
+	mcpClientToolsMock,
+	readUIMessageStreamMock,
+	ToolLoopAgentMock,
+} = vi.hoisted(() => {
+	return {
+		createAgentUIStreamMock: vi.fn(),
+		createMCPClientMock: vi.fn(),
+		mcpClientCloseMock: vi.fn(),
+		mcpClientToolsMock: vi.fn(),
+		readUIMessageStreamMock: vi.fn(),
+		ToolLoopAgentMock: vi.fn(function MockToolLoopAgent(this: unknown) {
+			return this;
+		}),
+	};
+});
 
 vi.mock("ai", () => {
 	return {
@@ -35,6 +44,12 @@ vi.mock("ai", () => {
 		isReasoningUIPart: (part: { type?: unknown }) => {
 			return typeof part?.type === "string" && part.type === "reasoning";
 		},
+	};
+});
+
+vi.mock("@ai-sdk/mcp", () => {
+	return {
+		createMCPClient: createMCPClientMock,
 	};
 });
 
@@ -123,8 +138,13 @@ const completedMessage: UIMessage = {
 	parts: [{ type: "text", text: "Done." }],
 };
 
+type RenderTemplateAgentHookOptions = {
+	currentFilePath?: string;
+	enabled?: boolean;
+};
+
 const renderTemplateAgentHook = (
-	options: { currentFilePath?: string } = {},
+	initialOptions: RenderTemplateAgentHookOptions = {},
 ) => {
 	let fileTree: FileTree = { "main.tf": "old" };
 	const getFileTree = () => fileTree;
@@ -132,20 +152,85 @@ const renderTemplateAgentHook = (
 		fileTree = updater(fileTree);
 	};
 
-	return renderHook(() =>
-		useTemplateAgent({
-			getFileTree,
-			setFileTree,
-			modelConfig: {
-				model: {
-					id: "gpt-4o-mini",
-					provider: "openai",
+	return renderHook(
+		(options: RenderTemplateAgentHookOptions) =>
+			useTemplateAgent({
+				getFileTree,
+				setFileTree,
+				modelConfig: {
+					model: {
+						id: "gpt-4o-mini",
+						provider: "openai",
+					},
 				},
-			},
-			...options,
-		}),
+				...options,
+			}),
+		{ initialProps: initialOptions },
 	);
 };
+
+beforeEach(() => {
+	mcpClientCloseMock.mockResolvedValue(undefined);
+	mcpClientToolsMock.mockResolvedValue({});
+	createMCPClientMock.mockResolvedValue({
+		close: mcpClientCloseMock,
+		tools: mcpClientToolsMock,
+	});
+});
+
+describe("useTemplateAgent MCP lifecycle", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("does not initialize MCP while disabled", () => {
+		renderTemplateAgentHook({ enabled: false });
+
+		expect(createMCPClientMock).not.toHaveBeenCalled();
+	});
+
+	it("initializes MCP once when enabled", async () => {
+		renderTemplateAgentHook({ enabled: true });
+
+		await waitFor(() => {
+			expect(createMCPClientMock).toHaveBeenCalledTimes(1);
+		});
+		expect(mcpClientToolsMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("closes MCP and clears external tools when disabled after startup", async () => {
+		mcpClientToolsMock.mockResolvedValue({
+			lookup: { description: "Registry lookup" },
+		});
+		enqueueUIMessageStreams([[completedMessage]]);
+		const { result, rerender } = renderTemplateAgentHook({ enabled: true });
+
+		await waitFor(() => {
+			expect(mcpClientToolsMock).toHaveBeenCalledTimes(1);
+		});
+
+		rerender({ enabled: false });
+
+		await waitFor(() => {
+			expect(mcpClientCloseMock).toHaveBeenCalledTimes(1);
+		});
+
+		act(() => {
+			result.current.send("Check available tools");
+		});
+
+		await waitFor(() => {
+			expect(createAgentUIStreamMock).toHaveBeenCalledTimes(1);
+		});
+		const toolLoopAgentCall = ToolLoopAgentMock.mock.calls.at(-1) as
+			| [{ tools: Record<string, unknown> }]
+			| undefined;
+		const toolLoopAgentOptions = toolLoopAgentCall?.[0];
+		expect(toolLoopAgentOptions?.tools).not.toHaveProperty(
+			"coder_registry_lookup",
+		);
+	});
+});
 
 describe("useTemplateAgent prompt guidance", () => {
 	beforeEach(() => {

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -41,6 +41,9 @@ vi.mock("ai", () => {
 			}
 			return part.type === "dynamic-tool" || part.type.startsWith("tool-");
 		},
+		isFileUIPart: (part: { type?: unknown }) => {
+			return typeof part?.type === "string" && part.type === "file";
+		},
 		isReasoningUIPart: (part: { type?: unknown }) => {
 			return typeof part?.type === "string" && part.type === "reasoning";
 		},
@@ -244,7 +247,7 @@ describe("useTemplateAgent MCP lifecycle", () => {
 		});
 
 		act(() => {
-			result.current.send("Check available tools");
+			void result.current.send("Check available tools");
 		});
 
 		await waitFor(() => {
@@ -270,7 +273,7 @@ describe("useTemplateAgent prompt guidance", () => {
 		const { result } = renderTemplateAgentHook({ currentFilePath: "main.tf" });
 
 		act(() => {
-			result.current.send("Update the template");
+			void result.current.send("Update the template");
 		});
 
 		await waitFor(() => {
@@ -297,17 +300,89 @@ describe("useTemplateAgent prompt guidance", () => {
 			"If editFile fails because oldContent was not found, matched multiple locations",
 		);
 		expect(instructions).toContain(
+			"Do not treat your own memory as the source of truth for Coder behavior",
+		);
+		expect(instructions).toContain(
+			"consult the official Coder tools instead of guessing",
+		);
+		expect(instructions).toContain(
 			'If you have not already inspected "main.tf" in this conversation, read it',
 		);
 		expect(instructions).toContain(
 			'If you already inspected "main.tf" and nothing indicates it changed, reuse that content',
 		);
 		expect(instructions).toContain(
-			"Use coder_docs_outline and coder_docs for official Coder product documentation that matches deployment version v2.99.99",
+			"Use coder_docs_outline and coder_docs as the primary external source of truth for official Coder product documentation that matches deployment version v2.99.99",
+		);
+		expect(instructions).toContain(
+			"Use the docs to look up product behavior, template authoring guidance, examples, and references instead of relying on memory",
 		);
 		expect(instructions).toContain(
 			"Start with coder_docs_outline to discover relevant markdown paths",
 		);
+		expect(instructions).toContain(
+			'A request like "turn that enable_fuse variable into a Coder parameter" should start by reading the current template file, then use coder_registry_ to confirm the supported parameter shape or example before editing',
+		);
+		expect(instructions).toContain(
+			"When interacting with or modifying template values, variables, parameters, module blocks, registry modules, or other template-owned settings, prefer coder_registry_ tools for authoritative examples and supported configuration details",
+		);
+	});
+});
+
+describe("useTemplateAgent attachments", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("sends pasted screenshots as file parts and exposes them in display messages", async () => {
+		enqueueUIMessageStreams([[completedMessage]]);
+		const { result } = renderTemplateAgentHook();
+		const screenshot = new File(["png-bytes"], "error.png", {
+			type: "image/png",
+		});
+
+		await act(async () => {
+			await expect(
+				result.current.send({
+					text: "What does this error mean?",
+					attachments: [screenshot],
+				}),
+			).resolves.toEqual({ accepted: true });
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toBe("idle");
+		});
+
+		const firstCall = createAgentUIStreamMock.mock.calls[0]?.[0] as
+			| { uiMessages: UIMessage[] }
+			| undefined;
+		expect(firstCall).toBeDefined();
+
+		const userMessage = firstCall?.uiMessages[0];
+		expect(userMessage).toBeDefined();
+		expect(userMessage?.role).toBe("user");
+		expect(userMessage?.parts).toEqual([
+			{ type: "text", text: "What does this error mean?" },
+			expect.objectContaining({
+				type: "file",
+				mediaType: "image/png",
+				filename: "error.png",
+				url: expect.stringContaining("data:image/png;base64,"),
+			}),
+		]);
+
+		expect(result.current.messages[0]).toMatchObject({
+			role: "user",
+			content: "What does this error mean?",
+			attachments: [
+				{
+					mediaType: "image/png",
+					filename: "error.png",
+					url: expect.stringContaining("data:image/png;base64,"),
+				},
+			],
+		});
 	});
 });
 
@@ -321,7 +396,7 @@ describe("useTemplateAgent approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Apply the edit");
+			void result.current.send("Apply the edit");
 		});
 
 		await waitFor(() => {
@@ -378,7 +453,7 @@ describe("useTemplateAgent approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Do the change");
+			void result.current.send("Do the change");
 		});
 
 		await waitFor(() => {
@@ -494,7 +569,7 @@ describe("useTemplateAgent buildTemplate approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Build it");
+			void result.current.send("Build it");
 		});
 
 		await waitFor(() => {
@@ -511,7 +586,7 @@ describe("useTemplateAgent buildTemplate approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Build it");
+			void result.current.send("Build it");
 		});
 
 		await waitFor(() => {
@@ -536,7 +611,7 @@ describe("useTemplateAgent buildTemplate approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Build it");
+			void result.current.send("Build it");
 		});
 
 		await waitFor(() => {
@@ -643,7 +718,7 @@ describe("useTemplateAgent publishTemplate approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Publish the template");
+			void result.current.send("Publish the template");
 		});
 
 		await waitFor(() => {
@@ -660,7 +735,7 @@ describe("useTemplateAgent publishTemplate approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Publish the template");
+			void result.current.send("Publish the template");
 		});
 
 		await waitFor(() => {
@@ -685,7 +760,7 @@ describe("useTemplateAgent publishTemplate approvals", () => {
 		const { result } = renderTemplateAgentHook();
 
 		act(() => {
-			result.current.send("Publish the template");
+			void result.current.send("Publish the template");
 		});
 
 		await waitFor(() => {

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.test.tsx
@@ -198,6 +198,32 @@ describe("useTemplateAgent MCP lifecycle", () => {
 		expect(mcpClientToolsMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("uses the current server MCP endpoint when initializing the client", async () => {
+		renderTemplateAgentHook({ enabled: true });
+
+		await waitFor(() => {
+			expect(createMCPClientMock).toHaveBeenCalledTimes(1);
+		});
+
+		const mcpClientOptions = createMCPClientMock.mock.calls[0]?.[0] as
+			| {
+					transport: {
+						type: string;
+						url: string;
+					};
+			  }
+			| undefined;
+		expect(mcpClientOptions).toEqual({
+			transport: {
+				type: "http",
+				url: new URL("/mcp/http", window.location.origin).toString(),
+			},
+		});
+		expect(mcpClientOptions?.transport.url).not.toContain(
+			"dev.registry.coder.com",
+		);
+	});
+
 	it("closes MCP and clears external tools when disabled after startup", async () => {
 		mcpClientToolsMock.mockResolvedValue({
 			lookup: { description: "Registry lookup" },

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -91,7 +91,41 @@ type MCPTools = Awaited<
 >;
 type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
 
+const MCP_TOOL_PREFIX = "coder_registry_";
 const MAX_STEPS = 20;
+
+const prefixToolNames = (tools: MCPTools): MCPTools =>
+	Object.fromEntries(
+		Object.entries(tools).map(([toolName, tool]) => [
+			`${MCP_TOOL_PREFIX}${toolName}`,
+			tool,
+		]),
+	) as MCPTools;
+
+const assertValidExternalToolNames = (
+	localTools: Record<string, unknown>,
+	externalTools: MCPTools,
+): void => {
+	const invalidPrefixedNames = Object.keys(externalTools).filter(
+		(toolName) =>
+			!toolName.startsWith(MCP_TOOL_PREFIX) ||
+			toolName.startsWith(`${MCP_TOOL_PREFIX}${MCP_TOOL_PREFIX}`),
+	);
+	if (invalidPrefixedNames.length > 0) {
+		throw new Error(
+			`MCP tool names must be prefixed exactly once with "${MCP_TOOL_PREFIX}": ${invalidPrefixedNames.sort().join(", ")}.`,
+		);
+	}
+
+	const collidingNames = Object.keys(externalTools).filter((toolName) =>
+		Object.hasOwn(localTools, toolName),
+	);
+	if (collidingNames.length > 0) {
+		throw new Error(
+			`Prefixed MCP tool names collide with local tool names: ${collidingNames.sort().join(", ")}.`,
+		);
+	}
+};
 
 const SYSTEM_PROMPT = `You are a Terraform template editing assistant for Coder.
 You help users modify Coder workspace templates (Terraform HCL files).
@@ -162,6 +196,7 @@ const createTemplateAgent = (
 		hasBuiltInCurrentRunRef,
 		callbacks,
 	);
+	assertValidExternalToolNames(localTools, externalTools);
 
 	return new ToolLoopAgent({
 		model: resolveProviderModel(
@@ -538,7 +573,7 @@ export const useTemplateAgent = ({
 				}
 
 				mcpClientRef.current = client;
-				mcpToolsRef.current = await client.tools();
+				mcpToolsRef.current = prefixToolNames(await client.tools());
 			} catch (error) {
 				// Best-effort integration: keep local tools available if MCP
 				// initialization fails.

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -256,6 +256,8 @@ interface UseTemplateAgentOptions {
 	getFileTree: () => FileTree;
 	setFileTree: (updater: (prev: FileTree) => FileTree) => void;
 	modelConfig: AIModelConfig;
+	/** Whether the assistant should initialize external integrations. */
+	enabled?: boolean;
 	/** The file the user is currently viewing, if any. */
 	currentFilePath?: string;
 	/** Called after a file is created or edited so the editor can navigate to it. */
@@ -557,6 +559,7 @@ export const useTemplateAgent = ({
 	getFileTree,
 	setFileTree,
 	modelConfig,
+	enabled = true,
 	currentFilePath,
 	onFileEdited,
 	onFileDeleted,
@@ -602,6 +605,11 @@ export const useTemplateAgent = ({
 	};
 
 	useEffect(() => {
+		if (!enabled) {
+			mcpToolsRef.current = {};
+			return;
+		}
+
 		let cancelled = false;
 
 		const initMCP = async () => {
@@ -636,7 +644,7 @@ export const useTemplateAgent = ({
 			}
 			mcpToolsRef.current = {};
 		};
-	}, []);
+	}, [enabled]);
 
 	const setConversationMessages = useCallback((next: UIMessage[]) => {
 		uiMessagesRef.current = next;

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -131,10 +131,23 @@ const BASE_SYSTEM_PROMPT = `You are a Terraform template editing assistant for C
 You help users modify Coder workspace templates (Terraform HCL files).
 
 Rules:
-- Always use listFiles first to see the template structure.
+- Use listFiles early in the conversation to learn the template structure,
+  and use it again only when something indicates the file list may have
+  changed or you need a refresh.
 - Treat the local template files as the primary source of truth for edit
   requests.
-- Always use readFile before editing a file.
+- Before editing a file, make sure you have read it at least once in this
+  conversation.
+- Earlier tool results remain available in this conversation. Reuse prior
+  readFile/listFiles results when nothing indicates the template changed,
+  instead of rereading files on every follow-up turn.
+- After a successful editFile call, treat that edit and its inputs as the
+  latest known state of the file unless something indicates it changed again.
+- If the user says they changed a file manually, reread it before relying on
+  earlier content.
+- If editFile fails because oldContent was not found, matched multiple
+  locations, or otherwise indicates stale or ambiguous context, reread the
+  file and retry with more precise oldContent.
 - Use editFile for targeted changes — provide enough context in oldContent
   to uniquely identify the edit location.
 - Keep HCL syntax valid. Use proper Terraform formatting conventions.
@@ -155,19 +168,21 @@ const getSystemPrompt = (currentFilePath?: string): string => {
 		currentFilePath !== undefined && currentFilePath.length > 0
 			? `Current editor context:
 - The user is currently viewing "${currentFilePath}".
-- After you use listFiles, read "${currentFilePath}" first before making assumptions, answering questions, or proposing edits whenever the request could plausibly refer to code already in that file.
+- If you have not already inspected "${currentFilePath}" in this conversation, read it before making assumptions, answering questions, or proposing edits whenever the request could plausibly refer to code already in that file.
+- If you already inspected "${currentFilePath}" and nothing indicates it changed, reuse that content instead of rereading it just because a new user turn started.
 - Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_registry_ tools, unless the user is clearly asking about another file or you truly need external registry information.
 - If you choose to work in a different file first, briefly explain why that file is more relevant.`
 			: `Current editor context:
 - The user does not currently have a file open.
-- After you use listFiles, choose and read the most relevant local file before making assumptions, answering questions, or proposing edits.
+- Choose and read the most relevant local file before making assumptions, answering questions, or proposing edits if you have not already inspected that file in this conversation.
+- Reuse earlier file reads when nothing indicates the file changed, instead of rereading files on every follow-up turn.
 - Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_registry_ tools, unless local files are insufficient and you genuinely need external registry information.`;
 
 	return `${BASE_SYSTEM_PROMPT}
 
 Additional guidance:
 - If the user asks to modify existing local template code, variables, resources, module blocks, or values, inspect the relevant local file(s) and make the change with listFiles/readFile/editFile before considering coder_registry_ tools.
-- A request like "turn that enable_fuse variable into a Coder parameter" is a local edit request, so read the current template file first and do not search the registry unless the local files are insufficient.
+- A request like "turn that enable_fuse variable into a Coder parameter" is a local edit request, so if you have not already read the current template file in this conversation, read it first. Otherwise, reuse the most recent known file state. Do not search the registry unless the local files are insufficient.
 - Use coder_registry_ tools for external registry modules, published examples, or authoritative configuration details that are not already available in the local files.
 - Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend changes based on external registry content.
 

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -92,7 +92,17 @@ type MCPTools = Awaited<
 type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
 
 const MCP_TOOL_PREFIX = "coder_registry_";
+const MCP_HTTP_PATH = "/mcp/http";
 const MAX_STEPS = 20;
+
+const getMCPTransportURL = (): string => {
+	const browserOrigin = globalThis.location?.origin;
+	if (typeof browserOrigin !== "string" || browserOrigin.length === 0) {
+		throw new Error("Browser origin is unavailable for MCP initialization.");
+	}
+
+	return new URL(MCP_HTTP_PATH, browserOrigin).toString();
+};
 
 const prefixToolNames = (tools: MCPTools): MCPTools =>
 	Object.fromEntries(
@@ -617,7 +627,7 @@ export const useTemplateAgent = ({
 				const client = await createMCPClient({
 					transport: {
 						type: "http",
-						url: "https://dev.registry.coder.com/mcp",
+						url: getMCPTransportURL(),
 					},
 				});
 				if (cancelled) {

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -528,8 +528,8 @@ export const useTemplateAgent = ({
 			try {
 				const client = await createMCPClient({
 					transport: {
-						type: "sse",
-						url: "https://registry.coder.com/mcp",
+						type: "http",
+						url: "https://dev.registry.coder.com/mcp",
 					},
 				});
 				if (cancelled) {

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { createMCPClient } from "@ai-sdk/mcp";
 import { createOpenAI } from "@ai-sdk/openai";
 import {
 	createAgentUIStream,
@@ -8,11 +9,12 @@ import {
 	readUIMessageStream,
 	stepCountIs,
 	ToolLoopAgent,
+	type ToolSet,
 	type UIMessage,
 } from "ai";
 import { API } from "api/api";
 import type { AIBridgeProvider, AIModelConfig } from "api/queries/aiBridge";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FileTree } from "utils/filetree";
 import type {
 	BuildOutput,
@@ -84,6 +86,10 @@ const resolveProviderModel = (provider: AIBridgeProvider, modelID: string) => {
 	return openAIProvider(modelID);
 };
 
+type MCPTools = Awaited<
+	ReturnType<Awaited<ReturnType<typeof createMCPClient>>["tools"]>
+>;
+
 const MAX_STEPS = 20;
 
 const SYSTEM_PROMPT = `You are a Terraform template editing assistant for Coder.
@@ -123,6 +129,7 @@ const createTemplateAgent = (
 			options?: PublishRequestOptions,
 		) => Promise<PublishResult>;
 	},
+	externalTools: MCPTools,
 ) => {
 	const providerOptions: NonNullable<
 		ConstructorParameters<typeof ToolLoopAgent>[0]["providerOptions"]
@@ -148,18 +155,20 @@ const createTemplateAgent = (
 		};
 	}
 
+	const localTools = createTemplateAgentTools(
+		getFileTree,
+		setFileTree,
+		hasBuiltInCurrentRunRef,
+		callbacks,
+	);
+
 	return new ToolLoopAgent({
 		model: resolveProviderModel(
 			modelConfig.model.provider,
 			modelConfig.model.id,
 		),
 		instructions: SYSTEM_PROMPT,
-		tools: createTemplateAgentTools(
-			getFileTree,
-			setFileTree,
-			hasBuiltInCurrentRunRef,
-			callbacks,
-		),
+		tools: { ...localTools, ...(externalTools as ToolSet) },
 		stopWhen: stepCountIs(MAX_STEPS),
 		providerOptions,
 	});
@@ -482,6 +491,10 @@ export const useTemplateAgent = ({
 	const messageCounter = useRef(0);
 	const abortRef = useRef<AbortController | null>(null);
 
+	const mcpClientRef =
+		useRef<Awaited<ReturnType<typeof createMCPClient>> | null>(null);
+	const mcpToolsRef = useRef<MCPTools>({});
+
 	// Tracks whether a successful build happened for the current chat
 	// session so publish can skip the dirty-file check after approval
 	// pauses resume the stream.
@@ -507,6 +520,43 @@ export const useTemplateAgent = ({
 		getBuildOutput,
 		onPublishRequested,
 	};
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const initMCP = async () => {
+			try {
+				const client = await createMCPClient({
+					transport: {
+						type: "sse",
+						url: "https://dev.registry.coder.com/mcp",
+					},
+				});
+				if (cancelled) {
+					await client.close();
+					return;
+				}
+
+				mcpClientRef.current = client;
+				mcpToolsRef.current = await client.tools();
+			} catch (error) {
+				// Best-effort integration: keep local tools available if MCP
+				// initialization fails.
+				console.warn("Failed to initialize MCP client:", error);
+			}
+		};
+
+		void initMCP();
+
+		return () => {
+			cancelled = true;
+			if (mcpClientRef.current) {
+				void mcpClientRef.current.close();
+				mcpClientRef.current = null;
+			}
+			mcpToolsRef.current = {};
+		};
+	}, []);
 
 	const setConversationMessages = useCallback((next: UIMessage[]) => {
 		uiMessagesRef.current = next;
@@ -563,6 +613,7 @@ export const useTemplateAgent = ({
 								})
 						: undefined,
 				},
+				mcpToolsRef.current,
 			);
 
 			let stream: Awaited<ReturnType<typeof createAgentUIStream>>;

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -132,6 +132,8 @@ You help users modify Coder workspace templates (Terraform HCL files).
 
 Rules:
 - Always use listFiles first to see the template structure.
+- Treat the local template files as the primary source of truth for edit
+  requests.
 - Always use readFile before editing a file.
 - Use editFile for targeted changes — provide enough context in oldContent
   to uniquely identify the edit location.
@@ -153,17 +155,21 @@ const getSystemPrompt = (currentFilePath?: string): string => {
 		currentFilePath !== undefined && currentFilePath.length > 0
 			? `Current editor context:
 - The user is currently viewing "${currentFilePath}".
-- After you use listFiles, read "${currentFilePath}" first for context before making assumptions, answering questions, or proposing edits unless the user is clearly asking about another file.
+- After you use listFiles, read "${currentFilePath}" first before making assumptions, answering questions, or proposing edits whenever the request could plausibly refer to code already in that file.
+- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_registry_ tools, unless the user is clearly asking about another file or you truly need external registry information.
 - If you choose to work in a different file first, briefly explain why that file is more relevant.`
 			: `Current editor context:
 - The user does not currently have a file open.
-- After you use listFiles, choose the most relevant file to read before making assumptions, answering questions, or proposing edits.`;
+- After you use listFiles, choose and read the most relevant local file before making assumptions, answering questions, or proposing edits.
+- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_registry_ tools, unless local files are insufficient and you genuinely need external registry information.`;
 
 	return `${BASE_SYSTEM_PROMPT}
 
 Additional guidance:
-- When you need details about Coder Registry modules, examples, or configuration options, prefer the available coder_registry_ tools instead of guessing or relying on memory.
-- Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend changes.
+- If the user asks to modify existing local template code, variables, resources, module blocks, or values, inspect the relevant local file(s) and make the change with listFiles/readFile/editFile before considering coder_registry_ tools.
+- A request like "turn that enable_fuse variable into a Coder parameter" is a local edit request, so read the current template file first and do not search the registry unless the local files are insufficient.
+- Use coder_registry_ tools for external registry modules, published examples, or authoritative configuration details that are not already available in the local files.
+- Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend changes based on external registry content.
 
 ${currentFileInstructions}`;
 };

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -173,26 +173,36 @@ Rules:
 - For publishTemplate: omit name to keep the current version name.
   Generate a short changelog message from the changes you made.`;
 
-const getSystemPrompt = (currentFilePath?: string): string => {
+const getSystemPrompt = (
+	currentFilePath?: string,
+	docsVersion?: string,
+): string => {
 	const currentFileInstructions =
 		currentFilePath !== undefined && currentFilePath.length > 0
 			? `Current editor context:
 - The user is currently viewing "${currentFilePath}".
 - If you have not already inspected "${currentFilePath}" in this conversation, read it before making assumptions, answering questions, or proposing edits whenever the request could plausibly refer to code already in that file.
 - If you already inspected "${currentFilePath}" and nothing indicates it changed, reuse that content instead of rereading it just because a new user turn started.
-- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_registry_ tools, unless the user is clearly asking about another file or you truly need external registry information.
+- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_docs or coder_registry_ tools, unless the user is clearly asking about another file or you truly need external documentation.
 - If you choose to work in a different file first, briefly explain why that file is more relevant.`
 			: `Current editor context:
 - The user does not currently have a file open.
 - Choose and read the most relevant local file before making assumptions, answering questions, or proposing edits if you have not already inspected that file in this conversation.
 - Reuse earlier file reads when nothing indicates the file changed, instead of rereading files on every follow-up turn.
-- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_registry_ tools, unless local files are insufficient and you genuinely need external registry information.`;
+- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_docs or coder_registry_ tools, unless local files are insufficient and you genuinely need external documentation.`;
+
+	const docsToolInstructions =
+		docsVersion !== undefined && docsVersion.length > 0
+			? `- Use coder_docs_outline and coder_docs for official Coder product documentation that matches deployment version ${docsVersion} when you need authoritative guidance about Coder template authoring, parameters, product behavior, or examples that are not already clear from the local files.
+- Start with coder_docs_outline to discover relevant markdown paths, then call coder_docs with an exact path from that outline.`
+			: "- coder_docs_outline and coder_docs may be unavailable if the deployment build version could not be determined.";
 
 	return `${BASE_SYSTEM_PROMPT}
 
 Additional guidance:
-- If the user asks to modify existing local template code, variables, resources, module blocks, or values, inspect the relevant local file(s) and make the change with listFiles/readFile/editFile before considering coder_registry_ tools.
-- A request like "turn that enable_fuse variable into a Coder parameter" is a local edit request, so if you have not already read the current template file in this conversation, read it first. Otherwise, reuse the most recent known file state. Do not search the registry unless the local files are insufficient.
+- If the user asks to modify existing local template code, variables, resources, module blocks, or values, inspect the relevant local file(s) and make the change with listFiles/readFile/editFile before considering coder_docs or coder_registry_ tools.
+- A request like "turn that enable_fuse variable into a Coder parameter" is a local edit request, so if you have not already read the current template file in this conversation, read it first. Otherwise, reuse the most recent known file state. Do not search the docs or registry unless the local files are insufficient.
+${docsToolInstructions}
 - Use coder_registry_ tools for external registry modules, published examples, or authoritative configuration details that are not already available in the local files.
 - Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend changes based on external registry content.
 
@@ -204,6 +214,7 @@ const createTemplateAgent = (
 	getFileTree: () => FileTree,
 	setFileTree: (updater: (prev: FileTree) => FileTree) => void,
 	hasBuiltInCurrentRunRef: { current: boolean },
+	docsVersion: string | undefined,
 	callbacks: {
 		onFileEdited?: (path: string) => void;
 		onFileDeleted?: (path: string) => void;
@@ -247,6 +258,7 @@ const createTemplateAgent = (
 		setFileTree,
 		hasBuiltInCurrentRunRef,
 		callbacks,
+		docsVersion,
 	);
 	assertValidExternalToolNames(localTools, externalTools);
 
@@ -274,6 +286,8 @@ interface UseTemplateAgentOptions {
 	onFileEdited?: (path: string) => void;
 	/** Called after a file is deleted so the editor can clear the active path if needed. */
 	onFileDeleted?: (path: string) => void;
+	/** Build-info version used to select the matching Coder docs tag. */
+	docsVersion?: string;
 	/** Triggers a template build (uploads files, creates version). */
 	onBuildRequested?: () => Promise<void>;
 	/** Returns a promise that resolves when the current build reaches a terminal state. */
@@ -573,6 +587,7 @@ export const useTemplateAgent = ({
 	currentFilePath,
 	onFileEdited,
 	onFileDeleted,
+	docsVersion,
 	onBuildRequested,
 	waitForBuildComplete,
 	getBuildOutput,
@@ -689,6 +704,7 @@ export const useTemplateAgent = ({
 				getFileTree,
 				setFileTree,
 				hasBuiltInCurrentRunRef,
+				docsVersion,
 				{
 					onFileEdited: (path) => toolCallbacksRef.current.onFileEdited?.(path),
 					onFileDeleted: (path) =>
@@ -719,7 +735,7 @@ export const useTemplateAgent = ({
 								})
 						: undefined,
 				},
-				getSystemPrompt(currentFilePath),
+				getSystemPrompt(currentFilePath, docsVersion),
 				mcpToolsRef.current,
 			);
 
@@ -781,6 +797,7 @@ export const useTemplateAgent = ({
 		},
 		[
 			currentFilePath,
+			docsVersion,
 			getFileTree,
 			modelConfig,
 			setConversationMessages,

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -89,6 +89,7 @@ const resolveProviderModel = (provider: AIBridgeProvider, modelID: string) => {
 type MCPTools = Awaited<
 	ReturnType<Awaited<ReturnType<typeof createMCPClient>>["tools"]>
 >;
+type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
 
 const MAX_STEPS = 20;
 
@@ -491,8 +492,7 @@ export const useTemplateAgent = ({
 	const messageCounter = useRef(0);
 	const abortRef = useRef<AbortController | null>(null);
 
-	const mcpClientRef =
-		useRef<Awaited<ReturnType<typeof createMCPClient>> | null>(null);
+	const mcpClientRef = useRef<MCPClientInstance | null>(null);
 	const mcpToolsRef = useRef<MCPTools>({});
 
 	// Tracks whether a successful build happened for the current chat

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -587,6 +587,7 @@ export const useTemplateAgent = ({
 
 	const mcpClientRef = useRef<MCPClientInstance | null>(null);
 	const mcpToolsRef = useRef<MCPTools>({});
+	const [mcpConnectionFailed, setMcpConnectionFailed] = useState(false);
 
 	// Tracks whether a successful build happened for the current chat
 	// session so publish can skip the dirty-file check after approval
@@ -637,10 +638,17 @@ export const useTemplateAgent = ({
 
 				mcpClientRef.current = client;
 				mcpToolsRef.current = prefixToolNames(await client.tools());
+				setMcpConnectionFailed(false);
 			} catch (error) {
 				// Best-effort integration: keep local tools available if MCP
-				// initialization fails.
-				console.warn("Failed to initialize MCP client:", error);
+				// initialization fails. Surface the failure so the UI can
+				// warn the user that registry tools are unavailable.
+				const errorType = error instanceof Error ? error.name : typeof error;
+				const errorMsg = error instanceof Error ? error.message : String(error);
+				console.warn(
+					`MCP client initialization failed (${errorType}): ${errorMsg}. Registry tools will be unavailable.`,
+				);
+				setMcpConnectionFailed(true);
 			}
 		};
 
@@ -913,6 +921,7 @@ export const useTemplateAgent = ({
 		isStreaming: status === "streaming",
 		status,
 		pendingApproval,
+		mcpConnectionFailed,
 		send,
 		approve,
 		reject,

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -92,17 +92,8 @@ type MCPTools = Awaited<
 type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
 
 const MCP_TOOL_PREFIX = "coder_registry_";
-const MCP_HTTP_PATH = "/mcp/http";
+const MCP_HTTP_URL = "https://registry.coder.com/mcp";
 const MAX_STEPS = 20;
-
-const getMCPTransportURL = (): string => {
-	const browserOrigin = globalThis.location?.origin;
-	if (typeof browserOrigin !== "string" || browserOrigin.length === 0) {
-		throw new Error("Browser origin is unavailable for MCP initialization.");
-	}
-
-	return new URL(MCP_HTTP_PATH, browserOrigin).toString();
-};
 
 const prefixToolNames = (tools: MCPTools): MCPTools =>
 	Object.fromEntries(
@@ -643,7 +634,7 @@ export const useTemplateAgent = ({
 				const client = await createMCPClient({
 					transport: {
 						type: "http",
-						url: getMCPTransportURL(),
+						url: MCP_HTTP_URL,
 					},
 				});
 				if (cancelled) {

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -127,7 +127,7 @@ const assertValidExternalToolNames = (
 	}
 };
 
-const SYSTEM_PROMPT = `You are a Terraform template editing assistant for Coder.
+const BASE_SYSTEM_PROMPT = `You are a Terraform template editing assistant for Coder.
 You help users modify Coder workspace templates (Terraform HCL files).
 
 Rules:
@@ -148,6 +148,26 @@ Rules:
 - For publishTemplate: omit name to keep the current version name.
   Generate a short changelog message from the changes you made.`;
 
+const getSystemPrompt = (currentFilePath?: string): string => {
+	const currentFileInstructions =
+		currentFilePath !== undefined && currentFilePath.length > 0
+			? `Current editor context:
+- The user is currently viewing "${currentFilePath}".
+- After you use listFiles, read "${currentFilePath}" first for context before making assumptions, answering questions, or proposing edits unless the user is clearly asking about another file.
+- If you choose to work in a different file first, briefly explain why that file is more relevant.`
+			: `Current editor context:
+- The user does not currently have a file open.
+- After you use listFiles, choose the most relevant file to read before making assumptions, answering questions, or proposing edits.`;
+
+	return `${BASE_SYSTEM_PROMPT}
+
+Additional guidance:
+- When you need details about Coder Registry modules, examples, or configuration options, prefer the available coder_registry_ tools instead of guessing or relying on memory.
+- Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend changes.
+
+${currentFileInstructions}`;
+};
+
 const createTemplateAgent = (
 	modelConfig: AIModelConfig,
 	getFileTree: () => FileTree,
@@ -164,6 +184,7 @@ const createTemplateAgent = (
 			options?: PublishRequestOptions,
 		) => Promise<PublishResult>;
 	},
+	instructions: string,
 	externalTools: MCPTools,
 ) => {
 	const providerOptions: NonNullable<
@@ -203,7 +224,7 @@ const createTemplateAgent = (
 			modelConfig.model.provider,
 			modelConfig.model.id,
 		),
-		instructions: SYSTEM_PROMPT,
+		instructions,
 		tools: { ...localTools, ...(externalTools as ToolSet) },
 		stopWhen: stepCountIs(MAX_STEPS),
 		providerOptions,
@@ -214,6 +235,8 @@ interface UseTemplateAgentOptions {
 	getFileTree: () => FileTree;
 	setFileTree: (updater: (prev: FileTree) => FileTree) => void;
 	modelConfig: AIModelConfig;
+	/** The file the user is currently viewing, if any. */
+	currentFilePath?: string;
 	/** Called after a file is created or edited so the editor can navigate to it. */
 	onFileEdited?: (path: string) => void;
 	/** Called after a file is deleted so the editor can clear the active path if needed. */
@@ -513,6 +536,7 @@ export const useTemplateAgent = ({
 	getFileTree,
 	setFileTree,
 	modelConfig,
+	currentFilePath,
 	onFileEdited,
 	onFileDeleted,
 	onBuildRequested,
@@ -648,6 +672,7 @@ export const useTemplateAgent = ({
 								})
 						: undefined,
 				},
+				getSystemPrompt(currentFilePath),
 				mcpToolsRef.current,
 			);
 
@@ -707,7 +732,13 @@ export const useTemplateAgent = ({
 			const pending = collectPendingApprovals(nextConversation);
 			finishRun(pending.length > 0 ? "awaiting_approval" : "idle");
 		},
-		[getFileTree, modelConfig, setConversationMessages, setFileTree],
+		[
+			currentFilePath,
+			getFileTree,
+			modelConfig,
+			setConversationMessages,
+			setFileTree,
+		],
 	);
 
 	const send = useCallback(

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -4,6 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import {
 	createAgentUIStream,
 	getToolName,
+	isFileUIPart,
 	isReasoningUIPart,
 	isToolUIPart,
 	readUIMessageStream,
@@ -16,6 +17,11 @@ import { API } from "api/api";
 import type { AIBridgeProvider, AIModelConfig } from "api/queries/aiBridge";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FileTree } from "utils/filetree";
+import {
+	MAX_CHAT_IMAGE_ATTACHMENTS,
+	readFileAsDataURL,
+	validateImageAttachment,
+} from "./attachments";
 import type {
 	BuildOutput,
 	BuildResult,
@@ -135,8 +141,13 @@ Rules:
 - Use listFiles early in the conversation to learn the template structure,
   and use it again only when something indicates the file list may have
   changed or you need a refresh.
-- Treat the local template files as the primary source of truth for edit
-  requests.
+- Treat the local template files as the source of truth for the user's
+  current template state.
+- Do not treat your own memory as the source of truth for Coder behavior,
+  examples, references, or supported configuration.
+- Before answering questions about Coder-specific behavior, template
+  authoring patterns, examples, or references, consult the official Coder
+  tools instead of guessing.
 - Before editing a file, make sure you have read it at least once in this
   conversation.
 - Earlier tool results remain available in this conversation. Reuse prior
@@ -153,6 +164,8 @@ Rules:
   to uniquely identify the edit location.
 - Keep HCL syntax valid. Use proper Terraform formatting conventions.
 - Explain what you're changing and why before making edits.
+- The user may attach screenshots or other image files. Inspect relevant
+  image attachments when they help answer the request or diagnose an error.
 - After making changes, use buildTemplate to validate them.
 - If a build fails, use getBuildLogs to understand the error and fix it.
 - When the user asks about build errors, use getBuildLogs to read the logs.
@@ -174,28 +187,33 @@ const getSystemPrompt = (
 - The user is currently viewing "${currentFilePath}".
 - If you have not already inspected "${currentFilePath}" in this conversation, read it before making assumptions, answering questions, or proposing edits whenever the request could plausibly refer to code already in that file.
 - If you already inspected "${currentFilePath}" and nothing indicates it changed, reuse that content instead of rereading it just because a new user turn started.
-- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_docs or coder_registry_ tools, unless the user is clearly asking about another file or you truly need external documentation.
+- Requests about changing existing local code, variables, resources, or values in the current template should still begin by reading the relevant local file(s) so you understand the current state before editing.
+- After inspecting the relevant local file(s), do not guess about Coder-specific behavior. Use coder_registry_ for template values, parameters, module settings, registry examples, and supported configuration details; use coder_docs for all other Coder documentation, references, and examples.
 - If you choose to work in a different file first, briefly explain why that file is more relevant.`
 			: `Current editor context:
 - The user does not currently have a file open.
 - Choose and read the most relevant local file before making assumptions, answering questions, or proposing edits if you have not already inspected that file in this conversation.
 - Reuse earlier file reads when nothing indicates the file changed, instead of rereading files on every follow-up turn.
-- Requests about changing existing local code, variables, resources, or values in the current template should start with local tools (listFiles, readFile, editFile), not coder_docs or coder_registry_ tools, unless local files are insufficient and you genuinely need external documentation.`;
+- Requests about changing existing local code, variables, resources, or values in the current template should begin by reading the relevant local file(s), then use coder_registry_ for template values, parameters, module settings, registry examples, and supported configuration details, and use coder_docs for other Coder documentation, references, and examples.`;
 
 	const docsToolInstructions =
 		docsVersion !== undefined && docsVersion.length > 0
-			? `- Use coder_docs_outline and coder_docs for official Coder product documentation that matches deployment version ${docsVersion} when you need authoritative guidance about Coder template authoring, parameters, product behavior, or examples that are not already clear from the local files.
-- Start with coder_docs_outline to discover relevant markdown paths, then call coder_docs with an exact path from that outline.`
-			: "- coder_docs_outline and coder_docs may be unavailable if the deployment build version could not be determined.";
+			? `- Use coder_docs_outline and coder_docs as the primary external source of truth for official Coder product documentation that matches deployment version ${docsVersion}.
+- Use the docs to look up product behavior, template authoring guidance, examples, and references instead of relying on memory.
+- Start with coder_docs_outline to discover relevant markdown paths, then call coder_docs with an exact path from that outline.
+- If the docs and your memory conflict, follow the docs.`
+			: "- coder_docs_outline and coder_docs may be unavailable if the deployment build version could not be determined. In that case, avoid guessing and rely on local files plus coder_registry_ results.";
 
 	return `${BASE_SYSTEM_PROMPT}
 
 Additional guidance:
-- If the user asks to modify existing local template code, variables, resources, module blocks, or values, inspect the relevant local file(s) and make the change with listFiles/readFile/editFile before considering coder_docs or coder_registry_ tools.
-- A request like "turn that enable_fuse variable into a Coder parameter" is a local edit request, so if you have not already read the current template file in this conversation, read it first. Otherwise, reuse the most recent known file state. Do not search the docs or registry unless the local files are insufficient.
+- Start with local tools to inspect the current template state before editing, but use official external sources to validate Coder-specific behavior instead of guessing.
+- A request like "turn that enable_fuse variable into a Coder parameter" should start by reading the current template file, then use coder_registry_ to confirm the supported parameter shape or example before editing.
 ${docsToolInstructions}
-- Use coder_registry_ tools for external registry modules, published examples, or authoritative configuration details that are not already available in the local files.
-- Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend changes based on external registry content.
+- When interacting with or modifying template values, variables, parameters, module blocks, registry modules, or other template-owned settings, prefer coder_registry_ tools for authoritative examples and supported configuration details.
+- Use coder_registry_ tool results to confirm module inputs, outputs, examples, and supported settings before you recommend or edit template values.
+- For all other Coder product behavior, authoring guidance, examples, and references, prefer coder_docs_outline then coder_docs and follow the documentation as closely as possible.
+- If local files, coder_docs, and coder_registry_ disagree, trust the local file for the user's current state, but trust coder_docs and coder_registry_ over memory for what Coder supports.
 
 ${currentFileInstructions}`;
 };
@@ -305,12 +323,31 @@ export interface DisplayReasoning {
 	isStreaming: boolean;
 }
 
+interface DisplayAttachment {
+	mediaType: string;
+	url: string;
+	filename?: string;
+}
+
 export interface DisplayMessage {
 	id: string;
 	role: "user" | "assistant";
 	content: string;
+	attachments: DisplayAttachment[];
 	toolCalls: DisplayToolCall[];
 	reasoning: DisplayReasoning[];
+}
+
+type SendMessageInput =
+	| string
+	| {
+			text: string;
+			attachments?: readonly File[];
+	  };
+
+interface SendMessageResult {
+	accepted: boolean;
+	error?: string;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -318,6 +355,53 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const toToolArgs = (input: unknown): Record<string, unknown> =>
 	isRecord(input) ? input : {};
+
+const toDisplayAttachment = (
+	part: Pick<DisplayAttachment, "mediaType" | "url" | "filename">,
+): DisplayAttachment => ({
+	mediaType: part.mediaType,
+	url: part.url,
+	filename: part.filename,
+});
+
+const normalizeSendInput = (
+	input: SendMessageInput,
+): { text: string; attachments: readonly File[] } => {
+	if (typeof input === "string") {
+		return { text: input, attachments: [] };
+	}
+	return {
+		text: input.text,
+		attachments: input.attachments ?? [],
+	};
+};
+
+const readAttachmentParts = async (
+	attachments: readonly File[],
+): Promise<UIMessage["parts"]> => {
+	if (attachments.length > MAX_CHAT_IMAGE_ATTACHMENTS) {
+		throw new Error(
+			`You can attach up to ${MAX_CHAT_IMAGE_ATTACHMENTS} screenshots per message.`,
+		);
+	}
+
+	const parts = await Promise.all(
+		attachments.map(async (file) => {
+			const validationError = validateImageAttachment(file);
+			if (validationError) {
+				throw new Error(validationError);
+			}
+			return {
+				type: "file" as const,
+				mediaType: file.type,
+				filename: file.name.length > 0 ? file.name : undefined,
+				url: await readFileAsDataURL(file),
+			};
+		}),
+	);
+
+	return parts;
+};
 
 const cloneMessage = <T>(value: T): T => {
 	if (typeof globalThis.structuredClone === "function") {
@@ -398,10 +482,14 @@ const toDisplayMessages = (uiMessages: UIMessage[]): DisplayMessage[] => {
 				)
 				.map((part) => part.text)
 				.join("");
+			const attachments = message.parts
+				.filter(isFileUIPart)
+				.map((part) => toDisplayAttachment(part));
 			result.push({
 				id: message.id,
 				role: "user",
 				content,
+				attachments,
 				toolCalls: [],
 				reasoning: [],
 			});
@@ -427,6 +515,7 @@ const toDisplayMessages = (uiMessages: UIMessage[]): DisplayMessage[] => {
 						id: `${message.id}-${segmentIndex++}`,
 						role: "assistant",
 						content: currentText,
+						attachments: [],
 						toolCalls: currentToolCalls,
 						reasoning: currentReasoning,
 					});
@@ -444,6 +533,7 @@ const toDisplayMessages = (uiMessages: UIMessage[]): DisplayMessage[] => {
 						id: `${message.id}-${segmentIndex++}`,
 						role: "assistant",
 						content: currentText,
+						attachments: [],
 						toolCalls: currentToolCalls,
 						reasoning: currentReasoning,
 					});
@@ -474,6 +564,7 @@ const toDisplayMessages = (uiMessages: UIMessage[]): DisplayMessage[] => {
 				id: segmentIndex > 0 ? `${message.id}-${segmentIndex}` : message.id,
 				role: "assistant",
 				content: currentText,
+				attachments: [],
 				toolCalls: currentToolCalls,
 				reasoning: currentReasoning,
 			});
@@ -590,6 +681,8 @@ export const useTemplateAgent = ({
 	const uiMessagesRef = useRef<UIMessage[]>([]);
 	const messageCounter = useRef(0);
 	const abortRef = useRef<AbortController | null>(null);
+
+	const sendPreparingRef = useRef(false);
 
 	const mcpClientRef = useRef<MCPClientInstance | null>(null);
 	const mcpToolsRef = useRef<MCPTools>({});
@@ -797,39 +890,63 @@ export const useTemplateAgent = ({
 	);
 
 	const send = useCallback(
-		(text: string) => {
+		async (input: SendMessageInput): Promise<SendMessageResult> => {
 			if (status === "streaming") {
-				return;
+				return { accepted: false };
 			}
 			// Don't allow new messages while approvals are pending.
 			if (status === "awaiting_approval") {
-				return;
+				return { accepted: false };
 			}
-			if (abortRef.current) {
-				return;
+			if (abortRef.current || sendPreparingRef.current) {
+				return { accepted: false };
 			}
 			if (status === "error") {
 				setStatus("idle");
 			}
 
+			const { text, attachments } = normalizeSendInput(input);
 			const trimmed = text.trim();
-			if (!trimmed) {
-				return;
+			if (!trimmed && attachments.length === 0) {
+				return { accepted: false };
 			}
 
-			if (uiMessagesRef.current.length === 0) {
-				hasBuiltInCurrentRunRef.current = false;
+			sendPreparingRef.current = true;
+			try {
+				const attachmentParts =
+					attachments.length === 0
+						? []
+						: await readAttachmentParts(attachments);
+				if (uiMessagesRef.current.length === 0) {
+					hasBuiltInCurrentRunRef.current = false;
+				}
+
+				const userMessage: UIMessage = {
+					id: `msg-${++messageCounter.current}`,
+					role: "user",
+					parts: [
+						...(trimmed.length > 0
+							? [{ type: "text" as const, text: trimmed }]
+							: []),
+						...attachmentParts,
+					],
+				};
+				const nextConversation = [...uiMessagesRef.current, userMessage];
+				setConversationMessages(nextConversation);
+
+				void runStream(nextConversation);
+				return { accepted: true };
+			} catch (error) {
+				return {
+					accepted: false,
+					error:
+						error instanceof Error
+							? error.message
+							: "Failed to read the attached screenshot.",
+				};
+			} finally {
+				sendPreparingRef.current = false;
 			}
-
-			const userMessage: UIMessage = {
-				id: `msg-${++messageCounter.current}`,
-				role: "user",
-				parts: [{ type: "text", text: trimmed }],
-			};
-			const nextConversation = [...uiMessagesRef.current, userMessage];
-			setConversationMessages(nextConversation);
-
-			void runStream(nextConversation);
 		},
 		[runStream, setConversationMessages, status],
 	);

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -1,0 +1,769 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+	createAgentUIStream,
+	getToolName,
+	isReasoningUIPart,
+	isToolUIPart,
+	readUIMessageStream,
+	stepCountIs,
+	ToolLoopAgent,
+	type UIMessage,
+} from "ai";
+import { API } from "api/api";
+import type { AIBridgeProvider, AIModelConfig } from "api/queries/aiBridge";
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { FileTree } from "utils/filetree";
+import type {
+	BuildOutput,
+	BuildResult,
+	PublishRequestData,
+	PublishRequestOptions,
+	PublishResult,
+} from "./tools";
+import { createTemplateAgentTools } from "./tools";
+import type { AgentStatus, PendingToolCall } from "./types";
+
+/**
+ * Read the runtime CSRF token from the Axios instance's default
+ * headers. This is the correct token in both development (hardcoded)
+ * and production (derived from the page's meta tag at startup).
+ * Using API.getCsrfToken() would always return the hardcoded
+ * development-only value.
+ */
+function getRuntimeCsrfToken(): string {
+	const headers = API.getAxiosInstance().defaults.headers.common;
+	const token = headers["X-CSRF-TOKEN"];
+	if (typeof token === "string") {
+		return token;
+	}
+	return "";
+}
+
+const openAIProvider = createOpenAI({
+	baseURL: "/api/v2/aibridge/openai/v1",
+	apiKey: "coder",
+	headers: {
+		"X-CSRF-TOKEN": getRuntimeCsrfToken(),
+		// Override the SDK's Authorization header so the AI bridge
+		// authenticates via the browser's session cookie instead of
+		// this placeholder key.
+		Authorization: "",
+	},
+});
+
+const anthropicProvider = createAnthropic({
+	baseURL: "/api/v2/aibridge/anthropic/v1",
+	apiKey: "coder",
+	headers: {
+		"X-CSRF-TOKEN": getRuntimeCsrfToken(),
+		// Override the SDK's x-api-key header so the AI bridge
+		// authenticates via the browser's session cookie instead of
+		// this placeholder key.
+		"x-api-key": "",
+	},
+});
+
+const anthropicModelPrefix = "anthropic/";
+
+const resolveProviderModel = (provider: AIBridgeProvider, modelID: string) => {
+	if (modelID.length === 0) {
+		throw new Error("Model ID cannot be empty.");
+	}
+
+	if (provider === "anthropic") {
+		const anthropicModelID = modelID.startsWith(anthropicModelPrefix)
+			? modelID.slice(anthropicModelPrefix.length)
+			: modelID;
+		if (anthropicModelID.length === 0) {
+			throw new Error("Anthropic model ID cannot be empty.");
+		}
+		return anthropicProvider(anthropicModelID);
+	}
+
+	return openAIProvider(modelID);
+};
+
+const MAX_STEPS = 20;
+
+const SYSTEM_PROMPT = `You are a Terraform template editing assistant for Coder.
+You help users modify Coder workspace templates (Terraform HCL files).
+
+Rules:
+- Always use listFiles first to see the template structure.
+- Always use readFile before editing a file.
+- Use editFile for targeted changes — provide enough context in oldContent
+  to uniquely identify the edit location.
+- Keep HCL syntax valid. Use proper Terraform formatting conventions.
+- Explain what you're changing and why before making edits.
+- After making changes, use buildTemplate to validate them.
+- If a build fails, use getBuildLogs to understand the error and fix it.
+- When the user asks about build errors, use getBuildLogs to read the logs.
+- When the user asks you to publish (or says "build and publish"),
+  call publishTemplate directly with sensible defaults — do not ask
+  follow-up questions about version name or changelog message.
+  The tool requires user approval, so they will get a chance to
+  review before it executes.
+- For publishTemplate: omit name to keep the current version name.
+  Generate a short changelog message from the changes you made.`;
+
+const createTemplateAgent = (
+	modelConfig: AIModelConfig,
+	getFileTree: () => FileTree,
+	setFileTree: (updater: (prev: FileTree) => FileTree) => void,
+	hasBuiltInCurrentRunRef: { current: boolean },
+	callbacks: {
+		onFileEdited?: (path: string) => void;
+		onFileDeleted?: (path: string) => void;
+		onBuildRequested?: () => Promise<void>;
+		waitForBuildComplete?: () => Promise<BuildResult>;
+		getBuildOutput?: () => BuildOutput | undefined;
+		onPublishRequested?: (
+			data: PublishRequestData,
+			options?: PublishRequestOptions,
+		) => Promise<PublishResult>;
+	},
+) => {
+	const providerOptions: NonNullable<
+		ConstructorParameters<typeof ToolLoopAgent>[0]["providerOptions"]
+	> = {};
+	if (
+		modelConfig.model.provider === "openai" &&
+		modelConfig.reasoningEffort !== undefined
+	) {
+		providerOptions.openai = {
+			reasoningEffort: modelConfig.reasoningEffort,
+			// Request reasoning summaries so we can display them
+			// in the chat UI. Without this, OpenAI reasoning
+			// models think internally but don't expose traces.
+			reasoningSummary: "auto",
+		};
+	}
+	if (modelConfig.model.provider === "anthropic" && modelConfig.thinking) {
+		providerOptions.anthropic = {
+			thinking: modelConfig.thinking,
+			...(modelConfig.anthropicEffort !== undefined && {
+				effort: modelConfig.anthropicEffort,
+			}),
+		};
+	}
+
+	return new ToolLoopAgent({
+		model: resolveProviderModel(
+			modelConfig.model.provider,
+			modelConfig.model.id,
+		),
+		instructions: SYSTEM_PROMPT,
+		tools: createTemplateAgentTools(
+			getFileTree,
+			setFileTree,
+			hasBuiltInCurrentRunRef,
+			callbacks,
+		),
+		stopWhen: stepCountIs(MAX_STEPS),
+		providerOptions,
+	});
+};
+
+interface UseTemplateAgentOptions {
+	getFileTree: () => FileTree;
+	setFileTree: (updater: (prev: FileTree) => FileTree) => void;
+	modelConfig: AIModelConfig;
+	/** Called after a file is created or edited so the editor can navigate to it. */
+	onFileEdited?: (path: string) => void;
+	/** Called after a file is deleted so the editor can clear the active path if needed. */
+	onFileDeleted?: (path: string) => void;
+	/** Triggers a template build (uploads files, creates version). */
+	onBuildRequested?: () => Promise<void>;
+	/** Returns a promise that resolves when the current build reaches a terminal state. */
+	waitForBuildComplete?: () => Promise<BuildResult>;
+	/** Returns the current build output snapshot, or undefined if no build has run. */
+	getBuildOutput?: () => BuildOutput | undefined;
+	/** Publishes the current template version. Returns success/error. */
+	onPublishRequested?: (
+		data: PublishRequestData,
+		options?: PublishRequestOptions,
+	) => Promise<PublishResult>;
+}
+
+export interface DisplayToolCall {
+	toolCallId: string;
+	toolName: string;
+	args: Record<string, unknown>;
+	result?: unknown;
+	state: "pending" | "result";
+}
+
+export interface DisplayReasoning {
+	text: string;
+	isStreaming: boolean;
+}
+
+export interface DisplayMessage {
+	id: string;
+	role: "user" | "assistant";
+	content: string;
+	toolCalls: DisplayToolCall[];
+	reasoning: DisplayReasoning[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+const toToolArgs = (input: unknown): Record<string, unknown> =>
+	isRecord(input) ? input : {};
+
+const cloneMessage = <T>(value: T): T => {
+	if (typeof globalThis.structuredClone === "function") {
+		return globalThis.structuredClone(value);
+	}
+	return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const upsertMessage = (
+	messages: UIMessage[],
+	message: UIMessage,
+): UIMessage[] => {
+	const index = messages.findIndex((existing) => existing.id === message.id);
+	if (index === -1) {
+		return [...messages, message];
+	}
+	const next = [...messages];
+	next[index] = message;
+	return next;
+};
+
+const mapToolStateToDisplay = (
+	part: Parameters<typeof getToolName>[0],
+): DisplayToolCall => {
+	const toolName = getToolName(part);
+	const args = toToolArgs(part.input);
+
+	switch (part.state) {
+		case "output-available":
+			return {
+				toolCallId: part.toolCallId,
+				toolName,
+				args,
+				result: part.output,
+				state: "result",
+			};
+		case "output-error":
+			return {
+				toolCallId: part.toolCallId,
+				toolName,
+				args,
+				result: { error: part.errorText },
+				state: "result",
+			};
+		case "output-denied":
+			return {
+				toolCallId: part.toolCallId,
+				toolName,
+				args,
+				result: {
+					error: part.approval.reason ?? "User rejected this action.",
+				},
+				state: "result",
+			};
+		default:
+			return {
+				toolCallId: part.toolCallId,
+				toolName,
+				args,
+				state: "pending",
+			};
+	}
+};
+
+const toDisplayMessages = (uiMessages: UIMessage[]): DisplayMessage[] => {
+	const result: DisplayMessage[] = [];
+
+	for (const message of uiMessages) {
+		if (message.role !== "user" && message.role !== "assistant") {
+			continue;
+		}
+
+		if (message.role === "user") {
+			const content = message.parts
+				.filter(
+					(part): part is { type: "text"; text: string } =>
+						part.type === "text",
+				)
+				.map((part) => part.text)
+				.join("");
+			result.push({
+				id: message.id,
+				role: "user",
+				content,
+				toolCalls: [],
+				reasoning: [],
+			});
+			continue;
+		}
+
+		// Split assistant messages into chronological segments.
+		// A new segment starts when a text part follows a tool
+		// part, preserving the natural conversation flow:
+		// reasoning → text → tool calls → reasoning → text → tool calls.
+		let segmentIndex = 0;
+		let currentText = "";
+		let currentToolCalls: DisplayToolCall[] = [];
+		let currentReasoning: DisplayReasoning[] = [];
+		let lastPartWasTool = false;
+
+		for (const part of message.parts) {
+			if (part.type === "text") {
+				// Flush the current segment when text follows
+				// tool calls — this starts a new visual block.
+				if (lastPartWasTool && currentToolCalls.length > 0) {
+					result.push({
+						id: `${message.id}-${segmentIndex++}`,
+						role: "assistant",
+						content: currentText,
+						toolCalls: currentToolCalls,
+						reasoning: currentReasoning,
+					});
+					currentText = "";
+					currentToolCalls = [];
+					currentReasoning = [];
+				}
+				currentText += part.text;
+				lastPartWasTool = false;
+			} else if (isReasoningUIPart(part)) {
+				// Flush when reasoning follows tool calls, just like
+				// text does — reasoning belongs to the next segment.
+				if (lastPartWasTool && currentToolCalls.length > 0) {
+					result.push({
+						id: `${message.id}-${segmentIndex++}`,
+						role: "assistant",
+						content: currentText,
+						toolCalls: currentToolCalls,
+						reasoning: currentReasoning,
+					});
+					currentText = "";
+					currentToolCalls = [];
+					currentReasoning = [];
+				}
+				currentReasoning.push({
+					text: part.text,
+					isStreaming: part.state === "streaming",
+				});
+				lastPartWasTool = false;
+			} else if (isToolUIPart(part)) {
+				currentToolCalls.push(mapToolStateToDisplay(part));
+				lastPartWasTool = true;
+			}
+		}
+
+		// Flush the final segment. Use the original message ID
+		// when only one segment was produced so that approval
+		// lookups still match by ID.
+		if (
+			currentText.length > 0 ||
+			currentToolCalls.length > 0 ||
+			currentReasoning.length > 0
+		) {
+			result.push({
+				id: segmentIndex > 0 ? `${message.id}-${segmentIndex}` : message.id,
+				role: "assistant",
+				content: currentText,
+				toolCalls: currentToolCalls,
+				reasoning: currentReasoning,
+			});
+		}
+	}
+
+	return result;
+};
+
+const collectPendingApprovals = (
+	uiMessages: UIMessage[],
+): PendingToolCall[] => {
+	const pending: PendingToolCall[] = [];
+
+	for (const message of uiMessages) {
+		if (message.role !== "assistant") {
+			continue;
+		}
+
+		for (const part of message.parts) {
+			if (!isToolUIPart(part) || part.state !== "approval-requested") {
+				continue;
+			}
+
+			const toolName = getToolName(part);
+			if (
+				toolName !== "editFile" &&
+				toolName !== "deleteFile" &&
+				toolName !== "buildTemplate" &&
+				toolName !== "publishTemplate"
+			) {
+				continue;
+			}
+
+			pending.push({
+				approvalId: part.approval.id,
+				toolCallId: part.toolCallId,
+				toolName,
+				args: toToolArgs(part.input),
+			});
+		}
+	}
+
+	return pending;
+};
+
+const applyApprovalResponse = (
+	messages: UIMessage[],
+	pending: PendingToolCall,
+	approved: boolean,
+	reason?: string,
+): { nextMessages: UIMessage[]; updated: boolean } => {
+	let updated = false;
+
+	const nextMessages = messages.map((message) => {
+		if (message.role !== "assistant") {
+			return message;
+		}
+
+		let messageUpdated = false;
+		const nextParts = message.parts.map((part) => {
+			if (!isToolUIPart(part)) {
+				return part;
+			}
+			if (
+				part.toolCallId !== pending.toolCallId ||
+				part.state !== "approval-requested"
+			) {
+				return part;
+			}
+			if (
+				getToolName(part) !== pending.toolName ||
+				part.approval.id !== pending.approvalId
+			) {
+				return part;
+			}
+
+			updated = true;
+			messageUpdated = true;
+
+			const approval = reason
+				? { id: pending.approvalId, approved, reason }
+				: { id: pending.approvalId, approved };
+			return {
+				...part,
+				state: "approval-responded",
+				approval,
+			} as UIMessage["parts"][number];
+		});
+
+		return messageUpdated ? { ...message, parts: nextParts } : message;
+	});
+
+	return { nextMessages, updated };
+};
+
+export const useTemplateAgent = ({
+	getFileTree,
+	setFileTree,
+	modelConfig,
+	onFileEdited,
+	onFileDeleted,
+	onBuildRequested,
+	waitForBuildComplete,
+	getBuildOutput,
+	onPublishRequested,
+}: UseTemplateAgentOptions) => {
+	const [uiMessages, setUIMessages] = useState<UIMessage[]>([]);
+	const [status, setStatus] = useState<AgentStatus>("idle");
+
+	const uiMessagesRef = useRef<UIMessage[]>([]);
+	const messageCounter = useRef(0);
+	const abortRef = useRef<AbortController | null>(null);
+
+	// Tracks whether a successful build happened for the current chat
+	// session so publish can skip the dirty-file check after approval
+	// pauses resume the stream.
+	const hasBuiltInCurrentRunRef = useRef(false);
+
+	// Ref wrappers for tool callbacks that may change between steps of a
+	// multi-step stream (e.g., dirty/build-status changes after an edit).
+	// Dereferencing through the ref ensures each tool invocation reads
+	// the latest editor/build state.
+	const toolCallbacksRef = useRef({
+		onFileEdited,
+		onFileDeleted,
+		onBuildRequested,
+		waitForBuildComplete,
+		getBuildOutput,
+		onPublishRequested,
+	});
+	toolCallbacksRef.current = {
+		onFileEdited,
+		onFileDeleted,
+		onBuildRequested,
+		waitForBuildComplete,
+		getBuildOutput,
+		onPublishRequested,
+	};
+
+	const setConversationMessages = useCallback((next: UIMessage[]) => {
+		uiMessagesRef.current = next;
+		setUIMessages(next);
+	}, []);
+
+	const runStream = useCallback(
+		async (conversation: UIMessage[]) => {
+			abortRef.current?.abort();
+			const abortController = new AbortController();
+			abortRef.current = abortController;
+			setStatus("streaming");
+
+			const finishRun = (nextStatus: AgentStatus) => {
+				if (abortRef.current !== abortController) {
+					return;
+				}
+				abortRef.current = null;
+				setStatus(nextStatus);
+			};
+
+			const agent = createTemplateAgent(
+				modelConfig,
+				getFileTree,
+				setFileTree,
+				hasBuiltInCurrentRunRef,
+				{
+					onFileEdited: (path) => toolCallbacksRef.current.onFileEdited?.(path),
+					onFileDeleted: (path) =>
+						toolCallbacksRef.current.onFileDeleted?.(path),
+					onBuildRequested: toolCallbacksRef.current.onBuildRequested
+						? () =>
+								toolCallbacksRef.current.onBuildRequested?.() ??
+								Promise.resolve()
+						: undefined,
+					waitForBuildComplete: toolCallbacksRef.current.waitForBuildComplete
+						? () =>
+								toolCallbacksRef.current.waitForBuildComplete?.() ??
+								Promise.resolve<BuildResult>({
+									status: "failed",
+									error: "Build tools are not available.",
+									logs: "",
+								})
+						: undefined,
+					getBuildOutput: toolCallbacksRef.current.getBuildOutput
+						? () => toolCallbacksRef.current.getBuildOutput?.()
+						: undefined,
+					onPublishRequested: toolCallbacksRef.current.onPublishRequested
+						? (data, options) =>
+								toolCallbacksRef.current.onPublishRequested?.(data, options) ??
+								Promise.resolve<PublishResult>({
+									success: false,
+									error: "Publish is not available.",
+								})
+						: undefined,
+				},
+			);
+
+			let stream: Awaited<ReturnType<typeof createAgentUIStream>>;
+			try {
+				stream = await createAgentUIStream({
+					agent,
+					uiMessages: conversation,
+					abortSignal: abortController.signal,
+				});
+			} catch {
+				if (!abortController.signal.aborted) {
+					finishRun("error");
+				} else {
+					finishRun("idle");
+				}
+				return;
+			}
+
+			let nextConversation = conversation;
+			const lastMessage = conversation[conversation.length - 1];
+			const initialAssistantMessage =
+				lastMessage?.role === "assistant"
+					? cloneMessage(lastMessage)
+					: {
+							id: `assistant-${++messageCounter.current}`,
+							role: "assistant" as const,
+							parts: [],
+						};
+
+			try {
+				for await (const message of readUIMessageStream({
+					stream,
+					message: initialAssistantMessage,
+				})) {
+					if (abortController.signal.aborted) {
+						break;
+					}
+
+					nextConversation = upsertMessage(uiMessagesRef.current, message);
+					setConversationMessages(nextConversation);
+				}
+			} catch {
+				if (!abortController.signal.aborted) {
+					finishRun("error");
+				} else {
+					finishRun("idle");
+				}
+				return;
+			}
+
+			if (abortController.signal.aborted) {
+				finishRun("idle");
+				return;
+			}
+
+			const pending = collectPendingApprovals(nextConversation);
+			finishRun(pending.length > 0 ? "awaiting_approval" : "idle");
+		},
+		[getFileTree, modelConfig, setConversationMessages, setFileTree],
+	);
+
+	const send = useCallback(
+		(text: string) => {
+			if (status === "streaming") {
+				return;
+			}
+			// Don't allow new messages while approvals are pending.
+			if (status === "awaiting_approval") {
+				return;
+			}
+			if (abortRef.current) {
+				return;
+			}
+			if (status === "error") {
+				setStatus("idle");
+			}
+
+			const trimmed = text.trim();
+			if (!trimmed) {
+				return;
+			}
+
+			if (uiMessagesRef.current.length === 0) {
+				hasBuiltInCurrentRunRef.current = false;
+			}
+
+			const userMessage: UIMessage = {
+				id: `msg-${++messageCounter.current}`,
+				role: "user",
+				parts: [{ type: "text", text: trimmed }],
+			};
+			const nextConversation = [...uiMessagesRef.current, userMessage];
+			setConversationMessages(nextConversation);
+
+			void runStream(nextConversation);
+		},
+		[runStream, setConversationMessages, status],
+	);
+
+	const pendingApprovals = useMemo(
+		() => collectPendingApprovals(uiMessages),
+		[uiMessages],
+	);
+
+	const approve = useCallback(() => {
+		if (status !== "awaiting_approval") {
+			return;
+		}
+
+		const current = pendingApprovals[0];
+		if (!current) {
+			return;
+		}
+
+		const { nextMessages, updated } = applyApprovalResponse(
+			uiMessagesRef.current,
+			current,
+			true,
+		);
+		if (!updated) {
+			setStatus("error");
+			return;
+		}
+
+		setConversationMessages(nextMessages);
+		const remaining = collectPendingApprovals(nextMessages);
+		if (remaining.length > 0) {
+			setStatus("awaiting_approval");
+			return;
+		}
+
+		void runStream(nextMessages);
+	}, [pendingApprovals, runStream, setConversationMessages, status]);
+
+	const reject = useCallback(() => {
+		if (status !== "awaiting_approval") {
+			return;
+		}
+
+		const current = pendingApprovals[0];
+		if (!current) {
+			return;
+		}
+
+		const { nextMessages, updated } = applyApprovalResponse(
+			uiMessagesRef.current,
+			current,
+			false,
+			"User rejected this action.",
+		);
+		if (!updated) {
+			setStatus("error");
+			return;
+		}
+
+		setConversationMessages(nextMessages);
+		const remaining = collectPendingApprovals(nextMessages);
+		if (remaining.length > 0) {
+			setStatus("awaiting_approval");
+			return;
+		}
+
+		void runStream(nextMessages);
+	}, [pendingApprovals, runStream, setConversationMessages, status]);
+
+	const stop = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+		const pending = collectPendingApprovals(uiMessagesRef.current);
+		setStatus(pending.length > 0 ? "awaiting_approval" : "idle");
+	}, []);
+
+	const reset = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+		hasBuiltInCurrentRunRef.current = false;
+		messageCounter.current = 0;
+		setConversationMessages([]);
+		setStatus("idle");
+	}, [setConversationMessages]);
+
+	const resetBuildState = useCallback(() => {
+		hasBuiltInCurrentRunRef.current = false;
+	}, []);
+
+	const messages = useMemo(() => toDisplayMessages(uiMessages), [uiMessages]);
+	const pendingApproval =
+		pendingApprovals.length > 0 ? pendingApprovals[0] : null;
+
+	return {
+		messages,
+		isStreaming: status === "streaming",
+		status,
+		pendingApproval,
+		send,
+		approve,
+		reject,
+		stop,
+		reset,
+		resetBuildState,
+	};
+};
+
+export type TemplateAgentState = ReturnType<typeof useTemplateAgent>;

--- a/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
+++ b/site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts
@@ -529,7 +529,7 @@ export const useTemplateAgent = ({
 				const client = await createMCPClient({
 					transport: {
 						type: "sse",
-						url: "https://dev.registry.coder.com/mcp",
+						url: "https://registry.coder.com/mcp",
 					},
 				});
 				if (cancelled) {


### PR DESCRIPTION
## Browser-Based AI Agent for Template Editor

Adds an AI coding assistant that runs entirely in the browser to the template version editor. Users interact via a resizable chat panel beside the Monaco editor, can approve/reject file edits, and then use the existing Preview → Publish flow to save changes.

### What's included

**Core AI infrastructure:**
- AI SDK v6 (`ai@^6`, `@ai-sdk/openai@^3`) + `zod@^3` for tool schemas
- 4 tools operating on the in-memory `FileTree`: `listFiles`, `readFile`, `editFile`, `deleteFile`
- `editFile`/`deleteFile` require explicit user approval before execution

**Agent hook (`useTemplateAgent`):**
- Full streaming conversation loop using AI SDK v6's `streamText`
- Connects to LLMs through the existing AI bridge proxy (`/api/v2/aibridge/openai/v1`)
- State machine: `idle` → `streaming` → `awaiting_approval` → `streaming` → `idle`
- Approval/rejection flow that pauses the agent loop and resumes after user decision

**UI components:**
- `AIChatPanel` — main chat panel with header, scrollable message list, input
- `ChatMessage` — renders user/assistant messages with tool call cards
- `ToolCallCard` — collapsed display for read-only tools (listFiles, readFile)
- `EditApprovalCard` — diff view + Approve/Reject buttons for editFile/deleteFile
- `ChatInput` — textarea with Enter-to-send, Shift+Enter for newlines

**Editor integration:**
- Resizable panel layout using `react-resizable-panels` (already installed)
- Sparkle toggle button in topbar (only visible when AI bridge is configured)
- Feature gate: probes `/api/v2/aibridge/openai/v1/models` on mount
- AI file edits correctly mark the template as dirty
- File navigation: clicking file names in chat navigates Monaco to that file

### Architecture decisions

- **No backend changes** — uses existing AI bridge proxy
- **No session persistence** — chat history is ephemeral (in React state)
- **Approval-based edits** — tools that mutate files have no `execute` function, causing the AI SDK to pause the loop for manual handling
- **Zod scoped to AI tools** — the project uses yup elsewhere; zod is required by AI SDK and only used in `tools.ts`

### Files added/modified

| File | Change |
|---|---|
| `site/package.json` | Added `ai`, `@ai-sdk/openai`, `zod` |
| `ai/types.ts` | Shared types (`PendingToolCall`, `AgentStatus`) |
| `ai/tools.ts` | Tool definitions + execute helpers |
| `ai/useTemplateAgent.ts` | Agent conversation hook |
| `ai/AIChatPanel.tsx` | Main chat panel |
| `ai/ChatMessage.tsx` | Message rendering |
| `ai/ToolCallCard.tsx` | Read-only tool display |
| `ai/EditApprovalCard.tsx` | Diff + approval UI |
| `ai/ChatInput.tsx` | Text input component |
| `TemplateVersionEditor.tsx` | Panel integration + toggle button + feature gate |

### Validation

- ✅ TypeScript compilation passes
- ✅ Biome lint passes (all 9 touched files)
- ✅ No circular dependencies
---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Browser-Based AI Agent for Template Editor

## Context & Goals

Add an AI coding agent that runs **entirely in the browser** to the existing template editor.
The agent uses AI SDK v6 to call tools that read/write the editor's in-memory `FileTree`,
connected to LLMs through Coder's existing AI bridge proxy. Users interact via a chat panel
beside the Monaco editor, can approve/reject file edits, and then use the existing
Preview → Publish flow to save changes. No backend changes, no session persistence,
no new storage layers.

**Non-goals**: OPFS, agentfs, just-bash, server-side execution, persisted chat history.

---

## Evidence / Key Facts

| Fact | Source |
|---|---|
| `FileTree = Record<string, string \| FileTree>`, managed via `useState` in `TemplateVersionEditor` | `site/src/utils/filetree.ts`, `TemplateVersionEditor.tsx` |
| Immutable helpers: `getFileText`, `existsFile`, `createFile`, `updateFile`, `removeFile` | `site/src/utils/filetree.ts` |
| AI bridge proxy streams SSE (`http.Flusher`-compliant middleware chain) | `enterprise/coderd/aibridgeproxy.go`, `coderd/tracing/status_writer.go` |
| OpenAI bridge URL: `/api/v2/aibridge/openai/v1` (chat completions at `.../chat/completions`) | `enterprise/coderd/aibridge.go` |
| Auth via `Coder-Session-Token` header on all API calls | `site/src/api/api.ts` |
| `react-resizable-panels@3.0.6` already installed, used in `TaskPage` | `site/package.json` |
| `zod` not installed (project uses `yup`) — needed for AI SDK tool schemas | `site/package.json` |
| Monaco `automaticLayout: true` — auto-resizes when container changes | `MonacoEditor.tsx` |
| `activePath` managed via URL search params in parent page | `TemplateVersionEditorPage.tsx` |
| AI SDK v6: `streamText` with `stopWhen`, `needsApproval` on tools pauses the stream | AI SDK v6 docs |
| AI SDK v6 packages: `ai@^6`, `@ai-sdk/openai@^3`, `@ai-sdk/anthropic@^3` | npm registry |

---

## Implementation

### Phase 0: Dependencies

**File:** `site/package.json`

```bash
cd site && pnpm add ai@^6 @ai-sdk/openai@^3 zod@^3
```

<details><summary>Why zod?</summary>

AI SDK v6 `tool()` requires `inputSchema` to be a Zod schema. The project uses yup elsewhere
but zod is the only option here — it's scoped to the agent tools only.
</details>

---

### Phase 1: Agent Tools (`site/src/pages/TemplateVersionEditorPage/ai/tools.ts`)

Define four tools that close over `getFileTree` / `setFileTree`:

#### `listFiles`
- No inputs.
- Calls a `traverse`-like walk over the FileTree, returns `{ files: string[] }` of all paths.

#### `readFile`
- Input: `{ path: string }`.
- Uses `existsFile` → `getFileText`. Returns content or error.

#### `editFile` — the core search-and-replace tool
- Input: `{ path: string, oldContent: string, newContent: string }`.
- `needsApproval: true` — pauses the agent loop so the UI can show a diff.
- Semantics:

| `oldContent` | File state | Behavior |
|---|---|---|
| `""` | doesn't exist | **Create** file with `newContent` via `createFile` |
| `""` | exists, empty | **Write** `newContent` via `updateFile` |
| `""` | exists, non-empty | **Append** `newContent` to end |
| non-empty string | exists | **Replace** the unique match; error if 0 or 2+ matches |
| non-empty string | doesn't exist | **Error** — file not found |

```typescript
execute: async ({ path, oldContent, newContent }) => {
  const tree = getFileTree();
  const exists = existsFile(path, tree);

  if (!exists && oldContent === "") {
    setFileTree((prev) => createFile(path, prev, newContent));
    return { success: true, action: "created" as const, path };
  }
  if (!exists) {
    return { error: `File not found: ${path}. Use listFiles first.` };
  }

  const current = getFileText(path, tree);

  if (oldContent === "") {
    const updated = current.length > 0 ? current + newContent : newContent;
    const action = current.length > 0 ? "appended" as const : "written" as const;
    setFileTree((prev) => updateFile(path, updated, prev));
    return { success: true, action, path };
  }

  const occurrences = current.split(oldContent).length - 1;
  if (occurrences === 0) {
    return { error: `oldContent not found in ${path}. Read the file first to get exact content.` };
  }
  if (occurrences > 1) {
    return {
      error: `oldContent matches ${occurrences} locations in ${path}. Include more surrounding context to make the match unique.`,
    };
  }

  setFileTree((prev) => updateFile(path, current.replace(oldContent, newContent), prev));
  return { success: true, action: "edited" as const, path };
};
```

#### `deleteFile`
- Input: `{ path: string }`.
- `needsApproval: true`.
- Uses `removeFile`.

All tools are created by a factory function:

```typescript
export function createTemplateAgentTools(
  getFileTree: () => FileTree,
  setFileTree: (updater: (prev: FileTree) => FileTree) => void,
) { ... }
```

---

### Phase 2: Agent Hook (`site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts`)

A React hook that manages the agent conversation loop:

```typescript
export function useTemplateAgent(opts: {
  getFileTree: () => FileTree;
  setFileTree: (updater: (prev: FileTree) => FileTree) => void;
  onFileEdited?: (path: string) => void;  // navigate Monaco to edited file
}) { ... }
```

**Returned interface:**

```typescript
{
  messages: UIMessage[];           // conversation history (ephemeral, in-state)
  isStreaming: boolean;            // true while streamText is active
  pendingApproval: PendingTool | null;  // tool call awaiting user decision
  send: (text: string) => void;   // user sends a message
  approve: () => void;            // approve pending tool call
  reject: () => void;             // reject pending tool call
  stop: () => void;               // abort current stream
  reset: () => void;              // clear conversation
}
```

**Core loop logic (inside `send`):**

```
1. Append user message to `messages`
2. Create OpenAI provider pointing at `/api/v2/aibridge/openai/v1`
3. Call `streamText({ model, system, messages, tools, stopWhen: stepCountIs(20) })`
4. As stream emits text chunks → update assistant message in state (live streaming)
5. As stream emits tool-call parts:
   a. Tools WITHOUT needsApproval → auto-executed, results appended, loop continues
   b. Tools WITH needsApproval → set `pendingApproval` state, stream pauses
6. When user calls `approve()`:
   a. Execute the tool
   b. Append tool result to messages
   c. Resume by calling `streamText` again with updated messages
7. When user calls `reject()`:
   a. Append a tool result with `{ error: "User rejected this edit" }`
   b. Resume `streamText`
8. Loop ends when model produces no tool calls or stepCount reached
```

<details><summary>Provider configuration</summary>

```typescript
import { createOpenAI } from "@ai-sdk/openai";

// Created once per hook instance, not per message
const provider = createOpenAI({
  baseURL: "/api/v2/aibridge/openai/v1",
  headers: { "Coder-Session-Token": getSessionToken() },
});
```

The session token is already available via the existing API client pattern in
`site/src/api/api.ts`. We can grab it from the same source.

</details>

<details><summary>System prompt</summary>

```
You are a Terraform template editing assistant for Coder.
You help users modify Coder workspace templates (Terraform HCL files).

Rules:
- Always use listFiles first to see the template structure.
- Always use readFile before editing a file.
- Use editFile for targeted changes — provide enough context in oldContent
  to uniquely identify the edit location.
- Keep HCL syntax valid. Use proper Terraform formatting conventions.
- Explain what you're changing and why before making edits.
```

</details>

---

### Phase 3: UI Components

#### 3a. AI Toggle Button in Topbar

**File:** `site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx`

Add a sparkle/wand icon button to the right-side action area of the topbar,
next to the existing Build/Publish buttons:

```tsx
<TopbarIconButton
  title="AI Assistant"
  onClick={() => setAIPanelOpen((v) => !v)}
  className={aiPanelOpen ? "text-content-primary" : undefined}
>
  <SparklesIcon />
</TopbarIconButton>
```

Only rendered when the AI bridge is available (see Phase 4 for feature gating).

#### 3b. Resizable Panel Split

**File:** `site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx`

Wrap the existing editor area in `PanelGroup` when the AI panel is open:

```tsx
// Before (current):
<div className="flex flex-1 basis-0 overflow-hidden relative">
  <Sidebar>...</Sidebar>
  <div className="flex flex-col w-full ...">
    <MonacoEditor ... />
    <BottomTabs ... />
  </div>
</div>

// After:
<div className="flex flex-1 basis-0 overflow-hidden relative">
  <Sidebar>...</Sidebar>
  <PanelGroup direction="horizontal" autoSaveId="template-editor-ai">
    <Panel minSize={40}>
      <div className="flex flex-col w-full ...">
        <MonacoEditor ... />
        <BottomTabs ... />
      </div>
    </Panel>
    {aiPanelOpen && (
      <>
        <PanelResizeHandle className="w-1 bg-border hover:bg-content-link transition-colors" />
        <Panel defaultSize={30} minSize={20}>
          <AIChatPanel agent={agent} onNavigateToFile={handleNavigateToFile} />
        </Panel>
      </>
    )}
  </PanelGroup>
</div>
```

Monaco's `automaticLayout: true` handles the resize automatically.

#### 3c. Chat Panel Component (`site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx`)

```
┌─ AI Assistant ──────────────── [×] ┐
│ (scrollable message list)          │
│                                    │
│  👤 User message                   │
│                                    │
│  🤖 Assistant                      │
│  ┌ 📂 listFiles ────────────────┐  │
│  │ main.tf, vars.tf, ...        │  │ ← auto-collapsed read-only tool
│  └──────────────────────────────┘  │
│  ┌ 📄 readFile: main.tf ───────┐  │
│  │ (248 lines)                  │  │ ← collapsed, click to expand
│  └──────────────────────────────┘  │
│                                    │
│  I'll add a GPU variable...        │  ← streaming markdown text
│                                    │
│  ┌ ✏️ editFile: vars.tf ────────┐  │
│  │ + variable "gpu_type" {      │  │ ← inline diff (green/red lines)
│  │ +   type    = string         │  │
│  │ +   default = "T4"           │  │
│  │ + }                          │  │
│  │                              │  │
│  │  [✓ Approve]  [✗ Reject]    │  │ ← approval buttons
│  └──────────────────────────────┘  │
│                                    │
│ ┌──────────────────────────── ⏎ ┐  │
│ │ Ask the AI...                  │  │ ← input textarea
│ └────────────────────────────────┘  │
└────────────────────────────────────┘
```

Sub-components:

| Component | Responsibility |
|---|---|
| `AIChatPanel` | Outer shell — header, message list (auto-scroll), input area |
| `ChatMessage` | Renders a single user or assistant message |
| `ToolCallCard` | Renders a tool invocation — icon, name, collapsible body |
| `EditApprovalCard` | Special card for `editFile` — shows diff, Approve/Reject buttons |
| `ChatInput` | Textarea with submit on Enter (Shift+Enter for newline) |

**Diff rendering in `EditApprovalCard`:**
Rather than embedding a full Monaco `DiffEditor` (heavyweight), use a simple
line-based diff: split `oldContent`/`newContent` by newlines, show removed lines
in red (`bg-surface-error`) and added lines in green (`bg-surface-positive`) with
`+`/`-` prefixes. This matches the style of tool call cards in existing chat UIs
and keeps bundle size minimal.

If `oldContent` is empty (create/append), just show the new content with all green lines.

---

### Phase 4: Feature Gating

The AI button should only appear when the AI bridge is configured. Add a lightweight
check on mount:

```typescript
// In TemplateVersionEditorPage.tsx or a small hook
const [aiAvailable, setAIAvailable] = useState(false);

useEffect(() => {
  // HEAD request to the AI bridge — 200 means configured, 404/401 means not
  fetch("/api/v2/aibridge/openai/v1/models", {
    method: "GET",
    headers: { "Coder-Session-Token": token },
  })
    .then((r) => setAIAvailable(r.ok))
    .catch(() => setAIAvailable(false));
}, []);
```

If `aiAvailable` is false, the sparkle button is not rendered. No broken UI.

---

### Phase 5: File Navigation Integration

When the agent reads or edits a file, clicking the file name in a `ToolCallCard`
should navigate Monaco to that file. This is trivial because `activePath` is already
managed via URL search params:

```typescript
const handleNavigateToFile = (path: string) => {
  onActivePathChange(path);  // existing prop on TemplateVersionEditor
};
```

For edits, after approval, automatically navigate to the edited file so the user
sees the change in context.

---

## File Inventory (new files)

| File | Purpose |
|---|---|
| `site/src/pages/TemplateVersionEditorPage/ai/tools.ts` | Tool definitions (listFiles, readFile, editFile, deleteFile) |
| `site/src/pages/TemplateVersionEditorPage/ai/useTemplateAgent.ts` | React hook: agent loop, streaming, approval state |
| `site/src/pages/TemplateVersionEditorPage/ai/AIChatPanel.tsx` | Main chat panel component |
| `site/src/pages/TemplateVersionEditorPage/ai/ChatMessage.tsx` | Message rendering (user + assistant) |
| `site/src/pages/TemplateVersionEditorPage/ai/ToolCallCard.tsx` | Tool call display (collapsed reads, expanded edits) |
| `site/src/pages/TemplateVersionEditorPage/ai/EditApprovalCard.tsx` | Diff view + approve/reject for editFile/deleteFile |
| `site/src/pages/TemplateVersionEditorPage/ai/ChatInput.tsx` | Text input with keyboard shortcuts |
| `site/src/pages/TemplateVersionEditorPage/ai/types.ts` | Shared types (PendingTool, etc.) |

**Modified files:**

| File | Change |
|---|---|
| `site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx` | Add AI panel state, PanelGroup wrap, sparkle button |
| `site/package.json` | Add `ai`, `@ai-sdk/openai`, `zod` |

---

## Implementation Order

1. **Dependencies** — add packages, verify they build
2. **Tools** — `tools.ts` with unit tests against mock FileTree objects
3. **Agent hook** — `useTemplateAgent.ts`, test the loop logic
4. **UI shell** — `AIChatPanel`, `ChatInput`, wire into editor with PanelGroup
5. **Tool cards** — `ToolCallCard`, `EditApprovalCard` with diff rendering
6. **Feature gate** — AI bridge availability check
7. **Polish** — file navigation on click, auto-scroll, loading states, error handling

---

## Risks & Mitigations

| Risk | Mitigation |
|---|---|
| AI SDK v6 is relatively new, API may shift | Pin exact versions; the core `streamText` + `tool()` API is stable |
| `zod` adds a new schema library alongside `yup` | Scoped to `ai/tools.ts` only — no project-wide migration |
| Large template files may exceed context window | Tools return content; model reads only what it asks for via `readFile` |
| AI bridge may not be configured in all deployments | Feature-gated: button hidden when bridge unavailable |
| `needsApproval` pause/resume adds complexity | Isolated in `useTemplateAgent` hook; clear state machine (idle → streaming → awaiting_approval → streaming → done) |

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh`_
