### PR TITLE
fix(site): handle ignored rw.Write error in bin.go

### DIFF
--- a/site/bin.go
+++ b/site/bin.go
@@ -52,7 +52,10 @@ var StandardEncoders = map[string]func(w io.Writer, level int) io.WriteCloser{
 func (h *binHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if !strings.HasPrefix(r.URL.Path, "/bin/") {
 		rw.WriteHeader(http.StatusNotFound)
-		_, _ = rw.Write([]byte("not found"))
+		// Best-effort write of error body to client.
+		if _, err := rw.Write([]byte("not found")); err != nil {
+			return
+		}
 		return
 	}
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/bin")


### PR DESCRIPTION
Return early on write failure instead of continuing. The write is best-effort after `WriteHeader` is called.

## Changes

- **site/bin.go**: The `rw.Write()` call had its error discarded. Now returns early on failure.

Part of the effort to enable `errcheck.check-blank` in golangci-lint.