### PR TITLE
feat(site): add TextareaField component and migrate MUI multiline TextFields

### DIFF
--- a/site/src/components/Textarea/TextareaField.stories.tsx
+++ b/site/src/components/Textarea/TextareaField.stories.tsx
@@ -97,3 +97,38 @@ export const FormIntegration: Story = {
 		fullWidth: true,
 	},
 };
+
+export const MuiVariant: Story = {
+	args: {
+		variant: "mui",
+		id: "description",
+		label: "Description",
+		defaultValue: "An organization that gets used for stuff.",
+		fullWidth: true,
+		rows: 2,
+	},
+};
+
+export const MuiVariantWithHelperText: Story = {
+	args: {
+		variant: "mui",
+		id: "message",
+		label: "Message",
+		helperText: "Markdown bold, italics, and links are supported.",
+		placeholder: "Enter a message for the banner",
+		fullWidth: true,
+	},
+};
+
+export const MuiVariantWithError: Story = {
+	args: {
+		variant: "mui",
+		id: "description",
+		label: "Description",
+		error: true,
+		helperText: "Description must be at most 128 characters.",
+		defaultValue:
+			"This value is too long and has triggered a validation error.",
+		fullWidth: true,
+	},
+};

--- a/site/src/components/Textarea/TextareaField.stories.tsx
+++ b/site/src/components/Textarea/TextareaField.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TextareaField } from "./TextareaField";
+
+const meta: Meta<typeof TextareaField> = {
+	title: "components/TextareaField",
+	component: TextareaField,
+	args: {},
+	argTypes: {
+		label: {
+			control: "text",
+			description: "Label rendered above the textarea",
+		},
+		error: {
+			control: "boolean",
+			description: "When true, applies destructive styling to the field",
+		},
+		helperText: {
+			control: "text",
+			description: "Text rendered below the textarea",
+		},
+		fullWidth: {
+			control: "boolean",
+			description: "When true, the field spans the full width of its container",
+		},
+		disabled: {
+			control: "boolean",
+			description:
+				"When true, prevents the user from interacting with the textarea",
+		},
+		placeholder: {
+			control: "text",
+			description: "Placeholder text displayed when the textarea is empty",
+		},
+		rows: {
+			control: "number",
+			description: "The number of rows to display",
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof TextareaField>;
+
+export const WithLabel: Story = {
+	args: {
+		label: "Description",
+		placeholder: "Enter a description...",
+	},
+};
+
+export const WithHelperText: Story = {
+	args: {
+		label: "Message",
+		helperText: "Markdown bold, italics, and links are supported.",
+		placeholder: "Enter your message...",
+	},
+};
+
+export const WithError: Story = {
+	args: {
+		label: "Description",
+		error: true,
+		helperText: "Description must be at most 128 characters.",
+		defaultValue:
+			"This value is too long and has triggered a validation error.",
+	},
+};
+
+export const FullWidth: Story = {
+	args: {
+		label: "Description",
+		helperText: "A short description of your template.",
+		placeholder: "Enter a description...",
+		fullWidth: true,
+		rows: 2,
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		label: "Message",
+		placeholder: "Enter a message...",
+		disabled: true,
+	},
+};
+
+export const FormIntegration: Story = {
+	args: {
+		// Simulates props injected by getFormHelpers()
+		name: "description",
+		id: "description",
+		value: "My workspace template",
+		error: false,
+		helperText: undefined,
+		label: "Description",
+		rows: 5,
+		fullWidth: true,
+	},
+};

--- a/site/src/components/Textarea/TextareaField.test.tsx
+++ b/site/src/components/Textarea/TextareaField.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { TextareaField } from "./TextareaField";
+
+describe("TextareaField", () => {
+	it("renders a textarea element", () => {
+		render(<TextareaField />);
+		expect(screen.getByRole("textbox")).toBeInTheDocument();
+	});
+
+	it("renders a label associated with the textarea", () => {
+		render(<TextareaField id="desc" label="Description" />);
+		const label = screen.getByText("Description");
+		expect(label.tagName).toBe("LABEL");
+		expect(label).toHaveAttribute("for", "desc");
+		expect(screen.getByLabelText("Description")).toBeInTheDocument();
+	});
+
+	it("does not render a label element when label is omitted", () => {
+		render(<TextareaField />);
+		expect(screen.queryByRole("label")).not.toBeInTheDocument();
+	});
+
+	it("renders helper text below the textarea", () => {
+		render(<TextareaField helperText="Markdown is supported." />);
+		expect(screen.getByText("Markdown is supported.")).toBeInTheDocument();
+	});
+
+	it("applies error styling to label and helper text when error is true", () => {
+		render(
+			<TextareaField id="msg" label="Message" error helperText="Required." />,
+		);
+		expect(screen.getByText("Message")).toHaveClass("text-content-destructive");
+		expect(screen.getByText("Required.")).toHaveClass(
+			"text-content-destructive",
+		);
+	});
+
+	it("does not apply error styling when error is false", () => {
+		render(
+			<TextareaField
+				id="msg"
+				label="Message"
+				error={false}
+				helperText="Optional note."
+			/>,
+		);
+		expect(screen.getByText("Message")).not.toHaveClass(
+			"text-content-destructive",
+		);
+		expect(screen.getByText("Optional note.")).not.toHaveClass(
+			"text-content-destructive",
+		);
+	});
+
+	it("sets aria-invalid and aria-errormessage when error is true", () => {
+		render(
+			<TextareaField id="msg" error helperText="This field is required." />,
+		);
+		const textarea = screen.getByRole("textbox");
+		expect(textarea).toHaveAttribute("aria-invalid", "true");
+		expect(textarea).toHaveAttribute("aria-errormessage", "msg-helper-text");
+		expect(textarea).not.toHaveAttribute("aria-describedby");
+	});
+
+	it("sets aria-describedby to the helper text when there is no error", () => {
+		render(
+			<TextareaField
+				id="msg"
+				error={false}
+				helperText="Markdown is supported."
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		expect(textarea).not.toHaveAttribute("aria-invalid");
+		expect(textarea).toHaveAttribute("aria-describedby", "msg-helper-text");
+		expect(textarea).not.toHaveAttribute("aria-errormessage");
+	});
+
+	it("gives the helper text element a matching id", () => {
+		render(<TextareaField id="msg" helperText="Some helper text." />);
+		expect(screen.getByText("Some helper text.")).toHaveAttribute(
+			"id",
+			"msg-helper-text",
+		);
+	});
+
+	it("passes through standard textarea props", () => {
+		render(
+			<TextareaField
+				name="licenseKey"
+				placeholder="Enter your license..."
+				rows={3}
+				defaultValue="hello"
+			/>,
+		);
+		const textarea = screen.getByRole("textbox");
+		expect(textarea).toHaveAttribute("name", "licenseKey");
+		expect(textarea).toHaveAttribute("placeholder", "Enter your license...");
+		expect(textarea).toHaveAttribute("rows", "3");
+		expect(textarea).toHaveValue("hello");
+	});
+
+	it("disables the textarea when disabled is true", () => {
+		render(<TextareaField disabled />);
+		expect(screen.getByRole("textbox")).toBeDisabled();
+	});
+});

--- a/site/src/components/Textarea/TextareaField.tsx
+++ b/site/src/components/Textarea/TextareaField.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { cn } from "utils/cn";
+import { Textarea } from "./Textarea";
+
+interface TextareaFieldProps extends React.ComponentPropsWithRef<"textarea"> {
+	label?: string;
+	error?: boolean;
+	helperText?: ReactNode;
+	fullWidth?: boolean;
+}
+
+export const TextareaField: React.FC<TextareaFieldProps> = ({
+	label,
+	error,
+	helperText,
+	fullWidth,
+	id,
+	className,
+	...textareaProps
+}) => {
+	const helperTextId = id && helperText ? `${id}-helper-text` : undefined;
+
+	return (
+		<div className={cn("flex flex-col gap-1.5", fullWidth && "w-full")}>
+			{label && (
+				<label
+					htmlFor={id}
+					className={cn(
+						"text-sm font-medium",
+						error ? "text-content-destructive" : "text-content-primary",
+					)}
+				>
+					{label}
+				</label>
+			)}
+			<Textarea
+				id={id}
+				aria-invalid={error || undefined}
+				aria-errormessage={error ? helperTextId : undefined}
+				aria-describedby={!error ? helperTextId : undefined}
+				className={cn(
+					error &&
+						"border-border-destructive focus-visible:ring-content-destructive",
+					className,
+				)}
+				{...textareaProps}
+			/>
+			{helperText && (
+				<p
+					id={helperTextId}
+					className={cn(
+						"text-xs",
+						error ? "text-content-destructive" : "text-content-secondary",
+					)}
+				>
+					{helperText}
+				</p>
+			)}
+		</div>
+	);
+};

--- a/site/src/components/Textarea/TextareaField.tsx
+++ b/site/src/components/Textarea/TextareaField.tsx
@@ -1,8 +1,137 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import type { ReactNode } from "react";
 import { cn } from "utils/cn";
 import { Textarea } from "./Textarea";
 
-interface TextareaFieldProps extends React.ComponentPropsWithRef<"textarea"> {
+const labelVariants = cva("text-sm font-medium", {
+	variants: {
+		error: {
+			true: "text-content-destructive",
+			false: "text-content-primary",
+		},
+	},
+	defaultVariants: { error: false },
+});
+
+const textareaVariants = cva("", {
+	variants: {
+		error: {
+			true: "border-border-destructive focus-visible:ring-content-destructive",
+			false: "",
+		},
+	},
+	defaultVariants: { error: false },
+});
+
+const helperTextVariants = cva("text-xs", {
+	variants: {
+		error: {
+			true: "text-content-destructive",
+			false: "text-content-secondary",
+		},
+	},
+	defaultVariants: { error: false },
+});
+
+interface SharedProps {
+	label?: string;
+	error?: boolean;
+	helperText?: ReactNode;
+	fullWidth?: boolean;
+	id?: string;
+	helperTextId?: string;
+	className?: string;
+}
+
+// Replicates MUI's outlined + floating-label style. Uses a native <fieldset>
+// with a visible <legend> so the browser naturally centers the label on the
+// border without any transform magic — it scales cleanly with text size.
+const MuiTextareaField: React.FC<
+	SharedProps & React.ComponentPropsWithRef<"textarea">
+> = ({
+	label,
+	error,
+	helperText,
+	fullWidth,
+	id,
+	helperTextId,
+	className,
+	...textareaProps
+}) => {
+	return (
+		<div className={cn("flex flex-col gap-1.5", fullWidth && "w-full")}>
+			{/* The fieldset border doubles as the outlined input border; the
+			    browser draws the legend notch automatically. */}
+			<fieldset
+				className={cn(
+					"group m-0 rounded-lg border border-solid p-0",
+					error
+						? "border-border-destructive"
+						: "border-border focus-within:border-2 focus-within:border-content-link",
+				)}
+			>
+				{label && (
+					<legend
+						className={cn(
+							"ml-3 px-1 text-xs font-medium leading-none",
+							error
+								? "text-content-destructive"
+								: "text-content-secondary group-focus-within:text-content-link",
+						)}
+					>
+						{/* <label> inside <legend> provides click-to-focus and
+						    proper form accessibility without extra ARIA. */}
+						<label htmlFor={id} className="cursor-pointer">
+							{label}
+						</label>
+					</legend>
+				)}
+
+				<Textarea
+					id={id}
+					aria-invalid={error || undefined}
+					aria-errormessage={error ? helperTextId : undefined}
+					aria-describedby={!error ? helperTextId : undefined}
+					className={cn(
+						// The fieldset provides the visual border; suppress the
+						// default Textarea border, shadow, and focus ring.
+						"border-none shadow-none focus-visible:ring-0",
+						"w-full px-[14px] py-[16.5px] text-base",
+						className,
+					)}
+					{...textareaProps}
+				/>
+			</fieldset>
+
+			{helperText && (
+				<p
+					id={helperTextId}
+					className={helperTextVariants({ error: error ?? false })}
+				>
+					{helperText}
+				</p>
+			)}
+		</div>
+	);
+};
+
+// Variants for the default (coderkit) layout.
+const wrapperVariants = cva("flex flex-col", {
+	variants: {
+		variant: {
+			default: "gap-1.5",
+			// mui uses a separate internal component — see MuiTextareaField above.
+			mui: "",
+		},
+	},
+	defaultVariants: { variant: "default" },
+});
+
+type TextareaFieldVariantProps = VariantProps<typeof wrapperVariants>;
+
+export interface TextareaFieldProps
+	extends React.ComponentPropsWithRef<"textarea">,
+		TextareaFieldVariantProps {
 	label?: string;
 	error?: boolean;
 	helperText?: ReactNode;
@@ -10,6 +139,7 @@ interface TextareaFieldProps extends React.ComponentPropsWithRef<"textarea"> {
 }
 
 export const TextareaField: React.FC<TextareaFieldProps> = ({
+	variant,
 	label,
 	error,
 	helperText,
@@ -20,15 +150,28 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
 }) => {
 	const helperTextId = id && helperText ? `${id}-helper-text` : undefined;
 
+	if (variant === "mui") {
+		return (
+			<MuiTextareaField
+				label={label}
+				error={error}
+				helperText={helperText}
+				fullWidth={fullWidth}
+				id={id}
+				helperTextId={helperTextId}
+				className={className}
+				{...textareaProps}
+			/>
+		);
+	}
+
+	// Default (coderkit style) label above, border on the textarea itself.
 	return (
-		<div className={cn("flex flex-col gap-1.5", fullWidth && "w-full")}>
+		<div className={cn(wrapperVariants({ variant }), fullWidth && "w-full")}>
 			{label && (
 				<label
 					htmlFor={id}
-					className={cn(
-						"text-sm font-medium",
-						error ? "text-content-destructive" : "text-content-primary",
-					)}
+					className={labelVariants({ error: error ?? false })}
 				>
 					{label}
 				</label>
@@ -38,20 +181,13 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
 				aria-invalid={error || undefined}
 				aria-errormessage={error ? helperTextId : undefined}
 				aria-describedby={!error ? helperTextId : undefined}
-				className={cn(
-					error &&
-						"border-border-destructive focus-visible:ring-content-destructive",
-					className,
-				)}
+				className={cn(textareaVariants({ error: error ?? false }), className)}
 				{...textareaProps}
 			/>
 			{helperText && (
 				<p
 					id={helperTextId}
-					className={cn(
-						"text-xs",
-						error ? "text-content-destructive" : "text-content-secondary",
-					)}
+					className={helperTextVariants({ error: error ?? false })}
 				>
 					{helperText}
 				</p>

--- a/site/src/components/Textarea/TextareaField.tsx
+++ b/site/src/components/Textarea/TextareaField.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { cn } from "utils/cn";
 import { Textarea } from "./Textarea";
 
@@ -148,6 +148,11 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
 	className,
 	...textareaProps
 }) => {
+	// hooks must be called unconditionally, so we generate an ID even if we
+	// don't end up using it
+	const fallbackId = useId();
+	const resolvedId = id || fallbackId;
+
 	const helperTextId = id && helperText ? `${id}-helper-text` : undefined;
 
 	if (variant === "mui") {
@@ -170,14 +175,14 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
 		<div className={cn(wrapperVariants({ variant }), fullWidth && "w-full")}>
 			{label && (
 				<label
-					htmlFor={id}
+					htmlFor={resolvedId}
 					className={labelVariants({ error: error ?? false })}
 				>
 					{label}
 				</label>
 			)}
 			<Textarea
-				id={id}
+				id={resolvedId}
 				aria-invalid={error || undefined}
 				aria-errormessage={error ? helperTextId : undefined}
 				aria-describedby={!error ? helperTextId : undefined}

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -22,6 +22,7 @@ import {
 import { IconField } from "components/IconField/IconField";
 import { OrganizationAutocomplete } from "components/OrganizationAutocomplete/OrganizationAutocomplete";
 import { Spinner } from "components/Spinner/Spinner";
+import { TextareaField } from "components/Textarea/TextareaField";
 import { useFormik } from "formik";
 import camelCase from "lodash/camelCase";
 import capitalize from "lodash/capitalize";
@@ -303,13 +304,12 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 						label="Display name"
 					/>
 
-					<TextField
+					<TextareaField
 						{...getFieldHelpers("description", {
 							maxLength: MAX_DESCRIPTION_CHAR_LIMIT,
 						})}
 						disabled={isSubmitting}
 						rows={5}
-						multiline
 						fullWidth
 						label="Description"
 					/>

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -305,6 +305,7 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 					/>
 
 					<TextareaField
+						variant="mui"
 						{...getFieldHelpers("description", {
 							maxLength: MAX_DESCRIPTION_CHAR_LIMIT,
 						})}

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
@@ -54,6 +54,7 @@ export const AnnouncementBannerDialog: FC<AnnouncementBannerDialogProps> = ({
 					<div>
 						<h4 css={styles.settingName}>Message</h4>
 						<TextareaField
+							variant="mui"
 							{...bannerFieldHelpers("message", {
 								helperText: "Markdown bold, italics, and links are supported.",
 							})}

--- a/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
+++ b/site/src/pages/DeploymentSettingsPage/AppearanceSettingsPage/AnnouncementBannerDialog.tsx
@@ -1,10 +1,10 @@
 import { type Interpolation, type Theme, useTheme } from "@emotion/react";
 import DialogActions from "@mui/material/DialogActions";
-import TextField from "@mui/material/TextField";
 import type { BannerConfig } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import { Dialog, DialogActionButtons } from "components/Dialogs/Dialog";
 import { Stack } from "components/Stack/Stack";
+import { TextareaField } from "components/Textarea/TextareaField";
 import { useFormik } from "formik";
 import { AnnouncementBannerView } from "modules/dashboard/AnnouncementBanners/AnnouncementBannerView";
 import { type FC, useState } from "react";
@@ -53,16 +53,13 @@ export const AnnouncementBannerDialog: FC<AnnouncementBannerDialogProps> = ({
 				<Stack>
 					<div>
 						<h4 css={styles.settingName}>Message</h4>
-						<TextField
+						<TextareaField
 							{...bannerFieldHelpers("message", {
 								helperText: "Markdown bold, italics, and links are supported.",
 							})}
 							fullWidth
-							multiline
-							inputProps={{
-								"aria-label": "Message",
-								placeholder: "Enter a message for the banner",
-							}}
+							aria-label="Message"
+							placeholder="Enter a message for the banner"
 						/>
 					</div>
 					<div>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
@@ -1,4 +1,3 @@
-import TextField from "@mui/material/TextField";
 import { getErrorDetail } from "api/errors";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Button } from "components/Button/Button";
@@ -9,6 +8,7 @@ import {
 	SettingsHeaderTitle,
 } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
+import { TextareaField } from "components/Textarea/TextareaField";
 import { ChevronLeftIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link as RouterLink } from "react-router";
@@ -103,10 +103,9 @@ export const AddNewLicensePageView: FC<AddNewLicenseProps> = ({
 						</Button>
 					}
 				>
-					<TextField
+					<TextareaField
 						name="licenseKey"
 						placeholder="Enter your license..."
-						multiline
 						rows={3}
 						fullWidth
 					/>

--- a/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
@@ -104,6 +104,7 @@ export const AddNewLicensePageView: FC<AddNewLicenseProps> = ({
 					}
 				>
 					<TextareaField
+						variant="mui"
 						name="licenseKey"
 						placeholder="Enter your license..."
 						rows={3}

--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
@@ -146,6 +146,7 @@ export const CreateOrganizationPageView: FC<
 										label="Display name"
 									/>
 									<TextareaField
+										variant="mui"
 										{...getFieldHelpers("description")}
 										label="Description"
 										rows={2}

--- a/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/CreateOrganizationPageView.tsx
@@ -9,6 +9,7 @@ import { IconField } from "components/IconField/IconField";
 import { PaywallPremium } from "components/Paywall/PaywallPremium";
 import { PopoverPaywall } from "components/Paywall/PopoverPaywall";
 import { Spinner } from "components/Spinner/Spinner";
+import { TextareaField } from "components/Textarea/TextareaField";
 import {
 	Tooltip,
 	TooltipContent,
@@ -144,9 +145,8 @@ export const CreateOrganizationPageView: FC<
 										fullWidth
 										label="Display name"
 									/>
-									<TextField
+									<TextareaField
 										{...getFieldHelpers("description")}
-										multiline
 										label="Description"
 										rows={2}
 									/>

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
@@ -122,6 +122,7 @@ export const OrganizationSettingsPageView: FC<
 								label="Display name"
 							/>
 							<TextareaField
+								variant="mui"
 								{...getFieldHelpers("description")}
 								fullWidth
 								label="Description"

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.tsx
@@ -21,6 +21,7 @@ import {
 	SettingsHeaderTitle,
 } from "components/SettingsHeader/SettingsHeader";
 import { Spinner } from "components/Spinner/Spinner";
+import { TextareaField } from "components/Textarea/TextareaField";
 import { useFormik } from "formik";
 import { type FC, useState } from "react";
 import {
@@ -120,9 +121,8 @@ export const OrganizationSettingsPageView: FC<
 								fullWidth
 								label="Display name"
 							/>
-							<TextField
+							<TextareaField
 								{...getFieldHelpers("description")}
-								multiline
 								fullWidth
 								label="Description"
 								rows={2}

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -140,6 +140,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 					/>
 
 					<TextareaField
+						variant="mui"
 						{...getFieldHelpers("description", {
 							maxLength: MAX_DESCRIPTION_CHAR_LIMIT,
 						})}

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -25,6 +25,7 @@ import {
 	StackLabel,
 	StackLabelHelperText,
 } from "components/StackLabel/StackLabel";
+import { TextareaField } from "components/Textarea/TextareaField";
 import { type FormikTouched, useFormik } from "formik";
 import type { FC } from "react";
 import { docs } from "utils/docs";
@@ -138,11 +139,10 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 						label="Display name"
 					/>
 
-					<TextField
+					<TextareaField
 						{...getFieldHelpers("description", {
 							maxLength: MAX_DESCRIPTION_CHAR_LIMIT,
 						})}
-						multiline
 						disabled={isSubmitting}
 						fullWidth
 						label="Description"

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -5,6 +5,7 @@ import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import type { DialogProps } from "components/Dialogs/Dialog";
 import { FormFields } from "components/Form/Form";
 import { Stack } from "components/Stack/Stack";
+import { TextareaField } from "components/Textarea/TextareaField";
 import { useFormik } from "formik";
 import type { PublishVersionData } from "pages/TemplateVersionEditorPage/types";
 import type { FC } from "react";
@@ -93,12 +94,11 @@ export const PublishTemplateVersionDialog: FC<
 								disabled={isPublishing}
 							/>
 
-							<TextField
+							<TextareaField
 								{...getFieldHelpers("message")}
 								label="Message"
 								placeholder={Language.messagePlaceholder}
 								disabled={isPublishing}
-								multiline
 								rows={5}
 							/>
 

--- a/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/PublishTemplateVersionDialog.tsx
@@ -95,6 +95,7 @@ export const PublishTemplateVersionDialog: FC<
 							/>
 
 							<TextareaField
+								variant="mui"
 								{...getFieldHelpers("message")}
 								label="Message"
 								placeholder={Language.messagePlaceholder}


### PR DESCRIPTION
Introduces `TextareaField`, a composite form field wrapping the existing `Textarea` component with optional label, error state, and helper text. Includes `aria-invalid`, `aria-errormessage`, and `aria-describedby` for accessibility. Migrates all 7 MUI TextField + multiline usages to the new component.

Co-Authored-By: Claude Sonnet 4.6