### PR TITLE
docs: add early access state to agent child pages and fix video URL

### DIFF
--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -8,7 +8,7 @@ agent that runs the agent loop directly within the Coder control plane.
 No specialized software, API keys, or network access is required inside your workspace. The only requirement is network access between the control plane and external LLM providers.
 
 <video autoplay playsinline loop>
-  <source src="https://github.com/coder/coder/blob/main/docs/images/guides/ai-agents/coder-agents-ui.mp4?raw=true" type="video/mp4">
+  <source src="https://raw.githubusercontent.com/coder/coder/refs/heads/main/docs/images/guides/ai-agents/coder-agents-ui.mp4" type="video/mp4">
 Your browser does not support the video tag.
 </video>
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1196,22 +1196,26 @@
 						{
 							"title": "Architecture",
 							"description": "How the agent in the control plane communicates with workspaces",
-							"path": "./ai-coder/agents/architecture.md"
+							"path": "./ai-coder/agents/architecture.md",
+							"state": ["early access"]
 						},
 						{
 							"title": "Models",
 							"description": "Configure LLM providers and models for Coder Agents",
-							"path": "./ai-coder/agents/models.md"
+							"path": "./ai-coder/agents/models.md",
+							"state": ["early access"]
 						},
 						{
 							"title": "Platform Controls",
 							"description": "How platform teams control agent behavior, models, and policies",
-							"path": "./ai-coder/agents/platform-controls.md"
+							"path": "./ai-coder/agents/platform-controls.md",
+							"state": ["early access"]
 						},
 						{
 							"title": "Early Access",
 							"description": "About the Coder Agents Early Access program",
-							"path": "./ai-coder/agents/early-access.md"
+							"path": "./ai-coder/agents/early-access.md",
+							"state": ["early access"]
 						}
 					]
 				}


### PR DESCRIPTION
## Changes

- Add `"state": ["early access"]` to all child pages under Coder Agents in `docs/manifest.json` (Architecture, Models, Platform Controls, Early Access).
- Point the Coder Agents video `<source>` directly at `raw.githubusercontent.com` instead of the `github.com/blob/` URL with `?raw=true`.