### PR TITLE
fix(chat): fix streaming bugs in edit notifications, persist race, and frontend reconnect

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1330,10 +1330,14 @@ func (p *Server) Subscribe(
 				}
 				return
 			case notify := <-notifications:
-				if notify.AfterMessageID > 0 {
+				if notify.AfterMessageID > 0 || notify.FullRefresh {
+					afterID := lastMessageID
+					if notify.FullRefresh {
+						afterID = 0
+					}
 					newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
 						ChatID:  chatID,
-						AfterID: lastMessageID,
+						AfterID: afterID,
 					})
 					if msgErr != nil {
 						p.logger.Warn(mergedCtx, "failed to get chat messages after pubsub notification",
@@ -1642,7 +1646,7 @@ func (p *Server) publishEditedMessage(chatID uuid.UUID, message database.ChatMes
 		Message: &sdkMessage,
 	})
 	p.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{
-		AfterMessageID: 0,
+		FullRefresh: true,
 	})
 }
 
@@ -2209,6 +2213,19 @@ func (p *Server) runChat(
 
 		var insertedMessages []database.ChatMessage
 		err := p.db.InTx(func(tx database.Store) error {
+			// Verify this worker still owns the chat before
+			// inserting messages. This closes the race where
+			// EditMessage truncates history and clears worker_id
+			// while persistInterruptedStep (which uses an
+			// uncancelable context) is still running.
+			lockedChat, lockErr := tx.GetChatByIDForUpdate(persistCtx, chat.ID)
+			if lockErr != nil {
+				return xerrors.Errorf("lock chat for persist: %w", lockErr)
+			}
+			if !lockedChat.WorkerID.Valid || lockedChat.WorkerID.UUID != p.workerID {
+				return chatloop.ErrInterrupted
+			}
+
 			if len(assistantBlocks) > 0 {
 				assistantContent, marshalErr := chatprompt.MarshalContent(assistantBlocks, nil)
 				if marshalErr != nil {

--- a/coderd/pubsub/chatstreamnotify.go
+++ b/coderd/pubsub/chatstreamnotify.go
@@ -34,4 +34,9 @@ type ChatStreamNotifyMessage struct {
 
 	// QueueUpdate is set when the queued messages change.
 	QueueUpdate bool `json:"queue_update,omitempty"`
+
+	// FullRefresh signals that subscribers should re-fetch all
+	// messages from the beginning (e.g. after an edit that
+	// truncates message history).
+	FullRefresh bool `json:"full_refresh,omitempty"`
 }

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -670,6 +670,17 @@ export const useChatStore = (
 							continue;
 						}
 						const { changed } = store.upsertDurableMessage(message);
+						// Keep lastMessageIdRef in sync with
+						// stream-delivered messages so reconnections use
+						// the correct after_id and don't re-fetch or
+						// miss events.
+						if (
+							message.id !== undefined &&
+							(lastMessageIdRef.current === undefined ||
+								message.id > lastMessageIdRef.current)
+						) {
+							lastMessageIdRef.current = message.id;
+						}
 						if (changed) {
 							scheduleStreamReset();
 						}
@@ -809,6 +820,13 @@ export const useChatStore = (
 				// while we are already retrying).
 				if (reconnectAttempt === 0) {
 					store.setStreamError("Chat stream disconnected. Reconnecting…");
+				}
+				// Clear "running" status on disconnect so the UI
+				// doesn't show a stale spinner. The reconnected
+				// stream will deliver the authoritative status.
+				const currentStatus = store.getSnapshot().chatStatus;
+				if (currentStatus === "running") {
+					store.setChatStatus(null);
 				}
 				scheduleReconnect();
 			};


### PR DESCRIPTION
## Summary

Fixes four bugs in the agent chat streaming system identified during a codebase audit.

### Bug 1: Edited messages invisible to remote subscribers in HA deployments

`publishEditedMessage` sent a pubsub notification with `AfterMessageID: 0`, but the subscriber handler gated DB re-fetching on `AfterMessageID > 0`. This meant remote subscribers on other replicas **never fetched edited messages**.

**Fix:** Added a `FullRefresh` boolean field to `ChatStreamNotifyMessage`. When set, the subscriber re-queries all messages from the beginning (`AfterID: 0`).

### Bug 2: `persistInterruptedStep` inserts messages after `EditMessage` truncation

When a user edits a message, `EditMessage` truncates all messages after the edit point and clears `worker_id`. However, the running chatloop's `persistInterruptedStep` uses `context.WithoutCancel(ctx)`, bypassing the `persistCtx.Err()` cancellation guard in `persistStep`. This allowed assistant/tool messages to be inserted **after the truncation point**, undoing the edit.

**Fix:** Added a `FOR UPDATE` ownership check at the start of the `persistStep` transaction. Before inserting any messages, it verifies `worker_id` still matches this worker. If not, it returns `ErrInterrupted`.

### Bug 3: Frontend `chatStatus` stuck on "running" after WebSocket disconnect

When the WebSocket disconnected, `handleDisconnect` did not touch `chatStatus`. If the server completed work while the client was disconnected, the reconnected stream wouldn't re-send the final status event (only events after `after_id`), leaving the UI stuck showing a "running" spinner forever.

**Fix:** On disconnect, if `chatStatus` is `"running"`, reset it to `null`. The reconnected stream will deliver the authoritative status.

### Bug 4: Frontend `afterID` not updated from stream-delivered messages

`lastMessageIdRef` was only updated from REST-fetched messages (`chatMessages`), not from stream-delivered durable messages via `upsertDurableMessage`. On WebSocket reconnect, the stale `after_id` caused the server to re-send all stream-delivered messages, or worse, miss them if the replay buffer was evicted.

**Fix:** Update `lastMessageIdRef` inside the `upsertDurableMessage` handler when a stream message has a higher ID than the current ref.

## Changes

| File | Change |
|------|--------|
| `coderd/pubsub/chatstreamnotify.go` | Add `FullRefresh` field to `ChatStreamNotifyMessage` |
| `coderd/chatd/chatd.go` | Use `FullRefresh: true` in `publishEditedMessage`; handle `FullRefresh` in subscriber; add ownership check in `persistStep` |
| `site/.../ChatContext.ts` | Update `lastMessageIdRef` from stream messages; reset `chatStatus` on disconnect |
