### PR TITLE
fix(coderd): strip markdown code fences from Anthropic task name responses

### DIFF
--- a/coderd/taskname/taskname.go
+++ b/coderd/taskname/taskname.go
@@ -98,23 +98,21 @@ var (
 
 // extractJSON strips optional markdown code fences (```json or
 // ```) that LLMs sometimes wrap around JSON output, returning
-// only the inner JSON string.
+// only the inner JSON string. Only well-formed fences with a
+// newline after the opening backticks are stripped; malformed
+// fences are left untouched so that json.Unmarshal fails
+// cleanly and the caller can fall back to other strategies.
 func extractJSON(s string) string {
 	s = strings.TrimSpace(s)
 	if strings.HasPrefix(s, "```") {
-		// Remove the opening fence line (```json or ```).
+		// Only strip when there is a newline separating the
+		// fence line from the body. Without one we cannot
+		// reliably tell the fence from the content.
 		if idx := strings.Index(s, "\n"); idx != -1 {
 			s = s[idx+1:]
-		} else {
-			// No newline: strip the backticks and any language
-			// tag up to the first '{' or '['.
-			if start := strings.IndexAny(s, "{["); start != -1 {
-				s = s[start:]
-			}
+			s = strings.TrimSuffix(s, "```")
+			s = strings.TrimSpace(s)
 		}
-		// Remove the closing fence.
-		s = strings.TrimSuffix(s, "```")
-		s = strings.TrimSpace(s)
 	}
 	return s
 }

--- a/coderd/taskname/taskname.go
+++ b/coderd/taskname/taskname.go
@@ -96,6 +96,23 @@ var (
 	ErrNoNameGenerated = xerrors.New("no task name generated")
 )
 
+// extractJSON strips optional markdown code fences (```json or
+// ```) that LLMs sometimes wrap around JSON output, returning
+// only the inner JSON string.
+func extractJSON(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "```") {
+		// Remove the opening fence line (```json or ```).
+		if idx := strings.Index(s, "\n"); idx != -1 {
+			s = s[idx+1:]
+		}
+		// Remove the closing fence.
+		s = strings.TrimSuffix(s, "```")
+		s = strings.TrimSpace(s)
+	}
+	return s
+}
+
 type TaskName struct {
 	Name        string `json:"task_name"`
 	DisplayName string `json:"display_name"`
@@ -188,7 +205,7 @@ func generateFromPrompt(prompt string) (TaskName, error) {
 // generateFromAnthropic uses Claude (Anthropic) to generate semantic task and display names from a user prompt.
 // It sends the prompt to Claude with a structured system prompt requesting JSON output containing both names.
 // Returns an error if the API call fails, the response is invalid, or Claude returns an "unnamed" placeholder.
-func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, model anthropic.Model) (TaskName, error) {
+func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, model anthropic.Model, opts ...anthropicoption.RequestOption) (TaskName, error) {
 	anthropicModel := model
 	if anthropicModel == "" {
 		anthropicModel = defaultModel
@@ -216,6 +233,7 @@ func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, mo
 
 	anthropicOptions := anthropic.DefaultClientOptions()
 	anthropicOptions = append(anthropicOptions, anthropicoption.WithAPIKey(apiKey))
+	anthropicOptions = append(anthropicOptions, opts...)
 	anthropicClient := anthropic.NewClient(anthropicOptions...)
 
 	stream, err := anthropicDataStream(ctx, anthropicClient, anthropicModel, conversation)
@@ -234,9 +252,11 @@ func generateFromAnthropic(ctx context.Context, prompt string, apiKey string, mo
 		return TaskName{}, ErrNoNameGenerated
 	}
 
-	// Parse the JSON response
+	// Parse the JSON response. LLMs sometimes wrap JSON in
+	// markdown code fences (```json ... ```), so we strip
+	// those before unmarshalling.
 	var taskNameResponse TaskName
-	if err := json.Unmarshal([]byte(acc.Messages()[0].Content), &taskNameResponse); err != nil {
+	if err := json.Unmarshal([]byte(extractJSON(acc.Messages()[0].Content)), &taskNameResponse); err != nil {
 		return TaskName{}, xerrors.Errorf("failed to parse anthropic response: %w", err)
 	}
 

--- a/coderd/taskname/taskname.go
+++ b/coderd/taskname/taskname.go
@@ -105,6 +105,12 @@ func extractJSON(s string) string {
 		// Remove the opening fence line (```json or ```).
 		if idx := strings.Index(s, "\n"); idx != -1 {
 			s = s[idx+1:]
+		} else {
+			// No newline: strip the backticks and any language
+			// tag up to the first '{' or '['.
+			if start := strings.IndexAny(s, "{["); start != -1 {
+				s = s[start:]
+			}
 		}
 		// Remove the closing fence.
 		s = strings.TrimSuffix(s, "```")

--- a/coderd/taskname/taskname_internal_test.go
+++ b/coderd/taskname/taskname_internal_test.go
@@ -1,6 +1,7 @@
 package taskname
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -155,6 +156,16 @@ func TestExtractJSON(t *testing.T) {
 			input:    "```json\n{\n  \"display_name\": \"Fix bug\",\n  \"task_name\": \"fix-bug\"\n}\n```",
 			expected: "{\n  \"display_name\": \"Fix bug\",\n  \"task_name\": \"fix-bug\"\n}",
 		},
+		{
+			name:     "FencedNoNewline",
+			input:    "```json{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}```",
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
+		{
+			name:     "FencedNoNewlineNoLanguage",
+			input:    "`````{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}```",
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -168,12 +179,14 @@ func TestExtractJSON(t *testing.T) {
 
 // fakeAnthropicSSE builds a minimal Anthropic Messages SSE stream
 // whose sole text content is the provided string.
-func fakeAnthropicSSE(text string) string {
-	// Escape for JSON embedding.
-	escaped := strings.ReplaceAll(text, `\`, `\\`)
-	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
-	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
-	escaped = strings.ReplaceAll(escaped, "\t", `\t`)
+func fakeAnthropicSSE(t *testing.T, text string) string {
+	t.Helper()
+
+	// Use json.Marshal to produce a correctly escaped JSON
+	// string value, then strip the surrounding quotes.
+	escapedBytes, err := json.Marshal(text)
+	require.NoError(t, err)
+	escaped := string(escapedBytes[1 : len(escapedBytes)-1])
 
 	return fmt.Sprintf(`event: message_start
 data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"claude-haiku-4-5-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}
@@ -230,7 +243,7 @@ func TestGenerateFromAnthropicMock(t *testing.T) {
 
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "text/event-stream")
-				_, _ = w.Write([]byte(fakeAnthropicSSE(tc.responseText)))
+				_, _ = w.Write([]byte(fakeAnthropicSSE(t, tc.responseText)))
 			}))
 			t.Cleanup(srv.Close)
 

--- a/coderd/taskname/taskname_internal_test.go
+++ b/coderd/taskname/taskname_internal_test.go
@@ -157,14 +157,14 @@ func TestExtractJSON(t *testing.T) {
 			expected: "{\n  \"display_name\": \"Fix bug\",\n  \"task_name\": \"fix-bug\"\n}",
 		},
 		{
-			name:     "FencedNoNewline",
+			name:     "FencedNoNewlinePassthrough",
 			input:    "```json{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}```",
-			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+			expected: "```json{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}```",
 		},
 		{
-			name:     "FencedNoNewlineNoLanguage",
-			input:    "`````{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}```",
-			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+			name:     "NonJSONFencedContent",
+			input:    "```foo: {}, bar: {}```",
+			expected: "```foo: {}, bar: {}```",
 		},
 	}
 

--- a/coderd/taskname/taskname_internal_test.go
+++ b/coderd/taskname/taskname_internal_test.go
@@ -2,9 +2,13 @@ package taskname
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/codersdk"
@@ -108,6 +112,139 @@ func TestGenerateFromPrompt(t *testing.T) {
 
 			// Validate task display name
 			require.NotEmpty(t, taskName.DisplayName)
+			require.Equal(t, tc.expectedDisplayName, taskName.DisplayName)
+		})
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "BareJSON",
+			input:    `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
+		{
+			name:     "FencedJSON",
+			input:    "```json\n{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}\n```",
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
+		{
+			name:     "FencedNoLanguage",
+			input:    "```\n{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}\n```",
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
+		{
+			name:     "FencedWithSurroundingWhitespace",
+			input:    "  \n```json\n{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}\n```\n  ",
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
+		{
+			name:     "BareJSONWithWhitespace",
+			input:    "  \n{\"display_name\": \"Fix bug\", \"task_name\": \"fix-bug\"}\n  ",
+			expected: `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+		},
+		{
+			name:     "FencedMultilineJSON",
+			input:    "```json\n{\n  \"display_name\": \"Fix bug\",\n  \"task_name\": \"fix-bug\"\n}\n```",
+			expected: "{\n  \"display_name\": \"Fix bug\",\n  \"task_name\": \"fix-bug\"\n}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractJSON(tc.input)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// fakeAnthropicSSE builds a minimal Anthropic Messages SSE stream
+// whose sole text content is the provided string.
+func fakeAnthropicSSE(text string) string {
+	// Escape for JSON embedding.
+	escaped := strings.ReplaceAll(text, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	escaped = strings.ReplaceAll(escaped, "\t", `\t`)
+
+	return fmt.Sprintf(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"claude-haiku-4-5-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"%s"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":20}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`, escaped)
+}
+
+func TestGenerateFromAnthropicMock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		responseText        string
+		expectedDisplayName string
+		expectedNamePrefix  string
+	}{
+		{
+			name:                "BareJSON",
+			responseText:        `{"display_name": "Fix bug", "task_name": "fix-bug"}`,
+			expectedDisplayName: "Fix bug",
+			expectedNamePrefix:  "fix-bug-",
+		},
+		{
+			name:                "FencedJSON",
+			responseText:        "```json\n{\"display_name\": \"Debug auth\", \"task_name\": \"debug-auth\"}\n```",
+			expectedDisplayName: "Debug auth",
+			expectedNamePrefix:  "debug-auth-",
+		},
+		{
+			name:                "FencedNoLanguage",
+			responseText:        "```\n{\"display_name\": \"Setup CI\", \"task_name\": \"setup-ci\"}\n```",
+			expectedDisplayName: "Setup CI",
+			expectedNamePrefix:  "setup-ci-",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(fakeAnthropicSSE(tc.responseText)))
+			}))
+			t.Cleanup(srv.Close)
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+
+			taskName, err := generateFromAnthropic(
+				ctx, "test prompt", "fake-key",
+				anthropic.ModelClaudeHaiku4_5,
+				anthropicoption.WithBaseURL(srv.URL),
+			)
+			require.NoError(t, err)
+			require.NoError(t, codersdk.NameValid(taskName.Name))
+			require.True(t, strings.HasPrefix(taskName.Name, tc.expectedNamePrefix),
+				"expected name %q to have prefix %q", taskName.Name, tc.expectedNamePrefix)
 			require.Equal(t, tc.expectedDisplayName, taskName.DisplayName)
 		})
 	}


### PR DESCRIPTION
## Problem

Claude sometimes wraps JSON output in markdown code fences (```json ... ```) despite the system prompt requesting raw JSON. This causes `json.Unmarshal` to fail with:

```
invalid character '`' looking for beginning of value
```

This error was appearing frequently in `coderd` logs at `coderd/taskname/taskname.go:240`.

## Fix

- Add `extractJSON()` to strip markdown code fences before JSON parsing.
- Wire it into the `json.Unmarshal` call in `generateFromAnthropic`.
- Accept variadic `RequestOption` in `generateFromAnthropic` so tests can inject a mock Anthropic server via `WithBaseURL`.

## Tests

- `TestExtractJSON` — 6 table-driven cases covering bare JSON, fenced with/without language tag, surrounding whitespace, and multiline JSON.
- `TestGenerateFromAnthropicMock` — 3 end-to-end cases using `httptest.NewServer` to serve fake Anthropic SSE streams with bare and fenced responses.