### PR TITLE
fix: respect start_blocks_login in SSH auto wait mode

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -292,12 +292,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 			case "no":
 				wait = false
 			case "auto":
-				for _, script := range workspaceAgent.Scripts {
-					if script.StartBlocksLogin {
-						wait = true
-						break
-					}
-				}
+				wait = anyStartupScriptBlocksLogin(workspaceAgent.Scripts)
 			default:
 				return xerrors.Errorf("unknown wait value %q", waitEnum)
 			}
@@ -993,6 +988,19 @@ func GetWorkspaceAndAgent(ctx context.Context, inv *serpent.Invocation, client *
 	}
 
 	return workspace, workspaceAgent, otherWorkspaceAgents, nil
+}
+
+// anyStartupScriptBlocksLogin returns true if any of the given scripts
+// are configured to block login on start (i.e., RunOnStart is true and
+// StartBlocksLogin is true). This is used to determine the wait behavior
+// when --wait=auto.
+func anyStartupScriptBlocksLogin(scripts []codersdk.WorkspaceAgentScript) bool {
+	for _, script := range scripts {
+		if script.RunOnStart && script.StartBlocksLogin {
+			return true
+		}
+	}
+	return false
 }
 
 func getWorkspaceAgent(workspace codersdk.Workspace, agentName string) (workspaceAgent codersdk.WorkspaceAgent, otherAgents []codersdk.WorkspaceAgent, err error) {

--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -352,6 +352,71 @@ func newAsyncCloser(ctx context.Context, t *testing.T) *asyncCloser {
 	}
 }
 
+func TestAnyStartupScriptBlocksLogin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoScripts", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, anyStartupScriptBlocksLogin(nil))
+		assert.False(t, anyStartupScriptBlocksLogin([]codersdk.WorkspaceAgentScript{}))
+	})
+
+	t.Run("StartBlocksLoginTrue_RunOnStartTrue", func(t *testing.T) {
+		t.Parallel()
+		scripts := []codersdk.WorkspaceAgentScript{
+			{RunOnStart: true, StartBlocksLogin: true},
+		}
+		assert.True(t, anyStartupScriptBlocksLogin(scripts))
+	})
+
+	t.Run("StartBlocksLoginFalse_RunOnStartTrue", func(t *testing.T) {
+		t.Parallel()
+		scripts := []codersdk.WorkspaceAgentScript{
+			{RunOnStart: true, StartBlocksLogin: false},
+		}
+		assert.False(t, anyStartupScriptBlocksLogin(scripts))
+	})
+
+	t.Run("StartBlocksLoginTrue_RunOnStartFalse", func(t *testing.T) {
+		t.Parallel()
+		// A script that doesn't run on start should not block login,
+		// even if start_blocks_login is set (e.g. a cron-only script).
+		scripts := []codersdk.WorkspaceAgentScript{
+			{RunOnStart: false, StartBlocksLogin: true},
+		}
+		assert.False(t, anyStartupScriptBlocksLogin(scripts))
+	})
+
+	t.Run("MixedScripts_OneBlocks", func(t *testing.T) {
+		t.Parallel()
+		scripts := []codersdk.WorkspaceAgentScript{
+			{RunOnStart: true, StartBlocksLogin: false},
+			{RunOnStart: true, StartBlocksLogin: true},
+			{RunOnStart: false, StartBlocksLogin: false},
+		}
+		assert.True(t, anyStartupScriptBlocksLogin(scripts))
+	})
+
+	t.Run("MixedScripts_NoneBlock", func(t *testing.T) {
+		t.Parallel()
+		scripts := []codersdk.WorkspaceAgentScript{
+			{RunOnStart: true, StartBlocksLogin: false},
+			{RunOnStart: false, StartBlocksLogin: true},
+			{RunOnStart: false, StartBlocksLogin: false},
+		}
+		assert.False(t, anyStartupScriptBlocksLogin(scripts))
+	})
+
+	t.Run("AllBlockLogin", func(t *testing.T) {
+		t.Parallel()
+		scripts := []codersdk.WorkspaceAgentScript{
+			{RunOnStart: true, StartBlocksLogin: true},
+			{RunOnStart: true, StartBlocksLogin: true},
+		}
+		assert.True(t, anyStartupScriptBlocksLogin(scripts))
+	})
+}
+
 func Test_getWorkspaceAgent(t *testing.T) {
 	t.Parallel()
 

--- a/cli/vscodessh.go
+++ b/cli/vscodessh.go
@@ -115,12 +115,7 @@ func (r *RootCmd) vscodeSSH() *serpent.Command {
 			case "no":
 				wait = false
 			case "auto":
-				for _, script := range workspaceAgent.Scripts {
-					if script.StartBlocksLogin {
-						wait = true
-						break
-					}
-				}
+				wait = anyStartupScriptBlocksLogin(workspaceAgent.Scripts)
 			default:
 				return xerrors.Errorf("unknown wait value %q", waitEnum)
 			}


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

## Summary
- When using `coder ssh` with `--wait=auto` (the default), the auto wait resolution now correctly checks both `run_on_start` and `start_blocks_login` on agent scripts
- Only block login when at least one script has both `run_on_start = true` AND `start_blocks_login = true`
- Previously, the check only looked at `start_blocks_login` without verifying `run_on_start`, which could cause incorrect blocking behavior for non-startup scripts (e.g., cron-only scripts)
- Extracted the logic into a shared `anyStartupScriptBlocksLogin` helper used by both `ssh.go` and `vscodessh.go`

Fixes #22745

## Changes
- `cli/ssh.go`: Replaced inline loop with `anyStartupScriptBlocksLogin()` helper that checks both `RunOnStart` and `StartBlocksLogin`
- `cli/vscodessh.go`: Same replacement for consistency
- `cli/ssh_internal_test.go`: Added comprehensive unit tests covering all combinations of `RunOnStart` and `StartBlocksLogin`

## Test plan
- [x] Unit tests for `anyStartupScriptBlocksLogin` covering: no scripts, blocking scripts, non-blocking scripts, mixed scripts, cron-only scripts with `start_blocks_login`
- [ ] `coder ssh` with `start_blocks_login = false` connects immediately
- [ ] `coder ssh` with `start_blocks_login = true` still waits for scripts
- [ ] `--wait=yes` and `--wait=no` still override the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)