### PR TITLE
fix(chatd): continue tool execution on FinishReasonLength

### DIFF
--- a/coderd/chatd/chatloop/chatloop.go
+++ b/coderd/chatd/chatloop/chatloop.go
@@ -609,8 +609,16 @@ func processStepStream(
 		}
 	}
 
+	// Continue when the model produced tool calls, regardless of
+	// whether the finish reason is "tool-calls" or "length". When
+	// the model hits MaxOutputTokens mid-response
+	// (FinishReasonLength) but had already emitted complete tool
+	// calls, those tools must still be executed. Otherwise the
+	// agent loop silently stops and the user has to manually
+	// prompt it to continue.
 	result.shouldContinue = len(result.toolCalls) > 0 &&
-		result.finishReason == fantasy.FinishReasonToolCalls
+		(result.finishReason == fantasy.FinishReasonToolCalls ||
+			result.finishReason == fantasy.FinishReasonLength)
 	return result, nil
 }
 

--- a/coderd/chatd/chatloop/chatloop_test.go
+++ b/coderd/chatd/chatloop/chatloop_test.go
@@ -505,6 +505,54 @@ func TestRun_ToolCallsWithFinishReasonLength(t *testing.T) {
 	require.True(t, foundToolResult, "second call prompt should contain tool result message")
 }
 
+func TestRun_FinishReasonLengthWithoutToolCallsStops(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var streamCalls int
+
+	model := &loopTestModel{
+		provider: "fake",
+		streamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+			mu.Lock()
+			streamCalls++
+			mu.Unlock()
+
+			// Return text-only response with FinishReasonLength
+			// (no tool calls). The loop must NOT continue.
+			return streamFromParts([]fantasy.StreamPart{
+				{Type: fantasy.StreamPartTypeTextStart, ID: "text-1"},
+				{Type: fantasy.StreamPartTypeTextDelta, ID: "text-1", Delta: "partial response truncated by token limit"},
+				{Type: fantasy.StreamPartTypeTextEnd, ID: "text-1"},
+				{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonLength},
+			}), nil
+		},
+	}
+
+	var persistStepCalls int
+	err := Run(context.Background(), RunOptions{
+		Model: model,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleUser, "write me an essay"),
+		},
+		Tools: []fantasy.AgentTool{
+			newNoopTool("read_file"),
+		},
+		MaxSteps: 5,
+		PersistStep: func(_ context.Context, _ PersistedStep) error {
+			persistStepCalls++
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	// Stream should be called exactly once. Even though the finish
+	// reason is FinishReasonLength, there are no tool calls so the
+	// loop must stop.
+	require.Equal(t, 1, streamCalls)
+	require.Equal(t, 1, persistStepCalls)
+}
+
 func hasAnthropicEphemeralCacheControl(message fantasy.Message) bool {
 	if len(message.ProviderOptions) == 0 {
 		return false

--- a/coderd/chatd/chatloop/chatloop_test.go
+++ b/coderd/chatd/chatloop/chatloop_test.go
@@ -405,6 +405,106 @@ func TestRun_PersistStepErrorPropagates(t *testing.T) {
 	require.ErrorContains(t, err, "database write failed")
 }
 
+func TestRun_ToolCallsWithFinishReasonLength(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var streamCalls int
+	var secondCallPrompt []fantasy.Message
+
+	model := &loopTestModel{
+		provider: "fake",
+		streamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			mu.Lock()
+			step := streamCalls
+			streamCalls++
+			mu.Unlock()
+
+			switch step {
+			case 0:
+				// Step 0: produce a complete tool call but finish
+				// with FinishReasonLength (max output tokens hit).
+				return streamFromParts([]fantasy.StreamPart{
+					{Type: fantasy.StreamPartTypeToolInputStart, ID: "tc-len-1", ToolCallName: "read_file"},
+					{Type: fantasy.StreamPartTypeToolInputDelta, ID: "tc-len-1", Delta: `{"path":"main.go"}`},
+					{Type: fantasy.StreamPartTypeToolInputEnd, ID: "tc-len-1"},
+					{
+						Type:          fantasy.StreamPartTypeToolCall,
+						ID:            "tc-len-1",
+						ToolCallName:  "read_file",
+						ToolCallInput: `{"path":"main.go"}`,
+					},
+					{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonLength},
+				}), nil
+			default:
+				// Step 1: capture the prompt, then return text.
+				mu.Lock()
+				secondCallPrompt = append([]fantasy.Message(nil), call.Prompt...)
+				mu.Unlock()
+				return streamFromParts([]fantasy.StreamPart{
+					{Type: fantasy.StreamPartTypeTextStart, ID: "text-1"},
+					{Type: fantasy.StreamPartTypeTextDelta, ID: "text-1", Delta: "all done"},
+					{Type: fantasy.StreamPartTypeTextEnd, ID: "text-1"},
+					{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop},
+				}), nil
+			}
+		},
+	}
+
+	var persistStepCalls int
+	err := Run(context.Background(), RunOptions{
+		Model: model,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleUser, "please read main.go"),
+		},
+		Tools: []fantasy.AgentTool{
+			newNoopTool("read_file"),
+		},
+		MaxSteps: 5,
+		PersistStep: func(_ context.Context, _ PersistedStep) error {
+			persistStepCalls++
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	// Stream should be called twice: once for the tool-call step
+	// (finished with FinishReasonLength), once for the follow-up.
+	require.Equal(t, 2, streamCalls)
+
+	// PersistStep is called once per step.
+	require.Equal(t, 2, persistStepCalls)
+
+	// The second call's prompt must contain the tool result from
+	// step 0, proving the tool was executed despite FinishReasonLength.
+	require.NotEmpty(t, secondCallPrompt)
+
+	var foundAssistantToolCall bool
+	var foundToolResult bool
+	for _, msg := range secondCallPrompt {
+		if msg.Role == fantasy.MessageRoleAssistant {
+			for _, part := range msg.Content {
+				if tc, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok {
+					if tc.ToolCallID == "tc-len-1" && tc.ToolName == "read_file" {
+						foundAssistantToolCall = true
+					}
+				}
+			}
+		}
+		if msg.Role == fantasy.MessageRoleTool {
+			for _, part := range msg.Content {
+				if tr, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok {
+					if tr.ToolCallID == "tc-len-1" {
+						foundToolResult = true
+					}
+				}
+			}
+		}
+	}
+	require.True(t, foundAssistantToolCall, "second call prompt should contain assistant tool call from step 0")
+	require.True(t, foundToolResult, "second call prompt should contain tool result message")
+}
+
 func hasAnthropicEphemeralCacheControl(message fantasy.Message) bool {
 	if len(message.ProviderOptions) == 0 {
 		return false


### PR DESCRIPTION
## Bug

When the LLM hits `MaxOutputTokens` (32k default), it returns `FinishReasonLength` instead of `FinishReasonToolCalls`. If complete tool calls had already been emitted before the stream was truncated, `shouldContinue` was `false`. The tools were never executed and the loop exited with `nil`. The chat went to `waiting` status with no error visible to the user, who had to manually prompt it to continue.

This became much more frequent after compaction re-entry was introduced (#22640), which adds summary messages to the context, pushing the model closer to its output token limit during tool-heavy work.

## Fix

Accept `FinishReasonLength` alongside `FinishReasonToolCalls` in the `shouldContinue` check so that emitted tool calls are always executed regardless of why the stream ended.

## Test

`TestRun_ToolCallsWithFinishReasonLength` mirrors the existing `TestRun_MultiStepToolExecution` test but uses `FinishReasonLength` on step 0. Verifies:
- Stream is called twice (tool-call step + follow-up)
- Both steps are persisted
- The follow-up prompt contains the tool result from step 0

RED/GREEN confirmed: test fails without the fix (`expected: 2, actual: 1`), passes with it.