### PR TITLE
fix: avoid derp-related panic during wsproxy registration

### DIFF
--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -39,40 +39,44 @@ func (r *RootCmd) Server(_ func()) *serpent.Command {
 			}
 		}
 
+		// Always generate a mesh key, even if the built-in DERP server is
+		// disabled. This mesh key is still used by workspace proxies running
+		// HA.
+		var meshKey string
+		err := options.Database.InTx(func(tx database.Store) error {
+			// This will block until the lock is acquired, and will be
+			// automatically released when the transaction ends.
+			err := tx.AcquireLock(ctx, database.LockIDEnterpriseDeploymentSetup)
+			if err != nil {
+				return xerrors.Errorf("acquire lock: %w", err)
+			}
+
+			meshKey, err = tx.GetDERPMeshKey(ctx)
+			if err == nil {
+				return nil
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return xerrors.Errorf("get DERP mesh key: %w", err)
+			}
+			meshKey, err = cryptorand.String(32)
+			if err != nil {
+				return xerrors.Errorf("generate DERP mesh key: %w", err)
+			}
+			err = tx.InsertDERPMeshKey(ctx, meshKey)
+			if err != nil {
+				return xerrors.Errorf("insert DERP mesh key: %w", err)
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		if meshKey == "" {
+			return nil, nil, xerrors.New("mesh key is empty")
+		}
+
 		if options.DeploymentValues.DERP.Server.Enable {
 			options.DERPServer = derp.NewServer(key.NewNode(), tailnet.Logger(options.Logger.Named("derp")))
-			var meshKey string
-			err := options.Database.InTx(func(tx database.Store) error {
-				// This will block until the lock is acquired, and will be
-				// automatically released when the transaction ends.
-				err := tx.AcquireLock(ctx, database.LockIDEnterpriseDeploymentSetup)
-				if err != nil {
-					return xerrors.Errorf("acquire lock: %w", err)
-				}
-
-				meshKey, err = tx.GetDERPMeshKey(ctx)
-				if err == nil {
-					return nil
-				}
-				if !errors.Is(err, sql.ErrNoRows) {
-					return xerrors.Errorf("get DERP mesh key: %w", err)
-				}
-				meshKey, err = cryptorand.String(32)
-				if err != nil {
-					return xerrors.Errorf("generate DERP mesh key: %w", err)
-				}
-				err = tx.InsertDERPMeshKey(ctx, meshKey)
-				if err != nil {
-					return xerrors.Errorf("insert DERP mesh key: %w", err)
-				}
-				return nil
-			}, nil)
-			if err != nil {
-				return nil, nil, err
-			}
-			if meshKey == "" {
-				return nil, nil, xerrors.New("mesh key is empty")
-			}
 			options.DERPServer.SetMeshKey(meshKey)
 		}
 


### PR DESCRIPTION
If the primary had DERP disabled, workspace proxy registrations would fail with a panic, as the registration endpoint would attempt to access the mesh key from the nil DerpServer.

Changes the endpoint to query the database for the key.

Closes https://github.com/coder/coder/issues/22317