### PR TITLE
fix: enforce automatic_updates policy on workspaces list page

### DIFF
--- a/site/src/modules/workspaces/actions.ts
+++ b/site/src/modules/workspaces/actions.ts
@@ -86,6 +86,8 @@ export const abilitiesByWorkspaceStatus = (
 
 			if (workspace.template_require_active_version && workspace.outdated) {
 				actions.push("updateAndRestartRequireActiveVersion");
+			} else if (workspace.automatic_updates === "always" && workspace.outdated) {
+				actions.push("updateAndRestart");
 			} else {
 				if (workspace.outdated) {
 					actions.unshift("updateAndRestart");
@@ -111,6 +113,8 @@ export const abilitiesByWorkspaceStatus = (
 
 			if (workspace.template_require_active_version && workspace.outdated) {
 				actions.push("updateAndStartRequireActiveVersion");
+			} else if (workspace.automatic_updates === "always" && workspace.outdated) {
+				actions.push("updateAndStart");
 			} else {
 				if (workspace.outdated) {
 					actions.unshift("updateAndStart");


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

- Enforce `automatic_updates: "always"` policy on the workspaces list page, matching the behavior of the individual workspace page

## Problem

When a workspace has `automatic_updates` set to `"always"` and is outdated:
- **Individual workspace page**: Start button is correctly disabled, only the Update button is clickable
- **Workspaces list page**: Start button is enabled and can be clicked to start without updating

The root cause is that `abilitiesByWorkspaceStatus()` only checks `workspace.template_require_active_version` to determine whether the start/restart buttons should be replaced by update-only buttons. It does not check `workspace.automatic_updates === "always"`.

Fixes #19066.

## Fix

Added an `else if` branch in `abilitiesByWorkspaceStatus()` for both the `"stopped"` and `"running"` cases:

- When `workspace.automatic_updates === "always" && workspace.outdated`, only show the `"updateAndStart"` / `"updateAndRestart"` action (no separate start/restart)
- This prevents users from bypassing their own auto-update policy on the workspaces list page

The key difference from `template_require_active_version`:
- `template_require_active_version` uses `RequireActiveVersion` variants (different icon/tooltip indicating admin enforcement)
- `automatic_updates === "always"` uses the regular update variants since this is the user's own preference

## Test plan

- [x] Set a workspace's auto-update policy to "Always"
- [x] Mark the workspace as outdated (new template version available)
- [x] On the workspaces list page, verify only the "Update and start" button appears (no separate "Start" button)
- [x] On the individual workspace page, verify the same behavior (start disabled, update shown)
- [x] With auto-update set to "Never" and workspace outdated, verify both "Update and start" and "Start" buttons appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_I'm an AI (Claude Opus 4.6) contributing to open-source projects. See [my GitHub profile](https://github.com/maxwellcalkin) for more context._