### PR TITLE
fix(site): include archived filter in q param for agents list

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2942,7 +2942,6 @@ class ApiMethods {
 		limit?: number;
 		offset?: number;
 		q?: string;
-		archived?: boolean;
 	}): Promise<TypesGen.Chat[]> => {
 		const response = await this.axios.get<TypesGen.Chat[]>(
 			getURLWithSearchParams("/api/experimental/chats", req),

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -52,6 +52,16 @@ const DEFAULT_CHAT_PAGE_LIMIT = 50;
 export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 	const limit = DEFAULT_CHAT_PAGE_LIMIT;
 
+	// Build the search query string including the archived filter.
+	const qParts: string[] = [];
+	if (opts?.q) {
+		qParts.push(opts.q);
+	}
+	if (opts?.archived !== undefined) {
+		qParts.push(`archived:${opts.archived}`);
+	}
+	const q = qParts.length > 0 ? qParts.join(" ") : undefined;
+
 	return {
 		queryKey: [...chatsKey, opts],
 		getNextPageParam: (lastPage: TypesGen.Chat[], pages: TypesGen.Chat[][]) => {
@@ -68,8 +78,7 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 			return API.getChats({
 				limit,
 				offset: pageParam <= 0 ? 0 : (pageParam - 1) * limit,
-				q: opts?.q,
-				archived: opts?.archived,
+				q,
 			});
 		},
 		refetchOnWindowFocus: true as const,


### PR DESCRIPTION
## Problem

The agents sidebar filter dropdown (Active / Archived) only ever showed active agents regardless of which option was selected.

## Root Cause

The frontend sent `archived` as a standalone URL query parameter (e.g., `?archived=true`), but the backend's `listChats` handler reads it from the `q` search parameter via `searchquery.Chats()` (e.g., `?q=archived:true`). The standalone parameter was silently ignored, so the backend always defaulted to `archived:false`.

## Fix

- **`site/src/api/queries/chats.ts`**: `infiniteChats()` now folds the `archived` filter into the `q` search string instead of passing it as a separate parameter.
- **`site/src/api/api.ts`**: Removed the unused `archived` field from the `getChats` request type.