### PR TITLE
chore(dogfood): bump mux to 1.4.0

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -375,7 +375,7 @@ module "personalize" {
 module "mux" {
   count           = data.coder_workspace.me.start_count
   source          = "registry.coder.com/coder/mux/coder"
-  version         = "1.3.1"
+  version         = "1.4.0"
   agent_id        = coder_agent.dev.id
   subdomain       = true
   display_name    = "Mux"


### PR DESCRIPTION
## Summary
- bump the dogfood template Mux module from 1.3.1 to 1.4.0

## Validation
- terraform -chdir=dogfood/coder validate
- terraform fmt -check dogfood/coder/main.tf