### PR TITLE
fix(agents): remove optimistic message rendering and fix auto-promote delivery

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1766,11 +1766,7 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 					} else {
 						status = database.ChatStatusPending
 
-						sdkMsg := db2sdk.ChatMessage(msg)
-						p.publishEvent(chat.ID, codersdk.ChatStreamEvent{
-							Type:    codersdk.ChatStreamEventTypeMessage,
-							Message: &sdkMsg,
-						})
+						p.publishMessage(chat.ID, msg)
 
 						remaining, qErr := tx.GetChatQueuedMessages(cleanupCtx, chat.ID)
 						if qErr == nil {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -18,15 +18,15 @@ export const chat = (chatId: string) => ({
 
 export const createChat = (queryClient: QueryClient) => ({
 	mutationFn: (req: TypesGen.CreateChatRequest) => API.createChat(req),
-	onSuccess: async () => {
-		await queryClient.invalidateQueries({ queryKey: chatsKey });
+	onSuccess: () => {
+		void queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
 });
 
 export const archiveChat = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) => API.archiveChat(chatId),
-	onSuccess: async () => {
-		await queryClient.invalidateQueries({ queryKey: chatsKey });
+	onSuccess: () => {
+		void queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
 });
 
@@ -36,8 +36,8 @@ export const createChatMessage = (
 ) => ({
 	mutationFn: (req: TypesGen.CreateChatMessageRequest) =>
 		API.createChatMessage(chatId, req),
-	onSuccess: async () => {
-		await queryClient.invalidateQueries({ queryKey: chatsKey });
+	onSuccess: () => {
+		void queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
 });
 
@@ -49,18 +49,16 @@ type EditChatMessageMutationArgs = {
 export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 	mutationFn: ({ messageId, req }: EditChatMessageMutationArgs) =>
 		API.editChatMessage(chatId, messageId, req),
-	onSuccess: async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({ queryKey: chatsKey }),
-			queryClient.invalidateQueries({ queryKey: chatKey(chatId) }),
-		]);
+	onSuccess: () => {
+		void queryClient.invalidateQueries({ queryKey: chatsKey });
+		void queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 	},
 });
 
 export const interruptChat = (queryClient: QueryClient, chatId: string) => ({
 	mutationFn: () => API.interruptChat(chatId),
-	onSuccess: async () => {
-		await queryClient.invalidateQueries({ queryKey: chatsKey });
+	onSuccess: () => {
+		void queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
 });
 
@@ -81,11 +79,9 @@ export const promoteChatQueuedMessage = (
 ) => ({
 	mutationFn: (queuedMessageId: number) =>
 		API.promoteChatQueuedMessage(chatId, queuedMessageId),
-	onSuccess: async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({ queryKey: chatsKey }),
-			queryClient.invalidateQueries({ queryKey: chatKey(chatId) }),
-		]);
+	onSuccess: () => {
+		void queryClient.invalidateQueries({ queryKey: chatsKey });
+		void queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 	},
 });
 

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -82,9 +82,6 @@ interface AgentChatInputProps {
 	// Pass `null` to render fallback values (e.g. when limit is unknown).
 	// Omit entirely to hide the indicator.
 	contextUsage?: AgentContextUsage | null;
-	// When true the entire input sticks to the bottom of the scroll
-	// container (used in the detail page).
-	sticky?: boolean;
 }
 
 const hasFiniteTokenValue = (value: number | undefined): value is number =>
@@ -239,7 +236,6 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 		isEditingHistoryMessage = false,
 		onCancelHistoryEdit,
 		contextUsage,
-		sticky = false,
 	}) => {
 		const internalRef = useRef<ChatMessageInputRef>(null);
 
@@ -296,7 +292,6 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 			}
 
 			onSend(text);
-			internalRef.current?.clear();
 			internalRef.current?.focus();
 		}, [
 			isDisabled,
@@ -396,7 +391,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 						initialValue={initialValue}
 						onChange={handleContentChange}
 						onEnter={handleSubmit}
-						disabled={isDisabled}
+						disabled={isDisabled || isLoading}
 						rows={4}
 						autoFocus
 					/>
@@ -466,12 +461,6 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 				</div>
 			</div>
 		);
-
-		if (sticky) {
-			return (
-				<div className="sticky bottom-0 z-50 bg-surface-primary">{content}</div>
-			);
-		}
 
 		return content;
 	},

--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -201,6 +201,98 @@ type Story = StoryObj<typeof AgentDetailLayout>;
 // Stories
 // ---------------------------------------------------------------------------
 
+/** Multi-turn conversation with message history and the chat input visible. */
+export const WithMessageHistory: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				chat: {
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Help me refactor this module",
+					status: "completed",
+				},
+				messages: [
+					{
+						id: 1,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:01:00.000Z",
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: "Can you help me refactor the authentication module? It's gotten pretty messy.",
+							},
+						],
+					},
+					{
+						id: 2,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:01:30.000Z",
+						role: "assistant",
+						content: [
+							{
+								type: "text",
+								text: "Sure! I'll start by looking at the current structure. The main issues I can see are:\n\n1. **Mixed concerns** — token validation and session management are interleaved\n2. **No error hierarchy** — all auth errors are treated the same\n3. **Duplicated middleware** — the same checks appear in three places\n\nLet me propose a cleaner separation.",
+							},
+						],
+					},
+					{
+						id: 3,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:02:00.000Z",
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: "That sounds right. Can you start with the token validation? I want to make sure we handle JWT expiration properly.",
+							},
+						],
+					},
+					{
+						id: 4,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:02:30.000Z",
+						role: "assistant",
+						content: [
+							{
+								type: "text",
+								text: "Here's the refactored token validation:\n\n```go\nfunc ValidateToken(ctx context.Context, token string) (*Claims, error) {\n    claims, err := parseToken(token)\n    if err != nil {\n        return nil, ErrInvalidToken\n    }\n    if claims.ExpiresAt.Before(time.Now()) {\n        return nil, ErrTokenExpired\n    }\n    return claims, nil\n}\n```\n\nKey changes:\n- Separated parsing from expiration checking\n- Added typed errors (`ErrInvalidToken`, `ErrTokenExpired`) so callers can distinguish between a malformed token and an expired one\n- The context parameter allows us to add tracing later",
+							},
+						],
+					},
+					{
+						id: 5,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:03:00.000Z",
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: "Looks good. Now what about the middleware deduplication?",
+							},
+						],
+					},
+					{
+						id: 6,
+						chat_id: CHAT_ID,
+						created_at: "2026-02-18T00:03:30.000Z",
+						role: "assistant",
+						content: [
+							{
+								type: "text",
+								text: "I've consolidated the three middleware instances into a single composable chain:\n\n```go\nfunc AuthMiddleware(opts ...AuthOption) func(http.Handler) http.Handler {\n    cfg := defaultAuthConfig()\n    for _, opt := range opts {\n        opt(&cfg)\n    }\n    return func(next http.Handler) http.Handler {\n        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n            claims, err := ValidateToken(r.Context(), extractToken(r))\n            if err != nil {\n                cfg.ErrorHandler(w, r, err)\n                return\n            }\n            ctx := context.WithValue(r.Context(), claimsKey, claims)\n            next.ServeHTTP(w, r.WithContext(ctx))\n        })\n    }\n}\n```\n\nThe functional options pattern lets each route customize behavior (e.g. optional auth, different error responses) without duplicating the core logic.",
+							},
+						],
+					},
+				],
+				queued_messages: [],
+			},
+			{ diffUrl: undefined },
+		),
+	},
+};
+
 /** Skeleton placeholder when no query data is available yet. */
 export const Loading: Story = {};
 

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -88,23 +88,6 @@ const isChatMessage = (
 	message: TypesGen.ChatMessage | undefined,
 ): message is TypesGen.ChatMessage => Boolean(message);
 
-const toOptimisticMessageParts = (
-	inputParts: readonly TypesGen.ChatInputPart[],
-): readonly TypesGen.ChatMessagePart[] =>
-	inputParts.map((part) => ({
-		type: "text",
-		...(part.text !== undefined ? { text: part.text } : {}),
-	}));
-
-const getOrderedMessagesFromStore = (
-	store: ChatStoreHandle,
-): readonly TypesGen.ChatMessage[] => {
-	const snapshot = store.getSnapshot();
-	return snapshot.orderedMessageIDs
-		.map((messageID) => snapshot.messagesByID.get(messageID))
-		.filter(isChatMessage);
-};
-
 interface AgentDetailTimelineProps {
 	store: ChatStoreHandle;
 	chatID: string;
@@ -298,54 +281,15 @@ const AgentDetailInput: FC<AgentDetailInputProps> = ({
 			modelSelectorPlaceholder={modelSelectorPlaceholder}
 			inputStatusText={inputStatusText}
 			modelCatalogStatusMessage={modelCatalogStatusMessage}
-			sticky
 		/>
 	);
 };
 
-interface AgentDetailConversationProps {
-	store: ChatStoreHandle;
-	chatID: string;
-	persistedErrorReason: string | undefined;
-	compressionThreshold: number | undefined;
-	onDeleteQueuedMessage: (id: number) => Promise<void>;
-	onPromoteQueuedMessage: (id: number) => Promise<void>;
+function useConversationEditingState(deps: {
 	onSend: (message: string, editedMessageID?: number) => Promise<void>;
-	onInterrupt: () => void;
-	isInputDisabled: boolean;
-	isSendPending: boolean;
-	isInterruptPending: boolean;
-	hasModelOptions: boolean;
-	selectedModel: string;
-	onModelChange: (modelID: string) => void;
-	modelOptions: readonly ModelSelectorOption[];
-	modelSelectorPlaceholder: string;
-	inputStatusText: string | null;
-	modelCatalogStatusMessage: string | null;
-	savingMessageId?: number | null;
-}
-
-const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
-	store,
-	chatID,
-	persistedErrorReason,
-	compressionThreshold,
-	onDeleteQueuedMessage,
-	onPromoteQueuedMessage,
-	onSend,
-	onInterrupt,
-	isInputDisabled,
-	isSendPending,
-	isInterruptPending,
-	hasModelOptions,
-	selectedModel,
-	onModelChange,
-	modelOptions,
-	modelSelectorPlaceholder,
-	inputStatusText,
-	modelCatalogStatusMessage,
-	savingMessageId,
-}) => {
+	onDeleteQueuedMessage: (id: number) => Promise<void>;
+}) {
+	const { onSend, onDeleteQueuedMessage } = deps;
 	const inputValueRef = useRef("");
 	const chatInputRef = useRef<ChatMessageInputRef>(null);
 	const [editorInitialValue, setEditorInitialValue] = useState("");
@@ -410,74 +354,38 @@ const AgentDetailConversation: FC<AgentDetailConversationProps> = ({
 				editingMessageId !== null ? editingMessageId : undefined;
 			const queueEditID = editingQueuedMessageID;
 
-			// Clear input and editing state optimistically.
-			setEditorInitialValue("");
-			inputValueRef.current = "";
-			if (editingMessageId !== null) {
-				setEditingMessageId(null);
-				setDraftBeforeHistoryEdit(null);
-			}
-			if (queueEditID !== null) {
-				setEditingQueuedMessageID(null);
-				setDraftBeforeQueueEdit(null);
-			}
-
-			void onSend(message, editedMessageID)
-				.then(() => {
-					if (queueEditID !== null) {
-						void onDeleteQueuedMessage(queueEditID);
-					}
-				})
-				.catch(() => {
-					// Restore input so the user can retry.
-					setEditorInitialValue(message);
-					inputValueRef.current = message;
-				});
+			void onSend(message, editedMessageID).then(() => {
+				// Clear input and editing state on success.
+				chatInputRef.current?.clear();
+				chatInputRef.current?.focus();
+				inputValueRef.current = "";
+				if (editingMessageId !== null) {
+					setEditingMessageId(null);
+					setDraftBeforeHistoryEdit(null);
+				}
+				if (queueEditID !== null) {
+					setEditingQueuedMessageID(null);
+					setDraftBeforeQueueEdit(null);
+					void onDeleteQueuedMessage(queueEditID);
+				}
+			});
 		},
 		[editingMessageId, editingQueuedMessageID, onDeleteQueuedMessage, onSend],
 	);
 
-	return (
-		<>
-			<AgentDetailTimeline
-				store={store}
-				chatID={chatID}
-				persistedErrorReason={persistedErrorReason}
-				onEditUserMessage={handleEditUserMessage}
-				editingMessageId={editingMessageId}
-				savingMessageId={savingMessageId}
-			/>
-			<AgentDetailInput
-				store={store}
-				compressionThreshold={compressionThreshold}
-				onSend={handleSendFromInput}
-				onDeleteQueuedMessage={onDeleteQueuedMessage}
-				onPromoteQueuedMessage={onPromoteQueuedMessage}
-				onInterrupt={onInterrupt}
-				isInputDisabled={isInputDisabled}
-				isSendPending={isSendPending}
-				isInterruptPending={isInterruptPending}
-				hasModelOptions={hasModelOptions}
-				selectedModel={selectedModel}
-				onModelChange={onModelChange}
-				modelOptions={modelOptions}
-				modelSelectorPlaceholder={modelSelectorPlaceholder}
-				inputStatusText={inputStatusText}
-				modelCatalogStatusMessage={modelCatalogStatusMessage}
-				inputRef={chatInputRef}
-				initialValue={editorInitialValue}
-				onContentChange={(content) => {
-					inputValueRef.current = content;
-				}}
-				editingQueuedMessageID={editingQueuedMessageID}
-				onStartQueueEdit={handleStartQueueEdit}
-				onCancelQueueEdit={handleCancelQueueEdit}
-				isEditingHistoryMessage={editingMessageId !== null}
-				onCancelHistoryEdit={handleCancelHistoryEdit}
-			/>
-		</>
-	);
-};
+	return {
+		inputValueRef,
+		chatInputRef,
+		editorInitialValue,
+		editingMessageId,
+		handleEditUserMessage,
+		handleCancelHistoryEdit,
+		editingQueuedMessageID,
+		handleStartQueueEdit,
+		handleCancelQueueEdit,
+		handleSendFromInput,
+	};
+}
 
 const AgentDetail: FC = () => {
 	const navigate = useNavigate();
@@ -670,32 +578,12 @@ const AgentDetail: FC = () => {
 			if (scrollContainerRef.current) {
 				scrollContainerRef.current.scrollTop = 0;
 			}
-			const previousChatStatus = store.getSnapshot().chatStatus;
-			const previousMessages = getOrderedMessagesFromStore(store);
-			const messageIndex = previousMessages.findIndex(
-				(msg) => msg.id === editedMessageID,
-			);
-			if (messageIndex !== -1) {
-				const optimisticEditedMessage: TypesGen.ChatMessage = {
-					...previousMessages[messageIndex],
-					content: toOptimisticMessageParts(request.content),
-				};
-				store.replaceMessages([
-					...previousMessages.slice(0, messageIndex),
-					optimisticEditedMessage,
-				]);
-			}
 			store.clearStreamState();
-			store.setChatStatus("pending");
 			try {
 				await editMutation.mutateAsync({
 					messageId: editedMessageID,
 					req: request,
 				});
-			} catch (error) {
-				store.replaceMessages(previousMessages);
-				store.setChatStatus(previousChatStatus);
-				throw error;
 			} finally {
 				setPendingEditMessageId(null);
 			}
@@ -713,38 +601,16 @@ const AgentDetail: FC = () => {
 			scrollContainerRef.current.scrollTop = 0;
 		}
 
-		// Inject an optimistic user message so the bubble appears in
-		// the timeline immediately, without waiting for the server.
-		const previousMessages = getOrderedMessagesFromStore(store);
-		const previousChatStatus = store.getSnapshot().chatStatus;
-		const optimisticMessage: TypesGen.ChatMessage = {
-			id: -Date.now(),
-			chat_id: agentId,
-			created_at: new Date().toISOString(),
-			role: "user",
-			content: toOptimisticMessageParts(content),
-		};
-		store.upsertDurableMessage(optimisticMessage);
+		// No optimistic rendering — the message will appear in the
+		// timeline when the server confirms via the POST response or
+		// via the SSE stream.
 		store.clearStreamState();
-		store.setChatStatus("pending");
-
-		try {
-			const response = await sendMutation.mutateAsync(request);
-			if (response.queued) {
-				// The server queued the message instead of processing
-				// it immediately (the agent is already busy). Roll back
-				// the optimistic timeline message so it doesn't appear
-				// as a sent message. The queue_update SSE event will
-				// add it to the queued messages list.
-				store.replaceMessages(previousMessages);
-				store.setChatStatus(previousChatStatus);
-			}
-		} catch (error) {
-			// Roll back the optimistic message so the timeline
-			// returns to its previous state.
-			store.replaceMessages(previousMessages);
-			store.setChatStatus(previousChatStatus);
-			throw error;
+		const response = await sendMutation.mutateAsync(request);
+		// When the server accepts the message immediately (not
+		// queued), insert it into the store so it appears in the
+		// timeline without waiting for the SSE stream.
+		if (!response.queued && response.message) {
+			store.upsertDurableMessage(response.message);
 		}
 		if (typeof window !== "undefined") {
 			if (selectedModelConfigID) {
@@ -802,6 +668,11 @@ const AgentDetail: FC = () => {
 		},
 		[promoteQueuedMutation, store],
 	);
+
+	const editing = useConversationEditingState({
+		onSend: handleSend,
+		onDeleteQueuedMessage: handleDeleteQueuedMessage,
+	});
 
 	const chatTitle = chatQuery.data?.chat?.title;
 
@@ -920,7 +791,7 @@ const AgentDetail: FC = () => {
 					isSidebarCollapsed={isSidebarCollapsed}
 					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 				/>
-				<div className="flex h-full flex-col-reverse overflow-hidden">
+				<div className="flex min-h-0 flex-1 flex-col-reverse overflow-hidden">
 					<div className="px-4">
 						<div className="mx-auto w-full max-w-3xl py-6">
 							<div className="flex flex-col gap-3">
@@ -948,21 +819,22 @@ const AgentDetail: FC = () => {
 								</div>
 							</div>
 						</div>
-						<AgentChatInput
-							onSend={() => {}}
-							initialValue=""
-							isDisabled={isInputDisabled}
-							isLoading={false}
-							selectedModel={selectedModel}
-							onModelChange={setSelectedModel}
-							modelOptions={modelOptions}
-							modelSelectorPlaceholder={modelSelectorPlaceholder}
-							hasModelOptions={hasModelOptions}
-							inputStatusText={inputStatusText}
-							modelCatalogStatusMessage={modelCatalogStatusMessage}
-							sticky
-						/>
 					</div>
+				</div>
+				<div className="shrink-0 px-4">
+					<AgentChatInput
+						onSend={() => {}}
+						initialValue=""
+						isDisabled={isInputDisabled}
+						isLoading={false}
+						selectedModel={selectedModel}
+						onModelChange={setSelectedModel}
+						modelOptions={modelOptions}
+						modelSelectorPlaceholder={modelSelectorPlaceholder}
+						hasModelOptions={hasModelOptions}
+						inputStatusText={inputStatusText}
+						modelCatalogStatusMessage={modelCatalogStatusMessage}
+					/>
 				</div>
 			</div>
 		);
@@ -1053,33 +925,50 @@ const AgentDetail: FC = () => {
 				</div>
 				<div
 					ref={scrollContainerRef}
-					className="flex h-full flex-col-reverse overflow-y-auto [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+					className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 				>
 					<div className="px-4">
-						<AgentDetailConversation
+						<AgentDetailTimeline
 							store={store}
 							chatID={agentId}
 							persistedErrorReason={
 								chatErrorReasons[agentId] || chatRecord?.last_error || undefined
 							}
-							compressionThreshold={compressionThreshold}
-							onDeleteQueuedMessage={handleDeleteQueuedMessage}
-							onPromoteQueuedMessage={handlePromoteQueuedMessage}
-							onSend={handleSend}
-							onInterrupt={handleInterrupt}
-							isInputDisabled={isInputDisabled}
-							isSendPending={isSubmissionPending}
-							isInterruptPending={interruptMutation.isPending}
-							hasModelOptions={hasModelOptions}
-							selectedModel={selectedModel}
-							onModelChange={setSelectedModel}
-							modelOptions={modelOptions}
-							modelSelectorPlaceholder={modelSelectorPlaceholder}
-							inputStatusText={inputStatusText}
-							modelCatalogStatusMessage={modelCatalogStatusMessage}
+							onEditUserMessage={editing.handleEditUserMessage}
+							editingMessageId={editing.editingMessageId}
 							savingMessageId={pendingEditMessageId}
 						/>
 					</div>
+				</div>
+				<div className="shrink-0 overflow-y-auto px-4 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+					<AgentDetailInput
+						store={store}
+						compressionThreshold={compressionThreshold}
+						onSend={editing.handleSendFromInput}
+						onDeleteQueuedMessage={handleDeleteQueuedMessage}
+						onPromoteQueuedMessage={handlePromoteQueuedMessage}
+						onInterrupt={handleInterrupt}
+						isInputDisabled={isInputDisabled}
+						isSendPending={isSubmissionPending}
+						isInterruptPending={interruptMutation.isPending}
+						hasModelOptions={hasModelOptions}
+						selectedModel={selectedModel}
+						onModelChange={setSelectedModel}
+						modelOptions={modelOptions}
+						modelSelectorPlaceholder={modelSelectorPlaceholder}
+						inputStatusText={inputStatusText}
+						modelCatalogStatusMessage={modelCatalogStatusMessage}
+						inputRef={editing.chatInputRef}
+						initialValue={editing.editorInitialValue}
+						onContentChange={(content) => {
+							editing.inputValueRef.current = content;
+						}}
+						editingQueuedMessageID={editing.editingQueuedMessageID}
+						onStartQueueEdit={editing.handleStartQueueEdit}
+						onCancelQueueEdit={editing.handleCancelQueueEdit}
+						isEditingHistoryMessage={editing.editingMessageId !== null}
+						onCancelHistoryEdit={editing.handleCancelHistoryEdit}
+					/>
 				</div>
 			</div>
 			<DiffRightPanel isOpen={shouldShowDiffPanel}>

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -237,17 +237,6 @@ export const createChatStore = (): ChatStore => {
 		const nextMessagesByID = new Map(state.messagesByID);
 		nextMessagesByID.set(message.id, message);
 
-		// When a real server message (positive ID) arrives, remove any
-		// optimistic placeholder (negative ID) for the same role so the
-		// user doesn't momentarily see the message twice.
-		if (message.id > 0) {
-			for (const [id, existing] of nextMessagesByID) {
-				if (id < 0 && existing.role === message.role) {
-					nextMessagesByID.delete(id);
-				}
-			}
-		}
-
 		const needsReorder =
 			!isDuplicate || nextMessagesByID.size !== state.messagesByID.size;
 		const nextOrderedMessageIDs = needsReorder

--- a/site/src/pages/AgentsPage/AgentDetail/chatStore.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/chatStore.test.ts
@@ -139,33 +139,6 @@ describe("upsertDurableMessage", () => {
 		);
 	});
 
-	it("removes optimistic (negative-ID) messages when a real message arrives", () => {
-		const store = createChatStore();
-		const optimistic = makeMessage(-1, "user", "typing...");
-		store.replaceMessages([optimistic]);
-		expect(store.getSnapshot().messagesByID.has(-1)).toBe(true);
-
-		const real = makeMessage(5, "user", "typed!");
-		store.upsertDurableMessage(real);
-
-		expect(store.getSnapshot().messagesByID.has(-1)).toBe(false);
-		expect(store.getSnapshot().messagesByID.has(5)).toBe(true);
-	});
-
-	it("only removes optimistic messages with the same role", () => {
-		const store = createChatStore();
-		const optimisticUser = makeMessage(-1, "user", "my prompt");
-		const optimisticAssistant = makeMessage(-2, "assistant", "placeholder");
-		store.replaceMessages([optimisticUser, optimisticAssistant]);
-
-		// A real "user" message arrives — only the user optimistic should
-		// be removed, not the assistant one.
-		store.upsertDurableMessage(makeMessage(5, "user", "real prompt"));
-
-		expect(store.getSnapshot().messagesByID.has(-1)).toBe(false);
-		expect(store.getSnapshot().messagesByID.has(-2)).toBe(true);
-	});
-
 	it("does not reorder when updating an existing message in place", () => {
 		const store = createChatStore();
 		store.upsertDurableMessage(makeMessage(1, "user", "first"));


### PR DESCRIPTION
## Problem

Two bugs in the agents chat flow:

1. **Optimistic rendering glitch**: When sending a message while the agent is busy, a fake message with a negative ID appears in the timeline, then gets rolled back to the queued state. This causes a jarring flash.

2. **Auto-promoted messages not appearing**: When the server auto-promotes a queued message after finishing a task, the promoted user message doesn't show up in the timeline until the LLM finishes its response.

## Root Causes

**Bug 1**: The optimistic rendering system injected placeholder messages with `id: -Date.now()` into the store. When the server responded with `queued: true`, the optimistic message was rolled back — but the user had already seen it flash in the timeline.

**Bug 2**: In `processChat`'s deferred cleanup, the auto-promoted message was published via `publishEvent()`, which only delivers to local in-process stream subscribers. The SSE subscriber goroutine only forwards `message_part` events from the local channel — it ignores `message` events. Durable events reach the SSE client via pubsub → DB read, but `publishEvent` doesn't trigger a pubsub notification. The explicit `PromoteQueued` endpoint correctly used `publishMessage()` (which does both), but the auto-promote path did not.

## Changes

### Frontend (`site/`)
- **AgentDetail.tsx**: Remove optimistic message injection from send and edit flows. Instead, use the `CreateChatMessageResponse.message` from the POST response to insert the real server message into the store immediately.
- **ChatContext.ts**: Remove the negative-ID cleanup logic from `upsertDurableMessage` that stripped optimistic placeholders when real messages arrived.
- **chatStore.test.ts**: Remove 2 tests for negative-ID optimistic message behavior.

### Backend (`coderd/chatd/`)
- **chatd.go**: In `processChat` cleanup, replace `publishEvent()` with `publishMessage()` for auto-promoted messages. This ensures the pubsub notification (`AfterMessageID`) is sent, so SSE subscribers read the new message from the DB immediately.