### PR TITLE
fix: resolve double-unlock panic in notifications Manager.Stop

### DIFF
--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -380,8 +380,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	m.mu.Unlock()     // Unlock to avoid blocking loop.
-	defer m.mu.Lock() // Re-lock the mutex due to earlier defer.
+	m.mu.Unlock() // Unlock to avoid blocking loop.
 
 	// Wait for the manager loop to exit or the context to be canceled, whichever comes first.
 	select {
@@ -392,9 +391,11 @@ func (m *Manager) Stop(ctx context.Context) error {
 		}
 		// For some reason, slog.Error returns {} for a context error.
 		m.log.Error(context.Background(), "graceful stop failed", slog.F("err", errStr))
+		m.mu.Lock() // Re-acquire the lock since the deferred unlock will still run.
 		return ctx.Err()
 	case <-m.done:
 		m.log.Debug(context.Background(), "gracefully stopped")
+		m.mu.Lock() // Re-acquire the lock since the deferred unlock will still run.
 		return nil
 	}
 }


### PR DESCRIPTION
The Stop() function had a double-unlock bug that would cause a runtime panic with 'sync: unlock of unlocked mutex'.

The bug was caused by:
1. m.mu.Lock() at line 360
2. defer m.mu.Unlock() at line 361 (will run when function returns)
3. explicit m.mu.Unlock() at line 383
4. defer m.mu.Lock() at line 384

When the function returned, the deferred Lock() from line 384 would run first (locking then unlocking on defer exit), followed by the deferred Unlock() from line 361 trying to unlock an already-unlocked mutex, causing a panic.

The fix removes the problematic deferred Lock() and instead explicitly re-acquires the lock before returning in both select branches, ensuring the original deferred Unlock() properly releases the mutex.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
