### PR TITLE
fix: remove opacity-50 from agents page logo so it renders black

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -477,7 +477,7 @@ const AgentsPage: FC = () => {
 						<div className="flex shrink-0 items-center gap-2 px-4 py-0.5">
 							<NavLink
 								to="/workspaces"
-								className="inline-flex shrink-0 opacity-50 md:hidden"
+								className="inline-flex shrink-0 md:hidden"
 							>
 								{appearance.logo_url ? (
 									<ExternalImage

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -621,7 +621,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 		<div className="flex h-full w-full min-h-0 flex-col border-0 border-r border-solid">
 			<div className="hidden border-b border-border-default px-3 pb-3 pt-1.5 md:block md:px-3.5">
 				<div className="mb-2.5 flex items-center justify-between">
-					<NavLink to="/workspaces" className="inline-flex opacity-50">
+					<NavLink to="/workspaces" className="inline-flex">
 						{logoUrl ? (
 							<ExternalImage className="h-6" src={logoUrl} alt="Logo" />
 						) : (


### PR DESCRIPTION
The Coder logo in the top-left of the agents page was rendered at 50% opacity due to `opacity-50` on the wrapping `NavLink`, making it appear gray instead of black. The main Navbar does not apply this opacity.

Removes `opacity-50` from the logo `NavLink` in both:
- `AgentsSidebar.tsx` (desktop sidebar logo)
- `AgentsPage.tsx` (mobile empty state logo)