### PR TITLE
fix: update offlinedocs/next-env.d.ts to match Next.js 15 output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -986,6 +986,9 @@ jobs:
         run: |
           make build/coder_docs_"$(./scripts/version.sh)".tgz
 
+      - name: Check for unstaged files
+        run: ./scripts/check_unstaged.sh
+
   required:
     runs-on: ubuntu-latest
     needs:

--- a/offlinedocs/next-env.d.ts
+++ b/offlinedocs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Problem

`offlinedocs/next-env.d.ts` was committed with content from an older Next.js version. Next.js 15 rewrites this file on every `next build` with two changes:

1. Adds `/// <reference path="./.next/types/routes.d.ts" />`
2. Updates the docs URL from `basic-features/typescript` to `pages/api-reference/config/typescript`

During `make pre-commit` / `make pre-push`, the `pnpm export` step triggers `next build`, which silently rewrites the file. The `check-unstaged` guard then detects the diff and fails. If the hook is interrupted, the regenerated file persists as an unstaged change, blocking subsequent commits/pushes.

## Fix

Update the committed file to match what the current Next.js 15 produces, making the build idempotent.