### PR TITLE
fix: add missing return after error response in returnDAUsInternal and fix %n format verbs

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -4421,7 +4421,7 @@ func TestGetUserStatusCounts(t *testing.T) {
 							assert.True(
 								t,
 								rowDate.Equal(expectedDate),
-								"expected date %s, but got %s for row %n",
+								"expected date %s, but got %s for row %d",
 								expectedDate.String(),
 								rowDate.String(),
 								i,
@@ -4594,7 +4594,7 @@ func TestGetUserStatusCounts(t *testing.T) {
 							require.True(
 								t,
 								rowDate.Equal(expectedDate),
-								"expected date %s, but got %s for row %n",
+								"expected date %s, but got %s for row %d",
 								expectedDate.String(),
 								rowDate.String(),
 								i,
@@ -4797,7 +4797,7 @@ func TestGetUserStatusCounts(t *testing.T) {
 					require.True(
 						t,
 						row.Date.In(tc.location).Equal(dbtime.StartOfDay(userCreatedAt).AddDate(0, 0, 1+i)),
-						"expected date %s, but got %s for row %n",
+						"expected date %s, but got %s for row %d",
 						dbtime.StartOfDay(userCreatedAt).AddDate(0, 0, 1+i),
 						row.Date.In(tc.location).String(),
 						i,
@@ -4864,7 +4864,7 @@ func TestGetUserStatusCounts(t *testing.T) {
 					assert.True(
 						t,
 						row.Date.Equal(target),
-						"expected date %s, but got %s for row %n",
+						"expected date %s, but got %s for row %d",
 						target.String(),
 						row.Date.String(),
 						i,

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -82,6 +82,7 @@ func (api *API) returnDAUsInternal(rw http.ResponseWriter, r *http.Request, temp
 			Message: "Internal error fetching DAUs.",
 			Detail:  err.Error(),
 		})
+		return
 	}
 
 	resp := codersdk.DAUsResponse{


### PR DESCRIPTION
## Bug 1: Missing `return` after error response in `coderd/insights.go`

**Line 85** — `returnDAUsInternal` writes a `500 Internal Server Error` response when `GetTemplateInsightsByInterval` fails, but **does not return**. Execution falls through to construct a `DAUsResponse` from the nil/empty `rows` slice and writes a **second** `200 OK` response to the same `http.ResponseWriter`.

This results in:
- A `superfluous response.WriteHeader` warning in server logs
- The client receiving a 500 status but potentially garbled response body
- An empty `DAUsResponse` being sent even on database errors

Every other error handler in the same file (lines 165, 255, 371, 526, 535) correctly returns after writing the error response. This one was simply missed.

**Fix:** Add `return` after the error write.

## Bug 2: Invalid `%n` format verb in `coderd/database/querier_test.go`

Four test assertions (lines 4424, 4597, 4800, 4867) use `%n` as a format verb for an `int` argument. `%n` is not a valid Go `fmt` verb, so on assertion failure the row index renders as `%!n(int=X)` instead of the actual integer, making failure messages unreadable.

**Fix:** Change `%n` to `%d`.