### PR TITLE
fix: rename agent-specific download button to 'Download agent logs'

### DIFF
--- a/site/src/modules/resources/DownloadAgentLogsButton.stories.tsx
+++ b/site/src/modules/resources/DownloadAgentLogsButton.stories.tsx
@@ -33,7 +33,7 @@ export const ClickOnDownload: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		await userEvent.click(
-			canvas.getByRole("button", { name: "Download logs" }),
+			canvas.getByRole("button", { name: "Download agent logs" }),
 		);
 		await waitFor(() =>
 			expect(args.download).toHaveBeenCalledWith(

--- a/site/src/modules/resources/DownloadAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadAgentLogsButton.tsx
@@ -58,7 +58,7 @@ export const DownloadAgentLogsButton: FC<DownloadAgentLogsButtonProps> = ({
 			}}
 		>
 			<DownloadIcon />
-			{isDownloading ? "Downloading..." : "Download logs"}
+			{isDownloading ? "Downloading..." : "Download agent logs"}
 		</Button>
 	);
 };


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #22138

Previously, both the agent-level download button and the workspace-level
kebab menu action were labeled "Download logs", despite downloading
different content (agent-only logs vs. all logs). This caused user
confusion about which logs would be downloaded.

Renamed the agent-specific button from "Download logs" to "Download
agent logs" to make the scope clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>