### PR TITLE
fix(site): polish agents diff panel UI

### DIFF
--- a/offlinedocs/next-env.d.ts
+++ b/offlinedocs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/offlinedocs/next-env.d.ts
+++ b/offlinedocs/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -1100,6 +1100,8 @@ const AgentDetail: FC = () => {
 				onToggleExpanded={() => setIsRightPanelExpanded((prev) => !prev)}
 				onClose={() => setShowSidebarPanel(false)}
 				onVisualExpandedChange={setDragVisualExpanded}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			>
 				<SidebarTabView
 					prTab={

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -231,7 +231,7 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 						)}
 					</DropdownMenuContent>
 				</DropdownMenu>
-				{diff.hasDiffStatus && diff.diffStatus && (
+				{(diff.hasDiffStatus || diff.hasGitRepos) && (
 					<Button
 						variant="subtle"
 						size="icon"

--- a/site/src/pages/AgentsPage/DiffStats.tsx
+++ b/site/src/pages/AgentsPage/DiffStats.tsx
@@ -13,7 +13,7 @@ interface DiffStatsProps {
  * Always renders both counters so that zero-line changes (e.g.
  * binary files like images) still display "+0 −0".
  */
-export const DiffStatNumbers: FC<DiffStatsProps> = ({
+const DiffStatNumbers: FC<DiffStatsProps> = ({
 	additions,
 	deletions,
 	className,
@@ -27,6 +27,33 @@ export const DiffStatNumbers: FC<DiffStatsProps> = ({
 		>
 			<span className="text-green-700 dark:text-green-500">+{additions}</span>
 			<span className="text-red-700 dark:text-red-400">&minus;{deletions}</span>
+		</span>
+	);
+};
+
+/**
+ * Pill-styled diff stats badge with coloured backgrounds,
+ * used inside the Git tab header.
+ */
+export const DiffStatBadge: FC<{ additions: number; deletions: number }> = ({
+	additions,
+	deletions,
+}) => {
+	if (additions === 0 && deletions === 0) {
+		return null;
+	}
+	return (
+		<span className="inline-flex h-full items-center self-stretch overflow-hidden rounded-[calc(theme(borderRadius.md)-1px)] font-mono text-xs font-medium">
+			{additions > 0 && (
+				<span className="flex h-full items-center bg-green-100 dark:bg-green-950 px-1.5 text-green-700 dark:text-green-500">
+					+{additions}
+				</span>
+			)}
+			{deletions > 0 && (
+				<span className="flex h-full items-center bg-red-100 dark:bg-red-950 px-1.5 text-red-700 dark:text-red-400">
+					&minus;{deletions}
+				</span>
+			)}
 		</span>
 	);
 };

--- a/site/src/pages/AgentsPage/DiffStats.tsx
+++ b/site/src/pages/AgentsPage/DiffStats.tsx
@@ -13,7 +13,7 @@ interface DiffStatsProps {
  * Always renders both counters so that zero-line changes (e.g.
  * binary files like images) still display "+0 −0".
  */
-const DiffStatNumbers: FC<DiffStatsProps> = ({
+export const DiffStatNumbers: FC<DiffStatsProps> = ({
 	additions,
 	deletions,
 	className,

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -41,10 +41,8 @@ interface DiffViewerProps {
 	error?: unknown;
 	/** Empty state message. */
 	emptyMessage?: string;
-	/** Controlled diff style. When provided, overrides internal state. */
-	diffStyle?: DiffStyle;
-	/** Callback when the diff style changes (for controlled mode). */
-	onDiffStyleChange?: (style: DiffStyle) => void;
+	/** Which diff rendering style to use. */
+	diffStyle: DiffStyle;
 }
 
 // -------------------------------------------------------------------
@@ -394,12 +392,10 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	isLoading,
 	error,
 	emptyMessage = "No file changes to display.",
-	diffStyle: controlledDiffStyle,
+	diffStyle,
 }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
-	const [internalDiffStyle] = useState<DiffStyle>(loadDiffStyle);
-	const diffStyle = controlledDiffStyle ?? internalDiffStyle;
 
 	const diffOptions = useMemo(() => {
 		const base = getDiffViewerOptions(isDark);

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -6,11 +6,10 @@ import {
 	DIFFS_FONT_STYLE,
 	getDiffViewerOptions,
 } from "components/ai-elements/tool/utils";
-import { Button } from "components/Button/Button";
 import { FileIcon } from "components/FileIcon/FileIcon";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import { Skeleton } from "components/Skeleton/Skeleton";
-import { ChevronRightIcon, Columns2Icon, Rows3Icon } from "lucide-react";
+import { ChevronRightIcon } from "lucide-react";
 import {
 	type ComponentProps,
 	type FC,
@@ -42,6 +41,10 @@ interface DiffViewerProps {
 	error?: unknown;
 	/** Empty state message. */
 	emptyMessage?: string;
+	/** Controlled diff style. When provided, overrides internal state. */
+	diffStyle?: DiffStyle;
+	/** Callback when the diff style changes (for controlled mode). */
+	onDiffStyleChange?: (style: DiffStyle) => void;
 }
 
 // -------------------------------------------------------------------
@@ -71,10 +74,10 @@ const STICKY_HEADER_CSS = [
 	"}",
 ].join(" ");
 
-type DiffStyle = "unified" | "split";
-const DIFF_STYLE_KEY = "agents.diff-view-style";
+export type DiffStyle = "unified" | "split";
+export const DIFF_STYLE_KEY = "agents.diff-view-style";
 
-function loadDiffStyle(): DiffStyle {
+export function loadDiffStyle(): DiffStyle {
 	if (typeof window === "undefined") {
 		return "unified";
 	}
@@ -391,14 +394,20 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	isLoading,
 	error,
 	emptyMessage = "No file changes to display.",
+	diffStyle: controlledDiffStyle,
 }) => {
 	const theme = useTheme();
 	const isDark = theme.palette.mode === "dark";
-	const [diffStyle, setDiffStyle] = useState<DiffStyle>(loadDiffStyle);
-	const handleSetDiffStyle = useCallback((style: DiffStyle) => {
-		setDiffStyle(style);
-		localStorage.setItem(DIFF_STYLE_KEY, style);
-	}, []);
+	const [internalDiffStyle] = useState<DiffStyle>(loadDiffStyle);
+	const diffStyle = controlledDiffStyle ?? internalDiffStyle;
+
+	// When the parent changes the diff style via props, sync to
+	// localStorage so the preference persists.
+	useEffect(() => {
+		if (controlledDiffStyle) {
+			localStorage.setItem(DIFF_STYLE_KEY, controlledDiffStyle);
+		}
+	}, [controlledDiffStyle]);
 
 	const diffOptions = useMemo(() => {
 		const base = getDiffViewerOptions(isDark);
@@ -612,36 +621,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 			className="flex h-full min-w-0 flex-col overflow-hidden"
 		>
 			{/* Header */}
-			<div className="flex items-center gap-1 px-3 py-2">
-				{headerLeft}
-				{/* Diff style toggle */}
-				<div className="ml-auto flex items-center gap-1">
-					<Button
-						variant={diffStyle === "unified" ? "outline" : "subtle"}
-						size="lg"
-						onClick={() => handleSetDiffStyle("unified")}
-						className={cn(
-							"min-w-0 h-6 px-2 py-0",
-							diffStyle === "unified" && "bg-surface-secondary",
-						)}
-						aria-label="Unified diff view"
-					>
-						<Rows3Icon className="!p-0 !size-3.5" />
-					</Button>
-					<Button
-						variant={diffStyle === "split" ? "outline" : "subtle"}
-						size="lg"
-						onClick={() => handleSetDiffStyle("split")}
-						className={cn(
-							"min-w-0 h-6 px-2 py-0",
-							diffStyle === "split" && "bg-surface-secondary",
-						)}
-						aria-label="Split diff view"
-					>
-						<Columns2Icon className="!p-0 !size-3.5" />
-					</Button>
-				</div>
-			</div>
+			<div className="flex items-center gap-1 px-3 py-2">{headerLeft}</div>
 			{/* Diff contents */}
 			{sortedFiles.length === 0 ? (
 				<div className="flex flex-1 items-center justify-center p-6 text-center text-xs text-content-secondary">

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -401,14 +401,6 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	const [internalDiffStyle] = useState<DiffStyle>(loadDiffStyle);
 	const diffStyle = controlledDiffStyle ?? internalDiffStyle;
 
-	// When the parent changes the diff style via props, sync to
-	// localStorage so the preference persists.
-	useEffect(() => {
-		if (controlledDiffStyle) {
-			localStorage.setItem(DIFF_STYLE_KEY, controlledDiffStyle);
-		}
-	}, [controlledDiffStyle]);
-
 	const diffOptions = useMemo(() => {
 		const base = getDiffViewerOptions(isDark);
 		return {

--- a/site/src/pages/AgentsPage/FilesChangedPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.stories.tsx
@@ -241,6 +241,7 @@ const meta: Meta<typeof FilesChangedPanel> = {
 	component: FilesChangedPanel,
 	args: {
 		chatId: "test-chat",
+		diffStyle: "unified",
 	},
 	decorators: [
 		(Story) => (

--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -7,11 +7,13 @@ import {
 } from "lucide-react";
 import { type FC, useMemo } from "react";
 import { useQuery } from "react-query";
-import { DiffViewer } from "./DiffViewer";
+import { type DiffStyle, DiffViewer } from "./DiffViewer";
 
 interface FilesChangedPanelProps {
 	chatId: string;
 	isExpanded?: boolean;
+	diffStyle?: DiffStyle;
+	onDiffStyleChange?: (style: DiffStyle) => void;
 }
 
 /**
@@ -37,6 +39,8 @@ function parsePullRequestUrl(url: string): {
 export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({
 	chatId,
 	isExpanded,
+	diffStyle,
+	onDiffStyleChange,
 }) => {
 	const diffStatusQuery = useQuery(chatDiffStatus(chatId));
 	const diffContentsQuery = useQuery({
@@ -106,6 +110,8 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({
 			isExpanded={isExpanded}
 			isLoading={diffContentsQuery.isLoading || diffStatusQuery.isLoading}
 			error={diffContentsQuery.isError ? diffContentsQuery.error : undefined}
+			diffStyle={diffStyle}
+			onDiffStyleChange={onDiffStyleChange}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -12,8 +12,7 @@ import { type DiffStyle, DiffViewer } from "./DiffViewer";
 interface FilesChangedPanelProps {
 	chatId: string;
 	isExpanded?: boolean;
-	diffStyle?: DiffStyle;
-	onDiffStyleChange?: (style: DiffStyle) => void;
+	diffStyle: DiffStyle;
 }
 
 /**
@@ -40,7 +39,6 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({
 	chatId,
 	isExpanded,
 	diffStyle,
-	onDiffStyleChange,
 }) => {
 	const diffStatusQuery = useQuery(chatDiffStatus(chatId));
 	const diffContentsQuery = useQuery({
@@ -111,7 +109,6 @@ export const FilesChangedPanel: FC<FilesChangedPanelProps> = ({
 			isLoading={diffContentsQuery.isLoading || diffStatusQuery.isLoading}
 			error={diffContentsQuery.isError ? diffContentsQuery.error : undefined}
 			diffStyle={diffStyle}
-			onDiffStyleChange={onDiffStyleChange}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/RepoChangesPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/RepoChangesPanel.stories.tsx
@@ -37,6 +37,7 @@ const meta: Meta<typeof RepoChangesPanel> = {
 		repo: baseRepo,
 		onRefresh: fn(),
 		onCommit: fn(),
+		diffStyle: "unified",
 	},
 };
 export default meta;

--- a/site/src/pages/AgentsPage/RepoChangesPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/RepoChangesPanel.stories.tsx
@@ -53,13 +53,10 @@ export const NoChanges: Story = {
 	},
 };
 
-export const LongRepoName: Story = {
+export const SplitDiffStyle: Story = {
 	args: {
-		repo: {
-			...baseRepo,
-			repo_root:
-				"/home/coder/very-long-repository-name-that-should-be-truncated-in-the-header",
-		},
+		repo: baseRepo,
+		diffStyle: "split",
 	},
 };
 
@@ -69,6 +66,22 @@ export const LongBranchName: Story = {
 			...baseRepo,
 			branch:
 				"feature/TICKET-12345-implement-very-long-branch-name-for-testing-truncation-behavior",
+		},
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ width: 400 }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const DeepRepoPath: Story = {
+	args: {
+		repo: {
+			...baseRepo,
+			repo_root: "/home/coder/workspaces/my-org/services/project",
 		},
 	},
 };

--- a/site/src/pages/AgentsPage/RepoChangesPanel.tsx
+++ b/site/src/pages/AgentsPage/RepoChangesPanel.tsx
@@ -23,8 +23,7 @@ interface RepoChangesPanelProps {
 	onRefresh: () => void;
 	onCommit: () => void;
 	isExpanded?: boolean;
-	diffStyle?: DiffStyle;
-	onDiffStyleChange?: (style: DiffStyle) => void;
+	diffStyle: DiffStyle;
 }
 
 function repoParentPath(repoRoot: string): string {
@@ -41,7 +40,6 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 	onCommit,
 	isExpanded,
 	diffStyle,
-	onDiffStyleChange,
 }) => {
 	const [spinning, setSpinning] = useState(false);
 	const spinTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -116,7 +114,6 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 			isExpanded={isExpanded}
 			emptyMessage="No file changes."
 			diffStyle={diffStyle}
-			onDiffStyleChange={onDiffStyleChange}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/RepoChangesPanel.tsx
+++ b/site/src/pages/AgentsPage/RepoChangesPanel.tsx
@@ -16,24 +16,23 @@ import {
 	useState,
 } from "react";
 import { cn } from "utils/cn";
-import { DiffViewer } from "./DiffViewer";
+import { type DiffStyle, DiffViewer } from "./DiffViewer";
 
 interface RepoChangesPanelProps {
 	repo: WorkspaceAgentRepoChanges;
 	onRefresh: () => void;
 	onCommit: () => void;
 	isExpanded?: boolean;
+	diffStyle?: DiffStyle;
+	onDiffStyleChange?: (style: DiffStyle) => void;
 }
 
-function splitRepoPath(repoRoot: string): { parent: string; name: string } {
+function repoParentPath(repoRoot: string): string {
 	const lastSlash = repoRoot.lastIndexOf("/");
 	if (lastSlash === -1) {
-		return { parent: "", name: repoRoot };
+		return "";
 	}
-	return {
-		parent: repoRoot.slice(0, lastSlash + 1),
-		name: repoRoot.slice(lastSlash + 1),
-	};
+	return repoRoot.slice(0, lastSlash + 1);
 }
 
 export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
@@ -41,6 +40,8 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 	onRefresh,
 	onCommit,
 	isExpanded,
+	diffStyle,
+	onDiffStyleChange,
 }) => {
 	const [spinning, setSpinning] = useState(false);
 	const spinTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -65,22 +66,21 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 		}
 	}, [repo.unified_diff]);
 
-	const { parent: repoParent, name: repoName } = splitRepoPath(repo.repo_root);
 	const hasChanges = parsedFiles.length > 0;
+	const parentPath = repoParentPath(repo.repo_root);
 
 	return (
 		<DiffViewer
 			headerLeft={
 				<div className="flex w-full min-w-0 items-center gap-1.5">
-					<FolderIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
-					<span className="shrink-0 text-xs font-medium text-content-primary">
-						{repoName}
-					</span>
-					<span className="truncate text-xs text-content-secondary">
-						{repoParent}
-					</span>
+					{parentPath && (
+						<div className="flex h-7 min-w-0 items-center gap-1 rounded-md border border-solid border-border-default px-1.5 text-xs text-content-secondary">
+							<FolderIcon className="h-3 w-3 shrink-0" />
+							<span className="truncate">{parentPath}</span>
+						</div>
+					)}
 					{repo.branch?.trim() && (
-						<div className="hidden items-center gap-1 rounded-md border border-solid border-border-default px-1.5 py-0.5 text-xs text-content-secondary sm:flex">
+						<div className="flex h-7 min-w-0 items-center gap-1 rounded-md border border-solid border-border-default px-1.5 text-xs text-content-secondary">
 							<GitBranchIcon className="h-3 w-3 shrink-0" />
 							<span className="truncate">{repo.branch}</span>
 						</div>
@@ -90,7 +90,7 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 							size="sm"
 							onClick={onCommit}
 							disabled={!hasChanges}
-							className="h-6 gap-1.5 border border-transparent bg-surface-invert-primary px-2 text-xs text-content-invert hover:bg-surface-invert-secondary active:opacity-80"
+							className="h-7 gap-1.5 border border-transparent bg-surface-invert-primary px-2 text-xs text-content-invert hover:bg-surface-invert-secondary active:opacity-80"
 						>
 							<CheckIcon className="h-3 w-3" />
 							Commit
@@ -100,7 +100,7 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 							size="icon"
 							onClick={handleRefresh}
 							aria-label="Refresh"
-							className="h-6 w-6 text-content-secondary hover:text-content-primary"
+							className="h-7 w-7 text-content-secondary hover:text-content-primary"
 						>
 							<RefreshCwIcon
 								className={cn(
@@ -115,6 +115,8 @@ export const RepoChangesPanel: FC<RepoChangesPanelProps> = ({
 			parsedFiles={parsedFiles}
 			isExpanded={isExpanded}
 			emptyMessage="No file changes."
+			diffStyle={diffStyle}
+			onDiffStyleChange={onDiffStyleChange}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/RightPanel.tsx
@@ -46,6 +46,8 @@ interface RightPanelProps {
 	 * null when the drag ends so the parent falls back to the
 	 * committed isExpanded prop. */
 	onVisualExpandedChange?: (visualExpanded: boolean | null) => void;
+	isSidebarCollapsed?: boolean;
+	onToggleSidebarCollapsed?: () => void;
 	children: ReactNode;
 }
 
@@ -61,6 +63,8 @@ function useResizableDrag({
 	isOpen,
 	onSnapCommit,
 	onVisualExpandedChange,
+	isSidebarCollapsed,
+	onToggleSidebarCollapsed,
 }: {
 	isExpanded: boolean;
 	width: number;
@@ -68,10 +72,13 @@ function useResizableDrag({
 	isOpen: boolean;
 	onSnapCommit: (snap: "normal" | "expanded" | "closed") => void;
 	onVisualExpandedChange?: (visualExpanded: boolean | null) => void;
+	isSidebarCollapsed?: boolean;
+	onToggleSidebarCollapsed?: () => void;
 }) {
 	const isDragging = useRef(false);
 	const startX = useRef(0);
 	const startWidth = useRef(0);
+	const sidebarCollapsedByDrag = useRef(false);
 	// Track snap state during a drag. This is state (not a ref) so
 	// the panel visually updates as the user drags across thresholds.
 	const [dragSnap, setDragSnap] = useState<
@@ -83,6 +90,7 @@ function useResizableDrag({
 			e.preventDefault();
 			isDragging.current = true;
 			setDragSnap(null);
+			sidebarCollapsedByDrag.current = false;
 			startX.current = e.clientX;
 			startWidth.current = isExpanded
 				? ((e.target as HTMLElement).closest(
@@ -103,6 +111,23 @@ function useResizableDrag({
 			const raw = startWidth.current + delta;
 			const maxWidth = getMaxWidth();
 
+			// Collapse/uncollapse the sidebar live when the pointer
+			// reaches the left edge of the viewport.
+			if (e.clientX < SNAP_THRESHOLD && !sidebarCollapsedByDrag.current) {
+				if (!isSidebarCollapsed && onToggleSidebarCollapsed) {
+					onToggleSidebarCollapsed();
+					sidebarCollapsedByDrag.current = true;
+				}
+			} else if (
+				e.clientX >= SNAP_THRESHOLD &&
+				sidebarCollapsedByDrag.current
+			) {
+				if (onToggleSidebarCollapsed) {
+					onToggleSidebarCollapsed();
+					sidebarCollapsedByDrag.current = false;
+				}
+			}
+
 			let nextSnap: "normal" | "expanded" | "closed";
 			if (raw > maxWidth + SNAP_THRESHOLD) {
 				nextSnap = "expanded";
@@ -121,7 +146,13 @@ function useResizableDrag({
 				(nextSnap !== "normal" && nextSnap !== "closed" && isExpanded);
 			onVisualExpandedChange?.(nextVisualExpanded);
 		},
-		[setWidth, isExpanded, onVisualExpandedChange],
+		[
+			setWidth,
+			isExpanded,
+			onVisualExpandedChange,
+			isSidebarCollapsed,
+			onToggleSidebarCollapsed,
+		],
 	);
 
 	const handlePointerUp = useCallback(
@@ -169,6 +200,8 @@ export const RightPanel = ({
 	onToggleExpanded,
 	onClose,
 	onVisualExpandedChange,
+	isSidebarCollapsed,
+	onToggleSidebarCollapsed,
 	children,
 }: RightPanelProps) => {
 	const [width, setWidth] = useState(loadPersistedWidth);
@@ -213,6 +246,8 @@ export const RightPanel = ({
 		isOpen,
 		onSnapCommit: handleSnapCommit,
 		onVisualExpandedChange,
+		isSidebarCollapsed,
+		onToggleSidebarCollapsed,
 	});
 
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/SidebarTabView.stories.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.stories.tsx
@@ -92,3 +92,51 @@ export const EmptyState: Story = {
 		repositories: new Map(),
 	},
 };
+
+export const SplitDiffMode: Story = {
+	args: {
+		prTab: undefined,
+		repositories: new Map([["/home/coder/project", makeRepo("project")]]),
+	},
+};
+
+export const ExpandedWithDiffToggle: Story = {
+	args: {
+		prTab: { prNumber: 42, chatId: "chat-1" },
+		repositories: new Map([["/home/coder/project", makeRepo("project")]]),
+		isExpanded: true,
+		chatTitle: "Fix authentication bug",
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: 600, width: 900 }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const WithDiffStats: Story = {
+	args: {
+		prTab: { prNumber: 99, chatId: "chat-3" },
+		repositories: new Map([
+			["/home/coder/frontend", makeRepo("frontend")],
+			["/home/coder/backend", makeRepo("backend", { branch: "feat/api" })],
+		]),
+		diffStatus: { additions: 150, deletions: 42 },
+	},
+};
+
+export const NarrowPanel: Story = {
+	args: {
+		prTab: { prNumber: 42, chatId: "chat-1" },
+		repositories: new Map([["/home/coder/project", makeRepo("project")]]),
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: 500, width: 360 }}>
+				<Story />
+			</div>
+		),
+	],
+};

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -255,30 +255,30 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				</div>
 
 				{/* Diff style toggle */}
-				<div className="flex shrink-0 items-center gap-0.5">
+				<div className="flex shrink-0 items-center gap-1">
 					<Button
 						variant={diffStyle === "unified" ? "outline" : "subtle"}
-						size="icon"
+						size="lg"
 						onClick={() => handleSetDiffStyle("unified")}
 						className={cn(
-							"h-7 w-7",
+							"min-w-0 h-6 px-2 py-0",
 							diffStyle === "unified" && "bg-surface-secondary",
 						)}
 						aria-label="Unified diff view"
 					>
-						<Rows3Icon className="!size-3.5" />
+						<Rows3Icon className="!p-0 !size-3.5" />
 					</Button>
 					<Button
 						variant={diffStyle === "split" ? "outline" : "subtle"}
-						size="icon"
+						size="lg"
 						onClick={() => handleSetDiffStyle("split")}
 						className={cn(
-							"h-7 w-7",
+							"min-w-0 h-6 px-2 py-0",
 							diffStyle === "split" && "bg-surface-secondary",
 						)}
 						aria-label="Split diff view"
 					>
-						<Columns2Icon className="!size-3.5" />
+						<Columns2Icon className="!p-0 !size-3.5" />
 					</Button>
 				</div>
 

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -307,7 +307,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						chatId={prTab.chatId}
 						isExpanded={isExpanded}
 						diffStyle={diffStyle}
-						onDiffStyleChange={handleSetDiffStyle}
 					/>
 				) : effectiveTab && repositories.has(effectiveTab) ? (
 					<RepoChangesPanel
@@ -316,7 +315,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						onCommit={() => onCommit(effectiveTab)}
 						isExpanded={isExpanded}
 						diffStyle={diffStyle}
-						onDiffStyleChange={handleSetDiffStyle}
 					/>
 				) : null}
 			</div>

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -109,7 +109,15 @@ function useTabScroll() {
 		});
 	}, []);
 
-	return { ref, canScrollLeft, canScrollRight, scrollLeft, scrollRight };
+	const hasOverflow = canScrollLeft || canScrollRight;
+	return {
+		ref,
+		hasOverflow,
+		canScrollLeft,
+		canScrollRight,
+		scrollLeft,
+		scrollRight,
+	};
 }
 
 function repoTabLabel(repoRoot: string): string {
@@ -251,18 +259,22 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						<PanelLeftIcon />
 					</Button>
 				)}
-
 				{/* Tabs – scrolls so right-side buttons stay visible */}
-				{tabScroll.canScrollLeft && (
+				{tabScroll.hasOverflow && (
 					<button
 						type="button"
 						onClick={tabScroll.scrollLeft}
 						aria-label="Scroll tabs left"
-						className="flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0"
+						aria-hidden={!tabScroll.canScrollLeft}
+						tabIndex={tabScroll.canScrollLeft ? 0 : -1}
+						className={cn(
+							"flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0",
+							!tabScroll.canScrollLeft && "invisible",
+						)}
 					>
 						<ChevronLeftIcon className="size-3.5" />
 					</button>
-				)}
+				)}{" "}
 				<div
 					ref={tabScroll.ref}
 					className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
@@ -320,17 +332,21 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						);
 					})}
 				</div>
-				{tabScroll.canScrollRight && (
+				{tabScroll.hasOverflow && (
 					<button
 						type="button"
 						onClick={tabScroll.scrollRight}
 						aria-label="Scroll tabs right"
-						className="flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0"
+						aria-hidden={!tabScroll.canScrollRight}
+						tabIndex={tabScroll.canScrollRight ? 0 : -1}
+						className={cn(
+							"flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0",
+							!tabScroll.canScrollRight && "invisible",
+						)}
 					>
 						<ChevronRightIcon className="size-3.5" />
 					</button>
 				)}
-
 				{/* Center: chat title when expanded */}
 				<div className="min-w-0 flex-1 text-center">
 					{isExpanded && chatTitle && (
@@ -339,7 +355,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						</span>
 					)}
 				</div>
-
 				{/* Diff style toggle */}
 				<div className="flex shrink-0 items-center gap-1">
 					<Button
@@ -367,7 +382,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						<Columns2Icon className="!p-0 !size-3.5" />
 					</Button>
 				</div>
-
 				{/* Right side: expand/contract button */}
 				<Button
 					variant="subtle"

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -3,8 +3,6 @@ import type { WorkspaceAgentRepoChanges } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
 	Columns2Icon,
-	FolderIcon,
-	GitPullRequestIcon,
 	MaximizeIcon,
 	MinimizeIcon,
 	PanelLeftIcon,
@@ -136,11 +134,11 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 
 	if (!hasPR && !hasRepos) {
 		return (
-			<div className="flex h-full min-w-0 flex-col overflow-hidden border-0 border-l border-solid bg-surface-primary">
+			<div className="flex h-full min-w-0 flex-col overflow-hidden bg-surface-primary">
 				{/* Tab bar – always visible for the expand button. */}
 				<div
 					role="tablist"
-					className="flex shrink-0 items-center gap-1 px-1 py-1.5 border-0 border-b border-solid border-border-default"
+					className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-border-default px-3 py-1"
 				>
 					<div className="min-w-0 flex-1 text-center">
 						{isExpanded && chatTitle && (
@@ -167,11 +165,11 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	}
 
 	return (
-		<div className="flex h-full min-w-0 flex-col overflow-hidden border-0 border-l border-solid bg-surface-primary">
+		<div className="flex h-full min-w-0 flex-col overflow-hidden bg-surface-primary">
 			{/* Tab bar */}
 			<div
 				role="tablist"
-				className="flex shrink-0 items-center gap-1 px-1 py-1.5 border-0 border-b border-solid border-border-default"
+				className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-border-default px-3 py-1"
 			>
 				{/* Sidebar toggle – only when expanded and sidebar is collapsed */}
 				{isExpanded && isSidebarCollapsed && onToggleSidebarCollapsed && (
@@ -186,61 +184,58 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					</Button>
 				)}
 
-				{/* Tabs – scrolls internally so right-side buttons stay visible */}
-				<div className="flex min-w-0 items-center overflow-x-auto rounded-lg bg-surface-secondary p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+				{/* Tabs – scrolls so right-side buttons stay visible */}
+				<div className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 					{hasPR && prTab && (
-						<button
-							type="button"
+						<Button
 							id={`${tabIdPrefix}-tab-pr`}
 							role="tab"
 							aria-selected={effectiveTab === "pr"}
 							onClick={() => setActiveTab("pr")}
+							variant={effectiveTab === "pr" ? "outline" : "subtle"}
+							size="lg"
 							className={cn(
-								"flex shrink-0 items-center gap-1.5 rounded-md border-0 px-2 py-1 text-xs font-medium transition-colors cursor-pointer outline-none",
-								effectiveTab === "pr"
-									? "bg-surface-primary text-content-primary shadow-sm"
-									: "bg-transparent text-content-secondary hover:text-content-primary",
+								"min-w-0 h-6 px-3 gap-3 py-0",
+								effectiveTab === "pr" && "bg-surface-secondary",
 							)}
 						>
-							<GitPullRequestIcon className="h-3.5 w-3.5" />#{prTab.prNumber}
+							#{prTab.prNumber}
 							{(prDiffAdditions > 0 || prDiffDeletions > 0) && (
 								<DiffStatNumbers
 									additions={prDiffAdditions}
 									deletions={prDiffDeletions}
-									className="ml-1 text-[10px]"
+									className="text-[10px]"
 								/>
 							)}
-						</button>
+						</Button>
 					)}
 					{repoEntries.map(([repoRoot]) => {
 						const stats = repoDiffStats.get(repoRoot);
 						const additions = stats?.additions ?? 0;
 						const deletions = stats?.deletions ?? 0;
 						return (
-							<button
-								type="button"
+							<Button
+								key={repoRoot}
 								id={`${tabIdPrefix}-tab-${repoRoot}`}
 								role="tab"
 								aria-selected={effectiveTab === repoRoot}
-								key={repoRoot}
 								onClick={() => setActiveTab(repoRoot)}
+								variant={effectiveTab === repoRoot ? "outline" : "subtle"}
+								size="lg"
 								className={cn(
-									"flex shrink-0 items-center gap-1.5 rounded-md border-0 px-2 py-1 text-xs font-medium transition-colors cursor-pointer outline-none",
-									effectiveTab === repoRoot
-										? "bg-surface-primary text-content-primary shadow-sm"
-										: "bg-transparent text-content-secondary hover:text-content-primary",
+									"min-w-0 h-6 px-3 gap-3 py-0",
+									effectiveTab === repoRoot && "bg-surface-secondary",
 								)}
 							>
-								<FolderIcon className="h-3.5 w-3.5" />
 								{repoTabLabel(repoRoot)}
 								{(additions > 0 || deletions > 0) && (
 									<DiffStatNumbers
 										additions={additions}
 										deletions={deletions}
-										className="ml-1 text-[10px]"
+										className="text-[10px]"
 									/>
 								)}
-							</button>
+							</Button>
 						);
 					})}
 				</div>

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -2,14 +2,18 @@ import { parsePatchFiles } from "@pierre/diffs";
 import type { WorkspaceAgentRepoChanges } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
+	Columns2Icon,
 	FolderIcon,
 	GitPullRequestIcon,
 	MaximizeIcon,
 	MinimizeIcon,
 	PanelLeftIcon,
+	Rows3Icon,
 } from "lucide-react";
-import { type FC, useMemo, useState } from "react";
+import { type FC, useCallback, useId, useMemo, useState } from "react";
 import { cn } from "utils/cn";
+import { DiffStatNumbers } from "./DiffStats";
+import { DIFF_STYLE_KEY, type DiffStyle, loadDiffStyle } from "./DiffViewer";
 import { FilesChangedPanel } from "./FilesChangedPanel";
 import { RepoChangesPanel } from "./RepoChangesPanel";
 
@@ -84,6 +88,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	chatTitle,
 	diffStatus,
 }) => {
+	const tabIdPrefix = useId();
 	const repoEntries = Array.from(repositories.entries()).sort(([a], [b]) =>
 		a.localeCompare(b),
 	);
@@ -99,6 +104,12 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 			: null;
 
 	const [activeTab, setActiveTab] = useState<string | null>(defaultTab);
+
+	const [diffStyle, setDiffStyle] = useState<DiffStyle>(loadDiffStyle);
+	const handleSetDiffStyle = useCallback((style: DiffStyle) => {
+		setDiffStyle(style);
+		localStorage.setItem(DIFF_STYLE_KEY, style);
+	}, []);
 
 	// Derive the effective tab inline to avoid a one-frame flash when
 	// activeTab is stale or null but a valid default exists.
@@ -129,7 +140,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				{/* Tab bar – always visible for the expand button. */}
 				<div
 					role="tablist"
-					className="flex shrink-0 items-center gap-1 overflow-x-auto px-1 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+					className="flex shrink-0 items-center gap-1 px-1 py-1.5"
 				>
 					<div className="min-w-0 flex-1 text-center">
 						{isExpanded && chatTitle && (
@@ -143,7 +154,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						size="icon"
 						onClick={onToggleExpanded}
 						aria-label={isExpanded ? "Collapse panel" : "Expand panel"}
-						className="h-7 w-7 text-content-secondary hover:text-content-primary"
+						className="h-7 w-7 shrink-0 text-content-secondary hover:text-content-primary"
 					>
 						{isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
 					</Button>
@@ -160,7 +171,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 			{/* Tab bar */}
 			<div
 				role="tablist"
-				className="flex shrink-0 items-center gap-1 overflow-x-auto px-1 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+				className="flex shrink-0 items-center gap-1 px-1 py-1.5"
 			>
 				{/* Sidebar toggle – only when expanded and sidebar is collapsed */}
 				{isExpanded && isSidebarCollapsed && onToggleSidebarCollapsed && (
@@ -169,82 +180,70 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						size="icon"
 						onClick={onToggleSidebarCollapsed}
 						aria-label="Expand sidebar"
-						className="mr-1 h-7 w-7 min-w-0 shrink-0"
+						className="mr-1 h-7 w-7 shrink-0"
 					>
 						<PanelLeftIcon />
 					</Button>
 				)}
 
-				{/* Tabs */}
-				{hasPR && prTab && (
-					<button
-						type="button"
-						id="sidebar-tab-pr"
-						role="tab"
-						aria-selected={effectiveTab === "pr"}
-						onClick={() => setActiveTab("pr")}
-						className={cn(
-							"flex shrink-0 items-center gap-1.5 rounded border border-solid border-border-default px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
-							effectiveTab === "pr"
-								? "bg-surface-tertiary text-content-primary"
-								: "bg-transparent text-content-secondary hover:bg-surface-secondary hover:text-content-primary",
-						)}
-					>
-						<GitPullRequestIcon className="h-3.5 w-3.5" />#{prTab.prNumber}
-						{(prDiffAdditions > 0 || prDiffDeletions > 0) && (
-							<span className="ml-1 inline-flex items-center gap-1 font-mono text-[10px] tabular-nums">
-								{prDiffAdditions > 0 && (
-									<span className="text-green-700 dark:text-green-500">
-										+{prDiffAdditions}
-									</span>
-								)}
-								{prDiffDeletions > 0 && (
-									<span className="text-red-700 dark:text-red-400">
-										&minus;{prDiffDeletions}
-									</span>
-								)}
-							</span>
-						)}
-					</button>
-				)}
-				{repoEntries.map(([repoRoot]) => {
-					const stats = repoDiffStats.get(repoRoot);
-					const additions = stats?.additions ?? 0;
-					const deletions = stats?.deletions ?? 0;
-					return (
+				{/* Tabs – scrolls internally so right-side buttons stay visible */}
+				<div className="flex min-w-0 items-center overflow-x-auto rounded-lg bg-surface-secondary p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+					{hasPR && prTab && (
 						<button
 							type="button"
-							id={`sidebar-tab-${repoRoot}`}
+							id={`${tabIdPrefix}-tab-pr`}
 							role="tab"
-							aria-selected={effectiveTab === repoRoot}
-							key={repoRoot}
-							onClick={() => setActiveTab(repoRoot)}
+							aria-selected={effectiveTab === "pr"}
+							onClick={() => setActiveTab("pr")}
 							className={cn(
-								"flex shrink-0 items-center gap-1.5 rounded border border-solid border-border-default px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
-								effectiveTab === repoRoot
-									? "bg-surface-tertiary text-content-primary"
-									: "bg-transparent text-content-secondary hover:bg-surface-secondary hover:text-content-primary",
+								"flex shrink-0 items-center gap-1.5 rounded-md border-0 px-2 py-1 text-xs font-medium transition-colors cursor-pointer outline-none",
+								effectiveTab === "pr"
+									? "bg-surface-primary text-content-primary shadow-sm"
+									: "bg-transparent text-content-secondary hover:text-content-primary",
 							)}
 						>
-							<FolderIcon className="h-3.5 w-3.5" />
-							{repoTabLabel(repoRoot)}
-							{(additions > 0 || deletions > 0) && (
-								<span className="ml-1 inline-flex items-center gap-1 font-mono text-[10px] tabular-nums">
-									{additions > 0 && (
-										<span className="text-green-700 dark:text-green-500">
-											+{additions}
-										</span>
-									)}
-									{deletions > 0 && (
-										<span className="text-red-700 dark:text-red-400">
-											&minus;{deletions}
-										</span>
-									)}
-								</span>
+							<GitPullRequestIcon className="h-3.5 w-3.5" />#{prTab.prNumber}
+							{(prDiffAdditions > 0 || prDiffDeletions > 0) && (
+								<DiffStatNumbers
+									additions={prDiffAdditions}
+									deletions={prDiffDeletions}
+									className="ml-1 text-[10px]"
+								/>
 							)}
 						</button>
-					);
-				})}
+					)}
+					{repoEntries.map(([repoRoot]) => {
+						const stats = repoDiffStats.get(repoRoot);
+						const additions = stats?.additions ?? 0;
+						const deletions = stats?.deletions ?? 0;
+						return (
+							<button
+								type="button"
+								id={`${tabIdPrefix}-tab-${repoRoot}`}
+								role="tab"
+								aria-selected={effectiveTab === repoRoot}
+								key={repoRoot}
+								onClick={() => setActiveTab(repoRoot)}
+								className={cn(
+									"flex shrink-0 items-center gap-1.5 rounded-md border-0 px-2 py-1 text-xs font-medium transition-colors cursor-pointer outline-none",
+									effectiveTab === repoRoot
+										? "bg-surface-primary text-content-primary shadow-sm"
+										: "bg-transparent text-content-secondary hover:text-content-primary",
+								)}
+							>
+								<FolderIcon className="h-3.5 w-3.5" />
+								{repoTabLabel(repoRoot)}
+								{(additions > 0 || deletions > 0) && (
+									<DiffStatNumbers
+										additions={additions}
+										deletions={deletions}
+										className="ml-1 text-[10px]"
+									/>
+								)}
+							</button>
+						);
+					})}
+				</div>
 
 				{/* Center: chat title when expanded */}
 				<div className="min-w-0 flex-1 text-center">
@@ -255,13 +254,41 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					)}
 				</div>
 
+				{/* Diff style toggle */}
+				<div className="flex shrink-0 items-center gap-0.5">
+					<Button
+						variant={diffStyle === "unified" ? "outline" : "subtle"}
+						size="icon"
+						onClick={() => handleSetDiffStyle("unified")}
+						className={cn(
+							"h-7 w-7",
+							diffStyle === "unified" && "bg-surface-secondary",
+						)}
+						aria-label="Unified diff view"
+					>
+						<Rows3Icon className="!size-3.5" />
+					</Button>
+					<Button
+						variant={diffStyle === "split" ? "outline" : "subtle"}
+						size="icon"
+						onClick={() => handleSetDiffStyle("split")}
+						className={cn(
+							"h-7 w-7",
+							diffStyle === "split" && "bg-surface-secondary",
+						)}
+						aria-label="Split diff view"
+					>
+						<Columns2Icon className="!size-3.5" />
+					</Button>
+				</div>
+
 				{/* Right side: expand/contract button */}
 				<Button
 					variant="subtle"
 					size="icon"
 					onClick={onToggleExpanded}
 					aria-label={isExpanded ? "Collapse panel" : "Expand panel"}
-					className="h-7 w-7 text-content-secondary hover:text-content-primary"
+					className="h-7 w-7 shrink-0 text-content-secondary hover:text-content-primary"
 				>
 					{isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
 				</Button>
@@ -271,18 +298,25 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 			<div
 				role="tabpanel"
 				aria-labelledby={
-					effectiveTab ? `sidebar-tab-${effectiveTab}` : undefined
+					effectiveTab ? `${tabIdPrefix}-tab-${effectiveTab}` : undefined
 				}
 				className="min-h-0 flex-1"
 			>
 				{effectiveTab === "pr" && prTab ? (
-					<FilesChangedPanel chatId={prTab.chatId} isExpanded={isExpanded} />
+					<FilesChangedPanel
+						chatId={prTab.chatId}
+						isExpanded={isExpanded}
+						diffStyle={diffStyle}
+						onDiffStyleChange={handleSetDiffStyle}
+					/>
 				) : effectiveTab && repositories.has(effectiveTab) ? (
 					<RepoChangesPanel
 						repo={repositories.get(effectiveTab)!}
 						onRefresh={onRefresh}
 						onCommit={() => onCommit(effectiveTab)}
 						isExpanded={isExpanded}
+						diffStyle={diffStyle}
+						onDiffStyleChange={handleSetDiffStyle}
 					/>
 				) : null}
 			</div>

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -109,15 +109,7 @@ function useTabScroll() {
 		});
 	}, []);
 
-	const hasOverflow = canScrollLeft || canScrollRight;
-	return {
-		ref,
-		hasOverflow,
-		canScrollLeft,
-		canScrollRight,
-		scrollLeft,
-		scrollRight,
-	};
+	return { ref, canScrollLeft, canScrollRight, scrollLeft, scrollRight };
 }
 
 function repoTabLabel(repoRoot: string): string {
@@ -259,94 +251,88 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						<PanelLeftIcon />
 					</Button>
 				)}
-				{/* Tabs – scrolls so right-side buttons stay visible */}
-				{tabScroll.hasOverflow && (
-					<button
-						type="button"
-						onClick={tabScroll.scrollLeft}
-						aria-label="Scroll tabs left"
-						aria-hidden={!tabScroll.canScrollLeft}
-						tabIndex={tabScroll.canScrollLeft ? 0 : -1}
-						className={cn(
-							"flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0",
-							!tabScroll.canScrollLeft && "invisible",
-						)}
-					>
-						<ChevronLeftIcon className="size-3.5" />
-					</button>
-				)}{" "}
-				<div
-					ref={tabScroll.ref}
-					className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-				>
-					{hasPR && prTab && (
-						<Button
-							id={`${tabIdPrefix}-tab-pr`}
-							role="tab"
-							aria-selected={effectiveTab === "pr"}
-							onClick={() => setActiveTab("pr")}
-							variant={effectiveTab === "pr" ? "outline" : "subtle"}
-							size="lg"
-							className={cn(
-								"min-w-0 h-6 px-3 gap-3 py-0",
-								effectiveTab === "pr" && "bg-surface-secondary",
-							)}
+
+				{/* Scrollable tab strip with overlay chevrons */}
+				<div className="relative flex min-w-0 items-center">
+					{tabScroll.canScrollLeft && (
+						<button
+							type="button"
+							onClick={tabScroll.scrollLeft}
+							aria-label="Scroll tabs left"
+							className="absolute left-0 z-10 flex h-full w-8 cursor-pointer items-center justify-start border-none p-0 pl-1 text-content-primary [background:linear-gradient(to_right,hsl(var(--surface-primary))_50%,transparent)]"
 						>
-							#{prTab.prNumber}
-							{(prDiffAdditions > 0 || prDiffDeletions > 0) && (
-								<DiffStatNumbers
-									additions={prDiffAdditions}
-									deletions={prDiffDeletions}
-									className="text-[10px]"
-								/>
-							)}
-						</Button>
+							<ChevronLeftIcon className="size-3.5" />
+						</button>
 					)}
-					{repoEntries.map(([repoRoot]) => {
-						const stats = repoDiffStats.get(repoRoot);
-						const additions = stats?.additions ?? 0;
-						const deletions = stats?.deletions ?? 0;
-						return (
+					<div
+						ref={tabScroll.ref}
+						className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+					>
+						{hasPR && prTab && (
 							<Button
-								key={repoRoot}
-								id={`${tabIdPrefix}-tab-${repoRoot}`}
+								id={`${tabIdPrefix}-tab-pr`}
 								role="tab"
-								aria-selected={effectiveTab === repoRoot}
-								onClick={() => setActiveTab(repoRoot)}
-								variant={effectiveTab === repoRoot ? "outline" : "subtle"}
+								aria-selected={effectiveTab === "pr"}
+								onClick={() => setActiveTab("pr")}
+								variant={effectiveTab === "pr" ? "outline" : "subtle"}
 								size="lg"
 								className={cn(
 									"min-w-0 h-6 px-3 gap-3 py-0",
-									effectiveTab === repoRoot && "bg-surface-secondary",
+									effectiveTab === "pr" && "bg-surface-secondary",
 								)}
 							>
-								{repoTabLabel(repoRoot)}
-								{(additions > 0 || deletions > 0) && (
+								#{prTab.prNumber}
+								{(prDiffAdditions > 0 || prDiffDeletions > 0) && (
 									<DiffStatNumbers
-										additions={additions}
-										deletions={deletions}
+										additions={prDiffAdditions}
+										deletions={prDiffDeletions}
 										className="text-[10px]"
 									/>
 								)}
 							</Button>
-						);
-					})}
-				</div>
-				{tabScroll.hasOverflow && (
-					<button
-						type="button"
-						onClick={tabScroll.scrollRight}
-						aria-label="Scroll tabs right"
-						aria-hidden={!tabScroll.canScrollRight}
-						tabIndex={tabScroll.canScrollRight ? 0 : -1}
-						className={cn(
-							"flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0",
-							!tabScroll.canScrollRight && "invisible",
 						)}
-					>
-						<ChevronRightIcon className="size-3.5" />
-					</button>
-				)}
+						{repoEntries.map(([repoRoot]) => {
+							const stats = repoDiffStats.get(repoRoot);
+							const additions = stats?.additions ?? 0;
+							const deletions = stats?.deletions ?? 0;
+							return (
+								<Button
+									key={repoRoot}
+									id={`${tabIdPrefix}-tab-${repoRoot}`}
+									role="tab"
+									aria-selected={effectiveTab === repoRoot}
+									onClick={() => setActiveTab(repoRoot)}
+									variant={effectiveTab === repoRoot ? "outline" : "subtle"}
+									size="lg"
+									className={cn(
+										"min-w-0 h-6 px-3 gap-3 py-0",
+										effectiveTab === repoRoot && "bg-surface-secondary",
+									)}
+								>
+									{repoTabLabel(repoRoot)}
+									{(additions > 0 || deletions > 0) && (
+										<DiffStatNumbers
+											additions={additions}
+											deletions={deletions}
+											className="text-[10px]"
+										/>
+									)}
+								</Button>
+							);
+						})}
+					</div>
+					{tabScroll.canScrollRight && (
+						<button
+							type="button"
+							onClick={tabScroll.scrollRight}
+							aria-label="Scroll tabs right"
+							className="absolute right-0 z-10 flex h-full w-8 cursor-pointer items-center justify-end border-none p-0 pr-1 text-content-primary [background:linear-gradient(to_left,hsl(var(--surface-primary))_50%,transparent)]"
+						>
+							<ChevronRightIcon className="size-3.5" />
+						</button>
+					)}
+				</div>
+
 				{/* Center: chat title when expanded */}
 				<div className="min-w-0 flex-1 text-center">
 					{isExpanded && chatTitle && (
@@ -355,6 +341,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						</span>
 					)}
 				</div>
+
 				{/* Diff style toggle */}
 				<div className="flex shrink-0 items-center gap-1">
 					<Button
@@ -382,6 +369,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						<Columns2Icon className="!p-0 !size-3.5" />
 					</Button>
 				</div>
+
 				{/* Right side: expand/contract button */}
 				<Button
 					variant="subtle"

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -140,7 +140,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				{/* Tab bar – always visible for the expand button. */}
 				<div
 					role="tablist"
-					className="flex shrink-0 items-center gap-1 px-1 py-1.5"
+					className="flex shrink-0 items-center gap-1 px-1 py-1.5 border-0 border-b border-solid border-border-default"
 				>
 					<div className="min-w-0 flex-1 text-center">
 						{isExpanded && chatTitle && (
@@ -171,7 +171,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 			{/* Tab bar */}
 			<div
 				role="tablist"
-				className="flex shrink-0 items-center gap-1 px-1 py-1.5"
+				className="flex shrink-0 items-center gap-1 px-1 py-1.5 border-0 border-b border-solid border-border-default"
 			>
 				{/* Sidebar toggle – only when expanded and sidebar is collapsed */}
 				{isExpanded && isSidebarCollapsed && onToggleSidebarCollapsed && (

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -20,7 +20,7 @@ import {
 	useState,
 } from "react";
 import { cn } from "utils/cn";
-import { DiffStatNumbers } from "./DiffStats";
+import { DiffStatBadge } from "./DiffStats";
 import { DIFF_STYLE_KEY, type DiffStyle, loadDiffStyle } from "./DiffViewer";
 import { FilesChangedPanel } from "./FilesChangedPanel";
 import { RepoChangesPanel } from "./RepoChangesPanel";
@@ -197,6 +197,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 
 	const prDiffAdditions = diffStatus?.additions ?? 0;
 	const prDiffDeletions = diffStatus?.deletions ?? 0;
+	const hasPrDiffStats = prDiffAdditions > 0 || prDiffDeletions > 0;
 
 	const tabScroll = useTabScroll();
 
@@ -208,7 +209,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					role="tablist"
 					className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-border-default px-3 py-1"
 				>
-					<div className="min-w-0 flex-1 text-center">
+					<div className="min-w-0 shrink-0 text-center">
 						{isExpanded && chatTitle && (
 							<span className="truncate text-sm text-content-primary">
 								{chatTitle}
@@ -253,20 +254,20 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				)}
 
 				{/* Scrollable tab strip with overlay chevrons */}
-				<div className="relative flex min-w-0 items-center">
+				<div className="relative min-w-0 flex-1">
 					{tabScroll.canScrollLeft && (
 						<button
 							type="button"
 							onClick={tabScroll.scrollLeft}
 							aria-label="Scroll tabs left"
-							className="absolute left-0 z-10 flex h-full w-8 cursor-pointer items-center justify-start border-none p-0 pl-1 text-content-primary [background:linear-gradient(to_right,hsl(var(--surface-primary))_50%,transparent)]"
+							className="absolute left-0 top-0 z-10 flex h-full w-8 cursor-pointer items-center justify-start border-none p-0 pl-1 text-content-primary [background:linear-gradient(to_right,hsl(var(--surface-primary))_50%,transparent)]"
 						>
 							<ChevronLeftIcon className="size-3.5" />
 						</button>
 					)}
 					<div
 						ref={tabScroll.ref}
-						className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+						className="flex w-full items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 					>
 						{hasPR && prTab && (
 							<Button
@@ -274,27 +275,26 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 								role="tab"
 								aria-selected={effectiveTab === "pr"}
 								onClick={() => setActiveTab("pr")}
-								variant={effectiveTab === "pr" ? "outline" : "subtle"}
+								variant="outline"
 								size="lg"
 								className={cn(
-									"min-w-0 h-6 px-3 gap-3 py-0",
-									effectiveTab === "pr" && "bg-surface-secondary",
+									"shrink-0 h-6 px-3 gap-3 py-0 bg-surface-primary",
+									effectiveTab === "pr" && "bg-surface-tertiary",
+									hasPrDiffStats && "pr-0",
 								)}
 							>
 								#{prTab.prNumber}
-								{(prDiffAdditions > 0 || prDiffDeletions > 0) && (
-									<DiffStatNumbers
-										additions={prDiffAdditions}
-										deletions={prDiffDeletions}
-										className="text-[10px]"
-									/>
-								)}
+								<DiffStatBadge
+									additions={prDiffAdditions}
+									deletions={prDiffDeletions}
+								/>
 							</Button>
 						)}
 						{repoEntries.map(([repoRoot]) => {
 							const stats = repoDiffStats.get(repoRoot);
 							const additions = stats?.additions ?? 0;
 							const deletions = stats?.deletions ?? 0;
+							const hasStats = additions > 0 || deletions > 0;
 							return (
 								<Button
 									key={repoRoot}
@@ -302,21 +302,16 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 									role="tab"
 									aria-selected={effectiveTab === repoRoot}
 									onClick={() => setActiveTab(repoRoot)}
-									variant={effectiveTab === repoRoot ? "outline" : "subtle"}
+									variant="outline"
 									size="lg"
 									className={cn(
-										"min-w-0 h-6 px-3 gap-3 py-0",
-										effectiveTab === repoRoot && "bg-surface-secondary",
+										"shrink-0 h-6 px-3 gap-3 py-0 bg-surface-primary",
+										effectiveTab === repoRoot && "bg-surface-tertiary",
+										hasStats && "pr-0",
 									)}
 								>
 									{repoTabLabel(repoRoot)}
-									{(additions > 0 || deletions > 0) && (
-										<DiffStatNumbers
-											additions={additions}
-											deletions={deletions}
-											className="text-[10px]"
-										/>
-									)}
+									<DiffStatBadge additions={additions} deletions={deletions} />
 								</Button>
 							);
 						})}
@@ -326,7 +321,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 							type="button"
 							onClick={tabScroll.scrollRight}
 							aria-label="Scroll tabs right"
-							className="absolute right-0 z-10 flex h-full w-8 cursor-pointer items-center justify-end border-none p-0 pr-1 text-content-primary [background:linear-gradient(to_left,hsl(var(--surface-primary))_50%,transparent)]"
+							className="absolute right-0 top-0 z-10 flex h-full w-8 cursor-pointer items-center justify-end border-none p-0 pr-1 text-content-primary [background:linear-gradient(to_left,hsl(var(--surface-primary))_50%,transparent)]"
 						>
 							<ChevronRightIcon className="size-3.5" />
 						</button>
@@ -334,7 +329,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				</div>
 
 				{/* Center: chat title when expanded */}
-				<div className="min-w-0 flex-1 text-center">
+				<div className="min-w-0 shrink-0 text-center">
 					{isExpanded && chatTitle && (
 						<span className="truncate text-sm text-content-primary">
 							{chatTitle}

--- a/site/src/pages/AgentsPage/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/SidebarTabView.tsx
@@ -2,13 +2,23 @@ import { parsePatchFiles } from "@pierre/diffs";
 import type { WorkspaceAgentRepoChanges } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
 import {
+	ChevronLeftIcon,
+	ChevronRightIcon,
 	Columns2Icon,
 	MaximizeIcon,
 	MinimizeIcon,
 	PanelLeftIcon,
 	Rows3Icon,
 } from "lucide-react";
-import { type FC, useCallback, useId, useMemo, useState } from "react";
+import {
+	type FC,
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { cn } from "utils/cn";
 import { DiffStatNumbers } from "./DiffStats";
 import { DIFF_STYLE_KEY, type DiffStyle, loadDiffStyle } from "./DiffViewer";
@@ -44,6 +54,62 @@ interface SidebarTabViewProps {
 	chatTitle?: string;
 	/** PR diff stats for the PR tab. */
 	diffStatus?: { additions?: number; deletions?: number };
+}
+
+/** How far (px) each chevron click scrolls the tab strip. */
+const TAB_SCROLL_AMOUNT = 120;
+
+/**
+ * Tracks whether the tab scroll container overflows and
+ * exposes scroll helpers for the chevron buttons.
+ */
+function useTabScroll() {
+	const ref = useRef<HTMLDivElement>(null);
+	const [canScrollLeft, setCanScrollLeft] = useState(false);
+	const [canScrollRight, setCanScrollRight] = useState(false);
+
+	const update = useCallback(() => {
+		const el = ref.current;
+		if (!el) return;
+		setCanScrollLeft(el.scrollLeft > 0);
+		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+	}, []);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		// Initial check.
+		update();
+
+		// Re-check on scroll.
+		el.addEventListener("scroll", update, { passive: true });
+
+		// Re-check when the container or its children resize.
+		const ro = new ResizeObserver(update);
+		ro.observe(el);
+
+		return () => {
+			el.removeEventListener("scroll", update);
+			ro.disconnect();
+		};
+	}, [update]);
+
+	const scrollLeft = useCallback(() => {
+		ref.current?.scrollBy({
+			left: -TAB_SCROLL_AMOUNT,
+			behavior: "smooth",
+		});
+	}, []);
+
+	const scrollRight = useCallback(() => {
+		ref.current?.scrollBy({
+			left: TAB_SCROLL_AMOUNT,
+			behavior: "smooth",
+		});
+	}, []);
+
+	return { ref, canScrollLeft, canScrollRight, scrollLeft, scrollRight };
 }
 
 function repoTabLabel(repoRoot: string): string {
@@ -132,6 +198,8 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	const prDiffAdditions = diffStatus?.additions ?? 0;
 	const prDiffDeletions = diffStatus?.deletions ?? 0;
 
+	const tabScroll = useTabScroll();
+
 	if (!hasPR && !hasRepos) {
 		return (
 			<div className="flex h-full min-w-0 flex-col overflow-hidden bg-surface-primary">
@@ -185,7 +253,20 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				)}
 
 				{/* Tabs – scrolls so right-side buttons stay visible */}
-				<div className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+				{tabScroll.canScrollLeft && (
+					<button
+						type="button"
+						onClick={tabScroll.scrollLeft}
+						aria-label="Scroll tabs left"
+						className="flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0"
+					>
+						<ChevronLeftIcon className="size-3.5" />
+					</button>
+				)}
+				<div
+					ref={tabScroll.ref}
+					className="flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+				>
 					{hasPR && prTab && (
 						<Button
 							id={`${tabIdPrefix}-tab-pr`}
@@ -239,6 +320,16 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						);
 					})}
 				</div>
+				{tabScroll.canScrollRight && (
+					<button
+						type="button"
+						onClick={tabScroll.scrollRight}
+						aria-label="Scroll tabs right"
+						className="flex shrink-0 items-center justify-center h-6 w-5 text-content-secondary hover:text-content-primary cursor-pointer border-0 bg-transparent p-0"
+					>
+						<ChevronRightIcon className="size-3.5" />
+					</button>
+				)}
 
 				{/* Center: chat title when expanded */}
 				<div className="min-w-0 flex-1 text-center">


### PR DESCRIPTION
## Summary

Polishes the right side panel UI for the agents diff view, focusing on tab
behavior, visual consistency, and interaction improvements.

## Changes

<img width="1845" height="1072" alt="image" src="https://github.com/user-attachments/assets/b7213f0d-ecdc-49f0-a545-d58910ef8299" />

### Tab bar

- Tabs use `variant="outline"` consistently to prevent layout shift when
  switching between active/inactive states
- Active tab uses `bg-surface-tertiary`, inactive uses `bg-surface-primary`
- Diff stats shown as colored pill badges (`DiffStatBadge`) with green/red
  backgrounds matching Kyle's design from #22636
- Scrollable tab strip with gradient-fade chevron buttons when tabs overflow
- Unified/split diff toggle moved from `DiffViewer` into the top tab bar
- `diffStyle` state lifted to `SidebarTabView` — `DiffViewer` now takes it
  as a controlled prop

### Panel behavior

- Panel toggle button now visible for git repos without a PR
  (`hasDiffStatus || hasGitRepos`)
- Dragging the panel edge to the left viewport edge collapses the sidebar,
  dragging back restores it
- Bottom border on tab bar

### Cleanup

- Replaced hardcoded element IDs with `useId()`
- Removed duplicate `border-l` from `SidebarTabView` (already on `RightPanel`)
- Reverted `offlinedocs/next-env.d.ts` to match main

## New stories

`SplitDiffMode`, `ExpandedWithDiffToggle`, `WithDiffStats`, `NarrowPanel`,
`ManyRepos`
