### PR TITLE
fix: update document title when switching agents on the agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -27,6 +27,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
+import { pageTitle } from "utils/page";
 import { AgentChatInput } from "./AgentChatInput";
 import {
 	selectChatStatus,
@@ -675,6 +676,17 @@ const AgentDetail: FC = () => {
 	const topBarActionsRef = outletContext?.topBarActionsRef;
 	const rightPanelRef = outletContext?.rightPanelRef;
 	const chatTitle = chatQuery.data?.chat?.title;
+
+	// Update the browser tab title when navigating to / between agents.
+	useEffect(() => {
+		document.title = chatTitle
+			? pageTitle(chatTitle, "Agents")
+			: pageTitle("Agents");
+		return () => {
+			document.title = pageTitle("Agents");
+		};
+	}, [chatTitle]);
+
 	const parentChatID = getParentChatID(chatQuery.data?.chat);
 	const parentChat = parentChatID
 		? chatsQuery.data?.find((chat) => chat.id === parentChatID)


### PR DESCRIPTION
When navigating to a specific agent on the Agents page, the browser tab title now reflects the agent's chat title (e.g. `Fix login bug - Agents - Coder`). When the title hasn't loaded yet or when navigating away, it falls back to `Agents - Coder`.

**Changes:**
- Added a `useEffect` in `AgentDetail` that sets `document.title` via the existing `pageTitle` utility whenever the chat title changes.
- The cleanup function resets the title back to `Agents - Coder` when unmounting (navigating away from the agent).