### PR TITLE
fix(site): convert div role="button" to native button in ai-elements tools

### DIFF
--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -92,17 +92,11 @@ export const ExecuteTool: React.FC<{
 
 					{/* Expand / collapse toggle at the bottom */}
 					{overflows && (
-						<div
-							role="button"
-							tabIndex={0}
+						<button
+							type="button"
 							aria-expanded={expanded}
 							onClick={() => setExpanded((v) => !v)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
-									setExpanded((v) => !v);
-								}
-							}}
-							className="flex w-full cursor-pointer items-center justify-center py-0.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary"
+							className="border-0 bg-transparent m-0 font-[inherit] text-[inherit] flex w-full cursor-pointer items-center justify-center py-0.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary"
 							aria-label={expanded ? "Collapse output" : "Expand output"}
 						>
 							<ChevronDownIcon
@@ -111,7 +105,7 @@ export const ExecuteTool: React.FC<{
 									expanded && "rotate-180",
 								)}
 							/>
-						</div>
+						</button>
 					)}
 				</>
 			)}

--- a/site/src/components/ai-elements/tool/ProcessOutputTool.tsx
+++ b/site/src/components/ai-elements/tool/ProcessOutputTool.tsx
@@ -73,17 +73,11 @@ export const ProcessOutputTool: React.FC<{
 
 					{/* Expand / collapse toggle at the bottom */}
 					{overflows && (
-						<div
-							role="button"
-							tabIndex={0}
+						<button
+							type="button"
 							aria-expanded={expanded}
 							onClick={() => setExpanded((v) => !v)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
-									setExpanded((v) => !v);
-								}
-							}}
-							className="flex w-full cursor-pointer items-center justify-center py-0.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary"
+							className="border-0 bg-transparent m-0 font-[inherit] text-[inherit] flex w-full cursor-pointer items-center justify-center py-0.5 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary"
 							aria-label={expanded ? "Collapse output" : "Expand output"}
 						>
 							<ChevronDownIcon
@@ -92,7 +86,7 @@ export const ProcessOutputTool: React.FC<{
 									expanded && "rotate-180",
 								)}
 							/>
-						</div>
+						</button>
 					)}
 				</>
 			) : (

--- a/site/src/components/ai-elements/tool/SubagentTool.tsx
+++ b/site/src/components/ai-elements/tool/SubagentTool.tsx
@@ -93,18 +93,13 @@ export const SubagentTool: React.FC<{
 
 	return (
 		<div className="w-full">
-			<div
-				role="button"
-				tabIndex={0}
+			<button
+				type="button"
 				aria-expanded={expanded}
 				onClick={() => hasExpandableContent && setExpanded((v) => !v)}
-				onKeyDown={(e) => {
-					if ((e.key === "Enter" || e.key === " ") && hasExpandableContent) {
-						setExpanded((v) => !v);
-					}
-				}}
 				className={cn(
-					"flex items-center gap-2",
+					"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
+					"flex w-full items-center gap-2",
 					hasExpandableContent && "cursor-pointer",
 				)}
 			>
@@ -142,7 +137,7 @@ export const SubagentTool: React.FC<{
 						)}
 					/>
 				)}
-			</div>
+			</button>
 
 			{expanded && hasPrompt && (
 				<ScrollArea

--- a/site/src/components/ai-elements/tool/ToolCollapsible.tsx
+++ b/site/src/components/ai-elements/tool/ToolCollapsible.tsx
@@ -24,19 +24,13 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 	return (
 		<div className={className}>
 			{hasContent ? (
-				<div
-					role="button"
-					tabIndex={0}
+				<button
+					type="button"
 					aria-expanded={expanded}
 					onClick={() => setExpanded(!expanded)}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === " ") {
-							e.preventDefault();
-							setExpanded(!expanded);
-						}
-					}}
 					className={cn(
-						"flex items-center gap-2 cursor-pointer",
+						"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
+						"flex w-full items-center gap-2 cursor-pointer",
 						headerClassName,
 					)}
 				>
@@ -47,7 +41,7 @@ export const ToolCollapsible: FC<ToolCollapsibleProps> = ({
 							expanded ? "rotate-0" : "-rotate-90",
 						)}
 					/>
-				</div>
+				</button>
 			) : (
 				<div className={cn("flex items-center gap-2", headerClassName)}>
 					{header}


### PR DESCRIPTION
## Summary

Replace `div role="button"` elements with proper `<button>` elements in the ai-elements tool components for improved accessibility and semantics.

## Changes

Native buttons provide built-in keyboard handling (Enter/Space) and focus management, eliminating the need for manual `tabIndex`, `role`, and `onKeyDown` attributes.

Since the project does not use Tailwind's CSS reset (preflight), browser default button styles are neutralized with explicit reset classes (`border-0`, `bg-transparent`, `font-[inherit]`, `text-[inherit]`, etc).

### Files changed (4 files, -39/+16 lines)

| File | Element |
|---|---|
| `ProcessOutputTool.tsx` | Expand/collapse output toggle |
| `ExecuteTool.tsx` | Expand/collapse output toggle |
| `ToolCollapsible.tsx` | Collapsible header |
| `SubagentTool.tsx` | Expandable header row |

### What was removed per element
- `role="button"` — native `<button>` already has this role
- `tabIndex={0}` — native `<button>` is already focusable
- Manual `onKeyDown` handlers — native `<button>` handles Enter/Space activation

### What was added
- `type="button"` to prevent implicit form submission
- Browser default style reset classes (`border-0 bg-transparent m-0 p-0 font-[inherit] text-[inherit]`) since there is no Tailwind preflight
