### PR TITLE
fix(site): add spacing between date groups in agents sidebar

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -465,6 +465,68 @@ export const DefaultShowsTimestampHidesMenu: Story = {
 	},
 };
 
+const yesterdayTimestamp = new Date(
+	Date.now() - 1 * 24 * 60 * 60 * 1000,
+).toISOString();
+const thisWeekTimestamp = new Date(
+	Date.now() - 3 * 24 * 60 * 60 * 1000,
+).toISOString();
+const olderTimestamp = new Date(
+	Date.now() - 14 * 24 * 60 * 60 * 1000,
+).toISOString();
+
+export const MultipleDateGroups: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "today-1",
+				title: "Today's first agent",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "today-2",
+				title: "Today's second agent",
+				updated_at: todayTimestamp,
+			}),
+			buildChat({
+				id: "yesterday-1",
+				title: "Yesterday's agent",
+				updated_at: yesterdayTimestamp,
+			}),
+			buildChat({
+				id: "week-1",
+				title: "This week's agent",
+				updated_at: thisWeekTimestamp,
+			}),
+			buildChat({
+				id: "older-1",
+				title: "Older agent",
+				updated_at: olderTimestamp,
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("Today")).toBeInTheDocument();
+			expect(canvas.getByText("Yesterday")).toBeInTheDocument();
+			expect(canvas.getByText("This Week")).toBeInTheDocument();
+			expect(canvas.getByText("Older")).toBeInTheDocument();
+		});
+		expect(canvas.getByText("Today's first agent")).toBeInTheDocument();
+		expect(canvas.getByText("Today's second agent")).toBeInTheDocument();
+		expect(canvas.getByText("Yesterday's agent")).toBeInTheDocument();
+		expect(canvas.getByText("This week's agent")).toBeInTheDocument();
+		expect(canvas.getByText("Older agent")).toBeInTheDocument();
+	},
+};
+
 export const ArchivedAgentUnarchiveOption: Story = {
 	args: {
 		chats: [

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -741,7 +741,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							) : (
 								<div className="divide-y divide-border">
 									{activeRootIDs.length > 0 && (
-										<div className="pb-2">
+										<div className="space-y-2 pb-2">
 											{TIME_GROUPS.map((group) => {
 												const groupChats = activeRootIDs
 													.map((id) => chatById.get(id))


### PR DESCRIPTION
## Problem

The date group headers (Today, Yesterday, This Week, Older) in the agents sidebar had no top margin, causing them to sit directly against the last chat item of the previous group with zero padding. This made the list look cramped.

## Solution

Added `space-y-2` to the date groups container, giving consistent vertical spacing between groups.

## Changes

- `site/src/pages/AgentsPage/AgentsSidebar.tsx`: Added `space-y-2` to the date groups wrapper div.