### PR TITLE
fix(site): disable chat input editor on archived agent chats

### DIFF
--- a/site/src/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/components/ChatMessageInput/ChatMessageInput.tsx
@@ -258,11 +258,7 @@ const ChatMessageInput = memo(
 				},
 				onError: (error: Error) => console.error("Lexical error:", error),
 				nodes: [],
-				editable: !disabled,
 			}),
-			// Intentionally only uses the initial disabled value;
-			// runtime changes are handled by EditableStatePlugin.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
 			[],
 		);
 		const style = useMemo(

--- a/site/src/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/components/ChatMessageInput/ChatMessageInput.tsx
@@ -26,8 +26,8 @@ import {
 	memo,
 	useCallback,
 	useEffect,
-	useLayoutEffect,
 	useImperativeHandle,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 } from "react";
@@ -259,8 +259,9 @@ const ChatMessageInput = memo(
 				},
 				onError: (error: Error) => console.error("Lexical error:", error),
 				nodes: [],
+				editable: !disabled,
 			}),
-			[],
+			[disabled],
 		);
 		const style = useMemo(
 			() => ({

--- a/site/src/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/components/ChatMessageInput/ChatMessageInput.tsx
@@ -221,6 +221,21 @@ interface ChatMessageInputProps
 	"aria-label"?: string;
 }
 
+// Keeps the Lexical editor's editable state in sync with the
+// disabled prop so that the underlying contentEditable element
+// becomes truly non-interactive when the input is disabled.
+const EditableStatePlugin: FC<{ disabled: boolean }> = memo(
+	function EditableStatePlugin({ disabled }) {
+		const [editor] = useLexicalComposerContext();
+
+		useEffect(() => {
+			editor.setEditable(!disabled);
+		}, [editor, disabled]);
+
+		return null;
+	},
+);
+
 const ChatMessageInput = memo(
 	({
 		className,
@@ -243,7 +258,11 @@ const ChatMessageInput = memo(
 				},
 				onError: (error: Error) => console.error("Lexical error:", error),
 				nodes: [],
+				editable: !disabled,
 			}),
+			// Intentionally only uses the initial disabled value;
+			// runtime changes are handled by EditableStatePlugin.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
 			[],
 		);
 		const style = useMemo(
@@ -380,6 +399,7 @@ const ChatMessageInput = memo(
 					<ContentChangePlugin onChange={handleContentChange} />
 					<ValueSyncPlugin initialValue={initialValue} />
 					<InsertTextPlugin onEditorReady={handleEditorReady} />
+					<EditableStatePlugin disabled={!!disabled} />
 					{autoFocus && <AutoFocusPlugin />}
 				</div>
 			</LexicalComposer>

--- a/site/src/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/components/ChatMessageInput/ChatMessageInput.tsx
@@ -26,6 +26,7 @@ import {
 	memo,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useImperativeHandle,
 	useMemo,
 	useRef,
@@ -228,7 +229,7 @@ const EditableStatePlugin: FC<{ disabled: boolean }> = memo(
 	function EditableStatePlugin({ disabled }) {
 		const [editor] = useLexicalComposerContext();
 
-		useEffect(() => {
+		useLayoutEffect(() => {
 			editor.setEditable(!disabled);
 		}, [editor, disabled]);
 

--- a/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
@@ -84,7 +84,9 @@ export const DisabledInput: Story = {
 		// The editor should be non-editable so users cannot click
 		// into it and type (e.g. archived chats).
 		const editor = canvas.getByTestId("chat-message-input");
-		expect(editor).toHaveAttribute("contenteditable", "false");
+		await waitFor(() => {
+			expect(editor).toHaveAttribute("contenteditable", "false");
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
@@ -80,6 +80,11 @@ export const DisabledInput: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByRole("button", { name: "Send" })).toBeDisabled();
+
+		// The editor should be non-editable so users cannot click
+		// into it and type (e.g. archived chats).
+		const editor = canvas.getByTestId("chat-message-input");
+		expect(editor).toHaveAttribute("contenteditable", "false");
 	},
 };
 


### PR DESCRIPTION
## Problem

On archived agent chats, users can still click into the chat input box and type. The input visually appears disabled (reduced opacity, not-allowed cursor) but the underlying Lexical `contentEditable` element remains editable.

## Solution

- Added an `EditableStatePlugin` to `ChatMessageInput` that calls `editor.setEditable(false)` when `disabled` is true, making the `contentEditable` element truly non-interactive.
- Set `editable: !disabled` in Lexical's `initialConfig` so the editor starts in the correct state on first render.
- Extended the `DisabledInput` story to assert `contenteditable="false"` on the editor element.