### PR TITLE
fix(site): wrap long lines in agents diff panel

### DIFF
--- a/site/src/pages/AgentsPage/FilesChangedPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.stories.tsx
@@ -9,10 +9,11 @@ const sampleUnifiedDiff = `diff --git a/site/src/pages/AgentsPage/FilesChangedPa
 index abc1234..def5678 100644
 --- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
 +++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
-@@ -1,10 +1,14 @@
+@@ -1,10 +1,15 @@
 +import { useTheme } from "@emotion/react";
  import { parsePatchFiles } from "@pierre/diffs";
  import { FileDiff } from "@pierre/diffs/react";
++import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore } from "react"; // deliberately long import to verify horizontal overflow handling in narrow panels
 +import {
 +  DIFFS_FONT_STYLE,
 +  getDiffViewerOptions,

--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -144,6 +144,7 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({ chatId }) => {
 								fileDiff={fileDiff}
 								options={{
 									...diffOptions,
+									overflow: "wrap",
 									enableLineSelection: true,
 									enableHoverUtility: true,
 									onLineSelected() {


### PR DESCRIPTION
The diff view on the `/agents` page had no way to handle lines wider than the panel. The `@pierre/diffs` library supports an `overflow` option — switching it from `"scroll"` (the shared default) to `"wrap"` for the side panel makes long lines wrap naturally instead of being clipped.

Also adds a long import line to the Storybook sample diff so the wrapping behavior is easy to verify visually.