### PR TITLE
fix: provide ReloadMessages to enable mid-loop auto compaction

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -2247,6 +2247,23 @@ func (p *Server) runChat(
 			p.publishMessagePart(chat.ID, string(role), part)
 		},
 		Compaction: compactionOptions,
+		ReloadMessages: func(reloadCtx context.Context) ([]fantasy.Message, error) {
+			reloadedDBMessages, err := p.db.GetChatMessagesForPromptByChatID(reloadCtx, chat.ID)
+			if err != nil {
+				return nil, xerrors.Errorf("reload chat messages: %w", err)
+			}
+			reloadedPrompt, err := chatprompt.ConvertMessages(reloadedDBMessages)
+			if err != nil {
+				return nil, xerrors.Errorf("convert reloaded messages: %w", err)
+			}
+			if chat.ParentChatID.Valid {
+				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, defaultSubagentInstruction)
+			}
+			if instruction := p.resolveInstructions(reloadCtx, chat, getWorkspaceConn); instruction != "" {
+				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, instruction)
+			}
+			return reloadedPrompt, nil
+		},
 
 		OnRetry: func(attempt int, retryErr error, delay time.Duration) {
 			logger.Warn(ctx, "retrying LLM stream",

--- a/coderd/chatd/chatloop/chatloop.go
+++ b/coderd/chatd/chatloop/chatloop.go
@@ -250,9 +250,29 @@ func Run(ctx context.Context, opts RunOptions) error {
 				persistInterruptedStep(ctx, opts, &result)
 				return ErrInterrupted
 			}
+			// Attempt compaction before returning the error.
+			// When a step fails (e.g. context length exceeded),
+			// we use the last successful step's usage to decide
+			// whether compaction is needed. If this is the first
+			// step, lastUsage is zero-valued and tryCompact
+			// safely skips via contextTokensFromUsage <= 0.
+			if !alreadyCompacted && opts.Compaction != nil {
+				if _, compactErr := tryCompact(
+					ctx,
+					opts.Model,
+					opts.Compaction,
+					opts.ContextLimitFallback,
+					lastUsage,
+					lastProviderMetadata,
+					messages,
+				); compactErr != nil {
+					if opts.Compaction.OnError != nil {
+						opts.Compaction.OnError(compactErr)
+					}
+				}
+			}
 			return xerrors.Errorf("stream response: %w", err)
 		}
-
 		// Execute tools before persisting so that tool results
 		// are included in the persisted step content. The
 		// persistence layer splits assistant and tool-result

--- a/coderd/chatd/chatloop/compaction_test.go
+++ b/coderd/chatd/chatloop/compaction_test.go
@@ -462,4 +462,93 @@ func TestRun_Compaction(t *testing.T) {
 		require.Error(t, compactionErr)
 		require.ErrorContains(t, compactionErr, "generate summary text")
 	})
+
+	t.Run("CompactsOnStreamError", func(t *testing.T) {
+		t.Parallel()
+
+		var mu sync.Mutex
+		var streamCallCount int
+		persistCompactionCalls := 0
+		var persistedCompaction CompactionResult
+
+		const summaryText = "summary after stream error"
+
+		model := &loopTestModel{
+			provider: "fake",
+			streamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				mu.Lock()
+				step := streamCallCount
+				streamCallCount++
+				mu.Unlock()
+
+				switch step {
+				case 0:
+					// Step 0: tool call with high usage (80/100 = 80% > 70%).
+					return streamFromParts([]fantasy.StreamPart{
+						{Type: fantasy.StreamPartTypeToolInputStart, ID: "tc-1", ToolCallName: "read_file"},
+						{Type: fantasy.StreamPartTypeToolInputDelta, ID: "tc-1", Delta: `{}`},
+						{Type: fantasy.StreamPartTypeToolInputEnd, ID: "tc-1"},
+						{
+							Type:          fantasy.StreamPartTypeToolCall,
+							ID:            "tc-1",
+							ToolCallName:  "read_file",
+							ToolCallInput: `{}`,
+						},
+						{
+							Type:         fantasy.StreamPartTypeFinish,
+							FinishReason: fantasy.FinishReasonToolCalls,
+							Usage: fantasy.Usage{
+								InputTokens: 80,
+								TotalTokens: 85,
+							},
+						},
+					}), nil
+				default:
+					// Step 1: simulate context length exceeded error.
+					return nil, xerrors.New("context length exceeded")
+				}
+			},
+			generateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+				return &fantasy.Response{
+					Content: []fantasy.Content{
+						fantasy.TextContent{Text: summaryText},
+					},
+				}, nil
+			},
+		}
+
+		err := Run(context.Background(), RunOptions{
+			Model: model,
+			Messages: []fantasy.Message{
+				textMessage(fantasy.MessageRoleUser, "hello"),
+			},
+			Tools: []fantasy.AgentTool{
+				newNoopTool("read_file"),
+			},
+			MaxSteps: 5,
+			PersistStep: func(_ context.Context, _ PersistedStep) error {
+				return nil
+			},
+			ContextLimitFallback: 100,
+			Compaction: &CompactionOptions{
+				ThresholdPercent: 70,
+				SummaryPrompt:    "summarize now",
+				Persist: func(_ context.Context, result CompactionResult) error {
+					persistCompactionCalls++
+					persistedCompaction = result
+					return nil
+				},
+			},
+		})
+		// Run returns the stream error.
+		require.Error(t, err)
+		require.ErrorContains(t, err, "context length exceeded")
+
+		// Compaction should have fired using step 0's usage
+		// before the error was returned.
+		require.Equal(t, 1, persistCompactionCalls)
+		require.Contains(t, persistedCompaction.SystemSummary, summaryText)
+		require.Equal(t, int64(80), persistedCompaction.ContextTokens)
+		require.Equal(t, int64(100), persistedCompaction.ContextLimit)
+	})
 }


### PR DESCRIPTION
Mid-loop compaction did not run in production because `chatloop.RunOptions.ReloadMessages` was not set in `chatd.runChat()`, the only production caller. The guard at `chatloop.go:327` requires both `opts.Compaction != nil && opts.ReloadMessages != nil`, so it always short-circuited. Tests set `ReloadMessages` directly, which is why they passed.

A second issue compounded this: when the model stream fails (e.g. `context length exceeded`), `chatloop.Run` returns the error at line 253 before reaching the post-run compaction safety net at line 363. `chatretry.go` classifies context-length errors as non-retryable, so the error propagates immediately. Without mid-loop compaction and with the error path bypassing post-run compaction, context could grow past the model limit with no compaction to recover.

The observed behavior: agent works past the 70% compaction threshold, user sends a follow-up at 90% with no compaction, agent exceeds 100% and hits an Anthropic API error, chat cannot recover.

**Commit 1** adds the `ReloadMessages` callback in `chatd.runChat()`, mirroring the existing message-building logic (same DB query, same `ConvertMessages`, same system instruction injection in the same order). It also adds a `tryCompact` call on the error path, guarded by `!alreadyCompacted` and safe on first-step failures (zero-valued `lastUsage` causes `contextTokensFromUsage <= 0`, skipping compaction).

**Commit 2** adds `!alreadyCompacted` to the mid-loop compaction guard for consistency with the error-path and post-run guards. Previously `tryCompact` was called on every step even after compaction had already fired (it returned false due to reduced usage, but the calls were unnecessary). Also adds two edge-case tests: `FirstStep` (verifies no compaction when step 0 fails with no prior usage) and `SkippedWhenAlreadyCompacted` (verifies no double-compaction when mid-loop compaction already fired before a stream error).