### PR TITLE
chore(cli): fix TestTokens harder

### DIFF
--- a/cli/tokens_test.go
+++ b/cli/tokens_test.go
@@ -185,13 +185,15 @@ func TestTokens(t *testing.T) {
 	clitest.SetupConfig(t, client, root)
 	buf = new(bytes.Buffer)
 	inv.Stdout = buf
-	var expiredAtBefore time.Time
+
 	// Precondition: validate token is not expired before expiring
-	if token, err := client.APIKeyByName(ctx, secondUser.ID.String(), "token-two"); assert.NoError(t, err) {
-		now := dbtime.Now()
-		require.True(t, token.ExpiresAt.After(now), "token should not be expired yet (expiresAt=%s, now=%s)", token.ExpiresAt.UTC(), now)
-		expiredAtBefore = token.ExpiresAt
-	}
+	var expiredAtBefore time.Time
+	token, err := client.APIKeyByName(ctx, secondUser.ID.String(), "token-two")
+	require.NoError(t, err)
+	now := dbtime.Now()
+	require.True(t, token.ExpiresAt.After(now), "token should not be expired yet (expiresAt=%s, now=%s)", token.ExpiresAt.UTC(), now)
+	expiredAtBefore = token.ExpiresAt
+
 	err = inv.WithContext(ctx).Run()
 	require.NoError(t, err)
 	// Validate that token was expired

--- a/cli/tokens_test.go
+++ b/cli/tokens_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -184,12 +185,20 @@ func TestTokens(t *testing.T) {
 	clitest.SetupConfig(t, client, root)
 	buf = new(bytes.Buffer)
 	inv.Stdout = buf
+	var expiredAtBefore time.Time
+	// Precondition: validate token is not expired before expiring
+	if token, err := client.APIKeyByName(ctx, secondUser.ID.String(), "token-two"); assert.NoError(t, err) {
+		now := dbtime.Now()
+		require.True(t, token.ExpiresAt.After(now), "token should not be expired yet (expiresAt=%s, now=%s)", token.ExpiresAt.UTC(), now)
+		expiredAtBefore = token.ExpiresAt
+	}
 	err = inv.WithContext(ctx).Run()
 	require.NoError(t, err)
 	// Validate that token was expired
 	if token, err := client.APIKeyByName(ctx, secondUser.ID.String(), "token-two"); assert.NoError(t, err) {
-		now := time.Now()
-		require.False(t, token.ExpiresAt.After(now), "token expiresAt should not be in the future, but was %s (now=%s)", token.ExpiresAt, now)
+		now := dbtime.Now()
+		require.NotEqual(t, token.ExpiresAt, expiredAtBefore, "token expiresAt is the same as before expiring, but should have been updated")
+		require.False(t, token.ExpiresAt.After(now), "token expiresAt should not be in the future after expiring, but was %s (now=%s)", token.ExpiresAt.UTC(), now)
 	}
 
 	// Delete by ID (explicit delete flag)


### PR DESCRIPTION
`time.Now()` is greater than microsecond precision while timestamps we store in Postgres are only microsecond precision. Flake potential is non-zero.