### PR TITLE
feat(site): add Open Terminal and Copy SSH Command to agent chat TopBar

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -820,7 +820,6 @@ const AgentDetail: FC = () => {
 		: null;
 	const canOpenWorkspace = Boolean(workspaceRoute);
 	const canOpenEditors = Boolean(workspace && workspaceAgent);
-	const canOpenTerminal = Boolean(workspace && workspaceAgent);
 	const terminalHref =
 		workspace && workspaceAgent
 			? getTerminalHref({
@@ -912,7 +911,6 @@ const AgentDetail: FC = () => {
 						canOpenWorkspace: false,
 						onOpenInEditor: () => {},
 						onViewWorkspace: () => {},
-						canOpenTerminal: false,
 						onOpenTerminal: () => {},
 						sshCommand: undefined,
 					}}
@@ -984,7 +982,6 @@ const AgentDetail: FC = () => {
 						canOpenWorkspace: false,
 						onOpenInEditor: () => {},
 						onViewWorkspace: () => {},
-						canOpenTerminal: false,
 						onOpenTerminal: () => {},
 						sshCommand: undefined,
 					}}
@@ -1026,7 +1023,6 @@ const AgentDetail: FC = () => {
 								void handleOpenInEditor(editor);
 							},
 							onViewWorkspace: handleViewWorkspace,
-							canOpenTerminal,
 							onOpenTerminal: handleOpenTerminal,
 							sshCommand,
 						}}

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -11,12 +11,18 @@ import {
 	interruptChat,
 	promoteChatQueuedMessage,
 } from "api/queries/chats";
+import { deploymentSSHConfig } from "api/queries/deployment";
 import { workspaceById } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { Skeleton } from "components/Skeleton/Skeleton";
 import { ArchiveIcon } from "lucide-react";
-import { getVSCodeHref, SESSION_TOKEN_PLACEHOLDER } from "modules/apps/apps";
+import {
+	getTerminalHref,
+	getVSCodeHref,
+	openAppInNewWindow,
+	SESSION_TOKEN_PLACEHOLDER,
+} from "modules/apps/apps";
 import {
 	type FC,
 	useCallback,
@@ -510,6 +516,7 @@ const AgentDetail: FC = () => {
 	});
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
+	const sshConfigQuery = useQuery(deploymentSSHConfig());
 	const hasDiffStatus = Boolean(diffStatusQuery.data?.url);
 	const workspace = workspaceQuery.data;
 	const workspaceAgent = getWorkspaceAgent(workspace, undefined);
@@ -813,6 +820,19 @@ const AgentDetail: FC = () => {
 		: null;
 	const canOpenWorkspace = Boolean(workspaceRoute);
 	const canOpenEditors = Boolean(workspace && workspaceAgent);
+	const canOpenTerminal = Boolean(workspace && workspaceAgent);
+	const terminalHref =
+		workspace && workspaceAgent
+			? getTerminalHref({
+					username: workspace.owner_name,
+					workspace: workspace.name,
+					agent: workspaceAgent.name,
+				})
+			: null;
+	const sshCommand =
+		workspace && workspaceAgent && sshConfigQuery.data?.hostname_suffix
+			? `ssh ${workspaceAgent.name}.${workspace.name}.${workspace.owner_name}.${sshConfigQuery.data.hostname_suffix}`
+			: undefined;
 	const shouldShowDiffPanel = hasDiffStatus && showDiffPanel;
 
 	const handleOpenInEditor = async (editor: "cursor" | "vscode") => {
@@ -863,6 +883,13 @@ const AgentDetail: FC = () => {
 		navigate(workspaceRoute);
 	};
 
+	const handleOpenTerminal = () => {
+		if (!terminalHref) {
+			return;
+		}
+		openAppInNewWindow(terminalHref);
+	};
+
 	const handleArchiveAgentAction = () => {
 		if (!agentId || isArchived) {
 			return;
@@ -885,6 +912,9 @@ const AgentDetail: FC = () => {
 						canOpenWorkspace: false,
 						onOpenInEditor: () => {},
 						onViewWorkspace: () => {},
+						canOpenTerminal: false,
+						onOpenTerminal: () => {},
+						sshCommand: undefined,
 					}}
 					onOpenParentChat={() => {}}
 					onArchiveAgent={() => {}}
@@ -954,6 +984,9 @@ const AgentDetail: FC = () => {
 						canOpenWorkspace: false,
 						onOpenInEditor: () => {},
 						onViewWorkspace: () => {},
+						canOpenTerminal: false,
+						onOpenTerminal: () => {},
+						sshCommand: undefined,
 					}}
 					onOpenParentChat={() => {}}
 					onArchiveAgent={() => {}}
@@ -993,6 +1026,9 @@ const AgentDetail: FC = () => {
 								void handleOpenInEditor(editor);
 							},
 							onViewWorkspace: handleViewWorkspace,
+							canOpenTerminal,
+							onOpenTerminal: handleOpenTerminal,
+							sshCommand,
 						}}
 						onArchiveAgent={handleArchiveAgentAction}
 						isArchived={isArchived}

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
@@ -24,8 +24,11 @@ const defaultProps = {
 	workspace: {
 		canOpenEditors: true,
 		canOpenWorkspace: true,
+		canOpenTerminal: true,
 		onOpenInEditor: () => {},
 		onViewWorkspace: () => {},
+		onOpenTerminal: () => {},
+		sshCommand: "ssh main.my-workspace.admin.coder",
 	},
 	onArchiveAgent: () => {},
 	isSidebarCollapsed: false,

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
@@ -24,7 +24,6 @@ const defaultProps = {
 	workspace: {
 		canOpenEditors: true,
 		canOpenWorkspace: true,
-		canOpenTerminal: true,
 		onOpenInEditor: () => {},
 		onViewWorkspace: () => {},
 		onOpenTerminal: () => {},

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -74,7 +74,6 @@ interface DiffPanelState {
 interface WorkspaceActions {
 	canOpenEditors: boolean;
 	canOpenWorkspace: boolean;
-	canOpenTerminal: boolean;
 	onOpenInEditor: (editor: "cursor" | "vscode") => void;
 	onViewWorkspace: () => void;
 	onOpenTerminal: () => void;
@@ -200,7 +199,8 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 							Open in VS Code
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							disabled={!workspace.canOpenTerminal}
+		                                        // You can think of the web terminal as an editor if you squint.
+							disabled={!workspace.canOpenEditors}
 							onSelect={workspace.onOpenTerminal}
 						>
 							<TerminalIcon className="h-3.5 w-3.5" />

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -200,6 +200,29 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 							Open in VS Code
 						</DropdownMenuItem>
 						<DropdownMenuItem
+							disabled={!workspace.canOpenTerminal}
+							onSelect={workspace.onOpenTerminal}
+						>
+							<TerminalIcon className="h-3.5 w-3.5" />
+							Open Terminal
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							disabled={!workspace.sshCommand}
+							onSelect={async () => {
+								if (!workspace.sshCommand) return;
+								try {
+									await navigator.clipboard.writeText(workspace.sshCommand);
+									toast.success("SSH command copied to clipboard");
+								} catch {
+									toast.error("Failed to copy SSH command");
+								}
+							}}
+						>
+							<CopyIcon className="h-3.5 w-3.5" />
+							Copy SSH Command
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
 							disabled={!workspace.canOpenWorkspace}
 							onSelect={workspace.onViewWorkspace}
 						>
@@ -207,24 +230,6 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 							View Workspace
 						</DropdownMenuItem>
 						<DropdownMenuSeparator />
-						<DropdownMenuItem
-							disabled={!workspace.canOpenTerminal}
-							onSelect={workspace.onOpenTerminal}
-						>
-							<TerminalIcon className="h-3.5 w-3.5" />
-							Open Terminal
-						</DropdownMenuItem>
-						{workspace.sshCommand && (
-							<DropdownMenuItem
-								onSelect={() => {
-									void navigator.clipboard.writeText(workspace.sshCommand!);
-									toast.success("SSH command copied to clipboard");
-								}}
-							>
-								<CopyIcon className="h-3.5 w-3.5" />
-								Copy SSH Command
-							</DropdownMenuItem>
-						)}
 						{!isArchived && (
 							<DropdownMenuItem
 								className="text-content-destructive focus:text-content-destructive"

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -5,6 +5,7 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
 import { useAuthenticated } from "hooks";
@@ -12,17 +13,20 @@ import {
 	ArchiveIcon,
 	ArrowLeftIcon,
 	ChevronRightIcon,
+	CopyIcon,
 	EllipsisIcon,
 	ExternalLinkIcon,
 	MonitorIcon,
 	PanelLeftIcon,
 	PanelRightCloseIcon,
 	PanelRightOpenIcon,
+	TerminalIcon,
 } from "lucide-react";
 import { UserDropdown } from "modules/dashboard/Navbar/UserDropdown/UserDropdown";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import { useNavigate } from "react-router";
+import { toast } from "sonner";
 import { WebPushButton } from "../WebPushButton";
 
 interface DiffStatsBadgeProps {
@@ -70,8 +74,11 @@ interface DiffPanelState {
 interface WorkspaceActions {
 	canOpenEditors: boolean;
 	canOpenWorkspace: boolean;
+	canOpenTerminal: boolean;
 	onOpenInEditor: (editor: "cursor" | "vscode") => void;
 	onViewWorkspace: () => void;
+	onOpenTerminal: () => void;
+	sshCommand: string | undefined;
 }
 
 type AgentDetailTopBarProps = {
@@ -199,6 +206,25 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 							<MonitorIcon className="h-3.5 w-3.5" />
 							View Workspace
 						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							disabled={!workspace.canOpenTerminal}
+							onSelect={workspace.onOpenTerminal}
+						>
+							<TerminalIcon className="h-3.5 w-3.5" />
+							Open Terminal
+						</DropdownMenuItem>
+						{workspace.sshCommand && (
+							<DropdownMenuItem
+								onSelect={() => {
+									void navigator.clipboard.writeText(workspace.sshCommand!);
+									toast.success("SSH command copied to clipboard");
+								}}
+							>
+								<CopyIcon className="h-3.5 w-3.5" />
+								Copy SSH Command
+							</DropdownMenuItem>
+						)}
 						{!isArchived && (
 							<DropdownMenuItem
 								className="text-content-destructive focus:text-content-destructive"


### PR DESCRIPTION
Adds two new items to the agent chat TopBar dropdown menu:

- **Open Terminal**: opens the workspace web terminal in a new browser window, reusing the existing `getTerminalHref`/`openAppInNewWindow` infra.
- **Copy SSH Command**: copies the SSH command (e.g. `ssh agent.workspace.owner.suffix`) to the clipboard with a toast confirmation. Only shown when the deployment SSH hostname suffix is configured.

Both items appear after a separator below the existing editor/workspace actions.

## Changes

| File | What |
|---|---|
| `TopBar.tsx` | Added `Open Terminal` and `Copy SSH Command` dropdown items with separator, `TerminalIcon`/`CopyIcon`, toast on copy |
| `AgentDetail.tsx` | Wired up `getTerminalHref`, `openAppInNewWindow`, `deploymentSSHConfig` query, and passed new props to TopBar in all 3 render paths |
| `TopBar.stories.tsx` | Added new fields to default story props |