### PR TITLE
fix: address race conditions and bugs in DERP latency reporting

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -1546,11 +1546,22 @@ func collectNetworkStats(ctx context.Context, agentConn workspacesdk.AgentConn, 
 	uploadSecs := float64(totalTx) / dur.Seconds()
 	downloadSecs := float64(totalRx) / dur.Seconds()
 
+	// Node or DERPMap may be nil early in the connection lifecycle
+	// before the tailnet has fully connected. Return stats with
+	// ping data but empty DERP fields rather than panicking.
+	if node == nil || derpMap == nil {
+		return &sshNetworkStats{
+			P2P:              p2p,
+			Latency:          float64(latency.Microseconds()) / 1000,
+			PreferredDERP:    "",
+			DERPLatency:      map[string]float64{},
+			UploadBytesSec:   int64(uploadSecs),
+			DownloadBytesSec: int64(downloadSecs),
+		}, nil
+	}
+
 	preferredDerpName := tailnet.ExtractPreferredDERPName(pingResult, node, derpMap)
 	derpLatency := tailnet.ExtractDERPLatency(node, derpMap)
-	if _, ok := derpLatency[preferredDerpName]; !ok {
-		derpLatency[preferredDerpName] = 0
-	}
 	derpLatencyMs := maps.Map(derpLatency, func(dur time.Duration) float64 {
 		return float64(dur) / float64(time.Millisecond)
 	})

--- a/tailnet/node.go
+++ b/tailnet/node.go
@@ -146,7 +146,7 @@ func (u *nodeUpdater) setNetInfo(ni *tailcfg.NetInfo) {
 	}
 	if !maps.Equal(u.derpLatency, ni.DERPLatency) {
 		dirty = true
-		u.derpLatency = ni.DERPLatency
+		u.derpLatency = maps.Clone(ni.DERPLatency)
 	}
 	if dirty {
 		u.dirty = true

--- a/tailnet/node_internal_test.go
+++ b/tailnet/node_internal_test.go
@@ -111,6 +111,55 @@ func TestNodeUpdater_setNetInfo_same(t *testing.T) {
 	_ = testutil.TryReceive(ctx, t, done)
 }
 
+func TestNodeUpdater_setNetInfo_clonesInput(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := testutil.Logger(t)
+	id := tailcfg.NodeID(1)
+	nodeKey := key.NewNode().Public()
+	discoKey := key.NewDisco().Public()
+	nodeCh := make(chan *Node)
+	uut := newNodeUpdater(
+		logger,
+		func(n *Node) {
+			nodeCh <- n
+		},
+		id, nodeKey, discoKey,
+	)
+	defer uut.close()
+
+	// Given: a DERPLatency map passed into setNetInfo
+	dl := map[string]float64{"1": 0.025}
+	uut.setNetInfo(&tailcfg.NetInfo{
+		PreferredDERP: 1,
+		DERPLatency:   dl,
+	})
+
+	node := testutil.TryReceive(ctx, t, nodeCh)
+	require.Equal(t, 1, node.PreferredDERP)
+	require.True(t, maps.Equal(map[string]float64{"1": 0.025}, node.DERPLatency))
+
+	// When: we mutate the original map after setNetInfo
+	dl["1"] = 99.0
+	dl["2"] = 50.0
+
+	// Then: the nodeUpdater's internal state is not affected.
+	uut.L.Lock()
+	require.Equal(t, map[string]float64{"1": 0.025}, uut.derpLatency)
+	uut.L.Unlock()
+
+	// Then: the Node already produced by the callback is also not
+	// affected.
+	require.Equal(t, map[string]float64{"1": 0.025}, node.DERPLatency)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		uut.close()
+	}()
+	_ = testutil.TryReceive(ctx, t, done)
+}
+
 func TestNodeUpdater_setDERPForcedWebsocket_different(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -622,20 +622,22 @@ func (u *updater) recordLatencies() {
 			go func() {
 				defer wg.Done()
 
+				// Fetch Node and DERPMap before the ping to ensure the
+				// latency data corresponds to the same DERP state that
+				// informed relay selection for this ping.
+				node := conn.Node()
+				derpMap := conn.DERPMap()
+				if node == nil || derpMap == nil {
+					u.logger.Warn(u.ctx, "failed to get DERP map or node before ping")
+					return
+				}
+
 				pingDur, didP2p, pingResult, err := conn.Ping(pingCtx, agentID)
 				if err != nil {
 					u.logger.Warn(u.ctx, "failed to ping agent", slog.F("agent_id", agentID), slog.Error(err))
 					return
 				}
 
-				// We fetch the Node and DERPMap after each ping, as it may have
-				// changed.
-				node := conn.Node()
-				derpMap := conn.DERPMap()
-				if node == nil || derpMap == nil {
-					u.logger.Warn(u.ctx, "failed to get DERP map or node after ping")
-					return
-				}
 				derpLatencies := tailnet.ExtractDERPLatency(node, derpMap)
 				preferredDerp := tailnet.ExtractPreferredDERPName(pingResult, node, derpMap)
 				var preferredDerpLatency *time.Duration


### PR DESCRIPTION
## Problem

Users have reported seeing a DERP server in a different region showing the same latency as a DERP server in their local region. Investigation revealed several concurrency and correctness bugs in how DERP latency is collected and reported.

## Root Causes

### 1. `derpLatency` map not cloned on input (`tailnet/node.go`)

`setNetInfo()` stored a direct reference to the caller's `DERPLatency` map without cloning:

```go
u.derpLatency = ni.DERPLatency // direct alias — no copy
```

The output path (`nodeLocked`) already cloned via `maps.Clone()`, and `setAddresses()` copies its input, making this an inconsistency. If the wireguard engine ever reused or mutated the `NetInfo` after the callback, the `nodeUpdater`'s internal state could be silently corrupted without lock protection.

### 2. Missing nil guards in `cli/ssh.go`

`collectNetworkStats()` passes `node` and `derpMap` to `ExtractPreferredDERPName` and `ExtractDERPLatency` without nil checks. The equivalent VPN code (`vpn/tunnel.go:635-638`) has these guards. A nil `derpMap` early in the connection lifecycle would cause a panic.

### 3. Misleading zero-latency fallback in `cli/ssh.go`

When the preferred DERP name wasn't found in the latency map, a zero-duration entry was inserted:

```go
if _, ok := derpLatency[preferredDerpName]; !ok {
    derpLatency[preferredDerpName] = 0
}
```

A zero value is indistinguishable from a real measurement and misleads users into thinking they have 0ms latency to a relay.

### 4. Non-atomic reads in `vpn/tunnel.go`

`recordLatencies()` called `Ping()` first, then `Node()` and `DERPMap()` after. Between the ping completing and `Node()` being called, `setNetInfo` could fire and wholesale-replace `preferredDERP` and `derpLatency`, causing the ping result's `DERPRegionID` and the node's `DERPLatency` map to be from different measurement cycles.

## Fixes

1. **Clone on input**: `u.derpLatency = maps.Clone(ni.DERPLatency)` — matches the defensive pattern on the output path and in `setAddresses`.
2. **Nil guards**: Return valid stats with empty DERP fields when `node`/`derpMap` is nil, instead of panicking.
3. **Remove zero-latency fallback**: If the preferred DERP isn't in the latency map, just don't include it.
4. **Fetch before ping**: Move `Node()`/`DERPMap()` calls before `Ping()` so the latency data corresponds to the DERP state that informed relay selection.

## Testing

- Added `TestNodeUpdater_setNetInfo_clonesInput` — verifies that mutating the original map after `setNetInfo` does not affect the `nodeUpdater`'s internal state or already-emitted nodes.
- All existing tests pass, including `TestTunnel_sendAgentUpdate`, `TestTunnel_slowPing`, and `TestTunnel_stopMidPing`.
- Race detector passes on all affected tests.