### PR TITLE
refactor(site): use query factory for archiveChat mutation

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -185,7 +185,7 @@ const AgentsPage: FC = () => {
 			chatId: string;
 			workspaceId: string;
 		}) => {
-			await API.archiveChat(chatId);
+			await archiveChatBase.mutationFn(chatId);
 			await API.deleteWorkspace(workspaceId);
 			return { chatId, workspaceId };
 		},


### PR DESCRIPTION
Replaces the direct `API.archiveChat(chatId)` call in `AgentsPage.tsx` with `archiveChatBase.mutationFn(chatId)` from the existing query factory, keeping the data access layer consistent.

## Change
1 file, 1 line — `site/src/pages/AgentsPage/AgentsPage.tsx`

The `archiveChatBase` variable was already defined from `archiveChat(queryClient)` (the query factory). The `archiveAndDeleteMutation` was the only place still bypassing it to call `API.archiveChat` directly.