### PR TITLE
fix(site): only play completion chime for top-level chat agents

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -390,12 +390,15 @@ const AgentsPage: FC = () => {
 			const prevStatus = currentChats?.find(
 				(c) => c.id === updatedChat.id,
 			)?.status;
-			maybePlayChime(
-				prevStatus,
-				updatedChat.status,
-				updatedChat.id,
-				activeChatIDRef.current,
-			);
+			// Only play the chime for top-level chats, not sub-agents.
+			if (!updatedChat.parent_chat_id) {
+				maybePlayChime(
+					prevStatus,
+					updatedChat.status,
+					updatedChat.id,
+					activeChatIDRef.current,
+				);
+			}
 
 			if (chatEvent.kind === "deleted") {
 				queryClient.setQueryData(


### PR DESCRIPTION
Sub-agent chats (those with a `parent_chat_id`) were triggering the workspace completion chime. This wraps the `maybePlayChime` call in a guard that skips chats with a `parent_chat_id`, so the chime only sounds for top-level agents.

## Changes

- `site/src/pages/AgentsPage/AgentsPage.tsx`: Guard the `maybePlayChime()` call with `!updatedChat.parent_chat_id` so sub-agent status transitions are ignored.