### PR TITLE
fix(site): remove scrollbar-gutter override causing layout shift on agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -106,19 +106,6 @@ const AgentsPage: FC = () => {
 		user.roles.some((role) => role.name === "owner" || role.name === "admin");
 	const canSetSystemPrompt = isAgentsAdmin;
 
-	// The global CSS sets scrollbar-gutter: stable on <html> to prevent
-	// layout shift on pages that toggle scrollbars. The agents page uses
-	// its own internal scroll containers so the reserved gutter space is
-	// unnecessary and wastes horizontal room.
-	useEffect(() => {
-		const html = document.documentElement;
-		const prev = html.style.scrollbarGutter;
-		html.style.scrollbarGutter = "auto";
-		return () => {
-			html.style.scrollbarGutter = prev;
-		};
-	}, []);
-
 	const chatsQuery = useQuery(chats());
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());


### PR DESCRIPTION
## Problem

Opening the agent actions dropdown (ellipsis menu) on the `/agents` page causes a layout shift.

## Root cause

The agents page was the **only** page in the codebase that overrode the global `scrollbar-gutter: stable` to `auto` on `<html>`. This broke the global scroll-lock fix in `index.css`:

```css
@supports (scrollbar-gutter: stable) {
  html {
    scrollbar-gutter: stable;
  }
  html body[data-scroll-locked] {
    --removed-body-scroll-bar-size: 0 !important;
    margin-right: 0 !important;
    overflow-y: scroll !important;
  }
}
```

That CSS assumes `scrollbar-gutter: stable` is always active and zeroes out Radix's scroll-lock compensation accordingly. When the agents page set `scrollbar-gutter: auto`, the contract broke:

1. User clicks the dropdown — Radix `RemoveScroll` fires (`modal` is `true` by default)
2. `body[data-scroll-locked]` is set with `overflow: hidden` + `margin-right: <scrollbar-width>px`
3. Global CSS overrides to `margin-right: 0 !important` + `overflow-y: scroll !important`
4. With `scrollbar-gutter: auto`, the forced scrollbar takes up space that wasn't reserved — **layout shift**

Every other page keeps the global `scrollbar-gutter: stable`, so their Radix modals and dropdowns work correctly with the global `body[data-scroll-locked]` fix.

## Fix

Remove the `scrollbar-gutter: auto` override. The original intent was to reclaim horizontal space wasted by the stable gutter on a page that uses its own internal scroll containers, but it's not worth the trade-off of breaking Radix's scroll-lock behavior.
