### PR TITLE
fix(chatd): update the spawn_agent tool description

### DIFF
--- a/coderd/chatd/subagent.go
+++ b/coderd/chatd/subagent.go
@@ -52,9 +52,17 @@ func (p *Server) subagentTools(currentChat func() database.Chat) []fantasy.Agent
 				"(e.g. fixing a specific bug, writing a single module, "+
 				"running a migration). Do NOT use for simple or quick "+
 				"operations you can handle directly with execute, "+
-				"read_file, or write_file. The child agent receives the "+
-				"same workspace tools but cannot spawn its own subagents. "+
-				"After spawning, use wait_agent to collect the result.",
+				"read_file, or write_file - for example, reading a group "+
+				"of files and outputting them verbatim does not need a "+
+				"subagent. Reserve subagents for tasks that require "+
+				"intellectual work such as code analysis, writing new "+
+				"code, or complex refactoring. Be careful when running "+
+				"parallel subagents: if two subagents modify the same "+
+				"files they will conflict with each other, so ensure "+
+				"parallel subagent tasks are independent. "+
+				"The child agent receives the same workspace tools but "+
+				"cannot spawn its own subagents. After spawning, use "+
+				"wait_agent to collect the result.",
 			func(ctx context.Context, args spawnAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil


### PR DESCRIPTION
I keep running into the same couple of issues with subagents:

- when I request code analysis, the main agent tends to spawn subagents to read files and output them verbatim to the main chat
- when I request to implement a feature, the main agent often spawns subagents that edit the same files and conflict with one another, reverting each other's changes.

This PR updates the `spawn_agent` tool description to mitigate those issues.