### PR TITLE
feat(chatd): add chat-level MCP server support

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -183,6 +183,7 @@ type CreateOptions struct {
 	ChatMode           database.NullChatMode
 	SystemPrompt       string
 	InitialUserContent []codersdk.ChatMessagePart
+	MCPServers         pqtype.NullRawMessage
 }
 
 // SendMessageBusyBehavior controls what happens when a chat is already active.
@@ -265,6 +266,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			LastModelConfigID: opts.ModelConfigID,
 			Title:             opts.Title,
 			Mode:              opts.ChatMode,
+			MCPServers:        opts.MCPServers,
 		})
 		if err != nil {
 			return xerrors.Errorf("insert chat: %w", err)
@@ -2596,6 +2598,72 @@ func (p *Server) runChat(
 		})...)
 	}
 
+	// Discover and register tools from chat-level MCP servers.
+	// Each server is connected in parallel for performance.
+	// Failures are treated as errors since the admin explicitly
+	// configured these servers and expects them to work.
+	if chat.MCPServers.Valid && len(chat.MCPServers.RawMessage) > 0 {
+		var mcpServers []codersdk.ChatMCPServer
+		if err := json.Unmarshal(chat.MCPServers.RawMessage, &mcpServers); err != nil {
+			return xerrors.Errorf("parse chat mcp_servers config: %w", err)
+		}
+
+		mcpCtx, mcpCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer mcpCancel()
+
+		type mcpResult struct {
+			slug    string
+			tools   []fantasy.AgentTool
+			cleanup func()
+		}
+
+		var (
+			mcpMu      sync.Mutex
+			mcpResults []mcpResult
+		)
+		var mcpGroup errgroup.Group
+		for _, server := range mcpServers {
+			server := server
+			mcpGroup.Go(func() error {
+				serverTools, cleanup, err := chattool.MCPServer(mcpCtx, server, logger)
+				if err != nil {
+					return xerrors.Errorf("MCP server %q: %w", server.Slug, err)
+				}
+				mcpMu.Lock()
+				mcpResults = append(mcpResults, mcpResult{
+					slug:    server.Slug,
+					tools:   serverTools,
+					cleanup: cleanup,
+				})
+				mcpMu.Unlock()
+				return nil
+			})
+		}
+		if err := mcpGroup.Wait(); err != nil {
+			// Clean up any servers that did connect before the error.
+			for _, r := range mcpResults {
+				if r.cleanup != nil {
+					r.cleanup()
+				}
+			}
+			return xerrors.Errorf("connect to MCP servers: %w", err)
+		}
+
+		for _, r := range mcpResults {
+			logger.Info(ctx, "discovered mcp server tools",
+				slog.F("mcp_server", r.slug),
+				slog.F("num_tools", len(r.tools)),
+			)
+			tools = append(tools, r.tools...)
+		}
+		defer func() {
+			for _, r := range mcpResults {
+				if r.cleanup != nil {
+					r.cleanup()
+				}
+			}
+		}()
+	}
 	// Build provider-native tools (e.g., web search) based on
 	// the model configuration.
 	var providerTools []chatloop.ProviderTool

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -16,6 +16,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
@@ -2120,4 +2123,166 @@ func TestComputerUseSubagentToolsAndModel(t *testing.T) {
 	require.True(t, children[0].Mode.Valid)
 	require.Equal(t, database.ChatModeComputerUse,
 		children[0].Mode.ChatMode)
+}
+
+func TestChatMCPServerConnectionFailure(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// Set up a fake OpenAI server that just returns text (we should
+	// never reach it if MCP connection fails first).
+	openAIURL := chattest.NewOpenAI(t, func(_ *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("should not reach here")...,
+		)
+	})
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	// Create a chat with an MCP server pointing to a dead URL.
+	mcpConfig, err := json.Marshal([]codersdk.ChatMCPServer{
+		{
+			Slug:        "dead-server",
+			URL:         "http://localhost:1/nonexistent",
+			DisplayName: "Dead Server",
+		},
+	})
+	require.NoError(t, err)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:       user.ID,
+		Title:         "mcp-failure-test",
+		ModelConfigID: model.ID,
+		MCPServers: pqtype.NullRawMessage{
+			RawMessage: mcpConfig,
+			Valid:      true,
+		},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("hello"),
+		},
+	})
+	require.NoError(t, err)
+
+	// Wait for the chat to be processed and fail due to MCP
+	// connection error.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusError
+	}, testutil.IntervalFast)
+
+	// Verify the error message mentions MCP.
+	fromDB, err := db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusError, fromDB.Status)
+	require.True(t, fromDB.LastError.Valid)
+	require.Contains(t, fromDB.LastError.String, "MCP")
+}
+
+func TestChatMCPServerToolsDiscovered(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	// Start a real MCP server with a simple tool.
+	mcpSrv := mcpserver.NewMCPServer("test", "1.0.0")
+	mcpSrv.AddTools(mcpserver.ServerTool{
+		Tool: mcp.NewTool("get_weather",
+			mcp.WithDescription("Get weather"),
+			mcp.WithString("city", mcp.Required()),
+		),
+		Handler: func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			city := req.GetArguments()["city"].(string)
+			return mcp.NewToolResultText(fmt.Sprintf("Sunny in %s", city)), nil
+		},
+	})
+	testSrv := mcpserver.NewTestStreamableHTTPServer(mcpSrv)
+	defer testSrv.Close()
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("ok")
+		}
+		// Just respond with text — we're verifying tools are
+		// discovered, not that the LLM uses them.
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("Done.")...,
+		)
+	})
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	mcpConfig, err := json.Marshal([]codersdk.ChatMCPServer{
+		{
+			Slug:        "weather",
+			URL:         testSrv.URL,
+			DisplayName: "Weather API",
+		},
+	})
+	require.NoError(t, err)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:       user.ID,
+		Title:         "mcp-tools-test",
+		ModelConfigID: model.ID,
+		MCPServers: pqtype.NullRawMessage{
+			RawMessage: mcpConfig,
+			Valid:      true,
+		},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("What is the weather?"),
+		},
+	})
+	require.NoError(t, err)
+
+	// Wait for the chat to complete — this means MCP server tools
+	// were successfully discovered and registered (the log confirms
+	// "discovered mcp server tools" with num_tools=1).
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusWaiting
+	}, testutil.IntervalFast)
+
+	// If we got here without error, the MCP server was connected,
+	// tools were discovered, and the chat completed normally.
+	fromDB, err := db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	require.False(t, fromDB.LastError.Valid,
+		"expected no error, got: %s", fromDB.LastError.String)
 }

--- a/coderd/chatd/chattool/mcpserver.go
+++ b/coderd/chatd/chattool/mcpserver.go
@@ -1,0 +1,274 @@
+package chattool
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"charm.land/fantasy"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/buildinfo"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// mcpToolNameSeparator is the double-underscore separator used to
+// namespace MCP tool names: mcp__{server_slug}__{tool_name}.
+const mcpToolNameSeparator = "__"
+
+// mcpServerClient wraps an mcp-go client and adapts its tools
+// to fantasy.AgentTool instances.
+type mcpServerClient struct {
+	client     *mcpclient.Client
+	server     codersdk.ChatMCPServer
+	logger     slog.Logger
+	allowRegex *regexp.Regexp
+	denyRegex  *regexp.Regexp
+}
+
+// MCPServer connects to a remote MCP server,
+// discovers its tools, applies allow/deny filters, and returns
+// them as fantasy.AgentTool instances. The returned cleanup
+// function closes the underlying MCP client and must be called
+// when the tools are no longer needed.
+func MCPServer(
+	ctx context.Context,
+	server codersdk.ChatMCPServer,
+	logger slog.Logger,
+) ([]fantasy.AgentTool, func(), error) {
+	var opts []transport.StreamableHTTPCOption
+
+	// Attach auth headers to every outgoing request.
+	if len(server.AuthHeaders) > 0 {
+		opts = append(opts, transport.WithHTTPHeaders(server.AuthHeaders))
+	}
+
+	c, err := mcpclient.NewStreamableHttpClient(server.URL, opts...)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("create MCP client for %q: %w", server.Slug, err)
+	}
+
+	if err := c.Start(ctx); err != nil {
+		_ = c.Close()
+		return nil, nil, xerrors.Errorf("start MCP client for %q: %w", server.Slug, err)
+	}
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{
+		Name:    "coder-chat",
+		Version: buildinfo.Version(),
+	}
+
+	if _, err := c.Initialize(ctx, initReq); err != nil {
+		_ = c.Close()
+		return nil, nil, xerrors.Errorf("initialize MCP server %q: %w", server.Slug, err)
+	}
+
+	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		_ = c.Close()
+		return nil, nil, xerrors.Errorf("list tools from MCP server %q: %w", server.Slug, err)
+	}
+
+	sc := &mcpServerClient{
+		client: c,
+		server: server,
+		logger: logger,
+	}
+
+	// Compile optional allow/deny regexes.
+	if server.ToolAllowRegex != "" {
+		sc.allowRegex, err = regexp.Compile(server.ToolAllowRegex)
+		if err != nil {
+			_ = c.Close()
+			return nil, nil, xerrors.Errorf(
+				"compile tool_allow_regex %q for MCP server %q: %w",
+				server.ToolAllowRegex, server.Slug, err,
+			)
+		}
+	}
+	if server.ToolDenyRegex != "" {
+		sc.denyRegex, err = regexp.Compile(server.ToolDenyRegex)
+		if err != nil {
+			_ = c.Close()
+			return nil, nil, xerrors.Errorf(
+				"compile tool_deny_regex %q for MCP server %q: %w",
+				server.ToolDenyRegex, server.Slug, err,
+			)
+		}
+	}
+
+	// Filter and adapt the discovered tools.
+	var tools []fantasy.AgentTool
+	for _, mcpTool := range toolsResult.Tools {
+		if !sc.toolAllowed(mcpTool.Name) {
+			logger.Debug(ctx, "skipping mcp tool filtered by regex",
+				slog.F("server", server.Slug),
+				slog.F("tool", mcpTool.Name),
+			)
+			continue
+		}
+		tools = append(tools, sc.adaptTool(mcpTool))
+	}
+
+	cleanup := func() {
+		if closeErr := c.Close(); closeErr != nil {
+			logger.Warn(context.Background(), "failed to close mcp client",
+				slog.F("server", server.Slug),
+				slog.Error(closeErr),
+			)
+		}
+	}
+
+	return tools, cleanup, nil
+}
+
+// toolAllowed returns true if the tool name passes both the
+// allow and deny regex filters.
+func (sc *mcpServerClient) toolAllowed(name string) bool {
+	if sc.allowRegex != nil && !sc.allowRegex.MatchString(name) {
+		return false
+	}
+	if sc.denyRegex != nil && sc.denyRegex.MatchString(name) {
+		return false
+	}
+	return true
+}
+
+// adaptTool converts an MCP tool definition into a
+// fantasy.AgentTool that proxies calls through the MCP client.
+func (sc *mcpServerClient) adaptTool(tool mcp.Tool) fantasy.AgentTool {
+	qualifiedName := fmt.Sprintf(
+		"mcp%s%s%s%s",
+		mcpToolNameSeparator,
+		sc.server.Slug,
+		mcpToolNameSeparator,
+		tool.Name,
+	)
+	displayName := sc.server.DisplayName
+	if displayName == "" {
+		displayName = sc.server.Slug
+	}
+	description := fmt.Sprintf(
+		"[MCP: %s] %s",
+		displayName,
+		tool.Description,
+	)
+	parameters := mcpInputSchemaToParameters(tool.InputSchema)
+	required := tool.InputSchema.Required
+
+	mcpToolName := tool.Name
+	client := sc.client
+	logger := sc.logger
+	serverSlug := sc.server.Slug
+
+	return &mcpAdaptedTool{
+		info: fantasy.ToolInfo{
+			Name:        qualifiedName,
+			Description: description,
+			Parameters:  parameters,
+			Required:    required,
+		},
+		run: func(ctx context.Context, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			var args map[string]any
+			if call.Input != "" {
+				if err := json.Unmarshal([]byte(call.Input), &args); err != nil {
+					return fantasy.NewTextErrorResponse(
+						fmt.Sprintf("invalid tool arguments: %s", err),
+					), nil
+				}
+			}
+
+			callReq := mcp.CallToolRequest{}
+			callReq.Params.Name = mcpToolName
+			callReq.Params.Arguments = args
+
+			result, err := client.CallTool(ctx, callReq)
+			if err != nil {
+				logger.Warn(ctx, "mcp tool call failed",
+					slog.F("server", serverSlug),
+					slog.F("tool", mcpToolName),
+					slog.Error(err),
+				)
+				return fantasy.NewTextErrorResponse(
+					fmt.Sprintf("MCP tool call failed: %s", err),
+				), nil
+			}
+
+			return mcpResultToToolResponse(result), nil
+		},
+	}
+}
+
+// mcpInputSchemaToParameters converts an MCP ToolInputSchema to
+// the map[string]any parameter format expected by fantasy.ToolInfo.
+func mcpInputSchemaToParameters(schema mcp.ToolInputSchema) map[string]any {
+	if schema.Properties == nil {
+		return make(map[string]any)
+	}
+	return schema.Properties
+}
+
+// mcpResultToToolResponse converts an MCP CallToolResult into a
+// fantasy.ToolResponse. It handles text and image content parts.
+func mcpResultToToolResponse(result *mcp.CallToolResult) fantasy.ToolResponse {
+	if result == nil {
+		return fantasy.NewTextResponse("")
+	}
+
+	var textParts []string
+	for _, content := range result.Content {
+		switch c := content.(type) {
+		case mcp.TextContent:
+			textParts = append(textParts, c.Text)
+		case mcp.ImageContent:
+			data, err := base64.StdEncoding.DecodeString(c.Data)
+			if err != nil {
+				textParts = append(textParts,
+					fmt.Sprintf("[image decode error: %s]", err),
+				)
+				continue
+			}
+			return fantasy.NewImageResponse(data, c.MIMEType)
+		}
+	}
+
+	text := strings.Join(textParts, "\n")
+
+	if result.IsError {
+		return fantasy.NewTextErrorResponse(text)
+	}
+	return fantasy.NewTextResponse(text)
+}
+
+// mcpAdaptedTool implements fantasy.AgentTool for an MCP tool
+// proxied through an MCP client.
+type mcpAdaptedTool struct {
+	info            fantasy.ToolInfo
+	run             func(ctx context.Context, call fantasy.ToolCall) (fantasy.ToolResponse, error)
+	providerOptions fantasy.ProviderOptions
+}
+
+func (t *mcpAdaptedTool) Info() fantasy.ToolInfo {
+	return t.info
+}
+
+func (t *mcpAdaptedTool) Run(ctx context.Context, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+	return t.run(ctx, call)
+}
+
+func (t *mcpAdaptedTool) ProviderOptions() fantasy.ProviderOptions {
+	return t.providerOptions
+}
+
+func (t *mcpAdaptedTool) SetProviderOptions(opts fantasy.ProviderOptions) {
+	t.providerOptions = opts
+}

--- a/coderd/chatd/chattool/mcpserver_test.go
+++ b/coderd/chatd/chattool/mcpserver_test.go
@@ -1,0 +1,299 @@
+package chattool_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func newTestMCPServer(t *testing.T, tools ...mcpserver.ServerTool) *httptest.Server {
+	t.Helper()
+	srv := mcpserver.NewMCPServer("test-mcp-server", "1.0.0")
+	srv.AddTools(tools...)
+	return mcpserver.NewTestStreamableHTTPServer(srv)
+}
+
+func TestMCPServer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+
+	t.Run("DiscoverTools", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t,
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("greet",
+					mcp.WithDescription("Say hello"),
+					mcp.WithString("name", mcp.Required()),
+				),
+				Handler: func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					name := req.GetArguments()["name"].(string)
+					return mcp.NewToolResultText("Hello, " + name + "!"), nil
+				},
+			},
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("add",
+					mcp.WithDescription("Add two numbers"),
+					mcp.WithNumber("a", mcp.Required()),
+					mcp.WithNumber("b", mcp.Required()),
+				),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("42"), nil
+				},
+			},
+		)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:        "test-server",
+			URL:         ts.URL,
+			DisplayName: "Test Server",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+
+		require.Len(t, tools, 2)
+
+		names := make([]string, len(tools))
+		for i, tool := range tools {
+			names[i] = tool.Info().Name
+		}
+		assert.Contains(t, names, "mcp__test-server__greet")
+		assert.Contains(t, names, "mcp__test-server__add")
+
+		for _, tool := range tools {
+			info := tool.Info()
+			assert.Contains(t, info.Description, "[MCP: Test Server]")
+		}
+	})
+
+	t.Run("CallTool", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t,
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("echo",
+					mcp.WithDescription("Echo input"),
+					mcp.WithString("message", mcp.Required()),
+				),
+				Handler: func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					msg := req.GetArguments()["message"].(string)
+					return mcp.NewToolResultText(msg), nil
+				},
+			},
+		)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:        "echo-srv",
+			URL:         ts.URL,
+			DisplayName: "Echo",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+		require.Len(t, tools, 1)
+
+		resp, err := tools[0].Run(ctx, fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "mcp__echo-srv__echo",
+			Input: `{"message":"hello world"}`,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", resp.Content)
+		assert.False(t, resp.IsError)
+	})
+
+	t.Run("ToolError", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t,
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("fail",
+					mcp.WithDescription("Always fails"),
+				),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultError("something went wrong"), nil
+				},
+			},
+		)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:        "fail-srv",
+			URL:         ts.URL,
+			DisplayName: "Fail",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+		require.Len(t, tools, 1)
+
+		resp, err := tools[0].Run(ctx, fantasy.ToolCall{
+			ID:    "call-2",
+			Name:  "mcp__fail-srv__fail",
+			Input: `{}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Contains(t, resp.Content, "something went wrong")
+	})
+
+	t.Run("AllowRegex", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t,
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("read_file", mcp.WithDescription("Read a file")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("write_file", mcp.WithDescription("Write a file")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("delete_file", mcp.WithDescription("Delete a file")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+		)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:           "filtered",
+			URL:            ts.URL,
+			DisplayName:    "Filtered",
+			ToolAllowRegex: "^read_",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+
+		require.Len(t, tools, 1)
+		assert.Equal(t, "mcp__filtered__read_file", tools[0].Info().Name)
+	})
+
+	t.Run("DenyRegex", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t,
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("safe_tool", mcp.WithDescription("Safe")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("dangerous_tool", mcp.WithDescription("Dangerous")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+		)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:          "deny-test",
+			URL:           ts.URL,
+			DisplayName:   "Deny Test",
+			ToolDenyRegex: "dangerous",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+
+		require.Len(t, tools, 1)
+		assert.Equal(t, "mcp__deny-test__safe_tool", tools[0].Info().Name)
+	})
+
+	t.Run("InvalidURL", func(t *testing.T) {
+		t.Parallel()
+
+		server := codersdk.ChatMCPServer{
+			Slug:        "bad-url",
+			URL:         "http://localhost:1/nonexistent",
+			DisplayName: "Bad URL",
+		}
+
+		_, _, err := chattool.MCPServer(ctx, server, logger)
+		require.Error(t, err)
+	})
+
+	t.Run("NoTools", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:        "empty",
+			URL:         ts.URL,
+			DisplayName: "Empty",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+		assert.Empty(t, tools)
+	})
+
+	t.Run("InvalidInput", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestMCPServer(t,
+			mcpserver.ServerTool{
+				Tool: mcp.NewTool("test",
+					mcp.WithDescription("Test"),
+					mcp.WithString("name", mcp.Required()),
+				),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+		)
+		defer ts.Close()
+
+		server := codersdk.ChatMCPServer{
+			Slug:        "input-test",
+			URL:         ts.URL,
+			DisplayName: "Input Test",
+		}
+
+		tools, cleanup, err := chattool.MCPServer(ctx, server, logger)
+		require.NoError(t, err)
+		defer cleanup()
+		require.Len(t, tools, 1)
+
+		resp, err := tools[0].Run(ctx, fantasy.ToolCall{
+			ID:    "call-3",
+			Name:  "mcp__input-test__test",
+			Input: `not-json`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Contains(t, resp.Content, "invalid tool arguments")
+	})
+}

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
+	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -231,6 +232,14 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Only admins can attach MCP servers to a chat.
+	if len(req.MCPServers) > 0 {
+		if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+			httpapi.Forbidden(rw)
+			return
+		}
+	}
+
 	contentBlocks, titleSource, inputError := createChatInputFromRequest(ctx, api.Database, req)
 	if inputError != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, *inputError)
@@ -259,6 +268,19 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var mcpServersJSON pqtype.NullRawMessage
+	if len(req.MCPServers) > 0 {
+		raw, err := json.Marshal(req.MCPServers)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Failed to encode MCP servers.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		mcpServersJSON = pqtype.NullRawMessage{RawMessage: raw, Valid: true}
+	}
+
 	chat, err := api.chatDaemon.CreateChat(ctx, chatd.CreateOptions{
 		OwnerID:            apiKey.UserID,
 		WorkspaceID:        workspaceSelection.WorkspaceID,
@@ -266,6 +288,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		ModelConfigID:      modelConfigID,
 		SystemPrompt:       api.resolvedChatSystemPrompt(ctx),
 		InitialUserContent: contentBlocks,
+		MCPServers:         mcpServersJSON,
 	})
 	if err != nil {
 		if database.IsForeignKeyViolation(
@@ -956,6 +979,33 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	var req codersdk.CreateChatMessageRequest
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
+	}
+
+	// Only admins can attach MCP servers to a chat.
+	if len(req.MCPServers) > 0 {
+		if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+			httpapi.Forbidden(rw)
+			return
+		}
+		raw, err := json.Marshal(req.MCPServers)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Failed to encode MCP servers.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		err = api.Database.UpdateChatMCPServers(ctx, database.UpdateChatMCPServersParams{
+			ID:         chatID,
+			MCPServers: raw,
+		})
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to update MCP servers.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 	}
 
 	contentBlocks, _, inputError := createChatInputFromParts(ctx, api.Database, req.Content, "content")
@@ -2467,6 +2517,16 @@ func convertChat(c database.Chat, diffStatus *database.ChatDiffStatus) codersdk.
 	}
 	if c.WorkspaceID.Valid {
 		chat.WorkspaceID = &c.WorkspaceID.UUID
+	}
+	if c.MCPServers.Valid && len(c.MCPServers.RawMessage) > 0 {
+		var servers []codersdk.ChatMCPServer
+		if err := json.Unmarshal(c.MCPServers.RawMessage, &servers); err == nil {
+			// Strip auth headers from the response — never leak secrets.
+			for i := range servers {
+				servers[i].AuthHeaders = nil
+			}
+			chat.MCPServers = servers
+		}
 	}
 	if diffStatus != nil {
 		convertedDiffStatus := convertChatDiffStatus(c.ID, diffStatus)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5330,6 +5330,17 @@ func (q *querier) UpdateChatHeartbeat(ctx context.Context, arg database.UpdateCh
 	return q.db.UpdateChatHeartbeat(ctx, arg)
 }
 
+func (q *querier) UpdateChatMCPServers(ctx context.Context, arg database.UpdateChatMCPServersParams) error {
+	chat, err := q.db.GetChatByID(ctx, arg.ID)
+	if err != nil {
+		return err
+	}
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, chat); err != nil {
+		return err
+	}
+	return q.db.UpdateChatMCPServers(ctx, arg)
+}
+
 func (q *querier) UpdateChatMessageByID(ctx context.Context, arg database.UpdateChatMessageByIDParams) (database.ChatMessage, error) {
 	// Authorize update on the parent chat of the edited message.
 	msg, err := q.db.GetChatMessageByID(ctx, arg.ID)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -719,6 +719,13 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().UpdateChatHeartbeat(gomock.Any(), arg).Return(int64(1), nil).AnyTimes()
 		check.Args(arg).Asserts(chat, policy.ActionUpdate).Returns(int64(1))
 	}))
+	s.Run("UpdateChatMCPServers", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		chat := testutil.Fake(s.T(), faker, database.Chat{})
+		arg := database.UpdateChatMCPServersParams{ID: chat.ID}
+		dbm.EXPECT().GetChatByID(gomock.Any(), chat.ID).Return(chat, nil).AnyTimes()
+		dbm.EXPECT().UpdateChatMCPServers(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(chat, policy.ActionUpdate)
+	}))
 	s.Run("UpdateChatMessageByID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})
 		msg := testutil.Fake(s.T(), faker, database.ChatMessage{ChatID: chat.ID})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3695,6 +3695,14 @@ func (m queryMetricsStore) UpdateChatHeartbeat(ctx context.Context, arg database
 	return r0, r1
 }
 
+func (m queryMetricsStore) UpdateChatMCPServers(ctx context.Context, arg database.UpdateChatMCPServersParams) error {
+	start := time.Now()
+	r0 := m.s.UpdateChatMCPServers(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateChatMCPServers").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpdateChatMCPServers").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) UpdateChatMessageByID(ctx context.Context, arg database.UpdateChatMessageByIDParams) (database.ChatMessage, error) {
 	start := time.Now()
 	r0, r1 := m.s.UpdateChatMessageByID(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6944,6 +6944,20 @@ func (mr *MockStoreMockRecorder) UpdateChatHeartbeat(ctx, arg any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChatHeartbeat", reflect.TypeOf((*MockStore)(nil).UpdateChatHeartbeat), ctx, arg)
 }
 
+// UpdateChatMCPServers mocks base method.
+func (m *MockStore) UpdateChatMCPServers(ctx context.Context, arg database.UpdateChatMCPServersParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateChatMCPServers", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateChatMCPServers indicates an expected call of UpdateChatMCPServers.
+func (mr *MockStoreMockRecorder) UpdateChatMCPServers(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChatMCPServers", reflect.TypeOf((*MockStore)(nil).UpdateChatMCPServers), ctx, arg)
+}
+
 // UpdateChatMessageByID mocks base method.
 func (m *MockStore) UpdateChatMessageByID(ctx context.Context, arg database.UpdateChatMessageByIDParams) (database.ChatMessage, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1319,7 +1319,8 @@ CREATE TABLE chats (
     last_model_config_id uuid NOT NULL,
     archived boolean DEFAULT false NOT NULL,
     last_error text,
-    mode chat_mode
+    mode chat_mode,
+    mcp_servers jsonb
 );
 
 CREATE TABLE connection_logs (

--- a/coderd/database/migrations/000439_chat_mcp_servers.down.sql
+++ b/coderd/database/migrations/000439_chat_mcp_servers.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chats DROP COLUMN mcp_servers;

--- a/coderd/database/migrations/000439_chat_mcp_servers.up.sql
+++ b/coderd/database/migrations/000439_chat_mcp_servers.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chats ADD COLUMN mcp_servers JSONB;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4012,22 +4012,23 @@ type BoundaryUsageStat struct {
 }
 
 type Chat struct {
-	ID                uuid.UUID      `db:"id" json:"id"`
-	OwnerID           uuid.UUID      `db:"owner_id" json:"owner_id"`
-	WorkspaceID       uuid.NullUUID  `db:"workspace_id" json:"workspace_id"`
-	Title             string         `db:"title" json:"title"`
-	Status            ChatStatus     `db:"status" json:"status"`
-	WorkerID          uuid.NullUUID  `db:"worker_id" json:"worker_id"`
-	StartedAt         sql.NullTime   `db:"started_at" json:"started_at"`
-	HeartbeatAt       sql.NullTime   `db:"heartbeat_at" json:"heartbeat_at"`
-	CreatedAt         time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt         time.Time      `db:"updated_at" json:"updated_at"`
-	ParentChatID      uuid.NullUUID  `db:"parent_chat_id" json:"parent_chat_id"`
-	RootChatID        uuid.NullUUID  `db:"root_chat_id" json:"root_chat_id"`
-	LastModelConfigID uuid.UUID      `db:"last_model_config_id" json:"last_model_config_id"`
-	Archived          bool           `db:"archived" json:"archived"`
-	LastError         sql.NullString `db:"last_error" json:"last_error"`
-	Mode              NullChatMode   `db:"mode" json:"mode"`
+	ID                uuid.UUID             `db:"id" json:"id"`
+	OwnerID           uuid.UUID             `db:"owner_id" json:"owner_id"`
+	WorkspaceID       uuid.NullUUID         `db:"workspace_id" json:"workspace_id"`
+	Title             string                `db:"title" json:"title"`
+	Status            ChatStatus            `db:"status" json:"status"`
+	WorkerID          uuid.NullUUID         `db:"worker_id" json:"worker_id"`
+	StartedAt         sql.NullTime          `db:"started_at" json:"started_at"`
+	HeartbeatAt       sql.NullTime          `db:"heartbeat_at" json:"heartbeat_at"`
+	CreatedAt         time.Time             `db:"created_at" json:"created_at"`
+	UpdatedAt         time.Time             `db:"updated_at" json:"updated_at"`
+	ParentChatID      uuid.NullUUID         `db:"parent_chat_id" json:"parent_chat_id"`
+	RootChatID        uuid.NullUUID         `db:"root_chat_id" json:"root_chat_id"`
+	LastModelConfigID uuid.UUID             `db:"last_model_config_id" json:"last_model_config_id"`
+	Archived          bool                  `db:"archived" json:"archived"`
+	LastError         sql.NullString        `db:"last_error" json:"last_error"`
+	Mode              NullChatMode          `db:"mode" json:"mode"`
+	MCPServers        pqtype.NullRawMessage `db:"mcp_servers" json:"mcp_servers"`
 }
 
 type ChatDiffStatus struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -736,6 +736,7 @@ type sqlcQuerier interface {
 	// Bumps the heartbeat timestamp for a running chat so that other
 	// replicas know the worker is still alive.
 	UpdateChatHeartbeat(ctx context.Context, arg UpdateChatHeartbeatParams) (int64, error)
+	UpdateChatMCPServers(ctx context.Context, arg UpdateChatMCPServersParams) error
 	UpdateChatMessageByID(ctx context.Context, arg UpdateChatMessageByIDParams) (ChatMessage, error)
 	UpdateChatModelConfig(ctx context.Context, arg UpdateChatModelConfigParams) (ChatModelConfig, error)
 	UpdateChatProvider(ctx context.Context, arg UpdateChatProviderParams) (ChatProvider, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2949,7 +2949,7 @@ WHERE
             $3::int
     )
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 `
 
 type AcquireChatsParams struct {
@@ -2986,6 +2986,7 @@ func (q *sqlQuerier) AcquireChats(ctx context.Context, arg AcquireChatsParams) (
 			&i.Archived,
 			&i.LastError,
 			&i.Mode,
+			&i.MCPServers,
 		); err != nil {
 			return nil, err
 		}
@@ -3189,7 +3190,7 @@ func (q *sqlQuerier) DeleteChatQueuedMessage(ctx context.Context, arg DeleteChat
 
 const getChatByID = `-- name: GetChatByID :one
 SELECT
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 FROM
     chats
 WHERE
@@ -3216,12 +3217,13 @@ func (q *sqlQuerier) GetChatByID(ctx context.Context, id uuid.UUID) (Chat, error
 		&i.Archived,
 		&i.LastError,
 		&i.Mode,
+		&i.MCPServers,
 	)
 	return i, err
 }
 
 const getChatByIDForUpdate = `-- name: GetChatByIDForUpdate :one
-SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode FROM chats WHERE id = $1::uuid FOR UPDATE
+SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers FROM chats WHERE id = $1::uuid FOR UPDATE
 `
 
 func (q *sqlQuerier) GetChatByIDForUpdate(ctx context.Context, id uuid.UUID) (Chat, error) {
@@ -3244,6 +3246,7 @@ func (q *sqlQuerier) GetChatByIDForUpdate(ctx context.Context, id uuid.UUID) (Ch
 		&i.Archived,
 		&i.LastError,
 		&i.Mode,
+		&i.MCPServers,
 	)
 	return i, err
 }
@@ -3949,7 +3952,7 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 
 const getChatsByOwnerID = `-- name: GetChatsByOwnerID :many
 SELECT
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 FROM
     chats
 WHERE
@@ -4027,6 +4030,7 @@ func (q *sqlQuerier) GetChatsByOwnerID(ctx context.Context, arg GetChatsByOwnerI
 			&i.Archived,
 			&i.LastError,
 			&i.Mode,
+			&i.MCPServers,
 		); err != nil {
 			return nil, err
 		}
@@ -4088,7 +4092,7 @@ func (q *sqlQuerier) GetLastChatMessageByRole(ctx context.Context, arg GetLastCh
 
 const getStaleChats = `-- name: GetStaleChats :many
 SELECT
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 FROM
     chats
 WHERE
@@ -4124,6 +4128,7 @@ func (q *sqlQuerier) GetStaleChats(ctx context.Context, staleThreshold time.Time
 			&i.Archived,
 			&i.LastError,
 			&i.Mode,
+			&i.MCPServers,
 		); err != nil {
 			return nil, err
 		}
@@ -4146,7 +4151,8 @@ INSERT INTO chats (
     root_chat_id,
     last_model_config_id,
     title,
-    mode
+    mode,
+    mcp_servers
 ) VALUES (
     $1::uuid,
     $2::uuid,
@@ -4154,20 +4160,22 @@ INSERT INTO chats (
     $4::uuid,
     $5::uuid,
     $6::text,
-    $7::chat_mode
+    $7::chat_mode,
+    $8::jsonb
 )
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 `
 
 type InsertChatParams struct {
-	OwnerID           uuid.UUID     `db:"owner_id" json:"owner_id"`
-	WorkspaceID       uuid.NullUUID `db:"workspace_id" json:"workspace_id"`
-	ParentChatID      uuid.NullUUID `db:"parent_chat_id" json:"parent_chat_id"`
-	RootChatID        uuid.NullUUID `db:"root_chat_id" json:"root_chat_id"`
-	LastModelConfigID uuid.UUID     `db:"last_model_config_id" json:"last_model_config_id"`
-	Title             string        `db:"title" json:"title"`
-	Mode              NullChatMode  `db:"mode" json:"mode"`
+	OwnerID           uuid.UUID             `db:"owner_id" json:"owner_id"`
+	WorkspaceID       uuid.NullUUID         `db:"workspace_id" json:"workspace_id"`
+	ParentChatID      uuid.NullUUID         `db:"parent_chat_id" json:"parent_chat_id"`
+	RootChatID        uuid.NullUUID         `db:"root_chat_id" json:"root_chat_id"`
+	LastModelConfigID uuid.UUID             `db:"last_model_config_id" json:"last_model_config_id"`
+	Title             string                `db:"title" json:"title"`
+	Mode              NullChatMode          `db:"mode" json:"mode"`
+	MCPServers        pqtype.NullRawMessage `db:"mcp_servers" json:"mcp_servers"`
 }
 
 func (q *sqlQuerier) InsertChat(ctx context.Context, arg InsertChatParams) (Chat, error) {
@@ -4179,6 +4187,7 @@ func (q *sqlQuerier) InsertChat(ctx context.Context, arg InsertChatParams) (Chat
 		arg.LastModelConfigID,
 		arg.Title,
 		arg.Mode,
+		arg.MCPServers,
 	)
 	var i Chat
 	err := row.Scan(
@@ -4198,6 +4207,7 @@ func (q *sqlQuerier) InsertChat(ctx context.Context, arg InsertChatParams) (Chat
 		&i.Archived,
 		&i.LastError,
 		&i.Mode,
+		&i.MCPServers,
 	)
 	return i, err
 }
@@ -4378,7 +4388,7 @@ SET
 WHERE
     id = $2::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 `
 
 type UpdateChatByIDParams struct {
@@ -4406,6 +4416,7 @@ func (q *sqlQuerier) UpdateChatByID(ctx context.Context, arg UpdateChatByIDParam
 		&i.Archived,
 		&i.LastError,
 		&i.Mode,
+		&i.MCPServers,
 	)
 	return i, err
 }
@@ -4434,6 +4445,20 @@ func (q *sqlQuerier) UpdateChatHeartbeat(ctx context.Context, arg UpdateChatHear
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const updateChatMCPServers = `-- name: UpdateChatMCPServers :exec
+UPDATE chats SET mcp_servers = $1::jsonb, updated_at = NOW() WHERE id = $2::uuid
+`
+
+type UpdateChatMCPServersParams struct {
+	MCPServers json.RawMessage `db:"mcp_servers" json:"mcp_servers"`
+	ID         uuid.UUID       `db:"id" json:"id"`
+}
+
+func (q *sqlQuerier) UpdateChatMCPServers(ctx context.Context, arg UpdateChatMCPServersParams) error {
+	_, err := q.db.ExecContext(ctx, updateChatMCPServers, arg.MCPServers, arg.ID)
+	return err
 }
 
 const updateChatMessageByID = `-- name: UpdateChatMessageByID :one
@@ -4493,7 +4518,7 @@ SET
 WHERE
     id = $6::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 `
 
 type UpdateChatStatusParams struct {
@@ -4532,6 +4557,7 @@ func (q *sqlQuerier) UpdateChatStatus(ctx context.Context, arg UpdateChatStatusP
 		&i.Archived,
 		&i.LastError,
 		&i.Mode,
+		&i.MCPServers,
 	)
 	return i, err
 }
@@ -4545,7 +4571,7 @@ SET
 WHERE
     id = $2::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_servers
 `
 
 type UpdateChatWorkspaceParams struct {
@@ -4573,6 +4599,7 @@ func (q *sqlQuerier) UpdateChatWorkspace(ctx context.Context, arg UpdateChatWork
 		&i.Archived,
 		&i.LastError,
 		&i.Mode,
+		&i.MCPServers,
 	)
 	return i, err
 }

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -143,7 +143,8 @@ INSERT INTO chats (
     root_chat_id,
     last_model_config_id,
     title,
-    mode
+    mode,
+    mcp_servers
 ) VALUES (
     @owner_id::uuid,
     sqlc.narg('workspace_id')::uuid,
@@ -151,10 +152,14 @@ INSERT INTO chats (
     sqlc.narg('root_chat_id')::uuid,
     @last_model_config_id::uuid,
     @title::text,
-    sqlc.narg('mode')::chat_mode
+    sqlc.narg('mode')::chat_mode,
+    sqlc.narg('mcp_servers')::jsonb
 )
 RETURNING
     *;
+
+-- name: UpdateChatMCPServers :exec
+UPDATE chats SET mcp_servers = @mcp_servers::jsonb, updated_at = NOW() WHERE id = @id::uuid;
 
 -- name: InsertChatMessage :one
 WITH updated_chat AS (

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -235,6 +235,7 @@ sql:
           aibridge_tool_usage: AIBridgeToolUsage
           aibridge_token_usage: AIBridgeTokenUsage
           aibridge_user_prompt: AIBridgeUserPrompt
+          mcp_servers: MCPServers
 rules:
   - name: do-not-use-public-schema-in-queries
     message: "do not use public schema in queries"

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -43,6 +43,7 @@ type Chat struct {
 	Status            ChatStatus      `json:"status"`
 	LastError         *string         `json:"last_error"`
 	DiffStatus        *ChatDiffStatus `json:"diff_status,omitempty"`
+	MCPServers        []ChatMCPServer `json:"mcp_servers,omitempty"`
 	CreatedAt         time.Time       `json:"created_at" format:"date-time"`
 	UpdatedAt         time.Time       `json:"updated_at" format:"date-time"`
 	Archived          bool            `json:"archived"`
@@ -233,11 +234,32 @@ type ChatInputPart struct {
 	Content string `json:"content,omitempty"`
 }
 
+// ChatMCPServer represents an MCP server attached to a chat session.
+// MCP servers provide additional tools to the chat agent via the
+// Model Context Protocol.
+type ChatMCPServer struct {
+	// Slug is a unique identifier for this MCP server within the chat.
+	// Tool names are namespaced as mcp__{slug}__{tool_name}.
+	Slug string `json:"slug"`
+	// URL is the MCP server endpoint (Streamable HTTP transport).
+	URL string `json:"url"`
+	// DisplayName is a human-readable name shown in tool descriptions.
+	DisplayName string `json:"display_name,omitempty"`
+	// AuthHeaders are sent with every request to the MCP server.
+	// Only admins may set this field. Values are encrypted at rest.
+	AuthHeaders map[string]string `json:"auth_headers,omitempty"`
+	// ToolAllowRegex, if set, only tools matching this regex are exposed.
+	ToolAllowRegex string `json:"tool_allow_regex,omitempty"`
+	// ToolDenyRegex, if set, tools matching this regex are excluded.
+	ToolDenyRegex string `json:"tool_deny_regex,omitempty"`
+}
+
 // CreateChatRequest is the request to create a new chat.
 type CreateChatRequest struct {
 	Content       []ChatInputPart `json:"content"`
 	WorkspaceID   *uuid.UUID      `json:"workspace_id,omitempty" format:"uuid"`
 	ModelConfigID *uuid.UUID      `json:"model_config_id,omitempty" format:"uuid"`
+	MCPServers    []ChatMCPServer `json:"mcp_servers,omitempty"`
 }
 
 // UpdateChatRequest is the request to update a chat.
@@ -249,6 +271,7 @@ type UpdateChatRequest struct {
 type CreateChatMessageRequest struct {
 	Content       []ChatInputPart `json:"content"`
 	ModelConfigID *uuid.UUID      `json:"model_config_id,omitempty" format:"uuid"`
+	MCPServers    []ChatMCPServer `json:"mcp_servers,omitempty"`
 }
 
 // EditChatMessageRequest is the request to edit a user message in a chat.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1066,6 +1066,7 @@ export interface Chat {
 	readonly status: ChatStatus;
 	readonly last_error: string | null;
 	readonly diff_status?: ChatDiffStatus;
+	readonly mcp_servers?: readonly ChatMCPServer[];
 	readonly created_at: string;
 	readonly updated_at: string;
 	readonly archived: boolean;
@@ -1253,6 +1254,41 @@ export const ChatInputPartTypes: ChatInputPartType[] = [
 	"file-reference",
 	"text",
 ];
+
+// From codersdk/chats.go
+/**
+ * ChatMCPServer represents an MCP server attached to a chat session.
+ * MCP servers provide additional tools to the chat agent via the
+ * Model Context Protocol.
+ */
+export interface ChatMCPServer {
+	/**
+	 * Slug is a unique identifier for this MCP server within the chat.
+	 * Tool names are namespaced as mcp__{slug}__{tool_name}.
+	 */
+	readonly slug: string;
+	/**
+	 * URL is the MCP server endpoint (Streamable HTTP transport).
+	 */
+	readonly url: string;
+	/**
+	 * DisplayName is a human-readable name shown in tool descriptions.
+	 */
+	readonly display_name?: string;
+	/**
+	 * AuthHeaders are sent with every request to the MCP server.
+	 * Only admins may set this field. Values are encrypted at rest.
+	 */
+	readonly auth_headers?: Record<string, string>;
+	/**
+	 * ToolAllowRegex, if set, only tools matching this regex are exposed.
+	 */
+	readonly tool_allow_regex?: string;
+	/**
+	 * ToolDenyRegex, if set, tools matching this regex are excluded.
+	 */
+	readonly tool_deny_regex?: string;
+}
 
 // From codersdk/chats.go
 /**
@@ -1907,6 +1943,7 @@ export interface ConvertLoginRequest {
 export interface CreateChatMessageRequest {
 	readonly content: readonly ChatInputPart[];
 	readonly model_config_id?: string;
+	readonly mcp_servers?: readonly ChatMCPServer[];
 }
 
 // From codersdk/chats.go
@@ -1954,6 +1991,7 @@ export interface CreateChatRequest {
 	readonly content: readonly ChatInputPart[];
 	readonly workspace_id?: string;
 	readonly model_config_id?: string;
+	readonly mcp_servers?: readonly ChatMCPServer[];
 }
 
 // From codersdk/users.go


### PR DESCRIPTION
## Summary

Adds the ability for admins to attach [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers to individual chats. MCP servers provide additional tools to the chat agent, enabling integration with external services like Linear, GitHub, Sentry, etc.

## API

### `POST /api/experimental/chats`

```jsonc
{
  "content": [{"type": "text", "text": "What are my open issues?"}],
  "mcp_servers": [  // optional, admin-only
    {
      "slug": "linear",
      "url": "https://mcp.linear.app/sse",
      "display_name": "Linear",
      "auth_headers": {"Authorization": "Bearer lin_api_..."},
      "tool_allow_regex": "",
      "tool_deny_regex": "delete_.*"
    }
  ]
}
```

### `POST /api/experimental/chats/{id}/messages`

Same `mcp_servers` field to update the config on subsequent messages.

### Response

`Chat` objects include `mcp_servers` in responses (auth headers are always stripped).

## Design decisions

- **Chat-level config, not a global registry.** Each chat is self-contained with its MCP configuration. No shared table, no admin UI, no CRUD API. A global registry can be layered on later.
- **Admin-only.** The `mcp_servers` field requires `ActionUpdate` on `ResourceDeploymentConfig`. Non-admins who omit it get a normal chat.
- **Parallel discovery with hard failure.** MCP servers are connected in parallel (30s timeout). If any server fails, the chat errors — because the admin configured it and expects it to work.
- **JSONB column on chats table.** Single nullable column, read once per chat turn, never queried on. Minimal schema impact.

## Implementation

- `chattool.MCPServer()` — Connects to a remote MCP server via Streamable HTTP, initializes the protocol, discovers tools, filters by allow/deny regex, and returns `fantasy.AgentTool` instances named `mcp__{slug}__{tool_name}`.
- `chatd.runChat()` — Parses `chat.MCPServers` JSONB, connects to all servers in parallel, registers tools before the chat loop starts.
- Auth headers are passed to MCP servers but never returned in API responses.

## Tests

- **`chattool/mcpserver_test.go`** (8 subtests) — Tool discovery, tool execution, error handling, allow/deny regex filtering, empty servers, invalid input.
- **`chatd_test.go`** (2 integration tests):
  - `TestChatMCPServerConnectionFailure` — Dead URL → chat errors with MCP message.
  - `TestChatMCPServerToolsDiscovered` — Real MCP server → tools registered, chat completes.