### PR TITLE
chore: setting time forward for expiration math

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -3093,7 +3093,10 @@ func shouldRefreshOIDCToken(link database.UserLink) bool {
 	//
 	// If an OIDC provider issues short-lived tokens less than our defined period,
 	// the token will always be refreshed on every workspace build.
-	assumeExpiredAt := dbtime.Now().Add(-1 * time.Minute * 10)
+	//
+	// By shifting the time forward, we are asking
+	//  "Will this token be valid in 10 minutes"
+	assumeExpiredAt := dbtime.Now().Add(time.Minute * 10)
 
 	// Return if the token is assumed to be expired.
 	return link.OAuthExpiry.Before(assumeExpiredAt)

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -3096,10 +3096,10 @@ func shouldRefreshOIDCToken(link database.UserLink) bool {
 	//
 	// By shifting the time forward, we are asking
 	//  "Will this token be valid in 10 minutes"
-	assumeExpiredAt := dbtime.Now().Add(time.Minute * 10)
+	expiryCheckTime := dbtime.Now().Add(time.Minute * 10)
 
 	// Return if the token is assumed to be expired.
-	return link.OAuthExpiry.Before(assumeExpiredAt)
+	return link.OAuthExpiry.Before(expiryCheckTime)
 }
 
 // obtainOIDCAccessToken returns a valid OpenID Connect access token

--- a/coderd/provisionerdserver/provisionerdserver_internal_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_internal_test.go
@@ -36,26 +36,59 @@ func TestShouldRefreshOIDCToken(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "ExpiredBeyondAssumedWindow",
+			name: "LongExpired",
 			link: database.UserLink{
 				OAuthRefreshToken: "refresh",
-				OAuthExpiry:       now.Add(-20 * time.Minute),
+				OAuthExpiry:       now.Add(-1 * time.Hour),
 			},
 			want: true,
 		},
 		{
-			name: "ExpiredWithinAssumedWindow",
+			// Edge being "+/- 10 minutes"
+			name: "EdgeExpired",
 			link: database.UserLink{
 				OAuthRefreshToken: "refresh",
-				OAuthExpiry:       now.Add(-5 * time.Minute),
+				OAuthExpiry:       now.Add(-1 * time.Minute * 10),
 			},
-			want: false,
+			want: true,
+		},
+		{
+			name: "Expired",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(-1 * time.Minute),
+			},
+			want: true,
+		},
+		{
+			name: "SoonToBeExpired",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(5 * time.Minute),
+			},
+			want: true,
+		},
+		{
+			name: "SoonToBeExpiredEdge",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(9 * time.Minute),
+			},
+			want: true,
 		},
 		{
 			name: "NotExpired",
 			link: database.UserLink{
 				OAuthRefreshToken: "refresh",
 				OAuthExpiry:       now.Add(time.Hour),
+			},
+			want: false,
+		},
+		{
+			name: "NotEvenCloseExpired",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(time.Hour * 24),
 			},
 			want: false,
 		},

--- a/coderd/provisionerdserver/provisionerdserver_internal_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_internal_test.go
@@ -77,6 +77,14 @@ func TestShouldRefreshOIDCToken(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "AfterEdge",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(11 * time.Minute),
+			},
+			want: false,
+		},
+		{
 			name: "NotExpired",
 			link: database.UserLink{
 				OAuthRefreshToken: "refresh",


### PR DESCRIPTION
It was set backwards, which allowed invalid refresh tokens. Making things worse.

