### PR TITLE
fix: track external auth polling state per-provider on workspace creation

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -193,7 +193,7 @@ const CreateWorkspacePage: FC = () => {
 
 	const {
 		externalAuth,
-		externalAuthPollingState,
+		getExternalAuthPollingState,
 		startPollingExternalAuth,
 		isLoadingExternalAuth,
 	} = useExternalAuth(realizedVersionId);
@@ -330,7 +330,7 @@ const CreateWorkspacePage: FC = () => {
 					versionId={realizedVersionId}
 					versionName={templateVersionQuery.data?.name}
 					externalAuth={externalAuth ?? []}
-					externalAuthPollingState={externalAuthPollingState}
+					getExternalAuthPollingState={getExternalAuthPollingState}
 					startPollingExternalAuth={startPollingExternalAuth}
 					hasAllRequiredExternalAuth={hasAllRequiredExternalAuth}
 					permissions={permissionsQuery.data as CreateWorkspacePermissions}
@@ -364,45 +364,80 @@ const CreateWorkspacePage: FC = () => {
 };
 
 const useExternalAuth = (versionId: string | undefined) => {
-	const [externalAuthPollingState, setExternalAuthPollingState] =
-		useState<ExternalAuthPollingState>("idle");
+	const [providerPollingState, setProviderPollingState] =
+		useState<Record<string, ExternalAuthPollingState>>({});
+	const timeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+		new Map(),
+	);
 
-	const startPollingExternalAuth = useCallback(() => {
-		setExternalAuthPollingState("polling");
+	const startPollingExternalAuth = useCallback((providerId: string) => {
+		setProviderPollingState((prev) => ({ ...prev, [providerId]: "polling" }));
+
+		// Clear existing timeout for this provider if any
+		const existing = timeoutsRef.current.get(providerId);
+		if (existing) clearTimeout(existing);
+
+		// Poll for a maximum of one minute per provider
+		const timeout = setTimeout(() => {
+			setProviderPollingState((prev) => ({
+				...prev,
+				[providerId]: "abandoned",
+			}));
+			timeoutsRef.current.delete(providerId);
+		}, 60_000);
+		timeoutsRef.current.set(providerId, timeout);
 	}, []);
+
+	const getExternalAuthPollingState = useCallback(
+		(providerId: string): ExternalAuthPollingState =>
+			providerPollingState[providerId] ?? "idle",
+		[providerPollingState],
+	);
+
+	const isPollingAny = Object.values(providerPollingState).includes("polling");
 
 	const { data: externalAuth, isLoading: isLoadingExternalAuth } = useQuery({
 		...templateVersionExternalAuth(versionId ?? ""),
 		enabled: Boolean(versionId),
-		refetchInterval: externalAuthPollingState === "polling" ? 1000 : false,
+		refetchInterval: isPollingAny ? 1000 : false,
 	});
 
-	const allSignedIn = externalAuth?.every((it) => it.authenticated);
-
+	// Stop polling for providers that have authenticated
 	useEffect(() => {
-		if (allSignedIn) {
-			setExternalAuthPollingState("idle");
-			return;
-		}
+		if (!externalAuth) return;
 
-		if (externalAuthPollingState !== "polling") {
-			return;
-		}
+		setProviderPollingState((prev) => {
+			const next = { ...prev };
+			let changed = false;
+			for (const auth of externalAuth) {
+				if (auth.authenticated && next[auth.id] === "polling") {
+					next[auth.id] = "idle";
+					changed = true;
+					const timeout = timeoutsRef.current.get(auth.id);
+					if (timeout) {
+						clearTimeout(timeout);
+						timeoutsRef.current.delete(auth.id);
+					}
+				}
+			}
+			return changed ? next : prev;
+		});
+	}, [externalAuth]);
 
-		// Poll for a maximum of one minute
-		const quitPolling = setTimeout(
-			() => setExternalAuthPollingState("abandoned"),
-			60_000,
-		);
+	// Cleanup timeouts on unmount
+	useEffect(() => {
+		const currentTimeouts = timeoutsRef.current;
 		return () => {
-			clearTimeout(quitPolling);
+			for (const t of currentTimeouts.values()) {
+				clearTimeout(t);
+			}
 		};
-	}, [externalAuthPollingState, allSignedIn]);
+	}, []);
 
 	return {
 		startPollingExternalAuth,
+		getExternalAuthPollingState,
 		externalAuth,
-		externalAuthPollingState,
 		isLoadingExternalAuth,
 	};
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof CreateWorkspacePageView> = {
 		defaultName: "",
 		defaultOwner: MockUserOwner,
 		externalAuth: [],
-		externalAuthPollingState: "idle",
+		getExternalAuthPollingState: () => "idle",
 		hasAllRequiredExternalAuth: true,
 		mode: "form",
 		parameters: [],

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -62,7 +62,7 @@ interface CreateWorkspacePageViewProps {
 	disabledParams?: string[];
 	error: unknown;
 	externalAuth: TypesGen.TemplateVersionExternalAuth[];
-	externalAuthPollingState: ExternalAuthPollingState;
+	getExternalAuthPollingState: (id: string) => ExternalAuthPollingState;
 	hasAllRequiredExternalAuth: boolean;
 	mode: CreateWorkspaceMode;
 	parameters: PreviewParameter[];
@@ -78,7 +78,7 @@ interface CreateWorkspacePageViewProps {
 	) => void;
 	resetMutation: () => void;
 	sendMessage: (message: Record<string, string>, ownerId?: string) => void;
-	startPollingExternalAuth: () => void;
+	startPollingExternalAuth: (id: string) => void;
 	owner: TypesGen.MinimalUser;
 	setOwner: (user: TypesGen.MinimalUser) => void;
 }
@@ -93,7 +93,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	disabledParams,
 	error,
 	externalAuth,
-	externalAuthPollingState,
+	getExternalAuthPollingState,
 	hasAllRequiredExternalAuth,
 	mode,
 	parameters,
@@ -538,9 +538,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 										key={auth.id}
 										error={error}
 										auth={auth}
-										isLoading={externalAuthPollingState === "polling"}
-										onStartPolling={startPollingExternalAuth}
-										displayRetry={externalAuthPollingState === "abandoned"}
+										isLoading={getExternalAuthPollingState(auth.id) === "polling"}
+										onStartPolling={() => startPollingExternalAuth(auth.id)}
+										displayRetry={getExternalAuthPollingState(auth.id) === "abandoned"}
 									/>
 								))}
 							</div>


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #22420

When creating a workspace with multiple external auth providers, clicking one auth button sets a **single shared** `externalAuthPollingState` to `"polling"`, which causes **all** auth buttons to show loading spinners simultaneously. Similarly, when polling times out after 60 seconds, all buttons show the retry state at once.

**Root cause:** `useExternalAuth` in `CreateWorkspacePage.tsx` uses a single `ExternalAuthPollingState` value shared across all providers. The view passes this single state to every `ExternalAuthButton`:

```tsx
// Before: shared state applied to all buttons
isLoading={externalAuthPollingState === "polling"}
displayRetry={externalAuthPollingState === "abandoned"}
```

**Fix:** Changed the local `useExternalAuth` hook to track polling state **per provider ID** using `Record<string, ExternalAuthPollingState>`. Each provider now has independent polling, timeout, and abandoned states:

- `startPollingExternalAuth(providerId)` — sets polling for a specific provider
- `getExternalAuthPollingState(providerId)` — returns that provider's state
- Per-provider 60-second timeouts (managed via `useRef` to avoid cross-provider interference)
- Authenticated providers are individually reset to `"idle"`

```tsx
// After: per-provider state
isLoading={getExternalAuthPollingState(auth.id) === "polling"}
onStartPolling={() => startPollingExternalAuth(auth.id)}
displayRetry={getExternalAuthPollingState(auth.id) === "abandoned"}
```

### Files changed

- `CreateWorkspacePage.tsx` — Rewrote local `useExternalAuth` hook to use per-provider state
- `CreateWorkspacePageView.tsx` — Updated prop types and `ExternalAuthButton` rendering to use per-provider state
- `CreateWorkspacePageView.stories.tsx` — Updated default args to match new prop interface

### Note

The shared `hooks/useExternalAuth.ts` hook (used by `TaskPrompt.tsx`) has the same single-state pattern and the same bug. This PR focuses on the workspace creation page per the issue report; the shared hook could be addressed in a follow-up.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>