### PR TITLE
feat(chat): add @ file search mentions in chat input

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -40,13 +40,13 @@ import (
 	"github.com/coder/clistat"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentexec"
-	"github.com/coder/coder/v2/agent/filefinder"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/agent/agentproc"
 	"github.com/coder/coder/v2/agent/agentscripts"
 	"github.com/coder/coder/v2/agent/agentsocket"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/agent/boundarylogproxy"
+	"github.com/coder/coder/v2/agent/filefinder"
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/agent/proto/resourcesmonitor"
 	"github.com/coder/coder/v2/agent/reconnectingpty"
@@ -304,9 +304,9 @@ type agent struct {
 	containerAPIOptions []agentcontainers.Option
 	containerAPI        *agentcontainers.API
 
-	filesAPI        *agentfiles.API
+	filesAPI         *agentfiles.API
 	fileFinderEngine *filefinder.Engine
-	processAPI      *agentproc.API
+	processAPI       *agentproc.API
 
 	socketServerEnabled bool
 	socketPath          string
@@ -2045,16 +2045,17 @@ func (a *agent) Close() error {
 	}
 
 	if err := a.processAPI.Close(); err != nil {
-			a.logger.Error(a.hardCtx, "process API close", slog.Error(err))
-		}
+		a.logger.Error(a.hardCtx, "process API close", slog.Error(err))
+	}
 
-		if a.fileFinderEngine != nil {
-			if err := a.fileFinderEngine.Close(); err != nil {
-				a.logger.Error(a.hardCtx, "file finder engine close", slog.Error(err))
-			}
+	if a.fileFinderEngine != nil {
+		if err := a.fileFinderEngine.Close(); err != nil {
+			a.logger.Error(a.hardCtx, "file finder engine close", slog.Error(err))
 		}
+	}
 
-		if a.boundaryLogProxy != nil {		err = a.boundaryLogProxy.Close()
+	if a.boundaryLogProxy != nil {
+		err = a.boundaryLogProxy.Close()
 		if err != nil {
 			a.logger.Warn(context.Background(), "close boundary log proxy", slog.Error(err))
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -40,6 +40,7 @@ import (
 	"github.com/coder/clistat"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentexec"
+	"github.com/coder/coder/v2/agent/filefinder"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/agent/agentproc"
 	"github.com/coder/coder/v2/agent/agentscripts"
@@ -303,8 +304,9 @@ type agent struct {
 	containerAPIOptions []agentcontainers.Option
 	containerAPI        *agentcontainers.API
 
-	filesAPI   *agentfiles.API
-	processAPI *agentproc.API
+	filesAPI        *agentfiles.API
+	fileFinderEngine *filefinder.Engine
+	processAPI      *agentproc.API
 
 	socketServerEnabled bool
 	socketPath          string
@@ -376,7 +378,8 @@ func (a *agent) init() {
 
 	a.containerAPI = agentcontainers.NewAPI(a.logger.Named("containers"), containerAPIOpts...)
 
-	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem)
+	a.fileFinderEngine = filefinder.NewEngine(a.logger.Named("file-finder"))
+	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem, a.fileFinderEngine)
 	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, a.updateCommandEnv)
 
 	a.reconnectingPTYServer = reconnectingpty.NewServer(
@@ -1230,6 +1233,14 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 		}
 
 		oldManifest := a.manifest.Swap(&manifest)
+
+		// Start indexing the workspace directory for file search.
+		if manifest.Directory != "" {
+			if err := a.fileFinderEngine.AddRoot(ctx, manifest.Directory); err != nil {
+				a.logger.Warn(ctx, "file finder failed to add root", slog.Error(err))
+			}
+		}
+
 		manifestOK.complete(nil)
 		sentResult = true
 
@@ -2034,11 +2045,16 @@ func (a *agent) Close() error {
 	}
 
 	if err := a.processAPI.Close(); err != nil {
-		a.logger.Error(a.hardCtx, "process API close", slog.Error(err))
-	}
+			a.logger.Error(a.hardCtx, "process API close", slog.Error(err))
+		}
 
-	if a.boundaryLogProxy != nil {
-		err = a.boundaryLogProxy.Close()
+		if a.fileFinderEngine != nil {
+			if err := a.fileFinderEngine.Close(); err != nil {
+				a.logger.Error(a.hardCtx, "file finder engine close", slog.Error(err))
+			}
+		}
+
+		if a.boundaryLogProxy != nil {		err = a.boundaryLogProxy.Close()
 		if err != nil {
 			a.logger.Warn(context.Background(), "close boundary log proxy", slog.Error(err))
 		}

--- a/agent/agentfiles/api.go
+++ b/agent/agentfiles/api.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/afero"
 
 	"cdr.dev/slog/v3"
-
 	"github.com/coder/coder/v2/agent/filefinder"
 )
 

--- a/agent/agentfiles/api.go
+++ b/agent/agentfiles/api.go
@@ -7,18 +7,22 @@ import (
 	"github.com/spf13/afero"
 
 	"cdr.dev/slog/v3"
+
+	"github.com/coder/coder/v2/agent/filefinder"
 )
 
 // API exposes file-related operations performed through the agent.
 type API struct {
 	logger     slog.Logger
 	filesystem afero.Fs
+	filefinder *filefinder.Engine
 }
 
-func NewAPI(logger slog.Logger, filesystem afero.Fs) *API {
+func NewAPI(logger slog.Logger, filesystem afero.Fs, ff *filefinder.Engine) *API {
 	api := &API{
 		logger:     logger,
 		filesystem: filesystem,
+		filefinder: ff,
 	}
 	return api
 }
@@ -32,6 +36,7 @@ func (api *API) Routes() http.Handler {
 	r.Get("/read-file-lines", api.HandleReadFileLines)
 	r.Post("/write-file", api.HandleWriteFile)
 	r.Post("/edit-files", api.HandleEditFiles)
+	r.Get("/file-search", api.HandleFileSearch)
 
 	return r
 }

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -116,7 +116,7 @@ func TestReadFile(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs)
+	api := agentfiles.NewAPI(logger, fs, nil)
 
 	dirPath := filepath.Join(tmpdir, "a-directory")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -296,7 +296,7 @@ func TestWriteFile(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs)
+	api := agentfiles.NewAPI(logger, fs, nil)
 
 	dirPath := filepath.Join(tmpdir, "directory")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -414,7 +414,7 @@ func TestEditFiles(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs)
+	api := agentfiles.NewAPI(logger, fs, nil)
 
 	dirPath := filepath.Join(tmpdir, "directory")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -851,7 +851,7 @@ func TestReadFileLines(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs)
+	api := agentfiles.NewAPI(logger, fs, nil)
 
 	dirPath := filepath.Join(tmpdir, "a-directory-lines")
 	err := fs.MkdirAll(dirPath, 0o755)

--- a/agent/agentfiles/filesearch.go
+++ b/agent/agentfiles/filesearch.go
@@ -1,0 +1,63 @@
+package agentfiles
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/coder/coder/v2/agent/filefinder"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// HandleFileSearch handles file search requests using the filefinder
+// engine. It returns a JSON object with a "results" array.
+func (api *API) HandleFileSearch(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if api.filefinder == nil {
+		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+			Message: "File search is not available.",
+			Detail:  "The file search engine has not been initialized.",
+		})
+		return
+	}
+
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Missing query parameter.",
+		})
+		return
+	}
+
+	results, err := api.filefinder.Search(ctx, query, filefinder.SearchOptions{
+		Limit: 20,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "File search failed.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	resp := make([]fileSearchResult, 0, len(results))
+	for _, r := range results {
+		resp = append(resp, fileSearchResult{
+			Path:  r.Path,
+			IsDir: r.IsDir,
+		})
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(rw).Encode(fileSearchResponse{Results: resp})
+}
+
+type fileSearchResponse struct {
+	Results []fileSearchResult `json:"results"`
+}
+
+type fileSearchResult struct {
+	Path  string `json:"path"`
+	IsDir bool   `json:"is_dir"`
+}

--- a/agent/agentfiles/filesearch.go
+++ b/agent/agentfiles/filesearch.go
@@ -1,7 +1,6 @@
 package agentfiles
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/coder/coder/v2/agent/filefinder"
@@ -49,8 +48,7 @@ func (api *API) HandleFileSearch(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	rw.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(rw).Encode(fileSearchResponse{Results: resp})
+	httpapi.Write(ctx, rw, http.StatusOK, fileSearchResponse{Results: resp})
 }
 
 type fileSearchResponse struct {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10179,6 +10179,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaceagents/{workspaceagent}/file-search": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Agents"
+                ],
+                "summary": "Search files in workspace agent",
+                "operationId": "search-files-in-workspace-agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace agent ID",
+                        "name": "workspaceagent",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "query",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/workspacesdk.FileSearchResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaceagents/{workspaceagent}/listening-ports": {
             "get": {
                 "security": [
@@ -23360,6 +23402,28 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "hostname_suffix": {
+                    "type": "string"
+                }
+            }
+        },
+        "workspacesdk.FileSearchResponse": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workspacesdk.FileSearchResult"
+                    }
+                }
+            }
+        },
+        "workspacesdk.FileSearchResult": {
+            "type": "object",
+            "properties": {
+                "is_dir": {
+                    "type": "boolean"
+                },
+                "path": {
                     "type": "string"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9010,6 +9010,44 @@
 				}
 			}
 		},
+		"/workspaceagents/{workspaceagent}/file-search": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["Agents"],
+				"summary": "Search files in workspace agent",
+				"operationId": "search-files-in-workspace-agent",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Workspace agent ID",
+						"name": "workspaceagent",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "Search query",
+						"name": "query",
+						"in": "query",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/workspacesdk.FileSearchResponse"
+						}
+					}
+				}
+			}
+		},
 		"/workspaceagents/{workspaceagent}/listening-ports": {
 			"get": {
 				"security": [
@@ -21512,6 +21550,28 @@
 					"type": "boolean"
 				},
 				"hostname_suffix": {
+					"type": "string"
+				}
+			}
+		},
+		"workspacesdk.FileSearchResponse": {
+			"type": "object",
+			"properties": {
+				"results": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/workspacesdk.FileSearchResult"
+					}
+				}
+			}
+		},
+		"workspacesdk.FileSearchResult": {
+			"type": "object",
+			"properties": {
+				"is_dir": {
+					"type": "boolean"
+				},
+				"path": {
 					"type": "string"
 				}
 			}

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -1976,6 +1976,19 @@ func createChatInputFromParts(
 			}
 			content = append(content, fantasy.TextContent{Text: text})
 			textParts = append(textParts, text)
+		case string(codersdk.ChatInputPartTypeFileReference):
+			filePath := strings.TrimSpace(part.FilePath)
+			if filePath == "" {
+				return nil, "", &codersdk.Response{
+					Message: "Invalid input part.",
+					Detail:  fmt.Sprintf("%s[%d].file_path cannot be empty.", fieldName, i),
+				}
+			}
+			// Inject the file path as a text reference for the LLM.
+			// File references are not appended to textParts so they
+			// do not influence the auto-generated chat title.
+			referenceText := fmt.Sprintf("[File: %s]", filePath)
+			content = append(content, fantasy.TextContent{Text: referenceText})
 		default:
 			return nil, "", &codersdk.Response{
 				Message: "Invalid input part.",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1541,6 +1541,7 @@ func New(options *Options) *API {
 				r.Get("/containers/watch", api.watchWorkspaceAgentContainers)
 				r.Delete("/containers/devcontainers/{devcontainer}", api.workspaceAgentDeleteDevcontainer)
 				r.Post("/containers/devcontainers/{devcontainer}/recreate", api.workspaceAgentRecreateDevcontainer)
+				r.Get("/file-search", api.workspaceAgentFileSearch)
 				r.Get("/coordinate", api.workspaceAgentClientCoordinate)
 
 				// PTY is part of workspaceAppServer.

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -780,6 +780,70 @@ func (api *API) workspaceAgentListeningPorts(rw http.ResponseWriter, r *http.Req
 	httpapi.Write(ctx, rw, http.StatusOK, portsResponse)
 }
 
+// @Summary Search files in workspace agent
+// @ID search-files-in-workspace-agent
+// @Security CoderSessionToken
+// @Tags Agents
+// @Produce json
+// @Param workspaceagent path string true "Workspace agent ID" format(uuid)
+// @Param query query string true "Search query"
+// @Success 200 {object} workspacesdk.FileSearchResponse
+// @Router /workspaceagents/{workspaceagent}/file-search [get]
+func (api *API) workspaceAgentFileSearch(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	waws := httpmw.WorkspaceAgentAndWorkspaceParam(r)
+
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Missing query parameter.",
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	apiAgent, err := db2sdk.WorkspaceAgent(
+		api.DERPMap(), *api.TailnetCoordinator.Load(), waws.WorkspaceAgent, nil, nil, nil, api.AgentInactiveDisconnectTimeout,
+		api.DeploymentValues.AgentFallbackTroubleshootingURL.String(),
+	)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error reading workspace agent.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if apiAgent.Status != codersdk.WorkspaceAgentConnected {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: fmt.Sprintf("Agent state is %q, it must be in the %q state.", apiAgent.Status, codersdk.WorkspaceAgentConnected),
+		})
+		return
+	}
+
+	agentConn, release, err := api.agentProvider.AgentConn(ctx, waws.WorkspaceAgent.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error dialing workspace agent.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	defer release()
+
+	resp, err := agentConn.FileSearch(ctx, query)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error searching files.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
 // @Summary Watch workspace agent for container updates.
 // @ID watch-workspace-agent-for-container-updates
 // @Security CoderSessionToken

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -101,13 +101,15 @@ type ChatMessagePart struct {
 type ChatInputPartType string
 
 const (
-	ChatInputPartTypeText ChatInputPartType = "text"
+	ChatInputPartTypeText          ChatInputPartType = "text"
+	ChatInputPartTypeFileReference ChatInputPartType = "file_reference"
 )
 
 // ChatInputPart is a single user input part for creating a chat.
 type ChatInputPart struct {
-	Type ChatInputPartType `json:"type"`
-	Text string            `json:"text,omitempty"`
+	Type     ChatInputPartType `json:"type"`
+	Text     string            `json:"text,omitempty"`
+	FilePath string            `json:"file_path,omitempty"`
 }
 
 // CreateChatRequest is the request to create a new chat.

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -66,6 +67,7 @@ type AgentConn interface {
 	SignalProcess(ctx context.Context, id string, signal string) error
 	StartProcess(ctx context.Context, req StartProcessRequest) (StartProcessResponse, error)
 	LS(ctx context.Context, path string, req LSRequest) (LSResponse, error)
+	FileSearch(ctx context.Context, query string) (FileSearchResponse, error)
 	ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error)
 	ReadFileLines(ctx context.Context, path string, offset, limit int64, limits ReadFileLinesLimits) (ReadFileLinesResponse, error)
 	WriteFile(ctx context.Context, path string, reader io.Reader) error
@@ -590,6 +592,17 @@ type LSFile struct {
 	IsDir              bool   `json:"is_dir"`
 }
 
+// FileSearchResponse is the response from a file search request.
+type FileSearchResponse struct {
+	Results []FileSearchResult `json:"results"`
+}
+
+// FileSearchResult is a single file search result.
+type FileSearchResult struct {
+	Path  string `json:"path"`
+	IsDir bool   `json:"is_dir"`
+}
+
 // LS lists a directory.
 func (c *agentConn) LS(ctx context.Context, path string, req LSRequest) (LSResponse, error) {
 	ctx, span := tracing.StartSpan(ctx)
@@ -607,6 +620,27 @@ func (c *agentConn) LS(ctx context.Context, path string, req LSRequest) (LSRespo
 	var m LSResponse
 	if err := json.NewDecoder(res.Body).Decode(&m); err != nil {
 		return LSResponse{}, xerrors.Errorf("decode response body: %w", err)
+	}
+	return m, nil
+}
+
+// FileSearch searches for files matching a query.
+func (c *agentConn) FileSearch(ctx context.Context, query string) (FileSearchResponse, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	res, err := c.apiRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v0/file-search?query=%s", url.QueryEscape(query)), nil)
+	if err != nil {
+		return FileSearchResponse{}, xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return FileSearchResponse{}, codersdk.ReadBodyAsError(res)
+	}
+
+	var m FileSearchResponse
+	if err := json.NewDecoder(res.Body).Decode(&m); err != nil {
+		return FileSearchResponse{}, xerrors.Errorf("decode response body: %w", err)
 	}
 	return m, nil
 }

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
-	"net/url"
+	neturl "net/url"
 	"strconv"
 	"time"
 
@@ -629,7 +629,8 @@ func (c *agentConn) FileSearch(ctx context.Context, query string) (FileSearchRes
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	res, err := c.apiRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v0/file-search?query=%s", url.QueryEscape(query)), nil)
+	qv := neturl.Values{"query": {query}}
+	res, err := c.apiRequest(ctx, http.MethodGet, "/api/v0/file-search?"+qv.Encode(), nil)
 	if err != nil {
 		return FileSearchResponse{}, xerrors.Errorf("do request: %w", err)
 	}

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -169,6 +169,21 @@ func (mr *MockAgentConnMockRecorder) EditFiles(ctx, edits any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditFiles", reflect.TypeOf((*MockAgentConn)(nil).EditFiles), ctx, edits)
 }
 
+// FileSearch mocks base method.
+func (m *MockAgentConn) FileSearch(ctx context.Context, query string) (workspacesdk.FileSearchResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileSearch", ctx, query)
+	ret0, _ := ret[0].(workspacesdk.FileSearchResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FileSearch indicates an expected call of FileSearch.
+func (mr *MockAgentConnMockRecorder) FileSearch(ctx, query any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileSearch", reflect.TypeOf((*MockAgentConn)(nil).FileSearch), ctx, query)
+}
+
 // GetPeerDiagnostics mocks base method.
 func (m *MockAgentConn) GetPeerDiagnostics() tailnet.PeerDiagnostics {
 	m.ctrl.T.Helper()

--- a/docs/reference/api/agents.md
+++ b/docs/reference/api/agents.md
@@ -1066,6 +1066,49 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/coo
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Search files in workspace agent
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/file-search?query=string \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspaceagents/{workspaceagent}/file-search`
+
+### Parameters
+
+| Name             | In    | Type         | Required | Description        |
+|------------------|-------|--------------|----------|--------------------|
+| `workspaceagent` | path  | string(uuid) | true     | Workspace agent ID |
+| `query`          | query | string       | true     | Search query       |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "results": [
+    {
+      "is_dir": true,
+      "path": "string"
+    }
+  ]
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                       |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [workspacesdk.FileSearchResponse](schemas.md#workspacesdkfilesearchresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get listening ports for workspace agent
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -14648,6 +14648,41 @@ None
 | `disable_direct_connections` | boolean                            | false    |              |             |
 | `hostname_suffix`            | string                             | false    |              |             |
 
+## workspacesdk.FileSearchResponse
+
+```json
+{
+  "results": [
+    {
+      "is_dir": true,
+      "path": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name      | Type                                                                    | Required | Restrictions | Description |
+|-----------|-------------------------------------------------------------------------|----------|--------------|-------------|
+| `results` | array of [workspacesdk.FileSearchResult](#workspacesdkfilesearchresult) | false    |              |             |
+
+## workspacesdk.FileSearchResult
+
+```json
+{
+  "is_dir": true,
+  "path": "string"
+}
+```
+
+### Properties
+
+| Name     | Type    | Required | Restrictions | Description |
+|----------|---------|----------|--------------|-------------|
+| `is_dir` | boolean | false    |              |             |
+| `path`   | string  | false    |              |             |
+
 ## wsproxysdk.CryptoKeysResponse
 
 ```json

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2762,6 +2762,17 @@ class ApiMethods {
 		return res.data;
 	};
 
+	getAgentFileSearch = async (
+		agentId: string,
+		query: string,
+	): Promise<{ results: { path: string; is_dir: boolean }[] }> => {
+		const response = await this.axios.get(
+			`/api/v2/workspaceagents/${agentId}/file-search`,
+			{ params: { query } },
+		);
+		return response.data;
+	};
+
 	getInboxNotifications = async (startingBeforeId?: string) => {
 		const params = new URLSearchParams();
 		if (startingBeforeId) {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1118,12 +1118,16 @@ export interface ChatGitChange {
 export interface ChatInputPart {
 	readonly type: ChatInputPartType;
 	readonly text?: string;
+	readonly file_path?: string;
 }
 
 // From codersdk/chats.go
-export type ChatInputPartType = "text";
+export type ChatInputPartType = "file_reference" | "text";
 
-export const ChatInputPartTypes: ChatInputPartType[] = ["text"];
+export const ChatInputPartTypes: ChatInputPartType[] = [
+	"file_reference",
+	"text",
+];
 
 // From codersdk/chats.go
 /**

--- a/site/src/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/components/ChatMessageInput/ChatMessageInput.tsx
@@ -31,6 +31,8 @@ import {
 	useRef,
 } from "react";
 import { cn } from "utils/cn";
+import { $isFileMentionNode, FileMentionNode } from "./FileMentionNode";
+import { FileMentionPlugin } from "./FileMentionPlugin";
 
 // Blocks Cmd+B/I/U and element formatting shortcuts so the editor
 // stays plain-text only.
@@ -207,6 +209,7 @@ export interface ChatMessageInputRef {
 	clear: () => void;
 	focus: () => void;
 	getValue: () => string;
+	getFileMentions: () => Array<{ path: string; fileName: string }>;
 }
 
 interface ChatMessageInputProps
@@ -219,6 +222,7 @@ interface ChatMessageInputProps
 	disabled?: boolean;
 	autoFocus?: boolean;
 	"aria-label"?: string;
+	agentId?: string;
 }
 
 const ChatMessageInput = memo(
@@ -232,6 +236,7 @@ const ChatMessageInput = memo(
 		disabled,
 		autoFocus,
 		"aria-label": ariaLabel,
+		agentId,
 		ref,
 		...props
 	}: ChatMessageInputProps & { ref?: React.Ref<ChatMessageInputRef> }) => {
@@ -242,7 +247,7 @@ const ChatMessageInput = memo(
 					paragraph: "m-0",
 				},
 				onError: (error: Error) => console.error("Lexical error:", error),
-				nodes: [],
+				nodes: [FileMentionNode],
 			}),
 			[],
 		);
@@ -341,6 +346,24 @@ const ChatMessageInput = memo(
 					});
 					return content;
 				},
+				getFileMentions: () => {
+					const editor = editorRef.current;
+					if (!editor) return [];
+					const mentions: Array<{ path: string; fileName: string }> = [];
+					editor.getEditorState().read(() => {
+						const root = $getRoot();
+						const textNodes = root.getAllTextNodes();
+						for (const node of textNodes) {
+							if ($isFileMentionNode(node)) {
+								mentions.push({
+									path: node.getFilePath(),
+									fileName: node.getFileName(),
+								});
+							}
+						}
+					});
+					return mentions;
+				},
 			}),
 			[],
 		);
@@ -380,6 +403,7 @@ const ChatMessageInput = memo(
 					<ContentChangePlugin onChange={handleContentChange} />
 					<ValueSyncPlugin initialValue={initialValue} />
 					<InsertTextPlugin onEditorReady={handleEditorReady} />
+					{agentId && <FileMentionPlugin agentId={agentId} />}
 					{autoFocus && <AutoFocusPlugin />}
 				</div>
 			</LexicalComposer>

--- a/site/src/components/ChatMessageInput/FileMentionNode.ts
+++ b/site/src/components/ChatMessageInput/FileMentionNode.ts
@@ -27,11 +27,7 @@ export class FileMentionNode extends TextNode {
 	}
 
 	static clone(node: FileMentionNode): FileMentionNode {
-		return new FileMentionNode(
-			node.__filePath,
-			node.__fileName,
-			node.__key,
-		);
+		return new FileMentionNode(node.__filePath, node.__fileName, node.__key);
 	}
 
 	constructor(filePath: string, fileName: string, key?: NodeKey) {
@@ -48,10 +44,7 @@ export class FileMentionNode extends TextNode {
 		dom.setAttribute("spellcheck", "false");
 
 		// Prepend a file icon using an SVG element.
-		const icon = document.createElementNS(
-			"http://www.w3.org/2000/svg",
-			"svg",
-		);
+		const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 		icon.setAttribute("width", "14");
 		icon.setAttribute("height", "14");
 		icon.setAttribute("viewBox", "0 0 24 24");
@@ -63,10 +56,7 @@ export class FileMentionNode extends TextNode {
 		icon.style.display = "inline";
 		icon.style.verticalAlign = "middle";
 		icon.style.flexShrink = "0";
-		const path = document.createElementNS(
-			"http://www.w3.org/2000/svg",
-			"path",
-		);
+		const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
 		path.setAttribute(
 			"d",
 			"M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",

--- a/site/src/components/ChatMessageInput/FileMentionNode.ts
+++ b/site/src/components/ChatMessageInput/FileMentionNode.ts
@@ -1,6 +1,5 @@
 import {
 	$applyNodeReplacement,
-	TextNode,
 	type DOMConversionMap,
 	type DOMExportOutput,
 	type EditorConfig,
@@ -8,9 +7,10 @@ import {
 	type NodeKey,
 	type SerializedTextNode,
 	type Spread,
+	TextNode,
 } from "lexical";
 
-export type SerializedFileMentionNode = Spread<
+type SerializedFileMentionNode = Spread<
 	{
 		filePath: string;
 		fileName: string;

--- a/site/src/components/ChatMessageInput/FileMentionNode.ts
+++ b/site/src/components/ChatMessageInput/FileMentionNode.ts
@@ -1,0 +1,161 @@
+import {
+	$applyNodeReplacement,
+	TextNode,
+	type DOMConversionMap,
+	type DOMExportOutput,
+	type EditorConfig,
+	type LexicalNode,
+	type NodeKey,
+	type SerializedTextNode,
+	type Spread,
+} from "lexical";
+
+export type SerializedFileMentionNode = Spread<
+	{
+		filePath: string;
+		fileName: string;
+	},
+	SerializedTextNode
+>;
+
+export class FileMentionNode extends TextNode {
+	__filePath: string;
+	__fileName: string;
+
+	static getType(): string {
+		return "file-mention";
+	}
+
+	static clone(node: FileMentionNode): FileMentionNode {
+		return new FileMentionNode(
+			node.__filePath,
+			node.__fileName,
+			node.__key,
+		);
+	}
+
+	constructor(filePath: string, fileName: string, key?: NodeKey) {
+		super(fileName, key);
+		this.__filePath = filePath;
+		this.__fileName = fileName;
+	}
+
+	createDOM(config: EditorConfig): HTMLElement {
+		const dom = super.createDOM(config);
+		dom.className =
+			"inline-flex items-center gap-1 rounded px-1.5 py-0.5 bg-content-link/15 text-content-link text-sm font-medium cursor-default mx-0.5";
+		dom.dataset.filePath = this.__filePath;
+		dom.setAttribute("spellcheck", "false");
+
+		// Prepend a file icon using an SVG element.
+		const icon = document.createElementNS(
+			"http://www.w3.org/2000/svg",
+			"svg",
+		);
+		icon.setAttribute("width", "14");
+		icon.setAttribute("height", "14");
+		icon.setAttribute("viewBox", "0 0 24 24");
+		icon.setAttribute("fill", "none");
+		icon.setAttribute("stroke", "currentColor");
+		icon.setAttribute("stroke-width", "2");
+		icon.setAttribute("stroke-linecap", "round");
+		icon.setAttribute("stroke-linejoin", "round");
+		icon.style.display = "inline";
+		icon.style.verticalAlign = "middle";
+		icon.style.flexShrink = "0";
+		const path = document.createElementNS(
+			"http://www.w3.org/2000/svg",
+			"path",
+		);
+		path.setAttribute(
+			"d",
+			"M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",
+		);
+		const polyline = document.createElementNS(
+			"http://www.w3.org/2000/svg",
+			"polyline",
+		);
+		polyline.setAttribute("points", "14 2 14 8 20 8");
+		icon.appendChild(path);
+		icon.appendChild(polyline);
+
+		dom.insertBefore(icon, dom.firstChild);
+
+		return dom;
+	}
+
+	updateDOM(): boolean {
+		// Returning true forces Lexical to recreate the DOM node.
+		return true;
+	}
+
+	static importJSON(
+		serializedNode: SerializedFileMentionNode,
+	): FileMentionNode {
+		const node = $createFileMentionNode(
+			serializedNode.filePath,
+			serializedNode.fileName,
+		);
+		node.setFormat(serializedNode.format);
+		node.setDetail(serializedNode.detail);
+		node.setMode(serializedNode.mode);
+		node.setStyle(serializedNode.style);
+		return node;
+	}
+
+	exportJSON(): SerializedFileMentionNode {
+		return {
+			...super.exportJSON(),
+			type: "file-mention",
+			filePath: this.__filePath,
+			fileName: this.__fileName,
+		};
+	}
+
+	exportDOM(): DOMExportOutput {
+		const element = document.createElement("span");
+		element.textContent = this.__fileName;
+		element.dataset.filePath = this.__filePath;
+		return { element };
+	}
+
+	static importDOM(): DOMConversionMap | null {
+		return null;
+	}
+
+	isTextEntity(): true {
+		return true;
+	}
+
+	canInsertTextBefore(): boolean {
+		return false;
+	}
+
+	canInsertTextAfter(): boolean {
+		return false;
+	}
+
+	getFilePath(): string {
+		return this.__filePath;
+	}
+
+	getFileName(): string {
+		return this.__fileName;
+	}
+}
+
+export function $createFileMentionNode(
+	filePath: string,
+	fileName: string,
+): FileMentionNode {
+	const node = new FileMentionNode(filePath, fileName);
+	// Mark as non-editable so the mention acts as an atomic token.
+	node.setMode("token");
+	return $applyNodeReplacement(node);
+}
+
+export function $isFileMentionNode(
+	node: LexicalNode | null | undefined,
+): node is FileMentionNode {
+	return node instanceof FileMentionNode;
+}

--- a/site/src/components/ChatMessageInput/FileMentionPlugin.tsx
+++ b/site/src/components/ChatMessageInput/FileMentionPlugin.tsx
@@ -1,14 +1,14 @@
-import { createPortal } from "react-dom";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
 	LexicalTypeaheadMenuPlugin,
 	MenuOption,
 	useBasicTypeaheadTriggerMatch,
 } from "@lexical/react/LexicalTypeaheadMenuPlugin";
-import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { API } from "api/api";
 import type { TextNode } from "lexical";
 import { FileIcon, FolderIcon, Loader2Icon } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { API } from "api/api";
+import { createPortal } from "react-dom";
 import { $createFileMentionNode } from "./FileMentionNode";
 
 class FileSearchOption extends MenuOption {

--- a/site/src/components/ChatMessageInput/FileMentionPlugin.tsx
+++ b/site/src/components/ChatMessageInput/FileMentionPlugin.tsx
@@ -7,14 +7,7 @@ import {
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import type { TextNode } from "lexical";
 import { FileIcon, FolderIcon, Loader2Icon } from "lucide-react";
-import {
-	memo,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { API } from "api/api";
 import { $createFileMentionNode } from "./FileMentionNode";
 
@@ -159,46 +152,51 @@ const FileMentionPlugin = memo<FileMentionPluginProps>(
 											Searching files...
 										</div>
 									) : (
-											<div role="listbox" className="max-h-[200px] overflow-y-auto py-1">
-												{options.map((option, index) => (
-													<div
-														key={option.key}
-														role="option"
-														tabIndex={-1}
-														aria-selected={selectedIndex === index}
-														className={`flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm ${
-															selectedIndex === index
-																? "bg-surface-secondary text-content-primary"
-																: "text-content-secondary hover:bg-surface-secondary/50"
-														}`}
-														onMouseEnter={() => setHighlightedIndex(index)}
-														onClick={() => {
+										<div
+											role="listbox"
+											className="max-h-[200px] overflow-y-auto py-1"
+										>
+											{options.map((option, index) => (
+												<div
+													key={option.key}
+													role="option"
+													tabIndex={-1}
+													aria-selected={selectedIndex === index}
+													className={`flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm ${
+														selectedIndex === index
+															? "bg-surface-secondary text-content-primary"
+															: "text-content-secondary hover:bg-surface-secondary/50"
+													}`}
+													onMouseEnter={() => setHighlightedIndex(index)}
+													onClick={() => {
+														selectOptionAndCleanUp(option);
+													}}
+													onKeyDown={(e) => {
+														if (e.key === "Enter" || e.key === " ") {
+															e.preventDefault();
 															selectOptionAndCleanUp(option);
-														}}
-														onKeyDown={(e) => {
-															if (e.key === "Enter" || e.key === " ") {
-																e.preventDefault();
-																selectOptionAndCleanUp(option);
-															}
-														}}
-														ref={(el) => {
-															option.setRefElement(el);
-														}}
-													>
-														{option.isDir ? (
-															<FolderIcon className="h-4 w-4 shrink-0 text-content-secondary" />
-														) : (
-															<FileIcon className="h-4 w-4 shrink-0 text-content-secondary" />
-														)}
-														<span className="truncate">{option.path}</span>
-													</div>
-												))}											{isLoading && results.length > 0 && (
+														}
+													}}
+													ref={(el) => {
+														option.setRefElement(el);
+													}}
+												>
+													{option.isDir ? (
+														<FolderIcon className="h-4 w-4 shrink-0 text-content-secondary" />
+													) : (
+														<FileIcon className="h-4 w-4 shrink-0 text-content-secondary" />
+													)}
+													<span className="truncate">{option.path}</span>
+												</div>
+											))}{" "}
+											{isLoading && results.length > 0 && (
 												<li className="flex items-center gap-2 px-3 py-1.5 text-sm text-content-secondary">
 													<Loader2Icon className="h-4 w-4 animate-spin" />
 													Searching...
 												</li>
 											)}
-											</div>									)}
+										</div>
+									)}
 								</div>,
 								anchorElementRef.current,
 							)

--- a/site/src/components/ChatMessageInput/FileMentionPlugin.tsx
+++ b/site/src/components/ChatMessageInput/FileMentionPlugin.tsx
@@ -1,0 +1,212 @@
+import { createPortal } from "react-dom";
+import {
+	LexicalTypeaheadMenuPlugin,
+	MenuOption,
+	useBasicTypeaheadTriggerMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import type { TextNode } from "lexical";
+import { FileIcon, FolderIcon, Loader2Icon } from "lucide-react";
+import {
+	memo,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { API } from "api/api";
+import { $createFileMentionNode } from "./FileMentionNode";
+
+class FileSearchOption extends MenuOption {
+	path: string;
+	fileName: string;
+	isDir: boolean;
+
+	constructor(path: string, isDir: boolean) {
+		const fileName = path.split("/").pop() ?? path;
+		super(path);
+		this.path = path;
+		this.fileName = fileName;
+		this.isDir = isDir;
+	}
+}
+
+interface FileMentionPluginProps {
+	agentId: string;
+}
+
+const DEBOUNCE_MS = 200;
+
+const FileMentionPlugin = memo<FileMentionPluginProps>(
+	function FileMentionPlugin({ agentId }) {
+		const [editor] = useLexicalComposerContext();
+		const [results, setResults] = useState<FileSearchOption[]>([]);
+		const [isLoading, setIsLoading] = useState(false);
+		const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+			undefined,
+		);
+		const abortRef = useRef<AbortController | undefined>(undefined);
+
+		const checkForTriggerMatch = useBasicTypeaheadTriggerMatch("@", {
+			minLength: 0,
+			maxLength: 75,
+		});
+
+		const onQueryChange = useCallback(
+			(matchingString: string | null) => {
+				if (debounceRef.current) {
+					clearTimeout(debounceRef.current);
+				}
+				if (abortRef.current) {
+					abortRef.current.abort();
+				}
+
+				if (matchingString === null || matchingString.trim() === "") {
+					setResults([]);
+					setIsLoading(false);
+					return;
+				}
+
+				setIsLoading(true);
+
+				debounceRef.current = setTimeout(async () => {
+					const controller = new AbortController();
+					abortRef.current = controller;
+
+					try {
+						const response = await API.getAgentFileSearch(
+							agentId,
+							matchingString.trim(),
+						);
+						if (!controller.signal.aborted) {
+							setResults(
+								response.results.map(
+									(r) => new FileSearchOption(r.path, r.is_dir),
+								),
+							);
+							setIsLoading(false);
+						}
+					} catch {
+						if (!controller.signal.aborted) {
+							setResults([]);
+							setIsLoading(false);
+						}
+					}
+				}, DEBOUNCE_MS);
+			},
+			[agentId],
+		);
+
+		// Clean up on unmount.
+		useEffect(() => {
+			return () => {
+				if (debounceRef.current) {
+					clearTimeout(debounceRef.current);
+				}
+				if (abortRef.current) {
+					abortRef.current.abort();
+				}
+			};
+		}, []);
+
+		const onSelectOption = useCallback(
+			(
+				selectedOption: FileSearchOption,
+				nodeToReplace: TextNode | null,
+				closeMenu: () => void,
+			) => {
+				editor.update(() => {
+					const mentionNode = $createFileMentionNode(
+						selectedOption.path,
+						selectedOption.fileName,
+					);
+					if (nodeToReplace) {
+						nodeToReplace.replace(mentionNode);
+					}
+					mentionNode.selectNext();
+					closeMenu();
+				});
+			},
+			[editor],
+		);
+
+		const options = useMemo(() => results, [results]);
+
+		return (
+			<LexicalTypeaheadMenuPlugin<FileSearchOption>
+				onQueryChange={onQueryChange}
+				onSelectOption={onSelectOption}
+				triggerFn={checkForTriggerMatch}
+				options={options}
+				menuRenderFn={(
+					anchorElementRef,
+					{ selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+				) => {
+					if (!anchorElementRef.current) {
+						return null;
+					}
+					if (results.length === 0 && !isLoading) {
+						return null;
+					}
+
+					return anchorElementRef.current
+						? createPortal(
+								<div className="min-w-[280px] max-w-[400px] overflow-hidden rounded-lg border border-border-default bg-surface-primary shadow-lg">
+									{isLoading && results.length === 0 ? (
+										<div className="flex items-center gap-2 px-3 py-2 text-sm text-content-secondary">
+											<Loader2Icon className="h-4 w-4 animate-spin" />
+											Searching files...
+										</div>
+									) : (
+											<div role="listbox" className="max-h-[200px] overflow-y-auto py-1">
+												{options.map((option, index) => (
+													<div
+														key={option.key}
+														role="option"
+														tabIndex={-1}
+														aria-selected={selectedIndex === index}
+														className={`flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm ${
+															selectedIndex === index
+																? "bg-surface-secondary text-content-primary"
+																: "text-content-secondary hover:bg-surface-secondary/50"
+														}`}
+														onMouseEnter={() => setHighlightedIndex(index)}
+														onClick={() => {
+															selectOptionAndCleanUp(option);
+														}}
+														onKeyDown={(e) => {
+															if (e.key === "Enter" || e.key === " ") {
+																e.preventDefault();
+																selectOptionAndCleanUp(option);
+															}
+														}}
+														ref={(el) => {
+															option.setRefElement(el);
+														}}
+													>
+														{option.isDir ? (
+															<FolderIcon className="h-4 w-4 shrink-0 text-content-secondary" />
+														) : (
+															<FileIcon className="h-4 w-4 shrink-0 text-content-secondary" />
+														)}
+														<span className="truncate">{option.path}</span>
+													</div>
+												))}											{isLoading && results.length > 0 && (
+												<li className="flex items-center gap-2 px-3 py-1.5 text-sm text-content-secondary">
+													<Loader2Icon className="h-4 w-4 animate-spin" />
+													Searching...
+												</li>
+											)}
+											</div>									)}
+								</div>,
+								anchorElementRef.current,
+							)
+						: null;
+				}}
+			/>
+		);
+	},
+);
+
+export { FileMentionPlugin };

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -44,6 +44,7 @@ interface AgentChatInputProps {
 	placeholder?: string;
 	isDisabled: boolean;
 	isLoading: boolean;
+	agentId?: string;
 	// Ref for the Lexical editor, exposed for imperative access.
 	inputRef?: React.Ref<ChatMessageInputRef>;
 	// Initial text to seed the editor with.
@@ -216,6 +217,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		placeholder = "Type a message...",
 		isDisabled,
 		isLoading,
+		agentId,
 		inputRef,
 		initialValue,
 		onContentChange,
@@ -390,6 +392,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 					)}
 					<ChatMessageInput
 						ref={setRef}
+						agentId={agentId}
 						aria-label="Chat message"
 						className="min-h-[120px] w-full resize-none bg-transparent px-3 py-2 font-sans text-[15px] leading-6 text-content-primary placeholder:text-content-secondary disabled:cursor-not-allowed disabled:opacity-70"
 						placeholder={placeholder}

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -82,11 +82,20 @@ const isChatMessage = (
 
 const toOptimisticMessageParts = (
 	inputParts: readonly TypesGen.ChatInputPart[],
-): readonly TypesGen.ChatMessagePart[] =>
-	inputParts.map((part) => ({
-		type: "text",
-		...(part.text !== undefined ? { text: part.text } : {}),
-	}));
+): readonly TypesGen.ChatMessagePart[] => {
+	const textParts: string[] = [];
+	for (const part of inputParts) {
+		if (part.type === "text" && part.text) {
+			textParts.push(part.text);
+		} else if (part.type === "file_reference" && part.file_path) {
+			textParts.push(`[File: ${part.file_path}]`);
+		}
+	}
+	if (textParts.length === 0) {
+		return [];
+	}
+	return [{ type: "text", text: textParts.join("\n") }];
+};
 
 const getOrderedMessagesFromStore = (
 	store: ChatStoreHandle,
@@ -189,6 +198,7 @@ interface AgentDetailInputProps {
 	store: ChatStoreHandle;
 	compressionThreshold: number | undefined;
 	onSend: (message: string) => void;
+	agentId?: string;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
 	onInterrupt: () => void;
@@ -218,6 +228,7 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 	store,
 	compressionThreshold,
 	onSend,
+	agentId: workspaceAgentId,
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
 	onInterrupt,
@@ -266,6 +277,7 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 	return (
 		<AgentChatInput
 			onSend={onSend}
+			agentId={workspaceAgentId}
 			inputRef={inputRef}
 			initialValue={initialValue}
 			onContentChange={onContentChange}
@@ -302,7 +314,12 @@ interface AgentDetailConversationProps {
 	compressionThreshold: number | undefined;
 	onDeleteQueuedMessage: (id: number) => Promise<void>;
 	onPromoteQueuedMessage: (id: number) => Promise<void>;
-	onSend: (message: string, editedMessageID?: number) => Promise<void>;
+	onSend: (
+		message: string,
+		editedMessageID?: number,
+		fileMentions?: Array<{ path: string }>,
+	) => Promise<void>;
+	agentId?: string;
 	onInterrupt: () => void;
 	isInputDisabled: boolean;
 	isSendPending: boolean;
@@ -325,6 +342,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 	onDeleteQueuedMessage,
 	onPromoteQueuedMessage,
 	onSend,
+	agentId: workspaceAgentId,
 	onInterrupt,
 	isInputDisabled,
 	isSendPending,
@@ -414,7 +432,8 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 				setDraftBeforeQueueEdit(null);
 			}
 
-			void onSend(message, editedMessageID)
+			const mentions = chatInputRef.current?.getFileMentions() ?? [];
+			void onSend(message, editedMessageID, mentions)
 				.then(() => {
 					if (queueEditID !== null) {
 						void onDeleteQueuedMessage(queueEditID);
@@ -443,6 +462,7 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 				store={store}
 				compressionThreshold={compressionThreshold}
 				onSend={handleSendFromInput}
+				agentId={workspaceAgentId}
 				onDeleteQueuedMessage={onDeleteQueuedMessage}
 				onPromoteQueuedMessage={onPromoteQueuedMessage}
 				onInterrupt={onInterrupt}
@@ -639,7 +659,11 @@ const AgentDetail: FC = () => {
 		interruptMutation.isPending;
 	const isInputDisabled = !hasModelOptions;
 
-	const handleSend = async (message: string, editedMessageID?: number) => {
+	const handleSend = async (
+		message: string,
+		editedMessageID?: number,
+		fileMentions?: Array<{ path: string }>,
+	) => {
 		if (
 			!message.trim() ||
 			isSubmissionPending ||
@@ -648,7 +672,13 @@ const AgentDetail: FC = () => {
 		) {
 			return;
 		}
-		const content: TypesGen.ChatInputPart[] = [{ type: "text", text: message }];
+		const content: TypesGen.ChatInputPart[] = [
+			{ type: "text", text: message },
+			...(fileMentions ?? []).map((m) => ({
+				type: "file_reference" as TypesGen.ChatInputPartType,
+				file_path: m.path,
+			})),
+		];
 		if (editedMessageID !== undefined) {
 			const request: TypesGen.EditChatMessageRequest = { content };
 			clearChatErrorReason(agentId);
@@ -1011,6 +1041,7 @@ const AgentDetail: FC = () => {
 							onDeleteQueuedMessage={handleDeleteQueuedMessage}
 							onPromoteQueuedMessage={handlePromoteQueuedMessage}
 							onSend={handleSend}
+							agentId={workspaceAgent?.id}
 							onInterrupt={handleInterrupt}
 							isInputDisabled={isInputDisabled}
 							isSendPending={isSubmissionPending}


### PR DESCRIPTION
## Summary

Adds the ability to type `@` in the chat input to search for files in the connected workspace agent. Files are indexed using the filefinder engine (trigram-based fuzzy search) and results appear in a typeahead dropdown.

Selected files are inserted as styled mention pills (blue transparent background with file icon) and sent as `file_reference` input parts that the backend injects as `[File: path]` text for the LLM.

## Changes

### Backend
- **agent/agent.go**: Initialize `filefinder.Engine`, call `AddRoot(manifest.Directory)` when manifest arrives, close on shutdown
- **agent/agentfiles/**: Add `HandleFileSearch` handler serving `GET /api/v0/file-search?query=...` on the agent
- **coderd/workspaceagents.go**: Add `workspaceAgentFileSearch` proxy handler at `GET /api/v2/workspaceagents/{id}/file-search`
- **coderd/coderd.go**: Register the new route
- **codersdk/workspacesdk/agentconn.go**: Add `FileSearch()` to `AgentConn` interface with `FileSearchResponse`/`FileSearchResult` types
- **codersdk/chats.go**: Add `ChatInputPartTypeFileReference` and `FilePath` field on `ChatInputPart`
- **coderd/chats.go**: Handle `file_reference` in `createChatInputFromParts` — injects `[File: path]` as text for the LLM

### Frontend
- **FileMentionNode.ts**: Custom Lexical `TextNode` subclass — renders as a blue pill with file icon
- **FileMentionPlugin.tsx**: `LexicalTypeaheadMenuPlugin` — triggers on `@`, debounced API calls (200ms), dropdown with file/folder icons
- **ChatMessageInput.tsx**: Register `FileMentionNode`, add `agentId` prop, render `FileMentionPlugin`, add `getFileMentions()` method
- **AgentChatInput.tsx**: Thread `agentId` prop
- **AgentDetail.tsx**: Pass `workspaceAgent?.id` through component tree, extract file mentions on send, update optimistic rendering
- **api.ts**: Add `getAgentFileSearch()` API method

## Data Flow

```
User types "@han" → FileMentionPlugin triggers
  → GET /api/v2/workspaceagents/{id}/file-search?query=han
    → coderd proxies to agent via tailnet
      → filefinder.Engine.Search("han")
  → Dropdown shows results
User selects → FileMentionNode pill inserted

User hits Send
  → [{type:"text", text:"fix this"}, {type:"file_reference", file_path:"src/handler.go"}]
  → Backend injects "fix this" + "[File: src/handler.go]" for the LLM
```

Builds on #22453 which added the `agent/filefinder` package.