### PR TITLE
fix: open coder_app links in new tab when open_in is tab

### DIFF
--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -80,10 +80,6 @@ export const getTerminalHref = ({
 };
 
 export const openAppInNewWindow = (href: string) => {
-	// window.open() returns null when "noopener" is in the features string
-	// (per WHATWG spec), making it indistinguishable from a blocked popup.
-	// We intentionally omit "noopener" here to preserve popup-block detection.
-	// The opened content is Coder-controlled, so the opener reference is safe.
 	const popup = window.open(href, "_blank", "width=900,height=600");
 	if (!popup) {
 		toast.error("Failed to open app in new window.", {

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -80,6 +80,10 @@ export const getTerminalHref = ({
 };
 
 export const openAppInNewWindow = (href: string) => {
+	// window.open() returns null when "noopener" is in the features string
+	// (per WHATWG spec), making it indistinguishable from a blocked popup.
+	// We intentionally omit "noopener" here to preserve popup-block detection.
+	// The opened content is Coder-controlled, so the opener reference is safe.
 	const popup = window.open(href, "_blank", "width=900,height=600");
 	if (!popup) {
 		toast.error("Failed to open app in new window.", {

--- a/site/src/modules/resources/AppLink/AppLink.test.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.test.tsx
@@ -1,11 +1,11 @@
-import { screen } from "@testing-library/react";
-import { ProxyProvider } from "contexts/ProxyContext";
 import {
 	MockWorkspace,
 	MockWorkspaceAgent,
 	MockWorkspaceApp,
 } from "testHelpers/entities";
 import { renderWithAuth } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import { ProxyProvider } from "contexts/ProxyContext";
 import { AppLink } from "./AppLink";
 
 const renderAppLink = (app: typeof MockWorkspaceApp) => {

--- a/site/src/modules/resources/AppLink/AppLink.test.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from "@testing-library/react";
+import { ProxyProvider } from "contexts/ProxyContext";
+import {
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+} from "testHelpers/entities";
+import { renderWithAuth } from "testHelpers/renderHelpers";
+import { AppLink } from "./AppLink";
+
+const renderAppLink = (app: typeof MockWorkspaceApp) => {
+	return renderWithAuth(
+		<ProxyProvider>
+			<AppLink app={app} workspace={MockWorkspace} agent={MockWorkspaceAgent} />
+		</ProxyProvider>,
+	);
+};
+
+// Regression tests for https://github.com/coder/coder/issues/18573:
+// open_in="tab" was not opening links in a new tab.
+describe("AppLink", () => {
+	it("sets target=_blank and rel=noopener noreferrer when open_in is tab", async () => {
+		renderAppLink({ ...MockWorkspaceApp, open_in: "tab" });
+		const link = await screen.findByRole("link");
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	// slim-window uses window.open() in onClick rather than a target attribute,
+	// so the anchor must not get target="_blank" or rel to avoid double-opening.
+	it("does not set target or rel when open_in is slim-window", async () => {
+		renderAppLink({ ...MockWorkspaceApp, open_in: "slim-window" });
+		const link = await screen.findByRole("link");
+		expect(link).not.toHaveAttribute("target");
+		expect(link).not.toHaveAttribute("rel");
+	});
+});

--- a/site/src/modules/resources/AppLink/AppLink.test.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.test.tsx
@@ -16,10 +16,10 @@ const renderAppLink = (app: typeof MockWorkspaceApp) => {
 // Regression test for https://github.com/coder/coder/issues/18573:
 // open_in="tab" was not opening links in a new tab.
 describe("AppLink", () => {
-	it("sets target=_blank and rel=noopener noreferrer when open_in is tab", async () => {
+	it("sets target=_blank and rel=noreferrer when open_in is tab", async () => {
 		renderAppLink({ ...MockWorkspaceApp, open_in: "tab" });
 		const link = await screen.findByRole("link");
 		expect(link).toHaveAttribute("target", "_blank");
-		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		expect(link).toHaveAttribute("rel", "noreferrer");
 	});
 });

--- a/site/src/modules/resources/AppLink/AppLink.test.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.test.tsx
@@ -5,18 +5,15 @@ import {
 } from "testHelpers/entities";
 import { renderWithAuth } from "testHelpers/renderHelpers";
 import { screen } from "@testing-library/react";
-import { ProxyProvider } from "contexts/ProxyContext";
 import { AppLink } from "./AppLink";
 
 const renderAppLink = (app: typeof MockWorkspaceApp) => {
 	return renderWithAuth(
-		<ProxyProvider>
-			<AppLink app={app} workspace={MockWorkspace} agent={MockWorkspaceAgent} />
-		</ProxyProvider>,
+		<AppLink app={app} workspace={MockWorkspace} agent={MockWorkspaceAgent} />,
 	);
 };
 
-// Regression tests for https://github.com/coder/coder/issues/18573:
+// Regression test for https://github.com/coder/coder/issues/18573:
 // open_in="tab" was not opening links in a new tab.
 describe("AppLink", () => {
 	it("sets target=_blank and rel=noopener noreferrer when open_in is tab", async () => {
@@ -24,14 +21,5 @@ describe("AppLink", () => {
 		const link = await screen.findByRole("link");
 		expect(link).toHaveAttribute("target", "_blank");
 		expect(link).toHaveAttribute("rel", "noopener noreferrer");
-	});
-
-	// slim-window uses window.open() in onClick rather than a target attribute,
-	// so the anchor must not get target="_blank" or rel to avoid double-opening.
-	it("does not set target or rel when open_in is slim-window", async () => {
-		renderAppLink({ ...MockWorkspaceApp, open_in: "slim-window" });
-		const link = await screen.findByRole("link");
-		expect(link).not.toHaveAttribute("target");
-		expect(link).not.toHaveAttribute("rel");
 	});
 });

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -135,7 +135,12 @@ export const AppLink: FC<AppLinkProps> = ({
 
 	const button = grouped ? (
 		<DropdownMenuItem asChild>
-			<a href={canClick ? link.href : undefined} onClick={link.onClick}>
+			<a
+				href={canClick ? link.href : undefined}
+				onClick={link.onClick}
+				target={app.open_in === "tab" ? "_blank" : undefined}
+				rel={app.open_in === "tab" ? "noopener noreferrer" : undefined}
+			>
 				{icon}
 				{link.label}
 				{ShareIcon && <ShareIcon />}
@@ -143,7 +148,12 @@ export const AppLink: FC<AppLinkProps> = ({
 		</DropdownMenuItem>
 	) : (
 		<AgentButton asChild>
-			<a href={canClick ? link.href : undefined} onClick={link.onClick}>
+			<a
+				href={canClick ? link.href : undefined}
+				onClick={link.onClick}
+				target={app.open_in === "tab" ? "_blank" : undefined}
+				rel={app.open_in === "tab" ? "noopener noreferrer" : undefined}
+			>
 				{icon}
 				{link.label}
 				{ShareIcon && <ShareIcon />}

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -139,7 +139,7 @@ export const AppLink: FC<AppLinkProps> = ({
 				href={canClick ? link.href : undefined}
 				onClick={link.onClick}
 				target={app.open_in === "tab" ? "_blank" : undefined}
-				rel={app.open_in === "tab" ? "noopener noreferrer" : undefined}
+				rel={app.open_in === "tab" ? "noreferrer" : undefined}
 			>
 				{icon}
 				{link.label}
@@ -152,7 +152,7 @@ export const AppLink: FC<AppLinkProps> = ({
 				href={canClick ? link.href : undefined}
 				onClick={link.onClick}
 				target={app.open_in === "tab" ? "_blank" : undefined}
-				rel={app.open_in === "tab" ? "noopener noreferrer" : undefined}
+				rel={app.open_in === "tab" ? "noreferrer" : undefined}
 			>
 				{icon}
 				{link.label}


### PR DESCRIPTION
Fixes #18573

## Changes

When a `coder_app` resource sets `open_in = "tab"`, clicking the app link now opens in a new browser tab instead of navigating in the same tab.

`target="_blank"` and `rel="noopener noreferrer"` are set inline on the `<a>` elements in `AppLink.tsx`, gated on `app.open_in === "tab"`. This follows the codebase convention of co-locating `target` and `rel` at the render site.

`noopener` prevents tabnabbing — without it, the opened page can redirect the Coder dashboard tab via `window.opener`. This is especially relevant for same-origin path-based apps, which would otherwise have full DOM access to the dashboard. `noreferrer` suppresses the Referer header to avoid leaking workspace IDs to destination servers.

> **Future enhancement**: template admins could opt into sending the referrer via a `coder_app` setting, enabling feedback pages built around workspace context.

## Tests

A vitest case is added in `AppLink.test.tsx` (rather than a Storybook story, since the assertions are purely behavioral with no visual component):

- **`sets target=_blank and rel=noopener noreferrer when open_in is tab`** — renders the app link with `open_in: "tab"` and asserts `target="_blank"` and `rel="noopener noreferrer"` are present on the anchor.

## Slim-window behavior

The `slim-window` test case and the `openAppInNewWindow()` comment in `apps.ts` have been split out into a follow-up PR for separate review, since the `window.open()` / `noopener` tradeoffs there deserve dedicated discussion.