### PR TITLE
build: remove defunct test-postgres rule

### DIFF
--- a/.claude/docs/DATABASE.md
+++ b/.claude/docs/DATABASE.md
@@ -189,8 +189,8 @@ func (q *sqlQuerier) UpdateUser(ctx context.Context, arg UpdateUserParams) (User
 ### Common Debug Commands
 
 ```bash
-# Check database connection
-make test-postgres
+# Run tests (starts Postgres automatically if needed)
+make test
 
 # Run specific database tests
 go test ./coderd/database/... -run TestSpecificFunction

--- a/.claude/docs/TESTING.md
+++ b/.claude/docs/TESTING.md
@@ -67,7 +67,6 @@ coderd/
 | `make test` | Run all Go tests |
 | `make test RUN=TestFunctionName` | Run specific test |
 | `go test -v ./path/to/package -run TestFunctionName` | Run test with verbose output |
-| `make test-postgres` | Run tests with Postgres database |
 | `make test-race` | Run tests with Go race detector |
 | `make test-e2e` | Run end-to-end tests |
 

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -109,7 +109,6 @@
 
 - Run full test suite: `make test`
 - Run specific test: `make test RUN=TestFunctionName`
-- Run with Postgres: `make test-postgres`
 - Run with race detector: `make test-race`
 - Run end-to-end tests: `make test-e2e`
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,9 +366,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
-    # `make test-postgres` to ensure we receive a trace of running
-    # goroutines. Setting this to the timeout +5m should work quite well
-    # even if some of the preceding steps are slow.
+    # `make test` to ensure we receive a trace of running goroutines.
+    # Setting this to the timeout +5m should work quite well even if
+    # some of the preceding steps are slow.
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -574,9 +574,9 @@ jobs:
       - changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
-    # `make test-postgres` to ensure we receive a trace of running
-    # goroutines. Setting this to the timeout +5m should work quite well
-    # even if some of the preceding steps are slow.
+    # `make test` to ensure we receive a trace of running goroutines.
+    # Setting this to the timeout +5m should work quite well even if
+    # some of the preceding steps are slow.
     timeout-minutes: 25
     steps:
       - name: Harden Runner

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -16,9 +16,9 @@ jobs:
     # when changing runner sizes
     runs-on: ${{ matrix.os == 'macos-latest' && github.repository_owner == 'coder' && 'depot-macos-latest' || matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'depot-windows-2022-16' || matrix.os }}
     # This timeout must be greater than the timeout set by `go test` in
-    # `make test-postgres` to ensure we receive a trace of running
-    # goroutines. Setting this to the timeout +5m should work quite well
-    # even if some of the preceding steps are slow.
+    # `make test` to ensure we receive a trace of running goroutines.
+    # Setting this to the timeout +5m should work quite well even if
+    # some of the preceding steps are slow.
     timeout-minutes: 25
     strategy:
       fail-fast: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,21 +37,20 @@ Only pause to ask for confirmation when:
 
 ## Essential Commands
 
-| Task              | Command                  | Notes                               |
-|-------------------|--------------------------|-------------------------------------|
-| **Development**   | `./scripts/develop.sh`   | ⚠️ Don't use manual build           |
-| **Build**         | `make build`             | Fat binaries (includes server)      |
-| **Build Slim**    | `make build-slim`        | Slim binaries                       |
-| **Test**          | `make test`              | Full test suite                     |
-| **Test Single**   | `make test RUN=TestName` | Faster than full suite              |
-| **Test Postgres** | `make test-postgres`     | Run tests with Postgres database    |
-| **Test Race**     | `make test-race`         | Run tests with Go race detector     |
-| **Lint**          | `make lint`              | Always run after changes            |
-| **Generate**      | `make gen`               | After database changes              |
-| **Format**        | `make fmt`               | Auto-format code                    |
-| **Clean**         | `make clean`             | Clean build artifacts               |
-| **Pre-commit**    | `make pre-commit`        | Fast CI checks (gen/fmt/lint/build) |
-| **Pre-push**      | `make pre-push`          | All CI checks including tests       |
+| Task            | Command                  | Notes                               |
+|-----------------|--------------------------|-------------------------------------|
+| **Development** | `./scripts/develop.sh`   | ⚠️ Don't use manual build           |
+| **Build**       | `make build`             | Fat binaries (includes server)      |
+| **Build Slim**  | `make build-slim`        | Slim binaries                       |
+| **Test**        | `make test`              | Full test suite                     |
+| **Test Single** | `make test RUN=TestName` | Faster than full suite              |
+| **Test Race**   | `make test-race`         | Run tests with Go race detector     |
+| **Lint**        | `make lint`              | Always run after changes            |
+| **Generate**    | `make gen`               | After database changes              |
+| **Format**      | `make fmt`               | Auto-format code                    |
+| **Clean**       | `make clean`             | Clean build artifacts               |
+| **Pre-commit**  | `make pre-commit`        | Fast CI checks (gen/fmt/lint/build) |
+| **Pre-push**    | `make pre-push`          | All CI checks including tests       |
 
 ### Documentation Commands
 

--- a/Makefile
+++ b/Makefile
@@ -706,9 +706,11 @@ lint/typos: build/typos-$(TYPOS_VERSION)
 # pre-push runs the full CI suite including tests. This is the git
 # pre-push hook default, catching everything CI would before pushing.
 #
-# Both use two-phase execution: gen+fmt first (writes files), then
-# lint+build (reads files). This avoids races where gen's `go run`
-# creates temporary .go files that lint's find-based checks pick up.
+# pre-push uses two-phase execution: gen+fmt+test-postgres-docker
+# first (writes files, starts Docker), then lint+build+test in
+# parallel. pre-commit uses two phases: gen+fmt first, then
+# lint+build. This avoids races where gen's `go run` creates
+# temporary .go files that lint's find-based checks pick up.
 # Within each phase, targets run in parallel via -j. Both fail if
 # any tracked files have unstaged changes afterward.
 #
@@ -717,7 +719,7 @@ lint/typos: build/typos-$(TYPOS_VERSION)
 #
 # pre-push only (need external services or are slow):
 #   site/out/index.html (pnpm build)
-#   test-postgres (needs Docker)
+#   test-postgres-docker + test (needs Docker)
 #   test-js, test-e2e (needs Playwright)
 #   sqlc-vet (needs Docker)
 #   offlinedocs/check
@@ -754,14 +756,14 @@ pre-commit:
 .PHONY: pre-commit
 
 pre-push:
-	$(MAKE) -j --output-sync=target gen fmt
+	$(MAKE) -j --output-sync=target gen fmt test-postgres-docker
 	$(check-unstaged)
 	$(MAKE) -j --output-sync=target \
 		lint \
 		lint/typos \
 		build/coder-slim_$(GOOS)_$(GOARCH)$(GOOS_BIN_EXT) \
 		site/out/index.html \
-		test-postgres \
+		test \
 		test-js \
 		test-e2e \
 		test-race \
@@ -1326,21 +1328,6 @@ sqlc-vet: test-postgres-docker
 	sqlc vet -f coderd/database/sqlc.yaml && echo "Passed sqlc vet"
 .PHONY: sqlc-vet
 
-# When updating -timeout for this test, keep in sync with
-# test-go-postgres (.github/workflows/coder.yaml).
-# Do add coverage flags so that test caching works.
-test-postgres: test-postgres-docker
-	# The postgres test is prone to failure, so we limit parallelism for
-	# more consistent execution.
-	$(GIT_FLAGS)  gotestsum \
-		--junitfile="gotests.xml" \
-		--jsonfile="gotests.json" \
-		$(GOTESTSUM_RETRY_FLAGS) \
-		--packages="./..." -- \
-		-tags=testsmallbatch \
-		-timeout=20m \
-		-count=1
-.PHONY: test-postgres
 
 test-migrations: test-postgres-docker
 	echo "--- test migrations"


### PR DESCRIPTION
The `test-postgres` Makefile rule was redundant — CI never used it (it runs `test-postgres-docker` + `make test` via the `test-go-pg` action), and `make test` auto-starts a Postgres Docker container when needed via `dbtestutil`.

- Remove the `test-postgres` rule from Makefile
- Update `pre-push` to run `test-postgres-docker` in the first phase (alongside gen/fmt) and `make test` in the second phase
- Fix stale comments in CI workflows referencing `make test-postgres`
- Remove redundant "Test Postgres" entries from docs since `make test` handles Postgres automatically

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.