### PR TITLE
feat(chatd): navigate to specific chat on push notification click

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1812,6 +1812,7 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 					Title: chat.Title,
 					Body:  "Agent has finished running.",
 					Icon:  "/favicon.ico",
+					Data:  map[string]string{"url": fmt.Sprintf("/agents/%s", chat.ID)},
 				}
 				if status == database.ChatStatusError {
 					pushMsg.Body = "Agent encountered an error."

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -1306,10 +1306,17 @@ func TestInterruptChatDoesNotSendWebPushNotification(t *testing.T) {
 // mockWebpushDispatcher implements webpush.Dispatcher and records Dispatch calls.
 type mockWebpushDispatcher struct {
 	dispatchCount atomic.Int32
+	mu            sync.Mutex
+	lastMessage   codersdk.WebpushMessage
+	lastUserID    uuid.UUID
 }
 
-func (m *mockWebpushDispatcher) Dispatch(_ context.Context, _ uuid.UUID, _ codersdk.WebpushMessage) error {
+func (m *mockWebpushDispatcher) Dispatch(_ context.Context, userID uuid.UUID, msg codersdk.WebpushMessage) error {
 	m.dispatchCount.Add(1)
+	m.mu.Lock()
+	m.lastMessage = msg
+	m.lastUserID = userID
+	m.mu.Unlock()
 	return nil
 }
 
@@ -1319,6 +1326,78 @@ func (*mockWebpushDispatcher) Test(_ context.Context, _ codersdk.WebpushSubscrip
 
 func (*mockWebpushDispatcher) PublicKey() string {
 	return "test-vapid-public-key"
+}
+
+func TestSuccessfulChatSendsWebPushWithNavigationData(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// Set up a mock OpenAI that returns a simple successful response.
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	// Mock webpush dispatcher that captures the dispatched message.
+	mockPush := &mockWebpushDispatcher{}
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+		WebpushDispatcher:          mockPush,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "push-nav-test",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []fantasy.Content{fantasy.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+
+	// Wait for the chat to complete and return to waiting status.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusWaiting && !fromDB.WorkerID.Valid
+	}, testutil.IntervalFast)
+
+	// Verify a web push notification was dispatched exactly once.
+	require.Equal(t, int32(1), mockPush.dispatchCount.Load(),
+		"expected exactly one web push dispatch for a completed chat")
+
+	// Verify the notification was sent to the correct user.
+	mockPush.mu.Lock()
+	capturedMsg := mockPush.lastMessage
+	capturedUserID := mockPush.lastUserID
+	mockPush.mu.Unlock()
+
+	require.Equal(t, user.ID, capturedUserID,
+		"web push should be dispatched to the chat owner")
+
+	// Verify the Data field contains the correct navigation URL.
+	expectedURL := fmt.Sprintf("/agents/%s", chat.ID)
+	require.Equal(t, expectedURL, capturedMsg.Data["url"],
+		"web push Data should contain the chat navigation URL")
 }
 
 func TestCloseDuringShutdownContextCanceledShouldRetryOnNewReplica(t *testing.T) {

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -225,6 +225,7 @@ type WebpushMessage struct {
 	Title   string                 `json:"title"`
 	Body    string                 `json:"body"`
 	Actions []WebpushMessageAction `json:"actions"`
+	Data    map[string]string      `json:"data,omitempty"`
 }
 
 type WebpushSubscription struct {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6799,6 +6799,7 @@ export interface WebpushMessage {
 	readonly title: string;
 	readonly body: string;
 	readonly actions: readonly WebpushMessageAction[];
+	readonly data?: Record<string, string>;
 }
 
 // From codersdk/notifications.go

--- a/site/src/serviceWorker.ts
+++ b/site/src/serviceWorker.ts
@@ -29,23 +29,26 @@ self.addEventListener("push", (event) => {
 		self.registration.showNotification(payload.title, {
 			body: payload.body || "",
 			icon: payload.icon || "/favicon.ico",
+			data: payload.data,
 		}),
 	);
 });
 
-// Handle notification click — navigate to the agents page
+// Handle notification click — navigate to the specific chat or agents page.
 self.addEventListener("notificationclick", (event) => {
 	event.notification.close();
+	const targetUrl: string = event.notification.data?.url || "/agents";
 	event.waitUntil(
 		self.clients
 			.matchAll({ type: "window", includeUncontrolled: true })
 			.then((clientList) => {
 				for (const client of clientList) {
 					if (client.url.includes("/agents") && "focus" in client) {
+						client.navigate(targetUrl);
 						return client.focus();
 					}
 				}
-				return self.clients.openWindow("/agents");
+				return self.clients.openWindow(targetUrl);
 			}),
 	);
 });


### PR DESCRIPTION
Clicking a web push notification for an agent chat now navigates to the specific chat (`/agents/{id}`) instead of the generic `/agents` page.

## Changes

- **`codersdk/notifications.go`**: Added `Data map[string]string` field to `WebpushMessage` for passing arbitrary metadata (like a URL) through push notifications.
- **`coderd/chatd/chatd.go`**: Populates the `Data` field with the chat-specific URL (`/agents/{chat_id}`) when sending push notifications.
- **`site/src/serviceWorker.ts`**: Updated the `push` handler to pass the `data` field through to `showNotification`, and the `notificationclick` handler to read `data.url` for navigation, falling back to `/agents` if not present.
- **`site/src/api/typesGenerated.ts`**: Regenerated to include the new `data` field on `WebpushMessage`.