### PR TITLE
fix(chatd): publish streaming message_part events during compaction

### DIFF
--- a/coderd/chatd/chatloop/compaction.go
+++ b/coderd/chatd/chatloop/compaction.go
@@ -30,6 +30,7 @@ type CompactionOptions struct {
 	SystemSummaryPrefix string
 	Timeout             time.Duration
 	Persist             func(context.Context, CompactionResult) error
+	OnStart             func()
 	OnError             func(error)
 }
 
@@ -132,6 +133,10 @@ func maybeCompact(
 	usagePercent := (float64(contextTokens) / float64(contextLimit)) * 100
 	if usagePercent < float64(config.ThresholdPercent) {
 		return nil
+	}
+
+	if config.OnStart != nil {
+		config.OnStart()
 	}
 
 	summary, err := generateCompactionSummary(


### PR DESCRIPTION
## Problem

Context compaction in chatd persisted durable messages for the `chat_summarized` tool call and result via `publishMessage`, but never published `message_part` streaming events via `publishMessagePart`. This meant connected clients had no streaming representation of the compaction.

The client's `streamState` (built entirely from `message_part` events in `streamState.ts`) never saw the compaction tool call, so:

- No **"Summarizing..."** running state was shown to the user during summary generation (which can take up to 90s).
- The durable `message` events arrived after or interleaved with the `status: waiting` event, causing the tool to appear as "Summarized" with the chat appearing to just stop.

## Fix

### 1. `CompactionOptions.OnStart` callback (chatloop)

Added an `OnStart` callback to `CompactionOptions`, called in `maybeCompact` right before `generateCompactionSummary` (the slow LLM call). This gives `chatd` a hook to publish the tool-call `message_part` immediately when compaction begins.

### 2. Tool-result streaming part (chatd)

`persistChatContextSummary` now publishes a tool-result `message_part` before the durable `message` events, so clients transition from "Summarizing..." to "Summarized" before the status change arrives.

### Event ordering is now:
1. `message_part` (tool call via `OnStart`) — client shows "Summarizing..."
2. LLM generates summary (up to 90s)
3. `message_part` (tool result) — client shows "Summarized" in stream state
4. `message` (assistant) — durable message persisted, stream state resets
5. `message` (tool) — durable tool result persisted
6. `status: waiting` — chat transitions to idle

## Tests

- **`OnStartFiresBeforePersist`**: Verifies callback ordering is `on_start` → `generate` → `persist`.
- **`OnStartNotCalledBelowThreshold`**: Verifies `OnStart` is not called when context usage is below the compaction threshold.