### PR TITLE
fix: use ExternalImage for preset icons in dark theme

### DIFF
--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -28,6 +28,7 @@ import {
 } from "components/Tooltip/Tooltip";
 import { useAuthenticated } from "hooks/useAuthenticated";
 import { useExternalAuth } from "hooks/useExternalAuth";
+import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { ArrowUpIcon, InfoIcon, RedoIcon, RotateCcwIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
@@ -343,7 +344,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 												<SelectItem value={preset.ID} key={preset.ID}>
 													<div className="flex items-center gap-2">
 														{preset.Icon && (
-															<img
+															<ExternalImage
 																data-slot="preset-icon"
 																src={preset.Icon}
 																alt={preset.Name}


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #22245.

The OpenAI/Codex preset icon in the task prompt preset selector is invisible on dark theme because it uses a plain `<img>` tag. The codebase already has an `ExternalImage` component that applies theme-aware CSS filters (e.g., `grayscale(100%) contrast(0%) brightness(250%)` for monochrome icons in dark mode), and `defaultParametersForBuiltinIcons` already maps both `/icon/openai.svg` and `/icon/openai-codex.svg` to `"monochrome"`.

## Changes

- **`site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx`**: Replace the preset icon `<img>` with `<ExternalImage>` so that theme-aware filters are applied automatically

This is the same approach used throughout the codebase for template icons, app icons, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)