### PR TITLE
test: reduce Await* polling interval from 250ms to 25ms

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1152,7 +1152,7 @@ func AwaitTemplateVersionJobCompleted(t testing.TB, client *codersdk.Client, ver
 		templateVersion, err = client.TemplateVersion(ctx, version)
 		t.Logf("template version job status: %s", templateVersion.Job.Status)
 		return assert.NoError(t, err) && templateVersion.Job.CompletedAt != nil
-	}, testutil.WaitLong, testutil.IntervalMedium, "make sure you set `IncludeProvisionerDaemon`!")
+	}, testutil.WaitLong, testutil.IntervalFast, "make sure you set `IncludeProvisionerDaemon`!")
 	t.Logf("template version %s job has completed", version)
 	return templateVersion
 }
@@ -1178,7 +1178,7 @@ func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, buil
 			return false
 		}
 		return true
-	}, testutil.WaitMedium, testutil.IntervalMedium)
+	}, testutil.WaitMedium, testutil.IntervalFast)
 	t.Logf("got workspace build job %s (status: %s)", build, workspaceBuild.Job.Status)
 	return workspaceBuild
 }
@@ -1302,7 +1302,7 @@ func (w WorkspaceAgentWaiter) WaitFor(criteria ...WaitForAgentFn) {
 			}
 		}
 		return true
-	}, testutil.IntervalMedium)
+	}, testutil.IntervalFast)
 }
 
 // Wait waits for the agent(s) to connect and fails the test if they do not connect before the
@@ -1354,7 +1354,7 @@ func (w WorkspaceAgentWaiter) Wait() []codersdk.WorkspaceResource {
 			return true
 		}
 		return w.resourcesMatcher(resources)
-	}, testutil.IntervalMedium)
+	}, testutil.IntervalFast)
 	w.t.Logf("got workspace agents (workspace %s)", w.workspaceID)
 	return resources
 }


### PR DESCRIPTION
## Summary

Change the four main `coderdtest` Await helper functions to poll at `IntervalFast` (25ms) instead of `IntervalMedium` (250ms):

- `AwaitTemplateVersionJobCompleted`
- `AwaitWorkspaceBuildJobCompleted`
- `WorkspaceAgentWaiter.WaitFor`
- `WorkspaceAgentWaiter.Wait`

These are called **~855 times** across the test suite. Each call previously wasted ~125ms on average waiting for the next poll tick. `AwaitTemplateVersionJobRunning` already used `IntervalFast` — this makes all Await helpers consistent.

## Measured Impact

Local benchmarks (postgres, `-short -count=1 -p 8 -parallel 8 -tags=testsmallbatch`):

| Package | Before | After | Delta |
|---|---|---|---|
| enterprise/coderd | 90.8s | 76.0s | **-16.3%** |
| coderd | 65.6s | 56.5s | **-13.8%** |
| cli | 57.9s | 37.8s | **-34.7%** |
| enterprise (root) | 41.1s | 39.9s | -2.9% |
| **Sum of all packages** | **623s** | **543s** | **-12.8%** |

Zero test failures across all 199 packages.