### PR TITLE
perf(site): improve FilesChangedPanel rendering for large diffs

### DIFF
--- a/site/src/pages/AgentsPage/FilesChangedPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.stories.tsx
@@ -5,6 +5,185 @@ import type { ChatDiffContents } from "api/typesGenerated";
 import { expect, screen, spyOn } from "storybook/test";
 import { FilesChangedPanel } from "./FilesChangedPanel";
 
+// ---------------------------------------------------------------------------
+// Large-diff generator — produces a realistic unified diff with the
+// requested number of additions and deletions spread across multiple
+// TypeScript files.  Used by the LargeDiff story to reproduce the
+// performance characteristics of a +2000 -1000 agent chat.
+// ---------------------------------------------------------------------------
+
+/** Generate a block of realistic-looking TypeScript lines. */
+function tsLines(prefix: string, count: number, startIdx = 0): string[] {
+	const templates = [
+		(i: number) => `  const ${prefix}Val${i} = computeValue(${i}, opts);`,
+		(i: number) => `  if (${prefix}Val${i} !== undefined) {`,
+		(i: number) =>
+			`    logger.info("Processing ${prefix} item", { index: ${i} });`,
+		(i: number) => `    results.push(await transform(${prefix}Val${i}));`,
+		(_i: number) => "  }",
+		(i: number) => `  // Handle edge case for ${prefix} iteration ${i}`,
+		(i: number) =>
+			`  const ${prefix}Mapped${i} = items.map((x) => x.${prefix}Field${i});`,
+		(i: number) =>
+			`  await db.query(\`SELECT * FROM ${prefix}_table WHERE id = \${${i}}\`);`,
+		(i: number) =>
+			`  export function ${prefix}Handler${i}(req: Request): Response {`,
+		(i: number) =>
+			`    return new Response(JSON.stringify({ ${prefix}: ${i} }));`,
+	];
+	const lines: string[] = [];
+	for (let i = 0; i < count; i++) {
+		const tpl = templates[(startIdx + i) % templates.length];
+		lines.push(tpl(startIdx + i));
+	}
+	return lines;
+}
+
+/**
+ * Build a single file section of a unified diff. `contextLines` lines
+ * of shared context surround each hunk.  `additions` new lines and
+ * `deletions` removed lines are interleaved across multiple hunks.
+ */
+function buildFileDiff(opts: {
+	oldPath: string;
+	newPath: string;
+	additions: number;
+	deletions: number;
+	contextPerHunk?: number;
+	hunks?: number;
+}): string {
+	const {
+		oldPath,
+		newPath,
+		additions,
+		deletions,
+		contextPerHunk = 5,
+		hunks = Math.max(1, Math.ceil((additions + deletions) / 80)),
+	} = opts;
+
+	const addPerHunk = Math.ceil(additions / hunks);
+	const delPerHunk = Math.ceil(deletions / hunks);
+	const prefix = oldPath.replace(/[^a-zA-Z]/g, "").slice(0, 6);
+
+	let output = `diff --git a/${oldPath} b/${newPath}\n`;
+	output += "index 1a2b3c4..5d6e7f8 100644\n";
+	output += `--- a/${oldPath}\n`;
+	output += `+++ b/${newPath}\n`;
+
+	let oldLine = 1;
+	let additionsLeft = additions;
+	let deletionsLeft = deletions;
+
+	for (let h = 0; h < hunks; h++) {
+		const ctxLines = tsLines(prefix, contextPerHunk, oldLine);
+		const hunkDel = Math.min(delPerHunk, deletionsLeft);
+		const hunkAdd = Math.min(addPerHunk, additionsLeft);
+		deletionsLeft -= hunkDel;
+		additionsLeft -= hunkAdd;
+
+		const oldCount = contextPerHunk + hunkDel + contextPerHunk;
+		const newCount = contextPerHunk + hunkAdd + contextPerHunk;
+		output += `@@ -${oldLine},${oldCount} +${oldLine},${newCount} @@\n`;
+
+		// Leading context.
+		for (const l of ctxLines) {
+			output += ` ${l}\n`;
+		}
+
+		// Deletions.
+		for (const l of tsLines(
+			`old${prefix}`,
+			hunkDel,
+			oldLine + contextPerHunk,
+		)) {
+			output += `-${l}\n`;
+		}
+
+		// Additions.
+		for (const l of tsLines(
+			`new${prefix}`,
+			hunkAdd,
+			oldLine + contextPerHunk,
+		)) {
+			output += `+${l}\n`;
+		}
+
+		// Trailing context.
+		for (const l of tsLines(
+			prefix,
+			contextPerHunk,
+			oldLine + contextPerHunk + hunkDel,
+		)) {
+			output += ` ${l}\n`;
+		}
+
+		oldLine += oldCount + 20;
+	}
+
+	return output;
+}
+
+/**
+ * Generate a complete multi-file unified diff targeting roughly
+ * `totalAdditions` added lines and `totalDeletions` removed lines.
+ */
+function generateLargeDiff(
+	totalAdditions: number,
+	totalDeletions: number,
+): string {
+	const files = [
+		{
+			path: "site/src/pages/AgentsPage/AgentDetail.tsx",
+			addPct: 0.25,
+			delPct: 0.2,
+		},
+		{
+			path: "site/src/components/ai-elements/tool/utils.ts",
+			addPct: 0.15,
+			delPct: 0.15,
+		},
+		{
+			path: "site/src/pages/AgentsPage/FilesChangedPanel.tsx",
+			addPct: 0.15,
+			delPct: 0.1,
+		},
+		{ path: "site/src/api/queries/chats.ts", addPct: 0.1, delPct: 0.15 },
+		{
+			path: "site/src/modules/resources/AgentLogs/AgentLogs.tsx",
+			addPct: 0.1,
+			delPct: 0.1,
+		},
+		{ path: "coderd/database/queries/chats.sql", addPct: 0.05, delPct: 0.1 },
+		{
+			path: "site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx",
+			addPct: 0.1,
+			delPct: 0.05,
+		},
+		{
+			path: "site/src/pages/AgentsPage/DiffRightPanel.tsx",
+			addPct: 0.05,
+			delPct: 0.1,
+		},
+		{ path: "site/src/hooks/useDiffViewer.ts", addPct: 0.05, delPct: 0.05 },
+	];
+
+	const patches: string[] = [];
+	for (const f of files) {
+		const add = Math.round(totalAdditions * f.addPct);
+		const del = Math.round(totalDeletions * f.delPct);
+		if (add === 0 && del === 0) continue;
+		patches.push(
+			buildFileDiff({
+				oldPath: f.path,
+				newPath: f.path,
+				additions: add,
+				deletions: del,
+			}),
+		);
+	}
+	return patches.join("");
+}
+
 const sampleUnifiedDiff = `diff --git a/site/src/pages/AgentsPage/FilesChangedPanel.tsx b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
 index abc1234..def5678 100644
 --- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -180,6 +359,71 @@ export const NoPullRequestLight: Story = {
 		spyOn(API, "getChatDiffContents").mockResolvedValue({
 			...defaultDiffContents,
 			diff: sampleUnifiedDiff,
+		});
+	},
+};
+
+/**
+ * Stress-test story: renders a diff with approximately +2000 -1000
+ * lines spread across 9 TypeScript files. Use this to reproduce
+ * and profile the performance issues reported for large agent chats.
+ *
+ * Open the browser DevTools Performance tab and record while this
+ * story loads to measure:
+ *  - Initial render blocking time (shiki tokenization)
+ *  - Total DOM node count
+ *  - Scroll jank / frame drops
+ */
+export const LargeDiff: Story = {
+	decorators: [
+		(Story) => (
+			<div style={{ height: 800, width: 600 }}>
+				<Story />
+			</div>
+		),
+	],
+	beforeEach: () => {
+		const largeDiff = generateLargeDiff(2000, 1000);
+		spyOn(API, "getChatDiffStatus").mockResolvedValue({
+			...defaultDiffStatus,
+			url: "https://github.com/coder/coder/pull/789",
+			additions: 2000,
+			deletions: 1000,
+			changed_files: 9,
+		});
+		spyOn(API, "getChatDiffContents").mockResolvedValue({
+			...defaultDiffContents,
+			diff: largeDiff,
+		});
+	},
+};
+
+/**
+ * Same as LargeDiff but in light mode for visual comparison.
+ */
+export const LargeDiffLight: Story = {
+	globals: {
+		theme: "light",
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: 800, width: 600 }}>
+				<Story />
+			</div>
+		),
+	],
+	beforeEach: () => {
+		const largeDiff = generateLargeDiff(2000, 1000);
+		spyOn(API, "getChatDiffStatus").mockResolvedValue({
+			...defaultDiffStatus,
+			url: "https://github.com/coder/coder/pull/789",
+			additions: 2000,
+			deletions: 1000,
+			changed_files: 9,
+		});
+		spyOn(API, "getChatDiffContents").mockResolvedValue({
+			...defaultDiffContents,
+			diff: largeDiff,
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@emotion/react";
+import type { FileDiffMetadata } from "@pierre/diffs";
 import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import { chatDiffContents, chatDiffStatus } from "api/queries/chats";
@@ -14,7 +15,14 @@ import {
 	GitBranchIcon,
 	GitPullRequestIcon,
 } from "lucide-react";
-import { type FC, useMemo } from "react";
+import {
+	type ComponentProps,
+	type FC,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useQuery } from "react-query";
 
 interface FilesChangedPanelProps {
@@ -50,6 +58,23 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({ chatId }) => {
 		};
 	}, [isDark]);
 
+	// Memoize the per-file options object so every <FileDiff>
+	// receives the same reference and avoids re-highlighting
+	// when the parent re-renders.
+	const fileOptions = useMemo(
+		() => ({
+			...diffOptions,
+			overflow: "wrap" as const,
+			enableLineSelection: true,
+			enableHoverUtility: true,
+			onLineSelected() {
+				// TODO: Make this add context to the input so the
+				// user can type.
+			},
+		}),
+		[diffOptions],
+	);
+
 	const diffStatusQuery = useQuery(chatDiffStatus(chatId));
 	const diffContentsQuery = useQuery({
 		...chatDiffContents(chatId),
@@ -62,12 +87,15 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({ chatId }) => {
 			return [];
 		}
 		try {
-			const patches = parsePatchFiles(diff);
+			// The cacheKeyPrefix enables the worker pool's LRU cache
+			// so highlighted ASTs are reused across re-renders instead
+			// of being re-computed on every render cycle.
+			const patches = parsePatchFiles(diff, `chat-${chatId}`);
 			return patches.flatMap((p) => p.files);
 		} catch {
 			return [];
 		}
-	}, [diffContentsQuery.data?.diff]);
+	}, [diffContentsQuery.data?.diff, chatId]);
 
 	const pullRequestUrl = diffStatusQuery.data?.url;
 	const pullRequestLabel = pullRequestUrl
@@ -147,24 +175,85 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({ chatId }) => {
 				<ScrollArea className="min-w-0 flex-1" scrollBarClassName="w-1.5">
 					<div className="min-w-0 text-xs">
 						{parsedFiles.map((fileDiff) => (
-							<FileDiff
+							<LazyFileDiff
 								key={fileDiff.name}
 								fileDiff={fileDiff}
-								options={{
-									...diffOptions,
-									overflow: "wrap",
-									enableLineSelection: true,
-									enableHoverUtility: true,
-									onLineSelected() {
-										// TODO: Make this add context to the input so the user can type.
-									},
-								}}
-								style={DIFFS_FONT_STYLE}
+								options={fileOptions}
 							/>
 						))}
 					</div>
 				</ScrollArea>
 			)}
 		</div>
+	);
+};
+
+// -----------------------------------------------------------------------
+// Estimated height per line in the diff viewer (px). Derived from
+// the --diffs-font-size (11px) and --diffs-line-height (1.5)
+// values set via DIFFS_FONT_STYLE, plus 1px for the border/gap.
+// -----------------------------------------------------------------------
+const LINE_HEIGHT_PX = 17.5;
+
+// Height of the file header row rendered by @pierre/diffs.
+const HEADER_HEIGHT_PX = 36;
+
+/**
+ * Estimate the rendered pixel height of a file diff so the
+ * placeholder occupies roughly the same space. This keeps the
+ * scroll position stable as files are lazily mounted.
+ */
+function estimateDiffHeight(fileDiff: FileDiffMetadata): number {
+	return HEADER_HEIGHT_PX + fileDiff.unifiedLineCount * LINE_HEIGHT_PX;
+}
+
+/**
+ * Wraps a single `<FileDiff>` with an IntersectionObserver so the
+ * heavy component (Shadow DOM + shiki highlighting) is only mounted
+ * once the placeholder scrolls into or near the viewport.
+ *
+ * Once mounted the component stays mounted — we never unmount a
+ * FileDiff that the user has already scrolled past, which avoids
+ * layout shifts and repeated highlighting work.
+ */
+const LazyFileDiff: FC<{
+	fileDiff: FileDiffMetadata;
+	options: ComponentProps<typeof FileDiff>["options"];
+}> = ({ fileDiff, options }) => {
+	const placeholderRef = useRef<HTMLDivElement>(null);
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		const el = placeholderRef.current;
+		if (!el || visible) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting) {
+					setVisible(true);
+					observer.disconnect();
+				}
+			},
+			// Pre-load files that are within one viewport-height of
+			// the visible area so they are ready before the user
+			// scrolls to them.
+			{ rootMargin: "100% 0px" },
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [visible]);
+
+	if (!visible) {
+		return (
+			<div
+				ref={placeholderRef}
+				style={{ height: estimateDiffHeight(fileDiff) }}
+			/>
+		);
+	}
+
+	return (
+		<FileDiff fileDiff={fileDiff} options={options} style={DIFFS_FONT_STYLE} />
 	);
 };


### PR DESCRIPTION
## Problem

The right-panel git diff viewer (`FilesChangedPanel`) becomes sluggish when rendering large diffs (~+2000 -1000 lines). All 9 file diffs mount simultaneously, each creating a Shadow DOM, running synchronous shiki tokenization, and generating full HAST trees — blocking the main thread for hundreds of milliseconds.

## Changes

### Runtime fixes (`FilesChangedPanel.tsx`)

1. **Lazy-mount file diffs via IntersectionObserver** — A new `LazyFileDiff` wrapper renders a height-estimated placeholder and only mounts the real `<FileDiff>` (Shadow DOM + shiki highlighting) once the placeholder scrolls within one viewport-height of the visible area. Once mounted, it stays mounted to avoid layout shifts.

2. **Enable worker pool LRU caching** — Passes a `cacheKeyPrefix` (`chat-${chatId}`) to `parsePatchFiles` so the `@pierre/diffs` worker pool's LRU cache is activated. Previously, every `FileDiffMetadata` had `cacheKey = undefined`, so highlighted ASTs were re-computed on every render cycle.

3. **Memoize per-file options** — Extracts the inline options object from the `.map()` into a `useMemo`-wrapped `fileOptions` variable so every `<FileDiff>` receives a stable reference and avoids unnecessary re-highlighting when the parent re-renders.

### Storybook (`FilesChangedPanel.stories.tsx`)

- Adds `LargeDiff` and `LargeDiffLight` stories with a `generateLargeDiff(2000, 1000)` helper that produces a realistic ~145KB unified diff across 9 TypeScript files (41 hunks). Useful for profiling with browser DevTools.

## Testing

- `tsc --noEmit` — zero errors
- `biome check` — zero errors
- Storybook stories render correctly

## Follow-up opportunities (not in this PR)

- Unmount `FilesChangedPanel` entirely when the diff panel is closed (currently stays mounted via CSS `hidden`)
- Debounce SSE-driven re-fetches on `diff_status_change` events
- Add `DiffsWorkerPoolProvider` to Storybook preview decorators