### PR TITLE
fix(site): add chromatic ignore to shimmer component

### DIFF
--- a/site/src/components/ai-elements/shimmer.tsx
+++ b/site/src/components/ai-elements/shimmer.tsx
@@ -48,6 +48,7 @@ const ShimmerComponent = ({
 	return (
 		<MotionConfig reducedMotion="user">
 			<MotionComponent
+				data-chromatic="ignore"
 				animate={{ backgroundPosition: "0% center" }}
 				className={cn(
 					"relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",


### PR DESCRIPTION
The shimmer component has an infinitely repeating animation that causes Chromatic snapshot diffs on every run. Adding `data-chromatic="ignore"` to prevent false positives, consistent with how other animated components in the codebase handle this (e.g. `Spinner`, `Alert`, `SyntaxHighlighter`).