### PR TITLE
chore(dogfood): update Rust from 1.86.0 to 1.93.1

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -1,5 +1,5 @@
-# 1.86.0
-FROM rust:slim@sha256:9663b80a1621253d30b146454f903de48f0af925c967be48c84745537cd35d8b AS rust-utils
+# 1.93.1
+FROM rust:slim@sha256:7e6fa79cf81be23fd45d857f75f583d80cfdbb11c91fa06180fd747fda37a61d AS rust-utils
 # Install rust helper programs
 ENV CARGO_INSTALL_ROOT=/tmp/
 # Use more reliable mirrors for Debian packages


### PR DESCRIPTION
Update the Rust Docker image in the dogfood template from 1.86.0 to 1.93.1, including the pinned `rust:slim` digest.