### PR TITLE
fix(site): improve git diff number contrast on light theme in agents sidebar

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.stories.tsx
@@ -465,6 +465,148 @@ export const DefaultShowsTimestampHidesMenu: Story = {
 	},
 };
 
+export const WithDiffStats: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "diff-both",
+				title: "Agent with additions and deletions",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-both",
+					url: "https://github.com/coder/coder/pull/1",
+					changes_requested: false,
+					additions: 42,
+					deletions: 7,
+					changed_files: 5,
+				},
+			}),
+			buildChat({
+				id: "diff-add-only",
+				title: "Agent with additions only",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-add-only",
+					url: "https://github.com/coder/coder/pull/2",
+					changes_requested: false,
+					additions: 120,
+					deletions: 0,
+					changed_files: 3,
+				},
+			}),
+			buildChat({
+				id: "diff-del-only",
+				title: "Agent with deletions only",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-del-only",
+					url: "https://github.com/coder/coder/pull/3",
+					changes_requested: false,
+					additions: 0,
+					deletions: 35,
+					changed_files: 2,
+				},
+			}),
+			buildChat({
+				id: "diff-none",
+				title: "Agent with no diff changes",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-none",
+					url: "https://github.com/coder/coder/pull/4",
+					changes_requested: false,
+					additions: 0,
+					deletions: 0,
+					changed_files: 0,
+				},
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("+42")).toBeInTheDocument();
+			expect(canvas.getByText("+120")).toBeInTheDocument();
+		});
+		// The deletions-only agent should show −35.
+		const delOnlyNode = canvas.getByTestId("agents-tree-node-diff-del-only");
+		expect(
+			within(delOnlyNode).getByText("35", { exact: false }),
+		).toBeInTheDocument();
+		// The zero-change agent should NOT render any diff numbers.
+		const noneNode = canvas.getByTestId("agents-tree-node-diff-none");
+		expect(within(noneNode).queryByText("+")).not.toBeInTheDocument();
+	},
+};
+
+export const WithDiffStatsLight: Story = {
+	globals: {
+		theme: "light",
+	},
+	args: {
+		chats: [
+			buildChat({
+				id: "diff-both-light",
+				title: "Agent with additions and deletions",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-both-light",
+					url: "https://github.com/coder/coder/pull/1",
+					changes_requested: false,
+					additions: 42,
+					deletions: 7,
+					changed_files: 5,
+				},
+			}),
+			buildChat({
+				id: "diff-add-only-light",
+				title: "Agent with additions only",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-add-only-light",
+					url: "https://github.com/coder/coder/pull/2",
+					changes_requested: false,
+					additions: 120,
+					deletions: 0,
+					changed_files: 3,
+				},
+			}),
+			buildChat({
+				id: "diff-del-only-light",
+				title: "Agent with deletions only",
+				updated_at: todayTimestamp,
+				diff_status: {
+					chat_id: "diff-del-only-light",
+					url: "https://github.com/coder/coder/pull/3",
+					changes_requested: false,
+					additions: 0,
+					deletions: 35,
+					changed_files: 2,
+				},
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(canvas.getByText("+42")).toBeInTheDocument();
+			expect(canvas.getByText("+120")).toBeInTheDocument();
+		});
+	},
+};
+
 export const ArchivedAgentUnarchiveOption: Story = {
 	args: {
 		chats: [

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -437,11 +437,15 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 											title={`${filesChangedLabel}, +${additions} -${deletions}`}
 										>
 											{additions > 0 && (
-												<span className="text-green-500">+{additions}</span>
+												<span className="text-green-700 dark:text-green-500">
+													+{additions}
+												</span>
 											)}
 											{deletions > 0 && (
-												<span className="text-red-400">&minus;{deletions}</span>
-											)}
+												<span className="text-red-700 dark:text-red-400">
+													&minus;{deletions}
+												</span>
+											)}{" "}
 										</span>
 									)}
 									<div


### PR DESCRIPTION
## Problem

The inline `+N` / `−N` git diff stats shown next to agents in the sidebar used `text-green-500` and `text-red-400` without `dark:` variants. These colors have poor contrast against light backgrounds, making the numbers nearly unreadable on light theme.

## Solution

Updated the Tailwind classes in `AgentsSidebar.tsx` to use the same light/dark pattern already established in `DiffStats.tsx`:

| Color | Before | After |
|-------|--------|-------|
| Additions | `text-green-500` | `text-green-700 dark:text-green-500` |
| Deletions | `text-red-400` | `text-red-700 dark:text-red-400` |

<img width="316" height="61" alt="image" src="https://github.com/user-attachments/assets/3a0cfdbc-c12f-453b-bc6a-f93b1920340a" />

<img width="316" height="60" alt="image" src="https://github.com/user-attachments/assets/70e6fdd0-05ff-4d14-82c6-2f91a7464a81" />


## Storybook coverage

Added two new stories to `AgentsSidebar.stories.tsx`:

- **WithDiffStats** (dark) — agents with additions+deletions, additions-only, deletions-only, and zero changes
- **WithDiffStatsLight** (light) — same variants rendered in light theme to visually verify contrast