### PR TITLE
fix(dogfood): remove subdomain from coder_app with command

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -904,7 +904,6 @@ resource "coder_app" "develop_sh" {
   icon         = "${data.coder_workspace.me.access_url}/emojis/1f4bb.png" // 💻
   command      = "screen -x develop_sh"
   share        = "authenticated"
-  subdomain    = true
   open_in      = "tab"
   order        = 0
 }


### PR DESCRIPTION
The `coder_app` resource no longer supports having both `command` and `subdomain` set simultaneously. This removes `subdomain = true` from the `develop_sh` app in dogfood, which uses `command`.

This was the only `coder_app` in the repo with both fields set.