### PR TITLE
chore(ci): tighten permissions for AI workflows

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -19,6 +19,9 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   classify-severity:
     name: AI Severity Classification
@@ -32,7 +35,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      actions: write
 
     steps:
       - name: Determine Issue Context

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -31,6 +31,9 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   code-review:
     name: AI Code Review
@@ -51,7 +54,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      actions: write
 
     steps:
       - name: Check if secrets are available

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -34,6 +34,9 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   doc-check:
     name: Analyze PR for Documentation Updates Needed
@@ -56,7 +59,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      actions: write
 
     steps:
       - name: Check if secrets are available

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -26,6 +26,9 @@ on:
         default: "traiage"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   traiage:
     name: Triage GitHub Issue with Claude Code
@@ -38,7 +41,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      actions: write
 
     steps:
       # This is only required for testing locally using nektos/act, so leaving commented out.


### PR DESCRIPTION
## Summary

Reduce GitHub Actions token permissions for AI workflow jobs by removing unnecessary `actions: write` grants and adding explicit top-level read permissions where missing.

### Changes

- Added top-level permissions to:
  - `.github/workflows/classify-issue-severity.yml`
  - `.github/workflows/code-review.yaml`
  - `.github/workflows/doc-check.yaml`
  - `.github/workflows/traiage.yaml`
- Removed job-level `actions: write` from the same workflows.

## Validation

- `go tool github.com/rhysd/actionlint/cmd/actionlint .github/workflows/classify-issue-severity.yml .github/workflows/code-review.yaml .github/workflows/doc-check.yaml .github/workflows/traiage.yaml`
- `./scripts/zizmor.sh --strict-collection --persona=regular .github/workflows/classify-issue-severity.yml .github/workflows/code-review.yaml .github/workflows/doc-check.yaml .github/workflows/traiage.yaml`

---
_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `high`_
