### PR TITLE
feat(site): suppress push notifications when agents page is visible

### DIFF
--- a/site/src/serviceWorker.test.ts
+++ b/site/src/serviceWorker.test.ts
@@ -6,9 +6,8 @@ import type { WebpushMessage } from "api/typesGenerated";
 
 const mockShowNotification = vi.fn(() => Promise.resolve());
 const mockRegistration = { showNotification: mockShowNotification };
-const mockMatchAll = vi.fn<
-	() => Promise<Array<{ visibilityState: string; url: string }>>
->();
+const mockMatchAll =
+	vi.fn<() => Promise<Array<{ visibilityState: string; url: string }>>>();
 const mockClients = {
 	matchAll: mockMatchAll,
 	claim: vi.fn(() => Promise.resolve()),
@@ -57,6 +56,7 @@ const testPayload: WebpushMessage = {
 	body: "Something happened",
 	icon: "/icon.png",
 	actions: [],
+	data: { url: "/agents/abc" },
 };
 
 // Import the service worker module. This executes the top-level
@@ -80,10 +80,11 @@ describe("serviceWorker push handler", () => {
 		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
 			body: testPayload.body,
 			icon: testPayload.icon,
+			data: testPayload.data,
 		});
 	});
 
-	it("suppresses notification when agents page is visible", async () => {
+	it("suppresses notification when viewing the specific chat", async () => {
 		mockMatchAll.mockResolvedValue([
 			{ visibilityState: "visible", url: "https://example.com/agents/abc" },
 		]);
@@ -95,7 +96,48 @@ describe("serviceWorker push handler", () => {
 		expect(mockShowNotification).not.toHaveBeenCalled();
 	});
 
-	it("shows notification when agents page exists but is hidden", async () => {
+	it("shows notification when viewing a different chat", async () => {
+		mockMatchAll.mockResolvedValue([
+			{
+				visibilityState: "visible",
+				url: "https://example.com/agents/other-chat-id",
+			},
+		]);
+
+		const event = makePushEvent(testPayload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
+			body: testPayload.body,
+			icon: testPayload.icon,
+			data: testPayload.data,
+		});
+	});
+
+	it("shows notification when payload has no data url", async () => {
+		mockMatchAll.mockResolvedValue([
+			{ visibilityState: "visible", url: "https://example.com/agents/abc" },
+		]);
+
+		const payload: WebpushMessage = {
+			title: "No Data",
+			body: "test",
+			icon: "/icon.png",
+			actions: [],
+		};
+		const event = makePushEvent(payload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).toHaveBeenCalledWith("No Data", {
+			body: "test",
+			icon: "/icon.png",
+			data: undefined,
+		});
+	});
+
+	it("shows notification when specific chat page exists but is hidden", async () => {
 		mockMatchAll.mockResolvedValue([
 			{ visibilityState: "hidden", url: "https://example.com/agents/abc" },
 		]);
@@ -107,6 +149,7 @@ describe("serviceWorker push handler", () => {
 		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
 			body: testPayload.body,
 			icon: testPayload.icon,
+			data: testPayload.data,
 		});
 	});
 
@@ -122,6 +165,7 @@ describe("serviceWorker push handler", () => {
 		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
 			body: testPayload.body,
 			icon: testPayload.icon,
+			data: testPayload.data,
 		});
 	});
 
@@ -149,6 +193,7 @@ describe("serviceWorker push handler", () => {
 		expect(mockShowNotification).toHaveBeenCalledWith("No Icon", {
 			body: "",
 			icon: "/favicon.ico",
+			data: undefined,
 		});
 	});
 });

--- a/site/src/serviceWorker.test.ts
+++ b/site/src/serviceWorker.test.ts
@@ -1,0 +1,150 @@
+import type { WebpushMessage } from "api/typesGenerated";
+
+// We need to mock the ServiceWorkerGlobalScope before importing the
+// module, since serviceWorker.ts registers event listeners at the
+// top level during module evaluation.
+
+const mockShowNotification = vi.fn(() => Promise.resolve());
+const mockRegistration = { showNotification: mockShowNotification };
+const mockMatchAll = vi.fn<[], Promise<Array<{ visibilityState: string; url: string }>>>();
+const mockClients = {
+	matchAll: mockMatchAll,
+	claim: vi.fn(() => Promise.resolve()),
+	openWindow: vi.fn(() => Promise.resolve(null)),
+};
+
+// Collect handlers registered via addEventListener so we can
+// invoke them directly in tests.
+const handlers: Record<string, (event: unknown) => void> = {};
+const mockSelf = {
+	addEventListener: vi.fn((event: string, handler: (event: unknown) => void) => {
+		handlers[event] = handler;
+	}),
+	skipWaiting: vi.fn(),
+	clients: mockClients,
+	registration: mockRegistration,
+};
+
+// Assign our mock to the global `self` that serviceWorker.ts
+// references via `declare const self`.
+Object.assign(globalThis, { self: mockSelf });
+
+// Helper to build a minimal PushEvent-like object that carries
+// a JSON payload and exposes waitUntil so we can await the
+// handler's async work.
+function makePushEvent(payload: WebpushMessage) {
+	let waitUntilPromise: Promise<unknown> = Promise.resolve();
+	return {
+		data: {
+			json: () => payload,
+		},
+		waitUntil: (p: Promise<unknown>) => {
+			waitUntilPromise = p;
+		},
+		// Expose the promise so tests can await it.
+		get _waitUntilPromise() {
+			return waitUntilPromise;
+		},
+	};
+}
+
+const testPayload: WebpushMessage = {
+	title: "Test Notification",
+	body: "Something happened",
+	icon: "/icon.png",
+	actions: [],
+};
+
+// Import the service worker module. This executes the top-level
+// addEventListener calls which populate our `handlers` map.
+beforeAll(async () => {
+	await import("./serviceWorker");
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("serviceWorker push handler", () => {
+	it("shows notification when no visible agents window exists", async () => {
+		mockMatchAll.mockResolvedValue([]);
+
+		const event = makePushEvent(testPayload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
+			body: testPayload.body,
+			icon: testPayload.icon,
+		});
+	});
+
+	it("suppresses notification when agents page is visible", async () => {
+		mockMatchAll.mockResolvedValue([
+			{ visibilityState: "visible", url: "https://example.com/agents/abc" },
+		]);
+
+		const event = makePushEvent(testPayload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).not.toHaveBeenCalled();
+	});
+
+	it("shows notification when agents page exists but is hidden", async () => {
+		mockMatchAll.mockResolvedValue([
+			{ visibilityState: "hidden", url: "https://example.com/agents/abc" },
+		]);
+
+		const event = makePushEvent(testPayload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
+			body: testPayload.body,
+			icon: testPayload.icon,
+		});
+	});
+
+	it("shows notification when visible window is not on agents page", async () => {
+		mockMatchAll.mockResolvedValue([
+			{ visibilityState: "visible", url: "https://example.com/settings" },
+		]);
+
+		const event = makePushEvent(testPayload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).toHaveBeenCalledWith(testPayload.title, {
+			body: testPayload.body,
+			icon: testPayload.icon,
+		});
+	});
+
+	it("does not show notification when push event has no data", () => {
+		const event = { data: null };
+		// Should return early without calling waitUntil, so no
+		// error and no notification.
+		handlers.push(event);
+		expect(mockShowNotification).not.toHaveBeenCalled();
+	});
+
+	it("uses default icon when payload icon is empty", async () => {
+		mockMatchAll.mockResolvedValue([]);
+
+		const payload: WebpushMessage = {
+			title: "No Icon",
+			body: "",
+			icon: "",
+			actions: [],
+		};
+		const event = makePushEvent(payload);
+		handlers.push(event);
+		await event._waitUntilPromise;
+
+		expect(mockShowNotification).toHaveBeenCalledWith("No Icon", {
+			body: "",
+			icon: "/favicon.ico",
+		});
+	});
+});

--- a/site/src/serviceWorker.test.ts
+++ b/site/src/serviceWorker.test.ts
@@ -6,7 +6,9 @@ import type { WebpushMessage } from "api/typesGenerated";
 
 const mockShowNotification = vi.fn(() => Promise.resolve());
 const mockRegistration = { showNotification: mockShowNotification };
-const mockMatchAll = vi.fn<[], Promise<Array<{ visibilityState: string; url: string }>>>();
+const mockMatchAll = vi.fn<
+	() => Promise<Array<{ visibilityState: string; url: string }>>
+>();
 const mockClients = {
 	matchAll: mockMatchAll,
 	claim: vi.fn(() => Promise.resolve()),
@@ -17,9 +19,11 @@ const mockClients = {
 // invoke them directly in tests.
 const handlers: Record<string, (event: unknown) => void> = {};
 const mockSelf = {
-	addEventListener: vi.fn((event: string, handler: (event: unknown) => void) => {
-		handlers[event] = handler;
-	}),
+	addEventListener: vi.fn(
+		(event: string, handler: (event: unknown) => void) => {
+			handlers[event] = handler;
+		},
+	),
 	skipWaiting: vi.fn(),
 	clients: mockClients,
 	registration: mockRegistration,

--- a/site/src/serviceWorker.ts
+++ b/site/src/serviceWorker.ts
@@ -26,13 +26,27 @@ self.addEventListener("push", (event) => {
 	}
 
 	event.waitUntil(
-		self.registration.showNotification(payload.title, {
-			body: payload.body || "",
-			icon: payload.icon || "/favicon.ico",
-			data: payload.data,
-		}),
-	);
-});
+			self.clients
+				.matchAll({ type: "window", includeUncontrolled: true })
+				.then((clientList) => {
+					const chatURL = payload.data?.url;
+					if (chatURL) {
+						const isVisible = clientList.some(
+							(client) =>
+								client.visibilityState === "visible" &&
+								client.url.includes(chatURL),
+						);
+						if (isVisible) {
+							return;
+						}
+					}
+					return self.registration.showNotification(payload.title, {
+						body: payload.body || "",
+						icon: payload.icon || "/favicon.ico",
+						data: payload.data,
+					});
+				}),
+		);});
 
 // Handle notification click — navigate to the specific chat or agents page.
 self.addEventListener("notificationclick", (event) => {

--- a/site/src/serviceWorker.ts
+++ b/site/src/serviceWorker.ts
@@ -26,27 +26,30 @@ self.addEventListener("push", (event) => {
 	}
 
 	event.waitUntil(
-			self.clients
-				.matchAll({ type: "window", includeUncontrolled: true })
-				.then((clientList) => {
-					const chatURL = payload.data?.url;
-					if (chatURL) {
-						const isVisible = clientList.some(
-							(client) =>
-								client.visibilityState === "visible" &&
-								client.url.includes(chatURL),
-						);
-						if (isVisible) {
-							return;
-						}
+		self.clients
+			.matchAll({ type: "window", includeUncontrolled: true })
+			.then((clientList) => {
+				// Only suppress if the user is actively viewing the
+				// specific chat that triggered this notification.
+				const chatURL = payload.data?.url;
+				if (chatURL) {
+					const isVisible = clientList.some(
+						(client) =>
+							client.visibilityState === "visible" &&
+							client.url.includes(chatURL),
+					);
+					if (isVisible) {
+						return;
 					}
-					return self.registration.showNotification(payload.title, {
-						body: payload.body || "",
-						icon: payload.icon || "/favicon.ico",
-						data: payload.data,
-					});
-				}),
-		);});
+				}
+				return self.registration.showNotification(payload.title, {
+					body: payload.body || "",
+					icon: payload.icon || "/favicon.ico",
+					data: payload.data,
+				});
+			}),
+	);
+});
 
 // Handle notification click — navigate to the specific chat or agents page.
 self.addEventListener("notificationclick", (event) => {


### PR DESCRIPTION
When a user already has the agents page open and visible in their browser, skip showing the push notification since they can already see the chat status updates in real-time.