### PR TITLE
fix(agent/reaper): eliminate Wait4 race using go-reap fork

### DIFF
--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -83,20 +82,19 @@ func TestReap(t *testing.T) {
 	}
 
 	pids := make(reap.PidCh, 1)
-	var reapLock sync.RWMutex
 	opts := append([]reaper.Option{
 		reaper.WithPIDCallback(pids),
-		reaper.WithExecArgs("/bin/sh", "-c", "exit 0"),
-		reaper.WithReapLock(&reapLock),
+		reaper.WithExecArgs("/bin/sh", "-c", "exec sleep inf >/dev/null 2>&1"),
 	}, withDone(t)...)
-	reapLock.RLock()
-	exitCode, err := reaper.ForkReap(opts...)
-	reapLock.RUnlock()
-	require.NoError(t, err)
-	require.Equal(t, 0, exitCode)
+
+	// Run ForkReap in the background so the child stays alive
+	// while we verify that the reaper forwards other PIDs.
+	go func() {
+		_, _ = reaper.ForkReap(opts...)
+	}()
 
 	cmd := exec.Command("tail", "-f", "/dev/null")
-	err = cmd.Start()
+	err := cmd.Start()
 	require.NoError(t, err)
 
 	cmd2 := exec.Command("tail", "-f", "/dev/null")
@@ -119,6 +117,10 @@ func TestReap(t *testing.T) {
 			require.Contains(t, expectedPIDs, pid)
 		}
 	}
+
+	// Test cleanup stops the reaper, which terminates ForkReap.
+	// The child's stdout/stderr are redirected to /dev/null so
+	// CombinedOutput won't hang on inherited pipes.
 }
 
 //nolint:tparallel // Subtests must be sequential, each starts its own reaper.
@@ -144,14 +146,10 @@ func TestForkReapExitCodes(t *testing.T) {
 	//nolint:paralleltest // Subtests must be sequential, each starts its own reaper.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var reapLock sync.RWMutex
 			opts := append([]reaper.Option{
 				reaper.WithExecArgs("/bin/sh", "-c", tt.command),
-				reaper.WithReapLock(&reapLock),
 			}, withDone(t)...)
-			reapLock.RLock()
 			exitCode, err := reaper.ForkReap(opts...)
-			reapLock.RUnlock()
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedCode, exitCode, "exit code mismatch for %q", tt.command)
 		})

--- a/agent/reaper/reaper_unix.go
+++ b/agent/reaper/reaper_unix.go
@@ -69,8 +69,13 @@ func ForkReap(opt ...Option) (int, error) {
 		o(opts)
 	}
 
+	// Buffered so the reaper won't block on send between our
+	// child exiting and the reaper stopping.
+	statuses := make(reap.StatusCh, 8)
+
 	go func() {
-		reap.ReapChildren(opts.PIDs, nil, opts.ReaperStop, opts.ReapLock)
+		reap.ReapChildrenWithStatus(statuses, nil, opts.ReaperStop, nil)
+		close(statuses)
 		if opts.ReaperStopped != nil {
 			close(opts.ReaperStopped)
 		}
@@ -102,23 +107,26 @@ func ForkReap(opt ...Option) (int, error) {
 
 	startSignalForwarding(opts.Logger, pid, opts.CatchSignals)
 
-	var wstatus syscall.WaitStatus
-	_, err = syscall.Wait4(pid, &wstatus, 0, nil)
-	for xerrors.Is(err, syscall.EINTR) {
-		_, err = syscall.Wait4(pid, &wstatus, 0, nil)
+	for cs := range statuses {
+		if opts.PIDs != nil && cs.Pid != pid {
+			opts.PIDs <- cs.Pid
+		}
+		if cs.Pid != pid {
+			continue
+		}
+		// Convert wait status to exit code using standard Unix conventions:
+		// - Normal exit: use the exit code
+		// - Signal termination: use 128 + signal number
+		ws := syscall.WaitStatus(cs.Status)
+		switch {
+		case ws.Exited():
+			return ws.ExitStatus(), nil
+		case ws.Signaled():
+			return 128 + int(ws.Signal()), nil
+		default:
+			return 1, nil
+		}
 	}
 
-	// Convert wait status to exit code using standard Unix conventions:
-	// - Normal exit: use the exit code
-	// - Signal termination: use 128 + signal number
-	var exitCode int
-	switch {
-	case wstatus.Exited():
-		exitCode = wstatus.ExitStatus()
-	case wstatus.Signaled():
-		exitCode = 128 + int(wstatus.Signal())
-	default:
-		exitCode = 1
-	}
-	return exitCode, err
+	return 1, xerrors.New("reaper exited before child process was reaped")
 }

--- a/go.mod
+++ b/go.mod
@@ -622,3 +622,5 @@ replace github.com/anthropics/anthropic-sdk-go v1.19.0 => github.com/dannykoppin
 
 // https://github.com/openai/openai-go/pull/602
 replace github.com/openai/openai-go/v3 => github.com/SasSwart/openai-go/v3 v3.0.0-20260204134041-fb987b42a728
+
+replace github.com/hashicorp/go-reap => github.com/coder/go-reap v0.0.0-20260310125653-03afbd91857d

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322/go.mod h1:rOLFDDVKVFiDqZFXoteXc97YXx7kFi9kYqR+2ETPkLQ=
+github.com/coder/go-reap v0.0.0-20260310125653-03afbd91857d h1:RXVQcJgSaZcuz3/dimDRr3j/7lszysBT8VphrzCYjG0=
+github.com/coder/go-reap v0.0.0-20260310125653-03afbd91857d/go.mod h1:TGNW2TJmp3wSQ8K4E1mrjS1d70xPL40mAFttt8UAyA0=
 github.com/coder/go-scim/pkg/v2 v2.0.0-20230221055123-1d63c1222136 h1:0RgB61LcNs24WOxc3PBvygSNTQurm0PYPujJjLLOzs0=
 github.com/coder/go-scim/pkg/v2 v2.0.0-20230221055123-1d63c1222136/go.mod h1:VkD1P761nykiq75dz+4iFqIQIZka189tx1BQLOp0Skc=
 github.com/coder/guts v1.6.1 h1:bMVBtDNP/1gW58NFRBdzStAQzXlveMrLAnORpwE9tYo=
@@ -682,8 +684,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshfk+mA=
 github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
-github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b h1:3GrpnZQBxcMj1gCXQLelfjCT1D5MPGTuGMKHVzSIH6A=
-github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b/go.mod h1:qIFzeFcJU3OIFk/7JreWXcUjFmcCaeHTH9KoNyHYVCs=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-terraform-address v0.0.0-20240523040243-ccea9d309e0c h1:5v6L/m/HcAZYbrLGYBpPkcCVtDWwIgFxq2+FUmfPxPk=


### PR DESCRIPTION
The reaper goroutine and ForkReap both called Wait4, racing to consume the child's waitable state. When the reaper won, ForkReap got ECHILD.

Switch to `coder/go-reap`'s `ReapChildrenWithStatus`, which reports both PID and WaitStatus on a channel. ForkReap reads from this channel instead of calling Wait4 itself. Single Wait4 owner, no lock needed.

Removes the `WithReapLock` workaround from #22894 since the race no longer exists.

Part 2 of 2. Stacks on #22894 (test subprocess isolation).
Depends on https://github.com/coder/go-reap/pull/1 (go-reap fork adding `ReapChildrenWithStatus`).

---

🤖 This PR was created with the help of AI, and directed & reviewed by a human 🏂🏻.