### PR TITLE
fix(site): remove redundant success toasts from agents feature

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -171,7 +171,6 @@ const AgentsPage: FC = () => {
 		...archiveChatBase,
 		onSuccess: (_data, chatId) => {
 			clearChatErrorReason(chatId);
-			toast.success("Agent archived.");
 		},
 		onError: (error, chatId, context) => {
 			archiveChatBase.onError(error, chatId, context);
@@ -194,8 +193,6 @@ const AgentsPage: FC = () => {
 			clearChatErrorReason(chatId);
 			await queryClient.invalidateQueries({ queryKey: chatsKey });
 			await queryClient.invalidateQueries({ queryKey: chatKey(chatId) });
-			toast.success("Agent archived.");
-			toast.success("Workspace deletion initiated.");
 		},
 		onError: (error) => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
@@ -204,9 +201,6 @@ const AgentsPage: FC = () => {
 	const unarchiveChatBase = unarchiveChat(queryClient);
 	const unarchiveAgentMutation = useMutation({
 		...unarchiveChatBase,
-		onSuccess: () => {
-			toast.success("Agent unarchived.");
-		},
 		onError: (error, chatId, context) => {
 			unarchiveChatBase.onError(error, chatId, context);
 			toast.error(getErrorMessage(error, "Failed to unarchive agent."));

--- a/site/src/pages/AgentsPage/WebPushButton.tsx
+++ b/site/src/pages/AgentsPage/WebPushButton.tsx
@@ -22,17 +22,12 @@ export const WebPushButton: FC = () => {
 		try {
 			if (webPush.subscribed) {
 				await webPush.unsubscribe();
-				toast.success("Notifications disabled.");
 			} else {
 				await webPush.subscribe();
-				toast.success("Notifications enabled.");
 			}
 		} catch (error) {
-			if (webPush.subscribed) {
-				toast.error(getErrorMessage(error, "Failed to disable notifications."));
-			} else {
-				toast.error(getErrorMessage(error, "Failed to enable notifications."));
-			}
+			const action = webPush.subscribed ? "disable" : "enable";
+			toast.error(getErrorMessage(error, `Failed to ${action} notifications.`));
 		}
 	};
 


### PR DESCRIPTION
## Summary

Remove success toasts that duplicate visual feedback already provided by the UI through optimistic updates or icon state changes.

## Removed toasts

| Location | Toast | Why redundant |
|---|---|---|
| Archive agent | `"Agent archived."` | Optimistic cache update moves chat to archived list instantly |
| Archive + delete | `"Agent archived."` + `"Workspace deletion initiated."` | Two toasts fired simultaneously, archive is optimistically reflected |
| Unarchive agent | `"Agent unarchived."` | Optimistic cache update moves chat back to active list instantly |
| Web push toggle | `"Notifications enabled/disabled."` | Bell icon changes color (green) and shape (BellIcon vs BellOffIcon) |

## Kept toasts

All **error** and **warning** toasts are preserved — failures have no other visual indicator.

## Simplification

- `unarchiveAgentMutation`: removed empty `onSuccess` handler
- `WebPushButton`: collapsed duplicated error branches into a single handler using a computed action string
