### PR TITLE
chore(dogfood): bump Mux to 1.3.0, use next channel and bun runner

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -373,13 +373,15 @@ module "personalize" {
 }
 
 module "mux" {
-  count        = data.coder_workspace.me.start_count
-  source       = "registry.coder.com/coder/mux/coder"
-  version      = "1.1.0"
-  agent_id     = coder_agent.dev.id
-  subdomain    = true
-  display_name = "Mux"
-  add-project  = local.repo_dir
+  count           = data.coder_workspace.me.start_count
+  source          = "registry.coder.com/coder/mux/coder"
+  version         = "1.3.0"
+  agent_id        = coder_agent.dev.id
+  subdomain       = true
+  display_name    = "Mux"
+  add-project     = local.repo_dir
+  install_version = "next"
+  runner          = "bun"
 }
 
 module "code-server" {

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -381,7 +381,7 @@ module "mux" {
   display_name    = "Mux"
   add-project     = local.repo_dir
   install_version = "next"
-  runner          = "bun"
+  package_manager = "bun"
 }
 
 module "code-server" {


### PR DESCRIPTION
Bump the Mux module in the dogfood template:

- Version: 1.1.0 → 1.3.0
- `install_version`: set to `"next"`
- `package_manager`: set to `"bun"`