### PR TITLE
fix(agent/ssh): improve disconnect reason reporting

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -340,32 +340,55 @@ func extractMagicSessionType(env []string) (magicType MagicSessionType, rawType 
 	})
 }
 
-// sessionCloseTracker is a wrapper around Session that tracks the exit code.
+// sessionCloseTracker is a wrapper around Session that tracks the
+// exit code and reason for session closure. Exit() always takes
+// priority over Close() because Exit carries an intentional exit
+// code from the process, while Close is a fallback (default code 1)
+// triggered by the SSH library or SFTP server teardown.
 type sessionCloseTracker struct {
 	ssh.Session
-	exitOnce sync.Once
-	code     atomic.Int64
+	mu     sync.Mutex
+	exited bool // true if Exit() was called
+	code   int
+	reason string
 }
 
 var _ ssh.Session = &sessionCloseTracker{}
 
-func (s *sessionCloseTracker) track(code int) {
-	s.exitOnce.Do(func() {
-		s.code.Store(int64(code))
-	})
+func (s *sessionCloseTracker) exitCode() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.code
 }
 
-func (s *sessionCloseTracker) exitCode() int {
-	return int(s.code.Load())
+// closeReason returns the reason recorded by Close() only if
+// Exit() was never called. This covers the case where the SSH
+// library or an internal component (e.g. sftp.Server) tears
+// down the session without going through an explicit Exit path.
+func (s *sessionCloseTracker) closeReason() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.exited {
+		return s.reason
+	}
+	return ""
 }
 
 func (s *sessionCloseTracker) Exit(code int) error {
-	s.track(code)
+	s.mu.Lock()
+	s.exited = true
+	s.code = code
+	s.mu.Unlock()
 	return s.Session.Exit(code)
 }
 
 func (s *sessionCloseTracker) Close() error {
-	s.track(1)
+	s.mu.Lock()
+	if !s.exited {
+		s.code = 1
+		s.reason = "session closed by the server or client disconnect"
+	}
+	s.mu.Unlock()
 	return s.Session.Close()
 }
 
@@ -449,6 +472,13 @@ func (s *Server) sessionHandler(session ssh.Session) {
 
 		disconnected := s.config.ReportConnection(id, magicType, remoteAddrString)
 		defer func() {
+			// If closeCause was never called but the tracker
+			// recorded a Close() (e.g. client disconnect, server
+			// shutdown, or SFTP teardown), use its reason so we
+			// never report a non-zero exit with an empty reason.
+			if reason == "" {
+				reason = scr.closeReason()
+			}
 			disconnected(scr.exitCode(), reason)
 		}()
 	}
@@ -527,7 +557,11 @@ func (s *Server) sessionHandler(session ssh.Session) {
 			slog.F("exit_code", code),
 		)
 
-		closeCause(fmt.Sprintf("process exited with error status: %d", exitError.ExitCode()))
+		// exitError.Error() includes signal information for
+		// signal deaths (e.g. "signal: killed", "signal:
+		// terminated") which is far more useful than just the
+		// numeric code (-1).
+		closeCause(fmt.Sprintf("process exited: %s", exitError))
 
 		// TODO(mafredri): For signal exit, there's also an "exit-signal"
 		// request (session.Exit sends "exit-status"), however, since it's

--- a/agent/agentssh/session_close_tracker_internal_test.go
+++ b/agent/agentssh/session_close_tracker_internal_test.go
@@ -1,0 +1,153 @@
+package agentssh
+
+import (
+	"testing"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+)
+
+// fakeSession implements ssh.Session for testing sessionCloseTracker.
+// Only Exit and Close are exercised; other methods panic if called.
+type fakeSession struct {
+	gliderssh.Session
+	exitCalled  bool
+	exitCode    int
+	closeCalled bool
+}
+
+func (f *fakeSession) Exit(code int) error {
+	f.exitCalled = true
+	f.exitCode = code
+	return nil
+}
+
+func (f *fakeSession) Close() error {
+	f.closeCalled = true
+	return nil
+}
+
+func TestSessionCloseTracker_ExitBeforeClose(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	err := scr.Exit(42)
+	require.NoError(t, err)
+	err = scr.Close()
+	require.NoError(t, err)
+
+	// Exit's code takes priority over Close's default of 1.
+	assert.Equal(t, 42, scr.exitCode())
+	// closeReason should be empty because Exit was called.
+	assert.Empty(t, scr.closeReason())
+}
+
+func TestSessionCloseTracker_CloseBeforeExit(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	// Close fires first (e.g. sftp.Server.Close() teardown).
+	err := scr.Close()
+	require.NoError(t, err)
+	// Exit fires second with the real exit code.
+	err = scr.Exit(0)
+	require.NoError(t, err)
+
+	// Exit always wins, even when Close ran first.
+	assert.Equal(t, 0, scr.exitCode())
+	// closeReason should be empty because Exit was called.
+	assert.Empty(t, scr.closeReason())
+}
+
+func TestSessionCloseTracker_CloseOnly(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	err := scr.Close()
+	require.NoError(t, err)
+
+	// Without Exit, Close sets code 1 and a default reason.
+	assert.Equal(t, 1, scr.exitCode())
+	assert.NotEmpty(t, scr.closeReason(), "should have a default reason when only Close is called")
+}
+
+func TestSessionCloseTracker_ExitOnly(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	err := scr.Exit(7)
+	require.NoError(t, err)
+
+	assert.Equal(t, 7, scr.exitCode())
+	assert.Empty(t, scr.closeReason())
+}
+
+func TestSessionCloseTracker_MultipleExitCalls(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	// Second Exit call should override the first.
+	err := scr.Exit(1)
+	require.NoError(t, err)
+	err = scr.Exit(2)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, scr.exitCode())
+}
+
+func TestSessionCloseTracker_ZeroValue(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	// Before any calls, defaults to zero.
+	assert.Equal(t, 0, scr.exitCode())
+	assert.Empty(t, scr.closeReason())
+}
+
+func TestSessionCloseTracker_DelegatesUnderlying(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSession{}
+	scr := &sessionCloseTracker{Session: fake}
+
+	err := scr.Exit(5)
+	require.NoError(t, err)
+	assert.True(t, fake.exitCalled, "should delegate Exit to underlying session")
+	assert.Equal(t, 5, fake.exitCode)
+
+	err = scr.Close()
+	require.NoError(t, err)
+	assert.True(t, fake.closeCalled, "should delegate Close to underlying session")
+}
+
+func TestSessionCloseTracker_ExitError(t *testing.T) {
+	t.Parallel()
+
+	// Simulate an underlying session that returns errors.
+	failSession := &failingSession{}
+	scr := &sessionCloseTracker{Session: failSession}
+
+	err := scr.Exit(1)
+	assert.Error(t, err)
+	// The code should still be tracked even if the underlying Exit fails.
+	assert.Equal(t, 1, scr.exitCode())
+}
+
+type failingSession struct {
+	gliderssh.Session
+}
+
+func (*failingSession) Exit(_ int) error {
+	return xerrors.New("exit failed")
+}
+
+func (*failingSession) Close() error {
+	return xerrors.New("close failed")
+}


### PR DESCRIPTION
Three issues caused useful disconnect information to be lost in SSH session reporting:

**1. sessionCloseTracker race: Close() could override Exit()**

Used `sync.Once`, so whichever of `Close()` or `Exit()` was called first won the race. For SFTP sessions, `sftp.Server.Close()` calls `session.Close()` internally before the handler calls `session.Exit(0)`, locking in exit code 1 with no reason for what were actually successful sessions.

Replaced with a mutex-based design where `Exit()` always takes priority over `Close()`.

**2. Signal deaths reported unhelpful exit code -1**

`closeCause(fmt.Sprintf("process exited with error status: %d", exitError.ExitCode()))` produced `"process exited with error status: -1"` for signal kills. Changed to use `exitError.Error()` which produces strings like `"signal: killed"`, `"signal: terminated"`.

**3. Close()-only path produced empty reason**

When the SSH library or server shutdown calls `Close()` without `Exit()`, `closeCause` was never invoked, resulting in empty reason strings alongside non-zero exit codes. `Close()` now records a default reason, and the deferred disconnect callback falls back to it.