### PR TITLE
fix: bump aibridge to v1.0.9 to forward Anthropic-Beta header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.0.8
+	github.com/coder/aibridge v1.0.9
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.3
 	github.com/coder/preview v1.0.4

--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.0.6
+	github.com/coder/aibridge v1.0.8
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.3
 	github.com/coder/preview v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.8 h1:VbhC9p/L5BN4aUG3Nzg2q/ri208+W0vTB2264egBA14=
-github.com/coder/aibridge v1.0.8/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
+github.com/coder/aibridge v1.0.9 h1:vZHpIi/6lo1yKv8cVkc/vwUR6EQwXs3Y0x3HP1tjqGM=
+github.com/coder/aibridge v1.0.9/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.8.3 h1:QOb5WYKieRH/gwyUgofC9FDHSSJHpdw1jTrB5zsHovA=

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.6 h1:RVcJCutgWAd8MOxNI5MNVBl+ttqShVsmMQvUAkfuU9Q=
-github.com/coder/aibridge v1.0.6/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
+github.com/coder/aibridge v1.0.8 h1:G5FG5/t58pUZgKx44H0IfBskCTWV1QBcPYzQyxSAIwA=
+github.com/coder/aibridge v1.0.8/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.8.3 h1:QOb5WYKieRH/gwyUgofC9FDHSSJHpdw1jTrB5zsHovA=

--- a/go.sum
+++ b/go.sum
@@ -928,7 +928,7 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.8 h1:G5FG5/t58pUZgKx44H0IfBskCTWV1QBcPYzQyxSAIwA=
+github.com/coder/aibridge v1.0.8 h1:VbhC9p/L5BN4aUG3Nzg2q/ri208+W0vTB2264egBA14=
 github.com/coder/aibridge v1.0.8/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=


### PR DESCRIPTION
Bumps aibridge to v1.0.9, which forwards the `Anthropic-Beta` header from client requests to the upstream Anthropic API: https://github.com/coder/aibridge/pull/205

This fixes the `context_management: Extra inputs are not permitted` error when using Claude Code with AI Bridge.

Note: v1.0.8 was retracted due to a conflict marker cached by the Go module proxy https://github.com/coder/aibridge/pull/208. v1.0.9 contains the same fix.