### PR TITLE
fix: include icons in multi-select default options

### DIFF
--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -391,14 +391,11 @@ const ParameterField: FC<ParameterFieldProps> = ({
 				disable: false,
 			}));
 
-			const optionMap = new Map(
-				parameter.options.map((opt) => [opt.value.value, opt.name]),
-			);
-
 			const selectedOptions: Option[] = parsedValues.values.map((val) => {
-				return {
+				const matchingOption = options.find((opt) => opt.value === val);
+				return matchingOption ?? {
 					value: val,
-					label: optionMap.get(val) || val,
+					label: val,
 					disable: false,
 				};
 			});


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

Fixes #19198

- Default/initial values for `form_type = 'multi-select'` parameters were missing icons (and descriptions) because `selectedOptions` was constructed using only a `value -> name` map, omitting the `icon` and `description` fields
- When a user manually re-selected an option from the dropdown, the full option object (with `icon`) was used, which is why icons appeared after re-adding
- Fix: look up the full option object from the already-constructed `options` array instead of using the limited map, so default selections include all fields (icon, description, etc.)

## Test plan

- [ ] Create a template with a `multi-select` parameter that has options with icons
- [ ] Set default values for some options
- [ ] Verify that the default selected options now display their icons in the badges
- [ ] Verify that manually adding/removing options still works correctly with icons
- [ ] Verify that options without a matching entry in the options array gracefully fall back to showing just value/label

🤖 Generated with [Claude Code](https://claude.com/claude-code)