### PR TITLE
refactor(site): replace double-negation with Boolean() in AgentsPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -421,11 +421,13 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 
 		// Track whether the editor has content so we can gate the
 		// send button without a controlled value prop.
-		const [hasContent, setHasContent] = useState(() => !!initialValue?.trim());
+		const [hasContent, setHasContent] = useState(() =>
+			Boolean(initialValue?.trim()),
+		);
 
 		const handleContentChange = useCallback(
 			(content: string) => {
-				setHasContent(!!content.trim());
+				setHasContent(Boolean(content.trim()));
 				onContentChange?.(content);
 			},
 			[onContentChange],

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelConfigFields.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelConfigFields.tsx
@@ -111,7 +111,7 @@ const InputField: FC<
 				placeholder={placeholder}
 				{...fieldProps}
 				disabled={disabled}
-				aria-invalid={!!fieldError}
+				aria-invalid={Boolean(fieldError)}
 				aria-describedby={fieldError ? errorId : undefined}
 			/>
 			{fieldError && (
@@ -171,7 +171,7 @@ const SelectField: FC<
 						"h-9 min-w-0 text-[13px]",
 						fieldError && "border-content-destructive",
 					)}
-					aria-invalid={!!fieldError}
+					aria-invalid={Boolean(fieldError)}
 					aria-describedby={fieldError ? errorId : undefined}
 				>
 					<SelectValue placeholder="Unset" />
@@ -235,7 +235,7 @@ const JSONField: FC<
 				placeholder={placeholder}
 				{...fieldProps}
 				disabled={disabled}
-				aria-invalid={!!fieldError}
+				aria-invalid={Boolean(fieldError)}
 				aria-describedby={fieldError ? errorId : undefined}
 			/>
 			{fieldError && (


### PR DESCRIPTION
Replaces 5 instances of `!!` double-negation with explicit `Boolean()` calls, per project convention.

## Changes (2 files)
- **ModelConfigFields.tsx** — 3× `!!fieldError` → `Boolean(fieldError)` in `aria-invalid` props
- **AgentChatInput.tsx** — 2× `!!value` → `Boolean(value)` in content-presence checks