### PR TITLE
fix(site): fix chat input button icon sizing and centering

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.stories.tsx
@@ -137,6 +137,28 @@ export const LoadingDisablesSend: Story = {
 	},
 };
 
+export const Streaming: Story = {
+	args: {
+		isStreaming: true,
+		onInterrupt: fn(),
+		isInterruptPending: false,
+		initialValue: "",
+		onAttach: fn(),
+		onRemoveAttachment: fn(),
+	},
+};
+
+export const StreamingInterruptPending: Story = {
+	args: {
+		isStreaming: true,
+		onInterrupt: fn(),
+		isInterruptPending: true,
+		initialValue: "",
+		onAttach: fn(),
+		onRemoveAttachment: fn(),
+	},
+};
+
 const longContent = Array.from(
 	{ length: 60 },
 	(_, i) =>

--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -640,12 +640,12 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 										type="button"
 										variant="outline"
 										size="icon"
-										className="size-7 shrink-0 rounded-full [&>svg]:p-0"
+										className="size-7 shrink-0 rounded-full [&>svg]:!size-icon-sm [&>svg]:p-0"
 										onClick={() => fileInputRef.current?.click()}
 										disabled={isDisabled}
 										aria-label="Attach files"
 									>
-										<ImageIcon className="h-4 w-4" />
+										<ImageIcon />
 									</Button>
 								</>
 							)}
@@ -653,11 +653,11 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								<Button
 									size="icon"
 									variant="default"
-									className="size-7 rounded-full transition-colors [&>svg]:p-0"
+									className="size-7 rounded-full transition-colors [&>svg]:!size-3 [&>svg]:p-0"
 									onClick={onInterrupt}
 									disabled={isInterruptPending}
 								>
-									<Square className="h-3 w-3 fill-current" />
+									<Square className="fill-current" />
 									<span className="sr-only">Stop</span>
 								</Button>
 							)}
@@ -665,7 +665,7 @@ export const AgentChatInput = memo<AgentChatInputProps>(
 								<Button
 									size="icon"
 									variant="default"
-									className="size-7 rounded-full transition-colors [&>svg]:!size-6 flex items-center justify-center"
+									className="size-7 rounded-full transition-colors [&>svg]:!size-5 [&>svg]:p-0"
 									onClick={handleSubmit}
 									disabled={!canSend}
 								>


### PR DESCRIPTION
## Problem

The three action buttons (attach, stop, send) in the agent chat input had inconsistent icon sizing and centering issues that varied with window size.

**Root cause:** The `Button` component's `size="icon"` variant applies `[&>svg]:size-icon-sm` (18px via the CSS `size` shorthand) to child SVGs. This silently overrides `h-*`/`w-*` classes set directly on the SVG elements because the `size` shorthand (`width` + `height`) takes precedence over individual `height`/`width` utilities. The base button also applies `[&>svg]:p-0.5` padding to all child SVGs.

This meant:
- **Stop button:** `h-3 w-3` (12px) on the Square was overridden to 18px by the variant, making it too large
- **Send button:** Used `[&>svg]:!size-6` (24px) which nearly filled the 28px button, and did not override the base `p-0.5` padding, causing off-center rendering at certain sizes
- **Attach button:** The `h-4 w-4` on ImageIcon was also overridden to 18px, though less noticeable

## Fix

Use `!important` size overrides on the parent button's `className` so icon sizes are deterministic regardless of Tailwind's generated CSS order:

| Button | Before (actual) | After | Class |
|--------|----------------|-------|-------|
| Attach | 18px (variant override) | 18px | `[&>svg]:!size-icon-sm` |
| Stop   | 18px (variant override) | 12px | `[&>svg]:!size-3` |
| Send   | ~20px visual (24px - 4px padding) | 20px | `[&>svg]:!size-5` |

All three buttons now also explicitly set `[&>svg]:p-0` to neutralize the base padding. Redundant `flex items-center justify-center` on the send button (already in the Button base) was removed.

## Stories

Added `Streaming` and `StreamingInterruptPending` stories to cover the stop button, which previously had no story.

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.