### PR TITLE
fix(site): remove stale ArchivedAgentsSearchAutoExpands story

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -389,38 +389,6 @@ export const ArchivedAgentsExpanded: Story = {
 	},
 };
 
-export const ArchivedAgentsSearchAutoExpands: Story = {
-	args: {
-		chats: [
-			buildChat({
-				id: "active-task",
-				title: "Active task",
-				updated_at: todayTimestamp,
-			}),
-			buildChat({
-				id: "old-archived",
-				title: "Old archived task",
-				archived: true,
-			}),
-		],
-	},
-	parameters: {
-		reactRouter: reactRouterParameters({
-			location: { path: "/agents" },
-			routing: agentsRouting,
-		}),
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.type(
-			canvas.getByPlaceholderText("Search agents..."),
-			"archived",
-		);
-		await waitFor(() => {
-			expect(canvas.getByText("Old archived task")).toBeInTheDocument();
-		});
-	},
-};
 
 export const NoArchivedSection: Story = {
 	args: {

--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -389,7 +389,6 @@ export const ArchivedAgentsExpanded: Story = {
 	},
 };
 
-
 export const NoArchivedSection: Story = {
 	args: {
 		chats: [


### PR DESCRIPTION
The search input was removed from `AgentsSidebar` but the `ArchivedAgentsSearchAutoExpands` story still referenced the `Search agents...` placeholder, causing the Storybook interaction test to fail:

```
within(<div#storybook-root>).getByPlaceholderText("Search agents...")
Unable to find an element with the placeholder text of: Search agents...
```

This PR removes the stale story.