### PR TITLE
fix: scroll to error in template editor build logs

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -502,7 +502,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 
 							{selectedTab === "logs" && (
 								<div className="flex flex-col h-[280px] overflow-y-auto">
-									{templateVersion.job.error ? (
+									{templateVersion.job.error && !gotBuildLogs && (
 										<div>
 											<ProvisionerAlert
 												title="Error during the build"
@@ -512,18 +512,18 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 												variant={AlertVariant.Inline}
 											/>
 										</div>
-									) : (
-										!gotBuildLogs && (
-											<>
-												<ProvisionerStatusAlert
-													matchingProvisioners={matchingProvisioners}
-													availableProvisioners={availableProvisioners}
-													tags={templateVersion.job.tags}
-													variant={AlertVariant.Inline}
-												/>
-												<Loader className="h-full" />
-											</>
-										)
+									)}
+
+									{!templateVersion.job.error && !gotBuildLogs && (
+										<>
+											<ProvisionerStatusAlert
+												matchingProvisioners={matchingProvisioners}
+												availableProvisioners={availableProvisioners}
+												tags={templateVersion.job.tags}
+												variant={AlertVariant.Inline}
+											/>
+											<Loader className="h-full" />
+										</>
 									)}
 
 									{gotBuildLogs && (
@@ -538,6 +538,18 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 											hideTimestamps
 											logs={buildLogs}
 										/>
+									)}
+
+									{templateVersion.job.error && gotBuildLogs && (
+										<div>
+											<ProvisionerAlert
+												title="Error during the build"
+												detail={templateVersion.job.error}
+												severity="error"
+												tags={templateVersion.job.tags}
+												variant={AlertVariant.Inline}
+											/>
+										</div>
 									)}
 
 									{resources && (


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #19463

## Summary
- When a template build fails in the web editor, the error alert was only displayed at the top of the build logs panel. Since the logs auto-scroll to the bottom as they stream in, users had to scroll all the way up to find the error.
- Move the error alert to appear after the build logs (at the bottom of the scrollable container) so it is immediately visible when the build completes with an error.
- When there are no build logs (error occurs before any logs are produced), the error still appears at the top as before.

## Test plan
- Open template editor and build a template with an error
- Verify the error alert is visible at the bottom of the logs without scrolling up
- Verify that builds without logs still show the error correctly
- Verify successful builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>