### PR TITLE
fix: log WARN on ErrConnectionClosed in tailnet.Controller.Run

### DIFF
--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"math"
+	"net"
 	"net/netip"
 	"slices"
 	"strings"
@@ -1431,6 +1432,11 @@ func (c *Controller) Run(ctx context.Context) {
 			if err != nil {
 				if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) {
 					return
+				}
+
+				if errors.Is(err, net.ErrClosed) {
+					c.logger.Warn(c.ctx, "control plane connection closed, retrying", slog.Error(err))
+					continue
 				}
 
 				// If the database is unreachable by the control plane, there's not much we can do, so we'll just retry later.


### PR DESCRIPTION
There's a lack of logs since the flake is so old but I think it makes sense to decrement ErrConnectionClosed to a `WARN`. Presumably this happens as we're tearing everything down and we shortly encounter a cancelled context thereafter.  

fixes https://github.com/coder/internal/issues/585
