### PR TITLE
fix(cli): handle ignored errors in ssh and scaletest commands

### DIFF
--- a/cli/exp_scaletest_llmmock.go
+++ b/cli/exp_scaletest_llmmock.go
@@ -57,7 +57,9 @@ func (*RootCmd) scaletestLLMMock() *serpent.Command {
 				return xerrors.Errorf("start mock LLM server: %w", err)
 			}
 			defer func() {
-				_ = srv.Stop()
+				if err := srv.Stop(); err != nil {
+					logger.Error(ctx, "failed to stop mock LLM server", slog.Error(err))
+				}
 			}()
 
 			_, _ = fmt.Fprintf(inv.Stdout, "Mock LLM API server started on %s\n", srv.APIAddress())

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -357,7 +357,13 @@ func (r *RootCmd) ssh() *serpent.Command {
 				// search domain expansion, which can add 20-30s of
 				// delay on corporate networks with search domains
 				// configured.
-				exists, _ := workspacesdk.ExistsViaCoderConnect(ctx, coderConnectHost+".")
+				exists, ccErr := workspacesdk.ExistsViaCoderConnect(ctx, coderConnectHost+".")
+				if ccErr != nil {
+					logger.Debug(ctx, "failed to check coder connect",
+						slog.F("hostname", coderConnectHost),
+						slog.Error(ccErr),
+					)
+				}
 				if exists {
 					defer cancel()
 


### PR DESCRIPTION
Handle errors that were previously assigned to blank identifiers in the `cli/` package.

## Changes

- **ssh.go**: Log `ExistsViaCoderConnect` DNS lookup error at debug level instead of silently discarding it. Fallthrough behavior (treating failure as "not exists") is preserved, but failures are now visible in debug logs.
- **exp_scaletest_llmmock.go**: Log `srv.Stop()` error via the existing logger instead of discarding it.

Part of the effort to enable `errcheck.check-blank` in golangci-lint.

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.