### PR TITLE
fix: reserve "me" as a username to prevent @me route conflict

### DIFF
--- a/codersdk/name.go
+++ b/codersdk/name.go
@@ -48,8 +48,9 @@ func NameValid(str string) error {
 	if len(str) < 1 {
 		return xerrors.New("must be >= 1 character")
 	}
-	// Avoid conflicts with routes like /templates/new and /groups/create.
-	if str == "new" || str == "create" {
+	// Avoid conflicts with routes like /templates/new, /groups/create,
+	// and the @me user alias used in workspace app routing.
+	if str == "new" || str == "create" || str == "me" {
 		return xerrors.Errorf("cannot use %q as a name", str)
 	}
 	matched := UsernameValidRegex.MatchString(str)
@@ -107,8 +108,9 @@ func GroupNameValid(str string) error {
 	if len(str) > limit {
 		return xerrors.New(fmt.Sprintf("must be <= %d characters", limit))
 	}
-	// Avoid conflicts with routes like /groups/new and /groups/create.
-	if str == "new" || str == "create" {
+	// Avoid conflicts with routes like /groups/new, /groups/create,
+	// and the @me user alias.
+	if str == "new" || str == "create" || str == "me" {
 		return xerrors.Errorf("cannot use %q as a name", str)
 	}
 	matched := UsernameValidRegex.MatchString(str)

--- a/codersdk/name_test.go
+++ b/codersdk/name_test.go
@@ -58,6 +58,9 @@ func TestUsernameValid(t *testing.T) {
 		{"123456789012345678901234567890123", false},
 		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},
 		{"123456789012345678901234567890123123456789012345678901234567890123", false},
+
+		// Reserved names
+		{"me", false},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.Username, func(t *testing.T) {
@@ -183,11 +186,14 @@ func TestFrom(t *testing.T) {
 		{"kyle+wow@kwc.io", "kylewow"},
 		{"kyle+testing", "kyletesting"},
 		{"kyle-testing", "kyle-testing"},
-		{"much.”more unusual”@example.com", "muchmoreunusual"},
+		{"much.\"more unusual\"@example.com", "muchmoreunusual"},
+
+		// Reserved names get a random username generated.
+		{"me", ""},
 
 		// Cases where an invalid string is provided, and the result is a random name.
 		{"123456789012345678901234567890123", ""},
-		{"very.unusual.”@”.unusual.com@example.com", ""},
+		{"very.unusual.\"@\".unusual.com@example.com", ""},
 		{"___@ok.com", ""},
 		{" something with spaces ", ""},
 		{"--test--", ""},
@@ -267,6 +273,7 @@ func TestGroupNameValid(t *testing.T) {
 		{"my-group", true},
 		{"create", false},
 		{"new", false},
+		{"me", false},
 		{"Lord Voldemort Team", false},
 		{random255String, true},
 		{random256String, false},


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

- Add `"me"` to the reserved names list in `NameValid()` and `GroupNameValid()` alongside existing `"new"` and `"create"` reservations
- Prevents users from setting username to `me`, which conflicts with the `@me` route alias used in workspace app routing (`coderd/workspaceapps/proxy.go:302`)
- Add test cases for the reserved name in `TestUsernameValid`, `TestFrom`, and `TestGroupNameValid`

Fixes #22699

## Root Cause

The `@me` alias is a special route in Coder's workspace app proxy that is explicitly rejected with a 404 and the message "Applications must be accessed with the full username, not @me." However, there was no validation preventing a user from actually setting their username to `me`, making their workspace apps permanently inaccessible.

## Test plan

- [x] Added `{"me", false}` test case to `TestUsernameValid`
- [x] Added `{"me", ""}` test case to `TestFrom` (verifies `UsernameFrom("me")` generates a random name instead)
- [x] Added `{"me", false}` test case to `TestGroupNameValid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)