### PR TITLE
fix(agent): handle ignored filepath.Walk error in filefinder 

### DIFF
--- a/agent/filefinder/watcher_fs.go
+++ b/agent/filefinder/watcher_fs.go
@@ -156,7 +156,7 @@ func (fw *fsWatcher) loop(ctx context.Context) {
 
 func (fw *fsWatcher) addRecursive(dir string) []FSEvent {
 	var events []FSEvent
-	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	if walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil //nolint:nilerr // best-effort
 		}
@@ -176,7 +176,10 @@ func (fw *fsWatcher) addRecursive(dir string) []FSEvent {
 		}
 		events = append(events, FSEvent{Op: OpCreate, Path: path, IsDir: false})
 		return nil
-	})
+	}); walkErr != nil {
+		fw.logger.Warn(context.Background(), "failed to walk directory",
+			slog.F("dir", dir), slog.Error(walkErr))
+	}
 	return events
 }
 


### PR DESCRIPTION
Properly handle errors that were previously assigned to blank identifiers in the `agent/` package tree.

## Changes

- **filefinder/watcher_fs.go**: Log `filepath.Walk` errors at warning level instead of silently discarding them. This is best-effort directory walking, so a warning is appropriate.

Part of the effort to enable `errcheck.check-blank` in golangci-lint.

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.