### PR TITLE
[WIP] feat: add agent skills auto-discovery

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -42,6 +42,7 @@ import (
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/agent/agentproc"
+	"github.com/coder/coder/v2/agent/agentskills"
 	"github.com/coder/coder/v2/agent/agentscripts"
 	"github.com/coder/coder/v2/agent/agentsocket"
 	"github.com/coder/coder/v2/agent/agentssh"
@@ -305,6 +306,7 @@ type agent struct {
 
 	filesAPI   *agentfiles.API
 	processAPI *agentproc.API
+	skillsAPI  *agentskills.API
 
 	socketServerEnabled bool
 	socketPath          string
@@ -378,6 +380,13 @@ func (a *agent) init() {
 
 	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem)
 	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, a.updateCommandEnv)
+
+	homeDir, err := userHomeDir()
+	if err != nil {
+		a.logger.Warn(a.hardCtx, "failed to determine home directory for skills discovery", slog.Error(err))
+		homeDir = "/"
+	}
+	a.skillsAPI = agentskills.NewAPI(a.logger.Named("skills"), homeDir)
 
 	a.reconnectingPTYServer = reconnectingpty.NewServer(
 		a.logger.Named("reconnecting-pty"),

--- a/agent/agentskills/api.go
+++ b/agent/agentskills/api.go
@@ -1,0 +1,62 @@
+package agentskills
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ammario/tlru"
+	"github.com/go-chi/chi/v5"
+
+	"cdr.dev/slog/v3"
+
+	"github.com/coder/coder/v2/coderd/httpapi"
+)
+
+// Skill represents a discovered skill's metadata.
+type Skill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+}
+
+// API exposes skill-discovery operations through the agent.
+type API struct {
+	logger  slog.Logger
+	homeDir string
+	cache   *tlru.Cache[string, []Skill]
+}
+
+const (
+	skillCacheTTL    = 5 * time.Minute
+	skillCacheMaxLen = 100
+	cacheKey         = "skills"
+)
+
+func NewAPI(logger slog.Logger, homeDir string) *API {
+	cache := tlru.New[string](tlru.ConstantCost[[]Skill], skillCacheMaxLen)
+	return &API{
+		logger:  logger,
+		homeDir: homeDir,
+		cache:   cache,
+	}
+}
+
+// Routes returns the HTTP handler for skill-related routes.
+func (api *API) Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/", api.handleListSkills)
+	return r
+}
+
+func (api *API) handleListSkills(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if skills, _, ok := api.cache.Get(cacheKey); ok {
+		httpapi.Write(ctx, rw, http.StatusOK, skills)
+		return
+	}
+
+	skills := discoverSkills(api.logger, api.homeDir)
+	api.cache.Set(cacheKey, skills, skillCacheTTL)
+	httpapi.Write(ctx, rw, http.StatusOK, skills)
+}

--- a/agent/agentskills/discover.go
+++ b/agent/agentskills/discover.go
@@ -1,0 +1,126 @@
+package agentskills
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"cdr.dev/slog/v3"
+	"gopkg.in/yaml.v3"
+)
+
+const skillFileName = "SKILL.md"
+
+// searchPath defines a directory to scan and its slug prefix for fallback naming.
+type searchPath struct {
+	dir        string // relative to homeDir, e.g. ".coder/skills"
+	slugPrefix string // e.g. "coder-skills"
+}
+
+// searchPaths is computed at init time because filepath.Join is not a constant expression.
+var searchPaths = []searchPath{
+	{dir: filepath.Join(".coder", "skills"), slugPrefix: "coder-skills"},
+	{dir: filepath.Join(".claude", "skills"), slugPrefix: "claude-skills"},
+}
+
+// skillFrontmatter represents the YAML frontmatter of a SKILL.md file.
+type skillFrontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// discoverSkills scans search paths for SKILL.md files and returns
+// deduplicated, sorted skill metadata.
+func discoverSkills(logger slog.Logger, homeDir string) []Skill {
+	seen := make(map[string]Skill)
+
+	for _, sp := range searchPaths {
+		dir := filepath.Join(homeDir, sp.dir)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				logger.Warn(context.Background(), "failed to read skills directory",
+					slog.F("path", dir),
+					slog.Error(err),
+				)
+			}
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			skillFile := filepath.Join(dir, entry.Name(), skillFileName)
+			raw, err := os.ReadFile(skillFile)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					logger.Warn(context.Background(), "failed to read skill file",
+						slog.F("path", skillFile),
+						slog.Error(err),
+					)
+				}
+				continue
+			}
+
+			fm := parseFrontmatter(logger, skillFile, raw)
+			name := fm.Name
+			if name == "" {
+				name = sp.slugPrefix + "-" + entry.Name()
+			}
+
+			// Dedup: first insert wins (.coder searched before .claude)
+			if _, exists := seen[name]; exists {
+				continue
+			}
+
+			seen[name] = Skill{
+				Name:        name,
+				Description: fm.Description,
+				Path:        skillFile,
+			}
+		}
+	}
+
+	skills := make([]Skill, 0, len(seen))
+	for _, s := range seen {
+		skills = append(skills, s)
+	}
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].Name < skills[j].Name
+	})
+
+	return skills
+}
+
+// parseFrontmatter extracts YAML frontmatter from a SKILL.md file.
+// Returns zero-value struct if no frontmatter is found or parsing fails.
+func parseFrontmatter(logger slog.Logger, filePath string, raw []byte) skillFrontmatter {
+	// Frontmatter must start with "---\n"
+	if !bytes.HasPrefix(raw, []byte("---\n")) && !bytes.HasPrefix(raw, []byte("---\r\n")) {
+		return skillFrontmatter{}
+	}
+
+	// Find the closing "---"
+	rest := raw[4:] // skip opening "---\n"
+	if bytes.HasPrefix(raw, []byte("---\r\n")) {
+		rest = raw[5:]
+	}
+	end := bytes.Index(rest, []byte("\n---"))
+	if end < 0 {
+		return skillFrontmatter{}
+	}
+
+	var fm skillFrontmatter
+	if err := yaml.Unmarshal(rest[:end], &fm); err != nil {
+		logger.Warn(context.Background(), "failed to parse skill frontmatter",
+			slog.F("path", filePath),
+			slog.Error(err),
+		)
+		return skillFrontmatter{}
+	}
+	return fm
+}

--- a/agent/agentskills/discover_test.go
+++ b/agent/agentskills/discover_test.go
@@ -1,0 +1,245 @@
+package agentskills
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+)
+
+// createSkillFile is a helper that creates a SKILL.md file under
+// homeDir/searchDir/skillName/SKILL.md and returns its absolute path.
+func createSkillFile(t *testing.T, homeDir, searchDir, skillName, content string) string {
+	t.Helper()
+	dir := filepath.Join(homeDir, searchDir, skillName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestDiscoverSkills_SingleCoderSkill(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	skillPath := createSkillFile(t, home, ".coder/skills", "code-review",
+		"---\nname: code-review\ndescription: Reviews code\n---\n\n# Body content\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "code-review", skills[0].Name)
+	require.Equal(t, "Reviews code", skills[0].Description)
+	require.Equal(t, skillPath, skills[0].Path)
+	require.True(t, filepath.IsAbs(skills[0].Path))
+}
+
+func TestDiscoverSkills_MultipleSkills_AlphabeticalOrder(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".coder/skills", "zebra",
+		"---\nname: zebra\ndescription: Z skill\n---\n")
+	createSkillFile(t, home, ".coder/skills", "alpha",
+		"---\nname: alpha\ndescription: A skill\n---\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 2)
+	require.Equal(t, "alpha", skills[0].Name)
+	require.Equal(t, "zebra", skills[1].Name)
+}
+
+func TestDiscoverSkills_ClaudePathFallback(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".claude/skills", "review",
+		"---\nname: review\ndescription: Claude review\n---\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "review", skills[0].Name)
+	require.Equal(t, "Claude review", skills[0].Description)
+}
+
+func TestDiscoverSkills_BothPaths_Merged(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".coder/skills", "lint",
+		"---\nname: lint\ndescription: Linter\n---\n")
+	createSkillFile(t, home, ".claude/skills", "format",
+		"---\nname: format\ndescription: Formatter\n---\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 2)
+	require.Equal(t, "format", skills[0].Name)
+	require.Equal(t, "lint", skills[1].Name)
+}
+
+func TestDiscoverSkills_Dedup_CoderWins(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".coder/skills", "review",
+		"---\nname: review\ndescription: Coder review\n---\n")
+	createSkillFile(t, home, ".claude/skills", "review",
+		"---\nname: review\ndescription: Claude review\n---\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "review", skills[0].Name)
+	require.Equal(t, "Coder review", skills[0].Description)
+}
+
+func TestDiscoverSkills_NoFrontmatter_SlugFallback(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".coder/skills", "foo",
+		"# Just a markdown body\n\nNo frontmatter here.\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "coder-skills-foo", skills[0].Name)
+	require.Equal(t, "", skills[0].Description)
+}
+
+func TestDiscoverSkills_ClaudePath_SlugFallback(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".claude/skills", "bar",
+		"# Just a markdown body\n\nNo frontmatter here.\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "claude-skills-bar", skills[0].Name)
+}
+
+func TestDiscoverSkills_DirWithoutSkillMd_Skipped(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	// Create an empty directory with no SKILL.md
+	emptyDir := filepath.Join(home, ".coder", "skills", "empty")
+	require.NoError(t, os.MkdirAll(emptyDir, 0o755))
+
+	// Create a valid skill
+	createSkillFile(t, home, ".coder/skills", "valid",
+		"---\nname: valid\ndescription: A valid skill\n---\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "valid", skills[0].Name)
+}
+
+func TestDiscoverSkills_NoSearchPaths_EmptyResult(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	skills := discoverSkills(logger, home)
+
+	require.NotNil(t, skills)
+	require.Empty(t, skills)
+}
+
+func TestDiscoverSkills_MalformedYAML_WarnAndFallback(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".coder/skills", "bad",
+		"---\n: broken\n---\n")
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "coder-skills-bad", skills[0].Name)
+}
+
+func TestDiscoverSkills_BodyNotIncluded(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	bigBody := strings.Repeat("A", 10*1024)
+	content := "---\nname: big\ndescription: Big skill\n---\n\n" + bigBody
+	createSkillFile(t, home, ".coder/skills", "big", content)
+
+	skills := discoverSkills(logger, home)
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "big", skills[0].Name)
+	require.Equal(t, "Big skill", skills[0].Description)
+	// The Skill struct should only carry name, description, path — no body.
+	b, err := json.Marshal(skills[0])
+	require.NoError(t, err)
+	require.NotContains(t, string(b), bigBody)
+}
+
+func TestSkillsEndpoint_ReturnsJSON(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	createSkillFile(t, home, ".coder/skills", "test-skill",
+		"---\nname: test-skill\ndescription: Test skill\n---\n")
+
+	api := NewAPI(logger, home)
+	handler := api.Routes()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var skills []Skill
+	err := json.NewDecoder(rec.Body).Decode(&skills)
+	require.NoError(t, err)
+	require.Len(t, skills, 1)
+	require.Equal(t, "test-skill", skills[0].Name)
+	require.Equal(t, "Test skill", skills[0].Description)
+}
+
+func TestSkillsEndpoint_EmptySkills_ReturnsEmptyArray(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	logger := slogtest.Make(t, nil)
+
+	api := NewAPI(logger, home)
+	handler := api.Routes()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := strings.TrimSpace(rec.Body.String())
+	require.Equal(t, "[]", body)
+}

--- a/agent/api.go
+++ b/agent/api.go
@@ -29,6 +29,7 @@ func (a *agent) apiHandler() http.Handler {
 
 	r.Mount("/api/v0", a.filesAPI.Routes())
 	r.Mount("/api/v0/processes", a.processAPI.Routes())
+	r.Mount("/api/v0/skills", a.skillsAPI.Routes())
 
 	if a.devcontainers {
 		r.Mount("/api/v0/containers", a.containerAPI.Routes())

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -2559,8 +2559,9 @@ func (p *Server) resolveInstructions(
 		directory = agent.Directory
 	}
 
-	// Read instruction files from the workspace agent.
+		// Read instruction files and discover skills from the workspace agent.
 	var sections []instructionFileSection
+	var skills []Skill
 	if getWorkspaceConn != nil {
 		instructionCtx, cancel := context.WithTimeout(ctx, homeInstructionLookupTimeout)
 		defer cancel()
@@ -2589,11 +2590,18 @@ func (p *Server) resolveInstructions(
 					sections = append(sections, instructionFileSection{content, source, truncated})
 				}
 			}
+
+			// Discover skills from the agent
+			if fetched, err := fetchSkillsFromAgent(instructionCtx, conn); err != nil {
+				p.logger.Debug(ctx, "failed to fetch skills from agent",
+					slog.F("chat_id", chat.ID), slog.Error(err))
+			} else {
+				skills = fetched
+			}
 		}
 	}
 
-	instruction := formatSystemInstructions(agent.OperatingSystem, directory, sections)
-
+	instruction := formatSystemInstructions(agent.OperatingSystem, directory, sections, skills)
 	p.instructionCacheMu.Lock()
 	p.instructionCache[agentID] = cachedInstruction{
 		instruction: instruction,

--- a/coderd/chatd/instruction.go
+++ b/coderd/chatd/instruction.go
@@ -111,6 +111,7 @@ func sanitizeInstructionMarkdown(content string) string {
 func formatSystemInstructions(
 	operatingSystem, directory string,
 	sections []instructionFileSection,
+	skills []Skill,
 ) string {
 	hasSections := false
 	for _, s := range sections {
@@ -119,7 +120,7 @@ func formatSystemInstructions(
 			break
 		}
 	}
-	if !hasSections && operatingSystem == "" && directory == "" {
+	if !hasSections && operatingSystem == "" && directory == "" && len(skills) == 0 {
 		return ""
 	}
 
@@ -146,6 +147,11 @@ func formatSystemInstructions(
 		}
 		_, _ = b.WriteString("\n")
 		_, _ = b.WriteString(s.content)
+		_, _ = b.WriteString("\n")
+	}
+	if skillsBlock := formatSkillsBlock(skills); skillsBlock != "" {
+		_, _ = b.WriteString("\n")
+		_, _ = b.WriteString(skillsBlock)
 		_, _ = b.WriteString("\n")
 	}
 	_, _ = b.WriteString("</workspace-context>")
@@ -175,4 +181,75 @@ func isCodersdkStatusCode(err error, statusCode int) bool {
 		return false
 	}
 	return sdkErr.StatusCode() == statusCode
+}
+
+// Skill represents a discovered skill's metadata from a workspace agent.
+type Skill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+}
+
+// fetchSkillsFromAgent calls the agent's /api/v0/skills endpoint to
+// retrieve discovered skill metadata.
+func fetchSkillsFromAgent(
+	ctx context.Context,
+	conn workspacesdk.AgentConn,
+) ([]Skill, error) {
+	if conn == nil {
+		return nil, nil
+	}
+
+	skills, err := conn.ListSkills(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("fetch skills from agent: %w", err)
+	}
+
+	// Convert from SDK type to local type
+	result := make([]Skill, 0, len(skills))
+	for _, s := range skills {
+		result = append(result, Skill{
+			Name:        s.Name,
+			Description: s.Description,
+			Path:        s.Path,
+		})
+	}
+	return result, nil
+}
+
+// formatSkillsBlock renders discovered skills as an <available_skills>
+// XML block for injection into the system prompt. Returns empty string
+// if there are no skills.
+func formatSkillsBlock(skills []Skill) string {
+	if len(skills) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	_, _ = b.WriteString("<available_skills>\n")
+	for _, s := range skills {
+		_, _ = b.WriteString("  <skill>\n")
+		_, _ = b.WriteString("    <name>")
+		_, _ = b.WriteString(xmlEscape(s.Name))
+		_, _ = b.WriteString("</name>\n")
+		_, _ = b.WriteString("    <description>")
+		_, _ = b.WriteString(xmlEscape(s.Description))
+		_, _ = b.WriteString("</description>\n")
+		_, _ = b.WriteString("    <location>")
+		_, _ = b.WriteString(xmlEscape(s.Path))
+		_, _ = b.WriteString("</location>\n")
+		_, _ = b.WriteString("  </skill>\n")
+	}
+	_, _ = b.WriteString("</available_skills>")
+	return b.String()
+}
+
+// xmlEscape escapes special XML characters in a string.
+func xmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	return s
 }

--- a/coderd/chatd/instruction_test.go
+++ b/coderd/chatd/instruction_test.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/fantasy"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/chatd/chatprompt"
 	"github.com/coder/coder/v2/codersdk"
@@ -193,7 +194,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 		got := formatSystemInstructions("linux", "/home/coder/project", []instructionFileSection{
 			{content: "home rules", source: "/home/coder/.coder/AGENTS.md"},
 			{content: "project rules", source: "/home/coder/project/AGENTS.md"},
-		})
+		}, nil)
 		require.Contains(t, got, "Operating System: linux")
 		require.Contains(t, got, "Working Directory: /home/coder/project")
 		require.Contains(t, got, "Source: /home/coder/.coder/AGENTS.md")
@@ -208,7 +209,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 		t.Parallel()
 		got := formatSystemInstructions("", "/home/coder/project", []instructionFileSection{
 			{content: "project rules", source: "/home/coder/project/AGENTS.md"},
-		})
+		}, nil)
 		require.Contains(t, got, "project rules")
 		require.Contains(t, got, "Source: /home/coder/project/AGENTS.md")
 		require.NotContains(t, got, ".coder/AGENTS.md")
@@ -216,7 +217,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 
 	t.Run("OnlyAgentContext", func(t *testing.T) {
 		t.Parallel()
-		got := formatSystemInstructions("darwin", "/Users/dev/repo", nil)
+		got := formatSystemInstructions("darwin", "/Users/dev/repo", nil, nil)
 		require.Contains(t, got, "Operating System: darwin")
 		require.Contains(t, got, "Working Directory: /Users/dev/repo")
 		require.NotContains(t, got, "Source:")
@@ -228,7 +229,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 		t.Parallel()
 		got := formatSystemInstructions("", "", []instructionFileSection{
 			{content: "home rules", source: "~/.coder/AGENTS.md"},
-		})
+		}, nil)
 		require.Contains(t, got, "Source: ~/.coder/AGENTS.md")
 		require.Contains(t, got, "home rules")
 		require.NotContains(t, got, "Operating System:")
@@ -237,7 +238,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 
 	t.Run("Empty", func(t *testing.T) {
 		t.Parallel()
-		got := formatSystemInstructions("", "", nil)
+		got := formatSystemInstructions("", "", nil, nil)
 		require.Empty(t, got)
 	})
 
@@ -245,7 +246,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 		t.Parallel()
 		got := formatSystemInstructions("windows", "", []instructionFileSection{
 			{content: "rules", source: "/path/AGENTS.md", truncated: true},
-		})
+		}, nil)
 		require.Contains(t, got, "truncated to 64KiB")
 		require.Contains(t, got, "Operating System: windows")
 	})
@@ -255,7 +256,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 		got := formatSystemInstructions("linux", "/home/project", []instructionFileSection{
 			{content: "home", source: "/home/.coder/AGENTS.md"},
 			{content: "pwd", source: "/home/project/AGENTS.md"},
-		})
+		}, nil)
 		osIdx := strings.Index(got, "Operating System:")
 		dirIdx := strings.Index(got, "Working Directory:")
 		homeSourceIdx := strings.Index(got, "Source: /home/.coder/AGENTS.md")
@@ -270,7 +271,7 @@ func TestFormatSystemInstructions(t *testing.T) {
 		got := formatSystemInstructions("linux", "", []instructionFileSection{
 			{content: "", source: "/empty"},
 			{content: "real", source: "/real/AGENTS.md"},
-		})
+		}, nil)
 		require.NotContains(t, got, "Source: /empty")
 		require.Contains(t, got, "Source: /real/AGENTS.md")
 	})
@@ -280,4 +281,150 @@ func TestPwdInstructionFilePath(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, "/home/coder/project/AGENTS.md", pwdInstructionFilePath("/home/coder/project"))
 	require.Empty(t, pwdInstructionFilePath(""))
+}
+
+func TestFormatSkillsBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SingleSkill", func(t *testing.T) {
+		t.Parallel()
+		got := formatSkillsBlock([]Skill{
+			{Name: "review", Description: "Reviews code", Path: "/home/coder/.coder/skills/review/SKILL.md"},
+		})
+		require.Contains(t, got, "<available_skills>")
+		require.Contains(t, got, "</available_skills>")
+		require.Contains(t, got, "<name>review</name>")
+		require.Contains(t, got, "<description>Reviews code</description>")
+		require.Contains(t, got, "<location>/home/coder/.coder/skills/review/SKILL.md</location>")
+	})
+
+	t.Run("MultipleSkills", func(t *testing.T) {
+		t.Parallel()
+		got := formatSkillsBlock([]Skill{
+			{Name: "alpha", Description: "First", Path: "/a/SKILL.md"},
+			{Name: "beta", Description: "Second", Path: "/b/SKILL.md"},
+		})
+		require.Contains(t, got, "<name>alpha</name>")
+		require.Contains(t, got, "<name>beta</name>")
+		// Verify order: alpha before beta
+		alphaIdx := strings.Index(got, "<name>alpha</name>")
+		betaIdx := strings.Index(got, "<name>beta</name>")
+		require.Less(t, alphaIdx, betaIdx)
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		t.Parallel()
+		got := formatSkillsBlock([]Skill{})
+		require.Empty(t, got)
+	})
+
+	t.Run("NilSlice", func(t *testing.T) {
+		t.Parallel()
+		got := formatSkillsBlock(nil)
+		require.Empty(t, got)
+	})
+
+	t.Run("EmptyDescription", func(t *testing.T) {
+		t.Parallel()
+		got := formatSkillsBlock([]Skill{
+			{Name: "test", Description: "", Path: "/test/SKILL.md"},
+		})
+		require.Contains(t, got, "<description></description>")
+	})
+
+	t.Run("SpecialCharactersEscaped", func(t *testing.T) {
+		t.Parallel()
+		got := formatSkillsBlock([]Skill{
+			{Name: "test<>&", Description: "a \"quoted\" & 'escaped' <value>", Path: "/path/SKILL.md"},
+		})
+		require.Contains(t, got, "<name>test&lt;&gt;&amp;</name>")
+		require.Contains(t, got, "a &quot;quoted&quot; &amp; &apos;escaped&apos; &lt;value&gt;")
+	})
+}
+
+func TestFormatSystemInstructions_WithSkills(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SkillsAfterAgentsMd", func(t *testing.T) {
+		t.Parallel()
+		got := formatSystemInstructions("linux", "/home/coder", []instructionFileSection{
+			{content: "home rules", source: "/home/coder/.coder/AGENTS.md"},
+		}, []Skill{
+			{Name: "review", Description: "Reviews code", Path: "/home/coder/.coder/skills/review/SKILL.md"},
+		})
+		require.Contains(t, got, "<available_skills>")
+		require.Contains(t, got, "</available_skills>")
+		agentsIdx := strings.Index(got, "home rules")
+		skillsIdx := strings.Index(got, "<available_skills>")
+		closeIdx := strings.Index(got, "</workspace-context>")
+		require.Less(t, agentsIdx, skillsIdx)
+		require.Less(t, skillsIdx, closeIdx)
+	})
+
+	t.Run("SkillsOnly", func(t *testing.T) {
+		t.Parallel()
+		got := formatSystemInstructions("", "", nil, []Skill{
+			{Name: "test", Description: "A test skill", Path: "/test/SKILL.md"},
+		})
+		require.Contains(t, got, "<workspace-context>")
+		require.Contains(t, got, "<available_skills>")
+		require.Contains(t, got, "</workspace-context>")
+	})
+
+	t.Run("NoSkills_NoBlock", func(t *testing.T) {
+		t.Parallel()
+		got := formatSystemInstructions("linux", "/home", []instructionFileSection{
+			{content: "rules", source: "/AGENTS.md"},
+		}, nil)
+		require.NotContains(t, got, "<available_skills>")
+	})
+}
+
+func TestFetchSkillsFromAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		conn := agentconnmock.NewMockAgentConn(ctrl)
+		conn.EXPECT().ListSkills(gomock.Any()).Return([]workspacesdk.SkillMetadata{
+			{Name: "review", Description: "Reviews code", Path: "/home/coder/.coder/skills/review/SKILL.md"},
+		}, nil)
+
+		skills, err := fetchSkillsFromAgent(context.Background(), conn)
+		require.NoError(t, err)
+		require.Len(t, skills, 1)
+		require.Equal(t, "review", skills[0].Name)
+		require.Equal(t, "Reviews code", skills[0].Description)
+		require.Equal(t, "/home/coder/.coder/skills/review/SKILL.md", skills[0].Path)
+	})
+
+	t.Run("AgentReturnsError", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		conn := agentconnmock.NewMockAgentConn(ctrl)
+		conn.EXPECT().ListSkills(gomock.Any()).Return(nil, xerrors.New("connection refused"))
+
+		skills, err := fetchSkillsFromAgent(context.Background(), conn)
+		require.Error(t, err)
+		require.Nil(t, skills)
+	})
+
+	t.Run("NilConnection", func(t *testing.T) {
+		t.Parallel()
+		skills, err := fetchSkillsFromAgent(context.Background(), nil)
+		require.NoError(t, err)
+		require.Nil(t, skills)
+	})
+
+	t.Run("EmptySkills", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		conn := agentconnmock.NewMockAgentConn(ctrl)
+		conn.EXPECT().ListSkills(gomock.Any()).Return([]workspacesdk.SkillMetadata{}, nil)
+
+		skills, err := fetchSkillsFromAgent(context.Background(), conn)
+		require.NoError(t, err)
+		require.Empty(t, skills)
+	})
 }

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -55,6 +55,7 @@ type AgentConn interface {
 	GetPeerDiagnostics() tailnet.PeerDiagnostics
 	ListContainers(ctx context.Context) (codersdk.WorkspaceAgentListContainersResponse, error)
 	ListProcesses(ctx context.Context) (ListProcessesResponse, error)
+	ListSkills(ctx context.Context) ([]SkillMetadata, error)
 	ListeningPorts(ctx context.Context) (codersdk.WorkspaceAgentListeningPortsResponse, error)
 	Netcheck(ctx context.Context) (healthsdk.AgentNetcheckReport, error)
 	Ping(ctx context.Context) (time.Duration, bool, *ipnstate.PingResult, error)
@@ -905,6 +906,29 @@ func (c *agentConn) apiClient() *http.Client {
 			},
 		},
 	}
+}
+
+// SkillMetadata describes a discovered skill exposed by a workspace agent.
+type SkillMetadata struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+}
+
+// ListSkills returns discovered skill metadata from the workspace agent.
+func (c *agentConn) ListSkills(ctx context.Context) ([]SkillMetadata, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+	res, err := c.apiRequest(ctx, http.MethodGet, "/api/v0/skills", nil)
+	if err != nil {
+		return nil, xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, codersdk.ReadBodyAsError(res)
+	}
+	var resp []SkillMetadata
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
 func (c *agentConn) GetPeerDiagnostics() tailnet.PeerDiagnostics {

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -228,6 +228,21 @@ func (mr *MockAgentConnMockRecorder) ListProcesses(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProcesses", reflect.TypeOf((*MockAgentConn)(nil).ListProcesses), ctx)
 }
 
+// ListSkills mocks base method.
+func (m *MockAgentConn) ListSkills(ctx context.Context) ([]workspacesdk.SkillMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSkills", ctx)
+	ret0, _ := ret[0].([]workspacesdk.SkillMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSkills indicates an expected call of ListSkills.
+func (mr *MockAgentConnMockRecorder) ListSkills(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSkills", reflect.TypeOf((*MockAgentConn)(nil).ListSkills), ctx)
+}
+
 // ListeningPorts mocks base method.
 func (m *MockAgentConn) ListeningPorts(ctx context.Context) (codersdk.WorkspaceAgentListeningPortsResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
🚧 PENDING CLEANUP

Adds filesystem-based skill auto-discovery to workspace agents. Skills are instruction files discovered from ~/.coder/skills/*/SKILL.md and ~/.claude/skills/*/SKILL.md. The agent exposes a new GET /api/v0/skills endpoint that returns skill metadata (name, description, absolute path). coderd/chatd calls this endpoint and injects the metadata into the chat system prompt as an <available_skills> XML block.

Key behaviors:
- YAML frontmatter parsing for name/description fields
- Path-derived slug fallback when frontmatter is missing
- Deduplication by name (.coder/skills takes priority)
- Alphabetical ordering by resolved name
- In-memory TLRU cache with 5-minute TTL on the agent
- All discovery warnings logged in agent log only
- XML escaping for special characters in skill metadata

Created by Claude Opus 4.6
