### PR TITLE
fix: handle invalid coder_app URLs gracefully instead of crashing

### DIFF
--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -101,13 +101,20 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
-		const isAllowedProtocol =
-			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
+		try {
+			const appProtocol = new URL(app.url).protocol;
+			const isAllowedProtocol =
+				ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 
-		return needsSessionToken(app) && isAllowedProtocol
-			? app.url.replaceAll(SESSION_TOKEN_PLACEHOLDER, token ?? "")
-			: app.url;
+			return needsSessionToken(app) && isAllowedProtocol
+				? app.url.replaceAll(SESSION_TOKEN_PLACEHOLDER, token ?? "")
+				: app.url;
+		} catch {
+			// If the URL is invalid (e.g. missing protocol), return it as-is
+			// rather than crashing the page. The browser will handle the error
+			// when the user clicks the link.
+			return app.url;
+		}
 	}
 
 	if (app.command) {


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

- Wraps `new URL(app.url)` in `getAppHref()` with try-catch to handle invalid URLs gracefully
- Invalid URLs (e.g. `"example"` without a protocol) no longer crash the Workspace List and Workspace detail pages
- Returns the raw URL as-is when parsing fails, letting the browser handle the error when the user clicks the link

Fixes #22396

## Details

The crash occurs in `site/src/modules/apps/apps.ts` at line 97:
```typescript
const appProtocol = new URL(app.url).protocol;
```

When a `coder_app` resource has an invalid URL like `"example"` (no protocol), `new URL()` throws a `TypeError`, which propagates up and crashes the page. The fix catches this error and returns `app.url` as-is — the app button will still render, and the browser will show an appropriate error if the user clicks it.

## Test plan

- [x] Verified `new URL("example")` throws `TypeError` (confirming the crash mechanism)
- [x] With the fix, `getAppHref()` returns `"example"` for invalid URLs instead of throwing
- [x] Valid URLs continue to work as before (try-catch only activates on invalid URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)