### PR TITLE
fix: emit Responses API lifecycle events in mock OpenAI server

### DIFF
--- a/coderd/chatd/chattest/openai.go
+++ b/coderd/chatd/chattest/openai.go
@@ -329,7 +329,47 @@ func writeResponsesAPIStreaming(w http.ResponseWriter, r *http.Request, chunks <
 			return
 		case chunk, ok = <-chunks:
 			if !ok {
-				_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+				// Emit Responses API lifecycle events so
+				// the fantasy client closes open text
+				// blocks and persists the step content.
+				for outputIndex, itemID := range itemIDs {
+					textDone, _ := json.Marshal(map[string]interface{}{
+						"type":          "response.output_text.done",
+						"item_id":       itemID,
+						"output_index":  outputIndex,
+						"content_index": 0,
+					})
+					_, _ = fmt.Fprintf(w, "data: %s\n\n", textDone)
+
+					itemDone, _ := json.Marshal(map[string]interface{}{
+						"type":         "response.output_item.done",
+						"item_id":      itemID,
+						"output_index": outputIndex,
+						"item": map[string]interface{}{
+							"id":   itemID,
+							"type": "message",
+						},
+					})
+					_, _ = fmt.Fprintf(w, "data: %s\n\n", itemDone)
+				}
+				completed, _ := json.Marshal(map[string]interface{}{
+					"type": "response.completed",
+					"response": map[string]interface{}{
+						"status":             "completed",
+						"incomplete_details": map[string]interface{}{"reason": ""},
+						"usage": map[string]interface{}{
+							"input_tokens":  0,
+							"output_tokens": 0,
+							"output_tokens_details": map[string]interface{}{
+								"reasoning_tokens": 0,
+							},
+							"input_tokens_details": map[string]interface{}{
+								"cached_tokens": 0,
+							},
+						},
+					},
+				})
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", completed)
 				flusher.Flush()
 				return
 			}
@@ -344,6 +384,21 @@ func writeResponsesAPIStreaming(w http.ResponseWriter, r *http.Request, chunks <
 			if !found {
 				itemID = fmt.Sprintf("msg_%s", uuid.New().String()[:8])
 				itemIDs[outputIndex] = itemID
+
+				// Emit response.output_item.added so the
+				// fantasy client triggers TextStart.
+				itemAdded, _ := json.Marshal(map[string]interface{}{
+					"type":         "response.output_item.added",
+					"output_index": outputIndex,
+					"item": map[string]interface{}{
+						"id":   itemID,
+						"type": "message",
+					},
+				})
+				if _, err := fmt.Fprintf(w, "data: %s\n\n", itemAdded); err != nil {
+					return
+				}
+				flusher.Flush()
 			}
 
 			chunkData := map[string]interface{}{

--- a/coderd/chatd/chattest/openai.go
+++ b/coderd/chatd/chattest/openai.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/openai/openai-go/v2/responses"
+	"github.com/openai/openai-go/v3/responses"
 )
 
 // OpenAIHandler handles OpenAI API requests and returns a response.

--- a/coderd/chatd/chattest/openai.go
+++ b/coderd/chatd/chattest/openai.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/openai/openai-go/v2/responses"
 )
 
 // OpenAIHandler handles OpenAI API requests and returns a response.
@@ -306,6 +307,17 @@ func writeChatCompletionsStreaming(w http.ResponseWriter, r *http.Request, chunk
 	}
 }
 
+// writeSSEEvent marshals v as JSON and writes it as an SSE data
+// frame. Returns any write error.
+func writeSSEEvent(w http.ResponseWriter, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "data: %s\n\n", data)
+	return err
+}
+
 func writeResponsesAPIStreaming(w http.ResponseWriter, r *http.Request, chunks <-chan OpenAIChunk) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -333,43 +345,19 @@ func writeResponsesAPIStreaming(w http.ResponseWriter, r *http.Request, chunks <
 				// the fantasy client closes open text
 				// blocks and persists the step content.
 				for outputIndex, itemID := range itemIDs {
-					textDone, _ := json.Marshal(map[string]interface{}{
-						"type":          "response.output_text.done",
-						"item_id":       itemID,
-						"output_index":  outputIndex,
-						"content_index": 0,
+					_ = writeSSEEvent(w, responses.ResponseTextDoneEvent{
+						ItemID:      itemID,
+						OutputIndex: int64(outputIndex),
 					})
-					_, _ = fmt.Fprintf(w, "data: %s\n\n", textDone)
-
-					itemDone, _ := json.Marshal(map[string]interface{}{
-						"type":         "response.output_item.done",
-						"item_id":      itemID,
-						"output_index": outputIndex,
-						"item": map[string]interface{}{
-							"id":   itemID,
-							"type": "message",
+					_ = writeSSEEvent(w, responses.ResponseOutputItemDoneEvent{
+						OutputIndex: int64(outputIndex),
+						Item: responses.ResponseOutputItemUnion{
+							ID:   itemID,
+							Type: "message",
 						},
 					})
-					_, _ = fmt.Fprintf(w, "data: %s\n\n", itemDone)
 				}
-				completed, _ := json.Marshal(map[string]interface{}{
-					"type": "response.completed",
-					"response": map[string]interface{}{
-						"status":             "completed",
-						"incomplete_details": map[string]interface{}{"reason": ""},
-						"usage": map[string]interface{}{
-							"input_tokens":  0,
-							"output_tokens": 0,
-							"output_tokens_details": map[string]interface{}{
-								"reasoning_tokens": 0,
-							},
-							"input_tokens_details": map[string]interface{}{
-								"cached_tokens": 0,
-							},
-						},
-					},
-				})
-				_, _ = fmt.Fprintf(w, "data: %s\n\n", completed)
+				_ = writeSSEEvent(w, responses.ResponseCompletedEvent{})
 				flusher.Flush()
 				return
 			}
@@ -387,15 +375,13 @@ func writeResponsesAPIStreaming(w http.ResponseWriter, r *http.Request, chunks <
 
 				// Emit response.output_item.added so the
 				// fantasy client triggers TextStart.
-				itemAdded, _ := json.Marshal(map[string]interface{}{
-					"type":         "response.output_item.added",
-					"output_index": outputIndex,
-					"item": map[string]interface{}{
-						"id":   itemID,
-						"type": "message",
+				if err := writeSSEEvent(w, responses.ResponseOutputItemAddedEvent{
+					OutputIndex: int64(outputIndex),
+					Item: responses.ResponseOutputItemUnion{
+						ID:   itemID,
+						Type: "message",
 					},
-				})
-				if _, err := fmt.Fprintf(w, "data: %s\n\n", itemAdded); err != nil {
+				}); err != nil {
 					return
 				}
 				flusher.Flush()

--- a/go.mod
+++ b/go.mod
@@ -490,6 +490,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/mark3labs/mcp-go v0.38.0
+	github.com/openai/openai-go/v2 v2.7.1
 	github.com/sergi/go-diff v1.4.0
 	gonum.org/v1/gonum v0.17.0
 )
@@ -573,7 +574,6 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/openai/openai-go v1.12.0 // indirect
-	github.com/openai/openai-go/v2 v2.7.1 // indirect
 	github.com/openai/openai-go/v3 v3.15.0 // indirect
 	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -490,7 +490,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/mark3labs/mcp-go v0.38.0
-	github.com/openai/openai-go/v2 v2.7.1
+	github.com/openai/openai-go/v3 v3.15.0
 	github.com/sergi/go-diff v1.4.0
 	gonum.org/v1/gonum v0.17.0
 )
@@ -574,7 +574,7 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/openai/openai-go v1.12.0 // indirect
-	github.com/openai/openai-go/v3 v3.15.0 // indirect
+	github.com/openai/openai-go/v2 v2.7.1 // indirect
 	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect


### PR DESCRIPTION
The mock `writeResponsesAPIStreaming` in `coderd/chatd/chattest/openai.go` only emitted `response.output_text.delta` events followed by `[DONE]`. The fantasy client's Responses API adapter requires proper lifecycle events to process the stream correctly:

- **`response.output_item.added`** (with `item.type = "message"`) — triggers `TextStart`, which begins accumulating text content in the chatloop's `processStepStream`.
- **`response.output_item.done`** (with `item.type = "message"`) — triggers `TextEnd`, which finalizes the text and appends it to `result.content` for persistence.
- **`response.completed`** (with `response` wrapper including `status`, `usage`, `incomplete_details`) — sets the finish reason.

Without these events, the chatloop's `persistStep` persisted empty steps, causing intermittent test failures in `TestSuccessfulChatSendsWebPushWithNavigationData` (the push notification was never dispatched because the chat completion flow didn't fully execute).

This also emits `response.output_text.done` for completeness, though the fantasy client doesn't currently process it.