### PR TITLE
fix: search template ACL users by username and name in addition to email

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -18731,11 +18731,12 @@ WHERE
 		ELSE true
 	END
 	-- Start filters
-	-- Filter by email or username
+	-- Filter by email, username, or name
 	AND CASE
 		WHEN $2 :: text != '' THEN (
 			email ILIKE concat('%', $2, '%')
 			OR username ILIKE concat('%', $2, '%')
+			OR name ILIKE concat('%', $2, '%')
 		)
 		ELSE true
 	END

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -247,11 +247,12 @@ WHERE
 		ELSE true
 	END
 	-- Start filters
-	-- Filter by email or username
+	-- Filter by email, username, or name
 	AND CASE
 		WHEN @search :: text != '' THEN (
 			email ILIKE concat('%', @search, '%')
 			OR username ILIKE concat('%', @search, '%')
+			OR name ILIKE concat('%', @search, '%')
 		)
 		ELSE true
 	END


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #21211

## Summary
- The `GetUsers` SQL query's `@search` filter only matched against `email` and `username` fields, causing the template permissions search (`/api/v2/templates/{id}/acl/available?q=...`) to only find users by email.
- Added `name` (display name) to the `@search` ILIKE filter so that searching in template settings > Permissions now finds users by email, username, or display name.

## Test plan
- Go to a template's settings > Permissions
- Search for a user by username — should find them
- Search by display name — should find them
- Search by email — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>