### PR TITLE
test: fail test and report on init error

### DIFF
--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -1107,6 +1107,7 @@ func TestProvision(t *testing.T) {
 				require.Contains(t, initComplete.Error, testCase.InitErrorContains)
 				return
 			}
+			require.Empty(t, initComplete.Error, "unexpected init error")
 
 			planRequest := &proto.Request{Type: &proto.Request_Plan{Plan: &proto.PlanRequest{
 				Metadata: testCase.Metadata,


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1353

Does not solve the issue, but the error is currently opaque. This fails the test when the init fails, hopefully raising up the error.