### PR TITLE
fix: hide web_search tool — preserve ProviderExecuted on DB-loaded tool results

### DIFF
--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1336,19 +1336,23 @@ func contentBlockToPart(block fantasy.Content) codersdk.ChatMessagePart {
 			Data:      value.Data,
 		}
 	case fantasy.ToolResultContent:
-		return chatprompt.ToolResultToPart(
+		part := chatprompt.ToolResultToPart(
 			value.ToolCallID,
 			value.ToolName,
 			toolResultOutputToRawJSON(value.Result),
 			toolResultOutputIsError(value.Result),
 		)
+		part.ProviderExecuted = value.ProviderExecuted
+		return part
 	case *fantasy.ToolResultContent:
-		return chatprompt.ToolResultToPart(
+		part := chatprompt.ToolResultToPart(
 			value.ToolCallID,
 			value.ToolName,
 			toolResultOutputToRawJSON(value.Result),
 			toolResultOutputIsError(value.Result),
 		)
+		part.ProviderExecuted = value.ProviderExecuted
+		return part
 	default:
 		return codersdk.ChatMessagePart{}
 	}

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -437,6 +437,61 @@ func TestAIBridgeInterception(t *testing.T) {
 	}
 }
 
+func TestChatMessage_PreservesProviderExecutedOnToolResults(t *testing.T) {
+	t.Parallel()
+
+	toolCallID := uuid.New().String()
+	toolName := "web_search"
+
+	// Build assistant content blocks with ProviderExecuted set.
+	toolCall := fantasy.ToolCallContent{
+		ToolCallID:       toolCallID,
+		ToolName:         toolName,
+		Input:            `{"query":"test"}`,
+		ProviderExecuted: true,
+	}
+	toolResult := fantasy.ToolResultContent{
+		ToolCallID:       toolCallID,
+		ToolName:         toolName,
+		Result:           fantasy.ToolResultOutputContentText{Text: `{"results":[]}`},
+		ProviderExecuted: true,
+	}
+
+	tcJSON, err := json.Marshal(toolCall)
+	require.NoError(t, err)
+	trJSON, err := json.Marshal(toolResult)
+	require.NoError(t, err)
+
+	rawContent := json.RawMessage("[" + string(tcJSON) + "," + string(trJSON) + "]")
+
+	dbMsg := database.ChatMessage{
+		ID:     1,
+		ChatID: uuid.New(),
+		Role:   string(fantasy.MessageRoleAssistant),
+		Content: pqtype.NullRawMessage{
+			RawMessage: rawContent,
+			Valid:      true,
+		},
+		CreatedAt: time.Now(),
+	}
+
+	result := db2sdk.ChatMessage(dbMsg)
+
+	require.Len(t, result.Content, 2)
+
+	// First part: tool call.
+	require.Equal(t, codersdk.ChatMessagePartTypeToolCall, result.Content[0].Type)
+	require.Equal(t, toolCallID, result.Content[0].ToolCallID)
+	require.Equal(t, toolName, result.Content[0].ToolName)
+	require.True(t, result.Content[0].ProviderExecuted, "tool call should preserve ProviderExecuted")
+
+	// Second part: tool result.
+	require.Equal(t, codersdk.ChatMessagePartTypeToolResult, result.Content[1].Type)
+	require.Equal(t, toolCallID, result.Content[1].ToolCallID)
+	require.Equal(t, toolName, result.Content[1].ToolName)
+	require.True(t, result.Content[1].ProviderExecuted, "tool result should preserve ProviderExecuted")
+}
+
 func TestChatQueuedMessage_ParsesUserContentParts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

When assistant messages containing provider-executed tool results (e.g. `web_search`) were loaded from the database, the `contentBlockToPart` function in `db2sdk` called `ToolResultToPart` which did **not** set the `ProviderExecuted` field. This caused the frontend to render `web_search` tool cards even though the results are already displayed via the sources component.

The streaming path correctly sets `provider_executed` (via `toolResultContentToPart` in chatprompt), so the tool was only visible after reloading a persisted chat.

## Fix

Preserve `ProviderExecuted` on the `ChatMessagePart` for both `fantasy.ToolResultContent` and `*fantasy.ToolResultContent` cases in `contentBlockToPart`, matching the existing behavior in `chatprompt.toolResultContentToPart`.

## Changes

- **`coderd/database/db2sdk/db2sdk.go`**: Set `part.ProviderExecuted = value.ProviderExecuted` after calling `ToolResultToPart` for tool result content blocks in assistant messages.
- **`coderd/database/db2sdk/db2sdk_test.go`**: Added `TestChatMessage_PreservesProviderExecutedOnToolResults` — verifies that tool call and tool result parts in assistant messages both preserve the `ProviderExecuted` flag when loaded from the database.