### PR TITLE
fix(scripts/githooks): add hooksPath self-protection to pre-commit and pre-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,21 +105,36 @@ app, err := api.Database.GetOAuth2ProviderAppByClientID(ctx, clientID)
 
 ### Full workflows available in imported WORKFLOWS.md
 
-### Git Hooks (MANDATORY)
+### Git Hooks (MANDATORY - DO NOT SKIP)
 
-Before your first commit, ensure the git hooks are installed.
-Two hooks run automatically:
+**You MUST install and use the git hooks. NEVER bypass them with
+`--no-verify`. Skipping hooks wastes CI cycles and is unacceptable.**
 
-- **pre-commit**: `make pre-commit` (gen, fmt, lint, typos, build).
-  Fast checks that catch most CI failures.
-- **pre-push**: `make pre-push` (full CI suite including tests).
-  Runs before pushing to catch everything CI would.
-
-Wait for them to complete, do not skip or bypass them.
+The first run will be slow as caches warm up. Consecutive runs are
+**significantly faster** (often 10x) thanks to Go build cache,
+generated file timestamps, and warm node_modules. This is NOT a
+reason to skip them. Wait for hooks to complete before proceeding,
+no matter how long they take.
 
 ```sh
 git config core.hooksPath scripts/githooks
 ```
+
+Two hooks run automatically:
+
+- **pre-commit**: `make pre-commit` (gen, fmt, lint, typos, build).
+  Fast checks that catch most CI failures. Allow at least 5 minutes.
+- **pre-push**: `make pre-push` (full CI suite including tests).
+  Runs before pushing to catch everything CI would. Allow at least
+  15 minutes (race tests are slow without cache).
+
+`git commit` and `git push` will appear to hang while hooks run.
+This is normal. Do not interrupt, retry, or reduce the timeout.
+
+NEVER run `git config core.hooksPath` to change or disable hooks.
+
+If a hook fails, fix the issue and retry. Do not work around the
+failure by skipping the hook.
 
 ### Git Workflow
 

--- a/scripts/githooks/post-checkout
+++ b/scripts/githooks/post-checkout
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Shield this worktree against shared config hooksPath poisoning.
+# Worktree-scoped config overrides the shared .git/config, so even if
+# another worktree runs `git config core.hooksPath /dev/null`, this
+# worktree continues to use the correct hooks.
+#
+# This hook runs on `git worktree add` and `git checkout`/`git switch`.
+git config --worktree core.hooksPath scripts/githooks 2>/dev/null || git config core.hooksPath scripts/githooks

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -16,4 +16,5 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 unset GIT_DIR
 
+git config --worktree core.hooksPath scripts/githooks 2>/dev/null || git config core.hooksPath scripts/githooks
 exec make pre-commit

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -19,4 +19,5 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 unset GIT_DIR
 
+git config --worktree core.hooksPath scripts/githooks 2>/dev/null || git config core.hooksPath scripts/githooks
 exec make pre-push


### PR DESCRIPTION
Mux creates agent worktrees with `git worktree add --no-checkout`, which
means the `post-checkout` hook never fires. That hook is where we write
`core.hooksPath` into the worktree-scoped config (`config.worktree`),
so these worktrees start life without it.

The problem: worktree config (`config.worktree`) overrides shared config
(`.git/config`), but only if `extensions.worktreeConfig = true` **and**
the key actually exists in `config.worktree`. Without it, the worktree
falls through to the shared config. If an agent runs
`git config core.hooksPath /dev/null` (which writes to `.git/config`),
it poisons every worktree that lacks its own override.

This adds a single `git config --worktree` call as the first action in
both `pre-commit` and `pre-push`, before the slow `make` targets. The
write takes ~10ms and is idempotent, so the cost is negligible. If the
agent kills the hook mid-flight and then clobbers the shared config, the
worktree is already protected.

For plain clones (no `extensions.worktreeConfig`), `--worktree` is not
available, so the hooks fall back to writing the shared config directly.
This is fine since there is only one working tree.

```bash
git config --worktree core.hooksPath scripts/githooks 2>/dev/null \
  || git config core.hooksPath scripts/githooks
```

> Created with [Mux](https://mux.coder.com) (Opus 4.6), and reviewed by a human.