### PR TITLE
refactor(site): standardize AgentsPage props to use interface

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -742,7 +742,7 @@ const StickyUserMessage: FC<{
 	);
 };
 
-type ConversationTimelineProps = {
+interface ConversationTimelineProps {
 	isEmpty: boolean;
 	hasMoreMessages: boolean;
 	loadMoreSentinelRef: RefObject<HTMLDivElement | null>;
@@ -762,7 +762,7 @@ type ConversationTimelineProps = {
 	) => void;
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
-};
+}
 
 export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 	isEmpty,

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -47,7 +47,7 @@ interface WorkspaceActions {
 	sshCommand: string | undefined;
 }
 
-type AgentDetailTopBarProps = {
+interface AgentDetailTopBarProps {
 	chatTitle?: string;
 	parentChat?: TypesGen.Chat;
 	onOpenParentChat: (chatId: string) => void;
@@ -60,7 +60,7 @@ type AgentDetailTopBarProps = {
 	isArchived?: boolean;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
-};
+}
 
 export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 	chatTitle,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
@@ -199,11 +199,11 @@ const useProviderStates = (
 
 // ── Component ──────────────────────────────────────────────────
 
-type ChatModelAdminPanelProps = {
+interface ChatModelAdminPanelProps {
 	className?: string;
 	section?: ChatModelAdminSection;
 	sectionLabel?: string;
-};
+}
 
 export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 	className,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -314,12 +314,12 @@ const SchemaField: FC<SchemaFieldProps> = ({
 
 // ── Main component ─────────────────────────────────────────────
 
-type ModelConfigFieldsProps = {
+interface ModelConfigFieldsProps {
 	provider: string;
 	form: FormikContextType<ModelFormValues>;
 	fieldErrors: ModelConfigFormBuildResult["fieldErrors"];
 	disabled: boolean;
-};
+}
 
 /**
  * Provider-specific fields (reasoning, tool calls, etc.) that

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -55,7 +55,7 @@ const validationSchema = Yup.object({
 
 // ── Component ──────────────────────────────────────────────────
 
-type ModelFormProps = {
+interface ModelFormProps {
 	/** When set, the form is in "edit" mode for the given model. */
 	editingModel?: TypesGen.ChatModelConfig;
 	providerStates: readonly ProviderState[];
@@ -74,7 +74,7 @@ type ModelFormProps = {
 	) => Promise<unknown>;
 	onCancel: () => void;
 	onDeleteModel?: (modelConfigId: string) => Promise<void>;
-};
+}
 
 export const ModelForm: FC<ModelFormProps> = ({
 	editingModel,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -30,7 +30,7 @@ type ModelView =
 	| { mode: "add"; provider: string }
 	| { mode: "edit"; model: TypesGen.ChatModelConfig };
 
-type ModelsSectionProps = {
+interface ModelsSectionProps {
 	sectionLabel?: string;
 	providerStates: readonly ProviderState[];
 	selectedProvider: string | null;
@@ -49,7 +49,7 @@ type ModelsSectionProps = {
 		req: TypesGen.UpdateChatModelConfigRequest,
 	) => Promise<unknown>;
 	onDeleteModel: (modelConfigId: string) => Promise<void>;
-};
+}
 
 export const ModelsSection: FC<ModelsSectionProps> = ({
 	sectionLabel,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
@@ -19,7 +19,7 @@ import { ProviderIcon } from "./ProviderIcon";
 // we know nothing changed.
 const API_KEY_PLACEHOLDER = "••••••••••••••••";
 
-type ProviderFormProps = {
+interface ProviderFormProps {
 	providerState: ProviderState;
 	providerConfigsUnavailable: boolean;
 	isProviderMutationPending: boolean;
@@ -32,7 +32,7 @@ type ProviderFormProps = {
 	) => Promise<unknown>;
 	onDeleteProvider: (providerConfigId: string) => Promise<void>;
 	onBack: () => void;
-};
+}
 
 export const ProviderForm: FC<ProviderFormProps> = ({
 	providerState,
@@ -314,13 +314,13 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 
 // ── Field wrapper ──────────────────────────────────────────────
 
-type ProviderFieldProps = {
+interface ProviderFieldProps {
 	label: string;
 	htmlFor: string;
 	required?: boolean;
 	description?: string;
 	children: React.ReactNode;
-};
+}
 
 const ProviderField: FC<ProviderFieldProps> = ({
 	label,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx
@@ -14,10 +14,10 @@ const providerIconMap: Record<string, string> = {
 	gemini: "/icon/gemini.svg",
 };
 
-type ProviderIconProps = {
+interface ProviderIconProps {
 	provider: string;
 	className?: string;
-};
+}
 
 export const ProviderIcon: FC<ProviderIconProps> = ({
 	provider,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
@@ -9,7 +9,7 @@ import { ProviderIcon } from "./ProviderIcon";
 
 type ProviderView = { mode: "list" } | { mode: "detail"; provider: string };
 
-type ProvidersSectionProps = {
+interface ProvidersSectionProps {
 	sectionLabel?: string;
 	providerStates: readonly ProviderState[];
 	providerConfigsUnavailable: boolean;
@@ -23,7 +23,7 @@ type ProvidersSectionProps = {
 	) => Promise<unknown>;
 	onDeleteProvider: (providerConfigId: string) => Promise<void>;
 	onSelectedProviderChange: (provider: string) => void;
-};
+}
 
 export const ProvidersSection: FC<ProvidersSectionProps> = ({
 	sectionLabel,

--- a/site/src/pages/AgentsPage/SectionHeader.tsx
+++ b/site/src/pages/AgentsPage/SectionHeader.tsx
@@ -1,10 +1,10 @@
 import type { FC, ReactNode } from "react";
 
-type SectionHeaderProps = {
+interface SectionHeaderProps {
 	label: string;
 	description?: string;
 	action?: ReactNode;
-};
+}
 
 export const SectionHeader: FC<SectionHeaderProps> = ({
 	label,


### PR DESCRIPTION
Standardizes all component props definitions in the AgentsPage feature to use `interface` instead of `type`, matching the convention in the top-level AgentsPage files.

## Changes
11 `type XProps = {` → `interface XProps {` conversions across 10 files:
- `AgentDetail/ConversationTimeline.tsx`
- `AgentDetail/TopBar.tsx`
- `ChatModelAdminPanel/ChatModelAdminPanel.tsx`
- `ChatModelAdminPanel/ModelsSection.tsx`
- `ChatModelAdminPanel/ProviderForm.tsx` (2 props types)
- `ChatModelAdminPanel/ModelConfigFields.tsx`
- `ChatModelAdminPanel/ProviderIcon.tsx`
- `ChatModelAdminPanel/ModelForm.tsx`
- `ChatModelAdminPanel/ProvidersSection.tsx`
- `SectionHeader.tsx`

Non-Props type aliases were left untouched.