### PR TITLE
fix(site): fix flaky TemplateVariablesPage submit test

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesPage.jest.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateVariablesPage/TemplateVariablesPage.jest.tsx
@@ -15,6 +15,14 @@ import { API } from "api/api";
 import { toast } from "sonner";
 import TemplateVariablesPage from "./TemplateVariablesPage";
 
+// The createAndBuildTemplateVersion mutation polls getTemplateVersion behind
+// a real `delay(1000)` call. Without this mock the 1 s wall-clock wait races
+// against the default `waitFor` timeout (also 1 s), making the "submit"
+// assertion flaky in CI.
+jest.mock("utils/delay", () => ({
+	delay: () => Promise.resolve(),
+}));
+
 const validFormValues = {
 	first_variable: "Hello world",
 	second_variable: "123",


### PR DESCRIPTION
## Root Cause

The `createAndBuildTemplateVersion` mutation calls `waitBuildToBeFinished`, which polls `getTemplateVersion` behind a real `delay()` call:

```ts
await delay(jobStatus === "pending" ? 250 : 1000);
```

On the first iteration, `jobStatus` is `undefined` (not `"pending"`), so the delay is **1000 ms**. The `waitFor` assertion in the test uses the default `@testing-library` timeout, which is also **1000 ms**. The `toast.success` call fires right at or after the timeout boundary, making the test flaky under CI load.

## Fix

Mock `utils/delay` to resolve immediately at the top of the test file. This eliminates the 1 s wall-clock wait in `waitBuildToBeFinished`, so the async submit chain completes in microtasks and the `toast.success` spy is called well within the `waitFor` window.

## Verification

- Both tests pass (`renders with variables` + `user submits the form successfully`)
- **50/50 passes** under stress testing (sequential runs with `--no-cache`)
- Submit test time dropped from ~2000 ms to ~1400 ms