### PR TITLE
fix(site): center image attachment icon in chat input button

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -639,7 +639,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 										type="button"
 										variant="outline"
 										size="icon"
-										className="size-7 shrink-0 rounded-full"
+										className="size-7 shrink-0 rounded-full [&>svg]:p-0"
 										onClick={() => fileInputRef.current?.click()}
 										disabled={isDisabled}
 										aria-label="Attach files"
@@ -652,7 +652,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								<Button
 									size="icon"
 									variant="default"
-									className="size-7 rounded-full transition-colors"
+									className="size-7 rounded-full transition-colors [&>svg]:p-0"
 									onClick={onInterrupt}
 									disabled={isInterruptPending}
 								>


### PR DESCRIPTION
The Button base styles apply `[&>svg]:p-0.5` (2px padding) to child SVGs. In the small `size-7` rounded attach button, this extra padding shifts the 16x16 ImageIcon off-center. Override with `[&>svg]:p-0` to remove it.