### PR TITLE
fix: remove extra left border from diff panel header on agents detail page

### DIFF
--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -77,7 +77,7 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({ chatId }) => {
 	if (diffContentsQuery.isLoading || diffStatusQuery.isLoading) {
 		return (
 			<div className="flex h-full min-w-0 flex-col overflow-hidden border-0 border-l border-solid bg-surface-primary">
-				<div className="flex items-center gap-2 border-0 border-b border-l border-solid px-4 py-3">
+				<div className="flex items-center gap-2 border-0 border-b border-solid px-4 py-3">
 					<Skeleton className="h-4 w-4 rounded" />
 					<Skeleton className="h-4 w-28" />
 				</div>
@@ -106,7 +106,7 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({ chatId }) => {
 	return (
 		<div className="flex h-full min-w-0 flex-col overflow-hidden border-0 border-l border-solid bg-surface-primary">
 			{/* Header */}
-			<div className="flex items-center justify-between gap-3 border-0 border-b border-l border-solid px-4 py-3">
+			<div className="flex items-center justify-between gap-3 border-0 border-b border-solid px-4 py-3">
 				<div className="flex min-w-0 items-center gap-2">
 					{pullRequestUrl ? (
 						<>


### PR DESCRIPTION
The header divs in `FilesChangedPanel` had a redundant `border-l` class. The parent container already applies `border-l`, causing a double left border on the repo name / PR link area.

This removes `border-l` from both the loading skeleton header and the main header.