### PR TITLE
docs: move IDE clarification to 'what agents is and isn't' section

### DIFF
--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -21,6 +21,11 @@ shell execution — and works with any LLM provider you configure.
 It is not a wrapper around third-party agent tools like Claude Code
 or Codex.
 
+Coder Agents is not a replacement for your text editor or IDE. It is the
+primary interface where developers work with and orchestrate coding agents.
+Developers still connect to workspaces via VS Code, Cursor, JetBrains, or any
+other editor to review, refine, and complete work that the agent produces.
+
 ## Who Coder Agents is for
 
 Coder Agents is designed for organizations that need to self-host their AI
@@ -39,11 +44,6 @@ strong fit for:
 
 Coder Agents runs entirely self-hosted. There is no SaaS or managed component — the agent
 loop, chat history, and all tool execution happen within your Coder deployment.
-
-Coder Agents is not a replacement for your text editor or IDE. It is the
-primary interface where developers work with and orchestrate coding agents.
-Developers still connect to workspaces via VS Code, Cursor, JetBrains, or any
-other editor to review, refine, and complete work that the agent produces.
 
 ## How it works
 


### PR DESCRIPTION
Moves the paragraph clarifying that Coder Agents is not a replacement for your text editor or IDE from the "Who Coder Agents is for" section to the end of the "What Coder Agents is and isn't" section, where it fits more naturally.