### PR TITLE
fix(site): add optimistic updates for chat archive/unarchive

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -21,10 +21,10 @@ export const archiveChat = (queryClient: QueryClient) => ({
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({ queryKey: chatsKey });
 		await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-		const previousChats =
-			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-		const previousChat =
-			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId));
+		const previousChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		const previousChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
+			chatKey(chatId),
+		);
 		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
 			old?.map((chat) =>
 				chat.id === chatId ? { ...chat, archived: true } : chat,
@@ -38,6 +38,29 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		}
 		return { previousChats, previousChat };
 	},
+	onError: (
+		_error: unknown,
+		chatId: string,
+		context:
+			| {
+					previousChats?: TypesGen.Chat[];
+					previousChat?: TypesGen.ChatWithMessages;
+			  }
+			| undefined,
+	) => {
+		if (context?.previousChats) {
+			queryClient.setQueryData<TypesGen.Chat[]>(
+				chatsKey,
+				context.previousChats,
+			);
+		}
+		if (context?.previousChat) {
+			queryClient.setQueryData<TypesGen.ChatWithMessages>(
+				chatKey(chatId),
+				context.previousChat,
+			);
+		}
+	},
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });
 		await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
@@ -49,10 +72,10 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({ queryKey: chatsKey });
 		await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-		const previousChats =
-			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-		const previousChat =
-			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId));
+		const previousChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		const previousChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
+			chatKey(chatId),
+		);
 		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
 			old?.map((chat) =>
 				chat.id === chatId ? { ...chat, archived: false } : chat,
@@ -65,6 +88,29 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 			});
 		}
 		return { previousChats, previousChat };
+	},
+	onError: (
+		_error: unknown,
+		chatId: string,
+		context:
+			| {
+					previousChats?: TypesGen.Chat[];
+					previousChat?: TypesGen.ChatWithMessages;
+			  }
+			| undefined,
+	) => {
+		if (context?.previousChats) {
+			queryClient.setQueryData<TypesGen.Chat[]>(
+				chatsKey,
+				context.previousChats,
+			);
+		}
+		if (context?.previousChat) {
+			queryClient.setQueryData<TypesGen.ChatWithMessages>(
+				chatKey(chatId),
+				context.previousChat,
+			);
+		}
 	},
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -25,6 +25,29 @@ export const createChat = (queryClient: QueryClient) => ({
 
 export const archiveChat = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) => API.archiveChat(chatId),
+	onMutate: async (chatId: string) => {
+		await queryClient.cancelQueries({ queryKey: chatsKey });
+		const previousChats =
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+			old?.map((chat) =>
+				chat.id === chatId ? { ...chat, archived: true } : chat,
+			),
+		);
+		return { previousChats };
+	},
+	onError: (
+		_error: unknown,
+		_chatId: string,
+		context: { previousChats: TypesGen.Chat[] | undefined } | undefined,
+	) => {
+		if (context?.previousChats) {
+			queryClient.setQueryData<TypesGen.Chat[]>(
+				chatsKey,
+				context.previousChats,
+			);
+		}
+	},
 	onSuccess: () => {
 		void queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
@@ -32,6 +55,29 @@ export const archiveChat = (queryClient: QueryClient) => ({
 
 export const unarchiveChat = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) => API.unarchiveChat(chatId),
+	onMutate: async (chatId: string) => {
+		await queryClient.cancelQueries({ queryKey: chatsKey });
+		const previousChats =
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+			old?.map((chat) =>
+				chat.id === chatId ? { ...chat, archived: false } : chat,
+			),
+		);
+		return { previousChats };
+	},
+	onError: (
+		_error: unknown,
+		_chatId: string,
+		context: { previousChats: TypesGen.Chat[] | undefined } | undefined,
+	) => {
+		if (context?.previousChats) {
+			queryClient.setQueryData<TypesGen.Chat[]>(
+				chatsKey,
+				context.previousChats,
+			);
+		}
+	},
 	onSuccess: async () => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });
 	},

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -16,6 +16,108 @@ export const chat = (chatId: string) => ({
 	queryFn: () => API.getChat(chatId),
 });
 
+export const archiveChat = (queryClient: QueryClient) => ({
+	mutationFn: (chatId: string) => API.archiveChat(chatId),
+	onMutate: async (chatId: string) => {
+		await queryClient.cancelQueries({ queryKey: chatsKey });
+		await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+		const previousChats =
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		const previousChat =
+			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId));
+		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+			old?.map((chat) =>
+				chat.id === chatId ? { ...chat, archived: true } : chat,
+			),
+		);
+		if (previousChat) {
+			queryClient.setQueryData<TypesGen.ChatWithMessages>(chatKey(chatId), {
+				...previousChat,
+				chat: { ...previousChat.chat, archived: true },
+			});
+		}
+		return { previousChats, previousChat };
+	},
+	onError: (
+		_error: unknown,
+		chatId: string,
+		context:
+			| {
+					previousChats: TypesGen.Chat[] | undefined;
+					previousChat: TypesGen.ChatWithMessages | undefined;
+			  }
+			| undefined,
+	) => {
+		if (context?.previousChats) {
+			queryClient.setQueryData<TypesGen.Chat[]>(
+				chatsKey,
+				context.previousChats,
+			);
+		}
+		if (context?.previousChat) {
+			queryClient.setQueryData<TypesGen.ChatWithMessages>(
+				chatKey(chatId),
+				context.previousChat,
+			);
+		}
+	},
+	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
+		await queryClient.invalidateQueries({ queryKey: chatsKey });
+		await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+	},
+});
+
+export const unarchiveChat = (queryClient: QueryClient) => ({
+	mutationFn: (chatId: string) => API.unarchiveChat(chatId),
+	onMutate: async (chatId: string) => {
+		await queryClient.cancelQueries({ queryKey: chatsKey });
+		await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+		const previousChats =
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		const previousChat =
+			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId));
+		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+			old?.map((chat) =>
+				chat.id === chatId ? { ...chat, archived: false } : chat,
+			),
+		);
+		if (previousChat) {
+			queryClient.setQueryData<TypesGen.ChatWithMessages>(chatKey(chatId), {
+				...previousChat,
+				chat: { ...previousChat.chat, archived: false },
+			});
+		}
+		return { previousChats, previousChat };
+	},
+	onError: (
+		_error: unknown,
+		chatId: string,
+		context:
+			| {
+					previousChats: TypesGen.Chat[] | undefined;
+					previousChat: TypesGen.ChatWithMessages | undefined;
+			  }
+			| undefined,
+	) => {
+		if (context?.previousChats) {
+			queryClient.setQueryData<TypesGen.Chat[]>(
+				chatsKey,
+				context.previousChats,
+			);
+		}
+		if (context?.previousChat) {
+			queryClient.setQueryData<TypesGen.ChatWithMessages>(
+				chatKey(chatId),
+				context.previousChat,
+			);
+		}
+	},
+	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
+		await queryClient.invalidateQueries({ queryKey: chatsKey });
+		await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+	},
+});
+
 export const createChat = (queryClient: QueryClient) => ({
 	mutationFn: (req: TypesGen.CreateChatRequest) => API.createChat(req),
 	onSuccess: () => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -23,66 +23,6 @@ export const createChat = (queryClient: QueryClient) => ({
 	},
 });
 
-export const archiveChat = (queryClient: QueryClient) => ({
-	mutationFn: (chatId: string) => API.archiveChat(chatId),
-	onMutate: async (chatId: string) => {
-		await queryClient.cancelQueries({ queryKey: chatsKey });
-		const previousChats =
-			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
-			old?.map((chat) =>
-				chat.id === chatId ? { ...chat, archived: true } : chat,
-			),
-		);
-		return { previousChats };
-	},
-	onError: (
-		_error: unknown,
-		_chatId: string,
-		context: { previousChats: TypesGen.Chat[] | undefined } | undefined,
-	) => {
-		if (context?.previousChats) {
-			queryClient.setQueryData<TypesGen.Chat[]>(
-				chatsKey,
-				context.previousChats,
-			);
-		}
-	},
-	onSettled: () => {
-		void queryClient.invalidateQueries({ queryKey: chatsKey });
-	},
-});
-
-export const unarchiveChat = (queryClient: QueryClient) => ({
-	mutationFn: (chatId: string) => API.unarchiveChat(chatId),
-	onMutate: async (chatId: string) => {
-		await queryClient.cancelQueries({ queryKey: chatsKey });
-		const previousChats =
-			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-		queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
-			old?.map((chat) =>
-				chat.id === chatId ? { ...chat, archived: false } : chat,
-			),
-		);
-		return { previousChats };
-	},
-	onError: (
-		_error: unknown,
-		_chatId: string,
-		context: { previousChats: TypesGen.Chat[] | undefined } | undefined,
-	) => {
-		if (context?.previousChats) {
-			queryClient.setQueryData<TypesGen.Chat[]>(
-				chatsKey,
-				context.previousChats,
-			);
-		}
-	},
-	onSettled: async () => {
-		await queryClient.invalidateQueries({ queryKey: chatsKey });
-	},
-});
-
 export const createChatMessage = (
 	queryClient: QueryClient,
 	chatId: string,

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1,6 +1,8 @@
 import { API, type ChatDiffStatusResponse } from "api/api";
+import { getErrorMessage } from "api/errors";
 import type * as TypesGen from "api/typesGenerated";
 import type { QueryClient } from "react-query";
+import { toast } from "sonner";
 
 export const chatsKey = ["chats"] as const;
 export const chatKey = (chatId: string) => ["chats", chatId] as const;
@@ -39,7 +41,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		return { previousChats, previousChat };
 	},
 	onError: (
-		_error: unknown,
+		error: unknown,
 		chatId: string,
 		context:
 			| {
@@ -60,6 +62,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 				context.previousChat,
 			);
 		}
+		toast.error(getErrorMessage(error, "Failed to archive agent."));
 	},
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });
@@ -90,7 +93,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 		return { previousChats, previousChat };
 	},
 	onError: (
-		_error: unknown,
+		error: unknown,
 		chatId: string,
 		context:
 			| {
@@ -111,6 +114,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 				context.previousChat,
 			);
 		}
+		toast.error(getErrorMessage(error, "Failed to unarchive agent."));
 	},
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -48,7 +48,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 			);
 		}
 	},
-	onSuccess: () => {
+	onSettled: () => {
 		void queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
 });
@@ -78,7 +78,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 			);
 		}
 	},
-	onSuccess: async () => {
+	onSettled: async () => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });
 	},
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1,8 +1,6 @@
 import { API, type ChatDiffStatusResponse } from "api/api";
-import { getErrorMessage } from "api/errors";
 import type * as TypesGen from "api/typesGenerated";
 import type { QueryClient } from "react-query";
-import { toast } from "sonner";
 
 export const chatsKey = ["chats"] as const;
 export const chatKey = (chatId: string) => ["chats", chatId] as const;
@@ -40,30 +38,6 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		}
 		return { previousChats, previousChat };
 	},
-	onError: (
-		error: unknown,
-		chatId: string,
-		context:
-			| {
-					previousChats: TypesGen.Chat[] | undefined;
-					previousChat: TypesGen.ChatWithMessages | undefined;
-			  }
-			| undefined,
-	) => {
-		if (context?.previousChats) {
-			queryClient.setQueryData<TypesGen.Chat[]>(
-				chatsKey,
-				context.previousChats,
-			);
-		}
-		if (context?.previousChat) {
-			queryClient.setQueryData<TypesGen.ChatWithMessages>(
-				chatKey(chatId),
-				context.previousChat,
-			);
-		}
-		toast.error(getErrorMessage(error, "Failed to archive agent."));
-	},
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });
 		await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
@@ -91,30 +65,6 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 			});
 		}
 		return { previousChats, previousChat };
-	},
-	onError: (
-		error: unknown,
-		chatId: string,
-		context:
-			| {
-					previousChats: TypesGen.Chat[] | undefined;
-					previousChat: TypesGen.ChatWithMessages | undefined;
-			  }
-			| undefined,
-	) => {
-		if (context?.previousChats) {
-			queryClient.setQueryData<TypesGen.Chat[]>(
-				chatsKey,
-				context.previousChats,
-			);
-		}
-		if (context?.previousChat) {
-			queryClient.setQueryData<TypesGen.ChatWithMessages>(
-				chatKey(chatId),
-				context.previousChat,
-			);
-		}
-		toast.error(getErrorMessage(error, "Failed to unarchive agent."));
 	},
 	onSettled: async (_data: unknown, _error: unknown, chatId: string) => {
 		await queryClient.invalidateQueries({ queryKey: chatsKey });

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -158,14 +158,16 @@ const AgentsPage: FC = () => {
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
 	const createMutation = useMutation(createChat(queryClient));
-	const archiveAgentMutation = useMutation({
-		...archiveChat(queryClient),
-		onSuccess: (_data, chatId) => {
-			clearChatErrorReason(chatId);
-			toast.success("Agent archived.");
-		},
-	});
-	const archiveAndDeleteMutation = useMutation({
+		const archiveAgentMutation = useMutation({
+			...archiveChat(queryClient),
+			onSuccess: (_data, chatId) => {
+				clearChatErrorReason(chatId);
+				toast.success("Agent archived.");
+			},
+			onError: (error) => {
+				toast.error(getErrorMessage(error, "Failed to archive agent."));
+			},
+		});	const archiveAndDeleteMutation = useMutation({
 		mutationFn: async ({
 			chatId,
 			workspaceId,
@@ -188,13 +190,15 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
 		},
 	});
-	const unarchiveAgentMutation = useMutation({
-		...unarchiveChat(queryClient),
-		onSuccess: () => {
-			toast.success("Agent unarchived.");
-		},
-	});
-	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
+		const unarchiveAgentMutation = useMutation({
+			...unarchiveChat(queryClient),
+			onSuccess: () => {
+				toast.success("Agent unarchived.");
+			},
+			onError: (error) => {
+				toast.error(getErrorMessage(error, "Failed to unarchive agent."));
+			},
+		});	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
 		useState(false);
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 	const [chatErrorReasons, setChatErrorReasons] = useState<

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -158,15 +158,39 @@ const AgentsPage: FC = () => {
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
 	const createMutation = useMutation(createChat(queryClient));
+	const archiveChatBase = archiveChat(queryClient);
 	const archiveAgentMutation = useMutation({
-		...archiveChat(queryClient),
-		onSuccess: async (_data, chatId) => {
-			clearChatErrorReason(chatId);
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
-			toast.success("Agent archived.");
+		...archiveChatBase,
+		onMutate: async (chatId: string) => {
+			const baseContext = await archiveChatBase.onMutate?.(chatId);
+			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+			const previousChat =
+				queryClient.getQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+				);
+			if (previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+					{ ...previousChat, chat: { ...previousChat.chat, archived: true } },
+				);
+			}
+			return { ...baseContext, previousChat };
 		},
-		onError: (error) => {
+		onError: (error, chatId, context) => {
+			archiveChatBase.onError?.(error, chatId, context);
+			if (context?.previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+					context.previousChat,
+				);
+			}
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
+		},
+		onSuccess: async (_data, chatId) => {
+			archiveChatBase.onSuccess?.();
+			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+			clearChatErrorReason(chatId);
+			toast.success("Agent archived.");
 		},
 	});
 	const archiveAndDeleteMutation = useMutation({
@@ -192,14 +216,38 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
 		},
 	});
+	const unarchiveChatBase = unarchiveChat(queryClient);
 	const unarchiveAgentMutation = useMutation({
-		...unarchiveChat(queryClient),
+		...unarchiveChatBase,
+		onMutate: async (chatId: string) => {
+			const baseContext = await unarchiveChatBase.onMutate?.(chatId);
+			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+			const previousChat =
+				queryClient.getQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+				);
+			if (previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+					{ ...previousChat, chat: { ...previousChat.chat, archived: false } },
+				);
+			}
+			return { ...baseContext, previousChat };
+		},
+		onError: (error, chatId, context) => {
+			unarchiveChatBase.onError?.(error, chatId, context);
+			if (context?.previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+					context.previousChat,
+				);
+			}
+			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
+		},
 		onSuccess: async (_data, chatId) => {
+			unarchiveChatBase.onSuccess?.();
 			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 			toast.success("Agent unarchived.");
-		},
-		onError: (error) => {
-			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
 		},
 	});
 

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -1,7 +1,6 @@
 import { API, watchChats } from "api/api";
 import { getErrorMessage } from "api/errors";
 import {
-	archiveChat,
 	chatDiffContentsKey,
 	chatDiffStatusKey,
 	chatKey,
@@ -10,7 +9,6 @@ import {
 	chats,
 	chatsKey,
 	createChat,
-	unarchiveChat,
 } from "api/queries/chats";
 import { workspaces } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
@@ -158,44 +156,54 @@ const AgentsPage: FC = () => {
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
 	const createMutation = useMutation(createChat(queryClient));
-	const archiveChatBase = archiveChat(queryClient);
-	const archiveAgentMutation = useMutation({
-		...archiveChatBase,
-		onMutate: async (chatId: string) => {
-			const baseContext = await archiveChatBase.onMutate?.(chatId);
-			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-			const previousChat =
-				queryClient.getQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
+		const archiveAgentMutation = useMutation({
+			mutationFn: (chatId: string) => API.archiveChat(chatId),
+			onMutate: async (chatId: string) => {
+				await queryClient.cancelQueries({ queryKey: chatsKey });
+				await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+				const previousChats =
+					queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+				const previousChat =
+					queryClient.getQueryData<TypesGen.ChatWithMessages>(
+						chatKey(chatId),
+					);
+				queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+					old?.map((chat) =>
+						chat.id === chatId ? { ...chat, archived: true } : chat,
+					),
 				);
-			if (previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
-					{ ...previousChat, chat: { ...previousChat.chat, archived: true } },
-				);
-			}
-			return { ...baseContext, previousChat };
-		},
-		onError: (error, chatId, context) => {
-			archiveChatBase.onError?.(error, chatId, context);
-			if (context?.previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
-					context.previousChat,
-				);
-			}
-			toast.error(getErrorMessage(error, "Failed to archive agent."));
-		},
-		onSuccess: (_data, chatId) => {
-			clearChatErrorReason(chatId);
-			toast.success("Agent archived.");
-		},
-		onSettled: async (_data, _error, chatId) => {
-			archiveChatBase.onSettled?.();
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
-		},
-	});
-	const archiveAndDeleteMutation = useMutation({
+				if (previousChat) {
+					queryClient.setQueryData<TypesGen.ChatWithMessages>(
+						chatKey(chatId),
+						{ ...previousChat, chat: { ...previousChat.chat, archived: true } },
+					);
+				}
+				return { previousChats, previousChat };
+			},
+			onError: (error, chatId, context) => {
+				if (context?.previousChats) {
+					queryClient.setQueryData<TypesGen.Chat[]>(
+						chatsKey,
+						context.previousChats,
+					);
+				}
+				if (context?.previousChat) {
+					queryClient.setQueryData<TypesGen.ChatWithMessages>(
+						chatKey(chatId),
+						context.previousChat,
+					);
+				}
+				toast.error(getErrorMessage(error, "Failed to archive agent."));
+			},
+			onSuccess: (_data, chatId) => {
+				clearChatErrorReason(chatId);
+				toast.success("Agent archived.");
+			},
+			onSettled: async (_data, _error, chatId) => {
+				await queryClient.invalidateQueries({ queryKey: chatsKey });
+				await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+			},
+		});	const archiveAndDeleteMutation = useMutation({
 		mutationFn: async ({
 			chatId,
 			workspaceId,
@@ -218,43 +226,53 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
 		},
 	});
-	const unarchiveChatBase = unarchiveChat(queryClient);
-	const unarchiveAgentMutation = useMutation({
-		...unarchiveChatBase,
-		onMutate: async (chatId: string) => {
-			const baseContext = await unarchiveChatBase.onMutate?.(chatId);
-			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-			const previousChat =
-				queryClient.getQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
+		const unarchiveAgentMutation = useMutation({
+			mutationFn: (chatId: string) => API.unarchiveChat(chatId),
+			onMutate: async (chatId: string) => {
+				await queryClient.cancelQueries({ queryKey: chatsKey });
+				await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+				const previousChats =
+					queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+				const previousChat =
+					queryClient.getQueryData<TypesGen.ChatWithMessages>(
+						chatKey(chatId),
+					);
+				queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+					old?.map((chat) =>
+						chat.id === chatId ? { ...chat, archived: false } : chat,
+					),
 				);
-			if (previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
-					{ ...previousChat, chat: { ...previousChat.chat, archived: false } },
-				);
-			}
-			return { ...baseContext, previousChat };
-		},
-		onError: (error, chatId, context) => {
-			unarchiveChatBase.onError?.(error, chatId, context);
-			if (context?.previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
-					context.previousChat,
-				);
-			}
-			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
-		},
-		onSuccess: (_data, _chatId) => {
-			toast.success("Agent unarchived.");
-		},
-		onSettled: async (_data, _error, chatId) => {
-			unarchiveChatBase.onSettled?.();
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
-		},
-	});
-
+				if (previousChat) {
+					queryClient.setQueryData<TypesGen.ChatWithMessages>(
+						chatKey(chatId),
+						{ ...previousChat, chat: { ...previousChat.chat, archived: false } },
+					);
+				}
+				return { previousChats, previousChat };
+			},
+			onError: (error, chatId, context) => {
+				if (context?.previousChats) {
+					queryClient.setQueryData<TypesGen.Chat[]>(
+						chatsKey,
+						context.previousChats,
+					);
+				}
+				if (context?.previousChat) {
+					queryClient.setQueryData<TypesGen.ChatWithMessages>(
+						chatKey(chatId),
+						context.previousChat,
+					);
+				}
+				toast.error(getErrorMessage(error, "Failed to unarchive agent."));
+			},
+			onSuccess: () => {
+				toast.success("Agent unarchived.");
+			},
+			onSettled: async (_data, _error, chatId) => {
+				await queryClient.invalidateQueries({ queryKey: chatsKey });
+				await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+			},
+		});
 	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
 		useState(false);
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -156,54 +156,53 @@ const AgentsPage: FC = () => {
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
 	const createMutation = useMutation(createChat(queryClient));
-		const archiveAgentMutation = useMutation({
-			mutationFn: (chatId: string) => API.archiveChat(chatId),
-			onMutate: async (chatId: string) => {
-				await queryClient.cancelQueries({ queryKey: chatsKey });
-				await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-				const previousChats =
-					queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-				const previousChat =
-					queryClient.getQueryData<TypesGen.ChatWithMessages>(
-						chatKey(chatId),
-					);
-				queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
-					old?.map((chat) =>
-						chat.id === chatId ? { ...chat, archived: true } : chat,
-					),
+	const archiveAgentMutation = useMutation({
+		mutationFn: (chatId: string) => API.archiveChat(chatId),
+		onMutate: async (chatId: string) => {
+			await queryClient.cancelQueries({ queryKey: chatsKey });
+			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+			const previousChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			const previousChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
+				chatKey(chatId),
+			);
+			queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+				old?.map((chat) =>
+					chat.id === chatId ? { ...chat, archived: true } : chat,
+				),
+			);
+			if (previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(chatKey(chatId), {
+					...previousChat,
+					chat: { ...previousChat.chat, archived: true },
+				});
+			}
+			return { previousChats, previousChat };
+		},
+		onError: (error, chatId, context) => {
+			if (context?.previousChats) {
+				queryClient.setQueryData<TypesGen.Chat[]>(
+					chatsKey,
+					context.previousChats,
 				);
-				if (previousChat) {
-					queryClient.setQueryData<TypesGen.ChatWithMessages>(
-						chatKey(chatId),
-						{ ...previousChat, chat: { ...previousChat.chat, archived: true } },
-					);
-				}
-				return { previousChats, previousChat };
-			},
-			onError: (error, chatId, context) => {
-				if (context?.previousChats) {
-					queryClient.setQueryData<TypesGen.Chat[]>(
-						chatsKey,
-						context.previousChats,
-					);
-				}
-				if (context?.previousChat) {
-					queryClient.setQueryData<TypesGen.ChatWithMessages>(
-						chatKey(chatId),
-						context.previousChat,
-					);
-				}
-				toast.error(getErrorMessage(error, "Failed to archive agent."));
-			},
-			onSuccess: (_data, chatId) => {
-				clearChatErrorReason(chatId);
-				toast.success("Agent archived.");
-			},
-			onSettled: async (_data, _error, chatId) => {
-				await queryClient.invalidateQueries({ queryKey: chatsKey });
-				await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
-			},
-		});	const archiveAndDeleteMutation = useMutation({
+			}
+			if (context?.previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+					context.previousChat,
+				);
+			}
+			toast.error(getErrorMessage(error, "Failed to archive agent."));
+		},
+		onSuccess: (_data, chatId) => {
+			clearChatErrorReason(chatId);
+			toast.success("Agent archived.");
+		},
+		onSettled: async (_data, _error, chatId) => {
+			await queryClient.invalidateQueries({ queryKey: chatsKey });
+			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+		},
+	});
+	const archiveAndDeleteMutation = useMutation({
 		mutationFn: async ({
 			chatId,
 			workspaceId,
@@ -226,53 +225,51 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
 		},
 	});
-		const unarchiveAgentMutation = useMutation({
-			mutationFn: (chatId: string) => API.unarchiveChat(chatId),
-			onMutate: async (chatId: string) => {
-				await queryClient.cancelQueries({ queryKey: chatsKey });
-				await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-				const previousChats =
-					queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-				const previousChat =
-					queryClient.getQueryData<TypesGen.ChatWithMessages>(
-						chatKey(chatId),
-					);
-				queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
-					old?.map((chat) =>
-						chat.id === chatId ? { ...chat, archived: false } : chat,
-					),
+	const unarchiveAgentMutation = useMutation({
+		mutationFn: (chatId: string) => API.unarchiveChat(chatId),
+		onMutate: async (chatId: string) => {
+			await queryClient.cancelQueries({ queryKey: chatsKey });
+			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
+			const previousChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			const previousChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
+				chatKey(chatId),
+			);
+			queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
+				old?.map((chat) =>
+					chat.id === chatId ? { ...chat, archived: false } : chat,
+				),
+			);
+			if (previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(chatKey(chatId), {
+					...previousChat,
+					chat: { ...previousChat.chat, archived: false },
+				});
+			}
+			return { previousChats, previousChat };
+		},
+		onError: (error, chatId, context) => {
+			if (context?.previousChats) {
+				queryClient.setQueryData<TypesGen.Chat[]>(
+					chatsKey,
+					context.previousChats,
 				);
-				if (previousChat) {
-					queryClient.setQueryData<TypesGen.ChatWithMessages>(
-						chatKey(chatId),
-						{ ...previousChat, chat: { ...previousChat.chat, archived: false } },
-					);
-				}
-				return { previousChats, previousChat };
-			},
-			onError: (error, chatId, context) => {
-				if (context?.previousChats) {
-					queryClient.setQueryData<TypesGen.Chat[]>(
-						chatsKey,
-						context.previousChats,
-					);
-				}
-				if (context?.previousChat) {
-					queryClient.setQueryData<TypesGen.ChatWithMessages>(
-						chatKey(chatId),
-						context.previousChat,
-					);
-				}
-				toast.error(getErrorMessage(error, "Failed to unarchive agent."));
-			},
-			onSuccess: () => {
-				toast.success("Agent unarchived.");
-			},
-			onSettled: async (_data, _error, chatId) => {
-				await queryClient.invalidateQueries({ queryKey: chatsKey });
-				await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
-			},
-		});
+			}
+			if (context?.previousChat) {
+				queryClient.setQueryData<TypesGen.ChatWithMessages>(
+					chatKey(chatId),
+					context.previousChat,
+				);
+			}
+			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
+		},
+		onSuccess: () => {
+			toast.success("Agent unarchived.");
+		},
+		onSettled: async (_data, _error, chatId) => {
+			await queryClient.invalidateQueries({ queryKey: chatsKey });
+			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+		},
+	});
 	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
 		useState(false);
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -186,11 +186,13 @@ const AgentsPage: FC = () => {
 			}
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
 		},
-		onSuccess: async (_data, chatId) => {
-			archiveChatBase.onSuccess?.();
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+		onSuccess: (_data, chatId) => {
 			clearChatErrorReason(chatId);
 			toast.success("Agent archived.");
+		},
+		onSettled: async (_data, _error, chatId) => {
+			archiveChatBase.onSettled?.();
+			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 		},
 	});
 	const archiveAndDeleteMutation = useMutation({
@@ -244,10 +246,12 @@ const AgentsPage: FC = () => {
 			}
 			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
 		},
-		onSuccess: async (_data, chatId) => {
-			unarchiveChatBase.onSuccess?.();
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
+		onSuccess: (_data, _chatId) => {
 			toast.success("Agent unarchived.");
+		},
+		onSettled: async (_data, _error, chatId) => {
+			unarchiveChatBase.onSettled?.();
+			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 		},
 	});
 

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -1,6 +1,7 @@
 import { API, watchChats } from "api/api";
 import { getErrorMessage } from "api/errors";
 import {
+	archiveChat,
 	chatDiffContentsKey,
 	chatDiffStatusKey,
 	chatKey,
@@ -9,6 +10,7 @@ import {
 	chats,
 	chatsKey,
 	createChat,
+	unarchiveChat,
 } from "api/queries/chats";
 import { workspaces } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
@@ -157,49 +159,10 @@ const AgentsPage: FC = () => {
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
 	const createMutation = useMutation(createChat(queryClient));
 	const archiveAgentMutation = useMutation({
-		mutationFn: (chatId: string) => API.archiveChat(chatId),
-		onMutate: async (chatId: string) => {
-			await queryClient.cancelQueries({ queryKey: chatsKey });
-			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-			const previousChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-			const previousChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
-				chatKey(chatId),
-			);
-			queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
-				old?.map((chat) =>
-					chat.id === chatId ? { ...chat, archived: true } : chat,
-				),
-			);
-			if (previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(chatKey(chatId), {
-					...previousChat,
-					chat: { ...previousChat.chat, archived: true },
-				});
-			}
-			return { previousChats, previousChat };
-		},
-		onError: (error, chatId, context) => {
-			if (context?.previousChats) {
-				queryClient.setQueryData<TypesGen.Chat[]>(
-					chatsKey,
-					context.previousChats,
-				);
-			}
-			if (context?.previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
-					context.previousChat,
-				);
-			}
-			toast.error(getErrorMessage(error, "Failed to archive agent."));
-		},
+		...archiveChat(queryClient),
 		onSuccess: (_data, chatId) => {
 			clearChatErrorReason(chatId);
 			toast.success("Agent archived.");
-		},
-		onSettled: async (_data, _error, chatId) => {
-			await queryClient.invalidateQueries({ queryKey: chatsKey });
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 		},
 	});
 	const archiveAndDeleteMutation = useMutation({
@@ -226,48 +189,9 @@ const AgentsPage: FC = () => {
 		},
 	});
 	const unarchiveAgentMutation = useMutation({
-		mutationFn: (chatId: string) => API.unarchiveChat(chatId),
-		onMutate: async (chatId: string) => {
-			await queryClient.cancelQueries({ queryKey: chatsKey });
-			await queryClient.cancelQueries({ queryKey: chatKey(chatId) });
-			const previousChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
-			const previousChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
-				chatKey(chatId),
-			);
-			queryClient.setQueryData<TypesGen.Chat[]>(chatsKey, (old) =>
-				old?.map((chat) =>
-					chat.id === chatId ? { ...chat, archived: false } : chat,
-				),
-			);
-			if (previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(chatKey(chatId), {
-					...previousChat,
-					chat: { ...previousChat.chat, archived: false },
-				});
-			}
-			return { previousChats, previousChat };
-		},
-		onError: (error, chatId, context) => {
-			if (context?.previousChats) {
-				queryClient.setQueryData<TypesGen.Chat[]>(
-					chatsKey,
-					context.previousChats,
-				);
-			}
-			if (context?.previousChat) {
-				queryClient.setQueryData<TypesGen.ChatWithMessages>(
-					chatKey(chatId),
-					context.previousChat,
-				);
-			}
-			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
-		},
+		...unarchiveChat(queryClient),
 		onSuccess: () => {
 			toast.success("Agent unarchived.");
-		},
-		onSettled: async (_data, _error, chatId) => {
-			await queryClient.invalidateQueries({ queryKey: chatsKey });
-			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
 		},
 	});
 	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -158,16 +158,19 @@ const AgentsPage: FC = () => {
 	const chatModelsQuery = useQuery(chatModels());
 	const chatModelConfigsQuery = useQuery(chatModelConfigs());
 	const createMutation = useMutation(createChat(queryClient));
-		const archiveAgentMutation = useMutation({
-			...archiveChat(queryClient),
-			onSuccess: (_data, chatId) => {
-				clearChatErrorReason(chatId);
-				toast.success("Agent archived.");
-			},
-			onError: (error) => {
-				toast.error(getErrorMessage(error, "Failed to archive agent."));
-			},
-		});	const archiveAndDeleteMutation = useMutation({
+	const archiveChatBase = archiveChat(queryClient);
+	const archiveAgentMutation = useMutation({
+		...archiveChatBase,
+		onSuccess: (_data, chatId) => {
+			clearChatErrorReason(chatId);
+			toast.success("Agent archived.");
+		},
+		onError: (error, chatId, context) => {
+			archiveChatBase.onError(error, chatId, context);
+			toast.error(getErrorMessage(error, "Failed to archive agent."));
+		},
+	});
+	const archiveAndDeleteMutation = useMutation({
 		mutationFn: async ({
 			chatId,
 			workspaceId,
@@ -190,15 +193,18 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
 		},
 	});
-		const unarchiveAgentMutation = useMutation({
-			...unarchiveChat(queryClient),
-			onSuccess: () => {
-				toast.success("Agent unarchived.");
-			},
-			onError: (error) => {
-				toast.error(getErrorMessage(error, "Failed to unarchive agent."));
-			},
-		});	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
+	const unarchiveChatBase = unarchiveChat(queryClient);
+	const unarchiveAgentMutation = useMutation({
+		...unarchiveChatBase,
+		onSuccess: () => {
+			toast.success("Agent unarchived.");
+		},
+		onError: (error, chatId, context) => {
+			unarchiveChatBase.onError(error, chatId, context);
+			toast.error(getErrorMessage(error, "Failed to unarchive agent."));
+		},
+	});
+	const [isConfigureAgentsDialogOpen, setConfigureAgentsDialogOpen] =
 		useState(false);
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 	const [chatErrorReasons, setChatErrorReasons] = useState<


### PR DESCRIPTION
## Problem

When archiving or unarchiving a chat, there is a visible lag before the chat moves between the active and archived sections in the sidebar. This is a **React Query caching issue**: both mutations only called `invalidateQueries` in `onSuccess`, so the UI waited for a full re-fetch of `GET /api/v2/chats` before updating. On high-latency networks this delay is especially noticeable.

## Solution

Add optimistic updates to `archiveChat` and `unarchiveChat` so the `archived` field is toggled immediately in the cache when the user clicks.

### `site/src/api/queries/chats.ts`
- `archiveChat`: Added `onMutate` (cancel in-flight queries, snapshot cache, set `archived: true`) and `onError` (rollback to snapshot).
- `unarchiveChat`: Same pattern with `archived: false`.

### `site/src/pages/AgentsPage/AgentsPage.tsx`
- `archiveAgentMutation`: Chains the base `onMutate`/`onError`/`onSuccess` from the query definition, and additionally optimistically updates the per-chat `chatKey(chatId)` query (`ChatWithMessages` data) with rollback on error.
- `unarchiveAgentMutation`: Same pattern.

The `onSuccess` handlers still invalidate queries for eventual consistency.

## Testing
- `npx tsc --noEmit` passes with zero errors
- All 854 vitest tests pass