### PR TITLE
fix(site): re-focus terminal on window focus for iframe embedding

### DIFF
--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -231,6 +231,25 @@ const TerminalPage: FC = () => {
 		copyToClipboard,
 	]);
 
+	// Re-focus the terminal when the window regains focus. This is especially
+	// useful when the terminal is embedded in an iframe (e.g. the Tasks view or
+	// third-party dashboards): the parent page can call
+	// `iframe.contentWindow.focus()` on tab switch, which fires the window
+	// "focus" event and lets the user start typing immediately without an
+	// extra click.
+	useEffect(() => {
+		if (!terminal) {
+			return;
+		}
+		const handleWindowFocus = () => {
+			terminal.focus();
+		};
+		window.addEventListener("focus", handleWindowFocus);
+		return () => {
+			window.removeEventListener("focus", handleWindowFocus);
+		};
+	}, [terminal]);
+
 	// Updates the reconnection token into the URL if necessary.
 	useEffect(() => {
 		if (searchParams.get("reconnect") === reconnectionToken) {


### PR DESCRIPTION
## Description

When the terminal page is embedded in an iframe (e.g. the Tasks view or third-party dashboards), switching between tabs causes the terminal to lose keyboard focus. The user has to click inside the terminal to start typing again.

The parent page can call `iframe.contentWindow.focus()` which fires the `window` `focus` event inside the iframe, but xterm.js does not listen for this event and does not re-focus its hidden textarea in response.

This adds a `window` focus event listener that calls `terminal.focus()`, so the terminal receives keyboard input immediately after a tab switch.

## Impact

- **Tasks view**: Fixes #21149 — switching between task tabs no longer requires an extra click to start typing
- **Iframe embedding**: Any page embedding the Coder terminal in an iframe can now programmatically transfer focus via `contentWindow.focus()`
- **Browser tab switching**: Terminal also regains focus when switching back to the browser tab

## Changes

One `useEffect` added to `TerminalPage.tsx` (~10 lines).

## Testing

1. Open the Tasks view with multiple task tabs
2. Click into the terminal and start typing
3. Switch to a different task tab, then switch back
4. Terminal should have focus — you can type immediately without clicking