### PR TITLE
refactor(site): add readonly to array props in AgentsPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -91,7 +91,7 @@ interface AgentChatInputProps {
 	// Pass `null` to render fallback values (e.g. when limit is unknown).
 	// Omit entirely to hide the indicator.
 	contextUsage?: AgentContextUsage | null;
-	attachments?: File[];
+	attachments?: readonly File[];
 	onAttach?: (files: File[]) => void;
 	onRemoveAttachment?: (index: number) => void;
 	uploadStates?: Map<File, UploadState>;
@@ -240,7 +240,7 @@ ImageThumbnail.displayName = "ImageThumbnail";
 
 /** Renders a horizontal strip of attachment thumbnails above the input. */
 export const AttachmentPreview = memo<{
-	attachments: File[];
+	attachments: readonly File[];
 	onRemove: (index: number) => void;
 	uploadStates?: Map<File, UploadState>;
 	previewUrls?: Map<File, string>;

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -108,7 +108,7 @@ interface AgentDetailTimelineProps {
 	onEditUserMessage?: (
 		messageId: number,
 		text: string,
-		fileBlocks?: Array<{ mediaType: string; data?: string }>,
+		fileBlocks?: readonly { mediaType: string; data?: string }[],
 	) => void;
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
@@ -222,11 +222,11 @@ interface AgentDetailInputProps {
 	onCancelHistoryEdit: () => void;
 	// File blocks from the message being edited, converted to
 	// File objects and pre-populated into attachments.
-	editingFileBlocks?: Array<{
+	editingFileBlocks?: readonly {
 		mediaType: string;
 		data?: string;
 		fileId?: string;
-	}>;
+	}[];
 }
 
 const AgentDetailInput: FC<AgentDetailInputProps> = ({
@@ -430,14 +430,18 @@ export function useConversationEditingState(deps: {
 		string | null
 	>(null);
 	const [editingFileBlocks, setEditingFileBlocks] = useState<
-		Array<{ mediaType: string; data?: string; fileId?: string }>
+		readonly { mediaType: string; data?: string; fileId?: string }[]
 	>([]);
 
 	const handleEditUserMessage = useCallback(
 		(
 			messageId: number,
 			text: string,
-			fileBlocks?: Array<{ mediaType: string; data?: string; fileId?: string }>,
+			fileBlocks?: readonly {
+				mediaType: string;
+				data?: string;
+				fileId?: string;
+			}[],
 		) => {
 			setDraftBeforeHistoryEdit((prev) =>
 				editingMessageId !== null ? prev : inputValueRef.current,

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -30,7 +30,7 @@ interface DiffViewerProps {
 	/** Fragment to display in the top-left of the header bar. */
 	headerLeft?: ReactNode;
 	/** Parsed file diffs to render. */
-	parsedFiles: FileDiffMetadata[];
+	parsedFiles: readonly FileDiffMetadata[];
 	/** Cache key prefix for parsePatchFiles worker pool LRU cache. */
 	cacheKeyPrefix?: string;
 	/** Whether the panel is in expanded mode (affects file tree threshold). */
@@ -165,7 +165,7 @@ interface FileTreeNode {
  * Single-child directory chains are collapsed so that e.g.
  * `src/pages/AgentsPage` renders as one row.
  */
-function buildFileTree(files: FileDiffMetadata[]): FileTreeNode[] {
+function buildFileTree(files: readonly FileDiffMetadata[]): FileTreeNode[] {
 	const root: FileTreeNode[] = [];
 
 	for (const file of files) {


### PR DESCRIPTION
Adds missing `readonly` modifiers to 4 array props in the AgentsPage feature, plus 3 cascading fixes at call sites.

## Changes (3 files)
- **AgentDetail.tsx** — `fileBlocks` and `editingFileBlocks` props + state generic
- **AgentChatInput.tsx** — `attachments` prop + downstream `AttachmentPreview` prop
- **DiffViewer.tsx** — `parsedFiles` prop + `buildFileTree` parameter