### PR TITLE
fix: prevent immutable dropdown parameters from being interactable

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -342,6 +342,7 @@ const ParameterField: FC<ParameterFieldProps> = ({
 				<Combobox
 					value={value}
 					onValueChange={(newValue) => onChange(newValue ?? "")}
+					open={disabled ? false : undefined}
 				>
 					<ComboboxTrigger asChild>
 						<ComboboxButton


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #22351

When a parameter with `form_type="dropdown"` is marked as immutable, users can still open the Combobox popover and change the value. This happens because Radix UI's `PopoverTrigger` with `asChild` can deliver pointer events through React's synthetic event system even when the underlying `<button>` element has the `disabled` attribute.

The fix controls the `Combobox` open state when disabled — forcing `open={false}` prevents the popover from ever opening. The existing `disabled` prop on `ComboboxButton` continues to provide visual disabled styling (grayed out, `pointer-events: none`).

This matches the behavior of the `radio` form type, where the `RadioGroup` properly respects its `disabled` prop.

## Changes

- `DynamicParameter.tsx`: Pass `open={disabled ? false : undefined}` to the `Combobox` in the `dropdown` case. When disabled, the popover is forced closed. When not disabled, `undefined` lets the internal state manage normally.

## Test plan

- [x] Create a template with an immutable parameter using `form_type = "dropdown"`
- [x] Create a workspace from that template
- [x] Go to workspace settings → parameters
- [x] Verify the dropdown is grayed out and cannot be opened (same behavior as `form_type = "radio"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>