### PR TITLE
feat: refactor deployment `<NotificationsPage />` components

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -64,6 +64,8 @@
 		"@radix-ui/react-slider": "1.3.6",
 		"@radix-ui/react-slot": "1.2.4",
 		"@radix-ui/react-switch": "1.2.6",
+		"@radix-ui/react-toggle": "1.1.10",
+		"@radix-ui/react-toggle-group": "1.1.11",
 		"@radix-ui/react-tooltip": "1.2.8",
 		"@tanstack/react-query-devtools": "5.77.0",
 		"@xterm/addon-canvas": "0.7.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -106,6 +106,12 @@ importers:
       '@radix-ui/react-switch':
         specifier: 1.2.6
         version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@radix-ui/react-toggle':
+        specifier: 1.1.10
+        version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@radix-ui/react-toggle-group':
+        specifier: 1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
@@ -1898,6 +1904,32 @@ packages:
 
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==, tarball: https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==, tarball: https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==, tarball: https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7914,6 +7946,32 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.2)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.7)(react@19.2.2)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.7)(react@19.2.2)
+      react: 19.2.2
+      react-dom: 19.2.2(react@19.2.2)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.2)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.7)(react@19.2.2)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.2)
+      react: 19.2.2
+      react-dom: 19.2.2(react@19.2.2)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.2)
       react: 19.2.2
       react-dom: 19.2.2(react@19.2.2)
     optionalDependencies:

--- a/site/src/components/Toggle/Toggle.tsx
+++ b/site/src/components/Toggle/Toggle.tsx
@@ -1,5 +1,5 @@
 /**
- * Copied from shadc/ui on 02/27/2026
+ * Copied from shadcn/ui on 02/27/2026
  * @see {@link https://ui.shadcn.com/docs/components/toggle}
  */
 import * as TogglePrimitive from "@radix-ui/react-toggle";

--- a/site/src/components/Toggle/Toggle.tsx
+++ b/site/src/components/Toggle/Toggle.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copied from shadc/ui on 02/27/2026
+ * @see {@link https://ui.shadcn.com/docs/components/toggle}
+ */
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "utils/cn";
+
+export const toggleVariants = cva(
+	`inline-flex items-center justify-center rounded-md border border-solid border-transparent
+	text-sm font-medium transition-colors shrink-0 cursor-pointer
+	focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
+	disabled:pointer-events-none disabled:text-content-disabled
+	[&>svg]:pointer-events-none [&>svg]:shrink-0`,
+	{
+		variants: {
+			variant: {
+				default: `
+					bg-transparent text-content-secondary
+					hover:text-content-primary
+					data-[state=on]:bg-surface-invert-primary data-[state=on]:text-content-invert
+					data-[state=on]:hover:bg-surface-invert-secondary
+					`,
+				outline: `
+					border-border-default bg-transparent text-content-secondary
+					hover:text-content-primary hover:bg-surface-secondary
+					data-[state=on]:border-border-default
+					data-[state=on]:bg-surface-secondary data-[state=on]:text-content-primary
+					data-[state=on]:hover:bg-surface-secondary
+					`,
+			},
+			size: {
+				default: "h-9 px-3 [&_svg]:size-icon-sm",
+				sm: "h-7 px-2 [&_svg]:size-icon-sm",
+				lg: "h-10 px-3 [&_svg]:size-icon-lg",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	},
+);
+
+export type ToggleProps = React.ComponentPropsWithRef<
+	typeof TogglePrimitive.Root
+> &
+	VariantProps<typeof toggleVariants>;
+
+export const Toggle: React.FC<ToggleProps> = ({
+	className,
+	variant,
+	size,
+	...props
+}) => {
+	return (
+		<TogglePrimitive.Root
+			className={cn(toggleVariants({ variant, size }), className)}
+			{...props}
+		/>
+	);
+};

--- a/site/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/site/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copied from shadc/ui on 02/27/2026
+ * @see {@link https://ui.shadcn.com/docs/components/toggle-group}
+ */
+
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import type { VariantProps } from "class-variance-authority";
+import { toggleVariants } from "components/Toggle/Toggle";
+import * as React from "react";
+import { cn } from "utils/cn";
+
+const ToggleGroupContext = React.createContext<
+	VariantProps<typeof toggleVariants> & {
+		spacing?: number;
+		orientation?: "horizontal" | "vertical";
+	}
+>({
+	size: "default",
+	variant: "default",
+	spacing: 0,
+	orientation: "horizontal",
+});
+
+type ToggleGroupProps = React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+	VariantProps<typeof toggleVariants> & {
+		spacing?: number;
+		orientation?: "horizontal" | "vertical";
+	};
+
+export const ToggleGroup: React.FC<ToggleGroupProps> = ({
+	className,
+	variant,
+	size,
+	spacing = 0,
+	orientation = "horizontal",
+	children,
+	...props
+}) => {
+	return (
+		<ToggleGroupPrimitive.Root
+			style={{ gap: spacing > 0 ? `${spacing}px` : undefined }}
+			className={cn(
+				"inline-flex w-fit items-center rounded-md",
+				orientation === "vertical" ? "flex-col items-stretch" : "flex-row",
+				spacing === 0 ? "gap-0" : "",
+				className,
+			)}
+			{...props}
+		>
+			<ToggleGroupContext.Provider
+				value={{ variant, size, spacing, orientation }}
+			>
+				{children}
+			</ToggleGroupContext.Provider>
+		</ToggleGroupPrimitive.Root>
+	);
+};
+
+type ToggleGroupItemProps = React.ComponentProps<
+	typeof ToggleGroupPrimitive.Item
+> &
+	VariantProps<typeof toggleVariants>;
+
+export const ToggleGroupItem: React.FC<ToggleGroupItemProps> = ({
+	className,
+	children,
+	variant = "default",
+	size = "default",
+	...props
+}) => {
+	const context = React.useContext(ToggleGroupContext);
+	const itemVariant = context.variant || variant;
+	const itemSize = context.size || size;
+	const hasSpacing = (context.spacing || 0) > 0;
+	const isVertical = context.orientation === "vertical";
+
+	return (
+		<ToggleGroupPrimitive.Item
+			className={cn(
+				toggleVariants({ variant: itemVariant, size: itemSize }),
+				"shrink-0 focus:z-10 focus-visible:z-10",
+				!hasSpacing &&
+					(isVertical
+						? "rounded-none first:rounded-t-md last:rounded-b-md"
+						: "rounded-none first:rounded-l-md last:rounded-r-md"),
+				!hasSpacing && itemVariant === "outline"
+					? "[&:not(:first-child)]:-ml-px"
+					: "",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</ToggleGroupPrimitive.Item>
+	);
+};

--- a/site/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/site/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,5 +1,5 @@
 /**
- * Copied from shadc/ui on 02/27/2026
+ * Copied from shadcn/ui on 02/27/2026
  * @see {@link https://ui.shadcn.com/docs/components/toggle-group}
  */
 

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
@@ -108,7 +108,7 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 				>
 					<div className="flex flex-col">
 						<header className="border-0 border-b border-solid bg-surface-secondary px-4 py-3">
-							<h3 className="text-sm font-medium">{group}</h3>
+							<h3 className="text-sm font-medium my-0">{group}</h3>
 						</header>
 
 						{templates.map((tpl, i) => {
@@ -118,7 +118,7 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 							return (
 								<Fragment key={tpl.id}>
 									<div
-										className={`flex items-center justify-between gap-3 px-4 py-3 border-0 border-solid ${
+										className={`flex items-center justify-between gap-3 px-4 py-1.5 border-0 border-solid ${
 											isLastItem ? "" : "border-b"
 										}`}
 									>

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationEvents.tsx
@@ -1,11 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
-import Card from "@mui/material/Card";
-import Divider from "@mui/material/Divider";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemText, { listItemTextClasses } from "@mui/material/ListItemText";
-import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import { getErrorDetail, getErrorMessage } from "api/errors";
 import {
 	type selectTemplatesByGroup,
@@ -14,7 +6,10 @@ import {
 import type { DeploymentValues } from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
 import { Button } from "components/Button/Button";
-import { Stack } from "components/Stack/Stack";
+import {
+	ToggleGroup,
+	ToggleGroupItem,
+} from "components/ToggleGroup/ToggleGroup";
 import {
 	Tooltip,
 	TooltipContent,
@@ -65,7 +60,7 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 	]);
 
 	return (
-		<Stack spacing={4}>
+		<div className="flex flex-col gap-8">
 			{hasWebhookNotifications && !isWebhookConfigured && (
 				<Alert
 					severity="warning"
@@ -107,15 +102,14 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 			)}
 
 			{Object.entries(templatesByGroup).map(([group, templates]) => (
-				<Card
+				<article
+					className="w-full overflow-hidden rounded-lg border border-solid"
 					key={group}
-					variant="outlined"
-					css={{ background: "transparent", width: "100%" }}
 				>
-					<List>
-						<ListItem css={styles.listHeader}>
-							<ListItemText css={styles.listItemText} primary={group} />
-						</ListItem>
+					<div className="flex flex-col">
+						<header className="border-0 border-b border-solid bg-surface-secondary px-4 py-3">
+							<h3 className="text-sm font-medium">{group}</h3>
+						</header>
 
 						{templates.map((tpl, i) => {
 							const value = castNotificationMethod(tpl.method || defaultMethod);
@@ -123,25 +117,25 @@ export const NotificationEvents: FC<NotificationEventsProps> = ({
 
 							return (
 								<Fragment key={tpl.id}>
-									<ListItem>
-										<ListItemText
-											css={styles.listItemText}
-											primary={tpl.name}
-										/>
+									<div
+										className={`flex items-center justify-between gap-3 px-4 py-3 border-0 border-solid ${
+											isLastItem ? "" : "border-b"
+										}`}
+									>
+										<span className="text-sm font-medium">{tpl.name}</span>
 										<MethodToggleGroup
 											templateId={tpl.id}
 											options={availableMethods}
 											value={value}
 										/>
-									</ListItem>
-									{!isLastItem && <Divider />}
+									</div>
 								</Fragment>
 							);
 						})}
-					</List>
-				</Card>
+					</div>
+				</article>
 			))}
-		</Stack>
+		</div>
 	);
 };
 
@@ -169,16 +163,24 @@ const MethodToggleGroup: FC<MethodToggleGroupProps> = ({
 	);
 
 	return (
-		<ToggleButtonGroup
-			exclusive
+		<ToggleGroup
+			type="single"
 			value={value}
-			size="small"
+			variant="outline"
 			aria-label="Notification method"
-			css={styles.toggleGroup}
-			onChange={async (_, method) => {
+			onValueChange={async (method) => {
+				// Keep one method selected and ignore empty deselection.
+				if (!method || method === value) {
+					return;
+				}
+
+				if (!options.includes(method as NotificationMethod)) {
+					return;
+				}
+
 				try {
 					await updateMethodMutation.mutateAsync({
-						method,
+						method: method as NotificationMethod,
 					});
 					toast.success("Notification method updated.");
 				} catch (error) {
@@ -196,62 +198,19 @@ const MethodToggleGroup: FC<MethodToggleGroupProps> = ({
 				const label = methodLabels[method];
 				return (
 					<Tooltip key={method}>
-						<TooltipTrigger asChild>
-							<ToggleButton
-								value={method}
-								css={styles.toggleButton}
-								onClick={(e) => {
-									// Retain the value if the user clicks the same button, ensuring
-									// at least one value remains selected.
-									if (method === value) {
-										e.preventDefault();
-										e.stopPropagation();
-										return;
-									}
-								}}
-							>
-								<Icon aria-label={label} />
-							</ToggleButton>
-						</TooltipTrigger>
-						<TooltipContent side="bottom">{label}</TooltipContent>
+						<ToggleGroupItem value={method}>
+							<TooltipTrigger asChild>
+								<span className="inline-flex">
+									<Icon aria-label={label} />
+								</span>
+							</TooltipTrigger>
+						</ToggleGroupItem>
+						<TooltipContent side="bottom" sideOffset={8}>
+							{label}
+						</TooltipContent>
 					</Tooltip>
 				);
 			})}
-		</ToggleButtonGroup>
+		</ToggleGroup>
 	);
 };
-
-const styles = {
-	listHeader: (theme) => ({
-		background: theme.palette.background.paper,
-		borderBottom: `1px solid ${theme.palette.divider}`,
-	}),
-	listItemText: {
-		[`& .${listItemTextClasses.primary}`]: {
-			fontSize: 14,
-			fontWeight: 500,
-		},
-		[`& .${listItemTextClasses.secondary}`]: {
-			fontSize: 14,
-		},
-	},
-	toggleGroup: (theme) => ({
-		border: `1px solid ${theme.palette.divider}`,
-		borderRadius: 4,
-	}),
-	toggleButton: (theme) => ({
-		border: 0,
-		borderRadius: 4,
-		fontSize: 16,
-		padding: "4px 8px",
-		color: theme.palette.text.disabled,
-
-		"&:hover": {
-			color: theme.palette.text.primary,
-		},
-
-		"& svg": {
-			fontSize: "inherit",
-		},
-	}),
-} as Record<string, Interpolation<Theme>>;

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -1,4 +1,3 @@
-import type { Interpolation, Theme } from "@emotion/react";
 import {
 	customNotificationTemplates,
 	notificationDispatchMethods,
@@ -87,7 +86,7 @@ const NotificationsPage: FC = () => {
 				</TabsList>
 			</Tabs>
 
-			<div css={styles.content}>
+			<div className="pt-6">
 				{ready ? (
 					tabState.value === "events" ? (
 						<NotificationEvents
@@ -118,7 +117,3 @@ const NotificationsPage: FC = () => {
 };
 
 export default NotificationsPage;
-
-const styles = {
-	content: { paddingTop: 24 },
-} as Record<string, Interpolation<Theme>>;


### PR DESCRIPTION
This pull-request removes the MUI components from `<NotificationsPage />` found in the `Deployment Settings`. This required adding two new components `Toggle.tsx` and `ToggleGroup.tsx` (pending tracking in Figma).

| Old | New |
| --- | --- |
| <img width="1039" height="516" alt="OLD_NOTIFICATIONS_PAGE" src="https://github.com/user-attachments/assets/93f1db99-afa0-46e8-95ae-a1ee002d81af" /> | <img width="1039" height="517" alt="NEW_NOTIFICATIONS_PAGE" src="https://github.com/user-attachments/assets/263bae77-dc95-475f-a04b-6e4fd6c5d728" /> |
