### PR TITLE
feat(site): add download chat logs to task row kebab menu

### DIFF
--- a/site/src/pages/TasksPage/TasksPage.stories.tsx
+++ b/site/src/pages/TasksPage/TasksPage.stories.tsx
@@ -3,6 +3,7 @@ import {
 	MockInitializingTasks,
 	MockSystemNotificationTemplates,
 	MockTask,
+	MockTaskLogsResponse,
 	MockTasks,
 	MockTemplate,
 	MockUserOwner,
@@ -246,6 +247,7 @@ export const OpenKebabMenu: Story = {
 	beforeEach: () => {
 		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
 		spyOn(API, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -253,6 +255,32 @@ export const OpenKebabMenu: Story = {
 			name: /show task actions/i,
 		});
 		await userEvent.click(kebabButtons[0]);
+	},
+};
+
+export const DownloadChatLogs: Story = {
+	beforeEach: () => {
+		spyOn(API, "getTemplates").mockResolvedValue([MockTemplate]);
+		spyOn(API, "getTasks").mockResolvedValue(MockTasks);
+		spyOn(API, "getTaskLogs").mockResolvedValue(MockTaskLogsResponse);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const kebabButtons = await canvas.findAllByRole("button", {
+			name: /show task actions/i,
+		});
+		await userEvent.click(kebabButtons[0]);
+
+		const downloadMenuItem = await screen.findByRole("menuitem", {
+			name: /download chat logs/i,
+		});
+		await fireEvent.click(downloadMenuItem);
+		await waitFor(() => {
+			expect(API.getTaskLogs).toHaveBeenCalledWith(
+				MockTask.owner_name,
+				MockTask.id,
+			);
+		});
 	},
 };
 

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -1,3 +1,4 @@
+import { API } from "api/api";
 import { getErrorDetail, getErrorMessage } from "api/errors";
 import { pauseTask, resumeTask } from "api/queries/tasks";
 import type { Task } from "api/typesGenerated";
@@ -25,8 +26,14 @@ import {
 	TableLoaderSkeleton,
 	TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
+import { saveAs } from "file-saver";
 import { useClickableTableRow } from "hooks";
-import { EllipsisVertical, RotateCcwIcon, TrashIcon } from "lucide-react";
+import {
+	DownloadIcon,
+	EllipsisVertical,
+	RotateCcwIcon,
+	TrashIcon,
+} from "lucide-react";
 import { TaskActionButton } from "modules/tasks/TaskActionButton";
 import { TaskDeleteDialog } from "modules/tasks/TaskDeleteDialog/TaskDeleteDialog";
 import { TaskStatus } from "modules/tasks/TaskStatus/TaskStatus";
@@ -205,6 +212,19 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 			});
 		},
 	});
+	const downloadLogsMutation = useMutation({
+		mutationFn: async () => {
+			const response = await API.getTaskLogs(task.owner_name, task.id);
+			const json = JSON.stringify(response, null, 2);
+			const blob = new Blob([json], { type: "application/json" });
+			saveAs(blob, `${task.name}-logs.json`);
+		},
+		onError: (error: unknown) => {
+			toast.error(getErrorMessage(error, "Failed to download chat logs."), {
+				description: getErrorDetail(error),
+			});
+		},
+	});
 
 	const taskPageLink = `/tasks/${task.owner_name}/${task.id}`;
 	// Discard role, breaks Chromatic.
@@ -297,6 +317,16 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 								</Button>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent align="end">
+								<DropdownMenuItem
+									disabled={downloadLogsMutation.isPending}
+									onClick={(e) => {
+										e.stopPropagation();
+										downloadLogsMutation.mutate();
+									}}
+								>
+									<DownloadIcon />
+									Download chat logs
+								</DropdownMenuItem>
 								<DropdownMenuItem
 									className="text-content-destructive focus:text-content-destructive"
 									onClick={(e) => {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -5048,6 +5048,30 @@ export const MockTask = {
 	updated_at: "2022-05-17T17:39:01.382927298Z",
 } satisfies TypesGen.Task;
 
+export const MockTaskLogsResponse: TypesGen.TaskLogsResponse = {
+	logs: [
+		{
+			id: 1,
+			content: "What would you like me to do?",
+			type: "output",
+			time: "2022-05-17T17:39:01.382927298Z",
+		},
+		{
+			id: 2,
+			content: "Fix the avatar size on the tasks page.",
+			type: "input",
+			time: "2022-05-17T17:39:05.382927298Z",
+		},
+		{
+			id: 3,
+			content: "I'll fix the avatar size now. Let me look at the code...",
+			type: "output",
+			time: "2022-05-17T17:39:10.382927298Z",
+		},
+	],
+	snapshot: false,
+};
+
 export const MockTaskWorkspace: TypesGen.Workspace = {
 	...MockWorkspace,
 	task_id: MockTask.id,


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1270 / Closes COCO-37

## Summary

Adds a "Download chat logs" option to the task row kebab (3-dot) menu on the Tasks page.

## Changes

### `site/src/pages/TasksPage/TasksTable.tsx`
- Added "Download chat logs" `DropdownMenuItem` above the existing "Delete" item
- Calls `API.getTaskLogs(owner_name, id)` and saves the raw JSON response via `file-saver`
- Filename: `{task-name}-logs.json`
- Shows loading state while downloading, error toast on failure

### `site/src/pages/TasksPage/TasksPage.stories.tsx`
- Added `DownloadChatLogs` story that opens the kebab menu and clicks the download item, asserting the API was called
- Updated `OpenKebabMenu` story to mock `getTaskLogs` so the menu renders correctly

### `site/src/testHelpers/entities.ts`
- Added `MockTaskLogsResponse` with sample log entries for story/test use

## Acceptance criteria
- [x] "Download chat logs" appears in task row menu
- [x] Downloads logs for both active and paused tasks (no status filter)
- [x] Uses existing logs endpoint response format (no transformation)
- [x] Filename includes task name
- [x] Storybook story with play test