### PR TITLE
feat: aiseat tracking for license consumption

### DIFF
--- a/coderd/aiseats/aiseats.go
+++ b/coderd/aiseats/aiseats.go
@@ -4,7 +4,6 @@ package aiseats
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 
@@ -44,10 +43,10 @@ func ReasonTask(description string) Reason {
 
 // SeatTracker records AI seat consumption state.
 type SeatTracker interface {
-	RecordUsage(ctx context.Context, userID uuid.UUID, reason Reason, at time.Time)
+	RecordUsage(ctx context.Context, userID uuid.UUID, reason Reason)
 }
 
 // Noop is an AGPL seat tracker that does nothing.
 type Noop struct{}
 
-func (Noop) RecordUsage(context.Context, uuid.UUID, Reason, time.Time) {}
+func (Noop) RecordUsage(context.Context, uuid.UUID, Reason) {}

--- a/coderd/aiseats/aiseats.go
+++ b/coderd/aiseats/aiseats.go
@@ -1,0 +1,51 @@
+package aiseats
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// Reason describes what AI event consumed the seat.
+type Reason interface {
+	isReason()
+}
+
+type reason struct {
+	eventType   database.AiSeatUsageReason
+	description string
+}
+
+func (reason) isReason() {}
+
+// ReasonValues extracts storage values from a Reason.
+func ReasonValues(r Reason) (database.AiSeatUsageReason, string, bool) {
+	rr, ok := r.(reason)
+	if !ok {
+		return "", "", false
+	}
+	return rr.eventType, rr.description, true
+}
+
+// ReasonAIBridge constructs a reason for usage originating from AI Bridge.
+func ReasonAIBridge(description string) Reason {
+	return reason{eventType: database.AiSeatUsageReasonAibridge, description: description}
+}
+
+// ReasonTask constructs a reason for usage originating from tasks.
+func ReasonTask(description string) Reason {
+	return reason{eventType: database.AiSeatUsageReasonTask, description: description}
+}
+
+// SeatTracker records AI seat consumption state.
+type SeatTracker interface {
+	RecordUsage(ctx context.Context, userID uuid.UUID, reason Reason, at time.Time)
+}
+
+// Noop is an AGPL seat tracker that does nothing.
+type Noop struct{}
+
+func (Noop) RecordUsage(context.Context, uuid.UUID, Reason, time.Time) {}

--- a/coderd/aiseats/aiseats.go
+++ b/coderd/aiseats/aiseats.go
@@ -1,3 +1,5 @@
+// Package aiseats is the AGPL version the package.
+// The actual implementation is in `enterprise/aiseats`.
 package aiseats
 
 import (

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -44,6 +44,7 @@ import (
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/agentapi"
 	"github.com/coder/coder/v2/coderd/agentapi/metadatabatcher"
+	"github.com/coder/coder/v2/coderd/aiseats"
 	_ "github.com/coder/coder/v2/coderd/apidoc" // Used for swagger docs.
 	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/coderd/audit"
@@ -627,6 +628,8 @@ func New(options *Options) *API {
 		),
 		dbRolluper: options.DatabaseRolluper,
 	}
+	api.AISeatTracker = aiseats.Noop{}
+
 	api.WorkspaceAppsProvider = workspaceapps.NewDBTokenProvider(
 		ctx,
 		options.Logger.Named("workspaceapps"),
@@ -1967,6 +1970,8 @@ type API struct {
 	dbRolluper *dbrollup.Rolluper
 	// chatDaemon handles background processing of pending chats.
 	chatDaemon *chatd.Server
+	// AISeatTracker records AI seat usage.
+	AISeatTracker aiseats.SeatTracker
 }
 
 // Close waits for all WebSocket connections to drain before returning.

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -2165,6 +2165,7 @@ func (api *API) CreateInMemoryTaggedProvisionerDaemon(dialCtx context.Context, n
 		provisionerdserver.Options{
 			OIDCConfig:          api.OIDCConfig,
 			ExternalAuthConfigs: api.ExternalAuthConfigs,
+			AISeatTracker:       api.AISeatTracker,
 			Clock:               api.Clock,
 			HeartbeatFn:         options.heartbeatFn,
 		},

--- a/coderd/database/aiseats_test.go
+++ b/coderd/database/aiseats_test.go
@@ -1,0 +1,80 @@
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestUpsertAISeatState(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	user := dbgen.User(t, db, database.User{})
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	t1 := dbtime.Now().Add(-time.Minute)
+	err := db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
+		UserID:               user.ID,
+		FirstUsedAt:          t1,
+		LastEventType:        database.AiSeatUsageReasonAibridge,
+		LastEventDescription: "first",
+	})
+	require.NoError(t, err)
+
+	t2 := dbtime.Now()
+	err = db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
+		UserID:               user.ID,
+		FirstUsedAt:          t2,
+		LastEventType:        database.AiSeatUsageReasonTask,
+		LastEventDescription: "second",
+	})
+	require.NoError(t, err)
+
+	rows, err := db.ListAISeatState(ctx)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, user.ID, rows[0].UserID)
+	require.True(t, t1.Equal(rows[0].FirstUsedAt))
+	require.True(t, t2.Equal(rows[0].LastUsedAt))
+	require.Equal(t, database.AiSeatUsageReasonTask, rows[0].LastEventType)
+	require.Equal(t, "second", rows[0].LastEventDescription)
+}
+
+func TestGetActiveAISeatCount(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitShort)
+	now := dbtime.Now()
+
+	active := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+	dormant := dbgen.User(t, db, database.User{Status: database.UserStatusDormant})
+
+	err := db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
+		UserID:               active.ID,
+		FirstUsedAt:          now,
+		LastEventType:        database.AiSeatUsageReasonAibridge,
+		LastEventDescription: "active",
+	})
+	require.NoError(t, err)
+
+	err = db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
+		UserID:               dormant.ID,
+		FirstUsedAt:          now,
+		LastEventType:        database.AiSeatUsageReasonTask,
+		LastEventDescription: "dormant",
+	})
+	require.NoError(t, err)
+
+	count, err := db.GetActiveAISeatCount(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+}

--- a/coderd/database/aiseats_test.go
+++ b/coderd/database/aiseats_test.go
@@ -29,7 +29,7 @@ func TestUpsertAISeatState(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	t2 := dbtime.Now()
+	t2 := t1.Add(time.Hour)
 	err = db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
 		UserID:               user.ID,
 		FirstUsedAt:          t2,
@@ -43,9 +43,10 @@ func TestUpsertAISeatState(t *testing.T) {
 	require.Len(t, rows, 1)
 	require.Equal(t, user.ID, rows[0].UserID)
 	require.True(t, t1.Equal(rows[0].FirstUsedAt))
-	require.True(t, t2.Equal(rows[0].LastUsedAt))
-	require.Equal(t, database.AiSeatUsageReasonTask, rows[0].LastEventType)
-	require.Equal(t, "second", rows[0].LastEventDescription)
+	require.True(t, t1.Equal(rows[0].LastUsedAt))
+	require.Equal(t, database.AiSeatUsageReasonAibridge, rows[0].LastEventType)
+	require.Equal(t, "first", rows[0].LastEventDescription)
+
 }
 
 func TestGetActiveAISeatCount(t *testing.T) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2321,6 +2321,10 @@ func (q *querier) GetAPIKeysLastUsedAfter(ctx context.Context, lastUsed time.Tim
 	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.GetAPIKeysLastUsedAfter)(ctx, lastUsed)
 }
 
+func (q *querier) GetActiveAISeatCount(ctx context.Context) (int64, error) {
+	panic("not implemented")
+}
+
 func (q *querier) GetActivePresetPrebuildSchedules(ctx context.Context) ([]database.TemplateVersionPresetPrebuildSchedule, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplate.All()); err != nil {
 		return nil, err
@@ -5139,6 +5143,13 @@ func (q *querier) ListAIBridgeUserPromptsByInterceptionIDs(ctx context.Context, 
 	return q.db.ListAIBridgeUserPromptsByInterceptionIDs(ctx, interceptionIDs)
 }
 
+func (q *querier) ListAISeatState(ctx context.Context) ([]database.AiSeatState, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceLicense); err != nil {
+		return nil, err
+	}
+	return q.db.ListAISeatState(ctx)
+}
+
 func (q *querier) ListChatsByRootID(ctx context.Context, rootChatID uuid.UUID) ([]database.Chat, error) {
 	return fetchWithPostFilter(q.auth, policy.ActionRead, q.db.ListChatsByRootID)(ctx, rootChatID)
 }
@@ -6458,6 +6469,13 @@ func (q *querier) UpdateWorkspacesTTLByTemplateID(ctx context.Context, arg datab
 		return err
 	}
 	return q.db.UpdateWorkspacesTTLByTemplateID(ctx, arg)
+}
+
+func (q *querier) UpsertAISeatState(ctx context.Context, arg database.UpsertAISeatStateParams) error {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
+		return err
+	}
+	return q.db.UpsertAISeatState(ctx, arg)
 }
 
 func (q *querier) UpsertAnnouncementBanners(ctx context.Context, value string) error {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2322,7 +2322,10 @@ func (q *querier) GetAPIKeysLastUsedAfter(ctx context.Context, lastUsed time.Tim
 }
 
 func (q *querier) GetActiveAISeatCount(ctx context.Context) (int64, error) {
-	panic("not implemented")
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceLicense); err != nil {
+		return 0, err
+	}
+	return q.db.GetActiveAISeatCount(ctx)
 }
 
 func (q *querier) GetActivePresetPrebuildSchedules(ctx context.Context) ([]database.TemplateVersionPresetPrebuildSchedule, error) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -871,6 +871,14 @@ func (m queryMetricsStore) GetAPIKeysLastUsedAfter(ctx context.Context, lastUsed
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetActiveAISeatCount(ctx context.Context) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetActiveAISeatCount(ctx)
+	m.queryLatencies.WithLabelValues("GetActiveAISeatCount").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetActiveAISeatCount").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetActivePresetPrebuildSchedules(ctx context.Context) ([]database.TemplateVersionPresetPrebuildSchedule, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetActivePresetPrebuildSchedules(ctx)
@@ -3511,6 +3519,14 @@ func (m queryMetricsStore) ListAIBridgeUserPromptsByInterceptionIDs(ctx context.
 	return r0, r1
 }
 
+func (m queryMetricsStore) ListAISeatState(ctx context.Context) ([]database.AiSeatState, error) {
+	start := time.Now()
+	r0, r1 := m.s.ListAISeatState(ctx)
+	m.queryLatencies.WithLabelValues("ListAISeatState").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "ListAISeatState").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) ListChatsByRootID(ctx context.Context, rootChatID uuid.UUID) ([]database.Chat, error) {
 	start := time.Now()
 	r0, r1 := m.s.ListChatsByRootID(ctx, rootChatID)
@@ -4451,6 +4467,14 @@ func (m queryMetricsStore) UpdateWorkspacesTTLByTemplateID(ctx context.Context, 
 	r0 := m.s.UpdateWorkspacesTTLByTemplateID(ctx, arg)
 	m.queryLatencies.WithLabelValues("UpdateWorkspacesTTLByTemplateID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateWorkspacesTTLByTemplateID").Inc()
+	return r0
+}
+
+func (m queryMetricsStore) UpsertAISeatState(ctx context.Context, arg database.UpsertAISeatStateParams) error {
+	start := time.Now()
+	r0 := m.s.UpsertAISeatState(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpsertAISeatState").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertAISeatState").Inc()
 	return r0
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1477,6 +1477,21 @@ func (mr *MockStoreMockRecorder) GetAPIKeysLastUsedAfter(ctx, lastUsed any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKeysLastUsedAfter", reflect.TypeOf((*MockStore)(nil).GetAPIKeysLastUsedAfter), ctx, lastUsed)
 }
 
+// GetActiveAISeatCount mocks base method.
+func (m *MockStore) GetActiveAISeatCount(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveAISeatCount", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActiveAISeatCount indicates an expected call of GetActiveAISeatCount.
+func (mr *MockStoreMockRecorder) GetActiveAISeatCount(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveAISeatCount", reflect.TypeOf((*MockStore)(nil).GetActiveAISeatCount), ctx)
+}
+
 // GetActivePresetPrebuildSchedules mocks base method.
 func (m *MockStore) GetActivePresetPrebuildSchedules(ctx context.Context) ([]database.TemplateVersionPresetPrebuildSchedule, error) {
 	m.ctrl.T.Helper()
@@ -6560,6 +6575,21 @@ func (mr *MockStoreMockRecorder) ListAIBridgeUserPromptsByInterceptionIDs(ctx, i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAIBridgeUserPromptsByInterceptionIDs", reflect.TypeOf((*MockStore)(nil).ListAIBridgeUserPromptsByInterceptionIDs), ctx, interceptionIds)
 }
 
+// ListAISeatState mocks base method.
+func (m *MockStore) ListAISeatState(ctx context.Context) ([]database.AiSeatState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAISeatState", ctx)
+	ret0, _ := ret[0].([]database.AiSeatState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAISeatState indicates an expected call of ListAISeatState.
+func (mr *MockStoreMockRecorder) ListAISeatState(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAISeatState", reflect.TypeOf((*MockStore)(nil).ListAISeatState), ctx)
+}
+
 // ListAuthorizedAIBridgeInterceptions mocks base method.
 func (m *MockStore) ListAuthorizedAIBridgeInterceptions(ctx context.Context, arg database.ListAIBridgeInterceptionsParams, prepared rbac.PreparedAuthorized) ([]database.ListAIBridgeInterceptionsRow, error) {
 	m.ctrl.T.Helper()
@@ -8329,6 +8359,20 @@ func (m *MockStore) UpdateWorkspacesTTLByTemplateID(ctx context.Context, arg dat
 func (mr *MockStoreMockRecorder) UpdateWorkspacesTTLByTemplateID(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspacesTTLByTemplateID", reflect.TypeOf((*MockStore)(nil).UpdateWorkspacesTTLByTemplateID), ctx, arg)
+}
+
+// UpsertAISeatState mocks base method.
+func (m *MockStore) UpsertAISeatState(ctx context.Context, arg database.UpsertAISeatStateParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertAISeatState", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertAISeatState indicates an expected call of UpsertAISeatState.
+func (mr *MockStoreMockRecorder) UpsertAISeatState(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertAISeatState", reflect.TypeOf((*MockStore)(nil).UpsertAISeatState), ctx, arg)
 }
 
 // UpsertAnnouncementBanners mocks base method.

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -10,6 +10,11 @@ CREATE TYPE agent_key_scope_enum AS ENUM (
     'no_user_data'
 );
 
+CREATE TYPE ai_seat_usage_reason AS ENUM (
+    'aibridge',
+    'task'
+);
+
 CREATE TYPE api_key_scope AS ENUM (
     'coder:all',
     'coder:application_connect',
@@ -1034,6 +1039,15 @@ BEGIN
 	END IF;
 END;
 $$;
+
+CREATE TABLE ai_seat_state (
+    user_id uuid NOT NULL,
+    first_used_at timestamp with time zone NOT NULL,
+    last_used_at timestamp with time zone NOT NULL,
+    last_event_type ai_seat_usage_reason NOT NULL,
+    last_event_description text NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
 
 CREATE TABLE aibridge_interceptions (
     id uuid NOT NULL,
@@ -3110,6 +3124,9 @@ ALTER TABLE ONLY workspace_resource_metadata ALTER COLUMN id SET DEFAULT nextval
 ALTER TABLE ONLY workspace_agent_stats
     ADD CONSTRAINT agent_stats_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY ai_seat_state
+    ADD CONSTRAINT ai_seat_state_pkey PRIMARY KEY (user_id);
+
 ALTER TABLE ONLY aibridge_interceptions
     ADD CONSTRAINT aibridge_interceptions_pkey PRIMARY KEY (id);
 
@@ -3445,6 +3462,8 @@ CREATE INDEX idx_agent_stats_created_at ON workspace_agent_stats USING btree (cr
 
 CREATE INDEX idx_agent_stats_user_id ON workspace_agent_stats USING btree (user_id);
 
+CREATE INDEX idx_ai_seat_state_last_used ON ai_seat_state USING btree (last_used_at);
+
 CREATE INDEX idx_aibridge_interceptions_client ON aibridge_interceptions USING btree (client);
 
 CREATE INDEX idx_aibridge_interceptions_initiator_id ON aibridge_interceptions USING btree (initiator_id);
@@ -3756,6 +3775,9 @@ CREATE TRIGGER workspace_agent_name_unique_trigger BEFORE INSERT OR UPDATE OF na
 COMMENT ON TRIGGER workspace_agent_name_unique_trigger ON workspace_agents IS 'Use a trigger instead of a unique constraint because existing data may violate
 the uniqueness requirement. A trigger allows us to enforce uniqueness going
 forward without requiring a migration to clean up historical data.';
+
+ALTER TABLE ONLY ai_seat_state
+    ADD CONSTRAINT ai_seat_state_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY aibridge_interceptions
     ADD CONSTRAINT aibridge_interceptions_initiator_id_fkey FOREIGN KEY (initiator_id) REFERENCES users(id);

--- a/coderd/database/foreign_key_constraint.go
+++ b/coderd/database/foreign_key_constraint.go
@@ -6,6 +6,7 @@ type ForeignKeyConstraint string
 
 // ForeignKeyConstraint enums.
 const (
+	ForeignKeyAiSeatStateUserID                                   ForeignKeyConstraint = "ai_seat_state_user_id_fkey"                                      // ALTER TABLE ONLY ai_seat_state ADD CONSTRAINT ai_seat_state_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 	ForeignKeyAibridgeInterceptionsInitiatorID                    ForeignKeyConstraint = "aibridge_interceptions_initiator_id_fkey"                        // ALTER TABLE ONLY aibridge_interceptions ADD CONSTRAINT aibridge_interceptions_initiator_id_fkey FOREIGN KEY (initiator_id) REFERENCES users(id);
 	ForeignKeyAPIKeysUserIDUUID                                   ForeignKeyConstraint = "api_keys_user_id_uuid_fkey"                                      // ALTER TABLE ONLY api_keys ADD CONSTRAINT api_keys_user_id_uuid_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 	ForeignKeyChatDiffStatusesChatID                              ForeignKeyConstraint = "chat_diff_statuses_chat_id_fkey"                                 // ALTER TABLE ONLY chat_diff_statuses ADD CONSTRAINT chat_diff_statuses_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE;

--- a/coderd/database/migrations/000427_ai_seat_state.down.sql
+++ b/coderd/database/migrations/000427_ai_seat_state.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX idx_ai_seat_state_last_used;
+
+DROP TABLE ai_seat_state;
+
+DROP TYPE ai_seat_usage_reason;

--- a/coderd/database/migrations/000427_ai_seat_state.up.sql
+++ b/coderd/database/migrations/000427_ai_seat_state.up.sql
@@ -1,0 +1,15 @@
+CREATE TYPE ai_seat_usage_reason AS ENUM (
+	'aibridge',
+	'task'
+);
+
+CREATE TABLE ai_seat_state (
+	user_id uuid NOT NULL PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE,
+	first_used_at timestamptz NOT NULL,
+	last_used_at timestamptz NOT NULL,
+	last_event_type ai_seat_usage_reason NOT NULL,
+	last_event_description text NOT NULL,
+	updated_at timestamptz NOT NULL
+);
+
+CREATE INDEX idx_ai_seat_state_last_used ON ai_seat_state (last_used_at);

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -741,6 +741,64 @@ func AllAgentKeyScopeEnumValues() []AgentKeyScopeEnum {
 	}
 }
 
+type AiSeatUsageReason string
+
+const (
+	AiSeatUsageReasonAibridge AiSeatUsageReason = "aibridge"
+	AiSeatUsageReasonTask     AiSeatUsageReason = "task"
+)
+
+func (e *AiSeatUsageReason) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = AiSeatUsageReason(s)
+	case string:
+		*e = AiSeatUsageReason(s)
+	default:
+		return fmt.Errorf("unsupported scan type for AiSeatUsageReason: %T", src)
+	}
+	return nil
+}
+
+type NullAiSeatUsageReason struct {
+	AiSeatUsageReason AiSeatUsageReason `json:"ai_seat_usage_reason"`
+	Valid             bool              `json:"valid"` // Valid is true if AiSeatUsageReason is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullAiSeatUsageReason) Scan(value interface{}) error {
+	if value == nil {
+		ns.AiSeatUsageReason, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.AiSeatUsageReason.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullAiSeatUsageReason) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.AiSeatUsageReason), nil
+}
+
+func (e AiSeatUsageReason) Valid() bool {
+	switch e {
+	case AiSeatUsageReasonAibridge,
+		AiSeatUsageReasonTask:
+		return true
+	}
+	return false
+}
+
+func AllAiSeatUsageReasonValues() []AiSeatUsageReason {
+	return []AiSeatUsageReason{
+		AiSeatUsageReasonAibridge,
+		AiSeatUsageReasonTask,
+	}
+}
+
 type AppSharingLevel string
 
 const (
@@ -3852,6 +3910,15 @@ type APIKey struct {
 	TokenName       string       `db:"token_name" json:"token_name"`
 	Scopes          APIKeyScopes `db:"scopes" json:"scopes"`
 	AllowList       AllowList    `db:"allow_list" json:"allow_list"`
+}
+
+type AiSeatState struct {
+	UserID               uuid.UUID         `db:"user_id" json:"user_id"`
+	FirstUsedAt          time.Time         `db:"first_used_at" json:"first_used_at"`
+	LastUsedAt           time.Time         `db:"last_used_at" json:"last_used_at"`
+	LastEventType        AiSeatUsageReason `db:"last_event_type" json:"last_event_type"`
+	LastEventDescription string            `db:"last_event_description" json:"last_event_description"`
+	UpdatedAt            time.Time         `db:"updated_at" json:"updated_at"`
 }
 
 type AuditLog struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -187,6 +187,7 @@ type sqlcQuerier interface {
 	GetAPIKeysByLoginType(ctx context.Context, arg GetAPIKeysByLoginTypeParams) ([]APIKey, error)
 	GetAPIKeysByUserID(ctx context.Context, arg GetAPIKeysByUserIDParams) ([]APIKey, error)
 	GetAPIKeysLastUsedAfter(ctx context.Context, lastUsed time.Time) ([]APIKey, error)
+	GetActiveAISeatCount(ctx context.Context) (int64, error)
 	GetActivePresetPrebuildSchedules(ctx context.Context) ([]TemplateVersionPresetPrebuildSchedule, error)
 	GetActiveUserCount(ctx context.Context, includeSystem bool) (int64, error)
 	GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, templateID uuid.UUID) ([]WorkspaceBuild, error)
@@ -688,6 +689,7 @@ type sqlcQuerier interface {
 	ListAIBridgeTokenUsagesByInterceptionIDs(ctx context.Context, interceptionIds []uuid.UUID) ([]AIBridgeTokenUsage, error)
 	ListAIBridgeToolUsagesByInterceptionIDs(ctx context.Context, interceptionIds []uuid.UUID) ([]AIBridgeToolUsage, error)
 	ListAIBridgeUserPromptsByInterceptionIDs(ctx context.Context, interceptionIds []uuid.UUID) ([]AIBridgeUserPrompt, error)
+	ListAISeatState(ctx context.Context) ([]AiSeatState, error)
 	ListChatsByRootID(ctx context.Context, rootChatID uuid.UUID) ([]Chat, error)
 	ListChildChatsByParentID(ctx context.Context, parentChatID uuid.UUID) ([]Chat, error)
 	ListProvisionerKeysByOrganization(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerKey, error)
@@ -827,6 +829,7 @@ type sqlcQuerier interface {
 	UpdateWorkspaceTTL(ctx context.Context, arg UpdateWorkspaceTTLParams) error
 	UpdateWorkspacesDormantDeletingAtByTemplateID(ctx context.Context, arg UpdateWorkspacesDormantDeletingAtByTemplateIDParams) ([]WorkspaceTable, error)
 	UpdateWorkspacesTTLByTemplateID(ctx context.Context, arg UpdateWorkspacesTTLByTemplateIDParams) error
+	UpsertAISeatState(ctx context.Context, arg UpsertAISeatStateParams) error
 	UpsertAnnouncementBanners(ctx context.Context, value string) error
 	UpsertAppSecurityKey(ctx context.Context, value string) error
 	UpsertApplicationName(ctx context.Context, value string) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1191,6 +1191,111 @@ func (q *sqlQuerier) UpdateAIBridgeInterceptionEnded(ctx context.Context, arg Up
 	return i, err
 }
 
+const getActiveAISeatCount = `-- name: GetActiveAISeatCount :one
+SELECT
+	COUNT(*)
+FROM
+	ai_seat_state ais
+JOIN
+	users u
+ON
+	ais.user_id = u.id
+WHERE
+	u.status = 'active'::user_status
+	AND u.deleted = false
+	AND u.is_system = false
+`
+
+func (q *sqlQuerier) GetActiveAISeatCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getActiveAISeatCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const listAISeatState = `-- name: ListAISeatState :many
+SELECT
+	ais.user_id, ais.first_used_at, ais.last_used_at, ais.last_event_type, ais.last_event_description, ais.updated_at
+FROM
+	ai_seat_state ais
+JOIN
+	users u
+ON
+	ais.user_id = u.id
+WHERE
+	u.status = 'active'::user_status
+	AND u.deleted = false
+	AND u.is_system = false
+ORDER BY
+	ais.last_used_at DESC
+`
+
+func (q *sqlQuerier) ListAISeatState(ctx context.Context) ([]AiSeatState, error) {
+	rows, err := q.db.QueryContext(ctx, listAISeatState)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AiSeatState
+	for rows.Next() {
+		var i AiSeatState
+		if err := rows.Scan(
+			&i.UserID,
+			&i.FirstUsedAt,
+			&i.LastUsedAt,
+			&i.LastEventType,
+			&i.LastEventDescription,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const upsertAISeatState = `-- name: UpsertAISeatState :exec
+INSERT INTO ai_seat_state (
+	user_id,
+	first_used_at,
+	last_used_at,
+	last_event_type,
+	last_event_description,
+	updated_at
+)
+VALUES
+	($1, $2, $2, $3, $4, $2)
+ON CONFLICT (user_id) DO UPDATE
+SET
+	last_used_at = EXCLUDED.last_used_at,
+	last_event_type = EXCLUDED.last_event_type,
+	last_event_description = EXCLUDED.last_event_description,
+	updated_at = EXCLUDED.updated_at
+`
+
+type UpsertAISeatStateParams struct {
+	UserID               uuid.UUID         `db:"user_id" json:"user_id"`
+	FirstUsedAt          time.Time         `db:"first_used_at" json:"first_used_at"`
+	LastEventType        AiSeatUsageReason `db:"last_event_type" json:"last_event_type"`
+	LastEventDescription string            `db:"last_event_description" json:"last_event_description"`
+}
+
+func (q *sqlQuerier) UpsertAISeatState(ctx context.Context, arg UpsertAISeatStateParams) error {
+	_, err := q.db.ExecContext(ctx, upsertAISeatState,
+		arg.UserID,
+		arg.FirstUsedAt,
+		arg.LastEventType,
+		arg.LastEventDescription,
+	)
+	return err
+}
+
 const deleteAPIKeyByID = `-- name: DeleteAPIKeyByID :exec
 DELETE FROM
 	api_keys

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1277,6 +1277,9 @@ SET
 	last_event_type = EXCLUDED.last_event_type,
 	last_event_description = EXCLUDED.last_event_description,
 	updated_at = EXCLUDED.updated_at
+	WHERE
+		-- Seat tracking does not need fine-grained updates for every event.
+		ai_seat_state.updated_at < NOW() - INTERVAL '6 hours'
 `
 
 type UpsertAISeatStateParams struct {

--- a/coderd/database/queries/aiseats.sql
+++ b/coderd/database/queries/aiseats.sql
@@ -14,7 +14,10 @@ SET
 	last_used_at = EXCLUDED.last_used_at,
 	last_event_type = EXCLUDED.last_event_type,
 	last_event_description = EXCLUDED.last_event_description,
-	updated_at = EXCLUDED.updated_at;
+	updated_at = EXCLUDED.updated_at
+	WHERE
+		-- Seat tracking does not need fine-grained updates for every event.
+		ai_seat_state.updated_at < NOW() - INTERVAL '6 hours';
 
 -- name: GetActiveAISeatCount :one
 SELECT

--- a/coderd/database/queries/aiseats.sql
+++ b/coderd/database/queries/aiseats.sql
@@ -1,0 +1,47 @@
+-- name: UpsertAISeatState :exec
+INSERT INTO ai_seat_state (
+	user_id,
+	first_used_at,
+	last_used_at,
+	last_event_type,
+	last_event_description,
+	updated_at
+)
+VALUES
+	($1, $2, $2, $3, $4, $2)
+ON CONFLICT (user_id) DO UPDATE
+SET
+	last_used_at = EXCLUDED.last_used_at,
+	last_event_type = EXCLUDED.last_event_type,
+	last_event_description = EXCLUDED.last_event_description,
+	updated_at = EXCLUDED.updated_at;
+
+-- name: GetActiveAISeatCount :one
+SELECT
+	COUNT(*)
+FROM
+	ai_seat_state ais
+JOIN
+	users u
+ON
+	ais.user_id = u.id
+WHERE
+	u.status = 'active'::user_status
+	AND u.deleted = false
+	AND u.is_system = false;
+
+-- name: ListAISeatState :many
+SELECT
+	ais.*
+FROM
+	ai_seat_state ais
+JOIN
+	users u
+ON
+	ais.user_id = u.id
+WHERE
+	u.status = 'active'::user_status
+	AND u.deleted = false
+	AND u.is_system = false
+ORDER BY
+	ais.last_used_at DESC;

--- a/coderd/database/unique_constraint.go
+++ b/coderd/database/unique_constraint.go
@@ -7,6 +7,7 @@ type UniqueConstraint string
 // UniqueConstraint enums.
 const (
 	UniqueAgentStatsPkey                                      UniqueConstraint = "agent_stats_pkey"                                                // ALTER TABLE ONLY workspace_agent_stats ADD CONSTRAINT agent_stats_pkey PRIMARY KEY (id);
+	UniqueAiSeatStatePkey                                     UniqueConstraint = "ai_seat_state_pkey"                                              // ALTER TABLE ONLY ai_seat_state ADD CONSTRAINT ai_seat_state_pkey PRIMARY KEY (user_id);
 	UniqueAibridgeInterceptionsPkey                           UniqueConstraint = "aibridge_interceptions_pkey"                                     // ALTER TABLE ONLY aibridge_interceptions ADD CONSTRAINT aibridge_interceptions_pkey PRIMARY KEY (id);
 	UniqueAibridgeTokenUsagesPkey                             UniqueConstraint = "aibridge_token_usages_pkey"                                      // ALTER TABLE ONLY aibridge_token_usages ADD CONSTRAINT aibridge_token_usages_pkey PRIMARY KEY (id);
 	UniqueAibridgeToolUsagesPkey                              UniqueConstraint = "aibridge_tool_usages_pkey"                                       // ALTER TABLE ONLY aibridge_tool_usages ADD CONSTRAINT aibridge_tool_usages_pkey PRIMARY KEY (id);

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -28,6 +28,7 @@ import (
 	protobuf "google.golang.org/protobuf/proto"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/apikey"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
@@ -76,6 +77,7 @@ const (
 type Options struct {
 	OIDCConfig          promoauth.OAuth2Config
 	ExternalAuthConfigs []*externalauth.Config
+	AISeatTracker       aiseats.SeatTracker
 
 	// Clock for testing
 	Clock quartz.Clock
@@ -120,6 +122,7 @@ type server struct {
 	NotificationsEnqueuer       notifications.Enqueuer
 	PrebuildsOrchestrator       *atomic.Pointer[prebuilds.ReconciliationOrchestrator]
 	UsageInserter               *atomic.Pointer[usage.Inserter]
+	AISeatTracker               aiseats.SeatTracker
 	Experiments                 codersdk.Experiments
 
 	OIDCConfig promoauth.OAuth2Config
@@ -215,6 +218,9 @@ func NewServer(
 	if err := tags.Valid(); err != nil {
 		return nil, xerrors.Errorf("invalid tags: %w", err)
 	}
+	if options.AISeatTracker == nil {
+		options.AISeatTracker = aiseats.Noop{}
+	}
 	if options.AcquireJobLongPollDur == 0 {
 		options.AcquireJobLongPollDur = DefaultAcquireJobLongPollDur
 	}
@@ -253,6 +259,7 @@ func NewServer(
 		heartbeatFn:                 options.HeartbeatFn,
 		PrebuildsOrchestrator:       prebuildsOrchestrator,
 		UsageInserter:               usageInserter,
+		AISeatTracker:               options.AISeatTracker,
 		metrics:                     metrics,
 		Experiments:                 experiments,
 	}
@@ -2415,6 +2422,12 @@ func (s *server) completeWorkspaceBuildJob(ctx context.Context, job database.Pro
 			Status:           http.StatusOK,
 			AdditionalFields: wriBytes,
 		})
+	}
+
+	// Record AI seat usage for successful task workspace builds.
+	if workspaceBuild.Transition == database.WorkspaceTransitionStart && workspace.TaskID.Valid {
+		s.AISeatTracker.RecordUsage(ctx, workspace.OwnerID,
+			aiseats.ReasonTask("task workspace build succeeded"))
 	}
 
 	if s.PrebuildsOrchestrator != nil && input.PrebuiltWorkspaceBuildStage == sdkproto.PrebuiltWorkspaceBuildStage_CLAIM {

--- a/enterprise/aibridgedserver/aibridgedserver.go
+++ b/enterprise/aibridgedserver/aibridgedserver.go
@@ -186,7 +186,7 @@ func (s *Server) RecordInterception(ctx context.Context, in *proto.RecordInterce
 	}
 
 	reason := aiseats.ReasonAIBridge("provider=" + in.Provider + ", model=" + in.Model)
-	s.aiSeatTracker.RecordUsage(ctx, initID, reason, in.StartedAt.AsTime())
+	s.aiSeatTracker.RecordUsage(ctx, initID, reason)
 	return &proto.RecordInterceptionResponse{}, nil
 }
 

--- a/enterprise/aibridgedserver/aibridgedserver.go
+++ b/enterprise/aibridgedserver/aibridgedserver.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/apikey"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -81,10 +82,12 @@ type Server struct {
 
 	coderMCPConfig    *proto.MCPServerConfig // may be nil if not available
 	structuredLogging bool
+	aiSeatTracker     aiseats.SeatTracker
 }
 
 func NewServer(lifecycleCtx context.Context, store store, logger slog.Logger, accessURL string,
 	bridgeCfg codersdk.AIBridgeConfig, externalAuthConfigs []*externalauth.Config, experiments codersdk.Experiments,
+	aiSeatTracker aiseats.SeatTracker,
 ) (*Server, error) {
 	eac := make(map[string]*externalauth.Config, len(externalAuthConfigs))
 
@@ -102,6 +105,7 @@ func NewServer(lifecycleCtx context.Context, store store, logger slog.Logger, ac
 		logger:              logger,
 		externalAuthConfigs: eac,
 		structuredLogging:   bridgeCfg.StructuredLogging.Value(),
+		aiSeatTracker:       aiSeatTracker,
 	}
 
 	if bridgeCfg.InjectCoderMCPTools {
@@ -181,6 +185,8 @@ func (s *Server) RecordInterception(ctx context.Context, in *proto.RecordInterce
 		return nil, xerrors.Errorf("start interception: %w", err)
 	}
 
+	reason := aiseats.ReasonAIBridge("provider=" + in.Provider + ", model=" + in.Model)
+	s.aiSeatTracker.RecordUsage(ctx, initID, reason, in.StartedAt.AsTime())
 	return &proto.RecordInterceptionResponse{}, nil
 }
 

--- a/enterprise/aibridgedserver/aibridgedserver_test.go
+++ b/enterprise/aibridgedserver/aibridgedserver_test.go
@@ -24,6 +24,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogjson"
+	"github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/apikey"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -176,7 +177,7 @@ func TestAuthorization(t *testing.T) {
 				tc.mocksFn(db, apiKey, user)
 			}
 
-			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments)
+			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments, aiseats.Noop{})
 			require.NoError(t, err)
 			require.NotNil(t, srv)
 
@@ -268,7 +269,7 @@ func TestGetMCPServerConfigs(t *testing.T) {
 			accessURL := "https://my-cool-deployment.com"
 			srv, err := aibridgedserver.NewServer(t.Context(), db, logger, accessURL, codersdk.AIBridgeConfig{
 				InjectCoderMCPTools: serpent.Bool(!tc.disableCoderMCPInjection),
-			}, tc.externalAuthConfigs, tc.experiments)
+			}, tc.externalAuthConfigs, tc.experiments, aiseats.Noop{})
 			require.NoError(t, err)
 			require.NotNil(t, srv)
 
@@ -318,7 +319,7 @@ func TestGetMCPServerAccessTokensBatch(t *testing.T) {
 		{
 			ID: "3",
 		},
-	}, requiredExperiments)
+	}, requiredExperiments, aiseats.Noop{})
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 
@@ -939,7 +940,7 @@ func testRecordMethod[Req any, Resp any](
 			}
 
 			ctx := testutil.Context(t, testutil.WaitLong)
-			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments)
+			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments, aiseats.Noop{})
 			require.NoError(t, err)
 
 			resp, err := callMethod(srv, ctx, tc.request)
@@ -1215,7 +1216,7 @@ func TestStructuredLogging(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitLong)
 			srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{
 				StructuredLogging: serpent.Bool(tc.structuredLogging),
-			}, nil, requiredExperiments)
+			}, nil, requiredExperiments, aiseats.Noop{})
 			require.NoError(t, err)
 
 			err = tc.recordFn(srv, ctx, interceptionID)
@@ -1257,7 +1258,7 @@ func TestInferredThreadsByToolCalls(t *testing.T) {
 
 	user := dbgen.User(t, db, database.User{})
 
-	srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments)
+	srv, err := aibridgedserver.NewServer(ctx, db, logger, "/", codersdk.AIBridgeConfig{}, nil, requiredExperiments, aiseats.Noop{})
 	require.NoError(t, err)
 
 	aID := uuid.New()

--- a/enterprise/aiseats/tracker.go
+++ b/enterprise/aiseats/tracker.go
@@ -64,7 +64,7 @@ func (t *SeatTracker) recordThrottle(userID uuid.UUID, now time.Time, d time.Dur
 	t.retryAfter[userID] = now.Add(d)
 }
 
-func (t *SeatTracker) RecordUsage(ctx context.Context, userID uuid.UUID, reason agplaiseats.Reason, at time.Time) {
+func (t *SeatTracker) RecordUsage(ctx context.Context, userID uuid.UUID, reason agplaiseats.Reason) {
 	now := t.clock.Now()
 	if t.skipRecord(userID, now) {
 		return
@@ -78,7 +78,7 @@ func (t *SeatTracker) RecordUsage(ctx context.Context, userID uuid.UUID, reason 
 
 	err := t.db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
 		UserID:               userID,
-		FirstUsedAt:          at,
+		FirstUsedAt:          now,
 		LastEventType:        eventType,
 		LastEventDescription: description,
 	})

--- a/enterprise/aiseats/tracker.go
+++ b/enterprise/aiseats/tracker.go
@@ -1,0 +1,45 @@
+package aiseats
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"cdr.dev/slog/v3"
+	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+type store interface {
+	UpsertAISeatState(ctx context.Context, arg database.UpsertAISeatStateParams) error
+}
+
+// SeatTracker records current AI seat state for users.
+type SeatTracker struct {
+	db     store
+	logger slog.Logger
+}
+
+func New(db store, logger slog.Logger) *SeatTracker {
+	return &SeatTracker{db: db, logger: logger}
+}
+
+func (t *SeatTracker) RecordUsage(ctx context.Context, userID uuid.UUID, reason agplaiseats.Reason, at time.Time) {
+	eventType, description, ok := agplaiseats.ReasonValues(reason)
+	if !ok {
+		t.logger.Warn(ctx, "invalid AI seat usage reason", slog.F("user_id", userID), slog.F("reason_type", fmt.Sprintf("%T", reason)))
+		return
+	}
+
+	err := t.db.UpsertAISeatState(ctx, database.UpsertAISeatStateParams{
+		UserID:               userID,
+		FirstUsedAt:          at,
+		LastEventType:        eventType,
+		LastEventDescription: description,
+	})
+	if err != nil {
+		t.logger.Warn(ctx, "upsert AI seat state", slog.Error(err), slog.F("user_id", userID), slog.F("event_type", eventType))
+	}
+}

--- a/enterprise/aiseats/tracker.go
+++ b/enterprise/aiseats/tracker.go
@@ -3,6 +3,7 @@ package aiseats
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,23 +11,65 @@ import (
 	"cdr.dev/slog/v3"
 	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/quartz"
 )
 
 type store interface {
 	UpsertAISeatState(ctx context.Context, arg database.UpsertAISeatStateParams) error
 }
 
+// throttleInterval is the minimum time between DB writes for the same user. This
+// is to prevent ai seat tracking from consuming more db resources. It is 30
+// minutes more than the db interval to ensure each insert has a better chance to
+// take effect in the db.
+//
+// These events are not critical to be recorded in real time, so we can afford to
+// skip almost all of them.
+const (
+	throttleInterval    = (6 * time.Hour) + time.Minute*30
+	failedRetryInterval = 10 * time.Minute
+)
+
 // SeatTracker records current AI seat state for users.
 type SeatTracker struct {
 	db     store
 	logger slog.Logger
+	clock  quartz.Clock
+
+	mu         sync.Mutex
+	retryAfter map[uuid.UUID]time.Time
 }
 
-func New(db store, logger slog.Logger) *SeatTracker {
-	return &SeatTracker{db: db, logger: logger}
+func New(db store, logger slog.Logger, clock quartz.Clock) *SeatTracker {
+	if clock == nil {
+		clock = quartz.NewReal()
+	}
+	return &SeatTracker{db: db, logger: logger, clock: clock, retryAfter: make(map[uuid.UUID]time.Time)}
+}
+
+// skipRecord returns true when the user is still in the retry cooldown
+// window and we should skip a DB write attempt.
+func (t *SeatTracker) skipRecord(userID uuid.UUID, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	retryAfter, ok := t.retryAfter[userID]
+	return ok && now.Before(retryAfter)
+}
+
+// recordThrottle sets the next time when DB writes for this user are allowed.
+func (t *SeatTracker) recordThrottle(userID uuid.UUID, now time.Time, d time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.retryAfter[userID] = now.Add(d)
 }
 
 func (t *SeatTracker) RecordUsage(ctx context.Context, userID uuid.UUID, reason agplaiseats.Reason, at time.Time) {
+	now := t.clock.Now()
+	if t.skipRecord(userID, now) {
+		return
+	}
+
 	eventType, description, ok := agplaiseats.ReasonValues(reason)
 	if !ok {
 		t.logger.Warn(ctx, "invalid AI seat usage reason", slog.F("user_id", userID), slog.F("reason_type", fmt.Sprintf("%T", reason)))
@@ -41,5 +84,9 @@ func (t *SeatTracker) RecordUsage(ctx context.Context, userID uuid.UUID, reason 
 	})
 	if err != nil {
 		t.logger.Warn(ctx, "upsert AI seat state", slog.Error(err), slog.F("user_id", userID), slog.F("event_type", eventType))
+		t.recordThrottle(userID, now, failedRetryInterval)
+		return
 	}
+
+	t.recordThrottle(userID, now, throttleInterval)
 }

--- a/enterprise/aiseats/tracker_test.go
+++ b/enterprise/aiseats/tracker_test.go
@@ -12,14 +12,17 @@ import (
 	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 type fakeStore struct {
+	calls   int
 	lastArg database.UpsertAISeatStateParams
 	err     error
 }
 
 func (f *fakeStore) UpsertAISeatState(_ context.Context, arg database.UpsertAISeatStateParams) error {
+	f.calls++
 	f.lastArg = arg
 	return f.err
 }
@@ -27,16 +30,36 @@ func (f *fakeStore) UpsertAISeatState(_ context.Context, arg database.UpsertAISe
 func TestRecordUsage(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now().UTC()
+	clock := quartz.NewMock(t)
+	now := clock.Now()
 	userID := uuid.New()
 	store := &fakeStore{}
-	tracker := New(store, testutil.Logger(t))
+	tracker := New(store, testutil.Logger(t), clock)
 
 	tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonAIBridge("used chatgpt"), now)
+	require.Equal(t, 1, store.calls)
 	require.Equal(t, userID, store.lastArg.UserID)
 	require.Equal(t, now, store.lastArg.FirstUsedAt)
 	require.Equal(t, database.AiSeatUsageReasonAibridge, store.lastArg.LastEventType)
 	require.Equal(t, "used chatgpt", store.lastArg.LastEventDescription)
+}
+
+func TestRecordUsageThrottle(t *testing.T) {
+	t.Parallel()
+
+	clock := quartz.NewMock(t)
+	store := &fakeStore{}
+	tracker := New(store, testutil.Logger(t), clock)
+	ctx := context.Background()
+	userID := uuid.New()
+
+	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"), clock.Now())
+	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"), clock.Now())
+	require.Equal(t, 1, store.calls)
+
+	_ = clock.Advance(throttleInterval + time.Second)
+	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"), clock.Now())
+	require.Equal(t, 2, store.calls)
 }
 
 func TestRecordUsageErrors(t *testing.T) {
@@ -45,16 +68,29 @@ func TestRecordUsageErrors(t *testing.T) {
 	t.Run("db error", func(t *testing.T) {
 		t.Parallel()
 
+		clock := quartz.NewMock(t)
 		store := &fakeStore{err: errors.New("boom")}
-		tracker := New(store, testutil.Logger(t))
-		tracker.RecordUsage(context.Background(), uuid.New(), agplaiseats.ReasonTask("from task"), time.Now().UTC())
+		tracker := New(store, testutil.Logger(t), clock)
+		userID := uuid.New()
+		now := clock.Now()
+
+		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"), now)
+		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"), now)
+		require.Equal(t, 1, store.calls)
+
+		_ = clock.Advance(failedRetryInterval + time.Second)
+		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"), clock.Now())
+		require.Equal(t, 2, store.calls)
 	})
 
 	t.Run("invalid reason", func(t *testing.T) {
 		t.Parallel()
 
-		tracker := New(&fakeStore{}, testutil.Logger(t))
+		clock := quartz.NewMock(t)
+		store := &fakeStore{}
+		tracker := New(store, testutil.Logger(t), clock)
 		var invalid agplaiseats.Reason
-		tracker.RecordUsage(context.Background(), uuid.New(), invalid, time.Now().UTC())
+		tracker.RecordUsage(context.Background(), uuid.New(), invalid, clock.Now())
+		require.Equal(t, 0, store.calls)
 	})
 }

--- a/enterprise/aiseats/tracker_test.go
+++ b/enterprise/aiseats/tracker_test.go
@@ -1,8 +1,6 @@
-package aiseats
+package aiseats_test
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -11,85 +9,203 @@ import (
 
 	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	enterpriseaiseats "github.com/coder/coder/v2/enterprise/aiseats"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
-type fakeStore struct {
-	calls   int
-	lastArg database.UpsertAISeatStateParams
-	err     error
-}
-
-func (f *fakeStore) UpsertAISeatState(_ context.Context, arg database.UpsertAISeatStateParams) error {
-	f.calls++
-	f.lastArg = arg
-	return f.err
-}
-
-func TestRecordUsage(t *testing.T) {
+func TestSeatTrackerDB(t *testing.T) {
 	t.Parallel()
 
-	clock := quartz.NewMock(t)
-	now := clock.Now()
-	userID := uuid.New()
-	store := &fakeStore{}
-	tracker := New(store, testutil.Logger(t), clock)
-
-	tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonAIBridge("used chatgpt"))
-	require.Equal(t, 1, store.calls)
-	require.Equal(t, userID, store.lastArg.UserID)
-	require.Equal(t, now, store.lastArg.FirstUsedAt)
-	require.Equal(t, database.AiSeatUsageReasonAibridge, store.lastArg.LastEventType)
-	require.Equal(t, "used chatgpt", store.lastArg.LastEventDescription)
-}
-
-func TestRecordUsageThrottle(t *testing.T) {
-	t.Parallel()
-
-	clock := quartz.NewMock(t)
-	store := &fakeStore{}
-	tracker := New(store, testutil.Logger(t), clock)
-	ctx := context.Background()
-	userID := uuid.New()
-
-	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"))
-	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"))
-	require.Equal(t, 1, store.calls)
-
-	_ = clock.Advance(throttleInterval + time.Second)
-	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"))
-	require.Equal(t, 2, store.calls)
-}
-
-func TestRecordUsageErrors(t *testing.T) {
-	t.Parallel()
-
-	t.Run("db error", func(t *testing.T) {
+	t.Run("ActiveUserRecorded", func(t *testing.T) {
 		t.Parallel()
 
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
 		clock := quartz.NewMock(t)
-		store := &fakeStore{err: errors.New("boom")}
-		tracker := New(store, testutil.Logger(t), clock)
-		userID := uuid.New()
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), clock)
 
-		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"))
-		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"))
-		require.Equal(t, 1, store.calls)
+		user := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		tracker.RecordUsage(ctx, user.ID, agplaiseats.ReasonAIBridge("active user event"))
 
-		_ = clock.Advance(failedRetryInterval + time.Second)
-		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"))
-		require.Equal(t, 2, store.calls)
+		count, err := db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count)
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, user.ID, rows[0].UserID)
+		require.Equal(t, database.AiSeatUsageReasonAibridge, rows[0].LastEventType)
+		require.Equal(t, "active user event", rows[0].LastEventDescription)
 	})
 
-	t.Run("invalid reason", func(t *testing.T) {
+	t.Run("DormantUserExcluded", func(t *testing.T) {
 		t.Parallel()
 
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), quartz.NewMock(t))
+
+		user := dbgen.User(t, db, database.User{Status: database.UserStatusDormant})
+		tracker.RecordUsage(ctx, user.ID, agplaiseats.ReasonTask("dormant user event"))
+
+		count, err := db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count)
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Empty(t, rows)
+	})
+
+	t.Run("SuspendedUserExcluded", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), quartz.NewMock(t))
+
+		user := dbgen.User(t, db, database.User{Status: database.UserStatusSuspended})
+		tracker.RecordUsage(ctx, user.ID, agplaiseats.ReasonTask("suspended user event"))
+
+		count, err := db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count)
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Empty(t, rows)
+	})
+
+	t.Run("StatusTransitions", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), quartz.NewMock(t))
+
+		user := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		tracker.RecordUsage(ctx, user.ID, agplaiseats.ReasonAIBridge("status transition"))
+
+		count, err := db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count)
+
+		_, err = db.UpdateUserStatus(ctx, database.UpdateUserStatusParams{
+			ID:         user.ID,
+			Status:     database.UserStatusDormant,
+			UpdatedAt:  dbtime.Now(),
+			UserIsSeen: false,
+		})
+		require.NoError(t, err)
+
+		count, err = db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count)
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Empty(t, rows)
+
+		_, err = db.UpdateUserStatus(ctx, database.UpdateUserStatusParams{
+			ID:         user.ID,
+			Status:     database.UserStatusActive,
+			UpdatedAt:  dbtime.Now().Add(time.Second),
+			UserIsSeen: false,
+		})
+		require.NoError(t, err)
+
+		count, err = db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count)
+
+		rows, err = db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, user.ID, rows[0].UserID)
+	})
+
+	t.Run("MultipleActiveUsers", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
 		clock := quartz.NewMock(t)
-		store := &fakeStore{}
-		tracker := New(store, testutil.Logger(t), clock)
-		var invalid agplaiseats.Reason
-		tracker.RecordUsage(context.Background(), uuid.New(), invalid)
-		require.Equal(t, 0, store.calls)
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), clock)
+
+		user1 := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		user2 := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+
+		tracker.RecordUsage(ctx, user1.ID, agplaiseats.ReasonTask("first active user"))
+		_ = clock.Advance(time.Second)
+		tracker.RecordUsage(ctx, user2.ID, agplaiseats.ReasonTask("second active user"))
+
+		count, err := db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, count)
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		require.Equal(t, user2.ID, rows[0].UserID)
+		require.Equal(t, user1.ID, rows[1].UserID)
+		require.True(t, rows[0].LastUsedAt.After(rows[1].LastUsedAt))
+	})
+
+	t.Run("MixedStatuses", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), quartz.NewMock(t))
+
+		active := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		dormant := dbgen.User(t, db, database.User{Status: database.UserStatusDormant})
+		suspended := dbgen.User(t, db, database.User{Status: database.UserStatusSuspended})
+
+		tracker.RecordUsage(ctx, active.ID, agplaiseats.ReasonAIBridge("active"))
+		tracker.RecordUsage(ctx, dormant.ID, agplaiseats.ReasonAIBridge("dormant"))
+		tracker.RecordUsage(ctx, suspended.ID, agplaiseats.ReasonTask("suspended"))
+
+		count, err := db.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count)
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, active.ID, rows[0].UserID)
+	})
+
+	t.Run("ReasonTypes", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := dbtestutil.NewDB(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		clock := quartz.NewMock(t)
+		tracker := enterpriseaiseats.New(db, testutil.Logger(t), clock)
+
+		aiBridgeUser := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+		taskUser := dbgen.User(t, db, database.User{Status: database.UserStatusActive})
+
+		tracker.RecordUsage(ctx, aiBridgeUser.ID, agplaiseats.ReasonAIBridge("aibridge event"))
+		_ = clock.Advance(time.Second)
+		tracker.RecordUsage(ctx, taskUser.ID, agplaiseats.ReasonTask("task event"))
+
+		rows, err := db.ListAISeatState(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+
+		reasonsByUser := map[uuid.UUID]database.AiSeatUsageReason{}
+		for _, row := range rows {
+			reasonsByUser[row.UserID] = row.LastEventType
+		}
+
+		require.Equal(t, database.AiSeatUsageReasonAibridge, reasonsByUser[aiBridgeUser.ID])
+		require.Equal(t, database.AiSeatUsageReasonTask, reasonsByUser[taskUser.ID])
 	})
 }

--- a/enterprise/aiseats/tracker_test.go
+++ b/enterprise/aiseats/tracker_test.go
@@ -36,7 +36,7 @@ func TestRecordUsage(t *testing.T) {
 	store := &fakeStore{}
 	tracker := New(store, testutil.Logger(t), clock)
 
-	tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonAIBridge("used chatgpt"), now)
+	tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonAIBridge("used chatgpt"))
 	require.Equal(t, 1, store.calls)
 	require.Equal(t, userID, store.lastArg.UserID)
 	require.Equal(t, now, store.lastArg.FirstUsedAt)
@@ -53,12 +53,12 @@ func TestRecordUsageThrottle(t *testing.T) {
 	ctx := context.Background()
 	userID := uuid.New()
 
-	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"), clock.Now())
-	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"), clock.Now())
+	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"))
+	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"))
 	require.Equal(t, 1, store.calls)
 
 	_ = clock.Advance(throttleInterval + time.Second)
-	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"), clock.Now())
+	tracker.RecordUsage(ctx, userID, agplaiseats.ReasonTask("from task"))
 	require.Equal(t, 2, store.calls)
 }
 
@@ -72,14 +72,13 @@ func TestRecordUsageErrors(t *testing.T) {
 		store := &fakeStore{err: errors.New("boom")}
 		tracker := New(store, testutil.Logger(t), clock)
 		userID := uuid.New()
-		now := clock.Now()
 
-		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"), now)
-		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"), now)
+		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"))
+		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"))
 		require.Equal(t, 1, store.calls)
 
 		_ = clock.Advance(failedRetryInterval + time.Second)
-		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"), clock.Now())
+		tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonTask("from task"))
 		require.Equal(t, 2, store.calls)
 	})
 
@@ -90,7 +89,7 @@ func TestRecordUsageErrors(t *testing.T) {
 		store := &fakeStore{}
 		tracker := New(store, testutil.Logger(t), clock)
 		var invalid agplaiseats.Reason
-		tracker.RecordUsage(context.Background(), uuid.New(), invalid, clock.Now())
+		tracker.RecordUsage(context.Background(), uuid.New(), invalid)
 		require.Equal(t, 0, store.calls)
 	})
 }

--- a/enterprise/aiseats/tracker_test.go
+++ b/enterprise/aiseats/tracker_test.go
@@ -1,0 +1,60 @@
+package aiseats
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/testutil"
+)
+
+type fakeStore struct {
+	lastArg database.UpsertAISeatStateParams
+	err     error
+}
+
+func (f *fakeStore) UpsertAISeatState(_ context.Context, arg database.UpsertAISeatStateParams) error {
+	f.lastArg = arg
+	return f.err
+}
+
+func TestRecordUsage(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	userID := uuid.New()
+	store := &fakeStore{}
+	tracker := New(store, testutil.Logger(t))
+
+	tracker.RecordUsage(context.Background(), userID, agplaiseats.ReasonAIBridge("used chatgpt"), now)
+	require.Equal(t, userID, store.lastArg.UserID)
+	require.Equal(t, now, store.lastArg.FirstUsedAt)
+	require.Equal(t, database.AiSeatUsageReasonAibridge, store.lastArg.LastEventType)
+	require.Equal(t, "used chatgpt", store.lastArg.LastEventDescription)
+}
+
+func TestRecordUsageErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("db error", func(t *testing.T) {
+		t.Parallel()
+
+		store := &fakeStore{err: errors.New("boom")}
+		tracker := New(store, testutil.Logger(t))
+		tracker.RecordUsage(context.Background(), uuid.New(), agplaiseats.ReasonTask("from task"), time.Now().UTC())
+	})
+
+	t.Run("invalid reason", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := New(&fakeStore{}, testutil.Logger(t))
+		var invalid agplaiseats.Reason
+		tracker.RecordUsage(context.Background(), uuid.New(), invalid, time.Now().UTC())
+	})
+}

--- a/enterprise/coderd/aibridged.go
+++ b/enterprise/coderd/aibridged.go
@@ -48,7 +48,7 @@ func (api *API) CreateInMemoryAIBridgeServer(dialCtx context.Context) (client ai
 
 	mux := drpcmux.New()
 	srv, err := aibridgedserver.NewServer(api.ctx, api.Database, api.Logger.Named("aibridgedserver"),
-		api.AccessURL.String(), api.DeploymentValues.AI.BridgeConfig, api.ExternalAuthConfigs, api.AGPL.Experiments)
+		api.AccessURL.String(), api.DeploymentValues.AI.BridgeConfig, api.ExternalAuthConfigs, api.AGPL.Experiments, api.aiSeatTracker)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -45,6 +45,7 @@ import (
 	agplusage "github.com/coder/coder/v2/coderd/usage"
 	"github.com/coder/coder/v2/coderd/wsbuilder"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/aiseats"
 	entchatd "github.com/coder/coder/v2/enterprise/coderd/chatd"
 	"github.com/coder/coder/v2/enterprise/coderd/connectionlog"
 	"github.com/coder/coder/v2/enterprise/coderd/dbauthz"
@@ -217,7 +218,10 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		},
 	})
 
+	api.aiSeatTracker = aiseats.New(options.Database, api.Logger.Named("aiseats"))
+
 	api.AGPL = coderd.New(options.Options)
+	api.AGPL.AISeatTracker = api.aiSeatTracker
 	defer func() {
 		if err != nil {
 			_ = api.Close()
@@ -785,6 +789,7 @@ type API struct {
 
 	aibridgedHandler      http.Handler
 	aibridgeproxydHandler http.Handler
+	aiSeatTracker         *aiseats.SeatTracker
 }
 
 // writeEntitlementWarningsHeader writes the entitlement warnings to the response header

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -218,7 +218,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		},
 	})
 
-	api.aiSeatTracker = aiseats.New(options.Database, api.Logger.Named("aiseats"))
+	api.aiSeatTracker = aiseats.New(options.Database, api.Logger.Named("aiseats"), quartz.NewReal())
 
 	api.AGPL = coderd.New(options.Options)
 	api.AGPL.AISeatTracker = api.aiSeatTracker

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -356,6 +356,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		provisionerdserver.Options{
 			ExternalAuthConfigs: api.ExternalAuthConfigs,
 			OIDCConfig:          api.OIDCConfig,
+			AISeatTracker:       api.AGPL.AISeatTracker,
 			Clock:               api.Clock,
 		},
 		api.NotificationsEnqueuer,


### PR DESCRIPTION
This moves ai seat tracking into it's own table. This does not track past usage, only usage after this PR. Any user that uses an ai feature will get included into this table.

# Alternate idea to just do a sql query

The alternative idea is just to do a SQL query on all the feature tables. This is a nice method in theory, but lacks audit capabilities. This method also is likely to be more durable than a manually tracked table.

If we want to audit the when and why, a table is just better suited. It also offers better performance than a query on the workspace builds + `aibridge_interceptions` table.


<details>

<summary>Example on the query for **just the workspace builds side of usage**</summary>

```sql
CREATE OR REPLACE VIEW workspace_builds_managed_agent_usage_candidates AS
SELECT
	wb.id                              AS workspace_build_id,
	wb.workspace_id,
	wb.build_number,
	wb.created_at                      AS build_created_at,
	wb.updated_at                      AS build_updated_at,
	wb.job_id                          AS provisioner_job_id,
	pj.started_at                      AS job_started_at,
	pj.completed_at                    AS job_completed_at,
	pj.job_status,
	w.name                             AS workspace_name,
	w.owner_id                         AS workspace_owner_id,
	owner_u.username                   AS workspace_owner_username,
	owner_u.name                       AS workspace_owner_name,
	w.organization_id,
	orgs.name                          AS organization_name,
	w.template_id,
	t.name                             AS template_name,
	wb.template_version_id,
	tv.name                            AS template_version_name,
	wb.initiator_id,
	wb.initiator_by_username,
	wb.initiator_by_name,
	wb.has_ai_task,
	wb.has_external_agent
FROM workspace_build_with_user wb
		 JOIN provisioner_jobs pj
			 ON pj.id = wb.job_id
		 JOIN workspaces w
			 ON w.id = wb.workspace_id
		 JOIN organizations orgs
			 ON orgs.id = w.organization_id
		 JOIN templates t
			 ON t.id = w.template_id
		 LEFT JOIN template_versions tv
			 ON tv.id = wb.template_version_id
		 LEFT JOIN users owner_u
			  ON owner_u.id = w.owner_id
WHERE 
	-- A workspace that is stopped/started will have each "start" count towards usage
	wb.transition = 'start'::workspace_transition
	-- Failed builds do not count to usage
  AND pj.job_status = 'succeeded'::provisioner_job_status
  -- Tasks -> build can be "many to 1". So do not use a join, that would create
  -- a row per task for the same workspace build.
  AND EXISTS (
    SELECT 1
    FROM tasks task
    WHERE task.workspace_id = wb.workspace_id
  );
 ;
```
</details>

