### PR TITLE
fix: use separate http.Transports for wsproxy tests

### DIFF
--- a/enterprise/coderd/coderdenttest/proxytest.go
+++ b/enterprise/coderd/coderdenttest/proxytest.go
@@ -146,8 +146,12 @@ func NewWorkspaceProxyReplica(t *testing.T, coderdAPI *coderd.API, owner *coders
 
 	logger := testutil.Logger(t).With(slog.F("server_url", serverURL.String()))
 
+	// nolint: forcetypeassert // This is a stdlib transport it's unnecessary to type assert especially in tests.
 	wssrv, err := wsproxy.New(ctx, &wsproxy.Options{
-		Logger:            logger,
+		Logger: logger,
+		// It's important to ensure each test has its own isolated transport to avoid interfering with other tests
+		// especially in shutdown.
+		HTTPClient:        &http.Client{Transport: http.DefaultTransport.(*http.Transport).Clone()},
 		Experiments:       options.Experiments,
 		DashboardURL:      coderdAPI.AccessURL,
 		AccessURL:         accessURL,

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -453,6 +453,7 @@ func (l *RegisterWorkspaceProxyLoop) failureFn(err error) {
 	if deregisterErr != nil {
 		l.opts.Logger.Error(context.Background(),
 			"failed to deregister workspace proxy with Coder primary (it will be automatically deregistered shortly)",
+			slog.F("root_error", err.Error()),
 			slog.Error(deregisterErr),
 		)
 	}


### PR DESCRIPTION
- Previously all tests were sharing the global http.Transport meaning on `Close` it would close connections presumed to be idle for other tests. 
fixes https://github.com/coder/internal/issues/112