### PR TITLE
chore: update setup-go action to fix Go download failures

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -5,9 +5,6 @@ inputs:
   version:
     description: "The Go version to use."
     default: "1.25.7"
-  use-preinstalled-go:
-    description: "Whether to use preinstalled Go."
-    default: "false"
   use-cache:
     description: "Whether to use the cache."
     default: "true"
@@ -17,7 +14,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
-        go-version: ${{ inputs.use-preinstalled-go == 'false' && inputs.version || '' }}
+        go-version: ${{ inputs.version }}
         cache: ${{ inputs.use-cache }}
 
     - name: Install gotestsum

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: ${{ inputs.use-preinstalled-go == 'false' && inputs.version || '' }}
         cache: ${{ inputs.use-cache }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -422,10 +422,6 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
-          # Runners have Go baked-in and Go will automatically
-          # download the toolchain configured in go.mod, so we don't
-          # need to reinstall it. It's faster on Windows runners.
-          use-preinstalled-go: ${{ runner.os == 'Windows' }}
           use-cache: true
 
       - name: Setup Terraform

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -64,11 +64,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-        with:
-          # Runners have Go baked-in and Go will automatically
-          # download the toolchain configured in go.mod, so we don't
-          # need to reinstall it. It's faster on Windows runners.
-          use-preinstalled-go: ${{ runner.os == 'Windows' }}
 
       - name: Setup Terraform
         uses: ./.github/actions/setup-tf


### PR DESCRIPTION
I have recently encountered setup-go failing to download Go https://github.com/coder/coder/actions/runs/22405536238/job/64864140712

<img width="1350" height="479" alt="Screenshot 2026-02-25 at 10 13 16 AM" src="https://github.com/user-attachments/assets/d475cb1e-5cd4-4a25-ba11-6dd3e02fbb8e" />

This has been sporadically happening, and we were advised by a member of the Go team that downloading Go from `storage.googleapis.com` is not guaranteed https://github.com/coder/internal/issues/1066#issuecomment-3416115068

This has been fixed in version 5.6.0 of setup-go https://github.com/actions/setup-go/releases/tag/v5.6.0
