### PR TITLE
fix: reserve route-conflicting usernames

### DIFF
--- a/codersdk/name.go
+++ b/codersdk/name.go
@@ -16,6 +16,23 @@ var (
 
 	templateVersionName = regexp.MustCompile(`^[a-zA-Z0-9]+(?:[_.-]{1}[a-zA-Z0-9]+)*$`)
 	templateDisplayName = regexp.MustCompile(`^[^\s](.*[^\s])?$`)
+
+	// reservedUsernames contains names that conflict with API routes
+	// under /api/v2/users/. Using these as usernames would cause
+	// routing ambiguity with endpoints like /users/roles,
+	// /users/authmethods, etc.
+	reservedUsernames = map[string]bool{
+		"me":                true,
+		"first":             true,
+		"roles":             true,
+		"authmethods":       true,
+		"login":             true,
+		"logout":            true,
+		"otp":               true,
+		"oauth2":            true,
+		"oidc":              true,
+		"validate-password": true,
+	}
 )
 
 // UsernameFrom returns a best-effort username from the provided string.
@@ -50,6 +67,10 @@ func NameValid(str string) error {
 	}
 	// Avoid conflicts with routes like /templates/new and /groups/create.
 	if str == "new" || str == "create" {
+		return xerrors.Errorf("cannot use %q as a name", str)
+	}
+	// Avoid conflicts with API routes under /api/v2/users/.
+	if reservedUsernames[str] {
 		return xerrors.Errorf("cannot use %q as a name", str)
 	}
 	matched := UsernameValidRegex.MatchString(str)

--- a/codersdk/name_test.go
+++ b/codersdk/name_test.go
@@ -35,6 +35,19 @@ func TestUsernameValid(t *testing.T) {
 		{"abcdefghijklmnopqrstu", true},
 		{"wow-test", true},
 
+		// Reserved usernames that conflict with API routes
+		// under /api/v2/users/.
+		{"me", false},
+		{"first", false},
+		{"roles", false},
+		{"authmethods", false},
+		{"login", false},
+		{"logout", false},
+		{"otp", false},
+		{"oauth2", false},
+		{"oidc", false},
+		{"validate-password", false},
+
 		{"", false},
 		{" ", false},
 		{" a", false},
@@ -184,6 +197,12 @@ func TestFrom(t *testing.T) {
 		{"kyle+testing", "kyletesting"},
 		{"kyle-testing", "kyle-testing"},
 		{"much.”more unusual”@example.com", "muchmoreunusual"},
+
+		// Reserved usernames produce a random name.
+		{"roles", ""},
+		{"me", ""},
+		{"first", ""},
+		{"authmethods", ""},
 
 		// Cases where an invalid string is provided, and the result is a random name.
 		{"123456789012345678901234567890123", ""},


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #19389

Adds reserved username validation to `NameValid()` for names that
conflict with API routes under `/api/v2/users/`. Creating users with
names like "roles", "authmethods", or "first" caused routing ambiguity
because these match sibling endpoints of `/users/{user}`.

The full set of reserved names covers all route segments registered as
siblings of `/{user}` in the users router: `me`, `first`, `roles`,
`authmethods`, `login`, `logout`, `otp`, `oauth2`, `oidc`, and
`validate-password`.

Extends the approach from PR #22754 (which addressed `me`) to cover
the remaining conflicting routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>