### PR TITLE
fix(e2e): handle bool parameter hydration race in fillParameters

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -1051,8 +1051,31 @@ const fillParameters = async (
 		switch (richParameter.type) {
 			case "bool":
 				{
+					const wantChecked = buildParameter.value === "true";
 					const parameterField = parameterLabel.locator("button");
-					await parameterField.click();
+					// Dynamic parameters can hydrate after initial render
+					// and reset the switch state. Check the current value
+					// and retry the click if needed.
+					for (let attempt = 0; attempt < 3; attempt++) {
+						const isChecked =
+							(await parameterField.getAttribute("aria-checked")) ===
+							"true";
+						if (isChecked !== wantChecked) {
+							await parameterField.click();
+						}
+						try {
+							await expect(parameterField).toHaveAttribute(
+								"aria-checked",
+								String(wantChecked),
+								{ timeout: 1000 },
+							);
+							break;
+						} catch (error) {
+							if (attempt === 2) {
+								throw error;
+							}
+						}
+					}
 				}
 				break;
 			case "string":


### PR DESCRIPTION
## Problem

The e2e test `create workspace and overwrite default parameters` was flaking because `fillParameters` blindly toggled the boolean switch with a single click. If dynamic parameters hydrated after the click and reset the switch state, the final value was wrong -- the verification step would find the checkbox still checked (`true`) when it expected `false`.

## Root Cause

The `bool` case in `fillParameters` (helpers.ts) did:
```ts
const parameterField = parameterLabel.locator("button");
await parameterField.click();
```

This toggle-style interaction is inherently racy: it assumes the switch has already rendered with its default value before the click. Dynamic parameters can hydrate after initial render and overwrite the toggled state, which is exactly the same class of bug that was already fixed for `string`/`number` parameters with a retry loop.

## Fix

Mirror the retry pattern already used for string/number parameters:
1. Read the current `aria-checked` attribute to determine switch state
2. Only click if the current state differs from the desired value
3. Verify the state matches after clicking
4. Retry up to 3 times to handle post-hydration resets