### PR TITLE
fix(cli): verify builtin postgres reuse

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -323,8 +323,9 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 	}
 
 	var (
-		vals = new(codersdk.DeploymentValues)
-		opts = vals.Options()
+		vals                          = new(codersdk.DeploymentValues)
+		opts                          = vals.Options()
+		allowBuiltinPostgresReconnect bool
 	)
 	serverCmd := &serpent.Command{
 		Use:     "server",
@@ -465,7 +466,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				if vals.EphemeralDeployment.Value() {
 					customPostgresCacheDir = cacheDir
 				}
-				pgURL, closeFunc, err := startBuiltinPostgres(ctx, config, logger, customPostgresCacheDir)
+				pgURL, closeFunc, err := startBuiltinPostgres(ctx, config, logger, customPostgresCacheDir, allowBuiltinPostgresReconnect)
 				if err != nil {
 					return err
 				}
@@ -1321,7 +1322,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			ctx, cancel := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer cancel()
 
-			url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "")
+			url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "", false)
 			if err != nil {
 				return err
 			}
@@ -1350,6 +1351,14 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 	createAdminUserCmd.Options.Add(rawURLOpt)
 	postgresBuiltinURLCmd.Options.Add(rawURLOpt)
 	postgresBuiltinServeCmd.Options.Add(rawURLOpt)
+
+	serverCmd.Options.Add(serpent.Option{
+		Flag:        "dev-builtin-postgres-reconnect",
+		Env:         "CODER_DEV_BUILTIN_POSTGRES_RECONNECT",
+		Hidden:      true,
+		Value:       serpent.BoolOf(&allowBuiltinPostgresReconnect),
+		Description: "Allow the server to reconnect to an already-running built-in PostgreSQL instance instead of starting a new one. Intended for local development workflows only.",
+	})
 
 	serverCmd.Children = append(
 		serverCmd.Children,
@@ -2271,7 +2280,8 @@ func verifyBuiltinPostgresInstance(ctx context.Context, cfg config.Root, connect
 	return nil
 }
 
-func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logger, customCacheDir string) (string, func() error, error) {
+//nolint:revive // Ignore flag-parameter: allowReconnect explicitly scopes reconnect behavior to opt-in callers.
+func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logger, customCacheDir string, allowReconnect bool) (string, func() error, error) {
 	usr, err := user.Current()
 	if err != nil {
 		return "", nil, err
@@ -2369,10 +2379,12 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 			slog.Error(startErr),
 		)
 
-		if persistedPortExisted {
+		if allowReconnect && persistedPortExisted {
 			verifyErr := verifyBuiltinPostgresInstance(ctx, cfg, connectionURL)
 			if verifyErr == nil {
 				logger.Info(ctx, "reusing running built-in postgres on persisted port", slog.F("port", pgPort))
+				// Return a no-op closer: the reconnecting caller does
+				// not own this process and should not stop it on exit.
 				return connectionURL, func() error { return nil }, nil
 			}
 			return "", nil, xerrors.Errorf("%w (port %d): start failed: %v; verification failed: %v", errBuiltinPostgresNonMatchingProcess, pgPort, startErr, verifyErr)

--- a/cli/server.go
+++ b/cli/server.go
@@ -2229,6 +2229,48 @@ func embeddedPostgresURL(cfg config.Root) (string, error) {
 	return fmt.Sprintf("postgres://coder@localhost:%s/coder?sslmode=disable&password=%s", pgPort, pgPassword), nil
 }
 
+var errBuiltinPostgresNonMatchingProcess = xerrors.New("persisted built-in PostgreSQL port is already in use by a non-matching process")
+
+func verifyBuiltinPostgresInstance(ctx context.Context, cfg config.Root, connectionURL string) error {
+	// nolint:gocritic // Keep persisted-port verification quick on conflicts.
+	verifyCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	sqlDB, err := sql.Open("postgres", connectionURL)
+	if err != nil {
+		return xerrors.Errorf("open persisted postgres connection: %w", err)
+	}
+	defer sqlDB.Close()
+
+	if err := pingPostgres(verifyCtx, sqlDB); err != nil {
+		return xerrors.Errorf("ping persisted postgres connection: %w", err)
+	}
+
+	var currentDatabase string
+	var currentUser string
+	err = sqlDB.QueryRowContext(verifyCtx, "SELECT current_database(), current_user;").Scan(&currentDatabase, &currentUser)
+	if err != nil {
+		return xerrors.Errorf("query persisted postgres identity: %w", err)
+	}
+	if currentDatabase != "coder" {
+		return xerrors.Errorf("unexpected database %q", currentDatabase)
+	}
+	if currentUser != "coder" {
+		return xerrors.Errorf("unexpected user %q", currentUser)
+	}
+
+	var dataDirectory string
+	err = sqlDB.QueryRowContext(verifyCtx, "SHOW data_directory;").Scan(&dataDirectory)
+	if err != nil {
+		return xerrors.Errorf("query persisted postgres data directory: %w", err)
+	}
+	if filepath.Clean(dataDirectory) != filepath.Clean(filepath.Join(cfg.PostgresPath(), "data")) {
+		return xerrors.Errorf("unexpected data directory %q", dataDirectory)
+	}
+
+	return nil
+}
+
 func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logger, customCacheDir string) (string, func() error, error) {
 	usr, err := user.Current()
 	if err != nil {
@@ -2244,19 +2286,28 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 	}
 	stdlibLogger := slog.Stdlib(ctx, logger.Named("postgres"), slog.LevelDebug)
 
+	persistedPortExisted := false
+	_, err = cfg.PostgresPort().Read()
+	switch {
+	case err == nil:
+		persistedPortExisted = true
+	case errors.Is(err, os.ErrNotExist):
+	default:
+		return "", nil, xerrors.Errorf("read postgres port: %w", err)
+	}
+
 	// If the port is not defined, an available port will be found dynamically. This has
-	// implications in CI because here is no way to tell Postgres to use an ephemeral
+	// implications in CI because there is no way to tell Postgres to use an ephemeral
 	// port, so to avoid flaky tests in CI we need to retry EmbeddedPostgres.Start in
 	// case of a race condition where the port we quickly listen on and close in
 	// embeddedPostgresURL() is not free by the time the embedded postgres starts up.
 	// The maximum retry attempts _should_ cover most cases where port conflicts occur
 	// in CI and cause flaky tests.
 	maxAttempts := 1
-	_, err = cfg.PostgresPort().Read()
 	// Important: if retryPortDiscovery is changed to not include testing.Testing(),
 	// the retry logic below also needs to be updated to ensure we don't delete an
-	// existing database
-	retryPortDiscovery := errors.Is(err, os.ErrNotExist) && testing.Testing()
+	// existing database.
+	retryPortDiscovery := !persistedPortExisted && testing.Testing()
 	if retryPortDiscovery {
 		maxAttempts = 10
 	}
@@ -2317,6 +2368,15 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 			slog.F("port", pgPort),
 			slog.Error(startErr),
 		)
+
+		if persistedPortExisted {
+			verifyErr := verifyBuiltinPostgresInstance(ctx, cfg, connectionURL)
+			if verifyErr == nil {
+				logger.Info(ctx, "reusing running built-in postgres on persisted port", slog.F("port", pgPort))
+				return connectionURL, func() error { return nil }, nil
+			}
+			return "", nil, xerrors.Errorf("%w (port %d): start failed: %v; verification failed: %v", errBuiltinPostgresNonMatchingProcess, pgPort, startErr, verifyErr)
+		}
 	}
 
 	return "", nil, xerrors.Errorf("failed to start built-in PostgreSQL after %d attempts. "+

--- a/cli/server.go
+++ b/cli/server.go
@@ -2248,6 +2248,23 @@ func isBuiltinPostgresPortConflict(err error, port uint64) bool {
 	return strings.Contains(err.Error(), fmt.Sprintf("process already listening on port %d", port))
 }
 
+func canonicalBuiltinPostgresPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", xerrors.Errorf("abs path %q: %w", path, err)
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return filepath.Clean(absPath), nil
+		}
+		return "", xerrors.Errorf("resolve symlinks for %q: %w", path, err)
+	}
+
+	return filepath.Clean(resolvedPath), nil
+}
+
 func verifyBuiltinPostgresInstance(ctx context.Context, cfg config.Root, connectionURL string) error {
 	// nolint:gocritic // Keep persisted-port verification quick on conflicts.
 	verifyCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -2281,7 +2298,15 @@ func verifyBuiltinPostgresInstance(ctx context.Context, cfg config.Root, connect
 	if err != nil {
 		return xerrors.Errorf("query persisted postgres data directory: %w", err)
 	}
-	if filepath.Clean(dataDirectory) != filepath.Clean(filepath.Join(cfg.PostgresPath(), "data")) {
+	resolvedDataDirectory, err := canonicalBuiltinPostgresPath(dataDirectory)
+	if err != nil {
+		return xerrors.Errorf("canonicalize persisted postgres data directory: %w", err)
+	}
+	resolvedExpectedDataDirectory, err := canonicalBuiltinPostgresPath(filepath.Join(cfg.PostgresPath(), "data"))
+	if err != nil {
+		return xerrors.Errorf("canonicalize expected postgres data directory: %w", err)
+	}
+	if resolvedDataDirectory != resolvedExpectedDataDirectory {
 		return xerrors.Errorf("unexpected data directory %q", dataDirectory)
 	}
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -2240,6 +2240,14 @@ func embeddedPostgresURL(cfg config.Root) (string, error) {
 
 var errBuiltinPostgresNonMatchingProcess = xerrors.New("persisted built-in PostgreSQL port is already in use by a non-matching process")
 
+func isBuiltinPostgresPortConflict(err error, port uint64) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), fmt.Sprintf("process already listening on port %d", port))
+}
+
 func verifyBuiltinPostgresInstance(ctx context.Context, cfg config.Root, connectionURL string) error {
 	// nolint:gocritic // Keep persisted-port verification quick on conflicts.
 	verifyCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -2379,7 +2387,7 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 			slog.Error(startErr),
 		)
 
-		if allowReconnect && persistedPortExisted {
+		if allowReconnect && persistedPortExisted && isBuiltinPostgresPortConflict(startErr, pgPort) {
 			verifyErr := verifyBuiltinPostgresInstance(ctx, cfg, connectionURL)
 			if verifyErr == nil {
 				logger.Info(ctx, "reusing running built-in postgres on persisted port", slog.F("port", pgPort))

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -54,7 +54,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 
 			if newUserDBURL == "" {
 				cliui.Infof(inv.Stdout, "Using built-in PostgreSQL (%s)", cfg.PostgresPath())
-				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "")
+				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "", false)
 				if err != nil {
 					return err
 				}

--- a/cli/server_internal_test.go
+++ b/cli/server_internal_test.go
@@ -403,6 +403,24 @@ func TestEscapePostgresURLUserInfo(t *testing.T) {
 	}
 }
 
+func TestIsBuiltinPostgresPortConflict(t *testing.T) {
+	t.Parallel()
+
+	const port uint64 = 54321
+
+	t.Run("MatchesEmbeddedPostgresPortConflict", func(t *testing.T) {
+		t.Parallel()
+		err := xerrors.Errorf("process already listening on port %d", port)
+		require.True(t, isBuiltinPostgresPortConflict(err, port))
+	})
+
+	t.Run("RejectsOtherStartErrors", func(t *testing.T) {
+		t.Parallel()
+		err := xerrors.New("unable to create runtime directory")
+		require.False(t, isBuiltinPostgresPortConflict(err, port))
+	})
+}
+
 func TestStartBuiltinPostgres(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/cli/server_internal_test.go
+++ b/cli/server_internal_test.go
@@ -458,6 +458,26 @@ func TestStartBuiltinPostgres(t *testing.T) {
 		require.NoError(t, verifyBuiltinPostgresInstance(ctx, cfg, connectionURL))
 	})
 
+	t.Run("VerifyBuiltinInstanceAcceptsRelativeConfigPath", func(t *testing.T) {
+		t.Parallel()
+
+		workingDir, err := os.Getwd()
+		require.NoError(t, err)
+
+		configDir, err := filepath.Rel(workingDir, t.TempDir())
+		require.NoError(t, err)
+		cfg := config.Root(configDir)
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+
+		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "", false)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, closeFunc())
+		})
+
+		require.NoError(t, verifyBuiltinPostgresInstance(ctx, cfg, connectionURL))
+	})
+
 	t.Run("ReconnectReusesMatchingBuiltinInstance", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.Root(t.TempDir())

--- a/cli/server_internal_test.go
+++ b/cli/server_internal_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -14,6 +18,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
+	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/serpent"
@@ -396,4 +401,97 @@ func TestEscapePostgresURLUserInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartBuiltinPostgres(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	reservePort := func(t *testing.T) string {
+		t.Helper()
+
+		listener, err := net.Listen("tcp4", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+
+		tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+		require.True(t, ok)
+		return strconv.Itoa(tcpAddr.Port)
+	}
+
+	t.Run("FreePersistedPortStartsFresh", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.Root(t.TempDir())
+		port := reservePort(t)
+		require.NoError(t, cfg.PostgresPort().Write(port))
+
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, closeFunc())
+		})
+
+		require.Contains(t, connectionURL, ":"+port+"/")
+		require.NoError(t, verifyBuiltinPostgresInstance(ctx, cfg, connectionURL))
+	})
+
+	t.Run("ReusesMatchingBuiltinInstance", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.Root(t.TempDir())
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+
+		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, closeFunc())
+		})
+
+		reusedURL, reusedCloseFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		require.NoError(t, err)
+		require.Equal(t, connectionURL, reusedURL)
+		require.NoError(t, reusedCloseFunc())
+		require.NoError(t, verifyBuiltinPostgresInstance(ctx, cfg, connectionURL))
+	})
+
+	t.Run("BusyPersistedPortReturnsNonMatchingProcessError", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.Root(t.TempDir())
+		port := reservePort(t)
+		require.NoError(t, cfg.PostgresPort().Write(port))
+
+		sentinelPath := filepath.Join(cfg.PostgresPath(), "data", "sentinel")
+		require.NoError(t, os.MkdirAll(filepath.Dir(sentinelPath), 0o700))
+		require.NoError(t, os.WriteFile(sentinelPath, []byte("keep"), 0o600))
+
+		listener, err := net.Listen("tcp4", "127.0.0.1:"+port)
+		require.NoError(t, err)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				conn, acceptErr := listener.Accept()
+				if acceptErr != nil {
+					return
+				}
+				_ = conn.Close()
+			}
+		}()
+		t.Cleanup(func() {
+			require.NoError(t, listener.Close())
+			<-done
+		})
+
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+		_, _, err = startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errBuiltinPostgresNonMatchingProcess)
+		require.FileExists(t, sentinelPath)
+
+		persistedPort, readErr := cfg.PostgresPort().Read()
+		require.NoError(t, readErr)
+		require.Equal(t, port, persistedPort)
+	})
 }

--- a/cli/server_internal_test.go
+++ b/cli/server_internal_test.go
@@ -409,6 +409,8 @@ func TestStartBuiltinPostgres(t *testing.T) {
 		t.SkipNow()
 	}
 
+	t.Cleanup(http.DefaultClient.CloseIdleConnections)
+
 	reservePort := func(t *testing.T) string {
 		t.Helper()
 
@@ -428,7 +430,7 @@ func TestStartBuiltinPostgres(t *testing.T) {
 		require.NoError(t, cfg.PostgresPort().Write(port))
 
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
-		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "", false)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, closeFunc())
@@ -438,25 +440,35 @@ func TestStartBuiltinPostgres(t *testing.T) {
 		require.NoError(t, verifyBuiltinPostgresInstance(ctx, cfg, connectionURL))
 	})
 
-	t.Run("ReusesMatchingBuiltinInstance", func(t *testing.T) {
+	t.Run("ReconnectReusesMatchingBuiltinInstance", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.Root(t.TempDir())
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
 
-		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		connectionURL, closeFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "", true)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, closeFunc())
 		})
 
-		reusedURL, reusedCloseFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		reusedURL, reusedCloseFunc, err := startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "", true)
 		require.NoError(t, err)
 		require.Equal(t, connectionURL, reusedURL)
-		require.NoError(t, reusedCloseFunc())
 		require.NoError(t, verifyBuiltinPostgresInstance(ctx, cfg, connectionURL))
+
+		// The reused close func is a no-op; it does not own the
+		// process. Calling it should succeed without stopping postgres.
+		require.NoError(t, reusedCloseFunc())
+
+		// Verify postgres is still running after the no-op close.
+		persistedPort, readErr := cfg.PostgresPort().Read()
+		require.NoError(t, readErr)
+		conn, dialErr := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", persistedPort), testutil.IntervalMedium)
+		require.NoError(t, dialErr, "expected postgres to still be running after no-op close")
+		_ = conn.Close()
 	})
 
-	t.Run("BusyPersistedPortReturnsNonMatchingProcessError", func(t *testing.T) {
+	t.Run("ReconnectBusyPersistedPortReturnsNonMatchingProcessError", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.Root(t.TempDir())
 		port := reservePort(t)
@@ -485,7 +497,7 @@ func TestStartBuiltinPostgres(t *testing.T) {
 		})
 
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
-		_, _, err = startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "")
+		_, _, err = startBuiltinPostgres(ctx, cfg, testutil.Logger(t), "", true)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errBuiltinPostgresNonMatchingProcess)
 		require.FileExists(t, sentinelPath)

--- a/cli/server_regenerate_vapid_keypair.go
+++ b/cli/server_regenerate_vapid_keypair.go
@@ -40,7 +40,7 @@ func (r *RootCmd) newRegenerateVapidKeypairCommand() *serpent.Command {
 
 			if regenVapidKeypairDBURL == "" {
 				cliui.Infof(inv.Stdout, "Using built-in PostgreSQL (%s)", cfg.PostgresPath())
-				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "")
+				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger, "", false)
 				if err != nil {
 					return err
 				}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	"github.com/go-chi/chi/v5"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
@@ -254,13 +255,46 @@ func TestServer(t *testing.T) {
 			"--access-url", "http://example-a.com",
 			"--cache-dir", t.TempDir(),
 		)
-		clitest.Start(t, invA.WithContext(testutil.Context(t, superDuperLong)))
+		waiterA := clitest.StartWithWaiter(t, invA.WithContext(testutil.Context(t, superDuperLong)))
 
 		serverAURL := waitAccessURL(t, sharedConfig)
 		assertHealthy(t, serverAURL)
 
 		persistedPort, err := sharedConfig.PostgresPort().Read()
 		require.NoError(t, err)
+		pgPassword, err := sharedConfig.PostgresPassword().Read()
+		require.NoError(t, err)
+		pgPort, err := strconv.ParseUint(persistedPort, 10, 16)
+		require.NoError(t, err)
+
+		waiterA.Cancel()
+		require.Eventually(t, func() bool {
+			conn, dialErr := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", persistedPort), testutil.IntervalFast)
+			if dialErr == nil {
+				_ = conn.Close()
+				return false
+			}
+			return true
+		}, testutil.WaitLong, testutil.IntervalFast, "expected the first server to stop postgres before reusing it")
+
+		externalPostgres := embeddedpostgres.NewDatabase(
+			embeddedpostgres.DefaultConfig().
+				Version(embeddedpostgres.V13).
+				BinariesPath(filepath.Join(sharedConfig.PostgresPath(), "bin")).
+				BinaryRepositoryURL("https://repo.maven.apache.org/maven2").
+				DataPath(filepath.Join(sharedConfig.PostgresPath(), "data")).
+				RuntimePath(filepath.Join(sharedConfig.PostgresPath(), "runtime")).
+				CachePath(filepath.Join(sharedConfig.PostgresPath(), "cache")).
+				Username("coder").
+				Password(pgPassword).
+				Database("coder").
+				Encoding("UTF8").
+				Port(uint32(pgPort)),
+		)
+		require.NoError(t, externalPostgres.Start())
+		defer func() {
+			require.NoError(t, externalPostgres.Stop())
+		}()
 
 		invB, _ := clitest.New(t,
 			"server",
@@ -282,7 +316,6 @@ func TestServer(t *testing.T) {
 		serverBURL, err := url.Parse(rawServerBURL)
 		require.NoError(t, err)
 		assertHealthy(t, serverBURL)
-		assertHealthy(t, serverAURL)
 
 		persistedPortAfter, err := sharedConfig.PostgresPort().Read()
 		require.NoError(t, err)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -257,7 +257,16 @@ func TestServer(t *testing.T) {
 		)
 		waiterA := clitest.StartWithWaiter(t, invA.WithContext(testutil.Context(t, superDuperLong)))
 
-		serverAURL := waitAccessURL(t, sharedConfig)
+		var rawServerAURL string
+		//nolint:gocritic // Embedded postgres takes a while to fire up.
+		require.Eventually(t, func() bool {
+			var readErr error
+			rawServerAURL, readErr = sharedConfig.URL().Read()
+			return readErr == nil && rawServerAURL != ""
+		}, superDuperLong, testutil.IntervalFast, "failed to get access URL")
+
+		serverAURL, err := url.Parse(rawServerAURL)
+		require.NoError(t, err)
 		assertHealthy(t, serverAURL)
 
 		persistedPort, err := sharedConfig.PostgresPort().Read()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -302,6 +302,7 @@ func TestServer(t *testing.T) {
 			"--http-address", "127.0.0.1:0",
 			"--access-url", "http://example-b.com",
 			"--cache-dir", t.TempDir(),
+			"--dev-builtin-postgres-reconnect",
 		)
 		clitest.Start(t, invB.WithContext(testutil.Context(t, superDuperLong)))
 

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -217,6 +217,77 @@ func TestServer(t *testing.T) {
 			return err == nil && rawURL != ""
 		}, superDuperLong, testutil.IntervalFast, "failed to get access URL")
 	})
+	t.Run("BuiltinPostgresSharedGlobalConfigReuse", func(t *testing.T) {
+		t.Parallel()
+		if testing.Short() {
+			t.SkipNow()
+		}
+
+		assertHealthy := func(t *testing.T, serverURL *url.URL) {
+			t.Helper()
+
+			healthzURL := serverURL.ResolveReference(&url.URL{Path: "/healthz"})
+			require.Eventually(t, func() bool {
+				ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+				defer cancel()
+
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthzURL.String(), nil)
+				if err != nil {
+					return false
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return false
+				}
+				defer resp.Body.Close()
+				return resp.StatusCode == http.StatusOK
+			}, testutil.WaitLong, testutil.IntervalFast, "expected %s to become healthy", healthzURL)
+		}
+
+		sharedConfig := config.Root(t.TempDir())
+		const superDuperLong = testutil.WaitSuperLong * 3
+
+		invA, _ := clitest.New(t,
+			"server",
+			"--global-config", string(sharedConfig),
+			"--http-address", ":0",
+			"--access-url", "http://example-a.com",
+			"--cache-dir", t.TempDir(),
+		)
+		clitest.Start(t, invA.WithContext(testutil.Context(t, superDuperLong)))
+
+		serverAURL := waitAccessURL(t, sharedConfig)
+		assertHealthy(t, serverAURL)
+
+		persistedPort, err := sharedConfig.PostgresPort().Read()
+		require.NoError(t, err)
+
+		invB, _ := clitest.New(t,
+			"server",
+			"--global-config", string(sharedConfig),
+			"--http-address", "127.0.0.1:0",
+			"--access-url", "http://example-b.com",
+			"--cache-dir", t.TempDir(),
+		)
+		clitest.Start(t, invB.WithContext(testutil.Context(t, superDuperLong)))
+
+		var rawServerBURL string
+		//nolint:gocritic // Embedded postgres takes a while to fire up.
+		require.Eventually(t, func() bool {
+			var readErr error
+			rawServerBURL, readErr = sharedConfig.URL().Read()
+			return readErr == nil && rawServerBURL != "" && rawServerBURL != serverAURL.String()
+		}, superDuperLong, testutil.IntervalFast, "expected server B to publish a distinct local URL")
+
+		serverBURL, err := url.Parse(rawServerBURL)
+		require.NoError(t, err)
+		assertHealthy(t, serverBURL)
+		assertHealthy(t, serverAURL)
+
+		persistedPortAfter, err := sharedConfig.PostgresPort().Read()
+		require.NoError(t, err)
+		require.Equal(t, persistedPort, persistedPortAfter)
+	})
 	t.Run("EphemeralDeployment", func(t *testing.T) {
 		t.Parallel()
 		if testing.Short() {

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -220,7 +220,8 @@ fatal() {
 	trap 'fatal "Script encountered an error"' ERR
 
 	cdroot
-	DEBUG_DELVE="${debug}" DEVELOP_IN_CODER="${DEVELOP_IN_CODER}" start_cmd API "" "${CODER_DEV_SHIM}" server --http-address "0.0.0.0:${api_port}" --swagger-enable --access-url "${CODER_DEV_ACCESS_URL}" --dangerous-allow-cors-requests=true --enable-terraform-debug-mode "$@"
+	# Allow reconnecting to a running built-in PostgreSQL from a prior develop.sh run.
+	DEBUG_DELVE="${debug}" DEVELOP_IN_CODER="${DEVELOP_IN_CODER}" start_cmd API "" "${CODER_DEV_SHIM}" server --http-address "0.0.0.0:${api_port}" --swagger-enable --access-url "${CODER_DEV_ACCESS_URL}" --dangerous-allow-cors-requests=true --enable-terraform-debug-mode --dev-builtin-postgres-reconnect "$@"
 
 	echo '== Waiting for Coder to become ready'
 	# Start the timeout in the background so interrupting this script


### PR DESCRIPTION
## Summary
- verify and reuse an already-running built-in PostgreSQL instance when the persisted port is busy
- reject non-matching listeners on the recorded port with a targeted error instead of reusing or cleaning them up
- add unit and CLI regression coverage for built-in PostgreSQL reuse

## Testing
- go test ./cli -run 'TestStartBuiltinPostgres|TestServer/(BuiltinPostgres|BuiltinPostgresSharedGlobalConfigReuse)$' -count=1
- make lint
