### PR TITLE
fix: restart running workspaces when updating parameters

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -38,13 +38,22 @@ const WorkspaceParametersPage: FC = () => {
 		workspaceBuildParameters(build.id),
 	);
 	const navigate = useNavigate();
+	const isRunning = workspace.latest_build.status === "running";
 	const updateParameters = useMutation({
-		mutationFn: (buildParameters: WorkspaceBuildParameter[]) =>
-			API.postWorkspaceBuild(workspace.id, {
+		mutationFn: async (buildParameters: WorkspaceBuildParameter[]) => {
+			if (isRunning) {
+				const stopBuild = await API.stopWorkspace(workspace.id);
+				const stoppedJob = await API.waitForBuild(stopBuild);
+				if (stoppedJob?.status === "canceled") {
+					return;
+				}
+			}
+			await API.postWorkspaceBuild(workspace.id, {
 				transition: "start",
 				rich_parameter_values: buildParameters,
 				reason: "dashboard",
-			}),
+			});
+		},
 		onSuccess: () => {
 			navigate(`/${workspace.owner_name}/${workspace.name}`);
 		},

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -45,7 +45,7 @@ const WorkspaceParametersPage: FC = () => {
 				const stopBuild = await API.stopWorkspace(workspace.id);
 				const stoppedJob = await API.waitForBuild(stopBuild);
 				if (stoppedJob?.status === "canceled") {
-					return;
+					throw new Error("Stop was canceled. Parameters were not updated.");
 				}
 			}
 			await API.postWorkspaceBuild(workspace.id, {

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -149,14 +149,23 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		workspace.owner_id,
 	]);
 
+	const isRunning = workspace.latest_build.status === "running";
 	const updateParameters = useMutation({
-		mutationFn: (buildParameters: WorkspaceBuildParameter[]) =>
-			API.postWorkspaceBuild(workspace.id, {
+		mutationFn: async (buildParameters: WorkspaceBuildParameter[]) => {
+			if (isRunning) {
+				const stopBuild = await API.stopWorkspace(workspace.id);
+				const stoppedJob = await API.waitForBuild(stopBuild);
+				if (stoppedJob?.status === "canceled") {
+					return;
+				}
+			}
+			await API.postWorkspaceBuild(workspace.id, {
 				transition: "start",
 				template_version_id: templateVersionId,
 				rich_parameter_values: buildParameters,
 				reason: "dashboard",
-			}),
+			});
+		},
 		onSuccess: () => {
 			navigate(`/@${workspace.owner_name}/${workspace.name}`);
 		},

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -156,7 +156,7 @@ const WorkspaceParametersPageExperimental: FC = () => {
 				const stopBuild = await API.stopWorkspace(workspace.id);
 				const stoppedJob = await API.waitForBuild(stopBuild);
 				if (stoppedJob?.status === "canceled") {
-					return;
+					throw new Error("Stop was canceled. Parameters were not updated.");
 				}
 			}
 			await API.postWorkspaceBuild(workspace.id, {


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #22020.

Updating workspace parameters on a **running** workspace via Workspace Settings > Parameters leaves it in an unhealthy state. The mutation unconditionally uses `transition: "start"`, which triggers a start-on-top-of-start instead of properly stopping and restarting.

## Changes

- **`WorkspaceParametersPage.tsx`** (classic parameter flow): Check `workspace.latest_build.status`; if `"running"`, stop the workspace and wait for completion before starting with new parameters
- **`WorkspaceParametersPageExperimental.tsx`** (dynamic parameter flow): Same fix, preserving the `template_version_id` passthrough

The stop-wait-start pattern matches the existing `API.restartWorkspace()` implementation (used by the workspace restart button), including handling the case where the stop is canceled mid-way.

## Root cause

`postWorkspaceBuild` with `transition: "start"` on an already-running workspace doesn't properly restart it — the workspace agent ends up in an unhealthy state. The correct approach (already used by the restart button) is to stop first, wait for the stop to complete, then start with the new parameters.

## Previous attempt

PR #21547 was closed due to UX issues (stale workspace data causing incorrect button state). This PR takes a simpler approach — just fix the mutation logic without adding transitional state UI, which can be addressed separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)