### PR TITLE
fix: bump aibridge to v1.0.9 to forward Anthropic-Beta header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -473,7 +473,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.0.6
+	github.com/coder/aibridge v1.0.9
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.6.0
 	github.com/coder/preview v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.0.6 h1:RVcJCutgWAd8MOxNI5MNVBl+ttqShVsmMQvUAkfuU9Q=
-github.com/coder/aibridge v1.0.6/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
+github.com/coder/aibridge v1.0.9 h1:vZHpIi/6lo1yKv8cVkc/vwUR6EQwXs3Y0x3HP1tjqGM=
+github.com/coder/aibridge v1.0.9/go.mod h1:c7Of2xfAksZUrPWN180Eh60fiKgzs7dyOjniTjft6AE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/boundary v0.6.0 h1:DfYVBIH8/6EBfg9I0qz7rX2jo+4blUx4P4amd13nib8=


### PR DESCRIPTION
Bumps aibridge to v1.0.9, which forwards the `Anthropic-Beta` header from client requests to the upstream Anthropic API: https://github.com/coder/aibridge/pull/205

This fixes the `context_management: Extra inputs are not permitted` error when using Claude Code with AI Bridge.

Note: v1.0.8 was retracted due to a conflict marker cached by the Go module proxy https://github.com/coder/aibridge/pull/208. v1.0.9 contains the same fix.

Related to internal Slack thread: https://codercom.slack.com/archives/C096PFVBZKN/p1773192289945009?thread_ts=1772811897.981709&cid=C096PFVBZKN