### PR TITLE
fix: open external apps in new tab when open_in is tab

### DIFF
--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -25,6 +25,7 @@ type AppLink = {
 	onClick: (e: React.MouseEvent) => void;
 	label: string;
 	hasToken: boolean;
+	target?: string;
 };
 
 export const useAppLink = (
@@ -112,5 +113,6 @@ export const useAppLink = (
 		onClick,
 		label,
 		hasToken: !!apiKeyResponse?.key,
+		target: app.open_in === "tab" ? "_blank" : undefined,
 	};
 };

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -135,7 +135,12 @@ export const AppLink: FC<AppLinkProps> = ({
 
 	const button = grouped ? (
 		<DropdownMenuItem asChild>
-			<a href={canClick ? link.href : undefined} onClick={link.onClick}>
+			<a
+				href={canClick ? link.href : undefined}
+				onClick={link.onClick}
+				target={link.target}
+				rel={link.target === "_blank" ? "noopener noreferrer" : undefined}
+			>
 				{icon}
 				{link.label}
 				{ShareIcon && <ShareIcon />}
@@ -143,7 +148,12 @@ export const AppLink: FC<AppLinkProps> = ({
 		</DropdownMenuItem>
 	) : (
 		<AgentButton asChild>
-			<a href={canClick ? link.href : undefined} onClick={link.onClick}>
+			<a
+				href={canClick ? link.href : undefined}
+				onClick={link.onClick}
+				target={link.target}
+				rel={link.target === "_blank" ? "noopener noreferrer" : undefined}
+			>
 				{icon}
 				{link.label}
 				{ShareIcon && <ShareIcon />}


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #18573

## Summary
- When a `coder_app` has `open_in = "tab"`, the `useAppLink` hook now returns `target: "_blank"` so the anchor element opens in a new browser tab instead of navigating in the same tab.
- The `AppLink` component passes the `target` and `rel="noopener noreferrer"` attributes through to the rendered `<a>` elements.

## Test plan
- Create a coder_app with `external = true` and `open_in = "tab"`
- Click the app button in the workspace
- Verify it opens in a new browser tab instead of navigating in the same tab
- Verify apps with `open_in = "slim-window"` still open in a popup window
- Verify apps without `open_in` set (defaulting to same-window behavior) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>