### PR TITLE
fix(site): prevent dropdown portal flash in agents sidebar

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -494,6 +494,8 @@ export const ArchivedAgentUnarchiveOption: Story = {
 			).toBeInTheDocument();
 		});
 		// Open the dropdown menu for the archived agent
+		const node = canvas.getByTestId("agents-tree-node-archived-unarchive");
+		await userEvent.hover(node);
 		const trigger = canvas.getByLabelText(
 			"Open actions for Archived agent with unarchive",
 		);

--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -494,8 +494,6 @@ export const ArchivedAgentUnarchiveOption: Story = {
 			).toBeInTheDocument();
 		});
 		// Open the dropdown menu for the archived agent
-		const node = canvas.getByTestId("agents-tree-node-archived-unarchive");
-		await userEvent.hover(node);
 		const trigger = canvas.getByLabelText(
 			"Open actions for Archived agent with unarchive",
 		);

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -48,6 +48,7 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { NavLink, useParams } from "react-router";
@@ -315,6 +316,27 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 		onUnarchiveAgent,
 		onArchiveAndDeleteWorkspace,
 	} = useChatTree();
+
+	// When an archive/unarchive action is selected from the
+	// dropdown, the optimistic cache update moves this node
+	// between the active and archived lists, unmounting the
+	// trigger element.  If the dropdown portal is still alive
+	// (mid-exit-animation) it loses its Popper anchor and
+	// briefly flashes at the top of the viewport.
+	//
+	// To avoid this we close the menu *without* an exit
+	// animation so Radix Presence unmounts the portal
+	// synchronously, then fire the mutation one frame later.
+	const [menuOpen, setMenuOpen] = useState(false);
+	const pendingAction = useRef<(() => void) | null>(null);
+	const handleMenuOpenChange = useCallback((open: boolean) => {
+		setMenuOpen(open);
+		if (!open && pendingAction.current) {
+			const action = pendingAction.current;
+			pendingAction.current = null;
+			requestAnimationFrame(action);
+		}
+	}, []);
 	const chatID = chat.id;
 	const childIDs = (chatTree.childrenById.get(chatID) ?? []).filter((childID) =>
 		visibleChatIDs.has(childID),
@@ -466,7 +488,12 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 							<span className="flex items-center justify-end text-xs text-content-secondary/50 tabular-nums [@media(hover:hover)]:group-hover:hidden group-has-[[data-state=open]]:hidden">
 								{shortRelativeTime(chat.updated_at)}
 							</span>
-							<DropdownMenu>
+							<DropdownMenu
+								open={menuOpen}
+								onOpenChange={handleMenuOpenChange}
+								modal={false}
+							>
+								{" "}
 								<DropdownMenuTrigger asChild>
 									<Button
 										size="icon"
@@ -477,11 +504,17 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										<EllipsisIcon className="h-3.5 w-3.5" />
 									</Button>
 								</DropdownMenuTrigger>
-								<DropdownMenuContent align="end">
+								<DropdownMenuContent
+									align="end"
+									className="data-[state=closed]:animate-none"
+								>
+									{" "}
 									{chat.archived ? (
 										<DropdownMenuItem
 											disabled={isArchiving}
-											onSelect={() => onUnarchiveAgent(chat.id)}
+											onSelect={() => {
+												pendingAction.current = () => onUnarchiveAgent(chat.id);
+											}}
 										>
 											<ArchiveRestoreIcon className="h-3.5 w-3.5" />
 											Unarchive agent
@@ -492,7 +525,9 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 											<DropdownMenuItem
 												className="text-content-destructive focus:text-content-destructive"
 												disabled={isArchiving}
-												onSelect={() => onArchiveAgent(chat.id)}
+												onSelect={() => {
+													pendingAction.current = () => onArchiveAgent(chat.id);
+												}}
 											>
 												<ArchiveIcon className="h-3.5 w-3.5" />
 												Archive agent
@@ -501,9 +536,10 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 												<DropdownMenuItem
 													className="text-content-destructive focus:text-content-destructive"
 													disabled={isArchiving}
-													onSelect={() =>
-														onArchiveAndDeleteWorkspace(chat.id, workspaceId)
-													}
+													onSelect={() => {
+														pendingAction.current = () =>
+															onArchiveAndDeleteWorkspace(chat.id, workspaceId);
+													}}
 												>
 													<Trash2Icon className="h-3.5 w-3.5" />
 													Archive & delete workspace
@@ -512,7 +548,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										</>
 									)}
 								</DropdownMenuContent>
-							</DropdownMenu>
+							</DropdownMenu>{" "}
 						</>
 					)}
 				</div>

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -48,7 +48,6 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
-	useRef,
 	useState,
 } from "react";
 import { NavLink, useParams } from "react-router";
@@ -317,29 +316,6 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 		onArchiveAndDeleteWorkspace,
 	} = useChatTree();
 
-	// When an archive/unarchive action is selected from the
-	// dropdown, the optimistic cache update moves this node
-	// between the active and archived lists, unmounting the
-	// trigger element.  If the dropdown portal is still alive
-	// (mid-exit-animation) it loses its Popper anchor and
-	// briefly flashes at the top of the viewport.
-	//
-	// To prevent this, each destructive onSelect handler calls
-	// event.preventDefault() so Radix does NOT auto-close the
-	// menu.  We then close the menu ourselves (setMenuOpen(false))
-	// and defer the mutation to the next animation frame, giving
-	// React time to unmount the portal before the optimistic
-	// update reshuffles the list.
-	const [menuOpen, setMenuOpen] = useState(false);
-	const pendingAction = useRef<(() => void) | null>(null);
-	const handleMenuOpenChange = useCallback((open: boolean) => {
-		setMenuOpen(open);
-		if (!open && pendingAction.current) {
-			const action = pendingAction.current;
-			pendingAction.current = null;
-			requestAnimationFrame(action);
-		}
-	}, []);
 	const chatID = chat.id;
 	const childIDs = (chatTree.childrenById.get(chatID) ?? []).filter((childID) =>
 		visibleChatIDs.has(childID),
@@ -491,11 +467,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 							<span className="flex items-center justify-end text-xs text-content-secondary/50 tabular-nums [@media(hover:hover)]:group-hover:hidden group-has-[[data-state=open]]:hidden">
 								{shortRelativeTime(chat.updated_at)}
 							</span>
-							<DropdownMenu
-								open={menuOpen}
-								onOpenChange={handleMenuOpenChange}
-								modal={false}
-							>
+							<DropdownMenu modal={false}>
 								<DropdownMenuTrigger asChild>
 									<Button
 										size="icon"
@@ -512,8 +484,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 											disabled={isArchiving}
 											onSelect={(e) => {
 												e.preventDefault();
-												pendingAction.current = () => onUnarchiveAgent(chat.id);
-												setMenuOpen(false);
+												onUnarchiveAgent(chat.id);
 											}}
 										>
 											<ArchiveRestoreIcon className="h-3.5 w-3.5" />
@@ -526,8 +497,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 												disabled={isArchiving}
 												onSelect={(e) => {
 													e.preventDefault();
-													pendingAction.current = () => onArchiveAgent(chat.id);
-													setMenuOpen(false);
+													onArchiveAgent(chat.id);
 												}}
 											>
 												<ArchiveIcon className="h-3.5 w-3.5" />
@@ -539,9 +509,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 													disabled={isArchiving}
 													onSelect={(e) => {
 														e.preventDefault();
-														pendingAction.current = () =>
-															onArchiveAndDeleteWorkspace(chat.id, workspaceId);
-														setMenuOpen(false);
+														onArchiveAndDeleteWorkspace(chat.id, workspaceId);
 													}}
 												>
 													<Trash2Icon className="h-3.5 w-3.5" />
@@ -551,7 +519,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										</>
 									)}
 								</DropdownMenuContent>
-							</DropdownMenu>
+							</DropdownMenu>{" "}
 						</>
 					)}
 				</div>{" "}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -324,9 +324,12 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 	// (mid-exit-animation) it loses its Popper anchor and
 	// briefly flashes at the top of the viewport.
 	//
-	// To avoid this we close the menu *without* an exit
-	// animation so Radix Presence unmounts the portal
-	// synchronously, then fire the mutation one frame later.
+	// To prevent this, each destructive onSelect handler calls
+	// event.preventDefault() so Radix does NOT auto-close the
+	// menu.  We then close the menu ourselves (setMenuOpen(false))
+	// and defer the mutation to the next animation frame, giving
+	// React time to unmount the portal before the optimistic
+	// update reshuffles the list.
 	const [menuOpen, setMenuOpen] = useState(false);
 	const pendingAction = useRef<(() => void) | null>(null);
 	const handleMenuOpenChange = useCallback((open: boolean) => {
@@ -493,7 +496,6 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 								onOpenChange={handleMenuOpenChange}
 								modal={false}
 							>
-								{" "}
 								<DropdownMenuTrigger asChild>
 									<Button
 										size="icon"
@@ -504,16 +506,14 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										<EllipsisIcon className="h-3.5 w-3.5" />
 									</Button>
 								</DropdownMenuTrigger>
-								<DropdownMenuContent
-									align="end"
-									className="data-[state=closed]:animate-none"
-								>
-									{" "}
+								<DropdownMenuContent align="end">
 									{chat.archived ? (
 										<DropdownMenuItem
 											disabled={isArchiving}
-											onSelect={() => {
+											onSelect={(e) => {
+												e.preventDefault();
 												pendingAction.current = () => onUnarchiveAgent(chat.id);
+												setMenuOpen(false);
 											}}
 										>
 											<ArchiveRestoreIcon className="h-3.5 w-3.5" />
@@ -521,12 +521,13 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										</DropdownMenuItem>
 									) : (
 										<>
-											{" "}
 											<DropdownMenuItem
 												className="text-content-destructive focus:text-content-destructive"
 												disabled={isArchiving}
-												onSelect={() => {
+												onSelect={(e) => {
+													e.preventDefault();
 													pendingAction.current = () => onArchiveAgent(chat.id);
+													setMenuOpen(false);
 												}}
 											>
 												<ArchiveIcon className="h-3.5 w-3.5" />
@@ -536,9 +537,11 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 												<DropdownMenuItem
 													className="text-content-destructive focus:text-content-destructive"
 													disabled={isArchiving}
-													onSelect={() => {
+													onSelect={(e) => {
+														e.preventDefault();
 														pendingAction.current = () =>
 															onArchiveAndDeleteWorkspace(chat.id, workspaceId);
+														setMenuOpen(false);
 													}}
 												>
 													<Trash2Icon className="h-3.5 w-3.5" />
@@ -548,10 +551,10 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										</>
 									)}
 								</DropdownMenuContent>
-							</DropdownMenu>{" "}
+							</DropdownMenu>
 						</>
 					)}
-				</div>
+				</div>{" "}
 			</div>
 
 			{hasChildren && isExpanded && (

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -458,7 +458,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 						</>
 					)}
 				</NavLink>
-				<div className="mr-1 mt-1 flex h-6 w-7 shrink-0 items-center justify-end">
+				<div className="relative mr-1 mt-1 flex h-6 w-7 shrink-0 items-center justify-end">
 					{isArchivingThisChat ? (
 						<Loader2Icon className="h-3.5 w-3.5 animate-spin text-content-secondary" />
 					) : (
@@ -471,16 +471,14 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 									<Button
 										size="icon"
 										variant="subtle"
-										className="hidden h-6 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:inline-flex data-[state=open]:inline-flex"
+										className="absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 pointer-events-none text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto data-[state=open]:opacity-100 data-[state=open]:pointer-events-auto"
 										aria-label={`Open actions for ${chat.title}`}
 									>
 										<EllipsisIcon className="h-3.5 w-3.5" />
 									</Button>
 								</DropdownMenuTrigger>
-								<DropdownMenuContent
-									align="end"
-									className="data-[state=closed]:!animate-none"
-								>
+								<DropdownMenuContent align="end">
+									{" "}
 									{chat.archived ? (
 										<DropdownMenuItem
 											disabled={isArchiving}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -315,7 +315,6 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 		onUnarchiveAgent,
 		onArchiveAndDeleteWorkspace,
 	} = useChatTree();
-
 	const chatID = chat.id;
 	const childIDs = (chatTree.childrenById.get(chatID) ?? []).filter((childID) =>
 		visibleChatIDs.has(childID),
@@ -467,12 +466,12 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 							<span className="flex items-center justify-end text-xs text-content-secondary/50 tabular-nums [@media(hover:hover)]:group-hover:hidden group-has-[[data-state=open]]:hidden">
 								{shortRelativeTime(chat.updated_at)}
 							</span>
-							<DropdownMenu modal={false}>
+							<DropdownMenu>
 								<DropdownMenuTrigger asChild>
 									<Button
 										size="icon"
 										variant="subtle"
-										className="hidden h-6 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:inline-flex data-[state=open]:inline-flex"
+										className="hidden h-6 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:inline-flex data-[state=open]:inline-flex data-[state=closed]:inline-flex"
 										aria-label={`Open actions for ${chat.title}`}
 									>
 										<EllipsisIcon className="h-3.5 w-3.5" />
@@ -482,23 +481,18 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 									{chat.archived ? (
 										<DropdownMenuItem
 											disabled={isArchiving}
-											onSelect={(e) => {
-												e.preventDefault();
-												onUnarchiveAgent(chat.id);
-											}}
+											onSelect={() => onUnarchiveAgent(chat.id)}
 										>
 											<ArchiveRestoreIcon className="h-3.5 w-3.5" />
 											Unarchive agent
 										</DropdownMenuItem>
 									) : (
 										<>
+											{" "}
 											<DropdownMenuItem
 												className="text-content-destructive focus:text-content-destructive"
 												disabled={isArchiving}
-												onSelect={(e) => {
-													e.preventDefault();
-													onArchiveAgent(chat.id);
-												}}
+												onSelect={() => onArchiveAgent(chat.id)}
 											>
 												<ArchiveIcon className="h-3.5 w-3.5" />
 												Archive agent
@@ -507,10 +501,9 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 												<DropdownMenuItem
 													className="text-content-destructive focus:text-content-destructive"
 													disabled={isArchiving}
-													onSelect={(e) => {
-														e.preventDefault();
-														onArchiveAndDeleteWorkspace(chat.id, workspaceId);
-													}}
+													onSelect={() =>
+														onArchiveAndDeleteWorkspace(chat.id, workspaceId)
+													}
 												>
 													<Trash2Icon className="h-3.5 w-3.5" />
 													Archive & delete workspace
@@ -519,10 +512,10 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 										</>
 									)}
 								</DropdownMenuContent>
-							</DropdownMenu>{" "}
+							</DropdownMenu>
 						</>
 					)}
-				</div>{" "}
+				</div>
 			</div>
 
 			{hasChildren && isExpanded && (

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -471,13 +471,16 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 									<Button
 										size="icon"
 										variant="subtle"
-										className="hidden h-6 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:inline-flex data-[state=open]:inline-flex data-[state=closed]:inline-flex"
+										className="hidden h-6 w-7 min-w-0 justify-end rounded-none px-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:inline-flex data-[state=open]:inline-flex"
 										aria-label={`Open actions for ${chat.title}`}
 									>
 										<EllipsisIcon className="h-3.5 w-3.5" />
 									</Button>
 								</DropdownMenuTrigger>
-								<DropdownMenuContent align="end">
+								<DropdownMenuContent
+									align="end"
+									className="data-[state=closed]:!animate-none"
+								>
 									{chat.archived ? (
 										<DropdownMenuItem
 											disabled={isArchiving}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -471,7 +471,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 									<Button
 										size="icon"
 										variant="subtle"
-										className="absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 pointer-events-none text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto data-[state=open]:opacity-100 data-[state=open]:pointer-events-auto"
+										className="absolute inset-0 flex h-6 w-7 min-w-0 justify-end rounded-none px-0 opacity-0 text-content-secondary hover:text-content-primary [@media(hover:hover)]:group-hover:opacity-100 data-[state=open]:opacity-100"
 										aria-label={`Open actions for ${chat.title}`}
 									>
 										<EllipsisIcon className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Problem

When closing the dropdown menu on an agent in the sidebar, the dropdown portal briefly flashes at the top-left corner of the viewport.

The trigger button uses `hidden` (display: none) by default and `data-[state=open]:inline-flex` to show when the menu is open. When the dropdown closes, Radix changes the trigger's `data-state` from `open` to `closed`. The trigger immediately becomes `display: none` and collapses to zero dimensions. Meanwhile, Radix Presence keeps the portal mounted for the CSS exit animation (~150ms). Popper loses its anchor and the portal snaps to `(0, 0)`.

This happens on **every** dropdown close where the cursor isn't over the row — not just archive actions.

## Fix

Switch the trigger from `display` toggling (`hidden` ↔ `inline-flex`) to `opacity` toggling (`opacity-0` ↔ `opacity-100`), with `absolute inset-0` positioning so it doesn't affect the timestamp layout.

The trigger always has valid dimensions in the DOM. Popper retains a stable anchor throughout the entire close animation.

| Before | After |
|---|---|
| `hidden ... data-[state=open]:inline-flex` | `absolute inset-0 opacity-0 ... data-[state=open]:opacity-100` |
| Trigger collapses to zero size on close | Trigger keeps dimensions, just invisible |
| Portal snaps to (0,0) during exit animation | Portal stays anchored, animates out cleanly |

### Changes

- **AgentsSidebar.tsx**: Add `relative` to the trigger container. Replace `hidden`/`inline-flex` display toggling with `opacity-0`/`opacity-100` + `absolute inset-0` on the trigger button.
- **AgentsSidebar.stories.tsx**: No changes needed (trigger remains clickable via aria-label).