### PR TITLE
chore: add GitHub Action to build+deploy coder.com whenever docs paths change

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
+      - "docs/manifest.json"
 
 jobs:
   deploy-docs:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,4 +1,9 @@
-name: Deploy docs
+# This workflow triggers a Vercel deploy hook which builds+deploys coder.com
+# (a Next.js app), to keep coder.com/docs URLs in sync with docs/manifest.json
+#
+# https://vercel.com/docs/deploy-hooks#triggering-a-deploy-hook
+
+name: Update coder.com/docs
 
 on:
   push:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,16 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy docs site
+        run: |
+          curl -X POST "${{ secrets.DEPLOY_DOCS_VERCEL_WEBHOOK }}"


### PR DESCRIPTION
## problem

Fixes an issue where updates to docs resulted in docs links returning HTTP 404, sometimes taking 4-12 hours before returning HTTP 200 (OK).

coder.com is deployed to Vercel from a separate Next.js repo, which has no knowledge of when docs pages in this repo get updated.

### examples (non-exhaustive)

PR | 404 description
---|---
#19625 | URL for https://coder.com/docs/install/offline was updated to https://coder.com/docs/install/airgap, but the latter returned 404 for 3 hr 56 min after the PR was merged
#21434 | URLs https://coder.com/docs/ai-coder/nsjail and https://coder.com/docs/ai-coder/landjail were added, but both paths 404ed for 1 hr 30 min after the PR was merged. Note that these paths have changed since then--don't be alarmed if clicking those links returns 404s while reviewing this PR
#21708 | URL https://coder.com/docs/ai-coder/boundary/agent-boundary was added, but it returned 404 for 1 hr 19 min after the PR was merged

## solution

All 3 PRs listed above modify manifest.json. This file is fetched during coder.com's `getStaticPaths` for docs pages, defining which docs URLs get statically generated at build time. In the latter 2 cases, the 404s were resolved by manually triggering a redeploy of coder.com in the Vercel dashboard.

The new CI workflow in this PR automatically triggers a Vercel deploy hook ([see docs](https://vercel.com/docs/deploy-hooks#triggering-a-deploy-hook)) with a POST request that runs whenever commits are pushed to main that modify manifest.json. The deploy hook initiates a new build+deploy of the coder.com Next.js app, which reruns `getStaticPaths`, updating docs pages' URLs.

**Note:** I have not tested this workflow yet. I will verify that it works after this PR is merged. I confirmed in a local terminal that the webhook URL does successfully initiate a new Vercel build. I also tested with a malformed URL and received error JSON output, so if the action fails for some reason, we should see error output in the workflow logs ([example](https://github.com/coder/coder/actions/runs/22361453442/job/64722503802)).