### PR TITLE
docs: add Early Access page under Coder Agents

### DIFF
--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -1,0 +1,56 @@
+# Early Access
+
+Coder Agents is available through Early Access for selected
+customers to evaluate while the product is under active development.
+Participation comes with important expectations and limitations described
+below.
+
+## What Early Access includes
+
+Early Access is a collaborative evaluation period between Coder and
+participating customers. It includes:
+
+- **Direct collaboration with the Coder product team** — work with Coder
+  engineers and product managers to share feedback, discuss use cases, and
+  influence product direction.
+- **Architecture and functionality documentation** — basic documentation
+  covering how Coder Agents works and how it integrates into existing
+  deployments.
+- **Feedback sessions** — periodic check-ins with the Coder team to discuss
+  real-world usage.
+- **Early exposure to new capabilities** — access to new features or
+  experimental functionality before public release.
+
+## What Early Access does not include
+
+Early Access is not a production-ready offering. It does not include:
+
+- **Formal support coverage** — no SLA-backed support.
+- **Stability guarantees** — features and behavior may change without notice.
+- **Production readiness guarantees** — functionality may not yet meet the
+  reliability or scalability expectations of a GA feature.
+- **Complete documentation or tooling** — operational guidance may be
+  incomplete and will evolve.
+- **Long-term compatibility guarantees** — APIs, configuration models, or
+  workflows may change before General Availability.
+
+## Feature scope
+
+Functionality available during Early Access may be a subset of planned
+capabilities. Some features may be incomplete, experimental, or subject to
+redesign.
+
+## Licensing and availability
+
+Features provided during Early Access may become paid licensed
+features at General Availability.
+Participants will receive reasonable advance notice before:
+
+- Coder Agents reaches General Availability
+- Early Access functionality transitions to a paid offering
+
+## Providing feedback
+
+Participants are encouraged to share workflow feedback, feature requests,
+performance observations, and operational challenges. Feedback channels are
+coordinated directly with the Coder product team.

--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -1,7 +1,7 @@
 # Early Access
 
-Coder Agents is available through Early Access for selected
-customers to evaluate while the product is under active development.
+Coder Agents is available through Early Access for the community
+to evaluate while the product is under active development.
 Participation comes with important expectations and limitations described
 below.
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -1,9 +1,5 @@
 # Coder Agents
 
-> [!NOTE]
-> Coder Agents is currently in internal preview. We are actively developing
-> the feature and demoing it with customers for feedback.
-
 Coder Agents is a chat interface and API for delegating development work and research to coding agents in your Coder deployment. Developers describe the work they want done, and Coder Agents handles selecting a template, provisioning a workspace, and executing the task.
 
 Coder Agents includes its own self-hosted AI coding

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1206,6 +1206,11 @@
 							"title": "Platform Controls",
 							"description": "How platform teams control agent behavior, models, and policies",
 							"path": "./ai-coder/agents/platform-controls.md"
+						},
+						{
+							"title": "Early Access",
+							"description": "About the Coder Agents Early Access program",
+							"path": "./ai-coder/agents/early-access.md"
 						}
 					]
 				}

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1191,6 +1191,7 @@
 					"title": "Coder Agents",
 					"description": "Self-hosted agent by Coder",
 					"path": "./ai-coder/agents/index.md",
+					"state": ["early access"],
 					"children": [
 						{
 							"title": "Architecture",


### PR DESCRIPTION
Adds a new child page at `/docs/ai-coder/agents/early-access` describing the Coder Agents Early Access, including what it includes, what it does not include, feature scope, licensing, and how to provide feedback.