### PR TITLE
fix: bump aibridge to v1.0.8 for Anthropic-Beta header forwarding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -480,7 +480,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.0.8-0.20260306115208-e559e5e4a7e2
+	github.com/coder/aibridge v1.0.8
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab
 	github.com/coder/preview v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.8-0.20260306115208-e559e5e4a7e2 h1:M6IDd4z4++rBVgH6xcPyezbUym/HsJdm65l9s7x3FMs=
-github.com/coder/aibridge v1.0.8-0.20260306115208-e559e5e4a7e2/go.mod h1:3BTl243k7OhpqtaITARAw647uC2V0YrxGOTQrkscnkk=
+github.com/coder/aibridge v1.0.8 h1:G5FG5/t58pUZgKx44H0IfBskCTWV1QBcPYzQyxSAIwA=
+github.com/coder/aibridge v1.0.8/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab h1:HrlxyTmMQpOHfSKzRU1vf5TxrmV6vL5OiWq+Dvn5qh0=


### PR DESCRIPTION
## Description

Updates aibridge library to [v1.0.8](https://github.com/coder/aibridge/releases/tag/v1.0.8)
Introduces: https://github.com/coder/aibridge/pull/205 related to https://github.com/coder/aibridge/issues/192

Related to internal Slack thread: https://codercom.slack.com/archives/C096PFVBZKN/p1772792545309049