### PR TITLE
fix(site): skip streaming animation on first engine update

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/SmoothText.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/SmoothText.test.ts
@@ -5,9 +5,33 @@ function makeText(length: number): string {
 	return "x".repeat(length);
 }
 
+/**
+ * Prepare an engine for streaming tests by consuming the first-update
+ * snap (which shows all initial text immediately) so that subsequent
+ * updates exercise the incremental animation path.
+ */
+function createStreamingEngine(initialText = ""): SmoothTextEngine {
+	const engine = new SmoothTextEngine();
+	engine.update(initialText, true, false);
+	return engine;
+}
+
 describe("SmoothTextEngine", () => {
-	it("reveals text steadily and reaches full length", () => {
+	it("snaps to full length on first update (no animation on reconnect)", () => {
 		const engine = new SmoothTextEngine();
+		const fullText = makeText(500);
+
+		engine.update(fullText, true, false);
+
+		// First update should show everything immediately — this
+		// prevents a "replay" animation when reconnecting to an
+		// in-progress stream.
+		expect(engine.visibleLength).toBe(fullText.length);
+		expect(engine.isCaughtUp).toBe(true);
+	});
+
+	it("reveals text steadily and reaches full length", () => {
+		const engine = createStreamingEngine();
 		const fullText = makeText(200);
 
 		engine.update(fullText, true, false);
@@ -32,7 +56,7 @@ describe("SmoothTextEngine", () => {
 	});
 
 	it("accelerates reveal speed when backlog is large", () => {
-		const engine = new SmoothTextEngine();
+		const engine = createStreamingEngine();
 		const fullText = makeText(500);
 
 		engine.update(fullText, true, false);
@@ -52,9 +76,7 @@ describe("SmoothTextEngine", () => {
 	});
 
 	it("caps visual lag when incoming text jumps ahead", () => {
-		const engine = new SmoothTextEngine();
-
-		engine.update(makeText(40), true, false);
+		const engine = createStreamingEngine(makeText(40));
 
 		while (!engine.isCaughtUp) {
 			engine.tick(16);
@@ -68,7 +90,7 @@ describe("SmoothTextEngine", () => {
 	});
 
 	it("flushes immediately when streaming ends", () => {
-		const engine = new SmoothTextEngine();
+		const engine = createStreamingEngine();
 		const fullText = makeText(120);
 
 		engine.update(fullText, true, false);
@@ -96,13 +118,7 @@ describe("SmoothTextEngine", () => {
 	});
 
 	it("clamps visible length when content shrinks", () => {
-		const engine = new SmoothTextEngine();
-
-		engine.update(makeText(100), true, false);
-
-		while (engine.visibleLength < 50) {
-			engine.tick(16);
-		}
+		const engine = createStreamingEngine(makeText(100));
 
 		engine.update(makeText(30), true, false);
 
@@ -110,7 +126,7 @@ describe("SmoothTextEngine", () => {
 	});
 
 	it("does not force reveal when budget is below one char", () => {
-		const engine = new SmoothTextEngine();
+		const engine = createStreamingEngine();
 		// With a 1-char backlog, adaptive rate is at floor (~24 cps).
 		// At 4ms per tick: 24 * 0.004 = 0.096 budget per tick.
 		// Budget reaches 1.0 after ceil(1 / 0.096) ≈ 11 ticks.
@@ -134,7 +150,7 @@ describe("SmoothTextEngine", () => {
 
 	it("keeps reveal near frame-rate invariant over equal wall time", () => {
 		const run = (frameMs: number) => {
-			const engine = new SmoothTextEngine();
+			const engine = createStreamingEngine();
 			engine.update(makeText(400), true, false);
 			for (let t = 0; t < 1000; t += frameMs) {
 				engine.tick(frameMs);

--- a/site/src/pages/AgentsPage/AgentDetail/SmoothText.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/SmoothText.ts
@@ -66,6 +66,11 @@ export class SmoothTextEngine {
 	private charBudget = 0;
 	private isStreaming = false;
 	private bypassSmoothing = false;
+	// True until the first streaming update has been applied.
+	// Used to skip the reveal animation for text that already
+	// existed when the engine was created (e.g. reconnect
+	// snapshot after a page navigation).
+	private firstUpdate = true;
 
 	private rafId: number | null = null;
 	private previousTimestamp: number | null = null;
@@ -150,7 +155,14 @@ export class SmoothTextEngine {
 			this.charBudget = 0;
 		}
 
-		if (!isStreaming || bypassSmoothing) {
+		// On the very first update, snap to full length so
+		// pre-existing text (e.g. a reconnect snapshot) renders
+		// instantly instead of replaying the reveal animation.
+		if (this.firstUpdate) {
+			this.firstUpdate = false;
+			this.visibleLengthValue = this.fullLength;
+			this.charBudget = 0;
+		} else if (!isStreaming || bypassSmoothing) {
 			this.visibleLengthValue = this.fullLength;
 			this.charBudget = 0;
 			this.stopLoop();
@@ -241,6 +253,7 @@ export class SmoothTextEngine {
 		this.charBudget = 0;
 		this.isStreaming = false;
 		this.bypassSmoothing = false;
+		this.firstUpdate = true;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

When navigating away from the agents chat page and returning, the smooth text streaming animation replays all existing text — you see the text animate in as if it's being freshly streamed.

## Root Cause

On reconnect, the WebSocket replays all buffered `message_part` events as a snapshot. The client rebuilds `streamState` from scratch, so `SmoothTextEngine` starts at `visibleLength = 0` and uses `requestAnimationFrame` to animate through all the text. Even with the `MAX_VISUAL_LAG_CHARS` (120) cap, the last 120 characters still visibly animate in.

## Fix

Added a `firstUpdate` flag to `SmoothTextEngine`. On the very first `update()` call, the engine snaps to the full text length instead of starting the RAF animation loop. This means:
- **Reconnect/page load**: snapshot text renders instantly (no replay)
- **Real-time streaming**: after the first update is consumed, subsequent updates animate normally

The flag resets on `reset()` and new engine instances start with it set to `true`.

## Changes

- `SmoothText.ts`: Added `firstUpdate` flag that bypasses animation on first `update()` call
- `SmoothText.test.ts`: Added explicit test for first-update snap behavior; updated existing tests to use `createStreamingEngine()` helper that consumes the first update so they continue testing incremental animation correctly