### PR TITLE
test(coderd): remove provisioner daemon from SendToNonActiveStates test

### DIFF
--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -832,7 +832,7 @@ func TestTasks(t *testing.T) {
 		t.Run("SendToNonActiveStates", func(t *testing.T) {
 			t.Parallel()
 
-			client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
 			owner := coderdtest.CreateFirstUser(t, client)
 			ctx := testutil.Context(t, testutil.WaitMedium)
 


### PR DESCRIPTION
The `SendToNonActiveStates` test creates tasks via `dbfake` and checks status-dependent error messages. None of its subtests need a running provisioner daemon.

With `IncludeProvisionerDaemon: true`, the daemon races against the `Pending` subtest by acquiring the pending provisioner job (~250ms poll interval) and transitioning the task from `pending` to `initializing` before the assertion runs. The test then sees `"Task is initializing."` instead of the expected `"pending"`.

The fix removes `IncludeProvisionerDaemon: true`, matching the pattern used by every other caller of `createTaskInState` in the file.

Validated with `-count=50` (0 failures).

Fixes coder/internal#1367