### PR TITLE
feat: implement error message on failure to popup

### DIFF
--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -3,6 +3,7 @@ import type {
 	WorkspaceAgent,
 	WorkspaceApp,
 } from "api/typesGenerated";
+import { toast } from "sonner";
 
 // This is a magic undocumented string that is replaced
 // with a brand-new session token from the backend.
@@ -79,7 +80,12 @@ export const getTerminalHref = ({
 };
 
 export const openAppInNewWindow = (href: string) => {
-	window.open(href, "_blank", "width=900,height=600");
+	const popup = window.open(href, "_blank", "width=900,height=600");
+	if (!popup) {
+		toast.error("Failed to open app in new window.", {
+			description: "Popup blocked. Allow popups to open this app.",
+		});
+	}
 };
 
 type GetAppHrefParams = {


### PR DESCRIPTION
This change adds user-facing feedback when opening apps in a new window fails due to popup blocking, replacing a silent no-op with a clear recovery message. It improves reliability and supportability across app-launch flows by helping users immediately understand and fix the issue.