### PR TITLE
fix(scaletest): handle ignored io.ReadAll error in bridge runner

### DIFF
--- a/scaletest/bridge/run.go
+++ b/scaletest/bridge/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -230,7 +231,10 @@ func (r *Runner) makeRequest(ctx context.Context, logger slog.Logger, url, token
 	r.cfg.Metrics.ObserveDuration(duration.Seconds())
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<failed to read response body: %s>", readErr))
+		}
 		err := xerrors.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 		span.RecordError(err)
 		return err


### PR DESCRIPTION
Surface the io.ReadAll error in the error message when an HTTP
request fails with a non-200 status, instead of silently
discarding it.

Part of the effort to enable `errcheck.check-blank` in golangci-lint.

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.