### PR TITLE
test: remove unnecessary dbauthz.AsSystemRestricted calls in tests

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -8413,7 +8413,7 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 		})
 
 		// Agent should still authenticate during stop build execution.
-		row, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent.AuthToken)
+		row, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent.AuthToken)
 		require.NoError(t, err, "agent should authenticate during stop build execution")
 		require.Equal(t, agent.ID, row.WorkspaceAgent.ID)
 		require.Equal(t, startBuild.ID, row.WorkspaceBuild.ID, "should return start build, not stop build")
@@ -8471,7 +8471,7 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 		})
 
 		// Agent should NOT authenticate after stop job completes.
-		_, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent.AuthToken)
+		_, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent.AuthToken)
 		require.ErrorIs(t, err, sql.ErrNoRows, "agent should not authenticate after stop job completes")
 	})
 
@@ -8525,7 +8525,7 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 		})
 
 		// Agent should NOT authenticate (start build failed).
-		_, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent.AuthToken)
+		_, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent.AuthToken)
 		require.ErrorIs(t, err, sql.ErrNoRows, "agent from failed start build should not authenticate")
 	})
 
@@ -8580,7 +8580,7 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 		})
 
 		// Agent should authenticate during pending stop build.
-		row, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent.AuthToken)
+		row, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent.AuthToken)
 		require.NoError(t, err, "agent should authenticate during pending stop build")
 		require.Equal(t, agent.ID, row.WorkspaceAgent.ID)
 		require.Equal(t, startBuild.ID, row.WorkspaceBuild.ID, "should return start build")
@@ -8677,13 +8677,13 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 		})
 
 		// Agent from build 3 should authenticate.
-		row, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent2.AuthToken)
+		row, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent2.AuthToken)
 		require.NoError(t, err, "agent from most recent start should authenticate during stop")
 		require.Equal(t, agent2.ID, row.WorkspaceAgent.ID)
 		require.Equal(t, startBuild2.ID, row.WorkspaceBuild.ID)
 
 		// Agent from build 1 should NOT authenticate.
-		_, err = db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent1.AuthToken)
+		_, err = db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent1.AuthToken)
 		require.ErrorIs(t, err, sql.ErrNoRows, "agent from old cycle should not authenticate")
 	})
 
@@ -8737,7 +8737,7 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 		})
 
 		// Agent from build 1 should NOT authenticate (latest is not STOP).
-		_, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(dbauthz.AsSystemRestricted(ctx), agent1.AuthToken)
+		_, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(ctx, agent1.AuthToken)
 		require.ErrorIs(t, err, sql.ErrNoRows, "agent should not authenticate when latest build is not STOP")
 	})
 }

--- a/coderd/externalauth/externalauth_test.go
+++ b/coderd/externalauth/externalauth_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/externalauth"
@@ -337,7 +336,7 @@ func TestRefreshToken(t *testing.T) {
 		require.Equal(t, 1, validateCalls, "token is validated")
 		require.Equal(t, 1, refreshCalls, "token is refreshed")
 		require.NotEqualf(t, link.OAuthAccessToken, updated.OAuthAccessToken, "token is updated")
-		dbLink, err := db.GetExternalAuthLink(dbauthz.AsSystemRestricted(context.Background()), database.GetExternalAuthLinkParams{
+		dbLink, err := db.GetExternalAuthLink(context.Background(), database.GetExternalAuthLinkParams{
 			ProviderID: link.ProviderID,
 			UserID:     link.UserID,
 		})

--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -15,7 +15,6 @@ import (
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/idpsync"
@@ -357,7 +356,7 @@ func TestGroupSyncTable(t *testing.T) {
 			},
 		}
 
-		defOrg, err := db.GetDefaultOrganization(dbauthz.AsSystemRestricted(ctx))
+		defOrg, err := db.GetDefaultOrganization(ctx)
 		require.NoError(t, err)
 		SetupOrganization(t, s, db, user, defOrg.ID, def)
 		asserts = append(asserts, func(t *testing.T) {
@@ -555,7 +554,6 @@ func TestApplyGroupDifference(t *testing.T) {
 			db, _ := dbtestutil.NewDB(t)
 
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			ctx = dbauthz.AsSystemRestricted(ctx)
 
 			org := dbgen.Organization(t, db, database.Organization{})
 			_, err := db.InsertAllUsersGroup(ctx, org.ID)

--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -13,7 +13,6 @@ import (
 
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -273,7 +272,7 @@ func TestRoleSyncTable(t *testing.T) {
 		}
 
 		// Also assert site wide roles
-		allRoles, err := db.GetAuthorizationUserRoles(dbauthz.AsSystemRestricted(ctx), user.ID)
+		allRoles, err := db.GetAuthorizationUserRoles(ctx, user.ID)
 		require.NoError(t, err)
 
 		allRoleIDs, err := allRoles.RoleNames()

--- a/coderd/notifications/manager_test.go
+++ b/coderd/notifications/manager_test.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
@@ -30,7 +29,6 @@ func TestBufferedUpdates(t *testing.T) {
 
 	// setup
 
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, ps := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -57,6 +55,7 @@ func TestBufferedUpdates(t *testing.T) {
 	user := dbgen.User(t, store, database.User{})
 
 	// WHEN: notifications are enqueued which should succeed and fail
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	_, err = enq.Enqueue(ctx, user.ID, notifications.TemplateWorkspaceDeleted, map[string]string{"nice": "true", "i": "0"}, "") // Will succeed.
 	require.NoError(t, err)
 	_, err = enq.Enqueue(ctx, user.ID, notifications.TemplateWorkspaceDeleted, map[string]string{"nice": "true", "i": "1"}, "") // Will succeed.
@@ -106,7 +105,6 @@ func TestBuildPayload(t *testing.T) {
 
 	// SETUP
 
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, _ := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -146,6 +144,7 @@ func TestBuildPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN: a notification is enqueued
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	_, err = enq.Enqueue(ctx, uuid.New(), notifications.TemplateWorkspaceDeleted, map[string]string{
 		"name": "my-workspace",
 	}, "test")
@@ -163,7 +162,6 @@ func TestStopBeforeRun(t *testing.T) {
 
 	// SETUP
 
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, ps := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -172,6 +170,7 @@ func TestStopBeforeRun(t *testing.T) {
 	require.NoError(t, err)
 
 	// THEN: validate that the manager can be stopped safely without Run() having been called yet
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	require.Eventually(t, func() bool {
 		assert.NoError(t, mgr.Stop(ctx))
 		return true
@@ -183,7 +182,6 @@ func TestRunStopRace(t *testing.T) {
 
 	// SETUP
 
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitMedium))
 	store, ps := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -194,6 +192,7 @@ func TestRunStopRace(t *testing.T) {
 	// Start Run and Stop after each other (run does "go loop()").
 	// This is to catch a (now fixed) race condition where the manager
 	// would be accessed/stopped while it was being created/starting up.
+	ctx := testutil.Context(t, testutil.WaitMedium)
 	mgr.Run(ctx)
 	err = mgr.Stop(ctx)
 	require.NoError(t, err)

--- a/coderd/notifications/metrics_test.go
+++ b/coderd/notifications/metrics_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
@@ -33,7 +32,6 @@ func TestMetrics(t *testing.T) {
 
 	// SETUP
 
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -57,6 +55,7 @@ func TestMetrics(t *testing.T) {
 
 	mgr, err := notifications.NewManager(cfg, store, pubsub, defaultHelpers(), metrics, logger.Named("manager"))
 	require.NoError(t, err)
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
@@ -221,7 +220,6 @@ func TestPendingUpdatesMetric(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -247,6 +245,7 @@ func TestPendingUpdatesMetric(t *testing.T) {
 	mgr, err := notifications.NewManager(cfg, interceptor, pubsub, defaultHelpers(), metrics, logger.Named("manager"),
 		notifications.WithTestClock(mClock))
 	require.NoError(t, err)
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
@@ -314,7 +313,6 @@ func TestInflightDispatchesMetric(t *testing.T) {
 	t.Parallel()
 
 	// SETUP
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -333,6 +331,7 @@ func TestInflightDispatchesMetric(t *testing.T) {
 
 	mgr, err := notifications.NewManager(cfg, store, pubsub, defaultHelpers(), metrics, logger.Named("manager"))
 	require.NoError(t, err)
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	t.Cleanup(func() {
 		assert.NoError(t, mgr.Stop(ctx))
 	})
@@ -386,7 +385,6 @@ func TestInflightDispatchesMetric(t *testing.T) {
 
 func TestCustomMethodMetricCollection(t *testing.T) {
 	t.Parallel()
-	ctx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitSuperLong))
 	store, pubsub := dbtestutil.NewDB(t)
 	logger := testutil.Logger(t)
 
@@ -401,6 +399,8 @@ func TestCustomMethodMetricCollection(t *testing.T) {
 		customMethod  = database.NotificationMethodWebhook
 		defaultMethod = database.NotificationMethodSmtp
 	)
+
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 	// GIVEN: a template whose notification method differs from the default.
 	out, err := store.UpdateNotificationTemplateMethodByID(ctx, database.UpdateNotificationTemplateMethodByIDParams{

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -1472,12 +1472,12 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 				// as appearance changes are enterprise features and we do not want to mix those
 				// can't use the api
 				if tc.appName != "" {
-					err = (*db).UpsertApplicationName(dbauthz.AsSystemRestricted(ctx), "Custom Application")
+					err = (*db).UpsertApplicationName(ctx, "Custom Application")
 					require.NoError(t, err)
 				}
 
 				if tc.logoURL != "" {
-					err = (*db).UpsertLogoURL(dbauthz.AsSystemRestricted(ctx), "https://custom.application/logo.png")
+					err = (*db).UpsertLogoURL(ctx, "https://custom.application/logo.png")
 					require.NoError(t, err)
 				}
 

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -21,7 +21,6 @@ import (
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics/insights"
@@ -127,7 +126,7 @@ func TestCollectInsights(t *testing.T) {
 		AppStatBatchSize: workspaceapps.DefaultStatsDBReporterBatchSize,
 	})
 	refTime := time.Now().Add(-3 * time.Minute).Truncate(time.Minute)
-	err = reporter.ReportAppStats(dbauthz.AsSystemRestricted(context.Background()), []workspaceapps.StatsReport{
+	err = reporter.ReportAppStats(context.Background(), []workspaceapps.StatsReport{
 		{
 			UserID:           user.ID,
 			WorkspaceID:      workspace1.ID,

--- a/enterprise/aibridged/aibridged_integration_test.go
+++ b/enterprise/aibridged/aibridged_integration_test.go
@@ -24,7 +24,6 @@ import (
 	aibtracing "github.com/coder/aibridge/tracing"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/externalauth"
@@ -168,7 +167,7 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create external auth link for the user.
-	authLink, err := db.InsertExternalAuthLink(dbauthz.AsSystemRestricted(ctx), database.InsertExternalAuthLinkParams{
+	authLink, err := db.InsertExternalAuthLink(ctx, database.InsertExternalAuthLinkParams{
 		ProviderID:        "mock",
 		UserID:            user.ID,
 		CreatedAt:         dbtime.Now(),

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -1334,8 +1334,7 @@ func TestTemplateUpdatePrebuilds(t *testing.T) {
 			}).Do()
 
 			// Mark the prebuilt workspace's agent as ready so the prebuild can be claimed
-			// nolint:gocritic
-			agentCtx := dbauthz.AsSystemRestricted(testutil.Context(t, testutil.WaitLong))
+			agentCtx := testutil.Context(t, testutil.WaitLong)
 			agent, err := db.GetAuthenticatedWorkspaceAgentAndBuildByAuthToken(agentCtx, uuid.MustParse(workspaceBuild.AgentToken))
 			require.NoError(t, err)
 			err = db.UpdateWorkspaceAgentLifecycleStateByID(agentCtx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{

--- a/enterprise/coderd/workspacequota_test.go
+++ b/enterprise/coderd/workspacequota_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -763,7 +762,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  +------------------------------+------------------+
 		// pq: could not serialize access due to concurrent update
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,
@@ -820,7 +818,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  +------------------------------+------------------+
 		// Works!
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,
@@ -888,7 +885,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  +---------------------+----------------------------------+
 		// pq: could not serialize access due to concurrent update
 		ctx := testutil.Context(t, testutil.WaitShort)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,
@@ -940,7 +936,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  | CommitTx()          |                                  |
 		//  +---------------------+----------------------------------+
 		ctx := testutil.Context(t, testutil.WaitShort)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,
@@ -983,7 +978,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  +---------------------+----------------------------------+
 		// Works!
 		ctx := testutil.Context(t, testutil.WaitShort)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 		var err error
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
@@ -1037,7 +1031,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  |                     | CommitTx()          |
 		//  +---------------------+---------------------+
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,
@@ -1094,7 +1087,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  |                     | CommitTx()          |
 		//  +---------------------+---------------------+
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,
@@ -1154,7 +1146,6 @@ func TestWorkspaceSerialization(t *testing.T) {
 		//  +---------------------+---------------------+
 		// pq: could not serialize access due to read/write dependencies among transactions
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		myWorkspace := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: org.Org.ID,


### PR DESCRIPTION
## Summary

Remove unnecessary `dbauthz.AsSystemRestricted()` calls across 11 test files. These calls were wrapping contexts passed to database stores that don't enforce authorization (e.g. `dbmem` in-memory fakes, raw `database.Store` from `dbtestutil.NewDB`), making the system-restricted context elevation a no-op.

Also removes now-unused `dbauthz` imports from files where all usages were eliminated.

## Approach

Each call site was individually tested by:
1. Removing the `AsSystemRestricted` wrapper
2. Running `make test` to verify the full suite passes
3. Keeping the removal only if all tests passed
4. Reverting if any test failed with `no authorization actor in context`

## Files changed (11)

| Area | Files |
|------|-------|
| Database tests | `coderd/database/querier_test.go` |
| External auth tests | `coderd/externalauth/externalauth_test.go` |
| IDP sync tests | `coderd/idpsync/group_test.go`, `coderd/idpsync/role_test.go` |
| Notifications tests | `coderd/notifications/manager_test.go`, `coderd/notifications/metrics_test.go`, `coderd/notifications/notifications_test.go` |
| Metrics tests | `coderd/prometheusmetrics/insights/metricscollector_test.go` |
| Enterprise tests | `enterprise/aibridged/aibridged_integration_test.go`, `enterprise/coderd/schedule/template_test.go`, `enterprise/coderd/workspacequota_test.go` |
