### PR TITLE
fix: center `view raw logs` button in `<WorkspaceBuildPage />`

### DIFF
--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -179,7 +179,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 								href={`/api/v2/workspacebuilds/${build.id}/logs?format=text`}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="flex items-center gap-1 px-4 pb-2 text-xs text-content-secondary hover:text-content-primary"
+								className="flex items-center gap-1 px-4 text-xs text-content-secondary hover:text-content-primary"
 							>
 								View raw logs
 								<ExternalLinkIcon className="size-3" />
@@ -190,7 +190,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 								href={`/api/v2/workspaceagents/${selectedAgent.id}/logs?format=text`}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="flex items-center gap-1 px-4 pb-2 text-xs text-content-secondary hover:text-content-primary"
+								className="flex items-center gap-1 px-4 text-xs text-content-secondary hover:text-content-primary"
 							>
 								View raw logs
 								<ExternalLinkIcon className="size-3" />


### PR DESCRIPTION
This pull-request resolves the location of `View Raw Logs` in `<WorkspaceBuildPage />`. It wasn't properly centred before due to some odd-padding.

| Old | New |
| --- | --- |
| <img width="304" height="210" alt="OLD_VIEW_RAW_LOGS" src="https://github.com/user-attachments/assets/80a5aa61-8d01-48eb-91c0-df61dd59d1fb" /> | <img width="310" height="210" alt="NEW_VIEW_RAW_LOGS" src="https://github.com/user-attachments/assets/8649a478-993d-4cd2-98bb-f503e0f22a5c" /> |