### PR TITLE
feat(dogfood): clean up named Docker volumes and Go build cache cron

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -37,6 +37,11 @@ locals {
   repo_base_dir  = data.coder_parameter.repo_base_dir.value == "~" ? "/home/coder" : replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
   repo_dir       = replace(try(module.git-clone[0].repo_dir, ""), "/^~\\//", "/home/coder/")
   container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+
+  // Derive a stable per-workspace hour and minute from the workspace ID
+  // so that cache cleanup crons don't all hit the filesystem at once.
+  cache_cleanup_hour   = parseint(substr(data.coder_workspace.me.id, 0, 2), 16) % 24
+  cache_cleanup_minute = parseint(substr(data.coder_workspace.me.id, 2, 2), 16) % 60
 }
 
 data "coder_workspace_preset" "pittsburgh" {
@@ -616,6 +621,17 @@ resource "coder_agent" "dev" {
     #   - all build cache
     docker system prune -a -f
 
+    # Remove dangling named volumes that are older than KEEP_DAYS. Using
+    # 30 here as a conservative default (vacation, holidays, etc.).
+    KEEP_DAYS=30
+    docker volume ls -qf dangling=true \
+      | xargs -r docker volume inspect \
+      | jq -r --argjson days "$KEEP_DAYS" '.[] | select(.CreatedAt != null) | ((now - (.CreatedAt | fromdateiso8601)) / 86400 | floor) as $a | select($a >= $days) | "\($a)\t\(.Name)"' \
+      | while IFS=$'\t' read -r age name; do
+      echo "Removing volume $name ($age d)"
+      docker volume rm "$name" >/dev/null
+    done
+
     # Stop the Docker service to prevent errors during workspace destroy.
     sudo service docker stop
   EOT
@@ -638,6 +654,26 @@ resource "coder_script" "install-deps" {
     # We want to use the playwright version from site/package.json
     cd "${local.repo_dir}" && make clean
     cd "${local.repo_dir}/site" && pnpm install
+  EOT
+}
+
+resource "coder_script" "go-cache-cleanup-cron" {
+  agent_id     = coder_agent.dev.id
+  display_name = "Go Build Cache Cleanup Cron"
+  icon         = "${data.coder_workspace.me.access_url}/emojis/1f9f9.png" // 🧹
+  cron         = "0 ${local.cache_cleanup_minute} ${local.cache_cleanup_hour} * * *"
+  script       = <<-EOT
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    cache_dir=$(go env GOCACHE)
+    echo "Cleaning Go build cache entries not used in the last 2 days..."
+    before=$(du -s "$cache_dir" 2>/dev/null | awk '{print $1}')
+    find "$cache_dir" -type f -mtime +2 -delete
+    find "$cache_dir" -type d -empty -delete
+    after=$(du -s "$cache_dir" 2>/dev/null | awk '{print $1}')
+    freed=$(( (before - after) / 1024 ))
+    echo "Freed $${freed}MB from Go build cache."
   EOT
 }
 


### PR DESCRIPTION
Docker keeps named volumes around, even if they're dangling. During
development users generate a lot of named coder- volumes and the like.
These are now cleaned on shutdown once they are 30 days old.

For long running workspaces, go build cache also accumulates, so now
we clean these up via cron as well. All cache older than 2 days is wiped
and the cron schedule is based on workspace ID to distribute the load.

---

My workspace was accumulating cruft:

```
150G    ~/.cache/go-build
175G    /var/lib/docker
```

Not only was the running PostgreSQL test container using 60G, but after removing everything I could think of, I was still left with 110G.

The Docker cleanup code:

```
Removing volume buildx_buildkit_envbuilder0_state (22 d)
Removing volume coder-3c6b402e-87ba-4810-bc0c-a12665ebf8c4-docker (246 d)
Removing volume coder-3c6b402e-87ba-4810-bc0c-a12665ebf8c4-home (246 d)
Removing volume coder-8fd6e348-6b47-45ed-9a2c-32b5cd010101-home (43 d)
Removing volume coder-29a01b2d-899c-4f15-97b8-fa55ca813ad0-home (108 d)
Removing volume coder-37de121d-3322-442b-af56-85b797c50dfa-home (134 d)
Removing volume coder-50f92138-f463-4f2b-abad-1816264b065f-home (203 d)
Removing volume coder-61b56379-5c46-4abc-883e-958b3d181dd9-home (108 d)
Removing volume coder-69ce876b-dfd0-4f25-883d-67ac334447f8-home (134 d)
Removing volume coder-279ac0d8-07ea-4484-ba74-12c8595364b8-home (134 d)
Removing volume coder-641bde37-3d71-424a-84f2-01348a9e22fe-home (101 d)
Removing volume coder-648c2935-4294-41f0-92a4-025e7db8b065-home (29 d)
Removing volume coder-870df1e8-bf57-4e4e-8732-a13683349314-docker (101 d)
Removing volume coder-870df1e8-bf57-4e4e-8732-a13683349314-home (101 d)
Removing volume coder-938bf432-e0ee-48f1-92c1-f38744d01fea-home (175 d)
Removing volume coder-969a7d0f-5143-45ff-9354-a9fcd7e1d57d-docker (246 d)
Removing volume coder-969a7d0f-5143-45ff-9354-a9fcd7e1d57d-home (246 d)
Removing volume coder-1357bbc1-77db-43c0-801a-58a5d50433c7-home (108 d)
Removing volume coder-4905ccc6-9768-4d5e-bb18-692b984759c6-home (108 d)
Removing volume coder-6773b1e4-8fa9-44ec-8c76-0e74125c1ccb-home (141 d)
Removing volume coder-663353be-b7b1-437b-a922-8d3a4b2f5526-home (262 d)
Removing volume coder-799253a0-ecb7-4f58-b111-e932ebbfa25c-home (43 d)
Removing volume coder-71860459-3d80-4410-921d-ef85ecc869eb-home (29 d)
Removing volume coder-a7a27450-ca16-4553-a6c5-9d6f04808569-home (203 d)
Removing volume coder-a249d48a-1d99-4bb5-a71e-b397edae9c16-home (258 d)
Removing volume coder-a4822be3-1bdf-4ac5-a3dd-90599db3a783-home (43 d)
Removing volume coder-aa4affea-9b7c-45c5-8343-b9a96ab67ba4-home (134 d)
Removing volume coder-b8ea9185-6110-4b5f-96e1-ddc8575e8271-home (31 d)
Removing volume coder-b8654f7b-d708-48f7-b8cb-a459c18c472f-home (134 d)
Removing volume coder-c30d0afd-5baf-48f4-a18a-804ad169b8fd-home (31 d)
Removing volume coder-c438a9d8-8cbe-4e40-badc-788c6d56bf97-docker (253 d)
Removing volume coder-c438a9d8-8cbe-4e40-badc-788c6d56bf97-home (253 d)
Removing volume coder-coder-devcontainer-home (258 d)
Removing volume coder-devcontainer-data (258 d)
Removing volume coder-e7b65a35-3e07-44c8-bf2e-03e5a41f608f-home (100 d)
Removing volume coder-e9f880c6-4572-4777-baa4-48766754d433-home (43 d)
Removing volume coder-eb0cab02-1209-48a1-819b-3780be9030bf-home (134 d)
Removing volume coder-f2bf8f3c-9986-482e-bd75-aeec0efc622f-home (100 d)
Removing volume coder-f08761c7-55c2-4308-9b91-74b754f586bd-docker (245 d)
Removing volume coder-f08761c7-55c2-4308-9b91-74b754f586bd-home (245 d)
Removing volume dev-containers-cli-bashhistory (259 d)
Removing volume dind-var-lib-docker-0sbkh59s6ppite8t3n9a778cpea6gjra1sedunlsb632llfljkf1 (258 d)
Removing volume dind-var-lib-docker-1pg2qmi4ieptu7atfh3f944uo4su3fbq1ur52hg9fcghp1er54al (260 d)
Removing volume dind-var-lib-docker-08s15c9i01bmard5f3eg7os3s245m6inso27ie7ac3vu71tb2agg (259 d)
Removing volume dind-var-lib-docker-188djrll4q61ascc3gh2s0phshvifcn964vkc68dp1l7v7eqqjtn (266 d)
Removing volume docker-cache (262 d)
Removing volume vscode (254 d)
```

The Go cleanup code, tested in `bash -l`.

```
coder@w:~/coder$ cache_dir=$(go env GOCACHE)
coder@w:~/coder$ before=$(du -s "$cache_dir" 2>/dev/null | awk '{print $1}')
coder@w:~/coder$ find "$cache_dir" -type f -mtime +2 -delete
coder@w:~/coder$ find "$cache_dir" -type d -empty -delete
coder@w:~/coder$ after=$(du -s "$cache_dir" 2>/dev/null | awk '{print $1}')
coder@w:~/coder$ freed=$(( (before - after) / 1024 ))
coder@w:~/coder$ echo "Freed ${freed}MB from Go build cache."
Freed 67308MB from Go build cache.
```