### PR TITLE
feat(site): show workspace name in archive & delete action

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -1086,7 +1086,7 @@ const AgentDetail: FC = () => {
 			chatErrorReasons={chatErrorReasons}
 			chatRecord={chatRecord}
 			isArchived={isArchived}
-			hasWorkspace={Boolean(workspaceId)}
+			workspaceName={workspace?.name}
 			store={store}
 			editing={editing}
 			pendingEditMessageId={pendingEditMessageId}

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -49,7 +49,7 @@ type AgentDetailTopBarProps = {
 	onArchiveAgent: () => void;
 	onUnarchiveAgent: () => void;
 	onArchiveAndDeleteWorkspace: () => void;
-	hasWorkspace?: boolean;
+	workspaceName?: string;
 	isArchived?: boolean;
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
@@ -64,7 +64,7 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 	onArchiveAgent,
 	onUnarchiveAgent,
 	onArchiveAndDeleteWorkspace,
-	hasWorkspace,
+	workspaceName,
 	isArchived,
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
@@ -201,18 +201,18 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 									<ArchiveIcon className="h-3.5 w-3.5" />
 									Archive Agent
 								</DropdownMenuItem>
-								{hasWorkspace && (
+								{workspaceName && (
 									<DropdownMenuItem
 										className="text-content-destructive focus:text-content-destructive"
 										onSelect={onArchiveAndDeleteWorkspace}
 									>
 										<Trash2Icon className="h-3.5 w-3.5" />
-										Archive & Delete Workspace
+										Archive & delete workspace "{workspaceName}"
 									</DropdownMenuItem>
 								)}
 							</>
 						)}
-					</DropdownMenuContent>
+					</DropdownMenuContent>{" "}
 				</DropdownMenu>
 				<Button
 					variant="subtle"

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -203,11 +203,16 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 								</DropdownMenuItem>
 								{workspaceName && (
 									<DropdownMenuItem
-										className="text-content-destructive focus:text-content-destructive"
+										className="items-start text-content-destructive focus:text-content-destructive"
 										onSelect={onArchiveAndDeleteWorkspace}
 									>
-										<Trash2Icon className="h-3.5 w-3.5" />
-										Archive & delete workspace "{workspaceName}"
+										<Trash2Icon className="mt-0.5 h-3.5 w-3.5" />
+										<div className="flex flex-col">
+											<span>Archive & delete workspace</span>
+											<span className="text-xs font-normal opacity-60">
+												{workspaceName}
+											</span>
+										</div>
 									</DropdownMenuItem>
 								)}
 							</>

--- a/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
@@ -101,7 +101,7 @@ const meta: Meta<typeof AgentDetailView> = {
 		chatErrorReasons: {},
 		chatRecord: buildChat(),
 		isArchived: false,
-		hasWorkspace: true,
+		workspaceName: "my-workspace",
 		store: createChatStore(),
 		editing: defaultEditing,
 		pendingEditMessageId: null,

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -53,7 +53,7 @@ interface AgentDetailViewProps {
 	chatErrorReasons: Record<string, string>;
 	chatRecord: TypesGen.Chat | undefined;
 	isArchived: boolean;
-	hasWorkspace: boolean;
+	workspaceName?: string;
 
 	// Store handle.
 	store: ChatStoreHandle;
@@ -122,7 +122,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	chatErrorReasons,
 	chatRecord,
 	isArchived,
-	hasWorkspace,
+	workspaceName,
 	store,
 	editing,
 	pendingEditMessageId,
@@ -252,7 +252,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 						onArchiveAgent={handleArchiveAgentAction}
 						onUnarchiveAgent={handleUnarchiveAgentAction}
 						onArchiveAndDeleteWorkspace={handleArchiveAndDeleteWorkspaceAction}
-						hasWorkspace={hasWorkspace}
+						workspaceName={workspaceName}
 						isArchived={isArchived}
 						isSidebarCollapsed={isSidebarCollapsed}
 						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
@@ -413,7 +413,6 @@ export const AgentDetailLoadingView: FC<AgentDetailLoadingViewProps> = ({
 				onArchiveAgent={() => {}}
 				onUnarchiveAgent={() => {}}
 				onArchiveAndDeleteWorkspace={() => {}}
-				hasWorkspace={false}
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>
@@ -497,7 +496,6 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
 				onArchiveAgent={() => {}}
 				onUnarchiveAgent={() => {}}
 				onArchiveAndDeleteWorkspace={() => {}}
-				hasWorkspace={false}
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			/>


### PR DESCRIPTION
Replace the `hasWorkspace` boolean prop with `workspaceName?: string` so the TopBar
delete menu item reads `Archive & delete workspace "my-workspace"` instead of the
generic `Archive & Delete Workspace`. The presence of the name now gates visibility
of the menu item, removing the redundant boolean.

The sidebar menu item is unchanged since the `Chat` type only carries `workspace_id`
and the workspace name is only fetched when viewing a specific chat detail.

---

🤖 This PR was created with the help of Coder Agents, and reviewed by a human 🏂🏻.