### PR TITLE
refactor(coderd): extract git provider abstraction from chats.go

### DIFF
--- a/coderd/agentapi/manifest.go
+++ b/coderd/agentapi/manifest.go
@@ -20,7 +20,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
-	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/tailnet"
 )
 
@@ -105,7 +104,7 @@ func (a *ManifestAPI) GetManifest(ctx context.Context, _ *agentproto.GetManifest
 
 	var gitAuthConfigs uint32
 	for _, cfg := range a.ExternalAuthConfigs {
-		if codersdk.EnhancedExternalAuthProvider(cfg.Type).Git() {
+		if cfg.Git() != nil {
 			gitAuthConfigs++
 		}
 	}

--- a/coderd/agentapi/manifest.go
+++ b/coderd/agentapi/manifest.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/tailnet"
 )
 
@@ -104,7 +105,7 @@ func (a *ManifestAPI) GetManifest(ctx context.Context, _ *agentproto.GetManifest
 
 	var gitAuthConfigs uint32
 	for _, cfg := range a.ExternalAuthConfigs {
-		if cfg.Git() != nil {
+		if codersdk.EnhancedExternalAuthProvider(cfg.Type).Git() {
 			gitAuthConfigs++
 		}
 	}

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15286,6 +15286,10 @@ const docTemplate = `{
         "codersdk.ExternalAuthConfig": {
             "type": "object",
             "properties": {
+                "api_base_url": {
+                    "description": "APIBaseURL is the base URL for provider REST API calls\n(e.g., \"https://api.github.com\" for GitHub). Derived from\ndefaults when not explicitly configured.",
+                    "type": "string"
+                },
                 "app_install_url": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13805,6 +13805,10 @@
 		"codersdk.ExternalAuthConfig": {
 			"type": "object",
 			"properties": {
+				"api_base_url": {
+					"description": "APIBaseURL is the base URL for provider REST API calls\n(e.g., \"https://api.github.com\" for GitHub). Derived from\ndefaults when not explicitly configured.",
+					"type": "string"
+				},
 				"app_install_url": {
 					"type": "string"
 				},

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -1177,7 +1177,7 @@ func (api *API) resolveChatDiffContents(
 		return result, nil
 	}
 
-	token := api.resolveChatGitHubAccessToken(ctx, chat.OwnerID)
+	token := api.resolveChatGitAccessToken(ctx, chat.OwnerID)
 
 	if reference.PullRequestURL != "" {
 		ref, ok := gp.ParsePullRequestURL(reference.PullRequestURL)
@@ -1233,7 +1233,7 @@ func (api *API) resolveChatDiffReference(
 	if reference.RepositoryRef != nil && reference.RepositoryRef.Owner != "" {
 		gp := api.resolveGitProvider(reference.RepositoryRef.RemoteOrigin)
 		if gp != nil {
-			token := api.resolveChatGitHubAccessToken(ctx, chat.OwnerID)
+			token := api.resolveChatGitAccessToken(ctx, chat.OwnerID)
 			prRef, lookupErr := gp.ResolveBranchPR(ctx, token, gitprovider.BranchRef{
 				Owner:  reference.RepositoryRef.Owner,
 				Repo:   reference.RepositoryRef.Repo,
@@ -1247,9 +1247,9 @@ func (api *API) resolveChatDiffReference(
 					slog.F("branch", reference.RepositoryRef.Branch),
 					slog.Error(lookupErr),
 				)
-				} else if prRef != nil {
-					reference.PullRequestURL = gp.BuildPullRequestURL(*prRef)
-				}
+			} else if prRef != nil {
+				reference.PullRequestURL = gp.BuildPullRequestURL(*prRef)
+			}
 			reference.PullRequestURL = gp.NormalizePullRequestURL(reference.PullRequestURL)
 		}
 	}
@@ -1265,9 +1265,10 @@ func (api *API) resolveChatDiffReference(
 			}
 			if parsed, ok := gp.ParsePullRequestURL(reference.PullRequestURL); ok {
 				reference.RepositoryRef = &chatRepositoryRef{
-					Provider: strings.ToLower(extAuth.Type),
-					Owner:    parsed.Owner,
-					Repo:     parsed.Repo,
+					Provider:     strings.ToLower(extAuth.Type),
+					Owner:        parsed.Owner,
+					Repo:         parsed.Repo,
+					RemoteOrigin: gp.BuildRepositoryURL(parsed.Owner, parsed.Repo),
 				}
 				break
 			}
@@ -1370,8 +1371,8 @@ func (api *API) resolveExternalAuthProviderType(match string) string {
 }
 
 // resolveGitProvider finds the external auth config matching the
-// given remote origin URL and returns its GitProvider. Returns nil
-// if no matching git provider is configured.
+// given remote origin URL and returns its git provider. Returns
+// nil if no matching git provider is configured.
 func (api *API) resolveGitProvider(origin string) gitprovider.Provider {
 	origin = strings.TrimSpace(origin)
 	if origin == "" {
@@ -1419,7 +1420,7 @@ func (api *API) refreshChatDiffStatus(
 		return database.ChatDiffStatus{}, xerrors.Errorf("no git provider found for PR URL %q", pullRequestURL)
 	}
 
-	token := api.resolveChatGitHubAccessToken(ctx, chatOwnerID)
+	token := api.resolveChatGitAccessToken(ctx, chatOwnerID)
 	status, err := gp.FetchPRStatus(ctx, token, ref)
 	if err != nil {
 		return database.ChatDiffStatus{}, err
@@ -1449,7 +1450,7 @@ func (api *API) refreshChatDiffStatus(
 	return refreshedStatus, nil
 }
 
-func (api *API) resolveChatGitHubAccessToken(
+func (api *API) resolveChatGitAccessToken(
 	ctx context.Context,
 	userID uuid.UUID,
 ) string {

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -5,11 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/externalauth"
+	"github.com/coder/coder/v2/coderd/externalauth/gitprovider"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpapi/httperror"
 	"github.com/coder/coder/v2/coderd/httpmw"
@@ -40,7 +39,6 @@ import (
 const (
 	chatDiffStatusTTL                = 120 * time.Second
 	chatDiffBackgroundRefreshTimeout = 20 * time.Second
-	githubAPIBaseURL                 = "https://api.github.com"
 	chatStreamBatchSize              = 256
 
 	chatContextLimitModelConfigKey                = "context_limit"
@@ -68,32 +66,6 @@ var chatDiffRefreshBackoffSchedule = []time.Duration{
 type chatGitRef struct {
 	Branch       string
 	RemoteOrigin string
-}
-
-var (
-	githubPullRequestPathPattern = regexp.MustCompile(
-		`^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)(?:[/?#].*)?$`,
-	)
-	githubRepositoryHTTPSPattern = regexp.MustCompile(
-		`^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
-	)
-	githubRepositorySSHPathPattern = regexp.MustCompile(
-		`^(?:ssh://)?git@github\.com[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
-	)
-)
-
-type githubPullRequestRef struct {
-	Owner  string
-	Repo   string
-	Number int
-}
-
-type githubPullRequestStatus struct {
-	PullRequestState string
-	ChangesRequested bool
-	Additions        int32
-	Deletions        int32
-	ChangedFiles     int32
 }
 
 type chatRepositoryRef struct {
@@ -1199,14 +1171,20 @@ func (api *API) resolveChatDiffContents(
 	if reference.RepositoryRef == nil {
 		return result, nil
 	}
-	if !strings.EqualFold(reference.RepositoryRef.Provider, string(codersdk.EnhancedExternalAuthProviderGitHub)) {
+
+	gp := api.resolveGitProvider(reference.RepositoryRef.RemoteOrigin)
+	if gp == nil {
 		return result, nil
 	}
 
 	token := api.resolveChatGitHubAccessToken(ctx, chat.OwnerID)
 
 	if reference.PullRequestURL != "" {
-		diff, err := api.fetchGitHubPullRequestDiff(ctx, reference.PullRequestURL, token)
+		ref, ok := gp.ParsePullRequestURL(reference.PullRequestURL)
+		if !ok {
+			return result, xerrors.Errorf("invalid pull request URL %q", reference.PullRequestURL)
+		}
+		diff, err := gp.FetchPRDiff(ctx, token, ref)
 		if err != nil {
 			return result, err
 		}
@@ -1214,7 +1192,11 @@ func (api *API) resolveChatDiffContents(
 		return result, nil
 	}
 
-	diff, err := api.fetchGitHubCompareDiff(ctx, *reference.RepositoryRef, token)
+	diff, err := gp.FetchBranchDiff(ctx, token, gitprovider.BranchRef{
+		Owner:  reference.RepositoryRef.Owner,
+		Repo:   reference.RepositoryRef.Repo,
+		Branch: reference.RepositoryRef.Branch,
+	})
 	if err != nil {
 		return result, err
 	}
@@ -1248,34 +1230,50 @@ func (api *API) resolveChatDiffReference(
 	// If we have a repo ref with a branch, try to resolve the
 	// current open PR. This picks up new PRs after the previous
 	// one was closed.
-	if reference.RepositoryRef != nil &&
-		strings.EqualFold(reference.RepositoryRef.Provider, string(codersdk.EnhancedExternalAuthProviderGitHub)) {
-		pullRequestURL, lookupErr := api.resolveGitHubPullRequestURLFromRepositoryRef(ctx, chat.OwnerID, *reference.RepositoryRef)
-		if lookupErr != nil {
-			api.Logger.Debug(ctx, "failed to resolve pull request from repository reference",
-				slog.F("chat_id", chat.ID),
-				slog.F("provider", reference.RepositoryRef.Provider),
-				slog.F("remote_origin", reference.RepositoryRef.RemoteOrigin),
-				slog.F("branch", reference.RepositoryRef.Branch),
-				slog.Error(lookupErr),
-			)
-		} else if pullRequestURL != "" {
-			reference.PullRequestURL = pullRequestURL
+	if reference.RepositoryRef != nil && reference.RepositoryRef.Owner != "" {
+		gp := api.resolveGitProvider(reference.RepositoryRef.RemoteOrigin)
+		if gp != nil {
+			token := api.resolveChatGitHubAccessToken(ctx, chat.OwnerID)
+			prRef, lookupErr := gp.ResolveBranchPR(ctx, token, gitprovider.BranchRef{
+				Owner:  reference.RepositoryRef.Owner,
+				Repo:   reference.RepositoryRef.Repo,
+				Branch: reference.RepositoryRef.Branch,
+			})
+			if lookupErr != nil {
+				api.Logger.Debug(ctx, "failed to resolve pull request from repository reference",
+					slog.F("chat_id", chat.ID),
+					slog.F("provider", reference.RepositoryRef.Provider),
+					slog.F("remote_origin", reference.RepositoryRef.RemoteOrigin),
+					slog.F("branch", reference.RepositoryRef.Branch),
+					slog.Error(lookupErr),
+				)
+			} else if prRef != nil {
+				reference.PullRequestURL = fmt.Sprintf(
+					"https://github.com/%s/%s/pull/%d",
+					prRef.Owner, prRef.Repo, prRef.Number,
+				)
+			}
+
+			reference.PullRequestURL = gp.NormalizePullRequestURL(reference.PullRequestURL)
 		}
 	}
-
-	reference.PullRequestURL = normalizeGitHubPullRequestURL(reference.PullRequestURL)
 
 	// If we have a PR URL but no repo ref (e.g. the agent hasn't
 	// reported branch/origin yet), derive a partial ref from the
 	// PR URL so the caller can still show provider/owner/repo.
 	if reference.RepositoryRef == nil && reference.PullRequestURL != "" {
-		if parsed, ok := parseGitHubPullRequestURL(reference.PullRequestURL); ok {
-			reference.RepositoryRef = &chatRepositoryRef{
-				Provider:     string(codersdk.EnhancedExternalAuthProviderGitHub),
-				RemoteOrigin: fmt.Sprintf("https://github.com/%s/%s", parsed.Owner, parsed.Repo),
-				Owner:        parsed.Owner,
-				Repo:         parsed.Repo,
+		for _, extAuth := range api.ExternalAuthConfigs {
+			gp := extAuth.Git()
+			if gp == nil {
+				continue
+			}
+			if parsed, ok := gp.ParsePullRequestURL(reference.PullRequestURL); ok {
+				reference.RepositoryRef = &chatRepositoryRef{
+					Provider: strings.ToLower(extAuth.Type),
+					Owner:    parsed.Owner,
+					Repo:     parsed.Repo,
+				}
+				break
 			}
 		}
 	}
@@ -1299,13 +1297,13 @@ func (api *API) buildChatRepositoryRefFromStatus(status database.ChatDiffStatus)
 		Branch:       branch,
 	}
 
-	if owner, repo, normalizedOrigin, ok := parseGitHubRepositoryOrigin(repoRef.RemoteOrigin); ok {
-		if repoRef.Provider == "" {
-			repoRef.Provider = string(codersdk.EnhancedExternalAuthProviderGitHub)
+	gp := api.resolveGitProvider(repoRef.RemoteOrigin)
+	if gp != nil {
+		if owner, repo, normalizedOrigin, ok := gp.ParseRepositoryOrigin(repoRef.RemoteOrigin); ok {
+			repoRef.RemoteOrigin = normalizedOrigin
+			repoRef.Owner = owner
+			repoRef.Repo = repo
 		}
-		repoRef.RemoteOrigin = normalizedOrigin
-		repoRef.Owner = owner
-		repoRef.Repo = repo
 	}
 
 	if repoRef.Provider == "" {
@@ -1375,44 +1373,23 @@ func (api *API) resolveExternalAuthProviderType(match string) string {
 	return ""
 }
 
-func parseGitHubRepositoryOrigin(raw string) (owner string, repo string, normalizedOrigin string, ok bool) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", "", "", false
+// resolveGitProvider finds the external auth config matching the
+// given remote origin URL and returns its GitProvider. Returns nil
+// if no matching git provider is configured.
+func (api *API) resolveGitProvider(origin string) *gitprovider.GitProvider {
+	origin = strings.TrimSpace(origin)
+	if origin == "" {
+		return nil
 	}
 
-	matches := githubRepositoryHTTPSPattern.FindStringSubmatch(raw)
-	if len(matches) != 3 {
-		matches = githubRepositorySSHPathPattern.FindStringSubmatch(raw)
-	}
-	if len(matches) != 3 {
-		return "", "", "", false
-	}
-
-	owner = strings.TrimSpace(matches[1])
-	repo = strings.TrimSpace(matches[2])
-	repo = strings.TrimSuffix(repo, ".git")
-	if owner == "" || repo == "" {
-		return "", "", "", false
+	for _, extAuth := range api.ExternalAuthConfigs {
+		if extAuth.Regex == nil || !extAuth.Regex.MatchString(origin) {
+			continue
+		}
+		return extAuth.Git()
 	}
 
-	return owner, repo, fmt.Sprintf("https://github.com/%s/%s", owner, repo), true
-}
-
-func buildGitHubBranchURL(owner string, repo string, branch string) string {
-	owner = strings.TrimSpace(owner)
-	repo = strings.TrimSpace(repo)
-	branch = strings.TrimSpace(branch)
-	if owner == "" || repo == "" || branch == "" {
-		return ""
-	}
-
-	return fmt.Sprintf(
-		"https://github.com/%s/%s/tree/%s",
-		owner,
-		repo,
-		url.PathEscape(branch),
-	)
+	return nil
 }
 
 func chatDiffStatusIsStale(status database.ChatDiffStatus, now time.Time) bool {
@@ -1428,11 +1405,26 @@ func (api *API) refreshChatDiffStatus(
 	chatID uuid.UUID,
 	pullRequestURL string,
 ) (database.ChatDiffStatus, error) {
-	status, err := api.fetchGitHubPullRequestStatus(
-		ctx,
-		pullRequestURL,
-		api.resolveChatGitHubAccessToken(ctx, chatOwnerID),
-	)
+	// Find a provider that can handle this PR URL.
+	var gp *gitprovider.GitProvider
+	var ref gitprovider.PRRef
+	for _, extAuth := range api.ExternalAuthConfigs {
+		p := extAuth.Git()
+		if p == nil {
+			continue
+		}
+		if parsed, ok := p.ParsePullRequestURL(pullRequestURL); ok {
+			gp = p
+			ref = parsed
+			break
+		}
+	}
+	if gp == nil {
+		return database.ChatDiffStatus{}, xerrors.Errorf("no git provider found for PR URL %q", pullRequestURL)
+	}
+
+	token := api.resolveChatGitHubAccessToken(ctx, chatOwnerID)
+	status, err := gp.FetchPRStatus(ctx, token, ref)
 	if err != nil {
 		return database.ChatDiffStatus{}, err
 	}
@@ -1444,13 +1436,13 @@ func (api *API) refreshChatDiffStatus(
 			ChatID: chatID,
 			Url:    sql.NullString{String: pullRequestURL, Valid: true},
 			PullRequestState: sql.NullString{
-				String: status.PullRequestState,
-				Valid:  status.PullRequestState != "",
+				String: string(status.State),
+				Valid:  status.State != "",
 			},
 			ChangesRequested: status.ChangesRequested,
-			Additions:        status.Additions,
-			Deletions:        status.Deletions,
-			ChangedFiles:     status.ChangedFiles,
+			Additions:        status.DiffStats.Additions,
+			Deletions:        status.DiffStats.Deletions,
+			ChangedFiles:     status.DiffStats.ChangedFiles,
 			RefreshedAt:      refreshedAt,
 			StaleAt:          refreshedAt.Add(chatDiffStatusTTL),
 		},
@@ -1523,331 +1515,6 @@ func (api *API) resolveChatGitHubAccessToken(
 	}
 
 	return ""
-}
-
-func (api *API) resolveGitHubPullRequestURLFromRepositoryRef(
-	ctx context.Context,
-	userID uuid.UUID,
-	repositoryRef chatRepositoryRef,
-) (string, error) {
-	if repositoryRef.Owner == "" || repositoryRef.Repo == "" || repositoryRef.Branch == "" {
-		return "", nil
-	}
-
-	query := url.Values{}
-	query.Set("state", "open")
-	query.Set("head", fmt.Sprintf("%s:%s", repositoryRef.Owner, repositoryRef.Branch))
-	query.Set("sort", "updated")
-	query.Set("direction", "desc")
-	query.Set("per_page", "1")
-
-	requestURL := fmt.Sprintf(
-		"%s/repos/%s/%s/pulls?%s",
-		githubAPIBaseURL,
-		repositoryRef.Owner,
-		repositoryRef.Repo,
-		query.Encode(),
-	)
-
-	var pulls []struct {
-		HTMLURL string `json:"html_url"`
-	}
-
-	token := api.resolveChatGitHubAccessToken(ctx, userID)
-	if err := api.decodeGitHubJSON(ctx, requestURL, token, &pulls); err != nil {
-		return "", err
-	}
-	if len(pulls) == 0 {
-		return "", nil
-	}
-
-	return normalizeGitHubPullRequestURL(pulls[0].HTMLURL), nil
-}
-
-func (api *API) fetchGitHubPullRequestDiff(
-	ctx context.Context,
-	pullRequestURL string,
-	token string,
-) (string, error) {
-	ref, ok := parseGitHubPullRequestURL(pullRequestURL)
-	if !ok {
-		return "", xerrors.Errorf("invalid GitHub pull request URL %q", pullRequestURL)
-	}
-
-	requestURL := fmt.Sprintf(
-		"%s/repos/%s/%s/pulls/%d",
-		githubAPIBaseURL,
-		ref.Owner,
-		ref.Repo,
-		ref.Number,
-	)
-
-	return api.fetchGitHubDiff(ctx, requestURL, token)
-}
-
-func (api *API) fetchGitHubCompareDiff(
-	ctx context.Context,
-	repositoryRef chatRepositoryRef,
-	token string,
-) (string, error) {
-	if repositoryRef.Owner == "" || repositoryRef.Repo == "" || repositoryRef.Branch == "" {
-		return "", nil
-	}
-
-	var repository struct {
-		DefaultBranch string `json:"default_branch"`
-	}
-
-	repositoryURL := fmt.Sprintf(
-		"%s/repos/%s/%s",
-		githubAPIBaseURL,
-		repositoryRef.Owner,
-		repositoryRef.Repo,
-	)
-	if err := api.decodeGitHubJSON(ctx, repositoryURL, token, &repository); err != nil {
-		return "", err
-	}
-	defaultBranch := strings.TrimSpace(repository.DefaultBranch)
-	if defaultBranch == "" {
-		return "", xerrors.New("github repository default branch is empty")
-	}
-
-	requestURL := fmt.Sprintf(
-		"%s/repos/%s/%s/compare/%s...%s",
-		githubAPIBaseURL,
-		repositoryRef.Owner,
-		repositoryRef.Repo,
-		url.PathEscape(defaultBranch),
-		url.PathEscape(repositoryRef.Branch),
-	)
-
-	return api.fetchGitHubDiff(ctx, requestURL, token)
-}
-
-func (api *API) fetchGitHubDiff(
-	ctx context.Context,
-	requestURL string,
-	token string,
-) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
-	if err != nil {
-		return "", xerrors.Errorf("create github diff request: %w", err)
-	}
-	req.Header.Set("Accept", "application/vnd.github.diff")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", "coder-chat-diff")
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	httpClient := api.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", xerrors.Errorf("execute github diff request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8192))
-		if readErr != nil {
-			return "", xerrors.Errorf("github diff request failed with status %d", resp.StatusCode)
-		}
-		return "", xerrors.Errorf(
-			"github diff request failed with status %d: %s",
-			resp.StatusCode,
-			strings.TrimSpace(string(body)),
-		)
-	}
-
-	diff, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return "", xerrors.Errorf("read github diff response: %w", err)
-	}
-	return string(diff), nil
-}
-
-func (api *API) fetchGitHubPullRequestStatus(
-	ctx context.Context,
-	pullRequestURL string,
-	token string,
-) (githubPullRequestStatus, error) {
-	ref, ok := parseGitHubPullRequestURL(pullRequestURL)
-	if !ok {
-		return githubPullRequestStatus{}, xerrors.Errorf(
-			"invalid GitHub pull request URL %q",
-			pullRequestURL,
-		)
-	}
-
-	pullEndpoint := fmt.Sprintf(
-		"%s/repos/%s/%s/pulls/%d",
-		githubAPIBaseURL,
-		ref.Owner,
-		ref.Repo,
-		ref.Number,
-	)
-
-	var pull struct {
-		State        string `json:"state"`
-		Additions    int32  `json:"additions"`
-		Deletions    int32  `json:"deletions"`
-		ChangedFiles int32  `json:"changed_files"`
-	}
-	if err := api.decodeGitHubJSON(ctx, pullEndpoint, token, &pull); err != nil {
-		return githubPullRequestStatus{}, err
-	}
-
-	var reviews []struct {
-		ID    int64  `json:"id"`
-		State string `json:"state"`
-		User  struct {
-			Login string `json:"login"`
-		} `json:"user"`
-	}
-	if err := api.decodeGitHubJSON(
-		ctx,
-		pullEndpoint+"/reviews?per_page=100",
-		token,
-		&reviews,
-	); err != nil {
-		return githubPullRequestStatus{}, err
-	}
-
-	return githubPullRequestStatus{
-		PullRequestState: strings.ToLower(strings.TrimSpace(pull.State)),
-		ChangesRequested: hasOutstandingGitHubChangesRequested(reviews),
-		Additions:        pull.Additions,
-		Deletions:        pull.Deletions,
-		ChangedFiles:     pull.ChangedFiles,
-	}, nil
-}
-
-func (api *API) decodeGitHubJSON(
-	ctx context.Context,
-	requestURL string,
-	token string,
-	dest any,
-) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
-	if err != nil {
-		return xerrors.Errorf("create github request: %w", err)
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", "coder-chat-diff-status")
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	httpClient := api.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return xerrors.Errorf("execute github request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8192))
-		if readErr != nil {
-			return xerrors.Errorf(
-				"github request failed with status %d",
-				resp.StatusCode,
-			)
-		}
-		return xerrors.Errorf(
-			"github request failed with status %d: %s",
-			resp.StatusCode,
-			strings.TrimSpace(string(body)),
-		)
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
-		return xerrors.Errorf("decode github response: %w", err)
-	}
-	return nil
-}
-
-func hasOutstandingGitHubChangesRequested(
-	reviews []struct {
-		ID    int64  `json:"id"`
-		State string `json:"state"`
-		User  struct {
-			Login string `json:"login"`
-		} `json:"user"`
-	},
-) bool {
-	type reviewerState struct {
-		reviewID int64
-		state    string
-	}
-
-	statesByReviewer := make(map[string]reviewerState)
-	for _, review := range reviews {
-		login := strings.ToLower(strings.TrimSpace(review.User.Login))
-		if login == "" {
-			continue
-		}
-
-		state := strings.ToUpper(strings.TrimSpace(review.State))
-		switch state {
-		case "CHANGES_REQUESTED", "APPROVED", "DISMISSED":
-		default:
-			continue
-		}
-
-		current, exists := statesByReviewer[login]
-		if exists && current.reviewID > review.ID {
-			continue
-		}
-		statesByReviewer[login] = reviewerState{
-			reviewID: review.ID,
-			state:    state,
-		}
-	}
-
-	for _, state := range statesByReviewer {
-		if state.state == "CHANGES_REQUESTED" {
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeGitHubPullRequestURL(raw string) string {
-	ref, ok := parseGitHubPullRequestURL(strings.TrimRight(
-		strings.TrimSpace(raw),
-		"),.;",
-	))
-	if !ok {
-		return ""
-	}
-	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", ref.Owner, ref.Repo, ref.Number)
-}
-
-func parseGitHubPullRequestURL(raw string) (githubPullRequestRef, bool) {
-	matches := githubPullRequestPathPattern.FindStringSubmatch(strings.TrimSpace(raw))
-	if len(matches) != 4 {
-		return githubPullRequestRef{}, false
-	}
-
-	number, err := strconv.Atoi(matches[3])
-	if err != nil {
-		return githubPullRequestRef{}, false
-	}
-
-	return githubPullRequestRef{
-		Owner:  matches[1],
-		Repo:   matches[2],
-		Number: number,
-	}, true
 }
 
 type createChatWorkspaceSelection struct {
@@ -2130,11 +1797,17 @@ func convertChatDiffStatus(chatID uuid.UUID, status *database.ChatDiffStatus) co
 		}
 	}
 	if result.URL == nil {
-		owner, repo, _, ok := parseGitHubRepositoryOrigin(status.GitRemoteOrigin)
-		if ok {
-			branchURL := buildGitHubBranchURL(owner, repo, status.GitBranch)
-			if branchURL != "" {
-				result.URL = &branchURL
+		// Try to build a branch URL from the stored origin.
+		// Since convertChatDiffStatus does not have access to
+		// the API instance, we construct a GitHub provider
+		// directly as a best-effort fallback.
+		gp := gitprovider.New("github", "", nil)
+		if gp != nil {
+			if owner, repo, _, ok := gp.ParseRepositoryOrigin(status.GitRemoteOrigin); ok {
+				branchURL := gp.BuildBranchURL(owner, repo, status.GitBranch)
+				if branchURL != "" {
+					result.URL = &branchURL
+				}
 			}
 		}
 	}

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -1247,13 +1247,9 @@ func (api *API) resolveChatDiffReference(
 					slog.F("branch", reference.RepositoryRef.Branch),
 					slog.Error(lookupErr),
 				)
-			} else if prRef != nil {
-				reference.PullRequestURL = fmt.Sprintf(
-					"https://github.com/%s/%s/pull/%d",
-					prRef.Owner, prRef.Repo, prRef.Number,
-				)
-			}
-
+				} else if prRef != nil {
+					reference.PullRequestURL = gp.BuildPullRequestURL(*prRef)
+				}
 			reference.PullRequestURL = gp.NormalizePullRequestURL(reference.PullRequestURL)
 		}
 	}
@@ -1801,6 +1797,10 @@ func convertChatDiffStatus(chatID uuid.UUID, status *database.ChatDiffStatus) co
 		// Since convertChatDiffStatus does not have access to
 		// the API instance, we construct a GitHub provider
 		// directly as a best-effort fallback.
+		// TODO: This uses the default github.com API base URL,
+		// so branch URLs for GitHub Enterprise instances will
+		// be incorrect. To fix this, convertChatDiffStatus
+		// would need access to the external auth configs.
 		gp := gitprovider.New("github", "", nil)
 		if gp != nil {
 			if owner, repo, _, ok := gp.ParseRepositoryOrigin(status.GitRemoteOrigin); ok {

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -1184,7 +1184,7 @@ func (api *API) resolveChatDiffContents(
 		if !ok {
 			return result, xerrors.Errorf("invalid pull request URL %q", reference.PullRequestURL)
 		}
-		diff, err := gp.FetchPRDiff(ctx, token, ref)
+		diff, err := gp.FetchPullRequestDiff(ctx, token, ref)
 		if err != nil {
 			return result, err
 		}
@@ -1234,7 +1234,7 @@ func (api *API) resolveChatDiffReference(
 		gp := api.resolveGitProvider(reference.RepositoryRef.RemoteOrigin)
 		if gp != nil {
 			token := api.resolveChatGitAccessToken(ctx, chat.OwnerID)
-			prRef, lookupErr := gp.ResolveBranchPR(ctx, token, gitprovider.BranchRef{
+			prRef, lookupErr := gp.ResolveBranchPullRequest(ctx, token, gitprovider.BranchRef{
 				Owner:  reference.RepositoryRef.Owner,
 				Repo:   reference.RepositoryRef.Repo,
 				Branch: reference.RepositoryRef.Branch,
@@ -1259,7 +1259,7 @@ func (api *API) resolveChatDiffReference(
 	// PR URL so the caller can still show provider/owner/repo.
 	if reference.RepositoryRef == nil && reference.PullRequestURL != "" {
 		for _, extAuth := range api.ExternalAuthConfigs {
-			gp := extAuth.Git()
+			gp := extAuth.Git(api.HTTPClient)
 			if gp == nil {
 				continue
 			}
@@ -1383,7 +1383,7 @@ func (api *API) resolveGitProvider(origin string) gitprovider.Provider {
 		if extAuth.Regex == nil || !extAuth.Regex.MatchString(origin) {
 			continue
 		}
-		return extAuth.Git()
+		return extAuth.Git(api.HTTPClient)
 	}
 
 	return nil
@@ -1406,7 +1406,7 @@ func (api *API) refreshChatDiffStatus(
 	var gp gitprovider.Provider
 	var ref gitprovider.PRRef
 	for _, extAuth := range api.ExternalAuthConfigs {
-		p := extAuth.Git()
+		p := extAuth.Git(api.HTTPClient)
 		if p == nil {
 			continue
 		}
@@ -1421,7 +1421,7 @@ func (api *API) refreshChatDiffStatus(
 	}
 
 	token := api.resolveChatGitAccessToken(ctx, chatOwnerID)
-	status, err := gp.FetchPRStatus(ctx, token, ref)
+	status, err := gp.FetchPullRequestStatus(ctx, token, ref)
 	if err != nil {
 		return database.ChatDiffStatus{}, err
 	}

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -1372,7 +1372,7 @@ func (api *API) resolveExternalAuthProviderType(match string) string {
 // resolveGitProvider finds the external auth config matching the
 // given remote origin URL and returns its GitProvider. Returns nil
 // if no matching git provider is configured.
-func (api *API) resolveGitProvider(origin string) *gitprovider.GitProvider {
+func (api *API) resolveGitProvider(origin string) gitprovider.Provider {
 	origin = strings.TrimSpace(origin)
 	if origin == "" {
 		return nil
@@ -1402,7 +1402,7 @@ func (api *API) refreshChatDiffStatus(
 	pullRequestURL string,
 ) (database.ChatDiffStatus, error) {
 	// Find a provider that can handle this PR URL.
-	var gp *gitprovider.GitProvider
+	var gp gitprovider.Provider
 	var ref gitprovider.PRRef
 	for _, extAuth := range api.ExternalAuthConfigs {
 		p := extAuth.Git()

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/externalauth/gitprovider"
 	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
@@ -82,6 +83,10 @@ type Config struct {
 	// a Git clone. e.g. "Username for 'https://github.com':"
 	// The regex would be `github\.com`..
 	Regex *regexp.Regexp
+	// APIBaseURL is the base URL for provider REST API calls
+	// (e.g., "https://api.github.com" for GitHub). Derived from
+	// defaults when not explicitly configured.
+	APIBaseURL string
 	// AppInstallURL is for GitHub App's (and hopefully others eventually)
 	// to provide a link to install the app. There's installation
 	// of the application, and user authentication. It's possible
@@ -104,6 +109,16 @@ type Config struct {
 	// This field can be nil if unspecified in the config.
 	MCPToolDenyRegex              *regexp.Regexp
 	CodeChallengeMethodsSupported []promoauth.Oauth2PKCEChallengeMethod
+}
+
+// Git returns a GitProvider for this config if the provider type
+// is a supported git hosting provider. Returns nil for non-git
+// providers (e.g. Slack, JFrog).
+func (c *Config) Git() *gitprovider.GitProvider {
+	if !codersdk.EnhancedExternalAuthProvider(c.Type).Git() {
+		return nil
+	}
+	return gitprovider.New(strings.ToLower(c.Type), c.APIBaseURL, nil)
 }
 
 // GenerateTokenExtra generates the extra token data to store in the database.
@@ -729,6 +744,7 @@ func ConvertConfig(instrument *promoauth.Factory, entries []codersdk.ExternalAut
 			ClientID:                      entry.ClientID,
 			ClientSecret:                  entry.ClientSecret,
 			Regex:                         regex,
+			APIBaseURL:                    entry.APIBaseURL,
 			Type:                          entry.Type,
 			NoRefresh:                     entry.NoRefresh,
 			ValidateURL:                   entry.ValidateURL,
@@ -862,6 +878,18 @@ func copyDefaultSettings(config *codersdk.ExternalAuthConfig, defaults codersdk.
 	}
 	if config.CodeChallengeMethodsSupported == nil {
 		config.CodeChallengeMethodsSupported = []string{string(promoauth.PKCEChallengeMethodSha256)}
+	}
+
+	// Set default API base URL for providers that need one.
+	if config.APIBaseURL == "" {
+		switch codersdk.EnhancedExternalAuthProvider(config.Type) {
+		case codersdk.EnhancedExternalAuthProviderGitHub:
+			config.APIBaseURL = "https://api.github.com"
+		case codersdk.EnhancedExternalAuthProviderGitLab:
+			config.APIBaseURL = "https://gitlab.com/api/v4"
+		case codersdk.EnhancedExternalAuthProviderGitea:
+			config.APIBaseURL = "https://gitea.com/api/v1"
+		}
 	}
 }
 

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -111,10 +111,10 @@ type Config struct {
 	CodeChallengeMethodsSupported []promoauth.Oauth2PKCEChallengeMethod
 }
 
-// Git returns a GitProvider for this config if the provider type
+// Git returns a Provider for this config if the provider type
 // is a supported git hosting provider. Returns nil for non-git
 // providers (e.g. Slack, JFrog).
-func (c *Config) Git() *gitprovider.GitProvider {
+func (c *Config) Git() gitprovider.Provider {
 	if !codersdk.EnhancedExternalAuthProvider(c.Type).Git() {
 		return nil
 	}

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -114,11 +114,11 @@ type Config struct {
 // Git returns a Provider for this config if the provider type
 // is a supported git hosting provider. Returns nil for non-git
 // providers (e.g. Slack, JFrog).
-func (c *Config) Git() gitprovider.Provider {
+func (c *Config) Git(client *http.Client) gitprovider.Provider {
 	if !codersdk.EnhancedExternalAuthProvider(c.Type).Git() {
 		return nil
 	}
-	return gitprovider.New(strings.ToLower(c.Type), c.APIBaseURL, nil)
+	return gitprovider.New(strings.ToLower(c.Type), c.APIBaseURL, client)
 }
 
 // GenerateTokenExtra generates the extra token data to store in the database.

--- a/coderd/externalauth/externalauth_internal_test.go
+++ b/coderd/externalauth/externalauth_internal_test.go
@@ -25,6 +25,7 @@ func TestGitlabDefaults(t *testing.T) {
 			DisplayName:                   "GitLab",
 			DisplayIcon:                   "/icon/gitlab.svg",
 			Regex:                         `^(https?://)?gitlab\.com(/.*)?$`,
+			APIBaseURL:                    "https://gitlab.com/api/v4",
 			Scopes:                        []string{"write_repository"},
 			CodeChallengeMethodsSupported: []string{string(promoauth.PKCEChallengeMethodSha256)},
 		}

--- a/coderd/externalauth/gitprovider/github.go
+++ b/coderd/externalauth/gitprovider/github.go
@@ -33,6 +33,9 @@ func newGitHub(apiBaseURL string, httpClient HTTPClient) *githubProvider {
 		apiBaseURL = defaultGitHubAPIBaseURL
 	}
 	apiBaseURL = strings.TrimRight(apiBaseURL, "/")
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 
 	// Derive the web base URL from the API base URL.
 	// github.com: api.github.com → github.com
@@ -160,6 +163,15 @@ func (g *githubProvider) BuildBranchURL(owner string, repo string, branch string
 		repo,
 		url.PathEscape(branch),
 	)
+}
+
+func (g *githubProvider) BuildRepositoryURL(owner string, repo string) string {
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	if owner == "" || repo == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/%s", g.webBaseURL, owner, repo)
 }
 
 func (g *githubProvider) BuildPullRequestURL(ref PRRef) string {
@@ -346,12 +358,7 @@ func (g *githubProvider) decodeJSON(
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	httpClient := g.httpClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
+	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return xerrors.Errorf("execute github request: %w", err)
 	}
@@ -394,12 +401,7 @@ func (g *githubProvider) fetchDiff(
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	httpClient := g.httpClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
+	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return "", xerrors.Errorf("execute github diff request: %w", err)
 	}

--- a/coderd/externalauth/gitprovider/github.go
+++ b/coderd/externalauth/gitprovider/github.go
@@ -20,7 +20,7 @@ const defaultGitHubAPIBaseURL = "https://api.github.com"
 type githubProvider struct {
 	apiBaseURL string
 	webBaseURL string
-	httpClient HTTPClient
+	httpClient *http.Client
 
 	// Compiled per-instance to support GitHub Enterprise hosts.
 	pullRequestPathPattern   *regexp.Regexp
@@ -28,7 +28,7 @@ type githubProvider struct {
 	repositorySSHPathPattern *regexp.Regexp
 }
 
-func newGitHub(apiBaseURL string, httpClient HTTPClient) *githubProvider {
+func newGitHub(apiBaseURL string, httpClient *http.Client) *githubProvider {
 	if apiBaseURL == "" {
 		apiBaseURL = defaultGitHubAPIBaseURL
 	}
@@ -181,7 +181,7 @@ func (g *githubProvider) BuildPullRequestURL(ref PRRef) string {
 	return fmt.Sprintf("%s/%s/%s/pull/%d", g.webBaseURL, ref.Owner, ref.Repo, ref.Number)
 }
 
-func (g *githubProvider) ResolveBranchPR(
+func (g *githubProvider) ResolveBranchPullRequest(
 	ctx context.Context,
 	token string,
 	ref BranchRef,
@@ -224,7 +224,7 @@ func (g *githubProvider) ResolveBranchPR(
 	return &prRef, nil
 }
 
-func (g *githubProvider) FetchPRStatus(
+func (g *githubProvider) FetchPullRequestStatus(
 	ctx context.Context,
 	token string,
 	ref PRRef,
@@ -287,7 +287,7 @@ func (g *githubProvider) FetchPRStatus(
 	}, nil
 }
 
-func (g *githubProvider) FetchPRDiff(
+func (g *githubProvider) FetchPullRequestDiff(
 	ctx context.Context,
 	token string,
 	ref PRRef,

--- a/coderd/externalauth/gitprovider/github.go
+++ b/coderd/externalauth/gitprovider/github.go
@@ -1,0 +1,415 @@
+package gitprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const defaultGitHubAPIBaseURL = "https://api.github.com"
+
+var (
+	githubPullRequestPathPattern = regexp.MustCompile(
+		`^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)(?:[/?#].*)?$`,
+	)
+	githubRepositoryHTTPSPattern = regexp.MustCompile(
+		`^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
+	)
+	githubRepositorySSHPathPattern = regexp.MustCompile(
+		`^(?:ssh://)?git@github\.com[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
+	)
+)
+
+type githubProvider struct {
+	apiBaseURL string
+	httpClient HTTPClient
+}
+
+func newGitHub(apiBaseURL string, httpClient HTTPClient) *githubProvider {
+	if apiBaseURL == "" {
+		apiBaseURL = defaultGitHubAPIBaseURL
+	}
+	return &githubProvider{
+		apiBaseURL: strings.TrimRight(apiBaseURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+func (g *githubProvider) ParseRepositoryOrigin(raw string) (owner string, repo string, normalizedOrigin string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", "", false
+	}
+
+	matches := githubRepositoryHTTPSPattern.FindStringSubmatch(raw)
+	if len(matches) != 3 {
+		matches = githubRepositorySSHPathPattern.FindStringSubmatch(raw)
+	}
+	if len(matches) != 3 {
+		return "", "", "", false
+	}
+
+	owner = strings.TrimSpace(matches[1])
+	repo = strings.TrimSpace(matches[2])
+	repo = strings.TrimSuffix(repo, ".git")
+	if owner == "" || repo == "" {
+		return "", "", "", false
+	}
+
+	return owner, repo, fmt.Sprintf("https://github.com/%s/%s", owner, repo), true
+}
+
+func (g *githubProvider) ParsePullRequestURL(raw string) (PRRef, bool) {
+	matches := githubPullRequestPathPattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if len(matches) != 4 {
+		return PRRef{}, false
+	}
+
+	number, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return PRRef{}, false
+	}
+
+	return PRRef{
+		Owner:  matches[1],
+		Repo:   matches[2],
+		Number: number,
+	}, true
+}
+
+func (g *githubProvider) NormalizePullRequestURL(raw string) string {
+	ref, ok := g.ParsePullRequestURL(strings.TrimRight(
+		strings.TrimSpace(raw),
+		"),.;",
+	))
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", ref.Owner, ref.Repo, ref.Number)
+}
+
+func (g *githubProvider) BuildBranchURL(owner string, repo string, branch string) string {
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	branch = strings.TrimSpace(branch)
+	if owner == "" || repo == "" || branch == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"https://github.com/%s/%s/tree/%s",
+		owner,
+		repo,
+		url.PathEscape(branch),
+	)
+}
+
+func (g *githubProvider) ResolveBranchPR(
+	ctx context.Context,
+	token string,
+	ref BranchRef,
+) (*PRRef, error) {
+	if ref.Owner == "" || ref.Repo == "" || ref.Branch == "" {
+		return nil, nil
+	}
+
+	query := url.Values{}
+	query.Set("state", "open")
+	query.Set("head", fmt.Sprintf("%s:%s", ref.Owner, ref.Branch))
+	query.Set("sort", "updated")
+	query.Set("direction", "desc")
+	query.Set("per_page", "1")
+
+	requestURL := fmt.Sprintf(
+		"%s/repos/%s/%s/pulls?%s",
+		g.apiBaseURL,
+		ref.Owner,
+		ref.Repo,
+		query.Encode(),
+	)
+
+	var pulls []struct {
+		HTMLURL string `json:"html_url"`
+		Number  int    `json:"number"`
+	}
+
+	if err := g.decodeJSON(ctx, requestURL, token, &pulls); err != nil {
+		return nil, err
+	}
+	if len(pulls) == 0 {
+		return nil, nil
+	}
+
+	prRef, ok := g.ParsePullRequestURL(pulls[0].HTMLURL)
+	if !ok {
+		return nil, nil
+	}
+	return &prRef, nil
+}
+
+func (g *githubProvider) FetchPRStatus(
+	ctx context.Context,
+	token string,
+	ref PRRef,
+) (*PRStatus, error) {
+	pullEndpoint := fmt.Sprintf(
+		"%s/repos/%s/%s/pulls/%d",
+		g.apiBaseURL,
+		ref.Owner,
+		ref.Repo,
+		ref.Number,
+	)
+
+	var pull struct {
+		State        string `json:"state"`
+		Merged       bool   `json:"merged"`
+		Draft        bool   `json:"draft"`
+		Additions    int32  `json:"additions"`
+		Deletions    int32  `json:"deletions"`
+		ChangedFiles int32  `json:"changed_files"`
+		Head         struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+	}
+	if err := g.decodeJSON(ctx, pullEndpoint, token, &pull); err != nil {
+		return nil, err
+	}
+
+	var reviews []struct {
+		ID    int64  `json:"id"`
+		State string `json:"state"`
+		User  struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := g.decodeJSON(
+		ctx,
+		pullEndpoint+"/reviews?per_page=100",
+		token,
+		&reviews,
+	); err != nil {
+		return nil, err
+	}
+
+	state := PRState(strings.ToLower(strings.TrimSpace(pull.State)))
+	if pull.Merged {
+		state = PRStateMerged
+	}
+
+	return &PRStatus{
+		State:   state,
+		Draft:   pull.Draft,
+		HeadSHA: pull.Head.SHA,
+		DiffStats: DiffStats{
+			Additions:    pull.Additions,
+			Deletions:    pull.Deletions,
+			ChangedFiles: pull.ChangedFiles,
+		},
+		ChangesRequested: hasOutstandingChangesRequested(reviews),
+		FetchedAt:        time.Now().UTC(),
+	}, nil
+}
+
+func (g *githubProvider) FetchPRDiff(
+	ctx context.Context,
+	token string,
+	ref PRRef,
+) (string, error) {
+	requestURL := fmt.Sprintf(
+		"%s/repos/%s/%s/pulls/%d",
+		g.apiBaseURL,
+		ref.Owner,
+		ref.Repo,
+		ref.Number,
+	)
+	return g.fetchDiff(ctx, requestURL, token)
+}
+
+func (g *githubProvider) FetchBranchDiff(
+	ctx context.Context,
+	token string,
+	ref BranchRef,
+) (string, error) {
+	if ref.Owner == "" || ref.Repo == "" || ref.Branch == "" {
+		return "", nil
+	}
+
+	var repository struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+
+	repositoryURL := fmt.Sprintf(
+		"%s/repos/%s/%s",
+		g.apiBaseURL,
+		ref.Owner,
+		ref.Repo,
+	)
+	if err := g.decodeJSON(ctx, repositoryURL, token, &repository); err != nil {
+		return "", err
+	}
+	defaultBranch := strings.TrimSpace(repository.DefaultBranch)
+	if defaultBranch == "" {
+		return "", xerrors.New("github repository default branch is empty")
+	}
+
+	requestURL := fmt.Sprintf(
+		"%s/repos/%s/%s/compare/%s...%s",
+		g.apiBaseURL,
+		ref.Owner,
+		ref.Repo,
+		url.PathEscape(defaultBranch),
+		url.PathEscape(ref.Branch),
+	)
+
+	return g.fetchDiff(ctx, requestURL, token)
+}
+
+func (g *githubProvider) decodeJSON(
+	ctx context.Context,
+	requestURL string,
+	token string,
+	dest any,
+) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return xerrors.Errorf("create github request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "coder-chat-diff-status")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	httpClient := g.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return xerrors.Errorf("execute github request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		if readErr != nil {
+			return xerrors.Errorf(
+				"github request failed with status %d",
+				resp.StatusCode,
+			)
+		}
+		return xerrors.Errorf(
+			"github request failed with status %d: %s",
+			resp.StatusCode,
+			strings.TrimSpace(string(body)),
+		)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		return xerrors.Errorf("decode github response: %w", err)
+	}
+	return nil
+}
+
+func (g *githubProvider) fetchDiff(
+	ctx context.Context,
+	requestURL string,
+	token string,
+) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return "", xerrors.Errorf("create github diff request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.diff")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "coder-chat-diff")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	httpClient := g.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", xerrors.Errorf("execute github diff request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		if readErr != nil {
+			return "", xerrors.Errorf("github diff request failed with status %d", resp.StatusCode)
+		}
+		return "", xerrors.Errorf(
+			"github diff request failed with status %d: %s",
+			resp.StatusCode,
+			strings.TrimSpace(string(body)),
+		)
+	}
+
+	diff, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return "", xerrors.Errorf("read github diff response: %w", err)
+	}
+	return string(diff), nil
+}
+
+func hasOutstandingChangesRequested(
+	reviews []struct {
+		ID    int64  `json:"id"`
+		State string `json:"state"`
+		User  struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	},
+) bool {
+	type reviewerState struct {
+		reviewID int64
+		state    string
+	}
+
+	statesByReviewer := make(map[string]reviewerState)
+	for _, review := range reviews {
+		login := strings.ToLower(strings.TrimSpace(review.User.Login))
+		if login == "" {
+			continue
+		}
+
+		state := strings.ToUpper(strings.TrimSpace(review.State))
+		switch state {
+		case "CHANGES_REQUESTED", "APPROVED", "DISMISSED":
+		default:
+			continue
+		}
+
+		current, exists := statesByReviewer[login]
+		if exists && current.reviewID > review.ID {
+			continue
+		}
+		statesByReviewer[login] = reviewerState{
+			reviewID: review.ID,
+			state:    state,
+		}
+	}
+
+	for _, state := range statesByReviewer {
+		if state.state == "CHANGES_REQUESTED" {
+			return true
+		}
+	}
+	return false
+}

--- a/coderd/externalauth/gitprovider/github.go
+++ b/coderd/externalauth/gitprovider/github.go
@@ -17,31 +17,79 @@ import (
 
 const defaultGitHubAPIBaseURL = "https://api.github.com"
 
-var (
-	githubPullRequestPathPattern = regexp.MustCompile(
-		`^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)(?:[/?#].*)?$`,
-	)
-	githubRepositoryHTTPSPattern = regexp.MustCompile(
-		`^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
-	)
-	githubRepositorySSHPathPattern = regexp.MustCompile(
-		`^(?:ssh://)?git@github\.com[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
-	)
-)
-
 type githubProvider struct {
 	apiBaseURL string
+	webBaseURL string
 	httpClient HTTPClient
+
+	// Compiled per-instance to support GitHub Enterprise hosts.
+	pullRequestPathPattern   *regexp.Regexp
+	repositoryHTTPSPattern   *regexp.Regexp
+	repositorySSHPathPattern *regexp.Regexp
 }
 
 func newGitHub(apiBaseURL string, httpClient HTTPClient) *githubProvider {
 	if apiBaseURL == "" {
 		apiBaseURL = defaultGitHubAPIBaseURL
 	}
+	apiBaseURL = strings.TrimRight(apiBaseURL, "/")
+
+	// Derive the web base URL from the API base URL.
+	// github.com: api.github.com → github.com
+	// GHE: ghes.corp.com/api/v3 → ghes.corp.com
+	webBaseURL := deriveWebBaseURL(apiBaseURL)
+
+	// Parse the host for regex construction.
+	host := extractHost(webBaseURL)
+
+	// Escape the host for use in regex patterns.
+	escapedHost := regexp.QuoteMeta(host)
+
 	return &githubProvider{
-		apiBaseURL: strings.TrimRight(apiBaseURL, "/"),
+		apiBaseURL: apiBaseURL,
+		webBaseURL: webBaseURL,
 		httpClient: httpClient,
+		pullRequestPathPattern: regexp.MustCompile(
+			`^https://` + escapedHost + `/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([0-9]+)(?:[/?#].*)?$`,
+		),
+		repositoryHTTPSPattern: regexp.MustCompile(
+			`^https://` + escapedHost + `/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
+		),
+		repositorySSHPathPattern: regexp.MustCompile(
+			`^(?:ssh://)?git@` + escapedHost + `[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$`,
+		),
 	}
+}
+
+// deriveWebBaseURL converts a GitHub API base URL to the
+// corresponding web base URL.
+//
+// github.com:  https://api.github.com       → https://github.com
+// GHE:         https://ghes.corp.com/api/v3 → https://ghes.corp.com
+func deriveWebBaseURL(apiBaseURL string) string {
+	u, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return "https://github.com"
+	}
+
+	// Standard github.com: API host is api.github.com.
+	if strings.EqualFold(u.Host, "api.github.com") {
+		return "https://github.com"
+	}
+
+	// GHE: strip /api/v3 path suffix.
+	u.Path = strings.TrimSuffix(u.Path, "/api/v3")
+	u.Path = strings.TrimSuffix(u.Path, "/")
+	return u.String()
+}
+
+// extractHost returns the host portion of a URL.
+func extractHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "github.com"
+	}
+	return u.Host
 }
 
 func (g *githubProvider) ParseRepositoryOrigin(raw string) (owner string, repo string, normalizedOrigin string, ok bool) {
@@ -50,9 +98,9 @@ func (g *githubProvider) ParseRepositoryOrigin(raw string) (owner string, repo s
 		return "", "", "", false
 	}
 
-	matches := githubRepositoryHTTPSPattern.FindStringSubmatch(raw)
+	matches := g.repositoryHTTPSPattern.FindStringSubmatch(raw)
 	if len(matches) != 3 {
-		matches = githubRepositorySSHPathPattern.FindStringSubmatch(raw)
+		matches = g.repositorySSHPathPattern.FindStringSubmatch(raw)
 	}
 	if len(matches) != 3 {
 		return "", "", "", false
@@ -65,11 +113,11 @@ func (g *githubProvider) ParseRepositoryOrigin(raw string) (owner string, repo s
 		return "", "", "", false
 	}
 
-	return owner, repo, fmt.Sprintf("https://github.com/%s/%s", owner, repo), true
+	return owner, repo, fmt.Sprintf("%s/%s/%s", g.webBaseURL, owner, repo), true
 }
 
 func (g *githubProvider) ParsePullRequestURL(raw string) (PRRef, bool) {
-	matches := githubPullRequestPathPattern.FindStringSubmatch(strings.TrimSpace(raw))
+	matches := g.pullRequestPathPattern.FindStringSubmatch(strings.TrimSpace(raw))
 	if len(matches) != 4 {
 		return PRRef{}, false
 	}
@@ -94,7 +142,7 @@ func (g *githubProvider) NormalizePullRequestURL(raw string) string {
 	if !ok {
 		return ""
 	}
-	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", ref.Owner, ref.Repo, ref.Number)
+	return fmt.Sprintf("%s/%s/%s/pull/%d", g.webBaseURL, ref.Owner, ref.Repo, ref.Number)
 }
 
 func (g *githubProvider) BuildBranchURL(owner string, repo string, branch string) string {
@@ -106,11 +154,19 @@ func (g *githubProvider) BuildBranchURL(owner string, repo string, branch string
 	}
 
 	return fmt.Sprintf(
-		"https://github.com/%s/%s/tree/%s",
+		"%s/%s/%s/tree/%s",
+		g.webBaseURL,
 		owner,
 		repo,
 		url.PathEscape(branch),
 	)
+}
+
+func (g *githubProvider) BuildPullRequestURL(ref PRRef) string {
+	if ref.Owner == "" || ref.Repo == "" || ref.Number <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/%s/pull/%d", g.webBaseURL, ref.Owner, ref.Repo, ref.Number)
 }
 
 func (g *githubProvider) ResolveBranchPR(

--- a/coderd/externalauth/gitprovider/github_test.go
+++ b/coderd/externalauth/gitprovider/github_test.go
@@ -1,0 +1,298 @@
+package gitprovider_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/externalauth/gitprovider"
+)
+
+func TestGitHubParseRepositoryOrigin(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("github", "", nil)
+	require.NotNil(t, gp)
+
+	tests := []struct {
+		name             string
+		raw              string
+		expectOK         bool
+		expectOwner      string
+		expectRepo       string
+		expectNormalized string
+	}{
+		{
+			name:             "HTTPS URL",
+			raw:              "https://github.com/coder/coder",
+			expectOK:         true,
+			expectOwner:      "coder",
+			expectRepo:       "coder",
+			expectNormalized: "https://github.com/coder/coder",
+		},
+		{
+			name:             "HTTPS URL with .git",
+			raw:              "https://github.com/coder/coder.git",
+			expectOK:         true,
+			expectOwner:      "coder",
+			expectRepo:       "coder",
+			expectNormalized: "https://github.com/coder/coder",
+		},
+		{
+			name:             "HTTPS URL with trailing slash",
+			raw:              "https://github.com/coder/coder/",
+			expectOK:         true,
+			expectOwner:      "coder",
+			expectRepo:       "coder",
+			expectNormalized: "https://github.com/coder/coder",
+		},
+		{
+			name:             "SSH URL",
+			raw:              "git@github.com:coder/coder.git",
+			expectOK:         true,
+			expectOwner:      "coder",
+			expectRepo:       "coder",
+			expectNormalized: "https://github.com/coder/coder",
+		},
+		{
+			name:             "SSH URL without .git",
+			raw:              "git@github.com:coder/coder",
+			expectOK:         true,
+			expectOwner:      "coder",
+			expectRepo:       "coder",
+			expectNormalized: "https://github.com/coder/coder",
+		},
+		{
+			name:             "SSH URL with ssh:// prefix",
+			raw:              "ssh://git@github.com/coder/coder.git",
+			expectOK:         true,
+			expectOwner:      "coder",
+			expectRepo:       "coder",
+			expectNormalized: "https://github.com/coder/coder",
+		},
+		{
+			name:     "GitLab URL does not match",
+			raw:      "https://gitlab.com/coder/coder",
+			expectOK: false,
+		},
+		{
+			name:     "Empty string",
+			raw:      "",
+			expectOK: false,
+		},
+		{
+			name:     "Not a URL",
+			raw:      "not-a-url",
+			expectOK: false,
+		},
+		{
+			name:             "Hyphenated owner and repo",
+			raw:              "https://github.com/my-org/my-repo.git",
+			expectOK:         true,
+			expectOwner:      "my-org",
+			expectRepo:       "my-repo",
+			expectNormalized: "https://github.com/my-org/my-repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			owner, repo, normalized, ok := gp.ParseRepositoryOrigin(tt.raw)
+			assert.Equal(t, tt.expectOK, ok)
+			if tt.expectOK {
+				assert.Equal(t, tt.expectOwner, owner)
+				assert.Equal(t, tt.expectRepo, repo)
+				assert.Equal(t, tt.expectNormalized, normalized)
+			}
+		})
+	}
+}
+
+func TestGitHubParsePullRequestURL(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("github", "", nil)
+	require.NotNil(t, gp)
+
+	tests := []struct {
+		name         string
+		raw          string
+		expectOK     bool
+		expectOwner  string
+		expectRepo   string
+		expectNumber int
+	}{
+		{
+			name:         "Standard PR URL",
+			raw:          "https://github.com/coder/coder/pull/123",
+			expectOK:     true,
+			expectOwner:  "coder",
+			expectRepo:   "coder",
+			expectNumber: 123,
+		},
+		{
+			name:         "PR URL with query string",
+			raw:          "https://github.com/coder/coder/pull/456?diff=split",
+			expectOK:     true,
+			expectOwner:  "coder",
+			expectRepo:   "coder",
+			expectNumber: 456,
+		},
+		{
+			name:         "PR URL with fragment",
+			raw:          "https://github.com/coder/coder/pull/789#discussion",
+			expectOK:     true,
+			expectOwner:  "coder",
+			expectRepo:   "coder",
+			expectNumber: 789,
+		},
+		{
+			name:     "Not a PR URL",
+			raw:      "https://github.com/coder/coder",
+			expectOK: false,
+		},
+		{
+			name:     "Issue URL (not PR)",
+			raw:      "https://github.com/coder/coder/issues/123",
+			expectOK: false,
+		},
+		{
+			name:     "GitLab MR URL",
+			raw:      "https://gitlab.com/coder/coder/-/merge_requests/123",
+			expectOK: false,
+		},
+		{
+			name:     "Empty string",
+			raw:      "",
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ref, ok := gp.ParsePullRequestURL(tt.raw)
+			assert.Equal(t, tt.expectOK, ok)
+			if tt.expectOK {
+				assert.Equal(t, tt.expectOwner, ref.Owner)
+				assert.Equal(t, tt.expectRepo, ref.Repo)
+				assert.Equal(t, tt.expectNumber, ref.Number)
+			}
+		})
+	}
+}
+
+func TestGitHubNormalizePullRequestURL(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("github", "", nil)
+	require.NotNil(t, gp)
+
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{
+			name:     "Already normalized",
+			raw:      "https://github.com/coder/coder/pull/123",
+			expected: "https://github.com/coder/coder/pull/123",
+		},
+		{
+			name:     "With trailing punctuation",
+			raw:      "https://github.com/coder/coder/pull/123).",
+			expected: "https://github.com/coder/coder/pull/123",
+		},
+		{
+			name:     "With query string",
+			raw:      "https://github.com/coder/coder/pull/123?diff=split",
+			expected: "https://github.com/coder/coder/pull/123",
+		},
+		{
+			name:     "With whitespace",
+			raw:      "  https://github.com/coder/coder/pull/123  ",
+			expected: "https://github.com/coder/coder/pull/123",
+		},
+		{
+			name:     "Not a PR URL",
+			raw:      "https://example.com",
+			expected: "",
+		},
+		{
+			name:     "Empty string",
+			raw:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := gp.NormalizePullRequestURL(tt.raw)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGitHubBuildBranchURL(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("github", "", nil)
+	require.NotNil(t, gp)
+
+	tests := []struct {
+		name     string
+		owner    string
+		repo     string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "Simple branch",
+			owner:    "coder",
+			repo:     "coder",
+			branch:   "main",
+			expected: "https://github.com/coder/coder/tree/main",
+		},
+		{
+			name:     "Branch with slash",
+			owner:    "coder",
+			repo:     "coder",
+			branch:   "feat/new-thing",
+			expected: "https://github.com/coder/coder/tree/feat%2Fnew-thing",
+		},
+		{
+			name:     "Empty owner",
+			owner:    "",
+			repo:     "coder",
+			branch:   "main",
+			expected: "",
+		},
+		{
+			name:     "Empty repo",
+			owner:    "coder",
+			repo:     "",
+			branch:   "main",
+			expected: "",
+		},
+		{
+			name:     "Empty branch",
+			owner:    "coder",
+			repo:     "coder",
+			branch:   "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := gp.BuildBranchURL(tt.owner, tt.repo, tt.branch)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewUnsupportedProvider(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("unsupported", "", nil)
+	assert.Nil(t, gp, "unsupported provider type should return nil")
+}

--- a/coderd/externalauth/gitprovider/github_test.go
+++ b/coderd/externalauth/gitprovider/github_test.go
@@ -291,6 +291,115 @@ func TestGitHubBuildBranchURL(t *testing.T) {
 	}
 }
 
+func TestGitHubBuildPullRequestURL(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("github", "", nil)
+	require.NotNil(t, gp)
+
+	tests := []struct {
+		name     string
+		ref      gitprovider.PRRef
+		expected string
+	}{
+		{
+			name:     "Valid PR ref",
+			ref:      gitprovider.PRRef{Owner: "coder", Repo: "coder", Number: 123},
+			expected: "https://github.com/coder/coder/pull/123",
+		},
+		{
+			name:     "Empty owner",
+			ref:      gitprovider.PRRef{Owner: "", Repo: "coder", Number: 123},
+			expected: "",
+		},
+		{
+			name:     "Empty repo",
+			ref:      gitprovider.PRRef{Owner: "coder", Repo: "", Number: 123},
+			expected: "",
+		},
+		{
+			name:     "Zero number",
+			ref:      gitprovider.PRRef{Owner: "coder", Repo: "coder", Number: 0},
+			expected: "",
+		},
+		{
+			name:     "Negative number",
+			ref:      gitprovider.PRRef{Owner: "coder", Repo: "coder", Number: -1},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := gp.BuildPullRequestURL(tt.ref)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGitHubEnterpriseURLs(t *testing.T) {
+	t.Parallel()
+	gp := gitprovider.New("github", "https://ghes.corp.com/api/v3", nil)
+	require.NotNil(t, gp)
+
+	t.Run("ParseRepositoryOrigin HTTPS", func(t *testing.T) {
+		t.Parallel()
+		owner, repo, normalized, ok := gp.ParseRepositoryOrigin("https://ghes.corp.com/org/repo.git")
+		assert.True(t, ok)
+		assert.Equal(t, "org", owner)
+		assert.Equal(t, "repo", repo)
+		assert.Equal(t, "https://ghes.corp.com/org/repo", normalized)
+	})
+
+	t.Run("ParseRepositoryOrigin SSH", func(t *testing.T) {
+		t.Parallel()
+		owner, repo, normalized, ok := gp.ParseRepositoryOrigin("git@ghes.corp.com:org/repo.git")
+		assert.True(t, ok)
+		assert.Equal(t, "org", owner)
+		assert.Equal(t, "repo", repo)
+		assert.Equal(t, "https://ghes.corp.com/org/repo", normalized)
+	})
+
+	t.Run("ParsePullRequestURL", func(t *testing.T) {
+		t.Parallel()
+		ref, ok := gp.ParsePullRequestURL("https://ghes.corp.com/org/repo/pull/42")
+		assert.True(t, ok)
+		assert.Equal(t, "org", ref.Owner)
+		assert.Equal(t, "repo", ref.Repo)
+		assert.Equal(t, 42, ref.Number)
+	})
+
+	t.Run("NormalizePullRequestURL", func(t *testing.T) {
+		t.Parallel()
+		result := gp.NormalizePullRequestURL("https://ghes.corp.com/org/repo/pull/42?x=y")
+		assert.Equal(t, "https://ghes.corp.com/org/repo/pull/42", result)
+	})
+
+	t.Run("BuildBranchURL", func(t *testing.T) {
+		t.Parallel()
+		result := gp.BuildBranchURL("org", "repo", "main")
+		assert.Equal(t, "https://ghes.corp.com/org/repo/tree/main", result)
+	})
+
+	t.Run("BuildPullRequestURL", func(t *testing.T) {
+		t.Parallel()
+		result := gp.BuildPullRequestURL(gitprovider.PRRef{Owner: "org", Repo: "repo", Number: 42})
+		assert.Equal(t, "https://ghes.corp.com/org/repo/pull/42", result)
+	})
+
+	t.Run("github.com URLs do not match GHE instance", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, ok := gp.ParseRepositoryOrigin("https://github.com/coder/coder")
+		assert.False(t, ok, "github.com HTTPS URL should not match GHE instance")
+
+		_, _, _, ok = gp.ParseRepositoryOrigin("git@github.com:coder/coder.git")
+		assert.False(t, ok, "github.com SSH URL should not match GHE instance")
+
+		_, ok = gp.ParsePullRequestURL("https://github.com/coder/coder/pull/123")
+		assert.False(t, ok, "github.com PR URL should not match GHE instance")
+	})
+}
+
 func TestNewUnsupportedProvider(t *testing.T) {
 	t.Parallel()
 	gp := gitprovider.New("unsupported", "", nil)

--- a/coderd/externalauth/gitprovider/gitprovider.go
+++ b/coderd/externalauth/gitprovider/gitprovider.go
@@ -73,12 +73,16 @@ type Provider interface {
 	ResolveBranchPullRequest(ctx context.Context, token string, ref BranchRef) (*PRRef, error)
 
 	// FetchPullRequestDiff returns the raw unified diff for a
-	// PR. Separate from FetchPullRequestStatus because diffs
-	// can be large and are not always needed.
+	// pull request. This uses the PR's actual base branch (which
+	// may differ from the repo default branch, e.g. a PR
+	// targeting "staging" instead of "main"), so it matches what
+	// the provider shows on the PR's "Files changed" tab.
 	FetchPullRequestDiff(ctx context.Context, token string, ref PRRef) (string, error)
 
 	// FetchBranchDiff returns the diff of a branch compared
-	// against the repository's default branch.
+	// against the repository's default branch. This is the
+	// fallback when no pull request exists yet (e.g. the agent
+	// pushed a branch but hasn't opened a PR).
 	FetchBranchDiff(ctx context.Context, token string, ref BranchRef) (string, error)
 
 	// ParseRepositoryOrigin parses a remote origin URL (HTTPS

--- a/coderd/externalauth/gitprovider/gitprovider.go
+++ b/coderd/externalauth/gitprovider/gitprovider.go
@@ -101,6 +101,10 @@ type Provider interface {
 	// BuildBranchURL constructs a URL to view a branch on
 	// the provider's web UI.
 	BuildBranchURL(owner, repo, branch string) string
+
+	// BuildPullRequestURL constructs a URL to view a pull
+	// request on the provider's web UI.
+	BuildPullRequestURL(ref PRRef) string
 }
 
 // GitProvider wraps an external auth config and provides
@@ -170,4 +174,9 @@ func (g *GitProvider) NormalizePullRequestURL(raw string) string {
 // BuildBranchURL delegates to the underlying provider.
 func (g *GitProvider) BuildBranchURL(owner, repo, branch string) string {
 	return g.provider.BuildBranchURL(owner, repo, branch)
+}
+
+// BuildPullRequestURL delegates to the underlying provider.
+func (g *GitProvider) BuildPullRequestURL(ref PRRef) string {
+	return g.provider.BuildPullRequestURL(ref)
 }

--- a/coderd/externalauth/gitprovider/gitprovider.go
+++ b/coderd/externalauth/gitprovider/gitprovider.go
@@ -1,0 +1,173 @@
+package gitprovider
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// PRState is the normalized state of a pull/merge request across
+// all providers.
+type PRState string
+
+const (
+	PRStateOpen   PRState = "open"
+	PRStateClosed PRState = "closed"
+	PRStateMerged PRState = "merged"
+)
+
+// PRRef identifies a pull request on any provider.
+type PRRef struct {
+	// Owner is the repository owner / project / workspace.
+	Owner string
+	// Repo is the repository name or slug.
+	Repo string
+	// Number is the PR number / IID / index.
+	Number int
+}
+
+// BranchRef identifies a branch in a repository, used for
+// branch-to-PR resolution.
+type BranchRef struct {
+	Owner  string
+	Repo   string
+	Branch string
+}
+
+// DiffStats summarizes the size of a PR's changes.
+type DiffStats struct {
+	Additions    int32
+	Deletions    int32
+	ChangedFiles int32
+}
+
+// PRStatus is the complete status of a pull/merge request.
+// This is the universal return type that all providers populate.
+type PRStatus struct {
+	// State is the PR's lifecycle state.
+	State PRState
+	// Draft indicates the PR is marked as draft/WIP.
+	Draft bool
+	// HeadSHA is the SHA of the head commit.
+	HeadSHA string
+	// DiffStats summarizes additions/deletions/files changed.
+	DiffStats DiffStats
+	// ChangesRequested is a convenience boolean: true if any
+	// reviewer's current state is "changes_requested".
+	ChangesRequested bool
+	// FetchedAt is when this status was fetched.
+	FetchedAt time.Time
+}
+
+// Provider defines the interface that all Git hosting providers
+// implement. Each method is designed to minimize API round-trips
+// for the specific provider.
+type Provider interface {
+	// FetchPRStatus retrieves the complete status of a pull
+	// request in the minimum number of API calls for this
+	// provider.
+	FetchPRStatus(ctx context.Context, token string, ref PRRef) (*PRStatus, error)
+
+	// ResolveBranchPR finds the open PR (if any) for the given
+	// branch. Returns nil, nil if no open PR exists.
+	ResolveBranchPR(ctx context.Context, token string, ref BranchRef) (*PRRef, error)
+
+	// FetchPRDiff returns the raw unified diff for a PR.
+	// Separate from FetchPRStatus because diffs can be large
+	// and are not always needed.
+	FetchPRDiff(ctx context.Context, token string, ref PRRef) (string, error)
+
+	// FetchBranchDiff returns the diff of a branch compared
+	// against the repository's default branch.
+	FetchBranchDiff(ctx context.Context, token string, ref BranchRef) (string, error)
+
+	// ParseRepositoryOrigin parses a remote origin URL (HTTPS
+	// or SSH) into owner and repo components, returning the
+	// normalized HTTPS URL. Returns false if the URL does not
+	// match this provider.
+	ParseRepositoryOrigin(raw string) (owner, repo, normalizedOrigin string, ok bool)
+
+	// ParsePullRequestURL parses a pull request URL into a
+	// PRRef. Returns false if the URL does not match this
+	// provider.
+	ParsePullRequestURL(raw string) (PRRef, bool)
+
+	// NormalizePullRequestURL normalizes a pull request URL,
+	// stripping trailing punctuation, query strings, and
+	// fragments. Returns empty string if the URL does not
+	// match this provider.
+	NormalizePullRequestURL(raw string) string
+
+	// BuildBranchURL constructs a URL to view a branch on
+	// the provider's web UI.
+	BuildBranchURL(owner, repo, branch string) string
+}
+
+// GitProvider wraps an external auth config and provides
+// Git hosting operations. Use externalauth.Config.Git() to
+// obtain an instance.
+type GitProvider struct {
+	provider Provider
+}
+
+// New creates a GitProvider for the given provider type and
+// API base URL. Returns nil if the provider type is not a
+// supported git provider.
+func New(providerType string, apiBaseURL string, httpClient HTTPClient) *GitProvider {
+	var p Provider
+	switch providerType {
+	case "github":
+		p = newGitHub(apiBaseURL, httpClient)
+	default:
+		// Other providers (gitlab, bitbucket-cloud, etc.) will be
+		// added here as they are implemented.
+		return nil
+	}
+	return &GitProvider{provider: p}
+}
+
+// HTTPClient is the interface for making HTTP requests. This
+// allows injecting instrumented clients or test mocks.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// FetchPRStatus delegates to the underlying provider.
+func (g *GitProvider) FetchPRStatus(ctx context.Context, token string, ref PRRef) (*PRStatus, error) {
+	return g.provider.FetchPRStatus(ctx, token, ref)
+}
+
+// ResolveBranchPR delegates to the underlying provider.
+func (g *GitProvider) ResolveBranchPR(ctx context.Context, token string, ref BranchRef) (*PRRef, error) {
+	return g.provider.ResolveBranchPR(ctx, token, ref)
+}
+
+// FetchPRDiff delegates to the underlying provider.
+func (g *GitProvider) FetchPRDiff(ctx context.Context, token string, ref PRRef) (string, error) {
+	return g.provider.FetchPRDiff(ctx, token, ref)
+}
+
+// FetchBranchDiff delegates to the underlying provider.
+func (g *GitProvider) FetchBranchDiff(ctx context.Context, token string, ref BranchRef) (string, error) {
+	return g.provider.FetchBranchDiff(ctx, token, ref)
+}
+
+// ParseRepositoryOrigin delegates to the underlying provider.
+func (g *GitProvider) ParseRepositoryOrigin(raw string) (owner, repo, normalizedOrigin string, ok bool) {
+	return g.provider.ParseRepositoryOrigin(raw)
+}
+
+// ParsePullRequestURL delegates to the underlying provider.
+func (g *GitProvider) ParsePullRequestURL(raw string) (PRRef, bool) {
+	return g.provider.ParsePullRequestURL(raw)
+}
+
+// NormalizePullRequestURL delegates to the underlying provider.
+func (g *GitProvider) NormalizePullRequestURL(raw string) string {
+	return g.provider.NormalizePullRequestURL(raw)
+}
+
+// BuildBranchURL delegates to the underlying provider.
+func (g *GitProvider) BuildBranchURL(owner, repo, branch string) string {
+	return g.provider.BuildBranchURL(owner, repo, branch)
+}

--- a/coderd/externalauth/gitprovider/gitprovider.go
+++ b/coderd/externalauth/gitprovider/gitprovider.go
@@ -107,76 +107,22 @@ type Provider interface {
 	BuildPullRequestURL(ref PRRef) string
 }
 
-// GitProvider wraps an external auth config and provides
-// Git hosting operations. Use externalauth.Config.Git() to
-// obtain an instance.
-type GitProvider struct {
-	provider Provider
-}
-
-// New creates a GitProvider for the given provider type and
-// API base URL. Returns nil if the provider type is not a
-// supported git provider.
-func New(providerType string, apiBaseURL string, httpClient HTTPClient) *GitProvider {
-	var p Provider
-	switch providerType {
-	case "github":
-		p = newGitHub(apiBaseURL, httpClient)
-	default:
-		// Other providers (gitlab, bitbucket-cloud, etc.) will be
-		// added here as they are implemented.
-		return nil
-	}
-	return &GitProvider{provider: p}
-}
-
 // HTTPClient is the interface for making HTTP requests. This
 // allows injecting instrumented clients or test mocks.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// FetchPRStatus delegates to the underlying provider.
-func (g *GitProvider) FetchPRStatus(ctx context.Context, token string, ref PRRef) (*PRStatus, error) {
-	return g.provider.FetchPRStatus(ctx, token, ref)
-}
-
-// ResolveBranchPR delegates to the underlying provider.
-func (g *GitProvider) ResolveBranchPR(ctx context.Context, token string, ref BranchRef) (*PRRef, error) {
-	return g.provider.ResolveBranchPR(ctx, token, ref)
-}
-
-// FetchPRDiff delegates to the underlying provider.
-func (g *GitProvider) FetchPRDiff(ctx context.Context, token string, ref PRRef) (string, error) {
-	return g.provider.FetchPRDiff(ctx, token, ref)
-}
-
-// FetchBranchDiff delegates to the underlying provider.
-func (g *GitProvider) FetchBranchDiff(ctx context.Context, token string, ref BranchRef) (string, error) {
-	return g.provider.FetchBranchDiff(ctx, token, ref)
-}
-
-// ParseRepositoryOrigin delegates to the underlying provider.
-func (g *GitProvider) ParseRepositoryOrigin(raw string) (owner, repo, normalizedOrigin string, ok bool) {
-	return g.provider.ParseRepositoryOrigin(raw)
-}
-
-// ParsePullRequestURL delegates to the underlying provider.
-func (g *GitProvider) ParsePullRequestURL(raw string) (PRRef, bool) {
-	return g.provider.ParsePullRequestURL(raw)
-}
-
-// NormalizePullRequestURL delegates to the underlying provider.
-func (g *GitProvider) NormalizePullRequestURL(raw string) string {
-	return g.provider.NormalizePullRequestURL(raw)
-}
-
-// BuildBranchURL delegates to the underlying provider.
-func (g *GitProvider) BuildBranchURL(owner, repo, branch string) string {
-	return g.provider.BuildBranchURL(owner, repo, branch)
-}
-
-// BuildPullRequestURL delegates to the underlying provider.
-func (g *GitProvider) BuildPullRequestURL(ref PRRef) string {
-	return g.provider.BuildPullRequestURL(ref)
+// New creates a Provider for the given provider type and API base
+// URL. Returns nil if the provider type is not a supported git
+// provider.
+func New(providerType string, apiBaseURL string, httpClient HTTPClient) Provider {
+	switch providerType {
+	case "github":
+		return newGitHub(apiBaseURL, httpClient)
+	default:
+		// Other providers (gitlab, bitbucket-cloud, etc.) will be
+		// added here as they are implemented.
+		return nil
+	}
 }

--- a/coderd/externalauth/gitprovider/gitprovider.go
+++ b/coderd/externalauth/gitprovider/gitprovider.go
@@ -63,19 +63,19 @@ type PRStatus struct {
 // implement. Each method is designed to minimize API round-trips
 // for the specific provider.
 type Provider interface {
-	// FetchPRStatus retrieves the complete status of a pull
-	// request in the minimum number of API calls for this
+	// FetchPullRequestStatus retrieves the complete status of a
+	// pull request in the minimum number of API calls for this
 	// provider.
-	FetchPRStatus(ctx context.Context, token string, ref PRRef) (*PRStatus, error)
+	FetchPullRequestStatus(ctx context.Context, token string, ref PRRef) (*PRStatus, error)
 
-	// ResolveBranchPR finds the open PR (if any) for the given
-	// branch. Returns nil, nil if no open PR exists.
-	ResolveBranchPR(ctx context.Context, token string, ref BranchRef) (*PRRef, error)
+	// ResolveBranchPullRequest finds the open PR (if any) for
+	// the given branch. Returns nil, nil if no open PR exists.
+	ResolveBranchPullRequest(ctx context.Context, token string, ref BranchRef) (*PRRef, error)
 
-	// FetchPRDiff returns the raw unified diff for a PR.
-	// Separate from FetchPRStatus because diffs can be large
-	// and are not always needed.
-	FetchPRDiff(ctx context.Context, token string, ref PRRef) (string, error)
+	// FetchPullRequestDiff returns the raw unified diff for a
+	// PR. Separate from FetchPullRequestStatus because diffs
+	// can be large and are not always needed.
+	FetchPullRequestDiff(ctx context.Context, token string, ref PRRef) (string, error)
 
 	// FetchBranchDiff returns the diff of a branch compared
 	// against the repository's default branch.
@@ -111,16 +111,10 @@ type Provider interface {
 	BuildPullRequestURL(ref PRRef) string
 }
 
-// HTTPClient is the interface for making HTTP requests. This
-// allows injecting instrumented clients or test mocks.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // New creates a Provider for the given provider type and API base
 // URL. Returns nil if the provider type is not a supported git
 // provider.
-func New(providerType string, apiBaseURL string, httpClient HTTPClient) Provider {
+func New(providerType string, apiBaseURL string, httpClient *http.Client) Provider {
 	switch providerType {
 	case "github":
 		return newGitHub(apiBaseURL, httpClient)

--- a/coderd/externalauth/gitprovider/gitprovider.go
+++ b/coderd/externalauth/gitprovider/gitprovider.go
@@ -102,6 +102,10 @@ type Provider interface {
 	// the provider's web UI.
 	BuildBranchURL(owner, repo, branch string) string
 
+	// BuildRepositoryURL constructs a URL to view a repository
+	// on the provider's web UI.
+	BuildRepositoryURL(owner, repo string) string
+
 	// BuildPullRequestURL constructs a URL to view a pull
 	// request on the provider's web UI.
 	BuildPullRequestURL(ref PRRef) string

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -980,6 +980,10 @@ type ExternalAuthConfig struct {
 	// 'Username for "https://github.com":'
 	// And sending it to the Coder server to match against the Regex.
 	Regex string `json:"regex" yaml:"regex"`
+	// APIBaseURL is the base URL for provider REST API calls
+	// (e.g., "https://api.github.com" for GitHub). Derived from
+	// defaults when not explicitly configured.
+	APIBaseURL string `json:"api_base_url" yaml:"api_base_url"`
 	// DisplayName is shown in the UI to identify the auth config.
 	DisplayName string `json:"display_name" yaml:"display_name"`
 	// DisplayIcon is a URL to an icon to display in the UI.

--- a/codersdk/testdata/githubcfg.yaml
+++ b/codersdk/testdata/githubcfg.yaml
@@ -22,6 +22,7 @@ externalAuthProviders:
     mcp_tool_allow_regex: .*
     mcp_tool_deny_regex: create_gist
     regex: ^https://example.com/.*$
+    api_base_url: ""
     display_name: GitHub
     display_icon: /static/icons/github.svg
     code_challenge_methods_supported:

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -277,6 +277,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "external_auth": {
       "value": [
         {
+          "api_base_url": "string",
           "app_install_url": "string",
           "app_installations_url": "string",
           "auth_url": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2778,6 +2778,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "external_auth": {
       "value": [
         {
+          "api_base_url": "string",
           "app_install_url": "string",
           "app_installations_url": "string",
           "auth_url": "string",
@@ -3347,6 +3348,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "external_auth": {
     "value": [
       {
+        "api_base_url": "string",
         "app_install_url": "string",
         "app_installations_url": "string",
         "auth_url": "string",
@@ -4094,6 +4096,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ```json
 {
+  "api_base_url": "string",
   "app_install_url": "string",
   "app_installations_url": "string",
   "auth_url": "string",
@@ -4123,22 +4126,23 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ### Properties
 
-| Name                               | Type            | Required | Restrictions | Description                                                                                                       |
-|------------------------------------|-----------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------|
-| `app_install_url`                  | string          | false    |              |                                                                                                                   |
-| `app_installations_url`            | string          | false    |              |                                                                                                                   |
-| `auth_url`                         | string          | false    |              |                                                                                                                   |
-| `client_id`                        | string          | false    |              |                                                                                                                   |
-| `code_challenge_methods_supported` | array of string | false    |              | Code challenge methods supported lists the PKCE code challenge methods The only one supported by Coder is "S256". |
-| `device_code_url`                  | string          | false    |              |                                                                                                                   |
-| `device_flow`                      | boolean         | false    |              |                                                                                                                   |
-| `display_icon`                     | string          | false    |              | Display icon is a URL to an icon to display in the UI.                                                            |
-| `display_name`                     | string          | false    |              | Display name is shown in the UI to identify the auth config.                                                      |
-| `id`                               | string          | false    |              | ID is a unique identifier for the auth config. It defaults to `type` when not provided.                           |
-| `mcp_tool_allow_regex`             | string          | false    |              |                                                                                                                   |
-| `mcp_tool_deny_regex`              | string          | false    |              |                                                                                                                   |
-| `mcp_url`                          | string          | false    |              |                                                                                                                   |
-| `no_refresh`                       | boolean         | false    |              |                                                                                                                   |
+| Name                               | Type            | Required | Restrictions | Description                                                                                                                                                 |
+|------------------------------------|-----------------|----------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api_base_url`                     | string          | false    |              | Api base URL is the base URL for provider REST API calls (e.g., "https://api.github.com" for GitHub). Derived from defaults when not explicitly configured. |
+| `app_install_url`                  | string          | false    |              |                                                                                                                                                             |
+| `app_installations_url`            | string          | false    |              |                                                                                                                                                             |
+| `auth_url`                         | string          | false    |              |                                                                                                                                                             |
+| `client_id`                        | string          | false    |              |                                                                                                                                                             |
+| `code_challenge_methods_supported` | array of string | false    |              | Code challenge methods supported lists the PKCE code challenge methods The only one supported by Coder is "S256".                                           |
+| `device_code_url`                  | string          | false    |              |                                                                                                                                                             |
+| `device_flow`                      | boolean         | false    |              |                                                                                                                                                             |
+| `display_icon`                     | string          | false    |              | Display icon is a URL to an icon to display in the UI.                                                                                                      |
+| `display_name`                     | string          | false    |              | Display name is shown in the UI to identify the auth config.                                                                                                |
+| `id`                               | string          | false    |              | ID is a unique identifier for the auth config. It defaults to `type` when not provided.                                                                     |
+| `mcp_tool_allow_regex`             | string          | false    |              |                                                                                                                                                             |
+| `mcp_tool_deny_regex`              | string          | false    |              |                                                                                                                                                             |
+| `mcp_url`                          | string          | false    |              |                                                                                                                                                             |
+| `no_refresh`                       | boolean         | false    |              |                                                                                                                                                             |
 |`regex`|string|false||Regex allows API requesters to match an auth config by a string (e.g. coder.com) instead of by it's type.
 Git clone makes use of this by parsing the URL from: 'Username for "https://github.com":' And sending it to the Coder server to match against the Regex.|
 |`revoke_url`|string|false|||
@@ -14156,6 +14160,7 @@ None
 {
   "value": [
     {
+      "api_base_url": "string",
       "app_install_url": "string",
       "app_installations_url": "string",
       "auth_url": "string",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2651,6 +2651,12 @@ export interface ExternalAuthConfig {
 	 */
 	readonly regex: string;
 	/**
+	 * APIBaseURL is the base URL for provider REST API calls
+	 * (e.g., "https://api.github.com" for GitHub). Derived from
+	 * defaults when not explicitly configured.
+	 */
+	readonly api_base_url: string;
+	/**
 	 * DisplayName is shown in the UI to identify the auth config.
 	 */
 	readonly display_name: string;

--- a/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta<typeof ExternalAuthSettingsPageView> = {
 					type: "GitHub",
 					client_id: "client_id",
 					regex: "regex",
+					api_base_url: "",
 					auth_url: "",
 					token_url: "",
 					validate_url: "",


### PR DESCRIPTION
## Summary

Introduces a `gitprovider` package under `coderd/externalauth/` that provides a provider-agnostic interface for git hosting operations (PR status, diffs, branch resolution, URL parsing).

## Motivation

The diff/PR status code in `chats.go` was tightly coupled to GitHub — ~475 lines of hardcoded GitHub API calls, URL parsing, and regex patterns. This blocked:
1. Adding PR status display in the sidebar (open/merged/closed)
2. Adding CI status to the chat view
3. Supporting other git providers (GitLab, Bitbucket, etc.)
4. Backend PR watching for auto-triggering chats on CI failures

## Changes

### New package: `coderd/externalauth/gitprovider/`

- **`gitprovider.go`** — Core types (`PRState`, `PRRef`, `BranchRef`, `DiffStats`, `PRStatus`) and the `Provider` interface with 8 methods designed to minimize API round-trips per provider
- **`github.go`** — GitHub implementation of the `Provider` interface, translated from the existing `chats.go` code
- **`github_test.go`** — 30 unit tests covering URL parsing, normalization, and branch URL construction

### `externalauth.Config` additions

- **`APIBaseURL` field** — Base URL for provider API calls (defaults: `https://api.github.com` for GitHub, etc.). Enables GitHub Enterprise support.
- **`Git()` method** — Returns a `*gitprovider.GitProvider` for git hosting providers, `nil` for non-git providers (Slack, JFrog). Follows the existing type-switch pattern used by `TokenRevocationRequest` etc.

### `chats.go` refactor

- Removed 12 GitHub-specific functions (~475 lines)
- Added `resolveGitProvider(origin)` helper that matches against configured `ExternalAuthConfigs` regex patterns
- Updated 5 caller functions to use the new `gitprovider` package
- Provider resolution is now dynamic (regex-matched) instead of hardcoded `"github"` checks

## Design decisions

- **`FetchPRStatus` returns everything in one shot** (state, reviews, CI, diff stats) — this lets GitHub use a single GraphQL query when we upgrade from REST later, and lets other providers batch internally
- **`GitProvider` wraps a `Provider` interface** — the interface is the extension point for new providers; callers use the concrete wrapper
- **No new abstraction layer** — extends the existing `externalauth.Config` system rather than introducing a separate provider registry
- **GitHub-only for now** — the `New()` factory returns `nil` for unsupported providers; GitLab/Bitbucket/etc. can be added incrementally

## Next steps (not in this PR)

- CI status fetching via GitHub GraphQL `statusCheckRollup`
- Background diff watcher for PR/CI polling
- GitLab provider implementation
- Frontend: display `pull_request_state` in sidebar (field already in API)