### PR TITLE
fix: update warning badge color for accessibility

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -53,7 +53,7 @@
 		--radius: 0.5rem;
 		--highlight-purple: 271, 61%, 35%;
 		--highlight-green: 143 64% 24%;
-		--highlight-orange: 30 100% 54%;
+		--highlight-orange: 17 88% 40%;
 		--highlight-grey: 240 5% 65%;
 		--highlight-sky: 195, 61%, 22%;
 		--highlight-red: 0 74% 42%;


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #22329.

The light theme warning badge `highlight-orange` color didn't pass accessibility contrast requirements. Updated from Tailwind `orange-500` equivalent to `orange-700` (`#c2410c`) as specified in the updated Coder Kit Figma design.

## Changes

- **`site/src/index.css`**: Changed `--highlight-orange` in light theme from `30 100% 54%` (≈ orange-500 `#f97316`) to `17 88% 40%` (= orange-700 `#c2410c`)

This only affects the light theme. The dark theme `--highlight-orange` (`31 100% 70%`) remains unchanged as it already has sufficient contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)