### PR TITLE
flake: increase test timeout for TemplateVersionEditorPage tests

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
@@ -156,7 +156,7 @@ test("Use custom name, message and set it as active when publishing", async () =
 	await waitFor(() => {
 		expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
 	});
-});
+}, 20_000);
 
 test("Do not mark as active if promote is not checked", async () => {
 	const user = userEvent.setup();


### PR DESCRIPTION
TemplateVersionEditorPage tests have been flaking since I ported them to vitest in 99a4ecd. Turns out our test timeout on jest is 20s (presumably for these sorts of page-level journey tests). I kinda like the current 5s timeout as it forces us to write speedy tests, but I think in this case it's unavoidable and makes sense to lengthen the timeout just for these tests.

Hopefully fixes coder/internal#1369

You may want the whitespaceless diff here: https://github.com/coder/coder/pull/22412/changes?w=1