### PR TITLE
feat(chatd): add X-Coder-Chat-Id header to outgoing LLM requests

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -64,6 +64,11 @@ const (
 	defaultSubagentInstruction = "You are running as a delegated sub-agent chat. Complete the delegated task and provide clear, concise assistant responses for the parent agent."
 )
 
+// ChatIDHeader is sent on all outgoing LLM API requests so that
+// AI Bridge (or any upstream proxy) can correlate requests to a
+// specific chat session.
+const ChatIDHeader = "X-Coder-Chat-Id"
+
 // Server handles background processing of pending chats.
 type Server struct {
 	cancel   context.CancelFunc
@@ -2847,6 +2852,7 @@ func (p *Server) resolveChatModel(
 
 	model, err := chatprovider.ModelFromConfig(
 		dbConfig.Provider, dbConfig.Model, keys,
+		map[string]string{ChatIDHeader: chat.ID.String()},
 	)
 	if err != nil {
 		return nil, database.ChatModelConfig{}, chatprovider.ProviderAPIKeys{}, xerrors.Errorf(
@@ -3143,7 +3149,7 @@ func (p *Server) maybeSendPushNotification(
 					if assistantText != "" {
 						model, _, keys, resolveErr := p.resolveChatModel(pushCtx, chat)
 						if resolveErr == nil {
-							if summary := generatePushSummary(pushCtx, chat.Title, assistantText, model, keys, logger); summary != "" {
+							if summary := generatePushSummary(pushCtx, chat.ID, chat.Title, assistantText, model, keys, logger); summary != "" {
 								pushBody = summary
 							}
 						}

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1742,4 +1743,70 @@ func TestSuccessfulChatSendsWebPushWithSummary(t *testing.T) {
 		"push body should be the LLM-generated summary")
 	require.NotEqual(t, "Agent has finished running.", msg.Body,
 		"push body should not use the default fallback text")
+}
+
+func TestChatIDHeaderSentToLLM(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// Capture headers from every LLM request.
+	var mu sync.Mutex
+	var streamHeaders []http.Header
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		mu.Lock()
+		streamHeaders = append(streamHeaders, req.Header.Clone())
+		mu.Unlock()
+
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "header-test",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []fantasy.Content{fantasy.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+
+	// Wait for the chat to complete.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusWaiting
+	}, testutil.IntervalFast)
+
+	// Every LLM request should carry the chat ID header.
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, streamHeaders, "expected at least one LLM request")
+	for i, h := range streamHeaders {
+		require.Equal(t, chat.ID.String(), h.Get("X-Coder-Chat-Id"),
+			"request %d should carry X-Coder-Chat-Id matching the chat", i)
+	}
 }

--- a/coderd/chatd/chatprovider/chatprovider.go
+++ b/coderd/chatd/chatprovider/chatprovider.go
@@ -921,6 +921,7 @@ func ModelFromConfig(
 	providerHint string,
 	modelName string,
 	providerKeys ProviderAPIKeys,
+	headers map[string]string,
 ) (fantasy.LanguageModel, error) {
 	provider, modelID, err := ResolveModelWithProviderHint(modelName, providerHint)
 	if err != nil {
@@ -942,24 +943,40 @@ func ModelFromConfig(
 		if baseURL != "" {
 			options = append(options, fantasyanthropic.WithBaseURL(baseURL))
 		}
+		if len(headers) > 0 {
+			options = append(options, fantasyanthropic.WithHeaders(headers))
+		}
 		providerClient, err = fantasyanthropic.New(options...)
 	case fantasyazure.Name:
 		if baseURL == "" {
 			return nil, xerrors.New("AZURE_OPENAI_BASE_URL is not set")
 		}
-		providerClient, err = fantasyazure.New(
+		options := []fantasyazure.Option{
 			fantasyazure.WithAPIKey(apiKey),
 			fantasyazure.WithBaseURL(baseURL),
 			fantasyazure.WithUseResponsesAPI(),
-		)
+		}
+		if len(headers) > 0 {
+			options = append(options, fantasyazure.WithHeaders(headers))
+		}
+		providerClient, err = fantasyazure.New(options...)
 	case fantasybedrock.Name:
-		providerClient, err = fantasybedrock.New(fantasybedrock.WithAPIKey(apiKey))
+		options := []fantasybedrock.Option{
+			fantasybedrock.WithAPIKey(apiKey),
+		}
+		if len(headers) > 0 {
+			options = append(options, fantasybedrock.WithHeaders(headers))
+		}
+		providerClient, err = fantasybedrock.New(options...)
 	case fantasygoogle.Name:
 		options := []fantasygoogle.Option{
 			fantasygoogle.WithGeminiAPIKey(apiKey),
 		}
 		if baseURL != "" {
 			options = append(options, fantasygoogle.WithBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			options = append(options, fantasygoogle.WithHeaders(headers))
 		}
 		providerClient, err = fantasygoogle.New(options...)
 	case fantasyopenai.Name:
@@ -970,6 +987,9 @@ func ModelFromConfig(
 		if baseURL != "" {
 			options = append(options, fantasyopenai.WithBaseURL(baseURL))
 		}
+		if len(headers) > 0 {
+			options = append(options, fantasyopenai.WithHeaders(headers))
+		}
 		providerClient, err = fantasyopenai.New(options...)
 	case fantasyopenaicompat.Name:
 		options := []fantasyopenaicompat.Option{
@@ -978,15 +998,27 @@ func ModelFromConfig(
 		if baseURL != "" {
 			options = append(options, fantasyopenaicompat.WithBaseURL(baseURL))
 		}
+		if len(headers) > 0 {
+			options = append(options, fantasyopenaicompat.WithHeaders(headers))
+		}
 		providerClient, err = fantasyopenaicompat.New(options...)
 	case fantasyopenrouter.Name:
-		providerClient, err = fantasyopenrouter.New(fantasyopenrouter.WithAPIKey(apiKey))
+		options := []fantasyopenrouter.Option{
+			fantasyopenrouter.WithAPIKey(apiKey),
+		}
+		if len(headers) > 0 {
+			options = append(options, fantasyopenrouter.WithHeaders(headers))
+		}
+		providerClient, err = fantasyopenrouter.New(options...)
 	case fantasyvercel.Name:
 		options := []fantasyvercel.Option{
 			fantasyvercel.WithAPIKey(apiKey),
 		}
 		if baseURL != "" {
 			options = append(options, fantasyvercel.WithBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			options = append(options, fantasyvercel.WithHeaders(headers))
 		}
 		providerClient, err = fantasyvercel.New(options...)
 	default:

--- a/coderd/chatd/chatprovider/chatprovider_headers_test.go
+++ b/coderd/chatd/chatprovider/chatprovider_headers_test.go
@@ -1,0 +1,116 @@
+package chatprovider_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/chatd/chatprovider"
+)
+
+// TestModelFromConfigHeaders verifies that custom headers passed to
+// ModelFromConfig arrive on every outgoing HTTP request to the LLM
+// provider.
+func TestModelFromConfigHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HeadersPresent", func(t *testing.T) {
+		t.Parallel()
+
+		chatID := uuid.New()
+		headers := map[string]string{
+			"X-Coder-Chat-Id": chatID.String(),
+		}
+
+		received := captureHeaders(t, headers)
+		assert.Equal(t, chatID.String(), received.Get("X-Coder-Chat-Id"))
+	})
+
+	t.Run("NilHeaders", func(t *testing.T) {
+		t.Parallel()
+
+		received := captureHeaders(t, nil)
+		assert.Empty(t, received.Get("X-Coder-Chat-Id"))
+	})
+}
+
+// captureHeaders creates an OpenAI-compatible test server, calls
+// ModelFromConfig with the given headers, invokes Generate, and
+// returns the HTTP headers that arrived at the server.
+func captureHeaders(t *testing.T, headers map[string]string) http.Header {
+	t.Helper()
+
+	var mu sync.Mutex
+	var captured http.Header
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured = r.Header.Clone()
+		mu.Unlock()
+
+		// Return a minimal valid OpenAI Responses API response.
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"id":      fmt.Sprintf("resp_%s", uuid.New().String()[:8]),
+			"object":  "response",
+			"created": time.Now().Unix(),
+			"model":   "gpt-4o-mini",
+			"output": []map[string]interface{}{
+				{
+					"id":   uuid.New().String(),
+					"type": "message",
+					"role": "assistant",
+					"content": []map[string]interface{}{
+						{
+							"type": "output_text",
+							"text": "hello",
+						},
+					},
+				},
+			},
+			"usage": map[string]int{
+				"input_tokens":  5,
+				"output_tokens": 1,
+				"total_tokens":  6,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	keys := chatprovider.ProviderAPIKeys{
+		OpenAI:            "test-key",
+		BaseURLByProvider: map[string]string{"openai": srv.URL},
+	}
+
+	model, err := chatprovider.ModelFromConfig("openai", "gpt-4o-mini", keys, headers)
+	require.NoError(t, err)
+
+	maxTokens := int64(10)
+	_, err = model.Generate(t.Context(), fantasy.Call{
+		Prompt: []fantasy.Message{
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "hi"},
+				},
+			},
+		},
+		MaxOutputTokens: &maxTokens,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, captured, "server should have received a request")
+	return captured
+}

--- a/coderd/chatd/quickgen.go
+++ b/coderd/chatd/quickgen.go
@@ -13,6 +13,7 @@ import (
 	fantasyopenai "charm.land/fantasy/providers/openai"
 	fantasyopenrouter "charm.land/fantasy/providers/openrouter"
 	fantasyvercel "charm.land/fantasy/providers/vercel"
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -77,6 +78,7 @@ func (p *Server) maybeGenerateChatTitle(
 	for _, c := range preferredTitleModels {
 		m, err := chatprovider.ModelFromConfig(
 			c.provider, c.model, keys,
+			map[string]string{ChatIDHeader: chat.ID.String()},
 		)
 		if err == nil {
 			candidates = append(candidates, m)
@@ -267,6 +269,7 @@ const pushSummaryPrompt = "You are a notification assistant. Given a chat title 
 // fall back to the provided model. Returns "" on any failure.
 func generatePushSummary(
 	ctx context.Context,
+	chatID uuid.UUID,
 	chatTitle string,
 	assistantText string,
 	fallbackModel fantasy.LanguageModel,
@@ -282,6 +285,7 @@ func generatePushSummary(
 	for _, c := range preferredTitleModels {
 		m, err := chatprovider.ModelFromConfig(
 			c.provider, c.model, keys,
+			map[string]string{ChatIDHeader: chatID.String()},
 		)
 		if err == nil {
 			candidates = append(candidates, m)


### PR DESCRIPTION
## Summary

Sends an `X-Coder-Chat-Id` header on every outgoing LLM API request so that AI Bridge (or any upstream proxy) can correlate requests to a specific chat session.

## Changes

### `coderd/chatd/chatd.go`
- Added `ChatIDHeader = "X-Coder-Chat-Id"` constant.
- `resolveChatModel()` passes the chat ID header to `ModelFromConfig`.
- Updated `generatePushSummary` caller to pass `chat.ID`.

### `coderd/chatd/chatprovider/chatprovider.go`
- `ModelFromConfig()` gains a `headers map[string]string` parameter.
- Each provider case passes headers via `WithHeaders(headers)` (guarded by `len(headers) > 0`): anthropic, azure, bedrock, google, openai, openaicompat, openrouter, vercel.

### `coderd/chatd/quickgen.go`
- `maybeGenerateChatTitle()`: passes the chat ID header for all title-model candidates.
- `generatePushSummary()`: added `chatID uuid.UUID` parameter, passes the header for all summary-model candidates.

## Coverage

Every outgoing LLM request now carries `X-Coder-Chat-Id`:
- Chat streaming (main agent loop)
- Compaction / context summarization (same model instance)
- Title generation (lightweight model candidates + fallback)
- Push notification summaries (lightweight model candidates + fallback)