### PR TITLE
fix: auto-scroll to bottom when switching chats on agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -385,6 +385,16 @@ const AgentDetail: FC = () => {
 		outletContext?.requestArchiveAgent ?? noopRequestArchiveAgent;
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
+	// When switching between chats, reset the scroll container to the
+	// bottom (scrollTop 0 in a flex-col-reverse container) so the user
+	// always sees the most recent messages instead of a stale scroll
+	// position from the previous chat.
+	useEffect(() => {
+		if (scrollContainerRef.current) {
+			scrollContainerRef.current.scrollTop = 0;
+		}
+	}, [agentId]);
+
 	const chatQuery = useQuery({
 		...chat(agentId ?? ""),
 		enabled: Boolean(agentId),

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -390,6 +390,7 @@ const AgentDetail: FC = () => {
 	// always sees the most recent messages instead of a stale scroll
 	// position from the previous chat.
 	useEffect(() => {
+		void agentId;
 		if (scrollContainerRef.current) {
 			scrollContainerRef.current.scrollTop = 0;
 		}


### PR DESCRIPTION
When switching between chats on the agents page, the scroll position was preserved from the previous chat instead of resetting to show the most recent messages.

## Problem
Clicking a different chat in the sidebar loaded the new chat's messages but kept the scroll container at whatever position the user had scrolled to in the previous chat. This meant users often landed in the middle of a conversation instead of at the bottom where the latest messages are.

## Fix
Added a `useEffect` in `AgentDetail` that resets `scrollTop` to `0` whenever `agentId` changes. The scroll container uses `flex-col-reverse`, so `scrollTop = 0` corresponds to the bottom (most recent messages).