### PR TITLE
fix: marshal `convertLicenses()` into a `[]` instead of `nil`

### DIFF
--- a/enterprise/coderd/licenses.go
+++ b/enterprise/coderd/licenses.go
@@ -349,7 +349,7 @@ func convertLicense(dl database.License, c jwt.MapClaims) codersdk.License {
 }
 
 func convertLicenses(licenses []database.License) ([]codersdk.License, error) {
-	var out []codersdk.License
+	out := make([]codersdk.License, 0, len(licenses))
 	for _, l := range licenses {
 		c, err := decodeClaims(l)
 		if err != nil {

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -134,7 +134,7 @@ const LicensesSettingsPageView: FC<Props> = ({
 					</Stack>
 				)}
 
-				{!isLoading && licenses === null && (
+				{!isLoading && licenses?.length === 0 && (
 					<div css={styles.root}>
 						<Stack alignItems="center" spacing={1}>
 							<Stack alignItems="center" spacing={0.5}>


### PR DESCRIPTION
This was a bad smell that was being addressed by the frontend. This type was generating out to be a `nil`/`null` instead of an empty `License[]`. Now this returns as an empty array and we can actively check if we have no licenses with a length of `0`.