### PR TITLE
docs(agents): convert markdown images to HTML img tags

### DIFF
--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -19,7 +19,7 @@ Three components are involved in every agent interaction:
    reads and writes files, and executes processes — exactly what occurs when a
    developer connects via their IDE.
 
-![Architecture diagram ](../../images/guides/ai-agents/agent-loop-detailed.png)
+<img src="../../images/guides/ai-agents/agent-loop-detailed.png" alt="Architecture diagram">
 
 ## The same connection your IDE uses
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -68,7 +68,7 @@ The workspace itself has no knowledge of AI. It is standard compute
 infrastructure — there are no LLM API keys, no agent harnesses, and no special
 software installed. All intelligence lives in the control plane.
 
-![Architecture diagram showing the control plane in the center, with arrows out to LLM providers and arrows to workspaces](../../images/guides/ai-agents/agent-loop.png)
+<img src="../../images/guides/ai-agents/agent-loop.png" alt="Architecture diagram showing the control plane in the center, with arrows out to LLM providers and arrows to workspaces">
 
 <small>The agent loop runs in the control plane. It makes outbound requests to LLM
 providers and connects to workspaces only when tool execution is needed.</small>
@@ -195,7 +195,7 @@ enterprise LLM proxies, self-hosted model endpoints, and internal gateways.
 Administrators can configure multiple providers simultaneously and set a default
 model. Developers select from enabled models when starting a chat.
 
-![Screenshot of the provider/model configuration admin panel](../../images/guides/ai-agents/llm-providers.png)
+<img src="../../images/guides/ai-agents/llm-providers.png" alt="Screenshot of the provider/model configuration admin panel">
 
 <small>The model configuration panel in the Coder dashboard.</small>
 

--- a/docs/ai-coder/agents/models.md
+++ b/docs/ai-coder/agents/models.md
@@ -37,12 +37,12 @@ models, internal gateways, or third-party proxies like LiteLLM.
    useful for enterprise proxies, regional endpoints, or self-hosted models.
 1. Click **Save**.
 
-![Screenshot of the providers list in the admin dialog](../../images/guides/ai-agents/models-providers.png)
+<img src="../../images/guides/ai-agents/models-providers.png" alt="Screenshot of the providers list in the admin dialog">
 
 <small>The providers list shows all supported providers and their configuration
 status.</small>
 
-![Screenshot of the add provider form](../../images/guides/ai-agents/models-add-provider.png)
+<img src="../../images/guides/ai-agents/models-add-provider.png" alt="Screenshot of the add provider form">
 
 <small>Adding a provider requires an API key. The base URL is optional.</small>
 
@@ -75,11 +75,11 @@ generation parameters, and provider-specific options.
 1. Configure any provider-specific options (see below).
 1. Click **Save**.
 
-![Screenshot of the models list in the admin dialog](../../images/guides/ai-agents/models-list.png)
+<img src="../../images/guides/ai-agents/models-list.png" alt="Screenshot of the models list in the admin dialog">
 
 <small>The models list shows all configured models grouped by provider.</small>
 
-![Screenshot of the add model form](../../images/guides/ai-agents/models-add-model.png)
+<img src="../../images/guides/ai-agents/models-add-model.png" alt="Screenshot of the add model form">
 
 <small>Adding a model requires a model identifier, display name, and context
 limit. Provider-specific options appear dynamically based on the selected


### PR DESCRIPTION
Converts all 7 markdown image references (`![alt](src)`) in the `docs/ai-coder/agents/` directory to HTML `<img>` tags.

**Files changed:**
- `docs/ai-coder/agents/architecture.md` (1 image)
- `docs/ai-coder/agents/models.md` (4 images)
- `docs/ai-coder/agents/index.md` (2 images)