### PR TITLE
fix(site): filter agents workspace dropdown to owner and show owner/name format

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -1,6 +1,6 @@
+import { MockWorkspace } from "testHelpers/entities";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
-import { MockWorkspace } from "testHelpers/entities";
 import { useRef } from "react";
 import {
 	expect,

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -107,6 +107,10 @@ export const WithWorkspaces: Story = {
 			count: 3,
 		});
 	},
+	play: async () => {
+		const trigger = await screen.findByText("Workspace");
+		await userEvent.click(trigger);
+	},
 };
 
 export const SavesBehaviorPromptAndRestores: Story = {

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
+import { MockWorkspace } from "testHelpers/entities";
 import { useRef } from "react";
 import {
 	expect,
@@ -75,6 +76,38 @@ export default meta;
 type Story = StoryObj<typeof AgentsEmptyStateWithPortal>;
 
 export const Default: Story = {};
+
+export const WithWorkspaces: Story = {
+	beforeEach: () => {
+		localStorage.clear();
+		spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces: [
+				{
+					...MockWorkspace,
+					id: "ws-1",
+					name: "my-project",
+					owner_name: "johndoe",
+					owner_id: "user-1",
+				},
+				{
+					...MockWorkspace,
+					id: "ws-2",
+					name: "my-project",
+					owner_name: "janedoe",
+					owner_id: "user-2",
+				},
+				{
+					...MockWorkspace,
+					id: "ws-3",
+					name: "backend-api",
+					owner_name: "johndoe",
+					owner_id: "user-1",
+				},
+			],
+			count: 3,
+		});
+	},
+};
 
 export const SavesBehaviorPromptAndRestores: Story = {
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -78,6 +78,9 @@ type Story = StoryObj<typeof AgentsEmptyStateWithPortal>;
 export const Default: Story = {};
 
 export const WithWorkspaces: Story = {
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 	beforeEach: () => {
 		localStorage.clear();
 		spyOn(API, "getWorkspaces").mockResolvedValue({

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -110,10 +110,10 @@ export const WithWorkspaces: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await waitFor(() => {
-			const trigger = canvas.getByRole("combobox");
+			const trigger = canvas.getByText("Workspace").closest("button")!;
 			expect(trigger).toBeEnabled();
 		});
-		await userEvent.click(canvas.getByRole("combobox"));
+		await userEvent.click(canvas.getByText("Workspace").closest("button")!);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -107,14 +107,13 @@ export const WithWorkspaces: Story = {
 			count: 3,
 		});
 	},
-	play: async () => {
-		// Wait for the workspaces query to resolve and the select to become
-		// enabled before clicking.
-		await waitFor(async () => {
-			const trigger = screen.getByText("Workspace").closest("button")!;
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			const trigger = canvas.getByRole("combobox");
 			expect(trigger).toBeEnabled();
-			await userEvent.click(trigger);
 		});
+		await userEvent.click(canvas.getByRole("combobox"));
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -108,8 +108,13 @@ export const WithWorkspaces: Story = {
 		});
 	},
 	play: async () => {
-		const trigger = await screen.findByText("Workspace");
-		await userEvent.click(trigger);
+		// Wait for the workspaces query to resolve and the select to become
+		// enabled before clicking.
+		await waitFor(async () => {
+			const trigger = screen.getByText("Workspace").closest("button")!;
+			expect(trigger).toBeEnabled();
+			await userEvent.click(trigger);
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -114,6 +114,8 @@ export const WithWorkspaces: Story = {
 			expect(trigger).toBeEnabled();
 		});
 		await userEvent.click(canvas.getByText("Workspace").closest("button")!);
+		// Wait for the portalled dropdown to appear so Chromatic captures it.
+		await within(canvasElement.ownerDocument.body).findByRole("listbox");
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentsPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.stories.tsx
@@ -78,9 +78,6 @@ type Story = StoryObj<typeof AgentsEmptyStateWithPortal>;
 export const Default: Story = {};
 
 export const WithWorkspaces: Story = {
-	parameters: {
-		chromatic: { disableSnapshot: true },
-	},
 	beforeEach: () => {
 		localStorage.clear();
 		spyOn(API, "getWorkspaces").mockResolvedValue({

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -688,11 +688,11 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 		[onCreateChat],
 	);
 
-	const selectedWorkspaceLabel = selectedWorkspaceId
-		? (() => {
-				const ws = workspaceOptions.find((ws) => ws.id === selectedWorkspaceId);
-				return ws ? `${ws.owner_name}/${ws.name}` : null;
-			})()
+	const selectedWorkspace = selectedWorkspaceId
+		? workspaceOptions.find((ws) => ws.id === selectedWorkspaceId)
+		: undefined;
+	const selectedWorkspaceLabel = selectedWorkspace
+		? `${selectedWorkspace.owner_name}/${selectedWorkspace.name}`
 		: null;
 
 	return (

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -693,7 +693,7 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 		: undefined;
 	const selectedWorkspaceLabel = selectedWorkspace
 		? `${selectedWorkspace.owner_name}/${selectedWorkspace.name}`
-		: null;
+		: undefined;
 
 	return (
 		<div className="flex min-h-0 flex-1 items-start justify-center overflow-auto p-4 pt-12 md:h-full md:items-center md:pt-4">

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -575,7 +575,7 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 		useState(initialSystemPrompt);
 	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
 		useState(false);
-	const workspacesQuery = useQuery(workspaces({ limit: 50 }));
+	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 50 }));
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
 		() => {
 			if (typeof window === "undefined") return null;
@@ -688,8 +688,11 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 		[onCreateChat],
 	);
 
-	const selectedWorkspaceName = selectedWorkspaceId
-		? workspaceOptions.find((ws) => ws.id === selectedWorkspaceId)?.name
+	const selectedWorkspaceLabel = selectedWorkspaceId
+		? (() => {
+				const ws = workspaceOptions.find((ws) => ws.id === selectedWorkspaceId);
+				return ws ? `${ws.owner_name}/${ws.name}` : null;
+			})()
 		: null;
 
 	return (
@@ -737,7 +740,7 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 							<SelectTrigger className="h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary [&>svg]:transition-colors [&>svg]:hover:text-content-primary focus:ring-0 focus-visible:ring-0">
 								<MonitorIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary group-hover:text-content-primary" />
 								<SelectValue>
-									{selectedWorkspaceName ?? "Workspace"}
+									{selectedWorkspaceLabel ?? "Workspace"}
 								</SelectValue>
 							</SelectTrigger>
 							<SelectContent
@@ -750,7 +753,7 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 								</SelectItem>
 								{workspaceOptions.map((workspace) => (
 									<SelectItem key={workspace.id} value={workspace.id}>
-										{workspace.name}
+										{workspace.owner_name}/{workspace.name}
 									</SelectItem>
 								))}
 								{workspaceOptions.length === 0 &&


### PR DESCRIPTION
## Problem

The workspace dropdown on the `/agents` page calls `GET /api/v2/workspaces` with no `q` filter. For admin/owner users, this returns **all workspaces across all users**. The dropdown then renders only `workspace.name` with no owner context, making it impossible to tell whose workspace is whose.

## Changes

- **Filter to `owner:me`** — The workspaces query now passes `q: "owner:me"` so only the current user's workspaces are listed, matching the default behavior of the main workspaces page.
- **Show `owner/name` format** — Both the dropdown items and the selected value display workspaces as `owner_name/name` for clarity.
- **Add `WithWorkspaces` story** — New Storybook story under `pages/AgentsPage/AgentsEmptyState` that demonstrates the dropdown with multiple workspaces from different owners.

## Testing

- TypeScript compiles cleanly.
- New Storybook story: `pages/AgentsPage/AgentsEmptyState > WithWorkspaces`