### PR TITLE
fix(nix): bump macOS SDK to 12.3 for Go 1.26 compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,9 @@
             python312Packages.setuptools # Needed for node-gyp
           ]
           ++ (lib.optionals stdenv.targetPlatform.isDarwin [
-            darwin.apple_sdk.frameworks.Foundation
+            darwin.apple_sdk_12_3.frameworks.CoreFoundation
+            darwin.apple_sdk_12_3.frameworks.Foundation
+            darwin.apple_sdk_12_3.frameworks.Security
             xcbuild
           ]);
 


### PR DESCRIPTION
Go 1.26's crypto/x509 uses SecTrustCopyCertificateChain, which requires the macOS 12+ SDK. The previous apple_sdk (11.0) caused linker failures in Nix shells on Darwin.
