### PR TITLE
fix: use Eventually for web push dispatch assertion in chatd test

### DIFF
--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -1537,8 +1537,12 @@ func TestSuccessfulChatSendsWebPushWithNavigationData(t *testing.T) {
 		return fromDB.Status == database.ChatStatusWaiting && !fromDB.WorkerID.Valid
 	}, testutil.IntervalFast)
 
-	// Verify a web push notification was dispatched exactly once.
-	require.Equal(t, int32(1), mockPush.dispatchCount.Load(),
+	// Wait for a web push notification to be dispatched. The dispatch
+	// happens asynchronously after the DB status is updated, so we need
+	// to poll rather than assert immediately.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		return mockPush.dispatchCount.Load() == 1
+	}, testutil.IntervalFast,
 		"expected exactly one web push dispatch for a completed chat")
 
 	// Verify the notification was sent to the correct user.


### PR DESCRIPTION
## Problem

`TestSuccessfulChatSendsWebPushWithNavigationData` was flaky because it used `require.Equal` to assert the web push dispatch count immediately after observing the chat status change in the database.

The production code in `chatd.go` commits the DB transaction (setting status to `waiting` and clearing `worker_id`) **before** dispatching the web push notification (lines 1771 → 1793 → 1798 → 1826). The test's `testutil.Eventually` loop would see the DB update and exit, then the immediate `require.Equal` would fire before the dispatch goroutine reached the `webpushDispatcher.Dispatch` call.

## Fix

Replace the immediate `require.Equal(t, int32(1), mockPush.dispatchCount.Load(), ...)` with `testutil.Eventually` that polls until the dispatch count reaches 1. This matches the async pattern used elsewhere in the test file.

Fixes coder/internal#1386