### PR TITLE
fix(site): lift ConfigureAgentsDialog out of AgentCreateForm

### DIFF
--- a/site/src/pages/AgentsPage/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentCreateForm.stories.tsx
@@ -2,15 +2,7 @@ import { MockWorkspace } from "testHelpers/entities";
 import { withDashboardProvider } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
-import {
-	expect,
-	fn,
-	screen,
-	spyOn,
-	userEvent,
-	waitFor,
-	within,
-} from "storybook/test";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { AgentCreateForm } from "./AgentCreateForm";
 
 const modelOptions = [
@@ -36,26 +28,12 @@ const meta: Meta<typeof AgentCreateForm> = {
 		modelConfigs: [],
 		isModelConfigsLoading: false,
 		modelCatalogError: undefined,
-		canSetSystemPrompt: true,
-		canManageChatModelConfigs: false,
-		isConfigureAgentsDialogOpen: false,
-		onConfigureAgentsDialogOpenChange: fn(),
 	},
 	beforeEach: () => {
 		localStorage.clear();
 		spyOn(API, "getWorkspaces").mockResolvedValue({
 			workspaces: [],
 			count: 0,
-		});
-		spyOn(API, "getChatSystemPrompt").mockResolvedValue({
-			system_prompt: "",
-		});
-		spyOn(API, "updateChatSystemPrompt").mockResolvedValue();
-		spyOn(API, "getUserChatCustomPrompt").mockResolvedValue({
-			custom_prompt: "",
-		});
-		spyOn(API, "updateUserChatCustomPrompt").mockResolvedValue({
-			custom_prompt: "",
 		});
 	},
 };
@@ -176,35 +154,6 @@ export const SelectWorkspaceViaSearch: Story = {
 		// The trigger should now show the selected workspace.
 		await waitFor(() => {
 			expect(canvas.getByText("janedoe/my-project")).toBeInTheDocument();
-		});
-	},
-};
-
-export const SavesBehaviorPromptAndRestores: Story = {
-	args: {
-		isConfigureAgentsDialogOpen: true,
-	},
-	play: async () => {
-		const dialog = await screen.findByRole("dialog");
-
-		// Find the System Instructions textarea by its unique placeholder.
-		const textareas = await within(dialog).findAllByPlaceholderText(
-			"Additional behavior, style, and tone preferences for all users",
-		);
-		const textarea = textareas[0];
-
-		await userEvent.type(textarea, "You are a focused coding assistant.");
-
-		// Click the Save button inside the System Instructions form.
-		// There are multiple Save buttons (one per form), so grab all and
-		// pick the last one which belongs to the system prompt section.
-		const saveButtons = within(dialog).getAllByRole("button", { name: "Save" });
-		await userEvent.click(saveButtons[saveButtons.length - 1]);
-
-		await waitFor(() => {
-			expect(API.updateChatSystemPrompt).toHaveBeenCalledWith({
-				system_prompt: "You are a focused coding assistant.",
-			});
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/AgentCreateForm.tsx
@@ -1,9 +1,3 @@
-import {
-	chatSystemPrompt,
-	chatUserCustomPrompt,
-	updateChatSystemPrompt,
-	updateUserChatCustomPrompt,
-} from "api/queries/chats";
 import { workspaces } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
@@ -22,17 +16,15 @@ import { MonitorIcon } from "lucide-react";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import {
 	type FC,
-	type FormEvent,
 	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
 	useState,
 } from "react";
-import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useQuery } from "react-query";
 import { toast } from "sonner";
 import { AgentChatInput } from "./AgentChatInput";
-import { ConfigureAgentsDialog } from "./ConfigureAgentsDialog";
 import {
 	getModelCatalogStatusMessage,
 	getModelSelectorPlaceholder,
@@ -118,10 +110,6 @@ interface AgentCreateFormProps {
 	modelConfigs: readonly TypesGen.ChatModelConfig[];
 	isModelConfigsLoading: boolean;
 	modelCatalogError: unknown;
-	canSetSystemPrompt: boolean;
-	canManageChatModelConfigs: boolean;
-	isConfigureAgentsDialogOpen: boolean;
-	onConfigureAgentsDialogOpenChange: (open: boolean) => void;
 }
 
 export const AgentCreateForm: FC<AgentCreateFormProps> = ({
@@ -134,27 +122,10 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	isModelCatalogLoading,
 	isModelConfigsLoading,
 	modelCatalogError,
-	canSetSystemPrompt,
-	canManageChatModelConfigs,
-	isConfigureAgentsDialogOpen,
-	onConfigureAgentsDialogOpenChange,
 }) => {
 	const { organizations } = useDashboard();
-	const queryClient = useQueryClient();
 	const { initialInputValue, handleContentChange, submitDraft, resetDraft } =
 		useEmptyStateDraft();
-	const systemPromptQuery = useQuery(chatSystemPrompt());
-	const {
-		mutate: saveSystemPrompt,
-		isPending: isSavingSystemPrompt,
-		isError: isSaveSystemPromptError,
-	} = useMutation(updateChatSystemPrompt(queryClient));
-	const userPromptQuery = useQuery(chatUserCustomPrompt());
-	const {
-		mutate: saveUserPrompt,
-		isPending: isSavingUserPrompt,
-		isError: isSaveUserPromptError,
-	} = useMutation(updateUserChatCustomPrompt(queryClient));
 	const [initialLastModelConfigID] = useState(() => {
 		if (typeof window === "undefined") {
 			return "";
@@ -214,12 +185,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		modelOptions.some((modelOption) => modelOption.id === userSelectedModel)
 			? userSelectedModel
 			: preferredModelID;
-	const serverPrompt = systemPromptQuery.data?.system_prompt ?? "";
-	const [localEdit, setLocalEdit] = useState<string | null>(null);
-	const systemPromptDraft = localEdit ?? serverPrompt;
-	const serverUserPrompt = userPromptQuery.data?.custom_prompt ?? "";
-	const [localUserEdit, setLocalUserEdit] = useState<string | null>(null);
-	const userPromptDraft = localUserEdit ?? serverUserPrompt;
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
 		() => {
@@ -276,23 +241,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	selectedWorkspaceIdRef.current = selectedWorkspaceId;
 	const selectedModelRef = useRef(selectedModel);
 	selectedModelRef.current = selectedModel;
-	const isSystemPromptDirty = localEdit !== null && localEdit !== serverPrompt;
-	const isUserPromptDirty =
-		localUserEdit !== null && localUserEdit !== serverUserPrompt;
-
-	const handleSaveUserPrompt = useCallback(
-		(event: FormEvent) => {
-			event.preventDefault();
-			if (!isUserPromptDirty) {
-				return;
-			}
-			saveUserPrompt(
-				{ custom_prompt: userPromptDraft },
-				{ onSuccess: () => setLocalUserEdit(null) },
-			);
-		},
-		[isUserPromptDirty, userPromptDraft, saveUserPrompt],
-	);
 
 	const handleWorkspaceChange = (value: string) => {
 		if (value === autoCreateWorkspaceValue) {
@@ -312,20 +260,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		setHasUserSelectedModel(true);
 		setUserSelectedModel(value);
 	}, []);
-
-	const handleSaveSystemPrompt = useCallback(
-		(event: FormEvent) => {
-			event.preventDefault();
-			if (!isSystemPromptDirty) {
-				return;
-			}
-			saveSystemPrompt(
-				{ system_prompt: systemPromptDraft },
-				{ onSuccess: () => setLocalEdit(null) },
-			);
-		},
-		[isSystemPromptDirty, systemPromptDraft, saveSystemPrompt],
-	);
 
 	const handleSend = useCallback(
 		async (message: string, fileIDs?: string[]) => {
@@ -460,24 +394,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					}
 				/>
 			</div>
-
-			<ConfigureAgentsDialog
-				open={isConfigureAgentsDialogOpen}
-				onOpenChange={onConfigureAgentsDialogOpenChange}
-				canManageChatModelConfigs={canManageChatModelConfigs}
-				canSetSystemPrompt={canSetSystemPrompt}
-				systemPromptDraft={systemPromptDraft}
-				onSystemPromptDraftChange={setLocalEdit}
-				onSaveSystemPrompt={handleSaveSystemPrompt}
-				isSystemPromptDirty={isSystemPromptDirty}
-				saveSystemPromptError={isSaveSystemPromptError}
-				userPromptDraft={userPromptDraft}
-				onUserPromptDraftChange={setLocalUserEdit}
-				onSaveUserPrompt={handleSaveUserPrompt}
-				isUserPromptDirty={isUserPromptDirty}
-				saveUserPromptError={isSaveUserPromptError}
-				isDisabled={isCreating || isSavingSystemPrompt || isSavingUserPrompt}
-			/>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -11,6 +11,7 @@ import { pageTitle } from "utils/page";
 import { AgentCreateForm, type CreateChatOptions } from "./AgentCreateForm";
 import { AgentsSidebar } from "./AgentsSidebar";
 import { ChimeButton } from "./ChimeButton";
+import { ConfigureAgentsDialog } from "./ConfigureAgentsDialog";
 import { WebPushButton } from "./WebPushButton";
 
 type ChatModelOption = ModelSelectorOption;
@@ -175,14 +176,17 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 							isModelCatalogLoading={isModelCatalogLoading}
 							isModelConfigsLoading={isModelConfigsLoading}
 							modelCatalogError={modelCatalogError}
-							canSetSystemPrompt={isAgentsAdmin}
-							canManageChatModelConfigs={isAgentsAdmin}
-							isConfigureAgentsDialogOpen={isConfigureAgentsDialogOpen}
-							onConfigureAgentsDialogOpenChange={setConfigureAgentsDialogOpen}
 						/>
 					</>
 				)}
 			</div>
+
+			<ConfigureAgentsDialog
+				open={isConfigureAgentsDialogOpen}
+				onOpenChange={setConfigureAgentsDialogOpen}
+				canManageChatModelConfigs={isAgentsAdmin}
+				canSetSystemPrompt={isAgentsAdmin}
+			/>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { API } from "api/api";
 import {
 	chatModelConfigsKey,
 	chatModelsKey,
@@ -9,7 +10,15 @@ import type {
 	ChatModelsResponse,
 	ChatProviderConfig,
 } from "api/typesGenerated";
-import { fn } from "storybook/test";
+import {
+	expect,
+	fn,
+	screen,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 import { ConfigureAgentsDialog } from "./ConfigureAgentsDialog";
 
 // Pre-seeded query data so that ChatModelAdminPanel renders
@@ -74,17 +83,18 @@ const meta: Meta<typeof ConfigureAgentsDialog> = {
 		onOpenChange: fn(),
 		canManageChatModelConfigs: false,
 		canSetSystemPrompt: false,
-		systemPromptDraft: "",
-		onSystemPromptDraftChange: fn(),
-		onSaveSystemPrompt: fn(),
-		isSystemPromptDirty: false,
-		saveSystemPromptError: false,
-		userPromptDraft: "",
-		onUserPromptDraftChange: fn(),
-		onSaveUserPrompt: fn(),
-		isUserPromptDirty: false,
-		saveUserPromptError: false,
-		isDisabled: false,
+	},
+	beforeEach: () => {
+		spyOn(API, "getChatSystemPrompt").mockResolvedValue({
+			system_prompt: "",
+		});
+		spyOn(API, "updateChatSystemPrompt").mockResolvedValue();
+		spyOn(API, "getUserChatCustomPrompt").mockResolvedValue({
+			custom_prompt: "",
+		});
+		spyOn(API, "updateUserChatCustomPrompt").mockResolvedValue({
+			custom_prompt: "",
+		});
 	},
 };
 
@@ -98,7 +108,11 @@ export const UserOnly: Story = {};
 export const AdminPrompts: Story = {
 	args: {
 		canSetSystemPrompt: true,
-		systemPromptDraft: "You are a helpful coding assistant.",
+	},
+	beforeEach: () => {
+		spyOn(API, "getChatSystemPrompt").mockResolvedValue({
+			system_prompt: "You are a helpful coding assistant.",
+		});
 	},
 };
 
@@ -107,7 +121,41 @@ export const AdminFull: Story = {
 	args: {
 		canSetSystemPrompt: true,
 		canManageChatModelConfigs: true,
-		systemPromptDraft: "Follow company coding standards.",
 	},
 	parameters: { queries: chatQueries },
+	beforeEach: () => {
+		spyOn(API, "getChatSystemPrompt").mockResolvedValue({
+			system_prompt: "Follow company coding standards.",
+		});
+	},
+};
+
+/** Verifies that typing and saving the system prompt calls the API. */
+export const SavesBehaviorPromptAndRestores: Story = {
+	args: {
+		canSetSystemPrompt: true,
+	},
+	play: async () => {
+		const dialog = await screen.findByRole("dialog");
+
+		// Find the System Instructions textarea by its unique placeholder.
+		const textareas = await within(dialog).findAllByPlaceholderText(
+			"Additional behavior, style, and tone preferences for all users",
+		);
+		const textarea = textareas[0];
+
+		await userEvent.type(textarea, "You are a focused coding assistant.");
+
+		// Click the Save button inside the System Instructions form.
+		// There are multiple Save buttons (one per form), so grab all and
+		// pick the last one which belongs to the system prompt section.
+		const saveButtons = within(dialog).getAllByRole("button", { name: "Save" });
+		await userEvent.click(saveButtons[saveButtons.length - 1]);
+
+		await waitFor(() => {
+			expect(API.updateChatSystemPrompt).toHaveBeenCalledWith({
+				system_prompt: "You are a focused coding assistant.",
+			});
+		});
+	},
 };

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -1,3 +1,9 @@
+import {
+	chatSystemPrompt,
+	chatUserCustomPrompt,
+	updateChatSystemPrompt,
+	updateUserChatCustomPrompt,
+} from "api/queries/chats";
 import { Button } from "components/Button/Button";
 import {
 	Dialog,
@@ -21,7 +27,15 @@ import {
 	UserIcon,
 	XIcon,
 } from "lucide-react";
-import { type FC, type FormEvent, useEffect, useMemo, useState } from "react";
+import {
+	type FC,
+	type FormEvent,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 import TextareaAutosize from "react-textarea-autosize";
 import { cn } from "utils/cn";
 import { ChatModelAdminPanel } from "./ChatModelAdminPanel/ChatModelAdminPanel";
@@ -60,17 +74,6 @@ interface ConfigureAgentsDialogProps {
 	onOpenChange: (open: boolean) => void;
 	canManageChatModelConfigs: boolean;
 	canSetSystemPrompt: boolean;
-	systemPromptDraft: string;
-	onSystemPromptDraftChange: (value: string) => void;
-	onSaveSystemPrompt: (event: FormEvent) => void;
-	isSystemPromptDirty: boolean;
-	saveSystemPromptError: boolean;
-	userPromptDraft: string;
-	onUserPromptDraftChange: (value: string) => void;
-	onSaveUserPrompt: (event: FormEvent) => void;
-	isUserPromptDirty: boolean;
-	saveUserPromptError: boolean;
-	isDisabled: boolean;
 }
 
 export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
@@ -78,18 +81,59 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 	onOpenChange,
 	canManageChatModelConfigs,
 	canSetSystemPrompt,
-	systemPromptDraft,
-	onSystemPromptDraftChange,
-	onSaveSystemPrompt,
-	isSystemPromptDirty,
-	saveSystemPromptError,
-	userPromptDraft,
-	onUserPromptDraftChange,
-	onSaveUserPrompt,
-	isUserPromptDirty,
-	saveUserPromptError,
-	isDisabled,
 }) => {
+	const queryClient = useQueryClient();
+
+	const systemPromptQuery = useQuery(chatSystemPrompt());
+	const {
+		mutate: saveSystemPrompt,
+		isPending: isSavingSystemPrompt,
+		isError: isSaveSystemPromptError,
+	} = useMutation(updateChatSystemPrompt(queryClient));
+
+	const userPromptQuery = useQuery(chatUserCustomPrompt());
+	const {
+		mutate: saveUserPrompt,
+		isPending: isSavingUserPrompt,
+		isError: isSaveUserPromptError,
+	} = useMutation(updateUserChatCustomPrompt(queryClient));
+
+	const serverPrompt = systemPromptQuery.data?.system_prompt ?? "";
+	const [localEdit, setLocalEdit] = useState<string | null>(null);
+	const systemPromptDraft = localEdit ?? serverPrompt;
+
+	const serverUserPrompt = userPromptQuery.data?.custom_prompt ?? "";
+	const [localUserEdit, setLocalUserEdit] = useState<string | null>(null);
+	const userPromptDraft = localUserEdit ?? serverUserPrompt;
+
+	const isSystemPromptDirty = localEdit !== null && localEdit !== serverPrompt;
+	const isUserPromptDirty =
+		localUserEdit !== null && localUserEdit !== serverUserPrompt;
+	const isDisabled = isSavingSystemPrompt || isSavingUserPrompt;
+
+	const handleSaveSystemPrompt = useCallback(
+		(event: FormEvent) => {
+			event.preventDefault();
+			if (!isSystemPromptDirty) return;
+			saveSystemPrompt(
+				{ system_prompt: systemPromptDraft },
+				{ onSuccess: () => setLocalEdit(null) },
+			);
+		},
+		[isSystemPromptDirty, systemPromptDraft, saveSystemPrompt],
+	);
+
+	const handleSaveUserPrompt = useCallback(
+		(event: FormEvent) => {
+			event.preventDefault();
+			if (!isUserPromptDirty) return;
+			saveUserPrompt(
+				{ custom_prompt: userPromptDraft },
+				{ onSuccess: () => setLocalUserEdit(null) },
+			);
+		},
+		[isUserPromptDirty, userPromptDraft, saveUserPrompt],
+	);
 	const configureSectionOptions = useMemo<
 		readonly ConfigureAgentsSectionOption[]
 	>(() => {
@@ -198,10 +242,10 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 							{/* ── Personal prompt (always visible) ── */}
 							<form
 								className="space-y-2"
-								onSubmit={(event) => void onSaveUserPrompt(event)}
+								onSubmit={(event) => void handleSaveUserPrompt(event)}
 							>
 								<h3 className="m-0 text-[13px] font-semibold text-content-primary">
-									Personal Instructions
+									Personal Instructions{" "}
 								</h3>
 								<p className="!mt-0.5 m-0 text-xs text-content-secondary">
 									Applied to all your chats. Only visible to you.
@@ -210,9 +254,7 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 									className={textareaClassName}
 									placeholder="Additional behavior, style, and tone preferences"
 									value={userPromptDraft}
-									onChange={(event) =>
-										onUserPromptDraftChange(event.target.value)
-									}
+									onChange={(event) => setLocalUserEdit(event.target.value)}
 									disabled={isDisabled}
 									minRows={1}
 								/>
@@ -221,11 +263,11 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 										size="sm"
 										variant="outline"
 										type="button"
-										onClick={() => onUserPromptDraftChange("")}
+										onClick={() => setLocalUserEdit("")}
 										disabled={isDisabled || !userPromptDraft}
 									>
 										Clear
-									</Button>
+									</Button>{" "}
 									<Button
 										size="sm"
 										type="submit"
@@ -234,7 +276,7 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 										Save
 									</Button>
 								</div>
-								{saveUserPromptError && (
+								{isSaveUserPromptError && (
 									<p className="m-0 text-xs text-content-destructive">
 										Failed to save personal instructions.
 									</p>
@@ -247,7 +289,7 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 									<hr className="my-5 border-0 border-t border-solid border-border" />
 									<form
 										className="space-y-2"
-										onSubmit={(event) => void onSaveSystemPrompt(event)}
+										onSubmit={(event) => void handleSaveSystemPrompt(event)}
 									>
 										<div className="flex items-center gap-2">
 											<h3 className="m-0 text-[13px] font-semibold text-content-primary">
@@ -263,9 +305,7 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 											className={textareaClassName}
 											placeholder="Additional behavior, style, and tone preferences for all users"
 											value={systemPromptDraft}
-											onChange={(event) =>
-												onSystemPromptDraftChange(event.target.value)
-											}
+											onChange={(event) => setLocalEdit(event.target.value)}
 											disabled={isDisabled}
 											minRows={1}
 										/>
@@ -274,11 +314,11 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 												size="sm"
 												variant="outline"
 												type="button"
-												onClick={() => onSystemPromptDraftChange("")}
+												onClick={() => setLocalEdit("")}
 												disabled={isDisabled || !systemPromptDraft}
 											>
 												Clear
-											</Button>
+											</Button>{" "}
 											<Button
 												size="sm"
 												type="submit"
@@ -287,7 +327,7 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 												Save
 											</Button>
 										</div>
-										{saveSystemPromptError && (
+										{isSaveSystemPromptError && (
 											<p className="m-0 text-xs text-content-destructive">
 												Failed to save system prompt.
 											</p>


### PR DESCRIPTION
## Problem

`ConfigureAgentsDialog` was rendered inside `AgentCreateForm`, which is only mounted when no agent is selected (the empty state). The sidebar settings button was always visible, but clicking it while viewing a conversation had no effect because the dialog was not in the DOM.

## Changes

- **`ConfigureAgentsDialog`**: Now self-contained. Manages its own system/user prompt queries, mutations, draft state, and save handlers internally. Props reduced from 15 to 4: `open`, `onOpenChange`, `canManageChatModelConfigs`, `canSetSystemPrompt`.
- **`AgentCreateForm`**: Removed all dialog/prompt-related code (4 props, prompt queries/mutations, draft state, save handlers, and the dialog render).
- **`AgentsPageView`**: `ConfigureAgentsDialog` now renders at the page root, outside the `agentId` conditional, so it is always mounted regardless of which view is active.
- **Stories**: Moved `SavesBehaviorPromptAndRestores` from `AgentCreateForm.stories` to `ConfigureAgentsDialog.stories` where it belongs. Moved prompt API mocks accordingly.