### PR TITLE
ci: remove unnecessary `brew install google-chrome` from macOS CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -475,11 +475,6 @@ jobs:
           mkdir -p /tmp/tmpfs
           sudo mount_tmpfs -o noowners -s 8g /tmp/tmpfs
 
-          # Install google-chrome for scaletests.
-          # As another concern, should we really have this kind of external dependency
-          # requirement on standard CI?
-          brew install google-chrome
-
           # macOS will output "The default interactive shell is now zsh" intermittently in CI.
           touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
 


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1391

## Problem

The `test-go-pg (macos-latest)` job hit its 25m timeout without ever running
tests because `brew install google-chrome` stalled for 23+ minutes downloading
from the Homebrew CDN:

```
==> Fetching downloads for: google-chrome
Error: The operation was canceled.
```

## Why this is safe to remove

`brew install google-chrome` was added in Oct 2023 (`70a4e56c0`) the day after
chromedp was integrated into the scaletest/dashboard package (`1c48610d5`). At
that time, `run.go` called `initChromeDPCtx` directly (hardcoded), so the unit
test actually launched a real Chrome process.

In Jun 2024, #13650 refactored this to accept a mock `InitChromeDPCtx` via the
`Config` struct, and the test now passes a stub that never launches a browser.
No test file in the repo references `chromedp` directly — the only test
(`scaletest/dashboard/run_test.go`) fully mocks Chrome initialization.

The `chromedp` Go library compiles fine without Chrome installed; it only needs
the binary at runtime, and no test exercises that path.

## Impact

- Removes a ~200MB+ download from every macOS CI run
- Eliminates a fragile external dependency on Homebrew CDN availability
- Saves several minutes per run even when the download succeeds

_Generated with mux but reviewed by a human_