### PR TITLE
feat: add codersdk constructor that uses an independent transport 

### DIFF
--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -126,37 +126,6 @@ func New(serverURL *url.URL, opts ...ClientOption) *Client {
 	return client
 }
 
-// NewWithIndependentTransport creates a Coder client with its own HTTP
-// transport, preventing connection sharing with http.DefaultTransport. This is
-// useful in scenarios where multiple clients need independent connection pools,
-// such as load testing, to ensure HTTP/2 connection multiplexing doesn't cause
-// all requests to route to a single backend server.
-//
-// The cloned transport maintains all the default settings (timeouts, TLS config,
-// etc.) but uses a separate connection pool, meaning each client will establish
-// its own connections to the server.
-func NewWithIndependentTransport(serverURL *url.URL, opts ...ClientOption) *Client {
-	// Clone the default transport to create a new connection pool.
-	// This is a shallow copy that shares configuration but creates independent
-	// connection state (DialContext, connection maps, etc.).
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		// This should never happen in practice, but handle it gracefully.
-		defaultTransport = &http.Transport{}
-	}
-	transport := defaultTransport.Clone()
-
-	client := &Client{
-		URL:                  serverURL,
-		HTTPClient:           &http.Client{Transport: transport},
-		SessionTokenProvider: FixedSessionTokenProvider{},
-	}
-	for _, opt := range opts {
-		opt(client)
-	}
-	return client
-}
-
 // Client is an HTTP caller for methods to the Coder API.
 // @typescript-ignore Client
 type Client struct {

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -126,6 +126,37 @@ func New(serverURL *url.URL, opts ...ClientOption) *Client {
 	return client
 }
 
+// NewWithIndependentTransport creates a Coder client with its own HTTP
+// transport, preventing connection sharing with http.DefaultTransport. This is
+// useful in scenarios where multiple clients need independent connection pools,
+// such as load testing, to ensure HTTP/2 connection multiplexing doesn't cause
+// all requests to route to a single backend server.
+//
+// The cloned transport maintains all the default settings (timeouts, TLS config,
+// etc.) but uses a separate connection pool, meaning each client will establish
+// its own connections to the server.
+func NewWithIndependentTransport(serverURL *url.URL, opts ...ClientOption) *Client {
+	// Clone the default transport to create a new connection pool.
+	// This is a shallow copy that shares configuration but creates independent
+	// connection state (DialContext, connection maps, etc.).
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// This should never happen in practice, but handle it gracefully.
+		defaultTransport = &http.Transport{}
+	}
+	transport := defaultTransport.Clone()
+
+	client := &Client{
+		URL:                  serverURL,
+		HTTPClient:           &http.Client{Transport: transport},
+		SessionTokenProvider: FixedSessionTokenProvider{},
+	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client
+}
+
 // Client is an HTTP caller for methods to the Coder API.
 // @typescript-ignore Client
 type Client struct {

--- a/scaletest/createusers/run.go
+++ b/scaletest/createusers/run.go
@@ -76,9 +76,13 @@ func (r *Runner) RunReturningUser(ctx context.Context, id string, logs io.Writer
 	r.user = user
 
 	_, _ = fmt.Fprintln(logs, "\nLogging in as new user...")
-	// Use NewWithIndependentTransport to ensure each user login gets its own
-	// HTTP connection pool, preventing connection sharing during load testing.
-	client := codersdk.NewWithIndependentTransport(r.client.URL)
+	// Duplicate the client with an independent transport to ensure each user
+	// login gets its own HTTP connection pool, preventing connection sharing
+	// during load testing.
+	client, err := loadtestutil.DupClientCopyingHeaders(r.client, nil)
+	if err != nil {
+		return User{}, xerrors.Errorf("duplicate client: %w", err)
+	}
 	loginRes, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
 		Email:    r.cfg.Email,
 		Password: password,

--- a/scaletest/createusers/run.go
+++ b/scaletest/createusers/run.go
@@ -76,7 +76,9 @@ func (r *Runner) RunReturningUser(ctx context.Context, id string, logs io.Writer
 	r.user = user
 
 	_, _ = fmt.Fprintln(logs, "\nLogging in as new user...")
-	client := codersdk.New(r.client.URL)
+	// Use NewWithIndependentTransport to ensure each user login gets its own
+	// HTTP connection pool, preventing connection sharing during load testing.
+	client := codersdk.NewWithIndependentTransport(r.client.URL)
 	loginRes, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
 		Email:    r.cfg.Email,
 		Password: password,

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -77,7 +77,11 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 			return xerrors.Errorf("create user: %w", err)
 		}
 		user = newUser.User
-		client = codersdk.New(r.client.URL)
+		// Use NewWithIndependentTransport to ensure each workspace creation
+		// gets its own HTTP connection pool. This prevents HTTP/2 connection
+		// multiplexing from causing all workspace GET requests to route to a
+		// single backend pod during load testing.
+		client = codersdk.NewWithIndependentTransport(r.client.URL)
 		client.SetSessionToken(newUser.SessionToken)
 	}
 

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -77,11 +77,14 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 			return xerrors.Errorf("create user: %w", err)
 		}
 		user = newUser.User
-		// Use NewWithIndependentTransport to ensure each workspace creation
-		// gets its own HTTP connection pool. This prevents HTTP/2 connection
-		// multiplexing from causing all workspace GET requests to route to a
-		// single backend pod during load testing.
-		client = codersdk.NewWithIndependentTransport(r.client.URL)
+		// Duplicate the client with an independent transport to ensure each
+		// workspace creation gets its own HTTP connection pool. This prevents
+		// HTTP/2 connection multiplexing from causing all workspace GET requests
+		// to route to a single backend pod during load testing.
+		client, err = loadtestutil.DupClientCopyingHeaders(r.client, nil)
+		if err != nil {
+			return xerrors.Errorf("duplicate client: %w", err)
+		}
 		client.SetSessionToken(newUser.SessionToken)
 	}
 


### PR DESCRIPTION
This is useful at least in the case of scaletests but potentially in other places as well. I noticed that scaletest workspace creation hammers a single coderd replica.
<img width="1251" height="663" alt="Screenshot 2026-02-23 at 2 42 56 PM" src="https://github.com/user-attachments/assets/5f1be8af-49fe-43b4-90c7-66d61cae03df" />

AFAICT, this is because all the clients we create use the reference to the default HTTP transport + are using HTTP2, which results in the same underlying TCP connection being used for all clients during WS creation. Once that TCP connection is established to a coderd replica it lives for the whole lifetime of the WS creations.

The change I have here is just to do explicit clones of the transport. We can see the difference between the above run and the 2nd run in this screenshot.

<img width="1251" height="712" alt="Screenshot 2026-02-23 at 5 25 16 PM" src="https://github.com/user-attachments/assets/66ac4ebe-a70c-4a7b-8aef-928e8a97de52" />
