### PR TITLE
feat(coderd): add paginated GET /chats/{chat}/messages endpoint

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1019,8 +1019,10 @@ func (p *Server) Subscribe(
 	// endpoint), so we only fetch newer ones to avoid sending
 	// duplicate data.
 	messages, err := p.db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chatID,
-		AfterID: afterMessageID,
+		ChatID:   chatID,
+		AfterID:  afterMessageID,
+		BeforeID: sql.NullInt64{},
+		LimitOpt: 0,
 	})
 	if err == nil {
 		for _, msg := range messages {
@@ -1265,8 +1267,10 @@ func (p *Server) Subscribe(
 					if notify.AfterMessageID > 0 {
 						// Read only new messages from DB.
 						messages, err := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
-							ChatID:  chatID,
-							AfterID: lastMessageID,
+							ChatID:   chatID,
+							AfterID:  lastMessageID,
+							BeforeID: sql.NullInt64{},
+							LimitOpt: 0,
 						})
 						if err == nil {
 							for _, msg := range messages {

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -360,8 +360,10 @@ func TestSendMessageQueueBehaviorQueuesWhenBusy(t *testing.T) {
 	require.Len(t, queued, 1)
 
 	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
+		ChatID:   chat.ID,
+		AfterID:  0,
+		BeforeID: sql.NullInt64{},
+		LimitOpt: 0,
 	})
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
@@ -413,8 +415,10 @@ func TestSendMessageInterruptBehaviorSendsImmediatelyWhenBusy(t *testing.T) {
 	require.Len(t, queued, 0)
 
 	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
+		ChatID:   chat.ID,
+		AfterID:  0,
+		BeforeID: sql.NullInt64{},
+		LimitOpt: 0,
 	})
 	require.NoError(t, err)
 	require.Len(t, messages, 2)
@@ -439,8 +443,10 @@ func TestEditMessageUpdatesAndTruncatesAndClearsQueue(t *testing.T) {
 	require.NoError(t, err)
 
 	initialMessages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
+		ChatID:   chat.ID,
+		AfterID:  0,
+		BeforeID: sql.NullInt64{},
+		LimitOpt: 0,
 	})
 	require.NoError(t, err)
 	require.Len(t, initialMessages, 1)
@@ -489,8 +495,10 @@ func TestEditMessageUpdatesAndTruncatesAndClearsQueue(t *testing.T) {
 	require.Equal(t, "edited", editedSDK.Content[0].Text)
 
 	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
+		ChatID:   chat.ID,
+		AfterID:  0,
+		BeforeID: sql.NullInt64{},
+		LimitOpt: 0,
 	})
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
@@ -1066,7 +1074,9 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 	require.Equal(t, workspaceName, workspace.Name)
 
 	var foundCreateWorkspaceResult bool
-	for _, message := range chatWithMessages.Messages {
+	messagesResp, err := client.GetChatMessages(ctx, chat.ID, nil, nil)
+	require.NoError(t, err)
+	for _, message := range messagesResp.Messages {
 		if message.Role != "tool" {
 			continue
 		}

--- a/coderd/chatd/subagent.go
+++ b/coderd/chatd/subagent.go
@@ -2,6 +2,7 @@ package chatd
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"sort"
 	"strings"
@@ -398,8 +399,10 @@ func latestSubagentAssistantMessage(
 	chatID uuid.UUID,
 ) (string, error) {
 	messages, err := store.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chatID,
-		AfterID: 0,
+		ChatID:   chatID,
+		AfterID:  0,
+		BeforeID: sql.NullInt64{},
+		LimitOpt: 0,
 	})
 	if err != nil {
 		return "", xerrors.Errorf("get chat messages: %w", err)

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -385,18 +385,6 @@ func (api *API) getChat(rw http.ResponseWriter, r *http.Request) {
 	chat := httpmw.ChatParam(r)
 	chatID := chat.ID
 
-	messages, err := api.Database.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chatID,
-		AfterID: 0,
-	})
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to get chat messages.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
 	queuedMessages, err := api.Database.GetChatQueuedMessages(ctx, chatID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -408,8 +396,77 @@ func (api *API) getChat(rw http.ResponseWriter, r *http.Request) {
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatWithMessages{
 		Chat:           convertChat(chat, nil),
-		Messages:       convertChatMessages(messages),
 		QueuedMessages: convertChatQueuedMessages(queuedMessages),
+	})
+}
+
+const defaultChatMessageLimit = 100
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+//nolint:revive // HTTP handler writes to ResponseWriter.
+func (api *API) getChatMessages(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	chat := httpmw.ChatParam(r)
+	chatID := chat.ID
+
+	var beforeID int64
+	if v := r.URL.Query().Get("before_id"); v != "" {
+		var err error
+		beforeID, err = strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid before_id parameter.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+	}
+
+	limit := defaultChatMessageLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		var err error
+		limit, err = strconv.Atoi(v)
+		if err != nil || limit < 1 || limit > 1000 {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid limit parameter. Must be between 1 and 1000.",
+			})
+			return
+		}
+	}
+
+	// Request one extra to determine if there are more messages.
+	//nolint:gosec // limit is validated to be between 1 and 1000.
+	dbLimit := int32(limit + 1)
+
+	messages, err := api.Database.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:   chatID,
+		AfterID:  0,
+		BeforeID: sql.NullInt64{Int64: beforeID, Valid: beforeID > 0},
+		LimitOpt: dbLimit,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get chat messages.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	hasMore := len(messages) > limit
+	if hasMore {
+		messages = messages[1:] // Remove the oldest extra message.
+	}
+
+	var afterID int64
+	if len(messages) > 0 {
+		afterID = messages[0].ID
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatMessagesResponse{
+		Messages: convertChatMessages(messages),
+		AfterID:  afterID,
+		HasMore:  hasMore,
 	})
 }
 

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -85,8 +85,11 @@ func TestPostChats(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, chat.ID, chatWithMessages.Chat.ID)
 
+		messagesResp, err := client.GetChatMessages(ctx, chat.ID, nil, nil)
+		require.NoError(t, err)
+
 		foundUserMessage := false
-		for _, message := range chatWithMessages.Messages {
+		for _, message := range messagesResp.Messages {
 			if message.Role != "user" {
 				continue
 			}
@@ -121,7 +124,10 @@ func TestPostChats(t *testing.T) {
 
 		chatWithMessages, err := client.GetChat(ctx, chat.ID)
 		require.NoError(t, err)
-		for _, message := range chatWithMessages.Messages {
+		_ = chatWithMessages
+		messagesResp, err := client.GetChatMessages(ctx, chat.ID, nil, nil)
+		require.NoError(t, err)
+		for _, message := range messagesResp.Messages {
 			require.NotEqual(t, "system", message.Role)
 		}
 	})
@@ -1113,11 +1119,13 @@ func TestGetChat(t *testing.T) {
 		require.Equal(t, "get chat route payload", chatWithMessages.Chat.Title)
 		require.NotZero(t, chatWithMessages.Chat.CreatedAt)
 		require.NotZero(t, chatWithMessages.Chat.UpdatedAt)
-		require.NotEmpty(t, chatWithMessages.Messages)
+		messagesResp, err := client.GetChatMessages(ctx, createdChat.ID, nil, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, messagesResp.Messages)
 		require.Empty(t, chatWithMessages.QueuedMessages)
 
 		foundUserMessage := false
-		for _, message := range chatWithMessages.Messages {
+		for _, message := range messagesResp.Messages {
 			require.Equal(t, createdChat.ID, message.ChatID)
 			require.NotEqual(t, "system", message.Role)
 			for _, part := range message.Content {
@@ -1442,7 +1450,11 @@ func TestPostChatMessages(t *testing.T) {
 						return true
 					}
 				}
-				for _, message := range chatWithMessages.Messages {
+				messagesResp, getErr := client.GetChatMessages(ctx, chat.ID, nil, nil)
+				if getErr != nil {
+					return false
+				}
+				for _, message := range messagesResp.Messages {
 					if message.Role == "user" && hasTextPart(message.Content, messageText) {
 						return true
 					}
@@ -1458,11 +1470,11 @@ func TestPostChatMessages(t *testing.T) {
 			require.True(t, hasTextPart(created.Message.Content, messageText))
 
 			require.Eventually(t, func() bool {
-				chatWithMessages, getErr := client.GetChat(ctx, chat.ID)
+				messagesResp, getErr := client.GetChatMessages(ctx, chat.ID, nil, nil)
 				if getErr != nil {
 					return false
 				}
-				for _, message := range chatWithMessages.Messages {
+				for _, message := range messagesResp.Messages {
 					if message.ID == created.Message.ID &&
 						message.Role == "user" &&
 						hasTextPart(message.Content, messageText) {
@@ -1548,9 +1560,13 @@ func TestPatchChatMessage(t *testing.T) {
 
 		chatWithMessages, err := client.GetChat(ctx, chat.ID)
 		require.NoError(t, err)
+		_ = chatWithMessages
+
+		messagesResp, err := client.GetChatMessages(ctx, chat.ID, nil, nil)
+		require.NoError(t, err)
 
 		var userMessageID int64
-		for _, message := range chatWithMessages.Messages {
+		for _, message := range messagesResp.Messages {
 			if message.Role == "user" {
 				userMessageID = message.ID
 				break
@@ -1580,9 +1596,12 @@ func TestPatchChatMessage(t *testing.T) {
 
 		updatedChat, err := client.GetChat(ctx, chat.ID)
 		require.NoError(t, err)
+		_ = updatedChat
+		updatedMsgsResp, err := client.GetChatMessages(ctx, chat.ID, nil, nil)
+		require.NoError(t, err)
 		foundEditedInChat := false
 		foundOriginalInChat := false
-		for _, message := range updatedChat.Messages {
+		for _, message := range updatedMsgsResp.Messages {
 			if message.Role != "user" {
 				continue
 			}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1131,6 +1131,7 @@ func New(options *Options) *API {
 				r.Get("/", api.getChat)
 				r.Post("/archive", api.archiveChat)
 				r.Post("/unarchive", api.unarchiveChat)
+				r.Get("/messages", api.getChatMessages)
 				r.Post("/messages", api.postChatMessages)
 				r.Patch("/messages/{message}", api.patchChatMessage)
 				r.Get("/stream", api.streamChat)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -473,7 +473,7 @@ func (s *MethodTestSuite) TestChats() {
 	s.Run("GetChatMessagesByChatID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})
 		msgs := []database.ChatMessage{testutil.Fake(s.T(), faker, database.ChatMessage{ChatID: chat.ID})}
-		arg := database.GetChatMessagesByChatIDParams{ChatID: chat.ID, AfterID: 0}
+		arg := database.GetChatMessagesByChatIDParams{ChatID: chat.ID, AfterID: 0, BeforeID: sql.NullInt64{}, LimitOpt: 0}
 		dbm.EXPECT().GetChatByID(gomock.Any(), chat.ID).Return(chat, nil).AnyTimes()
 		dbm.EXPECT().GetChatMessagesByChatID(gomock.Any(), arg).Return(msgs, nil).AnyTimes()
 		check.Args(arg).Asserts(chat, policy.ActionRead).Returns(msgs)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3153,25 +3153,45 @@ func (q *sqlQuerier) GetChatMessageByID(ctx context.Context, id int64) (ChatMess
 }
 
 const getChatMessagesByChatID = `-- name: GetChatMessagesByChatID :many
-SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed
-FROM
-    chat_messages
-WHERE
-    chat_id = $1::uuid
-    AND id > $2::bigint
-    AND visibility IN ('user', 'both')
+SELECT id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed FROM (
+    SELECT
+        id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed
+    FROM
+        chat_messages
+    WHERE
+        chat_id = $1::uuid
+        AND visibility IN ('user', 'both')
+        AND CASE
+            WHEN $2::bigint IS NOT NULL THEN id < $2::bigint
+            WHEN $3::bigint > 0 THEN id > $3::bigint
+            ELSE TRUE
+        END
+    ORDER BY
+        created_at DESC, id DESC
+    LIMIT
+        CASE
+            WHEN $4::integer > 0 THEN $4::integer
+            ELSE NULL
+        END
+) AS sub
 ORDER BY
-    created_at ASC
+    created_at ASC, id ASC
 `
 
 type GetChatMessagesByChatIDParams struct {
-	ChatID  uuid.UUID `db:"chat_id" json:"chat_id"`
-	AfterID int64     `db:"after_id" json:"after_id"`
+	ChatID   uuid.UUID     `db:"chat_id" json:"chat_id"`
+	BeforeID sql.NullInt64 `db:"before_id" json:"before_id"`
+	AfterID  int64         `db:"after_id" json:"after_id"`
+	LimitOpt int32         `db:"limit_opt" json:"limit_opt"`
 }
 
 func (q *sqlQuerier) GetChatMessagesByChatID(ctx context.Context, arg GetChatMessagesByChatIDParams) ([]ChatMessage, error) {
-	rows, err := q.db.QueryContext(ctx, getChatMessagesByChatID, arg.ChatID, arg.AfterID)
+	rows, err := q.db.QueryContext(ctx, getChatMessagesByChatID,
+		arg.ChatID,
+		arg.BeforeID,
+		arg.AfterID,
+		arg.LimitOpt,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -35,16 +35,29 @@ WHERE
     id = @id::bigint;
 
 -- name: GetChatMessagesByChatID :many
-SELECT
-    *
-FROM
-    chat_messages
-WHERE
-    chat_id = @chat_id::uuid
-    AND id > @after_id::bigint
-    AND visibility IN ('user', 'both')
+SELECT * FROM (
+    SELECT
+        *
+    FROM
+        chat_messages
+    WHERE
+        chat_id = @chat_id::uuid
+        AND visibility IN ('user', 'both')
+        AND CASE
+            WHEN sqlc.narg('before_id')::bigint IS NOT NULL THEN id < sqlc.narg('before_id')::bigint
+            WHEN @after_id::bigint > 0 THEN id > @after_id::bigint
+            ELSE TRUE
+        END
+    ORDER BY
+        created_at DESC, id DESC
+    LIMIT
+        CASE
+            WHEN @limit_opt::integer > 0 THEN @limit_opt::integer
+            ELSE NULL
+        END
+) AS sub
 ORDER BY
-    created_at ASC;
+    created_at ASC, id ASC;
 
 -- name: GetChatMessagesForPromptByChatID :many
 WITH latest_compressed_summary AS (

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -141,11 +142,21 @@ type CreateChatMessageResponse struct {
 	Queued        bool               `json:"queued"`
 }
 
-// ChatWithMessages is a chat along with its messages.
+// ChatWithMessages is a chat along with its queued messages.
 type ChatWithMessages struct {
 	Chat           Chat                `json:"chat"`
-	Messages       []ChatMessage       `json:"messages"`
 	QueuedMessages []ChatQueuedMessage `json:"queued_messages"`
+}
+
+// ChatMessagesResponse is the paginated response for chat messages.
+type ChatMessagesResponse struct {
+	Messages []ChatMessage `json:"messages"`
+	// AfterID is the ID of the oldest message in this page.
+	// Use this as the before_id parameter to fetch the previous
+	// page.
+	AfterID int64 `json:"after_id"`
+	// HasMore indicates if there are older messages to fetch.
+	HasMore bool `json:"has_more"`
 }
 
 // ChatModelProviderUnavailableReason explains why a provider cannot be used.
@@ -792,7 +803,7 @@ func (c *Client) StreamChat(ctx context.Context, chatID uuid.UUID) (<-chan ChatS
 	}), nil
 }
 
-// GetChat returns a chat by ID, including its messages.
+// GetChat returns a chat by ID, including its queued messages.
 func (c *Client) GetChat(ctx context.Context, chatID uuid.UUID) (ChatWithMessages, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s", chatID), nil)
 	if err != nil {
@@ -804,6 +815,33 @@ func (c *Client) GetChat(ctx context.Context, chatID uuid.UUID) (ChatWithMessage
 	}
 	var chat ChatWithMessages
 	return chat, json.NewDecoder(res.Body).Decode(&chat)
+}
+
+// GetChatMessages returns paginated messages for a chat.
+// Use beforeID to fetch messages older than a given ID.
+// Default limit is 100.
+func (c *Client) GetChatMessages(ctx context.Context, chatID uuid.UUID, beforeID *int64, limit *int) (ChatMessagesResponse, error) {
+	qp := url.Values{}
+	if beforeID != nil {
+		qp.Set("before_id", strconv.FormatInt(*beforeID, 10))
+	}
+	if limit != nil {
+		qp.Set("limit", strconv.Itoa(*limit))
+	}
+	reqURL := fmt.Sprintf("/api/experimental/chats/%s/messages", chatID)
+	if len(qp) > 0 {
+		reqURL += "?" + qp.Encode()
+	}
+	res, err := c.Request(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return ChatMessagesResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatMessagesResponse{}, ReadBodyAsError(res)
+	}
+	var resp ChatMessagesResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
 func (c *Client) ArchiveChat(ctx context.Context, chatID uuid.UUID) error {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2930,6 +2930,17 @@ class ApiMethods {
 		return response.data;
 	};
 
+	getChatMessages = async (
+		chatId: string,
+		params?: { before_id?: number; limit?: number },
+	): Promise<TypesGen.ChatMessagesResponse> => {
+		const response = await this.axios.get<TypesGen.ChatMessagesResponse>(
+			`/api/experimental/chats/${chatId}/messages`,
+			{ params },
+		);
+		return response.data;
+	};
+
 	createChat = async (
 		req: TypesGen.CreateChatRequest,
 	): Promise<TypesGen.Chat> => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -4,6 +4,8 @@ import type { QueryClient } from "react-query";
 
 export const chatsKey = ["chats"] as const;
 export const chatKey = (chatId: string) => ["chats", chatId] as const;
+export const chatMessagesKey = (chatId: string, beforeId?: number) =>
+	["chats", chatId, "messages", beforeId ?? "latest"] as const;
 
 export const chats = () => ({
 	queryKey: chatsKey,
@@ -14,6 +16,12 @@ export const chats = () => ({
 export const chat = (chatId: string) => ({
 	queryKey: chatKey(chatId),
 	queryFn: () => API.getChat(chatId),
+});
+
+export const chatMessages = (chatId: string, beforeId?: number) => ({
+	queryKey: chatMessagesKey(chatId, beforeId),
+	queryFn: () =>
+		API.getChatMessages(chatId, beforeId ? { before_id: beforeId } : undefined),
 });
 
 export const createChat = (queryClient: QueryClient) => ({

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1195,6 +1195,24 @@ export interface ChatMessageUsage {
 
 // From codersdk/chats.go
 /**
+ * ChatMessagesResponse is the paginated response for chat messages.
+ */
+export interface ChatMessagesResponse {
+	readonly messages: readonly ChatMessage[];
+	/**
+	 * AfterID is the ID of the oldest message in this page.
+	 * Use this as the before_id parameter to fetch the previous
+	 * page.
+	 */
+	readonly after_id: number;
+	/**
+	 * HasMore indicates if there are older messages to fetch.
+	 */
+	readonly has_more: boolean;
+}
+
+// From codersdk/chats.go
+/**
  * ChatModel represents a model in the chat model catalog.
  */
 export interface ChatModel {
@@ -1581,11 +1599,10 @@ export interface ChatStreamStatus {
 
 // From codersdk/chats.go
 /**
- * ChatWithMessages is a chat along with its messages.
+ * ChatWithMessages is a chat along with its queued messages.
  */
 export interface ChatWithMessages {
 	readonly chat: Chat;
-	readonly messages: readonly ChatMessage[];
 	readonly queued_messages: readonly ChatQueuedMessage[];
 }
 

--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -14,6 +14,7 @@ import {
 	chatDiffContentsKey,
 	chatDiffStatusKey,
 	chatKey,
+	chatMessagesKey,
 	chatModelsKey,
 	chatsKey,
 } from "api/queries/chats";
@@ -132,36 +133,55 @@ index abc1234..def5678 100644
 
 /** Build `parameters.queries` entries for a given chat data object. */
 const buildQueries = (
-	chatData: TypesGen.ChatWithMessages,
+	chatAndMessages: {
+		chat: TypesGen.Chat;
+		messages?: readonly TypesGen.ChatMessage[];
+		queued_messages: readonly TypesGen.ChatQueuedMessage[];
+	},
 	opts?: { diffUrl?: string },
-) => [
-	{ key: chatKey(CHAT_ID), data: chatData },
-	{ key: chatsKey, data: [chatData.chat] },
-	{
-		key: chatDiffStatusKey(CHAT_ID),
-		data: {
-			chat_id: CHAT_ID,
-			url: opts?.diffUrl,
-			changes_requested: false,
-			additions: opts?.diffUrl ? 4 : 0,
-			deletions: opts?.diffUrl ? 1 : 0,
-			changed_files: opts?.diffUrl ? 2 : 0,
-		} satisfies TypesGen.ChatDiffStatus,
-	},
-	{
-		key: chatDiffContentsKey(CHAT_ID),
-		data: {
-			chat_id: CHAT_ID,
-			diff: opts?.diffUrl ? sampleDiff : undefined,
-			pull_request_url: opts?.diffUrl,
-		} satisfies TypesGen.ChatDiffContents,
-	},
-	{
-		key: workspaceByIdKey(mockWorkspace.id),
-		data: mockWorkspace,
-	},
-	{ key: chatModelsKey, data: mockModelCatalog },
-];
+) => {
+	const chatData: TypesGen.ChatWithMessages = {
+		chat: chatAndMessages.chat,
+		queued_messages: chatAndMessages.queued_messages,
+	};
+	const messages = chatAndMessages.messages ?? [];
+	return [
+		{ key: chatKey(CHAT_ID), data: chatData },
+		{ key: chatsKey, data: [chatData.chat] },
+		{
+			key: chatMessagesKey(CHAT_ID),
+			data: {
+				messages,
+				after_id: messages.length > 0 ? messages[0].id : 0,
+				has_more: false,
+			} satisfies TypesGen.ChatMessagesResponse,
+		},
+		{
+			key: chatDiffStatusKey(CHAT_ID),
+			data: {
+				chat_id: CHAT_ID,
+				url: opts?.diffUrl,
+				changes_requested: false,
+				additions: opts?.diffUrl ? 4 : 0,
+				deletions: opts?.diffUrl ? 1 : 0,
+				changed_files: opts?.diffUrl ? 2 : 0,
+			} satisfies TypesGen.ChatDiffStatus,
+		},
+		{
+			key: chatDiffContentsKey(CHAT_ID),
+			data: {
+				chat_id: CHAT_ID,
+				diff: opts?.diffUrl ? sampleDiff : undefined,
+				pull_request_url: opts?.diffUrl,
+			} satisfies TypesGen.ChatDiffContents,
+		},
+		{
+			key: workspaceByIdKey(mockWorkspace.id),
+			data: mockWorkspace,
+		},
+		{ key: chatModelsKey, data: mockModelCatalog },
+	];
+};
 
 /**
  * Wrap a chat stream event payload in the JSON string format that

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -2,6 +2,7 @@ import { API } from "api/api";
 import {
 	chat,
 	chatDiffStatus,
+	chatMessages as chatMessagesQuery,
 	chatModelConfigs,
 	chatModels,
 	chats,
@@ -99,6 +100,9 @@ interface AgentDetailTimelineProps {
 	onEditUserMessage?: (messageId: number, text: string) => void;
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
+	hasMoreOnServer?: boolean;
+	onFetchMore?: () => void;
+	isFetchingMore?: boolean;
 }
 
 const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
@@ -108,6 +112,9 @@ const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 	onEditUserMessage,
 	editingMessageId,
 	savingMessageId,
+	hasMoreOnServer,
+	onFetchMore,
+	isFetchingMore,
 }) => {
 	const messagesByID = useChatSelector(store, selectMessagesByID);
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
@@ -135,6 +142,9 @@ const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 		useMessageWindow({
 			messages,
 			resetKey: chatID,
+			hasMoreOnServer,
+			onFetchMore,
+			isFetchingMore,
 		});
 	const parsedMessages = useMemo(
 		() => parseMessagesWithMergedTools(windowedMessages),
@@ -460,6 +470,10 @@ const AgentDetail: FC = () => {
 		...chat(agentId ?? ""),
 		enabled: Boolean(agentId),
 	});
+	const messagesQuery = useQuery({
+		...chatMessagesQuery(agentId ?? ""),
+		enabled: Boolean(agentId),
+	});
 	const chatsQuery = useQuery(chats());
 	const workspaceId = chatQuery.data?.chat?.workspace_id;
 	const workspaceQuery = useQuery({
@@ -479,7 +493,8 @@ const AgentDetail: FC = () => {
 	const chatData = chatQuery.data;
 	const chatRecord = chatData?.chat;
 	const isArchived = chatRecord?.archived ?? false;
-	const chatMessages = chatData?.messages;
+	const chatMessages = messagesQuery.data?.messages;
+	const messagesHasMore = messagesQuery.data?.has_more ?? false;
 	const chatQueuedMessages = chatData?.queued_messages;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
@@ -553,6 +568,39 @@ const AgentDetail: FC = () => {
 		setChatErrorReason,
 		clearChatErrorReason,
 	});
+
+	const [isFetchingMore, setIsFetchingMore] = useState(false);
+	const fetchMoreMessages = useCallback(async () => {
+		if (!agentId || isFetchingMore) return;
+		const oldestId = messagesQuery.data?.after_id;
+		if (!oldestId || !messagesQuery.data?.has_more) return;
+
+		setIsFetchingMore(true);
+		try {
+			const olderPage = await API.getChatMessages(agentId, {
+				before_id: oldestId,
+			});
+			queryClient.setQueryData<TypesGen.ChatMessagesResponse>(
+				chatMessagesQuery(agentId).queryKey,
+				(current) => {
+					if (!current) return current;
+					return {
+						messages: [...olderPage.messages, ...current.messages],
+						after_id: olderPage.after_id,
+						has_more: olderPage.has_more,
+					};
+				},
+			);
+		} finally {
+			setIsFetchingMore(false);
+		}
+	}, [
+		agentId,
+		isFetchingMore,
+		messagesQuery.data?.after_id,
+		messagesQuery.data?.has_more,
+		queryClient,
+	]);
 
 	useEffect(() => {
 		setSelectedModel((current) => {
@@ -992,6 +1040,9 @@ const AgentDetail: FC = () => {
 							onEditUserMessage={editing.handleEditUserMessage}
 							editingMessageId={editing.editingMessageId}
 							savingMessageId={pendingEditMessageId}
+							hasMoreOnServer={messagesHasMore}
+							onFetchMore={fetchMoreMessages}
+							isFetchingMore={isFetchingMore}
 						/>
 					</div>
 				</div>

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
@@ -187,7 +187,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -268,7 +267,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -343,7 +341,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -437,7 +434,6 @@ describe("useChatStore", () => {
 				chatRecord: makeChat(chatID),
 				chatData: {
 					chat: makeChat(chatID),
-					messages: [existingMessage],
 					queued_messages: [],
 				},
 				chatQueuedMessages: [],
@@ -511,7 +507,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -586,7 +581,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -674,7 +668,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID),
 			chatData: {
 				chat: makeChat(chatID),
-				messages: [existingMessage],
 				queued_messages: [queuedMessage],
 			},
 			chatQueuedMessages: [queuedMessage],
@@ -721,7 +714,6 @@ describe("useChatStore", () => {
 					...makeChat(chatID),
 					updated_at: "2025-01-01T00:00:01.000Z",
 				},
-				messages: [existingMessage],
 				queued_messages: [queuedMessage],
 			},
 			chatQueuedMessages: [queuedMessage],
@@ -751,7 +743,6 @@ describe("useChatStore", () => {
 		});
 		const initialChatData: TypesGen.ChatWithMessages = {
 			chat: makeChat(chatID),
-			messages: [existingMessage],
 			queued_messages: [queuedMessage],
 		};
 		queryClient.setQueryData(chatKey(chatID), initialChatData);
@@ -833,7 +824,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID1),
 			chatData: {
 				chat: makeChat(chatID1),
-				messages: [msg1],
 				queued_messages: [] as TypesGen.ChatQueuedMessage[],
 			},
 			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
@@ -882,7 +872,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID2),
 			chatData: {
 				chat: makeChat(chatID2),
-				messages: [msg2],
 				queued_messages: [],
 			},
 		});
@@ -920,7 +909,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [queuedMessage],
 					},
 					chatQueuedMessages: [queuedMessage],
@@ -976,7 +964,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1078,7 +1065,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [existingMessage],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1174,7 +1160,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID1),
 			chatData: {
 				chat: makeChat(chatID1),
-				messages: [msg1],
 				queued_messages: [] as TypesGen.ChatQueuedMessage[],
 			},
 			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
@@ -1223,7 +1208,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID2),
 			chatData: {
 				chat: makeChat(chatID2),
-				messages: [msg2],
 				queued_messages: [],
 			},
 		});
@@ -1265,7 +1249,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID1),
 			chatData: {
 				chat: makeChat(chatID1),
-				messages: [msg1],
 				queued_messages: [queuedMsg],
 			},
 			chatQueuedMessages: [queuedMsg],
@@ -1301,7 +1284,6 @@ describe("useChatStore", () => {
 			chatRecord: makeChat(chatID2),
 			chatData: {
 				chat: makeChat(chatID2),
-				messages: [],
 				queued_messages: [],
 			},
 			chatQueuedMessages: [],
@@ -1337,7 +1319,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1407,7 +1388,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1468,7 +1448,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1521,7 +1500,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1582,7 +1560,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1657,7 +1634,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1719,7 +1695,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1768,7 +1743,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],
@@ -1832,7 +1806,6 @@ describe("useChatStore", () => {
 					chatRecord: makeChat(chatID),
 					chatData: {
 						chat: makeChat(chatID),
-						messages: [],
 						queued_messages: [],
 					},
 					chatQueuedMessages: [],

--- a/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.ts
@@ -7,12 +7,18 @@ type UseMessageWindowOptions = {
 	messages: readonly TypesGen.ChatMessage[];
 	resetKey?: string;
 	pageSize?: number;
+	hasMoreOnServer?: boolean;
+	onFetchMore?: () => void;
+	isFetchingMore?: boolean;
 };
 
 export const useMessageWindow = ({
 	messages,
 	resetKey,
 	pageSize = DEFAULT_PAGE_SIZE,
+	hasMoreOnServer = false,
+	onFetchMore,
+	isFetchingMore = false,
 }: UseMessageWindowOptions) => {
 	const [renderedMessageCount, setRenderedMessageCount] = useState(pageSize);
 	const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
@@ -22,7 +28,9 @@ export const useMessageWindow = ({
 		setRenderedMessageCount(pageSize);
 	}, [resetKey, pageSize]);
 
-	const hasMoreMessages = renderedMessageCount < messages.length;
+	const hasMoreLocal = renderedMessageCount < messages.length;
+	const hasMoreMessages = hasMoreLocal || hasMoreOnServer;
+
 	const windowedMessages = useMemo(() => {
 		if (renderedMessageCount >= messages.length) {
 			return messages;
@@ -38,18 +46,32 @@ export const useMessageWindow = ({
 		const observer = new IntersectionObserver(
 			(entries) => {
 				if (entries[0]?.isIntersecting) {
-					setRenderedMessageCount((prev) => prev + pageSize);
+					if (hasMoreLocal) {
+						// Still have local messages to show.
+						setRenderedMessageCount((prev) => prev + pageSize);
+					} else if (hasMoreOnServer && onFetchMore && !isFetchingMore) {
+						// Exhausted local messages, fetch from server.
+						onFetchMore();
+					}
 				}
 			},
 			{ rootMargin: "200px" },
 		);
 		observer.observe(node);
 		return () => observer.disconnect();
-	}, [hasMoreMessages, pageSize]);
+	}, [
+		hasMoreMessages,
+		hasMoreLocal,
+		hasMoreOnServer,
+		onFetchMore,
+		isFetchingMore,
+		pageSize,
+	]);
 
 	return {
 		hasMoreMessages,
 		windowedMessages,
 		loadMoreSentinelRef,
+		isFetchingMore,
 	};
 };


### PR DESCRIPTION
## Summary

Adds a dedicated paginated endpoint for fetching chat messages, removing them from the `GET /chats/{chat}` response. This prevents unbounded response sizes as chat conversations grow.

## Changes

### Backend

- **New endpoint**: `GET /api/experimental/chats/{chat}/messages`
  - `before_id` query param for cursor-based backward pagination
  - `limit` query param (default 100, max 1000)
  - Returns `ChatMessagesResponse` with `messages`, `after_id`, and `has_more`
- **Updated SQL**: `GetChatMessagesByChatID` now supports `LIMIT` and `before_id` via a DESC subquery pattern (fetch newest N, return in ASC order)
- **Removed messages from `ChatWithMessages`**: The `GET /chats/{chat}` endpoint now returns only chat metadata + queued messages
- **New SDK method**: `GetChatMessages(ctx, chatID, beforeID, limit)`

### Frontend

- New `getChatMessages` API client method
- Separate react-query (`chatMessagesKey`) for messages
- `AgentDetail` fetches messages via the dedicated paginated endpoint
- `useMessageWindow` now supports server-side pagination — when the user scrolls to the top and local messages are exhausted, it triggers fetching older pages from the backend
- Updated stories and tests for new type shapes

### Pagination behavior

- Default: returns the **last 100 messages** (most recent) in ascending order
- Scrolling up triggers `before_id`-based fetches for older pages
- The WebSocket stream (`/stream?after_id=`) continues to work for real-time updates
