### PR TITLE
fix(stringutil): operate on runes instead of bytes in Truncate (#22388)

### DIFF
--- a/coderd/taskname/taskname.go
+++ b/coderd/taskname/taskname.go
@@ -169,7 +169,7 @@ func generateFromPrompt(prompt string) (TaskName, error) {
 		// Ensure display name is never empty
 		displayName = strings.ReplaceAll(name, "-", " ")
 	}
-	displayName = strings.ToUpper(displayName[:1]) + displayName[1:]
+	displayName = strutil.Capitalize(displayName)
 
 	return TaskName{
 		Name:        taskName,
@@ -261,7 +261,7 @@ func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, mo
 		// Ensure display name is never empty
 		displayName = strings.ReplaceAll(taskNameResponse.Name, "-", " ")
 	}
-	displayName = strings.ToUpper(displayName[:1]) + displayName[1:]
+	displayName = strutil.Capitalize(displayName)
 
 	return TaskName{
 		Name:        name,

--- a/coderd/taskname/taskname_test.go
+++ b/coderd/taskname/taskname_test.go
@@ -49,6 +49,19 @@ func TestGenerate(t *testing.T) {
 		require.NotEmpty(t, taskName.DisplayName)
 	})
 
+	t.Run("FromPromptMultiByte", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		taskName := taskname.Generate(ctx, testutil.Logger(t), "über cool feature")
+
+		require.NoError(t, codersdk.NameValid(taskName.Name))
+		require.True(t, len(taskName.DisplayName) > 0)
+		// The display name must start with "Ü", not corrupted bytes.
+		require.Equal(t, "Über cool feature", taskName.DisplayName)
+	})
+
 	t.Run("Fallback", func(t *testing.T) {
 		// Ensure no API key
 		t.Setenv("ANTHROPIC_API_KEY", "")

--- a/coderd/util/strings/strings_test.go
+++ b/coderd/util/strings/strings_test.go
@@ -57,6 +57,17 @@ func TestTruncate(t *testing.T) {
 		{"foo bar", 1, "…", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
 		{"foo bar", 0, "", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
 		{"This is a very long task prompt that should be truncated to 160 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 160, "This is a very long task prompt that should be truncated to 160 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor…", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
+		// Multi-byte rune handling.
+		{"日本語テスト", 3, "日本語", nil},
+		{"日本語テスト", 4, "日本語テ", nil},
+		{"日本語テスト", 6, "日本語テスト", nil},
+		{"日本語テスト", 4, "日本語…", []strings.TruncateOption{strings.TruncateWithEllipsis}},
+		{"🎉🎊🎈🎁", 2, "🎉🎊", nil},
+		{"🎉🎊🎈🎁", 3, "🎉🎊…", []strings.TruncateOption{strings.TruncateWithEllipsis}},
+		// Multi-byte with full-word truncation.
+		{"hello 日本語", 7, "hello…", []strings.TruncateOption{strings.TruncateWithFullWords, strings.TruncateWithEllipsis}},
+		{"hello 日本語", 8, "hello 日…", []strings.TruncateOption{strings.TruncateWithEllipsis}},
+		{"日本語 テスト", 4, "日本語", []strings.TruncateOption{strings.TruncateWithFullWords}},
 	} {
 		tName := fmt.Sprintf("%s_%d", tt.s, tt.n)
 		for _, opt := range tt.options {
@@ -104,6 +115,27 @@ func TestUISanitize(t *testing.T) {
 			t.Parallel()
 			actual := strings.UISanitize(tt.s)
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestCapitalize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"hello", "Hello"},
+		{"über", "Über"},
+		{"Hello", "Hello"},
+		{"a", "A"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.input), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, strings.Capitalize(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/22375

Updates `stringutil.Truncate` to properly handle multi-byte UTF-8 characters.
Adds tests for multi-byte truncation with word boundary.

Created by Mux using Opus 4.6

(cherry picked from commit 0cfa03718e557680fa10c9ea365c6b1f609febda)
