### PR TITLE
fix(site): improve error handling in AgentsPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -1,4 +1,5 @@
 import { API, watchWorkspace } from "api/api";
+import { getErrorMessage } from "api/errors";
 import {
 	chat,
 	chatDiffStatus,
@@ -69,6 +70,7 @@ import { buildStreamTools } from "./AgentDetail/streamState";
 import { useMessageWindow } from "./AgentDetail/useMessageWindow";
 import { useWorkspaceCreationWatcher } from "./AgentDetail/useWorkspaceCreationWatcher";
 import {
+	AgentDetailErrorView,
 	AgentDetailLoadingView,
 	AgentDetailNotFoundView,
 	AgentDetailView,
@@ -862,6 +864,8 @@ const AgentDetail: FC = () => {
 					messageId: editedMessageID,
 					req: request,
 				});
+			} catch (error) {
+				toast.error(getErrorMessage(error, "Failed to edit message."));
 			} finally {
 				setPendingEditMessageId(null);
 			}
@@ -885,22 +889,26 @@ const AgentDetail: FC = () => {
 		// timeline when the server confirms via the POST response or
 		// via the SSE stream.
 		store.clearStreamState();
-		const response = await sendMutation.mutateAsync(request);
-		// When the server accepts the message immediately (not
-		// queued), insert it into the store so it appears in the
-		// timeline without waiting for the SSE stream.
-		if (!response.queued && response.message) {
-			store.upsertDurableMessage(response.message);
-		}
-		if (typeof window !== "undefined") {
-			if (selectedModelConfigID) {
-				localStorage.setItem(
-					lastModelConfigIDStorageKey,
-					selectedModelConfigID,
-				);
-			} else {
-				localStorage.removeItem(lastModelConfigIDStorageKey);
+		try {
+			const response = await sendMutation.mutateAsync(request);
+			// When the server accepts the message immediately (not
+			// queued), insert it into the store so it appears in the
+			// timeline without waiting for the SSE stream.
+			if (!response.queued && response.message) {
+				store.upsertDurableMessage(response.message);
 			}
+			if (typeof window !== "undefined") {
+				if (selectedModelConfigID) {
+					localStorage.setItem(
+						lastModelConfigIDStorageKey,
+						selectedModelConfigID,
+					);
+				} else {
+					localStorage.removeItem(lastModelConfigIDStorageKey);
+				}
+			}
+		} catch (error) {
+			toast.error(getErrorMessage(error, "Failed to send message."));
 		}
 	};
 
@@ -908,7 +916,11 @@ const AgentDetail: FC = () => {
 		if (!agentId || interruptMutation.isPending) {
 			return;
 		}
-		void interruptMutation.mutateAsync();
+		interruptMutation.mutate(undefined, {
+			onError: (error) => {
+				toast.error(getErrorMessage(error, "Failed to interrupt agent."));
+			},
+		});
 	};
 
 	const handleDeleteQueuedMessage = useCallback(
@@ -921,7 +933,7 @@ const AgentDetail: FC = () => {
 				await deleteQueuedMutation.mutateAsync(id);
 			} catch (error) {
 				store.setQueuedMessages(previousQueuedMessages);
-				throw error;
+				toast.error(getErrorMessage(error, "Failed to delete queued message."));
 			}
 		},
 		[deleteQueuedMutation, store],
@@ -943,7 +955,9 @@ const AgentDetail: FC = () => {
 			} catch (error) {
 				store.setQueuedMessages(previousQueuedMessages);
 				store.setChatStatus(previousChatStatus);
-				throw error;
+				toast.error(
+					getErrorMessage(error, "Failed to promote queued message."),
+				);
 			}
 		},
 		[promoteQueuedMutation, store],
@@ -1063,6 +1077,18 @@ const AgentDetail: FC = () => {
 				hasModelOptions={hasModelOptions}
 				inputStatusText={inputStatusText}
 				modelCatalogStatusMessage={modelCatalogStatusMessage}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+			/>
+		);
+	}
+
+	if (chatQuery.error) {
+		return (
+			<AgentDetailErrorView
+				titleElement={titleElement}
+				error={chatQuery.error}
+				onRetry={() => void chatQuery.refetch()}
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -1,6 +1,8 @@
 import type { ChatDiffStatusResponse } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
 import type { ModelSelectorOption } from "components/ai-elements";
+import { Button } from "components/Button/Button";
 import { Skeleton } from "components/Skeleton/Skeleton";
 import { ArchiveIcon } from "lucide-react";
 import { type FC, type RefObject, useCallback, useMemo, useState } from "react";
@@ -456,6 +458,55 @@ export const AgentDetailLoadingView: FC<AgentDetailLoadingViewProps> = ({
 					inputStatusText={inputStatusText}
 					modelCatalogStatusMessage={modelCatalogStatusMessage}
 				/>
+			</div>
+		</div>
+	);
+};
+
+interface AgentDetailErrorViewProps {
+	titleElement: React.ReactNode;
+	error: unknown;
+	onRetry: () => void;
+	isSidebarCollapsed: boolean;
+	onToggleSidebarCollapsed: () => void;
+}
+
+export const AgentDetailErrorView: FC<AgentDetailErrorViewProps> = ({
+	titleElement,
+	error,
+	onRetry,
+	isSidebarCollapsed,
+	onToggleSidebarCollapsed,
+}) => {
+	return (
+		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+			{titleElement}
+			<AgentDetailTopBar
+				panel={{
+					showSidebarPanel: false,
+					onToggleSidebar: () => {},
+				}}
+				workspace={{
+					canOpenEditors: false,
+					canOpenWorkspace: false,
+					onOpenInEditor: () => {},
+					onViewWorkspace: () => {},
+					onOpenTerminal: () => {},
+					sshCommand: undefined,
+				}}
+				onOpenParentChat={() => {}}
+				onArchiveAgent={() => {}}
+				onUnarchiveAgent={() => {}}
+				onArchiveAndDeleteWorkspace={() => {}}
+				hasWorkspace={false}
+				isSidebarCollapsed={isSidebarCollapsed}
+				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+			/>
+			<div className="flex flex-1 flex-col items-center justify-center gap-4">
+				<ErrorAlert error={error} />
+				<Button variant="outline" onClick={onRetry}>
+					Retry
+				</Button>
 			</div>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -614,7 +614,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const {
 		mutate: saveSystemPrompt,
 		isPending: isSavingSystemPrompt,
-		isError: isSaveSystemPromptError,
+		error: saveSystemPromptError,
 	} = useMutation(updateChatSystemPrompt(queryClient));
 	const [initialLastModelConfigID] = useState(() => {
 		if (typeof window === "undefined") {
@@ -914,7 +914,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					onSystemPromptDraftChange={setLocalEdit}
 					onSaveSystemPrompt={handleSaveSystemPrompt}
 					isSystemPromptDirty={isSystemPromptDirty}
-					saveSystemPromptError={isSaveSystemPromptError}
+					saveSystemPromptError={saveSystemPromptError}
 					isDisabled={isCreating || isSavingSystemPrompt}
 				/>
 			)}

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "api/errors";
 import { Button } from "components/Button/Button";
 import {
 	Dialog,
@@ -32,7 +33,7 @@ interface ConfigureAgentsDialogProps {
 	onSystemPromptDraftChange: (value: string) => void;
 	onSaveSystemPrompt: (event: FormEvent) => void;
 	isSystemPromptDirty: boolean;
-	saveSystemPromptError: boolean;
+	saveSystemPromptError: unknown;
 	isDisabled: boolean;
 }
 
@@ -185,9 +186,12 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 											Save
 										</Button>
 									</div>
-									{saveSystemPromptError && (
+									{saveSystemPromptError != null && (
 										<p className="m-0 text-xs text-content-destructive">
-											Failed to save system prompt.
+											{getErrorMessage(
+												saveSystemPromptError,
+												"Failed to save system prompt.",
+											)}
 										</p>
 									)}
 								</div>


### PR DESCRIPTION
## Summary

This PR improves error handling across the AgentsPage feature, addressing several cases where errors were silently swallowed or misidentified.

### Changes

**AgentDetail.tsx:**
- **Chat fetch error vs "not found":** Added a dedicated `AgentDetailErrorView` to distinguish network/server errors from actual 404s. Previously, any fetch failure showed "Chat not found" with no retry option.
- **Send/edit mutation errors:** Wrapped `sendMutation.mutateAsync` and `editMutation.mutateAsync` in try/catch blocks with `toast.error()` feedback.
- **Interrupt mutation errors:** Changed from fire-and-forget `void mutateAsync()` to `mutate()` with an `onError` callback.
- **Queue operation errors:** Replaced silent `throw error` re-throws with `toast.error()` in `handleDeleteQueuedMessage` and `handlePromoteQueuedMessage`.

**AgentDetailView.tsx:**
- Added new `AgentDetailErrorView` component with `ErrorAlert` and retry button, following the same shell pattern as `AgentDetailNotFoundView`.

**ConfigureAgentsDialog.tsx + AgentsPage.tsx:**
- Changed system prompt save error from a boolean (`isError`) to the actual error object, using `getErrorMessage()` to show specific server errors instead of a hardcoded "Failed to save system prompt" string.

### Testing
- TypeScript compilation passes with zero errors.
