### PR TITLE
fix: return in-flight chats to pending on server shutdown

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1763,6 +1763,12 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 			status = database.ChatStatusWaiting
 			return
 		}
+		if isShutdownCancellation(ctx, chatCtx, err) {
+			logger.Info(ctx, "chat canceled during shutdown; returning to pending")
+			status = database.ChatStatusPending
+			lastError = ""
+			return
+		}
 		logger.Error(ctx, "failed to process chat", slog.Error(err))
 		if reason, ok := processingFailureReason(err); ok {
 			lastError = reason
@@ -1771,6 +1777,25 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		status = database.ChatStatusError
 		return
 	}
+}
+
+func isShutdownCancellation(
+	serverCtx context.Context,
+	chatCtx context.Context,
+	err error,
+) bool {
+	if err == nil {
+		return false
+	}
+	// During Close(), the server context is canceled. In-flight chats should
+	// be returned to pending so another replica can retry them.
+	if serverCtx.Err() == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return errors.Is(context.Cause(chatCtx), context.Canceled)
 }
 
 func (p *Server) runChat(


### PR DESCRIPTION
When a chatd server shuts down (`Close()`), the server context is canceled. Previously, in-flight chats would be marked as `error` because the `context.Canceled` error was not distinguished from actual processing failures.

This adds `isShutdownCancellation()` to detect when the error is caused by the server context being canceled (as opposed to a chat-specific cancellation like `ErrInterrupted`). When detected, the chat status is set to `pending` with no `last_error`, allowing another replica to pick it up and retry.

Extracted from #22440 — only the context cancellation bug fix, no chattest changes.