### PR TITLE
fix(enterprise/cli): use :0 for http-address in proxy server tests

### DIFF
--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -46,6 +46,7 @@ func Test_ProxyServer_Headers(t *testing.T) {
 		"--primary-access-url", srv.URL,
 		"--proxy-session-token", "test-token",
 		"--access-url", "http://localhost:8080",
+		"--http-address", ":0",
 		"--header", fmt.Sprintf("%s=%s", headerName1, headerVal1),
 		"--header-command", fmt.Sprintf("printf %s=%s", headerName2, headerVal2),
 	)
@@ -97,7 +98,7 @@ func TestWorkspaceProxy_Server_PrometheusEnabled(t *testing.T) {
 		"--primary-access-url", srv.URL,
 		"--proxy-session-token", "test-token",
 		"--access-url", "http://foobar:3001",
-		"--http-address", fmt.Sprintf("127.0.0.1:%d", testutil.RandomPort(t)),
+		"--http-address", ":0",
 		"--prometheus-enable",
 		"--prometheus-address", fmt.Sprintf("127.0.0.1:%d", prometheusPort),
 	)


### PR DESCRIPTION
`Test_ProxyServer_Headers` never passed `--http-address`, so it bound to
the default `127.0.0.1:3000`. `TestWorkspaceProxy_Server_PrometheusEnabled`
used `RandomPort(t)` for `--http-address` (a drive-by from #14972 which was
fixing the Prometheus port).

Both now use `--http-address :0`. `ConfigureHTTPServers` calls
`net.Listen("tcp", ":0")` and holds the listener open, so there is no
TOCTOU window. Neither test connects to the HTTP listener, so the
assigned port is irrelevant. This matches `cli/server_test.go` where
`:0` is used throughout.

> Built with [Mux](https://mux.coder.com) (Opus 4.6)