### PR TITLE
fix(cli): increase test timeout for TestOpenVSCodeDevContainer

### DIFF
--- a/cli/open_test.go
+++ b/cli/open_test.go
@@ -510,7 +510,7 @@ func TestOpenVSCodeDevContainer(t *testing.T) {
 			inv.Stdin = pty.Input()
 			inv.Stdout = pty.Output()
 
-			ctx := testutil.Context(t, testutil.WaitLong)
+			ctx := testutil.Context(t, testutil.WaitSuperLong)
 			inv = inv.WithContext(ctx)
 
 			for k, v := range tt.env {


### PR DESCRIPTION
## Problem

`TestOpenVSCodeDevContainer/ok_inside_workspace` flakes in CI with:

```
Get "http://127.0.0.1:.../api/v2/workspaceagents/.../containers": context deadline exceeded
```

The subtests use `testutil.WaitLong` (25s) as the context deadline for the `coder open vscode` invocation. Under CI load with the race detector, the HTTP round-trip through coderd to the agent containers API can be slow enough to exhaust this budget.

## Root cause

The real CLI path (`open.go:60`) uses `context.WithCancel(inv.Context())` — **no deadline**. The 25s pressure is entirely artificial from the test context.

## Fix

Bump the test context from `WaitLong` (25s) to `WaitSuperLong` (60s) in the `TestOpenVSCodeDevContainer` subtests.

Fixes coder/internal#596