### PR TITLE
fix: hide task apps panel and sidebar on mobile

### DIFF
--- a/site/src/hooks/useIsMobile.ts
+++ b/site/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export function useIsMobile(): boolean {
+	const [isMobile, setIsMobile] = useState(
+		() => window.matchMedia(MOBILE_QUERY).matches,
+	);
+
+	useEffect(() => {
+		const mq = window.matchMedia(MOBILE_QUERY);
+		const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, []);
+
+	return isMobile;
+}

--- a/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
+++ b/site/src/modules/tasks/TasksSidebar/TasksSidebar.tsx
@@ -23,6 +23,7 @@ import {
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
 import { useAuthenticated } from "hooks";
+import { useIsMobile } from "hooks/useIsMobile";
 import { useSearchParamsKey } from "hooks/useSearchParamsKey";
 import {
 	EditIcon,
@@ -49,7 +50,8 @@ export const TasksSidebar: FC = () => {
 		defaultValue: user.username,
 	});
 
-	const [isCollapsed, setIsCollapsed] = useState(false);
+	const isMobile = useIsMobile();
+	const [isCollapsed, setIsCollapsed] = useState(isMobile);
 
 	return (
 		<div

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -20,9 +20,12 @@ import { Loader } from "components/Loader/Loader";
 import { Margins } from "components/Margins/Margins";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import { Spinner } from "components/Spinner/Spinner";
+import { useIsMobile } from "hooks/useIsMobile";
 import { useWorkspaceBuildLogs } from "hooks/useWorkspaceBuildLogs";
 import {
 	ArrowLeftIcon,
+	MessageSquareIcon,
+	PanelRightOpenIcon,
 	PauseIcon,
 	RotateCcwIcon,
 	TriangleAlertIcon,
@@ -80,6 +83,8 @@ const TaskPageLayout: FC<PropsWithChildren> = ({ children }) => {
 };
 
 const TaskPage = () => {
+	const isMobile = useIsMobile();
+	const [showApps, setShowApps] = useState(false);
 	const [isModifyDialogOpen, setIsModifyDialogOpen] = useState(false);
 	const [isFollowUpDialogOpen, setIsFollowUpDialogOpen] = useState(false);
 	const [followUpDraft, setFollowUpDraft] = useState("");
@@ -328,33 +333,68 @@ const TaskPage = () => {
 		const chatApp = getAllAppsWithAgent(workspace).find(
 			(app) => app.id === task.workspace_app_id,
 		);
-		content = (
-			<PanelGroup autoSaveId="task" direction="horizontal">
-				<Panel defaultSize={25} minSize={20}>
-					{chatApp ? (
-						<TaskAppIFrame active workspace={workspace} app={chatApp} />
-					) : (
-						<div className="h-full flex items-center justify-center p-6 text-center">
-							<div className="flex flex-col items-center">
-								<h3 className="m-0 font-medium text-content-primary text-base">
-									Chat app not found
-								</h3>
-								<span className="text-content-secondary text-sm">
-									Please, make sure your template has a chat sidebar app
-									configured.
-								</span>
+
+		if (isMobile) {
+			content = (
+				<>
+					<div className="h-full w-full">
+						{showApps ? (
+							<TaskApps task={task} workspace={workspace} />
+						) : chatApp ? (
+							<TaskAppIFrame active workspace={workspace} app={chatApp} />
+						) : (
+							<div className="h-full flex items-center justify-center p-6 text-center">
+								<div className="flex flex-col items-center">
+									<h3 className="m-0 font-medium text-content-primary text-base">
+										Chat app not found
+									</h3>
+									<span className="text-content-secondary text-sm">
+										Please, make sure your template has a chat sidebar app
+										configured.
+									</span>
+								</div>
 							</div>
-						</div>
-					)}
-				</Panel>
-				<PanelResizeHandle>
-					<div className="w-1 bg-border h-full hover:bg-border-hover transition-all relative" />
-				</PanelResizeHandle>
-				<Panel className="[&>*]:h-full">
-					<TaskApps task={task} workspace={workspace} />
-				</Panel>
-			</PanelGroup>
-		);
+						)}
+					</div>
+					<Button
+						size="icon"
+						variant="outline"
+						className="fixed bottom-4 right-4 z-50 shadow-lg size-12 rounded-full"
+						onClick={() => setShowApps((v) => !v)}
+					>
+						{showApps ? <MessageSquareIcon /> : <PanelRightOpenIcon />}
+					</Button>
+				</>
+			);
+		} else {
+			content = (
+				<PanelGroup autoSaveId="task" direction="horizontal">
+					<Panel defaultSize={25} minSize={20}>
+						{chatApp ? (
+							<TaskAppIFrame active workspace={workspace} app={chatApp} />
+						) : (
+							<div className="h-full flex items-center justify-center p-6 text-center">
+								<div className="flex flex-col items-center">
+									<h3 className="m-0 font-medium text-content-primary text-base">
+										Chat app not found
+									</h3>
+									<span className="text-content-secondary text-sm">
+										Please, make sure your template has a chat sidebar app
+										configured.
+									</span>
+								</div>
+							</div>
+						)}
+					</Panel>
+					<PanelResizeHandle>
+						<div className="w-1 bg-border h-full hover:bg-border-hover transition-all relative" />
+					</PanelResizeHandle>
+					<Panel className="[&>*]:h-full">
+						<TaskApps task={task} workspace={workspace} />
+					</Panel>
+				</PanelGroup>
+			);
+		}
 	}
 
 	return (


### PR DESCRIPTION
On mobile viewports (<768px), the side-by-side PanelGroup layout caused the apps/diff panel to dominate the screen, making the chat view inaccessible.

## Changes

- **`useIsMobile` hook** (`site/src/hooks/useIsMobile.ts`): New shared hook using `window.matchMedia` to detect mobile viewports (<768px), with reactive updates on resize.

- **TaskPage**: On mobile, replaces the `PanelGroup` side-by-side layout with a single full-width view that defaults to showing the chat. A floating toggle button (bottom-right corner) lets users switch between chat and apps/diff views. Desktop layout is unchanged.

- **TasksSidebar**: Starts collapsed on mobile so it doesn't consume the full viewport width. Desktop behavior unchanged.

## How it works

- Mobile: chat is shown by default. Tap the floating button to switch to apps/diff. Tap again to go back to chat.
- Desktop: no changes to existing PanelGroup behavior.