### PR TITLE
fix: resolve chat title update race conditions and improve resilience

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -8,6 +8,7 @@ export const chatKey = (chatId: string) => ["chats", chatId] as const;
 export const chats = () => ({
 	queryKey: chatsKey,
 	queryFn: () => API.getChats(),
+	refetchOnWindowFocus: true as const,
 });
 
 export const chat = (chatId: string) => ({

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -267,6 +267,15 @@ const AgentsPage: FC = () => {
 
 	useEffect(() => {
 		const ws = watchChats();
+		ws.addEventListener("open", () => {
+			void queryClient.invalidateQueries({ queryKey: chatsKey });
+		});
+		ws.addEventListener("close", () => {
+			void queryClient.invalidateQueries({ queryKey: chatsKey });
+		});
+		ws.addEventListener("error", () => {
+			void queryClient.invalidateQueries({ queryKey: chatsKey });
+		});
 		ws.addEventListener("message", (event) => {
 			const sse = event.parsedMessage;
 			if (sse?.type !== "data" || !sse.data) {


### PR DESCRIPTION
## Problem

Chat titles sometimes don't update in the UI. The generated AI title gets stuck as the fallback (first 6 words of the message) even though the backend successfully generates a proper title.

## Root Causes

### 1. Cancelable context used during cleanup DB read (P0)
In `processChat`, the deferred cleanup re-reads the chat from the DB to pick up the AI-generated title for the `status_change` pubsub event. But it used the cancelable `ctx` instead of `cleanupCtx`:

```go
// Before — ctx may already be canceled here
if freshChat, readErr := p.db.GetChatByID(ctx, chat.ID); readErr == nil {
```

When the context is canceled, the DB read fails silently and the `status_change` event carries the stale fallback title.

### 2. Title goroutine not tracked by inflight WaitGroup (P2)
The `maybeGenerateChatTitle` goroutine was fire-and-forget — not tracked by `p.inflight`. During graceful shutdown, the server could exit before the goroutine completes its DB write or pubsub publish.

### 3. No recovery when watchChats() WebSocket misses events
The frontend relies entirely on the `watchChats()` SSE connection for title updates. If the connection drops or misses events, titles never recover — the only fix was a full page reload.

## Fixes

1. **Use `cleanupCtx`** for the `GetChatByID` call and logger in the deferred cleanup block.
2. **Track the title goroutine** with `p.inflight.Add(1)` / `defer p.inflight.Done()` so shutdown waits for it.
3. **Invalidate chats query** on WebSocket open/close/error events so missed updates are recovered via refetch. Also enable `refetchOnWindowFocus` for the chats query.