### PR TITLE
fix: prevent cancel button layout shift on bulk delete dialog

### DIFF
--- a/site/src/components/Dialogs/Dialog.tsx
+++ b/site/src/components/Dialogs/Dialog.tsx
@@ -54,9 +54,16 @@ export const DialogActionButtons: FC<DialogActionButtonsProps> = ({
 					onClick={onConfirm}
 					data-testid="confirm-button"
 					type="submit"
+					className="relative"
 				>
-					<Spinner loading={confirmLoading} />
-					{confirmText}
+					{confirmLoading && (
+						<span className="absolute inset-0 flex items-center justify-center">
+							<Spinner loading />
+						</span>
+					)}
+					<span className={confirmLoading ? "invisible" : undefined}>
+						{confirmText}
+					</span>
 				</Button>
 			)}
 		</>


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary

- Fixes the Cancel button shifting position when the loading spinner appears on the confirm button in the bulk delete dialog
- Uses absolute positioning for the spinner overlay instead of inline placement, so the button maintains its width during loading
- The confirm text is made invisible (but still occupies space) while loading, preventing any layout reflow

Fixes #21697

## How it works

Before: The `<Spinner>` was rendered inline before the confirm text inside the button. When loading started, the spinner appeared and added its width + gap, making the button wider and pushing the Cancel button.

After: The spinner is absolutely positioned over the button content (`absolute inset-0`), and the text is made `invisible` (hidden but still taking up space). This keeps the button the same width regardless of loading state.

## Test plan

- [ ] Open the Workspaces page, select multiple workspaces, and click Delete
- [ ] Proceed through the confirmation stages until the final delete button
- [ ] Click Delete and verify the Cancel button does not shift when the spinner appears
- [ ] Verify the spinner is centered within the confirm button
- [ ] Verify other ConfirmDialogs throughout the app still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)