### PR TITLE
fix: use testutil.Eventually in chatd interrupt test

### DIFF
--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -1244,35 +1244,35 @@ func TestInterruptChatDoesNotSendWebPushNotification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for the chat to be picked up and start streaming.
-	require.Eventually(t, func() bool {
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
 		if dbErr != nil {
 			return false
 		}
 		return fromDB.Status == database.ChatStatusRunning && fromDB.WorkerID.Valid
-	}, testutil.WaitMedium, testutil.IntervalFast)
+	}, testutil.IntervalFast)
 
-	require.Eventually(t, func() bool {
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		select {
 		case <-streamStarted:
 			return true
 		default:
 			return false
 		}
-	}, testutil.WaitMedium, testutil.IntervalFast)
+	}, testutil.IntervalFast)
 
 	// Interrupt the chat.
 	updated := server.InterruptChat(ctx, chat)
 	require.Equal(t, database.ChatStatusWaiting, updated.Status)
 
 	// Wait for the chat to finish processing and return to waiting.
-	require.Eventually(t, func() bool {
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
 		if dbErr != nil {
 			return false
 		}
 		return fromDB.Status == database.ChatStatusWaiting && !fromDB.WorkerID.Valid
-	}, testutil.WaitMedium, testutil.IntervalFast)
+	}, testutil.IntervalFast)
 
 	// Verify no web push notification was dispatched.
 	require.Equal(t, int32(0), mockPush.dispatchCount.Load(),


### PR DESCRIPTION
Follow-up to #22630. Addresses [review feedback](https://github.com/coder/coder/pull/22630#pullrequestreview-2953419963) that was missed due to auto-merge.

## Changes

Replaces three `require.Eventually` calls with `testutil.Eventually` in `TestInterruptChatDoesNotSendWebPushNotification`, linking the condition to the existing test context (`ctx`) created on line 1194. This ensures the test respects context cancellation instead of using a standalone timeout/tick pattern.