### PR TITLE
docs: add platform controls page for Coder Agents

### DIFF
--- a/docs/ai-coder/agents/platform-controls.md
+++ b/docs/ai-coder/agents/platform-controls.md
@@ -11,10 +11,11 @@ This means:
 - **All agent configuration is admin-level.** Providers, models, system prompts,
   and tool permissions are set by platform teams from the control plane. These
   are not user preferences — they are deployment-wide policies.
-- **Developers get zero options to manage.** The only choice a developer makes is
-  which workspace to use. They do not configure providers, enter API keys, or
-  modify system prompts. If no models are configured, the chat interface tells
-  them to contact an administrator.
+- **Developers never need to configure anything.** A developer just describes
+  the work they want done. They do not need to pick a provider, enter an API
+  key, or write a system prompt — the platform team has already set all of
+  that up. The goal is not to restrict developers, but to make configuration
+  unnecessary for a great experience.
 - **Enforcement, not defaults.** Settings configured by administrators are
   enforced server-side. Developers cannot override them. This is a deliberate
   distinction — a setting that a user can change is a preference, not a policy.
@@ -92,10 +93,6 @@ Examples of what this looks like:
   from the control plane, agent workspaces do not need outbound access to LLM
   providers. You can create templates that only permit access to your git
   provider and nothing else.
-- **Git proxy.** We are working on a git proxy server built into the control
-  plane, so that agent workspaces can pull and push to git without needing
-  direct network access to your git provider. This further reduces the network
-  surface of agent workspaces.
 - **Template scoping for agents.** We intend to let administrators restrict
   which templates are available in the agentic interface, separate from what
   developers see when manually creating workspaces. This lets you apply stricter

--- a/docs/ai-coder/agents/platform-controls.md
+++ b/docs/ai-coder/agents/platform-controls.md
@@ -1,0 +1,144 @@
+# Platform Controls
+
+This page describes how Coder Agents gives platform teams centralized control
+over agent behavior, and the principles behind our approach.
+
+## Design philosophy
+
+Coder Agents is built on a simple premise: platform teams should have full
+control over how agents operate, and developers should have zero configuration
+burden.
+
+This means:
+
+- **All agent configuration is admin-level.** Providers, models, system prompts,
+  and tool permissions are set by platform teams from the control plane. These
+  are not user preferences — they are deployment-wide policies.
+- **Developers get zero options to manage.** The only choice a developer makes is
+  which workspace to use. They do not configure providers, enter API keys, or
+  modify system prompts. If no models are configured, the chat interface tells
+  them to contact an administrator.
+- **Enforcement, not defaults.** Settings configured by administrators are
+  enforced server-side. Developers cannot override them. This is a deliberate
+  distinction — a setting that a user can change is a preference, not a policy.
+
+This is an architectural decision, not just a product choice. Because the agent
+loop runs in the control plane rather than inside developer workspaces, there is
+no local configuration for developers to modify and no agent software for them
+to reconfigure. The control plane is the single source of truth for how agents
+behave.
+
+## What platform teams control today
+
+### Providers and models
+
+Administrators configure which LLM providers and models are available from the
+Coder dashboard. This includes API keys, base URLs (for enterprise proxies or
+self-hosted models), and per-model parameters like context limits, thinking
+budgets, and reasoning effort.
+
+Developers select from the set of models an administrator has enabled. They
+cannot add their own providers, supply their own API keys, or access models that
+have not been explicitly configured.
+
+See [Models](./models.md) for setup instructions.
+
+### System prompt
+
+Administrators can set a system prompt that applies to all agent sessions. This
+is useful for establishing organizational conventions — coding standards,
+commit message formats, preferred libraries, or repository-specific context.
+
+The system prompt is enforced server-side. Developers cannot view or override it.
+
+### Template routing
+
+Platform teams control which templates are available to agents and how the agent
+selects them. When a developer describes a task, the agent reads template
+descriptions to determine which template to provision.
+
+By writing clear template descriptions — for example, "Use this template for
+Python backend services in the payments repo" — platform teams can guide the
+agent toward the correct infrastructure without requiring developers to
+understand template selection at all.
+
+## Where we are headed
+
+Coder Agents is in its early stages. The controls above — providers, models,
+and system prompt — are what is available today. We are actively building
+toward a broader set of platform controls based on what we are hearing from
+customers deploying agents in regulated and enterprise environments.
+
+The areas we are investing in include:
+
+### Usage controls and analytics
+
+We plan to give platform teams visibility into how agents are being used across
+the organization: token consumption per user, cost per PR, merge rates by model,
+and average time from prompt to merged pull request.
+
+The goal is to let platform teams make data-driven decisions — like switching
+the default model when analytics show one model produces higher merge rates —
+rather than relying on anecdotal feedback from individual developers.
+
+### Infrastructure-level enforcement
+
+We believe that security-critical behaviors should not depend on the system
+prompt. A system prompt can instruct an agent to "always push to the internal
+GitHub," but there is no guarantee the agent will comply every time.
+
+For controls that matter — network boundaries, git push targets, allowed
+hostnames — we intend to enforce them at the infrastructure and network layer.
+Examples of what this looks like:
+
+- **Network-restricted templates for agent workloads.** Because the AI comes
+  from the control plane, agent workspaces do not need outbound access to LLM
+  providers. You can create templates that only permit access to your git
+  provider and nothing else.
+- **Git proxy.** We are working on a git proxy server built into the control
+  plane, so that agent workspaces can pull and push to git without needing
+  direct network access to your git provider. This further reduces the network
+  surface of agent workspaces.
+- **Template scoping for agents.** We intend to let administrators restrict
+  which templates are available in the agentic interface, separate from what
+  developers see when manually creating workspaces. This lets you apply stricter
+  policies to agent-created workspaces without affecting the developer
+  experience for manually-created ones.
+
+### Tool customization
+
+The agent ships with a standard set of tools (file read/write, shell execution,
+sub-agents). We intend to let platform teams customize the available tool set —
+adding organization-specific tools or restricting default ones — without
+modifying agent source code.
+
+## Why we take this approach
+
+The common pattern in the industry today is that each developer installs and
+configures their own coding agent inside their development environment. This
+creates several problems for platform teams:
+
+- **No standardization.** Different developers use different agents with
+  different configurations. There is no unified way to enforce conventions or
+  improve the experience across the organization.
+- **Security is ad-hoc.** If the agent runs inside the workspace, it has access
+  to whatever the workspace has access to — API keys, network endpoints,
+  credentials. Restricting this requires per-workspace configuration that is
+  difficult to maintain at scale.
+- **Feedback is anecdotal.** Without centralized analytics, platform teams have
+  no way to know which models perform best, which prompts cause failures, or how
+  much agents are costing the organization.
+- **Configuration is a developer burden.** Developers — especially those who
+  are not power users — should not need to think about which agent to install,
+  which API key to use, or how to configure a system prompt. They should
+  describe the work they want done.
+
+Coder Agents addresses these problems by moving agent configuration out of
+developer hands entirely. Platform teams configure once, at the deployment
+level. Developers get a consistent, high-quality experience without needing to
+manage anything.
+
+As models improve and the differences between agent harnesses continue to
+shrink, we believe the leverage shifts toward platform-level controls: which
+models to offer, how to enforce security, and how to use analytics to
+continuously improve the development experience across the organization.

--- a/docs/ai-coder/agents/platform-controls.md
+++ b/docs/ai-coder/agents/platform-controls.md
@@ -1,8 +1,5 @@
 # Platform Controls
 
-This page describes how Coder Agents gives platform teams centralized control
-over agent behavior, and the principles behind our approach.
-
 ## Design philosophy
 
 Coder Agents is built on a simple premise: platform teams should have full
@@ -49,7 +46,8 @@ Administrators can set a system prompt that applies to all agent sessions. This
 is useful for establishing organizational conventions — coding standards,
 commit message formats, preferred libraries, or repository-specific context.
 
-The system prompt is enforced server-side. Developers cannot view or override it.
+The system prompt configuration is only accessible to administrators in the
+dashboard. Developers do not see or interact with it.
 
 ### Template routing
 
@@ -84,8 +82,7 @@ rather than relying on anecdotal feedback from individual developers.
 ### Infrastructure-level enforcement
 
 We believe that security-critical behaviors should not depend on the system
-prompt. A system prompt can instruct an agent to "always push to the internal
-GitHub," but there is no guarantee the agent will comply every time.
+prompt. A system prompt can instruct an agent to "always format branch names like... ," but there is no guarantee the agent will comply every time.
 
 For controls that matter — network boundaries, git push targets, allowed
 hostnames — we intend to enforce them at the infrastructure and network layer.
@@ -133,12 +130,7 @@ creates several problems for platform teams:
   which API key to use, or how to configure a system prompt. They should
   describe the work they want done.
 
-Coder Agents addresses these problems by moving agent configuration out of
-developer hands entirely. Platform teams configure once, at the deployment
-level. Developers get a consistent, high-quality experience without needing to
-manage anything.
-
 As models improve and the differences between agent harnesses continue to
-shrink, we believe the leverage shifts toward platform-level controls: which
+shrink, we believe the leverage shifts toward user experience and platform-level controls: which
 models to offer, how to enforce security, and how to use analytics to
 continuously improve the development experience across the organization.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1242,7 +1242,7 @@
           "children": [
             {
               "title": "Architecture",
-              "description": "How the agent in the control plane communicates with workspaces",
+              "description": "How the Coder agent communicates with workspaces",
               "path": "./ai-coder/agents/architecture.md"
             },
             {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,2340 +1,2287 @@
 {
-  "versions": [
-    "main"
-  ],
-  "routes": [
-    {
-      "title": "About",
-      "description": "Coder docs",
-      "path": "./README.md",
-      "icon_path": "./images/icons/home.svg",
-      "children": [
-        {
-          "title": "Screenshots",
-          "description": "View screenshots of the Coder platform",
-          "path": "./about/screenshots.md"
-        },
-        {
-          "title": "Quickstart",
-          "description": "Learn how to install and run Coder quickly",
-          "path": "./tutorials/quickstart.md"
-        },
-        {
-          "title": "Support",
-          "description": "How Coder supports your deployment and you",
-          "path": "./support/index.md",
-          "children": [
-            {
-              "title": "Generate a Support Bundle",
-              "description": "Generate and upload a Support Bundle to Coder Support",
-              "path": "./support/support-bundle.md"
-            }
-          ]
-        },
-        {
-          "title": "Contributing",
-          "description": "Learn how to contribute to Coder",
-          "path": "./about/contributing/CONTRIBUTING.md",
-          "icon_path": "./images/icons/contributing.svg",
-          "children": [
-            {
-              "title": "Code of Conduct",
-              "description": "See the code of conduct for contributing to Coder",
-              "path": "./about/contributing/CODE_OF_CONDUCT.md",
-              "icon_path": "./images/icons/circle-dot.svg"
-            },
-            {
-              "title": "Documentation",
-              "description": "Our style guide for use when authoring documentation",
-              "path": "./about/contributing/documentation.md",
-              "icon_path": "./images/icons/document.svg"
-            },
-            {
-              "title": "Modules",
-              "description": "Learn how to contribute modules to Coder",
-              "path": "./about/contributing/modules.md",
-              "icon_path": "./images/icons/gear.svg"
-            },
-            {
-              "title": "Templates",
-              "description": "Learn how to contribute templates to Coder",
-              "path": "./about/contributing/templates.md",
-              "icon_path": "./images/icons/picture.svg"
-            },
-            {
-              "title": "Backend",
-              "description": "Our guide for backend development",
-              "path": "./about/contributing/backend.md",
-              "icon_path": "./images/icons/gear.svg"
-            },
-            {
-              "title": "Frontend",
-              "description": "Our guide for frontend development",
-              "path": "./about/contributing/frontend.md",
-              "icon_path": "./images/icons/frontend.svg"
-            },
-            {
-              "title": "Security",
-              "description": "Security vulnerability disclosure policy",
-              "path": "./about/contributing/SECURITY.md",
-              "icon_path": "./images/icons/lock.svg"
-            },
-            {
-              "title": "AI Contribution Guidelines",
-              "description": "Guidelines for AI-generated contributions.",
-              "path": "./about/contributing/AI_CONTRIBUTING.md",
-              "icon_path": "./images/icons/ai_intelligence.svg"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "Install",
-      "description": "Installing Coder",
-      "path": "./install/index.md",
-      "icon_path": "./images/icons/download.svg",
-      "children": [
-        {
-          "title": "Coder CLI",
-          "description": "Install the standalone binary",
-          "path": "./install/cli.md",
-          "icon_path": "./images/icons/terminal.svg"
-        },
-        {
-          "title": "Docker",
-          "description": "Install Coder using Docker",
-          "path": "./install/docker.md",
-          "icon_path": "./images/icons/docker.svg"
-        },
-        {
-          "title": "Kubernetes",
-          "description": "Install Coder on Kubernetes",
-          "path": "./install/kubernetes.md",
-          "icon_path": "./images/icons/kubernetes.svg",
-          "children": [
-            {
-              "title": "Deploy Coder on Azure with an Application Gateway",
-              "description": "Deploy Coder on Azure with an Application Gateway",
-              "path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
-            }
-          ]
-        },
-        {
-          "title": "Rancher",
-          "description": "Deploy Coder on Rancher",
-          "path": "./install/rancher.md",
-          "icon_path": "./images/icons/rancher.svg"
-        },
-        {
-          "title": "OpenShift",
-          "description": "Install Coder on OpenShift",
-          "path": "./install/openshift.md",
-          "icon_path": "./images/icons/openshift.svg"
-        },
-        {
-          "title": "Cloud Providers",
-          "description": "Install Coder on cloud providers",
-          "path": "./install/cloud/index.md",
-          "icon_path": "./images/icons/cloud.svg",
-          "children": [
-            {
-              "title": "AWS EC2",
-              "description": "Install Coder on AWS EC2",
-              "path": "./install/cloud/ec2.md"
-            },
-            {
-              "title": "GCP Compute Engine",
-              "description": "Install Coder on GCP Compute Engine",
-              "path": "./install/cloud/compute-engine.md"
-            },
-            {
-              "title": "Azure VM",
-              "description": "Install Coder on an Azure VM",
-              "path": "./install/cloud/azure-vm.md"
-            }
-          ]
-        },
-        {
-          "title": "Air-gapped Deployments",
-          "description": "Run Coder in air-gapped / disconnected / offline environments",
-          "path": "./install/airgap.md",
-          "icon_path": "./images/icons/lan.svg"
-        },
-        {
-          "title": "Unofficial Install Methods",
-          "description": "Other installation methods",
-          "path": "./install/other/index.md",
-          "icon_path": "./images/icons/generic.svg"
-        },
-        {
-          "title": "Upgrading",
-          "description": "Learn how to upgrade Coder",
-          "path": "./install/upgrade.md",
-          "icon_path": "./images/icons/upgrade.svg",
-          "children": [
-            {
-              "title": "Upgrading Best Practices",
-              "description": "Best practices and troubleshooting for Coder upgrades",
-              "path": "./install/upgrade-best-practices.md"
-            }
-          ]
-        },
-        {
-          "title": "Uninstall",
-          "description": "Learn how to uninstall Coder",
-          "path": "./install/uninstall.md",
-          "icon_path": "./images/icons/trash.svg"
-        },
-        {
-          "title": "Releases",
-          "description": "Learn about the Coder release channels and schedule",
-          "path": "./install/releases/index.md",
-          "icon_path": "./images/icons/star.svg",
-          "children": [
-            {
-              "title": "Feature stages",
-              "description": "Information about pre-GA stages.",
-              "path": "./install/releases/feature-stages.md"
-            },
-            {
-              "title": "Upgrading from ESR 2.24 to 2.29",
-              "description": "Upgrade Guide for ESR Releases",
-              "path": "./install/releases/esr-2.24-2.29-upgrade.md"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "User Guides",
-      "description": "Guides for end-users of Coder",
-      "path": "./user-guides/index.md",
-      "icon_path": "./images/icons/users.svg",
-      "children": [
-        {
-          "title": "Access Workspaces",
-          "description": "Connect to your Coder workspaces",
-          "path": "./user-guides/workspace-access/index.md",
-          "icon_path": "./images/icons/access.svg",
-          "children": [
-            {
-              "title": "Visual Studio Code",
-              "description": "Use VSCode with Coder in the desktop or browser",
-              "path": "./user-guides/workspace-access/vscode.md"
-            },
-            {
-              "title": "Web Terminal",
-              "description": "Use the browser-based terminal to access your workspace",
-              "path": "./user-guides/workspace-access/web-terminal.md"
-            },
-            {
-              "title": "JetBrains IDEs",
-              "description": "Use JetBrains IDEs with Coder",
-              "path": "./user-guides/workspace-access/jetbrains/index.md",
-              "children": [
-                {
-                  "title": "JetBrains Fleet",
-                  "description": "Connect JetBrains Fleet to a Coder workspace",
-                  "path": "./user-guides/workspace-access/jetbrains/fleet.md"
-                },
-                {
-                  "title": "JetBrains Gateway",
-                  "description": "Use JetBrains Gateway to connect to Coder workspaces",
-                  "path": "./user-guides/workspace-access/jetbrains/gateway.md"
-                },
-                {
-                  "title": "JetBrains Toolbox",
-                  "description": "Access Coder workspaces from JetBrains Toolbox",
-                  "path": "./user-guides/workspace-access/jetbrains/toolbox.md",
-                  "state": [
-                    "beta"
-                  ]
-                }
-              ]
-            },
-            {
-              "title": "Remote Desktop",
-              "description": "Use RDP in Coder",
-              "path": "./user-guides/workspace-access/remote-desktops.md"
-            },
-            {
-              "title": "Emacs TRAMP",
-              "description": "Use Emacs TRAMP in Coder",
-              "path": "./user-guides/workspace-access/emacs-tramp.md"
-            },
-            {
-              "title": "Port Forwarding",
-              "description": "Access ports on your workspace",
-              "path": "./user-guides/workspace-access/port-forwarding.md"
-            },
-            {
-              "title": "Filebrowser",
-              "description": "Access your workspace files",
-              "path": "./user-guides/workspace-access/filebrowser.md"
-            },
-            {
-              "title": "Web IDEs and Coder Apps",
-              "description": "Access your workspace with IDEs in the browser",
-              "path": "./user-guides/workspace-access/web-ides.md"
-            },
-            {
-              "title": "code-server",
-              "description": "Access your workspace with code-server",
-              "path": "./user-guides/workspace-access/code-server.md"
-            },
-            {
-              "title": "Zed",
-              "description": "Access your workspace with Zed",
-              "path": "./user-guides/workspace-access/zed.md"
-            },
-            {
-              "title": "Cursor",
-              "description": "Access your workspace with Cursor",
-              "path": "./user-guides/workspace-access/cursor.md"
-            },
-            {
-              "title": "Windsurf",
-              "description": "Access your workspace with Windsurf",
-              "path": "./user-guides/workspace-access/windsurf.md"
-            },
-            {
-              "title": "Antigravity",
-              "description": "Access your workspace with Antigravity",
-              "path": "./user-guides/workspace-access/antigravity.md"
-            }
-          ]
-        },
-        {
-          "title": "Coder Desktop",
-          "description": "Transform remote workspaces into seamless local development environments with no port forwarding required",
-          "path": "./user-guides/desktop/index.md",
-          "icon_path": "./images/icons/computer-code.svg",
-          "children": [
-            {
-              "title": "Coder Desktop Connect and Sync",
-              "description": "Use Coder Desktop to manage your workspace code and files locally",
-              "path": "./user-guides/desktop/desktop-connect-sync.md"
-            }
-          ]
-        },
-        {
-          "title": "Workspace Management",
-          "description": "Manage workspaces",
-          "path": "./user-guides/workspace-management.md",
-          "icon_path": "./images/icons/generic.svg"
-        },
-        {
-          "title": "Workspace Sharing",
-          "description": "Sharing workspaces",
-          "path": "./user-guides/shared-workspaces.md",
-          "icon_path": "./images/icons/generic.svg",
-          "state": [
-            "beta"
-          ]
-        },
-        {
-          "title": "Workspace Scheduling",
-          "description": "Cost control with workspace schedules",
-          "path": "./user-guides/workspace-scheduling.md",
-          "icon_path": "./images/icons/stopwatch.svg"
-        },
-        {
-          "title": "Workspace Lifecycle",
-          "description": "A guide to the workspace lifecycle, from creation and status through stopping and deletion.",
-          "path": "./user-guides/workspace-lifecycle.md",
-          "icon_path": "./images/icons/circle-dot.svg"
-        },
-        {
-          "title": "Dev Containers",
-          "description": "Run containerized development environments in your Coder workspace using the dev containers specification.",
-          "path": "./user-guides/devcontainers/index.md",
-          "icon_path": "./images/icons/container.svg",
-          "children": [
-            {
-              "title": "Working with dev containers",
-              "description": "Access dev containers via SSH, your IDE, or web terminal.",
-              "path": "./user-guides/devcontainers/working-with-dev-containers.md"
-            },
-            {
-              "title": "Customizing dev containers",
-              "description": "Configure custom agent names, apps, and display options in devcontainer.json.",
-              "path": "./user-guides/devcontainers/customizing-dev-containers.md"
-            },
-            {
-              "title": "Troubleshooting dev containers",
-              "description": "Diagnose and resolve common issues with dev containers in your Coder workspace.",
-              "path": "./user-guides/devcontainers/troubleshooting-dev-containers.md"
-            }
-          ]
-        },
-        {
-          "title": "Dotfiles",
-          "description": "Personalize your environment with dotfiles",
-          "path": "./user-guides/workspace-dotfiles.md",
-          "icon_path": "./images/icons/art-pad.svg"
-        }
-      ]
-    },
-    {
-      "title": "Administration",
-      "description": "Guides for template and deployment administrators",
-      "path": "./admin/index.md",
-      "icon_path": "./images/icons/wrench.svg",
-      "children": [
-        {
-          "title": "Setup",
-          "description": "Configure user access to your control plane.",
-          "path": "./admin/setup/index.md",
-          "icon_path": "./images/icons/toggle_on.svg",
-          "children": [
-            {
-              "title": "Appearance",
-              "description": "Learn how to configure the appearance of Coder",
-              "path": "./admin/setup/appearance.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Telemetry",
-              "description": "Learn what usage telemetry Coder collects",
-              "path": "./admin/setup/telemetry.md"
-            },
-            {
-              "title": "Data Retention",
-              "description": "Configure data retention policies for database tables",
-              "path": "./admin/setup/data-retention.md"
-            }
-          ]
-        },
-        {
-          "title": "Infrastructure",
-          "description": "How to integrate Coder with your organization's compute",
-          "path": "./admin/infrastructure/index.md",
-          "icon_path": "./images/icons/container.svg",
-          "children": [
-            {
-              "title": "Architecture",
-              "description": "Learn about Coder's architecture",
-              "path": "./admin/infrastructure/architecture.md"
-            },
-            {
-              "title": "Validated Architectures",
-              "description": "Architectures for large Coder deployments",
-              "path": "./admin/infrastructure/validated-architectures/index.md",
-              "children": [
-                {
-                  "title": "Up to 1,000 Users",
-                  "description": "Hardware specifications and architecture guidance for Coder deployments that support up to 1,000 users",
-                  "path": "./admin/infrastructure/validated-architectures/1k-users.md"
-                },
-                {
-                  "title": "Up to 2,000 Users",
-                  "description": "Hardware specifications and architecture guidance for Coder deployments that support up to 2,000 users",
-                  "path": "./admin/infrastructure/validated-architectures/2k-users.md"
-                },
-                {
-                  "title": "Up to 3,000 Users",
-                  "description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 3,000 users",
-                  "path": "./admin/infrastructure/validated-architectures/3k-users.md"
-                },
-                {
-                  "title": "Up to 10,000 Users",
-                  "description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 10,000 users",
-                  "path": "./admin/infrastructure/validated-architectures/10k-users.md"
-                }
-              ]
-            },
-            {
-              "title": "Scale Testing",
-              "description": "Ensure your deployment can handle your organization's needs",
-              "path": "./admin/infrastructure/scale-testing.md"
-            },
-            {
-              "title": "Scaling Utilities",
-              "description": "Tools to help you scale your deployment",
-              "path": "./admin/infrastructure/scale-utility.md"
-            },
-            {
-              "title": "Scaling best practices",
-              "description": "How to prepare a Coder deployment for scale",
-              "path": "./tutorials/best-practices/scale-coder.md"
-            }
-          ]
-        },
-        {
-          "title": "Users",
-          "description": "Learn how to manage and audit users",
-          "path": "./admin/users/index.md",
-          "icon_path": "./images/icons/users.svg",
-          "children": [
-            {
-              "title": "OIDC Authentication",
-              "description": "Configure OpenID Connect authentication with identity providers like Okta or Active Directory",
-              "path": "./admin/users/oidc-auth/index.md",
-              "children": [
-                {
-                  "title": "Google",
-                  "description": "Configure Google as an OIDC provider",
-                  "path": "./admin/users/oidc-auth/google.md"
-                },
-                {
-                  "title": "Microsoft",
-                  "description": "Configure Microsoft Entra ID as an OIDC provider",
-                  "path": "./admin/users/oidc-auth/microsoft.md"
-                },
-                {
-                  "title": "Configure OIDC refresh tokens",
-                  "description": "How to configure OIDC refresh tokens",
-                  "path": "./admin/users/oidc-auth/refresh-tokens.md"
-                }
-              ]
-            },
-            {
-              "title": "GitHub Authentication",
-              "description": "Set up authentication through GitHub OAuth to enable secure user login and sign-up",
-              "path": "./admin/users/github-auth.md"
-            },
-            {
-              "title": "Password Authentication",
-              "description": "Manage username/password authentication settings and user password reset workflows",
-              "path": "./admin/users/password-auth.md"
-            },
-            {
-              "title": "Headless Authentication",
-              "description": "Create and manage headless service accounts for automated systems and API integrations",
-              "path": "./admin/users/headless-auth.md"
-            },
-            {
-              "title": "Groups & Roles",
-              "description": "Manage access control with user groups and role-based permissions for Coder resources",
-              "path": "./admin/users/groups-roles.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "IdP Sync",
-              "description": "Synchronize user groups, roles, and organizations from your identity provider to Coder",
-              "path": "./admin/users/idp-sync.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Organizations",
-              "description": "Segment and isolate resources by creating separate organizations for different teams or projects",
-              "path": "./admin/users/organizations.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Quotas",
-              "description": "Control resource usage by implementing workspace budgets and credit-based cost management",
-              "path": "./admin/users/quotas.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Sessions & API Tokens",
-              "description": "Manage authentication tokens for API access and configure session duration policies",
-              "path": "./admin/users/sessions-tokens.md"
-            }
-          ]
-        },
-        {
-          "title": "Templates",
-          "description": "Learn how to author and maintain Coder templates",
-          "path": "./admin/templates/index.md",
-          "icon_path": "./images/icons/picture.svg",
-          "children": [
-            {
-              "title": "Creating Templates",
-              "description": "Learn how to create templates with Terraform",
-              "path": "./admin/templates/creating-templates.md"
-            },
-            {
-              "title": "Managing Templates",
-              "description": "Learn how to manage templates and best practices",
-              "path": "./admin/templates/managing-templates/index.md",
-              "children": [
-                {
-                  "title": "Image Management",
-                  "description": "Learn about template image management",
-                  "path": "./admin/templates/managing-templates/image-management.md"
-                },
-                {
-                  "title": "Change Management",
-                  "description": "Learn about template change management and versioning",
-                  "path": "./admin/templates/managing-templates/change-management.md"
-                },
-                {
-                  "title": "Envbuilder",
-                  "description": "Shift environment definition to repositories",
-                  "path": "./admin/templates/managing-templates/envbuilder.md"
-                },
-                {
-                  "title": "Template Dependencies",
-                  "description": "Learn how to manage template dependencies",
-                  "path": "./admin/templates/managing-templates/dependencies.md"
-                },
-                {
-                  "title": "Workspace Scheduling",
-                  "description": "Learn how to control how workspaces are started and stopped",
-                  "path": "./admin/templates/managing-templates/schedule.md"
-                },
-                {
-                  "title": "External Workspaces",
-                  "description": "Learn how to manage external workspaces",
-                  "path": "./admin/templates/managing-templates/external-workspaces.md",
-                  "state": [
-                    "premium",
-                    "early access"
-                  ]
-                }
-              ]
-            },
-            {
-              "title": "Extending Templates",
-              "description": "Learn best practices in extending templates",
-              "path": "./admin/templates/extending-templates/index.md",
-              "children": [
-                {
-                  "title": "Agent Metadata",
-                  "description": "Retrieve real-time stats from the workspace agent",
-                  "path": "./admin/templates/extending-templates/agent-metadata.md"
-                },
-                {
-                  "title": "Build Parameters",
-                  "description": "Use parameters to customize workspaces at build",
-                  "path": "./admin/templates/extending-templates/parameters.md"
-                },
-                {
-                  "title": "Dynamic Parameters",
-                  "description": "Conditional, identity-aware parameter syntax for advanced users.",
-                  "path": "./admin/templates/extending-templates/dynamic-parameters.md"
-                },
-                {
-                  "title": "Prebuilt workspaces",
-                  "description": "Pre-provision a ready-to-deploy workspace with a defined set of parameters",
-                  "path": "./admin/templates/extending-templates/prebuilt-workspaces.md",
-                  "state": [
-                    "premium"
-                  ]
-                },
-                {
-                  "title": "Icons",
-                  "description": "Customize your template with built-in icons",
-                  "path": "./admin/templates/extending-templates/icons.md"
-                },
-                {
-                  "title": "Resource Metadata",
-                  "description": "Display resource state in the workspace dashboard",
-                  "path": "./admin/templates/extending-templates/resource-metadata.md"
-                },
-                {
-                  "title": "Resource Monitoring",
-                  "description": "Monitor resources in the workspace dashboard",
-                  "path": "./admin/templates/extending-templates/resource-monitoring.md"
-                },
-                {
-                  "title": "Resource Ordering",
-                  "description": "Design the UI of workspaces",
-                  "path": "./admin/templates/extending-templates/resource-ordering.md"
-                },
-                {
-                  "title": "Resource Persistence",
-                  "description": "Control resource persistence",
-                  "path": "./admin/templates/extending-templates/resource-persistence.md"
-                },
-                {
-                  "title": "Terraform Variables",
-                  "description": "Use variables to manage template state",
-                  "path": "./admin/templates/extending-templates/variables.md"
-                },
-                {
-                  "title": "Terraform Modules",
-                  "description": "Reuse terraform code across templates",
-                  "path": "./admin/templates/extending-templates/modules.md"
-                },
-                {
-                  "title": "Web IDEs and Coder Apps",
-                  "description": "Add and configure Web IDEs in your templates as coder apps",
-                  "path": "./admin/templates/extending-templates/web-ides.md"
-                },
-                {
-                  "title": "Pre-install JetBrains IDEs",
-                  "description": "Pre-install JetBrains IDEs in a template for faster IDE startup",
-                  "path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
-                },
-                {
-                  "title": "JetBrains IDEs in Air-Gapped Deployments",
-                  "description": "Configure JetBrains IDEs for air-gapped deployments",
-                  "path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
-                },
-                {
-                  "title": "Docker in Workspaces",
-                  "description": "Use Docker in your workspaces",
-                  "path": "./admin/templates/extending-templates/docker-in-workspaces.md"
-                },
-                {
-                  "title": "Workspace Tags",
-                  "description": "Control provisioning using Workspace Tags and Parameters",
-                  "path": "./admin/templates/extending-templates/workspace-tags.md"
-                },
-                {
-                  "title": "Provider Authentication",
-                  "description": "Authenticate with provider APIs to provision workspaces",
-                  "path": "./admin/templates/extending-templates/provider-authentication.md"
-                },
-                {
-                  "title": "Dev Containers",
-                  "description": "Extend templates with containerized dev environments",
-                  "path": "./admin/templates/extending-templates/devcontainers.md"
-                },
-                {
-                  "title": "Process Logging",
-                  "description": "Log workspace processes",
-                  "path": "./admin/templates/extending-templates/process-logging.md",
-                  "state": [
-                    "premium"
-                  ]
-                },
-                {
-                  "title": "Startup Dependencies",
-                  "description": "Coordinate workspace startup with dependency management",
-                  "path": "./admin/templates/startup-coordination/index.md",
-                  "state": [
-                    "early access"
-                  ],
-                  "children": [
-                    {
-                      "title": "Usage",
-                      "description": "How to use startup coordination",
-                      "path": "./admin/templates/startup-coordination/usage.md"
-                    },
-                    {
-                      "title": "Troubleshooting",
-                      "description": "Troubleshoot startup coordination",
-                      "path": "./admin/templates/startup-coordination/troubleshooting.md"
-                    },
-                    {
-                      "title": "Examples",
-                      "description": "Examples of startup coordination",
-                      "path": "./admin/templates/startup-coordination/example.md"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "title": "Open in Coder",
-              "description": "Open workspaces in Coder",
-              "path": "./admin/templates/open-in-coder.md"
-            },
-            {
-              "title": "Permissions & Policies",
-              "description": "Learn how to create templates with Terraform",
-              "path": "./admin/templates/template-permissions.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Troubleshooting Templates",
-              "description": "Learn how to troubleshoot template issues",
-              "path": "./admin/templates/troubleshooting.md"
-            }
-          ]
-        },
-        {
-          "title": "External Provisioners",
-          "description": "Learn how to run external provisioners with Coder",
-          "path": "./admin/provisioners/index.md",
-          "icon_path": "./images/icons/key.svg",
-          "state": [
-            "premium"
-          ],
-          "children": [
-            {
-              "title": "Manage Provisioner Jobs",
-              "description": "Learn how to run external provisioners with Coder",
-              "path": "./admin/provisioners/manage-provisioner-jobs.md",
-              "state": [
-                "premium"
-              ]
-            }
-          ]
-        },
-        {
-          "title": "External Authentication",
-          "description": "Learn how to configure external authentication",
-          "path": "./admin/external-auth/index.md",
-          "icon_path": "./images/icons/plug.svg"
-        },
-        {
-          "title": "Integrations",
-          "description": "Use integrations to extend Coder",
-          "path": "./admin/integrations/index.md",
-          "icon_path": "./images/icons/puzzle.svg",
-          "children": [
-            {
-              "title": "Prometheus",
-              "description": "Collect deployment metrics with Prometheus",
-              "path": "./admin/integrations/prometheus.md"
-            },
-            {
-              "title": "Kubernetes Logging",
-              "description": "Stream K8s event logs on workspace startup",
-              "path": "./admin/integrations/kubernetes-logs.md"
-            },
-            {
-              "title": "Additional Kubernetes Clusters",
-              "description": "Deploy workspaces on additional Kubernetes clusters",
-              "path": "./admin/integrations/multiple-kube-clusters.md"
-            },
-            {
-              "title": "JFrog Artifactory",
-              "description": "Integrate Coder with JFrog Artifactory",
-              "path": "./admin/integrations/jfrog-artifactory.md"
-            },
-            {
-              "title": "Island Secure Browser",
-              "description": "Integrate Coder with Island's Secure Browser",
-              "path": "./admin/integrations/island.md"
-            },
-            {
-              "title": "DX PlatformX",
-              "description": "Integrate Coder with DX PlatformX",
-              "path": "./admin/integrations/platformx.md"
-            },
-            {
-              "title": "DX Data Cloud",
-              "description": "Tag Coder Users with DX Data Cloud",
-              "path": "./admin/integrations/dx-data-cloud.md"
-            },
-            {
-              "title": "Hashicorp Vault",
-              "description": "Integrate Coder with Hashicorp Vault",
-              "path": "./admin/integrations/vault.md"
-            },
-            {
-              "title": "OAuth2 Provider",
-              "description": "Use Coder as an OAuth2 provider",
-              "path": "./admin/integrations/oauth2-provider.md"
-            },
-            {
-              "title": "Dev Containers",
-              "description": "Configure dev container support using Docker or Envbuilder",
-              "path": "./admin/integrations/devcontainers/index.md",
-              "children": [
-                {
-                  "title": "Dev Containers Integration",
-                  "description": "Configure native dev containers with Docker",
-                  "path": "./admin/integrations/devcontainers/integration.md"
-                },
-                {
-                  "title": "Envbuilder",
-                  "description": "Build dev containers without Docker",
-                  "path": "./admin/integrations/devcontainers/envbuilder/index.md",
-                  "children": [
-                    {
-                      "title": "Add an Envbuilder template",
-                      "description": "How to add an Envbuilder template",
-                      "path": "./admin/integrations/devcontainers/envbuilder/add-envbuilder.md"
-                    },
-                    {
-                      "title": "Security and caching",
-                      "description": "Configure authentication and caching",
-                      "path": "./admin/integrations/devcontainers/envbuilder/envbuilder-security-caching.md"
-                    },
-                    {
-                      "title": "Releases and known issues",
-                      "description": "Release channels and known issues",
-                      "path": "./admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "title": "Networking",
-          "description": "Understand Coder's networking layer",
-          "path": "./admin/networking/index.md",
-          "icon_path": "./images/icons/networking.svg",
-          "children": [
-            {
-              "title": "Port Forwarding",
-              "description": "Learn how to forward ports in Coder",
-              "path": "./admin/networking/port-forwarding.md"
-            },
-            {
-              "title": "STUN and NAT",
-              "description": "Learn how to forward ports in Coder",
-              "path": "./admin/networking/stun.md"
-            },
-            {
-              "title": "Workspace Proxies",
-              "description": "Run geo distributed workspace proxies",
-              "path": "./admin/networking/workspace-proxies.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "High Availability",
-              "description": "Learn how to configure Coder for High Availability",
-              "path": "./admin/networking/high-availability.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Wildcard Access URL",
-              "description": "Learn about wildcard access URL in Coder deployments",
-              "path": "./admin/networking/wildcard-access-url.md"
-            },
-            {
-              "title": "Troubleshooting",
-              "description": "Troubleshoot networking issues in Coder",
-              "path": "./admin/networking/troubleshooting.md"
-            }
-          ]
-        },
-        {
-          "title": "Monitoring",
-          "description": "Configure security policy and audit your deployment",
-          "path": "./admin/monitoring/index.md",
-          "icon_path": "./images/icons/speed.svg",
-          "children": [
-            {
-              "title": "Logs",
-              "description": "Learn about Coder's logs",
-              "path": "./admin/monitoring/logs.md"
-            },
-            {
-              "title": "Metrics",
-              "description": "Learn about Coder's logs",
-              "path": "./admin/monitoring/metrics.md"
-            },
-            {
-              "title": "Health Check",
-              "description": "Learn about Coder's automated health checks",
-              "path": "./admin/monitoring/health-check.md"
-            },
-            {
-              "title": "Connection Logs",
-              "description": "Monitor connections to workspaces",
-              "path": "./admin/monitoring/connection-logs.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Notifications",
-              "description": "Configure notifications for your deployment",
-              "path": "./admin/monitoring/notifications/index.md",
-              "children": [
-                {
-                  "title": "Slack Notifications",
-                  "description": "Learn how to setup Slack notifications",
-                  "path": "./admin/monitoring/notifications/slack.md"
-                },
-                {
-                  "title": "Microsoft Teams Notifications",
-                  "description": "Learn how to setup Microsoft Teams notifications",
-                  "path": "./admin/monitoring/notifications/teams.md"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "title": "Security",
-          "description": "Configure security policy and audit your deployment",
-          "path": "./admin/security/index.md",
-          "icon_path": "./images/icons/lock.svg",
-          "children": [
-            {
-              "title": "Audit Logs",
-              "description": "Audit actions taken inside Coder",
-              "path": "./admin/security/audit-logs.md",
-              "state": [
-                "premium"
-              ]
-            },
-            {
-              "title": "Secrets",
-              "description": "Use sensitive variables in your workspaces",
-              "path": "./admin/security/secrets.md"
-            },
-            {
-              "title": "Database Encryption",
-              "description": "Encrypt the database to prevent unauthorized access",
-              "path": "./admin/security/database-encryption.md",
-              "state": [
-                "premium"
-              ]
-            }
-          ]
-        },
-        {
-          "title": "Licensing",
-          "description": "Configure licensing for your deployment",
-          "path": "./admin/licensing/index.md",
-          "icon_path": "./images/icons/licensing.svg"
-        }
-      ]
-    },
-    {
-      "title": "Run AI Coding Agents in Coder",
-      "description": "Learn how to run and integrate agentic AI coding agents like GPT-Code, OpenDevin, or SWE-Agent in Coder workspaces to boost developer productivity.",
-      "path": "./ai-coder/index.md",
-      "icon_path": "./images/icons/wand.svg",
-      "children": [
-        {
-          "title": "Best Practices",
-          "description": "Best Practices running Coding Agents",
-          "path": "./ai-coder/best-practices.md"
-        },
-        {
-          "title": "In the IDE",
-          "description": "Run IDE agents with Coder",
-          "path": "./ai-coder/ide-agents.md"
-        },
-        {
-          "title": "Coder Tasks",
-          "description": "Run Coding Agents on your Own Infrastructure",
-          "path": "./ai-coder/tasks.md",
-          "children": [
-            {
-              "title": "Understanding Coder Tasks",
-              "description": "Core principles and concepts behind Coder Tasks",
-              "path": "./ai-coder/tasks-core-principles.md"
-            },
-            {
-              "title": "Custom Agents",
-              "description": "Run custom agents with Coder Tasks",
-              "path": "./ai-coder/custom-agents.md"
-            },
-            {
-              "title": "Task Lifecycle",
-              "description": "How tasks pause and resume, and what gets preserved",
-              "path": "./ai-coder/tasks-lifecycle.md"
-            },
-            {
-              "title": "Agent Compatibility",
-              "description": "Which AI agents support session persistence across workspace restarts",
-              "path": "./ai-coder/agent-compatibility.md"
-            },
-            {
-              "title": "Tasks Migration Guide",
-              "description": "Changes to Coder Tasks made in v2.28",
-              "path": "./ai-coder/tasks-migration.md"
-            },
-            {
-              "title": "Security & Boundaries",
-              "description": "Learn about security and boundaries when running AI coding agents in Coder",
-              "path": "./ai-coder/security.md"
-            },
-            {
-              "title": "Create a GitHub to Coder Tasks Workflow",
-              "description": "How to setup Coder Tasks to run in GitHub",
-              "path": "./ai-coder/github-to-tasks.md"
-            }
-          ]
-        },
-        {
-          "title": "AI Governance Add-On",
-          "description": "Features around managing agents at scale",
-          "path": "./ai-coder/ai-governance.md",
-          "state": [
-            "premium"
-          ],
-          "children": [
-            {
-              "title": "Agent Boundaries",
-              "description": "Understanding Agent Boundaries in Coder Tasks",
-              "path": "./ai-coder/agent-boundaries/index.md",
-              "state": [
-                "premium"
-              ],
-              "children": [
-                {
-                  "title": "NS Jail",
-                  "description": "Documentation for Namespace Jail",
-                  "path": "./ai-coder/agent-boundaries/nsjail/index.md",
-                  "children": [
-                    {
-                      "title": "NS Jail on Docker",
-                      "description": "Runtime and permission requirements for running NS Jail on Docker",
-                      "path": "./ai-coder/agent-boundaries/nsjail/docker.md"
-                    },
-                    {
-                      "title": "NS Jail on Kubernetes",
-                      "description": "Runtime and permission requirements for running NS Jail on Kubernetes",
-                      "path": "./ai-coder/agent-boundaries/nsjail/k8s.md"
-                    },
-                    {
-                      "title": "NS Jail on ECS",
-                      "description": "Runtime and permission requirements for running NS Jail on ECS",
-                      "path": "./ai-coder/agent-boundaries/nsjail/ecs.md"
-                    }
-                  ]
-                },
-                {
-                  "title": "LandJail",
-                  "description": "Documentation for LandJail",
-                  "path": "./ai-coder/agent-boundaries/landjail.md"
-                },
-                {
-                  "title": "Rules Engine",
-                  "description": "Documentation for the Boundary rules engine",
-                  "path": "./ai-coder/agent-boundaries/rules-engine.md"
-                },
-                {
-                  "title": "Version Compatibility",
-                  "description": "Version requirements and compatibility information",
-                  "path": "./ai-coder/agent-boundaries/version.md"
-                }
-              ]
-            },
-            {
-              "title": "AI Bridge",
-              "description": "AI Gateway for Enterprise Governance & Observability",
-              "path": "./ai-coder/ai-bridge/index.md",
-              "icon_path": "./images/icons/api.svg",
-              "state": [
-                "premium"
-              ],
-              "children": [
-                {
-                  "title": "Setup",
-                  "description": "How to set up and configure AI Bridge",
-                  "path": "./ai-coder/ai-bridge/setup.md"
-                },
-                {
-                  "title": "Client Configuration",
-                  "description": "How to configure your AI coding tools to use AI Bridge",
-                  "path": "./ai-coder/ai-bridge/clients/index.md",
-                  "children": [
-                    {
-                      "title": "Claude Code",
-                      "description": "Configure Claude Code to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/claude-code.md"
-                    },
-                    {
-                      "title": "Codex",
-                      "description": "Configure Codex to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/codex.md"
-                    },
-                    {
-                      "title": "Mux",
-                      "description": "Configure Mux to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/mux.md"
-                    },
-                    {
-                      "title": "OpenCode",
-                      "description": "Configure OpenCode to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/opencode.md"
-                    },
-                    {
-                      "title": "Factory",
-                      "description": "Configure Factory to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/factory.md"
-                    },
-                    {
-                      "title": "Cline",
-                      "description": "Configure Cline to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/cline.md"
-                    },
-                    {
-                      "title": "Kilo Code",
-                      "description": "Configure Kilo Code to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/kilo-code.md"
-                    },
-                    {
-                      "title": "Roo Code",
-                      "description": "Configure Roo Code to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/roo-code.md"
-                    },
-                    {
-                      "title": "VS Code",
-                      "description": "Configure VS Code to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/vscode.md"
-                    },
-                    {
-                      "title": "JetBrains",
-                      "description": "Configure JetBrains IDEs to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/jetbrains.md"
-                    },
-                    {
-                      "title": "Zed",
-                      "description": "Configure Zed to use AI Bridge",
-                      "path": "./ai-coder/ai-bridge/clients/zed.md"
-                    },
-                    {
-                      "title": "GitHub Copilot",
-                      "description": "Configure GitHub Copilot to use AI Bridge via AI Bridge Proxy",
-                      "path": "./ai-coder/ai-bridge/clients/copilot.md"
-                    }
-                  ]
-                },
-                {
-                  "title": "MCP Tools Injection",
-                  "description": "How to configure MCP servers for tools injection through AI Bridge",
-                  "path": "./ai-coder/ai-bridge/mcp.md",
-                  "state": [
-                    "early access"
-                  ]
-                },
-                {
-                  "title": "AI Bridge Proxy",
-                  "description": "Proxy for AI coding tools without base URL override support",
-                  "path": "./ai-coder/ai-bridge/ai-bridge-proxy/index.md",
-                  "state": [
-                    "premium"
-                  ],
-                  "children": [
-                    {
-                      "title": "Setup",
-                      "description": "How to set up and configure AI Bridge Proxy",
-                      "path": "./ai-coder/ai-bridge/ai-bridge-proxy/setup.md"
-                    }
-                  ]
-                },
-                {
-                  "title": "Monitoring",
-                  "description": "How to monitor AI Bridge",
-                  "path": "./ai-coder/ai-bridge/monitoring.md"
-                },
-                {
-                  "title": "Reference",
-                  "description": "Technical reference for AI Bridge",
-                  "path": "./ai-coder/ai-bridge/reference.md"
-                }
-              ]
-            },
-            {
-              "title": "Usage Data Reporting",
-              "description": "Configure AI usage data reporting",
-              "path": "./ai-coder/usage-data-reporting.md"
-            }
-          ]
-        },
-        {
-          "title": "MCP Server",
-          "description": "Connect to agents Coder with a MCP server",
-          "path": "./ai-coder/mcp-server.md",
-          "state": [
-            "beta"
-          ]
-        },
-        {
-          "title": "Coder Agents",
-          "description": "Self-hosted agent by Coder",
-          "path": "./ai-coder/agents/index.md",
-          "children": [
-            {
-              "title": "Architecture",
-              "description": "How the Coder agent communicates with workspaces",
-              "path": "./ai-coder/agents/architecture.md"
-            },
-            {
-              "title": "Models",
-              "description": "Configure LLM providers and models for Coder Agents",
-              "path": "./ai-coder/agents/models.md"
-            },
-            {
-              "title": "Platform Controls",
-              "description": "How platform teams control agent behavior, models, and policies",
-              "path": "./ai-coder/agents/platform-controls.md"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "Tutorials",
-      "description": "Coder knowledgebase for administrating your deployment",
-      "path": "./tutorials/index.md",
-      "icon_path": "./images/icons/generic.svg",
-      "children": [
-        {
-          "title": "Quickstart",
-          "description": "Learn how to install and run Coder quickly",
-          "path": "./tutorials/quickstart.md"
-        },
-        {
-          "title": "Write a Template from Scratch",
-          "description": "Learn how to author Coder templates",
-          "path": "./tutorials/template-from-scratch.md"
-        },
-        {
-          "title": "Using an External Database",
-          "description": "Use Coder with an external database",
-          "path": "./tutorials/external-database.md"
-        },
-        {
-          "title": "Image Management",
-          "description": "Learn about image management with Coder",
-          "path": "./admin/templates/managing-templates/image-management.md"
-        },
-        {
-          "title": "Configuring Okta",
-          "description": "Custom claims/scopes with Okta for group/role sync",
-          "path": "./tutorials/configuring-okta.md"
-        },
-        {
-          "title": "Google to AWS Federation",
-          "description": "Federating a Google Cloud service account to AWS",
-          "path": "./tutorials/gcp-to-aws.md"
-        },
-        {
-          "title": "JFrog Artifactory Integration",
-          "description": "Integrate Coder with JFrog Artifactory",
-          "path": "./admin/integrations/jfrog-artifactory.md"
-        },
-        {
-          "title": "Mirror Coder Registry with Artifactory",
-          "description": "Use JFrog Artifactory to mirror the Coder Registry for air-gapped deployments",
-          "path": "./install/registry-mirror-artifactory.md"
-        },
-        {
-          "title": "Istio Integration",
-          "description": "Integrate Coder with Istio",
-          "path": "./admin/integrations/istio.md"
-        },
-        {
-          "title": "Island Secure Browser Integration",
-          "description": "Integrate Coder with Island's Secure Browser",
-          "path": "./admin/integrations/island.md"
-        },
-        {
-          "title": "Template ImagePullSecrets",
-          "description": "Creating ImagePullSecrets for private registries",
-          "path": "./tutorials/image-pull-secret.md"
-        },
-        {
-          "title": "Postgres SSL",
-          "description": "Configure Coder to connect to Postgres over SSL",
-          "path": "./tutorials/postgres-ssl.md"
-        },
-        {
-          "title": "Azure Federation",
-          "description": "Federating Coder to Azure",
-          "path": "./tutorials/azure-federation.md"
-        },
-        {
-          "title": "Deploy Coder on Azure with an Application Gateway",
-          "description": "Deploy Coder on Azure with an Application Gateway",
-          "path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
-        },
-        {
-          "title": "Cloning Git Repositories",
-          "description": "Learn how to clone Git repositories in Coder",
-          "path": "./tutorials/cloning-git-repositories.md"
-        },
-        {
-          "title": "Test Templates Through CI/CD",
-          "description": "Learn how to test and publish Coder templates in a CI/CD pipeline",
-          "path": "./tutorials/testing-templates.md"
-        },
-        {
-          "title": "Use Apache as a Reverse Proxy",
-          "description": "Learn how to use Apache as a reverse proxy",
-          "path": "./tutorials/reverse-proxy-apache.md"
-        },
-        {
-          "title": "Use Caddy as a Reverse Proxy",
-          "description": "Learn how to use Caddy as a reverse proxy",
-          "path": "./tutorials/reverse-proxy-caddy.md"
-        },
-        {
-          "title": "Use NGINX as a Reverse Proxy",
-          "description": "Learn how to use NGINX as a reverse proxy",
-          "path": "./tutorials/reverse-proxy-nginx.md"
-        },
-        {
-          "title": "Pre-install JetBrains IDEs in Workspaces",
-          "description": "Pre-install JetBrains IDEs in workspaces",
-          "path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
-        },
-        {
-          "title": "Use JetBrains IDEs in Air-Gapped Deployments",
-          "description": "Configure JetBrains IDEs for air-gapped deployments",
-          "path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
-        },
-        {
-          "title": "FAQs",
-          "description": "Miscellaneous FAQs from our community",
-          "path": "./tutorials/faqs.md"
-        },
-        {
-          "title": "Best practices",
-          "description": "Guides to help you make the most of your Coder experience",
-          "path": "./tutorials/best-practices/index.md",
-          "children": [
-            {
-              "title": "Organizations - best practices",
-              "description": "How to make the best use of Coder Organizations",
-              "path": "./tutorials/best-practices/organizations.md"
-            },
-            {
-              "title": "Scale Coder",
-              "description": "How to prepare a Coder deployment for scale",
-              "path": "./tutorials/best-practices/scale-coder.md"
-            },
-            {
-              "title": "Security - best practices",
-              "description": "Make your Coder deployment more secure",
-              "path": "./tutorials/best-practices/security-best-practices.md"
-            },
-            {
-              "title": "Speed up your workspaces",
-              "description": "Speed up your Coder templates and workspaces",
-              "path": "./tutorials/best-practices/speed-up-templates.md"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "Reference",
-      "description": "Reference",
-      "path": "./reference/index.md",
-      "icon_path": "./images/icons/notes.svg",
-      "children": [
-        {
-          "title": "REST API",
-          "description": "Learn how to use Coderd API",
-          "path": "./reference/api/index.md",
-          "icon_path": "./images/icons/api.svg",
-          "children": [
-            {
-              "title": "General",
-              "path": "./reference/api/general.md"
-            },
-            {
-              "title": "AI Bridge",
-              "path": "./reference/api/aibridge.md"
-            },
-            {
-              "title": "Agents",
-              "path": "./reference/api/agents.md"
-            },
-            {
-              "title": "Applications",
-              "path": "./reference/api/applications.md"
-            },
-            {
-              "title": "Audit",
-              "path": "./reference/api/audit.md"
-            },
-            {
-              "title": "Authentication",
-              "path": "./reference/api/authentication.md"
-            },
-            {
-              "title": "Authorization",
-              "path": "./reference/api/authorization.md"
-            },
-            {
-              "title": "Builds",
-              "path": "./reference/api/builds.md"
-            },
-            {
-              "title": "Chats",
-              "path": "./reference/api/chats.md"
-            },
-            {
-              "title": "Debug",
-              "path": "./reference/api/debug.md"
-            },
-            {
-              "title": "Enterprise",
-              "path": "./reference/api/enterprise.md"
-            },
-            {
-              "title": "Files",
-              "path": "./reference/api/files.md"
-            },
-            {
-              "title": "Git",
-              "path": "./reference/api/git.md"
-            },
-            {
-              "title": "InitScript",
-              "path": "./reference/api/initscript.md"
-            },
-            {
-              "title": "Insights",
-              "path": "./reference/api/insights.md"
-            },
-            {
-              "title": "Members",
-              "path": "./reference/api/members.md"
-            },
-            {
-              "title": "Notifications",
-              "path": "./reference/api/notifications.md"
-            },
-            {
-              "title": "Organizations",
-              "path": "./reference/api/organizations.md"
-            },
-            {
-              "title": "PortSharing",
-              "path": "./reference/api/portsharing.md"
-            },
-            {
-              "title": "Prebuilds",
-              "path": "./reference/api/prebuilds.md"
-            },
-            {
-              "title": "Provisioning",
-              "path": "./reference/api/provisioning.md"
-            },
-            {
-              "title": "Schemas",
-              "path": "./reference/api/schemas.md"
-            },
-            {
-              "title": "Tasks",
-              "path": "./reference/api/tasks.md"
-            },
-            {
-              "title": "Templates",
-              "path": "./reference/api/templates.md"
-            },
-            {
-              "title": "Users",
-              "path": "./reference/api/users.md"
-            },
-            {
-              "title": "WorkspaceProxies",
-              "path": "./reference/api/workspaceproxies.md"
-            },
-            {
-              "title": "Workspaces",
-              "path": "./reference/api/workspaces.md"
-            }
-          ]
-        },
-        {
-          "title": "Command Line",
-          "description": "Learn how to use Coder CLI",
-          "path": "./reference/cli/index.md",
-          "icon_path": "./images/icons/terminal.svg",
-          "children": [
-            {
-              "title": "aibridge",
-              "description": "Manage AI Bridge.",
-              "path": "reference/cli/aibridge.md"
-            },
-            {
-              "title": "aibridge interceptions",
-              "description": "Manage AI Bridge interceptions.",
-              "path": "reference/cli/aibridge_interceptions.md"
-            },
-            {
-              "title": "aibridge interceptions list",
-              "description": "List AI Bridge interceptions as JSON.",
-              "path": "reference/cli/aibridge_interceptions_list.md"
-            },
-            {
-              "title": "autoupdate",
-              "description": "Toggle auto-update policy for a workspace",
-              "path": "reference/cli/autoupdate.md"
-            },
-            {
-              "title": "boundary",
-              "description": "Network isolation tool for monitoring and restricting HTTP/HTTPS requests",
-              "path": "reference/cli/boundary.md"
-            },
-            {
-              "title": "coder",
-              "path": "reference/cli/index.md"
-            },
-            {
-              "title": "completion",
-              "description": "Install or update shell completion scripts for the detected or chosen shell.",
-              "path": "reference/cli/completion.md"
-            },
-            {
-              "title": "config-ssh",
-              "description": "Add an SSH Host entry for your workspaces \"ssh workspace.coder\"",
-              "path": "reference/cli/config-ssh.md"
-            },
-            {
-              "title": "create",
-              "description": "Create a workspace",
-              "path": "reference/cli/create.md"
-            },
-            {
-              "title": "delete",
-              "description": "Delete a workspace",
-              "path": "reference/cli/delete.md"
-            },
-            {
-              "title": "dotfiles",
-              "description": "Personalize your workspace by applying a canonical dotfiles repository",
-              "path": "reference/cli/dotfiles.md"
-            },
-            {
-              "title": "external-auth",
-              "description": "Manage external authentication",
-              "path": "reference/cli/external-auth.md"
-            },
-            {
-              "title": "external-auth access-token",
-              "description": "Print auth for an external provider",
-              "path": "reference/cli/external-auth_access-token.md"
-            },
-            {
-              "title": "external-workspaces",
-              "description": "Create or manage external workspaces",
-              "path": "reference/cli/external-workspaces.md"
-            },
-            {
-              "title": "external-workspaces agent-instructions",
-              "description": "Get the instructions for an external agent",
-              "path": "reference/cli/external-workspaces_agent-instructions.md"
-            },
-            {
-              "title": "external-workspaces create",
-              "description": "Create a new external workspace",
-              "path": "reference/cli/external-workspaces_create.md"
-            },
-            {
-              "title": "external-workspaces list",
-              "description": "List external workspaces",
-              "path": "reference/cli/external-workspaces_list.md"
-            },
-            {
-              "title": "favorite",
-              "description": "Add a workspace to your favorites",
-              "path": "reference/cli/favorite.md"
-            },
-            {
-              "title": "features",
-              "description": "List Enterprise features",
-              "path": "reference/cli/features.md"
-            },
-            {
-              "title": "features list",
-              "path": "reference/cli/features_list.md"
-            },
-            {
-              "title": "groups",
-              "description": "Manage groups",
-              "path": "reference/cli/groups.md"
-            },
-            {
-              "title": "groups create",
-              "description": "Create a user group",
-              "path": "reference/cli/groups_create.md"
-            },
-            {
-              "title": "groups delete",
-              "description": "Delete a user group",
-              "path": "reference/cli/groups_delete.md"
-            },
-            {
-              "title": "groups edit",
-              "description": "Edit a user group",
-              "path": "reference/cli/groups_edit.md"
-            },
-            {
-              "title": "groups list",
-              "description": "List user groups",
-              "path": "reference/cli/groups_list.md"
-            },
-            {
-              "title": "licenses",
-              "description": "Add, delete, and list licenses",
-              "path": "reference/cli/licenses.md"
-            },
-            {
-              "title": "licenses add",
-              "description": "Add license to Coder deployment",
-              "path": "reference/cli/licenses_add.md"
-            },
-            {
-              "title": "licenses delete",
-              "description": "Delete license by ID",
-              "path": "reference/cli/licenses_delete.md"
-            },
-            {
-              "title": "licenses list",
-              "description": "List licenses (including expired)",
-              "path": "reference/cli/licenses_list.md"
-            },
-            {
-              "title": "list",
-              "description": "List workspaces",
-              "path": "reference/cli/list.md"
-            },
-            {
-              "title": "login",
-              "description": "Authenticate with Coder deployment",
-              "path": "reference/cli/login.md"
-            },
-            {
-              "title": "login token",
-              "description": "Print the current session token",
-              "path": "reference/cli/login_token.md"
-            },
-            {
-              "title": "logout",
-              "description": "Unauthenticate your local session",
-              "path": "reference/cli/logout.md"
-            },
-            {
-              "title": "logs",
-              "description": "View logs for a workspace",
-              "path": "reference/cli/logs.md"
-            },
-            {
-              "title": "netcheck",
-              "description": "Print network debug information for DERP and STUN",
-              "path": "reference/cli/netcheck.md"
-            },
-            {
-              "title": "notifications",
-              "description": "Manage Coder notifications",
-              "path": "reference/cli/notifications.md"
-            },
-            {
-              "title": "notifications custom",
-              "description": "Send a custom notification",
-              "path": "reference/cli/notifications_custom.md"
-            },
-            {
-              "title": "notifications pause",
-              "description": "Pause notifications",
-              "path": "reference/cli/notifications_pause.md"
-            },
-            {
-              "title": "notifications resume",
-              "description": "Resume notifications",
-              "path": "reference/cli/notifications_resume.md"
-            },
-            {
-              "title": "notifications test",
-              "description": "Send a test notification",
-              "path": "reference/cli/notifications_test.md"
-            },
-            {
-              "title": "open",
-              "description": "Open a workspace",
-              "path": "reference/cli/open.md"
-            },
-            {
-              "title": "open app",
-              "description": "Open a workspace application.",
-              "path": "reference/cli/open_app.md"
-            },
-            {
-              "title": "open vscode",
-              "description": "Open a workspace in VS Code Desktop",
-              "path": "reference/cli/open_vscode.md"
-            },
-            {
-              "title": "organizations",
-              "description": "Organization related commands",
-              "path": "reference/cli/organizations.md"
-            },
-            {
-              "title": "organizations create",
-              "description": "Create a new organization.",
-              "path": "reference/cli/organizations_create.md"
-            },
-            {
-              "title": "organizations delete",
-              "description": "Delete an organization",
-              "path": "reference/cli/organizations_delete.md"
-            },
-            {
-              "title": "organizations list",
-              "description": "List all organizations",
-              "path": "reference/cli/organizations_list.md"
-            },
-            {
-              "title": "organizations members",
-              "description": "Manage organization members",
-              "path": "reference/cli/organizations_members.md"
-            },
-            {
-              "title": "organizations members add",
-              "description": "Add a new member to the current organization",
-              "path": "reference/cli/organizations_members_add.md"
-            },
-            {
-              "title": "organizations members edit-roles",
-              "description": "Edit organization member's roles",
-              "path": "reference/cli/organizations_members_edit-roles.md"
-            },
-            {
-              "title": "organizations members list",
-              "description": "List all organization members",
-              "path": "reference/cli/organizations_members_list.md"
-            },
-            {
-              "title": "organizations members remove",
-              "description": "Remove a new member to the current organization",
-              "path": "reference/cli/organizations_members_remove.md"
-            },
-            {
-              "title": "organizations roles",
-              "description": "Manage organization roles.",
-              "path": "reference/cli/organizations_roles.md"
-            },
-            {
-              "title": "organizations roles create",
-              "description": "Create a new organization custom role",
-              "path": "reference/cli/organizations_roles_create.md"
-            },
-            {
-              "title": "organizations roles show",
-              "description": "Show role(s)",
-              "path": "reference/cli/organizations_roles_show.md"
-            },
-            {
-              "title": "organizations roles update",
-              "description": "Update an organization custom role",
-              "path": "reference/cli/organizations_roles_update.md"
-            },
-            {
-              "title": "organizations settings",
-              "description": "Manage organization settings.",
-              "path": "reference/cli/organizations_settings.md"
-            },
-            {
-              "title": "organizations settings set",
-              "description": "Update specified organization setting.",
-              "path": "reference/cli/organizations_settings_set.md"
-            },
-            {
-              "title": "organizations settings set group-sync",
-              "description": "Group sync settings to sync groups from an IdP.",
-              "path": "reference/cli/organizations_settings_set_group-sync.md"
-            },
-            {
-              "title": "organizations settings set organization-sync",
-              "description": "Organization sync settings to sync organization memberships from an IdP.",
-              "path": "reference/cli/organizations_settings_set_organization-sync.md"
-            },
-            {
-              "title": "organizations settings set role-sync",
-              "description": "Role sync settings to sync organization roles from an IdP.",
-              "path": "reference/cli/organizations_settings_set_role-sync.md"
-            },
-            {
-              "title": "organizations settings set workspace-sharing",
-              "description": "Workspace sharing settings for the organization.",
-              "path": "reference/cli/organizations_settings_set_workspace-sharing.md"
-            },
-            {
-              "title": "organizations settings show",
-              "description": "Outputs specified organization setting.",
-              "path": "reference/cli/organizations_settings_show.md"
-            },
-            {
-              "title": "organizations settings show group-sync",
-              "description": "Group sync settings to sync groups from an IdP.",
-              "path": "reference/cli/organizations_settings_show_group-sync.md"
-            },
-            {
-              "title": "organizations settings show organization-sync",
-              "description": "Organization sync settings to sync organization memberships from an IdP.",
-              "path": "reference/cli/organizations_settings_show_organization-sync.md"
-            },
-            {
-              "title": "organizations settings show role-sync",
-              "description": "Role sync settings to sync organization roles from an IdP.",
-              "path": "reference/cli/organizations_settings_show_role-sync.md"
-            },
-            {
-              "title": "organizations settings show workspace-sharing",
-              "description": "Workspace sharing settings for the organization.",
-              "path": "reference/cli/organizations_settings_show_workspace-sharing.md"
-            },
-            {
-              "title": "organizations show",
-              "description": "Show the organization. Using \"selected\" will show the selected organization from the \"--org\" flag. Using \"me\" will show all organizations you are a member of.",
-              "path": "reference/cli/organizations_show.md"
-            },
-            {
-              "title": "ping",
-              "description": "Ping a workspace",
-              "path": "reference/cli/ping.md"
-            },
-            {
-              "title": "port-forward",
-              "description": "Forward ports from a workspace to the local machine. For reverse port forwarding, use \"coder ssh -R\".",
-              "path": "reference/cli/port-forward.md"
-            },
-            {
-              "title": "prebuilds",
-              "description": "Manage Coder prebuilds",
-              "path": "reference/cli/prebuilds.md"
-            },
-            {
-              "title": "prebuilds pause",
-              "description": "Pause prebuilds",
-              "path": "reference/cli/prebuilds_pause.md"
-            },
-            {
-              "title": "prebuilds resume",
-              "description": "Resume prebuilds",
-              "path": "reference/cli/prebuilds_resume.md"
-            },
-            {
-              "title": "provisioner",
-              "description": "View and manage provisioner daemons and jobs",
-              "path": "reference/cli/provisioner.md"
-            },
-            {
-              "title": "provisioner jobs",
-              "description": "View and manage provisioner jobs",
-              "path": "reference/cli/provisioner_jobs.md"
-            },
-            {
-              "title": "provisioner jobs cancel",
-              "description": "Cancel a provisioner job",
-              "path": "reference/cli/provisioner_jobs_cancel.md"
-            },
-            {
-              "title": "provisioner jobs list",
-              "description": "List provisioner jobs",
-              "path": "reference/cli/provisioner_jobs_list.md"
-            },
-            {
-              "title": "provisioner keys",
-              "description": "Manage provisioner keys",
-              "path": "reference/cli/provisioner_keys.md"
-            },
-            {
-              "title": "provisioner keys create",
-              "description": "Create a new provisioner key",
-              "path": "reference/cli/provisioner_keys_create.md"
-            },
-            {
-              "title": "provisioner keys delete",
-              "description": "Delete a provisioner key",
-              "path": "reference/cli/provisioner_keys_delete.md"
-            },
-            {
-              "title": "provisioner keys list",
-              "description": "List provisioner keys in an organization",
-              "path": "reference/cli/provisioner_keys_list.md"
-            },
-            {
-              "title": "provisioner list",
-              "description": "List provisioner daemons in an organization",
-              "path": "reference/cli/provisioner_list.md"
-            },
-            {
-              "title": "provisioner start",
-              "description": "Run a provisioner daemon",
-              "path": "reference/cli/provisioner_start.md"
-            },
-            {
-              "title": "publickey",
-              "description": "Output your Coder public key used for Git operations",
-              "path": "reference/cli/publickey.md"
-            },
-            {
-              "title": "rename",
-              "description": "Rename a workspace",
-              "path": "reference/cli/rename.md"
-            },
-            {
-              "title": "reset-password",
-              "description": "Directly connect to the database to reset a user's password",
-              "path": "reference/cli/reset-password.md"
-            },
-            {
-              "title": "restart",
-              "description": "Restart a workspace",
-              "path": "reference/cli/restart.md"
-            },
-            {
-              "title": "schedule",
-              "description": "Schedule automated start and stop times for workspaces",
-              "path": "reference/cli/schedule.md"
-            },
-            {
-              "title": "schedule extend",
-              "description": "Extend the stop time of a currently running workspace instance.",
-              "path": "reference/cli/schedule_extend.md"
-            },
-            {
-              "title": "schedule show",
-              "description": "Show workspace schedules",
-              "path": "reference/cli/schedule_show.md"
-            },
-            {
-              "title": "schedule start",
-              "description": "Edit workspace start schedule",
-              "path": "reference/cli/schedule_start.md"
-            },
-            {
-              "title": "schedule stop",
-              "description": "Edit workspace stop schedule",
-              "path": "reference/cli/schedule_stop.md"
-            },
-            {
-              "title": "server",
-              "description": "Start a Coder server",
-              "path": "reference/cli/server.md"
-            },
-            {
-              "title": "server create-admin-user",
-              "description": "Create a new admin user with the given username, email and password and adds it to every organization.",
-              "path": "reference/cli/server_create-admin-user.md"
-            },
-            {
-              "title": "server dbcrypt",
-              "description": "Manage database encryption.",
-              "path": "reference/cli/server_dbcrypt.md"
-            },
-            {
-              "title": "server dbcrypt decrypt",
-              "description": "Decrypt a previously encrypted database.",
-              "path": "reference/cli/server_dbcrypt_decrypt.md"
-            },
-            {
-              "title": "server dbcrypt delete",
-              "description": "Delete all encrypted data from the database. THIS IS A DESTRUCTIVE OPERATION.",
-              "path": "reference/cli/server_dbcrypt_delete.md"
-            },
-            {
-              "title": "server dbcrypt rotate",
-              "description": "Rotate database encryption keys.",
-              "path": "reference/cli/server_dbcrypt_rotate.md"
-            },
-            {
-              "title": "server postgres-builtin-serve",
-              "description": "Run the built-in PostgreSQL deployment.",
-              "path": "reference/cli/server_postgres-builtin-serve.md"
-            },
-            {
-              "title": "server postgres-builtin-url",
-              "description": "Output the connection URL for the built-in PostgreSQL deployment.",
-              "path": "reference/cli/server_postgres-builtin-url.md"
-            },
-            {
-              "title": "show",
-              "description": "Display details of a workspace's resources and agents",
-              "path": "reference/cli/show.md"
-            },
-            {
-              "title": "speedtest",
-              "description": "Run upload and download tests from your machine to a workspace",
-              "path": "reference/cli/speedtest.md"
-            },
-            {
-              "title": "ssh",
-              "description": "Start a shell into a workspace or run a command",
-              "path": "reference/cli/ssh.md"
-            },
-            {
-              "title": "start",
-              "description": "Start a workspace",
-              "path": "reference/cli/start.md"
-            },
-            {
-              "title": "stat",
-              "description": "Show resource usage for the current workspace.",
-              "path": "reference/cli/stat.md"
-            },
-            {
-              "title": "stat cpu",
-              "description": "Show CPU usage, in cores.",
-              "path": "reference/cli/stat_cpu.md"
-            },
-            {
-              "title": "stat disk",
-              "description": "Show disk usage, in gigabytes.",
-              "path": "reference/cli/stat_disk.md"
-            },
-            {
-              "title": "stat mem",
-              "description": "Show memory usage, in gigabytes.",
-              "path": "reference/cli/stat_mem.md"
-            },
-            {
-              "title": "state",
-              "description": "Manually manage Terraform state to fix broken workspaces",
-              "path": "reference/cli/state.md"
-            },
-            {
-              "title": "state pull",
-              "description": "Pull a Terraform state file from a workspace.",
-              "path": "reference/cli/state_pull.md"
-            },
-            {
-              "title": "state push",
-              "description": "Push a Terraform state file to a workspace.",
-              "path": "reference/cli/state_push.md"
-            },
-            {
-              "title": "stop",
-              "description": "Stop a workspace",
-              "path": "reference/cli/stop.md"
-            },
-            {
-              "title": "support",
-              "description": "Commands for troubleshooting issues with a Coder deployment.",
-              "path": "reference/cli/support.md"
-            },
-            {
-              "title": "support bundle",
-              "description": "Generate a support bundle to troubleshoot issues connecting to a workspace.",
-              "path": "reference/cli/support_bundle.md"
-            },
-            {
-              "title": "task",
-              "description": "Manage tasks",
-              "path": "reference/cli/task.md"
-            },
-            {
-              "title": "task create",
-              "description": "Create a task",
-              "path": "reference/cli/task_create.md"
-            },
-            {
-              "title": "task delete",
-              "description": "Delete tasks",
-              "path": "reference/cli/task_delete.md"
-            },
-            {
-              "title": "task list",
-              "description": "List tasks",
-              "path": "reference/cli/task_list.md"
-            },
-            {
-              "title": "task logs",
-              "description": "Show a task's logs",
-              "path": "reference/cli/task_logs.md"
-            },
-            {
-              "title": "task pause",
-              "description": "Pause a task",
-              "path": "reference/cli/task_pause.md"
-            },
-            {
-              "title": "task resume",
-              "description": "Resume a task",
-              "path": "reference/cli/task_resume.md"
-            },
-            {
-              "title": "task send",
-              "description": "Send input to a task",
-              "path": "reference/cli/task_send.md"
-            },
-            {
-              "title": "task status",
-              "description": "Show the status of a task.",
-              "path": "reference/cli/task_status.md"
-            },
-            {
-              "title": "templates",
-              "description": "Manage templates",
-              "path": "reference/cli/templates.md"
-            },
-            {
-              "title": "templates archive",
-              "description": "Archive unused or failed template versions from a given template(s)",
-              "path": "reference/cli/templates_archive.md"
-            },
-            {
-              "title": "templates create",
-              "description": "DEPRECATED: Create a template from the current directory or as specified by flag",
-              "path": "reference/cli/templates_create.md"
-            },
-            {
-              "title": "templates delete",
-              "description": "Delete templates",
-              "path": "reference/cli/templates_delete.md"
-            },
-            {
-              "title": "templates edit",
-              "description": "Edit the metadata of a template by name.",
-              "path": "reference/cli/templates_edit.md"
-            },
-            {
-              "title": "templates init",
-              "description": "Get started with a templated template.",
-              "path": "reference/cli/templates_init.md"
-            },
-            {
-              "title": "templates list",
-              "description": "List all the templates available for the organization",
-              "path": "reference/cli/templates_list.md"
-            },
-            {
-              "title": "templates presets",
-              "description": "Manage presets of the specified template",
-              "path": "reference/cli/templates_presets.md"
-            },
-            {
-              "title": "templates presets list",
-              "description": "List all presets of the specified template. Defaults to the active template version.",
-              "path": "reference/cli/templates_presets_list.md"
-            },
-            {
-              "title": "templates pull",
-              "description": "Download the active, latest, or specified version of a template to a path.",
-              "path": "reference/cli/templates_pull.md"
-            },
-            {
-              "title": "templates push",
-              "description": "Create or update a template from the current directory or as specified by flag",
-              "path": "reference/cli/templates_push.md"
-            },
-            {
-              "title": "templates versions",
-              "description": "Manage different versions of the specified template",
-              "path": "reference/cli/templates_versions.md"
-            },
-            {
-              "title": "templates versions archive",
-              "description": "Archive a template version(s).",
-              "path": "reference/cli/templates_versions_archive.md"
-            },
-            {
-              "title": "templates versions list",
-              "description": "List all the versions of the specified template",
-              "path": "reference/cli/templates_versions_list.md"
-            },
-            {
-              "title": "templates versions promote",
-              "description": "Promote a template version to active.",
-              "path": "reference/cli/templates_versions_promote.md"
-            },
-            {
-              "title": "templates versions unarchive",
-              "description": "Unarchive a template version(s).",
-              "path": "reference/cli/templates_versions_unarchive.md"
-            },
-            {
-              "title": "tokens",
-              "description": "Manage personal access tokens",
-              "path": "reference/cli/tokens.md"
-            },
-            {
-              "title": "tokens create",
-              "description": "Create a token",
-              "path": "reference/cli/tokens_create.md"
-            },
-            {
-              "title": "tokens list",
-              "description": "List tokens",
-              "path": "reference/cli/tokens_list.md"
-            },
-            {
-              "title": "tokens remove",
-              "description": "Expire or delete a token",
-              "path": "reference/cli/tokens_remove.md"
-            },
-            {
-              "title": "tokens view",
-              "description": "Display detailed information about a token",
-              "path": "reference/cli/tokens_view.md"
-            },
-            {
-              "title": "unfavorite",
-              "description": "Remove a workspace from your favorites",
-              "path": "reference/cli/unfavorite.md"
-            },
-            {
-              "title": "update",
-              "description": "Will update and start a given workspace if it is out of date. If the workspace is already running, it will be stopped first.",
-              "path": "reference/cli/update.md"
-            },
-            {
-              "title": "users",
-              "description": "Manage users",
-              "path": "reference/cli/users.md"
-            },
-            {
-              "title": "users activate",
-              "description": "Update a user's status to 'active'. Active users can fully interact with the platform",
-              "path": "reference/cli/users_activate.md"
-            },
-            {
-              "title": "users create",
-              "description": "Create a new user.",
-              "path": "reference/cli/users_create.md"
-            },
-            {
-              "title": "users delete",
-              "description": "Delete a user by username or user_id.",
-              "path": "reference/cli/users_delete.md"
-            },
-            {
-              "title": "users edit-roles",
-              "description": "Edit a user's roles by username or id",
-              "path": "reference/cli/users_edit-roles.md"
-            },
-            {
-              "title": "users list",
-              "description": "Prints the list of users.",
-              "path": "reference/cli/users_list.md"
-            },
-            {
-              "title": "users show",
-              "description": "Show a single user. Use 'me' to indicate the currently authenticated user.",
-              "path": "reference/cli/users_show.md"
-            },
-            {
-              "title": "users suspend",
-              "description": "Update a user's status to 'suspended'. A suspended user cannot log into the platform",
-              "path": "reference/cli/users_suspend.md"
-            },
-            {
-              "title": "version",
-              "description": "Show coder version",
-              "path": "reference/cli/version.md"
-            },
-            {
-              "title": "whoami",
-              "description": "Fetch authenticated user info for Coder deployment",
-              "path": "reference/cli/whoami.md"
-            }
-          ]
-        },
-        {
-          "title": "Agent API",
-          "description": "Learn how to use Coder Agent API",
-          "path": "./reference/agent-api/index.md",
-          "icon_path": "./images/icons/api.svg",
-          "children": [
-            {
-              "title": "Debug",
-              "path": "./reference/agent-api/debug.md"
-            },
-            {
-              "title": "Schemas",
-              "path": "./reference/agent-api/schemas.md"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "title": "Coder Research",
-      "description": "Open source research projects exploring AI-assisted development",
-      "path": "./coder-research.md",
-      "icon_path": "./images/icons/wand.svg"
-    }
-  ]
+	"versions": ["main"],
+	"routes": [
+		{
+			"title": "About",
+			"description": "Coder docs",
+			"path": "./README.md",
+			"icon_path": "./images/icons/home.svg",
+			"children": [
+				{
+					"title": "Screenshots",
+					"description": "View screenshots of the Coder platform",
+					"path": "./about/screenshots.md"
+				},
+				{
+					"title": "Quickstart",
+					"description": "Learn how to install and run Coder quickly",
+					"path": "./tutorials/quickstart.md"
+				},
+				{
+					"title": "Support",
+					"description": "How Coder supports your deployment and you",
+					"path": "./support/index.md",
+					"children": [
+						{
+							"title": "Generate a Support Bundle",
+							"description": "Generate and upload a Support Bundle to Coder Support",
+							"path": "./support/support-bundle.md"
+						}
+					]
+				},
+				{
+					"title": "Contributing",
+					"description": "Learn how to contribute to Coder",
+					"path": "./about/contributing/CONTRIBUTING.md",
+					"icon_path": "./images/icons/contributing.svg",
+					"children": [
+						{
+							"title": "Code of Conduct",
+							"description": "See the code of conduct for contributing to Coder",
+							"path": "./about/contributing/CODE_OF_CONDUCT.md",
+							"icon_path": "./images/icons/circle-dot.svg"
+						},
+						{
+							"title": "Documentation",
+							"description": "Our style guide for use when authoring documentation",
+							"path": "./about/contributing/documentation.md",
+							"icon_path": "./images/icons/document.svg"
+						},
+						{
+							"title": "Modules",
+							"description": "Learn how to contribute modules to Coder",
+							"path": "./about/contributing/modules.md",
+							"icon_path": "./images/icons/gear.svg"
+						},
+						{
+							"title": "Templates",
+							"description": "Learn how to contribute templates to Coder",
+							"path": "./about/contributing/templates.md",
+							"icon_path": "./images/icons/picture.svg"
+						},
+						{
+							"title": "Backend",
+							"description": "Our guide for backend development",
+							"path": "./about/contributing/backend.md",
+							"icon_path": "./images/icons/gear.svg"
+						},
+						{
+							"title": "Frontend",
+							"description": "Our guide for frontend development",
+							"path": "./about/contributing/frontend.md",
+							"icon_path": "./images/icons/frontend.svg"
+						},
+						{
+							"title": "Security",
+							"description": "Security vulnerability disclosure policy",
+							"path": "./about/contributing/SECURITY.md",
+							"icon_path": "./images/icons/lock.svg"
+						},
+						{
+							"title": "AI Contribution Guidelines",
+							"description": "Guidelines for AI-generated contributions.",
+							"path": "./about/contributing/AI_CONTRIBUTING.md",
+							"icon_path": "./images/icons/ai_intelligence.svg"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Install",
+			"description": "Installing Coder",
+			"path": "./install/index.md",
+			"icon_path": "./images/icons/download.svg",
+			"children": [
+				{
+					"title": "Coder CLI",
+					"description": "Install the standalone binary",
+					"path": "./install/cli.md",
+					"icon_path": "./images/icons/terminal.svg"
+				},
+				{
+					"title": "Docker",
+					"description": "Install Coder using Docker",
+					"path": "./install/docker.md",
+					"icon_path": "./images/icons/docker.svg"
+				},
+				{
+					"title": "Kubernetes",
+					"description": "Install Coder on Kubernetes",
+					"path": "./install/kubernetes.md",
+					"icon_path": "./images/icons/kubernetes.svg",
+					"children": [
+						{
+							"title": "Deploy Coder on Azure with an Application Gateway",
+							"description": "Deploy Coder on Azure with an Application Gateway",
+							"path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
+						}
+					]
+				},
+				{
+					"title": "Rancher",
+					"description": "Deploy Coder on Rancher",
+					"path": "./install/rancher.md",
+					"icon_path": "./images/icons/rancher.svg"
+				},
+				{
+					"title": "OpenShift",
+					"description": "Install Coder on OpenShift",
+					"path": "./install/openshift.md",
+					"icon_path": "./images/icons/openshift.svg"
+				},
+				{
+					"title": "Cloud Providers",
+					"description": "Install Coder on cloud providers",
+					"path": "./install/cloud/index.md",
+					"icon_path": "./images/icons/cloud.svg",
+					"children": [
+						{
+							"title": "AWS EC2",
+							"description": "Install Coder on AWS EC2",
+							"path": "./install/cloud/ec2.md"
+						},
+						{
+							"title": "GCP Compute Engine",
+							"description": "Install Coder on GCP Compute Engine",
+							"path": "./install/cloud/compute-engine.md"
+						},
+						{
+							"title": "Azure VM",
+							"description": "Install Coder on an Azure VM",
+							"path": "./install/cloud/azure-vm.md"
+						}
+					]
+				},
+				{
+					"title": "Air-gapped Deployments",
+					"description": "Run Coder in air-gapped / disconnected / offline environments",
+					"path": "./install/airgap.md",
+					"icon_path": "./images/icons/lan.svg"
+				},
+				{
+					"title": "Unofficial Install Methods",
+					"description": "Other installation methods",
+					"path": "./install/other/index.md",
+					"icon_path": "./images/icons/generic.svg"
+				},
+				{
+					"title": "Upgrading",
+					"description": "Learn how to upgrade Coder",
+					"path": "./install/upgrade.md",
+					"icon_path": "./images/icons/upgrade.svg",
+					"children": [
+						{
+							"title": "Upgrading Best Practices",
+							"description": "Best practices and troubleshooting for Coder upgrades",
+							"path": "./install/upgrade-best-practices.md"
+						}
+					]
+				},
+				{
+					"title": "Uninstall",
+					"description": "Learn how to uninstall Coder",
+					"path": "./install/uninstall.md",
+					"icon_path": "./images/icons/trash.svg"
+				},
+				{
+					"title": "Releases",
+					"description": "Learn about the Coder release channels and schedule",
+					"path": "./install/releases/index.md",
+					"icon_path": "./images/icons/star.svg",
+					"children": [
+						{
+							"title": "Feature stages",
+							"description": "Information about pre-GA stages.",
+							"path": "./install/releases/feature-stages.md"
+						},
+						{
+							"title": "Upgrading from ESR 2.24 to 2.29",
+							"description": "Upgrade Guide for ESR Releases",
+							"path": "./install/releases/esr-2.24-2.29-upgrade.md"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "User Guides",
+			"description": "Guides for end-users of Coder",
+			"path": "./user-guides/index.md",
+			"icon_path": "./images/icons/users.svg",
+			"children": [
+				{
+					"title": "Access Workspaces",
+					"description": "Connect to your Coder workspaces",
+					"path": "./user-guides/workspace-access/index.md",
+					"icon_path": "./images/icons/access.svg",
+					"children": [
+						{
+							"title": "Visual Studio Code",
+							"description": "Use VSCode with Coder in the desktop or browser",
+							"path": "./user-guides/workspace-access/vscode.md"
+						},
+						{
+							"title": "Web Terminal",
+							"description": "Use the browser-based terminal to access your workspace",
+							"path": "./user-guides/workspace-access/web-terminal.md"
+						},
+						{
+							"title": "JetBrains IDEs",
+							"description": "Use JetBrains IDEs with Coder",
+							"path": "./user-guides/workspace-access/jetbrains/index.md",
+							"children": [
+								{
+									"title": "JetBrains Fleet",
+									"description": "Connect JetBrains Fleet to a Coder workspace",
+									"path": "./user-guides/workspace-access/jetbrains/fleet.md"
+								},
+								{
+									"title": "JetBrains Gateway",
+									"description": "Use JetBrains Gateway to connect to Coder workspaces",
+									"path": "./user-guides/workspace-access/jetbrains/gateway.md"
+								},
+								{
+									"title": "JetBrains Toolbox",
+									"description": "Access Coder workspaces from JetBrains Toolbox",
+									"path": "./user-guides/workspace-access/jetbrains/toolbox.md",
+									"state": ["beta"]
+								}
+							]
+						},
+						{
+							"title": "Remote Desktop",
+							"description": "Use RDP in Coder",
+							"path": "./user-guides/workspace-access/remote-desktops.md"
+						},
+						{
+							"title": "Emacs TRAMP",
+							"description": "Use Emacs TRAMP in Coder",
+							"path": "./user-guides/workspace-access/emacs-tramp.md"
+						},
+						{
+							"title": "Port Forwarding",
+							"description": "Access ports on your workspace",
+							"path": "./user-guides/workspace-access/port-forwarding.md"
+						},
+						{
+							"title": "Filebrowser",
+							"description": "Access your workspace files",
+							"path": "./user-guides/workspace-access/filebrowser.md"
+						},
+						{
+							"title": "Web IDEs and Coder Apps",
+							"description": "Access your workspace with IDEs in the browser",
+							"path": "./user-guides/workspace-access/web-ides.md"
+						},
+						{
+							"title": "code-server",
+							"description": "Access your workspace with code-server",
+							"path": "./user-guides/workspace-access/code-server.md"
+						},
+						{
+							"title": "Zed",
+							"description": "Access your workspace with Zed",
+							"path": "./user-guides/workspace-access/zed.md"
+						},
+						{
+							"title": "Cursor",
+							"description": "Access your workspace with Cursor",
+							"path": "./user-guides/workspace-access/cursor.md"
+						},
+						{
+							"title": "Windsurf",
+							"description": "Access your workspace with Windsurf",
+							"path": "./user-guides/workspace-access/windsurf.md"
+						},
+						{
+							"title": "Antigravity",
+							"description": "Access your workspace with Antigravity",
+							"path": "./user-guides/workspace-access/antigravity.md"
+						}
+					]
+				},
+				{
+					"title": "Coder Desktop",
+					"description": "Transform remote workspaces into seamless local development environments with no port forwarding required",
+					"path": "./user-guides/desktop/index.md",
+					"icon_path": "./images/icons/computer-code.svg",
+					"children": [
+						{
+							"title": "Coder Desktop Connect and Sync",
+							"description": "Use Coder Desktop to manage your workspace code and files locally",
+							"path": "./user-guides/desktop/desktop-connect-sync.md"
+						}
+					]
+				},
+				{
+					"title": "Workspace Management",
+					"description": "Manage workspaces",
+					"path": "./user-guides/workspace-management.md",
+					"icon_path": "./images/icons/generic.svg"
+				},
+				{
+					"title": "Workspace Sharing",
+					"description": "Sharing workspaces",
+					"path": "./user-guides/shared-workspaces.md",
+					"icon_path": "./images/icons/generic.svg",
+					"state": ["beta"]
+				},
+				{
+					"title": "Workspace Scheduling",
+					"description": "Cost control with workspace schedules",
+					"path": "./user-guides/workspace-scheduling.md",
+					"icon_path": "./images/icons/stopwatch.svg"
+				},
+				{
+					"title": "Workspace Lifecycle",
+					"description": "A guide to the workspace lifecycle, from creation and status through stopping and deletion.",
+					"path": "./user-guides/workspace-lifecycle.md",
+					"icon_path": "./images/icons/circle-dot.svg"
+				},
+				{
+					"title": "Dev Containers",
+					"description": "Run containerized development environments in your Coder workspace using the dev containers specification.",
+					"path": "./user-guides/devcontainers/index.md",
+					"icon_path": "./images/icons/container.svg",
+					"children": [
+						{
+							"title": "Working with dev containers",
+							"description": "Access dev containers via SSH, your IDE, or web terminal.",
+							"path": "./user-guides/devcontainers/working-with-dev-containers.md"
+						},
+						{
+							"title": "Customizing dev containers",
+							"description": "Configure custom agent names, apps, and display options in devcontainer.json.",
+							"path": "./user-guides/devcontainers/customizing-dev-containers.md"
+						},
+						{
+							"title": "Troubleshooting dev containers",
+							"description": "Diagnose and resolve common issues with dev containers in your Coder workspace.",
+							"path": "./user-guides/devcontainers/troubleshooting-dev-containers.md"
+						}
+					]
+				},
+				{
+					"title": "Dotfiles",
+					"description": "Personalize your environment with dotfiles",
+					"path": "./user-guides/workspace-dotfiles.md",
+					"icon_path": "./images/icons/art-pad.svg"
+				}
+			]
+		},
+		{
+			"title": "Administration",
+			"description": "Guides for template and deployment administrators",
+			"path": "./admin/index.md",
+			"icon_path": "./images/icons/wrench.svg",
+			"children": [
+				{
+					"title": "Setup",
+					"description": "Configure user access to your control plane.",
+					"path": "./admin/setup/index.md",
+					"icon_path": "./images/icons/toggle_on.svg",
+					"children": [
+						{
+							"title": "Appearance",
+							"description": "Learn how to configure the appearance of Coder",
+							"path": "./admin/setup/appearance.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Telemetry",
+							"description": "Learn what usage telemetry Coder collects",
+							"path": "./admin/setup/telemetry.md"
+						},
+						{
+							"title": "Data Retention",
+							"description": "Configure data retention policies for database tables",
+							"path": "./admin/setup/data-retention.md"
+						}
+					]
+				},
+				{
+					"title": "Infrastructure",
+					"description": "How to integrate Coder with your organization's compute",
+					"path": "./admin/infrastructure/index.md",
+					"icon_path": "./images/icons/container.svg",
+					"children": [
+						{
+							"title": "Architecture",
+							"description": "Learn about Coder's architecture",
+							"path": "./admin/infrastructure/architecture.md"
+						},
+						{
+							"title": "Validated Architectures",
+							"description": "Architectures for large Coder deployments",
+							"path": "./admin/infrastructure/validated-architectures/index.md",
+							"children": [
+								{
+									"title": "Up to 1,000 Users",
+									"description": "Hardware specifications and architecture guidance for Coder deployments that support up to 1,000 users",
+									"path": "./admin/infrastructure/validated-architectures/1k-users.md"
+								},
+								{
+									"title": "Up to 2,000 Users",
+									"description": "Hardware specifications and architecture guidance for Coder deployments that support up to 2,000 users",
+									"path": "./admin/infrastructure/validated-architectures/2k-users.md"
+								},
+								{
+									"title": "Up to 3,000 Users",
+									"description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 3,000 users",
+									"path": "./admin/infrastructure/validated-architectures/3k-users.md"
+								},
+								{
+									"title": "Up to 10,000 Users",
+									"description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 10,000 users",
+									"path": "./admin/infrastructure/validated-architectures/10k-users.md"
+								}
+							]
+						},
+						{
+							"title": "Scale Testing",
+							"description": "Ensure your deployment can handle your organization's needs",
+							"path": "./admin/infrastructure/scale-testing.md"
+						},
+						{
+							"title": "Scaling Utilities",
+							"description": "Tools to help you scale your deployment",
+							"path": "./admin/infrastructure/scale-utility.md"
+						},
+						{
+							"title": "Scaling best practices",
+							"description": "How to prepare a Coder deployment for scale",
+							"path": "./tutorials/best-practices/scale-coder.md"
+						}
+					]
+				},
+				{
+					"title": "Users",
+					"description": "Learn how to manage and audit users",
+					"path": "./admin/users/index.md",
+					"icon_path": "./images/icons/users.svg",
+					"children": [
+						{
+							"title": "OIDC Authentication",
+							"description": "Configure OpenID Connect authentication with identity providers like Okta or Active Directory",
+							"path": "./admin/users/oidc-auth/index.md",
+							"children": [
+								{
+									"title": "Google",
+									"description": "Configure Google as an OIDC provider",
+									"path": "./admin/users/oidc-auth/google.md"
+								},
+								{
+									"title": "Microsoft",
+									"description": "Configure Microsoft Entra ID as an OIDC provider",
+									"path": "./admin/users/oidc-auth/microsoft.md"
+								},
+								{
+									"title": "Configure OIDC refresh tokens",
+									"description": "How to configure OIDC refresh tokens",
+									"path": "./admin/users/oidc-auth/refresh-tokens.md"
+								}
+							]
+						},
+						{
+							"title": "GitHub Authentication",
+							"description": "Set up authentication through GitHub OAuth to enable secure user login and sign-up",
+							"path": "./admin/users/github-auth.md"
+						},
+						{
+							"title": "Password Authentication",
+							"description": "Manage username/password authentication settings and user password reset workflows",
+							"path": "./admin/users/password-auth.md"
+						},
+						{
+							"title": "Headless Authentication",
+							"description": "Create and manage headless service accounts for automated systems and API integrations",
+							"path": "./admin/users/headless-auth.md"
+						},
+						{
+							"title": "Groups \u0026 Roles",
+							"description": "Manage access control with user groups and role-based permissions for Coder resources",
+							"path": "./admin/users/groups-roles.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "IdP Sync",
+							"description": "Synchronize user groups, roles, and organizations from your identity provider to Coder",
+							"path": "./admin/users/idp-sync.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Organizations",
+							"description": "Segment and isolate resources by creating separate organizations for different teams or projects",
+							"path": "./admin/users/organizations.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Quotas",
+							"description": "Control resource usage by implementing workspace budgets and credit-based cost management",
+							"path": "./admin/users/quotas.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Sessions \u0026 API Tokens",
+							"description": "Manage authentication tokens for API access and configure session duration policies",
+							"path": "./admin/users/sessions-tokens.md"
+						}
+					]
+				},
+				{
+					"title": "Templates",
+					"description": "Learn how to author and maintain Coder templates",
+					"path": "./admin/templates/index.md",
+					"icon_path": "./images/icons/picture.svg",
+					"children": [
+						{
+							"title": "Creating Templates",
+							"description": "Learn how to create templates with Terraform",
+							"path": "./admin/templates/creating-templates.md"
+						},
+						{
+							"title": "Managing Templates",
+							"description": "Learn how to manage templates and best practices",
+							"path": "./admin/templates/managing-templates/index.md",
+							"children": [
+								{
+									"title": "Image Management",
+									"description": "Learn about template image management",
+									"path": "./admin/templates/managing-templates/image-management.md"
+								},
+								{
+									"title": "Change Management",
+									"description": "Learn about template change management and versioning",
+									"path": "./admin/templates/managing-templates/change-management.md"
+								},
+								{
+									"title": "Envbuilder",
+									"description": "Shift environment definition to repositories",
+									"path": "./admin/templates/managing-templates/envbuilder.md"
+								},
+								{
+									"title": "Template Dependencies",
+									"description": "Learn how to manage template dependencies",
+									"path": "./admin/templates/managing-templates/dependencies.md"
+								},
+								{
+									"title": "Workspace Scheduling",
+									"description": "Learn how to control how workspaces are started and stopped",
+									"path": "./admin/templates/managing-templates/schedule.md"
+								},
+								{
+									"title": "External Workspaces",
+									"description": "Learn how to manage external workspaces",
+									"path": "./admin/templates/managing-templates/external-workspaces.md",
+									"state": ["premium", "early access"]
+								}
+							]
+						},
+						{
+							"title": "Extending Templates",
+							"description": "Learn best practices in extending templates",
+							"path": "./admin/templates/extending-templates/index.md",
+							"children": [
+								{
+									"title": "Agent Metadata",
+									"description": "Retrieve real-time stats from the workspace agent",
+									"path": "./admin/templates/extending-templates/agent-metadata.md"
+								},
+								{
+									"title": "Build Parameters",
+									"description": "Use parameters to customize workspaces at build",
+									"path": "./admin/templates/extending-templates/parameters.md"
+								},
+								{
+									"title": "Dynamic Parameters",
+									"description": "Conditional, identity-aware parameter syntax for advanced users.",
+									"path": "./admin/templates/extending-templates/dynamic-parameters.md"
+								},
+								{
+									"title": "Prebuilt workspaces",
+									"description": "Pre-provision a ready-to-deploy workspace with a defined set of parameters",
+									"path": "./admin/templates/extending-templates/prebuilt-workspaces.md",
+									"state": ["premium"]
+								},
+								{
+									"title": "Icons",
+									"description": "Customize your template with built-in icons",
+									"path": "./admin/templates/extending-templates/icons.md"
+								},
+								{
+									"title": "Resource Metadata",
+									"description": "Display resource state in the workspace dashboard",
+									"path": "./admin/templates/extending-templates/resource-metadata.md"
+								},
+								{
+									"title": "Resource Monitoring",
+									"description": "Monitor resources in the workspace dashboard",
+									"path": "./admin/templates/extending-templates/resource-monitoring.md"
+								},
+								{
+									"title": "Resource Ordering",
+									"description": "Design the UI of workspaces",
+									"path": "./admin/templates/extending-templates/resource-ordering.md"
+								},
+								{
+									"title": "Resource Persistence",
+									"description": "Control resource persistence",
+									"path": "./admin/templates/extending-templates/resource-persistence.md"
+								},
+								{
+									"title": "Terraform Variables",
+									"description": "Use variables to manage template state",
+									"path": "./admin/templates/extending-templates/variables.md"
+								},
+								{
+									"title": "Terraform Modules",
+									"description": "Reuse terraform code across templates",
+									"path": "./admin/templates/extending-templates/modules.md"
+								},
+								{
+									"title": "Web IDEs and Coder Apps",
+									"description": "Add and configure Web IDEs in your templates as coder apps",
+									"path": "./admin/templates/extending-templates/web-ides.md"
+								},
+								{
+									"title": "Pre-install JetBrains IDEs",
+									"description": "Pre-install JetBrains IDEs in a template for faster IDE startup",
+									"path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
+								},
+								{
+									"title": "JetBrains IDEs in Air-Gapped Deployments",
+									"description": "Configure JetBrains IDEs for air-gapped deployments",
+									"path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
+								},
+								{
+									"title": "Docker in Workspaces",
+									"description": "Use Docker in your workspaces",
+									"path": "./admin/templates/extending-templates/docker-in-workspaces.md"
+								},
+								{
+									"title": "Workspace Tags",
+									"description": "Control provisioning using Workspace Tags and Parameters",
+									"path": "./admin/templates/extending-templates/workspace-tags.md"
+								},
+								{
+									"title": "Provider Authentication",
+									"description": "Authenticate with provider APIs to provision workspaces",
+									"path": "./admin/templates/extending-templates/provider-authentication.md"
+								},
+								{
+									"title": "Dev Containers",
+									"description": "Extend templates with containerized dev environments",
+									"path": "./admin/templates/extending-templates/devcontainers.md"
+								},
+								{
+									"title": "Process Logging",
+									"description": "Log workspace processes",
+									"path": "./admin/templates/extending-templates/process-logging.md",
+									"state": ["premium"]
+								},
+								{
+									"title": "Startup Dependencies",
+									"description": "Coordinate workspace startup with dependency management",
+									"path": "./admin/templates/startup-coordination/index.md",
+									"state": ["early access"],
+									"children": [
+										{
+											"title": "Usage",
+											"description": "How to use startup coordination",
+											"path": "./admin/templates/startup-coordination/usage.md"
+										},
+										{
+											"title": "Troubleshooting",
+											"description": "Troubleshoot startup coordination",
+											"path": "./admin/templates/startup-coordination/troubleshooting.md"
+										},
+										{
+											"title": "Examples",
+											"description": "Examples of startup coordination",
+											"path": "./admin/templates/startup-coordination/example.md"
+										}
+									]
+								}
+							]
+						},
+						{
+							"title": "Open in Coder",
+							"description": "Open workspaces in Coder",
+							"path": "./admin/templates/open-in-coder.md"
+						},
+						{
+							"title": "Permissions \u0026 Policies",
+							"description": "Learn how to create templates with Terraform",
+							"path": "./admin/templates/template-permissions.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Troubleshooting Templates",
+							"description": "Learn how to troubleshoot template issues",
+							"path": "./admin/templates/troubleshooting.md"
+						}
+					]
+				},
+				{
+					"title": "External Provisioners",
+					"description": "Learn how to run external provisioners with Coder",
+					"path": "./admin/provisioners/index.md",
+					"icon_path": "./images/icons/key.svg",
+					"state": ["premium"],
+					"children": [
+						{
+							"title": "Manage Provisioner Jobs",
+							"description": "Learn how to run external provisioners with Coder",
+							"path": "./admin/provisioners/manage-provisioner-jobs.md",
+							"state": ["premium"]
+						}
+					]
+				},
+				{
+					"title": "External Authentication",
+					"description": "Learn how to configure external authentication",
+					"path": "./admin/external-auth/index.md",
+					"icon_path": "./images/icons/plug.svg"
+				},
+				{
+					"title": "Integrations",
+					"description": "Use integrations to extend Coder",
+					"path": "./admin/integrations/index.md",
+					"icon_path": "./images/icons/puzzle.svg",
+					"children": [
+						{
+							"title": "Prometheus",
+							"description": "Collect deployment metrics with Prometheus",
+							"path": "./admin/integrations/prometheus.md"
+						},
+						{
+							"title": "Kubernetes Logging",
+							"description": "Stream K8s event logs on workspace startup",
+							"path": "./admin/integrations/kubernetes-logs.md"
+						},
+						{
+							"title": "Additional Kubernetes Clusters",
+							"description": "Deploy workspaces on additional Kubernetes clusters",
+							"path": "./admin/integrations/multiple-kube-clusters.md"
+						},
+						{
+							"title": "JFrog Artifactory",
+							"description": "Integrate Coder with JFrog Artifactory",
+							"path": "./admin/integrations/jfrog-artifactory.md"
+						},
+						{
+							"title": "Island Secure Browser",
+							"description": "Integrate Coder with Island's Secure Browser",
+							"path": "./admin/integrations/island.md"
+						},
+						{
+							"title": "DX PlatformX",
+							"description": "Integrate Coder with DX PlatformX",
+							"path": "./admin/integrations/platformx.md"
+						},
+						{
+							"title": "DX Data Cloud",
+							"description": "Tag Coder Users with DX Data Cloud",
+							"path": "./admin/integrations/dx-data-cloud.md"
+						},
+						{
+							"title": "Hashicorp Vault",
+							"description": "Integrate Coder with Hashicorp Vault",
+							"path": "./admin/integrations/vault.md"
+						},
+						{
+							"title": "OAuth2 Provider",
+							"description": "Use Coder as an OAuth2 provider",
+							"path": "./admin/integrations/oauth2-provider.md"
+						},
+						{
+							"title": "Dev Containers",
+							"description": "Configure dev container support using Docker or Envbuilder",
+							"path": "./admin/integrations/devcontainers/index.md",
+							"children": [
+								{
+									"title": "Dev Containers Integration",
+									"description": "Configure native dev containers with Docker",
+									"path": "./admin/integrations/devcontainers/integration.md"
+								},
+								{
+									"title": "Envbuilder",
+									"description": "Build dev containers without Docker",
+									"path": "./admin/integrations/devcontainers/envbuilder/index.md",
+									"children": [
+										{
+											"title": "Add an Envbuilder template",
+											"description": "How to add an Envbuilder template",
+											"path": "./admin/integrations/devcontainers/envbuilder/add-envbuilder.md"
+										},
+										{
+											"title": "Security and caching",
+											"description": "Configure authentication and caching",
+											"path": "./admin/integrations/devcontainers/envbuilder/envbuilder-security-caching.md"
+										},
+										{
+											"title": "Releases and known issues",
+											"description": "Release channels and known issues",
+											"path": "./admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md"
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"title": "Networking",
+					"description": "Understand Coder's networking layer",
+					"path": "./admin/networking/index.md",
+					"icon_path": "./images/icons/networking.svg",
+					"children": [
+						{
+							"title": "Port Forwarding",
+							"description": "Learn how to forward ports in Coder",
+							"path": "./admin/networking/port-forwarding.md"
+						},
+						{
+							"title": "STUN and NAT",
+							"description": "Learn how to forward ports in Coder",
+							"path": "./admin/networking/stun.md"
+						},
+						{
+							"title": "Workspace Proxies",
+							"description": "Run geo distributed workspace proxies",
+							"path": "./admin/networking/workspace-proxies.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "High Availability",
+							"description": "Learn how to configure Coder for High Availability",
+							"path": "./admin/networking/high-availability.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Wildcard Access URL",
+							"description": "Learn about wildcard access URL in Coder deployments",
+							"path": "./admin/networking/wildcard-access-url.md"
+						},
+						{
+							"title": "Troubleshooting",
+							"description": "Troubleshoot networking issues in Coder",
+							"path": "./admin/networking/troubleshooting.md"
+						}
+					]
+				},
+				{
+					"title": "Monitoring",
+					"description": "Configure security policy and audit your deployment",
+					"path": "./admin/monitoring/index.md",
+					"icon_path": "./images/icons/speed.svg",
+					"children": [
+						{
+							"title": "Logs",
+							"description": "Learn about Coder's logs",
+							"path": "./admin/monitoring/logs.md"
+						},
+						{
+							"title": "Metrics",
+							"description": "Learn about Coder's logs",
+							"path": "./admin/monitoring/metrics.md"
+						},
+						{
+							"title": "Health Check",
+							"description": "Learn about Coder's automated health checks",
+							"path": "./admin/monitoring/health-check.md"
+						},
+						{
+							"title": "Connection Logs",
+							"description": "Monitor connections to workspaces",
+							"path": "./admin/monitoring/connection-logs.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Notifications",
+							"description": "Configure notifications for your deployment",
+							"path": "./admin/monitoring/notifications/index.md",
+							"children": [
+								{
+									"title": "Slack Notifications",
+									"description": "Learn how to setup Slack notifications",
+									"path": "./admin/monitoring/notifications/slack.md"
+								},
+								{
+									"title": "Microsoft Teams Notifications",
+									"description": "Learn how to setup Microsoft Teams notifications",
+									"path": "./admin/monitoring/notifications/teams.md"
+								}
+							]
+						}
+					]
+				},
+				{
+					"title": "Security",
+					"description": "Configure security policy and audit your deployment",
+					"path": "./admin/security/index.md",
+					"icon_path": "./images/icons/lock.svg",
+					"children": [
+						{
+							"title": "Audit Logs",
+							"description": "Audit actions taken inside Coder",
+							"path": "./admin/security/audit-logs.md",
+							"state": ["premium"]
+						},
+						{
+							"title": "Secrets",
+							"description": "Use sensitive variables in your workspaces",
+							"path": "./admin/security/secrets.md"
+						},
+						{
+							"title": "Database Encryption",
+							"description": "Encrypt the database to prevent unauthorized access",
+							"path": "./admin/security/database-encryption.md",
+							"state": ["premium"]
+						}
+					]
+				},
+				{
+					"title": "Licensing",
+					"description": "Configure licensing for your deployment",
+					"path": "./admin/licensing/index.md",
+					"icon_path": "./images/icons/licensing.svg"
+				}
+			]
+		},
+		{
+			"title": "Run AI Coding Agents in Coder",
+			"description": "Learn how to run and integrate agentic AI coding agents like GPT-Code, OpenDevin, or SWE-Agent in Coder workspaces to boost developer productivity.",
+			"path": "./ai-coder/index.md",
+			"icon_path": "./images/icons/wand.svg",
+			"children": [
+				{
+					"title": "Best Practices",
+					"description": "Best Practices running Coding Agents",
+					"path": "./ai-coder/best-practices.md"
+				},
+				{
+					"title": "In the IDE",
+					"description": "Run IDE agents with Coder",
+					"path": "./ai-coder/ide-agents.md"
+				},
+				{
+					"title": "Coder Tasks",
+					"description": "Run Coding Agents on your Own Infrastructure",
+					"path": "./ai-coder/tasks.md",
+					"children": [
+						{
+							"title": "Understanding Coder Tasks",
+							"description": "Core principles and concepts behind Coder Tasks",
+							"path": "./ai-coder/tasks-core-principles.md"
+						},
+						{
+							"title": "Custom Agents",
+							"description": "Run custom agents with Coder Tasks",
+							"path": "./ai-coder/custom-agents.md"
+						},
+						{
+							"title": "Task Lifecycle",
+							"description": "How tasks pause and resume, and what gets preserved",
+							"path": "./ai-coder/tasks-lifecycle.md"
+						},
+						{
+							"title": "Agent Compatibility",
+							"description": "Which AI agents support session persistence across workspace restarts",
+							"path": "./ai-coder/agent-compatibility.md"
+						},
+						{
+							"title": "Tasks Migration Guide",
+							"description": "Changes to Coder Tasks made in v2.28",
+							"path": "./ai-coder/tasks-migration.md"
+						},
+						{
+							"title": "Security \u0026 Boundaries",
+							"description": "Learn about security and boundaries when running AI coding agents in Coder",
+							"path": "./ai-coder/security.md"
+						},
+						{
+							"title": "Create a GitHub to Coder Tasks Workflow",
+							"description": "How to setup Coder Tasks to run in GitHub",
+							"path": "./ai-coder/github-to-tasks.md"
+						}
+					]
+				},
+				{
+					"title": "AI Governance Add-On",
+					"description": "Features around managing agents at scale",
+					"path": "./ai-coder/ai-governance.md",
+					"state": ["premium"],
+					"children": [
+						{
+							"title": "Agent Boundaries",
+							"description": "Understanding Agent Boundaries in Coder Tasks",
+							"path": "./ai-coder/agent-boundaries/index.md",
+							"state": ["premium"],
+							"children": [
+								{
+									"title": "NS Jail",
+									"description": "Documentation for Namespace Jail",
+									"path": "./ai-coder/agent-boundaries/nsjail/index.md",
+									"children": [
+										{
+											"title": "NS Jail on Docker",
+											"description": "Runtime and permission requirements for running NS Jail on Docker",
+											"path": "./ai-coder/agent-boundaries/nsjail/docker.md"
+										},
+										{
+											"title": "NS Jail on Kubernetes",
+											"description": "Runtime and permission requirements for running NS Jail on Kubernetes",
+											"path": "./ai-coder/agent-boundaries/nsjail/k8s.md"
+										},
+										{
+											"title": "NS Jail on ECS",
+											"description": "Runtime and permission requirements for running NS Jail on ECS",
+											"path": "./ai-coder/agent-boundaries/nsjail/ecs.md"
+										}
+									]
+								},
+								{
+									"title": "LandJail",
+									"description": "Documentation for LandJail",
+									"path": "./ai-coder/agent-boundaries/landjail.md"
+								},
+								{
+									"title": "Rules Engine",
+									"description": "Documentation for the Boundary rules engine",
+									"path": "./ai-coder/agent-boundaries/rules-engine.md"
+								},
+								{
+									"title": "Version Compatibility",
+									"description": "Version requirements and compatibility information",
+									"path": "./ai-coder/agent-boundaries/version.md"
+								}
+							]
+						},
+						{
+							"title": "AI Bridge",
+							"description": "AI Gateway for Enterprise Governance \u0026 Observability",
+							"path": "./ai-coder/ai-bridge/index.md",
+							"icon_path": "./images/icons/api.svg",
+							"state": ["premium"],
+							"children": [
+								{
+									"title": "Setup",
+									"description": "How to set up and configure AI Bridge",
+									"path": "./ai-coder/ai-bridge/setup.md"
+								},
+								{
+									"title": "Client Configuration",
+									"description": "How to configure your AI coding tools to use AI Bridge",
+									"path": "./ai-coder/ai-bridge/clients/index.md",
+									"children": [
+										{
+											"title": "Claude Code",
+											"description": "Configure Claude Code to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/claude-code.md"
+										},
+										{
+											"title": "Codex",
+											"description": "Configure Codex to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/codex.md"
+										},
+										{
+											"title": "Mux",
+											"description": "Configure Mux to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/mux.md"
+										},
+										{
+											"title": "OpenCode",
+											"description": "Configure OpenCode to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/opencode.md"
+										},
+										{
+											"title": "Factory",
+											"description": "Configure Factory to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/factory.md"
+										},
+										{
+											"title": "Cline",
+											"description": "Configure Cline to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/cline.md"
+										},
+										{
+											"title": "Kilo Code",
+											"description": "Configure Kilo Code to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/kilo-code.md"
+										},
+										{
+											"title": "Roo Code",
+											"description": "Configure Roo Code to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/roo-code.md"
+										},
+										{
+											"title": "VS Code",
+											"description": "Configure VS Code to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/vscode.md"
+										},
+										{
+											"title": "JetBrains",
+											"description": "Configure JetBrains IDEs to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/jetbrains.md"
+										},
+										{
+											"title": "Zed",
+											"description": "Configure Zed to use AI Bridge",
+											"path": "./ai-coder/ai-bridge/clients/zed.md"
+										},
+										{
+											"title": "GitHub Copilot",
+											"description": "Configure GitHub Copilot to use AI Bridge via AI Bridge Proxy",
+											"path": "./ai-coder/ai-bridge/clients/copilot.md"
+										}
+									]
+								},
+								{
+									"title": "MCP Tools Injection",
+									"description": "How to configure MCP servers for tools injection through AI Bridge",
+									"path": "./ai-coder/ai-bridge/mcp.md",
+									"state": ["early access"]
+								},
+								{
+									"title": "AI Bridge Proxy",
+									"description": "Proxy for AI coding tools without base URL override support",
+									"path": "./ai-coder/ai-bridge/ai-bridge-proxy/index.md",
+									"state": ["premium"],
+									"children": [
+										{
+											"title": "Setup",
+											"description": "How to set up and configure AI Bridge Proxy",
+											"path": "./ai-coder/ai-bridge/ai-bridge-proxy/setup.md"
+										}
+									]
+								},
+								{
+									"title": "Monitoring",
+									"description": "How to monitor AI Bridge",
+									"path": "./ai-coder/ai-bridge/monitoring.md"
+								},
+								{
+									"title": "Reference",
+									"description": "Technical reference for AI Bridge",
+									"path": "./ai-coder/ai-bridge/reference.md"
+								}
+							]
+						},
+						{
+							"title": "Usage Data Reporting",
+							"description": "Configure AI usage data reporting",
+							"path": "./ai-coder/usage-data-reporting.md"
+						}
+					]
+				},
+				{
+					"title": "MCP Server",
+					"description": "Connect to agents Coder with a MCP server",
+					"path": "./ai-coder/mcp-server.md",
+					"state": ["beta"]
+				},
+				{
+					"title": "Coder Agents",
+					"description": "Self-hosted agent by Coder",
+					"path": "./ai-coder/agents/index.md",
+					"children": [
+						{
+							"title": "Architecture",
+							"description": "How the agent in the control plane communicates with workspaces",
+							"path": "./ai-coder/agents/architecture.md"
+						},
+						{
+							"title": "Models",
+							"description": "Configure LLM providers and models for Coder Agents",
+							"path": "./ai-coder/agents/models.md"
+						},
+						{
+							"title": "Platform Controls",
+							"description": "How platform teams control agent behavior, models, and policies",
+							"path": "./ai-coder/agents/platform-controls.md"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Tutorials",
+			"description": "Coder knowledgebase for administrating your deployment",
+			"path": "./tutorials/index.md",
+			"icon_path": "./images/icons/generic.svg",
+			"children": [
+				{
+					"title": "Quickstart",
+					"description": "Learn how to install and run Coder quickly",
+					"path": "./tutorials/quickstart.md"
+				},
+				{
+					"title": "Write a Template from Scratch",
+					"description": "Learn how to author Coder templates",
+					"path": "./tutorials/template-from-scratch.md"
+				},
+				{
+					"title": "Using an External Database",
+					"description": "Use Coder with an external database",
+					"path": "./tutorials/external-database.md"
+				},
+				{
+					"title": "Image Management",
+					"description": "Learn about image management with Coder",
+					"path": "./admin/templates/managing-templates/image-management.md"
+				},
+				{
+					"title": "Configuring Okta",
+					"description": "Custom claims/scopes with Okta for group/role sync",
+					"path": "./tutorials/configuring-okta.md"
+				},
+				{
+					"title": "Google to AWS Federation",
+					"description": "Federating a Google Cloud service account to AWS",
+					"path": "./tutorials/gcp-to-aws.md"
+				},
+				{
+					"title": "JFrog Artifactory Integration",
+					"description": "Integrate Coder with JFrog Artifactory",
+					"path": "./admin/integrations/jfrog-artifactory.md"
+				},
+				{
+					"title": "Mirror Coder Registry with Artifactory",
+					"description": "Use JFrog Artifactory to mirror the Coder Registry for air-gapped deployments",
+					"path": "./install/registry-mirror-artifactory.md"
+				},
+				{
+					"title": "Istio Integration",
+					"description": "Integrate Coder with Istio",
+					"path": "./admin/integrations/istio.md"
+				},
+				{
+					"title": "Island Secure Browser Integration",
+					"description": "Integrate Coder with Island's Secure Browser",
+					"path": "./admin/integrations/island.md"
+				},
+				{
+					"title": "Template ImagePullSecrets",
+					"description": "Creating ImagePullSecrets for private registries",
+					"path": "./tutorials/image-pull-secret.md"
+				},
+				{
+					"title": "Postgres SSL",
+					"description": "Configure Coder to connect to Postgres over SSL",
+					"path": "./tutorials/postgres-ssl.md"
+				},
+				{
+					"title": "Azure Federation",
+					"description": "Federating Coder to Azure",
+					"path": "./tutorials/azure-federation.md"
+				},
+				{
+					"title": "Deploy Coder on Azure with an Application Gateway",
+					"description": "Deploy Coder on Azure with an Application Gateway",
+					"path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
+				},
+				{
+					"title": "Cloning Git Repositories",
+					"description": "Learn how to clone Git repositories in Coder",
+					"path": "./tutorials/cloning-git-repositories.md"
+				},
+				{
+					"title": "Test Templates Through CI/CD",
+					"description": "Learn how to test and publish Coder templates in a CI/CD pipeline",
+					"path": "./tutorials/testing-templates.md"
+				},
+				{
+					"title": "Use Apache as a Reverse Proxy",
+					"description": "Learn how to use Apache as a reverse proxy",
+					"path": "./tutorials/reverse-proxy-apache.md"
+				},
+				{
+					"title": "Use Caddy as a Reverse Proxy",
+					"description": "Learn how to use Caddy as a reverse proxy",
+					"path": "./tutorials/reverse-proxy-caddy.md"
+				},
+				{
+					"title": "Use NGINX as a Reverse Proxy",
+					"description": "Learn how to use NGINX as a reverse proxy",
+					"path": "./tutorials/reverse-proxy-nginx.md"
+				},
+				{
+					"title": "Pre-install JetBrains IDEs in Workspaces",
+					"description": "Pre-install JetBrains IDEs in workspaces",
+					"path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
+				},
+				{
+					"title": "Use JetBrains IDEs in Air-Gapped Deployments",
+					"description": "Configure JetBrains IDEs for air-gapped deployments",
+					"path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
+				},
+				{
+					"title": "FAQs",
+					"description": "Miscellaneous FAQs from our community",
+					"path": "./tutorials/faqs.md"
+				},
+				{
+					"title": "Best practices",
+					"description": "Guides to help you make the most of your Coder experience",
+					"path": "./tutorials/best-practices/index.md",
+					"children": [
+						{
+							"title": "Organizations - best practices",
+							"description": "How to make the best use of Coder Organizations",
+							"path": "./tutorials/best-practices/organizations.md"
+						},
+						{
+							"title": "Scale Coder",
+							"description": "How to prepare a Coder deployment for scale",
+							"path": "./tutorials/best-practices/scale-coder.md"
+						},
+						{
+							"title": "Security - best practices",
+							"description": "Make your Coder deployment more secure",
+							"path": "./tutorials/best-practices/security-best-practices.md"
+						},
+						{
+							"title": "Speed up your workspaces",
+							"description": "Speed up your Coder templates and workspaces",
+							"path": "./tutorials/best-practices/speed-up-templates.md"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Reference",
+			"description": "Reference",
+			"path": "./reference/index.md",
+			"icon_path": "./images/icons/notes.svg",
+			"children": [
+				{
+					"title": "REST API",
+					"description": "Learn how to use Coderd API",
+					"path": "./reference/api/index.md",
+					"icon_path": "./images/icons/api.svg",
+					"children": [
+						{
+							"title": "General",
+							"path": "./reference/api/general.md"
+						},
+						{
+							"title": "AI Bridge",
+							"path": "./reference/api/aibridge.md"
+						},
+						{
+							"title": "Agents",
+							"path": "./reference/api/agents.md"
+						},
+						{
+							"title": "Applications",
+							"path": "./reference/api/applications.md"
+						},
+						{
+							"title": "Audit",
+							"path": "./reference/api/audit.md"
+						},
+						{
+							"title": "Authentication",
+							"path": "./reference/api/authentication.md"
+						},
+						{
+							"title": "Authorization",
+							"path": "./reference/api/authorization.md"
+						},
+						{
+							"title": "Builds",
+							"path": "./reference/api/builds.md"
+						},
+						{
+							"title": "Chats",
+							"path": "./reference/api/chats.md"
+						},
+						{
+							"title": "Debug",
+							"path": "./reference/api/debug.md"
+						},
+						{
+							"title": "Enterprise",
+							"path": "./reference/api/enterprise.md"
+						},
+						{
+							"title": "Files",
+							"path": "./reference/api/files.md"
+						},
+						{
+							"title": "Git",
+							"path": "./reference/api/git.md"
+						},
+						{
+							"title": "InitScript",
+							"path": "./reference/api/initscript.md"
+						},
+						{
+							"title": "Insights",
+							"path": "./reference/api/insights.md"
+						},
+						{
+							"title": "Members",
+							"path": "./reference/api/members.md"
+						},
+						{
+							"title": "Notifications",
+							"path": "./reference/api/notifications.md"
+						},
+						{
+							"title": "Organizations",
+							"path": "./reference/api/organizations.md"
+						},
+						{
+							"title": "PortSharing",
+							"path": "./reference/api/portsharing.md"
+						},
+						{
+							"title": "Prebuilds",
+							"path": "./reference/api/prebuilds.md"
+						},
+						{
+							"title": "Provisioning",
+							"path": "./reference/api/provisioning.md"
+						},
+						{
+							"title": "Schemas",
+							"path": "./reference/api/schemas.md"
+						},
+						{
+							"title": "Tasks",
+							"path": "./reference/api/tasks.md"
+						},
+						{
+							"title": "Templates",
+							"path": "./reference/api/templates.md"
+						},
+						{
+							"title": "Users",
+							"path": "./reference/api/users.md"
+						},
+						{
+							"title": "WorkspaceProxies",
+							"path": "./reference/api/workspaceproxies.md"
+						},
+						{
+							"title": "Workspaces",
+							"path": "./reference/api/workspaces.md"
+						}
+					]
+				},
+				{
+					"title": "Command Line",
+					"description": "Learn how to use Coder CLI",
+					"path": "./reference/cli/index.md",
+					"icon_path": "./images/icons/terminal.svg",
+					"children": [
+						{
+							"title": "aibridge",
+							"description": "Manage AI Bridge.",
+							"path": "reference/cli/aibridge.md"
+						},
+						{
+							"title": "aibridge interceptions",
+							"description": "Manage AI Bridge interceptions.",
+							"path": "reference/cli/aibridge_interceptions.md"
+						},
+						{
+							"title": "aibridge interceptions list",
+							"description": "List AI Bridge interceptions as JSON.",
+							"path": "reference/cli/aibridge_interceptions_list.md"
+						},
+						{
+							"title": "autoupdate",
+							"description": "Toggle auto-update policy for a workspace",
+							"path": "reference/cli/autoupdate.md"
+						},
+						{
+							"title": "boundary",
+							"description": "Network isolation tool for monitoring and restricting HTTP/HTTPS requests",
+							"path": "reference/cli/boundary.md"
+						},
+						{
+							"title": "coder",
+							"path": "reference/cli/index.md"
+						},
+						{
+							"title": "completion",
+							"description": "Install or update shell completion scripts for the detected or chosen shell.",
+							"path": "reference/cli/completion.md"
+						},
+						{
+							"title": "config-ssh",
+							"description": "Add an SSH Host entry for your workspaces \"ssh workspace.coder\"",
+							"path": "reference/cli/config-ssh.md"
+						},
+						{
+							"title": "create",
+							"description": "Create a workspace",
+							"path": "reference/cli/create.md"
+						},
+						{
+							"title": "delete",
+							"description": "Delete a workspace",
+							"path": "reference/cli/delete.md"
+						},
+						{
+							"title": "dotfiles",
+							"description": "Personalize your workspace by applying a canonical dotfiles repository",
+							"path": "reference/cli/dotfiles.md"
+						},
+						{
+							"title": "external-auth",
+							"description": "Manage external authentication",
+							"path": "reference/cli/external-auth.md"
+						},
+						{
+							"title": "external-auth access-token",
+							"description": "Print auth for an external provider",
+							"path": "reference/cli/external-auth_access-token.md"
+						},
+						{
+							"title": "external-workspaces",
+							"description": "Create or manage external workspaces",
+							"path": "reference/cli/external-workspaces.md"
+						},
+						{
+							"title": "external-workspaces agent-instructions",
+							"description": "Get the instructions for an external agent",
+							"path": "reference/cli/external-workspaces_agent-instructions.md"
+						},
+						{
+							"title": "external-workspaces create",
+							"description": "Create a new external workspace",
+							"path": "reference/cli/external-workspaces_create.md"
+						},
+						{
+							"title": "external-workspaces list",
+							"description": "List external workspaces",
+							"path": "reference/cli/external-workspaces_list.md"
+						},
+						{
+							"title": "favorite",
+							"description": "Add a workspace to your favorites",
+							"path": "reference/cli/favorite.md"
+						},
+						{
+							"title": "features",
+							"description": "List Enterprise features",
+							"path": "reference/cli/features.md"
+						},
+						{
+							"title": "features list",
+							"path": "reference/cli/features_list.md"
+						},
+						{
+							"title": "groups",
+							"description": "Manage groups",
+							"path": "reference/cli/groups.md"
+						},
+						{
+							"title": "groups create",
+							"description": "Create a user group",
+							"path": "reference/cli/groups_create.md"
+						},
+						{
+							"title": "groups delete",
+							"description": "Delete a user group",
+							"path": "reference/cli/groups_delete.md"
+						},
+						{
+							"title": "groups edit",
+							"description": "Edit a user group",
+							"path": "reference/cli/groups_edit.md"
+						},
+						{
+							"title": "groups list",
+							"description": "List user groups",
+							"path": "reference/cli/groups_list.md"
+						},
+						{
+							"title": "licenses",
+							"description": "Add, delete, and list licenses",
+							"path": "reference/cli/licenses.md"
+						},
+						{
+							"title": "licenses add",
+							"description": "Add license to Coder deployment",
+							"path": "reference/cli/licenses_add.md"
+						},
+						{
+							"title": "licenses delete",
+							"description": "Delete license by ID",
+							"path": "reference/cli/licenses_delete.md"
+						},
+						{
+							"title": "licenses list",
+							"description": "List licenses (including expired)",
+							"path": "reference/cli/licenses_list.md"
+						},
+						{
+							"title": "list",
+							"description": "List workspaces",
+							"path": "reference/cli/list.md"
+						},
+						{
+							"title": "login",
+							"description": "Authenticate with Coder deployment",
+							"path": "reference/cli/login.md"
+						},
+						{
+							"title": "login token",
+							"description": "Print the current session token",
+							"path": "reference/cli/login_token.md"
+						},
+						{
+							"title": "logout",
+							"description": "Unauthenticate your local session",
+							"path": "reference/cli/logout.md"
+						},
+						{
+							"title": "logs",
+							"description": "View logs for a workspace",
+							"path": "reference/cli/logs.md"
+						},
+						{
+							"title": "netcheck",
+							"description": "Print network debug information for DERP and STUN",
+							"path": "reference/cli/netcheck.md"
+						},
+						{
+							"title": "notifications",
+							"description": "Manage Coder notifications",
+							"path": "reference/cli/notifications.md"
+						},
+						{
+							"title": "notifications custom",
+							"description": "Send a custom notification",
+							"path": "reference/cli/notifications_custom.md"
+						},
+						{
+							"title": "notifications pause",
+							"description": "Pause notifications",
+							"path": "reference/cli/notifications_pause.md"
+						},
+						{
+							"title": "notifications resume",
+							"description": "Resume notifications",
+							"path": "reference/cli/notifications_resume.md"
+						},
+						{
+							"title": "notifications test",
+							"description": "Send a test notification",
+							"path": "reference/cli/notifications_test.md"
+						},
+						{
+							"title": "open",
+							"description": "Open a workspace",
+							"path": "reference/cli/open.md"
+						},
+						{
+							"title": "open app",
+							"description": "Open a workspace application.",
+							"path": "reference/cli/open_app.md"
+						},
+						{
+							"title": "open vscode",
+							"description": "Open a workspace in VS Code Desktop",
+							"path": "reference/cli/open_vscode.md"
+						},
+						{
+							"title": "organizations",
+							"description": "Organization related commands",
+							"path": "reference/cli/organizations.md"
+						},
+						{
+							"title": "organizations create",
+							"description": "Create a new organization.",
+							"path": "reference/cli/organizations_create.md"
+						},
+						{
+							"title": "organizations delete",
+							"description": "Delete an organization",
+							"path": "reference/cli/organizations_delete.md"
+						},
+						{
+							"title": "organizations list",
+							"description": "List all organizations",
+							"path": "reference/cli/organizations_list.md"
+						},
+						{
+							"title": "organizations members",
+							"description": "Manage organization members",
+							"path": "reference/cli/organizations_members.md"
+						},
+						{
+							"title": "organizations members add",
+							"description": "Add a new member to the current organization",
+							"path": "reference/cli/organizations_members_add.md"
+						},
+						{
+							"title": "organizations members edit-roles",
+							"description": "Edit organization member's roles",
+							"path": "reference/cli/organizations_members_edit-roles.md"
+						},
+						{
+							"title": "organizations members list",
+							"description": "List all organization members",
+							"path": "reference/cli/organizations_members_list.md"
+						},
+						{
+							"title": "organizations members remove",
+							"description": "Remove a new member to the current organization",
+							"path": "reference/cli/organizations_members_remove.md"
+						},
+						{
+							"title": "organizations roles",
+							"description": "Manage organization roles.",
+							"path": "reference/cli/organizations_roles.md"
+						},
+						{
+							"title": "organizations roles create",
+							"description": "Create a new organization custom role",
+							"path": "reference/cli/organizations_roles_create.md"
+						},
+						{
+							"title": "organizations roles show",
+							"description": "Show role(s)",
+							"path": "reference/cli/organizations_roles_show.md"
+						},
+						{
+							"title": "organizations roles update",
+							"description": "Update an organization custom role",
+							"path": "reference/cli/organizations_roles_update.md"
+						},
+						{
+							"title": "organizations settings",
+							"description": "Manage organization settings.",
+							"path": "reference/cli/organizations_settings.md"
+						},
+						{
+							"title": "organizations settings set",
+							"description": "Update specified organization setting.",
+							"path": "reference/cli/organizations_settings_set.md"
+						},
+						{
+							"title": "organizations settings set group-sync",
+							"description": "Group sync settings to sync groups from an IdP.",
+							"path": "reference/cli/organizations_settings_set_group-sync.md"
+						},
+						{
+							"title": "organizations settings set organization-sync",
+							"description": "Organization sync settings to sync organization memberships from an IdP.",
+							"path": "reference/cli/organizations_settings_set_organization-sync.md"
+						},
+						{
+							"title": "organizations settings set role-sync",
+							"description": "Role sync settings to sync organization roles from an IdP.",
+							"path": "reference/cli/organizations_settings_set_role-sync.md"
+						},
+						{
+							"title": "organizations settings set workspace-sharing",
+							"description": "Workspace sharing settings for the organization.",
+							"path": "reference/cli/organizations_settings_set_workspace-sharing.md"
+						},
+						{
+							"title": "organizations settings show",
+							"description": "Outputs specified organization setting.",
+							"path": "reference/cli/organizations_settings_show.md"
+						},
+						{
+							"title": "organizations settings show group-sync",
+							"description": "Group sync settings to sync groups from an IdP.",
+							"path": "reference/cli/organizations_settings_show_group-sync.md"
+						},
+						{
+							"title": "organizations settings show organization-sync",
+							"description": "Organization sync settings to sync organization memberships from an IdP.",
+							"path": "reference/cli/organizations_settings_show_organization-sync.md"
+						},
+						{
+							"title": "organizations settings show role-sync",
+							"description": "Role sync settings to sync organization roles from an IdP.",
+							"path": "reference/cli/organizations_settings_show_role-sync.md"
+						},
+						{
+							"title": "organizations settings show workspace-sharing",
+							"description": "Workspace sharing settings for the organization.",
+							"path": "reference/cli/organizations_settings_show_workspace-sharing.md"
+						},
+						{
+							"title": "organizations show",
+							"description": "Show the organization. Using \"selected\" will show the selected organization from the \"--org\" flag. Using \"me\" will show all organizations you are a member of.",
+							"path": "reference/cli/organizations_show.md"
+						},
+						{
+							"title": "ping",
+							"description": "Ping a workspace",
+							"path": "reference/cli/ping.md"
+						},
+						{
+							"title": "port-forward",
+							"description": "Forward ports from a workspace to the local machine. For reverse port forwarding, use \"coder ssh -R\".",
+							"path": "reference/cli/port-forward.md"
+						},
+						{
+							"title": "prebuilds",
+							"description": "Manage Coder prebuilds",
+							"path": "reference/cli/prebuilds.md"
+						},
+						{
+							"title": "prebuilds pause",
+							"description": "Pause prebuilds",
+							"path": "reference/cli/prebuilds_pause.md"
+						},
+						{
+							"title": "prebuilds resume",
+							"description": "Resume prebuilds",
+							"path": "reference/cli/prebuilds_resume.md"
+						},
+						{
+							"title": "provisioner",
+							"description": "View and manage provisioner daemons and jobs",
+							"path": "reference/cli/provisioner.md"
+						},
+						{
+							"title": "provisioner jobs",
+							"description": "View and manage provisioner jobs",
+							"path": "reference/cli/provisioner_jobs.md"
+						},
+						{
+							"title": "provisioner jobs cancel",
+							"description": "Cancel a provisioner job",
+							"path": "reference/cli/provisioner_jobs_cancel.md"
+						},
+						{
+							"title": "provisioner jobs list",
+							"description": "List provisioner jobs",
+							"path": "reference/cli/provisioner_jobs_list.md"
+						},
+						{
+							"title": "provisioner keys",
+							"description": "Manage provisioner keys",
+							"path": "reference/cli/provisioner_keys.md"
+						},
+						{
+							"title": "provisioner keys create",
+							"description": "Create a new provisioner key",
+							"path": "reference/cli/provisioner_keys_create.md"
+						},
+						{
+							"title": "provisioner keys delete",
+							"description": "Delete a provisioner key",
+							"path": "reference/cli/provisioner_keys_delete.md"
+						},
+						{
+							"title": "provisioner keys list",
+							"description": "List provisioner keys in an organization",
+							"path": "reference/cli/provisioner_keys_list.md"
+						},
+						{
+							"title": "provisioner list",
+							"description": "List provisioner daemons in an organization",
+							"path": "reference/cli/provisioner_list.md"
+						},
+						{
+							"title": "provisioner start",
+							"description": "Run a provisioner daemon",
+							"path": "reference/cli/provisioner_start.md"
+						},
+						{
+							"title": "publickey",
+							"description": "Output your Coder public key used for Git operations",
+							"path": "reference/cli/publickey.md"
+						},
+						{
+							"title": "rename",
+							"description": "Rename a workspace",
+							"path": "reference/cli/rename.md"
+						},
+						{
+							"title": "reset-password",
+							"description": "Directly connect to the database to reset a user's password",
+							"path": "reference/cli/reset-password.md"
+						},
+						{
+							"title": "restart",
+							"description": "Restart a workspace",
+							"path": "reference/cli/restart.md"
+						},
+						{
+							"title": "schedule",
+							"description": "Schedule automated start and stop times for workspaces",
+							"path": "reference/cli/schedule.md"
+						},
+						{
+							"title": "schedule extend",
+							"description": "Extend the stop time of a currently running workspace instance.",
+							"path": "reference/cli/schedule_extend.md"
+						},
+						{
+							"title": "schedule show",
+							"description": "Show workspace schedules",
+							"path": "reference/cli/schedule_show.md"
+						},
+						{
+							"title": "schedule start",
+							"description": "Edit workspace start schedule",
+							"path": "reference/cli/schedule_start.md"
+						},
+						{
+							"title": "schedule stop",
+							"description": "Edit workspace stop schedule",
+							"path": "reference/cli/schedule_stop.md"
+						},
+						{
+							"title": "server",
+							"description": "Start a Coder server",
+							"path": "reference/cli/server.md"
+						},
+						{
+							"title": "server create-admin-user",
+							"description": "Create a new admin user with the given username, email and password and adds it to every organization.",
+							"path": "reference/cli/server_create-admin-user.md"
+						},
+						{
+							"title": "server dbcrypt",
+							"description": "Manage database encryption.",
+							"path": "reference/cli/server_dbcrypt.md"
+						},
+						{
+							"title": "server dbcrypt decrypt",
+							"description": "Decrypt a previously encrypted database.",
+							"path": "reference/cli/server_dbcrypt_decrypt.md"
+						},
+						{
+							"title": "server dbcrypt delete",
+							"description": "Delete all encrypted data from the database. THIS IS A DESTRUCTIVE OPERATION.",
+							"path": "reference/cli/server_dbcrypt_delete.md"
+						},
+						{
+							"title": "server dbcrypt rotate",
+							"description": "Rotate database encryption keys.",
+							"path": "reference/cli/server_dbcrypt_rotate.md"
+						},
+						{
+							"title": "server postgres-builtin-serve",
+							"description": "Run the built-in PostgreSQL deployment.",
+							"path": "reference/cli/server_postgres-builtin-serve.md"
+						},
+						{
+							"title": "server postgres-builtin-url",
+							"description": "Output the connection URL for the built-in PostgreSQL deployment.",
+							"path": "reference/cli/server_postgres-builtin-url.md"
+						},
+						{
+							"title": "show",
+							"description": "Display details of a workspace's resources and agents",
+							"path": "reference/cli/show.md"
+						},
+						{
+							"title": "speedtest",
+							"description": "Run upload and download tests from your machine to a workspace",
+							"path": "reference/cli/speedtest.md"
+						},
+						{
+							"title": "ssh",
+							"description": "Start a shell into a workspace or run a command",
+							"path": "reference/cli/ssh.md"
+						},
+						{
+							"title": "start",
+							"description": "Start a workspace",
+							"path": "reference/cli/start.md"
+						},
+						{
+							"title": "stat",
+							"description": "Show resource usage for the current workspace.",
+							"path": "reference/cli/stat.md"
+						},
+						{
+							"title": "stat cpu",
+							"description": "Show CPU usage, in cores.",
+							"path": "reference/cli/stat_cpu.md"
+						},
+						{
+							"title": "stat disk",
+							"description": "Show disk usage, in gigabytes.",
+							"path": "reference/cli/stat_disk.md"
+						},
+						{
+							"title": "stat mem",
+							"description": "Show memory usage, in gigabytes.",
+							"path": "reference/cli/stat_mem.md"
+						},
+						{
+							"title": "state",
+							"description": "Manually manage Terraform state to fix broken workspaces",
+							"path": "reference/cli/state.md"
+						},
+						{
+							"title": "state pull",
+							"description": "Pull a Terraform state file from a workspace.",
+							"path": "reference/cli/state_pull.md"
+						},
+						{
+							"title": "state push",
+							"description": "Push a Terraform state file to a workspace.",
+							"path": "reference/cli/state_push.md"
+						},
+						{
+							"title": "stop",
+							"description": "Stop a workspace",
+							"path": "reference/cli/stop.md"
+						},
+						{
+							"title": "support",
+							"description": "Commands for troubleshooting issues with a Coder deployment.",
+							"path": "reference/cli/support.md"
+						},
+						{
+							"title": "support bundle",
+							"description": "Generate a support bundle to troubleshoot issues connecting to a workspace.",
+							"path": "reference/cli/support_bundle.md"
+						},
+						{
+							"title": "task",
+							"description": "Manage tasks",
+							"path": "reference/cli/task.md"
+						},
+						{
+							"title": "task create",
+							"description": "Create a task",
+							"path": "reference/cli/task_create.md"
+						},
+						{
+							"title": "task delete",
+							"description": "Delete tasks",
+							"path": "reference/cli/task_delete.md"
+						},
+						{
+							"title": "task list",
+							"description": "List tasks",
+							"path": "reference/cli/task_list.md"
+						},
+						{
+							"title": "task logs",
+							"description": "Show a task's logs",
+							"path": "reference/cli/task_logs.md"
+						},
+						{
+							"title": "task pause",
+							"description": "Pause a task",
+							"path": "reference/cli/task_pause.md"
+						},
+						{
+							"title": "task resume",
+							"description": "Resume a task",
+							"path": "reference/cli/task_resume.md"
+						},
+						{
+							"title": "task send",
+							"description": "Send input to a task",
+							"path": "reference/cli/task_send.md"
+						},
+						{
+							"title": "task status",
+							"description": "Show the status of a task.",
+							"path": "reference/cli/task_status.md"
+						},
+						{
+							"title": "templates",
+							"description": "Manage templates",
+							"path": "reference/cli/templates.md"
+						},
+						{
+							"title": "templates archive",
+							"description": "Archive unused or failed template versions from a given template(s)",
+							"path": "reference/cli/templates_archive.md"
+						},
+						{
+							"title": "templates create",
+							"description": "DEPRECATED: Create a template from the current directory or as specified by flag",
+							"path": "reference/cli/templates_create.md"
+						},
+						{
+							"title": "templates delete",
+							"description": "Delete templates",
+							"path": "reference/cli/templates_delete.md"
+						},
+						{
+							"title": "templates edit",
+							"description": "Edit the metadata of a template by name.",
+							"path": "reference/cli/templates_edit.md"
+						},
+						{
+							"title": "templates init",
+							"description": "Get started with a templated template.",
+							"path": "reference/cli/templates_init.md"
+						},
+						{
+							"title": "templates list",
+							"description": "List all the templates available for the organization",
+							"path": "reference/cli/templates_list.md"
+						},
+						{
+							"title": "templates presets",
+							"description": "Manage presets of the specified template",
+							"path": "reference/cli/templates_presets.md"
+						},
+						{
+							"title": "templates presets list",
+							"description": "List all presets of the specified template. Defaults to the active template version.",
+							"path": "reference/cli/templates_presets_list.md"
+						},
+						{
+							"title": "templates pull",
+							"description": "Download the active, latest, or specified version of a template to a path.",
+							"path": "reference/cli/templates_pull.md"
+						},
+						{
+							"title": "templates push",
+							"description": "Create or update a template from the current directory or as specified by flag",
+							"path": "reference/cli/templates_push.md"
+						},
+						{
+							"title": "templates versions",
+							"description": "Manage different versions of the specified template",
+							"path": "reference/cli/templates_versions.md"
+						},
+						{
+							"title": "templates versions archive",
+							"description": "Archive a template version(s).",
+							"path": "reference/cli/templates_versions_archive.md"
+						},
+						{
+							"title": "templates versions list",
+							"description": "List all the versions of the specified template",
+							"path": "reference/cli/templates_versions_list.md"
+						},
+						{
+							"title": "templates versions promote",
+							"description": "Promote a template version to active.",
+							"path": "reference/cli/templates_versions_promote.md"
+						},
+						{
+							"title": "templates versions unarchive",
+							"description": "Unarchive a template version(s).",
+							"path": "reference/cli/templates_versions_unarchive.md"
+						},
+						{
+							"title": "tokens",
+							"description": "Manage personal access tokens",
+							"path": "reference/cli/tokens.md"
+						},
+						{
+							"title": "tokens create",
+							"description": "Create a token",
+							"path": "reference/cli/tokens_create.md"
+						},
+						{
+							"title": "tokens list",
+							"description": "List tokens",
+							"path": "reference/cli/tokens_list.md"
+						},
+						{
+							"title": "tokens remove",
+							"description": "Expire or delete a token",
+							"path": "reference/cli/tokens_remove.md"
+						},
+						{
+							"title": "tokens view",
+							"description": "Display detailed information about a token",
+							"path": "reference/cli/tokens_view.md"
+						},
+						{
+							"title": "unfavorite",
+							"description": "Remove a workspace from your favorites",
+							"path": "reference/cli/unfavorite.md"
+						},
+						{
+							"title": "update",
+							"description": "Will update and start a given workspace if it is out of date. If the workspace is already running, it will be stopped first.",
+							"path": "reference/cli/update.md"
+						},
+						{
+							"title": "users",
+							"description": "Manage users",
+							"path": "reference/cli/users.md"
+						},
+						{
+							"title": "users activate",
+							"description": "Update a user's status to 'active'. Active users can fully interact with the platform",
+							"path": "reference/cli/users_activate.md"
+						},
+						{
+							"title": "users create",
+							"description": "Create a new user.",
+							"path": "reference/cli/users_create.md"
+						},
+						{
+							"title": "users delete",
+							"description": "Delete a user by username or user_id.",
+							"path": "reference/cli/users_delete.md"
+						},
+						{
+							"title": "users edit-roles",
+							"description": "Edit a user's roles by username or id",
+							"path": "reference/cli/users_edit-roles.md"
+						},
+						{
+							"title": "users list",
+							"description": "Prints the list of users.",
+							"path": "reference/cli/users_list.md"
+						},
+						{
+							"title": "users show",
+							"description": "Show a single user. Use 'me' to indicate the currently authenticated user.",
+							"path": "reference/cli/users_show.md"
+						},
+						{
+							"title": "users suspend",
+							"description": "Update a user's status to 'suspended'. A suspended user cannot log into the platform",
+							"path": "reference/cli/users_suspend.md"
+						},
+						{
+							"title": "version",
+							"description": "Show coder version",
+							"path": "reference/cli/version.md"
+						},
+						{
+							"title": "whoami",
+							"description": "Fetch authenticated user info for Coder deployment",
+							"path": "reference/cli/whoami.md"
+						}
+					]
+				},
+				{
+					"title": "Agent API",
+					"description": "Learn how to use Coder Agent API",
+					"path": "./reference/agent-api/index.md",
+					"icon_path": "./images/icons/api.svg",
+					"children": [
+						{
+							"title": "Debug",
+							"path": "./reference/agent-api/debug.md"
+						},
+						{
+							"title": "Schemas",
+							"path": "./reference/agent-api/schemas.md"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Coder Research",
+			"description": "Open source research projects exploring AI-assisted development",
+			"path": "./coder-research.md",
+			"icon_path": "./images/icons/wand.svg"
+		}
+	]
 }

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,2282 +1,2340 @@
 {
-	"versions": ["main"],
-	"routes": [
-		{
-			"title": "About",
-			"description": "Coder docs",
-			"path": "./README.md",
-			"icon_path": "./images/icons/home.svg",
-			"children": [
-				{
-					"title": "Screenshots",
-					"description": "View screenshots of the Coder platform",
-					"path": "./about/screenshots.md"
-				},
-				{
-					"title": "Quickstart",
-					"description": "Learn how to install and run Coder quickly",
-					"path": "./tutorials/quickstart.md"
-				},
-				{
-					"title": "Support",
-					"description": "How Coder supports your deployment and you",
-					"path": "./support/index.md",
-					"children": [
-						{
-							"title": "Generate a Support Bundle",
-							"description": "Generate and upload a Support Bundle to Coder Support",
-							"path": "./support/support-bundle.md"
-						}
-					]
-				},
-				{
-					"title": "Contributing",
-					"description": "Learn how to contribute to Coder",
-					"path": "./about/contributing/CONTRIBUTING.md",
-					"icon_path": "./images/icons/contributing.svg",
-					"children": [
-						{
-							"title": "Code of Conduct",
-							"description": "See the code of conduct for contributing to Coder",
-							"path": "./about/contributing/CODE_OF_CONDUCT.md",
-							"icon_path": "./images/icons/circle-dot.svg"
-						},
-						{
-							"title": "Documentation",
-							"description": "Our style guide for use when authoring documentation",
-							"path": "./about/contributing/documentation.md",
-							"icon_path": "./images/icons/document.svg"
-						},
-						{
-							"title": "Modules",
-							"description": "Learn how to contribute modules to Coder",
-							"path": "./about/contributing/modules.md",
-							"icon_path": "./images/icons/gear.svg"
-						},
-						{
-							"title": "Templates",
-							"description": "Learn how to contribute templates to Coder",
-							"path": "./about/contributing/templates.md",
-							"icon_path": "./images/icons/picture.svg"
-						},
-						{
-							"title": "Backend",
-							"description": "Our guide for backend development",
-							"path": "./about/contributing/backend.md",
-							"icon_path": "./images/icons/gear.svg"
-						},
-						{
-							"title": "Frontend",
-							"description": "Our guide for frontend development",
-							"path": "./about/contributing/frontend.md",
-							"icon_path": "./images/icons/frontend.svg"
-						},
-						{
-							"title": "Security",
-							"description": "Security vulnerability disclosure policy",
-							"path": "./about/contributing/SECURITY.md",
-							"icon_path": "./images/icons/lock.svg"
-						},
-						{
-							"title": "AI Contribution Guidelines",
-							"description": "Guidelines for AI-generated contributions.",
-							"path": "./about/contributing/AI_CONTRIBUTING.md",
-							"icon_path": "./images/icons/ai_intelligence.svg"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title": "Install",
-			"description": "Installing Coder",
-			"path": "./install/index.md",
-			"icon_path": "./images/icons/download.svg",
-			"children": [
-				{
-					"title": "Coder CLI",
-					"description": "Install the standalone binary",
-					"path": "./install/cli.md",
-					"icon_path": "./images/icons/terminal.svg"
-				},
-				{
-					"title": "Docker",
-					"description": "Install Coder using Docker",
-					"path": "./install/docker.md",
-					"icon_path": "./images/icons/docker.svg"
-				},
-				{
-					"title": "Kubernetes",
-					"description": "Install Coder on Kubernetes",
-					"path": "./install/kubernetes.md",
-					"icon_path": "./images/icons/kubernetes.svg",
-					"children": [
-						{
-							"title": "Deploy Coder on Azure with an Application Gateway",
-							"description": "Deploy Coder on Azure with an Application Gateway",
-							"path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
-						}
-					]
-				},
-				{
-					"title": "Rancher",
-					"description": "Deploy Coder on Rancher",
-					"path": "./install/rancher.md",
-					"icon_path": "./images/icons/rancher.svg"
-				},
-				{
-					"title": "OpenShift",
-					"description": "Install Coder on OpenShift",
-					"path": "./install/openshift.md",
-					"icon_path": "./images/icons/openshift.svg"
-				},
-				{
-					"title": "Cloud Providers",
-					"description": "Install Coder on cloud providers",
-					"path": "./install/cloud/index.md",
-					"icon_path": "./images/icons/cloud.svg",
-					"children": [
-						{
-							"title": "AWS EC2",
-							"description": "Install Coder on AWS EC2",
-							"path": "./install/cloud/ec2.md"
-						},
-						{
-							"title": "GCP Compute Engine",
-							"description": "Install Coder on GCP Compute Engine",
-							"path": "./install/cloud/compute-engine.md"
-						},
-						{
-							"title": "Azure VM",
-							"description": "Install Coder on an Azure VM",
-							"path": "./install/cloud/azure-vm.md"
-						}
-					]
-				},
-				{
-					"title": "Air-gapped Deployments",
-					"description": "Run Coder in air-gapped / disconnected / offline environments",
-					"path": "./install/airgap.md",
-					"icon_path": "./images/icons/lan.svg"
-				},
-				{
-					"title": "Unofficial Install Methods",
-					"description": "Other installation methods",
-					"path": "./install/other/index.md",
-					"icon_path": "./images/icons/generic.svg"
-				},
-				{
-					"title": "Upgrading",
-					"description": "Learn how to upgrade Coder",
-					"path": "./install/upgrade.md",
-					"icon_path": "./images/icons/upgrade.svg",
-					"children": [
-						{
-							"title": "Upgrading Best Practices",
-							"description": "Best practices and troubleshooting for Coder upgrades",
-							"path": "./install/upgrade-best-practices.md"
-						}
-					]
-				},
-				{
-					"title": "Uninstall",
-					"description": "Learn how to uninstall Coder",
-					"path": "./install/uninstall.md",
-					"icon_path": "./images/icons/trash.svg"
-				},
-				{
-					"title": "Releases",
-					"description": "Learn about the Coder release channels and schedule",
-					"path": "./install/releases/index.md",
-					"icon_path": "./images/icons/star.svg",
-					"children": [
-						{
-							"title": "Feature stages",
-							"description": "Information about pre-GA stages.",
-							"path": "./install/releases/feature-stages.md"
-						},
-						{
-							"title": "Upgrading from ESR 2.24 to 2.29",
-							"description": "Upgrade Guide for ESR Releases",
-							"path": "./install/releases/esr-2.24-2.29-upgrade.md"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title": "User Guides",
-			"description": "Guides for end-users of Coder",
-			"path": "./user-guides/index.md",
-			"icon_path": "./images/icons/users.svg",
-			"children": [
-				{
-					"title": "Access Workspaces",
-					"description": "Connect to your Coder workspaces",
-					"path": "./user-guides/workspace-access/index.md",
-					"icon_path": "./images/icons/access.svg",
-					"children": [
-						{
-							"title": "Visual Studio Code",
-							"description": "Use VSCode with Coder in the desktop or browser",
-							"path": "./user-guides/workspace-access/vscode.md"
-						},
-						{
-							"title": "Web Terminal",
-							"description": "Use the browser-based terminal to access your workspace",
-							"path": "./user-guides/workspace-access/web-terminal.md"
-						},
-						{
-							"title": "JetBrains IDEs",
-							"description": "Use JetBrains IDEs with Coder",
-							"path": "./user-guides/workspace-access/jetbrains/index.md",
-							"children": [
-								{
-									"title": "JetBrains Fleet",
-									"description": "Connect JetBrains Fleet to a Coder workspace",
-									"path": "./user-guides/workspace-access/jetbrains/fleet.md"
-								},
-								{
-									"title": "JetBrains Gateway",
-									"description": "Use JetBrains Gateway to connect to Coder workspaces",
-									"path": "./user-guides/workspace-access/jetbrains/gateway.md"
-								},
-								{
-									"title": "JetBrains Toolbox",
-									"description": "Access Coder workspaces from JetBrains Toolbox",
-									"path": "./user-guides/workspace-access/jetbrains/toolbox.md",
-									"state": ["beta"]
-								}
-							]
-						},
-						{
-							"title": "Remote Desktop",
-							"description": "Use RDP in Coder",
-							"path": "./user-guides/workspace-access/remote-desktops.md"
-						},
-						{
-							"title": "Emacs TRAMP",
-							"description": "Use Emacs TRAMP in Coder",
-							"path": "./user-guides/workspace-access/emacs-tramp.md"
-						},
-						{
-							"title": "Port Forwarding",
-							"description": "Access ports on your workspace",
-							"path": "./user-guides/workspace-access/port-forwarding.md"
-						},
-						{
-							"title": "Filebrowser",
-							"description": "Access your workspace files",
-							"path": "./user-guides/workspace-access/filebrowser.md"
-						},
-						{
-							"title": "Web IDEs and Coder Apps",
-							"description": "Access your workspace with IDEs in the browser",
-							"path": "./user-guides/workspace-access/web-ides.md"
-						},
-						{
-							"title": "code-server",
-							"description": "Access your workspace with code-server",
-							"path": "./user-guides/workspace-access/code-server.md"
-						},
-						{
-							"title": "Zed",
-							"description": "Access your workspace with Zed",
-							"path": "./user-guides/workspace-access/zed.md"
-						},
-						{
-							"title": "Cursor",
-							"description": "Access your workspace with Cursor",
-							"path": "./user-guides/workspace-access/cursor.md"
-						},
-						{
-							"title": "Windsurf",
-							"description": "Access your workspace with Windsurf",
-							"path": "./user-guides/workspace-access/windsurf.md"
-						},
-						{
-							"title": "Antigravity",
-							"description": "Access your workspace with Antigravity",
-							"path": "./user-guides/workspace-access/antigravity.md"
-						}
-					]
-				},
-				{
-					"title": "Coder Desktop",
-					"description": "Transform remote workspaces into seamless local development environments with no port forwarding required",
-					"path": "./user-guides/desktop/index.md",
-					"icon_path": "./images/icons/computer-code.svg",
-					"children": [
-						{
-							"title": "Coder Desktop Connect and Sync",
-							"description": "Use Coder Desktop to manage your workspace code and files locally",
-							"path": "./user-guides/desktop/desktop-connect-sync.md"
-						}
-					]
-				},
-				{
-					"title": "Workspace Management",
-					"description": "Manage workspaces",
-					"path": "./user-guides/workspace-management.md",
-					"icon_path": "./images/icons/generic.svg"
-				},
-				{
-					"title": "Workspace Sharing",
-					"description": "Sharing workspaces",
-					"path": "./user-guides/shared-workspaces.md",
-					"icon_path": "./images/icons/generic.svg",
-					"state": ["beta"]
-				},
-				{
-					"title": "Workspace Scheduling",
-					"description": "Cost control with workspace schedules",
-					"path": "./user-guides/workspace-scheduling.md",
-					"icon_path": "./images/icons/stopwatch.svg"
-				},
-				{
-					"title": "Workspace Lifecycle",
-					"description": "A guide to the workspace lifecycle, from creation and status through stopping and deletion.",
-					"path": "./user-guides/workspace-lifecycle.md",
-					"icon_path": "./images/icons/circle-dot.svg"
-				},
-				{
-					"title": "Dev Containers",
-					"description": "Run containerized development environments in your Coder workspace using the dev containers specification.",
-					"path": "./user-guides/devcontainers/index.md",
-					"icon_path": "./images/icons/container.svg",
-					"children": [
-						{
-							"title": "Working with dev containers",
-							"description": "Access dev containers via SSH, your IDE, or web terminal.",
-							"path": "./user-guides/devcontainers/working-with-dev-containers.md"
-						},
-						{
-							"title": "Customizing dev containers",
-							"description": "Configure custom agent names, apps, and display options in devcontainer.json.",
-							"path": "./user-guides/devcontainers/customizing-dev-containers.md"
-						},
-						{
-							"title": "Troubleshooting dev containers",
-							"description": "Diagnose and resolve common issues with dev containers in your Coder workspace.",
-							"path": "./user-guides/devcontainers/troubleshooting-dev-containers.md"
-						}
-					]
-				},
-				{
-					"title": "Dotfiles",
-					"description": "Personalize your environment with dotfiles",
-					"path": "./user-guides/workspace-dotfiles.md",
-					"icon_path": "./images/icons/art-pad.svg"
-				}
-			]
-		},
-		{
-			"title": "Administration",
-			"description": "Guides for template and deployment administrators",
-			"path": "./admin/index.md",
-			"icon_path": "./images/icons/wrench.svg",
-			"children": [
-				{
-					"title": "Setup",
-					"description": "Configure user access to your control plane.",
-					"path": "./admin/setup/index.md",
-					"icon_path": "./images/icons/toggle_on.svg",
-					"children": [
-						{
-							"title": "Appearance",
-							"description": "Learn how to configure the appearance of Coder",
-							"path": "./admin/setup/appearance.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Telemetry",
-							"description": "Learn what usage telemetry Coder collects",
-							"path": "./admin/setup/telemetry.md"
-						},
-						{
-							"title": "Data Retention",
-							"description": "Configure data retention policies for database tables",
-							"path": "./admin/setup/data-retention.md"
-						}
-					]
-				},
-				{
-					"title": "Infrastructure",
-					"description": "How to integrate Coder with your organization's compute",
-					"path": "./admin/infrastructure/index.md",
-					"icon_path": "./images/icons/container.svg",
-					"children": [
-						{
-							"title": "Architecture",
-							"description": "Learn about Coder's architecture",
-							"path": "./admin/infrastructure/architecture.md"
-						},
-						{
-							"title": "Validated Architectures",
-							"description": "Architectures for large Coder deployments",
-							"path": "./admin/infrastructure/validated-architectures/index.md",
-							"children": [
-								{
-									"title": "Up to 1,000 Users",
-									"description": "Hardware specifications and architecture guidance for Coder deployments that support up to 1,000 users",
-									"path": "./admin/infrastructure/validated-architectures/1k-users.md"
-								},
-								{
-									"title": "Up to 2,000 Users",
-									"description": "Hardware specifications and architecture guidance for Coder deployments that support up to 2,000 users",
-									"path": "./admin/infrastructure/validated-architectures/2k-users.md"
-								},
-								{
-									"title": "Up to 3,000 Users",
-									"description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 3,000 users",
-									"path": "./admin/infrastructure/validated-architectures/3k-users.md"
-								},
-								{
-									"title": "Up to 10,000 Users",
-									"description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 10,000 users",
-									"path": "./admin/infrastructure/validated-architectures/10k-users.md"
-								}
-							]
-						},
-						{
-							"title": "Scale Testing",
-							"description": "Ensure your deployment can handle your organization's needs",
-							"path": "./admin/infrastructure/scale-testing.md"
-						},
-						{
-							"title": "Scaling Utilities",
-							"description": "Tools to help you scale your deployment",
-							"path": "./admin/infrastructure/scale-utility.md"
-						},
-						{
-							"title": "Scaling best practices",
-							"description": "How to prepare a Coder deployment for scale",
-							"path": "./tutorials/best-practices/scale-coder.md"
-						}
-					]
-				},
-				{
-					"title": "Users",
-					"description": "Learn how to manage and audit users",
-					"path": "./admin/users/index.md",
-					"icon_path": "./images/icons/users.svg",
-					"children": [
-						{
-							"title": "OIDC Authentication",
-							"description": "Configure OpenID Connect authentication with identity providers like Okta or Active Directory",
-							"path": "./admin/users/oidc-auth/index.md",
-							"children": [
-								{
-									"title": "Google",
-									"description": "Configure Google as an OIDC provider",
-									"path": "./admin/users/oidc-auth/google.md"
-								},
-								{
-									"title": "Microsoft",
-									"description": "Configure Microsoft Entra ID as an OIDC provider",
-									"path": "./admin/users/oidc-auth/microsoft.md"
-								},
-								{
-									"title": "Configure OIDC refresh tokens",
-									"description": "How to configure OIDC refresh tokens",
-									"path": "./admin/users/oidc-auth/refresh-tokens.md"
-								}
-							]
-						},
-						{
-							"title": "GitHub Authentication",
-							"description": "Set up authentication through GitHub OAuth to enable secure user login and sign-up",
-							"path": "./admin/users/github-auth.md"
-						},
-						{
-							"title": "Password Authentication",
-							"description": "Manage username/password authentication settings and user password reset workflows",
-							"path": "./admin/users/password-auth.md"
-						},
-						{
-							"title": "Headless Authentication",
-							"description": "Create and manage headless service accounts for automated systems and API integrations",
-							"path": "./admin/users/headless-auth.md"
-						},
-						{
-							"title": "Groups \u0026 Roles",
-							"description": "Manage access control with user groups and role-based permissions for Coder resources",
-							"path": "./admin/users/groups-roles.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "IdP Sync",
-							"description": "Synchronize user groups, roles, and organizations from your identity provider to Coder",
-							"path": "./admin/users/idp-sync.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Organizations",
-							"description": "Segment and isolate resources by creating separate organizations for different teams or projects",
-							"path": "./admin/users/organizations.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Quotas",
-							"description": "Control resource usage by implementing workspace budgets and credit-based cost management",
-							"path": "./admin/users/quotas.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Sessions \u0026 API Tokens",
-							"description": "Manage authentication tokens for API access and configure session duration policies",
-							"path": "./admin/users/sessions-tokens.md"
-						}
-					]
-				},
-				{
-					"title": "Templates",
-					"description": "Learn how to author and maintain Coder templates",
-					"path": "./admin/templates/index.md",
-					"icon_path": "./images/icons/picture.svg",
-					"children": [
-						{
-							"title": "Creating Templates",
-							"description": "Learn how to create templates with Terraform",
-							"path": "./admin/templates/creating-templates.md"
-						},
-						{
-							"title": "Managing Templates",
-							"description": "Learn how to manage templates and best practices",
-							"path": "./admin/templates/managing-templates/index.md",
-							"children": [
-								{
-									"title": "Image Management",
-									"description": "Learn about template image management",
-									"path": "./admin/templates/managing-templates/image-management.md"
-								},
-								{
-									"title": "Change Management",
-									"description": "Learn about template change management and versioning",
-									"path": "./admin/templates/managing-templates/change-management.md"
-								},
-								{
-									"title": "Envbuilder",
-									"description": "Shift environment definition to repositories",
-									"path": "./admin/templates/managing-templates/envbuilder.md"
-								},
-								{
-									"title": "Template Dependencies",
-									"description": "Learn how to manage template dependencies",
-									"path": "./admin/templates/managing-templates/dependencies.md"
-								},
-								{
-									"title": "Workspace Scheduling",
-									"description": "Learn how to control how workspaces are started and stopped",
-									"path": "./admin/templates/managing-templates/schedule.md"
-								},
-								{
-									"title": "External Workspaces",
-									"description": "Learn how to manage external workspaces",
-									"path": "./admin/templates/managing-templates/external-workspaces.md",
-									"state": ["premium", "early access"]
-								}
-							]
-						},
-						{
-							"title": "Extending Templates",
-							"description": "Learn best practices in extending templates",
-							"path": "./admin/templates/extending-templates/index.md",
-							"children": [
-								{
-									"title": "Agent Metadata",
-									"description": "Retrieve real-time stats from the workspace agent",
-									"path": "./admin/templates/extending-templates/agent-metadata.md"
-								},
-								{
-									"title": "Build Parameters",
-									"description": "Use parameters to customize workspaces at build",
-									"path": "./admin/templates/extending-templates/parameters.md"
-								},
-								{
-									"title": "Dynamic Parameters",
-									"description": "Conditional, identity-aware parameter syntax for advanced users.",
-									"path": "./admin/templates/extending-templates/dynamic-parameters.md"
-								},
-								{
-									"title": "Prebuilt workspaces",
-									"description": "Pre-provision a ready-to-deploy workspace with a defined set of parameters",
-									"path": "./admin/templates/extending-templates/prebuilt-workspaces.md",
-									"state": ["premium"]
-								},
-								{
-									"title": "Icons",
-									"description": "Customize your template with built-in icons",
-									"path": "./admin/templates/extending-templates/icons.md"
-								},
-								{
-									"title": "Resource Metadata",
-									"description": "Display resource state in the workspace dashboard",
-									"path": "./admin/templates/extending-templates/resource-metadata.md"
-								},
-								{
-									"title": "Resource Monitoring",
-									"description": "Monitor resources in the workspace dashboard",
-									"path": "./admin/templates/extending-templates/resource-monitoring.md"
-								},
-								{
-									"title": "Resource Ordering",
-									"description": "Design the UI of workspaces",
-									"path": "./admin/templates/extending-templates/resource-ordering.md"
-								},
-								{
-									"title": "Resource Persistence",
-									"description": "Control resource persistence",
-									"path": "./admin/templates/extending-templates/resource-persistence.md"
-								},
-								{
-									"title": "Terraform Variables",
-									"description": "Use variables to manage template state",
-									"path": "./admin/templates/extending-templates/variables.md"
-								},
-								{
-									"title": "Terraform Modules",
-									"description": "Reuse terraform code across templates",
-									"path": "./admin/templates/extending-templates/modules.md"
-								},
-								{
-									"title": "Web IDEs and Coder Apps",
-									"description": "Add and configure Web IDEs in your templates as coder apps",
-									"path": "./admin/templates/extending-templates/web-ides.md"
-								},
-								{
-									"title": "Pre-install JetBrains IDEs",
-									"description": "Pre-install JetBrains IDEs in a template for faster IDE startup",
-									"path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
-								},
-								{
-									"title": "JetBrains IDEs in Air-Gapped Deployments",
-									"description": "Configure JetBrains IDEs for air-gapped deployments",
-									"path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
-								},
-								{
-									"title": "Docker in Workspaces",
-									"description": "Use Docker in your workspaces",
-									"path": "./admin/templates/extending-templates/docker-in-workspaces.md"
-								},
-								{
-									"title": "Workspace Tags",
-									"description": "Control provisioning using Workspace Tags and Parameters",
-									"path": "./admin/templates/extending-templates/workspace-tags.md"
-								},
-								{
-									"title": "Provider Authentication",
-									"description": "Authenticate with provider APIs to provision workspaces",
-									"path": "./admin/templates/extending-templates/provider-authentication.md"
-								},
-								{
-									"title": "Dev Containers",
-									"description": "Extend templates with containerized dev environments",
-									"path": "./admin/templates/extending-templates/devcontainers.md"
-								},
-								{
-									"title": "Process Logging",
-									"description": "Log workspace processes",
-									"path": "./admin/templates/extending-templates/process-logging.md",
-									"state": ["premium"]
-								},
-								{
-									"title": "Startup Dependencies",
-									"description": "Coordinate workspace startup with dependency management",
-									"path": "./admin/templates/startup-coordination/index.md",
-									"state": ["early access"],
-									"children": [
-										{
-											"title": "Usage",
-											"description": "How to use startup coordination",
-											"path": "./admin/templates/startup-coordination/usage.md"
-										},
-										{
-											"title": "Troubleshooting",
-											"description": "Troubleshoot startup coordination",
-											"path": "./admin/templates/startup-coordination/troubleshooting.md"
-										},
-										{
-											"title": "Examples",
-											"description": "Examples of startup coordination",
-											"path": "./admin/templates/startup-coordination/example.md"
-										}
-									]
-								}
-							]
-						},
-						{
-							"title": "Open in Coder",
-							"description": "Open workspaces in Coder",
-							"path": "./admin/templates/open-in-coder.md"
-						},
-						{
-							"title": "Permissions \u0026 Policies",
-							"description": "Learn how to create templates with Terraform",
-							"path": "./admin/templates/template-permissions.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Troubleshooting Templates",
-							"description": "Learn how to troubleshoot template issues",
-							"path": "./admin/templates/troubleshooting.md"
-						}
-					]
-				},
-				{
-					"title": "External Provisioners",
-					"description": "Learn how to run external provisioners with Coder",
-					"path": "./admin/provisioners/index.md",
-					"icon_path": "./images/icons/key.svg",
-					"state": ["premium"],
-					"children": [
-						{
-							"title": "Manage Provisioner Jobs",
-							"description": "Learn how to run external provisioners with Coder",
-							"path": "./admin/provisioners/manage-provisioner-jobs.md",
-							"state": ["premium"]
-						}
-					]
-				},
-				{
-					"title": "External Authentication",
-					"description": "Learn how to configure external authentication",
-					"path": "./admin/external-auth/index.md",
-					"icon_path": "./images/icons/plug.svg"
-				},
-				{
-					"title": "Integrations",
-					"description": "Use integrations to extend Coder",
-					"path": "./admin/integrations/index.md",
-					"icon_path": "./images/icons/puzzle.svg",
-					"children": [
-						{
-							"title": "Prometheus",
-							"description": "Collect deployment metrics with Prometheus",
-							"path": "./admin/integrations/prometheus.md"
-						},
-						{
-							"title": "Kubernetes Logging",
-							"description": "Stream K8s event logs on workspace startup",
-							"path": "./admin/integrations/kubernetes-logs.md"
-						},
-						{
-							"title": "Additional Kubernetes Clusters",
-							"description": "Deploy workspaces on additional Kubernetes clusters",
-							"path": "./admin/integrations/multiple-kube-clusters.md"
-						},
-						{
-							"title": "JFrog Artifactory",
-							"description": "Integrate Coder with JFrog Artifactory",
-							"path": "./admin/integrations/jfrog-artifactory.md"
-						},
-						{
-							"title": "Island Secure Browser",
-							"description": "Integrate Coder with Island's Secure Browser",
-							"path": "./admin/integrations/island.md"
-						},
-						{
-							"title": "DX PlatformX",
-							"description": "Integrate Coder with DX PlatformX",
-							"path": "./admin/integrations/platformx.md"
-						},
-						{
-							"title": "DX Data Cloud",
-							"description": "Tag Coder Users with DX Data Cloud",
-							"path": "./admin/integrations/dx-data-cloud.md"
-						},
-						{
-							"title": "Hashicorp Vault",
-							"description": "Integrate Coder with Hashicorp Vault",
-							"path": "./admin/integrations/vault.md"
-						},
-						{
-							"title": "OAuth2 Provider",
-							"description": "Use Coder as an OAuth2 provider",
-							"path": "./admin/integrations/oauth2-provider.md"
-						},
-						{
-							"title": "Dev Containers",
-							"description": "Configure dev container support using Docker or Envbuilder",
-							"path": "./admin/integrations/devcontainers/index.md",
-							"children": [
-								{
-									"title": "Dev Containers Integration",
-									"description": "Configure native dev containers with Docker",
-									"path": "./admin/integrations/devcontainers/integration.md"
-								},
-								{
-									"title": "Envbuilder",
-									"description": "Build dev containers without Docker",
-									"path": "./admin/integrations/devcontainers/envbuilder/index.md",
-									"children": [
-										{
-											"title": "Add an Envbuilder template",
-											"description": "How to add an Envbuilder template",
-											"path": "./admin/integrations/devcontainers/envbuilder/add-envbuilder.md"
-										},
-										{
-											"title": "Security and caching",
-											"description": "Configure authentication and caching",
-											"path": "./admin/integrations/devcontainers/envbuilder/envbuilder-security-caching.md"
-										},
-										{
-											"title": "Releases and known issues",
-											"description": "Release channels and known issues",
-											"path": "./admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md"
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"title": "Networking",
-					"description": "Understand Coder's networking layer",
-					"path": "./admin/networking/index.md",
-					"icon_path": "./images/icons/networking.svg",
-					"children": [
-						{
-							"title": "Port Forwarding",
-							"description": "Learn how to forward ports in Coder",
-							"path": "./admin/networking/port-forwarding.md"
-						},
-						{
-							"title": "STUN and NAT",
-							"description": "Learn how to forward ports in Coder",
-							"path": "./admin/networking/stun.md"
-						},
-						{
-							"title": "Workspace Proxies",
-							"description": "Run geo distributed workspace proxies",
-							"path": "./admin/networking/workspace-proxies.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "High Availability",
-							"description": "Learn how to configure Coder for High Availability",
-							"path": "./admin/networking/high-availability.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Wildcard Access URL",
-							"description": "Learn about wildcard access URL in Coder deployments",
-							"path": "./admin/networking/wildcard-access-url.md"
-						},
-						{
-							"title": "Troubleshooting",
-							"description": "Troubleshoot networking issues in Coder",
-							"path": "./admin/networking/troubleshooting.md"
-						}
-					]
-				},
-				{
-					"title": "Monitoring",
-					"description": "Configure security policy and audit your deployment",
-					"path": "./admin/monitoring/index.md",
-					"icon_path": "./images/icons/speed.svg",
-					"children": [
-						{
-							"title": "Logs",
-							"description": "Learn about Coder's logs",
-							"path": "./admin/monitoring/logs.md"
-						},
-						{
-							"title": "Metrics",
-							"description": "Learn about Coder's logs",
-							"path": "./admin/monitoring/metrics.md"
-						},
-						{
-							"title": "Health Check",
-							"description": "Learn about Coder's automated health checks",
-							"path": "./admin/monitoring/health-check.md"
-						},
-						{
-							"title": "Connection Logs",
-							"description": "Monitor connections to workspaces",
-							"path": "./admin/monitoring/connection-logs.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Notifications",
-							"description": "Configure notifications for your deployment",
-							"path": "./admin/monitoring/notifications/index.md",
-							"children": [
-								{
-									"title": "Slack Notifications",
-									"description": "Learn how to setup Slack notifications",
-									"path": "./admin/monitoring/notifications/slack.md"
-								},
-								{
-									"title": "Microsoft Teams Notifications",
-									"description": "Learn how to setup Microsoft Teams notifications",
-									"path": "./admin/monitoring/notifications/teams.md"
-								}
-							]
-						}
-					]
-				},
-				{
-					"title": "Security",
-					"description": "Configure security policy and audit your deployment",
-					"path": "./admin/security/index.md",
-					"icon_path": "./images/icons/lock.svg",
-					"children": [
-						{
-							"title": "Audit Logs",
-							"description": "Audit actions taken inside Coder",
-							"path": "./admin/security/audit-logs.md",
-							"state": ["premium"]
-						},
-						{
-							"title": "Secrets",
-							"description": "Use sensitive variables in your workspaces",
-							"path": "./admin/security/secrets.md"
-						},
-						{
-							"title": "Database Encryption",
-							"description": "Encrypt the database to prevent unauthorized access",
-							"path": "./admin/security/database-encryption.md",
-							"state": ["premium"]
-						}
-					]
-				},
-				{
-					"title": "Licensing",
-					"description": "Configure licensing for your deployment",
-					"path": "./admin/licensing/index.md",
-					"icon_path": "./images/icons/licensing.svg"
-				}
-			]
-		},
-		{
-			"title": "Run AI Coding Agents in Coder",
-			"description": "Learn how to run and integrate agentic AI coding agents like GPT-Code, OpenDevin, or SWE-Agent in Coder workspaces to boost developer productivity.",
-			"path": "./ai-coder/index.md",
-			"icon_path": "./images/icons/wand.svg",
-			"children": [
-				{
-					"title": "Best Practices",
-					"description": "Best Practices running Coding Agents",
-					"path": "./ai-coder/best-practices.md"
-				},
-				{
-					"title": "In the IDE",
-					"description": "Run IDE agents with Coder",
-					"path": "./ai-coder/ide-agents.md"
-				},
-				{
-					"title": "Coder Tasks",
-					"description": "Run Coding Agents on your Own Infrastructure",
-					"path": "./ai-coder/tasks.md",
-					"children": [
-						{
-							"title": "Understanding Coder Tasks",
-							"description": "Core principles and concepts behind Coder Tasks",
-							"path": "./ai-coder/tasks-core-principles.md"
-						},
-						{
-							"title": "Custom Agents",
-							"description": "Run custom agents with Coder Tasks",
-							"path": "./ai-coder/custom-agents.md"
-						},
-						{
-							"title": "Task Lifecycle",
-							"description": "How tasks pause and resume, and what gets preserved",
-							"path": "./ai-coder/tasks-lifecycle.md"
-						},
-						{
-							"title": "Agent Compatibility",
-							"description": "Which AI agents support session persistence across workspace restarts",
-							"path": "./ai-coder/agent-compatibility.md"
-						},
-						{
-							"title": "Tasks Migration Guide",
-							"description": "Changes to Coder Tasks made in v2.28",
-							"path": "./ai-coder/tasks-migration.md"
-						},
-						{
-							"title": "Security \u0026 Boundaries",
-							"description": "Learn about security and boundaries when running AI coding agents in Coder",
-							"path": "./ai-coder/security.md"
-						},
-						{
-							"title": "Create a GitHub to Coder Tasks Workflow",
-							"description": "How to setup Coder Tasks to run in GitHub",
-							"path": "./ai-coder/github-to-tasks.md"
-						}
-					]
-				},
-				{
-					"title": "AI Governance Add-On",
-					"description": "Features around managing agents at scale",
-					"path": "./ai-coder/ai-governance.md",
-					"state": ["premium"],
-					"children": [
-						{
-							"title": "Agent Boundaries",
-							"description": "Understanding Agent Boundaries in Coder Tasks",
-							"path": "./ai-coder/agent-boundaries/index.md",
-							"state": ["premium"],
-							"children": [
-								{
-									"title": "NS Jail",
-									"description": "Documentation for Namespace Jail",
-									"path": "./ai-coder/agent-boundaries/nsjail/index.md",
-									"children": [
-										{
-											"title": "NS Jail on Docker",
-											"description": "Runtime and permission requirements for running NS Jail on Docker",
-											"path": "./ai-coder/agent-boundaries/nsjail/docker.md"
-										},
-										{
-											"title": "NS Jail on Kubernetes",
-											"description": "Runtime and permission requirements for running NS Jail on Kubernetes",
-											"path": "./ai-coder/agent-boundaries/nsjail/k8s.md"
-										},
-										{
-											"title": "NS Jail on ECS",
-											"description": "Runtime and permission requirements for running NS Jail on ECS",
-											"path": "./ai-coder/agent-boundaries/nsjail/ecs.md"
-										}
-									]
-								},
-								{
-									"title": "LandJail",
-									"description": "Documentation for LandJail",
-									"path": "./ai-coder/agent-boundaries/landjail.md"
-								},
-								{
-									"title": "Rules Engine",
-									"description": "Documentation for the Boundary rules engine",
-									"path": "./ai-coder/agent-boundaries/rules-engine.md"
-								},
-								{
-									"title": "Version Compatibility",
-									"description": "Version requirements and compatibility information",
-									"path": "./ai-coder/agent-boundaries/version.md"
-								}
-							]
-						},
-						{
-							"title": "AI Bridge",
-							"description": "AI Gateway for Enterprise Governance \u0026 Observability",
-							"path": "./ai-coder/ai-bridge/index.md",
-							"icon_path": "./images/icons/api.svg",
-							"state": ["premium"],
-							"children": [
-								{
-									"title": "Setup",
-									"description": "How to set up and configure AI Bridge",
-									"path": "./ai-coder/ai-bridge/setup.md"
-								},
-								{
-									"title": "Client Configuration",
-									"description": "How to configure your AI coding tools to use AI Bridge",
-									"path": "./ai-coder/ai-bridge/clients/index.md",
-									"children": [
-										{
-											"title": "Claude Code",
-											"description": "Configure Claude Code to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/claude-code.md"
-										},
-										{
-											"title": "Codex",
-											"description": "Configure Codex to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/codex.md"
-										},
-										{
-											"title": "Mux",
-											"description": "Configure Mux to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/mux.md"
-										},
-										{
-											"title": "OpenCode",
-											"description": "Configure OpenCode to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/opencode.md"
-										},
-										{
-											"title": "Factory",
-											"description": "Configure Factory to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/factory.md"
-										},
-										{
-											"title": "Cline",
-											"description": "Configure Cline to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/cline.md"
-										},
-										{
-											"title": "Kilo Code",
-											"description": "Configure Kilo Code to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/kilo-code.md"
-										},
-										{
-											"title": "Roo Code",
-											"description": "Configure Roo Code to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/roo-code.md"
-										},
-										{
-											"title": "VS Code",
-											"description": "Configure VS Code to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/vscode.md"
-										},
-										{
-											"title": "JetBrains",
-											"description": "Configure JetBrains IDEs to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/jetbrains.md"
-										},
-										{
-											"title": "Zed",
-											"description": "Configure Zed to use AI Bridge",
-											"path": "./ai-coder/ai-bridge/clients/zed.md"
-										},
-										{
-											"title": "GitHub Copilot",
-											"description": "Configure GitHub Copilot to use AI Bridge via AI Bridge Proxy",
-											"path": "./ai-coder/ai-bridge/clients/copilot.md"
-										}
-									]
-								},
-								{
-									"title": "MCP Tools Injection",
-									"description": "How to configure MCP servers for tools injection through AI Bridge",
-									"path": "./ai-coder/ai-bridge/mcp.md",
-									"state": ["early access"]
-								},
-								{
-									"title": "AI Bridge Proxy",
-									"description": "Proxy for AI coding tools without base URL override support",
-									"path": "./ai-coder/ai-bridge/ai-bridge-proxy/index.md",
-									"state": ["premium"],
-									"children": [
-										{
-											"title": "Setup",
-											"description": "How to set up and configure AI Bridge Proxy",
-											"path": "./ai-coder/ai-bridge/ai-bridge-proxy/setup.md"
-										}
-									]
-								},
-								{
-									"title": "Monitoring",
-									"description": "How to monitor AI Bridge",
-									"path": "./ai-coder/ai-bridge/monitoring.md"
-								},
-								{
-									"title": "Reference",
-									"description": "Technical reference for AI Bridge",
-									"path": "./ai-coder/ai-bridge/reference.md"
-								}
-							]
-						},
-						{
-							"title": "Usage Data Reporting",
-							"description": "Configure AI usage data reporting",
-							"path": "./ai-coder/usage-data-reporting.md"
-						}
-					]
-				},
-				{
-					"title": "MCP Server",
-					"description": "Connect to agents Coder with a MCP server",
-					"path": "./ai-coder/mcp-server.md",
-					"state": ["beta"]
-				},
-				{
-					"title": "Coder Agents",
-					"description": "Self-hosted agent by Coder",
-					"path": "./ai-coder/agents/index.md",
-					"children": [
-						{
-							"title": "Architecture",
-							"description": "How the agent in the control plane communicates with workspaces",
-							"path": "./ai-coder/agents/architecture.md"
-						},
-						{
-							"title": "Models",
-							"description": "Configure LLM providers and models for Coder Agents",
-							"path": "./ai-coder/agents/models.md"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title": "Tutorials",
-			"description": "Coder knowledgebase for administrating your deployment",
-			"path": "./tutorials/index.md",
-			"icon_path": "./images/icons/generic.svg",
-			"children": [
-				{
-					"title": "Quickstart",
-					"description": "Learn how to install and run Coder quickly",
-					"path": "./tutorials/quickstart.md"
-				},
-				{
-					"title": "Write a Template from Scratch",
-					"description": "Learn how to author Coder templates",
-					"path": "./tutorials/template-from-scratch.md"
-				},
-				{
-					"title": "Using an External Database",
-					"description": "Use Coder with an external database",
-					"path": "./tutorials/external-database.md"
-				},
-				{
-					"title": "Image Management",
-					"description": "Learn about image management with Coder",
-					"path": "./admin/templates/managing-templates/image-management.md"
-				},
-				{
-					"title": "Configuring Okta",
-					"description": "Custom claims/scopes with Okta for group/role sync",
-					"path": "./tutorials/configuring-okta.md"
-				},
-				{
-					"title": "Google to AWS Federation",
-					"description": "Federating a Google Cloud service account to AWS",
-					"path": "./tutorials/gcp-to-aws.md"
-				},
-				{
-					"title": "JFrog Artifactory Integration",
-					"description": "Integrate Coder with JFrog Artifactory",
-					"path": "./admin/integrations/jfrog-artifactory.md"
-				},
-				{
-					"title": "Mirror Coder Registry with Artifactory",
-					"description": "Use JFrog Artifactory to mirror the Coder Registry for air-gapped deployments",
-					"path": "./install/registry-mirror-artifactory.md"
-				},
-				{
-					"title": "Istio Integration",
-					"description": "Integrate Coder with Istio",
-					"path": "./admin/integrations/istio.md"
-				},
-				{
-					"title": "Island Secure Browser Integration",
-					"description": "Integrate Coder with Island's Secure Browser",
-					"path": "./admin/integrations/island.md"
-				},
-				{
-					"title": "Template ImagePullSecrets",
-					"description": "Creating ImagePullSecrets for private registries",
-					"path": "./tutorials/image-pull-secret.md"
-				},
-				{
-					"title": "Postgres SSL",
-					"description": "Configure Coder to connect to Postgres over SSL",
-					"path": "./tutorials/postgres-ssl.md"
-				},
-				{
-					"title": "Azure Federation",
-					"description": "Federating Coder to Azure",
-					"path": "./tutorials/azure-federation.md"
-				},
-				{
-					"title": "Deploy Coder on Azure with an Application Gateway",
-					"description": "Deploy Coder on Azure with an Application Gateway",
-					"path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
-				},
-				{
-					"title": "Cloning Git Repositories",
-					"description": "Learn how to clone Git repositories in Coder",
-					"path": "./tutorials/cloning-git-repositories.md"
-				},
-				{
-					"title": "Test Templates Through CI/CD",
-					"description": "Learn how to test and publish Coder templates in a CI/CD pipeline",
-					"path": "./tutorials/testing-templates.md"
-				},
-				{
-					"title": "Use Apache as a Reverse Proxy",
-					"description": "Learn how to use Apache as a reverse proxy",
-					"path": "./tutorials/reverse-proxy-apache.md"
-				},
-				{
-					"title": "Use Caddy as a Reverse Proxy",
-					"description": "Learn how to use Caddy as a reverse proxy",
-					"path": "./tutorials/reverse-proxy-caddy.md"
-				},
-				{
-					"title": "Use NGINX as a Reverse Proxy",
-					"description": "Learn how to use NGINX as a reverse proxy",
-					"path": "./tutorials/reverse-proxy-nginx.md"
-				},
-				{
-					"title": "Pre-install JetBrains IDEs in Workspaces",
-					"description": "Pre-install JetBrains IDEs in workspaces",
-					"path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
-				},
-				{
-					"title": "Use JetBrains IDEs in Air-Gapped Deployments",
-					"description": "Configure JetBrains IDEs for air-gapped deployments",
-					"path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
-				},
-				{
-					"title": "FAQs",
-					"description": "Miscellaneous FAQs from our community",
-					"path": "./tutorials/faqs.md"
-				},
-				{
-					"title": "Best practices",
-					"description": "Guides to help you make the most of your Coder experience",
-					"path": "./tutorials/best-practices/index.md",
-					"children": [
-						{
-							"title": "Organizations - best practices",
-							"description": "How to make the best use of Coder Organizations",
-							"path": "./tutorials/best-practices/organizations.md"
-						},
-						{
-							"title": "Scale Coder",
-							"description": "How to prepare a Coder deployment for scale",
-							"path": "./tutorials/best-practices/scale-coder.md"
-						},
-						{
-							"title": "Security - best practices",
-							"description": "Make your Coder deployment more secure",
-							"path": "./tutorials/best-practices/security-best-practices.md"
-						},
-						{
-							"title": "Speed up your workspaces",
-							"description": "Speed up your Coder templates and workspaces",
-							"path": "./tutorials/best-practices/speed-up-templates.md"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title": "Reference",
-			"description": "Reference",
-			"path": "./reference/index.md",
-			"icon_path": "./images/icons/notes.svg",
-			"children": [
-				{
-					"title": "REST API",
-					"description": "Learn how to use Coderd API",
-					"path": "./reference/api/index.md",
-					"icon_path": "./images/icons/api.svg",
-					"children": [
-						{
-							"title": "General",
-							"path": "./reference/api/general.md"
-						},
-						{
-							"title": "AI Bridge",
-							"path": "./reference/api/aibridge.md"
-						},
-						{
-							"title": "Agents",
-							"path": "./reference/api/agents.md"
-						},
-						{
-							"title": "Applications",
-							"path": "./reference/api/applications.md"
-						},
-						{
-							"title": "Audit",
-							"path": "./reference/api/audit.md"
-						},
-						{
-							"title": "Authentication",
-							"path": "./reference/api/authentication.md"
-						},
-						{
-							"title": "Authorization",
-							"path": "./reference/api/authorization.md"
-						},
-						{
-							"title": "Builds",
-							"path": "./reference/api/builds.md"
-						},
-						{
-							"title": "Chats",
-							"path": "./reference/api/chats.md"
-						},
-						{
-							"title": "Debug",
-							"path": "./reference/api/debug.md"
-						},
-						{
-							"title": "Enterprise",
-							"path": "./reference/api/enterprise.md"
-						},
-						{
-							"title": "Files",
-							"path": "./reference/api/files.md"
-						},
-						{
-							"title": "Git",
-							"path": "./reference/api/git.md"
-						},
-						{
-							"title": "InitScript",
-							"path": "./reference/api/initscript.md"
-						},
-						{
-							"title": "Insights",
-							"path": "./reference/api/insights.md"
-						},
-						{
-							"title": "Members",
-							"path": "./reference/api/members.md"
-						},
-						{
-							"title": "Notifications",
-							"path": "./reference/api/notifications.md"
-						},
-						{
-							"title": "Organizations",
-							"path": "./reference/api/organizations.md"
-						},
-						{
-							"title": "PortSharing",
-							"path": "./reference/api/portsharing.md"
-						},
-						{
-							"title": "Prebuilds",
-							"path": "./reference/api/prebuilds.md"
-						},
-						{
-							"title": "Provisioning",
-							"path": "./reference/api/provisioning.md"
-						},
-						{
-							"title": "Schemas",
-							"path": "./reference/api/schemas.md"
-						},
-						{
-							"title": "Tasks",
-							"path": "./reference/api/tasks.md"
-						},
-						{
-							"title": "Templates",
-							"path": "./reference/api/templates.md"
-						},
-						{
-							"title": "Users",
-							"path": "./reference/api/users.md"
-						},
-						{
-							"title": "WorkspaceProxies",
-							"path": "./reference/api/workspaceproxies.md"
-						},
-						{
-							"title": "Workspaces",
-							"path": "./reference/api/workspaces.md"
-						}
-					]
-				},
-				{
-					"title": "Command Line",
-					"description": "Learn how to use Coder CLI",
-					"path": "./reference/cli/index.md",
-					"icon_path": "./images/icons/terminal.svg",
-					"children": [
-						{
-							"title": "aibridge",
-							"description": "Manage AI Bridge.",
-							"path": "reference/cli/aibridge.md"
-						},
-						{
-							"title": "aibridge interceptions",
-							"description": "Manage AI Bridge interceptions.",
-							"path": "reference/cli/aibridge_interceptions.md"
-						},
-						{
-							"title": "aibridge interceptions list",
-							"description": "List AI Bridge interceptions as JSON.",
-							"path": "reference/cli/aibridge_interceptions_list.md"
-						},
-						{
-							"title": "autoupdate",
-							"description": "Toggle auto-update policy for a workspace",
-							"path": "reference/cli/autoupdate.md"
-						},
-						{
-							"title": "boundary",
-							"description": "Network isolation tool for monitoring and restricting HTTP/HTTPS requests",
-							"path": "reference/cli/boundary.md"
-						},
-						{
-							"title": "coder",
-							"path": "reference/cli/index.md"
-						},
-						{
-							"title": "completion",
-							"description": "Install or update shell completion scripts for the detected or chosen shell.",
-							"path": "reference/cli/completion.md"
-						},
-						{
-							"title": "config-ssh",
-							"description": "Add an SSH Host entry for your workspaces \"ssh workspace.coder\"",
-							"path": "reference/cli/config-ssh.md"
-						},
-						{
-							"title": "create",
-							"description": "Create a workspace",
-							"path": "reference/cli/create.md"
-						},
-						{
-							"title": "delete",
-							"description": "Delete a workspace",
-							"path": "reference/cli/delete.md"
-						},
-						{
-							"title": "dotfiles",
-							"description": "Personalize your workspace by applying a canonical dotfiles repository",
-							"path": "reference/cli/dotfiles.md"
-						},
-						{
-							"title": "external-auth",
-							"description": "Manage external authentication",
-							"path": "reference/cli/external-auth.md"
-						},
-						{
-							"title": "external-auth access-token",
-							"description": "Print auth for an external provider",
-							"path": "reference/cli/external-auth_access-token.md"
-						},
-						{
-							"title": "external-workspaces",
-							"description": "Create or manage external workspaces",
-							"path": "reference/cli/external-workspaces.md"
-						},
-						{
-							"title": "external-workspaces agent-instructions",
-							"description": "Get the instructions for an external agent",
-							"path": "reference/cli/external-workspaces_agent-instructions.md"
-						},
-						{
-							"title": "external-workspaces create",
-							"description": "Create a new external workspace",
-							"path": "reference/cli/external-workspaces_create.md"
-						},
-						{
-							"title": "external-workspaces list",
-							"description": "List external workspaces",
-							"path": "reference/cli/external-workspaces_list.md"
-						},
-						{
-							"title": "favorite",
-							"description": "Add a workspace to your favorites",
-							"path": "reference/cli/favorite.md"
-						},
-						{
-							"title": "features",
-							"description": "List Enterprise features",
-							"path": "reference/cli/features.md"
-						},
-						{
-							"title": "features list",
-							"path": "reference/cli/features_list.md"
-						},
-						{
-							"title": "groups",
-							"description": "Manage groups",
-							"path": "reference/cli/groups.md"
-						},
-						{
-							"title": "groups create",
-							"description": "Create a user group",
-							"path": "reference/cli/groups_create.md"
-						},
-						{
-							"title": "groups delete",
-							"description": "Delete a user group",
-							"path": "reference/cli/groups_delete.md"
-						},
-						{
-							"title": "groups edit",
-							"description": "Edit a user group",
-							"path": "reference/cli/groups_edit.md"
-						},
-						{
-							"title": "groups list",
-							"description": "List user groups",
-							"path": "reference/cli/groups_list.md"
-						},
-						{
-							"title": "licenses",
-							"description": "Add, delete, and list licenses",
-							"path": "reference/cli/licenses.md"
-						},
-						{
-							"title": "licenses add",
-							"description": "Add license to Coder deployment",
-							"path": "reference/cli/licenses_add.md"
-						},
-						{
-							"title": "licenses delete",
-							"description": "Delete license by ID",
-							"path": "reference/cli/licenses_delete.md"
-						},
-						{
-							"title": "licenses list",
-							"description": "List licenses (including expired)",
-							"path": "reference/cli/licenses_list.md"
-						},
-						{
-							"title": "list",
-							"description": "List workspaces",
-							"path": "reference/cli/list.md"
-						},
-						{
-							"title": "login",
-							"description": "Authenticate with Coder deployment",
-							"path": "reference/cli/login.md"
-						},
-						{
-							"title": "login token",
-							"description": "Print the current session token",
-							"path": "reference/cli/login_token.md"
-						},
-						{
-							"title": "logout",
-							"description": "Unauthenticate your local session",
-							"path": "reference/cli/logout.md"
-						},
-						{
-							"title": "logs",
-							"description": "View logs for a workspace",
-							"path": "reference/cli/logs.md"
-						},
-						{
-							"title": "netcheck",
-							"description": "Print network debug information for DERP and STUN",
-							"path": "reference/cli/netcheck.md"
-						},
-						{
-							"title": "notifications",
-							"description": "Manage Coder notifications",
-							"path": "reference/cli/notifications.md"
-						},
-						{
-							"title": "notifications custom",
-							"description": "Send a custom notification",
-							"path": "reference/cli/notifications_custom.md"
-						},
-						{
-							"title": "notifications pause",
-							"description": "Pause notifications",
-							"path": "reference/cli/notifications_pause.md"
-						},
-						{
-							"title": "notifications resume",
-							"description": "Resume notifications",
-							"path": "reference/cli/notifications_resume.md"
-						},
-						{
-							"title": "notifications test",
-							"description": "Send a test notification",
-							"path": "reference/cli/notifications_test.md"
-						},
-						{
-							"title": "open",
-							"description": "Open a workspace",
-							"path": "reference/cli/open.md"
-						},
-						{
-							"title": "open app",
-							"description": "Open a workspace application.",
-							"path": "reference/cli/open_app.md"
-						},
-						{
-							"title": "open vscode",
-							"description": "Open a workspace in VS Code Desktop",
-							"path": "reference/cli/open_vscode.md"
-						},
-						{
-							"title": "organizations",
-							"description": "Organization related commands",
-							"path": "reference/cli/organizations.md"
-						},
-						{
-							"title": "organizations create",
-							"description": "Create a new organization.",
-							"path": "reference/cli/organizations_create.md"
-						},
-						{
-							"title": "organizations delete",
-							"description": "Delete an organization",
-							"path": "reference/cli/organizations_delete.md"
-						},
-						{
-							"title": "organizations list",
-							"description": "List all organizations",
-							"path": "reference/cli/organizations_list.md"
-						},
-						{
-							"title": "organizations members",
-							"description": "Manage organization members",
-							"path": "reference/cli/organizations_members.md"
-						},
-						{
-							"title": "organizations members add",
-							"description": "Add a new member to the current organization",
-							"path": "reference/cli/organizations_members_add.md"
-						},
-						{
-							"title": "organizations members edit-roles",
-							"description": "Edit organization member's roles",
-							"path": "reference/cli/organizations_members_edit-roles.md"
-						},
-						{
-							"title": "organizations members list",
-							"description": "List all organization members",
-							"path": "reference/cli/organizations_members_list.md"
-						},
-						{
-							"title": "organizations members remove",
-							"description": "Remove a new member to the current organization",
-							"path": "reference/cli/organizations_members_remove.md"
-						},
-						{
-							"title": "organizations roles",
-							"description": "Manage organization roles.",
-							"path": "reference/cli/organizations_roles.md"
-						},
-						{
-							"title": "organizations roles create",
-							"description": "Create a new organization custom role",
-							"path": "reference/cli/organizations_roles_create.md"
-						},
-						{
-							"title": "organizations roles show",
-							"description": "Show role(s)",
-							"path": "reference/cli/organizations_roles_show.md"
-						},
-						{
-							"title": "organizations roles update",
-							"description": "Update an organization custom role",
-							"path": "reference/cli/organizations_roles_update.md"
-						},
-						{
-							"title": "organizations settings",
-							"description": "Manage organization settings.",
-							"path": "reference/cli/organizations_settings.md"
-						},
-						{
-							"title": "organizations settings set",
-							"description": "Update specified organization setting.",
-							"path": "reference/cli/organizations_settings_set.md"
-						},
-						{
-							"title": "organizations settings set group-sync",
-							"description": "Group sync settings to sync groups from an IdP.",
-							"path": "reference/cli/organizations_settings_set_group-sync.md"
-						},
-						{
-							"title": "organizations settings set organization-sync",
-							"description": "Organization sync settings to sync organization memberships from an IdP.",
-							"path": "reference/cli/organizations_settings_set_organization-sync.md"
-						},
-						{
-							"title": "organizations settings set role-sync",
-							"description": "Role sync settings to sync organization roles from an IdP.",
-							"path": "reference/cli/organizations_settings_set_role-sync.md"
-						},
-						{
-							"title": "organizations settings set workspace-sharing",
-							"description": "Workspace sharing settings for the organization.",
-							"path": "reference/cli/organizations_settings_set_workspace-sharing.md"
-						},
-						{
-							"title": "organizations settings show",
-							"description": "Outputs specified organization setting.",
-							"path": "reference/cli/organizations_settings_show.md"
-						},
-						{
-							"title": "organizations settings show group-sync",
-							"description": "Group sync settings to sync groups from an IdP.",
-							"path": "reference/cli/organizations_settings_show_group-sync.md"
-						},
-						{
-							"title": "organizations settings show organization-sync",
-							"description": "Organization sync settings to sync organization memberships from an IdP.",
-							"path": "reference/cli/organizations_settings_show_organization-sync.md"
-						},
-						{
-							"title": "organizations settings show role-sync",
-							"description": "Role sync settings to sync organization roles from an IdP.",
-							"path": "reference/cli/organizations_settings_show_role-sync.md"
-						},
-						{
-							"title": "organizations settings show workspace-sharing",
-							"description": "Workspace sharing settings for the organization.",
-							"path": "reference/cli/organizations_settings_show_workspace-sharing.md"
-						},
-						{
-							"title": "organizations show",
-							"description": "Show the organization. Using \"selected\" will show the selected organization from the \"--org\" flag. Using \"me\" will show all organizations you are a member of.",
-							"path": "reference/cli/organizations_show.md"
-						},
-						{
-							"title": "ping",
-							"description": "Ping a workspace",
-							"path": "reference/cli/ping.md"
-						},
-						{
-							"title": "port-forward",
-							"description": "Forward ports from a workspace to the local machine. For reverse port forwarding, use \"coder ssh -R\".",
-							"path": "reference/cli/port-forward.md"
-						},
-						{
-							"title": "prebuilds",
-							"description": "Manage Coder prebuilds",
-							"path": "reference/cli/prebuilds.md"
-						},
-						{
-							"title": "prebuilds pause",
-							"description": "Pause prebuilds",
-							"path": "reference/cli/prebuilds_pause.md"
-						},
-						{
-							"title": "prebuilds resume",
-							"description": "Resume prebuilds",
-							"path": "reference/cli/prebuilds_resume.md"
-						},
-						{
-							"title": "provisioner",
-							"description": "View and manage provisioner daemons and jobs",
-							"path": "reference/cli/provisioner.md"
-						},
-						{
-							"title": "provisioner jobs",
-							"description": "View and manage provisioner jobs",
-							"path": "reference/cli/provisioner_jobs.md"
-						},
-						{
-							"title": "provisioner jobs cancel",
-							"description": "Cancel a provisioner job",
-							"path": "reference/cli/provisioner_jobs_cancel.md"
-						},
-						{
-							"title": "provisioner jobs list",
-							"description": "List provisioner jobs",
-							"path": "reference/cli/provisioner_jobs_list.md"
-						},
-						{
-							"title": "provisioner keys",
-							"description": "Manage provisioner keys",
-							"path": "reference/cli/provisioner_keys.md"
-						},
-						{
-							"title": "provisioner keys create",
-							"description": "Create a new provisioner key",
-							"path": "reference/cli/provisioner_keys_create.md"
-						},
-						{
-							"title": "provisioner keys delete",
-							"description": "Delete a provisioner key",
-							"path": "reference/cli/provisioner_keys_delete.md"
-						},
-						{
-							"title": "provisioner keys list",
-							"description": "List provisioner keys in an organization",
-							"path": "reference/cli/provisioner_keys_list.md"
-						},
-						{
-							"title": "provisioner list",
-							"description": "List provisioner daemons in an organization",
-							"path": "reference/cli/provisioner_list.md"
-						},
-						{
-							"title": "provisioner start",
-							"description": "Run a provisioner daemon",
-							"path": "reference/cli/provisioner_start.md"
-						},
-						{
-							"title": "publickey",
-							"description": "Output your Coder public key used for Git operations",
-							"path": "reference/cli/publickey.md"
-						},
-						{
-							"title": "rename",
-							"description": "Rename a workspace",
-							"path": "reference/cli/rename.md"
-						},
-						{
-							"title": "reset-password",
-							"description": "Directly connect to the database to reset a user's password",
-							"path": "reference/cli/reset-password.md"
-						},
-						{
-							"title": "restart",
-							"description": "Restart a workspace",
-							"path": "reference/cli/restart.md"
-						},
-						{
-							"title": "schedule",
-							"description": "Schedule automated start and stop times for workspaces",
-							"path": "reference/cli/schedule.md"
-						},
-						{
-							"title": "schedule extend",
-							"description": "Extend the stop time of a currently running workspace instance.",
-							"path": "reference/cli/schedule_extend.md"
-						},
-						{
-							"title": "schedule show",
-							"description": "Show workspace schedules",
-							"path": "reference/cli/schedule_show.md"
-						},
-						{
-							"title": "schedule start",
-							"description": "Edit workspace start schedule",
-							"path": "reference/cli/schedule_start.md"
-						},
-						{
-							"title": "schedule stop",
-							"description": "Edit workspace stop schedule",
-							"path": "reference/cli/schedule_stop.md"
-						},
-						{
-							"title": "server",
-							"description": "Start a Coder server",
-							"path": "reference/cli/server.md"
-						},
-						{
-							"title": "server create-admin-user",
-							"description": "Create a new admin user with the given username, email and password and adds it to every organization.",
-							"path": "reference/cli/server_create-admin-user.md"
-						},
-						{
-							"title": "server dbcrypt",
-							"description": "Manage database encryption.",
-							"path": "reference/cli/server_dbcrypt.md"
-						},
-						{
-							"title": "server dbcrypt decrypt",
-							"description": "Decrypt a previously encrypted database.",
-							"path": "reference/cli/server_dbcrypt_decrypt.md"
-						},
-						{
-							"title": "server dbcrypt delete",
-							"description": "Delete all encrypted data from the database. THIS IS A DESTRUCTIVE OPERATION.",
-							"path": "reference/cli/server_dbcrypt_delete.md"
-						},
-						{
-							"title": "server dbcrypt rotate",
-							"description": "Rotate database encryption keys.",
-							"path": "reference/cli/server_dbcrypt_rotate.md"
-						},
-						{
-							"title": "server postgres-builtin-serve",
-							"description": "Run the built-in PostgreSQL deployment.",
-							"path": "reference/cli/server_postgres-builtin-serve.md"
-						},
-						{
-							"title": "server postgres-builtin-url",
-							"description": "Output the connection URL for the built-in PostgreSQL deployment.",
-							"path": "reference/cli/server_postgres-builtin-url.md"
-						},
-						{
-							"title": "show",
-							"description": "Display details of a workspace's resources and agents",
-							"path": "reference/cli/show.md"
-						},
-						{
-							"title": "speedtest",
-							"description": "Run upload and download tests from your machine to a workspace",
-							"path": "reference/cli/speedtest.md"
-						},
-						{
-							"title": "ssh",
-							"description": "Start a shell into a workspace or run a command",
-							"path": "reference/cli/ssh.md"
-						},
-						{
-							"title": "start",
-							"description": "Start a workspace",
-							"path": "reference/cli/start.md"
-						},
-						{
-							"title": "stat",
-							"description": "Show resource usage for the current workspace.",
-							"path": "reference/cli/stat.md"
-						},
-						{
-							"title": "stat cpu",
-							"description": "Show CPU usage, in cores.",
-							"path": "reference/cli/stat_cpu.md"
-						},
-						{
-							"title": "stat disk",
-							"description": "Show disk usage, in gigabytes.",
-							"path": "reference/cli/stat_disk.md"
-						},
-						{
-							"title": "stat mem",
-							"description": "Show memory usage, in gigabytes.",
-							"path": "reference/cli/stat_mem.md"
-						},
-						{
-							"title": "state",
-							"description": "Manually manage Terraform state to fix broken workspaces",
-							"path": "reference/cli/state.md"
-						},
-						{
-							"title": "state pull",
-							"description": "Pull a Terraform state file from a workspace.",
-							"path": "reference/cli/state_pull.md"
-						},
-						{
-							"title": "state push",
-							"description": "Push a Terraform state file to a workspace.",
-							"path": "reference/cli/state_push.md"
-						},
-						{
-							"title": "stop",
-							"description": "Stop a workspace",
-							"path": "reference/cli/stop.md"
-						},
-						{
-							"title": "support",
-							"description": "Commands for troubleshooting issues with a Coder deployment.",
-							"path": "reference/cli/support.md"
-						},
-						{
-							"title": "support bundle",
-							"description": "Generate a support bundle to troubleshoot issues connecting to a workspace.",
-							"path": "reference/cli/support_bundle.md"
-						},
-						{
-							"title": "task",
-							"description": "Manage tasks",
-							"path": "reference/cli/task.md"
-						},
-						{
-							"title": "task create",
-							"description": "Create a task",
-							"path": "reference/cli/task_create.md"
-						},
-						{
-							"title": "task delete",
-							"description": "Delete tasks",
-							"path": "reference/cli/task_delete.md"
-						},
-						{
-							"title": "task list",
-							"description": "List tasks",
-							"path": "reference/cli/task_list.md"
-						},
-						{
-							"title": "task logs",
-							"description": "Show a task's logs",
-							"path": "reference/cli/task_logs.md"
-						},
-						{
-							"title": "task pause",
-							"description": "Pause a task",
-							"path": "reference/cli/task_pause.md"
-						},
-						{
-							"title": "task resume",
-							"description": "Resume a task",
-							"path": "reference/cli/task_resume.md"
-						},
-						{
-							"title": "task send",
-							"description": "Send input to a task",
-							"path": "reference/cli/task_send.md"
-						},
-						{
-							"title": "task status",
-							"description": "Show the status of a task.",
-							"path": "reference/cli/task_status.md"
-						},
-						{
-							"title": "templates",
-							"description": "Manage templates",
-							"path": "reference/cli/templates.md"
-						},
-						{
-							"title": "templates archive",
-							"description": "Archive unused or failed template versions from a given template(s)",
-							"path": "reference/cli/templates_archive.md"
-						},
-						{
-							"title": "templates create",
-							"description": "DEPRECATED: Create a template from the current directory or as specified by flag",
-							"path": "reference/cli/templates_create.md"
-						},
-						{
-							"title": "templates delete",
-							"description": "Delete templates",
-							"path": "reference/cli/templates_delete.md"
-						},
-						{
-							"title": "templates edit",
-							"description": "Edit the metadata of a template by name.",
-							"path": "reference/cli/templates_edit.md"
-						},
-						{
-							"title": "templates init",
-							"description": "Get started with a templated template.",
-							"path": "reference/cli/templates_init.md"
-						},
-						{
-							"title": "templates list",
-							"description": "List all the templates available for the organization",
-							"path": "reference/cli/templates_list.md"
-						},
-						{
-							"title": "templates presets",
-							"description": "Manage presets of the specified template",
-							"path": "reference/cli/templates_presets.md"
-						},
-						{
-							"title": "templates presets list",
-							"description": "List all presets of the specified template. Defaults to the active template version.",
-							"path": "reference/cli/templates_presets_list.md"
-						},
-						{
-							"title": "templates pull",
-							"description": "Download the active, latest, or specified version of a template to a path.",
-							"path": "reference/cli/templates_pull.md"
-						},
-						{
-							"title": "templates push",
-							"description": "Create or update a template from the current directory or as specified by flag",
-							"path": "reference/cli/templates_push.md"
-						},
-						{
-							"title": "templates versions",
-							"description": "Manage different versions of the specified template",
-							"path": "reference/cli/templates_versions.md"
-						},
-						{
-							"title": "templates versions archive",
-							"description": "Archive a template version(s).",
-							"path": "reference/cli/templates_versions_archive.md"
-						},
-						{
-							"title": "templates versions list",
-							"description": "List all the versions of the specified template",
-							"path": "reference/cli/templates_versions_list.md"
-						},
-						{
-							"title": "templates versions promote",
-							"description": "Promote a template version to active.",
-							"path": "reference/cli/templates_versions_promote.md"
-						},
-						{
-							"title": "templates versions unarchive",
-							"description": "Unarchive a template version(s).",
-							"path": "reference/cli/templates_versions_unarchive.md"
-						},
-						{
-							"title": "tokens",
-							"description": "Manage personal access tokens",
-							"path": "reference/cli/tokens.md"
-						},
-						{
-							"title": "tokens create",
-							"description": "Create a token",
-							"path": "reference/cli/tokens_create.md"
-						},
-						{
-							"title": "tokens list",
-							"description": "List tokens",
-							"path": "reference/cli/tokens_list.md"
-						},
-						{
-							"title": "tokens remove",
-							"description": "Expire or delete a token",
-							"path": "reference/cli/tokens_remove.md"
-						},
-						{
-							"title": "tokens view",
-							"description": "Display detailed information about a token",
-							"path": "reference/cli/tokens_view.md"
-						},
-						{
-							"title": "unfavorite",
-							"description": "Remove a workspace from your favorites",
-							"path": "reference/cli/unfavorite.md"
-						},
-						{
-							"title": "update",
-							"description": "Will update and start a given workspace if it is out of date. If the workspace is already running, it will be stopped first.",
-							"path": "reference/cli/update.md"
-						},
-						{
-							"title": "users",
-							"description": "Manage users",
-							"path": "reference/cli/users.md"
-						},
-						{
-							"title": "users activate",
-							"description": "Update a user's status to 'active'. Active users can fully interact with the platform",
-							"path": "reference/cli/users_activate.md"
-						},
-						{
-							"title": "users create",
-							"description": "Create a new user.",
-							"path": "reference/cli/users_create.md"
-						},
-						{
-							"title": "users delete",
-							"description": "Delete a user by username or user_id.",
-							"path": "reference/cli/users_delete.md"
-						},
-						{
-							"title": "users edit-roles",
-							"description": "Edit a user's roles by username or id",
-							"path": "reference/cli/users_edit-roles.md"
-						},
-						{
-							"title": "users list",
-							"description": "Prints the list of users.",
-							"path": "reference/cli/users_list.md"
-						},
-						{
-							"title": "users show",
-							"description": "Show a single user. Use 'me' to indicate the currently authenticated user.",
-							"path": "reference/cli/users_show.md"
-						},
-						{
-							"title": "users suspend",
-							"description": "Update a user's status to 'suspended'. A suspended user cannot log into the platform",
-							"path": "reference/cli/users_suspend.md"
-						},
-						{
-							"title": "version",
-							"description": "Show coder version",
-							"path": "reference/cli/version.md"
-						},
-						{
-							"title": "whoami",
-							"description": "Fetch authenticated user info for Coder deployment",
-							"path": "reference/cli/whoami.md"
-						}
-					]
-				},
-				{
-					"title": "Agent API",
-					"description": "Learn how to use Coder Agent API",
-					"path": "./reference/agent-api/index.md",
-					"icon_path": "./images/icons/api.svg",
-					"children": [
-						{
-							"title": "Debug",
-							"path": "./reference/agent-api/debug.md"
-						},
-						{
-							"title": "Schemas",
-							"path": "./reference/agent-api/schemas.md"
-						}
-					]
-				}
-			]
-		},
-		{
-			"title": "Coder Research",
-			"description": "Open source research projects exploring AI-assisted development",
-			"path": "./coder-research.md",
-			"icon_path": "./images/icons/wand.svg"
-		}
-	]
+  "versions": [
+    "main"
+  ],
+  "routes": [
+    {
+      "title": "About",
+      "description": "Coder docs",
+      "path": "./README.md",
+      "icon_path": "./images/icons/home.svg",
+      "children": [
+        {
+          "title": "Screenshots",
+          "description": "View screenshots of the Coder platform",
+          "path": "./about/screenshots.md"
+        },
+        {
+          "title": "Quickstart",
+          "description": "Learn how to install and run Coder quickly",
+          "path": "./tutorials/quickstart.md"
+        },
+        {
+          "title": "Support",
+          "description": "How Coder supports your deployment and you",
+          "path": "./support/index.md",
+          "children": [
+            {
+              "title": "Generate a Support Bundle",
+              "description": "Generate and upload a Support Bundle to Coder Support",
+              "path": "./support/support-bundle.md"
+            }
+          ]
+        },
+        {
+          "title": "Contributing",
+          "description": "Learn how to contribute to Coder",
+          "path": "./about/contributing/CONTRIBUTING.md",
+          "icon_path": "./images/icons/contributing.svg",
+          "children": [
+            {
+              "title": "Code of Conduct",
+              "description": "See the code of conduct for contributing to Coder",
+              "path": "./about/contributing/CODE_OF_CONDUCT.md",
+              "icon_path": "./images/icons/circle-dot.svg"
+            },
+            {
+              "title": "Documentation",
+              "description": "Our style guide for use when authoring documentation",
+              "path": "./about/contributing/documentation.md",
+              "icon_path": "./images/icons/document.svg"
+            },
+            {
+              "title": "Modules",
+              "description": "Learn how to contribute modules to Coder",
+              "path": "./about/contributing/modules.md",
+              "icon_path": "./images/icons/gear.svg"
+            },
+            {
+              "title": "Templates",
+              "description": "Learn how to contribute templates to Coder",
+              "path": "./about/contributing/templates.md",
+              "icon_path": "./images/icons/picture.svg"
+            },
+            {
+              "title": "Backend",
+              "description": "Our guide for backend development",
+              "path": "./about/contributing/backend.md",
+              "icon_path": "./images/icons/gear.svg"
+            },
+            {
+              "title": "Frontend",
+              "description": "Our guide for frontend development",
+              "path": "./about/contributing/frontend.md",
+              "icon_path": "./images/icons/frontend.svg"
+            },
+            {
+              "title": "Security",
+              "description": "Security vulnerability disclosure policy",
+              "path": "./about/contributing/SECURITY.md",
+              "icon_path": "./images/icons/lock.svg"
+            },
+            {
+              "title": "AI Contribution Guidelines",
+              "description": "Guidelines for AI-generated contributions.",
+              "path": "./about/contributing/AI_CONTRIBUTING.md",
+              "icon_path": "./images/icons/ai_intelligence.svg"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Install",
+      "description": "Installing Coder",
+      "path": "./install/index.md",
+      "icon_path": "./images/icons/download.svg",
+      "children": [
+        {
+          "title": "Coder CLI",
+          "description": "Install the standalone binary",
+          "path": "./install/cli.md",
+          "icon_path": "./images/icons/terminal.svg"
+        },
+        {
+          "title": "Docker",
+          "description": "Install Coder using Docker",
+          "path": "./install/docker.md",
+          "icon_path": "./images/icons/docker.svg"
+        },
+        {
+          "title": "Kubernetes",
+          "description": "Install Coder on Kubernetes",
+          "path": "./install/kubernetes.md",
+          "icon_path": "./images/icons/kubernetes.svg",
+          "children": [
+            {
+              "title": "Deploy Coder on Azure with an Application Gateway",
+              "description": "Deploy Coder on Azure with an Application Gateway",
+              "path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
+            }
+          ]
+        },
+        {
+          "title": "Rancher",
+          "description": "Deploy Coder on Rancher",
+          "path": "./install/rancher.md",
+          "icon_path": "./images/icons/rancher.svg"
+        },
+        {
+          "title": "OpenShift",
+          "description": "Install Coder on OpenShift",
+          "path": "./install/openshift.md",
+          "icon_path": "./images/icons/openshift.svg"
+        },
+        {
+          "title": "Cloud Providers",
+          "description": "Install Coder on cloud providers",
+          "path": "./install/cloud/index.md",
+          "icon_path": "./images/icons/cloud.svg",
+          "children": [
+            {
+              "title": "AWS EC2",
+              "description": "Install Coder on AWS EC2",
+              "path": "./install/cloud/ec2.md"
+            },
+            {
+              "title": "GCP Compute Engine",
+              "description": "Install Coder on GCP Compute Engine",
+              "path": "./install/cloud/compute-engine.md"
+            },
+            {
+              "title": "Azure VM",
+              "description": "Install Coder on an Azure VM",
+              "path": "./install/cloud/azure-vm.md"
+            }
+          ]
+        },
+        {
+          "title": "Air-gapped Deployments",
+          "description": "Run Coder in air-gapped / disconnected / offline environments",
+          "path": "./install/airgap.md",
+          "icon_path": "./images/icons/lan.svg"
+        },
+        {
+          "title": "Unofficial Install Methods",
+          "description": "Other installation methods",
+          "path": "./install/other/index.md",
+          "icon_path": "./images/icons/generic.svg"
+        },
+        {
+          "title": "Upgrading",
+          "description": "Learn how to upgrade Coder",
+          "path": "./install/upgrade.md",
+          "icon_path": "./images/icons/upgrade.svg",
+          "children": [
+            {
+              "title": "Upgrading Best Practices",
+              "description": "Best practices and troubleshooting for Coder upgrades",
+              "path": "./install/upgrade-best-practices.md"
+            }
+          ]
+        },
+        {
+          "title": "Uninstall",
+          "description": "Learn how to uninstall Coder",
+          "path": "./install/uninstall.md",
+          "icon_path": "./images/icons/trash.svg"
+        },
+        {
+          "title": "Releases",
+          "description": "Learn about the Coder release channels and schedule",
+          "path": "./install/releases/index.md",
+          "icon_path": "./images/icons/star.svg",
+          "children": [
+            {
+              "title": "Feature stages",
+              "description": "Information about pre-GA stages.",
+              "path": "./install/releases/feature-stages.md"
+            },
+            {
+              "title": "Upgrading from ESR 2.24 to 2.29",
+              "description": "Upgrade Guide for ESR Releases",
+              "path": "./install/releases/esr-2.24-2.29-upgrade.md"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "User Guides",
+      "description": "Guides for end-users of Coder",
+      "path": "./user-guides/index.md",
+      "icon_path": "./images/icons/users.svg",
+      "children": [
+        {
+          "title": "Access Workspaces",
+          "description": "Connect to your Coder workspaces",
+          "path": "./user-guides/workspace-access/index.md",
+          "icon_path": "./images/icons/access.svg",
+          "children": [
+            {
+              "title": "Visual Studio Code",
+              "description": "Use VSCode with Coder in the desktop or browser",
+              "path": "./user-guides/workspace-access/vscode.md"
+            },
+            {
+              "title": "Web Terminal",
+              "description": "Use the browser-based terminal to access your workspace",
+              "path": "./user-guides/workspace-access/web-terminal.md"
+            },
+            {
+              "title": "JetBrains IDEs",
+              "description": "Use JetBrains IDEs with Coder",
+              "path": "./user-guides/workspace-access/jetbrains/index.md",
+              "children": [
+                {
+                  "title": "JetBrains Fleet",
+                  "description": "Connect JetBrains Fleet to a Coder workspace",
+                  "path": "./user-guides/workspace-access/jetbrains/fleet.md"
+                },
+                {
+                  "title": "JetBrains Gateway",
+                  "description": "Use JetBrains Gateway to connect to Coder workspaces",
+                  "path": "./user-guides/workspace-access/jetbrains/gateway.md"
+                },
+                {
+                  "title": "JetBrains Toolbox",
+                  "description": "Access Coder workspaces from JetBrains Toolbox",
+                  "path": "./user-guides/workspace-access/jetbrains/toolbox.md",
+                  "state": [
+                    "beta"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Remote Desktop",
+              "description": "Use RDP in Coder",
+              "path": "./user-guides/workspace-access/remote-desktops.md"
+            },
+            {
+              "title": "Emacs TRAMP",
+              "description": "Use Emacs TRAMP in Coder",
+              "path": "./user-guides/workspace-access/emacs-tramp.md"
+            },
+            {
+              "title": "Port Forwarding",
+              "description": "Access ports on your workspace",
+              "path": "./user-guides/workspace-access/port-forwarding.md"
+            },
+            {
+              "title": "Filebrowser",
+              "description": "Access your workspace files",
+              "path": "./user-guides/workspace-access/filebrowser.md"
+            },
+            {
+              "title": "Web IDEs and Coder Apps",
+              "description": "Access your workspace with IDEs in the browser",
+              "path": "./user-guides/workspace-access/web-ides.md"
+            },
+            {
+              "title": "code-server",
+              "description": "Access your workspace with code-server",
+              "path": "./user-guides/workspace-access/code-server.md"
+            },
+            {
+              "title": "Zed",
+              "description": "Access your workspace with Zed",
+              "path": "./user-guides/workspace-access/zed.md"
+            },
+            {
+              "title": "Cursor",
+              "description": "Access your workspace with Cursor",
+              "path": "./user-guides/workspace-access/cursor.md"
+            },
+            {
+              "title": "Windsurf",
+              "description": "Access your workspace with Windsurf",
+              "path": "./user-guides/workspace-access/windsurf.md"
+            },
+            {
+              "title": "Antigravity",
+              "description": "Access your workspace with Antigravity",
+              "path": "./user-guides/workspace-access/antigravity.md"
+            }
+          ]
+        },
+        {
+          "title": "Coder Desktop",
+          "description": "Transform remote workspaces into seamless local development environments with no port forwarding required",
+          "path": "./user-guides/desktop/index.md",
+          "icon_path": "./images/icons/computer-code.svg",
+          "children": [
+            {
+              "title": "Coder Desktop Connect and Sync",
+              "description": "Use Coder Desktop to manage your workspace code and files locally",
+              "path": "./user-guides/desktop/desktop-connect-sync.md"
+            }
+          ]
+        },
+        {
+          "title": "Workspace Management",
+          "description": "Manage workspaces",
+          "path": "./user-guides/workspace-management.md",
+          "icon_path": "./images/icons/generic.svg"
+        },
+        {
+          "title": "Workspace Sharing",
+          "description": "Sharing workspaces",
+          "path": "./user-guides/shared-workspaces.md",
+          "icon_path": "./images/icons/generic.svg",
+          "state": [
+            "beta"
+          ]
+        },
+        {
+          "title": "Workspace Scheduling",
+          "description": "Cost control with workspace schedules",
+          "path": "./user-guides/workspace-scheduling.md",
+          "icon_path": "./images/icons/stopwatch.svg"
+        },
+        {
+          "title": "Workspace Lifecycle",
+          "description": "A guide to the workspace lifecycle, from creation and status through stopping and deletion.",
+          "path": "./user-guides/workspace-lifecycle.md",
+          "icon_path": "./images/icons/circle-dot.svg"
+        },
+        {
+          "title": "Dev Containers",
+          "description": "Run containerized development environments in your Coder workspace using the dev containers specification.",
+          "path": "./user-guides/devcontainers/index.md",
+          "icon_path": "./images/icons/container.svg",
+          "children": [
+            {
+              "title": "Working with dev containers",
+              "description": "Access dev containers via SSH, your IDE, or web terminal.",
+              "path": "./user-guides/devcontainers/working-with-dev-containers.md"
+            },
+            {
+              "title": "Customizing dev containers",
+              "description": "Configure custom agent names, apps, and display options in devcontainer.json.",
+              "path": "./user-guides/devcontainers/customizing-dev-containers.md"
+            },
+            {
+              "title": "Troubleshooting dev containers",
+              "description": "Diagnose and resolve common issues with dev containers in your Coder workspace.",
+              "path": "./user-guides/devcontainers/troubleshooting-dev-containers.md"
+            }
+          ]
+        },
+        {
+          "title": "Dotfiles",
+          "description": "Personalize your environment with dotfiles",
+          "path": "./user-guides/workspace-dotfiles.md",
+          "icon_path": "./images/icons/art-pad.svg"
+        }
+      ]
+    },
+    {
+      "title": "Administration",
+      "description": "Guides for template and deployment administrators",
+      "path": "./admin/index.md",
+      "icon_path": "./images/icons/wrench.svg",
+      "children": [
+        {
+          "title": "Setup",
+          "description": "Configure user access to your control plane.",
+          "path": "./admin/setup/index.md",
+          "icon_path": "./images/icons/toggle_on.svg",
+          "children": [
+            {
+              "title": "Appearance",
+              "description": "Learn how to configure the appearance of Coder",
+              "path": "./admin/setup/appearance.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Telemetry",
+              "description": "Learn what usage telemetry Coder collects",
+              "path": "./admin/setup/telemetry.md"
+            },
+            {
+              "title": "Data Retention",
+              "description": "Configure data retention policies for database tables",
+              "path": "./admin/setup/data-retention.md"
+            }
+          ]
+        },
+        {
+          "title": "Infrastructure",
+          "description": "How to integrate Coder with your organization's compute",
+          "path": "./admin/infrastructure/index.md",
+          "icon_path": "./images/icons/container.svg",
+          "children": [
+            {
+              "title": "Architecture",
+              "description": "Learn about Coder's architecture",
+              "path": "./admin/infrastructure/architecture.md"
+            },
+            {
+              "title": "Validated Architectures",
+              "description": "Architectures for large Coder deployments",
+              "path": "./admin/infrastructure/validated-architectures/index.md",
+              "children": [
+                {
+                  "title": "Up to 1,000 Users",
+                  "description": "Hardware specifications and architecture guidance for Coder deployments that support up to 1,000 users",
+                  "path": "./admin/infrastructure/validated-architectures/1k-users.md"
+                },
+                {
+                  "title": "Up to 2,000 Users",
+                  "description": "Hardware specifications and architecture guidance for Coder deployments that support up to 2,000 users",
+                  "path": "./admin/infrastructure/validated-architectures/2k-users.md"
+                },
+                {
+                  "title": "Up to 3,000 Users",
+                  "description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 3,000 users",
+                  "path": "./admin/infrastructure/validated-architectures/3k-users.md"
+                },
+                {
+                  "title": "Up to 10,000 Users",
+                  "description": "Enterprise-scale architecture recommendations for Coder deployments that support up to 10,000 users",
+                  "path": "./admin/infrastructure/validated-architectures/10k-users.md"
+                }
+              ]
+            },
+            {
+              "title": "Scale Testing",
+              "description": "Ensure your deployment can handle your organization's needs",
+              "path": "./admin/infrastructure/scale-testing.md"
+            },
+            {
+              "title": "Scaling Utilities",
+              "description": "Tools to help you scale your deployment",
+              "path": "./admin/infrastructure/scale-utility.md"
+            },
+            {
+              "title": "Scaling best practices",
+              "description": "How to prepare a Coder deployment for scale",
+              "path": "./tutorials/best-practices/scale-coder.md"
+            }
+          ]
+        },
+        {
+          "title": "Users",
+          "description": "Learn how to manage and audit users",
+          "path": "./admin/users/index.md",
+          "icon_path": "./images/icons/users.svg",
+          "children": [
+            {
+              "title": "OIDC Authentication",
+              "description": "Configure OpenID Connect authentication with identity providers like Okta or Active Directory",
+              "path": "./admin/users/oidc-auth/index.md",
+              "children": [
+                {
+                  "title": "Google",
+                  "description": "Configure Google as an OIDC provider",
+                  "path": "./admin/users/oidc-auth/google.md"
+                },
+                {
+                  "title": "Microsoft",
+                  "description": "Configure Microsoft Entra ID as an OIDC provider",
+                  "path": "./admin/users/oidc-auth/microsoft.md"
+                },
+                {
+                  "title": "Configure OIDC refresh tokens",
+                  "description": "How to configure OIDC refresh tokens",
+                  "path": "./admin/users/oidc-auth/refresh-tokens.md"
+                }
+              ]
+            },
+            {
+              "title": "GitHub Authentication",
+              "description": "Set up authentication through GitHub OAuth to enable secure user login and sign-up",
+              "path": "./admin/users/github-auth.md"
+            },
+            {
+              "title": "Password Authentication",
+              "description": "Manage username/password authentication settings and user password reset workflows",
+              "path": "./admin/users/password-auth.md"
+            },
+            {
+              "title": "Headless Authentication",
+              "description": "Create and manage headless service accounts for automated systems and API integrations",
+              "path": "./admin/users/headless-auth.md"
+            },
+            {
+              "title": "Groups & Roles",
+              "description": "Manage access control with user groups and role-based permissions for Coder resources",
+              "path": "./admin/users/groups-roles.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "IdP Sync",
+              "description": "Synchronize user groups, roles, and organizations from your identity provider to Coder",
+              "path": "./admin/users/idp-sync.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Organizations",
+              "description": "Segment and isolate resources by creating separate organizations for different teams or projects",
+              "path": "./admin/users/organizations.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Quotas",
+              "description": "Control resource usage by implementing workspace budgets and credit-based cost management",
+              "path": "./admin/users/quotas.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Sessions & API Tokens",
+              "description": "Manage authentication tokens for API access and configure session duration policies",
+              "path": "./admin/users/sessions-tokens.md"
+            }
+          ]
+        },
+        {
+          "title": "Templates",
+          "description": "Learn how to author and maintain Coder templates",
+          "path": "./admin/templates/index.md",
+          "icon_path": "./images/icons/picture.svg",
+          "children": [
+            {
+              "title": "Creating Templates",
+              "description": "Learn how to create templates with Terraform",
+              "path": "./admin/templates/creating-templates.md"
+            },
+            {
+              "title": "Managing Templates",
+              "description": "Learn how to manage templates and best practices",
+              "path": "./admin/templates/managing-templates/index.md",
+              "children": [
+                {
+                  "title": "Image Management",
+                  "description": "Learn about template image management",
+                  "path": "./admin/templates/managing-templates/image-management.md"
+                },
+                {
+                  "title": "Change Management",
+                  "description": "Learn about template change management and versioning",
+                  "path": "./admin/templates/managing-templates/change-management.md"
+                },
+                {
+                  "title": "Envbuilder",
+                  "description": "Shift environment definition to repositories",
+                  "path": "./admin/templates/managing-templates/envbuilder.md"
+                },
+                {
+                  "title": "Template Dependencies",
+                  "description": "Learn how to manage template dependencies",
+                  "path": "./admin/templates/managing-templates/dependencies.md"
+                },
+                {
+                  "title": "Workspace Scheduling",
+                  "description": "Learn how to control how workspaces are started and stopped",
+                  "path": "./admin/templates/managing-templates/schedule.md"
+                },
+                {
+                  "title": "External Workspaces",
+                  "description": "Learn how to manage external workspaces",
+                  "path": "./admin/templates/managing-templates/external-workspaces.md",
+                  "state": [
+                    "premium",
+                    "early access"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Extending Templates",
+              "description": "Learn best practices in extending templates",
+              "path": "./admin/templates/extending-templates/index.md",
+              "children": [
+                {
+                  "title": "Agent Metadata",
+                  "description": "Retrieve real-time stats from the workspace agent",
+                  "path": "./admin/templates/extending-templates/agent-metadata.md"
+                },
+                {
+                  "title": "Build Parameters",
+                  "description": "Use parameters to customize workspaces at build",
+                  "path": "./admin/templates/extending-templates/parameters.md"
+                },
+                {
+                  "title": "Dynamic Parameters",
+                  "description": "Conditional, identity-aware parameter syntax for advanced users.",
+                  "path": "./admin/templates/extending-templates/dynamic-parameters.md"
+                },
+                {
+                  "title": "Prebuilt workspaces",
+                  "description": "Pre-provision a ready-to-deploy workspace with a defined set of parameters",
+                  "path": "./admin/templates/extending-templates/prebuilt-workspaces.md",
+                  "state": [
+                    "premium"
+                  ]
+                },
+                {
+                  "title": "Icons",
+                  "description": "Customize your template with built-in icons",
+                  "path": "./admin/templates/extending-templates/icons.md"
+                },
+                {
+                  "title": "Resource Metadata",
+                  "description": "Display resource state in the workspace dashboard",
+                  "path": "./admin/templates/extending-templates/resource-metadata.md"
+                },
+                {
+                  "title": "Resource Monitoring",
+                  "description": "Monitor resources in the workspace dashboard",
+                  "path": "./admin/templates/extending-templates/resource-monitoring.md"
+                },
+                {
+                  "title": "Resource Ordering",
+                  "description": "Design the UI of workspaces",
+                  "path": "./admin/templates/extending-templates/resource-ordering.md"
+                },
+                {
+                  "title": "Resource Persistence",
+                  "description": "Control resource persistence",
+                  "path": "./admin/templates/extending-templates/resource-persistence.md"
+                },
+                {
+                  "title": "Terraform Variables",
+                  "description": "Use variables to manage template state",
+                  "path": "./admin/templates/extending-templates/variables.md"
+                },
+                {
+                  "title": "Terraform Modules",
+                  "description": "Reuse terraform code across templates",
+                  "path": "./admin/templates/extending-templates/modules.md"
+                },
+                {
+                  "title": "Web IDEs and Coder Apps",
+                  "description": "Add and configure Web IDEs in your templates as coder apps",
+                  "path": "./admin/templates/extending-templates/web-ides.md"
+                },
+                {
+                  "title": "Pre-install JetBrains IDEs",
+                  "description": "Pre-install JetBrains IDEs in a template for faster IDE startup",
+                  "path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
+                },
+                {
+                  "title": "JetBrains IDEs in Air-Gapped Deployments",
+                  "description": "Configure JetBrains IDEs for air-gapped deployments",
+                  "path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
+                },
+                {
+                  "title": "Docker in Workspaces",
+                  "description": "Use Docker in your workspaces",
+                  "path": "./admin/templates/extending-templates/docker-in-workspaces.md"
+                },
+                {
+                  "title": "Workspace Tags",
+                  "description": "Control provisioning using Workspace Tags and Parameters",
+                  "path": "./admin/templates/extending-templates/workspace-tags.md"
+                },
+                {
+                  "title": "Provider Authentication",
+                  "description": "Authenticate with provider APIs to provision workspaces",
+                  "path": "./admin/templates/extending-templates/provider-authentication.md"
+                },
+                {
+                  "title": "Dev Containers",
+                  "description": "Extend templates with containerized dev environments",
+                  "path": "./admin/templates/extending-templates/devcontainers.md"
+                },
+                {
+                  "title": "Process Logging",
+                  "description": "Log workspace processes",
+                  "path": "./admin/templates/extending-templates/process-logging.md",
+                  "state": [
+                    "premium"
+                  ]
+                },
+                {
+                  "title": "Startup Dependencies",
+                  "description": "Coordinate workspace startup with dependency management",
+                  "path": "./admin/templates/startup-coordination/index.md",
+                  "state": [
+                    "early access"
+                  ],
+                  "children": [
+                    {
+                      "title": "Usage",
+                      "description": "How to use startup coordination",
+                      "path": "./admin/templates/startup-coordination/usage.md"
+                    },
+                    {
+                      "title": "Troubleshooting",
+                      "description": "Troubleshoot startup coordination",
+                      "path": "./admin/templates/startup-coordination/troubleshooting.md"
+                    },
+                    {
+                      "title": "Examples",
+                      "description": "Examples of startup coordination",
+                      "path": "./admin/templates/startup-coordination/example.md"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Open in Coder",
+              "description": "Open workspaces in Coder",
+              "path": "./admin/templates/open-in-coder.md"
+            },
+            {
+              "title": "Permissions & Policies",
+              "description": "Learn how to create templates with Terraform",
+              "path": "./admin/templates/template-permissions.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Troubleshooting Templates",
+              "description": "Learn how to troubleshoot template issues",
+              "path": "./admin/templates/troubleshooting.md"
+            }
+          ]
+        },
+        {
+          "title": "External Provisioners",
+          "description": "Learn how to run external provisioners with Coder",
+          "path": "./admin/provisioners/index.md",
+          "icon_path": "./images/icons/key.svg",
+          "state": [
+            "premium"
+          ],
+          "children": [
+            {
+              "title": "Manage Provisioner Jobs",
+              "description": "Learn how to run external provisioners with Coder",
+              "path": "./admin/provisioners/manage-provisioner-jobs.md",
+              "state": [
+                "premium"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "External Authentication",
+          "description": "Learn how to configure external authentication",
+          "path": "./admin/external-auth/index.md",
+          "icon_path": "./images/icons/plug.svg"
+        },
+        {
+          "title": "Integrations",
+          "description": "Use integrations to extend Coder",
+          "path": "./admin/integrations/index.md",
+          "icon_path": "./images/icons/puzzle.svg",
+          "children": [
+            {
+              "title": "Prometheus",
+              "description": "Collect deployment metrics with Prometheus",
+              "path": "./admin/integrations/prometheus.md"
+            },
+            {
+              "title": "Kubernetes Logging",
+              "description": "Stream K8s event logs on workspace startup",
+              "path": "./admin/integrations/kubernetes-logs.md"
+            },
+            {
+              "title": "Additional Kubernetes Clusters",
+              "description": "Deploy workspaces on additional Kubernetes clusters",
+              "path": "./admin/integrations/multiple-kube-clusters.md"
+            },
+            {
+              "title": "JFrog Artifactory",
+              "description": "Integrate Coder with JFrog Artifactory",
+              "path": "./admin/integrations/jfrog-artifactory.md"
+            },
+            {
+              "title": "Island Secure Browser",
+              "description": "Integrate Coder with Island's Secure Browser",
+              "path": "./admin/integrations/island.md"
+            },
+            {
+              "title": "DX PlatformX",
+              "description": "Integrate Coder with DX PlatformX",
+              "path": "./admin/integrations/platformx.md"
+            },
+            {
+              "title": "DX Data Cloud",
+              "description": "Tag Coder Users with DX Data Cloud",
+              "path": "./admin/integrations/dx-data-cloud.md"
+            },
+            {
+              "title": "Hashicorp Vault",
+              "description": "Integrate Coder with Hashicorp Vault",
+              "path": "./admin/integrations/vault.md"
+            },
+            {
+              "title": "OAuth2 Provider",
+              "description": "Use Coder as an OAuth2 provider",
+              "path": "./admin/integrations/oauth2-provider.md"
+            },
+            {
+              "title": "Dev Containers",
+              "description": "Configure dev container support using Docker or Envbuilder",
+              "path": "./admin/integrations/devcontainers/index.md",
+              "children": [
+                {
+                  "title": "Dev Containers Integration",
+                  "description": "Configure native dev containers with Docker",
+                  "path": "./admin/integrations/devcontainers/integration.md"
+                },
+                {
+                  "title": "Envbuilder",
+                  "description": "Build dev containers without Docker",
+                  "path": "./admin/integrations/devcontainers/envbuilder/index.md",
+                  "children": [
+                    {
+                      "title": "Add an Envbuilder template",
+                      "description": "How to add an Envbuilder template",
+                      "path": "./admin/integrations/devcontainers/envbuilder/add-envbuilder.md"
+                    },
+                    {
+                      "title": "Security and caching",
+                      "description": "Configure authentication and caching",
+                      "path": "./admin/integrations/devcontainers/envbuilder/envbuilder-security-caching.md"
+                    },
+                    {
+                      "title": "Releases and known issues",
+                      "description": "Release channels and known issues",
+                      "path": "./admin/integrations/devcontainers/envbuilder/envbuilder-releases-known-issues.md"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Networking",
+          "description": "Understand Coder's networking layer",
+          "path": "./admin/networking/index.md",
+          "icon_path": "./images/icons/networking.svg",
+          "children": [
+            {
+              "title": "Port Forwarding",
+              "description": "Learn how to forward ports in Coder",
+              "path": "./admin/networking/port-forwarding.md"
+            },
+            {
+              "title": "STUN and NAT",
+              "description": "Learn how to forward ports in Coder",
+              "path": "./admin/networking/stun.md"
+            },
+            {
+              "title": "Workspace Proxies",
+              "description": "Run geo distributed workspace proxies",
+              "path": "./admin/networking/workspace-proxies.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "High Availability",
+              "description": "Learn how to configure Coder for High Availability",
+              "path": "./admin/networking/high-availability.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Wildcard Access URL",
+              "description": "Learn about wildcard access URL in Coder deployments",
+              "path": "./admin/networking/wildcard-access-url.md"
+            },
+            {
+              "title": "Troubleshooting",
+              "description": "Troubleshoot networking issues in Coder",
+              "path": "./admin/networking/troubleshooting.md"
+            }
+          ]
+        },
+        {
+          "title": "Monitoring",
+          "description": "Configure security policy and audit your deployment",
+          "path": "./admin/monitoring/index.md",
+          "icon_path": "./images/icons/speed.svg",
+          "children": [
+            {
+              "title": "Logs",
+              "description": "Learn about Coder's logs",
+              "path": "./admin/monitoring/logs.md"
+            },
+            {
+              "title": "Metrics",
+              "description": "Learn about Coder's logs",
+              "path": "./admin/monitoring/metrics.md"
+            },
+            {
+              "title": "Health Check",
+              "description": "Learn about Coder's automated health checks",
+              "path": "./admin/monitoring/health-check.md"
+            },
+            {
+              "title": "Connection Logs",
+              "description": "Monitor connections to workspaces",
+              "path": "./admin/monitoring/connection-logs.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Notifications",
+              "description": "Configure notifications for your deployment",
+              "path": "./admin/monitoring/notifications/index.md",
+              "children": [
+                {
+                  "title": "Slack Notifications",
+                  "description": "Learn how to setup Slack notifications",
+                  "path": "./admin/monitoring/notifications/slack.md"
+                },
+                {
+                  "title": "Microsoft Teams Notifications",
+                  "description": "Learn how to setup Microsoft Teams notifications",
+                  "path": "./admin/monitoring/notifications/teams.md"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Security",
+          "description": "Configure security policy and audit your deployment",
+          "path": "./admin/security/index.md",
+          "icon_path": "./images/icons/lock.svg",
+          "children": [
+            {
+              "title": "Audit Logs",
+              "description": "Audit actions taken inside Coder",
+              "path": "./admin/security/audit-logs.md",
+              "state": [
+                "premium"
+              ]
+            },
+            {
+              "title": "Secrets",
+              "description": "Use sensitive variables in your workspaces",
+              "path": "./admin/security/secrets.md"
+            },
+            {
+              "title": "Database Encryption",
+              "description": "Encrypt the database to prevent unauthorized access",
+              "path": "./admin/security/database-encryption.md",
+              "state": [
+                "premium"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Licensing",
+          "description": "Configure licensing for your deployment",
+          "path": "./admin/licensing/index.md",
+          "icon_path": "./images/icons/licensing.svg"
+        }
+      ]
+    },
+    {
+      "title": "Run AI Coding Agents in Coder",
+      "description": "Learn how to run and integrate agentic AI coding agents like GPT-Code, OpenDevin, or SWE-Agent in Coder workspaces to boost developer productivity.",
+      "path": "./ai-coder/index.md",
+      "icon_path": "./images/icons/wand.svg",
+      "children": [
+        {
+          "title": "Best Practices",
+          "description": "Best Practices running Coding Agents",
+          "path": "./ai-coder/best-practices.md"
+        },
+        {
+          "title": "In the IDE",
+          "description": "Run IDE agents with Coder",
+          "path": "./ai-coder/ide-agents.md"
+        },
+        {
+          "title": "Coder Tasks",
+          "description": "Run Coding Agents on your Own Infrastructure",
+          "path": "./ai-coder/tasks.md",
+          "children": [
+            {
+              "title": "Understanding Coder Tasks",
+              "description": "Core principles and concepts behind Coder Tasks",
+              "path": "./ai-coder/tasks-core-principles.md"
+            },
+            {
+              "title": "Custom Agents",
+              "description": "Run custom agents with Coder Tasks",
+              "path": "./ai-coder/custom-agents.md"
+            },
+            {
+              "title": "Task Lifecycle",
+              "description": "How tasks pause and resume, and what gets preserved",
+              "path": "./ai-coder/tasks-lifecycle.md"
+            },
+            {
+              "title": "Agent Compatibility",
+              "description": "Which AI agents support session persistence across workspace restarts",
+              "path": "./ai-coder/agent-compatibility.md"
+            },
+            {
+              "title": "Tasks Migration Guide",
+              "description": "Changes to Coder Tasks made in v2.28",
+              "path": "./ai-coder/tasks-migration.md"
+            },
+            {
+              "title": "Security & Boundaries",
+              "description": "Learn about security and boundaries when running AI coding agents in Coder",
+              "path": "./ai-coder/security.md"
+            },
+            {
+              "title": "Create a GitHub to Coder Tasks Workflow",
+              "description": "How to setup Coder Tasks to run in GitHub",
+              "path": "./ai-coder/github-to-tasks.md"
+            }
+          ]
+        },
+        {
+          "title": "AI Governance Add-On",
+          "description": "Features around managing agents at scale",
+          "path": "./ai-coder/ai-governance.md",
+          "state": [
+            "premium"
+          ],
+          "children": [
+            {
+              "title": "Agent Boundaries",
+              "description": "Understanding Agent Boundaries in Coder Tasks",
+              "path": "./ai-coder/agent-boundaries/index.md",
+              "state": [
+                "premium"
+              ],
+              "children": [
+                {
+                  "title": "NS Jail",
+                  "description": "Documentation for Namespace Jail",
+                  "path": "./ai-coder/agent-boundaries/nsjail/index.md",
+                  "children": [
+                    {
+                      "title": "NS Jail on Docker",
+                      "description": "Runtime and permission requirements for running NS Jail on Docker",
+                      "path": "./ai-coder/agent-boundaries/nsjail/docker.md"
+                    },
+                    {
+                      "title": "NS Jail on Kubernetes",
+                      "description": "Runtime and permission requirements for running NS Jail on Kubernetes",
+                      "path": "./ai-coder/agent-boundaries/nsjail/k8s.md"
+                    },
+                    {
+                      "title": "NS Jail on ECS",
+                      "description": "Runtime and permission requirements for running NS Jail on ECS",
+                      "path": "./ai-coder/agent-boundaries/nsjail/ecs.md"
+                    }
+                  ]
+                },
+                {
+                  "title": "LandJail",
+                  "description": "Documentation for LandJail",
+                  "path": "./ai-coder/agent-boundaries/landjail.md"
+                },
+                {
+                  "title": "Rules Engine",
+                  "description": "Documentation for the Boundary rules engine",
+                  "path": "./ai-coder/agent-boundaries/rules-engine.md"
+                },
+                {
+                  "title": "Version Compatibility",
+                  "description": "Version requirements and compatibility information",
+                  "path": "./ai-coder/agent-boundaries/version.md"
+                }
+              ]
+            },
+            {
+              "title": "AI Bridge",
+              "description": "AI Gateway for Enterprise Governance & Observability",
+              "path": "./ai-coder/ai-bridge/index.md",
+              "icon_path": "./images/icons/api.svg",
+              "state": [
+                "premium"
+              ],
+              "children": [
+                {
+                  "title": "Setup",
+                  "description": "How to set up and configure AI Bridge",
+                  "path": "./ai-coder/ai-bridge/setup.md"
+                },
+                {
+                  "title": "Client Configuration",
+                  "description": "How to configure your AI coding tools to use AI Bridge",
+                  "path": "./ai-coder/ai-bridge/clients/index.md",
+                  "children": [
+                    {
+                      "title": "Claude Code",
+                      "description": "Configure Claude Code to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/claude-code.md"
+                    },
+                    {
+                      "title": "Codex",
+                      "description": "Configure Codex to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/codex.md"
+                    },
+                    {
+                      "title": "Mux",
+                      "description": "Configure Mux to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/mux.md"
+                    },
+                    {
+                      "title": "OpenCode",
+                      "description": "Configure OpenCode to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/opencode.md"
+                    },
+                    {
+                      "title": "Factory",
+                      "description": "Configure Factory to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/factory.md"
+                    },
+                    {
+                      "title": "Cline",
+                      "description": "Configure Cline to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/cline.md"
+                    },
+                    {
+                      "title": "Kilo Code",
+                      "description": "Configure Kilo Code to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/kilo-code.md"
+                    },
+                    {
+                      "title": "Roo Code",
+                      "description": "Configure Roo Code to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/roo-code.md"
+                    },
+                    {
+                      "title": "VS Code",
+                      "description": "Configure VS Code to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/vscode.md"
+                    },
+                    {
+                      "title": "JetBrains",
+                      "description": "Configure JetBrains IDEs to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/jetbrains.md"
+                    },
+                    {
+                      "title": "Zed",
+                      "description": "Configure Zed to use AI Bridge",
+                      "path": "./ai-coder/ai-bridge/clients/zed.md"
+                    },
+                    {
+                      "title": "GitHub Copilot",
+                      "description": "Configure GitHub Copilot to use AI Bridge via AI Bridge Proxy",
+                      "path": "./ai-coder/ai-bridge/clients/copilot.md"
+                    }
+                  ]
+                },
+                {
+                  "title": "MCP Tools Injection",
+                  "description": "How to configure MCP servers for tools injection through AI Bridge",
+                  "path": "./ai-coder/ai-bridge/mcp.md",
+                  "state": [
+                    "early access"
+                  ]
+                },
+                {
+                  "title": "AI Bridge Proxy",
+                  "description": "Proxy for AI coding tools without base URL override support",
+                  "path": "./ai-coder/ai-bridge/ai-bridge-proxy/index.md",
+                  "state": [
+                    "premium"
+                  ],
+                  "children": [
+                    {
+                      "title": "Setup",
+                      "description": "How to set up and configure AI Bridge Proxy",
+                      "path": "./ai-coder/ai-bridge/ai-bridge-proxy/setup.md"
+                    }
+                  ]
+                },
+                {
+                  "title": "Monitoring",
+                  "description": "How to monitor AI Bridge",
+                  "path": "./ai-coder/ai-bridge/monitoring.md"
+                },
+                {
+                  "title": "Reference",
+                  "description": "Technical reference for AI Bridge",
+                  "path": "./ai-coder/ai-bridge/reference.md"
+                }
+              ]
+            },
+            {
+              "title": "Usage Data Reporting",
+              "description": "Configure AI usage data reporting",
+              "path": "./ai-coder/usage-data-reporting.md"
+            }
+          ]
+        },
+        {
+          "title": "MCP Server",
+          "description": "Connect to agents Coder with a MCP server",
+          "path": "./ai-coder/mcp-server.md",
+          "state": [
+            "beta"
+          ]
+        },
+        {
+          "title": "Coder Agents",
+          "description": "Self-hosted agent by Coder",
+          "path": "./ai-coder/agents/index.md",
+          "children": [
+            {
+              "title": "Architecture",
+              "description": "How the agent in the control plane communicates with workspaces",
+              "path": "./ai-coder/agents/architecture.md"
+            },
+            {
+              "title": "Models",
+              "description": "Configure LLM providers and models for Coder Agents",
+              "path": "./ai-coder/agents/models.md"
+            },
+            {
+              "title": "Platform Controls",
+              "description": "How platform teams control agent behavior, models, and policies",
+              "path": "./ai-coder/agents/platform-controls.md"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Tutorials",
+      "description": "Coder knowledgebase for administrating your deployment",
+      "path": "./tutorials/index.md",
+      "icon_path": "./images/icons/generic.svg",
+      "children": [
+        {
+          "title": "Quickstart",
+          "description": "Learn how to install and run Coder quickly",
+          "path": "./tutorials/quickstart.md"
+        },
+        {
+          "title": "Write a Template from Scratch",
+          "description": "Learn how to author Coder templates",
+          "path": "./tutorials/template-from-scratch.md"
+        },
+        {
+          "title": "Using an External Database",
+          "description": "Use Coder with an external database",
+          "path": "./tutorials/external-database.md"
+        },
+        {
+          "title": "Image Management",
+          "description": "Learn about image management with Coder",
+          "path": "./admin/templates/managing-templates/image-management.md"
+        },
+        {
+          "title": "Configuring Okta",
+          "description": "Custom claims/scopes with Okta for group/role sync",
+          "path": "./tutorials/configuring-okta.md"
+        },
+        {
+          "title": "Google to AWS Federation",
+          "description": "Federating a Google Cloud service account to AWS",
+          "path": "./tutorials/gcp-to-aws.md"
+        },
+        {
+          "title": "JFrog Artifactory Integration",
+          "description": "Integrate Coder with JFrog Artifactory",
+          "path": "./admin/integrations/jfrog-artifactory.md"
+        },
+        {
+          "title": "Mirror Coder Registry with Artifactory",
+          "description": "Use JFrog Artifactory to mirror the Coder Registry for air-gapped deployments",
+          "path": "./install/registry-mirror-artifactory.md"
+        },
+        {
+          "title": "Istio Integration",
+          "description": "Integrate Coder with Istio",
+          "path": "./admin/integrations/istio.md"
+        },
+        {
+          "title": "Island Secure Browser Integration",
+          "description": "Integrate Coder with Island's Secure Browser",
+          "path": "./admin/integrations/island.md"
+        },
+        {
+          "title": "Template ImagePullSecrets",
+          "description": "Creating ImagePullSecrets for private registries",
+          "path": "./tutorials/image-pull-secret.md"
+        },
+        {
+          "title": "Postgres SSL",
+          "description": "Configure Coder to connect to Postgres over SSL",
+          "path": "./tutorials/postgres-ssl.md"
+        },
+        {
+          "title": "Azure Federation",
+          "description": "Federating Coder to Azure",
+          "path": "./tutorials/azure-federation.md"
+        },
+        {
+          "title": "Deploy Coder on Azure with an Application Gateway",
+          "description": "Deploy Coder on Azure with an Application Gateway",
+          "path": "./install/kubernetes/kubernetes-azure-app-gateway.md"
+        },
+        {
+          "title": "Cloning Git Repositories",
+          "description": "Learn how to clone Git repositories in Coder",
+          "path": "./tutorials/cloning-git-repositories.md"
+        },
+        {
+          "title": "Test Templates Through CI/CD",
+          "description": "Learn how to test and publish Coder templates in a CI/CD pipeline",
+          "path": "./tutorials/testing-templates.md"
+        },
+        {
+          "title": "Use Apache as a Reverse Proxy",
+          "description": "Learn how to use Apache as a reverse proxy",
+          "path": "./tutorials/reverse-proxy-apache.md"
+        },
+        {
+          "title": "Use Caddy as a Reverse Proxy",
+          "description": "Learn how to use Caddy as a reverse proxy",
+          "path": "./tutorials/reverse-proxy-caddy.md"
+        },
+        {
+          "title": "Use NGINX as a Reverse Proxy",
+          "description": "Learn how to use NGINX as a reverse proxy",
+          "path": "./tutorials/reverse-proxy-nginx.md"
+        },
+        {
+          "title": "Pre-install JetBrains IDEs in Workspaces",
+          "description": "Pre-install JetBrains IDEs in workspaces",
+          "path": "./admin/templates/extending-templates/jetbrains-preinstall.md"
+        },
+        {
+          "title": "Use JetBrains IDEs in Air-Gapped Deployments",
+          "description": "Configure JetBrains IDEs for air-gapped deployments",
+          "path": "./admin/templates/extending-templates/jetbrains-airgapped.md"
+        },
+        {
+          "title": "FAQs",
+          "description": "Miscellaneous FAQs from our community",
+          "path": "./tutorials/faqs.md"
+        },
+        {
+          "title": "Best practices",
+          "description": "Guides to help you make the most of your Coder experience",
+          "path": "./tutorials/best-practices/index.md",
+          "children": [
+            {
+              "title": "Organizations - best practices",
+              "description": "How to make the best use of Coder Organizations",
+              "path": "./tutorials/best-practices/organizations.md"
+            },
+            {
+              "title": "Scale Coder",
+              "description": "How to prepare a Coder deployment for scale",
+              "path": "./tutorials/best-practices/scale-coder.md"
+            },
+            {
+              "title": "Security - best practices",
+              "description": "Make your Coder deployment more secure",
+              "path": "./tutorials/best-practices/security-best-practices.md"
+            },
+            {
+              "title": "Speed up your workspaces",
+              "description": "Speed up your Coder templates and workspaces",
+              "path": "./tutorials/best-practices/speed-up-templates.md"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Reference",
+      "description": "Reference",
+      "path": "./reference/index.md",
+      "icon_path": "./images/icons/notes.svg",
+      "children": [
+        {
+          "title": "REST API",
+          "description": "Learn how to use Coderd API",
+          "path": "./reference/api/index.md",
+          "icon_path": "./images/icons/api.svg",
+          "children": [
+            {
+              "title": "General",
+              "path": "./reference/api/general.md"
+            },
+            {
+              "title": "AI Bridge",
+              "path": "./reference/api/aibridge.md"
+            },
+            {
+              "title": "Agents",
+              "path": "./reference/api/agents.md"
+            },
+            {
+              "title": "Applications",
+              "path": "./reference/api/applications.md"
+            },
+            {
+              "title": "Audit",
+              "path": "./reference/api/audit.md"
+            },
+            {
+              "title": "Authentication",
+              "path": "./reference/api/authentication.md"
+            },
+            {
+              "title": "Authorization",
+              "path": "./reference/api/authorization.md"
+            },
+            {
+              "title": "Builds",
+              "path": "./reference/api/builds.md"
+            },
+            {
+              "title": "Chats",
+              "path": "./reference/api/chats.md"
+            },
+            {
+              "title": "Debug",
+              "path": "./reference/api/debug.md"
+            },
+            {
+              "title": "Enterprise",
+              "path": "./reference/api/enterprise.md"
+            },
+            {
+              "title": "Files",
+              "path": "./reference/api/files.md"
+            },
+            {
+              "title": "Git",
+              "path": "./reference/api/git.md"
+            },
+            {
+              "title": "InitScript",
+              "path": "./reference/api/initscript.md"
+            },
+            {
+              "title": "Insights",
+              "path": "./reference/api/insights.md"
+            },
+            {
+              "title": "Members",
+              "path": "./reference/api/members.md"
+            },
+            {
+              "title": "Notifications",
+              "path": "./reference/api/notifications.md"
+            },
+            {
+              "title": "Organizations",
+              "path": "./reference/api/organizations.md"
+            },
+            {
+              "title": "PortSharing",
+              "path": "./reference/api/portsharing.md"
+            },
+            {
+              "title": "Prebuilds",
+              "path": "./reference/api/prebuilds.md"
+            },
+            {
+              "title": "Provisioning",
+              "path": "./reference/api/provisioning.md"
+            },
+            {
+              "title": "Schemas",
+              "path": "./reference/api/schemas.md"
+            },
+            {
+              "title": "Tasks",
+              "path": "./reference/api/tasks.md"
+            },
+            {
+              "title": "Templates",
+              "path": "./reference/api/templates.md"
+            },
+            {
+              "title": "Users",
+              "path": "./reference/api/users.md"
+            },
+            {
+              "title": "WorkspaceProxies",
+              "path": "./reference/api/workspaceproxies.md"
+            },
+            {
+              "title": "Workspaces",
+              "path": "./reference/api/workspaces.md"
+            }
+          ]
+        },
+        {
+          "title": "Command Line",
+          "description": "Learn how to use Coder CLI",
+          "path": "./reference/cli/index.md",
+          "icon_path": "./images/icons/terminal.svg",
+          "children": [
+            {
+              "title": "aibridge",
+              "description": "Manage AI Bridge.",
+              "path": "reference/cli/aibridge.md"
+            },
+            {
+              "title": "aibridge interceptions",
+              "description": "Manage AI Bridge interceptions.",
+              "path": "reference/cli/aibridge_interceptions.md"
+            },
+            {
+              "title": "aibridge interceptions list",
+              "description": "List AI Bridge interceptions as JSON.",
+              "path": "reference/cli/aibridge_interceptions_list.md"
+            },
+            {
+              "title": "autoupdate",
+              "description": "Toggle auto-update policy for a workspace",
+              "path": "reference/cli/autoupdate.md"
+            },
+            {
+              "title": "boundary",
+              "description": "Network isolation tool for monitoring and restricting HTTP/HTTPS requests",
+              "path": "reference/cli/boundary.md"
+            },
+            {
+              "title": "coder",
+              "path": "reference/cli/index.md"
+            },
+            {
+              "title": "completion",
+              "description": "Install or update shell completion scripts for the detected or chosen shell.",
+              "path": "reference/cli/completion.md"
+            },
+            {
+              "title": "config-ssh",
+              "description": "Add an SSH Host entry for your workspaces \"ssh workspace.coder\"",
+              "path": "reference/cli/config-ssh.md"
+            },
+            {
+              "title": "create",
+              "description": "Create a workspace",
+              "path": "reference/cli/create.md"
+            },
+            {
+              "title": "delete",
+              "description": "Delete a workspace",
+              "path": "reference/cli/delete.md"
+            },
+            {
+              "title": "dotfiles",
+              "description": "Personalize your workspace by applying a canonical dotfiles repository",
+              "path": "reference/cli/dotfiles.md"
+            },
+            {
+              "title": "external-auth",
+              "description": "Manage external authentication",
+              "path": "reference/cli/external-auth.md"
+            },
+            {
+              "title": "external-auth access-token",
+              "description": "Print auth for an external provider",
+              "path": "reference/cli/external-auth_access-token.md"
+            },
+            {
+              "title": "external-workspaces",
+              "description": "Create or manage external workspaces",
+              "path": "reference/cli/external-workspaces.md"
+            },
+            {
+              "title": "external-workspaces agent-instructions",
+              "description": "Get the instructions for an external agent",
+              "path": "reference/cli/external-workspaces_agent-instructions.md"
+            },
+            {
+              "title": "external-workspaces create",
+              "description": "Create a new external workspace",
+              "path": "reference/cli/external-workspaces_create.md"
+            },
+            {
+              "title": "external-workspaces list",
+              "description": "List external workspaces",
+              "path": "reference/cli/external-workspaces_list.md"
+            },
+            {
+              "title": "favorite",
+              "description": "Add a workspace to your favorites",
+              "path": "reference/cli/favorite.md"
+            },
+            {
+              "title": "features",
+              "description": "List Enterprise features",
+              "path": "reference/cli/features.md"
+            },
+            {
+              "title": "features list",
+              "path": "reference/cli/features_list.md"
+            },
+            {
+              "title": "groups",
+              "description": "Manage groups",
+              "path": "reference/cli/groups.md"
+            },
+            {
+              "title": "groups create",
+              "description": "Create a user group",
+              "path": "reference/cli/groups_create.md"
+            },
+            {
+              "title": "groups delete",
+              "description": "Delete a user group",
+              "path": "reference/cli/groups_delete.md"
+            },
+            {
+              "title": "groups edit",
+              "description": "Edit a user group",
+              "path": "reference/cli/groups_edit.md"
+            },
+            {
+              "title": "groups list",
+              "description": "List user groups",
+              "path": "reference/cli/groups_list.md"
+            },
+            {
+              "title": "licenses",
+              "description": "Add, delete, and list licenses",
+              "path": "reference/cli/licenses.md"
+            },
+            {
+              "title": "licenses add",
+              "description": "Add license to Coder deployment",
+              "path": "reference/cli/licenses_add.md"
+            },
+            {
+              "title": "licenses delete",
+              "description": "Delete license by ID",
+              "path": "reference/cli/licenses_delete.md"
+            },
+            {
+              "title": "licenses list",
+              "description": "List licenses (including expired)",
+              "path": "reference/cli/licenses_list.md"
+            },
+            {
+              "title": "list",
+              "description": "List workspaces",
+              "path": "reference/cli/list.md"
+            },
+            {
+              "title": "login",
+              "description": "Authenticate with Coder deployment",
+              "path": "reference/cli/login.md"
+            },
+            {
+              "title": "login token",
+              "description": "Print the current session token",
+              "path": "reference/cli/login_token.md"
+            },
+            {
+              "title": "logout",
+              "description": "Unauthenticate your local session",
+              "path": "reference/cli/logout.md"
+            },
+            {
+              "title": "logs",
+              "description": "View logs for a workspace",
+              "path": "reference/cli/logs.md"
+            },
+            {
+              "title": "netcheck",
+              "description": "Print network debug information for DERP and STUN",
+              "path": "reference/cli/netcheck.md"
+            },
+            {
+              "title": "notifications",
+              "description": "Manage Coder notifications",
+              "path": "reference/cli/notifications.md"
+            },
+            {
+              "title": "notifications custom",
+              "description": "Send a custom notification",
+              "path": "reference/cli/notifications_custom.md"
+            },
+            {
+              "title": "notifications pause",
+              "description": "Pause notifications",
+              "path": "reference/cli/notifications_pause.md"
+            },
+            {
+              "title": "notifications resume",
+              "description": "Resume notifications",
+              "path": "reference/cli/notifications_resume.md"
+            },
+            {
+              "title": "notifications test",
+              "description": "Send a test notification",
+              "path": "reference/cli/notifications_test.md"
+            },
+            {
+              "title": "open",
+              "description": "Open a workspace",
+              "path": "reference/cli/open.md"
+            },
+            {
+              "title": "open app",
+              "description": "Open a workspace application.",
+              "path": "reference/cli/open_app.md"
+            },
+            {
+              "title": "open vscode",
+              "description": "Open a workspace in VS Code Desktop",
+              "path": "reference/cli/open_vscode.md"
+            },
+            {
+              "title": "organizations",
+              "description": "Organization related commands",
+              "path": "reference/cli/organizations.md"
+            },
+            {
+              "title": "organizations create",
+              "description": "Create a new organization.",
+              "path": "reference/cli/organizations_create.md"
+            },
+            {
+              "title": "organizations delete",
+              "description": "Delete an organization",
+              "path": "reference/cli/organizations_delete.md"
+            },
+            {
+              "title": "organizations list",
+              "description": "List all organizations",
+              "path": "reference/cli/organizations_list.md"
+            },
+            {
+              "title": "organizations members",
+              "description": "Manage organization members",
+              "path": "reference/cli/organizations_members.md"
+            },
+            {
+              "title": "organizations members add",
+              "description": "Add a new member to the current organization",
+              "path": "reference/cli/organizations_members_add.md"
+            },
+            {
+              "title": "organizations members edit-roles",
+              "description": "Edit organization member's roles",
+              "path": "reference/cli/organizations_members_edit-roles.md"
+            },
+            {
+              "title": "organizations members list",
+              "description": "List all organization members",
+              "path": "reference/cli/organizations_members_list.md"
+            },
+            {
+              "title": "organizations members remove",
+              "description": "Remove a new member to the current organization",
+              "path": "reference/cli/organizations_members_remove.md"
+            },
+            {
+              "title": "organizations roles",
+              "description": "Manage organization roles.",
+              "path": "reference/cli/organizations_roles.md"
+            },
+            {
+              "title": "organizations roles create",
+              "description": "Create a new organization custom role",
+              "path": "reference/cli/organizations_roles_create.md"
+            },
+            {
+              "title": "organizations roles show",
+              "description": "Show role(s)",
+              "path": "reference/cli/organizations_roles_show.md"
+            },
+            {
+              "title": "organizations roles update",
+              "description": "Update an organization custom role",
+              "path": "reference/cli/organizations_roles_update.md"
+            },
+            {
+              "title": "organizations settings",
+              "description": "Manage organization settings.",
+              "path": "reference/cli/organizations_settings.md"
+            },
+            {
+              "title": "organizations settings set",
+              "description": "Update specified organization setting.",
+              "path": "reference/cli/organizations_settings_set.md"
+            },
+            {
+              "title": "organizations settings set group-sync",
+              "description": "Group sync settings to sync groups from an IdP.",
+              "path": "reference/cli/organizations_settings_set_group-sync.md"
+            },
+            {
+              "title": "organizations settings set organization-sync",
+              "description": "Organization sync settings to sync organization memberships from an IdP.",
+              "path": "reference/cli/organizations_settings_set_organization-sync.md"
+            },
+            {
+              "title": "organizations settings set role-sync",
+              "description": "Role sync settings to sync organization roles from an IdP.",
+              "path": "reference/cli/organizations_settings_set_role-sync.md"
+            },
+            {
+              "title": "organizations settings set workspace-sharing",
+              "description": "Workspace sharing settings for the organization.",
+              "path": "reference/cli/organizations_settings_set_workspace-sharing.md"
+            },
+            {
+              "title": "organizations settings show",
+              "description": "Outputs specified organization setting.",
+              "path": "reference/cli/organizations_settings_show.md"
+            },
+            {
+              "title": "organizations settings show group-sync",
+              "description": "Group sync settings to sync groups from an IdP.",
+              "path": "reference/cli/organizations_settings_show_group-sync.md"
+            },
+            {
+              "title": "organizations settings show organization-sync",
+              "description": "Organization sync settings to sync organization memberships from an IdP.",
+              "path": "reference/cli/organizations_settings_show_organization-sync.md"
+            },
+            {
+              "title": "organizations settings show role-sync",
+              "description": "Role sync settings to sync organization roles from an IdP.",
+              "path": "reference/cli/organizations_settings_show_role-sync.md"
+            },
+            {
+              "title": "organizations settings show workspace-sharing",
+              "description": "Workspace sharing settings for the organization.",
+              "path": "reference/cli/organizations_settings_show_workspace-sharing.md"
+            },
+            {
+              "title": "organizations show",
+              "description": "Show the organization. Using \"selected\" will show the selected organization from the \"--org\" flag. Using \"me\" will show all organizations you are a member of.",
+              "path": "reference/cli/organizations_show.md"
+            },
+            {
+              "title": "ping",
+              "description": "Ping a workspace",
+              "path": "reference/cli/ping.md"
+            },
+            {
+              "title": "port-forward",
+              "description": "Forward ports from a workspace to the local machine. For reverse port forwarding, use \"coder ssh -R\".",
+              "path": "reference/cli/port-forward.md"
+            },
+            {
+              "title": "prebuilds",
+              "description": "Manage Coder prebuilds",
+              "path": "reference/cli/prebuilds.md"
+            },
+            {
+              "title": "prebuilds pause",
+              "description": "Pause prebuilds",
+              "path": "reference/cli/prebuilds_pause.md"
+            },
+            {
+              "title": "prebuilds resume",
+              "description": "Resume prebuilds",
+              "path": "reference/cli/prebuilds_resume.md"
+            },
+            {
+              "title": "provisioner",
+              "description": "View and manage provisioner daemons and jobs",
+              "path": "reference/cli/provisioner.md"
+            },
+            {
+              "title": "provisioner jobs",
+              "description": "View and manage provisioner jobs",
+              "path": "reference/cli/provisioner_jobs.md"
+            },
+            {
+              "title": "provisioner jobs cancel",
+              "description": "Cancel a provisioner job",
+              "path": "reference/cli/provisioner_jobs_cancel.md"
+            },
+            {
+              "title": "provisioner jobs list",
+              "description": "List provisioner jobs",
+              "path": "reference/cli/provisioner_jobs_list.md"
+            },
+            {
+              "title": "provisioner keys",
+              "description": "Manage provisioner keys",
+              "path": "reference/cli/provisioner_keys.md"
+            },
+            {
+              "title": "provisioner keys create",
+              "description": "Create a new provisioner key",
+              "path": "reference/cli/provisioner_keys_create.md"
+            },
+            {
+              "title": "provisioner keys delete",
+              "description": "Delete a provisioner key",
+              "path": "reference/cli/provisioner_keys_delete.md"
+            },
+            {
+              "title": "provisioner keys list",
+              "description": "List provisioner keys in an organization",
+              "path": "reference/cli/provisioner_keys_list.md"
+            },
+            {
+              "title": "provisioner list",
+              "description": "List provisioner daemons in an organization",
+              "path": "reference/cli/provisioner_list.md"
+            },
+            {
+              "title": "provisioner start",
+              "description": "Run a provisioner daemon",
+              "path": "reference/cli/provisioner_start.md"
+            },
+            {
+              "title": "publickey",
+              "description": "Output your Coder public key used for Git operations",
+              "path": "reference/cli/publickey.md"
+            },
+            {
+              "title": "rename",
+              "description": "Rename a workspace",
+              "path": "reference/cli/rename.md"
+            },
+            {
+              "title": "reset-password",
+              "description": "Directly connect to the database to reset a user's password",
+              "path": "reference/cli/reset-password.md"
+            },
+            {
+              "title": "restart",
+              "description": "Restart a workspace",
+              "path": "reference/cli/restart.md"
+            },
+            {
+              "title": "schedule",
+              "description": "Schedule automated start and stop times for workspaces",
+              "path": "reference/cli/schedule.md"
+            },
+            {
+              "title": "schedule extend",
+              "description": "Extend the stop time of a currently running workspace instance.",
+              "path": "reference/cli/schedule_extend.md"
+            },
+            {
+              "title": "schedule show",
+              "description": "Show workspace schedules",
+              "path": "reference/cli/schedule_show.md"
+            },
+            {
+              "title": "schedule start",
+              "description": "Edit workspace start schedule",
+              "path": "reference/cli/schedule_start.md"
+            },
+            {
+              "title": "schedule stop",
+              "description": "Edit workspace stop schedule",
+              "path": "reference/cli/schedule_stop.md"
+            },
+            {
+              "title": "server",
+              "description": "Start a Coder server",
+              "path": "reference/cli/server.md"
+            },
+            {
+              "title": "server create-admin-user",
+              "description": "Create a new admin user with the given username, email and password and adds it to every organization.",
+              "path": "reference/cli/server_create-admin-user.md"
+            },
+            {
+              "title": "server dbcrypt",
+              "description": "Manage database encryption.",
+              "path": "reference/cli/server_dbcrypt.md"
+            },
+            {
+              "title": "server dbcrypt decrypt",
+              "description": "Decrypt a previously encrypted database.",
+              "path": "reference/cli/server_dbcrypt_decrypt.md"
+            },
+            {
+              "title": "server dbcrypt delete",
+              "description": "Delete all encrypted data from the database. THIS IS A DESTRUCTIVE OPERATION.",
+              "path": "reference/cli/server_dbcrypt_delete.md"
+            },
+            {
+              "title": "server dbcrypt rotate",
+              "description": "Rotate database encryption keys.",
+              "path": "reference/cli/server_dbcrypt_rotate.md"
+            },
+            {
+              "title": "server postgres-builtin-serve",
+              "description": "Run the built-in PostgreSQL deployment.",
+              "path": "reference/cli/server_postgres-builtin-serve.md"
+            },
+            {
+              "title": "server postgres-builtin-url",
+              "description": "Output the connection URL for the built-in PostgreSQL deployment.",
+              "path": "reference/cli/server_postgres-builtin-url.md"
+            },
+            {
+              "title": "show",
+              "description": "Display details of a workspace's resources and agents",
+              "path": "reference/cli/show.md"
+            },
+            {
+              "title": "speedtest",
+              "description": "Run upload and download tests from your machine to a workspace",
+              "path": "reference/cli/speedtest.md"
+            },
+            {
+              "title": "ssh",
+              "description": "Start a shell into a workspace or run a command",
+              "path": "reference/cli/ssh.md"
+            },
+            {
+              "title": "start",
+              "description": "Start a workspace",
+              "path": "reference/cli/start.md"
+            },
+            {
+              "title": "stat",
+              "description": "Show resource usage for the current workspace.",
+              "path": "reference/cli/stat.md"
+            },
+            {
+              "title": "stat cpu",
+              "description": "Show CPU usage, in cores.",
+              "path": "reference/cli/stat_cpu.md"
+            },
+            {
+              "title": "stat disk",
+              "description": "Show disk usage, in gigabytes.",
+              "path": "reference/cli/stat_disk.md"
+            },
+            {
+              "title": "stat mem",
+              "description": "Show memory usage, in gigabytes.",
+              "path": "reference/cli/stat_mem.md"
+            },
+            {
+              "title": "state",
+              "description": "Manually manage Terraform state to fix broken workspaces",
+              "path": "reference/cli/state.md"
+            },
+            {
+              "title": "state pull",
+              "description": "Pull a Terraform state file from a workspace.",
+              "path": "reference/cli/state_pull.md"
+            },
+            {
+              "title": "state push",
+              "description": "Push a Terraform state file to a workspace.",
+              "path": "reference/cli/state_push.md"
+            },
+            {
+              "title": "stop",
+              "description": "Stop a workspace",
+              "path": "reference/cli/stop.md"
+            },
+            {
+              "title": "support",
+              "description": "Commands for troubleshooting issues with a Coder deployment.",
+              "path": "reference/cli/support.md"
+            },
+            {
+              "title": "support bundle",
+              "description": "Generate a support bundle to troubleshoot issues connecting to a workspace.",
+              "path": "reference/cli/support_bundle.md"
+            },
+            {
+              "title": "task",
+              "description": "Manage tasks",
+              "path": "reference/cli/task.md"
+            },
+            {
+              "title": "task create",
+              "description": "Create a task",
+              "path": "reference/cli/task_create.md"
+            },
+            {
+              "title": "task delete",
+              "description": "Delete tasks",
+              "path": "reference/cli/task_delete.md"
+            },
+            {
+              "title": "task list",
+              "description": "List tasks",
+              "path": "reference/cli/task_list.md"
+            },
+            {
+              "title": "task logs",
+              "description": "Show a task's logs",
+              "path": "reference/cli/task_logs.md"
+            },
+            {
+              "title": "task pause",
+              "description": "Pause a task",
+              "path": "reference/cli/task_pause.md"
+            },
+            {
+              "title": "task resume",
+              "description": "Resume a task",
+              "path": "reference/cli/task_resume.md"
+            },
+            {
+              "title": "task send",
+              "description": "Send input to a task",
+              "path": "reference/cli/task_send.md"
+            },
+            {
+              "title": "task status",
+              "description": "Show the status of a task.",
+              "path": "reference/cli/task_status.md"
+            },
+            {
+              "title": "templates",
+              "description": "Manage templates",
+              "path": "reference/cli/templates.md"
+            },
+            {
+              "title": "templates archive",
+              "description": "Archive unused or failed template versions from a given template(s)",
+              "path": "reference/cli/templates_archive.md"
+            },
+            {
+              "title": "templates create",
+              "description": "DEPRECATED: Create a template from the current directory or as specified by flag",
+              "path": "reference/cli/templates_create.md"
+            },
+            {
+              "title": "templates delete",
+              "description": "Delete templates",
+              "path": "reference/cli/templates_delete.md"
+            },
+            {
+              "title": "templates edit",
+              "description": "Edit the metadata of a template by name.",
+              "path": "reference/cli/templates_edit.md"
+            },
+            {
+              "title": "templates init",
+              "description": "Get started with a templated template.",
+              "path": "reference/cli/templates_init.md"
+            },
+            {
+              "title": "templates list",
+              "description": "List all the templates available for the organization",
+              "path": "reference/cli/templates_list.md"
+            },
+            {
+              "title": "templates presets",
+              "description": "Manage presets of the specified template",
+              "path": "reference/cli/templates_presets.md"
+            },
+            {
+              "title": "templates presets list",
+              "description": "List all presets of the specified template. Defaults to the active template version.",
+              "path": "reference/cli/templates_presets_list.md"
+            },
+            {
+              "title": "templates pull",
+              "description": "Download the active, latest, or specified version of a template to a path.",
+              "path": "reference/cli/templates_pull.md"
+            },
+            {
+              "title": "templates push",
+              "description": "Create or update a template from the current directory or as specified by flag",
+              "path": "reference/cli/templates_push.md"
+            },
+            {
+              "title": "templates versions",
+              "description": "Manage different versions of the specified template",
+              "path": "reference/cli/templates_versions.md"
+            },
+            {
+              "title": "templates versions archive",
+              "description": "Archive a template version(s).",
+              "path": "reference/cli/templates_versions_archive.md"
+            },
+            {
+              "title": "templates versions list",
+              "description": "List all the versions of the specified template",
+              "path": "reference/cli/templates_versions_list.md"
+            },
+            {
+              "title": "templates versions promote",
+              "description": "Promote a template version to active.",
+              "path": "reference/cli/templates_versions_promote.md"
+            },
+            {
+              "title": "templates versions unarchive",
+              "description": "Unarchive a template version(s).",
+              "path": "reference/cli/templates_versions_unarchive.md"
+            },
+            {
+              "title": "tokens",
+              "description": "Manage personal access tokens",
+              "path": "reference/cli/tokens.md"
+            },
+            {
+              "title": "tokens create",
+              "description": "Create a token",
+              "path": "reference/cli/tokens_create.md"
+            },
+            {
+              "title": "tokens list",
+              "description": "List tokens",
+              "path": "reference/cli/tokens_list.md"
+            },
+            {
+              "title": "tokens remove",
+              "description": "Expire or delete a token",
+              "path": "reference/cli/tokens_remove.md"
+            },
+            {
+              "title": "tokens view",
+              "description": "Display detailed information about a token",
+              "path": "reference/cli/tokens_view.md"
+            },
+            {
+              "title": "unfavorite",
+              "description": "Remove a workspace from your favorites",
+              "path": "reference/cli/unfavorite.md"
+            },
+            {
+              "title": "update",
+              "description": "Will update and start a given workspace if it is out of date. If the workspace is already running, it will be stopped first.",
+              "path": "reference/cli/update.md"
+            },
+            {
+              "title": "users",
+              "description": "Manage users",
+              "path": "reference/cli/users.md"
+            },
+            {
+              "title": "users activate",
+              "description": "Update a user's status to 'active'. Active users can fully interact with the platform",
+              "path": "reference/cli/users_activate.md"
+            },
+            {
+              "title": "users create",
+              "description": "Create a new user.",
+              "path": "reference/cli/users_create.md"
+            },
+            {
+              "title": "users delete",
+              "description": "Delete a user by username or user_id.",
+              "path": "reference/cli/users_delete.md"
+            },
+            {
+              "title": "users edit-roles",
+              "description": "Edit a user's roles by username or id",
+              "path": "reference/cli/users_edit-roles.md"
+            },
+            {
+              "title": "users list",
+              "description": "Prints the list of users.",
+              "path": "reference/cli/users_list.md"
+            },
+            {
+              "title": "users show",
+              "description": "Show a single user. Use 'me' to indicate the currently authenticated user.",
+              "path": "reference/cli/users_show.md"
+            },
+            {
+              "title": "users suspend",
+              "description": "Update a user's status to 'suspended'. A suspended user cannot log into the platform",
+              "path": "reference/cli/users_suspend.md"
+            },
+            {
+              "title": "version",
+              "description": "Show coder version",
+              "path": "reference/cli/version.md"
+            },
+            {
+              "title": "whoami",
+              "description": "Fetch authenticated user info for Coder deployment",
+              "path": "reference/cli/whoami.md"
+            }
+          ]
+        },
+        {
+          "title": "Agent API",
+          "description": "Learn how to use Coder Agent API",
+          "path": "./reference/agent-api/index.md",
+          "icon_path": "./images/icons/api.svg",
+          "children": [
+            {
+              "title": "Debug",
+              "path": "./reference/agent-api/debug.md"
+            },
+            {
+              "title": "Schemas",
+              "path": "./reference/agent-api/schemas.md"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Coder Research",
+      "description": "Open source research projects exploring AI-assisted development",
+      "path": "./coder-research.md",
+      "icon_path": "./images/icons/wand.svg"
+    }
+  ]
 }


### PR DESCRIPTION
Adds a docs page under /docs/ai-coder/agents describing our philosophy on platform team control over agent behavior: admin-level configuration, zero developer options, enforcement over defaults. Covers what's available today (providers, models, system prompt, template routing) and where we're headed (usage analytics, infra-level enforcement, tool customization).