### PR TITLE
feat(chatd): use lightweight model candidates for title generation

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1944,7 +1944,10 @@ func (p *Server) runChat(
 			p.providerAPIKeys, dbProviders,
 		)
 
-		// Preferred lightweight models for title generation.
+		// Preferred lightweight models for title generation,
+		// one per provider type. Each provider uses its
+		// cheapest/fastest small model as identified by the
+		// charmbracelet/catwalk model catalog.
 		candidates := make([]fantasy.LanguageModel, 0, 3)
 		for _, c := range []struct {
 			provider string
@@ -1952,6 +1955,11 @@ func (p *Server) runChat(
 		}{
 			{"anthropic", "claude-haiku-4-5"},
 			{"openai", "gpt-4o-mini"},
+			{"google", "gemini-2.5-flash"},
+			{"azure", "gpt-4o-mini"},
+			{"bedrock", "anthropic.claude-haiku-4-5-20251001-v1:0"},
+			{"openrouter", "anthropic/claude-3.5-haiku"},
+			{"vercel", "anthropic/claude-haiku-4.5"},
 		} {
 			m, err := chatprovider.ModelFromConfig(
 				c.provider, c.model, keys,

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1926,9 +1926,7 @@ func (p *Server) runChat(
 	p.inflight.Add(1)
 	go func() {
 		defer p.inflight.Done()
-		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, func() []fantasy.LanguageModel {
-			return p.titleModelCandidates(ctx, model)
-		}, logger)
+		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, model, logger)
 	}()
 
 	prompt, err := chatprompt.ConvertMessages(messages)

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1923,10 +1923,51 @@ func (p *Server) runChat(
 	// Fire title generation asynchronously so it doesn't block the
 	// chat response. It uses a detached context so it can finish
 	// even after the chat processing context is canceled.
+	titleModels := func() []fantasy.LanguageModel {
+		// Resolve provider keys so we can try lightweight models
+		// before falling back to the user's chat model.
+		providers, err := p.db.GetEnabledChatProviders(ctx)
+		if err != nil {
+			return []fantasy.LanguageModel{model}
+		}
+		dbProviders := make(
+			[]chatprovider.ConfiguredProvider, 0, len(providers),
+		)
+		for _, provider := range providers {
+			dbProviders = append(dbProviders, chatprovider.ConfiguredProvider{
+				Provider: provider.Provider,
+				APIKey:   provider.APIKey,
+				BaseURL:  provider.BaseUrl,
+			})
+		}
+		keys := chatprovider.MergeProviderAPIKeys(
+			p.providerAPIKeys, dbProviders,
+		)
+
+		// Preferred lightweight models for title generation.
+		candidates := make([]fantasy.LanguageModel, 0, 3)
+		for _, c := range []struct {
+			provider string
+			model    string
+		}{
+			{"anthropic", "claude-haiku-4-5"},
+			{"openai", "gpt-4o-mini"},
+		} {
+			m, err := chatprovider.ModelFromConfig(
+				c.provider, c.model, keys,
+			)
+			if err == nil {
+				candidates = append(candidates, m)
+			}
+		}
+		// Always fall back to the user's chat model.
+		candidates = append(candidates, model)
+		return candidates
+	}
 	p.inflight.Add(1)
 	go func() {
 		defer p.inflight.Done()
-		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, model, logger)
+		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, titleModels, logger)
 	}()
 
 	prompt, err := chatprompt.ConvertMessages(messages)

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1923,59 +1923,12 @@ func (p *Server) runChat(
 	// Fire title generation asynchronously so it doesn't block the
 	// chat response. It uses a detached context so it can finish
 	// even after the chat processing context is canceled.
-	titleModels := func() []fantasy.LanguageModel {
-		// Resolve provider keys so we can try lightweight models
-		// before falling back to the user's chat model.
-		providers, err := p.db.GetEnabledChatProviders(ctx)
-		if err != nil {
-			return []fantasy.LanguageModel{model}
-		}
-		dbProviders := make(
-			[]chatprovider.ConfiguredProvider, 0, len(providers),
-		)
-		for _, provider := range providers {
-			dbProviders = append(dbProviders, chatprovider.ConfiguredProvider{
-				Provider: provider.Provider,
-				APIKey:   provider.APIKey,
-				BaseURL:  provider.BaseUrl,
-			})
-		}
-		keys := chatprovider.MergeProviderAPIKeys(
-			p.providerAPIKeys, dbProviders,
-		)
-
-		// Preferred lightweight models for title generation,
-		// one per provider type. Each provider uses its
-		// cheapest/fastest small model as identified by the
-		// charmbracelet/catwalk model catalog.
-		candidates := make([]fantasy.LanguageModel, 0, 3)
-		for _, c := range []struct {
-			provider string
-			model    string
-		}{
-			{"anthropic", "claude-haiku-4-5"},
-			{"openai", "gpt-4o-mini"},
-			{"google", "gemini-2.5-flash"},
-			{"azure", "gpt-4o-mini"},
-			{"bedrock", "anthropic.claude-haiku-4-5-20251001-v1:0"},
-			{"openrouter", "anthropic/claude-3.5-haiku"},
-			{"vercel", "anthropic/claude-haiku-4.5"},
-		} {
-			m, err := chatprovider.ModelFromConfig(
-				c.provider, c.model, keys,
-			)
-			if err == nil {
-				candidates = append(candidates, m)
-			}
-		}
-		// Always fall back to the user's chat model.
-		candidates = append(candidates, model)
-		return candidates
-	}
 	p.inflight.Add(1)
 	go func() {
 		defer p.inflight.Done()
-		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, titleModels, logger)
+		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, func() []fantasy.LanguageModel {
+			return p.titleModelCandidates(ctx, model)
+		}, logger)
 	}()
 
 	prompt, err := chatprompt.ConvertMessages(messages)

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1904,7 +1904,7 @@ func (p *Server) runChat(
 	chat database.Chat,
 	logger slog.Logger,
 ) error {
-	model, modelConfig, err := p.resolveChatModel(ctx, chat)
+	model, modelConfig, providerKeys, err := p.resolveChatModel(ctx, chat)
 	if err != nil {
 		return err
 	}
@@ -1926,7 +1926,7 @@ func (p *Server) runChat(
 	p.inflight.Add(1)
 	go func() {
 		defer p.inflight.Done()
-		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, model, logger)
+		p.maybeGenerateChatTitle(context.WithoutCancel(ctx), chat, messages, model, providerKeys, logger)
 	}()
 
 	prompt, err := chatprompt.ConvertMessages(messages)
@@ -2403,17 +2403,17 @@ func (p *Server) persistChatContextSummary(
 func (p *Server) resolveChatModel(
 	ctx context.Context,
 	chat database.Chat,
-) (fantasy.LanguageModel, database.ChatModelConfig, error) {
+) (fantasy.LanguageModel, database.ChatModelConfig, chatprovider.ProviderAPIKeys, error) {
 	dbConfig, err := p.resolveModelConfig(ctx, chat)
 	if err != nil {
-		return nil, database.ChatModelConfig{}, xerrors.Errorf(
+		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
 			"resolve model config: %w", err,
 		)
 	}
 
 	providers, err := p.db.GetEnabledChatProviders(ctx)
 	if err != nil {
-		return nil, database.ChatModelConfig{}, xerrors.Errorf(
+		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
 			"get enabled chat providers: %w", err,
 		)
 	}
@@ -2435,11 +2435,11 @@ func (p *Server) resolveChatModel(
 		dbConfig.Provider, dbConfig.Model, keys,
 	)
 	if err != nil {
-		return nil, database.ChatModelConfig{}, xerrors.Errorf(
+		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
 			"create model: %w", err,
 		)
 	}
-	return model, dbConfig, nil
+	return model, dbConfig, keys, nil
 }
 
 // resolveModelConfig looks up the chat's model config by its

--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -143,12 +143,14 @@ func generateTitle(
 		},
 	}
 
+	var maxOutputTokens int64 = 256
+
 	var response *fantasy.Response
 	err := chatretry.Retry(ctx, func(retryCtx context.Context) error {
 		var genErr error
 		response, genErr = model.Generate(retryCtx, fantasy.Call{
 			Prompt:          prompt,
-			MaxOutputTokens: ptr(int64(256)),
+			MaxOutputTokens: &maxOutputTokens,
 		})
 		return genErr
 	}, nil)
@@ -162,8 +164,6 @@ func generateTitle(
 	}
 	return title, nil
 }
-
-func ptr[T any](v T) *T { return &v }
 
 // titleInput returns the first user message text and whether title
 // generation should proceed. It returns false when the chat already

--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -22,11 +22,6 @@ const titleGenerationPrompt = "Generate a concise title (2-8 words) for the user
 	"Return plain text only — no quotes, no emoji, no markdown, no code fences, " +
 	"no special characters, no trailing punctuation. Sentence case."
 
-// TitleModelFunc returns candidate language models for title
-// generation. Models are returned in preference order — cheap, fast
-// models first, with the user's chat model as a last resort.
-type TitleModelFunc func() []fantasy.LanguageModel
-
 // preferredTitleModels are lightweight models used for title
 // generation, one per provider type. Each entry uses the
 // cheapest/fastest small model for that provider as identified
@@ -93,7 +88,7 @@ func (p *Server) maybeGenerateChatTitle(
 	ctx context.Context,
 	chat database.Chat,
 	messages []database.ChatMessage,
-	titleModels TitleModelFunc,
+	fallbackModel fantasy.LanguageModel,
 	logger slog.Logger,
 ) {
 	input, ok := titleInput(chat, messages)
@@ -104,7 +99,7 @@ func (p *Server) maybeGenerateChatTitle(
 	titleCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	candidates := titleModels()
+	candidates := p.titleModelCandidates(ctx, fallbackModel)
 	var lastErr error
 	for _, model := range candidates {
 		title, err := generateTitle(titleCtx, model, input)

--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -47,55 +47,18 @@ var preferredTitleModels = []struct {
 	{fantasyvercel.Name, "anthropic/claude-haiku-4.5"},
 }
 
-// titleModelCandidates returns an ordered list of models to try for
-// title generation. It resolves provider keys, attempts to create
-// each preferred lightweight model, and appends fallback as the
-// last resort.
-func (p *Server) titleModelCandidates(
-	ctx context.Context,
-	fallback fantasy.LanguageModel,
-) []fantasy.LanguageModel {
-	providers, err := p.db.GetEnabledChatProviders(ctx)
-	if err != nil {
-		return []fantasy.LanguageModel{fallback}
-	}
-	dbProviders := make(
-		[]chatprovider.ConfiguredProvider, 0, len(providers),
-	)
-	for _, provider := range providers {
-		dbProviders = append(dbProviders, chatprovider.ConfiguredProvider{
-			Provider: provider.Provider,
-			APIKey:   provider.APIKey,
-			BaseURL:  provider.BaseUrl,
-		})
-	}
-	keys := chatprovider.MergeProviderAPIKeys(
-		p.providerAPIKeys, dbProviders,
-	)
-
-	candidates := make([]fantasy.LanguageModel, 0, len(preferredTitleModels)+1)
-	for _, c := range preferredTitleModels {
-		m, err := chatprovider.ModelFromConfig(
-			c.provider, c.model, keys,
-		)
-		if err == nil {
-			candidates = append(candidates, m)
-		}
-	}
-	// Always fall back to the user's chat model.
-	candidates = append(candidates, fallback)
-	return candidates
-}
-
 // maybeGenerateChatTitle generates an AI title for the chat when
 // appropriate (first user message, no assistant reply yet, and the
 // current title is either empty or still the fallback truncation).
-// It is a best-effort operation that logs and swallows errors.
+// It tries cheap, fast models first and falls back to the user's
+// chat model. It is a best-effort operation that logs and swallows
+// errors.
 func (p *Server) maybeGenerateChatTitle(
 	ctx context.Context,
 	chat database.Chat,
 	messages []database.ChatMessage,
 	fallbackModel fantasy.LanguageModel,
+	keys chatprovider.ProviderAPIKeys,
 	logger slog.Logger,
 ) {
 	input, ok := titleInput(chat, messages)
@@ -106,7 +69,18 @@ func (p *Server) maybeGenerateChatTitle(
 	titleCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	candidates := p.titleModelCandidates(ctx, fallbackModel)
+	// Build candidate list: preferred lightweight models first,
+	// then the user's chat model as last resort.
+	candidates := make([]fantasy.LanguageModel, 0, len(preferredTitleModels)+1)
+	for _, c := range preferredTitleModels {
+		m, err := chatprovider.ModelFromConfig(
+			c.provider, c.model, keys,
+		)
+		if err == nil {
+			candidates = append(candidates, m)
+		}
+	}
+	candidates = append(candidates, fallbackModel)
 	var lastErr error
 	for _, model := range candidates {
 		title, err := generateTitle(titleCtx, model, input)
@@ -174,7 +148,7 @@ func generateTitle(
 		var genErr error
 		response, genErr = model.Generate(retryCtx, fantasy.Call{
 			Prompt:          prompt,
-			MaxOutputTokens: int64Ptr(256),
+			MaxOutputTokens: ptr(int64(256)),
 		})
 		return genErr
 	}, nil)
@@ -189,7 +163,7 @@ func generateTitle(
 	return title, nil
 }
 
-func int64Ptr(v int64) *int64 { return &v }
+func ptr[T any](v T) *T { return &v }
 
 // titleInput returns the first user message text and whether title
 // generation should proceed. It returns false when the chat already

--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -10,6 +10,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/database"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
@@ -25,6 +26,64 @@ const titleGenerationPrompt = "Generate a concise title (2-8 words) for the user
 // generation. Models are returned in preference order — cheap, fast
 // models first, with the user's chat model as a last resort.
 type TitleModelFunc func() []fantasy.LanguageModel
+
+// preferredTitleModels are lightweight models used for title
+// generation, one per provider type. Each entry uses the
+// cheapest/fastest small model for that provider as identified
+// by the charmbracelet/catwalk model catalog. Providers that
+// aren't configured (no API key) are silently skipped.
+var preferredTitleModels = []struct {
+	provider string
+	model    string
+}{
+	{"anthropic", "claude-haiku-4-5"},
+	{"openai", "gpt-4o-mini"},
+	{"google", "gemini-2.5-flash"},
+	{"azure", "gpt-4o-mini"},
+	{"bedrock", "anthropic.claude-haiku-4-5-20251001-v1:0"},
+	{"openrouter", "anthropic/claude-3.5-haiku"},
+	{"vercel", "anthropic/claude-haiku-4.5"},
+}
+
+// titleModelCandidates returns an ordered list of models to try for
+// title generation. It resolves provider keys, attempts to create
+// each preferred lightweight model, and appends fallback as the
+// last resort.
+func (p *Server) titleModelCandidates(
+	ctx context.Context,
+	fallback fantasy.LanguageModel,
+) []fantasy.LanguageModel {
+	providers, err := p.db.GetEnabledChatProviders(ctx)
+	if err != nil {
+		return []fantasy.LanguageModel{fallback}
+	}
+	dbProviders := make(
+		[]chatprovider.ConfiguredProvider, 0, len(providers),
+	)
+	for _, provider := range providers {
+		dbProviders = append(dbProviders, chatprovider.ConfiguredProvider{
+			Provider: provider.Provider,
+			APIKey:   provider.APIKey,
+			BaseURL:  provider.BaseUrl,
+		})
+	}
+	keys := chatprovider.MergeProviderAPIKeys(
+		p.providerAPIKeys, dbProviders,
+	)
+
+	candidates := make([]fantasy.LanguageModel, 0, len(preferredTitleModels)+1)
+	for _, c := range preferredTitleModels {
+		m, err := chatprovider.ModelFromConfig(
+			c.provider, c.model, keys,
+		)
+		if err == nil {
+			candidates = append(candidates, m)
+		}
+	}
+	// Always fall back to the user's chat model.
+	candidates = append(candidates, fallback)
+	return candidates
+}
 
 // maybeGenerateChatTitle generates an AI title for the chat when
 // appropriate (first user message, no assistant reply yet, and the

--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -15,9 +15,16 @@ import (
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 )
 
-const titleGenerationPrompt = "Generate a concise title (max 8 words, under 128 characters) for " +
-	"the user's first message. Return plain text only — no quotes, no emoji, " +
-	"no markdown, no special characters."
+const titleGenerationPrompt = "Generate a concise title (2-8 words) for the user's message. " +
+	"Use verb-noun format describing the primary intent (e.g. \"Fix sidebar layout\", " +
+	"\"Add user authentication\", \"Refactor database queries\"). " +
+	"Return plain text only — no quotes, no emoji, no markdown, no code fences, " +
+	"no special characters, no trailing punctuation. Sentence case."
+
+// TitleModelFunc returns candidate language models for title
+// generation. Models are returned in preference order — cheap, fast
+// models first, with the user's chat model as a last resort.
+type TitleModelFunc func() []fantasy.LanguageModel
 
 // maybeGenerateChatTitle generates an AI title for the chat when
 // appropriate (first user message, no assistant reply yet, and the
@@ -27,7 +34,7 @@ func (p *Server) maybeGenerateChatTitle(
 	ctx context.Context,
 	chat database.Chat,
 	messages []database.ChatMessage,
-	model fantasy.LanguageModel,
+	titleModels TitleModelFunc,
 	logger slog.Logger,
 ) {
 	input, ok := titleInput(chat, messages)
@@ -38,31 +45,44 @@ func (p *Server) maybeGenerateChatTitle(
 	titleCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	title, err := generateTitle(titleCtx, model, input)
-	if err != nil {
-		logger.Debug(ctx, "failed to generate chat title",
-			slog.F("chat_id", chat.ID),
-			slog.Error(err),
-		)
-		return
-	}
-	if title == "" || title == chat.Title {
+	candidates := titleModels()
+	var lastErr error
+	for _, model := range candidates {
+		title, err := generateTitle(titleCtx, model, input)
+		if err != nil {
+			lastErr = err
+			logger.Debug(ctx, "title model candidate failed",
+				slog.F("chat_id", chat.ID),
+				slog.Error(err),
+			)
+			continue
+		}
+		if title == "" || title == chat.Title {
+			return
+		}
+
+		_, err = p.db.UpdateChatByID(ctx, database.UpdateChatByIDParams{
+			ID:    chat.ID,
+			Title: title,
+		})
+		if err != nil {
+			logger.Warn(ctx, "failed to update generated chat title",
+				slog.F("chat_id", chat.ID),
+				slog.Error(err),
+			)
+			return
+		}
+		chat.Title = title
+		p.publishChatPubsubEvent(chat, coderdpubsub.ChatEventKindTitleChange)
 		return
 	}
 
-	_, err = p.db.UpdateChatByID(ctx, database.UpdateChatByIDParams{
-		ID:    chat.ID,
-		Title: title,
-	})
-	if err != nil {
-		logger.Warn(ctx, "failed to update generated chat title",
+	if lastErr != nil {
+		logger.Debug(ctx, "all title model candidates failed",
 			slog.F("chat_id", chat.ID),
-			slog.Error(err),
+			slog.Error(lastErr),
 		)
-		return
 	}
-	chat.Title = title
-	p.publishChatPubsubEvent(chat, coderdpubsub.ChatEventKindTitleChange)
 }
 
 // generateTitle calls the model with a title-generation system prompt
@@ -87,14 +107,13 @@ func generateTitle(
 			},
 		},
 	}
-	toolChoice := fantasy.ToolChoiceNone
 
 	var response *fantasy.Response
 	err := chatretry.Retry(ctx, func(retryCtx context.Context) error {
 		var genErr error
 		response, genErr = model.Generate(retryCtx, fantasy.Call{
-			Prompt:     prompt,
-			ToolChoice: &toolChoice,
+			Prompt:          prompt,
+			MaxOutputTokens: int64Ptr(256),
 		})
 		return genErr
 	}, nil)
@@ -108,6 +127,8 @@ func generateTitle(
 	}
 	return title, nil
 }
+
+func int64Ptr(v int64) *int64 { return &v }
 
 // titleInput returns the first user message text and whether title
 // generation should proceed. It returns false when the chat already

--- a/coderd/chatd/title.go
+++ b/coderd/chatd/title.go
@@ -6,6 +6,13 @@ import (
 	"time"
 
 	"charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyazure "charm.land/fantasy/providers/azure"
+	fantasybedrock "charm.land/fantasy/providers/bedrock"
+	fantasygoogle "charm.land/fantasy/providers/google"
+	fantasyopenai "charm.land/fantasy/providers/openai"
+	fantasyopenrouter "charm.land/fantasy/providers/openrouter"
+	fantasyvercel "charm.land/fantasy/providers/vercel"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -31,13 +38,13 @@ var preferredTitleModels = []struct {
 	provider string
 	model    string
 }{
-	{"anthropic", "claude-haiku-4-5"},
-	{"openai", "gpt-4o-mini"},
-	{"google", "gemini-2.5-flash"},
-	{"azure", "gpt-4o-mini"},
-	{"bedrock", "anthropic.claude-haiku-4-5-20251001-v1:0"},
-	{"openrouter", "anthropic/claude-3.5-haiku"},
-	{"vercel", "anthropic/claude-haiku-4.5"},
+	{fantasyanthropic.Name, "claude-haiku-4-5"},
+	{fantasyopenai.Name, "gpt-4o-mini"},
+	{fantasygoogle.Name, "gemini-2.5-flash"},
+	{fantasyazure.Name, "gpt-4o-mini"},
+	{fantasybedrock.Name, "anthropic.claude-haiku-4-5-20251001-v1:0"},
+	{fantasyopenrouter.Name, "anthropic/claude-3.5-haiku"},
+	{fantasyvercel.Name, "anthropic/claude-haiku-4.5"},
 }
 
 // titleModelCandidates returns an ordered list of models to try for


### PR DESCRIPTION
## Problem

Title generation uses the same model the user selected for chat. This breaks when:

1. **Thinking/extended thinking models** — `ToolChoice: None` conflicts with extended thinking on Anthropic. The bare call has no thinking config, so provider-level defaults can conflict.
2. **Expensive models** — User picks `o3` or `claude-opus-4`, and a trivial 8-word title generation burns through tokens/cost unnecessarily.
3. **Provider quirks** — Different providers have different constraints around thinking mode + tool choice combinations.

## Solution

Modeled after how `coder/mux` handles this with `NAME_GEN_PREFERRED_MODELS` + ordered candidate fallback:

### Phase 1: Candidate model list with fallback
- New `TitleModelFunc` type returns an ordered list of candidate models
- Tries `claude-haiku-4-5` → `gpt-4o-mini` → user's model
- Gracefully skips unavailable candidates (missing API key, provider not configured)
- Falls back to the user's chat model as last resort

### Phase 2: Provider-safe call options
- Removed `ToolChoice: None` which conflicts with extended thinking on some providers
- Added `MaxOutputTokens: 256` to cap token usage
- Improved title prompt with verb-noun format guidance (`Fix sidebar layout`, `Add user authentication`) and explicit no-markdown/no-code-fences instructions

### Files changed
- `coderd/chatd/title.go` — Candidate loop, improved prompt, safe call options
- `coderd/chatd/chatd.go` — Build `TitleModelFunc` closure with lightweight candidates