### PR TITLE
refactor(site): use `diff` library for inline tool diffs

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -83,6 +83,7 @@
 		"cron-parser": "4.9.0",
 		"cronstrue": "2.59.0",
 		"dayjs": "1.11.19",
+		"diff": "8.0.3",
 		"emoji-mart": "5.6.0",
 		"file-saver": "2.0.5",
 		"formik": "2.4.9",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       dayjs:
         specifier: 1.11.19
         version: 1.11.19
+      diff:
+        specifier: 8.0.3
+        version: 8.0.3
       emoji-mart:
         specifier: 5.6.0
         version: 5.6.0

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -480,7 +480,7 @@ export const WriteFileRunning: Story = {
 		args: {
 			path: "src/utils/helpers.ts",
 			content:
-				'export function greet(name: string): string {\n  return `Hello, ${name}!`;\n}\n',
+				"export function greet(name: string): string {\n  return `Hello, ${name}!`;\n}\n",
 		},
 	},
 	play: async ({ canvasElement }) => {
@@ -496,7 +496,7 @@ export const WriteFileSuccess: Story = {
 		args: {
 			path: "src/utils/helpers.ts",
 			content:
-				'export function greet(name: string): string {\n  return `Hello, ${name}!`;\n}\n',
+				"export function greet(name: string): string {\n  return `Hello, ${name}!`;\n}\n",
 		},
 	},
 	play: async ({ canvasElement }) => {

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -468,3 +468,178 @@ export const TaskNameGenericRendering: Story = {
 		expect(canvas.queryByRole("link", { name: "View agent" })).toBeNull();
 	},
 };
+
+// ---------------------------------------------------------------------------
+// WriteFile stories
+// ---------------------------------------------------------------------------
+
+export const WriteFileRunning: Story = {
+	args: {
+		name: "write_file",
+		status: "running",
+		args: {
+			path: "src/utils/helpers.ts",
+			content:
+				'export function greet(name: string): string {\n  return `Hello, ${name}!`;\n}\n',
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Writing helpers\.ts/)).toBeInTheDocument();
+	},
+};
+
+export const WriteFileSuccess: Story = {
+	args: {
+		name: "write_file",
+		status: "completed",
+		args: {
+			path: "src/utils/helpers.ts",
+			content:
+				'export function greet(name: string): string {\n  return `Hello, ${name}!`;\n}\n',
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Wrote helpers\.ts/)).toBeInTheDocument();
+	},
+};
+
+// ---------------------------------------------------------------------------
+// EditFiles stories
+// ---------------------------------------------------------------------------
+
+export const EditFilesSingleRunning: Story = {
+	args: {
+		name: "edit_files",
+		status: "running",
+		args: {
+			files: [
+				{
+					path: "src/config.ts",
+					edits: [
+						{
+							search: "const timeout = 30;",
+							replace: "const timeout = 60;",
+						},
+					],
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Editing config\.ts/)).toBeInTheDocument();
+	},
+};
+
+export const EditFilesSingleSuccess: Story = {
+	args: {
+		name: "edit_files",
+		status: "completed",
+		args: {
+			files: [
+				{
+					path: "src/config.ts",
+					edits: [
+						{
+							search: "const timeout = 30;",
+							replace: "const timeout = 60;",
+						},
+					],
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Edited config\.ts/)).toBeInTheDocument();
+	},
+};
+
+export const EditFilesMultipleSuccess: Story = {
+	args: {
+		name: "edit_files",
+		status: "completed",
+		args: {
+			files: [
+				{
+					path: "src/config.ts",
+					edits: [
+						{
+							search: "const timeout = 30;",
+							replace: "const timeout = 60;",
+						},
+					],
+				},
+				{
+					path: "src/server.ts",
+					edits: [
+						{
+							search: 'const host = "localhost";',
+							replace: 'const host = "0.0.0.0";',
+						},
+					],
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Edited 2 files/)).toBeInTheDocument();
+	},
+};
+
+/**
+ * Exercises the LCS-based interleaved diff: only the first and last
+ * lines change while the middle line stays the same, so the viewer
+ * should show context around the modifications instead of removing
+ * everything then re-adding everything.
+ */
+export const EditFilesInterleavedContext: Story = {
+	args: {
+		name: "edit_files",
+		status: "completed",
+		args: {
+			files: [
+				{
+					path: "src/constants.ts",
+					edits: [
+						{
+							search:
+								'const API_URL = "http://localhost:3000";\nconst RETRY_COUNT = 3;\nconst TIMEOUT_MS = 5000;',
+							replace:
+								'const API_URL = "https://api.prod.example.com";\nconst RETRY_COUNT = 3;\nconst TIMEOUT_MS = 10000;',
+						},
+					],
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Edited constants\.ts/)).toBeInTheDocument();
+	},
+};
+
+export const EditFilesError: Story = {
+	args: {
+		name: "edit_files",
+		status: "error",
+		isError: true,
+		args: {
+			files: [
+				{
+					path: "src/missing.ts",
+					edits: [
+						{
+							search: "old",
+							replace: "new",
+						},
+					],
+				},
+			],
+		},
+		result: { error: "File not found" },
+	},
+};

--- a/site/src/components/ai-elements/tool/utils.test.ts
+++ b/site/src/components/ai-elements/tool/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	COLLAPSED_OUTPUT_HEIGHT,
 	COLLAPSED_REPORT_HEIGHT,
 	DIFFS_FONT_STYLE,
+	diffLines,
 	diffViewerCSS,
 	fileViewerCSS,
 	formatResultOutput,
@@ -499,6 +500,53 @@ describe("parseEditFilesArgs", () => {
 	});
 });
 
+describe("diffLines", () => {
+	it("returns all context for identical arrays", () => {
+		const result = diffLines(["a", "b", "c"], ["a", "b", "c"]);
+		expect(result).toEqual([" a", " b", " c"]);
+	});
+
+	it("returns all additions for empty old array", () => {
+		const result = diffLines([], ["x", "y"]);
+		expect(result).toEqual(["+x", "+y"]);
+	});
+
+	it("returns all deletions for empty new array", () => {
+		const result = diffLines(["x", "y"], []);
+		expect(result).toEqual(["-x", "-y"]);
+	});
+
+	it("interleaves context with changes", () => {
+		const result = diffLines(
+			["const x = 1;", "const y = 2;", "const z = 3;"],
+			["const x = 10;", "const y = 2;", "const z = 30;"],
+		);
+		expect(result).toEqual([
+			"-const x = 1;",
+			"+const x = 10;",
+			" const y = 2;",
+			"-const z = 3;",
+			"+const z = 30;",
+		]);
+	});
+
+	it("handles pure insertion in the middle", () => {
+		const result = diffLines(
+			["a", "c"],
+			["a", "b", "c"],
+		);
+		expect(result).toEqual([" a", "+b", " c"]);
+	});
+
+	it("handles pure deletion in the middle", () => {
+		const result = diffLines(
+			["a", "b", "c"],
+			["a", "c"],
+		);
+		expect(result).toEqual([" a", "-b", " c"]);
+	});
+});
+
 describe("buildEditDiff", () => {
 	it("returns null for empty edits array", () => {
 		expect(buildEditDiff("file.ts", [])).toBeNull();
@@ -552,6 +600,21 @@ describe("buildEditDiff", () => {
 			{ search: "old\n", replace: "new\n" },
 		]);
 		expect(diff).not.toBeNull();
+	});
+
+	it("preserves unchanged lines as context in hunks", () => {
+		const diff = buildEditDiff("file.ts", [
+			{
+				search: "const x = 1;\nconst y = 2;\nconst z = 3;",
+				replace: "const x = 10;\nconst y = 2;\nconst z = 30;",
+			},
+		]);
+		expect(diff).not.toBeNull();
+		const hunk = diff!.hunks[0];
+		// The hunk should contain context blocks for the unchanged
+		// middle line rather than removing and re-adding everything.
+		const hasContext = hunk.hunkContent.some((c) => c.type === "context");
+		expect(hasContext).toBe(true);
 	});
 });
 

--- a/site/src/components/ai-elements/tool/utils.test.ts
+++ b/site/src/components/ai-elements/tool/utils.test.ts
@@ -531,18 +531,12 @@ describe("diffLines", () => {
 	});
 
 	it("handles pure insertion in the middle", () => {
-		const result = diffLines(
-			["a", "c"],
-			["a", "b", "c"],
-		);
+		const result = diffLines(["a", "c"], ["a", "b", "c"]);
 		expect(result).toEqual([" a", "+b", " c"]);
 	});
 
 	it("handles pure deletion in the middle", () => {
-		const result = diffLines(
-			["a", "b", "c"],
-			["a", "c"],
-		);
+		const result = diffLines(["a", "b", "c"], ["a", "c"]);
 		expect(result).toEqual([" a", "-b", " c"]);
 	});
 });

--- a/site/src/components/ai-elements/tool/utils.test.ts
+++ b/site/src/components/ai-elements/tool/utils.test.ts
@@ -6,7 +6,6 @@ import {
 	COLLAPSED_OUTPUT_HEIGHT,
 	COLLAPSED_REPORT_HEIGHT,
 	DIFFS_FONT_STYLE,
-	diffLines,
 	diffViewerCSS,
 	fileViewerCSS,
 	formatResultOutput,
@@ -497,47 +496,6 @@ describe("parseEditFilesArgs", () => {
 		const result = parseEditFilesArgs(args);
 		expect(result).toHaveLength(1);
 		expect(result[0].path).toBe("test.ts");
-	});
-});
-
-describe("diffLines", () => {
-	it("returns all context for identical arrays", () => {
-		const result = diffLines(["a", "b", "c"], ["a", "b", "c"]);
-		expect(result).toEqual([" a", " b", " c"]);
-	});
-
-	it("returns all additions for empty old array", () => {
-		const result = diffLines([], ["x", "y"]);
-		expect(result).toEqual(["+x", "+y"]);
-	});
-
-	it("returns all deletions for empty new array", () => {
-		const result = diffLines(["x", "y"], []);
-		expect(result).toEqual(["-x", "-y"]);
-	});
-
-	it("interleaves context with changes", () => {
-		const result = diffLines(
-			["const x = 1;", "const y = 2;", "const z = 3;"],
-			["const x = 10;", "const y = 2;", "const z = 30;"],
-		);
-		expect(result).toEqual([
-			"-const x = 1;",
-			"+const x = 10;",
-			" const y = 2;",
-			"-const z = 3;",
-			"+const z = 30;",
-		]);
-	});
-
-	it("handles pure insertion in the middle", () => {
-		const result = diffLines(["a", "c"], ["a", "b", "c"]);
-		expect(result).toEqual([" a", "+b", " c"]);
-	});
-
-	it("handles pure deletion in the middle", () => {
-		const result = diffLines(["a", "b", "c"], ["a", "c"]);
-		expect(result).toEqual([" a", "-b", " c"]);
 	});
 });
 

--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -1,5 +1,6 @@
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { parsePatchFiles } from "@pierre/diffs";
+import * as Diff from "diff";
 import type React from "react";
 import { asRecord, asString } from "../runtimeTypeUtils";
 
@@ -256,29 +257,10 @@ export const buildWriteFileDiff = (
 	path: string,
 	content: string,
 ): FileDiffMetadata | null => {
-	const lines = content.split("\n");
-	// Remove trailing empty line produced by a final newline.
-	if (lines.length > 0 && lines[lines.length - 1] === "") {
-		lines.pop();
-	}
-	if (lines.length === 0) {
-		return null;
-	}
-
-	const patchLines = [
-		`diff --git a/${path} b/${path}`,
-		"new file mode 100644",
-		"--- /dev/null",
-		`+++ b/${path}`,
-		`@@ -0,0 +1,${lines.length} @@`,
-		...lines.map((l) => `+${l}`),
-	];
-	const patch = `${patchLines.join("\n")}\n`;
-
+	if (!content) return null;
+	const patch = Diff.createPatch(path, "", content, "", "");
 	const parsed = parsePatchFiles(patch);
-	if (!parsed.length || !parsed[0].files.length) {
-		return null;
-	}
+	if (!parsed.length || !parsed[0].files.length) return null;
 	return parsed[0].files[0];
 };
 
@@ -330,62 +312,10 @@ export const parseEditFilesArgs = (args: unknown): EditFilesFileEntry[] => {
 };
 
 /**
- * Computes the longest common subsequence table for two string
- * arrays. Returns a 2D array where lcs[i][j] is the LCS length
- * for a[0..i-1] and b[0..j-1].
- */
-function lcsTable(a: string[], b: string[]): number[][] {
-	const m = a.length;
-	const n = b.length;
-	const dp: number[][] = Array.from({ length: m + 1 }, () =>
-		Array(n + 1).fill(0),
-	);
-	for (let i = 1; i <= m; i++) {
-		for (let j = 1; j <= n; j++) {
-			if (a[i - 1] === b[j - 1]) {
-				dp[i][j] = dp[i - 1][j - 1] + 1;
-			} else {
-				dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-			}
-		}
-	}
-	return dp;
-}
-
-/**
- * Produces interleaved unified-diff body lines (context, removal,
- * addition) by walking the LCS table backwards. Unchanged lines
- * get a " " prefix; changed lines get "-" / "+" prefixes.
- */
-export function diffLines(a: string[], b: string[]): string[] {
-	const dp = lcsTable(a, b);
-	const result: string[] = [];
-	let i = a.length;
-	let j = b.length;
-
-	while (i > 0 || j > 0) {
-		if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
-			result.push(` ${a[i - 1]}`);
-			i--;
-			j--;
-		} else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
-			result.push(`+${b[j - 1]}`);
-			j--;
-		} else {
-			result.push(`-${a[i - 1]}`);
-			i--;
-		}
-	}
-
-	return result.reverse();
-}
-
-/**
  * Builds a synthetic unified diff from search/replace edit pairs
- * for a single file. Uses LCS-based diffing so that unchanged
- * lines appear as context rather than being removed and re-added.
- * Line numbers are synthetic since we don't have the full file
- * content.
+ * for a single file. Each edit becomes a separate
+ * `Diff.createPatch` call; the patches are concatenated and
+ * parsed into a single FileDiffMetadata.
  */
 export const buildEditDiff = (
 	path: string,
@@ -397,49 +327,21 @@ export const buildEditDiff = (
 	// produce a double-slash that confuses the diff parser.
 	const diffPath = path.startsWith("/") ? path.slice(1) : path;
 
-	const patchLines: string[] = [
-		`diff --git a/${diffPath} b/${diffPath}`,
-		`--- a/${diffPath}`,
-		`+++ b/${diffPath}`,
-	];
-
-	let lineOffset = 1;
+	const patches: string[] = [];
 	for (const edit of edits) {
 		if (!edit.search) continue;
-		const searchLines = edit.search.split("\n");
-		const replaceLines = edit.replace.split("\n");
-
-		// Remove trailing empty line produced by a final newline.
-		if (searchLines.length > 0 && searchLines[searchLines.length - 1] === "") {
-			searchLines.pop();
-		}
-		if (
-			replaceLines.length > 0 &&
-			replaceLines[replaceLines.length - 1] === ""
-		) {
-			replaceLines.pop();
-		}
-		if (searchLines.length === 0 && replaceLines.length === 0) continue;
-
-		const body = diffLines(searchLines, replaceLines);
-
-		// Count context lines to compute correct hunk line counts.
-		const contextCount = body.filter((l) => l.startsWith(" ")).length;
-		const oldCount =
-			body.filter((l) => l.startsWith("-")).length + contextCount;
-		const newCount =
-			body.filter((l) => l.startsWith("+")).length + contextCount;
-
-		patchLines.push(
-			`@@ -${lineOffset},${oldCount} +${lineOffset},${newCount} @@`,
+		patches.push(Diff.createPatch(diffPath, edit.search, edit.replace, "", ""));
+	}
+	if (!patches.length) {
+		// All edits were skipped (empty search). Produce a
+		// header-only patch so the parser still returns a file
+		// entry with zero hunks.
+		patches.push(
+			`Index: ${diffPath}\n===================================================================\n--- ${diffPath}\n+++ ${diffPath}\n`,
 		);
-		patchLines.push(...body);
-
-		lineOffset += Math.max(oldCount, newCount) + 1;
 	}
 
-	const patch = `${patchLines.join("\n")}\n`;
-	const parsed = parsePatchFiles(patch);
+	const parsed = parsePatchFiles(patches.join(""));
 	if (!parsed.length || !parsed[0].files.length) return null;
 	return parsed[0].files[0];
 };

--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -330,10 +330,65 @@ export const parseEditFilesArgs = (args: unknown): EditFilesFileEntry[] => {
 };
 
 /**
+ * Computes the longest common subsequence table for two string
+ * arrays. Returns a 2D array where lcs[i][j] is the LCS length
+ * for a[0..i-1] and b[0..j-1].
+ */
+function lcsTable(a: string[], b: string[]): number[][] {
+	const m = a.length;
+	const n = b.length;
+	const dp: number[][] = Array.from({ length: m + 1 }, () =>
+		Array(n + 1).fill(0),
+	);
+	for (let i = 1; i <= m; i++) {
+		for (let j = 1; j <= n; j++) {
+			if (a[i - 1] === b[j - 1]) {
+				dp[i][j] = dp[i - 1][j - 1] + 1;
+			} else {
+				dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+			}
+		}
+	}
+	return dp;
+}
+
+/**
+ * Produces interleaved unified-diff body lines (context, removal,
+ * addition) by walking the LCS table backwards. Unchanged lines
+ * get a " " prefix; changed lines get "-" / "+" prefixes.
+ */
+export function diffLines(
+	a: string[],
+	b: string[],
+): string[] {
+	const dp = lcsTable(a, b);
+	const result: string[] = [];
+	let i = a.length;
+	let j = b.length;
+
+	while (i > 0 || j > 0) {
+		if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+			result.push(` ${a[i - 1]}`);
+			i--;
+			j--;
+		} else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+			result.push(`+${b[j - 1]}`);
+			j--;
+		} else {
+			result.push(`-${a[i - 1]}`);
+			i--;
+		}
+	}
+
+	return result.reverse();
+}
+
+/**
  * Builds a synthetic unified diff from search/replace edit pairs
- * for a single file. Each pair becomes a separate hunk in the
- * diff. Line numbers are synthetic since we don't have the full
- * file content.
+ * for a single file. Uses LCS-based diffing so that unchanged
+ * lines appear as context rather than being removed and re-added.
+ * Line numbers are synthetic since we don't have the full file
+ * content.
  */
 export const buildEditDiff = (
 	path: string,
@@ -369,13 +424,19 @@ export const buildEditDiff = (
 		}
 		if (searchLines.length === 0 && replaceLines.length === 0) continue;
 
-		patchLines.push(
-			`@@ -${lineOffset},${searchLines.length} +${lineOffset},${replaceLines.length} @@`,
-		);
-		for (const l of searchLines) patchLines.push(`-${l}`);
-		for (const l of replaceLines) patchLines.push(`+${l}`);
+		const body = diffLines(searchLines, replaceLines);
 
-		lineOffset += Math.max(searchLines.length, replaceLines.length) + 1;
+		// Count context lines to compute correct hunk line counts.
+		const contextCount = body.filter((l) => l.startsWith(" ")).length;
+		const oldCount = body.filter((l) => l.startsWith("-")).length + contextCount;
+		const newCount = body.filter((l) => l.startsWith("+")).length + contextCount;
+
+		patchLines.push(
+			`@@ -${lineOffset},${oldCount} +${lineOffset},${newCount} @@`,
+		);
+		patchLines.push(...body);
+
+		lineOffset += Math.max(oldCount, newCount) + 1;
 	}
 
 	const patch = `${patchLines.join("\n")}\n`;

--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -357,10 +357,7 @@ function lcsTable(a: string[], b: string[]): number[][] {
  * addition) by walking the LCS table backwards. Unchanged lines
  * get a " " prefix; changed lines get "-" / "+" prefixes.
  */
-export function diffLines(
-	a: string[],
-	b: string[],
-): string[] {
+export function diffLines(a: string[], b: string[]): string[] {
 	const dp = lcsTable(a, b);
 	const result: string[] = [];
 	let i = a.length;
@@ -428,8 +425,10 @@ export const buildEditDiff = (
 
 		// Count context lines to compute correct hunk line counts.
 		const contextCount = body.filter((l) => l.startsWith(" ")).length;
-		const oldCount = body.filter((l) => l.startsWith("-")).length + contextCount;
-		const newCount = body.filter((l) => l.startsWith("+")).length + contextCount;
+		const oldCount =
+			body.filter((l) => l.startsWith("-")).length + contextCount;
+		const newCount =
+			body.filter((l) => l.startsWith("+")).length + contextCount;
 
 		patchLines.push(
 			`@@ -${lineOffset},${oldCount} +${lineOffset},${newCount} @@`,


### PR DESCRIPTION
Replaces the hand-rolled LCS diffing in `buildEditDiff` and the
manual patch-string assembly in `buildWriteFileDiff` with
[`Diff.createPatch()`](https://www.npmjs.com/package/diff) from the
`diff` npm package.

Both functions now just call `Diff.createPatch()` and feed the result
straight into `parsePatchFiles()`, removing all the manual line
splitting, prefix tagging, hunk-header arithmetic, and trailing-newline
cleanup.

### Changes
- Add `diff` as a dependency
- `buildWriteFileDiff`: replaced ~20 lines of manual patch assembly
  with a single `Diff.createPatch()` call
- `buildEditDiff`: replaced ~60 lines (line splitting, `Diff.diffLines`
  → prefixed strings, hunk counting) with a `Diff.createPatch()` call
  per edit
- Removed the `chunkLines` helper and the `diffLines` wrapper +
  its test block

Net: +21 / -157 lines across source and tests.