### PR TITLE
fix(agent): make stats and metadata RPC errors non-fatal

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -728,13 +728,17 @@ func (a *agent) reportMetadata(ctx context.Context, aAPI proto.DRPCAgentClient28
 			updatedMetadata[mr.key] = mr.result
 			continue
 		case err := <-reportError:
-			logMsg := "batch update metadata complete"
-			if err != nil {
-				a.logger.Debug(ctx, logMsg, slog.Error(err))
-				return xerrors.Errorf("failed to report metadata: %w", err)
-			}
-			a.logger.Debug(ctx, logMsg)
 			reportInFlight = false
+			if err != nil {
+				// RPC errors for metadata are non-fatal. The
+				// data will be re-collected and sent on the
+				// next tick. Returning here would tear down
+				// the entire API connection errgroup.
+				// See #22864.
+				a.logger.Warn(ctx, "failed to report metadata", slog.Error(err))
+				continue
+			}
+			a.logger.Debug(ctx, "batch update metadata complete")
 		case <-report:
 			if len(updatedMetadata) == 0 {
 				continue

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -106,7 +106,11 @@ func (s *statsReporter) reportLoop(ctx context.Context, dest statsDest) error {
 		}
 		s.unreported = false
 		if err = s.reportLocked(ctx, dest, s.networkStats); err != nil {
-			return xerrors.Errorf("report stats: %w", err)
+			// RPC errors during stats reporting are non-fatal.
+			// Stats will be re-sent on the next callback.
+			// Returning here would tear down the entire API
+			// connection errgroup. See #22864.
+			s.logger.Warn(ctx, "failed to report stats", slog.Error(err))
 		}
 	}
 }

--- a/agent/stats_internal_test.go
+++ b/agent/stats_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"tailscale.com/types/ipproto"
 	"tailscale.com/types/netlogtype"
@@ -133,6 +134,92 @@ func TestStatsReporter(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestStatsReporter_NonFatalRPCError verifies that a transient RPC
+// error from UpdateStats does not cause reportLoop to exit. The
+// loop should log the error and continue reporting on the next
+// callback. Regression test for #22864.
+func TestStatsReporter_NonFatalRPCError(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := testutil.Logger(t)
+	fSource := newFakeNetworkStatsSource(ctx, t)
+	fCollector := newFakeCollector(t)
+	fDest := newFakeErrStatsDest()
+	uut := newStatsReporter(logger, fSource, fCollector)
+
+	loopErr := make(chan error, 1)
+	loopCtx, loopCancel := context.WithCancel(ctx)
+	go func() {
+		loopErr <- uut.reportLoop(loopCtx, fDest)
+	}()
+
+	// Initial request to get the reporting interval.
+	req := testutil.TryReceive(ctx, t, fDest.reqs)
+	require.NotNil(t, req)
+	require.Nil(t, req.Stats)
+	interval := 34 * time.Second
+	testutil.RequireSend(ctx, t, fDest.resps,
+		&proto.UpdateStatsResponse{
+			ReportInterval: durationpb.New(interval),
+		})
+
+	// Source configured with callback and interval.
+	gotInterval := testutil.TryReceive(ctx, t, fSource.period)
+	require.Equal(t, interval, gotInterval)
+
+	// First callback delivers network stats.
+	netStats := map[netlogtype.Connection]netlogtype.Counts{
+		{
+			Proto: ipproto.TCP,
+			Src:   netip.MustParseAddrPort("10.0.0.1:1234"),
+			Dst:   netip.MustParseAddrPort("10.0.0.2:5678"),
+		}: {TxPackets: 1, TxBytes: 2, RxPackets: 3, RxBytes: 4},
+	}
+	fSource.callback(time.Now(), time.Now(), netStats, nil)
+
+	// Collector is called; supply stats.
+	gotNetStats := testutil.TryReceive(ctx, t, fCollector.calls)
+	require.Equal(t, netStats, gotNetStats)
+	stats := &proto.Stats{SessionCountJetbrains: 10}
+	testutil.RequireSend(ctx, t, fCollector.stats, stats)
+
+	// Destination receives the request, but we return an error.
+	update := testutil.TryReceive(ctx, t, fDest.reqs)
+	require.NotNil(t, update)
+	require.Equal(t, stats, update.Stats)
+	testutil.RequireSend(ctx, t, fDest.errs,
+		xerrors.New("transient RPC failure"))
+
+	// The loop must NOT have exited. Send another callback and
+	// verify it is reported successfully.
+	netStats2 := map[netlogtype.Connection]netlogtype.Counts{
+		{
+			Proto: ipproto.TCP,
+			Src:   netip.MustParseAddrPort("10.0.0.1:1234"),
+			Dst:   netip.MustParseAddrPort("10.0.0.2:5678"),
+		}: {TxPackets: 5, TxBytes: 6, RxPackets: 7, RxBytes: 8},
+	}
+	fSource.callback(time.Now(), time.Now(), netStats2, nil)
+
+	gotNetStats2 := testutil.TryReceive(ctx, t, fCollector.calls)
+	require.Equal(t, netStats2, gotNetStats2)
+	stats2 := &proto.Stats{SessionCountJetbrains: 20}
+	testutil.RequireSend(ctx, t, fCollector.stats, stats2)
+
+	update2 := testutil.TryReceive(ctx, t, fDest.reqs)
+	require.NotNil(t, update2)
+	require.Equal(t, stats2, update2.Stats)
+	testutil.RequireSend(ctx, t, fDest.resps,
+		&proto.UpdateStatsResponse{
+			ReportInterval: durationpb.New(interval),
+		})
+
+	// Clean shutdown — loop exits without error.
+	loopCancel()
+	err := testutil.TryReceive(ctx, t, loopErr)
+	require.NoError(t, err)
+}
+
 type fakeNetworkStatsSource struct {
 	sync.Mutex
 	ctx      context.Context
@@ -217,5 +304,41 @@ func newFakeStatsDest() *fakeStatsDest {
 	return &fakeStatsDest{
 		reqs:  make(chan *proto.UpdateStatsRequest),
 		resps: make(chan *proto.UpdateStatsResponse),
+	}
+}
+
+// fakeErrStatsDest is like fakeStatsDest but can return errors on
+// demand via the errs channel. When a value is available on errs,
+// it is returned instead of waiting for resps.
+type fakeErrStatsDest struct {
+	reqs  chan *proto.UpdateStatsRequest
+	resps chan *proto.UpdateStatsResponse
+	errs  chan error
+}
+
+func (f *fakeErrStatsDest) UpdateStats(
+	ctx context.Context, req *proto.UpdateStatsRequest,
+) (*proto.UpdateStatsResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case f.reqs <- req:
+		// OK
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-f.errs:
+		return nil, err
+	case resp := <-f.resps:
+		return resp, nil
+	}
+}
+
+func newFakeErrStatsDest() *fakeErrStatsDest {
+	return &fakeErrStatsDest{
+		reqs:  make(chan *proto.UpdateStatsRequest),
+		resps: make(chan *proto.UpdateStatsResponse),
+		errs:  make(chan error),
 	}
 }


### PR DESCRIPTION
## Problem

The `apiConnRoutineManager` uses a single `errgroup.Group`. When
`reportMetadata` or `statsReporter.reportLoop` encounters a transient
RPC error (e.g. from network disruption), the error propagates through
the errgroup, canceling its context and tearing down ALL routines,
including critical ones like coordination and DERP map subscription.

During network disruption, these periodic, non-critical RPCs fail first,
forcing a full API reconnection cycle that compounds the disruption.

## Solution

Both routines now log the error as a warning and continue the loop
instead of returning the error to the errgroup:

- **`reportMetadata`**: `BatchUpdateMetadata` errors are logged, and
  `reportInFlight` is reset so the next tick can retry. Metadata will be
  re-collected and sent on the next tick.
- **`statsReporter.reportLoop`**: `UpdateStats` errors in the main loop
  are logged and the loop continues. Stats will be re-sent on the next
  callback. The initial `UpdateStats` call (to get the report interval)
  remains fatal since the interval is needed to configure the callback.

## Testing

- New `TestStatsReporter_NonFatalRPCError`: injects a transient error on
  `UpdateStats`, verifies the loop does NOT exit, then verifies the next
  stats report is sent successfully.
- Existing `TestStatsReporter` and `TestAgent_Metadata` tests pass.

Refs #22864