### PR TITLE
fix: show login_type:none users in organization member dropdown

### DIFF
--- a/site/src/components/UserAutocomplete/UserAutocomplete.tsx
+++ b/site/src/components/UserAutocomplete/UserAutocomplete.tsx
@@ -159,7 +159,7 @@ const InnerAutocomplete = <T extends SelectedUser>({
 			setFilter(nextFilter);
 		}, DEBOUNCE_MS);
 
-	const selectedInputValue = value?.email ?? value?.username ?? "";
+	const selectedInputValue = value?.email || value?.username || "";
 	const selectedFilterValue = value?.username ?? "";
 	// Keep spinner only while typing away from the selected value.
 	const isLoadingOptions =
@@ -203,7 +203,7 @@ const InnerAutocomplete = <T extends SelectedUser>({
 									fallback={value.username}
 								/>
 							)}
-							{value?.email ?? value?.username ?? "Select a user"}
+							{value?.email || value?.username || "Select a user"}
 						</span>
 						<ChevronDownIcon className="p-0.5" />
 					</Button>
@@ -233,7 +233,7 @@ const InnerAutocomplete = <T extends SelectedUser>({
 								<ComboboxItem
 									key={option.username}
 									value={option.username}
-									keywords={[option.username, option.email ?? ""]}
+									keywords={[option.username, option.email || ""]}
 									className="m-1"
 								>
 									<AvatarData


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #20090

## Summary
- Changed `??` (nullish coalescing) to `||` (logical OR) in the `UserAutocomplete` component when falling back from `email` to `username`
- The nullish coalescing operator only handles `null`/`undefined`, so an empty email string `""` was not falling through to the username fallback
- This caused users with `login_type:none` (who may have empty emails) to show incorrectly in the autocomplete: empty display text, broken re-open behavior, and wrong keyword matching in filtered variants

## Test plan
- Create a user with `login_type:none` (and optionally an empty email)
- Go to `/organizations/{org_name}`
- Type the user's name in the add member dropdown
- Verify the user appears in the autocomplete results
- Select the user and verify the trigger button displays their username (not blank)
- Reopen the dropdown and verify it pre-fills correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>