### PR TITLE
fix: make OAuth2 authorization cancel button functional

### DIFF
--- a/coderd/oauth2provider/authorize.go
+++ b/coderd/oauth2provider/authorize.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	htmltemplate "html/template"
 	"net/http"
 	"net/url"
 	"strings"
@@ -148,10 +149,13 @@ func ShowAuthorizePage(accessURL *url.URL) http.HandlerFunc {
 		cancelQuery.Add("error", "access_denied")
 		cancel.RawQuery = cancelQuery.Encode()
 
+		// Use htmltemplate.URL so Go's html/template does not
+		// sanitize non-standard schemes (e.g. custom OAuth2
+		// callback URIs) to "#ZgotmplZ".
 		site.RenderOAuthAllowPage(rw, r, site.RenderOAuthAllowData{
 			AppIcon:     app.Icon,
 			AppName:     app.Name,
-			CancelURI:   cancel.String(),
+			CancelURI:   htmltemplate.URL(cancel.String()), // #nosec G203 -- cancel URI is built from the registered app callback URL, not user input.
 			RedirectURI: r.URL.String(),
 			CSRFToken:   nosurf.Token(r),
 			Username:    ua.FriendlyName,

--- a/coderd/oauth2provider/authorize_test.go
+++ b/coderd/oauth2provider/authorize_test.go
@@ -1,6 +1,7 @@
 package oauth2provider_test
 
 import (
+	htmltemplate "html/template"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,4 +30,50 @@ func TestOAuthConsentFormIncludesCSRFToken(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
 	assert.Contains(t, rec.Body.String(), `name="csrf_token"`)
 	assert.Contains(t, rec.Body.String(), `value="`+csrfFieldValue+`"`)
+}
+
+func TestOAuthConsentCancelButtonRendersURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cancelURI string
+	}{
+		{
+			name:      "StandardHTTPS",
+			cancelURI: "https://example.com/callback?error=access_denied",
+		},
+		{
+			name:      "Localhost",
+			cancelURI: "http://127.0.0.1:9090/callback?error=access_denied",
+		},
+		{
+			name:      "CustomScheme",
+			cancelURI: "custom-scheme://app/callback?error=access_denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "https://coder.com/oauth2/authorize", nil)
+			rec := httptest.NewRecorder()
+
+			site.RenderOAuthAllowPage(rec, req, site.RenderOAuthAllowData{
+				AppName:     "Test App",
+				CancelURI:   htmltemplate.URL(tt.cancelURI),
+				RedirectURI: "https://coder.com/oauth2/authorize?client_id=test",
+				CSRFToken:   "token",
+				Username:    "test-user",
+			})
+
+			require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+			body := rec.Body.String()
+			// The Cancel link must contain the actual URI, not a
+			// sanitized placeholder like "#ZgotmplZ".
+			assert.Contains(t, body, tt.cancelURI)
+			assert.NotContains(t, body, "#ZgotmplZ")
+		})
+	}
 }

--- a/site/site.go
+++ b/site/site.go
@@ -726,9 +726,10 @@ func (jfs justFilesSystem) Open(name string) (fs.File, error) {
 // RenderOAuthAllowData contains the variables that are found in
 // site/static/oauth2allow.html.
 type RenderOAuthAllowData struct {
-	AppIcon     string
-	AppName     string
-	CancelURI   string
+	AppIcon   string
+	AppName   string
+	CancelURI htmltemplate.URL
+	// RedirectURI is used as the form action for the POST request.
 	RedirectURI string
 	CSRFToken   string
 	Username    string


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #20323

## Summary
- The Cancel button on the OAuth2 authorization page (`/oauth2/authorize`) rendered as a no-op link for apps using non-standard callback URI schemes (e.g. `custom-scheme://`). Go's `html/template` package sanitizes URLs with unrecognized schemes by replacing the `href` value with `#ZgotmplZ`, a deliberate safety placeholder.
- Changed the `CancelURI` field in `RenderOAuthAllowData` from `string` to `html/template.URL` so the template engine preserves the URI verbatim. The cancel URI is derived from the registered app callback URL, not from user input, so bypassing the sanitizer is safe.
- Added a test (`TestOAuthConsentCancelButtonRendersURL`) covering standard HTTPS, localhost, and custom-scheme cancel URIs to prevent regressions.

## Test plan
- Navigate to OAuth2 authorization page with an app using a custom callback scheme
- Click Cancel button
- Verify it redirects to the callback URI with `error=access_denied`
- Run `go test ./coderd/oauth2provider/...` to confirm the new test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>