### PR TITLE
fix(coderd,site): auto-reconnect dynamic parameters WebSocket and reduce idle timeout

### DIFF
--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -128,9 +128,17 @@ func (*API) handleParameterEvaluate(rw http.ResponseWriter, r *http.Request, ini
 	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
+// dynamicParameterIdleTimeout is the idle timeout for the dynamic
+// parameters WebSocket. The connection is closed if no messages are
+// received within this duration. Each client message resets the timer.
+const dynamicParameterIdleTimeout = 3 * time.Minute
+
 func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request, initial codersdk.DynamicParametersRequest, render dynamicparameters.Renderer) {
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Minute)
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
+
+	idleTimer := time.AfterFunc(dynamicParameterIdleTimeout, cancel)
+	defer idleTimer.Stop()
 
 	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {
@@ -178,6 +186,8 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 				// The connection has been closed, so there is no one to write to
 				return
 			}
+
+			idleTimer.Reset(dynamicParameterIdleTimeout)
 
 			// Take a nil uuid to mean the previous owner ID.
 			// This just removes the need to constantly send who you are.

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1146,12 +1146,8 @@ class ApiMethods {
 		userId: string,
 		{
 			onMessage,
-			onError,
-			onClose,
 		}: {
 			onMessage: (response: TypesGen.DynamicParametersResponse) => void;
-			onError: (error: Error) => void;
-			onClose: () => void;
 		},
 	): WebSocket => {
 		const socket = createWebSocket(
@@ -1162,15 +1158,6 @@ class ApiMethods {
 		socket.addEventListener("message", (event) =>
 			onMessage(JSON.parse(event.data) as TypesGen.DynamicParametersResponse),
 		);
-
-		socket.addEventListener("error", () => {
-			onError(new Error("Connection for dynamic parameters failed."));
-			socket.close();
-		});
-
-		socket.addEventListener("close", () => {
-			onClose();
-		});
 
 		return socket;
 	};

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3237,7 +3237,7 @@ function getConfiguredAxiosInstance(): AxiosInstance {
 /**
  * Utility function to help create a WebSocket connection with Coder's API.
  */
-function createWebSocket(
+export function createWebSocket(
 	path: string,
 	params: URLSearchParams = new URLSearchParams(),
 ) {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3237,7 +3237,7 @@ function getConfiguredAxiosInstance(): AxiosInstance {
 /**
  * Utility function to help create a WebSocket connection with Coder's API.
  */
-export function createWebSocket(
+function createWebSocket(
 	path: string,
 	params: URLSearchParams = new URLSearchParams(),
 ) {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx
@@ -56,14 +56,6 @@ describe("CreateWorkspacePage", () => {
 				mockWebSocket.addEventListener("message", (event) => {
 					callbacks.onMessage(JSON.parse(event.data));
 				});
-				mockWebSocket.addEventListener("error", () => {
-					callbacks.onError(
-						new Error("Connection for dynamic parameters failed."),
-					);
-				});
-				mockWebSocket.addEventListener("close", () => {
-					callbacks.onClose();
-				});
 
 				publisher.publishOpen(new Event("open"));
 				publisher.publishMessage(
@@ -91,8 +83,6 @@ describe("CreateWorkspacePage", () => {
 				MockUserOwner.id,
 				expect.objectContaining({
 					onMessage: expect.any(Function),
-					onError: expect.any(Function),
-					onClose: expect.any(Function),
 				}),
 			);
 
@@ -112,14 +102,6 @@ describe("CreateWorkspacePage", () => {
 				.mockImplementation((_versionId, _ownerId, callbacks) => {
 					mockWebSocket.addEventListener("message", (event) => {
 						callbacks.onMessage(JSON.parse(event.data));
-					});
-					mockWebSocket.addEventListener("error", () => {
-						callbacks.onError(
-							new Error("Connection for dynamic parameters failed."),
-						);
-					});
-					mockWebSocket.addEventListener("close", () => {
-						callbacks.onClose();
 					});
 
 					publisher.publishOpen(new Event("open"));
@@ -170,53 +152,38 @@ describe("CreateWorkspacePage", () => {
 			jest.useRealTimers();
 		});
 
-		it("handles WebSocket error gracefully", async () => {
+		it("shows error when WebSocket disconnects", async () => {
 			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
 
 			jest
 				.spyOn(API, "templateVersionDynamicParameters")
 				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("error", () => {
-						callbacks.onError(new Error("Connection failed"));
+					mockWebSocket.addEventListener("message", (event) => {
+						callbacks.onMessage(JSON.parse(event.data));
 					});
+
+					mockPublisher.publishOpen(new Event("open"));
+					mockPublisher.publishMessage(
+						new MessageEvent("message", {
+							data: JSON.stringify(MockDynamicParametersResponse),
+						}),
+					);
 
 					return mockWebSocket;
 				});
 
 			renderCreateWorkspacePage();
+			await waitForLoaderToBeRemoved();
+
+			// Simulate a disconnect via the close event, which
+			// createReconnectingWebSocket forwards as onDisconnect.
+			mockPublisher.publishClose(new Event("close") as CloseEvent);
 
 			await waitFor(() => {
-				expect(mockPublisher).toBeDefined();
-				mockPublisher.publishError(new Event("Connection failed"));
-				const alert = screen.getByRole("alert");
-				expect(
-					within(alert).getByRole("heading", { name: /connection failed/i }),
-				).toBeInTheDocument();
-			});
-		});
-
-		it("handles WebSocket close event", async () => {
-			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
-					mockWebSocket.addEventListener("close", () => {
-						callbacks.onClose();
-					});
-
-					return mockWebSocket;
-				});
-
-			renderCreateWorkspacePage();
-
-			await waitFor(() => {
-				expect(mockPublisher).toBeDefined();
-				mockPublisher.publishClose(new Event("close") as CloseEvent);
 				const alert = screen.getByRole("alert");
 				expect(
 					within(alert).getByRole("heading", {
-						name: /websocket connection.*unexpectedly closed/i,
+						name: /dynamic parameters lost/i,
 					}),
 				).toBeInTheDocument();
 			});

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -21,6 +21,7 @@ import userEvent from "@testing-library/user-event";
 import { API } from "api/api";
 import type { DynamicParametersResponse } from "api/typesGenerated";
 import { act } from "react";
+import { vi } from "vitest";
 import CreateWorkspacePage from "./CreateWorkspacePage";
 
 describe("CreateWorkspacePage", () => {
@@ -40,17 +41,16 @@ describe("CreateWorkspacePage", () => {
 	};
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 
-		jest.spyOn(API, "getTemplate").mockResolvedValue(MockTemplate);
-		jest.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([]);
-		jest.spyOn(API, "getTemplateVersionPresets").mockResolvedValue([]);
-		jest.spyOn(API, "createWorkspace").mockResolvedValue(MockWorkspace);
-		jest.spyOn(API, "checkAuthorization").mockResolvedValue(MockPermissions);
+		vi.spyOn(API, "getTemplate").mockResolvedValue(MockTemplate);
+		vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([]);
+		vi.spyOn(API, "getTemplateVersionPresets").mockResolvedValue([]);
+		vi.spyOn(API, "createWorkspace").mockResolvedValue(MockWorkspace);
+		vi.spyOn(API, "checkAuthorization").mockResolvedValue(MockPermissions);
 
-		jest
-			.spyOn(API, "templateVersionDynamicParameters")
-			.mockImplementation((_versionId, _ownerId, callbacks) => {
+		vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+			(_versionId, _ownerId, callbacks) => {
 				const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
 
 				mockWebSocket.addEventListener("message", (event) => {
@@ -65,11 +65,12 @@ describe("CreateWorkspacePage", () => {
 				);
 
 				return mockWebSocket;
-			});
+			},
+		);
 	});
 
 	afterEach(() => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	});
 
 	describe("WebSocket Integration", () => {
@@ -97,13 +98,11 @@ describe("CreateWorkspacePage", () => {
 		it("sends parameter updates via WebSocket when form values change", async () => {
 			const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
 
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
+			vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+				(_versionId, _ownerId, callbacks) => {
 					mockWebSocket.addEventListener("message", (event) => {
 						callbacks.onMessage(JSON.parse(event.data));
 					});
-
 					publisher.publishOpen(new Event("open"));
 					publisher.publishMessage(
 						new MessageEvent("message", {
@@ -112,7 +111,8 @@ describe("CreateWorkspacePage", () => {
 					);
 
 					return mockWebSocket;
-				});
+				},
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -125,8 +125,7 @@ describe("CreateWorkspacePage", () => {
 			const instanceTypeSelect = within(instanceTypeField).getByRole("button");
 			expect(instanceTypeSelect).toBeInTheDocument();
 
-			jest.useFakeTimers();
-
+			vi.useFakeTimers({ shouldAdvanceTime: true });
 			await waitFor(async () => {
 				await userEvent.click(instanceTypeSelect);
 			});
@@ -142,22 +141,24 @@ describe("CreateWorkspacePage", () => {
 			});
 
 			act(() => {
-				jest.runAllTimers();
+				vi.runAllTimers();
 			});
 
-			expect(mockWebSocket.send).toHaveBeenCalledWith(
-				expect.stringContaining('"instance_type":"t3.medium"'),
-			);
+			expect(
+				publisher.clientSentData.some(
+					(d) =>
+						typeof d === "string" && d.includes('"instance_type":"t3.medium"'),
+				),
+			).toBe(true);
 
-			jest.useRealTimers();
+			vi.useRealTimers();
 		});
 
 		it("shows error when WebSocket disconnects", async () => {
 			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
 
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
+			vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+				(_versionId, _ownerId, callbacks) => {
 					mockWebSocket.addEventListener("message", (event) => {
 						callbacks.onMessage(JSON.parse(event.data));
 					});
@@ -170,7 +171,8 @@ describe("CreateWorkspacePage", () => {
 					);
 
 					return mockWebSocket;
-				});
+				},
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -191,9 +193,8 @@ describe("CreateWorkspacePage", () => {
 
 		it("only parameters from latest response are displayed", async () => {
 			const [mockWebSocket, mockPublisher] = createMockWebSocket("ws://test");
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
+			vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+				(_versionId, _ownerId, callbacks) => {
 					mockWebSocket.addEventListener("message", (event) => {
 						callbacks.onMessage(JSON.parse(event.data));
 					});
@@ -210,7 +211,8 @@ describe("CreateWorkspacePage", () => {
 					);
 
 					return mockWebSocket;
-				});
+				},
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -243,9 +245,8 @@ describe("CreateWorkspacePage", () => {
 
 	describe("Dynamic Parameter Types", () => {
 		it("displays parameter validation errors", async () => {
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
+			vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+				(_versionId, _ownerId, callbacks) => {
 					const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
 
 					mockWebSocket.addEventListener("message", (event) => {
@@ -259,7 +260,8 @@ describe("CreateWorkspacePage", () => {
 					);
 
 					return mockWebSocket;
-				});
+				},
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -303,9 +305,8 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			jest
-				.spyOn(API, "templateVersionDynamicParameters")
-				.mockImplementation((_versionId, _ownerId, callbacks) => {
+			vi.spyOn(API, "templateVersionDynamicParameters").mockImplementation(
+				(_versionId, _ownerId, callbacks) => {
 					const [mockWebSocket, publisher] = createMockWebSocket("ws://test");
 
 					mockWebSocket.addEventListener("message", (event) => {
@@ -321,7 +322,7 @@ describe("CreateWorkspacePage", () => {
 					);
 
 					const originalSend = mockWebSocket.send;
-					mockWebSocket.send = jest.fn((data) => {
+					mockWebSocket.send = (data) => {
 						originalSend.call(mockWebSocket, data);
 
 						if (typeof data === "string" && data.includes('"200"')) {
@@ -331,10 +332,11 @@ describe("CreateWorkspacePage", () => {
 								}),
 							);
 						}
-					});
+					};
 
 					return mockWebSocket;
-				});
+				},
+			);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -380,9 +382,9 @@ describe("CreateWorkspacePage", () => {
 
 	describe("External Authentication", () => {
 		it("displays external auth providers", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([MockTemplateVersionExternalAuthGithub]);
+			vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithub,
+			]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -396,11 +398,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("shows authenticated state for connected providers", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([
-					MockTemplateVersionExternalAuthGithubAuthenticated,
-				]);
+			vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithubAuthenticated,
+			]);
 
 			renderCreateWorkspacePage();
 			await waitForLoaderToBeRemoved();
@@ -412,9 +412,9 @@ describe("CreateWorkspacePage", () => {
 		});
 
 		it("prevents auto-creation when required external auth is missing", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([MockTemplateVersionExternalAuthGithub]);
+			vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithub,
+			]);
 
 			renderCreateWorkspacePage(
 				`/templates/${MockTemplate.name}/workspace?mode=auto&version=${MockTemplate.id}`,
@@ -436,14 +436,12 @@ describe("CreateWorkspacePage", () => {
 
 	describe("Auto-creation Mode", () => {
 		it("falls back to form mode when auto-creation fails", async () => {
-			jest
-				.spyOn(API, "getTemplateVersionExternalAuth")
-				.mockResolvedValue([
-					MockTemplateVersionExternalAuthGithubAuthenticated,
-				]);
-			jest
-				.spyOn(API, "createWorkspace")
-				.mockRejectedValue(new Error("Auto-creation failed"));
+			vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithubAuthenticated,
+			]);
+			vi.spyOn(API, "createWorkspace").mockRejectedValue(
+				new Error("Auto-creation failed"),
+			);
 
 			renderCreateWorkspacePage(
 				`/templates/${MockTemplate.name}/workspace?mode=auto`,

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -1,5 +1,5 @@
 import { API } from "api/api";
-import type { ApiErrorResponse } from "api/errors";
+import { type ApiErrorResponse, DetailedError } from "api/errors";
 import { checkAuthorization } from "api/queries/authCheck";
 import {
 	templateByName,
@@ -181,7 +181,14 @@ const CreateWorkspacePage: FC = () => {
 				// Reset so initial parameters are re-sent on reconnect.
 				initialParamsSentRef.current = false;
 			},
-			onDisconnect() {},
+			onDisconnect() {
+				setWsError(
+					new DetailedError(
+						"WebSocket connection for dynamic parameters lost.",
+						"Attempting to reconnect...",
+					),
+				);
+			},
 		});
 
 		return () => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -1,5 +1,5 @@
-import { API } from "api/api";
-import { type ApiErrorResponse, DetailedError } from "api/errors";
+import { createWebSocket } from "api/api";
+import type { ApiErrorResponse } from "api/errors";
 import { checkAuthorization } from "api/queries/authCheck";
 import {
 	templateByName,
@@ -31,6 +31,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { pageTitle } from "utils/page";
+import { createReconnectingWebSocket } from "utils/reconnectingWebSocket";
 import type { AutofillBuildParameter } from "utils/richParameters";
 import { AutoCreateConsentDialog } from "./AutoCreateConsentDialog";
 import { CreateWorkspacePageView } from "./CreateWorkspacePageView";
@@ -159,33 +160,33 @@ const CreateWorkspacePage: FC = () => {
 	useEffect(() => {
 		if (!realizedVersionId) return;
 
-		const socket = API.templateVersionDynamicParameters(
-			realizedVersionId,
-			defaultOwner.id,
-			{
-				onMessage,
-				onError: (error) => {
-					if (ws.current === socket) {
-						setWsError(error);
-					}
-				},
-				onClose: () => {
-					if (ws.current === socket) {
-						setWsError(
-							new DetailedError(
-								"Websocket connection for dynamic parameters unexpectedly closed.",
-								"Refresh the page to reset the form.",
-							),
-						);
-					}
-				},
-			},
-		);
+		const dispose = createReconnectingWebSocket({
+			connect() {
+				const socket = createWebSocket(
+					`/api/v2/templateversions/${realizedVersionId}/dynamic-parameters`,
+					new URLSearchParams({ user_id: defaultOwner.id }),
+				);
 
-		ws.current = socket;
+				socket.addEventListener("message", (event) => {
+					const response = JSON.parse(
+						event.data as string,
+					) as DynamicParametersResponse;
+					onMessage(response);
+				});
+
+				ws.current = socket;
+				return socket;
+			},
+			onOpen() {
+				setWsError(null);
+				// Reset so initial parameters are re-sent on reconnect.
+				initialParamsSentRef.current = false;
+			},
+			onDisconnect() {},
+		});
 
 		return () => {
-			socket.close();
+			dispose();
 		};
 	}, [realizedVersionId, onMessage, defaultOwner.id]);
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { createWebSocket } from "api/api";
+import { API } from "api/api";
 import type { ApiErrorResponse } from "api/errors";
 import { checkAuthorization } from "api/queries/authCheck";
 import {
@@ -162,17 +162,16 @@ const CreateWorkspacePage: FC = () => {
 
 		const dispose = createReconnectingWebSocket({
 			connect() {
-				const socket = createWebSocket(
-					`/api/v2/templateversions/${realizedVersionId}/dynamic-parameters`,
-					new URLSearchParams({ user_id: defaultOwner.id }),
+				const socket = API.templateVersionDynamicParameters(
+					realizedVersionId,
+					defaultOwner.id,
+					{
+						onMessage,
+						// Lifecycle is managed by createReconnectingWebSocket.
+						onError: () => {},
+						onClose: () => {},
+					},
 				);
-
-				socket.addEventListener("message", (event) => {
-					const response = JSON.parse(
-						event.data as string,
-					) as DynamicParametersResponse;
-					onMessage(response);
-				});
 
 				ws.current = socket;
 				return socket;

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -165,12 +165,7 @@ const CreateWorkspacePage: FC = () => {
 				const socket = API.templateVersionDynamicParameters(
 					realizedVersionId,
 					defaultOwner.id,
-					{
-						onMessage,
-						// Lifecycle is managed by createReconnectingWebSocket.
-						onError: () => {},
-						onClose: () => {},
-					},
+					{ onMessage },
 				);
 
 				ws.current = socket;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -69,12 +69,7 @@ const TemplateEmbedPageExperimental: FC = () => {
 				const socket = API.templateVersionDynamicParameters(
 					template.active_version_id,
 					me.id,
-					{
-						onMessage,
-						// Lifecycle is managed by createReconnectingWebSocket.
-						onError: () => {},
-						onClose: () => {},
-					},
+					{ onMessage },
 				);
 
 				ws.current = socket;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -1,4 +1,4 @@
-import { createWebSocket } from "api/api";
+import { API } from "api/api";
 import type {
 	DynamicParametersRequest,
 	DynamicParametersResponse,
@@ -65,17 +65,16 @@ const TemplateEmbedPageExperimental: FC = () => {
 
 		const dispose = createReconnectingWebSocket({
 			connect() {
-				const socket = createWebSocket(
-					`/api/v2/templateversions/${template.active_version_id}/dynamic-parameters`,
-					new URLSearchParams({ user_id: me.id }),
+				const socket = API.templateVersionDynamicParameters(
+					template.active_version_id,
+					me.id,
+					{
+						onMessage,
+						// Lifecycle is managed by createReconnectingWebSocket.
+						onError: () => {},
+						onClose: () => {},
+					},
 				);
-
-				socket.addEventListener("message", (event) => {
-					const response = JSON.parse(
-						event.data as string,
-					) as DynamicParametersResponse;
-					onMessage(response);
-				});
 
 				ws.current = socket;
 				return socket;

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -1,4 +1,5 @@
 import { API } from "api/api";
+import { DetailedError } from "api/errors";
 import type {
 	DynamicParametersRequest,
 	DynamicParametersResponse,
@@ -82,7 +83,14 @@ const TemplateEmbedPageExperimental: FC = () => {
 			onOpen() {
 				setWsError(null);
 			},
-			onDisconnect() {},
+			onDisconnect() {
+				setWsError(
+					new DetailedError(
+						"WebSocket connection for dynamic parameters lost.",
+						"Attempting to reconnect...",
+					),
+				);
+			},
 		});
 
 		return () => {

--- a/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
+++ b/site/src/pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPageExperimental.tsx
@@ -1,5 +1,4 @@
-import { API } from "api/api";
-import { DetailedError } from "api/errors";
+import { createWebSocket } from "api/api";
 import type {
 	DynamicParametersRequest,
 	DynamicParametersResponse,
@@ -24,6 +23,7 @@ import {
 import { useTemplateLayoutContext } from "pages/TemplatePage/TemplateLayout";
 import { type FC, useEffect, useMemo, useRef, useState } from "react";
 import { pageTitle } from "utils/page";
+import { createReconnectingWebSocket } from "utils/reconnectingWebSocket";
 
 type ButtonValues = Record<string, string>;
 
@@ -63,33 +63,31 @@ const TemplateEmbedPageExperimental: FC = () => {
 			return;
 		}
 
-		const socket = API.templateVersionDynamicParameters(
-			template.active_version_id,
-			me.id,
-			{
-				onMessage,
-				onError: (error) => {
-					if (ws.current === socket) {
-						setWsError(error);
-					}
-				},
-				onClose: () => {
-					if (ws.current === socket) {
-						setWsError(
-							new DetailedError(
-								"Websocket connection for dynamic parameters unexpectedly closed.",
-								"Refresh the page to reset the form.",
-							),
-						);
-					}
-				},
-			},
-		);
+		const dispose = createReconnectingWebSocket({
+			connect() {
+				const socket = createWebSocket(
+					`/api/v2/templateversions/${template.active_version_id}/dynamic-parameters`,
+					new URLSearchParams({ user_id: me.id }),
+				);
 
-		ws.current = socket;
+				socket.addEventListener("message", (event) => {
+					const response = JSON.parse(
+						event.data as string,
+					) as DynamicParametersResponse;
+					onMessage(response);
+				});
+
+				ws.current = socket;
+				return socket;
+			},
+			onOpen() {
+				setWsError(null);
+			},
+			onDisconnect() {},
+		});
 
 		return () => {
-			socket.close();
+			dispose();
 		};
 	}, [template.active_version_id, onMessage, me]);
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -1,5 +1,4 @@
-import { API } from "api/api";
-import { DetailedError } from "api/errors";
+import { API, createWebSocket } from "api/api";
 import { checkAuthorization } from "api/queries/authCheck";
 import type {
 	DynamicParametersRequest,
@@ -24,6 +23,7 @@ import { useMutation, useQuery } from "react-query";
 import { useNavigate, useSearchParams } from "react-router";
 import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
+import { createReconnectingWebSocket } from "utils/reconnectingWebSocket";
 import type { AutofillBuildParameter } from "utils/richParameters";
 import {
 	type WorkspacePermissions,
@@ -114,33 +114,35 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		if (!templateVersionId && !workspace.latest_build.template_version_id)
 			return;
 
-		const socket = API.templateVersionDynamicParameters(
-			templateVersionId ?? workspace.latest_build.template_version_id,
-			workspace.owner_id,
-			{
-				onMessage,
-				onError: (error) => {
-					if (ws.current === socket) {
-						setWsError(error);
-					}
-				},
-				onClose: () => {
-					if (ws.current === socket) {
-						setWsError(
-							new DetailedError(
-								"Websocket connection for dynamic parameters unexpectedly closed.",
-								"Refresh the page to reset the form.",
-							),
-						);
-					}
-				},
-			},
-		);
+		const versionId =
+			templateVersionId ?? workspace.latest_build.template_version_id;
 
-		ws.current = socket;
+		const dispose = createReconnectingWebSocket({
+			connect() {
+				const socket = createWebSocket(
+					`/api/v2/templateversions/${versionId}/dynamic-parameters`,
+					new URLSearchParams({ user_id: workspace.owner_id }),
+				);
+
+				socket.addEventListener("message", (event) => {
+					const response = JSON.parse(
+						event.data as string,
+					) as DynamicParametersResponse;
+					onMessage(response);
+				});
+
+				ws.current = socket;
+				return socket;
+			},
+			onOpen() {
+				setWsError(null);
+				initialParamsSentRef.current = false;
+			},
+			onDisconnect() {},
+		});
 
 		return () => {
-			socket.close();
+			dispose();
 		};
 	}, [
 		templateVersionId,

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -1,4 +1,4 @@
-import { API, createWebSocket } from "api/api";
+import { API } from "api/api";
 import { checkAuthorization } from "api/queries/authCheck";
 import type {
 	DynamicParametersRequest,
@@ -119,17 +119,16 @@ const WorkspaceParametersPageExperimental: FC = () => {
 
 		const dispose = createReconnectingWebSocket({
 			connect() {
-				const socket = createWebSocket(
-					`/api/v2/templateversions/${versionId}/dynamic-parameters`,
-					new URLSearchParams({ user_id: workspace.owner_id }),
+				const socket = API.templateVersionDynamicParameters(
+					versionId,
+					workspace.owner_id,
+					{
+						onMessage,
+						// Lifecycle is managed by createReconnectingWebSocket.
+						onError: () => {},
+						onClose: () => {},
+					},
 				);
-
-				socket.addEventListener("message", (event) => {
-					const response = JSON.parse(
-						event.data as string,
-					) as DynamicParametersResponse;
-					onMessage(response);
-				});
 
 				ws.current = socket;
 				return socket;

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -1,4 +1,5 @@
 import { API } from "api/api";
+import { DetailedError } from "api/errors";
 import { checkAuthorization } from "api/queries/authCheck";
 import type {
 	DynamicParametersRequest,
@@ -137,7 +138,14 @@ const WorkspaceParametersPageExperimental: FC = () => {
 				setWsError(null);
 				initialParamsSentRef.current = false;
 			},
-			onDisconnect() {},
+			onDisconnect() {
+				setWsError(
+					new DetailedError(
+						"WebSocket connection for dynamic parameters lost.",
+						"Attempting to reconnect...",
+					),
+				);
+			},
 		});
 
 		return () => {

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -123,12 +123,7 @@ const WorkspaceParametersPageExperimental: FC = () => {
 				const socket = API.templateVersionDynamicParameters(
 					versionId,
 					workspace.owner_id,
-					{
-						onMessage,
-						// Lifecycle is managed by createReconnectingWebSocket.
-						onError: () => {},
-						onClose: () => {},
-					},
+					{ onMessage },
 				);
 
 				ws.current = socket;

--- a/site/src/testHelpers/websockets.ts
+++ b/site/src/testHelpers/websockets.ts
@@ -16,26 +16,13 @@ type CallbackStore = {
 	[K in keyof WebSocketEventMap]: Set<(event: WebSocketEventMap[K]) => void>;
 };
 
-type MockWebSocket = Omit<WebSocket, "send"> & {
+type MockWebSocket = Omit<WebSocket, "send" | "dispatchEvent"> & {
 	/**
-	 * A version of the WebSocket `send` method that has been pre-wrapped inside
-	 * a Jest mock.
-	 *
-	 * The Jest mock functionality should be used at a minimum. Basically:
-	 * 1. If you want to check that the mock socket sent something to the mock
-	 *    server: call the `send` method as a function, and then check the
-	 *    `clientSentData` on `MockWebSocketServer` to see what data got
-	 *    received.
-	 * 2. If you need to make sure that the client-side `send` method got called
-	 *    at all: you can use the Jest mock functionality, but you should
-	 *    probably also be checking `clientSentData` still and making additional
-	 *    assertions with it.
-	 *
-	 * Generally, tests should center around whether socket-to-server
-	 * communication was successful, not whether the client-side method was
-	 * called.
+	 * If you want to check that the mock socket sent something to the
+	 * mock server, check `clientSentData` on `MockWebSocketServer`.
 	 */
-	send: jest.Mock<void, [SocketSendData], unknown>;
+	send: (data: SocketSendData) => void;
+	dispatchEvent: (event: Event) => boolean;
 };
 
 export function createMockWebSocket(
@@ -76,14 +63,14 @@ export function createMockWebSocket(
 		onerror: null,
 		onmessage: null,
 		onopen: null,
-		dispatchEvent: jest.fn(),
+		dispatchEvent: () => false,
 
-		send: jest.fn((data) => {
+		send: (data: SocketSendData) => {
 			if (!isOpen) {
 				return;
 			}
 			sentData.push(data);
-		}),
+		},
 
 		addEventListener: <E extends WebSocketEventType>(
 			eventType: E,


### PR DESCRIPTION
## Summary

Fixes https://github.com/coder/coder/issues/20846

### Backend

Reduce the dynamic parameters WebSocket timeout from a hard 30-minute deadline to a renewable 3-minute idle timeout. Uses `context.WithCancel` + `time.AfterFunc` instead of `context.WithTimeout`. Each client message resets the idle timer, so active sessions stay alive indefinitely while abandoned connections are cleaned up after 3 minutes of inactivity.

### Frontend

Replace the one-shot WebSocket connection with `createReconnectingWebSocket` (existing utility) in all three pages that use dynamic parameters:
- `CreateWorkspacePage`
- `WorkspaceParametersPageExperimental`
- `TemplateEmbedPageExperimental`

On disconnect, the utility auto-reconnects with capped exponential backoff (1s base, 10s max). On successful reconnect:
- Error state (`wsError`) is cleared so the error banner disappears.
- `initialParamsSentRef` is reset so the backend receives the current form state.

Simplified `templateVersionDynamicParameters` API method to only accept `onMessage` callback. The `onError`/`onClose` callbacks were removed since WebSocket lifecycle is now managed entirely by `createReconnectingWebSocket`. A `DetailedError` is shown to the user via `onDisconnect` when the connection drops, and cleared via `onOpen` when it recovers.

### Changes
| File | Change |
|---|---|
| `coderd/parameters.go` | 3-min renewable idle timeout (was 30-min hard deadline) |
| `site/src/api/api.ts` | Removed `onError`/`onClose` from `templateVersionDynamicParameters` |
| `site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx` | Use `createReconnectingWebSocket` with disconnect/reconnect error handling |
| `site/src/pages/.../WorkspaceParametersPageExperimental.tsx` | Use `createReconnectingWebSocket` with disconnect/reconnect error handling |
| `site/src/pages/.../TemplateEmbedPageExperimental.tsx` | Use `createReconnectingWebSocket` with disconnect/reconnect error handling |
| `site/src/pages/CreateWorkspacePage/CreateWorkspacePage.jest.tsx` | Updated tests for new API shape and disconnect behavior |