### PR TITLE
test(cli): fix flaky TestGitSSH/Local_SSH_Keys on Windows CI

### DIFF
--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -58,7 +58,7 @@ func prepareTestGitSSH(ctx context.Context, t *testing.T) (*agentsdk.Client, str
 	_ = agenttest.New(t, client.URL, r.AgentToken, func(o *agent.Options) {
 		o.Client = agentClient
 	})
-	_ = coderdtest.AwaitWorkspaceAgents(t, client, r.Workspace.ID)
+	_ = coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).WithContext(ctx).Wait()
 	return agentClient, r.AgentToken, pubkey
 }
 
@@ -167,7 +167,7 @@ func TestGitSSH(t *testing.T) {
 		require.NoError(t, err)
 		writePrivateKeyToFile(t, idFile, privkey)
 
-		setupCtx := testutil.Context(t, testutil.WaitLong)
+		setupCtx := testutil.Context(t, testutil.WaitSuperLong)
 		client, token, coderPubkey := prepareTestGitSSH(setupCtx, t)
 
 		authkey := make(chan gossh.PublicKey, 1)


### PR DESCRIPTION
The `TestGitSSH/Local_SSH_Keys` test was flaking on Windows CI with a
context deadline exceeded error when calling `client.GitSSHKey(ctx)`.

Two issues contributed to the flake:

1. `prepareTestGitSSH` called `coderdtest.AwaitWorkspaceAgents` without
   passing the caller's context. This created a separate internal 25s
   timeout, wasting time budget independently of the setup context.
   Changed to use `NewWorkspaceAgentWaiter(...).WithContext(ctx).Wait()`
   so the agent wait shares the caller's timeout.

2. The `Local SSH Keys` subtest used `WaitLong` (25s) for its setup
   context, but this subtest does more work than `Dial` (runs the
   command twice). Bumped to `WaitSuperLong` (60s) to give slow
   Windows CI runners enough time.

Fixes https://github.com/coder/internal/issues/770

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.