### PR TITLE
feat: distinguish failed workspace statuses by build type

### DIFF
--- a/site/src/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator.stories.tsx
@@ -1,6 +1,6 @@
 import { MockWorkspace } from "testHelpers/entities";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { Workspace, WorkspaceStatus } from "api/typesGenerated";
+import type { Workspace, WorkspaceStatus, WorkspaceTransition } from "api/typesGenerated";
 import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
 
 const meta: Meta<typeof WorkspaceStatusIndicator> = {
@@ -17,6 +17,19 @@ const createWorkspaceWithStatus = (status: WorkspaceStatus): Workspace => {
 		latest_build: {
 			...MockWorkspace.latest_build,
 			status,
+		},
+	} as Workspace;
+};
+
+const createFailedWorkspaceWithTransition = (
+	transition: WorkspaceTransition,
+): Workspace => {
+	return {
+		...MockWorkspace,
+		latest_build: {
+			...MockWorkspace.latest_build,
+			status: "failed" as WorkspaceStatus,
+			transition,
 		},
 	} as Workspace;
 };
@@ -60,6 +73,24 @@ export const Stopping: Story = {
 export const Failed: Story = {
 	args: {
 		workspace: createWorkspaceWithStatus("failed"),
+	},
+};
+
+export const FailedStart: Story = {
+	args: {
+		workspace: createFailedWorkspaceWithTransition("start"),
+	},
+};
+
+export const FailedStop: Story = {
+	args: {
+		workspace: createFailedWorkspaceWithTransition("stop"),
+	},
+};
+
+export const FailedDelete: Story = {
+	args: {
+		workspace: createFailedWorkspaceWithTransition("delete"),
 	},
 };
 

--- a/site/src/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator.tsx
+++ b/site/src/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator.tsx
@@ -1,4 +1,4 @@
-import type { Workspace } from "api/typesGenerated";
+import type { Workspace, WorkspaceTransition } from "api/typesGenerated";
 import {
 	StatusIndicator,
 	StatusIndicatorDot,
@@ -28,6 +28,12 @@ const variantByStatusType: Record<
 	warning: "warning",
 };
 
+const failedTransitionTooltips: Record<WorkspaceTransition, string> = {
+	start: "Build failed during start",
+	stop: "Build failed during stop",
+	delete: "Build failed during deletion",
+};
+
 type WorkspaceStatusIndicatorProps = {
 	workspace: Workspace;
 	children?: React.ReactNode;
@@ -46,7 +52,20 @@ export const WorkspaceStatusIndicator: FC<WorkspaceStatusIndicatorProps> = ({
 		type = "warning";
 	}
 
-	const statusIndicator = (
+	const isFailed = workspace.latest_build.status === "failed";
+	const isUnhealthy = !workspace.health.healthy;
+
+	// Determine tooltip text based on workspace state
+	let tooltipText: string | undefined;
+	if (isFailed) {
+		tooltipText =
+			failedTransitionTooltips[workspace.latest_build.transition];
+	} else if (isUnhealthy) {
+		tooltipText =
+			"Your workspace is running but some agents are unhealthy.";
+	}
+
+	const statusIndicatorContent = (
 		<StatusIndicator variant={variantByStatusType[type]}>
 			<StatusIndicatorDot />
 			<span className="sr-only">Workspace status:</span> {text}
@@ -54,22 +73,16 @@ export const WorkspaceStatusIndicator: FC<WorkspaceStatusIndicatorProps> = ({
 		</StatusIndicator>
 	);
 
-	if (workspace.health.healthy) {
-		return statusIndicator;
+	if (!tooltipText) {
+		return statusIndicatorContent;
 	}
 
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<StatusIndicator variant={variantByStatusType[type]}>
-					<StatusIndicatorDot />
-					<span className="sr-only">Workspace status:</span> {text}
-					{children}
-				</StatusIndicator>
+				{statusIndicatorContent}
 			</TooltipTrigger>
-			<TooltipContent>
-				Your workspace is running but some agents are unhealthy.
-			</TooltipContent>
+			<TooltipContent>{tooltipText}</TooltipContent>
 		</Tooltip>
 	);
 };


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary
- Add tooltip text to the `WorkspaceStatusIndicator` component that distinguishes between failed starts, stops, and deletions by reading the build's `transition` field (`"start"`, `"stop"`, `"delete"`)
- When status is `"failed"` and transition is `"start"`: tooltip shows "Build failed during start"
- When status is `"failed"` and transition is `"stop"`: tooltip shows "Build failed during stop"
- When status is `"failed"` and transition is `"delete"`: tooltip shows "Build failed during deletion"
- Badge text remains "Failed" in all cases — only the tooltip changes
- Refactored duplicated StatusIndicator JSX into a single `statusIndicatorContent` variable
- Added Storybook stories for `FailedStart`, `FailedStop`, and `FailedDelete` variants

Closes #13753

## Test plan
- [ ] Hover over a "Failed" badge for a workspace whose latest build transition was `start` — tooltip should say "Build failed during start"
- [ ] Hover over a "Failed" badge for a workspace whose latest build transition was `stop` — tooltip should say "Build failed during stop"
- [ ] Hover over a "Failed" badge for a workspace whose latest build transition was `delete` — tooltip should say "Build failed during deletion"
- [ ] Verify that unhealthy workspace tooltip ("Your workspace is running but some agents are unhealthy.") still works correctly
- [ ] Verify that healthy, non-failed workspaces show no tooltip (same as before)
- [ ] Check Storybook stories render correctly: `FailedStart`, `FailedStop`, `FailedDelete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)