### PR TITLE
fix: raise diff panel drag handle z-index above sticky file headers

### DIFF
--- a/site/src/pages/AgentsPage/DiffRightPanel.tsx
+++ b/site/src/pages/AgentsPage/DiffRightPanel.tsx
@@ -110,7 +110,7 @@ export const DiffRightPanel = ({ isOpen, children }: DiffRightPanelProps) => {
 				onPointerDown={handlePointerDown}
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerUp}
-				className="absolute top-0 left-0 z-10 hidden h-full w-1 cursor-col-resize select-none transition-colors hover:bg-content-link xl:block"
+				className="absolute top-0 left-0 z-20 hidden h-full w-1 cursor-col-resize select-none transition-colors hover:bg-content-link xl:block"
 			/>
 			{children}
 		</div>


### PR DESCRIPTION
## Problem

The drag handle (resize slider) on the diff right panel and the sticky file headers inside `FilesChangedPanel` both had `z-index: 10`. Because the sticky headers render later in the DOM and are positioned, they painted on top of the drag handle — making it appear to go "below" the headers when dragging.

## Fix

Bump the drag handle from `z-10` to `z-20` so it always stays above the sticky `[data-diffs-header]` elements (`z-index: 10`).