### PR TITLE
ci(docs): rewrite same-repo links to PR head SHA in linkspector

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -30,6 +30,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Rewrite same-repo links for PR branch
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Rewrite same-repo blob/tree main links to the PR head SHA
+          # so that files or directories introduced in the PR are
+          # reachable during link checking.
+          {
+            echo 'replacementPatterns:'
+            echo "  - pattern: \"https://github.com/coder/coder/blob/main/\""
+            echo "    replacement: \"https://github.com/coder/coder/blob/${HEAD_SHA}/\""
+            echo "  - pattern: \"https://github.com/coder/coder/tree/main/\""
+            echo "    replacement: \"https://github.com/coder/coder/tree/${HEAD_SHA}/\""
+          } >> .github/.linkspector.yml
+
       - name: Check Markdown links
         uses: umbrelladocs/action-linkspector@652f85bc57bb1e7d4327260decc10aa68f7694c3 # v1.4.0
         id: markdown-link-check


### PR DESCRIPTION
When a PR introduces new files and docs link to them via
`github.com/coder/coder/blob/main/...`, linkspector returns 404
because the files don't exist on `main` yet.

This adds a step that, for `pull_request` events only, appends
`replacementPatterns` to the linkspector config rewriting
`blob/main/` and `tree/main/` URLs to use the PR's head commit SHA.

- **PR runs:** links resolve to the commit where files exist
- **Scheduled/manual runs:** unchanged, links check against `main`

Refs #22922