### PR TITLE
fix(agent): don't overwrite existing vscode git auth settings

### DIFF
--- a/cli/gitauth/vscode.go
+++ b/cli/gitauth/vscode.go
@@ -19,12 +19,18 @@ func OverrideVSCodeConfigs(fs afero.Fs) error {
 		return err
 	}
 	mutate := func(m map[string]interface{}) {
-		// This prevents VS Code from overriding GIT_ASKPASS, which
-		// we use to automatically authenticate Git providers.
-		m["git.useIntegratedAskPass"] = false
-		// This prevents VS Code from using it's own GitHub authentication
-		// which would circumvent cloning with Coder-configured providers.
-		m["github.gitAuthentication"] = false
+		// These defaults prevent VS Code from overriding
+		// GIT_ASKPASS and using its own GitHub authentication,
+		// which would circumvent cloning with Coder-configured
+		// providers. We only set them if they are not already
+		// present so that template authors can override them
+		// via module settings (e.g. the vscode-web module).
+		if _, ok := m["git.useIntegratedAskPass"]; !ok {
+			m["git.useIntegratedAskPass"] = false
+		}
+		if _, ok := m["github.gitAuthentication"]; !ok {
+			m["github.gitAuthentication"] = false
+		}
 	}
 
 	for _, configPath := range []string{

--- a/cli/gitauth/vscode_test.go
+++ b/cli/gitauth/vscode_test.go
@@ -61,4 +61,31 @@ func TestOverrideVSCodeConfigs(t *testing.T) {
 			require.Equal(t, "something", mapping["hotdogs"])
 		}
 	})
+	t.Run("NoOverwrite", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		mapping := map[string]interface{}{
+			"git.useIntegratedAskPass": true,
+			"github.gitAuthentication": true,
+			"other.setting":            "preserved",
+		}
+		data, err := json.Marshal(mapping)
+		require.NoError(t, err)
+		for _, configPath := range configPaths {
+			err = afero.WriteFile(fs, configPath, data, 0o600)
+			require.NoError(t, err)
+		}
+		err = gitauth.OverrideVSCodeConfigs(fs)
+		require.NoError(t, err)
+		for _, configPath := range configPaths {
+			data, err := afero.ReadFile(fs, configPath)
+			require.NoError(t, err)
+			mapping := map[string]interface{}{}
+			err = json.Unmarshal(data, &mapping)
+			require.NoError(t, err)
+			require.Equal(t, true, mapping["git.useIntegratedAskPass"])
+			require.Equal(t, true, mapping["github.gitAuthentication"])
+			require.Equal(t, "preserved", mapping["other.setting"])
+		}
+	})
 }


### PR DESCRIPTION
OverrideVSCodeConfigs previously unconditionally set `git.useIntegratedAskPass` and `github.gitAuthentication` to false, clobbering any values provided by template authors via module settings (e.g. the vscode-web module's settings block). This change only set these keys when they are not already present, so template-provided values are preserved.

Registry PR [#758](https://github.com/coder/registry/pull/758) fixed the module side (run.sh merges template-author settings into the existing settings.json instead of overwriting the file). But the agent still unconditionally stamped false onto both keys before the script ran, so the merge base always contained the agent's values and template authors couldn't set them to anything else. This change fixes the agent side by only writing defaults when the keys are absent.

https://github.com/coder/coder/issues/19007

## Test Plan

Prerequisites:

Start develop.sh with an external auth provider configured:

`CODER_EXTERNAL_AUTH_0_ID=test-github CODER_EXTERNAL_AUTH_0_TYPE=github CODER_EXTERNAL_AUTH_0_CLIENT_ID=fake CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=fake scripts/develop.sh`

Use a template with the vscode-web module overriding the git auth settings (ensure version 1.5.0):

```tf
    module "vscode-web" {
      count          = data.coder_workspace.me.start_count
      source         = "registry.coder.com/modules/vscode-web/coder"
      version        = "1.5.0"
      agent_id       = coder_agent.main.id
      accept_license = true

      settings = {
        "git.useIntegratedAskPass" = true
        "github.gitAuthentication" = true
      }
    }
```

Tests:

1. Fresh start: create a workspace, verify the module's true values survive the agent's defaults:
   `coder ssh <workspace> -- cat '~/.vscode-server/data/Machine/settings.json'`
   Expected: both keys are true.

2. Restart: restart the workspace, verify the agent doesn't clobber them back to false :
   ```
   coder restart <workspace>
   coder ssh <workspace> -- cat '~/.vscode-server/data/Machine/settings.json'
   ```
   Expected: both keys are still true .
