### PR TITLE
fix: wire agents-tab-visible metadata to experiments flag

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -28,6 +28,7 @@
 	<meta property="docs-url" content="{{ .DocsURL }}" />
 	<meta property="logo-url" content="{{ .LogoURL }}" />
 	<meta property="tasks-tab-visible" content="{{ .TasksTabVisible }}" />
+	<meta property="agents-tab-visible" content="{{ .AgentsTabVisible }}" />
 	<link
 		rel="alternate icon"
 		type="image/png"

--- a/site/site.go
+++ b/site/site.go
@@ -262,7 +262,8 @@ type htmlState struct {
 	Regions        string
 	DocsURL        string
 
-	TasksTabVisible string
+	TasksTabVisible  string
+	AgentsTabVisible string
 }
 
 type csrfState struct {
@@ -505,6 +506,16 @@ func (h *Handler) renderHTMLWithState(r *http.Request, filePath string, state ht
 				state.TasksTabVisible = html.EscapeString(string(tasksTabVisible))
 			}
 		}()
+		wg.Go(func() {
+			agentsTabVisible := false
+			if experiments != nil {
+				agentsTabVisible = experiments.Enabled(codersdk.ExperimentAgents)
+			}
+			data, err := json.Marshal(agentsTabVisible)
+			if err == nil {
+				state.AgentsTabVisible = html.EscapeString(string(data))
+			}
+		})
 		wg.Wait()
 	}
 


### PR DESCRIPTION
The frontend checks for an `agents-tab-visible` embedded metadata value to decide whether to show the **Agents** nav item, but the backend never populated it.

## Changes

- **`site/site.go`**: Add `AgentsTabVisible` field to `htmlState` and set it based on `experiments.Enabled(codersdk.ExperimentAgents)`.
- **`site/index.html`**: Add `<meta property="agents-tab-visible">` template tag.

When a deployment has `--experiments=agents` enabled, the Agents nav item will now appear.