### PR TITLE
feat(namesgenerator): expand auto-generated name digit suffix to 00-99

### DIFF
--- a/coderd/util/namesgenerator/namesgenerator.go
+++ b/coderd/util/namesgenerator/namesgenerator.go
@@ -9,6 +9,7 @@
 package namesgenerator
 
 import (
+	"fmt"
 	"math/rand/v2"
 	"strconv"
 	"strings"
@@ -34,17 +35,14 @@ func NameWith(delim string) string {
 	return adjective + delim + last
 }
 
-// NameDigitWith returns a random name with a single random digit suffix (1-9),
-// in the format "[adjective][delim][surname][digit]" e.g. "happy_smith9".
+// NameDigitWith returns a random name with a two-digit suffix (00-99),
+// in the format "[adjective][delim][surname][digit]" e.g. "happy_smith42".
 // Provides some collision resistance while keeping names short and clean.
 // Not guaranteed to be unique.
 func NameDigitWith(delim string) string {
-	const (
-		minDigit = 1
-		maxDigit = 9
-	)
 	//nolint:gosec // The random digit doesn't need to be cryptographically secure.
-	return NameWith(delim) + strconv.Itoa(rand.IntN(maxDigit-minDigit+1))
+	name := NameWith(delim) + fmt.Sprintf("%02d", rand.IntN(100))
+	return truncate(name, maxNameLen)
 }
 
 // UniqueName returns a random name with a monotonically increasing suffix,

--- a/coderd/util/namesgenerator/namesgenerator_internal_test.go
+++ b/coderd/util/namesgenerator/namesgenerator_internal_test.go
@@ -93,6 +93,21 @@ func TestUniqueNameWithLength(t *testing.T) {
 	}
 }
 
+func TestNameDigitWithLength(t *testing.T) {
+	t.Parallel()
+
+	const iter = 10000
+	for range iter {
+		name := NameDigitWith("_")
+		assert.LessOrEqual(t, len(name), maxNameLen)
+		assert.Contains(t, name, "_")
+		assert.Equal(t, name, strings.ToLower(name))
+		verifyNoWhitespace(t, name)
+		// Must end with exactly 2 digits.
+		assert.Regexp(t, `[a-z]\d{2}$`, name)
+	}
+}
+
 func verifyNoWhitespace(t *testing.T, s string) {
 	t.Helper()
 	for _, r := range s {


### PR DESCRIPTION
## Summary

Expands the digit suffix in auto-generated names from a single digit (0-8) to a zero-padded two-digit range (00-99), increasing possible unique name combinations from ~977K to ~10.8M (~11x improvement in collision resistance).

## Changes

- `NameDigitWith` now uses `fmt.Sprintf("%02d", rand.IntN(100))` for a two-digit suffix instead of `strconv.Itoa(rand.IntN(9))`.
- Added `truncate()` call to enforce the 32-character name limit, matching `UniqueNameWith` behavior.
- Added `TestNameDigitWithLength` test (10K iterations) validating length, format, and two-digit suffix.

Fixes #22169