### PR TITLE
fix(scripts): handle ignored enc.Encode error in telemetry server

### DIFF
--- a/scripts/telemetry-server/main.go
+++ b/scripts/telemetry-server/main.go
@@ -43,7 +43,9 @@ func main() {
 				"version": r.Header.Get("X-Telemetry-Version"),
 				"data":    json.RawMessage(body),
 			}
-			_ = enc.Encode(output)
+			if err := enc.Encode(output); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error encoding telemetry output: %v\n", err)
+			}
 
 			w.WriteHeader(http.StatusAccepted)
 		}


### PR DESCRIPTION
Check the `json.Encoder.Encode` error and print to stderr, matching the file's existing error reporting pattern.

## Changes

- **scripts/telemetry-server/main.go**: The `enc.Encode(output)` call had its error discarded. Now checks the error and prints it to stderr.

Part of the effort to enable `errcheck.check-blank` in golangci-lint.

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.