### PR TITLE
ci: remove ci action to push schema to sqlc cloud

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -978,12 +978,3 @@ jobs:
       # We need golang to run the migration main.go
       - name: Setup Go
         uses: ./.github/actions/setup-go
-
-      - name: Setup sqlc
-        uses: ./.github/actions/setup-sqlc
-
-      - name: Push schema to sqlc cloud
-        # Don't block a release on this
-        continue-on-error: true
-        run: |
-          make sqlc-push


### PR DESCRIPTION
SQLc cloud no longer exists

