### PR TITLE
feat(chatd): add start_workspace tool and fix stale agent connections

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -66,8 +66,8 @@ type Server struct {
 	agentConnFn            AgentConnFunc
 	createWorkspaceFn      chattool.CreateWorkspaceFn
 	createWorkspaceBuildFn chattool.CreateWorkspaceBuildFn
-	pubsub                pubsub.Pubsub
-	providerAPIKeys   chatprovider.ProviderAPIKeys
+	pubsub                 pubsub.Pubsub
+	providerAPIKeys        chatprovider.ProviderAPIKeys
 
 	// streamMu guards chatStreams which tracks in-flight chat
 	// stream state for broadcasting ephemeral events.

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -63,9 +63,10 @@ type Server struct {
 
 	remotePartsProvider RemotePartsProvider
 
-	agentConnFn       AgentConnFunc
-	createWorkspaceFn chattool.CreateWorkspaceFn
-	pubsub            pubsub.Pubsub
+	agentConnFn            AgentConnFunc
+	createWorkspaceFn      chattool.CreateWorkspaceFn
+	createWorkspaceBuildFn chattool.CreateWorkspaceBuildFn
+	pubsub                pubsub.Pubsub
 	providerAPIKeys   chatprovider.ProviderAPIKeys
 
 	// streamMu guards chatStreams which tracks in-flight chat
@@ -842,6 +843,7 @@ type Config struct {
 	InFlightChatStaleAfter     time.Duration
 	AgentConn                  AgentConnFunc
 	CreateWorkspace            chattool.CreateWorkspaceFn
+	CreateWorkspaceBuild       chattool.CreateWorkspaceBuildFn
 	Pubsub                     pubsub.Pubsub
 	ProviderAPIKeys            chatprovider.ProviderAPIKeys
 }
@@ -876,6 +878,7 @@ func New(cfg Config) *Server {
 		remotePartsProvider:        cfg.RemotePartsProvider,
 		agentConnFn:                cfg.AgentConn,
 		createWorkspaceFn:          cfg.CreateWorkspace,
+		createWorkspaceBuildFn:     cfg.CreateWorkspaceBuild,
 		pubsub:                     cfg.Pubsub,
 		providerAPIKeys:            cfg.ProviderAPIKeys,
 		chatStreams:                make(map[uuid.UUID]*chatStreamState),
@@ -1824,6 +1827,7 @@ func (p *Server) runChat(
 		chatStateMu sync.Mutex
 		workspaceMu sync.Mutex
 		conn        workspacesdk.AgentConn
+		connAgentID uuid.UUID // tracks which agent ID the cached conn belongs to
 		releaseConn func()
 	)
 	closeConn := func() {
@@ -1831,38 +1835,47 @@ func (p *Server) runChat(
 			releaseConn()
 			releaseConn = nil
 		}
+		conn = nil
+		connAgentID = uuid.Nil
 	}
 	defer closeConn()
 
 	getWorkspaceConn := func(ctx context.Context) (workspacesdk.AgentConn, error) {
+		// Reload the chat snapshot from the DB so we pick up
+		// agent ID changes from start_workspace/create_workspace.
+		refreshedChat, refreshErr := loadChatSnapshot(ctx, currentChat.ID)
+		if refreshErr == nil {
+			chatStateMu.Lock()
+			currentChat = refreshedChat
+			chatStateMu.Unlock()
+		}
+
 		chatStateMu.Lock()
-		if conn != nil {
+		chatSnapshot := currentChat
+
+		// If we have a cached connection and the agent ID
+		// hasn't changed, reuse it.
+		if conn != nil && chatSnapshot.WorkspaceAgentID.Valid &&
+			connAgentID == chatSnapshot.WorkspaceAgentID.UUID {
 			currentConn := conn
 			chatStateMu.Unlock()
 			return currentConn, nil
 		}
-		chatSnapshot := currentChat
+
+		// Agent ID changed (e.g. workspace restarted) or no
+		// cached conn — release any stale connection.
+		if conn != nil {
+			if releaseConn != nil {
+				releaseConn()
+			}
+			conn = nil
+			connAgentID = uuid.Nil
+			releaseConn = nil
+		}
 		chatStateMu.Unlock()
 
 		if p.agentConnFn == nil {
 			return nil, xerrors.New("workspace agent connector is not configured")
-		}
-
-		if !chatSnapshot.WorkspaceAgentID.Valid {
-			refreshedChat, refreshErr := refreshChatWorkspaceSnapshot(
-				ctx,
-				chatSnapshot,
-				loadChatSnapshot,
-			)
-			if refreshErr != nil {
-				return nil, refreshErr
-			}
-			if refreshedChat.WorkspaceAgentID.Valid {
-				chatStateMu.Lock()
-				currentChat = refreshedChat
-				chatSnapshot = refreshedChat
-				chatStateMu.Unlock()
-			}
 		}
 
 		if !chatSnapshot.WorkspaceAgentID.Valid {
@@ -1877,6 +1890,7 @@ func (p *Server) runChat(
 		chatStateMu.Lock()
 		if conn == nil {
 			conn = agentConn
+			connAgentID = chatSnapshot.WorkspaceAgentID.UUID
 			releaseConn = agentRelease
 			chatStateMu.Unlock()
 			return agentConn, nil
@@ -2058,6 +2072,14 @@ func (p *Server) runChat(
 			CreateFn:    p.createWorkspaceFn,
 			AgentConnFn: chattool.AgentConnFunc(p.agentConnFn),
 			WorkspaceMu: &workspaceMu,
+		}),
+		chattool.StartWorkspace(chattool.StartWorkspaceOptions{
+			DB:                   p.db,
+			OwnerID:              chat.OwnerID,
+			ChatID:               chat.ID,
+			CreateWorkspaceBuild: p.createWorkspaceBuildFn,
+			AgentConnFn:          chattool.AgentConnFunc(p.agentConnFn),
+			WorkspaceMu:          &workspaceMu,
 		}),
 		chattool.ReadFile(chattool.ReadFileOptions{
 			GetWorkspaceConn: getWorkspaceConn,
@@ -2348,23 +2370,6 @@ func usageNullInt64(value int64, valid bool) sql.NullInt64 {
 		Int64: value,
 		Valid: valid,
 	}
-}
-
-func refreshChatWorkspaceSnapshot(
-	ctx context.Context,
-	chat database.Chat,
-	loadChat func(context.Context, uuid.UUID) (database.Chat, error),
-) (database.Chat, error) {
-	if chat.WorkspaceAgentID.Valid || loadChat == nil {
-		return chat, nil
-	}
-
-	refreshedChat, err := loadChat(ctx, chat.ID)
-	if err != nil {
-		return chat, xerrors.Errorf("reload chat workspace state: %w", err)
-	}
-
-	return refreshedChat, nil
 }
 
 // resolveInstructions returns the combined system instructions for the

--- a/coderd/chatd/chattool/startworkspace.go
+++ b/coderd/chatd/chattool/startworkspace.go
@@ -1,0 +1,238 @@
+package chattool
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// CreateWorkspaceBuildFn creates a workspace build (start/stop/delete)
+// for the given workspace.
+type CreateWorkspaceBuildFn func(
+	ctx context.Context,
+	ownerID uuid.UUID,
+	workspaceID uuid.UUID,
+	req codersdk.CreateWorkspaceBuildRequest,
+) (codersdk.WorkspaceBuild, error)
+
+// StartWorkspaceOptions configures the start_workspace tool.
+type StartWorkspaceOptions struct {
+	DB                   database.Store
+	OwnerID              uuid.UUID
+	ChatID               uuid.UUID
+	CreateWorkspaceBuild CreateWorkspaceBuildFn
+	AgentConnFn          AgentConnFunc
+	WorkspaceMu          *sync.Mutex
+}
+
+type startWorkspaceArgs struct{}
+
+// StartWorkspace returns a tool that starts the chat's workspace if it
+// is stopped. After the build completes it refreshes the chat's
+// workspace_agent_id (agents get new IDs on each build) and waits for
+// the agent to become reachable.
+func StartWorkspace(options StartWorkspaceOptions) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		"start_workspace",
+		"Start the workspace associated with this chat. "+
+			"Use this when the workspace exists but is stopped. "+
+			"The tool waits for the build to finish and the "+
+			"workspace agent to become reachable before returning.",
+		func(ctx context.Context, _ startWorkspaceArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if options.CreateWorkspaceBuild == nil {
+				return fantasy.NewTextErrorResponse("workspace build creator is not configured"), nil
+			}
+
+			// Serialize workspace operations to prevent parallel
+			// tool calls from racing.
+			if options.WorkspaceMu != nil {
+				options.WorkspaceMu.Lock()
+				defer options.WorkspaceMu.Unlock()
+			}
+
+			if options.DB == nil || options.ChatID == uuid.Nil {
+				return fantasy.NewTextErrorResponse("chat context is not available"), nil
+			}
+
+			chat, err := options.DB.GetChatByID(ctx, options.ChatID)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("load chat: %w", err).Error(),
+				), nil
+			}
+			if !chat.WorkspaceID.Valid {
+				return fantasy.NewTextErrorResponse(
+					"chat has no workspace; use create_workspace first",
+				), nil
+			}
+
+			// Check if workspace still exists.
+			ws, err := options.DB.GetWorkspaceByID(ctx, chat.WorkspaceID.UUID)
+			if err != nil {
+				if xerrors.Is(err, sql.ErrNoRows) {
+					return fantasy.NewTextErrorResponse(
+						"workspace was deleted; use create_workspace to create a new one",
+					), nil
+				}
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("load workspace: %w", err).Error(),
+				), nil
+			}
+
+			// Check the current build state to provide a
+			// helpful response if already running or building.
+			build, err := options.DB.GetLatestWorkspaceBuildByWorkspaceID(ctx, ws.ID)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("get latest build: %w", err).Error(),
+				), nil
+			}
+
+			job, err := options.DB.GetProvisionerJobByID(ctx, build.JobID)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("get provisioner job: %w", err).Error(),
+				), nil
+			}
+
+			switch {
+			case (job.JobStatus == database.ProvisionerJobStatusPending ||
+				job.JobStatus == database.ProvisionerJobStatusRunning) &&
+				build.Transition == database.WorkspaceTransitionStart:
+				// Already starting — wait for it.
+				if err := waitForBuild(ctx, options.DB, ws.ID); err != nil {
+					return fantasy.NewTextErrorResponse(
+						xerrors.Errorf("existing start build failed: %w", err).Error(),
+					), nil
+				}
+				// Refresh agent ID after the build completes.
+				if refreshErr := refreshChatAgentID(ctx, options.DB, options.ChatID, ws.ID); refreshErr != nil {
+					return fantasy.NewTextErrorResponse(refreshErr.Error()), nil
+				}
+				return toolResponse(map[string]any{
+					"started":        true,
+					"workspace_name": ws.Name,
+					"message":        "workspace was already starting and is now ready",
+				}), nil
+
+			case job.JobStatus == database.ProvisionerJobStatusSucceeded &&
+				build.Transition == database.WorkspaceTransitionStart:
+				// Already running — check agent connectivity.
+				if chat.WorkspaceAgentID.Valid && options.AgentConnFn != nil {
+					pingCtx, cancel := context.WithTimeout(ctx, agentPingTimeout)
+					defer cancel()
+					conn, release, connErr := options.AgentConnFn(pingCtx, chat.WorkspaceAgentID.UUID)
+					if connErr == nil {
+						release()
+						_ = conn
+						return toolResponse(map[string]any{
+							"started":        false,
+							"workspace_name": ws.Name,
+							"status":         "already_running",
+							"message":        "workspace is already running and reachable",
+						}), nil
+					}
+				}
+				// Agent unreachable despite succeeded start build —
+				// the agent ID may be stale. Refresh it.
+				if refreshErr := refreshChatAgentID(ctx, options.DB, options.ChatID, ws.ID); refreshErr != nil {
+					return fantasy.NewTextErrorResponse(refreshErr.Error()), nil
+				}
+				return toolResponse(map[string]any{
+					"started":        true,
+					"workspace_name": ws.Name,
+					"message":        "workspace is running; agent connection refreshed",
+				}), nil
+			}
+
+			// Workspace is stopped, failed, or in a non-start
+			// state — issue a start build.
+			ownerCtx, ownerErr := asOwner(ctx, options.DB, options.OwnerID)
+			if ownerErr != nil {
+				return fantasy.NewTextErrorResponse(ownerErr.Error()), nil
+			}
+
+			_, err = options.CreateWorkspaceBuild(ownerCtx, options.OwnerID, ws.ID, codersdk.CreateWorkspaceBuildRequest{
+				Transition: codersdk.WorkspaceTransitionStart,
+			})
+			if err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("start workspace: %w", err).Error(),
+				), nil
+			}
+
+			// Wait for the build to complete.
+			if err := waitForBuild(ctx, options.DB, ws.ID); err != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("workspace start build failed: %w", err).Error(),
+				), nil
+			}
+
+			// Refresh the chat's workspace_agent_id since agents
+			// get new IDs on each build.
+			if refreshErr := refreshChatAgentID(ctx, options.DB, options.ChatID, ws.ID); refreshErr != nil {
+				return fantasy.NewTextErrorResponse(refreshErr.Error()), nil
+			}
+
+			// Wait for the agent to come online.
+			agents, agentErr := options.DB.GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx, ws.ID)
+			if agentErr == nil && len(agents) > 0 && options.AgentConnFn != nil {
+				if err := waitForAgent(ctx, options.AgentConnFn, agents[0].ID); err != nil {
+					return toolResponse(map[string]any{
+						"started":        true,
+						"workspace_name": ws.Name,
+						"agent_status":   "not_ready",
+						"agent_error":    err.Error(),
+					}), nil
+				}
+			}
+
+			return toolResponse(map[string]any{
+				"started":        true,
+				"workspace_name": ws.Name,
+			}), nil
+		},
+	)
+}
+
+// refreshChatAgentID looks up the first agent in the workspace's
+// latest build and updates the chat's workspace_agent_id. This is
+// necessary because workspace agents get new UUIDs on each build, so
+// after a start transition the old agent ID is stale.
+func refreshChatAgentID(
+	ctx context.Context,
+	db database.Store,
+	chatID uuid.UUID,
+	workspaceID uuid.UUID,
+) error {
+	agents, err := db.GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return xerrors.Errorf("get workspace agents: %w", err)
+	}
+	if len(agents) == 0 {
+		return xerrors.New("workspace has no agents in the latest build")
+	}
+
+	_, err = db.UpdateChatWorkspace(ctx, database.UpdateChatWorkspaceParams{
+		ID: chatID,
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		WorkspaceAgentID: uuid.NullUUID{
+			UUID:  agents[0].ID,
+			Valid: true,
+		},
+	})
+	if err != nil {
+		return xerrors.Errorf("update chat workspace agent: %w", err)
+	}
+	return nil
+}

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/provisionerjobs"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpapi/httperror"
@@ -34,6 +35,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/coderd/wsbuilder"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -916,6 +918,67 @@ func (api *API) chatCreateWorkspace(
 
 	sw.WriteHeader(http.StatusCreated)
 	return workspace, nil
+}
+
+// chatCreateWorkspaceBuild provides workspace build creation (start,
+// stop) for the chat processor. It uses the workspace builder to
+// create builds with proper RBAC authorization.
+func (api *API) chatCreateWorkspaceBuild(
+	ctx context.Context,
+	ownerID uuid.UUID,
+	workspaceID uuid.UUID,
+	req codersdk.CreateWorkspaceBuildRequest,
+) (codersdk.WorkspaceBuild, error) {
+	actor, _, err := httpmw.UserRBACSubject(ctx, api.Database, ownerID, rbac.ScopeAll)
+	if err != nil {
+		return codersdk.WorkspaceBuild{}, xerrors.Errorf("load user authorization: %w", err)
+	}
+	ctx = dbauthz.As(ctx, actor)
+
+	workspace, err := api.Database.GetWorkspaceByID(ctx, workspaceID)
+	if err != nil {
+		return codersdk.WorkspaceBuild{}, xerrors.Errorf("get workspace: %w", err)
+	}
+
+	transition := database.WorkspaceTransition(req.Transition)
+	builder := wsbuilder.New(workspace, transition, *api.BuildUsageChecker.Load()).
+		Initiator(ownerID).
+		DeploymentValues(api.Options.DeploymentValues).
+		Experiments(api.Experiments).
+		BuildMetrics(api.WorkspaceBuilderMetrics)
+
+	var provisionerJob *database.ProvisionerJob
+
+	err = api.Database.InTx(func(tx database.Store) error {
+		var buildErr error
+		_, provisionerJob, _, buildErr = builder.Build(
+			ctx,
+			tx,
+			api.FileCache,
+			func(_ policy.Action, _ rbac.Objecter) bool {
+				// RBAC is already enforced via dbauthz.As above.
+				return true
+			},
+			audit.WorkspaceBuildBaggage{},
+		)
+		return buildErr
+	}, nil)
+	if err != nil {
+		return codersdk.WorkspaceBuild{}, xerrors.Errorf("create workspace build: %w", err)
+	}
+
+	if provisionerJob != nil {
+		if err := provisionerjobs.PostJob(api.Pubsub, *provisionerJob); err != nil {
+			api.Logger.Error(ctx, "chat: failed to post provisioner job to pubsub", slog.Error(err))
+		}
+	}
+
+	// The chat tool only needs the build to be queued, not
+	// the full SDK representation. Return a minimal result.
+	return codersdk.WorkspaceBuild{
+		WorkspaceID: workspaceID,
+		Transition:  req.Transition,
+	}, nil
 }
 
 func chatWorkspaceAuditStatus(err error) int {

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -1,6 +1,7 @@
 package coderd_test
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -9,9 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"charm.land/fantasy"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/chatd/chattool"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -19,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd/externalauth"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
@@ -2044,6 +2048,214 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 		require.Equal(t, "Invalid queued message ID.", sdkErr.Message)
 		require.Contains(t, sdkErr.Detail, "invalid syntax")
 	})
+}
+
+func TestStartWorkspaceTool(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StartsStoppedWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			DeploymentValues:         chatDeploymentValues(t),
+			IncludeProvisionerDaemon: true,
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		// Create a workspace with an agent and wait for the initial build.
+		authToken := uuid.NewString()
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionInit:  echo.InitComplete,
+			ProvisionPlan:  echo.PlanComplete,
+			ProvisionGraph: echo.ProvisionGraphWithAgent(authToken),
+			ProvisionApply: echo.ApplyComplete,
+		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		// Stop the workspace so start_workspace has something to do.
+		workspace = coderdtest.MustTransitionWorkspace(
+			t, client, workspace.ID,
+			codersdk.WorkspaceTransitionStart,
+			codersdk.WorkspaceTransitionStop,
+		)
+		require.Equal(t, codersdk.WorkspaceTransitionStop, workspace.LatestBuild.Transition)
+
+		// Create a chat linked to the stopped workspace.
+		chat := insertChatWithWorkspace(t, ctx, db, user.UserID, modelConfig.ID, workspace.ID)
+
+		// The tool runs under a system-restricted context in
+		// production (chatd.go line 891).
+		sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+		tool := chattool.StartWorkspace(chattool.StartWorkspaceOptions{
+			DB:      db,
+			OwnerID: user.UserID,
+			ChatID:  chat.ID,
+			CreateWorkspaceBuild: func(
+				buildCtx context.Context,
+				_ uuid.UUID,
+				workspaceID uuid.UUID,
+				req codersdk.CreateWorkspaceBuildRequest,
+			) (codersdk.WorkspaceBuild, error) {
+				return client.CreateWorkspaceBuild(buildCtx, workspaceID, req)
+			},
+		})
+
+		resp, err := tool.Run(sysCtx, fantasy.ToolCall{
+			ID:    "test-call",
+			Name:  "start_workspace",
+			Input: "{}",
+		})
+		require.NoError(t, err)
+		require.False(t, resp.IsError, "tool returned error: %s", resp.Content)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		require.Equal(t, true, result["started"])
+		require.Equal(t, workspace.Name, result["workspace_name"])
+
+		// Verify the workspace transitioned back to start.
+		updated, err := client.Workspace(ctx, workspace.ID)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.WorkspaceTransitionStart, updated.LatestBuild.Transition)
+	})
+
+	t.Run("NoChatWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		// Chat without a workspace association.
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "no workspace",
+		})
+		require.NoError(t, err)
+
+		sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+		tool := chattool.StartWorkspace(chattool.StartWorkspaceOptions{
+			DB:      db,
+			OwnerID: user.UserID,
+			ChatID:  chat.ID,
+			CreateWorkspaceBuild: func(
+				_ context.Context,
+				_ uuid.UUID,
+				_ uuid.UUID,
+				_ codersdk.CreateWorkspaceBuildRequest,
+			) (codersdk.WorkspaceBuild, error) {
+				t.Fatal("build function should not be called")
+				return codersdk.WorkspaceBuild{}, nil
+			},
+		})
+
+		resp, err := tool.Run(sysCtx, fantasy.ToolCall{
+			ID:    "test-call",
+			Name:  "start_workspace",
+			Input: "{}",
+		})
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.Contains(t, resp.Content, "use create_workspace first")
+	})
+
+	t.Run("AlreadyRunning", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			DeploymentValues:         chatDeploymentValues(t),
+			IncludeProvisionerDaemon: true,
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		// Create a workspace with an agent and leave it running.
+		authToken := uuid.NewString()
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionInit:  echo.InitComplete,
+			ProvisionPlan:  echo.PlanComplete,
+			ProvisionGraph: echo.ProvisionGraphWithAgent(authToken),
+			ProvisionApply: echo.ApplyComplete,
+		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		// Create a chat linked to the running workspace.
+		chat := insertChatWithWorkspace(t, ctx, db, user.UserID, modelConfig.ID, workspace.ID)
+
+		sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+		tool := chattool.StartWorkspace(chattool.StartWorkspaceOptions{
+			DB:      db,
+			OwnerID: user.UserID,
+			ChatID:  chat.ID,
+			CreateWorkspaceBuild: func(
+				_ context.Context,
+				_ uuid.UUID,
+				_ uuid.UUID,
+				_ codersdk.CreateWorkspaceBuildRequest,
+			) (codersdk.WorkspaceBuild, error) {
+				t.Fatal("build function should not be called for already running workspace")
+				return codersdk.WorkspaceBuild{}, nil
+			},
+		})
+
+		resp, err := tool.Run(sysCtx, fantasy.ToolCall{
+			ID:    "test-call",
+			Name:  "start_workspace",
+			Input: "{}",
+		})
+		require.NoError(t, err)
+		require.False(t, resp.IsError, "tool returned error: %s", resp.Content)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		require.Equal(t, "workspace is running; agent connection refreshed", result["message"])
+	})
+}
+
+// insertChatWithWorkspace creates a chat row linked to the given workspace.
+func insertChatWithWorkspace(
+	t testing.TB,
+	ctx context.Context,
+	db database.Store,
+	ownerID uuid.UUID,
+	modelConfigID uuid.UUID,
+	workspaceID uuid.UUID,
+) database.Chat {
+	t.Helper()
+
+	chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Title:             "start workspace test",
+	})
+	require.NoError(t, err)
+
+	chat, err = db.UpdateChatWorkspace(dbauthz.AsSystemRestricted(ctx), database.UpdateChatWorkspaceParams{
+		ID: chat.ID,
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+	})
+	require.NoError(t, err)
+
+	return chat
 }
 
 func createChatModelConfig(t *testing.T, client *codersdk.Client) codersdk.ChatModelConfig {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -766,6 +766,7 @@ func New(options *Options) *API {
 		ProviderAPIKeys:     chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
 		AgentConn:           api.agentProvider.AgentConn,
 		CreateWorkspace:     api.chatCreateWorkspace,
+		CreateWorkspaceBuild: api.chatCreateWorkspaceBuild,
 		Pubsub:              options.Pubsub,
 	})
 	if options.DeploymentValues.Prometheus.Enable {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -759,15 +759,15 @@ func New(options *Options) *API {
 	api.agentProvider = stn
 
 	api.chatDaemon = chatd.New(chatd.Config{
-		Logger:              options.Logger.Named("chats"),
-		Database:            options.Database,
-		ReplicaID:           api.ID,
-		RemotePartsProvider: options.ChatRemotePartsProvider,
-		ProviderAPIKeys:     chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
-		AgentConn:           api.agentProvider.AgentConn,
-		CreateWorkspace:     api.chatCreateWorkspace,
+		Logger:               options.Logger.Named("chats"),
+		Database:             options.Database,
+		ReplicaID:            api.ID,
+		RemotePartsProvider:  options.ChatRemotePartsProvider,
+		ProviderAPIKeys:      chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
+		AgentConn:            api.agentProvider.AgentConn,
+		CreateWorkspace:      api.chatCreateWorkspace,
 		CreateWorkspaceBuild: api.chatCreateWorkspaceBuild,
-		Pubsub:              options.Pubsub,
+		Pubsub:               options.Pubsub,
 	})
 	if options.DeploymentValues.Prometheus.Enable {
 		options.PrometheusRegistry.MustRegister(stn)


### PR DESCRIPTION
## Problem

Two issues with workspace tools in agent chats:

1. **No way to start a stopped workspace** — If a workspace stops, the LLM can only `create_workspace` which creates a brand new one. There's no resumption path.
2. **Stale `workspace_agent_id`** — Agent IDs change on every workspace build. After a workspace restart, the chat's cached agent ID points to a dead agent, and the cached connection is never invalidated.

## Changes

### New `start_workspace` tool (`coderd/chatd/chattool/startworkspace.go`)
- Starts the chat's associated workspace if it's stopped.
- Checks current build state: if already starting, waits; if already running, verifies connectivity; otherwise issues a start build.
- After a build completes, calls `refreshChatAgentID()` to update the chat's `workspace_agent_id` in the DB with `agents[0].ID` from the new build.
- Waits for the agent to become reachable before returning.
- Uses the same `workspaceMu` mutex as `create_workspace` to prevent races.

### Fixed stale agent connections (`coderd/chatd/chatd.go`)
Rewrote `getWorkspaceConn` to:
- Always reload the chat snapshot from the DB before checking the cached connection.
- Track `connAgentID` alongside the cached `conn`.
- If the agent ID changed (e.g. workspace restarted), release the stale connection and reconnect to the new agent.
- Removed the old `refreshChatWorkspaceSnapshot` function (replaced by the always-refresh approach).

### Workspace build creation (`coderd/chats.go`)
- New `chatCreateWorkspaceBuild()` using `wsbuilder` with proper RBAC authorization, mirroring the pattern of the existing `chatCreateWorkspace()`.

### Wiring (`coderd/coderd.go`, `coderd/chatd/chatd.go`)
- `CreateWorkspaceBuildFn` type added to chattool for dependency injection.
- Plumbed through `Config` → `Server` → tool registration.

## Open question

Right now this is a dedicated `start_workspace` tool. An alternative would be a single generic lifecycle tool (like the MCP toolsdk's `coder_create_workspace_build` with a `transition` param) to avoid tool sprawl if we later need stop/delete. Currently the LLM only needs start, so this is the minimal useful change.