### PR TITLE
fix(agents): prevent updated_at regression causing sidebar group flicker

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -1,0 +1,265 @@
+import { API } from "api/api";
+import type * as TypesGen from "api/typesGenerated";
+import { QueryClient } from "react-query";
+import { describe, expect, it, vi } from "vitest";
+import { archiveChat, chatKey, chatsKey, unarchiveChat } from "./chats";
+
+vi.mock("api/api", () => ({
+	API: {
+		archiveChat: vi.fn(),
+		unarchiveChat: vi.fn(),
+	},
+}));
+
+const makeChat = (
+	id: string,
+	overrides?: Partial<TypesGen.Chat>,
+): TypesGen.Chat => ({
+	id,
+	owner_id: "owner-1",
+	last_model_config_id: "model-1",
+	title: `Chat ${id}`,
+	status: "running",
+	created_at: "2025-01-01T00:00:00.000Z",
+	updated_at: "2025-01-01T00:00:00.000Z",
+	archived: false,
+	last_error: null,
+	...overrides,
+});
+
+const makeChatWithMessages = (
+	chatId: string,
+	overrides?: Partial<TypesGen.Chat>,
+): TypesGen.ChatWithMessages => ({
+	chat: makeChat(chatId, overrides),
+	messages: [],
+	queued_messages: [],
+});
+
+const createTestQueryClient = (): QueryClient =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				gcTime: Number.POSITIVE_INFINITY,
+				refetchOnWindowFocus: false,
+				networkMode: "offlineFirst",
+			},
+		},
+	});
+
+describe("archiveChat optimistic update", () => {
+	it("optimistically sets archived to true in the chats list", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const initialChats = [makeChat(chatId), makeChat("chat-2")];
+		queryClient.setQueryData(chatsKey, initialChats);
+
+		vi.mocked(API.archiveChat).mockResolvedValue();
+
+		const mutation = archiveChat(queryClient);
+		await mutation.onMutate(chatId);
+
+		const updatedChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		expect(updatedChats).toHaveLength(2);
+		expect(updatedChats?.find((c) => c.id === chatId)?.archived).toBe(true);
+		// Other chats are unchanged.
+		expect(updatedChats?.find((c) => c.id === "chat-2")?.archived).toBe(false);
+	});
+
+	it("optimistically sets archived to true in the individual chat cache", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
+		queryClient.setQueryData(chatKey(chatId), makeChatWithMessages(chatId));
+
+		vi.mocked(API.archiveChat).mockResolvedValue();
+
+		const mutation = archiveChat(queryClient);
+		await mutation.onMutate(chatId);
+
+		const cachedChat = queryClient.getQueryData<TypesGen.ChatWithMessages>(
+			chatKey(chatId),
+		);
+		expect(cachedChat?.chat.archived).toBe(true);
+	});
+
+	it("rolls back the chats list on error", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const initialChats = [makeChat(chatId)];
+		queryClient.setQueryData(chatsKey, initialChats);
+		queryClient.setQueryData(chatKey(chatId), makeChatWithMessages(chatId));
+
+		const mutation = archiveChat(queryClient);
+		const context = await mutation.onMutate(chatId);
+
+		// Verify the optimistic update took effect.
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey)?.[0].archived,
+		).toBe(true);
+
+		// Simulate an error — the onError handler should restore original
+		// data.
+		mutation.onError(new Error("server error"), chatId, context);
+
+		const rolledBack = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		expect(rolledBack?.[0].archived).toBe(false);
+	});
+
+	it("rolls back the individual chat cache on error", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
+		queryClient.setQueryData(chatKey(chatId), makeChatWithMessages(chatId));
+
+		const mutation = archiveChat(queryClient);
+		const context = await mutation.onMutate(chatId);
+
+		expect(
+			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId))?.chat
+				.archived,
+		).toBe(true);
+
+		mutation.onError(new Error("server error"), chatId, context);
+
+		const rolledBack = queryClient.getQueryData<TypesGen.ChatWithMessages>(
+			chatKey(chatId),
+		);
+		expect(rolledBack?.chat.archived).toBe(false);
+	});
+
+	it("handles error rollback gracefully when context is undefined", () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId, { archived: true })]);
+
+		const mutation = archiveChat(queryClient);
+
+		// Calling onError with undefined context should not throw.
+		expect(() => {
+			mutation.onError(new Error("fail"), chatId, undefined);
+		}).not.toThrow();
+
+		// Data should remain unchanged since there was nothing to roll
+		// back to.
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey)?.[0].archived,
+		).toBe(true);
+	});
+
+	it("handles onMutate when no individual chat cache exists", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
+		// Deliberately do NOT set chatKey(chatId) data.
+
+		const mutation = archiveChat(queryClient);
+		const context = await mutation.onMutate(chatId);
+
+		// The list should still be optimistically updated.
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey)?.[0].archived,
+		).toBe(true);
+		// previousChat should be undefined.
+		expect(context?.previousChat).toBeUndefined();
+	});
+
+	it("invalidates queries on settled regardless of outcome", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+		const mutation = archiveChat(queryClient);
+		await mutation.onSettled(undefined, undefined, chatId);
+
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: chatsKey,
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: chatKey(chatId),
+		});
+	});
+});
+
+describe("unarchiveChat optimistic update", () => {
+	it("optimistically sets archived to false in the chats list", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId, { archived: true })]);
+
+		const mutation = unarchiveChat(queryClient);
+		await mutation.onMutate(chatId);
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey)?.[0].archived,
+		).toBe(false);
+	});
+
+	it("optimistically sets archived to false in the individual chat cache", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId, { archived: true })]);
+		queryClient.setQueryData(
+			chatKey(chatId),
+			makeChatWithMessages(chatId, { archived: true }),
+		);
+
+		const mutation = unarchiveChat(queryClient);
+		await mutation.onMutate(chatId);
+
+		expect(
+			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId))?.chat
+				.archived,
+		).toBe(false);
+	});
+
+	it("rolls back both caches on error", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatsKey, [makeChat(chatId, { archived: true })]);
+		queryClient.setQueryData(
+			chatKey(chatId),
+			makeChatWithMessages(chatId, { archived: true }),
+		);
+
+		const mutation = unarchiveChat(queryClient);
+		const context = await mutation.onMutate(chatId);
+
+		// Verify optimistic update.
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey)?.[0].archived,
+		).toBe(false);
+		expect(
+			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId))?.chat
+				.archived,
+		).toBe(false);
+
+		// Roll back.
+		mutation.onError(new Error("server error"), chatId, context);
+
+		expect(
+			queryClient.getQueryData<TypesGen.Chat[]>(chatsKey)?.[0].archived,
+		).toBe(true);
+		expect(
+			queryClient.getQueryData<TypesGen.ChatWithMessages>(chatKey(chatId))?.chat
+				.archived,
+		).toBe(true);
+	});
+
+	it("invalidates queries on settled", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+		const mutation = unarchiveChat(queryClient);
+		await mutation.onSettled(undefined, undefined, chatId);
+
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: chatsKey,
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: chatKey(chatId),
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { watchChat } from "api/api";
-import { chatKey } from "api/queries/chats";
+import { chatKey, chatsKey } from "api/queries/chats";
 import type * as TypesGen from "api/typesGenerated";
 import type { FC, PropsWithChildren } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -2026,6 +2026,487 @@ describe("useChatStore", () => {
 
 		await waitFor(() => {
 			expect(clearChatErrorReason).toHaveBeenCalledWith(chatID);
+		});
+	});
+});
+
+describe("updateSidebarChat via stream events", () => {
+	it("updates sidebar chat status on status stream event", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-sidebar-status";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const initialChat = makeChat(chatID);
+		// Seed the chats list so updateSidebarChat can find it.
+		queryClient.setQueryData(chatsKey, [initialChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: initialChat,
+					chatData: {
+						chat: initialChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return { chatStatus: useChatSelector(store, selectChatStatus) };
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "completed" },
+			});
+		});
+
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			expect(sidebarChats?.[0].status).toBe("completed");
+		});
+	});
+
+	it("does not change sidebar updated_at on message stream event", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-sidebar-message";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const initialChat = makeChat(chatID);
+		queryClient.setQueryData(chatsKey, [initialChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: initialChat,
+					chatData: {
+						chat: initialChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		const messageTimestamp = "2025-06-15T12:00:00.000Z";
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: {
+					...makeMessage(chatID, 42, "assistant", "hello"),
+					created_at: messageTimestamp,
+				},
+			});
+		});
+
+		// The per-chat WebSocket does not write updated_at — only the
+		// global chat-list WebSocket delivers the authoritative server
+		// timestamp. Verify it stays at the original value.
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			expect(sidebarChats?.[0].updated_at).toBe(initialChat.updated_at);
+		});
+	});
+
+	it("updates sidebar chat status to error on error stream event", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-sidebar-error";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const initialChat = makeChat(chatID);
+		queryClient.setQueryData(chatsKey, [initialChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: initialChat,
+					chatData: {
+						chat: initialChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return { chatStatus: useChatSelector(store, selectChatStatus) };
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: { message: "something went wrong" },
+			});
+		});
+
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			expect(sidebarChats?.[0].status).toBe("error");
+		});
+	});
+
+	it("does not update sidebar for a different chatID", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-active";
+		const otherChatID = "chat-other";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const activeChat = makeChat(chatID);
+		const otherChat = makeChat(otherChatID);
+		queryClient.setQueryData(chatsKey, [activeChat, otherChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: activeChat,
+					chatData: {
+						chat: activeChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		// Emit a status event for the *active* chat.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "completed" },
+			});
+		});
+
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			expect(sidebarChats?.find((c) => c.id === chatID)?.status).toBe(
+				"completed",
+			);
+		});
+
+		// The other chat should remain unchanged.
+		const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+		expect(sidebarChats?.find((c) => c.id === otherChatID)?.status).toBe(
+			"running",
+		);
+	});
+
+	it("does not regress updated_at on message events", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-no-regress-msg";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const futureTimestamp = "2099-01-01T00:00:00.000Z";
+		const initialChat = { ...makeChat(chatID), updated_at: futureTimestamp };
+		queryClient.setQueryData(chatsKey, [initialChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: initialChat,
+					chatData: {
+						chat: initialChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		// The per-chat WS no longer writes updated_at, so any
+		// message event should leave it untouched.
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: {
+					...makeMessage(chatID, 99, "assistant", "old message"),
+					created_at: "2020-01-01T00:00:00.000Z",
+				},
+			});
+		});
+
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			expect(sidebarChats?.[0].updated_at).toBe(futureTimestamp);
+		});
+	});
+
+	it("does not change updated_at on status events", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-no-regress-status";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const initialChat = makeChat(chatID);
+		queryClient.setQueryData(chatsKey, [initialChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: initialChat,
+					chatData: {
+						chat: initialChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return { chatStatus: useChatSelector(store, selectChatStatus) };
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "completed" },
+			});
+		});
+
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			// Status should update, but updated_at must stay untouched.
+			expect(sidebarChats?.[0].status).toBe("completed");
+			expect(sidebarChats?.[0].updated_at).toBe(initialChat.updated_at);
+		});
+	});
+
+	it("does not change updated_at on error events", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-no-regress-error";
+		const mockSocket = createMockSocket();
+		vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					gcTime: Number.POSITIVE_INFINITY,
+					refetchOnWindowFocus: false,
+					networkMode: "offlineFirst",
+				},
+			},
+		});
+		const initialChat = makeChat(chatID);
+		queryClient.setQueryData(chatsKey, [initialChat]);
+
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: initialChat,
+					chatData: {
+						chat: initialChat,
+						messages: [],
+						queued_messages: [],
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return { chatStatus: useChatSelector(store, selectChatStatus) };
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitData({
+				type: "error",
+				chat_id: chatID,
+				error: { message: "something broke" },
+			});
+		});
+
+		await waitFor(() => {
+			const sidebarChats = queryClient.getQueryData<TypesGen.Chat[]>(chatsKey);
+			expect(sidebarChats?.[0].status).toBe("error");
+			expect(sidebarChats?.[0].updated_at).toBe(initialChat.updated_at);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -636,11 +636,12 @@ export const useChatStore = (
 						if (changed) {
 							scheduleStreamReset();
 						}
-							// Do not update updated_at here. The global
-							// chat-list WebSocket delivers the authoritative
-							// server timestamp; fabricating a client-side
-							// value causes the chat to flicker between time
-							// groups when the two sources race.						continue;
+						// Do not update updated_at here. The global
+						// chat-list WebSocket delivers the authoritative
+						// server timestamp; fabricating a client-side
+						// value causes the chat to flicker between time
+						// groups when the two sources race.
+						continue;
 					}
 					case "queue_update":
 						{
@@ -676,10 +677,10 @@ export const useChatStore = (
 						if (nextStatus !== "error") {
 							clearChatErrorReason(chatID);
 						}
-							updateSidebarChat((chat) => ({
-								...chat,
-								status: nextStatus,
-							}));
+						updateSidebarChat((chat) => ({
+							...chat,
+							status: nextStatus,
+						}));
 						continue;
 					}
 					case "error": {
@@ -690,10 +691,11 @@ export const useChatStore = (
 						store.setStreamError(reason);
 						store.clearRetryState();
 						setChatErrorReason(chatID, reason);
-							updateSidebarChat((chat) => ({
-								...chat,
-								status: "error",
-							}));						continue;
+						updateSidebarChat((chat) => ({
+							...chat,
+							status: "error",
+						}));
+						continue;
 					}
 					case "retry": {
 						const retry = streamEvent.retry;

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -636,11 +636,11 @@ export const useChatStore = (
 						if (changed) {
 							scheduleStreamReset();
 						}
-						updateSidebarChat((chat) => ({
-							...chat,
-							updated_at: message.created_at ?? new Date().toISOString(),
-						}));
-						continue;
+							// Do not update updated_at here. The global
+							// chat-list WebSocket delivers the authoritative
+							// server timestamp; fabricating a client-side
+							// value causes the chat to flicker between time
+							// groups when the two sources race.						continue;
 					}
 					case "queue_update":
 						{
@@ -676,12 +676,10 @@ export const useChatStore = (
 						if (nextStatus !== "error") {
 							clearChatErrorReason(chatID);
 						}
-						updateSidebarChat((chat) => ({
-							...chat,
-							status: nextStatus,
-							updated_at: new Date().toISOString(),
-						}));
-
+							updateSidebarChat((chat) => ({
+								...chat,
+								status: nextStatus,
+							}));
 						continue;
 					}
 					case "error": {
@@ -692,12 +690,10 @@ export const useChatStore = (
 						store.setStreamError(reason);
 						store.clearRetryState();
 						setChatErrorReason(chatID, reason);
-						updateSidebarChat((chat) => ({
-							...chat,
-							status: "error",
-							updated_at: new Date().toISOString(),
-						}));
-						continue;
+							updateSidebarChat((chat) => ({
+								...chat,
+								status: "error",
+							}));						continue;
 					}
 					case "retry": {
 						const retry = streamEvent.retry;

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -449,7 +449,10 @@ const AgentsPage: FC = () => {
 										...c,
 										status: updatedChat.status,
 										title: updatedChat.title,
-										updated_at: updatedChat.updated_at,
+										updated_at:
+											c.updated_at > updatedChat.updated_at
+												? c.updated_at
+												: updatedChat.updated_at,
 									}
 								: c,
 						);
@@ -472,7 +475,10 @@ const AgentsPage: FC = () => {
 							...previousChat.chat,
 							status: updatedChat.status,
 							title: updatedChat.title,
-							updated_at: updatedChat.updated_at,
+							updated_at:
+								previousChat.chat.updated_at > updatedChat.updated_at
+									? previousChat.chat.updated_at
+									: updatedChat.updated_at,
 						},
 					};
 				},

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -53,6 +53,7 @@ import {
 import { NavLink, useParams } from "react-router";
 import { cn } from "utils/cn";
 import { shortRelativeTime } from "utils/time";
+import { getTimeGroup, TIME_GROUPS } from "./timeGroups";
 
 interface AgentsSidebarProps {
 	chats: readonly Chat[];
@@ -87,24 +88,6 @@ type ChatTree = {
 	readonly childrenById: ReadonlyMap<string, readonly string[]>;
 	readonly parentById: ReadonlyMap<string, string | undefined>;
 };
-
-const TIME_GROUPS = ["Today", "Yesterday", "This Week", "Older"] as const;
-type TimeGroup = (typeof TIME_GROUPS)[number];
-
-function getTimeGroup(dateStr: string): TimeGroup {
-	const now = new Date();
-	const date = new Date(dateStr);
-	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-	const yesterday = new Date(today);
-	yesterday.setDate(yesterday.getDate() - 1);
-	const weekAgo = new Date(today);
-	weekAgo.setDate(weekAgo.getDate() - 7);
-
-	if (date >= today) return "Today";
-	if (date >= yesterday) return "Yesterday";
-	if (date >= weekAgo) return "This Week";
-	return "Older";
-}
 
 const getStatusConfig = (status: ChatStatus) => {
 	return statusConfig[status] ?? statusConfig.completed;

--- a/site/src/pages/AgentsPage/timeGroups.test.ts
+++ b/site/src/pages/AgentsPage/timeGroups.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getTimeGroup, TIME_GROUPS } from "./timeGroups";
+
+describe("getTimeGroup", () => {
+	beforeEach(() => {
+		// Pin "now" to 2025-07-15T14:30:00.000Z (a Tuesday) so all
+		// assertions are deterministic.
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2025-07-15T14:30:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("exports the expected group labels in order", () => {
+		expect(TIME_GROUPS).toEqual(["Today", "Yesterday", "This Week", "Older"]);
+	});
+
+	it('returns "Today" for a date later today', () => {
+		expect(getTimeGroup("2025-07-15T18:00:00.000Z")).toBe("Today");
+	});
+
+	it('returns "Today" for a date at start of today (midnight)', () => {
+		expect(getTimeGroup("2025-07-15T00:00:00.000Z")).toBe("Today");
+	});
+
+	it('returns "Today" for a date earlier today', () => {
+		expect(getTimeGroup("2025-07-15T08:00:00.000Z")).toBe("Today");
+	});
+
+	it('returns "Yesterday" for a date in the previous calendar day', () => {
+		expect(getTimeGroup("2025-07-14T10:00:00.000Z")).toBe("Yesterday");
+	});
+
+	it('returns "Yesterday" for exactly midnight of yesterday', () => {
+		expect(getTimeGroup("2025-07-14T00:00:00.000Z")).toBe("Yesterday");
+	});
+
+	it('returns "This Week" for a date 2 days ago', () => {
+		expect(getTimeGroup("2025-07-13T12:00:00.000Z")).toBe("This Week");
+	});
+
+	it('returns "This Week" for a date 6 days ago', () => {
+		expect(getTimeGroup("2025-07-09T12:00:00.000Z")).toBe("This Week");
+	});
+
+	it('returns "This Week" for exactly 7 days ago at midnight', () => {
+		// weekAgo = today - 7 days = 2025-07-08T00:00:00 local.
+		// A date at exactly that boundary should be "This Week"
+		// because the comparison is date >= weekAgo.
+		expect(getTimeGroup("2025-07-08T00:00:00.000Z")).toBe("This Week");
+	});
+
+	it('returns "Older" for a date 8 days ago', () => {
+		expect(getTimeGroup("2025-07-07T23:59:59.000Z")).toBe("Older");
+	});
+
+	it('returns "Older" for a date far in the past', () => {
+		expect(getTimeGroup("2024-01-01T00:00:00.000Z")).toBe("Older");
+	});
+
+	it('returns "Today" for a date in the future', () => {
+		expect(getTimeGroup("2025-07-20T00:00:00.000Z")).toBe("Today");
+	});
+
+	describe("midnight boundary edge cases", () => {
+		it('classifies 1 second before midnight as "Yesterday"', () => {
+			// One second before today's midnight in UTC.
+			expect(getTimeGroup("2025-07-14T23:59:59.000Z")).toBe("Yesterday");
+		});
+
+		it('classifies exactly midnight as "Today"', () => {
+			expect(getTimeGroup("2025-07-15T00:00:00.000Z")).toBe("Today");
+		});
+
+		it('classifies 1 second after midnight as "Today"', () => {
+			expect(getTimeGroup("2025-07-15T00:00:01.000Z")).toBe("Today");
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/timeGroups.ts
+++ b/site/src/pages/AgentsPage/timeGroups.ts
@@ -1,0 +1,26 @@
+/**
+ * Time-based grouping utility used by the sidebar to categorize
+ * chats into "Today", "Yesterday", "This Week", and "Older".
+ */
+export const TIME_GROUPS = [
+	"Today",
+	"Yesterday",
+	"This Week",
+	"Older",
+] as const;
+export type TimeGroup = (typeof TIME_GROUPS)[number];
+
+export function getTimeGroup(dateStr: string): TimeGroup {
+	const now = new Date();
+	const date = new Date(dateStr);
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const yesterday = new Date(today);
+	yesterday.setDate(yesterday.getDate() - 1);
+	const weekAgo = new Date(today);
+	weekAgo.setDate(weekAgo.getDate() - 7);
+
+	if (date >= today) return "Today";
+	if (date >= yesterday) return "Yesterday";
+	if (date >= weekAgo) return "This Week";
+	return "Older";
+}

--- a/site/src/pages/AgentsPage/timeGroups.ts
+++ b/site/src/pages/AgentsPage/timeGroups.ts
@@ -8,7 +8,7 @@ export const TIME_GROUPS = [
 	"This Week",
 	"Older",
 ] as const;
-export type TimeGroup = (typeof TIME_GROUPS)[number];
+type TimeGroup = (typeof TIME_GROUPS)[number];
 
 export function getTimeGroup(dateStr: string): TimeGroup {
 	const now = new Date();


### PR DESCRIPTION
## Problem

When clicking into an agent chat, it briefly jumps to the "Yesterday" group in the sidebar and then pops back to "Today". This is caused by a race between two WebSocket-driven `updated_at` writers:

1. **Per-chat WebSocket** (`ChatContext.ts`) — on status/message/error events, was setting `updated_at` to `new Date().toISOString()` (a fabricated client-side timestamp).
2. **Global chat-list WebSocket** (`AgentsPage.tsx`) — delivers the server's authoritative `updated_at`, which may be older than what the per-chat WS just wrote.

The per-chat WS fires first (→ "Today"), then the global WS overwrites with the older server value (→ "Yesterday"), then the next real update corrects it (→ "Today").

## Fix

Two changes:

### 1. Stop fabricating `updated_at` in the per-chat WebSocket handler

The per-chat WS handler (`updateSidebarChat`) only needs to update `status`. The `updated_at` field is never sent to the database — it was purely a client-side cache mutation. The authoritative value comes from the server via the global chat-list WS and `refetchOnWindowFocus`. Removed all three `updated_at` writes from `ChatContext.ts` (message, status, error handlers).

### 2. Apply `max(existing, incoming)` in the global WS handler

In `AgentsPage.tsx`, the global chat-list WS handler now uses `max(c.updated_at, updatedChat.updated_at)` so that even out-of-order server events cannot regress the timestamp. This is a belt-and-suspenders defense.

## Tests

- **3 tests** verifying the per-chat WS does not touch `updated_at` on message, status, or error events
- **1 test** verifying `updated_at` is preserved when a message arrives (was previously asserting the message timestamp was written — now asserts it stays unchanged)
- **15 tests** for `getTimeGroup` (extracted to `timeGroups.ts`) covering all four groups and midnight boundary edge cases
- **11 tests** for `archiveChat`/`unarchiveChat` optimistic updates, rollbacks, and invalidation
- **4 tests** for `updateSidebarChat` via status/message/error stream events and isolation

**58 total tests across 3 files, all passing.**