### PR TITLE
chore: update test directions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,8 +198,7 @@ reviewer time and clutters the diff.
 **Don't delete existing comments** that explain non-obvious behavior. These
 comments preserve important context about why code works a certain way.
 
-**When adding tests for new behavior**, do not introduce new tests if they
-would duplicate coverage of existing tests. Check coverage if you are unsure.
+**When adding tests for new behavior**, first check if the existing tests cover this behavior to prevent duplication.
 
 ## Detailed Development Guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ reviewer time and clutters the diff.
 **Don't delete existing comments** that explain non-obvious behavior. These
 comments preserve important context about why code works a certain way.
 
-**When adding tests for new behavior**, first check if the existing tests cover this behavior to prevent duplication.
+**When adding tests for new behavior**, read existing tests first to understand what's covered. Add new cases for uncovered behavior. Edit existing tests as needed, but don't change what they verify.
 
 ## Detailed Development Guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,9 +198,8 @@ reviewer time and clutters the diff.
 **Don't delete existing comments** that explain non-obvious behavior. These
 comments preserve important context about why code works a certain way.
 
-**When adding tests for new behavior**, add new test cases instead of modifying
-existing ones. This preserves coverage for the original behavior and makes it
-clear what the new test covers.
+**When adding tests for new behavior**, do not introduce new tests if they
+would duplicate coverage of existing tests. Check coverage if you are unsure.
 
 ## Detailed Development Guides
 


### PR DESCRIPTION
Our `AGENTS.md` previously contained this directive:

> When adding tests for new behavior, add new test cases instead of modifying existing ones. This preserves coverage for the original behavior and makes it clear what the new test covers.

This leads to inflated diffs and test explosions. Updating it to bias more towards updating existing tests where applicable.