### PR TITLE
fix(agent/reaper): prevent SIGINT from killing test process

### DIFF
--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -141,6 +141,17 @@ func TestReapInterrupt(t *testing.T) {
 	}()
 
 	require.Equal(t, <-usrSig, syscall.SIGUSR1)
+
+	// Prevent SIGINT from terminating the test process. Under the
+	// race detector, the catchSignals goroutine in ForkReap may not
+	// have called signal.Notify yet, so the default Go handler
+	// could kill us. Registering our own Notify disables the
+	// default behavior. Both this channel and the one inside
+	// catchSignals receive independent copies of the signal.
+	intC := make(chan os.Signal, 1)
+	signal.Notify(intC, os.Interrupt)
+	defer signal.Stop(intC)
+
 	err := syscall.Kill(os.Getpid(), syscall.SIGINT)
 	require.NoError(t, err)
 	require.Equal(t, <-usrSig, syscall.SIGUSR2)


### PR DESCRIPTION
The `TestReapInterrupt` test sends SIGINT to its own process. Under the race detector, the `catchSignals` goroutine inside `ForkReap` may not have registered `signal.Notify` yet, so Go's default SIGINT handler can terminate the test binary with `signal: interrupt`.

Fix: register `signal.Notify` for `os.Interrupt` in the test before sending SIGINT. This disables the default termination behavior while still allowing the `catchSignals` handler to receive the signal independently.