### PR TITLE
refactor(site): simplify AgentChatInput into a controlled component

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
@@ -16,7 +16,9 @@ const meta: Meta<typeof AgentChatInput> = {
 	component: AgentChatInput,
 	args: {
 		onSend: fn(),
+		onChange: fn(),
 		onModelChange: fn(),
+		value: "",
 		isDisabled: false,
 		isLoading: false,
 		selectedModel: defaultModelOptions[0].id,
@@ -36,37 +38,32 @@ export const Default: Story = {};
 export const DisablesSendUntilInput: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const input = canvas.getByPlaceholderText("Type a message...");
 		const sendButton = canvas.getByRole("button", { name: "Send" });
 
 		expect(sendButton).toBeDisabled();
-		await userEvent.type(input, "Write tests");
-		expect(sendButton).toBeEnabled();
 	},
 };
 
 export const SendsAndClearsInput: Story = {
 	args: {
-		onSend: fn().mockResolvedValue(undefined),
+		onSend: fn(),
+		value: "Run focused tests",
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const input = canvas.getByPlaceholderText("Type a message...");
 
-		await userEvent.type(input, "Run focused tests");
 		await userEvent.click(canvas.getByRole("button", { name: "Send" }));
 
 		await waitFor(() => {
-			expect(args.onSend).toHaveBeenCalledWith("Run focused tests", undefined);
+			expect(args.onSend).toHaveBeenCalledWith("Run focused tests");
 		});
-		expect(input).toHaveValue("");
 	},
 };
 
 export const DisabledInput: Story = {
 	args: {
 		isDisabled: true,
-		initialValue: "Should not send",
+		value: "Should not send",
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -78,7 +75,7 @@ export const NoModelOptions: Story = {
 	args: {
 		isDisabled: false,
 		hasModelOptions: false,
-		initialValue: "Model required",
+		value: "Model required",
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -90,7 +87,7 @@ export const LoadingSpinner: Story = {
 	args: {
 		isDisabled: true,
 		isLoading: true,
-		initialValue: "Sending...",
+		value: "Sending...",
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -106,7 +103,7 @@ export const LoadingDisablesSend: Story = {
 	args: {
 		isDisabled: false,
 		isLoading: true,
-		initialValue: "Another message",
+		value: "Another message",
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
@@ -101,3 +101,18 @@ export const LoadingSpinner: Story = {
 		expect(sendButton.querySelector(".animate-spin")).toBeTruthy();
 	},
 };
+
+export const LoadingDisablesSend: Story = {
+	args: {
+		isDisabled: false,
+		isLoading: true,
+		initialValue: "Another message",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const sendButton = canvas.getByRole("button", { name: "Send" });
+		// The send button should be disabled while a previous send is
+		// in-flight, even though the textarea has content.
+		expect(sendButton).toBeDisabled();
+	},
+};

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "api/errors";
 import type { ChatQueuedMessage } from "api/typesGenerated";
 import {
 	ModelSelector,
@@ -25,6 +26,8 @@ import {
 	useState,
 } from "react";
 import TextareaAutosize from "react-textarea-autosize";
+import { toast } from "sonner";
+import { cn } from "utils/cn";
 import { formatProviderLabel } from "./modelOptions";
 import { QueuedMessagesList } from "./QueuedMessagesList";
 
@@ -144,7 +147,6 @@ const ContextUsageIndicator = memo<{ usage: AgentContextUsage | null }>(
 		const hasPercent = percentUsed !== null;
 		const percentLabel =
 			percentUsed === null ? "--" : `${Math.round(percentUsed)}%`;
-		const indicatorLabel = null;
 		const clampedPercent = hasPercent
 			? Math.min(Math.max(percentUsed, 0), 100)
 			: 100;
@@ -158,14 +160,13 @@ const ContextUsageIndicator = memo<{ usage: AgentContextUsage | null }>(
 		return (
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<span
-						role="button"
-						tabIndex={0}
+					<button
+						type="button"
 						aria-label={ariaLabel}
-						className="relative inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full outline-none transition-colors hover:bg-surface-secondary/60 focus-visible:ring-2 focus-visible:ring-content-link/40"
+						className="relative inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-none bg-transparent p-0 outline-none transition-colors hover:bg-surface-secondary/60 focus-visible:ring-2 focus-visible:ring-content-link/40"
 					>
 						<svg
-							className={`h-5 w-5 -rotate-90 ${toneClassName}`}
+							className={cn("h-5 w-5 -rotate-90", toneClassName)}
 							viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
 							aria-hidden
 						>
@@ -191,12 +192,7 @@ const ContextUsageIndicator = memo<{ usage: AgentContextUsage | null }>(
 								}}
 							/>
 						</svg>
-						{indicatorLabel !== null && (
-							<span className="pointer-events-none absolute text-[7px] font-semibold tabular-nums text-content-secondary">
-								{indicatorLabel}
-							</span>
-						)}
-					</span>
+					</button>
 				</TooltipTrigger>
 				<TooltipContent side="top">
 					<div className="text-xs text-content-primary">
@@ -265,20 +261,29 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] = useState<
 			string | null
 		>(null);
+
+		// Refs to read current values inside the editRequest effect
+		// without adding them as dependencies (which would cause the
+		// effect to re-fire on every keystroke).
+		const inputRef = useRef(input);
+		inputRef.current = input;
+		const isEditingHistoryRef = useRef(isEditingHistoryMessage);
+		isEditingHistoryRef.current = isEditingHistoryMessage;
+
 		useEffect(() => {
 			if (!editRequest || editRequest.key === lastEditKeyRef.current) {
 				return;
 			}
 			lastEditKeyRef.current = editRequest.key;
 			setDraftBeforeHistoryEdit((current) =>
-				isEditingHistoryMessage ? current : input,
+				isEditingHistoryRef.current ? current : inputRef.current,
 			);
 			setIsEditingHistoryMessage(true);
 			setEditingHistoryMessageID(editRequest.messageId ?? null);
 			setInput(editRequest.text);
 			onInputChange?.(editRequest.text);
 			textareaRef.current?.focus();
-		}, [editRequest, input, isEditingHistoryMessage, onInputChange]);
+		}, [editRequest, onInputChange]);
 
 		const handleCancelHistoryEdit = useCallback(() => {
 			if (!isEditingHistoryMessage) {
@@ -315,7 +320,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 
 		const handleSubmit = useCallback(async () => {
 			const text = input.trim();
-			if (!text || isDisabled || !hasModelOptions) {
+			if (!text || isDisabled || isLoading || !hasModelOptions) {
 				return;
 			}
 
@@ -328,31 +333,35 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 			// it if the request fails.
 			const capturedInput = input;
 
-			// Clear the input and editing state immediately so the
-			// user can start typing their next message without waiting
-			// for the network round-trip.
+			// Clear the input immediately so the user can start typing
+			// their next message without waiting for the network
+			// round-trip. Editing state is cleared only after the
+			// request succeeds so it can be restored on failure.
 			setInput("");
 			onInputChange?.("");
-			if (queueEditID !== null) {
-				setEditingQueuedMessageID(null);
-				setDraftBeforeQueueEdit(null);
-			}
-			if (isEditingHistoryMessage) {
-				setIsEditingHistoryMessage(false);
-				setEditingHistoryMessageID(null);
-				setDraftBeforeHistoryEdit(null);
-				onEditCleared?.();
-			}
 
 			try {
 				await onSend(capturedInput, editedMessageID);
 				if (queueEditID !== null && onDeleteQueuedMessage) {
 					await onDeleteQueuedMessage(queueEditID);
 				}
-			} catch {
+				// Clear editing state only on success so we can
+				// restore it if the request fails above.
+				if (queueEditID !== null) {
+					setEditingQueuedMessageID(null);
+					setDraftBeforeQueueEdit(null);
+				}
+				if (isEditingHistoryMessage) {
+					setIsEditingHistoryMessage(false);
+					setEditingHistoryMessageID(null);
+					setDraftBeforeHistoryEdit(null);
+					onEditCleared?.();
+				}
+			} catch (error) {
 				// Restore the input so the user can retry.
 				setInput(capturedInput);
 				onInputChange?.(capturedInput);
+				toast.error(getErrorMessage(error, "Failed to send message."));
 			} finally {
 				// Re-focus the textarea so the user can keep typing.
 				textareaRef.current?.focus();
@@ -364,6 +373,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 			input,
 			isDisabled,
 			isEditingHistoryMessage,
+			isLoading,
 			onDeleteQueuedMessage,
 			onEditCleared,
 			onInputChange,
@@ -419,6 +429,8 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 					// promote the first one instead of submitting.
 					if (
 						!input.trim() &&
+						!isDisabled &&
+						!isLoading &&
 						queuedMessages.length > 0 &&
 						onPromoteQueuedMessage
 					) {
@@ -434,8 +446,10 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 				handleCancelQueueEdit,
 				handleSubmit,
 				input,
+				isDisabled,
 				isEditingHistoryMessage,
 				isInterruptPending,
+				isLoading,
 				isStreaming,
 				onInterrupt,
 				onPromoteQueuedMessage,
@@ -528,7 +542,6 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								formatProviderLabel={formatProviderLabel}
 								dropdownSide="top"
 								dropdownAlign="center"
-								className=""
 							/>
 							{leftActions}
 							{inputStatusText && (
@@ -558,8 +571,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								variant="default"
 								className="size-7 rounded-full transition-colors [&>svg]:!size-6 flex items-center justify-center"
 								onClick={() => void handleSubmit()}
-								disabled={isDisabled || !hasModelOptions || !input.trim()}
-								title={sendButtonLabel}
+								disabled={isDisabled || isLoading || !hasModelOptions || !input.trim()}
 							>
 								{isLoading ? (
 									<Loader2Icon className="animate-spin" />

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -1,4 +1,3 @@
-import { getErrorMessage } from "api/errors";
 import type { ChatQueuedMessage } from "api/typesGenerated";
 import {
 	ModelSelector,
@@ -20,13 +19,14 @@ import {
 import {
 	memo,
 	type ReactNode,
+	type Ref,
 	useCallback,
 	useEffect,
+	useImperativeHandle,
 	useRef,
 	useState,
 } from "react";
 import TextareaAutosize from "react-textarea-autosize";
-import { toast } from "sonner";
 import { cn } from "utils/cn";
 import { formatProviderLabel } from "./modelOptions";
 import { QueuedMessagesList } from "./QueuedMessagesList";
@@ -82,13 +82,11 @@ interface AgentChatInputProps {
 	// When true the entire input sticks to the bottom of the scroll
 	// container (used in the detail page).
 	sticky?: boolean;
-	// External edit request — when set, replaces the input text and
-	// focuses the textarea. Use a unique `key` to allow re-editing the
-	// same text.
-	editRequest?: { text: string; messageId?: number; key: number } | null;
 	// Called when the user cancels or completes a history edit so the
 	// parent can clear the editing highlight.
 	onEditCleared?: () => void;
+	// Imperative handle ref for the parent to trigger edit requests.
+	ref?: Ref<AgentChatInputHandle>;
 }
 
 const hasFiniteTokenValue = (value: number | undefined): value is number =>
@@ -214,6 +212,10 @@ const ContextUsageIndicator = memo<{ usage: AgentContextUsage | null }>(
 );
 ContextUsageIndicator.displayName = "ContextUsageIndicator";
 
+export interface AgentChatInputHandle {
+	applyEditRequest: (text: string, messageId?: number) => void;
+}
+
 export const AgentChatInput = memo<AgentChatInputProps>(
 	({
 		onSend,
@@ -238,8 +240,8 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		onPromoteQueuedMessage,
 		contextUsage,
 		sticky = false,
-		editRequest = null,
 		onEditCleared,
+		ref,
 	}) => {
 		const [input, setInput] = useState(initialValue);
 		const [editingQueuedMessageID, setEditingQueuedMessageID] = useState<
@@ -250,9 +252,6 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		>(null);
 		const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-		// Handle external edit requests (e.g. clicking a historical
-		// user message's edit icon).
-		const lastEditKeyRef = useRef<number | null>(null);
 		const [isEditingHistoryMessage, setIsEditingHistoryMessage] =
 			useState(false);
 		const [editingHistoryMessageID, setEditingHistoryMessageID] = useState<
@@ -262,28 +261,22 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 			string | null
 		>(null);
 
-		// Refs to read current values inside the editRequest effect
-		// without adding them as dependencies (which would cause the
-		// effect to re-fire on every keystroke).
-		const inputRef = useRef(input);
-		inputRef.current = input;
-		const isEditingHistoryRef = useRef(isEditingHistoryMessage);
-		isEditingHistoryRef.current = isEditingHistoryMessage;
-
-		useEffect(() => {
-			if (!editRequest || editRequest.key === lastEditKeyRef.current) {
-				return;
-			}
-			lastEditKeyRef.current = editRequest.key;
-			setDraftBeforeHistoryEdit((current) =>
-				isEditingHistoryRef.current ? current : inputRef.current,
-			);
-			setIsEditingHistoryMessage(true);
-			setEditingHistoryMessageID(editRequest.messageId ?? null);
-			setInput(editRequest.text);
-			onInputChange?.(editRequest.text);
-			textareaRef.current?.focus();
-		}, [editRequest, onInputChange]);
+		useImperativeHandle(
+			ref,
+			() => ({
+				applyEditRequest: (text: string, messageId?: number) => {
+					setDraftBeforeHistoryEdit((current) =>
+						isEditingHistoryMessage ? current : input,
+					);
+					setIsEditingHistoryMessage(true);
+					setEditingHistoryMessageID(messageId ?? null);
+					setInput(text);
+					onInputChange?.(text);
+					textareaRef.current?.focus();
+				},
+			}),
+			[input, isEditingHistoryMessage, onInputChange],
+		);
 
 		const handleCancelHistoryEdit = useCallback(() => {
 			if (!isEditingHistoryMessage) {
@@ -329,41 +322,32 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 				isEditingHistoryMessage && editingHistoryMessageID !== null
 					? editingHistoryMessageID
 					: undefined;
-			// Capture the raw input before clearing so we can restore
-			// it if the request fails.
 			const capturedInput = input;
 
-			// Clear the input immediately so the user can start typing
-			// their next message without waiting for the network
-			// round-trip. Editing state is cleared only after the
-			// request succeeds so it can be restored on failure.
+			// Clear input and editing state optimistically.
 			setInput("");
 			onInputChange?.("");
+			if (queueEditID !== null) {
+				setEditingQueuedMessageID(null);
+				setDraftBeforeQueueEdit(null);
+			}
+			if (isEditingHistoryMessage) {
+				setIsEditingHistoryMessage(false);
+				setEditingHistoryMessageID(null);
+				setDraftBeforeHistoryEdit(null);
+				onEditCleared?.();
+			}
 
 			try {
 				await onSend(capturedInput, editedMessageID);
 				if (queueEditID !== null && onDeleteQueuedMessage) {
 					await onDeleteQueuedMessage(queueEditID);
 				}
-				// Clear editing state only on success so we can
-				// restore it if the request fails above.
-				if (queueEditID !== null) {
-					setEditingQueuedMessageID(null);
-					setDraftBeforeQueueEdit(null);
-				}
-				if (isEditingHistoryMessage) {
-					setIsEditingHistoryMessage(false);
-					setEditingHistoryMessageID(null);
-					setDraftBeforeHistoryEdit(null);
-					onEditCleared?.();
-				}
-			} catch (error) {
+			} catch {
 				// Restore the input so the user can retry.
 				setInput(capturedInput);
 				onInputChange?.(capturedInput);
-				toast.error(getErrorMessage(error, "Failed to send message."));
 			} finally {
-				// Re-focus the textarea so the user can keep typing.
 				textareaRef.current?.focus();
 			}
 		}, [
@@ -571,7 +555,9 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								variant="default"
 								className="size-7 rounded-full transition-colors [&>svg]:!size-6 flex items-center justify-center"
 								onClick={() => void handleSubmit()}
-								disabled={isDisabled || isLoading || !hasModelOptions || !input.trim()}
+								disabled={
+									isDisabled || isLoading || !hasModelOptions || !input.trim()
+								}
 							>
 								{isLoading ? (
 									<Loader2Icon className="animate-spin" />

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -278,9 +278,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		};
 
 		const sendButtonLabel =
-			isStreaming && editingQueuedMessageID === null
-				? "Queue message"
-				: "Send";
+			isStreaming && editingQueuedMessageID === null ? "Queue message" : "Send";
 
 		const content = (
 			<div className="mx-auto w-full max-w-3xl pb-4">

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -16,16 +16,7 @@ import {
 	Square,
 	XIcon,
 } from "lucide-react";
-import {
-	memo,
-	type ReactNode,
-	type Ref,
-	useCallback,
-	useEffect,
-	useImperativeHandle,
-	useRef,
-	useState,
-} from "react";
+import { memo, type ReactNode, useRef } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { cn } from "utils/cn";
 import { formatProviderLabel } from "./modelOptions";
@@ -44,16 +35,13 @@ export interface AgentContextUsage {
 }
 
 interface AgentChatInputProps {
-	onSend: (message: string, editedMessageID?: number) => Promise<void>;
+	onSend: (message: string) => void;
 	placeholder?: string;
 	isDisabled: boolean;
 	isLoading: boolean;
-	// Optional initial value for the textarea (e.g. restored from
-	// localStorage on the create page).
-	initialValue?: string;
-	// Fires whenever the textarea value changes, useful for persisting
-	// the draft externally.
-	onInputChange?: (value: string) => void;
+	// Controlled input value. The parent owns the text state.
+	value: string;
+	onChange: (value: string) => void;
 	// Model selector.
 	selectedModel: string;
 	onModelChange: (value: string) => void;
@@ -74,6 +62,13 @@ interface AgentChatInputProps {
 	queuedMessages?: readonly ChatQueuedMessage[];
 	onDeleteQueuedMessage?: (id: number) => Promise<void> | void;
 	onPromoteQueuedMessage?: (id: number) => Promise<void> | void;
+	// Queue editing state, owned by the parent.
+	editingQueuedMessageID?: number | null;
+	onStartQueueEdit?: (id: number, text: string) => void;
+	onCancelQueueEdit?: () => void;
+	// History editing state, owned by the parent.
+	isEditingHistoryMessage?: boolean;
+	onCancelHistoryEdit?: () => void;
 
 	// Optional context-usage summary shown to the left of the send button.
 	// Pass `null` to render fallback values (e.g. when limit is unknown).
@@ -82,11 +77,6 @@ interface AgentChatInputProps {
 	// When true the entire input sticks to the bottom of the scroll
 	// container (used in the detail page).
 	sticky?: boolean;
-	// Called when the user cancels or completes a history edit so the
-	// parent can clear the editing highlight.
-	onEditCleared?: () => void;
-	// Imperative handle ref for the parent to trigger edit requests.
-	ref?: Ref<AgentChatInputHandle>;
 }
 
 const hasFiniteTokenValue = (value: number | undefined): value is number =>
@@ -212,18 +202,14 @@ const ContextUsageIndicator = memo<{ usage: AgentContextUsage | null }>(
 );
 ContextUsageIndicator.displayName = "ContextUsageIndicator";
 
-export interface AgentChatInputHandle {
-	applyEditRequest: (text: string, messageId?: number) => void;
-}
-
 export const AgentChatInput = memo<AgentChatInputProps>(
 	({
 		onSend,
 		placeholder = "Type a message...",
 		isDisabled,
 		isLoading,
-		initialValue = "",
-		onInputChange,
+		value,
+		onChange,
 		selectedModel,
 		onModelChange,
 		modelOptions,
@@ -238,208 +224,63 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		queuedMessages = [],
 		onDeleteQueuedMessage,
 		onPromoteQueuedMessage,
+		editingQueuedMessageID = null,
+		onStartQueueEdit,
+		onCancelQueueEdit,
+		isEditingHistoryMessage = false,
+		onCancelHistoryEdit,
 		contextUsage,
 		sticky = false,
-		onEditCleared,
-		ref,
 	}) => {
-		const [input, setInput] = useState(initialValue);
-		const [editingQueuedMessageID, setEditingQueuedMessageID] = useState<
-			number | null
-		>(null);
-		const [draftBeforeQueueEdit, setDraftBeforeQueueEdit] = useState<
-			string | null
-		>(null);
 		const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-		const [isEditingHistoryMessage, setIsEditingHistoryMessage] =
-			useState(false);
-		const [editingHistoryMessageID, setEditingHistoryMessageID] = useState<
-			number | null
-		>(null);
-		const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] = useState<
-			string | null
-		>(null);
+		const canSend =
+			!isDisabled && !isLoading && hasModelOptions && !!value.trim();
 
-		useImperativeHandle(
-			ref,
-			() => ({
-				applyEditRequest: (text: string, messageId?: number) => {
-					setDraftBeforeHistoryEdit((current) =>
-						isEditingHistoryMessage ? current : input,
-					);
-					setIsEditingHistoryMessage(true);
-					setEditingHistoryMessageID(messageId ?? null);
-					setInput(text);
-					onInputChange?.(text);
-					textareaRef.current?.focus();
-				},
-			}),
-			[input, isEditingHistoryMessage, onInputChange],
-		);
-
-		const handleCancelHistoryEdit = useCallback(() => {
-			if (!isEditingHistoryMessage) {
+		const handleSubmit = () => {
+			if (!canSend) {
 				return;
 			}
-			const restored = draftBeforeHistoryEdit ?? "";
-			setIsEditingHistoryMessage(false);
-			setEditingHistoryMessageID(null);
-			setDraftBeforeHistoryEdit(null);
-			setInput(restored);
-			onInputChange?.(restored);
-			onEditCleared?.();
+			onSend(value.trim());
 			textareaRef.current?.focus();
-		}, [
-			draftBeforeHistoryEdit,
-			isEditingHistoryMessage,
-			onEditCleared,
-			onInputChange,
-		]);
+		};
 
-		useEffect(() => {
-			if (editingQueuedMessageID === null) {
-				return;
-			}
-			const stillQueued = queuedMessages.some(
-				(message) => message.id === editingQueuedMessageID,
-			);
-			if (stillQueued) {
-				return;
-			}
-			setEditingQueuedMessageID(null);
-			setDraftBeforeQueueEdit(null);
-		}, [editingQueuedMessageID, queuedMessages]);
-
-		const handleSubmit = useCallback(async () => {
-			const text = input.trim();
-			if (!text || isDisabled || isLoading || !hasModelOptions) {
-				return;
-			}
-
-			const queueEditID = editingQueuedMessageID;
-			const editedMessageID =
-				isEditingHistoryMessage && editingHistoryMessageID !== null
-					? editingHistoryMessageID
-					: undefined;
-			const capturedInput = input;
-
-			// Clear input and editing state optimistically.
-			setInput("");
-			onInputChange?.("");
-			if (queueEditID !== null) {
-				setEditingQueuedMessageID(null);
-				setDraftBeforeQueueEdit(null);
-			}
-			if (isEditingHistoryMessage) {
-				setIsEditingHistoryMessage(false);
-				setEditingHistoryMessageID(null);
-				setDraftBeforeHistoryEdit(null);
-				onEditCleared?.();
-			}
-
-			try {
-				await onSend(capturedInput, editedMessageID);
-				if (queueEditID !== null && onDeleteQueuedMessage) {
-					await onDeleteQueuedMessage(queueEditID);
+		const handleKeyDown = (e: React.KeyboardEvent) => {
+			if (e.key === "Escape") {
+				if (editingQueuedMessageID !== null) {
+					e.preventDefault();
+					onCancelQueueEdit?.();
+				} else if (isEditingHistoryMessage) {
+					e.preventDefault();
+					onCancelHistoryEdit?.();
+				} else if (isStreaming && onInterrupt && !isInterruptPending) {
+					e.preventDefault();
+					onInterrupt();
 				}
-			} catch {
-				// Restore the input so the user can retry.
-				setInput(capturedInput);
-				onInputChange?.(capturedInput);
-			} finally {
-				textareaRef.current?.focus();
-			}
-		}, [
-			editingQueuedMessageID,
-			editingHistoryMessageID,
-			hasModelOptions,
-			input,
-			isDisabled,
-			isEditingHistoryMessage,
-			isLoading,
-			onDeleteQueuedMessage,
-			onEditCleared,
-			onInputChange,
-			onSend,
-		]);
-
-		const handleStartQueueEdit = useCallback(
-			(id: number, text: string) => {
-				setDraftBeforeQueueEdit((current) =>
-					editingQueuedMessageID === null ? input : current,
-				);
-				setEditingQueuedMessageID(id);
-				setInput(text);
-				onInputChange?.(text);
-				textareaRef.current?.focus();
-			},
-			[editingQueuedMessageID, input, onInputChange],
-		);
-
-		const handleCancelQueueEdit = useCallback(() => {
-			if (editingQueuedMessageID === null) {
 				return;
 			}
-			const restored = draftBeforeQueueEdit ?? "";
-			setEditingQueuedMessageID(null);
-			setDraftBeforeQueueEdit(null);
-			setInput(restored);
-			onInputChange?.(restored);
-			textareaRef.current?.focus();
-		}, [draftBeforeQueueEdit, editingQueuedMessageID, onInputChange]);
-
-		const sendButtonLabel =
-			isStreaming && editingQueuedMessageID === null ? "Queue message" : "Send";
-
-		const handleKeyDown = useCallback(
-			(e: React.KeyboardEvent) => {
-				if (e.key === "Escape") {
-					if (editingQueuedMessageID !== null) {
-						e.preventDefault();
-						handleCancelQueueEdit();
-					} else if (isEditingHistoryMessage) {
-						e.preventDefault();
-						handleCancelHistoryEdit();
-					} else if (isStreaming && onInterrupt && !isInterruptPending) {
-						e.preventDefault();
-						onInterrupt();
-					}
+			if (e.key === "Enter" && !e.shiftKey) {
+				e.preventDefault();
+				// If the input is empty and there are queued messages,
+				// promote the first one instead of submitting.
+				if (
+					!value.trim() &&
+					!isDisabled &&
+					!isLoading &&
+					queuedMessages.length > 0 &&
+					onPromoteQueuedMessage
+				) {
+					void onPromoteQueuedMessage(queuedMessages[0].id);
 					return;
 				}
-				if (e.key === "Enter" && !e.shiftKey) {
-					e.preventDefault();
-					// If the input is empty and there are queued messages,
-					// promote the first one instead of submitting.
-					if (
-						!input.trim() &&
-						!isDisabled &&
-						!isLoading &&
-						queuedMessages.length > 0 &&
-						onPromoteQueuedMessage
-					) {
-						void onPromoteQueuedMessage(queuedMessages[0].id);
-						return;
-					}
-					void handleSubmit();
-				}
-			},
-			[
-				editingQueuedMessageID,
-				handleCancelHistoryEdit,
-				handleCancelQueueEdit,
-				handleSubmit,
-				input,
-				isDisabled,
-				isEditingHistoryMessage,
-				isInterruptPending,
-				isLoading,
-				isStreaming,
-				onInterrupt,
-				onPromoteQueuedMessage,
-				queuedMessages,
-			],
-		);
+				handleSubmit();
+			}
+		};
+
+		const sendButtonLabel =
+			isStreaming && editingQueuedMessageID === null
+				? "Queue message"
+				: "Send";
 
 		const content = (
 			<div className="mx-auto w-full max-w-3xl pb-4">
@@ -448,17 +289,17 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 						messages={queuedMessages}
 						onDelete={(id) => {
 							if (id === editingQueuedMessageID) {
-								handleCancelQueueEdit();
+								onCancelQueueEdit?.();
 							}
 							void onDeleteQueuedMessage?.(id);
 						}}
 						onPromote={(id) => {
 							if (id === editingQueuedMessageID) {
-								handleCancelQueueEdit();
+								onCancelQueueEdit?.();
 							}
 							void onPromoteQueuedMessage?.(id);
 						}}
-						onEdit={handleStartQueueEdit}
+						onEdit={onStartQueueEdit}
 						editingMessageID={editingQueuedMessageID}
 						className="mb-2"
 					/>
@@ -473,7 +314,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								type="button"
 								variant="subtle"
 								size="sm"
-								onClick={handleCancelQueueEdit}
+								onClick={onCancelQueueEdit}
 								className="h-7 px-2 text-content-secondary hover:text-content-primary"
 							>
 								Cancel
@@ -493,7 +334,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								variant="subtle"
 								size="icon"
 								aria-label="Cancel editing"
-								onClick={handleCancelHistoryEdit}
+								onClick={onCancelHistoryEdit}
 								disabled={isLoading}
 								className="size-6 rounded text-content-secondary hover:text-content-primary"
 							>
@@ -506,11 +347,8 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 						aria-label="Chat message"
 						className="min-h-[120px] w-full resize-none border-none bg-transparent px-3 py-2 font-sans text-[15px] leading-6 text-content-primary outline-none placeholder:text-content-secondary disabled:cursor-not-allowed disabled:opacity-70"
 						placeholder={placeholder}
-						value={input}
-						onChange={(e) => {
-							setInput(e.target.value);
-							onInputChange?.(e.target.value);
-						}}
+						value={value}
+						onChange={(e) => onChange(e.target.value)}
 						onKeyDown={handleKeyDown}
 						disabled={isDisabled}
 						minRows={4}
@@ -554,10 +392,8 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								size="icon"
 								variant="default"
 								className="size-7 rounded-full transition-colors [&>svg]:!size-6 flex items-center justify-center"
-								onClick={() => void handleSubmit()}
-								disabled={
-									isDisabled || isLoading || !hasModelOptions || !input.trim()
-								}
+								onClick={handleSubmit}
+								disabled={!canSend}
 							>
 								{isLoading ? (
 									<Loader2Icon className="animate-spin" />

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -28,7 +28,10 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
 import { pageTitle } from "utils/page";
-import { AgentChatInput } from "./AgentChatInput";
+import {
+	AgentChatInput,
+	type AgentChatInputHandle,
+} from "./AgentChatInput";
 import {
 	selectChatStatus,
 	selectHasStreamState,
@@ -198,7 +201,7 @@ interface AgentDetailInputProps {
 	modelSelectorPlaceholder: string;
 	inputStatusText: string | null;
 	modelCatalogStatusMessage: string | null;
-	editRequest?: { text: string; messageId?: number; key: number } | null;
+	inputRef?: React.Ref<AgentChatInputHandle>;
 	onEditCleared?: () => void;
 }
 
@@ -219,7 +222,7 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 	modelSelectorPlaceholder,
 	inputStatusText,
 	modelCatalogStatusMessage,
-	editRequest,
+	inputRef,
 	onEditCleared,
 }) => {
 	const messagesByID = useChatSelector(store, selectMessagesByID);
@@ -264,7 +267,7 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 			modelSelectorPlaceholder={modelSelectorPlaceholder}
 			inputStatusText={inputStatusText}
 			modelCatalogStatusMessage={modelCatalogStatusMessage}
-			editRequest={editRequest}
+			ref={inputRef}
 			onEditCleared={onEditCleared}
 			sticky
 		/>
@@ -314,21 +317,21 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 	modelCatalogStatusMessage,
 	savingMessageId,
 }) => {
-	const [editRequest, setEditRequest] = useState<{
-		text: string;
-		messageId: number;
-		key: number;
-	} | null>(null);
+	const chatInputRef = useRef<AgentChatInputHandle>(null);
+	const [editingMessageId, setEditingMessageId] = useState<number | null>(
+		null,
+	);
 
 	const handleEditUserMessage = useCallback(
 		(messageId: number, text: string) => {
-			setEditRequest({ text, messageId, key: Date.now() });
+			setEditingMessageId(messageId);
+			chatInputRef.current?.applyEditRequest(text, messageId);
 		},
 		[],
 	);
 
 	const handleEditCleared = useCallback(() => {
-		setEditRequest(null);
+		setEditingMessageId(null);
 	}, []);
 
 	return (
@@ -338,7 +341,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 				chatID={chatID}
 				persistedErrorReason={persistedErrorReason}
 				onEditUserMessage={handleEditUserMessage}
-				editingMessageId={editRequest?.messageId ?? null}
+				editingMessageId={editingMessageId}
 				savingMessageId={savingMessageId}
 			/>
 			<AgentDetailInput
@@ -358,7 +361,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 				modelSelectorPlaceholder={modelSelectorPlaceholder}
 				inputStatusText={inputStatusText}
 				modelCatalogStatusMessage={modelCatalogStatusMessage}
-				editRequest={editRequest}
+				inputRef={chatInputRef}
 				onEditCleared={handleEditCleared}
 			/>
 		</>

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -334,9 +334,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 	const [inputValue, setInputValue] = useState("");
 
 	// -- History editing state --
-	const [editingMessageId, setEditingMessageId] = useState<number | null>(
-		null,
-	);
+	const [editingMessageId, setEditingMessageId] = useState<number | null>(null);
 	const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] = useState<
 		string | null
 	>(null);
@@ -413,12 +411,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 					setInputValue(message);
 				});
 		},
-		[
-			editingMessageId,
-			editingQueuedMessageID,
-			onDeleteQueuedMessage,
-			onSend,
-		],
+		[editingMessageId, editingQueuedMessageID, onDeleteQueuedMessage, onSend],
 	);
 
 	return (

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -28,10 +28,7 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { toast } from "sonner";
 import { pageTitle } from "utils/page";
-import {
-	AgentChatInput,
-	type AgentChatInputHandle,
-} from "./AgentChatInput";
+import { AgentChatInput } from "./AgentChatInput";
 import {
 	selectChatStatus,
 	selectHasStreamState,
@@ -187,7 +184,7 @@ const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 interface AgentDetailInputProps {
 	store: ChatStoreHandle;
 	compressionThreshold: number | undefined;
-	onSend: (message: string, editedMessageID?: number) => Promise<void>;
+	onSend: (message: string) => void;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
 	onInterrupt: () => void;
@@ -201,8 +198,15 @@ interface AgentDetailInputProps {
 	modelSelectorPlaceholder: string;
 	inputStatusText: string | null;
 	modelCatalogStatusMessage: string | null;
-	inputRef?: React.Ref<AgentChatInputHandle>;
-	onEditCleared?: () => void;
+	// Controlled input value and editing state, owned by the
+	// conversation component.
+	inputValue: string;
+	onInputChange: (value: string) => void;
+	editingQueuedMessageID: number | null;
+	onStartQueueEdit: (id: number, text: string) => void;
+	onCancelQueueEdit: () => void;
+	isEditingHistoryMessage: boolean;
+	onCancelHistoryEdit: () => void;
 }
 
 const AgentDetailInput: FC<AgentDetailInputProps> = ({
@@ -222,8 +226,13 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 	modelSelectorPlaceholder,
 	inputStatusText,
 	modelCatalogStatusMessage,
-	inputRef,
-	onEditCleared,
+	inputValue,
+	onInputChange,
+	editingQueuedMessageID,
+	onStartQueueEdit,
+	onCancelQueueEdit,
+	isEditingHistoryMessage,
+	onCancelHistoryEdit,
 }) => {
 	const messagesByID = useChatSelector(store, selectMessagesByID);
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
@@ -251,9 +260,16 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 	return (
 		<AgentChatInput
 			onSend={onSend}
+			value={inputValue}
+			onChange={onInputChange}
 			queuedMessages={queuedMessages}
 			onDeleteQueuedMessage={onDeleteQueuedMessage}
 			onPromoteQueuedMessage={onPromoteQueuedMessage}
+			editingQueuedMessageID={editingQueuedMessageID}
+			onStartQueueEdit={onStartQueueEdit}
+			onCancelQueueEdit={onCancelQueueEdit}
+			isEditingHistoryMessage={isEditingHistoryMessage}
+			onCancelHistoryEdit={onCancelHistoryEdit}
 			isDisabled={isInputDisabled}
 			isLoading={isSendPending}
 			isStreaming={isStreaming}
@@ -267,8 +283,6 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 			modelSelectorPlaceholder={modelSelectorPlaceholder}
 			inputStatusText={inputStatusText}
 			modelCatalogStatusMessage={modelCatalogStatusMessage}
-			ref={inputRef}
-			onEditCleared={onEditCleared}
 			sticky
 		/>
 	);
@@ -317,22 +331,95 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 	modelCatalogStatusMessage,
 	savingMessageId,
 }) => {
-	const chatInputRef = useRef<AgentChatInputHandle>(null);
+	const [inputValue, setInputValue] = useState("");
+
+	// -- History editing state --
 	const [editingMessageId, setEditingMessageId] = useState<number | null>(
 		null,
 	);
+	const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] = useState<
+		string | null
+	>(null);
 
 	const handleEditUserMessage = useCallback(
 		(messageId: number, text: string) => {
+			setDraftBeforeHistoryEdit((prev) =>
+				editingMessageId !== null ? prev : inputValue,
+			);
 			setEditingMessageId(messageId);
-			chatInputRef.current?.applyEditRequest(text, messageId);
+			setInputValue(text);
 		},
-		[],
+		[editingMessageId, inputValue],
 	);
 
-	const handleEditCleared = useCallback(() => {
+	const handleCancelHistoryEdit = useCallback(() => {
+		setInputValue(draftBeforeHistoryEdit ?? "");
 		setEditingMessageId(null);
-	}, []);
+		setDraftBeforeHistoryEdit(null);
+	}, [draftBeforeHistoryEdit]);
+
+	// -- Queue editing state --
+	const [editingQueuedMessageID, setEditingQueuedMessageID] = useState<
+		number | null
+	>(null);
+	const [draftBeforeQueueEdit, setDraftBeforeQueueEdit] = useState<
+		string | null
+	>(null);
+
+	const handleStartQueueEdit = useCallback(
+		(id: number, text: string) => {
+			setDraftBeforeQueueEdit((prev) =>
+				editingQueuedMessageID === null ? inputValue : prev,
+			);
+			setEditingQueuedMessageID(id);
+			setInputValue(text);
+		},
+		[editingQueuedMessageID, inputValue],
+	);
+
+	const handleCancelQueueEdit = useCallback(() => {
+		setInputValue(draftBeforeQueueEdit ?? "");
+		setEditingQueuedMessageID(null);
+		setDraftBeforeQueueEdit(null);
+	}, [draftBeforeQueueEdit]);
+
+	// Wraps the parent onSend to clear local input/editing state
+	// and handle queue-edit deletion.
+	const handleSendFromInput = useCallback(
+		(message: string) => {
+			const editedMessageID =
+				editingMessageId !== null ? editingMessageId : undefined;
+			const queueEditID = editingQueuedMessageID;
+
+			// Clear input and editing state optimistically.
+			setInputValue("");
+			if (editingMessageId !== null) {
+				setEditingMessageId(null);
+				setDraftBeforeHistoryEdit(null);
+			}
+			if (queueEditID !== null) {
+				setEditingQueuedMessageID(null);
+				setDraftBeforeQueueEdit(null);
+			}
+
+			void onSend(message, editedMessageID)
+				.then(() => {
+					if (queueEditID !== null) {
+						void onDeleteQueuedMessage(queueEditID);
+					}
+				})
+				.catch(() => {
+					// Restore input so the user can retry.
+					setInputValue(message);
+				});
+		},
+		[
+			editingMessageId,
+			editingQueuedMessageID,
+			onDeleteQueuedMessage,
+			onSend,
+		],
+	);
 
 	return (
 		<>
@@ -347,7 +434,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 			<AgentDetailInput
 				store={store}
 				compressionThreshold={compressionThreshold}
-				onSend={onSend}
+				onSend={handleSendFromInput}
 				onDeleteQueuedMessage={onDeleteQueuedMessage}
 				onPromoteQueuedMessage={onPromoteQueuedMessage}
 				onInterrupt={onInterrupt}
@@ -361,8 +448,13 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 				modelSelectorPlaceholder={modelSelectorPlaceholder}
 				inputStatusText={inputStatusText}
 				modelCatalogStatusMessage={modelCatalogStatusMessage}
-				inputRef={chatInputRef}
-				onEditCleared={handleEditCleared}
+				inputValue={inputValue}
+				onInputChange={setInputValue}
+				editingQueuedMessageID={editingQueuedMessageID}
+				onStartQueueEdit={handleStartQueueEdit}
+				onCancelQueueEdit={handleCancelQueueEdit}
+				isEditingHistoryMessage={editingMessageId !== null}
+				onCancelHistoryEdit={handleCancelHistoryEdit}
 			/>
 		</>
 	);
@@ -812,7 +904,9 @@ const AgentDetail: FC = () => {
 							</div>
 						</div>
 						<AgentChatInput
-							onSend={handleSend}
+							onSend={() => {}}
+							value=""
+							onChange={() => {}}
 							isDisabled={isInputDisabled}
 							isLoading={false}
 							selectedModel={selectedModel}

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -520,24 +520,24 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 	canManageChatModelConfigs,
 	topBarActionsRef,
 }) => {
-	const initialInput = useMemo(() => {
+	const [inputValue, setInputValue] = useState(() => {
 		if (typeof window === "undefined") {
 			return "";
 		}
 		return localStorage.getItem(emptyInputStorageKey) ?? "";
-	}, []);
-	const initialSystemPrompt = useMemo(() => {
+	});
+	const initialSystemPrompt = () => {
 		if (typeof window === "undefined") {
 			return "";
 		}
 		return localStorage.getItem(systemPromptStorageKey) ?? "";
-	}, []);
-	const initialLastModelConfigID = useMemo(() => {
+	};
+	const [initialLastModelConfigID] = useState(() => {
 		if (typeof window === "undefined") {
 			return "";
 		}
 		return localStorage.getItem(lastModelConfigIDStorageKey) ?? "";
-	}, []);
+	});
 	const modelIDByConfigID = useMemo(() => {
 		const optionIDByRef = new Map<string, string>();
 		for (const option of modelOptions) {
@@ -671,6 +671,7 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 	};
 
 	const handleInputChange = useCallback((value: string) => {
+		setInputValue(value);
 		if (typeof window !== "undefined") {
 			localStorage.setItem(emptyInputStorageKey, value);
 		}
@@ -700,8 +701,8 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 	);
 
 	const handleSend = useCallback(
-		async (message: string) => {
-			await onCreateChat({
+		(message: string) => {
+			void onCreateChat({
 				message,
 				workspaceId: selectedWorkspaceIdRef.current ?? undefined,
 				model: selectedModelRef.current || undefined,
@@ -741,8 +742,8 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 					placeholder="Ask Coder to build, fix bugs, or explore your project..."
 					isDisabled={isCreating}
 					isLoading={isCreating}
-					initialValue={initialInput}
-					onInputChange={handleInputChange}
+					value={inputValue}
+					onChange={handleInputChange}
 					selectedModel={selectedModel}
 					onModelChange={handleModelChange}
 					modelOptions={modelOptions}


### PR DESCRIPTION
## Summary

Refactors `AgentChatInput` from an overcomplicated stateful component into a simple controlled input driven entirely by props.

### Problem

`AgentChatInput` managed 6 `useState` variables, 5 `useCallback` wrappers, 1 `useEffect`, and 1 `useImperativeHandle` — all to handle editing state that the parent needed to control anyway. The parent (`AgentDetailConversation`) stored `editingMessageId` in its own state and poked text into the input via an imperative ref handle, creating bidirectional state synchronization.

### Changes

**`AgentChatInput.tsx`** (597 → 432 lines)
- Now a pure controlled component: `value`/`onChange` replaces `initialValue`/`onInputChange`
- Removed `AgentChatInputHandle` imperative ref API entirely
- Removed all internal state (`useState`), effects (`useEffect`), imperative handles (`useImperativeHandle`), and memoized callbacks (`useCallback`)
- `onSend` simplified to `(message: string) => void` — parent handles input clearing, error recovery, and edit-vs-create dispatch
- Editing banners driven by declarative props (`isEditingHistoryMessage`, `editingQueuedMessageID`) instead of internal state
- Only remaining hook: 1 `useRef` for textarea focus-after-submit

**`AgentDetail.tsx`**
- `AgentDetailConversation` now owns input text, queue-edit state, and history-edit state
- Removed `useRef<AgentChatInputHandle>` — no more imperative handle
- `handleEditUserMessage` directly sets state instead of poking a ref
- `handleSendFromInput` wraps parent `onSend`, clears state optimistically, restores on error

**`AgentsPage.tsx`**
- Added `useState` initializer callbacks to own input text (replaces `useMemo`-for-behavior pattern)
- Fixed three `useMemo(() => localStorage.getItem(...), [])` that relied on memo for behavioral correctness (compute-once semantics) — replaced with `useState(() => ...)` initializer callbacks

**`AgentChatInput.stories.tsx`**
- Updated to use `value`/`onChange` props