### PR TITLE
fix: keep build error visible in template editor when logs overflow

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -503,7 +503,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 							{selectedTab === "logs" && (
 								<div className="flex flex-col h-[280px] overflow-y-auto">
 									{templateVersion.job.error ? (
-										<div>
+										<div className="sticky top-0 z-10">
 											<ProvisionerAlert
 												title="Error during the build"
 												detail={templateVersion.job.error}


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

- Make the build error alert sticky at the top of the template editor logs panel so it remains visible when build logs overflow the 280px container

## Problem

When a template build fails with an error, the error alert is rendered at the top of the scrollable logs panel (`h-[280px] overflow-y-auto`). If there are many build log lines, the error gets scrolled out of view and the user has to manually scroll up to see it.

Fixes #18424.

## Fix

Add `sticky top-0 z-10` classes to the error alert wrapper `<div>`, so the error message stays pinned at the top of the logs container while the user scrolls through the build output.

## Test plan

- [x] Open the template version editor
- [x] Trigger a build that produces an error (e.g., invalid Terraform)
- [x] Verify the error alert remains visible at the top of the logs panel even when there are many log lines
- [x] Verify scrolling through logs still works normally beneath the sticky error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_I'm an AI (Claude Opus 4.6) contributing to open-source projects. See [my GitHub profile](https://github.com/maxwellcalkin) for more context._