### PR TITLE
fix(coderd): use dbtime.Now() for tailnet telemetry timestamps

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2170,7 +2170,7 @@ func (api *API) tailnetRPCConn(rw http.ResponseWriter, r *http.Request) {
 	userID := apiKey.UserID.String()
 
 	// Store connection telemetry event
-	now := time.Now()
+	now := dbtime.Now()
 	connectionTelemetryEvent := telemetry.UserTailnetConnection{
 		ConnectedAt:         now,
 		DisconnectedAt:      nil,
@@ -2187,7 +2187,7 @@ func (api *API) tailnetRPCConn(rw http.ResponseWriter, r *http.Request) {
 	})
 	defer func() {
 		// Update telemetry event with disconnection time
-		disconnectTime := time.Now()
+		disconnectTime := dbtime.Now()
 		connectionTelemetryEvent.DisconnectedAt = &disconnectTime
 		api.Telemetry.Report(&telemetry.Snapshot{
 			UserTailnetConnections: []telemetry.UserTailnetConnection{connectionTelemetryEvent},

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -3021,7 +3021,7 @@ func TestUserTailnetTelemetry(t *testing.T) {
 			q.Set("version", "2.0")
 			u.RawQuery = q.Encode()
 
-			predialTime := time.Now()
+			predialTime := dbtime.Now()
 
 			//nolint:bodyclose // websocket package closes this for you
 			wsConn, resp, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{


### PR DESCRIPTION
Fixes a flaky test (`TestUserTailnetTelemetry/invalid_header`) caused by sub-microsecond precision mismatch between `time.Now()` calls on Windows.

The server used `time.Now()` (nanosecond precision) for `ConnectedAt` and `DisconnectedAt`, while the test compared against its own `time.Now()`. On Windows, wall-clock jitter can cause the server timestamp to appear slightly before the test's `predialTime`.

Switch to `dbtime.Now()` which rounds to microsecond precision (matching Postgres), consistent with all other timestamps in `workspaceagents.go`.

Relates to: https://github.com/coder/internal/issues/1390