### PR TITLE
fix: allow coderd to start with empty DERP map when built-in server is disabled

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -599,13 +599,22 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				defaultRegion = nil
 			}
 
-			derpMap, err := tailnet.NewDERPMap(
-				ctx, defaultRegion, vals.DERP.Server.STUNAddresses,
-				vals.DERP.Config.URL.String(), vals.DERP.Config.Path.String(),
-				vals.DERP.Config.BlockDirect.Value(),
-			)
-			if err != nil {
-				return xerrors.Errorf("create derp map: %w", err)
+			var derpMap *tailcfg.DERPMap
+			if !vals.DERP.Server.Enable && vals.DERP.Config.URL.String() == "" && vals.DERP.Config.Path.String() == "" {
+				logger.Warn(ctx, "built-in DERP server is disabled and no DERP map is configured; networking will not work until workspace proxies are connected")
+				derpMap = &tailcfg.DERPMap{
+					Regions: map[int]*tailcfg.DERPRegion{},
+				}
+			} else {
+				var err error
+				derpMap, err = tailnet.NewDERPMap(
+					ctx, defaultRegion, vals.DERP.Server.STUNAddresses,
+					vals.DERP.Config.URL.String(), vals.DERP.Config.Path.String(),
+					vals.DERP.Config.BlockDirect.Value(),
+				)
+				if err != nil {
+					return xerrors.Errorf("create derp map: %w", err)
+				}
 			}
 
 			appHostname := vals.WildcardAccessURL.String()


### PR DESCRIPTION
> **AI Disclosure:** This PR was authored by Claude (AI), operating as [maxwellcalkin](https://github.com/maxwellcalkin). The code has been reviewed and tested. See the [AI career project](https://github.com/maxwellcalkin) for context on this transparent AI contribution experiment.

Fixes #22324
Related: #22317

## Problem

When starting coderd with `--derp-server-enable=false` and no DERP config URL or path set, coderd fails with:

```
error: create derp map: DERP map has no regions. A valid DERP map is required for networking to work.
You must either supply your own DERP map or use the built-in DERP server
```

This is a valid configuration for enterprise customers who disable the built-in DERP server and use workspace proxies instead. The workspace proxies connect later and update the DERP map with their regions.

## Solution

Before calling `tailnet.NewDERPMap()`, check if:
1. The built-in DERP server is disabled (`--derp-server-enable=false`)
2. No DERP config URL is set (`--derp-config-url=""`)
3. No DERP config path is set (`--derp-config-path=""`)

When all three conditions are met, skip the `NewDERPMap()` call (which would fail with the "no regions" error) and instead create an empty DERP map with a warning log. The DERP map will be populated later when workspace proxies register.

When the DERP server is disabled but a config URL or path _is_ provided, the existing behavior is preserved — `NewDERPMap()` will still be called and will validate that the provided config has valid regions.

## Changes

- `cli/server.go`: Add conditional check before `NewDERPMap()` call. When the built-in DERP server is disabled and no external DERP config is provided, initialize an empty `DERPMap` with a warning instead of returning a fatal error.

---

> 🤖 Generated with [Claude Code](https://claude.ai/code)
>
> Co-Authored-By: Claude <noreply@anthropic.com>