### PR TITLE
refactor(site): simplify useChatStore hook initialization and effects

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -517,7 +517,6 @@ const AgentDetail: FC = () => {
 	const chatRecord = chatData?.chat;
 	const isArchived = chatRecord?.archived ?? false;
 	const chatMessages = chatData?.messages;
-	const chatQueuedMessages = chatData?.queued_messages;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
 	// Auto-open the diff panel when diff status first appears.
@@ -581,16 +580,14 @@ const AgentDetail: FC = () => {
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
 
-	const { store, clearStreamError } = useChatStore({
-		chatID: agentId,
-		chatMessages,
-		chatRecord,
-		chatData,
-		chatQueuedMessages,
-		setChatErrorReason,
-		clearChatErrorReason,
-	});
-
+		const { store, clearStreamError } = useChatStore({
+			chatID: agentId,
+			chatMessages,
+			chatRecord,
+			chatData,
+			setChatErrorReason,
+			clearChatErrorReason,
+		});
 	useEffect(() => {
 		setSelectedModel((current) => {
 			if (current && modelOptions.some((model) => model.id === current)) {

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
@@ -190,7 +190,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -271,7 +270,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -346,7 +344,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -440,7 +437,6 @@ describe("useChatStore", () => {
 					messages: [existingMessage],
 					queued_messages: [],
 				},
-				chatQueuedMessages: [],
 				setChatErrorReason,
 				clearChatErrorReason,
 			});
@@ -514,7 +510,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -589,7 +584,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -677,7 +671,6 @@ describe("useChatStore", () => {
 				messages: [existingMessage],
 				queued_messages: [queuedMessage],
 			},
-			chatQueuedMessages: [queuedMessage],
 			setChatErrorReason,
 			clearChatErrorReason,
 		};
@@ -724,7 +717,6 @@ describe("useChatStore", () => {
 				messages: [existingMessage],
 				queued_messages: [queuedMessage],
 			},
-			chatQueuedMessages: [queuedMessage],
 		});
 
 		await waitFor(() => {
@@ -769,7 +761,6 @@ describe("useChatStore", () => {
 					chatMessages: [existingMessage],
 					chatRecord: makeChat(chatID),
 					chatData: initialChatData,
-					chatQueuedMessages: [queuedMessage],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -836,7 +827,6 @@ describe("useChatStore", () => {
 				messages: [msg1],
 				queued_messages: [] as TypesGen.ChatQueuedMessage[],
 			},
-			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
 			setChatErrorReason,
 			clearChatErrorReason,
 		};
@@ -923,7 +913,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [queuedMessage],
 					},
-					chatQueuedMessages: [queuedMessage],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -979,7 +968,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1081,7 +1069,6 @@ describe("useChatStore", () => {
 						messages: [existingMessage],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1177,7 +1164,6 @@ describe("useChatStore", () => {
 				messages: [msg1],
 				queued_messages: [] as TypesGen.ChatQueuedMessage[],
 			},
-			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
 			setChatErrorReason,
 			clearChatErrorReason,
 		};
@@ -1268,7 +1254,6 @@ describe("useChatStore", () => {
 				messages: [msg1],
 				queued_messages: [queuedMsg],
 			},
-			chatQueuedMessages: [queuedMsg],
 			setChatErrorReason,
 			clearChatErrorReason,
 		};
@@ -1304,7 +1289,6 @@ describe("useChatStore", () => {
 				messages: [],
 				queued_messages: [],
 			},
-			chatQueuedMessages: [],
 		});
 
 		// After the switch, queued messages from chat-1 should NOT be
@@ -1340,7 +1324,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1410,7 +1393,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1471,7 +1453,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1524,7 +1505,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1585,7 +1565,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1660,7 +1639,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1722,7 +1700,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1771,7 +1748,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});
@@ -1835,7 +1811,6 @@ describe("useChatStore", () => {
 						messages: [],
 						queued_messages: [],
 					},
-					chatQueuedMessages: [],
 					setChatErrorReason,
 					clearChatErrorReason,
 				});

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -7,6 +7,7 @@ import {
 	useCallback,
 	useEffect,
 	useRef,
+	useState,
 	useSyncExternalStore,
 } from "react";
 import { useQueryClient } from "react-query";
@@ -394,7 +395,6 @@ interface UseChatStoreOptions {
 	chatMessages: readonly TypesGen.ChatMessage[] | undefined;
 	chatRecord: TypesGen.Chat | undefined;
 	chatData: TypesGen.ChatWithMessages | undefined;
-	chatQueuedMessages: readonly TypesGen.ChatQueuedMessage[] | undefined;
 	setChatErrorReason: (chatID: string, reason: string) => void;
 	clearChatErrorReason: (chatID: string) => void;
 }
@@ -421,19 +421,15 @@ export const useChatStore = (
 		chatMessages,
 		chatRecord,
 		chatData,
-		chatQueuedMessages,
 		setChatErrorReason,
 		clearChatErrorReason,
 	} = options;
 
 	const queryClient = useQueryClient();
-	const storeRef = useRef<ChatStore>(createChatStore());
+	const [store] = useState(createChatStore);
 	const streamResetFrameRef = useRef<number | null>(null);
 	const queuedMessagesHydratedChatIDRef = useRef<string | null>(null);
 	const activeChatIDRef = useRef<string | null>(null);
-	const prevChatIDRef = useRef<string | undefined>(chatID);
-
-	const store = storeRef.current;
 
 	// Compute the last REST-fetched message ID so the stream can
 	// skip messages the client already has. We use a ref so the
@@ -518,39 +514,37 @@ export const useChatStore = (
 		[chatID, queryClient],
 	);
 
+	// Sync query data into the store. All three values derive from
+	// the same react-query cache entry, so they update together.
+	// Each store method no-ops when the value is unchanged, so
+	// redundant calls are cheap.
+	//
+	// Queued messages use a hydration guard: we seed the store
+	// from the initial query data exactly once per chatID. After
+	// that the WebSocket pushes live updates directly into the
+	// store, and we must avoid overwriting those with stale query
+	// data when this effect re-runs.
 	useEffect(() => {
-		// When the active chat changes, clear stale messages immediately
-		// so the previous chat's messages aren't briefly visible while
-		// the new chat's query resolves.
-		if (prevChatIDRef.current !== chatID) {
-			prevChatIDRef.current = chatID;
-			store.replaceMessages([]);
-		}
 		store.replaceMessages(chatMessages);
-	}, [chatID, chatMessages, store]);
 
+		if (queuedMessagesHydratedChatIDRef.current !== (chatID ?? null)) {
+			queuedMessagesHydratedChatIDRef.current = null;
+			store.setQueuedMessages([]);
+		}
+		if (chatID && chatData && queuedMessagesHydratedChatIDRef.current !== chatID) {
+			queuedMessagesHydratedChatIDRef.current = chatID;
+			store.setQueuedMessages(chatData.queued_messages);
+		}
+	}, [chatID, chatData, chatMessages, store]);
+
+	// Status is synced separately because the WebSocket also
+	// pushes status changes directly into the store. Merging
+	// this with the data-sync effect above would cause status
+	// to be overwritten by the (stale) query-cache value every
+	// time messages change.
 	useEffect(() => {
 		store.setChatStatus(chatRecord?.status ?? null);
 	}, [chatRecord?.status, store]);
-
-	useEffect(() => {
-		queuedMessagesHydratedChatIDRef.current = null;
-		store.setQueuedMessages([]);
-		if (!chatID) {
-			return;
-		}
-	}, [chatID, store]);
-
-	useEffect(() => {
-		if (!chatID || !chatData) {
-			return;
-		}
-		if (queuedMessagesHydratedChatIDRef.current === chatID) {
-			return;
-		}
-		queuedMessagesHydratedChatIDRef.current = chatID;
-		store.setQueuedMessages(chatQueuedMessages);
-	}, [chatData, chatID, chatQueuedMessages, store]);
 
 	useEffect(() => {
 		cancelScheduledStreamReset();


### PR DESCRIPTION
## Summary

Simplifies the `useChatStore` hook by reducing refs, effects, and interface surface area.

### Changes

- **Lazy store initialization**: Replace `useRef<ChatStore>(createChatStore())` with `useState(createChatStore)`. The old pattern called `createChatStore()` on every render (discarding all but the first result). The `useState` lazy initializer runs exactly once.

- **Merge queued-message effects**: The previous implementation used two separate effects for queued-message reset (effect 3) and hydration (effect 4) that relied on declaration order to work correctly. Merged into a single effect with an explicit hydration guard, making the ordering dependency self-documenting.

- **Remove `prevChatIDRef`**: This ref existed to clear stale messages when the chat ID changed. It's unnecessary because react-query returns `undefined` for a new chat ID's query before it resolves, so `replaceMessages(undefined)` naturally clears the store.

- **Remove `chatQueuedMessages` from options**: The hook now reads `chatData.queued_messages` directly, removing a redundant prop that duplicated data already available via `chatData`.

- **Keep status effect separate** (intentionally): The WebSocket also pushes status changes directly into the store. Merging the status sync into the data-sync effect would cause the stale query-cache status to overwrite WebSocket-driven updates on every re-render.

### Net result

| Before | After |
|--------|-------|
| 6 refs | 4 refs |
| 4 sync effects + 1 WebSocket effect | 2 sync effects + 1 WebSocket effect |
| `chatQueuedMessages` in options interface | Removed |
| Fragile effect ordering dependency | Self-contained single effect |

All 260 AgentsPage tests pass.