### PR TITLE
feat(coderd): add GET /api/experimental/chats/stats endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -481,6 +481,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/chats/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat stats",
+                "operationId": "get-chat-stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start time (RFC 3339, inclusive)",
+                        "name": "start_time",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "End time (RFC 3339, exclusive)",
+                        "name": "end_time",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatStatsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/chats/{chat}/archive": {
             "post": {
                 "tags": [
@@ -13737,6 +13778,78 @@ const docTemplate = `{
                 },
                 "password": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatStatsResponse": {
+            "type": "object",
+            "properties": {
+                "active_users": {
+                    "type": "integer"
+                },
+                "by_status": {
+                    "$ref": "#/definitions/codersdk.ChatStatusCounts"
+                },
+                "end_time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "start_time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "total_assistant_messages": {
+                    "type": "integer"
+                },
+                "total_cache_creation_tokens": {
+                    "type": "integer"
+                },
+                "total_cache_read_tokens": {
+                    "type": "integer"
+                },
+                "total_chats": {
+                    "type": "integer"
+                },
+                "total_input_tokens": {
+                    "type": "integer"
+                },
+                "total_messages": {
+                    "type": "integer"
+                },
+                "total_output_tokens": {
+                    "type": "integer"
+                },
+                "total_reasoning_tokens": {
+                    "type": "integer"
+                },
+                "total_sub_chats": {
+                    "type": "integer"
+                },
+                "total_user_messages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatStatusCounts": {
+            "type": "object",
+            "properties": {
+                "completed": {
+                    "type": "integer"
+                },
+                "error": {
+                    "type": "integer"
+                },
+                "paused": {
+                    "type": "integer"
+                },
+                "pending": {
+                    "type": "integer"
+                },
+                "running": {
+                    "type": "integer"
+                },
+                "waiting": {
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -410,6 +410,43 @@
 				}
 			}
 		},
+		"/chats/stats": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat stats",
+				"operationId": "get-chat-stats",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Start time (RFC 3339, inclusive)",
+						"name": "start_time",
+						"in": "query",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "End time (RFC 3339, exclusive)",
+						"name": "end_time",
+						"in": "query",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatStatsResponse"
+						}
+					}
+				}
+			}
+		},
 		"/chats/{chat}/archive": {
 			"post": {
 				"tags": ["Chats"],
@@ -12310,6 +12347,78 @@
 				},
 				"password": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatStatsResponse": {
+			"type": "object",
+			"properties": {
+				"active_users": {
+					"type": "integer"
+				},
+				"by_status": {
+					"$ref": "#/definitions/codersdk.ChatStatusCounts"
+				},
+				"end_time": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"start_time": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"total_assistant_messages": {
+					"type": "integer"
+				},
+				"total_cache_creation_tokens": {
+					"type": "integer"
+				},
+				"total_cache_read_tokens": {
+					"type": "integer"
+				},
+				"total_chats": {
+					"type": "integer"
+				},
+				"total_input_tokens": {
+					"type": "integer"
+				},
+				"total_messages": {
+					"type": "integer"
+				},
+				"total_output_tokens": {
+					"type": "integer"
+				},
+				"total_reasoning_tokens": {
+					"type": "integer"
+				},
+				"total_sub_chats": {
+					"type": "integer"
+				},
+				"total_user_messages": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatStatusCounts": {
+			"type": "object",
+			"properties": {
+				"completed": {
+					"type": "integer"
+				},
+				"error": {
+					"type": "integer"
+				},
+				"paused": {
+					"type": "integer"
+				},
+				"pending": {
+					"type": "integer"
+				},
+				"running": {
+					"type": "integer"
+				},
+				"waiting": {
+					"type": "integer"
 				}
 			}
 		},

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -2214,6 +2214,87 @@ func convertChatDiffStatus(chatID uuid.UUID, status *database.ChatDiffStatus) co
 	return result
 }
 
+// chatStats returns deployment-level chat usage statistics for a time range.
+//
+// @Summary Get chat stats
+// @ID get-chat-stats
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param start_time query string true "Start time (RFC 3339, inclusive)"
+// @Param end_time query string true "End time (RFC 3339, exclusive)"
+// @Success 200 {object} codersdk.ChatStatsResponse
+// @Router /chats/stats [get]
+func (api *API) chatStats(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	p := httpapi.NewQueryParamParser().
+		RequiredNotEmpty("start_time").
+		RequiredNotEmpty("end_time")
+	vals := r.URL.Query()
+	startTime := p.Time3339Nano(vals, time.Time{}, "start_time")
+	endTime := p.Time3339Nano(vals, time.Time{}, "end_time")
+	p.ErrorExcessParams(vals)
+	if len(p.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: p.Errors,
+		})
+		return
+	}
+
+	if !endTime.After(startTime) {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Query parameter has invalid value.",
+			Validations: []codersdk.ValidationError{
+				{Field: "end_time", Detail: "end_time must be after start_time"},
+			},
+		})
+		return
+	}
+
+	row, err := api.Database.GetChatStats(ctx, database.GetChatStatsParams{
+		StartTime: startTime,
+		EndTime:   endTime,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get chat stats.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatStatsResponse{
+		StartTime:                startTime,
+		EndTime:                  endTime,
+		TotalChats:               row.TotalChats,
+		ActiveUsers:              row.ActiveUsers,
+		TotalSubChats:            row.TotalSubChats,
+		TotalMessages:            row.TotalMessages,
+		TotalUserMessages:        row.TotalUserMessages,
+		TotalAssistantMessages:   row.TotalAssistantMessages,
+		TotalInputTokens:         row.TotalInputTokens,
+		TotalOutputTokens:        row.TotalOutputTokens,
+		TotalReasoningTokens:     row.TotalReasoningTokens,
+		TotalCacheReadTokens:     row.TotalCacheReadTokens,
+		TotalCacheCreationTokens: row.TotalCacheCreationTokens,
+		ByStatus: codersdk.ChatStatusCounts{
+			Waiting:   row.StatusWaiting,
+			Pending:   row.StatusPending,
+			Running:   row.StatusRunning,
+			Paused:    row.StatusPaused,
+			Completed: row.StatusCompleted,
+			Error:     row.StatusError,
+		},
+	})
+}
+
 func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	//nolint:gocritic // System context required to read enabled chat providers.

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -2120,6 +2121,184 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
 		require.Equal(t, "Invalid queued message ID.", sdkErr.Message)
 		require.Contains(t, sdkErr.Detail, "invalid syntax")
+	})
+}
+
+func TestChatStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		_, secondUser := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		modelConfig := createChatModelConfig(t, client)
+
+		// Insert two top-level chats from different users.
+		chat1, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           firstUser.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "chat-stats-test-1",
+		})
+		require.NoError(t, err)
+
+		chat2, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           secondUser.ID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "chat-stats-test-2",
+		})
+		require.NoError(t, err)
+
+		// Insert a sub chat (parent_chat_id set). Counted separately
+		// from top-level chats, but its messages and tokens are
+		// included in the totals.
+		subChat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           firstUser.UserID,
+			LastModelConfigID: modelConfig.ID,
+			ParentChatID:      uuid.NullUUID{UUID: chat1.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: chat1.ID, Valid: true},
+			Title:             "subagent-chat",
+		})
+		require.NoError(t, err)
+
+		// Sub chat gets its own LLM interaction with token usage.
+		_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+			ChatID:     subChat.ID,
+			Role:       "user",
+			Content:    pqtype.NullRawMessage{RawMessage: json.RawMessage(`[{"type":"text","text":"delegated task"}]`), Valid: true},
+			Visibility: database.ChatMessageVisibilityBoth,
+		})
+		require.NoError(t, err)
+		_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+			ChatID:              subChat.ID,
+			ModelConfigID:       uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+			Role:                "assistant",
+			Content:             pqtype.NullRawMessage{RawMessage: json.RawMessage(`[{"type":"text","text":"done"}]`), Valid: true},
+			Visibility:          database.ChatMessageVisibilityBoth,
+			InputTokens:         sql.NullInt64{Int64: 200, Valid: true},
+			OutputTokens:        sql.NullInt64{Int64: 80, Valid: true},
+			ReasoningTokens:     sql.NullInt64{Int64: 15, Valid: true},
+			CacheReadTokens:     sql.NullInt64{Int64: 30, Valid: true},
+			CacheCreationTokens: sql.NullInt64{Int64: 10, Valid: true},
+		})
+		require.NoError(t, err)
+
+		// Insert a user message for chat1.
+		_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+			ChatID:     chat1.ID,
+			Role:       "user",
+			Content:    pqtype.NullRawMessage{RawMessage: json.RawMessage(`[{"type":"text","text":"hello"}]`), Valid: true},
+			Visibility: database.ChatMessageVisibilityBoth,
+		})
+		require.NoError(t, err)
+
+		// Insert an assistant message for chat1 with token usage.
+		_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+			ChatID:              chat1.ID,
+			ModelConfigID:       uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+			Role:                "assistant",
+			Content:             pqtype.NullRawMessage{RawMessage: json.RawMessage(`[{"type":"text","text":"hi there"}]`), Valid: true},
+			Visibility:          database.ChatMessageVisibilityBoth,
+			InputTokens:         sql.NullInt64{Int64: 100, Valid: true},
+			OutputTokens:        sql.NullInt64{Int64: 50, Valid: true},
+			ReasoningTokens:     sql.NullInt64{Int64: 10, Valid: true},
+			CacheReadTokens:     sql.NullInt64{Int64: 20, Valid: true},
+			CacheCreationTokens: sql.NullInt64{Int64: 5, Valid: true},
+		})
+		require.NoError(t, err)
+
+		// Insert a user message for chat2.
+		_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+			ChatID:     chat2.ID,
+			Role:       "user",
+			Content:    pqtype.NullRawMessage{RawMessage: json.RawMessage(`[{"type":"text","text":"hey"}]`), Valid: true},
+			Visibility: database.ChatMessageVisibilityBoth,
+		})
+		require.NoError(t, err)
+
+		startTime := chat1.CreatedAt.Add(-time.Hour)
+		endTime := chat2.CreatedAt.Add(time.Hour)
+
+		stats, err := client.GetChatStats(ctx, startTime, endTime)
+		require.NoError(t, err)
+
+		// Two top-level chats, one sub chat. Token/message totals
+		// include all chats so real LLM usage isn't undercounted.
+		require.Equal(t, int64(2), stats.TotalChats)
+		require.Equal(t, int64(1), stats.TotalSubChats)
+		require.Equal(t, int64(2), stats.ActiveUsers)
+		require.Equal(t, int64(5), stats.TotalMessages)             // 3 top-level + 2 sub chat
+		require.Equal(t, int64(3), stats.TotalUserMessages)         // 2 top-level + 1 sub chat
+		require.Equal(t, int64(2), stats.TotalAssistantMessages)    // 1 top-level + 1 sub chat
+		require.Equal(t, int64(300), stats.TotalInputTokens)        // 100 + 200
+		require.Equal(t, int64(130), stats.TotalOutputTokens)       // 50 + 80
+		require.Equal(t, int64(25), stats.TotalReasoningTokens)     // 10 + 15
+		require.Equal(t, int64(50), stats.TotalCacheReadTokens)     // 20 + 30
+		require.Equal(t, int64(15), stats.TotalCacheCreationTokens) // 5 + 10
+
+		// Both top-level chats default to "waiting" status.
+		require.Equal(t, int64(2), stats.ByStatus.Waiting)
+		require.Equal(t, int64(0), stats.ByStatus.Pending)
+		require.Equal(t, int64(0), stats.ByStatus.Running)
+		require.Equal(t, int64(0), stats.ByStatus.Paused)
+		require.Equal(t, int64(0), stats.ByStatus.Completed)
+		require.Equal(t, int64(0), stats.ByStatus.Error)
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+
+		now := time.Now()
+		_, err := memberClient.GetChatStats(ctx, now.Add(-time.Hour), now)
+		requireSDKError(t, err, http.StatusForbidden)
+	})
+
+	t.Run("EmptyRange", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		coderdtest.CreateFirstUser(t, client)
+
+		// A future time range with no chats should return zeros.
+		future := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+		stats, err := client.GetChatStats(ctx, future, future.Add(time.Hour))
+		require.NoError(t, err)
+		require.Equal(t, int64(0), stats.TotalChats)
+		require.Equal(t, int64(0), stats.ActiveUsers)
+		require.Equal(t, int64(0), stats.TotalMessages)
+		require.Equal(t, int64(0), stats.TotalInputTokens)
+	})
+
+	t.Run("EndTimeBeforeStartTime", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		coderdtest.CreateFirstUser(t, client)
+
+		now := time.Now()
+		_, err := client.GetChatStats(ctx, now, now.Add(-time.Hour))
+		requireSDKError(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("EqualStartAndEndTime", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		coderdtest.CreateFirstUser(t, client)
+
+		now := time.Now()
+		_, err := client.GetChatStats(ctx, now, now)
+		requireSDKError(t, err, http.StatusBadRequest)
 	})
 }
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1109,6 +1109,7 @@ func New(options *Options) *API {
 			r.Get("/", api.listChats)
 			r.Post("/", api.postChats)
 			r.Get("/models", api.listChatModels)
+			r.Get("/stats", api.chatStats)
 			r.Get("/watch", api.watchChats)
 			r.Route("/providers", func(r chi.Router) {
 				r.Get("/", api.listChatProviders)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2540,6 +2540,13 @@ func (q *querier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) (
 	return q.db.GetChatQueuedMessages(ctx, chatID)
 }
 
+func (q *querier) GetChatStats(ctx context.Context, arg database.GetChatStatsParams) (database.GetChatStatsRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return database.GetChatStatsRow{}, err
+	}
+	return q.db.GetChatStats(ctx, arg)
+}
+
 func (q *querier) GetChatsByOwnerID(ctx context.Context, ownerID database.GetChatsByOwnerIDParams) ([]database.Chat, error) {
 	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.GetChatsByOwnerID)(ctx, ownerID)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -527,6 +527,12 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatProviders(gomock.Any()).Return([]database.ChatProvider{providerA, providerB}, nil).AnyTimes()
 		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns([]database.ChatProvider{providerA, providerB})
 	}))
+	s.Run("GetChatStats", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		arg := testutil.Fake(s.T(), faker, database.GetChatStatsParams{})
+		row := testutil.Fake(s.T(), faker, database.GetChatStatsRow{})
+		dbm.EXPECT().GetChatStats(gomock.Any(), arg).Return(row, nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead).Returns(row)
+	}))
 	s.Run("GetChatsByOwnerID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		c1 := testutil.Fake(s.T(), faker, database.Chat{})
 		c2 := testutil.Fake(s.T(), faker, database.Chat{})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1087,6 +1087,14 @@ func (m queryMetricsStore) GetChatQueuedMessages(ctx context.Context, chatID uui
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatStats(ctx context.Context, arg database.GetChatStatsParams) (database.GetChatStatsRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatStats(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetChatStats").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatStats").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatsByOwnerID(ctx context.Context, ownerID database.GetChatsByOwnerIDParams) ([]database.Chat, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatsByOwnerID(ctx, ownerID)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1987,6 +1987,21 @@ func (mr *MockStoreMockRecorder) GetChatQueuedMessages(ctx, chatID any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatQueuedMessages", reflect.TypeOf((*MockStore)(nil).GetChatQueuedMessages), ctx, chatID)
 }
 
+// GetChatStats mocks base method.
+func (m *MockStore) GetChatStats(ctx context.Context, arg database.GetChatStatsParams) (database.GetChatStatsRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatStats", ctx, arg)
+	ret0, _ := ret[0].(database.GetChatStatsRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatStats indicates an expected call of GetChatStats.
+func (mr *MockStoreMockRecorder) GetChatStats(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatStats", reflect.TypeOf((*MockStore)(nil).GetChatStats), ctx, arg)
+}
+
 // GetChatsByOwnerID mocks base method.
 func (m *MockStore) GetChatsByOwnerID(ctx context.Context, arg database.GetChatsByOwnerIDParams) ([]database.Chat, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -228,6 +228,7 @@ type sqlcQuerier interface {
 	GetChatProviderByProvider(ctx context.Context, provider string) (ChatProvider, error)
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
+	GetChatStats(ctx context.Context, arg GetChatStatsParams) (GetChatStatsRow, error)
 	GetChatsByOwnerID(ctx context.Context, arg GetChatsByOwnerIDParams) ([]Chat, error)
 	GetConnectionLogsOffset(ctx context.Context, arg GetConnectionLogsOffsetParams) ([]GetConnectionLogsOffsetRow, error)
 	GetCoordinatorResumeTokenSigningKey(ctx context.Context) (string, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3340,6 +3340,101 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 	return items, nil
 }
 
+const getChatStats = `-- name: GetChatStats :one
+WITH filtered_chats AS (
+	SELECT
+		c.id, c.owner_id, c.status, c.parent_chat_id
+	FROM
+		chats c
+	WHERE
+		c.created_at >= $1::timestamptz
+		AND c.created_at < $2::timestamptz
+),
+chat_counts AS (
+	SELECT
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL)::bigint AS total_chats,
+		COUNT(DISTINCT fc.owner_id) FILTER (WHERE fc.parent_chat_id IS NULL)::bigint AS active_users,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NOT NULL)::bigint AS total_sub_chats,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'waiting')::bigint AS status_waiting,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'pending')::bigint AS status_pending,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'running')::bigint AS status_running,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'paused')::bigint AS status_paused,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'completed')::bigint AS status_completed,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'error')::bigint AS status_error
+	FROM
+		filtered_chats fc
+),
+message_counts AS (
+	SELECT
+		COUNT(*)::bigint AS total_messages,
+		COUNT(*) FILTER (WHERE cm.role = 'user')::bigint AS total_user_messages,
+		COUNT(*) FILTER (WHERE cm.role = 'assistant')::bigint AS total_assistant_messages,
+		COALESCE(SUM(cm.input_tokens), 0)::bigint AS total_input_tokens,
+		COALESCE(SUM(cm.output_tokens), 0)::bigint AS total_output_tokens,
+		COALESCE(SUM(cm.reasoning_tokens), 0)::bigint AS total_reasoning_tokens,
+		COALESCE(SUM(cm.cache_read_tokens), 0)::bigint AS total_cache_read_tokens,
+		COALESCE(SUM(cm.cache_creation_tokens), 0)::bigint AS total_cache_creation_tokens
+	FROM
+		chat_messages cm
+	JOIN
+		filtered_chats fc ON cm.chat_id = fc.id
+)
+SELECT
+	cc.total_chats, cc.active_users, cc.total_sub_chats, cc.status_waiting, cc.status_pending, cc.status_running, cc.status_paused, cc.status_completed, cc.status_error, mc.total_messages, mc.total_user_messages, mc.total_assistant_messages, mc.total_input_tokens, mc.total_output_tokens, mc.total_reasoning_tokens, mc.total_cache_read_tokens, mc.total_cache_creation_tokens
+FROM
+	chat_counts cc, message_counts mc
+`
+
+type GetChatStatsParams struct {
+	StartTime time.Time `db:"start_time" json:"start_time"`
+	EndTime   time.Time `db:"end_time" json:"end_time"`
+}
+
+type GetChatStatsRow struct {
+	TotalChats               int64 `db:"total_chats" json:"total_chats"`
+	ActiveUsers              int64 `db:"active_users" json:"active_users"`
+	TotalSubChats            int64 `db:"total_sub_chats" json:"total_sub_chats"`
+	StatusWaiting            int64 `db:"status_waiting" json:"status_waiting"`
+	StatusPending            int64 `db:"status_pending" json:"status_pending"`
+	StatusRunning            int64 `db:"status_running" json:"status_running"`
+	StatusPaused             int64 `db:"status_paused" json:"status_paused"`
+	StatusCompleted          int64 `db:"status_completed" json:"status_completed"`
+	StatusError              int64 `db:"status_error" json:"status_error"`
+	TotalMessages            int64 `db:"total_messages" json:"total_messages"`
+	TotalUserMessages        int64 `db:"total_user_messages" json:"total_user_messages"`
+	TotalAssistantMessages   int64 `db:"total_assistant_messages" json:"total_assistant_messages"`
+	TotalInputTokens         int64 `db:"total_input_tokens" json:"total_input_tokens"`
+	TotalOutputTokens        int64 `db:"total_output_tokens" json:"total_output_tokens"`
+	TotalReasoningTokens     int64 `db:"total_reasoning_tokens" json:"total_reasoning_tokens"`
+	TotalCacheReadTokens     int64 `db:"total_cache_read_tokens" json:"total_cache_read_tokens"`
+	TotalCacheCreationTokens int64 `db:"total_cache_creation_tokens" json:"total_cache_creation_tokens"`
+}
+
+func (q *sqlQuerier) GetChatStats(ctx context.Context, arg GetChatStatsParams) (GetChatStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getChatStats, arg.StartTime, arg.EndTime)
+	var i GetChatStatsRow
+	err := row.Scan(
+		&i.TotalChats,
+		&i.ActiveUsers,
+		&i.TotalSubChats,
+		&i.StatusWaiting,
+		&i.StatusPending,
+		&i.StatusRunning,
+		&i.StatusPaused,
+		&i.StatusCompleted,
+		&i.StatusError,
+		&i.TotalMessages,
+		&i.TotalUserMessages,
+		&i.TotalAssistantMessages,
+		&i.TotalInputTokens,
+		&i.TotalOutputTokens,
+		&i.TotalReasoningTokens,
+		&i.TotalCacheReadTokens,
+		&i.TotalCacheCreationTokens,
+	)
+	return i, err
+}
+
 const getChatsByOwnerID = `-- name: GetChatsByOwnerID :many
 SELECT
     id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -411,3 +411,47 @@ RETURNING *;
 
 -- name: GetChatByIDForUpdate :one
 SELECT * FROM chats WHERE id = @id::uuid FOR UPDATE;
+
+-- name: GetChatStats :one
+WITH filtered_chats AS (
+	SELECT
+		c.id, c.owner_id, c.status, c.parent_chat_id
+	FROM
+		chats c
+	WHERE
+		c.created_at >= @start_time::timestamptz
+		AND c.created_at < @end_time::timestamptz
+),
+chat_counts AS (
+	SELECT
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL)::bigint AS total_chats,
+		COUNT(DISTINCT fc.owner_id) FILTER (WHERE fc.parent_chat_id IS NULL)::bigint AS active_users,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NOT NULL)::bigint AS total_sub_chats,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'waiting')::bigint AS status_waiting,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'pending')::bigint AS status_pending,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'running')::bigint AS status_running,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'paused')::bigint AS status_paused,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'completed')::bigint AS status_completed,
+		COUNT(*) FILTER (WHERE fc.parent_chat_id IS NULL AND fc.status = 'error')::bigint AS status_error
+	FROM
+		filtered_chats fc
+),
+message_counts AS (
+	SELECT
+		COUNT(*)::bigint AS total_messages,
+		COUNT(*) FILTER (WHERE cm.role = 'user')::bigint AS total_user_messages,
+		COUNT(*) FILTER (WHERE cm.role = 'assistant')::bigint AS total_assistant_messages,
+		COALESCE(SUM(cm.input_tokens), 0)::bigint AS total_input_tokens,
+		COALESCE(SUM(cm.output_tokens), 0)::bigint AS total_output_tokens,
+		COALESCE(SUM(cm.reasoning_tokens), 0)::bigint AS total_reasoning_tokens,
+		COALESCE(SUM(cm.cache_read_tokens), 0)::bigint AS total_cache_read_tokens,
+		COALESCE(SUM(cm.cache_creation_tokens), 0)::bigint AS total_cache_creation_tokens
+	FROM
+		chat_messages cm
+	JOIN
+		filtered_chats fc ON cm.chat_id = fc.id
+)
+SELECT
+	cc.*, mc.*
+FROM
+	chat_counts cc, message_counts mc;

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -502,6 +502,35 @@ type chatStreamEnvelope struct {
 	Data json.RawMessage     `json:"data,omitempty"`
 }
 
+// ChatStatusCounts is the number of chats in each status.
+type ChatStatusCounts struct {
+	Waiting   int64 `json:"waiting"`
+	Pending   int64 `json:"pending"`
+	Running   int64 `json:"running"`
+	Paused    int64 `json:"paused"`
+	Completed int64 `json:"completed"`
+	Error     int64 `json:"error"`
+}
+
+// ChatStatsResponse contains deployment-level chat usage statistics
+// over a given time range.
+type ChatStatsResponse struct {
+	StartTime                time.Time        `json:"start_time" format:"date-time"`
+	EndTime                  time.Time        `json:"end_time" format:"date-time"`
+	TotalChats               int64            `json:"total_chats"`
+	ActiveUsers              int64            `json:"active_users"`
+	TotalSubChats            int64            `json:"total_sub_chats"`
+	TotalMessages            int64            `json:"total_messages"`
+	TotalUserMessages        int64            `json:"total_user_messages"`
+	TotalAssistantMessages   int64            `json:"total_assistant_messages"`
+	TotalInputTokens         int64            `json:"total_input_tokens"`
+	TotalOutputTokens        int64            `json:"total_output_tokens"`
+	TotalReasoningTokens     int64            `json:"total_reasoning_tokens"`
+	TotalCacheReadTokens     int64            `json:"total_cache_read_tokens"`
+	TotalCacheCreationTokens int64            `json:"total_cache_creation_tokens"`
+	ByStatus                 ChatStatusCounts `json:"by_status"`
+}
+
 // ListChatsOptions are optional parameters for ListChats.
 type ListChatsOptions struct {
 	Archived *bool
@@ -523,6 +552,26 @@ func (c *Client) ListChats(ctx context.Context, opts *ListChatsOptions) ([]Chat,
 	}
 	var chats []Chat
 	return chats, json.NewDecoder(res.Body).Decode(&chats)
+}
+
+// GetChatStats returns deployment-level chat usage statistics for the
+// given time range.
+func (c *Client) GetChatStats(ctx context.Context, startTime, endTime time.Time) (ChatStatsResponse, error) {
+	qp := url.Values{}
+	qp.Add("start_time", startTime.Format(time.RFC3339))
+	qp.Add("end_time", endTime.Format(time.RFC3339))
+	res, err := c.Request(ctx, http.MethodGet,
+		fmt.Sprintf("/api/experimental/chats/stats?%s", qp.Encode()),
+		nil)
+	if err != nil {
+		return ChatStatsResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatStatsResponse{}, ReadBodyAsError(res)
+	}
+	var stats ChatStatsResponse
+	return stats, json.NewDecoder(res.Body).Decode(&stats)
 }
 
 // ListChatModels returns the available chat model catalog.

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -1,5 +1,63 @@
 # Chats
 
+## Get chat stats
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/chats/stats?start_time=string&end_time=string \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /chats/stats`
+
+### Parameters
+
+| Name         | In    | Type   | Required | Description                      |
+|--------------|-------|--------|----------|----------------------------------|
+| `start_time` | query | string | true     | Start time (RFC 3339, inclusive) |
+| `end_time`   | query | string | true     | End time (RFC 3339, exclusive)   |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "active_users": 0,
+  "by_status": {
+    "completed": 0,
+    "error": 0,
+    "paused": 0,
+    "pending": 0,
+    "running": 0,
+    "waiting": 0
+  },
+  "end_time": "2019-08-24T14:15:22Z",
+  "start_time": "2019-08-24T14:15:22Z",
+  "total_assistant_messages": 0,
+  "total_cache_creation_tokens": 0,
+  "total_cache_read_tokens": 0,
+  "total_chats": 0,
+  "total_input_tokens": 0,
+  "total_messages": 0,
+  "total_output_tokens": 0,
+  "total_reasoning_tokens": 0,
+  "total_sub_chats": 0,
+  "total_user_messages": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                             |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatStatsResponse](schemas.md#codersdkchatstatsresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Archive a chat
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1547,6 +1547,77 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `one_time_passcode` | string | true     |              |             |
 | `password`          | string | true     |              |             |
 
+## codersdk.ChatStatsResponse
+
+```json
+{
+  "active_users": 0,
+  "by_status": {
+    "completed": 0,
+    "error": 0,
+    "paused": 0,
+    "pending": 0,
+    "running": 0,
+    "waiting": 0
+  },
+  "end_time": "2019-08-24T14:15:22Z",
+  "start_time": "2019-08-24T14:15:22Z",
+  "total_assistant_messages": 0,
+  "total_cache_creation_tokens": 0,
+  "total_cache_read_tokens": 0,
+  "total_chats": 0,
+  "total_input_tokens": 0,
+  "total_messages": 0,
+  "total_output_tokens": 0,
+  "total_reasoning_tokens": 0,
+  "total_sub_chats": 0,
+  "total_user_messages": 0
+}
+```
+
+### Properties
+
+| Name                          | Type                                                   | Required | Restrictions | Description |
+|-------------------------------|--------------------------------------------------------|----------|--------------|-------------|
+| `active_users`                | integer                                                | false    |              |             |
+| `by_status`                   | [codersdk.ChatStatusCounts](#codersdkchatstatuscounts) | false    |              |             |
+| `end_time`                    | string                                                 | false    |              |             |
+| `start_time`                  | string                                                 | false    |              |             |
+| `total_assistant_messages`    | integer                                                | false    |              |             |
+| `total_cache_creation_tokens` | integer                                                | false    |              |             |
+| `total_cache_read_tokens`     | integer                                                | false    |              |             |
+| `total_chats`                 | integer                                                | false    |              |             |
+| `total_input_tokens`          | integer                                                | false    |              |             |
+| `total_messages`              | integer                                                | false    |              |             |
+| `total_output_tokens`         | integer                                                | false    |              |             |
+| `total_reasoning_tokens`      | integer                                                | false    |              |             |
+| `total_sub_chats`             | integer                                                | false    |              |             |
+| `total_user_messages`         | integer                                                | false    |              |             |
+
+## codersdk.ChatStatusCounts
+
+```json
+{
+  "completed": 0,
+  "error": 0,
+  "paused": 0,
+  "pending": 0,
+  "running": 0,
+  "waiting": 0
+}
+```
+
+### Properties
+
+| Name        | Type    | Required | Restrictions | Description |
+|-------------|---------|----------|--------------|-------------|
+| `completed` | integer | false    |              |             |
+| `error`     | integer | false    |              |             |
+| `paused`    | integer | false    |              |             |
+| `pending`   | integer | false    |              |             |
+| `running`   | integer | false    |              |             |
+| `waiting`   | integer | false    |              |             |
+
 ## codersdk.ConnectionLatency
 
 ```json

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1480,6 +1480,28 @@ export interface ChatQueuedMessage {
 }
 
 // From codersdk/chats.go
+/**
+ * ChatStatsResponse contains deployment-level chat usage statistics
+ * over a given time range.
+ */
+export interface ChatStatsResponse {
+	readonly start_time: string;
+	readonly end_time: string;
+	readonly total_chats: number;
+	readonly active_users: number;
+	readonly total_sub_chats: number;
+	readonly total_messages: number;
+	readonly total_user_messages: number;
+	readonly total_assistant_messages: number;
+	readonly total_input_tokens: number;
+	readonly total_output_tokens: number;
+	readonly total_reasoning_tokens: number;
+	readonly total_cache_read_tokens: number;
+	readonly total_cache_creation_tokens: number;
+	readonly by_status: ChatStatusCounts;
+}
+
+// From codersdk/chats.go
 export type ChatStatus =
 	| "completed"
 	| "error"
@@ -1487,6 +1509,19 @@ export type ChatStatus =
 	| "pending"
 	| "running"
 	| "waiting";
+
+// From codersdk/chats.go
+/**
+ * ChatStatusCounts is the number of chats in each status.
+ */
+export interface ChatStatusCounts {
+	readonly waiting: number;
+	readonly pending: number;
+	readonly running: number;
+	readonly paused: number;
+	readonly completed: number;
+	readonly error: number;
+}
 
 export const ChatStatuses: ChatStatus[] = [
 	"completed",


### PR DESCRIPTION
Add an admin-only endpoint that returns deployment-level chat usage
statistics over a time range. Returns chat counts, active users,
message counts by role, token usage totals, and per-status breakdowns.

Sub chats (spawned by subagent delegation) are counted separately via
total_sub_chats, but their messages and token usage are included in
the totals so real LLM consumption is not undercounted. Chat counts,
active users, and by_status only reflect top-level conversations.

Authorization uses ResourceDeploymentConfig + ActionRead, matching
the existing chat admin endpoints.
