### PR TITLE
fix(coderd): fix flaky TestGetUserStatusCounts timezone boundary

### DIFF
--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -2495,9 +2495,15 @@ func TestGetUserStatusCounts(t *testing.T) {
 		require.Len(t, resp.StatusCounts, 1)
 		require.NotNil(t, resp.StatusCounts[codersdk.UserStatusActive])
 		require.Len(t, resp.StatusCounts[codersdk.UserStatusActive], 61)
-		for _, count := range resp.StatusCounts[codersdk.UserStatusActive] {
+		// Depending on the current time of day relative to the
+		// timezone/offset, the first user's creation may land on the
+		// last date in the range. All earlier dates must be zero; the
+		// last date may be 0 or 1.
+		counts := resp.StatusCounts[codersdk.UserStatusActive]
+		for _, count := range counts[:len(counts)-1] {
 			require.Zero(t, count.Count)
 		}
+		require.LessOrEqual(t, counts[len(counts)-1].Count, int64(1))
 	}
 	testcases := []testCase{
 		{


### PR DESCRIPTION
## Problem

`TestGetUserStatusCounts/OK_when_offset_is_provided_without_timezone` fails intermittently in CI:

```
Error:      Should be zero, but was 1
Test:       TestGetUserStatusCounts/OK_when_offset_is_provided_without_timezone
```

## Root Cause

The `happyResponseCheck` asserts `count=0` for all 61 dates. The test creates a first user, which inserts a `user_status_changes` row with `new_status=active` and `changed_at=now()`.

The query computes its date range using the requested timezone/offset:

```go
nextHourInLoc = dbtime.Now().Truncate(time.Hour).Add(time.Hour).In(loc)
sixtyDaysAgo  = dbtime.StartOfDay(nextHourInLoc).AddDate(0, 0, -60)
```

When the UTC time of day is earlier than the timezone offset (e.g. UTC 01:30 with offset `-2` means local time is 23:30 previous day), `StartOfDay(nextHourInLoc)` rounds forward to start-of-today in the target timezone, which is *after* the current UTC time. The last `date_of_interest` in the SQL query ends up ahead of `now()` in UTC, so the user's `changed_at` satisfies `changed_at <= date` — producing `count=1` on the last date.

This happens ~8% of the time for offset `-2` (when UTC hour is 0 or 1) and ~15% for `America/St_Johns` (UTC-3:30).

## Fix

Allow the last date entry to have count 0 or 1 (only 1 user exists) while keeping all earlier dates strictly zero. This correctly accounts for the timezone boundary without weakening the test's structural validation.