### PR TITLE
fix(docs): reorder Coder Agents section in manifest.json (#22604)

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -957,11 +957,6 @@
 			"icon_path": "./images/icons/wand.svg",
 			"children": [
 				{
-					"title": "Coder Agents",
-					"description": "Self-hosted agent by Coder",
-					"path": "./ai-coder/agents.md"
-				},
-				{
 					"title": "Best Practices",
 					"description": "Best Practices running Coding Agents",
 					"path": "./ai-coder/best-practices.md"
@@ -1186,6 +1181,11 @@
 					"description": "Connect to agents Coder with a MCP server",
 					"path": "./ai-coder/mcp-server.md",
 					"state": ["beta"]
+				},
+				{
+					"title": "Coder Agents",
+					"description": "Self-hosted agent by Coder",
+					"path": "./ai-coder/agents.md"
 				}
 			]
 		},


### PR DESCRIPTION
## Changes

- Moved the Coder Agents entry to the end of the children array to improve the organization of the documentation structure.
- Added smaller version of the video on this page.

<img width="368" height="688" alt="image" src="https://github.com/user-attachments/assets/3117acfd-8c8a-4522-84e7-a748a7596cc6" />


<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
