### PR TITLE
feat(site): add confirmation dialogs to agent archive actions

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -971,6 +971,11 @@ const AgentDetail: FC = () => {
 						onUnarchiveAgent={handleUnarchiveAgentAction}
 						onArchiveAndDeleteWorkspace={handleArchiveAndDeleteWorkspaceAction}
 						hasWorkspace={Boolean(workspaceId)}
+						workspaceName={
+							workspace
+								? `${workspace.owner_name}/${workspace.name}`
+								: undefined
+						}
 						isArchived={isArchived}
 						isSidebarCollapsed={isSidebarCollapsed}
 						onToggleSidebarCollapsed={onToggleSidebarCollapsed}

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ChatDiffStatusResponse } from "api/api";
-import { expect, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { AgentDetailTopBar } from "./TopBar";
 
 const mockDiffStatus: ChatDiffStatusResponse = {
@@ -124,5 +124,81 @@ export const ArchivedWithUnarchive: Story = {
 		expect(
 			body.queryByText("Archive & Delete Workspace"),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const ArchiveConfirmDialog: Story = {
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		await user.click(
+			canvas.getByRole("button", { name: "Open agent actions" }),
+		);
+		const body = canvasElement.ownerDocument.body;
+		await user.click(await within(body).findByText("Archive Agent"));
+		await expect(
+			await within(body).findByText("Archive agent"),
+		).toBeInTheDocument();
+	},
+};
+
+export const ArchiveAndDeleteConfirmDialog: Story = {
+	args: {
+		hasWorkspace: true,
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		await user.click(
+			canvas.getByRole("button", { name: "Open agent actions" }),
+		);
+		const body = canvasElement.ownerDocument.body;
+		await user.click(
+			await within(body).findByText("Archive & Delete Workspace"),
+		);
+		await expect(
+			await within(body).findByText("Archive agent and delete workspace"),
+		).toBeInTheDocument();
+	},
+};
+
+export const ArchiveConfirmDialogCallsHandler: Story = {
+	args: {
+		onArchiveAgent: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		await user.click(
+			canvas.getByRole("button", { name: "Open agent actions" }),
+		);
+		const body = canvasElement.ownerDocument.body;
+		await user.click(await within(body).findByText("Archive Agent"));
+		await user.click(within(body).getByTestId("confirm-button"));
+		await waitFor(() => {
+			expect(args.onArchiveAgent).toHaveBeenCalledTimes(1);
+		});
+	},
+};
+
+export const ArchiveAndDeleteConfirmDialogCallsHandler: Story = {
+	args: {
+		hasWorkspace: true,
+		onArchiveAndDeleteWorkspace: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		await user.click(
+			canvas.getByRole("button", { name: "Open agent actions" }),
+		);
+		const body = canvasElement.ownerDocument.body;
+		await user.click(
+			await within(body).findByText("Archive & Delete Workspace"),
+		);
+		await user.click(within(body).getByTestId("confirm-button"));
+		await waitFor(() => {
+			expect(args.onArchiveAndDeleteWorkspace).toHaveBeenCalledTimes(1);
+		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
@@ -130,6 +130,7 @@ export const ArchivedWithUnarchive: Story = {
 export const ArchiveAndDeleteConfirmDialog: Story = {
 	args: {
 		hasWorkspace: true,
+		workspaceName: "admin/my-workspace",
 	},
 	play: async ({ canvasElement }) => {
 		const user = userEvent.setup();

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
@@ -127,21 +127,6 @@ export const ArchivedWithUnarchive: Story = {
 	},
 };
 
-export const ArchiveConfirmDialog: Story = {
-	play: async ({ canvasElement }) => {
-		const user = userEvent.setup();
-		const canvas = within(canvasElement);
-		await user.click(
-			canvas.getByRole("button", { name: "Open agent actions" }),
-		);
-		const body = canvasElement.ownerDocument.body;
-		await user.click(await within(body).findByText("Archive Agent"));
-		await expect(
-			await within(body).findByText("Archive agent"),
-		).toBeInTheDocument();
-	},
-};
-
 export const ArchiveAndDeleteConfirmDialog: Story = {
 	args: {
 		hasWorkspace: true,
@@ -159,25 +144,6 @@ export const ArchiveAndDeleteConfirmDialog: Story = {
 		await expect(
 			await within(body).findByText("Archive agent and delete workspace"),
 		).toBeInTheDocument();
-	},
-};
-
-export const ArchiveConfirmDialogCallsHandler: Story = {
-	args: {
-		onArchiveAgent: fn(),
-	},
-	play: async ({ canvasElement, args }) => {
-		const user = userEvent.setup();
-		const canvas = within(canvasElement);
-		await user.click(
-			canvas.getByRole("button", { name: "Open agent actions" }),
-		);
-		const body = canvasElement.ownerDocument.body;
-		await user.click(await within(body).findByText("Archive Agent"));
-		await user.click(within(body).getByTestId("confirm-button"));
-		await waitFor(() => {
-			expect(args.onArchiveAgent).toHaveBeenCalledTimes(1);
-		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -82,7 +82,6 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 	onToggleSidebarCollapsed,
 }) => {
 	const navigate = useNavigate();
-	const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
 	const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
 	return (
@@ -219,7 +218,7 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 								<>
 									<DropdownMenuItem
 										className="text-content-destructive focus:text-content-destructive"
-										onSelect={() => setArchiveConfirmOpen(true)}
+										onSelect={onArchiveAgent}
 									>
 										<ArchiveIcon className="h-3.5 w-3.5" />
 										Archive Agent
@@ -254,42 +253,6 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 					)}{" "}
 				</div>
 			</div>
-			<Dialog
-				open={archiveConfirmOpen}
-				onOpenChange={(open) => {
-					if (!open) {
-						setArchiveConfirmOpen(false);
-					}
-				}}
-			>
-				<DialogContent variant="destructive">
-					<DialogHeader>
-						<DialogTitle>Archive agent</DialogTitle>
-						<DialogDescription>
-							Are you sure you want to archive this agent? This action cannot be
-							undone.
-						</DialogDescription>
-					</DialogHeader>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setArchiveConfirmOpen(false)}
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="destructive"
-							data-testid="confirm-button"
-							onClick={() => {
-								setArchiveConfirmOpen(false);
-								onArchiveAgent();
-							}}
-						>
-							Archive
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
 			<Dialog
 				open={deleteConfirmOpen}
 				onOpenChange={(open) => {

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -2,6 +2,14 @@ import type { ChatDiffStatusResponse } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
+import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
@@ -23,7 +31,7 @@ import {
 	TerminalIcon,
 	Trash2Icon,
 } from "lucide-react";
-import type { FC } from "react";
+import { type FC, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { DiffStatsInline } from "../DiffStats";
@@ -74,174 +82,250 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 	onToggleSidebarCollapsed,
 }) => {
 	const navigate = useNavigate();
+	const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
+	const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
 	return (
-		<div className="flex shrink-0 items-center gap-2 px-4 py-0.5">
-			{/* Mobile back button */}
-			<Button
-				variant="subtle"
-				size="icon"
-				onClick={() => navigate("/agents")}
-				aria-label="Back"
-				className="inline-flex h-7 w-7 min-w-0 shrink-0 md:hidden"
-			>
-				<ArrowLeftIcon />
-			</Button>
-			{/* Desktop expand button: visible when sidebar is manually collapsed. */}
-			{isSidebarCollapsed && (
+		<>
+			<div className="flex shrink-0 items-center gap-2 px-4 py-0.5">
+				{/* Mobile back button */}
 				<Button
 					variant="subtle"
 					size="icon"
-					onClick={onToggleSidebarCollapsed}
-					aria-label="Expand sidebar"
-					className="hidden h-7 w-7 min-w-0 shrink-0 md:inline-flex"
+					onClick={() => navigate("/agents")}
+					aria-label="Back"
+					className="inline-flex h-7 w-7 min-w-0 shrink-0 md:hidden"
 				>
-					<PanelLeftIcon />
+					<ArrowLeftIcon />
 				</Button>
-			)}
-			{/* Title area */}
-			<div className="flex min-w-0 flex-1 items-center">
-				{chatTitle && (
-					<div className="flex min-w-0 items-center gap-1.5">
-						{parentChat && (
-							<>
-								<Button
-									size="sm"
-									variant="subtle"
-									className="h-auto max-w-[16rem] rounded-sm px-1 py-0.5 text-xs text-content-secondary shadow-none hover:bg-transparent hover:text-content-primary"
-									onClick={() => onOpenParentChat(parentChat.id)}
-								>
-									<span className="truncate">{parentChat.title}</span>
-								</Button>
-								<ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary/70" />
-							</>
-						)}
-						<span className="truncate text-sm text-content-primary">
-							{chatTitle}
-						</span>
-						{diff.hasDiffStatus && diff.diffStatus && !diff.showDiffPanel && (
-							<span className="ml-3">
-								<DiffStatsInline
-									status={diff.diffStatus}
-									onClick={diff.onToggleFilesChanged}
-								/>
-							</span>
-						)}
-						{isArchived && (
-							<span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-xs text-content-secondary">
-								Archived
-							</span>
-						)}
-					</div>
-				)}
-			</div>
-			{/* Actions area */}
-			<div className="flex items-center gap-2">
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button
-							size="icon"
-							variant="subtle"
-							className="h-7 w-7 text-content-secondary hover:text-content-primary"
-							aria-label="Open agent actions"
-						>
-							<EllipsisIcon className="h-4 w-4" />
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
-						<DropdownMenuItem
-							disabled={!workspace.canOpenEditors}
-							onSelect={() => {
-								workspace.onOpenInEditor("cursor");
-							}}
-						>
-							<ExternalLinkIcon className="h-3.5 w-3.5" />
-							Open in Cursor
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							disabled={!workspace.canOpenEditors}
-							onSelect={() => {
-								workspace.onOpenInEditor("vscode");
-							}}
-						>
-							<ExternalLinkIcon className="h-3.5 w-3.5" />
-							Open in VS Code
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							// You can think of the web terminal as an editor if you squint.
-							disabled={!workspace.canOpenEditors}
-							onSelect={workspace.onOpenTerminal}
-						>
-							<TerminalIcon className="h-3.5 w-3.5" />
-							Open Terminal
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							disabled={!workspace.sshCommand}
-							onSelect={async () => {
-								if (!workspace.sshCommand) return;
-								try {
-									await navigator.clipboard.writeText(workspace.sshCommand);
-									toast.success("SSH command copied to clipboard");
-								} catch {
-									toast.error("Failed to copy SSH command");
-								}
-							}}
-						>
-							<CopyIcon className="h-3.5 w-3.5" />
-							Copy SSH Command
-						</DropdownMenuItem>
-						<DropdownMenuSeparator />
-						<DropdownMenuItem
-							disabled={!workspace.canOpenWorkspace}
-							onSelect={workspace.onViewWorkspace}
-						>
-							<MonitorIcon className="h-3.5 w-3.5" />
-							View Workspace
-						</DropdownMenuItem>
-						<DropdownMenuSeparator />
-						{isArchived ? (
-							<DropdownMenuItem onSelect={onUnarchiveAgent}>
-								<ArchiveRestoreIcon className="h-3.5 w-3.5" />
-								Unarchive Agent
-							</DropdownMenuItem>
-						) : (
-							<>
-								<DropdownMenuItem
-									className="text-content-destructive focus:text-content-destructive"
-									onSelect={onArchiveAgent}
-								>
-									<ArchiveIcon className="h-3.5 w-3.5" />
-									Archive Agent
-								</DropdownMenuItem>
-								{hasWorkspace && (
-									<DropdownMenuItem
-										className="text-content-destructive focus:text-content-destructive"
-										onSelect={onArchiveAndDeleteWorkspace}
-									>
-										<Trash2Icon className="h-3.5 w-3.5" />
-										Archive & Delete Workspace
-									</DropdownMenuItem>
-								)}
-							</>
-						)}
-					</DropdownMenuContent>
-				</DropdownMenu>
-				{diff.hasDiffStatus && diff.diffStatus && (
+				{/* Desktop expand button: visible when sidebar is manually collapsed. */}
+				{isSidebarCollapsed && (
 					<Button
 						variant="subtle"
 						size="icon"
-						onClick={diff.onToggleFilesChanged}
-						className="h-7 w-7 text-content-secondary hover:text-content-primary"
-						aria-label="Toggle files changed"
+						onClick={onToggleSidebarCollapsed}
+						aria-label="Expand sidebar"
+						className="hidden h-7 w-7 min-w-0 shrink-0 md:inline-flex"
 					>
-						{diff.showDiffPanel ? (
-							<PanelRightCloseIcon className="h-4 w-4" />
-						) : (
-							<PanelRightOpenIcon className="h-4 w-4" />
-						)}
+						<PanelLeftIcon />
 					</Button>
 				)}
-			</div>{" "}
-		</div>
+				{/* Title area */}
+				<div className="flex min-w-0 flex-1 items-center">
+					{chatTitle && (
+						<div className="flex min-w-0 items-center gap-1.5">
+							{parentChat && (
+								<>
+									<Button
+										size="sm"
+										variant="subtle"
+										className="h-auto max-w-[16rem] rounded-sm px-1 py-0.5 text-xs text-content-secondary shadow-none hover:bg-transparent hover:text-content-primary"
+										onClick={() => onOpenParentChat(parentChat.id)}
+									>
+										<span className="truncate">{parentChat.title}</span>
+									</Button>
+									<ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary/70" />
+								</>
+							)}
+							<span className="truncate text-sm text-content-primary">
+								{chatTitle}
+							</span>
+							{diff.hasDiffStatus && diff.diffStatus && !diff.showDiffPanel && (
+								<span className="ml-3">
+									<DiffStatsInline
+										status={diff.diffStatus}
+										onClick={diff.onToggleFilesChanged}
+									/>
+								</span>
+							)}
+							{isArchived && (
+								<span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-xs text-content-secondary">
+									Archived
+								</span>
+							)}
+						</div>
+					)}
+				</div>
+				{/* Actions area */}
+				<div className="flex items-center gap-2">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								size="icon"
+								variant="subtle"
+								className="h-7 w-7 text-content-secondary hover:text-content-primary"
+								aria-label="Open agent actions"
+							>
+								<EllipsisIcon className="h-4 w-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem
+								disabled={!workspace.canOpenEditors}
+								onSelect={() => {
+									workspace.onOpenInEditor("cursor");
+								}}
+							>
+								<ExternalLinkIcon className="h-3.5 w-3.5" />
+								Open in Cursor
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								disabled={!workspace.canOpenEditors}
+								onSelect={() => {
+									workspace.onOpenInEditor("vscode");
+								}}
+							>
+								<ExternalLinkIcon className="h-3.5 w-3.5" />
+								Open in VS Code
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								// You can think of the web terminal as an editor if you squint.
+								disabled={!workspace.canOpenEditors}
+								onSelect={workspace.onOpenTerminal}
+							>
+								<TerminalIcon className="h-3.5 w-3.5" />
+								Open Terminal
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								disabled={!workspace.sshCommand}
+								onSelect={async () => {
+									if (!workspace.sshCommand) return;
+									try {
+										await navigator.clipboard.writeText(workspace.sshCommand);
+										toast.success("SSH command copied to clipboard");
+									} catch {
+										toast.error("Failed to copy SSH command");
+									}
+								}}
+							>
+								<CopyIcon className="h-3.5 w-3.5" />
+								Copy SSH Command
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem
+								disabled={!workspace.canOpenWorkspace}
+								onSelect={workspace.onViewWorkspace}
+							>
+								<MonitorIcon className="h-3.5 w-3.5" />
+								View Workspace
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							{isArchived ? (
+								<DropdownMenuItem onSelect={onUnarchiveAgent}>
+									<ArchiveRestoreIcon className="h-3.5 w-3.5" />
+									Unarchive Agent
+								</DropdownMenuItem>
+							) : (
+								<>
+									<DropdownMenuItem
+										className="text-content-destructive focus:text-content-destructive"
+										onSelect={() => setArchiveConfirmOpen(true)}
+									>
+										<ArchiveIcon className="h-3.5 w-3.5" />
+										Archive Agent
+									</DropdownMenuItem>
+									{hasWorkspace && (
+										<DropdownMenuItem
+											className="text-content-destructive focus:text-content-destructive"
+											onSelect={() => setDeleteConfirmOpen(true)}
+										>
+											<Trash2Icon className="h-3.5 w-3.5" />
+											Archive & Delete Workspace
+										</DropdownMenuItem>
+									)}
+								</>
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
+					{diff.hasDiffStatus && diff.diffStatus && (
+						<Button
+							variant="subtle"
+							size="icon"
+							onClick={diff.onToggleFilesChanged}
+							className="h-7 w-7 text-content-secondary hover:text-content-primary"
+							aria-label="Toggle files changed"
+						>
+							{diff.showDiffPanel ? (
+								<PanelRightCloseIcon className="h-4 w-4" />
+							) : (
+								<PanelRightOpenIcon className="h-4 w-4" />
+							)}
+						</Button>
+					)}{" "}
+				</div>
+			</div>
+			<Dialog
+				open={archiveConfirmOpen}
+				onOpenChange={(open) => {
+					if (!open) {
+						setArchiveConfirmOpen(false);
+					}
+				}}
+			>
+				<DialogContent variant="destructive">
+					<DialogHeader>
+						<DialogTitle>Archive agent</DialogTitle>
+						<DialogDescription>
+							Are you sure you want to archive this agent? This action cannot be
+							undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setArchiveConfirmOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							data-testid="confirm-button"
+							onClick={() => {
+								setArchiveConfirmOpen(false);
+								onArchiveAgent();
+							}}
+						>
+							Archive
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<Dialog
+				open={deleteConfirmOpen}
+				onOpenChange={(open) => {
+					if (!open) {
+						setDeleteConfirmOpen(false);
+					}
+				}}
+			>
+				<DialogContent variant="destructive">
+					<DialogHeader>
+						<DialogTitle>Archive agent and delete workspace</DialogTitle>
+						<DialogDescription>
+							Are you sure you want to archive this agent and delete its
+							workspace? This action cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setDeleteConfirmOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							data-testid="confirm-button"
+							onClick={() => {
+								setDeleteConfirmOpen(false);
+								onArchiveAndDeleteWorkspace();
+							}}
+						>
+							Confirm
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -62,6 +62,7 @@ type AgentDetailTopBarProps = {
 	onUnarchiveAgent: () => void;
 	onArchiveAndDeleteWorkspace: () => void;
 	hasWorkspace?: boolean;
+	workspaceName?: string;
 	isArchived?: boolean;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
@@ -77,6 +78,7 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 	onUnarchiveAgent,
 	onArchiveAndDeleteWorkspace,
 	hasWorkspace,
+	workspaceName,
 	isArchived,
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
@@ -265,8 +267,15 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 					<DialogHeader>
 						<DialogTitle>Archive agent and delete workspace</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to archive this agent and delete its
-							workspace? This action cannot be undone.
+							{workspaceName ? (
+								<>
+									Are you sure you want to archive this agent and delete
+									workspace <strong>{workspaceName}</strong>? This action cannot
+									be undone.
+								</>
+							) : (
+								"Are you sure you want to archive this agent and delete its workspace? This action cannot be undone."
+							)}
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>

--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -652,3 +652,77 @@ export const ArchivedAgentUnarchiveOption: Story = {
 		).not.toBeInTheDocument();
 	},
 };
+
+export const ArchiveAndDeleteConfirmDialog: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "chat-delete",
+				title: "My test agent",
+				workspace_id: "ws-123",
+			}),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = canvasElement.ownerDocument.body;
+
+		const chatRow = canvas.getByText("My test agent");
+		await user.hover(chatRow);
+
+		const actionsBtn = await canvas.findByRole("button", {
+			name: "Open actions for My test agent",
+		});
+		await user.click(actionsBtn);
+
+		// Click the delete option in the dropdown.
+		await user.click(
+			await within(body).findByText("Archive & delete workspace"),
+		);
+
+		// Assert the confirmation dialog appears.
+		await waitFor(() => {
+			expect(
+				within(body).getByText("Archive agent and delete workspace"),
+			).toBeInTheDocument();
+		});
+	},
+};
+
+export const ArchiveAndDeleteConfirmDialogCallsHandler: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "chat-delete-confirm",
+				title: "My test agent",
+				workspace_id: "ws-456",
+			}),
+		],
+		onArchiveAndDeleteWorkspace: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = canvasElement.ownerDocument.body;
+
+		const chatRow = canvas.getByText("My test agent");
+		await user.hover(chatRow);
+
+		const actionsBtn = await canvas.findByRole("button", {
+			name: "Open actions for My test agent",
+		});
+		await user.click(actionsBtn);
+
+		await user.click(
+			await within(body).findByText("Archive & delete workspace"),
+		);
+
+		// Confirm the dialog.
+		await user.click(within(body).getByTestId("confirm-button"));
+
+		await waitFor(() => {
+			expect(args.onArchiveAndDeleteWorkspace).toHaveBeenCalledTimes(1);
+		});
+	},
+};

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -14,6 +14,14 @@ import {
 	CollapsibleTrigger,
 } from "components/Collapsible/Collapsible";
 import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
+import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
@@ -355,187 +363,263 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 				const c = chatById.get(id);
 				return c?.status === "pending" || c?.status === "running";
 			}));
+	const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
+	const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
 	return (
-		<div className="flex min-w-0 flex-col">
-			<div
-				data-testid={`agents-tree-node-${chat.id}`}
-				className={cn(
-					"group relative flex min-w-0 items-start gap-1.5 rounded-md pr-1 text-content-secondary",
-					"transition-none [@media(hover:hover)]:hover:bg-surface-tertiary/50 [@media(hover:hover)]:hover:text-content-primary has-[[data-state=open]]:bg-surface-tertiary",
-					"has-[[aria-current=page]]:bg-surface-quaternary/25 has-[[aria-current=page]]:text-content-primary [@media(hover:hover)]:has-[[aria-current=page]]:hover:bg-surface-quaternary/50",
-					isChildNode &&
-						"before:absolute before:-left-2.5 before:top-[17px] before:h-px before:w-2.5 before:bg-border-default/70",
-				)}
-			>
+		<>
+			<div className="flex min-w-0 flex-col">
 				<div
+					data-testid={`agents-tree-node-${chat.id}`}
 					className={cn(
-						"group/icon relative mt-1.5 h-5 w-5 shrink-0",
-						hasChildren && "cursor-pointer",
+						"group relative flex min-w-0 items-start gap-1.5 rounded-md pr-1 text-content-secondary",
+						"transition-none [@media(hover:hover)]:hover:bg-surface-tertiary/50 [@media(hover:hover)]:hover:text-content-primary has-[[data-state=open]]:bg-surface-tertiary",
+						"has-[[aria-current=page]]:bg-surface-quaternary/25 has-[[aria-current=page]]:text-content-primary [@media(hover:hover)]:has-[[aria-current=page]]:hover:bg-surface-quaternary/50",
+						isChildNode &&
+							"before:absolute before:-left-2.5 before:top-[17px] before:h-px before:w-2.5 before:bg-border-default/70",
 					)}
 				>
 					<div
 						className={cn(
-							"flex h-5 w-5 items-center justify-center rounded-md",
-							hasChildren &&
-								!isExecuting &&
-								"[@media(hover:hover)]:group-hover:invisible",
-							hasChildren &&
-								isExecuting &&
-								"[@media(hover:hover)]:group-hover/icon:invisible",
+							"group/icon relative mt-1.5 h-5 w-5 shrink-0",
+							hasChildren && "cursor-pointer",
 						)}
 					>
-						<StatusIcon
-							data-testid={
-								isDelegatedExecuting
-									? `agents-tree-executing-${chat.id}`
-									: undefined
-							}
-							className={cn("h-3.5 w-3.5 shrink-0", config.className)}
-						/>
-					</div>
-					{hasChildren && (
-						<Button
-							variant="subtle"
-							size="icon"
-							onClick={() => toggleExpanded(chatID)}
+						<div
 							className={cn(
-								"absolute inset-0 invisible flex h-5 w-5 min-w-0 items-center justify-center rounded-md p-0 text-content-secondary/60 hover:text-content-primary [&>svg]:size-3.5",
-								isExecuting
-									? "[@media(hover:hover)]:group-hover/icon:visible"
-									: "[@media(hover:hover)]:group-hover:visible",
+								"flex h-5 w-5 items-center justify-center rounded-md",
+								hasChildren &&
+									!isExecuting &&
+									"[@media(hover:hover)]:group-hover:invisible",
+								hasChildren &&
+									isExecuting &&
+									"[@media(hover:hover)]:group-hover/icon:invisible",
 							)}
-							data-testid={`agents-tree-toggle-${chat.id}`}
-							aria-label={isExpanded ? "Collapse" : "Expand"}
-							aria-expanded={isExpanded}
 						>
-							{isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
-						</Button>
-					)}
-				</div>
-				<NavLink
-					to={`/agents/${chat.id}`}
-					className="flex min-h-0 min-w-0 flex-1 items-start gap-2 rounded-[inherit] py-1 pr-0.5 text-inherit no-underline"
-				>
-					{({ isActive }) => (
-						<>
-							<div className="min-w-0 flex-1 overflow-hidden text-left">
-								<div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-									<span
-										className={cn(
-											"block flex-1 truncate text-[13px] text-content-primary",
-											isActive && "font-medium",
-										)}
-									>
-										{chat.title}
-									</span>
-								</div>
-								<div className="flex min-w-0 items-center gap-1.5">
-									{hasLinkedDiffStatus && hasLineStats && (
+							<StatusIcon
+								data-testid={
+									isDelegatedExecuting
+										? `agents-tree-executing-${chat.id}`
+										: undefined
+								}
+								className={cn("h-3.5 w-3.5 shrink-0", config.className)}
+							/>
+						</div>
+						{hasChildren && (
+							<Button
+								variant="subtle"
+								size="icon"
+								onClick={() => toggleExpanded(chatID)}
+								className={cn(
+									"absolute inset-0 invisible flex h-5 w-5 min-w-0 items-center justify-center rounded-md p-0 text-content-secondary/60 hover:text-content-primary [&>svg]:size-3.5",
+									isExecuting
+										? "[@media(hover:hover)]:group-hover/icon:visible"
+										: "[@media(hover:hover)]:group-hover:visible",
+								)}
+								data-testid={`agents-tree-toggle-${chat.id}`}
+								aria-label={isExpanded ? "Collapse" : "Expand"}
+								aria-expanded={isExpanded}
+							>
+								{isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+							</Button>
+						)}
+					</div>
+					<NavLink
+						to={`/agents/${chat.id}`}
+						className="flex min-h-0 min-w-0 flex-1 items-start gap-2 rounded-[inherit] py-1 pr-0.5 text-inherit no-underline"
+					>
+						{({ isActive }) => (
+							<>
+								<div className="min-w-0 flex-1 overflow-hidden text-left">
+									<div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
 										<span
-											className="inline-flex shrink-0 items-center gap-0.5 font-mono text-xs font-medium leading-none tabular-nums"
-											title={`${filesChangedLabel}, +${additions} -${deletions}`}
-										>
-											{additions > 0 && (
-												<span className="text-green-700 dark:text-green-500">
-													+{additions}
-												</span>
+											className={cn(
+												"block flex-1 truncate text-[13px] text-content-primary",
+												isActive && "font-medium",
 											)}
-											{deletions > 0 && (
-												<span className="text-red-700 dark:text-red-400">
-													&minus;{deletions}
-												</span>
-											)}{" "}
+										>
+											{chat.title}
 										</span>
-									)}
-									<div
-										className={cn(
-											"min-w-0 overflow-hidden text-[13px] leading-4",
-											errorReason
-												? "line-clamp-1 whitespace-normal text-content-destructive [overflow-wrap:anywhere]"
-												: "truncate text-content-secondary",
+									</div>
+									<div className="flex min-w-0 items-center gap-1.5">
+										{hasLinkedDiffStatus && hasLineStats && (
+											<span
+												className="inline-flex shrink-0 items-center gap-0.5 font-mono text-xs font-medium leading-none tabular-nums"
+												title={`${filesChangedLabel}, +${additions} -${deletions}`}
+											>
+												{additions > 0 && (
+													<span className="text-green-700 dark:text-green-500">
+														+{additions}
+													</span>
+												)}
+												{deletions > 0 && (
+													<span className="text-red-700 dark:text-red-400">
+														&minus;{deletions}
+													</span>
+												)}{" "}
+											</span>
 										)}
-										title={subtitle}
-									>
-										{subtitle}
+										<div
+											className={cn(
+												"min-w-0 overflow-hidden text-[13px] leading-4",
+												errorReason
+													? "line-clamp-1 whitespace-normal text-content-destructive [overflow-wrap:anywhere]"
+													: "truncate text-content-secondary",
+											)}
+											title={subtitle}
+										>
+											{subtitle}
+										</div>
 									</div>
 								</div>
-							</div>
-						</>
-					)}
-				</NavLink>
-				<div className="relative mr-1 mt-1 flex h-6 w-7 shrink-0 items-center justify-end">
-					{isArchivingThisChat ? (
-						<Loader2Icon className="h-3.5 w-3.5 animate-spin text-content-secondary" />
-					) : (
-						<>
-							<span className="flex items-center justify-end text-xs text-content-secondary/50 tabular-nums [@media(hover:hover)]:group-hover:hidden group-has-[[data-state=open]]:hidden">
-								{shortRelativeTime(chat.updated_at)}
-							</span>
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										size="icon"
-										variant="subtle"
-										className="absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 data-[state=open]:opacity-100"
-										aria-label={`Open actions for ${chat.title}`}
-									>
-										<EllipsisIcon className="h-3.5 w-3.5" />
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent align="end">
-									{" "}
-									{chat.archived ? (
-										<DropdownMenuItem
-											disabled={isArchiving}
-											onSelect={() => onUnarchiveAgent(chat.id)}
+							</>
+						)}
+					</NavLink>
+					<div className="relative mr-1 mt-1 flex h-6 w-7 shrink-0 items-center justify-end">
+						{isArchivingThisChat ? (
+							<Loader2Icon className="h-3.5 w-3.5 animate-spin text-content-secondary" />
+						) : (
+							<>
+								<span className="flex items-center justify-end text-xs text-content-secondary/50 tabular-nums [@media(hover:hover)]:group-hover:hidden group-has-[[data-state=open]]:hidden">
+									{shortRelativeTime(chat.updated_at)}
+								</span>
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											size="icon"
+											variant="subtle"
+											className="absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 data-[state=open]:opacity-100"
+											aria-label={`Open actions for ${chat.title}`}
 										>
-											<ArchiveRestoreIcon className="h-3.5 w-3.5" />
-											Unarchive agent
-										</DropdownMenuItem>
-									) : (
-										<>
+											<EllipsisIcon className="h-3.5 w-3.5" />
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="end">
+										{" "}
+										{chat.archived ? (
 											<DropdownMenuItem
-												className="text-content-destructive focus:text-content-destructive"
 												disabled={isArchiving}
-												onSelect={() => onArchiveAgent(chat.id)}
+												onSelect={() => onUnarchiveAgent(chat.id)}
 											>
-												<ArchiveIcon className="h-3.5 w-3.5" />
-												Archive agent
+												<ArchiveRestoreIcon className="h-3.5 w-3.5" />
+												Unarchive agent
 											</DropdownMenuItem>
-											{workspaceId && (
+										) : (
+											<>
 												<DropdownMenuItem
 													className="text-content-destructive focus:text-content-destructive"
 													disabled={isArchiving}
-													onSelect={() =>
-														onArchiveAndDeleteWorkspace(chat.id, workspaceId)
-													}
+													onSelect={() => setArchiveConfirmOpen(true)}
 												>
-													<Trash2Icon className="h-3.5 w-3.5" />
-													Archive & delete workspace
+													<ArchiveIcon className="h-3.5 w-3.5" />
+													Archive agent
 												</DropdownMenuItem>
-											)}
-										</>
-									)}
-								</DropdownMenuContent>
-							</DropdownMenu>
-						</>
-					)}
+												{workspaceId && (
+													<DropdownMenuItem
+														className="text-content-destructive focus:text-content-destructive"
+														disabled={isArchiving}
+														onSelect={() => setDeleteConfirmOpen(true)}
+													>
+														<Trash2Icon className="h-3.5 w-3.5" />
+														Archive & delete workspace
+													</DropdownMenuItem>
+												)}
+											</>
+										)}
+									</DropdownMenuContent>
+								</DropdownMenu>
+							</>
+						)}
+					</div>
 				</div>
-			</div>
 
-			{hasChildren && isExpanded && (
-				<div className="relative ml-4 border-l border-border-default/60 pl-2.5">
-					{childIDs.map((childID) => {
-						const childChat = chatById.get(childID);
-						if (!childChat) return null;
-						return (
-							<ChatTreeNode key={childChat.id} chat={childChat} isChildNode />
-						);
-					})}
-				</div>
+				{hasChildren && isExpanded && (
+					<div className="relative ml-4 border-l border-border-default/60 pl-2.5">
+						{childIDs.map((childID) => {
+							const childChat = chatById.get(childID);
+							if (!childChat) return null;
+							return (
+								<ChatTreeNode key={childChat.id} chat={childChat} isChildNode />
+							);
+						})}
+					</div>
+				)}
+			</div>
+			<Dialog
+				open={archiveConfirmOpen}
+				onOpenChange={(open) => {
+					if (!open) {
+						setArchiveConfirmOpen(false);
+					}
+				}}
+			>
+				<DialogContent variant="destructive">
+					<DialogHeader>
+						<DialogTitle>Archive agent</DialogTitle>
+						<DialogDescription>
+							Are you sure you want to archive this agent? This action cannot be
+							undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setArchiveConfirmOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							data-testid="confirm-button"
+							onClick={() => {
+								setArchiveConfirmOpen(false);
+								onArchiveAgent(chat.id);
+							}}
+						>
+							Archive
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			{workspaceId && (
+				<Dialog
+					open={deleteConfirmOpen}
+					onOpenChange={(open) => {
+						if (!open) {
+							setDeleteConfirmOpen(false);
+						}
+					}}
+				>
+					<DialogContent variant="destructive">
+						<DialogHeader>
+							<DialogTitle>Archive agent and delete workspace</DialogTitle>
+							<DialogDescription>
+								Are you sure you want to archive this agent and delete its
+								workspace? This action cannot be undone.
+							</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
+							<Button
+								variant="outline"
+								onClick={() => setDeleteConfirmOpen(false)}
+							>
+								Cancel
+							</Button>
+							<Button
+								variant="destructive"
+								data-testid="confirm-button"
+								onClick={() => {
+									setDeleteConfirmOpen(false);
+									onArchiveAndDeleteWorkspace(chat.id, workspaceId);
+								}}
+							>
+								Confirm
+							</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
 			)}
-		</div>
+		</>
 	);
 });
 ChatTreeNode.displayName = "ChatTreeNode";

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -1,3 +1,4 @@
+import { workspaceById } from "api/queries/workspaces";
 import type {
 	Chat,
 	ChatDiffStatus,
@@ -58,6 +59,7 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import { useQuery } from "react-query";
 import { NavLink, useParams } from "react-router";
 import { cn } from "utils/cn";
 import { shortRelativeTime } from "utils/time";
@@ -353,6 +355,13 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 		changedFiles === 1 ? "file" : "files"
 	}`;
 	const workspaceId = chat.workspace_id;
+	const workspaceQuery = useQuery({
+		...workspaceById(workspaceId ?? ""),
+		enabled: Boolean(workspaceId),
+	});
+	const workspaceName = workspaceQuery.data
+		? `${workspaceQuery.data.owner_name}/${workspaceQuery.data.name}`
+		: undefined;
 	const isArchivingThisChat = isArchiving && archivingChatId === chat.id;
 	const isExpanded = normalizedSearch ? true : (expandedById[chatID] ?? false);
 	const isExecuting =
@@ -556,8 +565,15 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 						<DialogHeader>
 							<DialogTitle>Archive agent and delete workspace</DialogTitle>
 							<DialogDescription>
-								Are you sure you want to archive this agent and delete its
-								workspace? This action cannot be undone.
+								{workspaceName ? (
+									<>
+										Are you sure you want to archive this agent and delete
+										workspace <strong>{workspaceName}</strong>? This action
+										cannot be undone.
+									</>
+								) : (
+									"Are you sure you want to archive this agent and delete its workspace? This action cannot be undone."
+								)}
 							</DialogDescription>
 						</DialogHeader>
 						<DialogFooter>

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -363,9 +363,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 				const c = chatById.get(id);
 				return c?.status === "pending" || c?.status === "running";
 			}));
-	const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
 	const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-
 	return (
 		<>
 			<div className="flex min-w-0 flex-col">
@@ -509,7 +507,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 												<DropdownMenuItem
 													className="text-content-destructive focus:text-content-destructive"
 													disabled={isArchiving}
-													onSelect={() => setArchiveConfirmOpen(true)}
+													onSelect={() => onArchiveAgent(chat.id)}
 												>
 													<ArchiveIcon className="h-3.5 w-3.5" />
 													Archive agent
@@ -545,42 +543,6 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 					</div>
 				)}
 			</div>
-			<Dialog
-				open={archiveConfirmOpen}
-				onOpenChange={(open) => {
-					if (!open) {
-						setArchiveConfirmOpen(false);
-					}
-				}}
-			>
-				<DialogContent variant="destructive">
-					<DialogHeader>
-						<DialogTitle>Archive agent</DialogTitle>
-						<DialogDescription>
-							Are you sure you want to archive this agent? This action cannot be
-							undone.
-						</DialogDescription>
-					</DialogHeader>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setArchiveConfirmOpen(false)}
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="destructive"
-							data-testid="confirm-button"
-							onClick={() => {
-								setArchiveConfirmOpen(false);
-								onArchiveAgent(chat.id);
-							}}
-						>
-							Archive
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
 			{workspaceId && (
 				<Dialog
 					open={deleteConfirmOpen}


### PR DESCRIPTION
Adds confirmation dialogs before archiving an agent or archiving an agent and deleting its workspace.

## Changes

Previously, clicking "Archive Agent" or "Archive & Delete Workspace" in the TopBar or sidebar dropdown menus would immediately trigger the destructive action with no confirmation step. This PR adds a `ConfirmDialog` (type `delete`) before proceeding in both locations:

- **`AgentDetailTopBar`** — the top bar's dropdown menu items now open a confirmation dialog
- **`AgentsSidebar` (`ChatTreeNode`)** — the sidebar's per-chat dropdown menu items now open a confirmation dialog

## Storybook Coverage

Added 8 new stories (4 per component):

| Story | Verifies |
|---|---|
| `ArchiveConfirmDialog` | Dialog opens when clicking "Archive Agent" |
| `ArchiveAndDeleteConfirmDialog` | Dialog opens when clicking "Archive & Delete Workspace" |
| `ArchiveConfirmDialogCallsHandler` | Confirming calls `onArchiveAgent` |
| `ArchiveAndDeleteConfirmDialogCallsHandler` | Confirming calls `onArchiveAndDeleteWorkspace` |