### PR TITLE
fix: allow non-owners to cancel pending workspace builds

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5753,7 +5753,9 @@ func (q *querier) UpdateProvisionerJobWithCancelByID(ctx context.Context, arg da
 
 		// Template can specify if cancels are allowed.
 		// Would be nice to have a way in the rbac rego to do this.
-		if !template.AllowUserCancelWorkspaceJobs {
+		// Pending jobs haven't started provisioning, so cancelling is always
+		// non-destructive and should be allowed regardless of template settings.
+		if !template.AllowUserCancelWorkspaceJobs && job.JobStatus != database.ProvisionerJobStatusPending {
 			// Only owners can cancel workspace builds
 			actor, ok := ActorFromContext(ctx)
 			if !ok {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1020,6 +1020,20 @@ func (s *MethodTestSuite) TestProvisionerJob() {
 		dbm.EXPECT().UpdateProvisionerJobWithCancelByID(gomock.Any(), arg).Return(nil).AnyTimes()
 		check.Args(arg).Asserts(ws, policy.ActionUpdate).Returns()
 	}))
+	s.Run("BuildPendingFalseCancel/UpdateProvisionerJobWithCancelByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		// Pending jobs should always be cancellable, even when AllowUserCancelWorkspaceJobs is false.
+		tpl := testutil.Fake(s.T(), faker, database.Template{AllowUserCancelWorkspaceJobs: false})
+		ws := testutil.Fake(s.T(), faker, database.Workspace{TemplateID: tpl.ID})
+		j := testutil.Fake(s.T(), faker, database.ProvisionerJob{Type: database.ProvisionerJobTypeWorkspaceBuild, JobStatus: database.ProvisionerJobStatusPending})
+		build := testutil.Fake(s.T(), faker, database.WorkspaceBuild{JobID: j.ID, WorkspaceID: ws.ID})
+		arg := database.UpdateProvisionerJobWithCancelByIDParams{ID: j.ID}
+		dbm.EXPECT().GetProvisionerJobByID(gomock.Any(), j.ID).Return(j, nil).AnyTimes()
+		dbm.EXPECT().GetWorkspaceBuildByJobID(gomock.Any(), j.ID).Return(build, nil).AnyTimes()
+		dbm.EXPECT().GetWorkspaceByID(gomock.Any(), ws.ID).Return(ws, nil).AnyTimes()
+		dbm.EXPECT().GetTemplateByID(gomock.Any(), tpl.ID).Return(tpl, nil).AnyTimes()
+		dbm.EXPECT().UpdateProvisionerJobWithCancelByID(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(ws, policy.ActionUpdate).Returns()
+	}))
 	s.Run("TemplateVersion/UpdateProvisionerJobWithCancelByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		tpl := testutil.Fake(s.T(), faker, database.Template{})
 		j := testutil.Fake(s.T(), faker, database.ProvisionerJob{Type: database.ProvisionerJobTypeTemplateVersionImport})


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #22174.

Non-owner users get a 500 error when cancelling **pending** (queued) workspace builds on templates with `allow_user_cancel_workspace_jobs = false`. The handler-level check in `verifyUserCanCancelWorkspaceBuilds` correctly exempts pending jobs (since they haven't started provisioning and cancellation is non-destructive), but the dbauthz layer's `UpdateProvisionerJobWithCancelByID` did not have the same exemption.

## Changes

- **`coderd/database/dbauthz/dbauthz.go`**: Add `job.JobStatus != database.ProvisionerJobStatusPending` condition to the `AllowUserCancelWorkspaceJobs` check, matching the handler-level logic
- **`coderd/database/dbauthz/dbauthz_test.go`**: Add `BuildPendingFalseCancel` test case verifying pending jobs can be cancelled even when `AllowUserCancelWorkspaceJobs` is false

## Root cause

Two code paths check cancel permissions and disagreed on pending jobs:

1. `verifyUserCanCancelWorkspaceBuilds` (handler) — returns `true` for pending jobs ✅
2. `UpdateProvisionerJobWithCancelByID` (dbauthz) — did NOT exempt pending jobs ❌

The handler check passes, but the dbauthz wrapper rejects the subsequent DB call with "only owners can cancel workspace builds", returning a 500 instead of a proper 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)