### PR TITLE
fix: replace workspace selector with searchable combobox on agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -12,22 +12,14 @@ import {
 	createChat,
 	unarchiveChat,
 } from "api/queries/chats";
-import { workspaces } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { Button } from "components/Button/Button";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { CoderIcon } from "components/Icons/CoderIcon";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "components/Select/Select";
 import { useAuthenticated } from "hooks";
-import { MonitorIcon, PanelLeftIcon } from "lucide-react";
+import { PanelLeftIcon } from "lucide-react";
 import { UserDropdown } from "modules/dashboard/Navbar/UserDropdown/UserDropdown";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import {
@@ -56,6 +48,7 @@ import {
 } from "./modelOptions";
 import { useAgentsPageKeybindings } from "./useAgentsPageKeybindings";
 import { WebPushButton } from "./WebPushButton";
+import { WorkspaceCombobox } from "./WorkspaceCombobox";
 
 /** @internal Exported for testing. */
 const emptyInputStorageKey = "agents.empty-input";
@@ -705,15 +698,12 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 		useState(initialSystemPrompt);
 	const [systemPromptDraft, setSystemPromptDraft] =
 		useState(initialSystemPrompt);
-	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 50 }));
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
 		() => {
 			if (typeof window === "undefined") return null;
 			return localStorage.getItem(selectedWorkspaceIdStorageKey) || null;
 		},
 	);
-	const workspaceOptions = workspacesQuery.data?.workspaces ?? [];
-	const autoCreateWorkspaceValue = "__auto_create_workspace__";
 	const hasAdminControls = canSetSystemPrompt || canManageChatModelConfigs;
 	const hasModelOptions = modelOptions.length > 0;
 	const hasConfiguredModels = hasConfiguredModelsInCatalog(modelCatalog);
@@ -764,17 +754,14 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 	selectedModelRef.current = selectedModel;
 	const isSystemPromptDirty = systemPromptDraft !== savedSystemPrompt;
 
-	const handleWorkspaceChange = (value: string) => {
-		if (value === autoCreateWorkspaceValue) {
-			setSelectedWorkspaceId(null);
-			if (typeof window !== "undefined") {
-				localStorage.removeItem(selectedWorkspaceIdStorageKey);
-			}
-			return;
-		}
+	const handleWorkspaceChange = (value: string | null) => {
 		setSelectedWorkspaceId(value);
 		if (typeof window !== "undefined") {
-			localStorage.setItem(selectedWorkspaceIdStorageKey, value);
+			if (value === null) {
+				localStorage.removeItem(selectedWorkspaceIdStorageKey);
+			} else {
+				localStorage.setItem(selectedWorkspaceIdStorageKey, value);
+			}
 		}
 	};
 
@@ -827,20 +814,10 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 		[onCreateChat],
 	);
 
-	const selectedWorkspace = selectedWorkspaceId
-		? workspaceOptions.find((ws) => ws.id === selectedWorkspaceId)
-		: undefined;
-	const selectedWorkspaceLabel = selectedWorkspace
-		? `${selectedWorkspace.owner_name}/${selectedWorkspace.name}`
-		: undefined;
-
 	return (
 		<div className="flex min-h-0 flex-1 items-start justify-center overflow-auto p-4 pt-12 md:h-full md:items-center md:pt-4">
 			<div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
 				{createError ? <ErrorAlert error={createError} /> : null}
-				{workspacesQuery.isError && (
-					<ErrorAlert error={workspacesQuery.error} />
-				)}
 
 				<AgentChatInput
 					onSend={handleSend}
@@ -857,38 +834,11 @@ export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
 					inputStatusText={inputStatusText}
 					modelCatalogStatusMessage={modelCatalogStatusMessage}
 					leftActions={
-						<Select
-							value={selectedWorkspaceId ?? autoCreateWorkspaceValue}
+						<WorkspaceCombobox
+							value={selectedWorkspaceId}
 							onValueChange={handleWorkspaceChange}
-							disabled={isCreating || workspacesQuery.isLoading}
-						>
-							<SelectTrigger className="h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary [&>svg]:transition-colors [&>svg]:hover:text-content-primary focus:ring-0 focus-visible:ring-0">
-								<MonitorIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary group-hover:text-content-primary" />
-								<SelectValue>
-									{selectedWorkspaceLabel ?? "Workspace"}
-								</SelectValue>
-							</SelectTrigger>
-							<SelectContent
-								side="top"
-								align="center"
-								className="[&_[role=option]]:text-xs"
-							>
-								<SelectItem value={autoCreateWorkspaceValue}>
-									Auto-create Workspace
-								</SelectItem>
-								{workspaceOptions.map((workspace) => (
-									<SelectItem key={workspace.id} value={workspace.id}>
-										{workspace.owner_name}/{workspace.name}
-									</SelectItem>
-								))}
-								{workspaceOptions.length === 0 &&
-									!workspacesQuery.isLoading && (
-										<SelectItem value="no-workspaces" disabled>
-											No workspaces found
-										</SelectItem>
-									)}
-							</SelectContent>
-						</Select>
+							disabled={isCreating}
+						/>
 					}
 				/>
 			</div>

--- a/site/src/pages/AgentsPage/WorkspaceCombobox.tsx
+++ b/site/src/pages/AgentsPage/WorkspaceCombobox.tsx
@@ -1,0 +1,142 @@
+import { workspaceById, workspaces } from "api/queries/workspaces";
+import type { Workspace } from "api/typesGenerated";
+import { Button } from "components/Button/Button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "components/Command/Command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "components/Popover/Popover";
+import { useDebouncedValue } from "hooks/debounce";
+import { CheckIcon, ChevronsUpDownIcon, MonitorIcon } from "lucide-react";
+import { type FC, useState } from "react";
+import { keepPreviousData, useQuery } from "react-query";
+import { cn } from "utils/cn";
+
+const autoCreateWorkspaceValue = "__auto_create_workspace__";
+
+type WorkspaceComboboxProps = {
+	value: string | null;
+	onValueChange: (value: string | null) => void;
+	disabled?: boolean;
+};
+
+export const WorkspaceCombobox: FC<WorkspaceComboboxProps> = ({
+	value,
+	onValueChange,
+	disabled = false,
+}) => {
+	const [open, setOpen] = useState(false);
+	const [search, setSearch] = useState("");
+	const debouncedSearch = useDebouncedValue(search, 250);
+
+	const searchQuery = debouncedSearch
+		? `owner:me ${debouncedSearch}`
+		: "owner:me";
+
+	const { data: workspacesData, isFetched } = useQuery({
+		...workspaces({ q: searchQuery }),
+		placeholderData: keepPreviousData,
+	});
+
+	const workspaceList = workspacesData?.workspaces ?? [];
+
+	// If a workspace is selected but not in current search results, fetch it
+	// separately so the trigger label is always correct and it appears in the list.
+	const selectedNotInList =
+		value !== null && !workspaceList.some((ws) => ws.id === value);
+	const { data: selectedWorkspaceData } = useQuery({
+		...workspaceById(value ?? ""),
+		enabled: selectedNotInList && value !== null,
+	});
+
+	// Build the final options list, ensuring the selected workspace is included.
+	const options: readonly Workspace[] =
+		selectedNotInList && selectedWorkspaceData
+			? [selectedWorkspaceData, ...workspaceList]
+			: workspaceList;
+
+	const selectedWorkspace = value
+		? options.find((ws) => ws.id === value)
+		: undefined;
+	const triggerLabel = selectedWorkspace
+		? `${selectedWorkspace.owner_name}/${selectedWorkspace.name}`
+		: "Workspace";
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					disabled={disabled || !isFetched}
+					role="combobox"
+					aria-expanded={open}
+					className="h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary [&>svg]:transition-colors [&>svg]:hover:text-content-primary focus:ring-0 focus-visible:ring-0"
+				>
+					<MonitorIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary group-hover:text-content-primary" />
+					<span className="max-w-[200px] truncate">{triggerLabel}</span>
+					<ChevronsUpDownIcon className="h-3 w-3 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="flex flex-col w-[280px] p-0"
+				side="top"
+				align="start"
+			>
+				<Command className="flex-1 min-h-0" shouldFilter={false}>
+					<CommandInput
+						placeholder="Search workspaces..."
+						value={search}
+						onValueChange={setSearch}
+						aria-label="Search workspaces"
+					/>
+					<CommandList className="flex-1 min-h-0 max-h-64 overflow-y-auto">
+						<CommandEmpty>No workspaces found.</CommandEmpty>
+						<CommandGroup>
+							<CommandItem
+								value={autoCreateWorkspaceValue}
+								onSelect={() => {
+									onValueChange(null);
+									setOpen(false);
+								}}
+							>
+								Auto-create Workspace
+								<CheckIcon
+									className={cn(
+										"ml-auto h-4 w-4",
+										value === null ? "opacity-100" : "opacity-0",
+									)}
+								/>
+							</CommandItem>
+							{options.map((workspace) => (
+								<CommandItem
+									key={workspace.id}
+									keywords={[workspace.name, workspace.owner_name]}
+									value={workspace.id}
+									onSelect={() => {
+										onValueChange(workspace.id);
+										setOpen(false);
+									}}
+								>
+									{workspace.owner_name}/{workspace.name}
+									<CheckIcon
+										className={cn(
+											"ml-auto h-4 w-4",
+											value === workspace.id ? "opacity-100" : "opacity-0",
+										)}
+									/>
+								</CommandItem>
+							))}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+};


### PR DESCRIPTION
## Summary

Fixes #22602

Replaces the non-searchable `<Select>` dropdown on the `/agents` page with a searchable `WorkspaceCombobox` component.

### Problem

1. **Non-searchable dropdown** — Users with many workspaces had to visually scan a flat `<Select>` list.
2. **Hard cap of 50 workspaces** — The query used `limit: 50`, making workspaces beyond that invisible.
3. **Stale selection** — A workspace saved in localStorage that fell outside the top-50 results wouldn't appear in the dropdown.

### Solution

Created a new `WorkspaceCombobox` component (`site/src/pages/AgentsPage/WorkspaceCombobox.tsx`) that:

- Uses `Popover` + `Command` (cmdk) for a searchable combobox UI — same pattern as `UserCombobox`
- Performs **server-side search** with debounced queries (`owner:me <search>`) — no hard limit
- Uses `keepPreviousData` to avoid UI flashing during search
- Fetches the selected workspace by ID separately when it falls outside current search results, so the trigger label is always correct
- Retains the "Auto-create Workspace" option
- Preserves `localStorage` persistence of selected workspace ID

### Changes

| File | Change |
|------|--------|
| `site/src/pages/AgentsPage/WorkspaceCombobox.tsx` | **New** — Searchable workspace combobox component |
| `site/src/pages/AgentsPage/AgentsPage.tsx` | Replaced `<Select>` with `<WorkspaceCombobox>`, removed unused imports (`Select`, `MonitorIcon`, `workspaces` query), simplified `handleWorkspaceChange` |
