### PR TITLE
fix(provisionerdserver): refresh OIDC token when expiring within 10 m…

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -3093,7 +3093,7 @@ func shouldRefreshOIDCToken(link database.UserLink) bool {
 	//
 	// If an OIDC provider issues short-lived tokens less than our defined period,
 	// the token will always be refreshed on every workspace build.
-	assumeExpiredAt := dbtime.Now().Add(-1 * time.Minute * 10)
+	assumeExpiredAt := dbtime.Now().Add(time.Minute * 10)
 
 	// Return if the token is assumed to be expired.
 	return link.OAuthExpiry.Before(assumeExpiredAt)

--- a/coderd/provisionerdserver/provisionerdserver_internal_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_internal_test.go
@@ -44,10 +44,31 @@ func TestShouldRefreshOIDCToken(t *testing.T) {
 			want: true,
 		},
 		{
+			// A token that already expired should always be refreshed.
 			name: "ExpiredWithinAssumedWindow",
 			link: database.UserLink{
 				OAuthRefreshToken: "refresh",
 				OAuthExpiry:       now.Add(-5 * time.Minute),
+			},
+			want: true,
+		},
+		{
+			// Token expiring within the 10-minute buffer should be proactively
+			// refreshed to avoid expiry mid-build.
+			name: "ExpiresWithinBuffer",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(5 * time.Minute),
+			},
+			want: true,
+		},
+		{
+			// Token expiring just outside the 10-minute buffer should not
+			// be refreshed yet (boundary condition).
+			name: "ExpiresJustAfterBuffer",
+			link: database.UserLink{
+				OAuthRefreshToken: "refresh",
+				OAuthExpiry:       now.Add(11 * time.Minute),
 			},
 			want: false,
 		},


### PR DESCRIPTION
This is a follow-up to #22606.

The sign on the buffer duration in `shouldRefreshOIDCToken` was inverted: `now - 10min` only matched tokens that had *already* been expired for more than 10 minutes, leaving tokens about to expire untouched. The intent is to proactively refresh before a workspace build starts if the token would expire mid-build, so the threshold should be `now + 10min`.

