### PR TITLE
fix: show access denied instead of 404 for template version files

### DIFF
--- a/site/src/pages/TemplatePage/TemplateFilesPage/TemplateFilesPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateFilesPage/TemplateFilesPage.tsx
@@ -1,5 +1,7 @@
 import { previousTemplateVersion, templateFiles } from "api/queries/templates";
+import { Alert, AlertDescription, AlertTitle } from "components/Alert/Alert";
 import { Loader } from "components/Loader/Loader";
+import { LockIcon } from "lucide-react";
 import { TemplateFiles } from "modules/templates/TemplateFiles/TemplateFiles";
 import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
 import type { FC } from "react";
@@ -12,7 +14,7 @@ const TemplateFilesPage: FC = () => {
 		organization?: string;
 	};
 	const { template, activeVersion } = useTemplateLayoutContext();
-	const { data: currentFiles } = useQuery(
+	const currentFilesQuery = useQuery(
 		templateFiles(activeVersion.job.file_id),
 	);
 	const previousVersionQuery = useQuery(
@@ -29,19 +31,32 @@ const TemplateFilesPage: FC = () => {
 		...templateFiles(previousVersion?.job.file_id ?? ""),
 		enabled: hasPreviousVersion,
 	});
+
+	const hasError = Boolean(currentFilesQuery.error);
 	const shouldDisplayFiles =
-		currentFiles && (!hasPreviousVersion || previousFiles);
+		currentFilesQuery.data && (!hasPreviousVersion || previousFiles);
 
 	return (
 		<>
 			<title>{getTemplatePageTitle("Source Code", template)}</title>
 
-			{shouldDisplayFiles ? (
+			{hasError ? (
+				<Alert severity="warning">
+					<AlertTitle className="flex items-center gap-2">
+						<LockIcon className="size-4" />
+						Insufficient permissions to view source code
+					</AlertTitle>
+					<AlertDescription>
+						You do not have permission to view the source code for this
+						template. Contact an administrator to request access.
+					</AlertDescription>
+				</Alert>
+			) : shouldDisplayFiles ? (
 				<TemplateFiles
 					organizationName={template.organization_name}
 					templateName={template.name}
 					versionName={activeVersion.name}
-					currentFiles={currentFiles}
+					currentFiles={currentFilesQuery.data}
 					baseFiles={previousFiles}
 				/>
 			) : (

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPage.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPage.tsx
@@ -67,8 +67,10 @@ const TemplateVersionPage: FC = () => {
 				error={
 					templateQuery.error ||
 					selectedVersionQuery.error ||
+					activeVersionQuery.error
+				}
+				filesError={
 					selectedVersionFilesQuery.error ||
-					activeVersionQuery.error ||
 					activeVersionFilesQuery.error
 				}
 				currentVersion={selectedVersionQuery.data}

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.stories.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.stories.tsx
@@ -35,6 +35,7 @@ const defaultArgs: TemplateVersionPageViewProps = {
 	},
 	baseFiles: undefined,
 	error: undefined,
+	filesError: undefined,
 };
 
 const meta: Meta<typeof TemplateVersionPageView> = {
@@ -62,6 +63,16 @@ export const WithError: Story = {
 		currentFiles: undefined,
 		error: mockApiError({
 			message: "Error on loading the template version",
+		}),
+	},
+};
+
+export const WithFilesPermissionError: Story = {
+	args: {
+		...defaultArgs,
+		currentFiles: undefined,
+		filesError: mockApiError({
+			message: "Forbidden",
 		}),
 	},
 };

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
@@ -1,4 +1,5 @@
 import type { TemplateVersion } from "api/typesGenerated";
+import { Alert, AlertDescription, AlertTitle } from "components/Alert/Alert";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Button } from "components/Button/Button";
 import { Loader } from "components/Loader/Loader";
@@ -10,7 +11,7 @@ import {
 } from "components/PageHeader/PageHeader";
 import { Stack } from "components/Stack/Stack";
 import { Stats, StatsItem } from "components/Stats/Stats";
-import { EditIcon, ExternalLinkIcon, PlusIcon } from "lucide-react";
+import { EditIcon, ExternalLinkIcon, LockIcon, PlusIcon } from "lucide-react";
 import { linkToTemplate, useLinks } from "modules/navigation";
 import { TemplateFiles } from "modules/templates/TemplateFiles/TemplateFiles";
 import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
@@ -25,6 +26,7 @@ export interface TemplateVersionPageViewProps {
 	versionName: string;
 	createWorkspaceUrl?: string;
 	error: unknown;
+	filesError: unknown;
 	currentVersion: TemplateVersion | undefined;
 	currentFiles: TemplateVersionFiles | undefined;
 	baseFiles: TemplateVersionFiles | undefined;
@@ -39,9 +41,11 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
 	currentFiles,
 	baseFiles,
 	error,
+	filesError,
 }) => {
 	const getLink = useLinks();
 	const templateLink = getLink(linkToTemplate(organizationName, templateName));
+	const hasFilesPermissionError = Boolean(filesError);
 
 	return (
 		<Margins>
@@ -69,7 +73,7 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
 				<PageHeaderTitle>{versionName}</PageHeaderTitle>
 			</PageHeader>
 
-			{!currentFiles && !error && <Loader />}
+			{!currentVersion && !error && <Loader />}
 
 			<Stack spacing={4}>
 				{Boolean(error) && <ErrorAlert error={error} />}
@@ -78,7 +82,7 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
 						{currentVersion.message}
 					</TemplateUpdateMessage>
 				)}
-				{currentVersion && currentFiles && (
+				{currentVersion && (
 					<>
 						<Stats className="justify-between">
 							<div className="flex flex-wrap items-center">
@@ -108,13 +112,28 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
 							</a>
 						</Stats>
 
-						<TemplateFiles
-							organizationName={organizationName}
-							templateName={templateName}
-							versionName={versionName}
-							currentFiles={currentFiles}
-							baseFiles={baseFiles}
-						/>
+						{hasFilesPermissionError ? (
+							<Alert severity="warning">
+								<AlertTitle className="flex items-center gap-2">
+									<LockIcon className="size-4" />
+									Insufficient permissions to view source code
+								</AlertTitle>
+								<AlertDescription>
+									You do not have permission to view the source code for this
+									template version. Contact an administrator to request access.
+								</AlertDescription>
+							</Alert>
+						) : currentFiles ? (
+							<TemplateFiles
+								organizationName={organizationName}
+								templateName={templateName}
+								versionName={versionName}
+								currentFiles={currentFiles}
+								baseFiles={baseFiles}
+							/>
+						) : (
+							<Loader />
+						)}
 					</>
 				)}
 			</Stack>


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #20708

## Summary
- Separated file-fetch errors from template/version errors in `TemplateVersionPage` so that a permission error on the files endpoint no longer blocks the entire page
- When files fail to load due to insufficient permissions, the template version metadata (stats, created by, message) still renders, and a clear "Insufficient permissions to view source code" warning is shown in place of the file viewer
- Added error handling to `TemplateFilesPage` for when a user navigates directly to the `/files` URL without `update` permission (previously showed an infinite loader)
- The existing behavior of hiding the "Source Code" tab in `TemplateLayout` for users without `canUpdateTemplate` remains unchanged

## Test plan
- Log in as a non-admin member
- Navigate to a template version's page (via the versions list)
- Verify the version info (template name, created by, created date) is shown
- Verify a clear "Insufficient permissions to view source code" warning is displayed instead of 404
- Navigate directly to a template's files URL (`/templates/<name>/files`)
- Verify the same permission warning is shown instead of an infinite loader
- Log in as an admin/owner and verify source code still displays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>