### PR TITLE
fix(coderd/agentapi/metadatabatcher): use clock.Since instead of time.Since in flush

### DIFF
--- a/coderd/agentapi/metadatabatcher/metadata_batcher.go
+++ b/coderd/agentapi/metadatabatcher/metadata_batcher.go
@@ -387,9 +387,9 @@ func (b *Batcher) flush(ctx context.Context, reason string) {
 	b.Metrics.BatchSize.Observe(float64(count))
 	b.Metrics.MetadataTotal.Add(float64(count))
 	b.Metrics.BatchesTotal.WithLabelValues(reason).Inc()
-	b.Metrics.FlushDuration.WithLabelValues(reason).Observe(time.Since(start).Seconds())
+	elapsed = b.clock.Since(start)
+	b.Metrics.FlushDuration.WithLabelValues(reason).Observe(elapsed.Seconds())
 
-	elapsed = time.Since(start)
 	b.log.Debug(ctx, "flush complete",
 		slog.F("count", count),
 		slog.F("elapsed", elapsed),


### PR DESCRIPTION
The `flush` method sets `start := b.clock.Now()` but later computes duration with `time.Since(start)` instead of `b.clock.Since(start)` for the `FlushDuration` metric and the debug log. Line 352 already uses `b.clock.Since(start)` correctly — this makes the rest consistent.

Test output before fix:
```
flush complete  count=100  elapsed=19166h12m30.265728663s  reason=scheduled
```

After fix:
```
flush complete  count=100  elapsed=0s  reason=scheduled
```

---

Background: I accidentally prompted the agent to fix the latest _ticker_ (not ticket), and here's the result.

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.