### PR TITLE
fix: improve Create a workspace button visibility on publish banner

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -307,7 +307,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 								dismissible
 								actions={
 									<Button
-										variant="subtle"
+										variant="outline"
 										size="sm"
 										onClick={onCreateWorkspace}
 									>


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary
- Changed the "Create a workspace" button variant from `"subtle"` to `"outline"` on the success banner shown after publishing a template version
- The `subtle` variant (`bg-transparent text-content-secondary`) had poor contrast against the green `bg-surface-green` success banner background, making the button hard to see
- The `outline` variant (`border border-border-default bg-transparent text-content-primary`) provides a visible border and uses primary text color for much better contrast

Fixes #22244

## Test plan
- [ ] Publish a new template version and verify the success banner appears with the "Create a workspace" button
- [ ] Confirm the button is clearly visible against the green success banner background
- [ ] Verify the button click still navigates to workspace creation
- [ ] Check visual appearance in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)