### PR TITLE
feat(site): add collapsible archived agents section to sidebar

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -364,13 +364,10 @@ export const ArchivedAgentsCollapsed: Story = {
 			expect(canvas.getByText("Active agent one")).toBeInTheDocument();
 			expect(canvas.getByText("Active agent two")).toBeInTheDocument();
 			expect(canvas.getByText("Archived (2)")).toBeInTheDocument();
-			});
-			expect(
-				canvas.queryByText("Archived agent one"),
-			).not.toBeInTheDocument();
-			expect(
-				canvas.queryByText("Archived agent two"),
-			).not.toBeInTheDocument();	},
+		});
+		expect(canvas.queryByText("Archived agent one")).not.toBeInTheDocument();
+		expect(canvas.queryByText("Archived agent two")).not.toBeInTheDocument();
+	},
 };
 
 export const ArchivedAgentsExpanded: Story = {

--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -363,15 +363,14 @@ export const ArchivedAgentsCollapsed: Story = {
 		await waitFor(() => {
 			expect(canvas.getByText("Active agent one")).toBeInTheDocument();
 			expect(canvas.getByText("Active agent two")).toBeInTheDocument();
-			expect(canvas.getByText("Archived")).toBeInTheDocument();
-		});
-		expect(
-			canvas.queryByText("Archived agent one"),
-		).not.toBeInTheDocument();
-		expect(
-			canvas.queryByText("Archived agent two"),
-		).not.toBeInTheDocument();
-	},
+			expect(canvas.getByText("Archived (2)")).toBeInTheDocument();
+			});
+			expect(
+				canvas.queryByText("Archived agent one"),
+			).not.toBeInTheDocument();
+			expect(
+				canvas.queryByText("Archived agent two"),
+			).not.toBeInTheDocument();	},
 };
 
 export const ArchivedAgentsExpanded: Story = {
@@ -408,9 +407,9 @@ export const ArchivedAgentsExpanded: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await waitFor(() => {
-			expect(canvas.getByText("Archived")).toBeInTheDocument();
+			expect(canvas.getByText("Archived (2)")).toBeInTheDocument();
 		});
-		await userEvent.click(canvas.getByText("Archived"));
+		await userEvent.click(canvas.getByText("Archived (2)"));
 		await waitFor(() => {
 			expect(canvas.getByText("Archived agent one")).toBeInTheDocument();
 			expect(canvas.getByText("Archived agent two")).toBeInTheDocument();
@@ -478,6 +477,6 @@ export const NoArchivedSection: Story = {
 			expect(canvas.getByText("First active agent")).toBeInTheDocument();
 			expect(canvas.getByText("Second active agent")).toBeInTheDocument();
 		});
-		expect(canvas.queryByText("Archived")).not.toBeInTheDocument();
+		expect(canvas.queryByText(/^Archived \(/)).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -59,6 +59,7 @@ const meta: Meta<typeof AgentsSidebar> = {
 		modelOptions: defaultModelOptions,
 		modelConfigs: defaultModelConfigs,
 		onArchiveAgent: fn(),
+		onArchiveAndDeleteWorkspace: fn(),
 		onNewAgent: fn(),
 		isCreating: false,
 	},
@@ -321,5 +322,162 @@ export const ActiveChatAncestryExpanded: Story = {
 		await expect(
 			canvas.getByTestId("agents-tree-toggle-child-active"),
 		).toHaveAttribute("aria-expanded", "true");
+	},
+};
+
+const todayTimestamp = new Date().toISOString();
+
+export const ArchivedAgentsCollapsed: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "active-1",
+				title: "Active agent one",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "active-2",
+				title: "Active agent two",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "archived-1",
+				title: "Archived agent one",
+				archived: true,
+			}),
+			buildChat({
+				id: "archived-2",
+				title: "Archived agent two",
+				archived: true,
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("Active agent one")).toBeInTheDocument();
+			expect(canvas.getByText("Active agent two")).toBeInTheDocument();
+			expect(canvas.getByText("Archived")).toBeInTheDocument();
+		});
+		expect(
+			canvas.queryByText("Archived agent one"),
+		).not.toBeInTheDocument();
+		expect(
+			canvas.queryByText("Archived agent two"),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const ArchivedAgentsExpanded: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "active-1",
+				title: "Active agent one",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "active-2",
+				title: "Active agent two",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "archived-1",
+				title: "Archived agent one",
+				archived: true,
+			}),
+			buildChat({
+				id: "archived-2",
+				title: "Archived agent two",
+				archived: true,
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("Archived")).toBeInTheDocument();
+		});
+		await userEvent.click(canvas.getByText("Archived"));
+		await waitFor(() => {
+			expect(canvas.getByText("Archived agent one")).toBeInTheDocument();
+			expect(canvas.getByText("Archived agent two")).toBeInTheDocument();
+		});
+	},
+};
+
+export const ArchivedAgentsSearchAutoExpands: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "active-task",
+				title: "Active task",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "old-archived",
+				title: "Old archived task",
+				archived: true,
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.type(
+			canvas.getByPlaceholderText("Search agents..."),
+			"archived",
+		);
+		await waitFor(() => {
+			expect(canvas.getByText("Old archived task")).toBeInTheDocument();
+		});
+	},
+};
+
+export const NoArchivedSection: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "chat-a",
+				title: "First active agent",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "chat-b",
+				title: "Second active agent",
+				updated_at: todayTimestamp,
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("First active agent")).toBeInTheDocument();
+			expect(canvas.getByText("Second active agent")).toBeInTheDocument();
+		});
+		expect(canvas.queryByText("Archived")).not.toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -578,9 +578,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 		[visibleRootIDs, chatById],
 	);
 	const effectiveArchivedExpanded =
-		normalizedSearch && archivedRootIDs.length > 0
-			? true
-			: isArchivedExpanded;
+		normalizedSearch && archivedRootIDs.length > 0 ? true : isArchivedExpanded;
 
 	// Auto-expand ancestors of the active chat so it's always visible.
 	useEffect(() => {
@@ -729,75 +727,90 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							</div>
 						</>
 					) : (
-							<ChatTreeContext.Provider value={chatTreeCtx}>
-								{activeRootIDs.length === 0 && archivedRootIDs.length === 0 ? (
-									<div className="rounded-lg border border-dashed border-border-default bg-surface-primary p-4 text-center text-xs text-content-secondary">
-										{normalizedSearch ? "No matching agents" : "No agents yet"}
-									</div>
-								) : (
-									<>
-										{TIME_GROUPS.map((group) => {
-											const groupChats = activeRootIDs
-												.map((id) => chatById.get(id))
-												.filter(
-													(chat): chat is Chat =>
-														chat !== undefined &&
-														getTimeGroup(chat.updated_at) === group,
-												);
-											if (groupChats.length === 0) return null;
-											return (
-												<div key={group}>
-													<div className="mb-1 ml-2.5 flex items-center justify-between text-xs font-medium text-content-secondary">
-														<span>{group}</span>
-													</div>
-													<div className="flex flex-col gap-0.5">
-														{groupChats.map((chat) => (
-															<ChatTreeNode
-																key={chat.id}
-																chat={chat}
-																isChildNode={false}
-															/>
-														))}
-													</div>
-												</div>
+						<ChatTreeContext.Provider value={chatTreeCtx}>
+							{activeRootIDs.length === 0 && archivedRootIDs.length === 0 ? (
+								<div className="rounded-lg border border-dashed border-border-default bg-surface-primary p-4 text-center text-xs text-content-secondary">
+									{normalizedSearch ? "No matching agents" : "No agents yet"}
+								</div>
+							) : (
+								<>
+									{TIME_GROUPS.map((group) => {
+										const groupChats = activeRootIDs
+											.map((id) => chatById.get(id))
+											.filter(
+												(chat): chat is Chat =>
+													chat !== undefined &&
+													getTimeGroup(chat.updated_at) === group,
 											);
-										})}
+										if (groupChats.length === 0) return null;
+										return (
+											<div key={group}>
+												<div className="mb-1 ml-2.5 flex items-center justify-between text-xs font-medium text-content-secondary">
+													<span>{group}</span>
+												</div>
+												<div className="flex flex-col gap-0.5">
+													{groupChats.map((chat) => (
+														<ChatTreeNode
+															key={chat.id}
+															chat={chat}
+															isChildNode={false}
+														/>
+													))}
+												</div>
+											</div>
+										);
+									})}
 
-											{archivedRootIDs.length > 0 && (
-												<Collapsible
-													open={effectiveArchivedExpanded}
-													onOpenChange={setIsArchivedExpanded}
-												>
-														<CollapsibleTrigger asChild>
-															<Button
-																variant="subtle"
-																className="mb-1 ml-2.5 h-auto min-w-0 gap-1 p-0 text-xs font-medium"
-															>
-																{effectiveArchivedExpanded ? (
-																	<ChevronDownIcon className="h-3 w-3" />
-																) : (
-																	<ChevronRightIcon className="h-3 w-3" />
-																)}
-																<ArchiveIcon className="h-3 w-3" />
-																<span>Archived</span>
-																<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
-															</Button>
-														</CollapsibleTrigger>													<CollapsibleContent>
-														<div className="flex flex-col gap-0.5">
-															{archivedRootIDs.map((id) => {
-																const chat = chatById.get(id);
-																if (!chat) return null;
-																return <ChatTreeNode key={chat.id} chat={chat} isChildNode={false} />;
-															})}
-														</div>
-													</CollapsibleContent>
-												</Collapsible>
-											)}									</>
-								)}
-							</ChatTreeContext.Provider>
-						)}
-					</div>
-				</ScrollArea>
+									{archivedRootIDs.length > 0 && (
+										<>
+											{activeRootIDs.length > 0 && (
+												<hr className="my-2 border-border-default" />
+											)}
+											<Collapsible
+												open={effectiveArchivedExpanded}
+												onOpenChange={setIsArchivedExpanded}
+											>
+												<CollapsibleTrigger asChild>
+													<Button
+														variant="subtle"
+														className="mb-1 ml-2.5 h-auto min-w-0 gap-1 p-0 text-xs font-medium"
+													>
+														{effectiveArchivedExpanded ? (
+															<ChevronDownIcon className="h-3 w-3" />
+														) : (
+															<ChevronRightIcon className="h-3 w-3" />
+														)}
+														<ArchiveIcon className="h-3 w-3" />
+														<span>Archived</span>
+														<span className="text-content-secondary/50">
+															({archivedRootIDs.length})
+														</span>
+													</Button>
+												</CollapsibleTrigger>{" "}
+												<CollapsibleContent>
+													<div className="flex flex-col gap-0.5">
+														{archivedRootIDs.map((id) => {
+															const chat = chatById.get(id);
+															if (!chat) return null;
+															return (
+																<ChatTreeNode
+																	key={chat.id}
+																	chat={chat}
+																	isChildNode={false}
+																/>
+															);
+														})}
+													</div>
+												</CollapsibleContent>
+											</Collapsible>
+										</>
+									)}
+								</>
+							)}{" "}
+						</ChatTreeContext.Provider>
+					)}
+				</div>
+			</ScrollArea>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -771,9 +771,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 											open={effectiveArchivedExpanded}
 											onOpenChange={setIsArchivedExpanded}
 										>
-											{" "}
-											<CollapsibleTrigger asChild>
-												<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
+												<CollapsibleTrigger asChild>												<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
 													<span>Archived ({archivedRootIDs.length})</span>
 													{effectiveArchivedExpanded ? (
 														<ChevronDownIcon className="h-3 w-3" />
@@ -781,9 +779,8 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 														<ChevronRightIcon className="h-3 w-3" />
 													)}
 												</div>
-											</CollapsibleTrigger>{" "}
-											<CollapsibleContent>
-												<div className="flex flex-col gap-0.5">
+												</CollapsibleTrigger>
+												<CollapsibleContent>												<div className="flex flex-col gap-0.5">
 													{archivedRootIDs.map((id) => {
 														const chat = chatById.get(id);
 														if (!chat) return null;
@@ -800,7 +797,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 										</Collapsible>
 									)}
 								</div>
-							)}{" "}
+							)}
 						</ChatTreeContext.Provider>
 					)}
 				</div>

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -764,40 +764,40 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 											})}
 										</div>
 									)}
-
-										{archivedRootIDs.length > 0 && (
-											<Collapsible
-												className="pt-2"
-												open={effectiveArchivedExpanded}
-												onOpenChange={setIsArchivedExpanded}
-											>
-												<CollapsibleTrigger asChild>
-													<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
-														<span>Archived ({archivedRootIDs.length})</span>
-														{effectiveArchivedExpanded ? (
-															<ChevronDownIcon className="h-3 w-3" />
-														) : (
-															<ChevronRightIcon className="h-3 w-3" />
-														)}
-													</div>
-												</CollapsibleTrigger>
-												<CollapsibleContent>
-													<div className="flex flex-col gap-0.5">
-														{archivedRootIDs.map((id) => {
-															const chat = chatById.get(id);
-															if (!chat) return null;
-															return (
-																<ChatTreeNode
-																	key={chat.id}
-																	chat={chat}
-																	isChildNode={false}
-																/>
-															);
-														})}
-													</div>
-												</CollapsibleContent>
-											</Collapsible>
-										)}								</div>
+									{archivedRootIDs.length > 0 && (
+										<Collapsible
+											className="pt-2"
+											open={effectiveArchivedExpanded}
+											onOpenChange={setIsArchivedExpanded}
+										>
+											<CollapsibleTrigger asChild>
+												<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
+													<span>Archived ({archivedRootIDs.length})</span>
+													{effectiveArchivedExpanded ? (
+														<ChevronDownIcon className="h-3 w-3" />
+													) : (
+														<ChevronRightIcon className="h-3 w-3" />
+													)}
+												</div>
+											</CollapsibleTrigger>
+											<CollapsibleContent>
+												<div className="flex flex-col gap-0.5">
+													{archivedRootIDs.map((id) => {
+														const chat = chatById.get(id);
+														if (!chat) return null;
+														return (
+															<ChatTreeNode
+																key={chat.id}
+																chat={chat}
+																isChildNode={false}
+															/>
+														);
+													})}
+												</div>
+											</CollapsibleContent>
+										</Collapsible>
+									)}{" "}
+								</div>
 							)}
 						</ChatTreeContext.Provider>
 					)}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -768,7 +768,8 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 													open={effectiveArchivedExpanded}
 													onOpenChange={setIsArchivedExpanded}
 												>
-													<CollapsibleTrigger className="mb-1 ml-0.5 flex w-full items-center gap-1 text-xs font-medium text-content-secondary hover:text-content-primary">
+													<CollapsibleTrigger asChild>
+														<button className="mb-1 ml-2.5 flex w-full items-center gap-1 border-0 bg-transparent p-0 text-xs font-medium text-content-secondary hover:text-content-primary">
 														{effectiveArchivedExpanded ? (
 															<ChevronDownIcon className="h-3 w-3" />
 														) : (
@@ -777,6 +778,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 														<ArchiveIcon className="h-3 w-3" />
 														<span>Archived</span>
 														<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
+														</button>
 													</CollapsibleTrigger>
 													<CollapsibleContent>
 														<div className="flex flex-col gap-0.5">

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -537,6 +537,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 	const [search, setSearch] = useState("");
 	const normalizedSearch = search.trim().toLowerCase();
 	const [expandedById, setExpandedById] = useState<Record<string, boolean>>({});
+	const [isArchivedExpanded, setIsArchivedExpanded] = useState(false);
 
 	const chatTree = useMemo(() => buildChatTree(chats), [chats]);
 	const chatById = useMemo(() => {
@@ -555,6 +556,26 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 		() => chatTree.rootIds.filter((chatID) => visibleChatIDs.has(chatID)),
 		[chatTree.rootIds, visibleChatIDs],
 	);
+	const activeRootIDs = useMemo(
+		() =>
+			visibleRootIDs.filter((id) => {
+				const chat = chatById.get(id);
+				return chat && !chat.archived;
+			}),
+		[visibleRootIDs, chatById],
+	);
+	const archivedRootIDs = useMemo(
+		() =>
+			visibleRootIDs.filter((id) => {
+				const chat = chatById.get(id);
+				return chat?.archived;
+			}),
+		[visibleRootIDs, chatById],
+	);
+	const effectiveArchivedExpanded =
+		normalizedSearch && archivedRootIDs.length > 0
+			? true
+			: isArchivedExpanded;
 
 	// Auto-expand ancestors of the active chat so it's always visible.
 	useEffect(() => {
@@ -703,43 +724,72 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							</div>
 						</>
 					) : (
-						<ChatTreeContext.Provider value={chatTreeCtx}>
-							{visibleRootIDs.length === 0 ? (
-								<div className="rounded-lg border border-dashed border-border-default bg-surface-primary p-4 text-center text-xs text-content-secondary">
-									{normalizedSearch ? "No matching agents" : "No agents yet"}
-								</div>
-							) : (
-								TIME_GROUPS.map((group) => {
-									const groupChats = visibleRootIDs
-										.map((id) => chatById.get(id))
-										.filter(
-											(chat): chat is Chat =>
-												chat !== undefined &&
-												getTimeGroup(chat.updated_at) === group,
-										);
-									if (groupChats.length === 0) return null;
-									return (
-										<div key={group}>
-											<div className="mb-1 ml-2.5 flex items-center justify-between text-xs font-medium text-content-secondary">
-												<span>{group}</span>
+							<ChatTreeContext.Provider value={chatTreeCtx}>
+								{activeRootIDs.length === 0 && archivedRootIDs.length === 0 ? (
+									<div className="rounded-lg border border-dashed border-border-default bg-surface-primary p-4 text-center text-xs text-content-secondary">
+										{normalizedSearch ? "No matching agents" : "No agents yet"}
+									</div>
+								) : (
+									<>
+										{TIME_GROUPS.map((group) => {
+											const groupChats = activeRootIDs
+												.map((id) => chatById.get(id))
+												.filter(
+													(chat): chat is Chat =>
+														chat !== undefined &&
+														getTimeGroup(chat.updated_at) === group,
+												);
+											if (groupChats.length === 0) return null;
+											return (
+												<div key={group}>
+													<div className="mb-1 ml-2.5 flex items-center justify-between text-xs font-medium text-content-secondary">
+														<span>{group}</span>
+													</div>
+													<div className="flex flex-col gap-0.5">
+														{groupChats.map((chat) => (
+															<ChatTreeNode
+																key={chat.id}
+																chat={chat}
+																isChildNode={false}
+															/>
+														))}
+													</div>
+												</div>
+											);
+										})}
+
+										{archivedRootIDs.length > 0 && (
+											<div>
+												<button
+													onClick={() => setIsArchivedExpanded((prev) => !prev)}
+													className="mb-1 ml-0.5 flex w-full items-center gap-1 text-xs font-medium text-content-secondary hover:text-content-primary"
+												>
+													{effectiveArchivedExpanded ? (
+														<ChevronDownIcon className="h-3 w-3" />
+													) : (
+														<ChevronRightIcon className="h-3 w-3" />
+													)}
+													<ArchiveIcon className="h-3 w-3" />
+													<span>Archived</span>
+													<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
+												</button>
+												{effectiveArchivedExpanded && (
+													<div className="flex flex-col gap-0.5">
+														{archivedRootIDs.map((id) => {
+															const chat = chatById.get(id);
+															if (!chat) return null;
+															return <ChatTreeNode key={chat.id} chat={chat} isChildNode={false} />;
+														})}
+													</div>
+												)}
 											</div>
-											<div className="flex flex-col gap-0.5">
-												{groupChats.map((chat) => (
-													<ChatTreeNode
-														key={chat.id}
-														chat={chat}
-														isChildNode={false}
-													/>
-												))}
-											</div>
-										</div>
-									);
-								})
-							)}
-						</ChatTreeContext.Provider>
-					)}
-				</div>
-			</ScrollArea>
+										)}
+									</>
+								)}
+							</ChatTreeContext.Provider>
+						)}
+					</div>
+				</ScrollArea>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -12,6 +12,7 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "components/Collapsible/Collapsible";
+import { Separator } from "components/Separator/Separator";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -764,8 +765,8 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									{archivedRootIDs.length > 0 && (
 										<>
 											{activeRootIDs.length > 0 && (
-												<hr className="my-2 border-border-default" />
-											)}
+												<Separator className="my-2" />
+											)}{" "}
 											<Collapsible
 												open={effectiveArchivedExpanded}
 												onOpenChange={setIsArchivedExpanded}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -768,19 +768,21 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 													open={effectiveArchivedExpanded}
 													onOpenChange={setIsArchivedExpanded}
 												>
-													<CollapsibleTrigger asChild>
-														<button className="mb-1 ml-2.5 flex w-full items-center gap-1 border-0 bg-transparent p-0 text-xs font-medium text-content-secondary hover:text-content-primary">
-														{effectiveArchivedExpanded ? (
-															<ChevronDownIcon className="h-3 w-3" />
-														) : (
-															<ChevronRightIcon className="h-3 w-3" />
-														)}
-														<ArchiveIcon className="h-3 w-3" />
-														<span>Archived</span>
-														<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
-														</button>
-													</CollapsibleTrigger>
-													<CollapsibleContent>
+														<CollapsibleTrigger asChild>
+															<Button
+																variant="subtle"
+																className="mb-1 ml-2.5 h-auto min-w-0 gap-1 p-0 text-xs font-medium"
+															>
+																{effectiveArchivedExpanded ? (
+																	<ChevronDownIcon className="h-3 w-3" />
+																) : (
+																	<ChevronRightIcon className="h-3 w-3" />
+																)}
+																<ArchiveIcon className="h-3 w-3" />
+																<span>Archived</span>
+																<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
+															</Button>
+														</CollapsibleTrigger>													<CollapsibleContent>
 														<div className="flex flex-col gap-0.5">
 															{archivedRootIDs.map((id) => {
 																const chat = chatById.get(id);

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -12,7 +12,6 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "components/Collapsible/Collapsible";
-import { Separator } from "components/Separator/Separator";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -734,72 +733,73 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									{normalizedSearch ? "No matching agents" : "No agents yet"}
 								</div>
 							) : (
-								<>
-									{TIME_GROUPS.map((group) => {
-										const groupChats = activeRootIDs
-											.map((id) => chatById.get(id))
-											.filter(
-												(chat): chat is Chat =>
-													chat !== undefined &&
-													getTimeGroup(chat.updated_at) === group,
-											);
-										if (groupChats.length === 0) return null;
-										return (
-											<div key={group}>
-												<div className="mb-1 ml-2.5 flex items-center justify-between text-xs font-medium text-content-secondary">
-													<span>{group}</span>
-												</div>
-												<div className="flex flex-col gap-0.5">
-													{groupChats.map((chat) => (
-														<ChatTreeNode
-															key={chat.id}
-															chat={chat}
-															isChildNode={false}
-														/>
-													))}
-												</div>
-											</div>
-										);
-									})}
-
-									{archivedRootIDs.length > 0 && (
-										<>
-											{activeRootIDs.length > 0 && (
-												<Separator className="my-2" />
-											)}{" "}
-											<Collapsible
-												open={effectiveArchivedExpanded}
-												onOpenChange={setIsArchivedExpanded}
-											>
-												<CollapsibleTrigger asChild>
-													<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
-														<span>Archived ({archivedRootIDs.length})</span>
-														{effectiveArchivedExpanded ? (
-															<ChevronDownIcon className="h-3 w-3" />
-														) : (
-															<ChevronRightIcon className="h-3 w-3" />
-														)}
-													</div>
-												</CollapsibleTrigger>{" "}
-												<CollapsibleContent>
-													<div className="flex flex-col gap-0.5">
-														{archivedRootIDs.map((id) => {
-															const chat = chatById.get(id);
-															if (!chat) return null;
-															return (
+								<div className="divide-y divide-border">
+									{activeRootIDs.length > 0 && (
+										<div className="pb-2">
+											{TIME_GROUPS.map((group) => {
+												const groupChats = activeRootIDs
+													.map((id) => chatById.get(id))
+													.filter(
+														(chat): chat is Chat =>
+															chat !== undefined &&
+															getTimeGroup(chat.updated_at) === group,
+													);
+												if (groupChats.length === 0) return null;
+												return (
+													<div key={group}>
+														<div className="mb-1 ml-2.5 flex items-center justify-between text-xs font-medium text-content-secondary">
+															<span>{group}</span>
+														</div>
+														<div className="flex flex-col gap-0.5">
+															{groupChats.map((chat) => (
 																<ChatTreeNode
 																	key={chat.id}
 																	chat={chat}
 																	isChildNode={false}
 																/>
-															);
-														})}
+															))}
+														</div>
 													</div>
-												</CollapsibleContent>
-											</Collapsible>
-										</>
+												);
+											})}
+										</div>
 									)}
-								</>
+
+									{archivedRootIDs.length > 0 && (
+										<Collapsible
+											className="pt-2"
+											open={effectiveArchivedExpanded}
+											onOpenChange={setIsArchivedExpanded}
+										>
+											{" "}
+											<CollapsibleTrigger asChild>
+												<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
+													<span>Archived ({archivedRootIDs.length})</span>
+													{effectiveArchivedExpanded ? (
+														<ChevronDownIcon className="h-3 w-3" />
+													) : (
+														<ChevronRightIcon className="h-3 w-3" />
+													)}
+												</div>
+											</CollapsibleTrigger>{" "}
+											<CollapsibleContent>
+												<div className="flex flex-col gap-0.5">
+													{archivedRootIDs.map((id) => {
+														const chat = chatById.get(id);
+														if (!chat) return null;
+														return (
+															<ChatTreeNode
+																key={chat.id}
+																chat={chat}
+																isChildNode={false}
+															/>
+														);
+													})}
+												</div>
+											</CollapsibleContent>
+										</Collapsible>
+									)}
+								</div>
 							)}{" "}
 						</ChatTreeContext.Provider>
 					)}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -772,21 +772,14 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 												onOpenChange={setIsArchivedExpanded}
 											>
 												<CollapsibleTrigger asChild>
-													<Button
-														variant="subtle"
-														className="mb-1 ml-2.5 h-auto min-w-0 gap-1 p-0 text-xs font-medium"
-													>
+													<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
+														<span>Archived ({archivedRootIDs.length})</span>
 														{effectiveArchivedExpanded ? (
 															<ChevronDownIcon className="h-3 w-3" />
 														) : (
 															<ChevronRightIcon className="h-3 w-3" />
 														)}
-														<ArchiveIcon className="h-3 w-3" />
-														<span>Archived</span>
-														<span className="text-content-secondary/50">
-															({archivedRootIDs.length})
-														</span>
-													</Button>
+													</div>
 												</CollapsibleTrigger>{" "}
 												<CollapsibleContent>
 													<div className="flex flex-col gap-0.5">

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -765,38 +765,39 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 										</div>
 									)}
 
-									{archivedRootIDs.length > 0 && (
-										<Collapsible
-											className="pt-2"
-											open={effectiveArchivedExpanded}
-											onOpenChange={setIsArchivedExpanded}
-										>
-												<CollapsibleTrigger asChild>												<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
-													<span>Archived ({archivedRootIDs.length})</span>
-													{effectiveArchivedExpanded ? (
-														<ChevronDownIcon className="h-3 w-3" />
-													) : (
-														<ChevronRightIcon className="h-3 w-3" />
-													)}
-												</div>
+										{archivedRootIDs.length > 0 && (
+											<Collapsible
+												className="pt-2"
+												open={effectiveArchivedExpanded}
+												onOpenChange={setIsArchivedExpanded}
+											>
+												<CollapsibleTrigger asChild>
+													<div className="mb-1 ml-2.5 flex cursor-pointer items-center justify-between text-xs font-medium text-content-secondary">
+														<span>Archived ({archivedRootIDs.length})</span>
+														{effectiveArchivedExpanded ? (
+															<ChevronDownIcon className="h-3 w-3" />
+														) : (
+															<ChevronRightIcon className="h-3 w-3" />
+														)}
+													</div>
 												</CollapsibleTrigger>
-												<CollapsibleContent>												<div className="flex flex-col gap-0.5">
-													{archivedRootIDs.map((id) => {
-														const chat = chatById.get(id);
-														if (!chat) return null;
-														return (
-															<ChatTreeNode
-																key={chat.id}
-																chat={chat}
-																isChildNode={false}
-															/>
-														);
-													})}
-												</div>
-											</CollapsibleContent>
-										</Collapsible>
-									)}
-								</div>
+												<CollapsibleContent>
+													<div className="flex flex-col gap-0.5">
+														{archivedRootIDs.map((id) => {
+															const chat = chatById.get(id);
+															if (!chat) return null;
+															return (
+																<ChatTreeNode
+																	key={chat.id}
+																	chat={chat}
+																	isChildNode={false}
+																/>
+															);
+														})}
+													</div>
+												</CollapsibleContent>
+											</Collapsible>
+										)}								</div>
 							)}
 						</ChatTreeContext.Provider>
 					)}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -8,6 +8,11 @@ import { ErrorAlert } from "components/Alert/ErrorAlert";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { Button } from "components/Button/Button";
 import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "components/Collapsible/Collapsible";
+import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
@@ -758,33 +763,32 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 											);
 										})}
 
-										{archivedRootIDs.length > 0 && (
-											<div>
-												<button
-													onClick={() => setIsArchivedExpanded((prev) => !prev)}
-													className="mb-1 ml-0.5 flex w-full items-center gap-1 text-xs font-medium text-content-secondary hover:text-content-primary"
+											{archivedRootIDs.length > 0 && (
+												<Collapsible
+													open={effectiveArchivedExpanded}
+													onOpenChange={setIsArchivedExpanded}
 												>
-													{effectiveArchivedExpanded ? (
-														<ChevronDownIcon className="h-3 w-3" />
-													) : (
-														<ChevronRightIcon className="h-3 w-3" />
-													)}
-													<ArchiveIcon className="h-3 w-3" />
-													<span>Archived</span>
-													<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
-												</button>
-												{effectiveArchivedExpanded && (
-													<div className="flex flex-col gap-0.5">
-														{archivedRootIDs.map((id) => {
-															const chat = chatById.get(id);
-															if (!chat) return null;
-															return <ChatTreeNode key={chat.id} chat={chat} isChildNode={false} />;
-														})}
-													</div>
-												)}
-											</div>
-										)}
-									</>
+													<CollapsibleTrigger className="mb-1 ml-0.5 flex w-full items-center gap-1 text-xs font-medium text-content-secondary hover:text-content-primary">
+														{effectiveArchivedExpanded ? (
+															<ChevronDownIcon className="h-3 w-3" />
+														) : (
+															<ChevronRightIcon className="h-3 w-3" />
+														)}
+														<ArchiveIcon className="h-3 w-3" />
+														<span>Archived</span>
+														<span className="text-content-secondary/50">({archivedRootIDs.length})</span>
+													</CollapsibleTrigger>
+													<CollapsibleContent>
+														<div className="flex flex-col gap-0.5">
+															{archivedRootIDs.map((id) => {
+																const chat = chatById.get(id);
+																if (!chat) return null;
+																return <ChatTreeNode key={chat.id} chat={chat} isChildNode={false} />;
+															})}
+														</div>
+													</CollapsibleContent>
+												</Collapsible>
+											)}									</>
 								)}
 							</ChatTreeContext.Provider>
 						)}


### PR DESCRIPTION
## Summary

Adds a collapsible **Archived** section at the bottom of the agents sidebar. Archived agents (`chat.archived === true`) are separated from active agents and displayed in their own section that is collapsed by default.

## Changes

### `AgentsSidebar.tsx`
- Split visible root chats into `activeRootIDs` and `archivedRootIDs`
- Active chats continue rendering in time groups (Today, Yesterday, This Week, Older)
- Added collapsible Archived section below active chats with:
  - Toggle button (chevron + archive icon + "Archived" label + count badge)
  - Collapsed by default
  - Auto-expands when a search query matches archived agents
- Empty state only shows when both active and archived lists are empty

### `AgentsSidebar.stories.tsx`
- Added 4 new stories: `ArchivedAgentsCollapsed`, `ArchivedAgentsExpanded`, `ArchivedAgentsSearchAutoExpands`, `NoArchivedSection`
- Fixed missing `onArchiveAndDeleteWorkspace` in story meta args