### PR TITLE
fix: accept exported JSON format in org role import

### DIFF
--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -173,17 +173,20 @@ func (r *RootCmd) createOrganizationRole(orgContext *OrganizationContext) *serpe
 					return xerrors.Errorf("reading stdin: %w", err)
 				}
 
+				// The exported JSON from 'roles show' is an
+				// array of roles. If the input is an array with
+				// exactly one element, unwrap it.
+				bytes, err = unwrapSingleArrayElement(bytes)
+				if err != nil {
+					return err
+				}
+
 				err = json.Unmarshal(bytes, &customRole)
 				if err != nil {
 					return xerrors.Errorf("parsing stdin json: %w", err)
 				}
 
 				if customRole.Name == "" {
-					arr := make([]json.RawMessage, 0)
-					err = json.Unmarshal(bytes, &arr)
-					if err == nil && len(arr) > 0 {
-						return xerrors.Errorf("the input appears to be an array, only 1 role can be sent at a time")
-					}
 					return xerrors.Errorf("json input does not appear to be a valid role")
 				}
 
@@ -299,17 +302,20 @@ func (r *RootCmd) updateOrganizationRole(orgContext *OrganizationContext) *serpe
 					return xerrors.Errorf("reading stdin: %w", err)
 				}
 
+				// The exported JSON from 'roles show' is an
+				// array of roles. If the input is an array with
+				// exactly one element, unwrap it.
+				bytes, err = unwrapSingleArrayElement(bytes)
+				if err != nil {
+					return err
+				}
+
 				err = json.Unmarshal(bytes, &customRole)
 				if err != nil {
 					return xerrors.Errorf("parsing stdin json: %w", err)
 				}
 
 				if customRole.Name == "" {
-					arr := make([]json.RawMessage, 0)
-					err = json.Unmarshal(bytes, &arr)
-					if err == nil && len(arr) > 0 {
-						return xerrors.Errorf("only 1 role can be sent at a time")
-					}
 					return xerrors.Errorf("json input does not appear to be a valid role")
 				}
 
@@ -518,6 +524,31 @@ func existingRole(newRoleName string, existingRoles []codersdk.AssignableRoles) 
 	}
 
 	return nil
+}
+
+// unwrapSingleArrayElement handles JSON input that may be an array
+// containing a single element. The 'roles show -ojson' command exports
+// roles as an array, but the create/update commands expect a single
+// object. This function unwraps an array of exactly one element so
+// that exported JSON can be re-imported directly.
+func unwrapSingleArrayElement(input []byte) ([]byte, error) {
+	var arr []json.RawMessage
+	// Try to parse as an array first.
+	if err := json.Unmarshal(input, &arr); err != nil {
+		// Not a valid JSON array, return the original input
+		// so it can be parsed as a single object.
+		//nolint:nilnil // Returning nil error with original bytes.
+		return input, nil
+	}
+
+	switch len(arr) {
+	case 0:
+		return nil, xerrors.Errorf("json input array is empty, expected a single role")
+	case 1:
+		return arr[0], nil
+	default:
+		return nil, xerrors.Errorf("json input array has %d elements, only 1 role can be sent at a time", len(arr))
+	}
 }
 
 type roleTableRow struct {

--- a/cli/organizationroles_test.go
+++ b/cli/organizationroles_test.go
@@ -2,6 +2,8 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -12,6 +14,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -47,5 +50,179 @@ func TestShowOrganizationRoles(t *testing.T) {
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), expectedRole)
+	})
+}
+
+
+func TestCreateOrganizationRoleFromExportedJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ArrayInput", func(t *testing.T) {
+		t.Parallel()
+
+		ownerClient, _ := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+		owner := coderdtest.CreateFirstUser(t, ownerClient)
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+
+		// Simulate the JSON array output from 'roles show -ojson'.
+		// This includes extra fields like 'assignable' and 'built_in'
+		// that are present in AssignableRoles but not in Role.
+		exportedRoles := []codersdk.AssignableRoles{
+			{
+				Role: codersdk.Role{
+					Name:           "new-imported-role",
+					OrganizationID: owner.OrganizationID.String(),
+					DisplayName:    "Imported Role",
+					SitePermissions: []codersdk.Permission{},
+					OrganizationPermissions: []codersdk.Permission{
+						{
+							ResourceType: codersdk.ResourceWorkspace,
+							Action:       codersdk.ActionRead,
+						},
+					},
+					UserPermissions: []codersdk.Permission{},
+				},
+				Assignable: true,
+				BuiltIn:    false,
+			},
+		}
+
+		jsonBytes, err := json.Marshal(exportedRoles)
+		require.NoError(t, err)
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		inv, root := clitest.New(t, "organization", "roles", "create", "--stdin")
+		clitest.SetupConfig(t, client, root)
+
+		inv.Stdin = bytes.NewReader(jsonBytes)
+		buf := new(bytes.Buffer)
+		inv.Stdout = buf
+		err = inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "new-imported-role")
+	})
+
+	t.Run("SingleObjectInput", func(t *testing.T) {
+		t.Parallel()
+
+		ownerClient, _ := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+		owner := coderdtest.CreateFirstUser(t, ownerClient)
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+
+		// A single role object (not wrapped in an array) should
+		// still work.
+		role := codersdk.Role{
+			Name:                    "single-object-role",
+			OrganizationID:          owner.OrganizationID.String(),
+			DisplayName:             "Single Object Role",
+			SitePermissions:         []codersdk.Permission{},
+			OrganizationPermissions: []codersdk.Permission{},
+			UserPermissions:         []codersdk.Permission{},
+		}
+
+		jsonBytes, err := json.Marshal(role)
+		require.NoError(t, err)
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		inv, root := clitest.New(t, "organization", "roles", "create", "--stdin")
+		clitest.SetupConfig(t, client, root)
+
+		inv.Stdin = bytes.NewReader(jsonBytes)
+		buf := new(bytes.Buffer)
+		inv.Stdout = buf
+		err = inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "single-object-role")
+	})
+
+	t.Run("MultipleElementArrayRejected", func(t *testing.T) {
+		t.Parallel()
+
+		ownerClient, _ := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+		owner := coderdtest.CreateFirstUser(t, ownerClient)
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+
+		// An array with multiple roles should be rejected.
+		roles := []codersdk.Role{
+			{
+				Name:           "role-one",
+				OrganizationID: owner.OrganizationID.String(),
+			},
+			{
+				Name:           "role-two",
+				OrganizationID: owner.OrganizationID.String(),
+			},
+		}
+
+		jsonBytes, err := json.Marshal(roles)
+		require.NoError(t, err)
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		inv, root := clitest.New(t, "organization", "roles", "create", "--stdin")
+		clitest.SetupConfig(t, client, root)
+
+		inv.Stdin = bytes.NewReader(jsonBytes)
+		buf := new(bytes.Buffer)
+		inv.Stdout = buf
+		err = inv.WithContext(ctx).Run()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fmt.Sprintf("json input array has %d elements", len(roles)))
+	})
+
+	t.Run("ShowThenCreateRoundTrip", func(t *testing.T) {
+		t.Parallel()
+
+		ownerClient, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{})
+		owner := coderdtest.CreateFirstUser(t, ownerClient)
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
+
+		// Create a role in the database to export.
+		dbgen.CustomRole(t, db, database.CustomRole{
+			Name:            "export-me",
+			DisplayName:     "Export Me",
+			SitePermissions: nil,
+			OrgPermissions:  nil,
+			UserPermissions: nil,
+			OrganizationID: uuid.NullUUID{
+				UUID:  owner.OrganizationID,
+				Valid: true,
+			},
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		// Export using 'show -ojson'.
+		showInv, showRoot := clitest.New(t, "organization", "roles", "show", "export-me", "-ojson")
+		clitest.SetupConfig(t, client, showRoot)
+		showBuf := new(bytes.Buffer)
+		showInv.Stdout = showBuf
+		err := showInv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		exportedJSON := showBuf.Bytes()
+		require.NotEmpty(t, exportedJSON)
+
+		// Modify the name so we can import as a new role.
+		var exported []json.RawMessage
+		err = json.Unmarshal(exportedJSON, &exported)
+		require.NoError(t, err)
+		require.Len(t, exported, 1)
+
+		var roleMap map[string]any
+		err = json.Unmarshal(exported[0], &roleMap)
+		require.NoError(t, err)
+		roleMap["name"] = "imported-from-export"
+		modifiedJSON, err := json.Marshal([]any{roleMap})
+		require.NoError(t, err)
+
+		// Import the modified JSON via 'create --stdin'.
+		createInv, createRoot := clitest.New(t, "organization", "roles", "create", "--stdin")
+		clitest.SetupConfig(t, client, createRoot)
+		createInv.Stdin = bytes.NewReader(modifiedJSON)
+		createBuf := new(bytes.Buffer)
+		createInv.Stdout = createBuf
+		err = createInv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Contains(t, createBuf.String(), "imported-from-export")
 	})
 }


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #21350

## Summary
- The `roles show -ojson` command exports roles as a JSON array of `AssignableRoles` objects (which include extra fields like `assignable` and `built_in`), but the `create --stdin` and `update --stdin` commands expected a single `Role` object. Importing the exported JSON failed because `json.Unmarshal` of an array into a struct produces an empty struct with no `Name`.
- Added `unwrapSingleArrayElement` helper that transparently unwraps single-element JSON arrays before unmarshaling, applied to both `create` and `update` handlers. Arrays with 0 or 2+ elements produce clear error messages. Single object input continues to work unchanged. Extra fields (`assignable`, `built_in`) are silently ignored by Go's JSON decoder.

## Test plan
- Export a custom org role: `coder organizations roles show <role> -ojson`
- Modify the exported JSON (change name)
- Import it: `coder organizations roles create --stdin < file.json`
- Verify import succeeds
- Added tests for: array input, single object input, multi-element array rejection, and full show-then-create roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>