### PR TITLE
fix(stringutil): operate on runes instead of bytes in Truncate

### DIFF
--- a/coderd/taskname/taskname.go
+++ b/coderd/taskname/taskname.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
@@ -109,6 +111,16 @@ func getAnthropicModelFromEnv() anthropic.Model {
 	return anthropic.Model(os.Getenv("ANTHROPIC_MODEL"))
 }
 
+// capitalize returns s with its first rune upper-cased. It is safe for
+// multi-byte UTF-8 characters, unlike naive byte-slicing approaches.
+func capitalize(s string) string {
+	r, size := utf8.DecodeRuneInString(s)
+	if size == 0 {
+		return s
+	}
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
 // generateSuffix generates a random hex string between `0000` and `ffff`.
 func generateSuffix() string {
 	numMin := 0x00000
@@ -177,7 +189,7 @@ func generateFromPrompt(prompt string) (TaskName, error) {
 		// Ensure display name is never empty
 		displayName = strings.ReplaceAll(name, "-", " ")
 	}
-	displayName = strings.ToUpper(displayName[:1]) + displayName[1:]
+	displayName = capitalize(displayName)
 
 	return TaskName{
 		Name:        taskName,
@@ -269,7 +281,7 @@ func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, mo
 		// Ensure display name is never empty
 		displayName = strings.ReplaceAll(taskNameResponse.Name, "-", " ")
 	}
-	displayName = strings.ToUpper(displayName[:1]) + displayName[1:]
+	displayName = capitalize(displayName)
 
 	return TaskName{
 		Name:        name,

--- a/coderd/taskname/taskname.go
+++ b/coderd/taskname/taskname.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
@@ -111,16 +109,6 @@ func getAnthropicModelFromEnv() anthropic.Model {
 	return anthropic.Model(os.Getenv("ANTHROPIC_MODEL"))
 }
 
-// capitalize returns s with its first rune upper-cased. It is safe for
-// multi-byte UTF-8 characters, unlike naive byte-slicing approaches.
-func capitalize(s string) string {
-	r, size := utf8.DecodeRuneInString(s)
-	if size == 0 {
-		return s
-	}
-	return string(unicode.ToUpper(r)) + s[size:]
-}
-
 // generateSuffix generates a random hex string between `0000` and `ffff`.
 func generateSuffix() string {
 	numMin := 0x00000
@@ -189,7 +177,7 @@ func generateFromPrompt(prompt string) (TaskName, error) {
 		// Ensure display name is never empty
 		displayName = strings.ReplaceAll(name, "-", " ")
 	}
-	displayName = capitalize(displayName)
+	displayName = strutil.Capitalize(displayName)
 
 	return TaskName{
 		Name:        taskName,
@@ -281,7 +269,7 @@ func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, mo
 		// Ensure display name is never empty
 		displayName = strings.ReplaceAll(taskNameResponse.Name, "-", " ")
 	}
-	displayName = capitalize(displayName)
+	displayName = strutil.Capitalize(displayName)
 
 	return TaskName{
 		Name:        name,

--- a/coderd/taskname/taskname_test.go
+++ b/coderd/taskname/taskname_test.go
@@ -49,6 +49,19 @@ func TestGenerate(t *testing.T) {
 		require.NotEmpty(t, taskName.DisplayName)
 	})
 
+	t.Run("FromPromptMultiByte", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		taskName := taskname.Generate(ctx, testutil.Logger(t), "über cool feature")
+
+		require.NoError(t, codersdk.NameValid(taskName.Name))
+		require.True(t, len(taskName.DisplayName) > 0)
+		// The display name must start with "Ü", not corrupted bytes.
+		require.Equal(t, "Über cool feature", taskName.DisplayName)
+	})
+
 	t.Run("Fallback", func(t *testing.T) {
 		// Ensure no API key
 		t.Setenv("ANTHROPIC_API_KEY", "")

--- a/coderd/util/strings/strings.go
+++ b/coderd/util/strings/strings.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/acarl005/stripansi"
 	"github.com/microcosm-cc/bluemonday"
@@ -126,4 +127,14 @@ func UISanitize(in string) string {
 		}
 	}
 	return strings.TrimSpace(b.String())
+}
+
+// Capitalize returns s with its first rune upper-cased. It is safe for
+// multi-byte UTF-8 characters, unlike naive byte-slicing approaches.
+func Capitalize(s string) string {
+	r, size := utf8.DecodeRuneInString(s)
+	if size == 0 {
+		return s
+	}
+	return string(unicode.ToUpper(r)) + s[size:]
 }

--- a/coderd/util/strings/strings.go
+++ b/coderd/util/strings/strings.go
@@ -53,7 +53,7 @@ const (
 	TruncateWithFullWords TruncateOption = 1 << 1
 )
 
-// Truncate truncates s to n characters.
+// Truncate truncates s to n runes.
 // Additional behaviors can be specified using TruncateOptions.
 func Truncate(s string, n int, opts ...TruncateOption) string {
 	var options TruncateOption
@@ -63,7 +63,8 @@ func Truncate(s string, n int, opts ...TruncateOption) string {
 	if n < 1 {
 		return ""
 	}
-	if len(s) <= n {
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
 
@@ -72,18 +73,18 @@ func Truncate(s string, n int, opts ...TruncateOption) string {
 		maxLen--
 	}
 	var sb strings.Builder
-	// If we need to truncate to full words, find the last word boundary before n.
 	if options&TruncateWithFullWords != 0 {
-		lastWordBoundary := strings.LastIndexFunc(s[:maxLen], unicode.IsSpace)
+		// Convert the rune-safe prefix to a string, then find
+		// the last word boundary (byte offset within that prefix).
+		truncated := string(runes[:maxLen])
+		lastWordBoundary := strings.LastIndexFunc(truncated, unicode.IsSpace)
 		if lastWordBoundary < 0 {
-			// We cannot find a word boundary. At this point, we'll truncate the string.
-			// It's better than nothing.
-			_, _ = sb.WriteString(s[:maxLen])
-		} else { // lastWordBoundary <= maxLen
-			_, _ = sb.WriteString(s[:lastWordBoundary])
+			_, _ = sb.WriteString(truncated)
+		} else {
+			_, _ = sb.WriteString(truncated[:lastWordBoundary])
 		}
 	} else {
-		_, _ = sb.WriteString(s[:maxLen])
+		_, _ = sb.WriteString(string(runes[:maxLen]))
 	}
 
 	if options&TruncateWithEllipsis != 0 {

--- a/coderd/util/strings/strings_test.go
+++ b/coderd/util/strings/strings_test.go
@@ -139,4 +139,3 @@ func TestCapitalize(t *testing.T) {
 		})
 	}
 }
-

--- a/coderd/util/strings/strings_test.go
+++ b/coderd/util/strings/strings_test.go
@@ -118,3 +118,25 @@ func TestUISanitize(t *testing.T) {
 		})
 	}
 }
+
+func TestCapitalize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"hello", "Hello"},
+		{"über", "Über"},
+		{"Hello", "Hello"},
+		{"a", "A"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.input), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, strings.Capitalize(tt.input))
+		})
+	}
+}
+

--- a/coderd/util/strings/strings_test.go
+++ b/coderd/util/strings/strings_test.go
@@ -57,6 +57,17 @@ func TestTruncate(t *testing.T) {
 		{"foo bar", 1, "…", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
 		{"foo bar", 0, "", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
 		{"This is a very long task prompt that should be truncated to 160 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 160, "This is a very long task prompt that should be truncated to 160 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor…", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
+		// Multi-byte rune handling.
+		{"日本語テスト", 3, "日本語", nil},
+		{"日本語テスト", 4, "日本語テ", nil},
+		{"日本語テスト", 6, "日本語テスト", nil},
+		{"日本語テスト", 4, "日本語…", []strings.TruncateOption{strings.TruncateWithEllipsis}},
+		{"🎉🎊🎈🎁", 2, "🎉🎊", nil},
+		{"🎉🎊🎈🎁", 3, "🎉🎊…", []strings.TruncateOption{strings.TruncateWithEllipsis}},
+		// Multi-byte with full-word truncation.
+		{"hello 日本語", 7, "hello…", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
+		{"hello 日本語", 8, "hello 日…", []strings.TruncateOption{strings.TruncateWithEllipsis}},
+		{"日本語 テスト", 4, "日本語", []strings.TruncateOption{strings.TruncateWithFullWords}},
 	} {
 		tName := fmt.Sprintf("%s_%d", tt.s, tt.n)
 		for _, opt := range tt.options {


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/22375

Updates `stringutil.Truncate` to properly handle multi-byte UTF-8 characters.
Adds tests for multi-byte truncation with word boundary.

Created by Mux using Opus 4.6