### PR TITLE
fix(chatd): increase title generation timeout from 10s to 30s

### DIFF
--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -35,7 +35,7 @@ func (p *Server) maybeGenerateChatTitle(
 		return
 	}
 
-	titleCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	titleCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	title, err := generateTitle(titleCtx, model, input)


### PR DESCRIPTION
## Problem

Production logs frequently show:

```
[debu] coderd.chats.chat-processor: failed to generate chat title
    error= generate title text: context deadline exceeded
```

## Root Cause

The title generation timeout in `maybeGenerateChatTitle` is 10 seconds. Many LLM providers routinely exceed this under load (cold starts, rate limits, large models). Since `chatretry` classifies `context deadline exceeded` as non-retryable, the first timeout kills the entire attempt with no retry.

## Fix

Increase the timeout from 10s to 30s. Title generation is async and best-effort — it runs in a background goroutine and doesn't block the chat response — so a longer timeout has no user-facing impact.