### PR TITLE
fix(site): reduce iOS Safari keyboard nav bar on agents chat input

### DIFF
--- a/site/src/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/components/ChatMessageInput/ChatMessageInput.tsx
@@ -381,6 +381,7 @@ const ChatMessageInput = memo(
 								style={{ minHeight: "inherit" }}
 								aria-label={ariaLabel}
 								aria-disabled={disabled}
+								enterKeyHint="send"
 							/>
 						}
 						placeholder={


### PR DESCRIPTION
## Problem

On iOS Safari, the agents page chat input shows the form navigation bar (up/down arrows + checkmark) above the keyboard, which clutters the UI for a single-input chat experience.

## Changes

**`ChatMessageInput.tsx`** — Added `enterKeyHint="send"` to the Lexical `ContentEditable`. This is a standard HTML attribute that tells iOS to show a "Send" return key instead of the default one.

**`AgentChatInput.tsx`** — Changed the chat input wrapper from a `<div>` to a `<form action="#" onSubmit={e => e.preventDefault()}>`. iOS Safari shows the prev/next arrow navigation bar when it detects multiple focusable form fields in the same implicit form scope. Wrapping the input in its own `<form>` isolates the `contentEditable` as the only field, which should suppress the navigation bar.

## Caveats

The `enterKeyHint` part is guaranteed behavior per the HTML spec. The `<form>` isolation for suppressing the nav bar is a best-effort workaround — iOS Safari's heuristics for showing that toolbar are not publicly documented and vary across iOS versions. This should be tested on a real iOS device.