### PR TITLE
fix: clear agents chat input optimistically on submit

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -324,25 +324,33 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 				isEditingHistoryMessage && editingHistoryMessageID !== null
 					? editingHistoryMessageID
 					: undefined;
+
+			// Clear the input optimistically before awaiting the mutation so
+			// that it doesn't linger when the parent navigates away or
+			// re-renders during the async gap (e.g. query invalidation).
+			const previousInput = input;
+			setInput("");
+			onInputChange?.("");
+			if (queueEditID !== null) {
+				setEditingQueuedMessageID(null);
+				setDraftBeforeQueueEdit(null);
+			}
+			if (isEditingHistoryMessage) {
+				setIsEditingHistoryMessage(false);
+				setEditingHistoryMessageID(null);
+				setDraftBeforeHistoryEdit(null);
+				onEditCleared?.();
+			}
+
 			try {
-				await onSend(input, editedMessageID);
+				await onSend(previousInput, editedMessageID);
 				if (queueEditID !== null && onDeleteQueuedMessage) {
 					await onDeleteQueuedMessage(queueEditID);
 				}
-				setInput("");
-				onInputChange?.("");
-				if (queueEditID !== null) {
-					setEditingQueuedMessageID(null);
-					setDraftBeforeQueueEdit(null);
-				}
-				if (isEditingHistoryMessage) {
-					setIsEditingHistoryMessage(false);
-					setEditingHistoryMessageID(null);
-					setDraftBeforeHistoryEdit(null);
-					onEditCleared?.();
-				}
 			} catch {
-				// Keep input on failure so the user can retry.
+				// Restore input on failure so the user can retry.
+				setInput(previousInput);
+				onInputChange?.(previousInput);
 			} finally {
 				// Re-focus the textarea so the user can keep typing.
 				textareaRef.current?.focus();


### PR DESCRIPTION
## Problem

The input box on the `/agents` page doesn't always clear after submitting a message.

## Root Cause

In `AgentChatInput.handleSubmit`, `setInput('')` only ran **after** `await onSend()` resolved. Since `onSend` uses `mutateAsync` (which waits for both the HTTP request and the `onSuccess` query invalidation to complete), there is an async gap during which:

- **Create page (`/agents`):** `navigate()` unmounts `AgentChatInput` before the input is cleared, and `localStorage` retains the stale draft. When the user navigates back, the input re-mounts with the old text.
- **Detail page (`/agents/:id`):** Query invalidation triggered by `onSuccess` can re-render the component tree mid-await, causing the delayed `setInput('')` to be lost.

## Fix

Clear the input **optimistically** (synchronously, before `await onSend()`) and restore it in the `catch` block if the mutation fails so the user can retry. The original input text is captured in `previousInput` and passed to `onSend` so the correct message is still submitted.