### PR TITLE
fix(site): use declarative title elements in AgentsPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -904,15 +904,11 @@ const AgentDetail: FC = () => {
 
 	const chatTitle = chatQuery.data?.chat?.title;
 
-	// Update the browser tab title when navigating to / between agents.
-	useEffect(() => {
-		document.title = chatTitle
-			? pageTitle(chatTitle, "Agents")
-			: pageTitle("Agents");
-		return () => {
-			document.title = pageTitle("Agents");
-		};
-	}, [chatTitle]);
+	const titleElement = (
+		<title>
+			{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
+		</title>
+	);
 
 	const parentChatID = getParentChatID(chatQuery.data?.chat);
 	const parentChat = parentChatID
@@ -1004,6 +1000,7 @@ const AgentDetail: FC = () => {
 	if (chatQuery.isLoading) {
 		return (
 			<div className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col">
+				{titleElement}
 				<AgentDetailTopBar
 					diff={{
 						hasDiffStatus: false,
@@ -1082,6 +1079,7 @@ const AgentDetail: FC = () => {
 	if (!chatQuery.data || !agentId) {
 		return (
 			<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+				{titleElement}
 				<AgentDetailTopBar
 					diff={{
 						hasDiffStatus: false,
@@ -1122,6 +1120,7 @@ const AgentDetail: FC = () => {
 				shouldShowSidebar && !visualExpanded && "flex-row",
 			)}
 		>
+			{titleElement}
 			<div
 				className={cn(
 					"relative flex min-h-0 min-w-0 flex-1 flex-col",

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -562,16 +562,13 @@ const AgentsPage: FC = () => {
 		};
 	}, [queryClient]);
 
-	useEffect(() => {
-		document.title = pageTitle("Agents");
-	}, []);
-
 	useAgentsPageKeybindings({
 		onNewAgent: handleNewAgent,
 	});
 
 	return (
 		<div className="flex h-full min-h-0 flex-col overflow-hidden bg-surface-primary md:flex-row">
+			<title>{pageTitle("Agents")}</title>
 			<div
 				className={cn(
 					"md:h-full md:w-[320px] md:min-h-0 md:border-b-0",


### PR DESCRIPTION
Replaces imperative `document.title = pageTitle(...)` calls with declarative React 19 `<title>` JSX elements in the AgentsPage feature, matching the pattern used by all other pages in the codebase.

## Changes
- `AgentsPage.tsx`: Removed `useEffect` that set `document.title`, added `<title>{pageTitle("Agents")}</title>` in JSX.
- `AgentDetail.tsx`: Removed `useEffect` with title set/cleanup, added dynamic `<title>` element that updates based on chat title.

React 19's `<title>` automatically manages `document.title` including cleanup on unmount.