### PR TITLE
fix: resolve bugs in pubsub and codersdk chat packages

### DIFF
--- a/coderd/pubsub/chatevent.go
+++ b/coderd/pubsub/chatevent.go
@@ -23,7 +23,7 @@ func HandleChatEvent(cb func(ctx context.Context, payload ChatEvent, err error))
 		}
 		var payload ChatEvent
 		if err := json.Unmarshal(message, &payload); err != nil {
-			cb(ctx, ChatEvent{}, xerrors.Errorf("unmarshal chat event"))
+			cb(ctx, ChatEvent{}, xerrors.Errorf("unmarshal chat event: %w", err))
 			return
 		}
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -802,7 +802,7 @@ func (c *Client) StreamChat(ctx context.Context, chatID uuid.UUID, opts *StreamC
 
 	return events, closeFunc(func() error {
 		streamCancel()
-		return conn.Close(websocket.StatusNormalClosure, "")
+		return nil
 	}), nil
 }
 


### PR DESCRIPTION
Split from #22693 per review feedback.

Small fixes for error wrapping in pubsub and double-close prevention in codersdk.