### PR TITLE
fix: resolve double border on `<WorkspaceBuildPageView />`

### DIFF
--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -151,7 +151,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
 				</Sidebar>
 
 				<ScrollArea>
-					<div className="flex items-center justify-between border-b border-solid border-border">
+					<div className="flex items-center justify-between border-0 border-b border-solid border-border">
 						<Tabs active={tabState.value}>
 							<TabsList className="gap-0">
 								<TabLink


### PR DESCRIPTION
Not sure how I didn't see this before in #22362 , theres a sneaky double border which makes things slightly thicker than we would expect. This border should only be showing with the `border-b` and we forget to reset down to `border-0` first.

<img width="1253" height="109" alt="image" src="https://github.com/user-attachments/assets/4b31f5bd-e48b-48d8-a0a3-abeac3d6720b" />
<img width="1244" height="199" alt="image" src="https://github.com/user-attachments/assets/01c2567e-e723-47ea-a5cc-ed8e025df5d0" />