### PR TITLE
feat(site): add `aria-errormessage` for form field helpers

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
@@ -56,13 +56,13 @@ export const AnnouncementBannerDialog: FC<AnnouncementBannerDialogProps> = ({
 						<TextField
 							{...bannerFieldHelpers("message", {
 								helperText: "Markdown bold, italics, and links are supported.",
+								inputProps: {
+									"aria-label": "Message",
+									placeholder: "Enter a message for the banner",
+								},
 							})}
 							fullWidth
 							multiline
-							inputProps={{
-								"aria-label": "Message",
-								placeholder: "Enter a message for the banner",
-							}}
 						/>
 					</div>
 					<div>

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -99,14 +99,15 @@ export const AppearanceSettingsPageView: FC<
 				button={!isEntitled && <Button disabled>Submit</Button>}
 			>
 				<TextField
-					{...applicationNameFieldHelpers("application_name")}
+					{...applicationNameFieldHelpers("application_name", {
+						inputProps: {
+							"aria-label": "Application name",
+						},
+					})}
 					defaultValue={appearance.application_name}
 					fullWidth
 					placeholder='Leave empty to display "Coder".'
 					disabled={!isEntitled}
-					inputProps={{
-						"aria-label": "Application name",
-					}}
 				/>
 			</Fieldset>
 
@@ -123,7 +124,11 @@ export const AppearanceSettingsPageView: FC<
 				button={!isEntitled && <Button disabled>Submit</Button>}
 			>
 				<TextField
-					{...logoFieldHelpers("logo_url")}
+					{...logoFieldHelpers("logo_url", {
+						inputProps: {
+							"aria-label": "Logo URL",
+						},
+					})}
 					defaultValue={appearance.logo_url}
 					fullWidth
 					placeholder="Leave empty to display the Coder logo."
@@ -155,9 +160,6 @@ export const AppearanceSettingsPageView: FC<
 								/>
 							</InputAdornment>
 						),
-					}}
-					inputProps={{
-						"aria-label": "Logo URL",
 					}}
 				/>
 			</Fieldset>

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -301,14 +301,13 @@ export const SetupPageView: FC<SetupPageViewProps> = ({
 								renderInput={(params) => (
 									<TextField
 										{...params}
-										{...getFieldHelpers("trial_info.country")}
+										{...getFieldHelpers("trial_info.country", {
+											inputProps: params.inputProps,
+										})}
 										id="trial_info.country"
 										name="trial_info.country"
 										label={Language.countryLabel}
 										fullWidth
-										inputProps={{
-											...params.inputProps,
-										}}
 										InputLabelProps={{ shrink: true }}
 									/>
 								)}

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.jest.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.jest.tsx
@@ -8,7 +8,7 @@ import {
 	waitForLoaderToBeRemoved,
 } from "testHelpers/renderHelpers";
 import { server } from "testHelpers/server";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { API, withDefaultFeatures } from "api/api";
 import type { UpdateTemplateMeta } from "api/typesGenerated";
@@ -131,14 +131,19 @@ describe("TemplateSettingsPage", () => {
 		);
 		await fillAndSubmitForm(validFormValues);
 		await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
-		const form = await screen.findByRole("form", {
-			name: /template settings/i,
-		});
-		expect(
-			await within(form).findByText(
-				"This value is already in use and should be unique.",
-			),
-		).toBeInTheDocument();
+
+		const nameField = await screen.findByLabelText("Name");
+
+		expect(nameField).toHaveAttribute("aria-invalid", "true");
+		expect(nameField).toHaveAttribute("aria-errormessage", "name-helper-text");
+
+		const helperTextAndToast = await screen.findAllByText(
+			"This value is already in use and should be unique.",
+		);
+
+		// The error message should be shown both as helper text for the field and
+		// in a toast notification
+		expect(helperTextAndToast).toHaveLength(2);
 	});
 
 	it("allows a description of 128 chars", () => {

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.test.tsx
@@ -13,6 +13,7 @@ import userEvent from "@testing-library/user-event";
 import { API, withDefaultFeatures } from "api/api";
 import type { UpdateTemplateMeta } from "api/typesGenerated";
 import { HttpResponse, http } from "msw";
+import { act } from "react";
 import { validationSchema } from "./TemplateSettingsForm";
 import TemplateSettingsPage from "./TemplateSettingsPage";
 
@@ -77,48 +78,52 @@ const fillAndSubmitForm = async ({
 	icon,
 	allow_user_cancel_workspace_jobs,
 }: FormValues) => {
+	const user = userEvent.setup();
+
 	const nameField = await screen.findByLabelText("Name");
-	await userEvent.clear(nameField);
-	await userEvent.type(nameField, name);
+	await user.clear(nameField);
+	await user.type(nameField, name);
 
 	const displayNameField = await screen.findByLabelText("Display name");
-	await userEvent.clear(displayNameField);
-	await userEvent.type(displayNameField, display_name);
+	await user.clear(displayNameField);
+	await user.type(displayNameField, display_name);
 
 	const descriptionField = await screen.findByLabelText("Description");
-	await userEvent.clear(descriptionField);
-	await userEvent.type(descriptionField, description);
+	await user.clear(descriptionField);
+	await user.type(descriptionField, description);
 
 	const iconField = await screen.findByLabelText("Icon");
-	await userEvent.clear(iconField);
-	await userEvent.type(iconField, icon);
+	await user.clear(iconField);
+	await user.type(iconField, icon);
 
 	const allowCancelJobsField = screen.getByRole("checkbox", {
 		name: /allow users to cancel in-progress workspace jobs/i,
 	});
 	// checkbox is checked by default, so it must be clicked to get unchecked
 	if (!allow_user_cancel_workspace_jobs) {
-		await userEvent.click(allowCancelJobsField);
+		await user.click(allowCancelJobsField);
 	}
 
 	const submitButton = await screen.findByText(/save/i);
-	await userEvent.click(submitButton);
+	await user.click(submitButton);
 };
 
 describe("TemplateSettingsPage", () => {
 	it("succeeds", async () => {
 		await renderTemplateSettingsPage();
-		jest.spyOn(API, "updateTemplateMeta").mockResolvedValueOnce({
+		vi.spyOn(API, "updateTemplateMeta").mockResolvedValueOnce({
 			...MockTemplate,
 			...validFormValues,
 		});
-		await fillAndSubmitForm(validFormValues);
+		await act(async () => {
+			await fillAndSubmitForm(validFormValues);
+		});
 		await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
 	});
 
 	it("displays an error if the name is taken", async () => {
 		await renderTemplateSettingsPage();
-		jest.spyOn(API, "updateTemplateMeta").mockRejectedValueOnce(
+		vi.spyOn(API, "updateTemplateMeta").mockRejectedValueOnce(
 			mockApiError({
 				message: `Template with name "test-template" already exists`,
 				validations: [
@@ -129,7 +134,10 @@ describe("TemplateSettingsPage", () => {
 				],
 			}),
 		);
-		await fillAndSubmitForm(validFormValues);
+
+		await act(async () => {
+			await fillAndSubmitForm(validFormValues);
+		});
 		await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
 
 		const nameField = await screen.findByLabelText("Name");
@@ -178,11 +186,14 @@ describe("TemplateSettingsPage", () => {
 					});
 				}),
 			);
-			const updateTemplateMetaSpy = jest.spyOn(API, "updateTemplateMeta");
+			const updateTemplateMetaSpy = vi.spyOn(API, "updateTemplateMeta");
 			const deprecationMessage = "This template is deprecated";
 
 			await renderTemplateSettingsPage();
-			await deprecateTemplate(deprecationMessage);
+
+			await act(async () => {
+				await deprecateTemplate(deprecationMessage);
+			});
 
 			const [templateId, data] = updateTemplateMetaSpy.mock.calls[0];
 
@@ -203,10 +214,15 @@ describe("TemplateSettingsPage", () => {
 					});
 				}),
 			);
-			const updateTemplateMetaSpy = jest.spyOn(API, "updateTemplateMeta");
+			const updateTemplateMetaSpy = vi.spyOn(API, "updateTemplateMeta");
 
 			await renderTemplateSettingsPage();
-			await deprecateTemplate("This template should not be able to deprecate");
+
+			await act(async () => {
+				await deprecateTemplate(
+					"This template should not be able to deprecate",
+				);
+			});
 
 			const [templateId, data] = updateTemplateMetaSpy.mock.calls[0];
 
@@ -219,8 +235,9 @@ describe("TemplateSettingsPage", () => {
 });
 
 async function deprecateTemplate(message: string) {
+	const user = userEvent.setup();
 	const deprecationField = screen.getByLabelText("Deprecation Message");
-	await userEvent.type(deprecationField, message);
+	await user.type(deprecationField, message);
 	const submitButton = await screen.findByRole("button", { name: /save/i });
-	await userEvent.click(submitButton);
+	await user.click(submitButton);
 }

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -293,10 +293,10 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 							helperText: (
 								<DefaultTTLHelperText ttl={form.values.default_ttl_ms} />
 							),
+							inputProps: { min: 0, step: 1 },
 						})}
 						disabled={isSubmitting}
 						fullWidth
-						inputProps={{ min: 0, step: 1 }}
 						label="Default autostop (hours)"
 						type="number"
 					/>
@@ -309,10 +309,10 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 									defaultTTL={form.values.default_ttl_ms}
 								/>
 							),
+							inputProps: { min: 0, step: 1 },
 						})}
 						disabled={isSubmitting || !form.values.default_ttl_ms}
 						fullWidth
-						inputProps={{ min: 0, step: 1 }}
 						label="Activity bump (hours)"
 						type="number"
 					/>
@@ -354,6 +354,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 										weeks={form.values.autostop_requirement_weeks}
 									/>
 								),
+								inputProps: { min: 1, max: 16, step: 1 },
 							})}
 							disabled={
 								isSubmitting ||
@@ -362,7 +363,6 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 								)
 							}
 							fullWidth
-							inputProps={{ min: 1, max: 16, step: 1 }}
 							label="Weeks between required stops"
 							type="number"
 						/>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -418,6 +418,7 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
 						{...formHelpers("ttl", {
 							helperText: ttlShutdownAt(form.values.ttl),
 							backendFieldName: "ttl_ms",
+							inputProps: { min: 0, step: "any", maxLength: 5 },
 						})}
 						// disabled if autostop disabled at template level or
 						// if autostop feature is toggled off via the switch above
@@ -426,7 +427,6 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
 							!template.allow_user_autostop ||
 							!form.values.autostopEnabled
 						}
-						inputProps={{ min: 0, step: "any", maxLength: 5 }}
 						label={Language.ttlLabel}
 						type="number"
 						fullWidth

--- a/site/src/utils/formUtils.test.ts
+++ b/site/src/utils/formUtils.test.ts
@@ -94,6 +94,14 @@ describe("form util functions", () => {
 				expect(touchedGoodResult.helperText).toBeUndefined();
 				expect(touchedBadResult.helperText).toEqual("oops!");
 			});
+			it('sets aria-errormessage to "{field name}-error" if touched and invalid', () => {
+				expect(untouchedGoodResult.inputProps).toBeUndefined();
+				expect(untouchedBadResult.inputProps).toBeUndefined();
+				expect(touchedGoodResult.inputProps).toBeUndefined();
+				expect(touchedBadResult.inputProps).toEqual({
+					"aria-errormessage": "touchedBadField-helper-text",
+				});
+			});
 			it("allows short entries", () => {
 				expect(maxLengthOk.error).toBe(false);
 				expect(maxLengthOk.helperText).toBeUndefined();
@@ -105,6 +113,9 @@ describe("form util functions", () => {
 			it("reports an error for entries that are too long", () => {
 				expect(maxLengthOver.error).toBe(true);
 				expect(maxLengthOver.helperText).toBeDefined();
+				expect(maxLengthOver.inputProps).toEqual({
+					"aria-errormessage": "maxLengthOver-helper-text",
+				});
 			});
 		});
 		describe("with API errors", () => {
@@ -123,12 +134,18 @@ describe("form util functions", () => {
 				const result = getFieldHelpers("touchedGoodField");
 				expect(result.error).toBeTruthy();
 				expect(result.helperText).toEqual("API error!");
+				expect(result.inputProps).toEqual({
+					"aria-errormessage": "touchedGoodField-helper-text",
+				});
 			});
 			it("shows an error if there is only a validation error", () => {
 				const getFieldHelpers = getFormHelpers<TestType>(form, {});
 				const result = getFieldHelpers("touchedBadField");
 				expect(result.error).toBeTruthy();
 				expect(result.helperText).toEqual("oops!");
+				expect(result.inputProps).toEqual({
+					"aria-errormessage": "touchedBadField-helper-text",
+				});
 			});
 			it("shows the API error if both are present", () => {
 				const getFieldHelpers = getFormHelpers<TestType>(
@@ -145,6 +162,9 @@ describe("form util functions", () => {
 				const result = getFieldHelpers("touchedBadField");
 				expect(result.error).toBeTruthy();
 				expect(result.helperText).toEqual("API error!");
+				expect(result.inputProps).toEqual({
+					"aria-errormessage": "touchedBadField-helper-text",
+				});
 			});
 		});
 	});

--- a/site/src/utils/formUtils.ts
+++ b/site/src/utils/formUtils.ts
@@ -4,6 +4,7 @@ import type {
 	ChangeEvent,
 	ChangeEventHandler,
 	FocusEventHandler,
+	InputHTMLAttributes,
 	ReactNode,
 } from "react";
 import * as Yup from "yup";
@@ -36,6 +37,13 @@ interface GetFormHelperOptions {
 	 * over the limit. Zero and negative values will be ignored.
 	 */
 	maxLength?: number;
+	/**
+	 * inputProps are merged with the computed aria-errormessage attribute and
+	 * returned as inputProps on the FormHelpers object. Use this instead of
+	 * passing inputProps directly to the input so that aria-errormessage is
+	 * not overridden.
+	 */
+	inputProps?: InputHTMLAttributes<HTMLInputElement>;
 }
 
 export interface FormHelpers {
@@ -46,6 +54,7 @@ export interface FormHelpers {
 	value?: string | number;
 	error: boolean;
 	helperText?: ReactNode;
+	inputProps?: InputHTMLAttributes<HTMLInputElement>;
 }
 
 export const getFormHelpers =
@@ -93,11 +102,22 @@ export const getFormHelpers =
 		const errorToDisplay =
 			(touched && apiError) || lengthError || (touched && formError);
 
+		const inputProps = errorToDisplay
+			? {
+					...options.inputProps,
+					// MUI sets id="${fieldName}-helper-text" on the FormHelperText
+					// element when the TextField has id="${fieldName}", so this value
+					// is always in sync with the helper text that displays the error.
+					"aria-errormessage": `${fieldName}-helper-text`,
+				}
+			: options.inputProps;
+
 		return {
 			...fieldProps,
 			id: fieldName.toString(),
 			error: Boolean(errorToDisplay),
 			helperText: errorToDisplay || helperText,
+			inputProps,
 		};
 	};
 


### PR DESCRIPTION
[aria-errormessage](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage#specifications) is an ARIA a11y attribute that can be placed on an invalid form input (with`aria-invalid="true"`). The value of the attribute is an ID that points to another element that contains the error message text. 

**Notable Changes**

- `inputProps` should now be provided to `getFieldHelpers` instead of on the component itself. This ensures we don't overwrite the `aria-errormessage` attribute
- TemplateSettingsPage.jest.tsx → TemplateSettingsPage.test.tsx (port to vitest)