### PR TITLE
fix(site): open View Workspace link in new window on agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -871,7 +871,7 @@ const AgentDetail: FC = () => {
 		if (!workspaceRoute) {
 			return;
 		}
-		navigate(workspaceRoute);
+		window.open(workspaceRoute, "_blank");
 	};
 
 	const handleOpenTerminal = () => {


### PR DESCRIPTION
On the `/agents` page, the "View Workspace" link in the header dropdown menu was navigating in the same tab via `navigate()`. This changes it to `window.open(workspaceRoute, "_blank")` so it opens in a new browser window/tab instead.

It's frustrating when I want to view my workspace and then I have to go back and find my chat.