### PR TITLE
fix(site): add missing aria-labels to AgentsPage icon buttons

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -207,6 +207,7 @@ function renderBlockList({
 							<button
 								key={`${keyPrefix}-file-${index}`}
 								type="button"
+								aria-label="View image"
 								className="inline-block rounded-md border-0 bg-transparent p-0"
 								onClick={(e) => {
 									e.stopPropagation();
@@ -347,6 +348,7 @@ const ChatMessageItem = memo<{
 													<button
 														key={`user-file-${i}`}
 														type="button"
+														aria-label="View image"
 														className="inline-block rounded-md border-0 bg-transparent p-0"
 														onClick={(e) => {
 															e.stopPropagation();

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -199,6 +199,11 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 											handleSetDefault(modelConfig);
 										}}
 										aria-disabled={isUpdating || modelConfig.is_default}
+										aria-label={
+											modelConfig.is_default
+												? "Default model"
+												: "Set as default model"
+										}
 										className={cn(
 											"flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-transparent border-0 p-0 transition-colors",
 											modelConfig.is_default

--- a/site/src/pages/AgentsPage/ChimeButton.tsx
+++ b/site/src/pages/AgentsPage/ChimeButton.tsx
@@ -24,6 +24,9 @@ export const ChimeButton: FC = () => {
 					variant="subtle"
 					size="icon"
 					onClick={handleClick}
+					aria-label={
+						enabled ? "Mute completion chime" : "Enable completion chime"
+					}
 					className="h-7 w-7 text-content-secondary hover:text-content-primary"
 				>
 					{enabled ? (

--- a/site/src/pages/AgentsPage/DiffStats.tsx
+++ b/site/src/pages/AgentsPage/DiffStats.tsx
@@ -78,6 +78,7 @@ export const DiffStatsInline: FC<{
 		<button
 			type="button"
 			onClick={onClick}
+			aria-label="View diff statistics"
 			className="inline-flex shrink-0 cursor-pointer items-center border-0 bg-transparent p-0 leading-none transition-opacity hover:opacity-80 outline-none"
 		>
 			<DiffStatNumbers additions={additions} deletions={deletions} />

--- a/site/src/pages/AgentsPage/WebPushButton.tsx
+++ b/site/src/pages/AgentsPage/WebPushButton.tsx
@@ -43,6 +43,11 @@ export const WebPushButton: FC = () => {
 					size="icon"
 					disabled={webPush.loading}
 					onClick={handleClick}
+					aria-label={
+						webPush.subscribed
+							? "Disable notifications"
+							: "Enable notifications"
+					}
 					className="h-7 w-7 text-content-secondary hover:text-content-primary"
 				>
 					{webPush.loading ? (


### PR DESCRIPTION
Adds `aria-label` attributes to 6 icon-only buttons in the AgentsPage feature that were missing accessible names.

## Changes (5 files)
- **ChimeButton.tsx** — `aria-label={enabled ? "Mute completion chime" : "Enable completion chime"}`
- **WebPushButton.tsx** — `aria-label={subscribed ? "Disable notifications" : "Enable notifications"}`
- **ModelsSection.tsx** — `aria-label={is_default ? "Default model" : "Set as default model"}`
- **ConversationTimeline.tsx** (×2) — `aria-label="View image"` on image lightbox triggers
- **DiffStats.tsx** — `aria-label="View diff statistics"` on clickable diff badge