### PR TITLE
feat(dbtestutil): use STRATEGY FILE_COPY for template DB cloning

### DIFF
--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -38,26 +38,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up XFS with reflink for CoW clones (Linux)
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        set -euo pipefail
-        if ! command -v mkfs.xfs >/dev/null 2>&1; then
-          sudo apt-get install -yqq xfsprogs
-        fi
-        sudo truncate -s 8G /dev/shm/pgdata.img
-        sudo mkfs.xfs -f -m reflink=1 /dev/shm/pgdata.img
-        sudo mkdir -p /mnt/pgdata
-        sudo mount -o loop /dev/shm/pgdata.img /mnt/pgdata
-        sudo chmod 777 /mnt/pgdata
-
     - name: Start PostgreSQL Docker container (Linux)
       if: runner.os == 'Linux'
       shell: bash
       env:
         POSTGRES_VERSION: ${{ inputs.postgres-version }}
-        PGDATA_DIR: /mnt/pgdata
       run: make test-postgres-docker
 
     - name: Setup Embedded Postgres (Windows/macOS)

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -5,7 +5,7 @@ inputs:
   postgres-version:
     description: "PostgreSQL version to use"
     required: false
-    default: "17"
+    default: "18"
   test-parallelism-packages:
     description: "Number of packages to test in parallel (-p flag)"
     required: false

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -5,7 +5,7 @@ inputs:
   postgres-version:
     description: "PostgreSQL version to use"
     required: false
-    default: "13"
+    default: "15"
   test-parallelism-packages:
     description: "Number of packages to test in parallel (-p flag)"
     required: false

--- a/.github/actions/test-go-pg/action.yaml
+++ b/.github/actions/test-go-pg/action.yaml
@@ -5,7 +5,7 @@ inputs:
   postgres-version:
     description: "PostgreSQL version to use"
     required: false
-    default: "15"
+    default: "17"
   test-parallelism-packages:
     description: "Number of packages to test in parallel (-p flag)"
     required: false
@@ -38,11 +38,26 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up XFS with reflink for CoW clones (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v mkfs.xfs >/dev/null 2>&1; then
+          sudo apt-get install -yqq xfsprogs
+        fi
+        sudo truncate -s 8G /dev/shm/pgdata.img
+        sudo mkfs.xfs -f -m reflink=1 /dev/shm/pgdata.img
+        sudo mkdir -p /mnt/pgdata
+        sudo mount -o loop /dev/shm/pgdata.img /mnt/pgdata
+        sudo chmod 777 /mnt/pgdata
+
     - name: Start PostgreSQL Docker container (Linux)
       if: runner.os == 'Linux'
       shell: bash
       env:
         POSTGRES_VERSION: ${{ inputs.postgres-version }}
+        PGDATA_DIR: /mnt/pgdata
       run: make test-postgres-docker
 
     - name: Setup Embedded Postgres (Windows/macOS)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -497,7 +497,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "17"
+          postgres-version: "18"
           # Our Linux runners have 8 cores.
           test-parallelism-packages: "8"
           test-parallelism-tests: "8"
@@ -509,7 +509,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "17"
+          postgres-version: "18"
           # Our macOS runners have 8 cores.
           # Even though this parallelism seems high, we've observed relatively low flakiness in the past.
           # See https://github.com/coder/coder/pull/21091#discussion_r2609891540.
@@ -527,7 +527,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "17"
+          postgres-version: "18"
           # Our Windows runners have 16 cores.
           # On Windows Postgres chokes up when we have 16x16=256 tests
           # running in parallel, and dbtestutil.NewDB starts to take more than
@@ -616,7 +616,7 @@ jobs:
       - name: Test with PostgreSQL Database
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "17"
+          postgres-version: "18"
           # Our Linux runners have 8 cores.
           test-parallelism-packages: "8"
           test-parallelism-tests: "8"
@@ -684,7 +684,7 @@ jobs:
       - name: Run Tests
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "17"
+          postgres-version: "18"
           test-parallelism-packages: "4"
           test-parallelism-tests: "4"
           race-detection: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -497,7 +497,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "15"
+          postgres-version: "17"
           # Our Linux runners have 8 cores.
           test-parallelism-packages: "8"
           test-parallelism-tests: "8"
@@ -509,7 +509,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "15"
+          postgres-version: "17"
           # Our macOS runners have 8 cores.
           # Even though this parallelism seems high, we've observed relatively low flakiness in the past.
           # See https://github.com/coder/coder/pull/21091#discussion_r2609891540.
@@ -527,7 +527,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "15"
+          postgres-version: "17"
           # Our Windows runners have 16 cores.
           # On Windows Postgres chokes up when we have 16x16=256 tests
           # running in parallel, and dbtestutil.NewDB starts to take more than

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -497,7 +497,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "13"
+          postgres-version: "15"
           # Our Linux runners have 8 cores.
           test-parallelism-packages: "8"
           test-parallelism-tests: "8"
@@ -509,7 +509,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "13"
+          postgres-version: "15"
           # Our macOS runners have 8 cores.
           # Even though this parallelism seems high, we've observed relatively low flakiness in the past.
           # See https://github.com/coder/coder/pull/21091#discussion_r2609891540.
@@ -527,7 +527,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/test-go-pg
         with:
-          postgres-version: "13"
+          postgres-version: "15"
           # Our Windows runners have 16 cores.
           # On Windows Postgres chokes up when we have 16x16=256 tests
           # running in parallel, and dbtestutil.NewDB starts to take more than

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,6 @@ VERSION      := $(shell ./scripts/version.sh)
 POSTGRES_VERSION ?= 17
 POSTGRES_IMAGE   ?= us-docker.pkg.dev/coder-v2-images-public/public/postgres:$(POSTGRES_VERSION)
 
-# file_copy_method=clone requires PostgreSQL 17+.
-ifeq ($(shell test $(POSTGRES_VERSION) -ge 17 2>/dev/null && echo yes),yes)
-POSTGRES_EXTRA_FLAGS = -c file_copy_method=clone
-else
-POSTGRES_EXTRA_FLAGS =
-endif
-
 # Use the highest ZSTD compression level in CI.
 ifdef CI
 ZSTDFLAGS := -22 --ultra
@@ -1197,8 +1190,7 @@ test-postgres-docker:
 		-c fsync=off \
 		-c synchronous_commit=off \
 		-c full_page_writes=off \
-		-c log_statement=all \
-		${POSTGRES_EXTRA_FLAGS}
+		-c log_statement=all
 	while ! pg_isready -h 127.0.0.1
 	do
 		echo "$(date) - waiting for database to start"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GOOS_BIN_EXT := $(if $(filter windows, $(GOOS)),.exe,)
 VERSION      := $(shell ./scripts/version.sh)
 
 POSTGRES_VERSION ?= 17
-POSTGRES_IMAGE   ?= us-docker.pkg.dev/coder-v2-images-public/public/postgres:$(POSTGRES_VERSION)
+POSTGRES_IMAGE   ?= postgres:$(POSTGRES_VERSION)
 
 # Use the highest ZSTD compression level in CI.
 ifdef CI

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ GOARCH       := $(shell go env GOARCH)
 GOOS_BIN_EXT := $(if $(filter windows, $(GOOS)),.exe,)
 VERSION      := $(shell ./scripts/version.sh)
 
-POSTGRES_VERSION ?= 17
+POSTGRES_VERSION ?= 18
 POSTGRES_IMAGE   ?= postgres:$(POSTGRES_VERSION)
 
 # Use the highest ZSTD compression level in CI.
@@ -1190,7 +1190,8 @@ test-postgres-docker:
 		-c fsync=off \
 		-c synchronous_commit=off \
 		-c full_page_writes=off \
-		-c log_statement=all
+		-c log_statement=all \
+		-c file_copy_method=clone
 	while ! pg_isready -h 127.0.0.1
 	do
 		echo "$(date) - waiting for database to start"

--- a/Makefile
+++ b/Makefile
@@ -40,22 +40,6 @@ VERSION      := $(shell ./scripts/version.sh)
 POSTGRES_VERSION ?= 17
 POSTGRES_IMAGE   ?= postgres:$(POSTGRES_VERSION)
 
-# file_copy_method=clone requires PostgreSQL 17+ and a CoW filesystem
-# (e.g. xfs with reflink). PGDATA_DIR should point to such a mount.
-ifeq ($(shell test $(POSTGRES_VERSION) -ge 17 2>/dev/null && echo yes),yes)
-POSTGRES_EXTRA_FLAGS = -c file_copy_method=clone
-else
-POSTGRES_EXTRA_FLAGS =
-endif
-
-# When PGDATA_DIR is set (to an xfs+reflink mount), bind-mount it into
-# the container so FICLONE works. Otherwise fall back to --tmpfs.
-ifdef PGDATA_DIR
-PGDATA_DOCKER_ARGS = -v $(PGDATA_DIR):/tmp
-else
-PGDATA_DOCKER_ARGS = --tmpfs /tmp
-endif
-
 # Use the highest ZSTD compression level in CI.
 ifdef CI
 ZSTDFLAGS := -22 --ultra
@@ -1192,7 +1176,7 @@ test-postgres-docker:
 		--env POSTGRES_USER=postgres \
 		--env POSTGRES_DB=postgres \
 		--env PGDATA=/tmp \
-		${PGDATA_DOCKER_ARGS} \
+		--tmpfs /tmp \
 		--publish 5432:5432 \
 		--name test-postgres-docker-${POSTGRES_VERSION} \
 		--restart no \
@@ -1206,8 +1190,7 @@ test-postgres-docker:
 		-c fsync=off \
 		-c synchronous_commit=off \
 		-c full_page_writes=off \
-		-c log_statement=all \
-		${POSTGRES_EXTRA_FLAGS}
+		-c log_statement=all
 	while ! pg_isready -h 127.0.0.1
 	do
 		echo "$(date) - waiting for database to start"

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,22 @@ VERSION      := $(shell ./scripts/version.sh)
 POSTGRES_VERSION ?= 17
 POSTGRES_IMAGE   ?= postgres:$(POSTGRES_VERSION)
 
+# file_copy_method=clone requires PostgreSQL 17+ and a CoW filesystem
+# (e.g. xfs with reflink). PGDATA_DIR should point to such a mount.
+ifeq ($(shell test $(POSTGRES_VERSION) -ge 17 2>/dev/null && echo yes),yes)
+POSTGRES_EXTRA_FLAGS = -c file_copy_method=clone
+else
+POSTGRES_EXTRA_FLAGS =
+endif
+
+# When PGDATA_DIR is set (to an xfs+reflink mount), bind-mount it into
+# the container so FICLONE works. Otherwise fall back to --tmpfs.
+ifdef PGDATA_DIR
+PGDATA_DOCKER_ARGS = -v $(PGDATA_DIR):/tmp
+else
+PGDATA_DOCKER_ARGS = --tmpfs /tmp
+endif
+
 # Use the highest ZSTD compression level in CI.
 ifdef CI
 ZSTDFLAGS := -22 --ultra
@@ -1176,7 +1192,7 @@ test-postgres-docker:
 		--env POSTGRES_USER=postgres \
 		--env POSTGRES_DB=postgres \
 		--env PGDATA=/tmp \
-		--tmpfs /tmp \
+		${PGDATA_DOCKER_ARGS} \
 		--publish 5432:5432 \
 		--name test-postgres-docker-${POSTGRES_VERSION} \
 		--restart no \
@@ -1190,7 +1206,8 @@ test-postgres-docker:
 		-c fsync=off \
 		-c synchronous_commit=off \
 		-c full_page_writes=off \
-		-c log_statement=all
+		-c log_statement=all \
+		${POSTGRES_EXTRA_FLAGS}
 	while ! pg_isready -h 127.0.0.1
 	do
 		echo "$(date) - waiting for database to start"

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,13 @@ VERSION      := $(shell ./scripts/version.sh)
 POSTGRES_VERSION ?= 17
 POSTGRES_IMAGE   ?= us-docker.pkg.dev/coder-v2-images-public/public/postgres:$(POSTGRES_VERSION)
 
+# file_copy_method=clone requires PostgreSQL 17+.
+ifeq ($(shell test $(POSTGRES_VERSION) -ge 17 2>/dev/null && echo yes),yes)
+POSTGRES_EXTRA_FLAGS = -c file_copy_method=clone
+else
+POSTGRES_EXTRA_FLAGS =
+endif
+
 # Use the highest ZSTD compression level in CI.
 ifdef CI
 ZSTDFLAGS := -22 --ultra
@@ -1190,7 +1197,8 @@ test-postgres-docker:
 		-c fsync=off \
 		-c synchronous_commit=off \
 		-c full_page_writes=off \
-		-c log_statement=all
+		-c log_statement=all \
+		${POSTGRES_EXTRA_FLAGS}
 	while ! pg_isready -h 127.0.0.1
 	do
 		echo "$(date) - waiting for database to start"

--- a/coderd/database/dbtestutil/broker.go
+++ b/coderd/database/dbtestutil/broker.go
@@ -66,12 +66,17 @@ func (b *Broker) Create(t TBSubset, opts ...OpenOption) (ConnectionParams, error
 		return ConnectionParams{}, xerrors.Errorf("insert test_database row: %w", err)
 	}
 
+	pgVersion, err := pgMajorVersion(b.coderTestingDB)
+	if err != nil {
+		return ConnectionParams{}, xerrors.Errorf("get pg version: %w", err)
+	}
+
 	// if empty createDatabaseFromTemplate will create a new template db
 	templateDBName := os.Getenv("DB_FROM")
 	if openOptions.DBFrom != nil {
 		templateDBName = *openOptions.DBFrom
 	}
-	if err = createDatabaseFromTemplate(t, defaultConnectionParams, b.coderTestingDB, dbName, templateDBName); err != nil {
+	if err = createDatabaseFromTemplate(t, defaultConnectionParams, b.coderTestingDB, dbName, templateDBName, pgVersion); err != nil {
 		return ConnectionParams{}, xerrors.Errorf("create database: %w", err)
 	}
 

--- a/coderd/database/dbtestutil/postgres.go
+++ b/coderd/database/dbtestutil/postgres.go
@@ -185,14 +185,14 @@ func Open(t TBSubset, opts ...OpenOption) (string, error) {
 // If templateDBName is empty, it will create a new template database based on
 // the current migrations, and name it "tpl_<migrations_hash>". Or if it's
 // already been created, it will use that.
-func createDatabaseFromTemplate(t TBSubset, connParams ConnectionParams, db *sql.DB, newDBName string, templateDBName string) error {
+func createDatabaseFromTemplate(t TBSubset, connParams ConnectionParams, db *sql.DB, newDBName string, templateDBName string, pgVersion int) error {
 	t.Helper()
 
 	emptyTemplateDBName := templateDBName == ""
 	if emptyTemplateDBName {
 		templateDBName = fmt.Sprintf("tpl_%s", migrations.GetMigrationsHash()[:32])
 	}
-	_, err := db.Exec("CREATE DATABASE " + newDBName + " WITH TEMPLATE " + templateDBName)
+	_, err := db.Exec(createFromTemplateExpr(newDBName, templateDBName, pgVersion))
 	if err == nil {
 		// Template database already exists and we successfully created the new database.
 		return nil
@@ -220,7 +220,7 @@ func createDatabaseFromTemplate(t TBSubset, connParams ConnectionParams, db *sql
 	}
 
 	// Try to create the database again now that a template exists.
-	if _, err = db.Exec("CREATE DATABASE " + newDBName + " WITH TEMPLATE " + templateDBName); err != nil {
+	if _, err = db.Exec(createFromTemplateExpr(newDBName, templateDBName, pgVersion)); err != nil {
 		return xerrors.Errorf("create db with template after migrations: %w", err)
 	}
 	return nil
@@ -494,6 +494,27 @@ func OpenContainerized(t TBSubset, opts DBContainerOptions) (string, func(), err
 	}
 
 	return dbURL, containerCleanup, nil
+}
+
+// pgMajorVersion returns the major version of PostgreSQL, e.g. 17.
+func pgMajorVersion(db *sql.DB) (int, error) {
+	var version int
+	err := db.QueryRow("SHOW server_version_num").Scan(&version)
+	if err != nil {
+		return 0, xerrors.Errorf("query server version: %w", err)
+	}
+	// server_version_num is formatted as XXYYYZZ (major, minor, patch)
+	return version / 10000, nil
+}
+
+// createFromTemplateExpr returns a CREATE DATABASE statement that optionally
+// uses STRATEGY FILE_COPY for PostgreSQL 15+.
+func createFromTemplateExpr(newDBName, templateDBName string, pgVersion int) string {
+	stmt := "CREATE DATABASE " + newDBName + " WITH TEMPLATE " + templateDBName
+	if pgVersion >= 15 {
+		stmt += " STRATEGY FILE_COPY"
+	}
+	return stmt
 }
 
 func containsAnySubstring(s string, substrings []string) bool {

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/fatih/structs v1.1.0
 	github.com/fatih/structtag v1.2.0
-	github.com/fergusstrange/embedded-postgres v1.32.0
+	github.com/fergusstrange/embedded-postgres v1.33.0
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/gen2brain/beeep v0.11.1
 	github.com/gliderlabs/ssh v0.3.8

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fergusstrange/embedded-postgres v1.32.0 h1:kh2ozEvAx2A0LoIJZEGNwHmoFTEQD243KrHjifcYGMo=
-github.com/fergusstrange/embedded-postgres v1.32.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
+github.com/fergusstrange/embedded-postgres v1.33.0 h1:ka8vmRpm4IDsES7NPXQ/NThAp1fc/f+crcXYjCW7wK0=
+github.com/fergusstrange/embedded-postgres v1.33.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
@@ -85,8 +86,14 @@ func main() {
 		`ALTER SYSTEM SET max_connections = '1000';`,
 		`ALTER SYSTEM SET shared_buffers = '1GB';`,
 		`ALTER SYSTEM SET synchronous_commit = 'off';`,
-		`ALTER SYSTEM SET file_copy_method = 'clone';`,
 		`ALTER SYSTEM SET client_encoding = 'UTF8';`,
+	}
+	// file_copy_method=clone uses CoW filesystem clones for
+	// CREATE DATABASE ... STRATEGY FILE_COPY. macOS APFS supports
+	// this natively. Skip on Windows where NTFS has no CoW support
+	// and PG would fail on the next restart.
+	if runtime.GOOS != "windows" {
+		paramQueries = append(paramQueries, `ALTER SYSTEM SET file_copy_method = 'clone';`)
 	}
 	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
@@ -35,7 +36,7 @@ func main() {
 
 	ep := embeddedpostgres.NewDatabase(
 		embeddedpostgres.DefaultConfig().
-			Version(embeddedpostgres.V16).
+			Version(embeddedpostgres.V17).
 			BinariesPath(filepath.Join(postgresPath, "bin")).
 			BinaryRepositoryURL("https://repo.maven.apache.org/maven2").
 			DataPath(filepath.Join(postgresPath, "data")).
@@ -86,6 +87,12 @@ func main() {
 		`ALTER SYSTEM SET shared_buffers = '1GB';`,
 		`ALTER SYSTEM SET synchronous_commit = 'off';`,
 		`ALTER SYSTEM SET client_encoding = 'UTF8';`,
+	}
+	// file_copy_method=clone uses CoW filesystem clones for
+	// CREATE DATABASE ... STRATEGY FILE_COPY. macOS APFS supports
+	// this natively. Skip on Windows where NTFS has no CoW support.
+	if runtime.GOOS != "windows" {
+		paramQueries = append(paramQueries, `ALTER SYSTEM SET file_copy_method = 'clone';`)
 	}
 	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	ep := embeddedpostgres.NewDatabase(
 		embeddedpostgres.DefaultConfig().
-			Version(embeddedpostgres.V17).
+			Version(embeddedpostgres.V18).
 			BinariesPath(filepath.Join(postgresPath, "bin")).
 			BinaryRepositoryURL("https://repo.maven.apache.org/maven2").
 			DataPath(filepath.Join(postgresPath, "data")).
@@ -85,6 +85,7 @@ func main() {
 		`ALTER SYSTEM SET max_connections = '1000';`,
 		`ALTER SYSTEM SET shared_buffers = '1GB';`,
 		`ALTER SYSTEM SET synchronous_commit = 'off';`,
+		`ALTER SYSTEM SET file_copy_method = 'clone';`,
 		`ALTER SYSTEM SET client_encoding = 'UTF8';`,
 	}
 	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")

--- a/scripts/embedded-pg/main.go
+++ b/scripts/embedded-pg/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
@@ -87,12 +86,6 @@ func main() {
 		`ALTER SYSTEM SET shared_buffers = '1GB';`,
 		`ALTER SYSTEM SET synchronous_commit = 'off';`,
 		`ALTER SYSTEM SET client_encoding = 'UTF8';`,
-	}
-	// file_copy_method=clone uses CoW filesystem clones for
-	// CREATE DATABASE ... STRATEGY FILE_COPY. macOS APFS supports
-	// this natively. Skip on Windows where NTFS has no CoW support.
-	if runtime.GOOS != "windows" {
-		paramQueries = append(paramQueries, `ALTER SYSTEM SET file_copy_method = 'clone';`)
 	}
 	db, err := sql.Open("postgres", "postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable")
 	if err != nil {


### PR DESCRIPTION
Uses `CREATE DATABASE ... STRATEGY FILE_COPY` when cloning template databases on PostgreSQL 15+. This uses file-level copy operations instead of block-level, which is faster for template cloning.

Also sets `file_copy_method=clone` on the CI PostgreSQL 17+ container so `FILE_COPY` uses CoW filesystem clones when available.

### Changes

- **`coderd/database/dbtestutil/postgres.go`**: Added `pgMajorVersion()` helper to detect PG version, and `createFromTemplateExpr()` that appends `STRATEGY FILE_COPY` for PG 15+.
- **`coderd/database/dbtestutil/broker.go`**: Queries PG version and passes it through to `createDatabaseFromTemplate()`.
- **`Makefile`**: Conditionally adds `-c file_copy_method=clone` to the `test-postgres-docker` container when `POSTGRES_VERSION >= 17`.