### PR TITLE
fix(webpush): clean up stale subscriptions even when delivery fails

### DIFF
--- a/coderd/webpush/webpush.go
+++ b/coderd/webpush/webpush.go
@@ -133,16 +133,21 @@ func (n *Webpusher) Dispatch(ctx context.Context, userID uuid.UUID, msg codersdk
 	}
 
 	err = eg.Wait()
-	if err != nil {
-		return xerrors.Errorf("send webpush notifications: %w", err)
-	}
 
+	// Always clean up stale subscriptions, even if some sends failed.
+	// Otherwise, a delivery error in one subscription would prevent
+	// cleanup of expired (410 Gone) subscriptions, causing them to
+	// accumulate in the database and be retried on every dispatch.
 	if len(cleanupSubscriptions) > 0 {
 		// nolint:gocritic // These are known to be invalid subscriptions.
-		err = n.store.DeleteWebpushSubscriptions(dbauthz.AsNotifier(ctx), cleanupSubscriptions)
-		if err != nil {
-			n.log.Error(ctx, "failed to delete stale push subscriptions", slog.Error(err))
+		delErr := n.store.DeleteWebpushSubscriptions(dbauthz.AsNotifier(ctx), cleanupSubscriptions)
+		if delErr != nil {
+			n.log.Error(ctx, "failed to delete stale push subscriptions", slog.Error(delErr))
 		}
+	}
+
+	if err != nil {
+		return xerrors.Errorf("send webpush notifications: %w", err)
 	}
 
 	return nil

--- a/coderd/webpush/webpush_test.go
+++ b/coderd/webpush/webpush_test.go
@@ -168,6 +168,61 @@ func TestPush(t *testing.T) {
 		}
 	})
 
+	t.Run("GoneAndFailedSubscriptions", func(t *testing.T) {
+		// When one subscription returns 410 Gone and another returns an
+		// error (e.g. 400), the stale subscription should still be
+		// cleaned up from the database.
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		manager, store, serverBadURL := setupPushTest(ctx, t, func(w http.ResponseWriter, r *http.Request) {
+			assertWebpushPayload(t, r)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("Invalid request"))
+		})
+
+		serverGone := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertWebpushPayload(t, r)
+			w.WriteHeader(http.StatusGone)
+		}))
+		defer serverGone.Close()
+		serverGoneURL := serverGone.URL
+
+		user := dbgen.User(t, store, database.User{})
+
+		subBad, err := store.InsertWebpushSubscription(ctx, database.InsertWebpushSubscriptionParams{
+			UserID:            user.ID,
+			Endpoint:          serverBadURL,
+			EndpointAuthKey:   validEndpointAuthKey,
+			EndpointP256dhKey: validEndpointP256dhKey,
+			CreatedAt:         dbtime.Now(),
+		})
+		require.NoError(t, err)
+
+		_, err = store.InsertWebpushSubscription(ctx, database.InsertWebpushSubscriptionParams{
+			UserID:            user.ID,
+			Endpoint:          serverGoneURL,
+			EndpointAuthKey:   validEndpointAuthKey,
+			EndpointP256dhKey: validEndpointP256dhKey,
+			CreatedAt:         dbtime.Now(),
+		})
+		require.NoError(t, err)
+
+		msg := randomWebpushMessage(t)
+		err = manager.Dispatch(ctx, user.ID, msg)
+		// Should still return an error for the failed delivery.
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid request")
+
+		// The gone subscription should have been cleaned up despite the
+		// error from the other subscription.
+		subscriptions, err := store.GetWebpushSubscriptionsByUserID(ctx, user.ID)
+		require.NoError(t, err)
+		if assert.Len(t, subscriptions, 1, "Only the non-gone subscription should remain") {
+			assert.Equal(t, subscriptions[0].ID, subBad.ID, "The failed (non-gone) subscription should not be deleted")
+		}
+	})
+
 	t.Run("NotificationPayload", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Bug

When dispatching push notifications to multiple subscriptions concurrently, if one subscription returns `410 Gone` (expired) and another returns a delivery error (e.g. `400 Bad Request`), the `errgroup.Wait()` error caused an early return **before** the cleanup block ran. This meant expired subscriptions were never deleted from the database, accumulating permanently and being retried on every subsequent `Dispatch` call.

## Fix

Move the stale subscription cleanup before the error check so expired subscriptions are always deleted regardless of whether other subscriptions had delivery failures. The delivery error is still returned to the caller.

## Test

Added `TestPush/GoneAndFailedSubscriptions` — sets up two subscriptions (one returns `400`, one returns `410`), dispatches a notification, and verifies the `410` subscription is cleaned up even though the `400` subscription causes `Dispatch` to return an error.