### PR TITLE
fix(coderd/chatd): reorder trailing assistant message to prevent Anthropic prefill rejection

### DIFF
--- a/coderd/chatd/chatprompt/chatprompt.go
+++ b/coderd/chatd/chatprompt/chatprompt.go
@@ -245,6 +245,7 @@ func ConvertMessagesWithFiles(
 		prompt,
 		toolNameByCallID,
 	)
+	prompt = reorderTrailingAssistantMessage(prompt)
 	return prompt, nil
 }
 
@@ -813,6 +814,56 @@ func ReasoningTitleFromFirstLine(text string) string {
 	}
 
 	return compactReasoningSummaryTitle(title)
+}
+
+// reorderTrailingAssistantMessage fixes a race condition in the
+// interrupt flow where the partial assistant response is persisted
+// after the new user message (because persistInterruptedStep runs
+// with context.WithoutCancel after the user message was already
+// inserted). The DB orders by (created_at, id), so the assistant
+// message ends up last. The Anthropic API rejects a trailing
+// assistant message as unsupported prefill on many models. This
+// function moves such a trailing assistant message before the
+// preceding user message so the prompt ends with a user turn.
+func reorderTrailingAssistantMessage(prompt []fantasy.Message) []fantasy.Message {
+	if len(prompt) < 2 {
+		return prompt
+	}
+	last := prompt[len(prompt)-1]
+	if last.Role != fantasy.MessageRoleAssistant {
+		return prompt
+	}
+	// Only reorder when the assistant message has no tool calls.
+	// Messages with tool calls will have synthetic tool results
+	// injected by injectMissingToolResults, which produces a
+	// trailing tool (user) message instead.
+	if len(ExtractToolCalls(last.Content)) > 0 {
+		return prompt
+	}
+	// Find the last user message before this assistant message.
+	userIdx := -1
+	for i := len(prompt) - 2; i >= 0; i-- {
+		if prompt[i].Role == fantasy.MessageRoleUser {
+			userIdx = i
+			break
+		}
+		// Stop at system messages — don't reorder across the
+		// system/conversation boundary.
+		if prompt[i].Role == fantasy.MessageRoleSystem {
+			break
+		}
+	}
+	if userIdx < 0 {
+		return prompt
+	}
+	// Move the trailing assistant message to just before the user
+	// message at userIdx, so the conversation ends with the user
+	// turn.
+	reordered := make([]fantasy.Message, 0, len(prompt))
+	reordered = append(reordered, prompt[:userIdx]...)
+	reordered = append(reordered, last)
+	reordered = append(reordered, prompt[userIdx:len(prompt)-1]...)
+	return reordered
 }
 
 func injectMissingToolResults(prompt []fantasy.Message) []fantasy.Message {

--- a/coderd/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/chatd/chatprompt/chatprompt_test.go
@@ -222,6 +222,125 @@ func TestInjectFileID_StripsInlineData(t *testing.T) {
 	require.Nil(t, envelope.Data.Data, "inline data should be stripped")
 }
 
+// TestConvertMessages_TrailingAssistantTextOnly verifies that when an
+// interrupted agent persists a text-only assistant message after the
+// user's interrupt message (a race inherent to the interrupt flow),
+// the resulting prompt does not end with an assistant message. The
+// Anthropic API interprets a trailing assistant message as "prefill"
+// and rejects it on models that do not support that feature.
+func TestConvertMessages_TrailingAssistantTextOnly(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the DB order after interrupt: the user message was
+	// inserted at T1, then the partial assistant text was persisted
+	// at T2 (T2 > T1), so the assistant message is last.
+	assistantContent, err := chatprompt.MarshalContent([]fantasy.Content{
+		fantasy.TextContent{Text: "partial response before interrupt"},
+	}, nil)
+	require.NoError(t, err)
+
+	userContent, err := json.Marshal([]json.RawMessage{
+		mustJSON(t, map[string]any{
+			"type": "text",
+			"data": map[string]any{"text": "initial request"},
+		}),
+	})
+	require.NoError(t, err)
+
+	interruptContent, err := json.Marshal([]json.RawMessage{
+		mustJSON(t, map[string]any{
+			"type": "text",
+			"data": map[string]any{"text": "new instruction after interrupt"},
+		}),
+	})
+	require.NoError(t, err)
+
+	prompt, err := chatprompt.ConvertMessages([]database.ChatMessage{
+		{
+			Role:       string(fantasy.MessageRoleUser),
+			Visibility: database.ChatMessageVisibilityBoth,
+			Content:    pqtype.NullRawMessage{RawMessage: userContent, Valid: true},
+		},
+		// The interrupt user message was inserted before the partial
+		// assistant response was persisted.
+		{
+			Role:       string(fantasy.MessageRoleUser),
+			Visibility: database.ChatMessageVisibilityBoth,
+			Content:    pqtype.NullRawMessage{RawMessage: interruptContent, Valid: true},
+		},
+		// Partial assistant text persisted after the interrupt.
+		{
+			Role:       string(fantasy.MessageRoleAssistant),
+			Visibility: database.ChatMessageVisibilityBoth,
+			Content:    assistantContent,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, prompt)
+
+	lastMsg := prompt[len(prompt)-1]
+	require.NotEqual(t, fantasy.MessageRoleAssistant, lastMsg.Role,
+		"prompt must not end with an assistant message; "+
+			"Anthropic rejects this as unsupported prefill")
+
+	// The reordered prompt should place the assistant message
+	// before the interrupt user message.
+	require.Len(t, prompt, 3)
+	require.Equal(t, fantasy.MessageRoleUser, prompt[0].Role)
+	require.Equal(t, fantasy.MessageRoleAssistant, prompt[1].Role)
+	require.Equal(t, fantasy.MessageRoleUser, prompt[2].Role)
+}
+
+// TestConvertMessages_TrailingAssistantWithToolCalls verifies that
+// a trailing assistant message containing tool calls is NOT
+// reordered. The existing injectMissingToolResults logic already
+// appends synthetic tool-result messages (role=tool) after such
+// assistant messages, so the prompt naturally ends with a
+// tool/user turn.
+func TestConvertMessages_TrailingAssistantWithToolCalls(t *testing.T) {
+	t.Parallel()
+
+	assistantContent, err := chatprompt.MarshalContent([]fantasy.Content{
+		fantasy.TextContent{Text: "let me check that"},
+		fantasy.ToolCallContent{
+			ToolCallID: "toolu_interrupted",
+			ToolName:   "read_file",
+			Input:      `{"path":"main.go"}`,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	userContent, err := json.Marshal([]json.RawMessage{
+		mustJSON(t, map[string]any{
+			"type": "text",
+			"data": map[string]any{"text": "do something"},
+		}),
+	})
+	require.NoError(t, err)
+
+	prompt, err := chatprompt.ConvertMessages([]database.ChatMessage{
+		{
+			Role:       string(fantasy.MessageRoleUser),
+			Visibility: database.ChatMessageVisibilityBoth,
+			Content:    pqtype.NullRawMessage{RawMessage: userContent, Valid: true},
+		},
+		{
+			Role:       string(fantasy.MessageRoleAssistant),
+			Visibility: database.ChatMessageVisibilityBoth,
+			Content:    assistantContent,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, prompt)
+
+	// injectMissingToolResults should have added a synthetic tool
+	// result, so the last message should be a tool message.
+	lastMsg := prompt[len(prompt)-1]
+	require.Equal(t, fantasy.MessageRoleTool, lastMsg.Role,
+		"trailing assistant with tool calls should get synthetic "+
+			"tool results appended by injectMissingToolResults")
+}
+
 func mustJSON(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(v)


### PR DESCRIPTION
## Problem

When a chat agent is interrupted via `message_agent` with `interrupt=true`, there is a race condition in the persist ordering:

1. `SendMessage()` inserts the new **user message** into the DB at time T1 and sets the chat to pending
2. The running chat loop detects the interrupt via pubsub, cancels with `ErrInterrupted`
3. `persistInterruptedStep()` saves the partial **assistant response** at time T2 (using `context.WithoutCancel`)

Since T2 > T1, the DB query (`ORDER BY created_at ASC, id ASC`) returns the assistant message *after* the user message. When the chat resumes, the prompt sent to the LLM ends with an assistant message.

The Anthropic API interprets a trailing assistant message as "prefill" (pre-seeding the model's response). Many models reject this with:

```
This model does not support assistant message prefill. The conversation must end with a user message.
```

## Fix

Add `reorderTrailingAssistantMessage()` to the prompt construction pipeline in `ConvertMessagesWithFiles`. When the last non-system message is a **text-only** assistant message (no tool calls), it is moved before the preceding user message so the prompt ends with a user turn.

Assistant messages with tool calls are **not affected** because the existing `injectMissingToolResults` already appends synthetic tool-result messages after them, ensuring the prompt ends with a tool (user) message.

## Tests

- `TestConvertMessages_TrailingAssistantTextOnly` — verifies the trailing text-only assistant message is reordered before the user message
- `TestConvertMessages_TrailingAssistantWithToolCalls` — verifies assistant messages with tool calls are left to `injectMissingToolResults` (not reordered)