### PR TITLE
fix: use "idle timeout" as task auto-pause reason

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -500,7 +500,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 								"task":         task.Name,
 								"task_id":      task.ID.String(),
 								"workspace":    ws.Name,
-								"pause_reason": "inactivity exceeded the dormancy threshold",
+								"pause_reason": "idle timeout",
 							},
 							"lifecycle_executor",
 							ws.ID, ws.OwnerID, ws.OrganizationID,

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -2082,6 +2082,6 @@ func TestExecutorTaskWorkspace(t *testing.T) {
 		require.Equal(t, task.Name, sent[0].Labels["task"])
 		require.Equal(t, task.ID.String(), sent[0].Labels["task_id"])
 		require.Equal(t, workspace.Name, sent[0].Labels["workspace"])
-		require.Equal(t, "inactivity exceeded the dormancy threshold", sent[0].Labels["pause_reason"])
+		require.Equal(t, "idle timeout", sent[0].Labels["pause_reason"])
 	})
 }


### PR DESCRIPTION
## Summary

The task auto-pause notification was using `"inactivity exceeded the dormancy threshold"` as the `pause_reason`. This is misleading because the actual trigger is the **workspace build deadline expiring** (autostop TTL), not dormancy.

**Dormancy** is a completely separate mechanism that checks `LastUsedAt` against `TimeTilDormant` and produces `BuildReasonDormancy` — it never triggers the task pause notification.

The real flow is:
1. Task workspace gets a deadline based on the template's `DefaultTTL`
2. While the AI agent is active, activity bumps extend the deadline
3. When the agent goes idle and bumps stop, the deadline expires
4. `isEligibleForAutostop()` fires → becomes `BuildReasonTaskAutoPause`

## Changes

- **`coderd/autobuild/lifecycle_executor.go`**: Changed `pause_reason` from `"inactivity exceeded the dormancy threshold"` to `"idle timeout"`
- **`coderd/autobuild/lifecycle_executor_test.go`**: Updated test assertion to match

## Testing

`TestExecutorTaskWorkspace/AutostopNotification` passes ✅

---

> Written by Coder Mux w/ Opus 4.6