### PR TITLE
fix(e2e): use retrying assertions for bool in verifyParameters

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -211,8 +211,18 @@ export const verifyParameters = async (
 					case "bool":
 						{
 							const parameterField = parameterLabel.locator("input");
-							const value = await parameterField.isChecked();
-							expect(value.toString()).toEqual(buildParameter.value);
+							// Dynamic parameters can hydrate after initial render
+							// and reset checkbox state. Use auto-retrying assertions
+							// instead of a one-shot isChecked() snapshot.
+							if (buildParameter.value === "true") {
+								await expect(parameterField).toBeChecked({
+									timeout: 15_000,
+								});
+							} else {
+								await expect(parameterField).not.toBeChecked({
+									timeout: 15_000,
+								});
+							}
 						}
 						break;
 					case "string":


### PR DESCRIPTION
The `verifyParameters` helper used a one-shot `isChecked()` call to verify boolean parameter state. Dynamic parameter hydration can reset the checkbox after page load, causing a race where the snapshot reads the stale default value instead of the expected one.

Replace with Playwright's auto-retrying `toBeChecked()` / `not.toBeChecked()` assertions with a 15s timeout, matching the pattern already used for string and number parameters.

Fixes the flaky test:
```
[tests] > e2e/tests/workspaces/createWorkspace.spec.ts:112:5 > create workspace and overwrite default parameters
```