### PR TITLE
fix: stop MCP task spinner when workspace is stopped

### DIFF
--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -55,6 +55,9 @@ export const AppStatuses: FC<AppStatusesProps> = ({
 	const comparisonDate = referenceDate ?? new Date();
 	const latestStatus = allStatuses[0];
 	const otherStatuses = allStatuses.slice(1);
+	// When the workspace is not running, disable the animated spinner
+	// so the last reported status is shown as a static indicator.
+	const isWorkspaceStopped = workspace.latest_build.status !== "running";
 
 	return (
 		<div className="flex flex-col border border-solid border-border rounded-lg">
@@ -66,7 +69,11 @@ export const AppStatuses: FC<AppStatusesProps> = ({
 			>
 				<div className="flex flex-col overflow-hidden">
 					<div className="text-sm font-medium text-content-primary flex items-center gap-2 ">
-						<AppStatusStateIcon state={latestStatus.state} latest />
+						<AppStatusStateIcon
+							state={latestStatus.state}
+							latest
+							disabled={isWorkspaceStopped}
+						/>
 						<span className="block flex-1 whitespace-nowrap overflow-hidden text-ellipsis">
 							{latestStatus.message || capitalize(latestStatus.state)}
 						</span>


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #17928

## Summary
- When a workspace is stopped mid-task, the `AppStatuses` component on the workspace detail page continued to show an animated spinner for the latest "working" status because `AppStatusStateIcon` was called without the `disabled` prop.
- Pass `disabled={true}` to `AppStatusStateIcon` when `workspace.latest_build.status` is not `"running"`, so the spinner is replaced by a static indicator showing the last known task status.

## Test plan
- Start a workspace with an agent reporting tasks via MCP
- Stop the workspace mid-task
- Verify the task spinner stops and shows static last status
- Verify the spinner still animates normally when the workspace is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>