### PR TITLE
fix: skip redundant navigate in service worker notificationclick handler

### DIFF
--- a/site/src/serviceWorker.test.ts
+++ b/site/src/serviceWorker.test.ts
@@ -269,6 +269,8 @@ describe("serviceWorker notificationclick handler", () => {
 	it("focuses existing client without navigating when already on the target URL", async () => {
 		const mockClient = {
 			url: "https://example.com/agents/abc",
+			visibilityState: "visible",
+			focused: true,
 			focus: vi.fn(() => Promise.resolve()),
 			navigate: vi.fn(() => Promise.resolve()),
 		};
@@ -286,6 +288,8 @@ describe("serviceWorker notificationclick handler", () => {
 	it("navigates and focuses existing client when on a different agents page", async () => {
 		const mockClient = {
 			url: "https://example.com/agents/other",
+			visibilityState: "visible",
+			focused: true,
 			focus: vi.fn(() => Promise.resolve()),
 			navigate: vi.fn(() => Promise.resolve()),
 		};

--- a/site/src/serviceWorker.test.ts
+++ b/site/src/serviceWorker.test.ts
@@ -245,3 +245,80 @@ describe("serviceWorker push handler", () => {
 		});
 	});
 });
+
+// Helper to build a minimal NotificationEvent-like object for
+// the notificationclick handler.
+function makeNotificationClickEvent(url?: string) {
+	let waitUntilPromise: Promise<unknown> = Promise.resolve();
+	return {
+		notification: {
+			close: vi.fn(),
+			data: url !== undefined ? { url } : undefined,
+		},
+		waitUntil: (p: Promise<unknown>) => {
+			waitUntilPromise = p;
+		},
+		// Expose the promise so tests can await it.
+		get _waitUntilPromise() {
+			return waitUntilPromise;
+		},
+	};
+}
+
+describe("serviceWorker notificationclick handler", () => {
+	it("focuses existing client without navigating when already on the target URL", async () => {
+		const mockClient = {
+			url: "https://example.com/agents/abc",
+			focus: vi.fn(() => Promise.resolve()),
+			navigate: vi.fn(() => Promise.resolve()),
+		};
+		mockMatchAll.mockResolvedValue([mockClient]);
+
+		const event = makeNotificationClickEvent("/agents/abc");
+		handlers.notificationclick(event);
+		await event._waitUntilPromise;
+
+		expect(event.notification.close).toHaveBeenCalled();
+		expect(mockClient.navigate).not.toHaveBeenCalled();
+		expect(mockClient.focus).toHaveBeenCalled();
+	});
+
+	it("navigates and focuses existing client when on a different agents page", async () => {
+		const mockClient = {
+			url: "https://example.com/agents/other",
+			focus: vi.fn(() => Promise.resolve()),
+			navigate: vi.fn(() => Promise.resolve()),
+		};
+		mockMatchAll.mockResolvedValue([mockClient]);
+
+		const event = makeNotificationClickEvent("/agents/abc");
+		handlers.notificationclick(event);
+		await event._waitUntilPromise;
+
+		expect(event.notification.close).toHaveBeenCalled();
+		expect(mockClient.navigate).toHaveBeenCalledWith("/agents/abc");
+		expect(mockClient.focus).toHaveBeenCalled();
+	});
+
+	it("opens new window when no matching client exists", async () => {
+		mockMatchAll.mockResolvedValue([]);
+
+		const event = makeNotificationClickEvent("/agents/abc");
+		handlers.notificationclick(event);
+		await event._waitUntilPromise;
+
+		expect(event.notification.close).toHaveBeenCalled();
+		expect(mockClients.openWindow).toHaveBeenCalledWith("/agents/abc");
+	});
+
+	it("defaults to /agents when notification has no data url", async () => {
+		mockMatchAll.mockResolvedValue([]);
+
+		const event = makeNotificationClickEvent();
+		handlers.notificationclick(event);
+		await event._waitUntilPromise;
+
+		expect(event.notification.close).toHaveBeenCalled();
+		expect(mockClients.openWindow).toHaveBeenCalledWith("/agents");
+	});
+});

--- a/site/src/serviceWorker.ts
+++ b/site/src/serviceWorker.ts
@@ -64,7 +64,9 @@ self.addEventListener("notificationclick", (event) => {
 			.then((clientList) => {
 				for (const client of clientList) {
 					if (client.url.includes("/agents") && "focus" in client) {
-						client.navigate(targetUrl);
+						if (!client.url.includes(targetUrl)) {
+							client.navigate(targetUrl);
+						}
 						return client.focus();
 					}
 				}


### PR DESCRIPTION
## Bug

When a user has a chat open and clicks a push notification for that same chat (e.g. clicking an OS notification to bring the browser back to the foreground), the service worker's `notificationclick` handler unconditionally calls `client.navigate(targetUrl)`, causing the page to reload unnecessarily.

## Fix

Guard the `navigate()` call — if the client's URL already contains the target path, skip navigation and just focus the existing tab.

```ts
if (!client.url.includes(targetUrl)) {
    client.navigate(targetUrl);
}
return client.focus();
```

This is consistent with how the `push` handler already uses `client.url.includes(chatURL)` for its visibility check.

## Tests

Added 4 test cases for the `notificationclick` handler:
- Focuses without navigating when already on the target URL
- Navigates and focuses when on a different agents page
- Opens new window when no matching client exists
- Defaults to `/agents` when notification has no data URL