### PR TITLE
fix(coderd/database): move context creation to first use in migration tests

### DIFF
--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -295,10 +295,6 @@ func TestMigrateUpWithFixtures(t *testing.T) {
 
 			db := testSQLDB(t)
 
-			// This test occasionally timed out in CI, which is understandable
-			// considering the amount of migrations and fixtures we have.
-			ctx := testutil.Context(t, testutil.WaitSuperLong)
-
 			// Prepare database for stepping up.
 			err := migrations.Down(db)
 			require.NoError(t, err)
@@ -336,6 +332,8 @@ func TestMigrateUpWithFixtures(t *testing.T) {
 				t.Logf("migrated to version %d, fixture version %d", version, fixtureVer)
 			}
 
+			ctx := testutil.Context(t, testutil.WaitSuperLong)
+
 			// Gather number of rows for all existing tables
 			// at the end of the migrations and fixtures.
 			var tables pq.StringArray
@@ -372,9 +370,6 @@ func TestMigration000362AggregateUsageEvents(t *testing.T) {
 	t.Parallel()
 
 	const migrationVersion = 362
-
-	// Similarly to the other test, this test will probably time out in CI.
-	ctx := testutil.Context(t, testutil.WaitSuperLong)
 
 	sqlDB := testSQLDB(t)
 	db := database.New(sqlDB)
@@ -430,6 +425,7 @@ func TestMigration000362AggregateUsageEvents(t *testing.T) {
 		},
 	}
 
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	for _, usageEvent := range usageEvents {
 		err := db.InsertUsageEvent(ctx, database.InsertUsageEventParams{
 			ID:        uuid.New().String(),
@@ -494,7 +490,6 @@ func TestMigration000387MigrateTaskWorkspaces(t *testing.T) {
 
 	const migrationVersion = 387
 
-	ctx := testutil.Context(t, testutil.WaitLong)
 	sqlDB := testSQLDB(t)
 
 	// Migrate up to the migration before the task workspace migration.
@@ -562,6 +557,7 @@ func TestMigration000387MigrateTaskWorkspaces(t *testing.T) {
 	wsAntBuild1ID := uuid.New()
 
 	// Create all fixtures in a single transaction.
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
 	tx, err := sqlDB.BeginTx(ctx, nil)
 	require.NoError(t, err)
 	defer tx.Rollback()


### PR DESCRIPTION
Fixes flaky `TestMigration000387MigrateTaskWorkspaces` that intermittently fails with `context deadline exceeded` at `migrate_test.go:566`.

The 25s context was created before the 386-step Stepper loop, so by the time `BeginTx` ran the deadline was already expired. Moves context creation to immediately before first use in all three affected tests, and bumps `TestMigration000387` from `WaitLong` (25s) to `WaitSuperLong` (60s).

Fixes https://github.com/coder/internal/issues/1398