### PR TITLE
fix: upgrade docker provider to v3.6.2

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 3.0"
+      version = "~> 3.6"
     }
   }
 }


### PR DESCRIPTION
Context: https://github.com/coder/internal/issues/1382#issuecomment-4010773056
Closes: https://github.com/coder/internal/issues/1382

The lock file already references v3.6.2 so it doesn't update when I run `terraform init -upgrade`.