### PR TITLE
fix(agents): add model form footer bottom padding

### DIFF
--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -506,7 +506,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 					</div>
 				</div>
 				{/* Footer — pushed to bottom */}
-				<div className="mt-auto pt-6">
+				<div className="mt-auto py-6">
 					<hr className="mb-4 border-0 border-t border-solid border-border" />
 					{confirmingDelete && onDeleteModel && editingModel ? (
 						<div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add bottom padding to the LLM model configuration form footer
- keep the vertical footer spacing symmetric with `py-6`
- prevent action buttons from sitting against the panel border when scrolled to the bottom

## Testing
- make fmt
- make lint

Before
<img width="917" height="732" alt="image" src="https://github.com/user-attachments/assets/9e27901a-694b-4a1a-80e2-0bc2253e4099" />

After
<img width="908" height="733" alt="image" src="https://github.com/user-attachments/assets/98327518-bb6b-4974-8670-44297058a6d7" />
