### PR TITLE
fix(cli/sessionstore): don't run Windows keyring tests in parallel

### DIFF
--- a/cli/sessionstore/sessionstore_test.go
+++ b/cli/sessionstore/sessionstore_test.go
@@ -21,9 +21,8 @@ type storedCredentials map[string]struct {
 	APIToken string `json:"api_token"`
 }
 
+//nolint:paralleltest, tparallel // OS keyring is flaky under concurrent access
 func TestKeyring(t *testing.T) {
-	t.Parallel()
-
 	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		t.Skip("linux is not supported yet")
 	}
@@ -37,8 +36,6 @@ func TestKeyring(t *testing.T) {
 	)
 
 	t.Run("ReadNonExistent", func(t *testing.T) {
-		t.Parallel()
-
 		backend := sessionstore.NewKeyringWithService(testhelpers.KeyringServiceName(t))
 		srvURL, err := url.Parse(testURL)
 		require.NoError(t, err)
@@ -50,8 +47,6 @@ func TestKeyring(t *testing.T) {
 	})
 
 	t.Run("DeleteNonExistent", func(t *testing.T) {
-		t.Parallel()
-
 		backend := sessionstore.NewKeyringWithService(testhelpers.KeyringServiceName(t))
 		srvURL, err := url.Parse(testURL)
 		require.NoError(t, err)
@@ -63,8 +58,6 @@ func TestKeyring(t *testing.T) {
 	})
 
 	t.Run("WriteAndRead", func(t *testing.T) {
-		t.Parallel()
-
 		backend := sessionstore.NewKeyringWithService(testhelpers.KeyringServiceName(t))
 		srvURL, err := url.Parse(testURL)
 		require.NoError(t, err)
@@ -91,8 +84,6 @@ func TestKeyring(t *testing.T) {
 	})
 
 	t.Run("WriteAndDelete", func(t *testing.T) {
-		t.Parallel()
-
 		backend := sessionstore.NewKeyringWithService(testhelpers.KeyringServiceName(t))
 		srvURL, err := url.Parse(testURL)
 		require.NoError(t, err)
@@ -115,8 +106,6 @@ func TestKeyring(t *testing.T) {
 	})
 
 	t.Run("OverwriteToken", func(t *testing.T) {
-		t.Parallel()
-
 		backend := sessionstore.NewKeyringWithService(testhelpers.KeyringServiceName(t))
 		srvURL, err := url.Parse(testURL)
 		require.NoError(t, err)
@@ -146,8 +135,6 @@ func TestKeyring(t *testing.T) {
 	})
 
 	t.Run("MultipleServers", func(t *testing.T) {
-		t.Parallel()
-
 		backend := sessionstore.NewKeyringWithService(testhelpers.KeyringServiceName(t))
 		srvURL, err := url.Parse(testURL)
 		require.NoError(t, err)
@@ -199,7 +186,6 @@ func TestKeyring(t *testing.T) {
 	})
 
 	t.Run("StorageFormat", func(t *testing.T) {
-		t.Parallel()
 		// The storage format must remain consistent to ensure we don't break
 		// compatibility with other Coder related applications that may read
 		// or decode the same credential.

--- a/cli/sessionstore/sessionstore_windows_test.go
+++ b/cli/sessionstore/sessionstore_windows_test.go
@@ -25,9 +25,8 @@ func readRawKeychainCredential(t *testing.T, serviceName string) []byte {
 	return winCred.CredentialBlob
 }
 
+//nolint:paralleltest, tparallel // OS keyring is flaky under concurrent access
 func TestWindowsKeyring_WriteReadDelete(t *testing.T) {
-	t.Parallel()
-
 	const testURL = "http://127.0.0.1:1337"
 	srvURL, err := url.Parse(testURL)
 	require.NoError(t, err)


### PR DESCRIPTION
Removes `t.Parallel()` from `TestKeyring` and `TestWindowsKeyring_WriteReadDelete`. The OS keyring is a shared system resource that's flaky under concurrent access, especially Windows Credential Manager in CI.

Fixes coder/internal#1370