### PR TITLE
fix(site): improve accessibility in AgentsPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/AgentChatInput.tsx
@@ -191,7 +191,7 @@ const ContextUsageIndicator = memo<{ usage: AgentContextUsage | null }>(
 								fill="none"
 								strokeWidth={RING_STROKE}
 								strokeLinecap="round"
-								className="stroke-current transition-all duration-300 ease-out"
+								className="stroke-current transition-[stroke-dashoffset] duration-300 ease-out"
 								style={{
 									strokeDasharray: `${RING_CIRCUMFERENCE} ${RING_CIRCUMFERENCE}`,
 									strokeDashoffset: dashOffset,

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -818,6 +818,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 					<DropdownMenuTrigger asChild>
 						<button
 							type="button"
+							aria-label="User menu"
 							className="flex w-full items-center gap-2 bg-transparent border-0 cursor-pointer px-3 py-3 text-left hover:bg-surface-tertiary/50 transition-colors"
 						>
 							<Avatar

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -311,7 +311,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						type="text"
 						{...form.getFieldProps("displayName")}
 						disabled={isSaving}
-						className="m-0 w-full border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
+						className="m-0 w-full border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-offset-0"
 						placeholder={
 							isEditing ? (editingModel?.model ?? "Model name") : "Model name"
 						}

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
@@ -173,7 +173,7 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 						value={displayName || formatProviderLabel(provider)}
 						onChange={(e) => setDisplayName(e.target.value)}
 						disabled={isDisabled || isAPIKeyEnvManaged}
-						className="m-0 w-full border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
+						className="m-0 w-full border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-offset-0"
 						placeholder={formatProviderLabel(provider)}
 					/>
 				</div>

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -9,7 +9,14 @@ import {
 } from "components/Dialog/Dialog";
 import type { LucideIcon } from "lucide-react";
 import { BoxesIcon, KeyRoundIcon, UserIcon, XIcon } from "lucide-react";
-import { type FC, type FormEvent, useEffect, useId, useMemo, useState } from "react";
+import {
+	type FC,
+	type FormEvent,
+	useEffect,
+	useId,
+	useMemo,
+	useState,
+} from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { cn } from "utils/cn";
 import { ChatModelAdminPanel } from "./ChatModelAdminPanel/ChatModelAdminPanel";

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "components/Dialog/Dialog";
 import type { LucideIcon } from "lucide-react";
 import { BoxesIcon, KeyRoundIcon, UserIcon, XIcon } from "lucide-react";
-import { type FC, type FormEvent, useEffect, useMemo, useState } from "react";
+import { type FC, type FormEvent, useEffect, useId, useMemo, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { cn } from "utils/cn";
 import { ChatModelAdminPanel } from "./ChatModelAdminPanel/ChatModelAdminPanel";
@@ -48,6 +48,8 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 	saveSystemPromptError,
 	isDisabled,
 }) => {
+	const systemPromptLabelId = useId();
+
 	const configureSectionOptions = useMemo<
 		readonly ConfigureAgentsSectionOption[]
 	>(() => {
@@ -150,7 +152,10 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 								onSubmit={(event) => void onSaveSystemPrompt(event)}
 							>
 								<div className="space-y-2">
-									<h3 className="m-0 text-[13px] font-semibold text-content-primary">
+									<h3
+										id={systemPromptLabelId}
+										className="m-0 text-[13px] font-semibold text-content-primary"
+									>
 										System Prompt
 									</h3>
 									<p className="m-0 text-xs text-content-secondary">
@@ -158,6 +163,7 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 										the built-in default prompt is used.
 									</p>
 									<TextareaAutosize
+										aria-labelledby={systemPromptLabelId}
 										className="min-h-[220px] w-full resize-y rounded-lg border border-border bg-surface-primary px-4 py-3 font-sans text-[13px] leading-relaxed text-content-primary placeholder:text-content-secondary focus:outline-none focus:ring-2 focus:ring-content-link/30"
 										placeholder="Optional. Set deployment-wide instructions for all new chats."
 										value={systemPromptDraft}

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -260,7 +260,7 @@ const FileTreeNodeView: FC<{
 				<button
 					type="button"
 					onClick={() => setExpanded((v) => !v)}
-					className="flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left text-content-secondary hover:bg-surface-secondary cursor-pointer outline-none"
+					className="flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left text-content-secondary hover:bg-surface-secondary cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset"
 					style={{ paddingLeft: 4 + depth * 8, fontSize: 13 }}
 					aria-expanded={expanded}
 				>
@@ -293,7 +293,7 @@ const FileTreeNodeView: FC<{
 			type="button"
 			onClick={() => onFileClick(node.fullPath)}
 			className={cn(
-				"flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left cursor-pointer outline-none border-0 border-r-2 border-solid border-transparent",
+				"flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset border-0 border-r-2 border-solid border-transparent",
 				"hover:bg-surface-secondary",
 				isActive && "bg-surface-secondary border-content-link",
 			)}

--- a/site/src/pages/AgentsPage/FilesChangedPanel.tsx
+++ b/site/src/pages/AgentsPage/FilesChangedPanel.tsx
@@ -322,7 +322,7 @@ const FileTreeNodeView: FC<{
 				<button
 					type="button"
 					onClick={() => setExpanded((v) => !v)}
-					className="flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left text-content-secondary hover:bg-surface-secondary cursor-pointer outline-none"
+					className="flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left text-content-secondary hover:bg-surface-secondary cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset"
 					style={{ paddingLeft: 4 + depth * 8, fontSize: 13 }}
 					aria-expanded={expanded}
 				>
@@ -355,7 +355,7 @@ const FileTreeNodeView: FC<{
 			type="button"
 			onClick={() => onFileClick(node.fullPath)}
 			className={cn(
-				"flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left cursor-pointer outline-none border-0 border-r-2 border-solid border-transparent",
+				"flex w-full items-center gap-1.5 rounded-none border-none bg-transparent py-1 text-left cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset border-0 border-r-2 border-solid border-transparent",
 				"hover:bg-surface-secondary",
 				isActive && "bg-surface-secondary border-content-link",
 			)}
@@ -412,7 +412,7 @@ const InlinePromptInput: FC<{
 			<div className="rounded-lg border border-border-default bg-surface-secondary p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40">
 				<textarea
 					ref={textareaRef}
-					className="w-full resize-none border-none bg-transparent px-2.5 py-1.5 font-sans text-[13px] leading-5 text-content-primary placeholder:text-content-secondary outline-none ring-0 focus:outline-none focus:ring-0"
+					className="w-full resize-none border-none bg-transparent px-2.5 py-1.5 font-sans text-[13px] leading-5 text-content-primary placeholder:text-content-secondary outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset"
 					placeholder="Add a comment to include with this reference..."
 					rows={1}
 					value={text}

--- a/site/src/pages/AgentsPage/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/GitPanel.tsx
@@ -102,7 +102,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 						type="button"
 						onClick={() => setView("remote")}
 						className={cn(
-							"flex cursor-pointer items-center gap-3 border-none font-medium transition-colors outline-none focus-visible:outline-none",
+							"flex cursor-pointer items-center gap-3 border-none font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset",
 							view === "remote"
 								? "bg-surface-quaternary/25 text-content-primary"
 								: "bg-surface-primary text-content-secondary hover:bg-surface-tertiary/50 hover:text-content-primary",
@@ -128,7 +128,7 @@ export const GitPanel: FC<GitPanelProps> = ({
 						type="button"
 						onClick={() => setView("local")}
 						className={cn(
-							"flex cursor-pointer items-center gap-3 border-0 border-l border-solid border-border-default font-medium transition-colors outline-none focus-visible:outline-none",
+							"flex cursor-pointer items-center gap-3 border-0 border-l border-solid border-border-default font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset",
 							view === "local"
 								? "bg-surface-quaternary/25 text-content-primary"
 								: "bg-surface-primary text-content-secondary hover:bg-surface-tertiary/50 hover:text-content-primary",


### PR DESCRIPTION
## Summary

This PR fixes accessibility violations in the AgentsPage feature, primarily around keyboard focus visibility and ARIA labeling.

### Changes

**Focus visibility (9 locations):**
- **ModelForm.tsx, ProviderForm.tsx:** Replaced `focus:ring-0` with `focus-visible:ring-2 focus-visible:ring-content-link` on inline edit inputs.
- **DiffViewer.tsx** (2 buttons): Added `focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset`.
- **FilesChangedPanel.tsx** (3 locations): Added focus-visible ring classes; textarea replaced `ring-0 focus:outline-none focus:ring-0` with the standard focus-visible ring.
- **GitPanel.tsx** (2 buttons): Replaced `focus-visible:outline-none` with `focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ring-inset`.

All instances previously had `outline-none` with no visible focus indicator, making them invisible to keyboard users.

**`transition-all` anti-pattern:**
- **AgentChatInput.tsx:** Changed `transition-all` to `transition-[stroke-dashoffset]` on the context-usage SVG ring. This is more performant and follows the web design guideline to list explicit transition properties.

**Missing form label:**
- **ConfigureAgentsDialog.tsx:** Added `id="system-prompt-label"` to the heading and `aria-labelledby="system-prompt-label"` to the system prompt textarea.

**Missing aria-label:**
- **AgentsSidebar.tsx:** Added `aria-label="User menu"` to the user dropdown trigger button.

### Testing
- TypeScript compilation passes with zero errors.
