### PR TITLE
fix: render +0 -0 diff stats for zero-line changes (e.g. images)

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -340,7 +340,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 	const changedFiles = diffStatus?.changed_files ?? 0;
 	const additions = diffStatus?.additions ?? 0;
 	const deletions = diffStatus?.deletions ?? 0;
-	const hasLineStats = additions > 0 || deletions > 0;
+	const hasLineStats = additions > 0 || deletions > 0 || changedFiles > 0;
 	const filesChangedLabel = `${changedFiles} ${
 		changedFiles === 1 ? "file" : "files"
 	}`;
@@ -436,18 +436,14 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 											className="inline-flex shrink-0 items-center gap-0.5 font-mono text-xs font-medium leading-none tabular-nums"
 											title={`${filesChangedLabel}, +${additions} -${deletions}`}
 										>
-											{additions > 0 && (
-												<span className="text-green-700 dark:text-green-500">
-													+{additions}
-												</span>
-											)}
-											{deletions > 0 && (
-												<span className="text-red-700 dark:text-red-400">
-													&minus;{deletions}
-												</span>
-											)}{" "}
+											<span className="text-green-700 dark:text-green-500">
+												+{additions}
+											</span>
+											<span className="text-red-700 dark:text-red-400">
+												&minus;{deletions}
+											</span>{" "}
 										</span>
-									)}
+									)}{" "}
 									<div
 										className={cn(
 											"min-w-0 overflow-hidden text-[13px] leading-4",

--- a/site/src/pages/AgentsPage/DiffStats.tsx
+++ b/site/src/pages/AgentsPage/DiffStats.tsx
@@ -10,16 +10,14 @@ interface DiffStatsProps {
 
 /**
  * Renders +N / −N counters for diff additions and deletions.
- * Returns null when both values are zero.
+ * Always renders both counters so that zero-line changes (e.g.
+ * binary files like images) still display "+0 −0".
  */
 const DiffStatNumbers: FC<DiffStatsProps> = ({
 	additions,
 	deletions,
 	className,
 }) => {
-	if (additions === 0 && deletions === 0) {
-		return null;
-	}
 	return (
 		<span
 			className={cn(
@@ -27,14 +25,8 @@ const DiffStatNumbers: FC<DiffStatsProps> = ({
 				className,
 			)}
 		>
-			{additions > 0 && (
-				<span className="text-green-700 dark:text-green-500">+{additions}</span>
-			)}
-			{deletions > 0 && (
-				<span className="text-red-700 dark:text-red-400">
-					&minus;{deletions}
-				</span>
-			)}
+			<span className="text-green-700 dark:text-green-500">+{additions}</span>
+			<span className="text-red-700 dark:text-red-400">&minus;{deletions}</span>
 		</span>
 	);
 };
@@ -48,21 +40,18 @@ export const DiffStatBadge: FC<{ diffStatus?: ChatDiffStatusResponse }> = ({
 }) => {
 	const additions = diffStatus?.additions ?? 0;
 	const deletions = diffStatus?.deletions ?? 0;
-	if (additions === 0 && deletions === 0) {
+	const hasChangedFiles = (diffStatus?.changed_files ?? 0) > 0;
+	if (!hasChangedFiles && additions === 0 && deletions === 0) {
 		return null;
 	}
 	return (
 		<span className="inline-flex h-full items-center self-stretch overflow-hidden rounded-[calc(theme(borderRadius.md)-1px)] font-mono text-xs font-medium">
-			{additions > 0 && (
-				<span className="flex h-full items-center bg-green-100 dark:bg-green-950 px-1.5 text-green-700 dark:text-green-500">
-					+{additions}
-				</span>
-			)}
-			{deletions > 0 && (
-				<span className="flex h-full items-center bg-red-100 dark:bg-red-950 px-1.5 text-red-700 dark:text-red-400">
-					&minus;{deletions}
-				</span>
-			)}
+			<span className="flex h-full items-center bg-green-100 dark:bg-green-950 px-1.5 text-green-700 dark:text-green-500">
+				+{additions}
+			</span>
+			<span className="flex h-full items-center bg-red-100 dark:bg-red-950 px-1.5 text-red-700 dark:text-red-400">
+				&minus;{deletions}
+			</span>
 		</span>
 	);
 };
@@ -77,8 +66,9 @@ export const DiffStatsInline: FC<{
 }> = ({ status, onClick }) => {
 	const additions = status.additions ?? 0;
 	const deletions = status.deletions ?? 0;
+	const hasChangedFiles = (status.changed_files ?? 0) > 0;
 
-	if (additions === 0 && deletions === 0) {
+	if (!hasChangedFiles && additions === 0 && deletions === 0) {
 		return null;
 	}
 


### PR DESCRIPTION
When a git change has zero additions and zero deletions (like adding a binary file/image), the diff stats were hidden entirely because of `additions === 0 && deletions === 0` early-return guards.

This changes the behavior so that `+0 -0` is always rendered when there are changed files, ensuring visibility in both the sidebar and the Git tab.

### Changes

**`DiffStats.tsx`**
- `DiffStatNumbers`: Removed the `null` early return — always renders both `+N` and `−N` counters.
- `DiffStatBadge`: Now only returns `null` when there are no changed files AND both counts are zero. Always renders both pills.
- `DiffStatsInline`: Same guard — shows `+0 −0` clickable stats when files changed but lines are zero.

**`AgentsSidebar.tsx`**
- `hasLineStats` now also checks `changedFiles > 0`, so the sidebar entry shows `+0 -0` for binary-only diffs.
- Removed the `additions > 0` / `deletions > 0` conditional wrappers — both values are always rendered.