### PR TITLE
refactor(site): use dedicated task pause/resume API endpoints (#22303) (cherry-pick/v2.31)

### DIFF
--- a/site/src/api/queries/tasks.ts
+++ b/site/src/api/queries/tasks.ts
@@ -17,10 +17,7 @@ export const taskLogs = (user: string, taskId: string) => ({
 export const pauseTask = (task: Task, queryClient: QueryClient) => {
 	return {
 		mutationFn: async () => {
-			if (!task.workspace_id) {
-				throw new Error("Task has no workspace");
-			}
-			return API.stopWorkspace(task.workspace_id);
+			return API.pauseTask(task.owner_name, task.id);
 		},
 		onSuccess: async () => {
 			await queryClient.invalidateQueries({ queryKey: ["tasks"] });
@@ -31,15 +28,7 @@ export const pauseTask = (task: Task, queryClient: QueryClient) => {
 export const resumeTask = (task: Task, queryClient: QueryClient) => {
 	return {
 		mutationFn: async () => {
-			if (!task.workspace_id) {
-				throw new Error("Task has no workspace");
-			}
-			return API.startWorkspace(
-				task.workspace_id,
-				task.template_version_id,
-				undefined,
-				undefined,
-			);
+			return API.resumeTask(task.owner_name, task.id);
 		},
 		onSuccess: async () => {
 			await queryClient.invalidateQueries({ queryKey: ["tasks"] });

--- a/site/src/pages/TaskPage/TaskPage.stories.tsx
+++ b/site/src/pages/TaskPage/TaskPage.stories.tsx
@@ -739,9 +739,9 @@ export const TaskResuming: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
-		spyOn(API, "startWorkspace").mockResolvedValue(
-			MockStartingWorkspace.latest_build,
-		);
+		spyOn(API, "resumeTask").mockResolvedValue({
+			workspace_build: MockStartingWorkspace.latest_build,
+		});
 		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 	parameters: {
@@ -766,7 +766,7 @@ export const TaskResuming: Story = {
 		await userEvent.click(resumeButton);
 
 		await waitFor(async () => {
-			expect(API.startWorkspace).toBeCalled();
+			expect(API.resumeTask).toBeCalled();
 		});
 	},
 };
@@ -781,7 +781,7 @@ export const TaskResumeFailure: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
-		spyOn(API, "startWorkspace").mockRejectedValue(
+		spyOn(API, "resumeTask").mockRejectedValue(
 			new Error("Some unexpected error"),
 		);
 		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
@@ -820,7 +820,7 @@ export const TaskResumeFailureWithDialog: Story = {
 		spyOn(API, "getWorkspaceByOwnerAndName").mockResolvedValue(
 			MockStoppedWorkspace,
 		);
-		spyOn(API, "startWorkspace").mockRejectedValue({
+		spyOn(API, "resumeTask").mockRejectedValue({
 			...mockApiError({
 				message: "Bad Request",
 				detail: "Invalid build parameters provided",

--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -361,7 +361,9 @@ export const PauseTask: Story = {
 		spyOn(API, "getTasks").mockResolvedValue([
 			{ ...MockTask, status: "active" },
 		]);
-		spyOn(API, "stopWorkspace").mockResolvedValue(MockWorkspaceBuildStop);
+		spyOn(API, "pauseTask").mockResolvedValue({
+			workspace_build: MockWorkspaceBuildStop,
+		});
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -370,7 +372,10 @@ export const PauseTask: Story = {
 		});
 		await userEvent.click(pauseButton);
 		await waitFor(() => {
-			expect(API.stopWorkspace).toHaveBeenCalledWith(MockTask.workspace_id);
+			expect(API.pauseTask).toHaveBeenCalledWith(
+				MockTask.owner_name,
+				MockTask.id,
+			);
 		});
 	},
 };
@@ -394,7 +399,9 @@ export const ResumeTask: Story = {
 		spyOn(API, "getTasks").mockResolvedValue([
 			{ ...MockTask, status: "paused" },
 		]);
-		spyOn(API, "startWorkspace").mockResolvedValue(MockWorkspaceBuildStop);
+		spyOn(API, "resumeTask").mockResolvedValue({
+			workspace_build: MockWorkspaceBuildStop,
+		});
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -403,11 +410,9 @@ export const ResumeTask: Story = {
 		});
 		await userEvent.click(resumeButton);
 		await waitFor(() => {
-			expect(API.startWorkspace).toHaveBeenCalledWith(
-				MockTask.workspace_id,
-				MockTask.template_version_id,
-				undefined,
-				undefined,
+			expect(API.resumeTask).toHaveBeenCalledWith(
+				MockTask.owner_name,
+				MockTask.id,
 			);
 		});
 	},


### PR DESCRIPTION
Switch from workspace stop/start operations to the dedicated tasks pause and resume endpoints for cleaner semantics.

(cherry picked from commit bf639d0016d23e31a0fafaf98e172d9993aa73f9)

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
