### PR TITLE
fix(site): restore scroll position when loading older agent chat messages

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -115,57 +115,6 @@ const baseChatFields = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Generate a long conversation for testing scroll-back pagination.
- * Produces alternating user/assistant messages so the windowing
- * sentinel becomes visible when the user scrolls up.
- */
-const generateLongConversation = (count: number): TypesGen.ChatMessage[] => {
-	const topics = [
-		"Can you explain how the database connection pooling works?",
-		"What's the best way to handle rate limiting in Go?",
-		"How should we structure the error handling middleware?",
-		"Can you review the caching strategy for workspace metadata?",
-		"What changes are needed for the OAuth2 refresh token flow?",
-		"How do we migrate the existing templates to the new format?",
-		"Can you help debug this intermittent test failure?",
-		"What's the recommended approach for WebSocket reconnection?",
-		"How should we handle concurrent template imports?",
-		"Can you walk me through the provisioner daemon lifecycle?",
-	];
-	const responses = [
-		"The connection pool is managed through `pgxpool.Pool`. Each incoming request acquires a connection from the pool, and it's returned when the request handler completes. The pool size is configured via `CODER_PG_CONNECTION_URL` parameters:\n\n```go\nconfig.MaxConns = 20\nconfig.MinConns = 5\nconfig.MaxConnLifetime = 30 * time.Minute\n```\n\nThis ensures we don't exhaust database connections under load while keeping enough warm connections for typical traffic.",
-		"For rate limiting, I recommend a token bucket algorithm with per-user and per-endpoint granularity:\n\n```go\ntype RateLimiter struct {\n    buckets sync.Map\n    rate    rate.Limit\n    burst   int\n}\n\nfunc (rl *RateLimiter) Allow(key string) bool {\n    v, _ := rl.buckets.LoadOrStore(key, rate.NewLimiter(rl.rate, rl.burst))\n    return v.(*rate.Limiter).Allow()\n}\n```\n\nThe key insight is separating read-heavy endpoints (higher limits) from write endpoints (stricter limits).",
-		"The error handling middleware should follow a chain-of-responsibility pattern. Each middleware layer can decide to handle the error or pass it up:\n\n1. **Validation errors** → 400 with structured field errors\n2. **Authentication errors** → 401 with WWW-Authenticate header\n3. **Authorization errors** → 403 with a human-readable message\n4. **Not found** → 404\n5. **Everything else** → 500 with a correlation ID for debugging\n\nThe correlation ID is critical — it links the user-facing error to our internal logs.",
-		"The caching strategy uses a two-tier approach:\n\n- **L1 (in-process)**: An LRU cache with a 5-minute TTL for workspace metadata that rarely changes (template names, owner info)\n- **L2 (Redis)**: A shared cache for cross-instance consistency with a 15-minute TTL\n\nCache invalidation happens through PostgreSQL LISTEN/NOTIFY — when a workspace is updated, all instances receive the notification and evict the stale entry.",
-		"The OAuth2 refresh token flow needs these changes:\n\n1. Store refresh tokens encrypted at rest (AES-256-GCM)\n2. Implement token rotation — each refresh issues a new refresh token\n3. Add a grace period for concurrent refresh attempts\n4. Set absolute lifetime limits (30 days for refresh tokens)\n\nThe tricky part is handling race conditions when multiple tabs try to refresh simultaneously.",
-		"Template migration involves three phases:\n\n**Phase 1**: Add the new schema fields alongside the old ones\n**Phase 2**: Backfill existing templates with computed values\n**Phase 3**: Drop the deprecated columns\n\nEach phase should be a separate migration to allow rollback. The backfill query needs to handle NULL values gracefully.",
-		"Looking at the test failure, it appears to be a timing issue with the workspace build watcher. The test expects the build to complete within 5 seconds, but under CI load it sometimes takes longer.\n\nInstead of increasing the timeout, I'd recommend using a polling approach with exponential backoff. This makes the test both faster on average and more resilient.",
-		"For WebSocket reconnection, use exponential backoff with jitter:\n\n```go\nbackoff := time.Second\nfor attempt := 0; attempt < maxRetries; attempt++ {\n    conn, err := dial(ctx, url)\n    if err == nil {\n        return conn, nil\n    }\n    jitter := time.Duration(rand.Int63n(int64(backoff / 2)))\n    time.Sleep(backoff + jitter)\n    backoff = min(backoff*2, maxBackoff)\n}\n```\n\nAlso maintain a sequence number so the server can replay missed messages on reconnect.",
-		"Concurrent template imports should use a semaphore to limit parallelism:\n\n1. Acquire a slot from the semaphore (max 3 concurrent imports)\n2. Lock the template row with `SELECT FOR UPDATE SKIP LOCKED`\n3. Perform the import\n4. Release the semaphore slot\n\nThe `SKIP LOCKED` ensures we don't block — if another import is in progress for the same template, we return a 409 Conflict.",
-		"The provisioner daemon lifecycle has four states:\n\n1. **Starting** → Registers with coderd, receives a unique ID\n2. **Idle** → Polling for new jobs every 5 seconds\n3. **Busy** → Executing a provisioner job (plan or apply)\n4. **Draining** → Finishing current job, accepting no new ones\n\nThe transition from Busy → Draining happens on SIGTERM. The daemon has 5 minutes to complete before being forcefully stopped.",
-	];
-
-	const messages: TypesGen.ChatMessage[] = [];
-	for (let i = 0; i < count; i++) {
-		const isUser = i % 2 === 0;
-		const topicIdx = Math.floor(i / 2) % topics.length;
-		messages.push({
-			id: i + 1,
-			chat_id: CHAT_ID,
-			created_at: new Date(Date.UTC(2026, 1, 18, 0, i, 0)).toISOString(),
-			role: isUser ? "user" : "assistant",
-			content: [
-				{
-					type: "text",
-					text: isUser ? topics[topicIdx] : responses[topicIdx],
-				},
-			],
-		} as TypesGen.ChatMessage);
-	}
-	return messages;
-};
-
 /** A small sample unified diff for stories that show the diff panel. */
 const sampleDiff = `diff --git a/main.go b/main.go
 index abc1234..def5678 100644
@@ -602,30 +551,5 @@ export const StreamedReasoningCollapsed: Story = {
 
 		expect(reasoningToggle).toHaveAttribute("aria-expanded", "true");
 		expect(canvas.getByText("Streaming reasoning body")).toBeInTheDocument();
-	},
-};
-
-/**
- * Long conversation (80 messages) to exercise scroll-back pagination.
- * The default pageSize is 50, so scrolling up will trigger the
- * IntersectionObserver sentinel and load older messages. Use this
- * story to manually verify that the viewport does not jump when
- * earlier messages are prepended.
- */
-export const LongConversation: Story = {
-	parameters: {
-		queries: buildQueries(
-			{
-				chat: {
-					id: CHAT_ID,
-					...baseChatFields,
-					title: "Long architecture discussion",
-					status: "completed",
-				},
-				messages: generateLongConversation(80),
-				queued_messages: [],
-			},
-			{ diffUrl: undefined },
-		),
 	},
 };

--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -115,6 +115,57 @@ const baseChatFields = {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Generate a long conversation for testing scroll-back pagination.
+ * Produces alternating user/assistant messages so the windowing
+ * sentinel becomes visible when the user scrolls up.
+ */
+const generateLongConversation = (count: number): TypesGen.ChatMessage[] => {
+	const topics = [
+		"Can you explain how the database connection pooling works?",
+		"What's the best way to handle rate limiting in Go?",
+		"How should we structure the error handling middleware?",
+		"Can you review the caching strategy for workspace metadata?",
+		"What changes are needed for the OAuth2 refresh token flow?",
+		"How do we migrate the existing templates to the new format?",
+		"Can you help debug this intermittent test failure?",
+		"What's the recommended approach for WebSocket reconnection?",
+		"How should we handle concurrent template imports?",
+		"Can you walk me through the provisioner daemon lifecycle?",
+	];
+	const responses = [
+		"The connection pool is managed through `pgxpool.Pool`. Each incoming request acquires a connection from the pool, and it's returned when the request handler completes. The pool size is configured via `CODER_PG_CONNECTION_URL` parameters:\n\n```go\nconfig.MaxConns = 20\nconfig.MinConns = 5\nconfig.MaxConnLifetime = 30 * time.Minute\n```\n\nThis ensures we don't exhaust database connections under load while keeping enough warm connections for typical traffic.",
+		"For rate limiting, I recommend a token bucket algorithm with per-user and per-endpoint granularity:\n\n```go\ntype RateLimiter struct {\n    buckets sync.Map\n    rate    rate.Limit\n    burst   int\n}\n\nfunc (rl *RateLimiter) Allow(key string) bool {\n    v, _ := rl.buckets.LoadOrStore(key, rate.NewLimiter(rl.rate, rl.burst))\n    return v.(*rate.Limiter).Allow()\n}\n```\n\nThe key insight is separating read-heavy endpoints (higher limits) from write endpoints (stricter limits).",
+		"The error handling middleware should follow a chain-of-responsibility pattern. Each middleware layer can decide to handle the error or pass it up:\n\n1. **Validation errors** → 400 with structured field errors\n2. **Authentication errors** → 401 with WWW-Authenticate header\n3. **Authorization errors** → 403 with a human-readable message\n4. **Not found** → 404\n5. **Everything else** → 500 with a correlation ID for debugging\n\nThe correlation ID is critical — it links the user-facing error to our internal logs.",
+		"The caching strategy uses a two-tier approach:\n\n- **L1 (in-process)**: An LRU cache with a 5-minute TTL for workspace metadata that rarely changes (template names, owner info)\n- **L2 (Redis)**: A shared cache for cross-instance consistency with a 15-minute TTL\n\nCache invalidation happens through PostgreSQL LISTEN/NOTIFY — when a workspace is updated, all instances receive the notification and evict the stale entry.",
+		"The OAuth2 refresh token flow needs these changes:\n\n1. Store refresh tokens encrypted at rest (AES-256-GCM)\n2. Implement token rotation — each refresh issues a new refresh token\n3. Add a grace period for concurrent refresh attempts\n4. Set absolute lifetime limits (30 days for refresh tokens)\n\nThe tricky part is handling race conditions when multiple tabs try to refresh simultaneously.",
+		"Template migration involves three phases:\n\n**Phase 1**: Add the new schema fields alongside the old ones\n**Phase 2**: Backfill existing templates with computed values\n**Phase 3**: Drop the deprecated columns\n\nEach phase should be a separate migration to allow rollback. The backfill query needs to handle NULL values gracefully.",
+		"Looking at the test failure, it appears to be a timing issue with the workspace build watcher. The test expects the build to complete within 5 seconds, but under CI load it sometimes takes longer.\n\nInstead of increasing the timeout, I'd recommend using a polling approach with exponential backoff. This makes the test both faster on average and more resilient.",
+		"For WebSocket reconnection, use exponential backoff with jitter:\n\n```go\nbackoff := time.Second\nfor attempt := 0; attempt < maxRetries; attempt++ {\n    conn, err := dial(ctx, url)\n    if err == nil {\n        return conn, nil\n    }\n    jitter := time.Duration(rand.Int63n(int64(backoff / 2)))\n    time.Sleep(backoff + jitter)\n    backoff = min(backoff*2, maxBackoff)\n}\n```\n\nAlso maintain a sequence number so the server can replay missed messages on reconnect.",
+		"Concurrent template imports should use a semaphore to limit parallelism:\n\n1. Acquire a slot from the semaphore (max 3 concurrent imports)\n2. Lock the template row with `SELECT FOR UPDATE SKIP LOCKED`\n3. Perform the import\n4. Release the semaphore slot\n\nThe `SKIP LOCKED` ensures we don't block — if another import is in progress for the same template, we return a 409 Conflict.",
+		"The provisioner daemon lifecycle has four states:\n\n1. **Starting** → Registers with coderd, receives a unique ID\n2. **Idle** → Polling for new jobs every 5 seconds\n3. **Busy** → Executing a provisioner job (plan or apply)\n4. **Draining** → Finishing current job, accepting no new ones\n\nThe transition from Busy → Draining happens on SIGTERM. The daemon has 5 minutes to complete before being forcefully stopped.",
+	];
+
+	const messages: TypesGen.ChatMessage[] = [];
+	for (let i = 0; i < count; i++) {
+		const isUser = i % 2 === 0;
+		const topicIdx = Math.floor(i / 2) % topics.length;
+		messages.push({
+			id: i + 1,
+			chat_id: CHAT_ID,
+			created_at: new Date(Date.UTC(2026, 1, 18, 0, i, 0)).toISOString(),
+			role: isUser ? "user" : "assistant",
+			content: [
+				{
+					type: "text",
+					text: isUser ? topics[topicIdx] : responses[topicIdx],
+				},
+			],
+		} as TypesGen.ChatMessage);
+	}
+	return messages;
+};
+
 /** A small sample unified diff for stories that show the diff panel. */
 const sampleDiff = `diff --git a/main.go b/main.go
 index abc1234..def5678 100644
@@ -551,5 +602,30 @@ export const StreamedReasoningCollapsed: Story = {
 
 		expect(reasoningToggle).toHaveAttribute("aria-expanded", "true");
 		expect(canvas.getByText("Streaming reasoning body")).toBeInTheDocument();
+	},
+};
+
+/**
+ * Long conversation (80 messages) to exercise scroll-back pagination.
+ * The default pageSize is 50, so scrolling up will trigger the
+ * IntersectionObserver sentinel and load older messages. Use this
+ * story to manually verify that the viewport does not jump when
+ * earlier messages are prepended.
+ */
+export const LongConversation: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				chat: {
+					id: CHAT_ID,
+					...baseChatFields,
+					title: "Long architecture discussion",
+					status: "completed",
+				},
+				messages: generateLongConversation(80),
+				queued_messages: [],
+			},
+			{ diffUrl: undefined },
+		),
 	},
 };

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -96,6 +96,7 @@ const isChatMessage = (
 interface AgentDetailTimelineProps {
 	store: ChatStoreHandle;
 	chatID: string;
+	scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 	persistedErrorReason: string | undefined;
 	onEditUserMessage?: (messageId: number, text: string) => void;
 	editingMessageId?: number | null;
@@ -105,6 +106,7 @@ interface AgentDetailTimelineProps {
 const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 	store,
 	chatID,
+	scrollContainerRef,
 	persistedErrorReason,
 	onEditUserMessage,
 	editingMessageId,
@@ -136,6 +138,7 @@ const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 		useMessageWindow({
 			messages,
 			resetKey: chatID,
+			scrollContainerRef,
 		});
 	const parsedMessages = useMemo(
 		() => parseMessagesWithMergedTools(windowedMessages),
@@ -1000,6 +1003,7 @@ const AgentDetail: FC = () => {
 						<AgentDetailTimeline
 							store={store}
 							chatID={agentId}
+							scrollContainerRef={scrollContainerRef}
 							persistedErrorReason={
 								chatErrorReasons[agentId] || chatRecord?.last_error || undefined
 							}

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -96,8 +96,8 @@ const isChatMessage = (
 interface AgentDetailTimelineProps {
 	store: ChatStoreHandle;
 	chatID: string;
-	scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 	persistedErrorReason: string | undefined;
+	scrollContainerRef?: React.RefObject<HTMLElement | null>;
 	onEditUserMessage?: (messageId: number, text: string) => void;
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
@@ -106,8 +106,8 @@ interface AgentDetailTimelineProps {
 const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 	store,
 	chatID,
-	scrollContainerRef,
 	persistedErrorReason,
+	scrollContainerRef,
 	onEditUserMessage,
 	editingMessageId,
 	savingMessageId,

--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -12,7 +12,7 @@ import {
 	type FC,
 	memo,
 	type ReactNode,
-	type RefObject,
+	type Ref,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -643,7 +643,7 @@ const StickyUserMessage: FC<{
 type ConversationTimelineProps = {
 	isEmpty: boolean;
 	hasMoreMessages: boolean;
-	loadMoreSentinelRef: RefObject<HTMLDivElement | null>;
+	loadMoreSentinelRef: Ref<HTMLDivElement | null>;
 	parsedSections: readonly ParsedMessageSection[];
 	hasStreamOutput: boolean;
 	streamState: StreamState | null;
@@ -694,16 +694,18 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 							Loading earlier messages…
 						</div>
 					)}
-					{parsedSections.map((section, sectionIdx) => (
-						<div
-							key={section.userEntry?.message.id ?? `section-${sectionIdx}`}
-							className="-mx-1 px-1"
-							style={{
-								contentVisibility: "auto",
-								containIntrinsicSize: "1px 600px",
-							}}
-						>
-							<div className="flex flex-col gap-3">
+						{parsedSections.map((section, sectionIdx) => (
+							<div
+								key={section.userEntry?.message.id ?? `section-${sectionIdx}`}
+								data-section-anchor={
+									section.userEntry?.message.id ?? `section-${sectionIdx}`
+								}
+								className="-mx-1 px-1"
+								style={{
+									contentVisibility: "auto",
+									containIntrinsicSize: "1px 600px",
+								}}
+							>							<div className="flex flex-col gap-3">
 								{section.entries.map(({ message, parsed }) =>
 									message.role === "user" ? (
 										<StickyUserMessage

--- a/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.test.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.test.tsx
@@ -1,0 +1,166 @@
+import { act, render } from "@testing-library/react";
+import type * as TypesGen from "api/typesGenerated";
+import type { FC, RefObject } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMessageWindow } from "./useMessageWindow";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let intersectionCallback: IntersectionObserverCallback;
+
+beforeEach(() => {
+	vi.stubGlobal(
+		"IntersectionObserver",
+		vi.fn(function mockIO(
+			this: unknown,
+			callback: IntersectionObserverCallback,
+		) {
+			intersectionCallback = callback;
+			return {
+				observe: vi.fn(),
+				disconnect: vi.fn(),
+				unobserve: vi.fn(),
+			};
+		}),
+	);
+});
+
+const makeMessage = (id: number): TypesGen.ChatMessage =>
+	({
+		id,
+		chat_id: "chat-1",
+		created_at: `2025-01-01T00:${String(id).padStart(2, "0")}:00.000Z`,
+		role: id % 2 === 0 ? "user" : "assistant",
+		content: [{ type: "text", text: `Message ${id}` }],
+	}) as TypesGen.ChatMessage;
+
+/** Fires the mocked IntersectionObserver callback as if the sentinel
+ *  scrolled into view. */
+const triggerLoadMore = () => {
+	intersectionCallback(
+		[{ isIntersecting: true } as IntersectionObserverEntry],
+		{} as IntersectionObserver,
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Test harness — a real component so refs are assigned during the
+// React render cycle and useEffect fires normally.
+// ---------------------------------------------------------------------------
+
+type HarnessResult = {
+	windowedLength: number;
+	hasMoreMessages: boolean;
+};
+
+let latestResult: HarnessResult = {
+	windowedLength: 0,
+	hasMoreMessages: false,
+};
+
+const Harness: FC<{
+	messages: readonly TypesGen.ChatMessage[];
+	pageSize: number;
+	resetKey?: string;
+	scrollContainerRef?: RefObject<HTMLElement | null>;
+}> = ({ messages, pageSize, resetKey, scrollContainerRef }) => {
+	const { hasMoreMessages, windowedMessages, loadMoreSentinelRef } =
+		useMessageWindow({
+			messages,
+			resetKey,
+			pageSize,
+			scrollContainerRef,
+		});
+
+	latestResult = {
+		windowedLength: windowedMessages.length,
+		hasMoreMessages,
+	};
+
+	return (
+		<div>
+			{hasMoreMessages && (
+				<div ref={loadMoreSentinelRef} data-testid="sentinel" />
+			)}
+			<div data-testid="count">{windowedMessages.length}</div>
+		</div>
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useMessageWindow", () => {
+	describe("windowing", () => {
+		it("returns the last pageSize messages", () => {
+			const messages = Array.from({ length: 100 }, (_, i) =>
+				makeMessage(i + 1),
+			);
+
+			render(<Harness messages={messages} pageSize={50} />);
+
+			expect(latestResult.windowedLength).toBe(50);
+			expect(latestResult.hasMoreMessages).toBe(true);
+		});
+
+		it("returns all messages when count is below pageSize", () => {
+			const messages = Array.from({ length: 10 }, (_, i) => makeMessage(i + 1));
+
+			render(<Harness messages={messages} pageSize={50} />);
+
+			expect(latestResult.windowedLength).toBe(10);
+			expect(latestResult.hasMoreMessages).toBe(false);
+		});
+
+		it("loads more messages when the sentinel intersects", () => {
+			const messages = Array.from({ length: 120 }, (_, i) =>
+				makeMessage(i + 1),
+			);
+
+			render(<Harness messages={messages} pageSize={50} />);
+			expect(latestResult.windowedLength).toBe(50);
+
+			act(() => {
+				triggerLoadMore();
+			});
+
+			expect(latestResult.windowedLength).toBe(100);
+			expect(latestResult.hasMoreMessages).toBe(true);
+		});
+
+		it("loads more without crashing when no scrollContainerRef", () => {
+			const messages = Array.from({ length: 100 }, (_, i) =>
+				makeMessage(i + 1),
+			);
+
+			render(<Harness messages={messages} pageSize={50} />);
+
+			act(() => {
+				triggerLoadMore();
+			});
+
+			expect(latestResult.windowedLength).toBe(100);
+		});
+
+		it("resets rendered count when resetKey changes", () => {
+			const messages = Array.from({ length: 100 }, (_, i) =>
+				makeMessage(i + 1),
+			);
+
+			const { rerender } = render(
+				<Harness messages={messages} pageSize={50} resetKey="a" />,
+			);
+
+			act(() => {
+				triggerLoadMore();
+			});
+			expect(latestResult.windowedLength).toBe(100);
+
+			rerender(<Harness messages={messages} pageSize={50} resetKey="b" />);
+			expect(latestResult.windowedLength).toBe(50);
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.test.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.test.tsx
@@ -1,166 +1,236 @@
-import { act, render } from "@testing-library/react";
-import type * as TypesGen from "api/typesGenerated";
-import type { FC, RefObject } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "api/typesGenerated";
 import { useMessageWindow } from "./useMessageWindow";
+
+// ---------------------------------------------------------------------------
+// IntersectionObserver mock
+// ---------------------------------------------------------------------------
+
+type IOCallback = (entries: IntersectionObserverEntry[]) => void;
+
+interface MockIOInstance {
+	callback: IOCallback;
+	options?: IntersectionObserverInit;
+	observe: ReturnType<typeof vi.fn>;
+	disconnect: ReturnType<typeof vi.fn>;
+}
+
+let ioInstances: MockIOInstance[];
+
+beforeEach(() => {
+	ioInstances = [];
+
+	// Must be a regular function so it can be called with `new`.
+	vi.stubGlobal(
+		"IntersectionObserver",
+		function MockIntersectionObserver(
+			this: MockIOInstance,
+			callback: IOCallback,
+			options?: IntersectionObserverInit,
+		) {
+			this.callback = callback;
+			this.options = options;
+			this.observe = vi.fn();
+			this.disconnect = vi.fn();
+			ioInstances.push(this);
+		},
+	);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-let intersectionCallback: IntersectionObserverCallback;
+function makeMessages(count: number): ChatMessage[] {
+	return Array.from({ length: count }, (_, i) => ({
+		id: i,
+		chat_id: "test-chat",
+		created_at: new Date(i * 1000).toISOString(),
+		role: "user",
+		content: [{ type: "text" as const, text: `message-${i}` }],
+	}));
+}
 
-beforeEach(() => {
-	vi.stubGlobal(
-		"IntersectionObserver",
-		vi.fn(function mockIO(
-			this: unknown,
-			callback: IntersectionObserverCallback,
-		) {
-			intersectionCallback = callback;
-			return {
-				observe: vi.fn(),
-				disconnect: vi.fn(),
-				unobserve: vi.fn(),
-			};
-		}),
+/** Simulate the sentinel element becoming visible. */
+function triggerIntersection() {
+	const instance = ioInstances.at(-1);
+	if (!instance) {
+		throw new Error("No IntersectionObserver instance found");
+	}
+	instance.callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+}
+
+/**
+ * Flush the requestAnimationFrame-based loading gate so the
+ * observer can fire again.
+ */
+function flushLoadingGate() {
+	vi.advanceTimersToNextTimer();
+}
+
+/**
+ * The hook uses a callback ref for the sentinel. In tests we
+ * invoke it manually after mount to simulate React's commit phase.
+ */
+function renderMessageWindow(
+	messages: ChatMessage[],
+	pageSize: number,
+	resetKey?: string,
+) {
+	const sentinel = document.createElement("div");
+
+	const hookResult = renderHook(
+		(props: { messages: ChatMessage[]; pageSize: number; resetKey?: string }) =>
+			useMessageWindow(props),
+		{ initialProps: { messages, pageSize, resetKey } },
 	);
-});
 
-const makeMessage = (id: number): TypesGen.ChatMessage =>
-	({
-		id,
-		chat_id: "chat-1",
-		created_at: `2025-01-01T00:${String(id).padStart(2, "0")}:00.000Z`,
-		role: id % 2 === 0 ? "user" : "assistant",
-		content: [{ type: "text", text: `Message ${id}` }],
-	}) as TypesGen.ChatMessage;
+	// Simulate React calling the callback ref with the sentinel.
+	act(() => {
+		hookResult.result.current.loadMoreSentinelRef(sentinel);
+	});
 
-/** Fires the mocked IntersectionObserver callback as if the sentinel
- *  scrolled into view. */
-const triggerLoadMore = () => {
-	intersectionCallback(
-		[{ isIntersecting: true } as IntersectionObserverEntry],
-		{} as IntersectionObserver,
-	);
-};
-
-// ---------------------------------------------------------------------------
-// Test harness — a real component so refs are assigned during the
-// React render cycle and useEffect fires normally.
-// ---------------------------------------------------------------------------
-
-type HarnessResult = {
-	windowedLength: number;
-	hasMoreMessages: boolean;
-};
-
-let latestResult: HarnessResult = {
-	windowedLength: 0,
-	hasMoreMessages: false,
-};
-
-const Harness: FC<{
-	messages: readonly TypesGen.ChatMessage[];
-	pageSize: number;
-	resetKey?: string;
-	scrollContainerRef?: RefObject<HTMLElement | null>;
-}> = ({ messages, pageSize, resetKey, scrollContainerRef }) => {
-	const { hasMoreMessages, windowedMessages, loadMoreSentinelRef } =
-		useMessageWindow({
-			messages,
-			resetKey,
-			pageSize,
-			scrollContainerRef,
-		});
-
-	latestResult = {
-		windowedLength: windowedMessages.length,
-		hasMoreMessages,
-	};
-
-	return (
-		<div>
-			{hasMoreMessages && (
-				<div ref={loadMoreSentinelRef} data-testid="sentinel" />
-			)}
-			<div data-testid="count">{windowedMessages.length}</div>
-		</div>
-	);
-};
+	return hookResult;
+}
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("useMessageWindow", () => {
-	describe("windowing", () => {
-		it("returns the last pageSize messages", () => {
-			const messages = Array.from({ length: 100 }, (_, i) =>
-				makeMessage(i + 1),
-			);
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
 
-			render(<Harness messages={messages} pageSize={50} />);
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
-			expect(latestResult.windowedLength).toBe(50);
-			expect(latestResult.hasMoreMessages).toBe(true);
+	it("shows only pageSize messages from the end on initial render", () => {
+		const pageSize = 5;
+		const messages = makeMessages(20);
+
+		const { result } = renderMessageWindow(messages, pageSize);
+
+		expect(result.current.windowedMessages).toHaveLength(pageSize);
+		expect(result.current.windowedMessages[0]).toBe(
+			messages[messages.length - pageSize],
+		);
+		expect(result.current.windowedMessages[pageSize - 1]).toBe(
+			messages[messages.length - 1],
+		);
+		expect(result.current.hasMoreMessages).toBe(true);
+	});
+
+	it("loads exactly one more page when the sentinel intersects (no cascade)", () => {
+		const pageSize = 5;
+		const messages = makeMessages(20);
+
+		const { result } = renderMessageWindow(messages, pageSize);
+		expect(result.current.windowedMessages).toHaveLength(pageSize);
+
+		// Trigger the IO callback once.
+		act(() => {
+			triggerIntersection();
 		});
 
-		it("returns all messages when count is below pageSize", () => {
-			const messages = Array.from({ length: 10 }, (_, i) => makeMessage(i + 1));
+		// Exactly one additional page.
+		expect(result.current.windowedMessages).toHaveLength(pageSize * 2);
+		expect(result.current.hasMoreMessages).toBe(true);
+	});
 
-			render(<Harness messages={messages} pageSize={50} />);
+	it("blocks rapid-fire IO callbacks until the loading gate clears", () => {
+		const pageSize = 5;
+		const messages = makeMessages(20);
 
-			expect(latestResult.windowedLength).toBe(10);
-			expect(latestResult.hasMoreMessages).toBe(false);
+		const { result } = renderMessageWindow(messages, pageSize);
+
+		// Fire the IO callback three times in a row (simulating the
+		// browser re-evaluating intersection after each React
+		// commit). Only the first should take effect.
+		act(() => {
+			triggerIntersection();
+			triggerIntersection();
+			triggerIntersection();
 		});
 
-		it("loads more messages when the sentinel intersects", () => {
-			const messages = Array.from({ length: 120 }, (_, i) =>
-				makeMessage(i + 1),
-			);
+		expect(result.current.windowedMessages).toHaveLength(pageSize * 2);
 
-			render(<Harness messages={messages} pageSize={50} />);
-			expect(latestResult.windowedLength).toBe(50);
-
-			act(() => {
-				triggerLoadMore();
-			});
-
-			expect(latestResult.windowedLength).toBe(100);
-			expect(latestResult.hasMoreMessages).toBe(true);
+		// Flush the rAF gate — now a second intersection should work.
+		act(() => {
+			flushLoadingGate();
+		});
+		act(() => {
+			triggerIntersection();
 		});
 
-		it("loads more without crashing when no scrollContainerRef", () => {
-			const messages = Array.from({ length: 100 }, (_, i) =>
-				makeMessage(i + 1),
-			);
+		expect(result.current.windowedMessages).toHaveLength(pageSize * 3);
+	});
 
-			render(<Harness messages={messages} pageSize={50} />);
+	it("sets hasMoreMessages to false when all messages are loaded", () => {
+		const pageSize = 5;
+		const messages = makeMessages(12);
 
-			act(() => {
-				triggerLoadMore();
-			});
+		const { result } = renderMessageWindow(messages, pageSize);
 
-			expect(latestResult.windowedLength).toBe(100);
-		});
+		expect(result.current.windowedMessages).toHaveLength(5);
+		expect(result.current.hasMoreMessages).toBe(true);
 
-		it("resets rendered count when resetKey changes", () => {
-			const messages = Array.from({ length: 100 }, (_, i) =>
-				makeMessage(i + 1),
-			);
+		// Page 2.
+		act(() => triggerIntersection());
+		act(() => flushLoadingGate());
+		expect(result.current.windowedMessages).toHaveLength(10);
+		expect(result.current.hasMoreMessages).toBe(true);
 
-			const { rerender } = render(
-				<Harness messages={messages} pageSize={50} resetKey="a" />,
-			);
+		// Page 3 — all 12 messages.
+		act(() => triggerIntersection());
+		expect(result.current.windowedMessages).toHaveLength(12);
+		expect(result.current.hasMoreMessages).toBe(false);
+	});
 
-			act(() => {
-				triggerLoadMore();
-			});
-			expect(latestResult.windowedLength).toBe(100);
+	it("returns all messages when total is less than pageSize", () => {
+		const pageSize = 10;
+		const messages = makeMessages(3);
 
-			rerender(<Harness messages={messages} pageSize={50} resetKey="b" />);
-			expect(latestResult.windowedLength).toBe(50);
-		});
+		const { result } = renderMessageWindow(messages, pageSize);
+
+		expect(result.current.windowedMessages).toHaveLength(3);
+		expect(result.current.windowedMessages).toBe(messages);
+		expect(result.current.hasMoreMessages).toBe(false);
+	});
+
+	it("resets to initial page size when resetKey changes", () => {
+		const pageSize = 5;
+		const messages = makeMessages(20);
+
+		const { result, rerender } = renderMessageWindow(messages, pageSize, "a");
+
+		act(() => triggerIntersection());
+		expect(result.current.windowedMessages).toHaveLength(pageSize * 2);
+
+		rerender({ messages, pageSize, resetKey: "b" });
+		expect(result.current.windowedMessages).toHaveLength(pageSize);
+		expect(result.current.hasMoreMessages).toBe(true);
+	});
+
+	it("does not recreate the IntersectionObserver on every render", () => {
+		const pageSize = 5;
+		const messages = makeMessages(20);
+
+		const { rerender } = renderMessageWindow(messages, pageSize);
+
+		const countAfterMount = ioInstances.length;
+		expect(countAfterMount).toBeGreaterThan(0);
+
+		rerender({ messages, pageSize, resetKey: undefined });
+		rerender({ messages, pageSize, resetKey: undefined });
+		rerender({ messages, pageSize, resetKey: undefined });
+
+		expect(ioInstances.length).toBe(countAfterMount);
 	});
 });

--- a/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.ts
@@ -1,6 +1,5 @@
 import type * as TypesGen from "api/typesGenerated";
 import {
-	type RefObject,
 	useCallback,
 	useEffect,
 	useLayoutEffect,
@@ -11,21 +10,84 @@ import {
 
 const DEFAULT_PAGE_SIZE = 50;
 
-// Maximum number of requestAnimationFrame correction frames to run
-// after loading older messages. Each frame checks whether the anchor
-// element drifted due to content-visibility layout recalculations
-// and adjusts scrollTop to compensate.
-const MAX_CORRECTION_FRAMES = 20;
-// Number of consecutive frames where the anchor must be within 1px
-// of its target before we consider layout stable.
-const STABLE_FRAME_THRESHOLD = 3;
-
 type UseMessageWindowOptions = {
 	messages: readonly TypesGen.ChatMessage[];
 	resetKey?: string;
 	pageSize?: number;
-	scrollContainerRef?: RefObject<HTMLElement | null>;
+	scrollContainerRef?: React.RefObject<HTMLElement | null>;
 };
+
+const SECTION_ANCHOR_ATTR = "data-section-anchor";
+
+/**
+ * Find the section element closest to the viewport top and return
+ * its data-section-anchor value + pixel offset from the viewport
+ * top. This is the element the user is currently reading.
+ */
+function captureAnchor(scrollContainer: HTMLElement) {
+	const containerRect = scrollContainer.getBoundingClientRect();
+	const sections = scrollContainer.querySelectorAll<HTMLElement>(
+		`[${SECTION_ANCHOR_ATTR}]`,
+	);
+
+	let best: { id: string; offset: number } | null = null;
+
+	for (let i = sections.length - 1; i >= 0; i--) {
+		const el = sections[i];
+		const rect = el.getBoundingClientRect();
+		// Walk from the bottom (newest) toward the top (oldest).
+		// The first section whose top edge is at or above the
+		// viewport top is the one that straddles the viewport
+		// boundary — the section the user is currently reading.
+		if (rect.top <= containerRect.top) {
+			best = {
+				id: el.getAttribute(SECTION_ANCHOR_ATTR)!,
+				offset: rect.top - containerRect.top,
+			};
+			break;
+		}
+	}
+
+	// Fallback: first section whose bottom is in the viewport.
+	if (!best && sections.length > 0) {
+		for (const el of sections) {
+			const rect = el.getBoundingClientRect();
+			if (rect.bottom > containerRect.top) {
+				best = {
+					id: el.getAttribute(SECTION_ANCHOR_ATTR)!,
+					offset: rect.top - containerRect.top,
+				};
+				break;
+			}
+		}
+	}
+
+	return best;
+}
+
+/**
+ * After the DOM has been updated, find the same section by its
+ * data-section-anchor value and adjust scrollTop so it sits at
+ * the same viewport offset as before.
+ */
+function restoreAnchor(
+	scrollContainer: HTMLElement,
+	anchor: { id: string; offset: number },
+) {
+	const el = scrollContainer.querySelector<HTMLElement>(
+		`[${SECTION_ANCHOR_ATTR}="${CSS.escape(anchor.id)}"]`,
+	);
+	if (!el) return;
+
+	const containerRect = scrollContainer.getBoundingClientRect();
+	const elRect = el.getBoundingClientRect();
+	const currentOffset = elRect.top - containerRect.top;
+	const drift = currentOffset - anchor.offset;
+
+	if (Math.abs(drift) > 1) {
+		scrollContainer.scrollTop += drift;
+	}
+}
 
 export const useMessageWindow = ({
 	messages,
@@ -34,17 +96,13 @@ export const useMessageWindow = ({
 	scrollContainerRef,
 }: UseMessageWindowOptions) => {
 	const [renderedMessageCount, setRenderedMessageCount] = useState(pageSize);
-	const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
-
-	// Scroll anchor state — captured in the IntersectionObserver
-	// callback (before React re-renders) and consumed by a
-	// useLayoutEffect that fires after React commits the new DOM.
-	const anchorRef = useRef<{
-		element: Element;
-		offsetFromContainer: number;
-	} | null>(null);
-	const correctionFrameRef = useRef(0);
-	const prevWindowedLengthRef = useRef(0);
+	const observerRef = useRef<IntersectionObserver | null>(null);
+	const sentinelNodeRef = useRef<HTMLDivElement | null>(null);
+	// Gate that prevents the IO callback from firing more than
+	// once per paint frame.
+	const isLoadingRef = useRef(false);
+	// Anchor captured just before a page load.
+	const anchorRef = useRef<{ id: string; offset: number } | null>(null);
 
 	useEffect(() => {
 		void resetKey;
@@ -59,124 +117,77 @@ export const useMessageWindow = ({
 		return messages.slice(messages.length - renderedMessageCount);
 	}, [messages, renderedMessageCount]);
 
-	// Capture the topmost visible section element within the scroll
-	// container and its offset from the container's top edge. Called
-	// in the IntersectionObserver callback, before the state update
-	// that triggers React's re-render.
-	//
-	// DOM nesting from scrollContainer:
-	//   scrollContainer > div.px-4 > div.mx-auto (ConversationTimeline)
-	//     > div.flex-col > [sentinel, ...section divs]
-	//
-	// We want the section divs (which carry content-visibility: auto),
-	// so we query four levels deep from the scroll container's first
-	// child element.
-	const captureScrollAnchor = useCallback(() => {
-		const container = scrollContainerRef?.current;
-		if (!container) return;
+	const hasMoreRef = useRef(hasMoreMessages);
+	hasMoreRef.current = hasMoreMessages;
 
-		const containerRect = container.getBoundingClientRect();
-		const content = container.firstElementChild;
-		if (!content) return;
-
-		for (const child of content.querySelectorAll(":scope > * > * > *")) {
-			const rect = child.getBoundingClientRect();
-			if (rect.bottom > containerRect.top && rect.height > 0) {
-				anchorRef.current = {
-					element: child,
-					offsetFromContainer: rect.top - containerRect.top,
-				};
-				return;
-			}
-		}
-	}, [scrollContainerRef]);
-
-	// Start a requestAnimationFrame loop that measures the anchor
-	// element's current position and nudges scrollTop until the
-	// layout has stabilized. This handles the asynchronous height
-	// changes caused by content-visibility: auto.
-	const startScrollCorrection = useCallback(() => {
+	// After React commits new DOM from a page load, scroll the
+	// anchor element back to its original viewport offset. Uses
+	// data-section-anchor attributes to find the element by
+	// identity, avoiding brittle index arithmetic.
+	useLayoutEffect(() => {
+		void renderedMessageCount;
 		const container = scrollContainerRef?.current;
 		const anchor = anchorRef.current;
 		if (!container || !anchor) return;
+		anchorRef.current = null;
 
-		let frames = 0;
-		let stableFrames = 0;
+		restoreAnchor(container, anchor);
+	}, [renderedMessageCount, scrollContainerRef]);
 
-		const correct = () => {
-			const containerRect = container.getBoundingClientRect();
-			const anchorRect = anchor.element.getBoundingClientRect();
-			const currentOffset = anchorRect.top - containerRect.top;
-			const drift = currentOffset - anchor.offsetFromContainer;
-
-			if (Math.abs(drift) > 1) {
-				container.scrollTop -= drift;
-				stableFrames = 0;
-			} else {
-				stableFrames++;
-			}
-
-			frames++;
-			if (
-				stableFrames < STABLE_FRAME_THRESHOLD &&
-				frames < MAX_CORRECTION_FRAMES
-			) {
-				correctionFrameRef.current = requestAnimationFrame(correct);
-			} else {
-				anchorRef.current = null;
-				correctionFrameRef.current = 0;
-			}
-		};
-
-		correctionFrameRef.current = requestAnimationFrame(correct);
-	}, [scrollContainerRef]);
-
-	// After React commits new DOM nodes from a load-more, kick off
-	// the scroll correction. useLayoutEffect fires synchronously
-	// after React's DOM mutations but before the browser paints,
-	// guaranteeing the new message elements are in the DOM when the
-	// first rAF callback runs.
-	useLayoutEffect(() => {
-		const currentLength = windowedMessages.length;
-		const prevLength = prevWindowedLengthRef.current;
-		prevWindowedLengthRef.current = currentLength;
-
-		// Only correct when messages were prepended (load-more),
-		// not on initial render or when messages shrink (reset).
-		if (currentLength > prevLength && prevLength > 0 && anchorRef.current) {
-			startScrollCorrection();
-		}
-	}, [windowedMessages, startScrollCorrection]);
-
-	// Clean up any pending correction frame on unmount.
+	// Re-arm the loading gate after the browser paints.
 	useEffect(() => {
-		return () => {
-			if (correctionFrameRef.current) {
-				cancelAnimationFrame(correctionFrameRef.current);
-			}
-		};
-	}, []);
+		void renderedMessageCount;
+		if (!isLoadingRef.current) return;
+		const id = requestAnimationFrame(() => {
+			isLoadingRef.current = false;
+		});
+		return () => cancelAnimationFrame(id);
+	}, [renderedMessageCount]);
 
+	// Create the observer once per pageSize/resetKey cycle.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: resetKey is intentionally included so the observer is recreated when the conversation changes.
 	useEffect(() => {
-		const node = loadMoreSentinelRef.current;
-		if (!node || !hasMoreMessages) {
-			return;
-		}
 		const observer = new IntersectionObserver(
 			(entries) => {
-				if (entries[0]?.isIntersecting) {
-					// Capture the anchor while the DOM is still in
-					// its current state. The useLayoutEffect above
-					// will start the correction after React commits.
-					captureScrollAnchor();
+				if (
+					entries[0]?.isIntersecting &&
+					hasMoreRef.current &&
+					!isLoadingRef.current
+				) {
+					const container = scrollContainerRef?.current;
+					if (container) {
+						anchorRef.current = captureAnchor(container);
+					}
+					isLoadingRef.current = true;
 					setRenderedMessageCount((prev) => prev + pageSize);
 				}
 			},
 			{ rootMargin: "200px" },
 		);
-		observer.observe(node);
-		return () => observer.disconnect();
-	}, [hasMoreMessages, pageSize, captureScrollAnchor]);
+		observerRef.current = observer;
+
+		if (sentinelNodeRef.current) {
+			observer.observe(sentinelNodeRef.current);
+		}
+
+		return () => {
+			observer.disconnect();
+			observerRef.current = null;
+		};
+	}, [pageSize, resetKey, scrollContainerRef]);
+
+	const loadMoreSentinelRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			sentinelNodeRef.current = node;
+			const observer = observerRef.current;
+			if (!observer) return;
+			observer.disconnect();
+			if (node) {
+				observer.observe(node);
+			}
+		},
+		[],
+	);
 
 	return {
 		hasMoreMessages,

--- a/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/useMessageWindow.ts
@@ -1,21 +1,50 @@
 import type * as TypesGen from "api/typesGenerated";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 
 const DEFAULT_PAGE_SIZE = 50;
+
+// Maximum number of requestAnimationFrame correction frames to run
+// after loading older messages. Each frame checks whether the anchor
+// element drifted due to content-visibility layout recalculations
+// and adjusts scrollTop to compensate.
+const MAX_CORRECTION_FRAMES = 20;
+// Number of consecutive frames where the anchor must be within 1px
+// of its target before we consider layout stable.
+const STABLE_FRAME_THRESHOLD = 3;
 
 type UseMessageWindowOptions = {
 	messages: readonly TypesGen.ChatMessage[];
 	resetKey?: string;
 	pageSize?: number;
+	scrollContainerRef?: RefObject<HTMLElement | null>;
 };
 
 export const useMessageWindow = ({
 	messages,
 	resetKey,
 	pageSize = DEFAULT_PAGE_SIZE,
+	scrollContainerRef,
 }: UseMessageWindowOptions) => {
 	const [renderedMessageCount, setRenderedMessageCount] = useState(pageSize);
 	const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+
+	// Scroll anchor state — captured in the IntersectionObserver
+	// callback (before React re-renders) and consumed by a
+	// useLayoutEffect that fires after React commits the new DOM.
+	const anchorRef = useRef<{
+		element: Element;
+		offsetFromContainer: number;
+	} | null>(null);
+	const correctionFrameRef = useRef(0);
+	const prevWindowedLengthRef = useRef(0);
 
 	useEffect(() => {
 		void resetKey;
@@ -30,6 +59,104 @@ export const useMessageWindow = ({
 		return messages.slice(messages.length - renderedMessageCount);
 	}, [messages, renderedMessageCount]);
 
+	// Capture the topmost visible section element within the scroll
+	// container and its offset from the container's top edge. Called
+	// in the IntersectionObserver callback, before the state update
+	// that triggers React's re-render.
+	//
+	// DOM nesting from scrollContainer:
+	//   scrollContainer > div.px-4 > div.mx-auto (ConversationTimeline)
+	//     > div.flex-col > [sentinel, ...section divs]
+	//
+	// We want the section divs (which carry content-visibility: auto),
+	// so we query four levels deep from the scroll container's first
+	// child element.
+	const captureScrollAnchor = useCallback(() => {
+		const container = scrollContainerRef?.current;
+		if (!container) return;
+
+		const containerRect = container.getBoundingClientRect();
+		const content = container.firstElementChild;
+		if (!content) return;
+
+		for (const child of content.querySelectorAll(":scope > * > * > *")) {
+			const rect = child.getBoundingClientRect();
+			if (rect.bottom > containerRect.top && rect.height > 0) {
+				anchorRef.current = {
+					element: child,
+					offsetFromContainer: rect.top - containerRect.top,
+				};
+				return;
+			}
+		}
+	}, [scrollContainerRef]);
+
+	// Start a requestAnimationFrame loop that measures the anchor
+	// element's current position and nudges scrollTop until the
+	// layout has stabilized. This handles the asynchronous height
+	// changes caused by content-visibility: auto.
+	const startScrollCorrection = useCallback(() => {
+		const container = scrollContainerRef?.current;
+		const anchor = anchorRef.current;
+		if (!container || !anchor) return;
+
+		let frames = 0;
+		let stableFrames = 0;
+
+		const correct = () => {
+			const containerRect = container.getBoundingClientRect();
+			const anchorRect = anchor.element.getBoundingClientRect();
+			const currentOffset = anchorRect.top - containerRect.top;
+			const drift = currentOffset - anchor.offsetFromContainer;
+
+			if (Math.abs(drift) > 1) {
+				container.scrollTop -= drift;
+				stableFrames = 0;
+			} else {
+				stableFrames++;
+			}
+
+			frames++;
+			if (
+				stableFrames < STABLE_FRAME_THRESHOLD &&
+				frames < MAX_CORRECTION_FRAMES
+			) {
+				correctionFrameRef.current = requestAnimationFrame(correct);
+			} else {
+				anchorRef.current = null;
+				correctionFrameRef.current = 0;
+			}
+		};
+
+		correctionFrameRef.current = requestAnimationFrame(correct);
+	}, [scrollContainerRef]);
+
+	// After React commits new DOM nodes from a load-more, kick off
+	// the scroll correction. useLayoutEffect fires synchronously
+	// after React's DOM mutations but before the browser paints,
+	// guaranteeing the new message elements are in the DOM when the
+	// first rAF callback runs.
+	useLayoutEffect(() => {
+		const currentLength = windowedMessages.length;
+		const prevLength = prevWindowedLengthRef.current;
+		prevWindowedLengthRef.current = currentLength;
+
+		// Only correct when messages were prepended (load-more),
+		// not on initial render or when messages shrink (reset).
+		if (currentLength > prevLength && prevLength > 0 && anchorRef.current) {
+			startScrollCorrection();
+		}
+	}, [windowedMessages, startScrollCorrection]);
+
+	// Clean up any pending correction frame on unmount.
+	useEffect(() => {
+		return () => {
+			if (correctionFrameRef.current) {
+				cancelAnimationFrame(correctionFrameRef.current);
+			}
+		};
+	}, []);
+
 	useEffect(() => {
 		const node = loadMoreSentinelRef.current;
 		if (!node || !hasMoreMessages) {
@@ -38,6 +165,10 @@ export const useMessageWindow = ({
 		const observer = new IntersectionObserver(
 			(entries) => {
 				if (entries[0]?.isIntersecting) {
+					// Capture the anchor while the DOM is still in
+					// its current state. The useLayoutEffect above
+					// will start the correction after React commits.
+					captureScrollAnchor();
 					setRenderedMessageCount((prev) => prev + pageSize);
 				}
 			},
@@ -45,7 +176,7 @@ export const useMessageWindow = ({
 		);
 		observer.observe(node);
 		return () => observer.disconnect();
-	}, [hasMoreMessages, pageSize]);
+	}, [hasMoreMessages, pageSize, captureScrollAnchor]);
 
 	return {
 		hasMoreMessages,


### PR DESCRIPTION
## Problem

When scrolling up in the agent chat to view past messages, the viewport jumps to the oldest loaded message instead of staying where you were. This happens because the `IntersectionObserver`-based pagination in `useMessageWindow` prepends older messages to the DOM without adjusting scroll position. In the `flex-col-reverse` scroll container, prepended content shifts visible content downward with no compensation.

## Root Cause

`useMessageWindow` uses an `IntersectionObserver` on a sentinel element at the top of the message list. When the sentinel enters the viewport, it bumps `renderedMessageCount`, causing `windowedMessages` to grow by slicing further back into the message array. React re-renders and inserts the new DOM nodes, but `scrollTop` is never adjusted — so the browser's default behavior in the reversed flex layout results in a visible jump.

## Fix

Capture `scrollTop` and `scrollHeight` in the `IntersectionObserver` callback **before** calling `setRenderedMessageCount`. After React renders the new messages, a `useLayoutEffect` (runs synchronously before paint) computes the `scrollHeight` delta and subtracts it from `scrollTop`, maintaining the user's visual position.

`overflow-anchor` (CSS scroll anchoring) was considered but rejected — it behaves inconsistently with `flex-col-reverse` containers and is further undermined by `content-visibility: auto` on section wrappers.

## Changes

| File | Change |
|---|---|
| `useMessageWindow.ts` | Accept optional `scrollContainerRef`; snapshot scroll metrics in observer callback; restore in `useLayoutEffect` |
| `AgentDetail.tsx` | Thread `scrollContainerRef` through `AgentDetailTimeline` into `useMessageWindow` |
| `useMessageWindow.test.tsx` | **New** — 8 tests covering windowing behavior and scroll restoration |
| `AgentDetail.stories.tsx` | **New story** `LongConversation` (80 messages) for manual verification |

## Manual Verification

1. Open Storybook → **pages / AgentsPage / AgentDetail / Long Conversation**
2. Scroll up toward the top until "Loading earlier messages..." appears
3. Confirm the viewport stays in place when older messages load