### PR TITLE
fix: restore dividing line in `<BuildParametersPopover />`

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/BuildParametersPopover.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/BuildParametersPopover.tsx
@@ -145,14 +145,14 @@ const BuildParametersPopoverContent: FC<BuildParametersPopoverContentProps> = ({
 		<>
 			{buildParameters && ephemeralParameters ? (
 				ephemeralParameters.length > 0 ? (
-					<>
+					<div className="divide-y">
 						<div className="p-5 text-content-secondary">
 							<HelpTooltipTitle>Build Options</HelpTooltipTitle>
 							<HelpTooltipText>
 								These parameters only apply for a single workspace start.
 							</HelpTooltipText>
 						</div>
-						<div className="p-5">
+						<div className="border-0 border-solid p-5">
 							<Form
 								onSubmit={(buildParameters) => {
 									onSubmit(buildParameters);
@@ -167,7 +167,7 @@ const BuildParametersPopoverContent: FC<BuildParametersPopoverContentProps> = ({
 								)}
 							/>
 						</div>
-					</>
+					</div>
 				) : (
 					<div className="p-5 text-content-secondary">
 						<HelpTooltipTitle>Build Options</HelpTooltipTitle>


### PR DESCRIPTION
Related to #22367 

It was pointed out to me that we actually did regress this mildly by removing a dividing line in the changes made in #22367, I've restored this in a better way by taking advantage of `divide-y` and wrapping this in a proper `<div />`.

<img width="332" height="385" alt="image" src="https://github.com/user-attachments/assets/2827a9ae-7b54-4c48-aae9-2f6e965e7f8b" />
