### PR TITLE
fix: enable monotonic parameter validation in workspace settings

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -62,6 +62,7 @@ export const WorkspaceParametersForm: FC<WorkspaceParameterFormProps> = ({
 		validationSchema: Yup.object({
 			rich_parameter_values: useValidationSchemaForRichParameters(
 				templateVersionRichParameters,
+				autofillParams,
 			),
 		}),
 	});


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #20978.

`useValidationSchemaForRichParameters` in `WorkspaceParametersForm` is called without the second `lastBuildParameters` argument, so monotonic constraints (`validation_monotonic = "increasing"` or `"decreasing"`) are never enforced client-side. Users can enter values that violate monotonic rules, and the error only appears after the server rejects the submission.

**Fix:** Pass `autofillParams` (which contains the previous build parameter values) as the second argument. This is the same pattern used in `CreateWorkspacePageView.tsx`.

## Changes

- `WorkspaceParametersForm.tsx`: Add `autofillParams` as the second argument to `useValidationSchemaForRichParameters`

## Test plan

- [ ] Create a template with a `validation { monotonic = "increasing" }` parameter
- [ ] Build a workspace with the parameter set to e.g. 1500
- [ ] Go to Workspace Settings > Parameters
- [ ] Try entering a value less than 1500
- [ ] Verify inline validation error: "Value must only ever increase (last value was 1500)"
- [ ] Verify valid values (>= 1500) can be submitted successfully

---

> [!NOTE]
> This PR was authored by Claude Opus 4.6 (AI). Happy to address any review feedback.