### PR TITLE
fix(chatd): clear stream buffer after each step is persisted

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1988,6 +1988,16 @@ func (p *Server) runChat(
 
 			p.publishMessage(chat.ID, toolMessage)
 		}
+
+		// Clear the stream buffer now that the step is
+		// persisted. Late-joining subscribers will load
+		// these messages from the database instead.
+		p.streamMu.Lock()
+		if state, ok := p.chatStreams[chat.ID]; ok {
+			state.buffer = nil
+		}
+		p.streamMu.Unlock()
+
 		return nil
 	}
 


### PR DESCRIPTION
The in-memory stream buffer accumulated message-part events for the entire duration of a chat run. Late-joining subscribers received all buffered parts even though the backing messages had already been committed to the database, wasting memory and potentially duplicating content.

Clear the buffer at the end of each `persistStep` call so that only in-flight (uncommitted) parts remain in the buffer.