### PR TITLE
fix(nix): bump macOS SDK to 12.3 for Go 1.26 compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
             python312Packages.setuptools # Needed for node-gyp
           ]
           ++ (lib.optionals stdenv.targetPlatform.isDarwin [
-            darwin.apple_sdk.frameworks.Foundation
+            darwin.apple_sdk_12_3.frameworks.Foundation
             xcbuild
           ]);
 
@@ -292,7 +292,13 @@
         inherit formatter;
 
         devShells = {
-          default = pkgs.mkShell {
+          default =
+            (pkgs.mkShell.override (
+              pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+                stdenv = pkgs.overrideSDK pkgs.stdenv "12.3";
+              }
+            ))
+            {
             buildInputs = devShellPackages;
 
             PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;


### PR DESCRIPTION
Go 1.26's crypto/x509 calls SecTrustCopyCertificateChain via cgo, a Security framework function introduced in macOS 12. The devShell's default stdenv uses the macOS 11 SDK, so clang can't find the symbol at link time.

Override the devShell stdenv on Darwin with overrideSDK "12.3" so the clang wrapper links against the 12.3 SDK, and update frontendPackages to use apple_sdk_12_3 frameworks for consistency.

I'm not a nix expert, so Claude did most of the heavy lifting here. Without this change, I was seeing linker errors locally when running `./scripts/develop.sh`:
```
[nix-shell:~/src/coder]$ ./scripts/develop.sh
# command-line-arguments
/nix/store/sz1ry9vf187bzdvsalla73ycxwfjv3pq-go-1.26.0/share/go/pkg/tool/darwin_arm64/link: running clang failed: exit status 1
/nix/store/5xl5cwg2j76sd2kd2zafd6i07rmmxizf-clang-wrapper-16.0.6/bin/clang -arch arm64 -Wl,-S -Wl,-x -o $WORK/b001/exe/main -Qunused-arguments /private/tmp/nix-shell-98006-977254935/go-link-1434515870/go.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000000.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000001.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000002.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000003.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000004.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000005.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000006.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000007.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000008.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000009.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000010.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000011.o /private/tmp/nix-shell-98006-977254935/go-link-1434515870/000012.o -lresolv -O2 -g -O2 -g -framework CoreFoundation -framework CoreFoundation -framework Security
Undefined symbols for architecture arm64:
  "_SecTrustCopyCertificateChain", referenced from:
      _crypto/x509/internal/macos.x509_SecTrustCopyCertificateChain_trampoline.abi0 in go.o
ld: symbol(s) not found for architecture arm64
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [Makefile:1102: site/src/api/rbacresourcesGenerated.ts] Error 1
```