### PR TITLE
fix(site): prevent stale title clobber in sidebar from watchChats race

### DIFF
--- a/offlinedocs/next-env.d.ts
+++ b/offlinedocs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -492,25 +492,32 @@ const AgentsPage: FC = () => {
 					return;
 				}
 
+				// Scope field updates by event kind so that
+				// status_change events (which may carry a stale title
+				// snapshot from before async title generation
+				// finished) don't clobber a title_change that already
+				// landed.
+				const isTitleEvent = chatEvent.kind === "title_change";
+				const isStatusEvent = chatEvent.kind === "status_change";
+
 				queryClient.setQueryData(
 					chatsKey,
 					(prev: TypesGen.Chat[] | undefined) => {
 						if (!prev) return prev;
 						const exists = prev.some((c) => c.id === updatedChat.id);
 						if (exists) {
-							return prev.map((c) =>
-								c.id === updatedChat.id
-									? {
-											...c,
-											status: updatedChat.status,
-											title: updatedChat.title,
-											updated_at:
-												c.updated_at > updatedChat.updated_at
-													? c.updated_at
-													: updatedChat.updated_at,
-										}
-									: c,
-							);
+							return prev.map((c) => {
+								if (c.id !== updatedChat.id) return c;
+								return {
+									...c,
+									...(isStatusEvent && { status: updatedChat.status }),
+									...(isTitleEvent && { title: updatedChat.title }),
+									updated_at:
+										c.updated_at > updatedChat.updated_at
+											? c.updated_at
+											: updatedChat.updated_at,
+								};
+							});
 						}
 						if (chatEvent.kind === "created") {
 							return [updatedChat, ...prev];
@@ -528,8 +535,8 @@ const AgentsPage: FC = () => {
 							...previousChat,
 							chat: {
 								...previousChat.chat,
-								status: updatedChat.status,
-								title: updatedChat.title,
+								...(isStatusEvent && { status: updatedChat.status }),
+								...(isTitleEvent && { title: updatedChat.title }),
 								updated_at:
 									previousChat.chat.updated_at > updatedChat.updated_at
 										? previousChat.chat.updated_at


### PR DESCRIPTION
## Problem

The chat sidebar title would revert to the old fallback title (first ~6 words of the message) after the AI-generated title had already appeared, requiring a page refresh to see the correct title.

## Root Cause

Two WebSocket connections update the same react-query cache (`chatsKey`):

1. **`watchChats` (global)** — receives `ChatEvent` pubsub events for all chats
2. **`watchChat` (per-chat)** — receives per-chat stream events

The `watchChats` handler was unconditionally writing both `status` and `title` from every event into the cache, regardless of event kind. Title generation runs **asynchronously** in a background goroutine on the backend, so `status_change` events often carry a stale title snapshot (from before the AI title was generated). When a `status_change` event arrived after a `title_change` had already updated the sidebar, it would clobber the new title with the old one.

### Race sequence:
1. User sends first message → chat created with fallback truncated title
2. `title_change` event arrives → sidebar updated to AI-generated title ✅
3. `status_change` event arrives (e.g. `running` → `waiting`) with stale title in its `Chat` payload → overwrites sidebar back to fallback title ❌

## Fix

Scope the `setQueryData` updates by event kind:
- `status_change` → only updates `status` + `updated_at`
- `title_change` → only updates `title` + `updated_at`
- `created` → inserts full chat (first time in cache)
- `deleted` / `diff_status_change` → already handled separately

This is the principled approach — each event kind is only authoritative for the fields in its domain.