### PR TITLE
fix(codersdk): propagate HTTPClient to WebSocket dial options

### DIFF
--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -369,6 +369,14 @@ func (c *Client) Dial(ctx context.Context, path string, opts *websocket.DialOpti
 		opts = &websocket.DialOptions{}
 	}
 	c.SessionTokenProvider.SetDialOption(opts)
+	// Propagate the configured HTTP client so WebSocket dials
+	// use the same transport (e.g. TLS config for inter-replica
+	// mesh communication). Without this, websocket.Dial falls
+	// back to http.DefaultClient which may lack the necessary
+	// TLS certificates or follow unexpected redirects.
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = c.HTTPClient
+	}
 
 	conn, resp, err := websocket.Dial(ctx, u.String(), opts)
 	if resp != nil && resp.Body != nil {


### PR DESCRIPTION
## Summary

Fixes cross-replica chat relay failing with:

```
expected handshake response status code 101 but got 200
```

## Root cause

`codersdk.Client.Dial` never passed `c.HTTPClient` to `websocket.DialOptions`. All WebSocket dials fell back to `http.DefaultClient`, which lacks the mesh TLS certificates configured on the `ReplicaHTTPClient`.

In the enterprise chat relay path (`enterprise/coderd/chatd/chatd.go`), `dialRelay` creates an SDK client with the replica HTTP client:

```go
sdkClient := codersdk.New(baseURL)
sdkClient.HTTPClient = cfg.ReplicaHTTPClient  // has mesh TLS config
```

But when `StreamChat` calls `c.Dial`, the WebSocket library receives `opts.HTTPClient == nil` and defaults to `http.DefaultClient`. The relay request then either fails the TLS handshake or gets redirected, ultimately hitting the SPA catch-all handler which returns HTTP 200 with `index.html` instead of upgrading to WebSocket 101.

This caused subscribers on one replica to see accurate `status=running` (delivered via pubsub) but miss all in-progress `message_part` events (delivered only via the relay WebSocket).

## Fix

Propagate `c.HTTPClient` to `opts.HTTPClient` in `Client.Dial` when the caller hasn't set one explicitly.

## Observed logs

```
failed to open initial relay for chat stream
    error= dial relay stream: - failed to WebSocket dial: expected handshake response status code 101 but got 200

failed to open relay for message parts
    error= dial relay stream: - failed to WebSocket dial: expected handshake response status code 101 but got 200
```