### PR TITLE
fix(site): prevent layout shift when opening dropdowns on /agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -107,15 +107,45 @@ const AgentsPage: FC = () => {
 	const canSetSystemPrompt = isAgentsAdmin;
 
 	// The global CSS sets scrollbar-gutter: stable on <html> to prevent
-	// layout shift on pages that toggle scrollbars. The agents page uses
-	// its own internal scroll containers so the reserved gutter space is
-	// unnecessary and wastes horizontal room.
+	// layout shift on pages that toggle scrollbars. The agents page
+	// uses its own internal scroll containers so the reserved gutter
+	// space is unnecessary and wastes horizontal room.
+	//
+	// Removing the gutter requires three things:
+	//
+	// 1. overflow:hidden on both <html> and <body> so neither element
+	//    can produce a scrollbar.
+	// 2. scrollbar-gutter:auto on <html> so the browser stops
+	//    reserving space for a scrollbar that will never appear.
+	//    This is what makes react-remove-scroll-bar measure a gap of
+	//    0 when a Radix dropdown opens, so it injects no padding or
+	//    margin compensation.
+	// 3. An injected <style> that overrides the global
+	//    `overflow-y: scroll !important` on body[data-scroll-locked].
+	//    Without this, opening any Radix dropdown would force a
+	//    scrollbar onto <body>, re-introducing the layout shift.
 	useEffect(() => {
 		const html = document.documentElement;
-		const prev = html.style.scrollbarGutter;
+		const body = document.body;
+
+		const prevHtmlOverflow = html.style.overflow;
+		const prevHtmlScrollbarGutter = html.style.scrollbarGutter;
+		const prevBodyOverflow = body.style.overflow;
+
+		html.style.overflow = "hidden";
 		html.style.scrollbarGutter = "auto";
+		body.style.overflow = "hidden";
+
+		const style = document.createElement("style");
+		style.textContent =
+			"html body[data-scroll-locked] { overflow-y: hidden !important; }";
+		document.head.appendChild(style);
+
 		return () => {
-			html.style.scrollbarGutter = prev;
+			html.style.overflow = prevHtmlOverflow;
+			html.style.scrollbarGutter = prevHtmlScrollbarGutter;
+			body.style.overflow = prevBodyOverflow;
+			style.remove();
 		};
 	}, []);
 


### PR DESCRIPTION
## Problem

Opening any dropdown (Select, DropdownMenu) on the `/agents` page caused visible layout shift.

The agents page previously overrode the global `scrollbar-gutter: stable` to `auto` on `<html>` to reclaim the unused gutter space (the page uses internal scroll containers). This broke the global `body[data-scroll-locked]` CSS in `index.css`, which assumes stable gutter is always active.

When a Radix dropdown opened, two mechanisms caused the shift:

1. **`react-remove-scroll-bar` gap compensation** — it measures `window.innerWidth - document.documentElement.clientWidth`. With `scrollbar-gutter: stable` the gutter is reserved even without overflow, so the gap is non-zero and the library injects `padding-right`/`margin-right` on `<html>`/`<body>`.

2. **Global `overflow-y: scroll !important`** — the CSS rule on `html body[data-scroll-locked]` forces a scrollbar onto `<body>` when Radix locks scroll, creating a scrollbar that never existed on this page.

## Fix

A single `useEffect` in `AgentsPage.tsx` that:

- Sets `overflow: hidden` on both `<html>` and `<body>` so neither can produce a scrollbar.
- Sets `scrollbar-gutter: auto` on `<html>` so the browser stops reserving gutter space, making `react-remove-scroll-bar` measure a gap of 0.
- Injects a `<style>` tag (`html body[data-scroll-locked] { overflow-y: hidden !important }`) that overrides the global rule with matching specificity, winning by source order.

Everything is cleaned up on unmount — no other pages are affected.