### PR TITLE
fix: allow agent-reported final states, add SSE reconnection

### DIFF
--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -265,7 +265,7 @@ Bad Tasks
 Use the "state" field to indicate your progress. Periodically report
 progress with state "working" to keep the user updated. It is not possible to send too many updates!
 
-ONLY report an "idle" or "failure" state if you have FULLY completed the task.
+ONLY report a "complete", "idle", or "failure" state if you have FULLY completed the task.
 `,
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
@@ -279,9 +279,10 @@ ONLY report an "idle" or "failure" state if you have FULLY completed the task.
 				},
 				"state": map[string]any{
 					"type":        "string",
-					"description": "The state of your task. This can be one of the following: working, idle, or failure. Select the state that best represents your current progress.",
+					"description": "The state of your task. This can be one of the following: working, complete, idle, or failure. Select the state that best represents your current progress.",
 					"enum": []string{
 						string(codersdk.WorkspaceAppStatusStateWorking),
+						string(codersdk.WorkspaceAppStatusStateComplete),
 						string(codersdk.WorkspaceAppStatusStateIdle),
 						string(codersdk.WorkspaceAppStatusStateFailure),
 					},


### PR DESCRIPTION
When AgentAPI is configured, `WithTaskReporter` unconditionally overrides all self-reported states to `working`. The intent was to distrust the agent's `idle` and rely on the screen watcher, but the override also blocks `failure` and `complete`, which only the agent can produce (the screen watcher only knows `running`/`stable`). Tasks get stuck as `working` or `null` forever.

Now only `idle` is overridden to `working`; `failure`, `complete`, and `working` pass through as-is.

Also:
- Remove misplaced unconditional `"Failed to watch screen events"` log that fired on every startup
- Add SSE reconnection with exponential backoff (1s-30s) in `startWatcher` so it recovers from dropped connections instead of dying silently
- Add `complete` to the `coder_report_task` tool enum, which the `coder/claude-code` registry module already instructs agents to use but was missing from the schema

Refs coder/internal#1350