### PR TITLE
feat: add Mux icon to client column in AI Bridge request log page

### DIFF
--- a/docs/ai-coder/ai-bridge/monitoring.md
+++ b/docs/ai-coder/ai-bridge/monitoring.md
@@ -39,6 +39,7 @@ Available query filters:
   - `GitHub Copilot (VS Code)`
   - `GitHub Copilot (CLI)`
   - `Kilo Code`
+  - `Mux`
   - `Roo Code`
   - `Cursor`
   - `Unknown`

--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
@@ -43,6 +43,13 @@ export const AIBridgeClientIcon = ({
 					className={cn(iconClassName, className)}
 				/>
 			);
+		case "Mux":
+			return (
+				<ExternalImage
+					src="/icon/mux.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
 		case "Zed":
 			return (
 				<ExternalImage


### PR DESCRIPTION
Adds Mux to the recognized clients list in AI Bridge documentation.

Adds Mux icon to AI Bridge requests log page:
<img width="1886" height="848" alt="image" src="https://github.com/user-attachments/assets/e7cb8d47-595c-4be3-93c9-00dbea3d1153" />

Fixes: https://github.com/coder/aibridge/issues/193