### PR TITLE
fix(site): WCAG 2.1 AA remediation — table semantics, interactive naming, and image alt policy

### DIFF
--- a/site/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -257,9 +257,7 @@ export const ClearSelection: Story = {
 		onChangeSpy.mockClear();
 
 		const clearButton = canvas.getByLabelText("Clear selection");
-		expect(clearButton).toHaveAttribute("role", "button");
-		expect(clearButton).toHaveAttribute("tabindex", "0");
-		expect(clearButton.tagName).toBe("SPAN");
+		expect(clearButton.tagName).toBe("BUTTON");
 
 		await userEvent.click(clearButton);
 		await waitFor(() => expect(onChangeSpy).toHaveBeenCalledWith(null));

--- a/site/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,0 +1,104 @@
+import { renderComponent } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { Autocomplete } from "./Autocomplete";
+
+interface FruitOption {
+	id: string;
+	name: string;
+}
+
+const fruitOptions: FruitOption[] = [
+	{ id: "1", name: "Mango" },
+	{ id: "2", name: "Banana" },
+	{ id: "3", name: "Pineapple" },
+];
+
+const renderAutocomplete = () => {
+	const onChange = vi.fn<(value: FruitOption | null) => void>();
+
+	const TestComponent = () => {
+		const [value, setValue] = useState<FruitOption | null>(fruitOptions[0]);
+
+		const handleChange = (newValue: FruitOption | null) => {
+			onChange(newValue);
+			setValue(newValue);
+		};
+
+		return (
+			<div className="w-80">
+				<Autocomplete
+					value={value}
+					onChange={handleChange}
+					options={fruitOptions}
+					getOptionValue={(option) => option.id}
+					getOptionLabel={(option) => option.name}
+					placeholder="Select a fruit"
+				/>
+			</div>
+		);
+	};
+
+	renderComponent(<TestComponent />);
+
+	return { onChange };
+};
+
+describe(Autocomplete.name, () => {
+	it("does not render nested interactive elements in the trigger", () => {
+		renderAutocomplete();
+
+		const trigger = screen.getByRole("button", { name: /mango/i });
+		const clearButton = screen.getByRole("button", {
+			name: /clear selection/i,
+		});
+
+		expect(trigger).not.toContainElement(clearButton);
+		expect(
+			trigger.querySelector(
+				"button, a, input, select, textarea, [role='button'], [tabindex]:not([tabindex='-1'])",
+			),
+		).toBeNull();
+	});
+
+	it("allows clearing with keyboard activation", async () => {
+		const { onChange } = renderAutocomplete();
+		const user = userEvent.setup();
+
+		const trigger = screen.getByRole("button", { name: /mango/i });
+		const clearButton = screen.getByRole("button", {
+			name: /clear selection/i,
+		});
+
+		await user.tab();
+		expect(trigger).toHaveFocus();
+
+		await user.tab();
+		expect(clearButton).toHaveFocus();
+
+		await user.keyboard("{Enter}");
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith(null);
+		expect(
+			screen.getByRole("button", { name: /select a fruit/i }),
+		).toBeInTheDocument();
+	});
+
+	it("clears the value and fires onChange when clicked", async () => {
+		const { onChange } = renderAutocomplete();
+		const user = userEvent.setup();
+		const clearButton = screen.getByRole("button", {
+			name: /clear selection/i,
+		});
+
+		await user.click(clearButton);
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith(null);
+		expect(
+			screen.getByRole("button", { name: /select a fruit/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/site/src/components/Autocomplete/Autocomplete.tsx
+++ b/site/src/components/Autocomplete/Autocomplete.tsx
@@ -115,14 +115,10 @@ export function Autocomplete<TOption>({
 		[isSelected, clearable, onChange, handleOpenChange],
 	);
 
-	const handleClear = useCallback(
-		(e: React.SyntheticEvent) => {
-			e.stopPropagation();
-			onChange(null);
-			handleInputChange("");
-		},
-		[onChange, handleInputChange],
-	);
+	const handleClear = useCallback(() => {
+		onChange(null);
+		handleInputChange("");
+	}, [onChange, handleInputChange]);
 
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent<HTMLInputElement>) => {
@@ -138,64 +134,61 @@ export function Autocomplete<TOption>({
 
 	return (
 		<Popover open={isOpen} onOpenChange={handleOpenChange}>
-			<PopoverTrigger asChild disabled={disabled}>
-				<button
-					type="button"
-					id={id}
-					data-testid={testId}
-					aria-expanded={isOpen}
-					aria-haspopup="listbox"
-					disabled={disabled}
-					className={cn(
-						`flex h-10 w-full items-center justify-between gap-2
+			<div className="relative">
+				<PopoverTrigger asChild disabled={disabled}>
+					<button
+						type="button"
+						id={id}
+						data-testid={testId}
+						aria-expanded={isOpen}
+						aria-haspopup="listbox"
+						disabled={disabled}
+						className={cn(
+							`flex h-10 w-full items-center justify-between gap-2
 						rounded-md border border-border border-solid bg-transparent px-3 py-2
 						text-sm shadow-sm transition-colors
 						placeholder:text-content-secondary
 						focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
 						disabled:cursor-not-allowed disabled:opacity-50`,
-						className,
-					)}
-				>
-					<span className="flex items-center gap-2 overflow-hidden flex-1 min-w-0">
-						{startAdornment}
-						<span
-							className={cn(
-								"truncate text-left",
-								displayValue
-									? "text-content-primary"
-									: "text-content-secondary",
-							)}
-						>
-							{displayValue || placeholder}
-						</span>
-					</span>
-					<span className="flex items-center shrink-0">
-						{loading && <Spinner size="sm" loading className="mr-1" />}
-						{showClearButton && (
-							<span
-								role="button"
-								tabIndex={0}
-								onClick={handleClear}
-								onKeyDown={(e) => {
-									if (e.key === "Enter" || e.key === " ") {
-										handleClear(e);
-									}
-								}}
-								className="flex items-center justify-center size-5 rounded hover:bg-surface-secondary transition-colors cursor-pointer"
-								aria-label="Clear selection"
-							>
-								<X className="size-4 text-content-secondary hover:text-content-primary" />
-							</span>
+							className,
 						)}
-						<span className="flex items-center justify-center size-5">
-							<ChevronDownIcon
-								open={isOpen}
-								className="size-4 text-content-secondary"
-							/>
+					>
+						<span className="flex items-center gap-2 overflow-hidden flex-1 min-w-0">
+							{startAdornment}
+							<span
+								className={cn(
+									"truncate text-left",
+									displayValue
+										? "text-content-primary"
+										: "text-content-secondary",
+								)}
+							>
+								{displayValue || placeholder}
+							</span>
 						</span>
-					</span>
-				</button>
-			</PopoverTrigger>
+						<span className="flex items-center shrink-0">
+							{loading && <Spinner size="sm" loading className="mr-1" />}
+							{showClearButton && <span aria-hidden className="size-5" />}
+							<span className="flex items-center justify-center size-5">
+								<ChevronDownIcon
+									open={isOpen}
+									className="size-4 text-content-secondary"
+								/>
+							</span>
+						</span>
+					</button>
+				</PopoverTrigger>
+				{showClearButton && (
+					<button
+						type="button"
+						onClick={handleClear}
+						aria-label="Clear selection"
+						className="absolute right-8 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded transition-colors hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+					>
+						<X className="size-4 text-content-secondary hover:text-content-primary" />
+					</button>
+				)}
+			</div>
 			<PopoverContent
 				className="w-[var(--radix-popover-trigger-width)] p-0"
 				align="start"

--- a/site/src/components/ExternalImage/DecorativeImage.test.tsx
+++ b/site/src/components/ExternalImage/DecorativeImage.test.tsx
@@ -1,0 +1,15 @@
+import { renderComponent } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import { DecorativeImage } from "./DecorativeImage";
+
+describe(DecorativeImage.name, () => {
+	it("renders decorative semantics", () => {
+		renderComponent(
+			<DecorativeImage src="/icon/github.svg" data-testid="decorative-image" />,
+		);
+
+		const image = screen.getByTestId("decorative-image");
+		expect(image).toHaveAttribute("alt", "");
+		expect(image).toHaveAttribute("aria-hidden", "true");
+	});
+});

--- a/site/src/components/ExternalImage/DecorativeImage.tsx
+++ b/site/src/components/ExternalImage/DecorativeImage.tsx
@@ -1,0 +1,7 @@
+import { ExternalImage, type ExternalImageProps } from "./ExternalImage";
+
+type DecorativeImageProps = Omit<ExternalImageProps, "alt">;
+
+export const DecorativeImage: React.FC<DecorativeImageProps> = (props) => {
+	return <ExternalImage {...props} alt="" aria-hidden="true" />;
+};

--- a/site/src/components/ExternalImage/ExternalImage.a11y.test.tsx
+++ b/site/src/components/ExternalImage/ExternalImage.a11y.test.tsx
@@ -1,0 +1,20 @@
+import { renderComponent } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import { DecorativeImage } from "./DecorativeImage";
+import { ExternalImage } from "./ExternalImage";
+
+describe("ExternalImage accessibility", () => {
+	it("exposes informative images by role and accessible name", () => {
+		renderComponent(<ExternalImage src="/icon/github.svg" alt="GitHub logo" />);
+
+		expect(
+			screen.getByRole("img", { name: "GitHub logo" }),
+		).toBeInTheDocument();
+	});
+
+	it("excludes decorative images from role-based image queries", () => {
+		renderComponent(<DecorativeImage src="/icon/github.svg" />);
+
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
+});

--- a/site/src/components/ExternalImage/ExternalImage.test.tsx
+++ b/site/src/components/ExternalImage/ExternalImage.test.tsx
@@ -1,0 +1,32 @@
+import { renderComponent } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import { ExternalImage } from "./ExternalImage";
+
+describe(ExternalImage.name, () => {
+	it("renders informative alt text", () => {
+		renderComponent(<ExternalImage src="/icon/github.svg" alt="GitHub logo" />);
+
+		expect(
+			screen.getByRole("img", { name: "GitHub logo" }),
+		).toBeInTheDocument();
+	});
+
+	it("passes standard image props through to the underlying element", () => {
+		renderComponent(
+			<ExternalImage
+				alt="GitHub logo"
+				src="/icon/github.svg"
+				width={20}
+				height={20}
+				loading="lazy"
+				data-testid="external-image"
+			/>,
+		);
+
+		const image = screen.getByTestId("external-image");
+		expect(image).toHaveAttribute("src", "/icon/github.svg");
+		expect(image).toHaveAttribute("width", "20");
+		expect(image).toHaveAttribute("height", "20");
+		expect(image).toHaveAttribute("loading", "lazy");
+	});
+});

--- a/site/src/components/ExternalImage/ExternalImage.tsx
+++ b/site/src/components/ExternalImage/ExternalImage.tsx
@@ -1,16 +1,24 @@
 import { useTheme } from "@emotion/react";
 import { getExternalImageStylesFromUrl } from "theme/externalImages";
 
-export const ExternalImage: React.FC<React.ComponentPropsWithRef<"img">> = ({
+export type ExternalImageProps = Omit<
+	React.ComponentPropsWithRef<"img">,
+	"alt"
+> & {
+	alt: string;
+};
+
+export const ExternalImage: React.FC<ExternalImageProps> = ({
+	alt,
 	...props
 }) => {
 	const theme = useTheme();
 
 	return (
-		// biome-ignore lint/a11y/useAltText: alt should be passed in as a prop
 		<img
 			css={getExternalImageStylesFromUrl(theme.externalImages, props.src)}
 			{...props}
+			alt={alt}
 		/>
 	);
 };

--- a/site/src/components/ExternalImage/index.ts
+++ b/site/src/components/ExternalImage/index.ts
@@ -1,0 +1,5 @@
+// Use ExternalImage for informative images that need screen-reader alt text.
+// Use DecorativeImage when adjacent text already conveys the same meaning.
+
+export { DecorativeImage } from "./DecorativeImage";
+export { ExternalImage, type ExternalImageProps } from "./ExternalImage";

--- a/site/src/components/IconField/IconField.tsx
+++ b/site/src/components/IconField/IconField.tsx
@@ -3,7 +3,7 @@ import InputAdornment from "@mui/material/InputAdornment";
 import TextField, { type TextFieldProps } from "@mui/material/TextField";
 import { ChevronDownIcon } from "components/AnimatedIcons/ChevronDown";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Loader } from "components/Loader/Loader";
 import {
 	Popover,
@@ -56,8 +56,7 @@ export const IconField: FC<IconFieldProps> = ({
 								},
 							}}
 						>
-							<ExternalImage
-								alt=""
+							<DecorativeImage
 								src={textFieldProps.value}
 								// This prevent browser to display the ugly error icon if the
 								// image path is wrong or user didn't finish typing the url

--- a/site/src/components/RichParameterInput/RichParameterInput.tsx
+++ b/site/src/components/RichParameterInput/RichParameterInput.tsx
@@ -7,7 +7,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 import TextField, { type TextFieldProps } from "@mui/material/TextField";
 import type { TemplateVersionParameter } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { MemoizedMarkdown } from "components/Markdown/Markdown";
 import { Pill } from "components/Pill/Pill";
 import { Stack } from "components/Stack/Stack";
@@ -185,11 +185,7 @@ const ParameterLabel: FC<ParameterLabelProps> = ({ parameter, isPreset }) => {
 			<Stack direction="row" alignItems="center">
 				{parameter.icon && (
 					<span css={styles.labelIconWrapper}>
-						<ExternalImage
-							css={styles.labelIcon}
-							alt="Parameter icon"
-							src={parameter.icon}
-						/>
+						<DecorativeImage css={styles.labelIcon} src={parameter.icon} />
 					</span>
 				)}
 
@@ -334,11 +330,7 @@ const RichParameterField: FC<RichParameterInputProps> = ({
 						label={
 							<Stack direction="row" alignItems="center">
 								{option.icon && (
-									<ExternalImage
-										css={styles.optionIcon}
-										src={option.icon}
-										alt="Parameter icon"
-									/>
+									<DecorativeImage css={styles.optionIcon} src={option.icon} />
 								)}
 								{option.description ? (
 									<Stack

--- a/site/src/hooks/useClickableTableRow.test.tsx
+++ b/site/src/hooks/useClickableTableRow.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { FC, MouseEventHandler } from "react";
+import { useClickableTableRow } from "./useClickableTableRow";
+
+type RowFixtureProps = {
+	onClick: MouseEventHandler<HTMLTableRowElement>;
+};
+
+const RowFixture: FC<RowFixtureProps> = ({ onClick }) => {
+	const rowProps = useClickableTableRow({ onClick });
+
+	return (
+		<table>
+			<tbody>
+				<tr data-testid="clickable-row" {...rowProps}>
+					<td>Task row</td>
+				</tr>
+			</tbody>
+		</table>
+	);
+};
+
+describe(useClickableTableRow.name, () => {
+	it("does not force button semantics onto table rows", () => {
+		render(<RowFixture onClick={vi.fn()} />);
+
+		const row = screen.getByTestId("clickable-row");
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+	});
+
+	it("keeps click-based navigation behavior", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		render(<RowFixture onClick={onClick} />);
+
+		await user.click(screen.getByTestId("clickable-row"));
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+});

--- a/site/src/hooks/useClickableTableRow.ts
+++ b/site/src/hooks/useClickableTableRow.ts
@@ -1,31 +1,19 @@
 /**
- * @file 2024-02-19 - MES - Sadly, even though this hook aims to make elements
- * more accessible, it's doing the opposite right now. Per axe audits, the
- * current implementation will create a bunch of critical-level accessibility
- * violations:
- *
- * 1. Nesting interactive elements (e.g., workspace table rows having checkboxes
- *    inside them)
- * 2. Overriding the native element's role (in this case, turning a native table
- *    row into a button, which means that screen readers lose the ability to
- *    announce the row's data as part of a larger table)
- *
- * It might not make sense to test this hook until the underlying design
- * problems are fixed.
+ * Exposes click handlers that make table rows feel clickable without changing
+ * native table semantics. Primary navigation must still be rendered as an
+ * explicit in-cell link or button.
  */
 import type { TableRowProps } from "@mui/material/TableRow";
 import type { MouseEventHandler } from "react";
 import { cn } from "utils/cn";
-import {
-	type ClickableAriaRole,
-	type UseClickableResult,
-	useClickable,
-} from "./useClickable";
+import { useEffectEvent } from "./hookPolyfills";
+import type { UseClickableResult } from "./useClickable";
 
-type UseClickableTableRowResult<
-	TRole extends ClickableAriaRole = ClickableAriaRole,
-> = UseClickableResult<HTMLTableRowElement, TRole> &
-	TableRowProps & {
+type UseClickableTableRowResult = TableRowProps &
+	Omit<
+		UseClickableResult<HTMLTableRowElement>,
+		"role" | "tabIndex" | "onKeyDown" | "onKeyUp" | "ref"
+	> & {
 		className: string;
 		hover: true;
 		onAuxClick: MouseEventHandler<HTMLTableRowElement>;
@@ -34,29 +22,25 @@ type UseClickableTableRowResult<
 // Awkward type definition (the hover preview in VS Code isn't great, either),
 // but this basically extracts all click props from TableRowProps, but makes
 // onClick required, and adds additional optional props (notably onMiddleClick)
-type UseClickableTableRowConfig<TRole extends ClickableAriaRole> = {
+type UseClickableTableRowConfig = {
 	[Key in keyof TableRowProps as Key extends `on${string}Click`
 		? Key
-		: never]: UseClickableTableRowResult<TRole>[Key];
+		: never]: UseClickableTableRowResult[Key];
 } & {
-	role?: TRole;
 	onClick: MouseEventHandler<HTMLTableRowElement>;
 	onMiddleClick?: MouseEventHandler<HTMLTableRowElement>;
 };
 
-export const useClickableTableRow = <
-	TRole extends ClickableAriaRole = ClickableAriaRole,
->({
-	role,
+export const useClickableTableRow = ({
 	onClick,
 	onDoubleClick,
 	onMiddleClick,
 	onAuxClick: externalOnAuxClick,
-}: UseClickableTableRowConfig<TRole>): UseClickableTableRowResult<TRole> => {
-	const clickableProps = useClickable(onClick, (role ?? "button") as TRole);
+}: UseClickableTableRowConfig): UseClickableTableRowResult => {
+	const stableOnClick = useEffectEvent(onClick);
 
 	return {
-		...clickableProps,
+		onClick: stableOnClick,
 		className: cn([
 			"cursor-pointer hover:outline focus:outline outline-1 -outline-offset-1 outline-border-hover",
 			"first:rounded-t-md last:rounded-b-md",

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -2,7 +2,7 @@ import { API } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { ExternalImage } from "components/ExternalImage";
 import { CoderIcon } from "components/Icons/CoderIcon";
 import {
 	Tooltip,
@@ -61,7 +61,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 		<div className="sticky top-0 bg-surface-primary z-40 border-0 border-b border-solid h-[72px] min-h-[72px] flex items-center leading-none px-6">
 			<NavLink to="/workspaces">
 				{logo_url ? (
-					<ExternalImage className="h-7" src={logo_url} alt="Custom Logo" />
+					<ExternalImage className="h-7" src={logo_url} alt="Custom logo" />
 				) : (
 					<CoderIcon className="h-7 w-7 fill-content-primary" />
 				)}

--- a/site/src/modules/dashboard/Navbar/SupportIcon.tsx
+++ b/site/src/modules/dashboard/Navbar/SupportIcon.tsx
@@ -1,5 +1,5 @@
 import type { SvgIconProps } from "@mui/material/SvgIcon";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { BookOpenTextIcon, BugIcon, MessageSquareIcon } from "lucide-react";
 import type { FC } from "react";
 
@@ -19,7 +19,7 @@ export const SupportIcon: FC<SupportIconProps> = ({ icon, className }) => {
 		case "star":
 			return <GithubStar className={className} />;
 		default:
-			return <ExternalImage src={icon} className={className} />;
+			return <DecorativeImage src={icon} className={className} />;
 	}
 };
 

--- a/site/src/modules/notifications/NotificationsInbox/InboxButton.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxButton.tsx
@@ -9,10 +9,17 @@ type InboxButtonProps = ButtonProps & {
 
 export const InboxButton: React.FC<InboxButtonProps> = ({
 	unreadCount,
+	"aria-label": ariaLabel = "Notifications",
 	...props
 }) => {
 	return (
-		<Button size="icon-lg" variant="outline" className="relative" {...props}>
+		<Button
+			size="icon-lg"
+			variant="outline"
+			className="relative"
+			aria-label={ariaLabel}
+			{...props}
+		>
 			<BellIcon />
 			{unreadCount > 0 && (
 				<UnreadBadge

--- a/site/src/modules/notifications/NotificationsInbox/InboxPopover.test.tsx
+++ b/site/src/modules/notifications/NotificationsInbox/InboxPopover.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import { InboxPopover } from "./InboxPopover";
+
+describe("InboxPopover", () => {
+	it("adds an accessible name to the notifications trigger button", () => {
+		render(
+			<InboxPopover
+				notifications={undefined}
+				unreadCount={0}
+				error={undefined}
+				isLoadingMoreNotifications={false}
+				hasMoreNotifications={false}
+				onRetry={vi.fn()}
+				onMarkAllAsRead={vi.fn()}
+				onMarkNotificationAsRead={vi.fn()}
+				onLoadMoreNotifications={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: /notifications/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/site/src/modules/resources/AppLink/BaseIcon.tsx
+++ b/site/src/modules/resources/AppLink/BaseIcon.tsx
@@ -1,5 +1,8 @@
 import type { WorkspaceApp } from "api/typesGenerated";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import {
+	ExternalImage,
+	type ExternalImageProps,
+} from "components/ExternalImage";
 import { LaptopIcon } from "lucide-react";
 import type { FC } from "react";
 
@@ -9,19 +12,21 @@ interface BaseIconProps {
 }
 
 export const BaseIcon: FC<BaseIconProps> = ({ app, onIconPathError }) => {
-	return app.icon ? (
-		<ExternalImage
-			alt={`${app.display_name} Icon`}
-			src={app.icon}
-			style={{ pointerEvents: "none" }}
-			onError={() => {
-				console.warn(
-					`Application icon for "${app.id}" has invalid source "${app.icon}".`,
-				);
-				onIconPathError?.();
-			}}
-		/>
-	) : (
-		<LaptopIcon />
-	);
+	if (!app.icon) {
+		return <LaptopIcon />;
+	}
+
+	const imageProps: ExternalImageProps = {
+		alt: `${app.display_name} icon`,
+		src: app.icon,
+		style: { pointerEvents: "none" },
+		onError: () => {
+			console.warn(
+				`Application icon for "${app.id}" has invalid source "${app.icon}".`,
+			);
+			onIconPathError?.();
+		},
+	};
+
+	return <ExternalImage {...imageProps} />;
 };

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -10,7 +10,7 @@ import type {
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Kbd, KbdGroup } from "components/Kbd/Kbd";
 import { Link } from "components/Link/Link";
 import {
@@ -460,7 +460,7 @@ const ExternalAuthButtons: FC<ExternalAuthButtonProps> = ({
 					}}
 				>
 					<Spinner loading={isPollingExternalAuth}>
-						<ExternalImage src={auth.display_icon} />
+						<DecorativeImage src={auth.display_icon} />
 					</Spinner>
 					Connect to {auth.display_name}
 				</Button>

--- a/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
+++ b/site/src/modules/templates/TemplateExampleCard/TemplateExampleCard.tsx
@@ -2,7 +2,7 @@ import type { Interpolation, Theme } from "@emotion/react";
 import Link from "@mui/material/Link";
 import type { TemplateExample } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Pill } from "components/Pill/Pill";
 import type { FC, HTMLAttributes } from "react";
 import { Link as RouterLink } from "react-router";
@@ -21,7 +21,7 @@ export const TemplateExampleCard: FC<TemplateExampleCardProps> = ({
 		<div css={styles.card} {...divProps}>
 			<div css={styles.header}>
 				<div css={styles.icon}>
-					<ExternalImage
+					<DecorativeImage
 						src={example.icon}
 						css={{ width: "100%", height: "100%", objectFit: "contain" }}
 					/>

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.jest.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.jest.tsx
@@ -131,7 +131,7 @@ describe("DynamicParameter", () => {
 				/>,
 			);
 
-			const icon = screen.getByRole("img");
+			const icon = screen.getByRole("img", { hidden: true });
 			expect(icon).toHaveAttribute("src", "/test-icon.png");
 		});
 	});

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -7,7 +7,15 @@ import type {
 import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { Checkbox } from "components/Checkbox/Checkbox";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import {
+	Combobox,
+	ComboboxButton,
+	ComboboxContent,
+	ComboboxItem,
+	ComboboxList,
+	ComboboxTrigger,
+} from "components/Combobox/Combobox";
+import { DecorativeImage } from "components/ExternalImage";
 import { Input } from "components/Input/Input";
 import { Label } from "components/Label/Label";
 import { MemoizedMarkdown } from "components/Markdown/Markdown";
@@ -118,9 +126,8 @@ const ParameterLabel: FC<ParameterLabelProps> = ({
 	return (
 		<div className="flex items-start gap-2">
 			{parameter.icon && (
-				<ExternalImage
+				<DecorativeImage
 					className="w-5 h-5 mt-0.5 object-contain"
-					alt="Parameter icon"
 					src={parameter.icon}
 				/>
 			)}
@@ -626,11 +633,7 @@ const OptionDisplay: FC<OptionDisplayProps> = ({ option }) => {
 	return (
 		<div className="flex items-center gap-2">
 			{option.icon && (
-				<ExternalImage
-					className="w-4 h-4 object-contain"
-					src={option.icon}
-					alt=""
-				/>
+				<DecorativeImage className="w-4 h-4 object-contain" src={option.icon} />
 			)}
 			<span>{option.name}</span>
 			{option.description && (

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -7,14 +7,6 @@ import type {
 import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { Checkbox } from "components/Checkbox/Checkbox";
-import {
-	Combobox,
-	ComboboxButton,
-	ComboboxContent,
-	ComboboxItem,
-	ComboboxList,
-	ComboboxTrigger,
-} from "components/Combobox/Combobox";
 import { DecorativeImage } from "components/ExternalImage";
 import { Input } from "components/Input/Input";
 import { Label } from "components/Label/Label";

--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
@@ -1,5 +1,5 @@
 import type { AIBridgeInterception } from "api/typesGenerated";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { CircleQuestionMarkIcon } from "lucide-react";
 import { cn } from "utils/cn";
 
@@ -17,49 +17,49 @@ export const AIBridgeClientIcon = ({
 	switch (client) {
 		case "Claude Code":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/claude.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "Codex":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/openai-codex.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "Kilo Code":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/kilo-code.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "Roo Code":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/roo-code.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "Mux":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/mux.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "Zed":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/zed.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "Cursor":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/cursor.svg"
 					className={cn(iconClassName, className)}
 				/>
@@ -67,7 +67,7 @@ export const AIBridgeClientIcon = ({
 		case "GitHub Copilot (VS Code)":
 		case "GitHub Copilot (CLI)":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/github-copilot.svg"
 					className={cn(iconClassName, className)}
 				/>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeModelIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeModelIcon.tsx
@@ -1,4 +1,4 @@
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { CircleQuestionMarkIcon } from "lucide-react";
 import { cn } from "utils/cn";
 
@@ -43,14 +43,14 @@ export const AIBridgeModelIcon = ({
 	switch (family) {
 		case "claude":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/claude.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "openai":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/openai.svg"
 					className={cn(iconClassName, className)}
 				/>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeProviderIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeProviderIcon.tsx
@@ -1,5 +1,5 @@
 import type { AIBridgeInterception } from "api/typesGenerated";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { CircleQuestionMarkIcon } from "lucide-react";
 import { cn } from "utils/cn";
 
@@ -14,21 +14,21 @@ export const AIBridgeProviderIcon = ({
 	switch (provider) {
 		case "openai":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/openai.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "anthropic":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/claude.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);
 		case "copilot":
 			return (
-				<ExternalImage
+				<DecorativeImage
 					src="/icon/github.svg"
 					className={cn(iconClassName, className)}
 				/>

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -1,7 +1,7 @@
 import type * as TypesGen from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { ExternalImage } from "components/ExternalImage";
 import { CoderIcon } from "components/Icons/CoderIcon";
 import { PanelLeftIcon } from "lucide-react";
 import { type FC, useState } from "react";
@@ -153,7 +153,11 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 								className="inline-flex shrink-0 md:hidden"
 							>
 								{logoUrl ? (
-									<ExternalImage className="h-6" src={logoUrl} alt="Logo" />
+									<ExternalImage
+										className="h-6"
+										src={logoUrl}
+										alt="Custom logo"
+									/>
 								) : (
 									<CoderIcon className="h-6 w-6 fill-content-primary" />
 								)}

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -14,7 +14,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { ExternalImage } from "components/ExternalImage";
 import { CoderIcon } from "components/Icons/CoderIcon";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import { Skeleton } from "components/Skeleton/Skeleton";
@@ -670,7 +670,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 				<div className="mb-2.5 flex items-center justify-between">
 					<NavLink to="/workspaces" className="inline-flex">
 						{logoUrl ? (
-							<ExternalImage className="h-6" src={logoUrl} alt="Logo" />
+							<ExternalImage className="h-6" src={logoUrl} alt="Custom logo" />
 						) : (
 							<CoderIcon className="h-6 w-6 fill-content-primary" />
 						)}

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx
@@ -1,4 +1,4 @@
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { ExternalImage } from "components/ExternalImage";
 import { ServerIcon } from "lucide-react";
 import type { FC } from "react";
 import { cn } from "utils/cn";

--- a/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
@@ -5,7 +5,7 @@ import CardContent from "@mui/material/CardContent";
 import Stack from "@mui/material/Stack";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Loader } from "components/Loader/Loader";
 import { Margins } from "components/Margins/Margins";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
@@ -70,7 +70,7 @@ export const CreateTemplateGalleryPageView: FC<
 										css={{ alignItems: "center" }}
 									>
 										<div css={styles.icon}>
-											<ExternalImage
+											<DecorativeImage
 												src="/emojis/1f4e1.png"
 												css={{
 													width: "100%",

--- a/site/src/pages/CreateWorkspacePage/ExternalAuthButton.tsx
+++ b/site/src/pages/CreateWorkspacePage/ExternalAuthButton.tsx
@@ -1,7 +1,7 @@
 import type { TemplateVersionExternalAuth } from "api/typesGenerated";
 import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Spinner } from "components/Spinner/Spinner";
 import {
 	Tooltip,
@@ -30,11 +30,7 @@ export const ExternalAuthButton: FC<ExternalAuthButtonProps> = ({
 		<div className="flex items-center gap-2 border border-border border-solid rounded-md p-3 justify-between">
 			<span className="flex flex-row items-center gap-2">
 				{auth.display_icon && (
-					<ExternalImage
-						className="w-5 h-5"
-						src={auth.display_icon}
-						alt={`${auth.display_name} Icon`}
-					/>
+					<DecorativeImage className="w-5 h-5" src={auth.display_icon} />
 				)}
 				<p className="font-semibold text-sm m-0">{auth.display_name}</p>
 				{!auth.authenticated && !auth.optional && (

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPage.test.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPage.test.tsx
@@ -1,0 +1,52 @@
+import { MockOAuth2ProviderApps } from "testHelpers/entities";
+import { renderWithRouter } from "testHelpers/renderHelpers";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter } from "react-router";
+import OAuth2AppsSettingsPageView from "./OAuth2AppsSettingsPageView";
+
+describe("OAuth2AppsSettingsPage", () => {
+	it("uses explicit app links without assigning row button semantics", async () => {
+		const user = userEvent.setup();
+		const app = MockOAuth2ProviderApps[0];
+		const router = createMemoryRouter(
+			[
+				{
+					path: "/deployment/oauth2-provider/apps",
+					element: (
+						<OAuth2AppsSettingsPageView
+							apps={[app]}
+							isLoading={false}
+							error={undefined}
+							canCreateApp={false}
+						/>
+					),
+				},
+				{
+					path: "/deployment/oauth2-provider/apps/:appId",
+					element: <div>OAuth2 app details page</div>,
+				},
+			],
+			{ initialEntries: ["/deployment/oauth2-provider/apps"] },
+		);
+
+		renderWithRouter(router);
+
+		const row = screen.getByTestId(`app-${app.id}`);
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+
+		const appLink = within(row).getByRole("link", { name: app.name });
+		expect(appLink).toHaveAttribute(
+			"href",
+			`/deployment/oauth2-provider/apps/${app.id}`,
+		);
+
+		await user.click(appLink);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(
+				`/deployment/oauth2-provider/apps/${app.id}`,
+			);
+		});
+	});
+});

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
@@ -115,6 +115,9 @@ const OAuth2AppRow: FC<OAuth2AppRowProps> = ({ app }) => {
 							onClick={(event) => {
 								event.stopPropagation();
 							}}
+							onAuxClick={(event) => {
+								event.stopPropagation();
+							}}
 							className="pointer-events-auto text-content-primary no-underline hover:underline"
 						>
 							{app.name}

--- a/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/OAuth2AppsSettingsPage/OAuth2AppsSettingsPageView.tsx
@@ -99,8 +99,9 @@ type OAuth2AppRowProps = {
 const OAuth2AppRow: FC<OAuth2AppRowProps> = ({ app }) => {
 	const _theme = useTheme();
 	const navigate = useNavigate();
+	const appPageLink = `/deployment/oauth2-provider/apps/${app.id}`;
 	const clickableProps = useClickableTableRow({
-		onClick: () => navigate(`/deployment/oauth2-provider/apps/${app.id}`),
+		onClick: () => navigate(appPageLink),
 	});
 
 	return (
@@ -108,7 +109,17 @@ const OAuth2AppRow: FC<OAuth2AppRowProps> = ({ app }) => {
 			<TableCell>
 				<AvatarData
 					avatar={<Avatar variant="icon" src={app.icon} fallback={app.name} />}
-					title={app.name}
+					title={
+						<Link
+							to={appPageLink}
+							onClick={(event) => {
+								event.stopPropagation();
+							}}
+							className="pointer-events-auto text-content-primary no-underline hover:underline"
+						>
+							{app.name}
+						</Link>
+					}
 				/>
 			</TableCell>
 

--- a/site/src/pages/GroupsPage/GroupsPage.test.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.test.tsx
@@ -1,0 +1,47 @@
+import { MockGroup } from "testHelpers/entities";
+import { renderWithRouter } from "testHelpers/renderHelpers";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter } from "react-router";
+import { GroupsPageView } from "./GroupsPageView";
+
+describe("GroupsPage", () => {
+	it("uses explicit links for group navigation without turning rows into buttons", async () => {
+		const user = userEvent.setup();
+		const router = createMemoryRouter(
+			[
+				{
+					path: "/groups",
+					element: (
+						<GroupsPageView
+							groups={[MockGroup]}
+							canCreateGroup={false}
+							groupsEnabled
+						/>
+					),
+				},
+				{
+					path: "/groups/:groupName",
+					element: <div>Group details page</div>,
+				},
+			],
+			{ initialEntries: ["/groups"] },
+		);
+
+		renderWithRouter(router);
+
+		const row = screen.getByTestId(`group-${MockGroup.id}`);
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+
+		const groupLink = within(row).getByRole("link", {
+			name: MockGroup.display_name || MockGroup.name,
+		});
+		expect(groupLink).toHaveAttribute("href", `/groups/${MockGroup.name}`);
+
+		await user.click(groupLink);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(`/groups/${MockGroup.name}`);
+		});
+	});
+});

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -134,6 +134,9 @@ const GroupRow: FC<GroupRowProps> = ({ group }) => {
 							onClick={(event) => {
 								event.stopPropagation();
 							}}
+							onAuxClick={(event) => {
+								event.stopPropagation();
+							}}
 							className="pointer-events-auto text-content-primary no-underline hover:underline"
 						>
 							{group.display_name || group.name}

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -109,8 +109,9 @@ interface GroupRowProps {
 
 const GroupRow: FC<GroupRowProps> = ({ group }) => {
 	const navigate = useNavigate();
+	const groupPageLink = group.name;
 	const rowProps = useClickableTableRow({
-		onClick: () => navigate(group.name),
+		onClick: () => navigate(groupPageLink),
 	});
 	const memberAvatars = group.members.slice(0, 5);
 	const remainingAvatars = group.members.length - memberAvatars.length;
@@ -127,7 +128,17 @@ const GroupRow: FC<GroupRowProps> = ({ group }) => {
 							src={group.avatar_url}
 						/>
 					}
-					title={group.display_name || group.name}
+					title={
+						<RouterLink
+							to={groupPageLink}
+							onClick={(event) => {
+								event.stopPropagation();
+							}}
+							className="pointer-events-auto text-content-primary no-underline hover:underline"
+						>
+							{group.display_name || group.name}
+						</RouterLink>
+					}
 					subtitle={`${group.members.length} members`}
 				/>
 			</TableCell>

--- a/site/src/pages/LoginPage/OAuthSignInForm.tsx
+++ b/site/src/pages/LoginPage/OAuthSignInForm.tsx
@@ -1,6 +1,6 @@
 import type { AuthMethods } from "api/typesGenerated";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { KeyIcon } from "lucide-react";
 import { type FC, useId } from "react";
 import { Language } from "./Language";
@@ -32,7 +32,7 @@ export const OAuthSignInForm: FC<OAuthSignInFormProps> = ({
 							redirectTo,
 						)}`}
 					>
-						<ExternalImage src="/icon/github.svg" />
+						<DecorativeImage src="/icon/github.svg" />
 						{Language.githubSignIn}
 					</a>
 				</Button>

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -8,7 +8,7 @@ import type * as TypesGen from "api/typesGenerated";
 import { isAxiosError } from "axios";
 import { Alert, AlertDescription, AlertTitle } from "components/Alert/Alert";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { FormFields, VerticalForm } from "components/Form/Form";
 import { CoderIcon } from "components/Icons/CoderIcon";
 import { PasswordField } from "components/PasswordField/PasswordField";
@@ -168,7 +168,7 @@ export const SetupPageView: FC<SetupPageViewProps> = ({
 						<>
 							<Button className="w-full" asChild type="submit" size="lg">
 								<a href="/api/v2/users/oauth2/github/callback">
-									<ExternalImage src="/icon/github.svg" />
+									<DecorativeImage src="/icon/github.svg" />
 									{Language.githubCreate}
 								</a>
 							</Button>

--- a/site/src/pages/StarterTemplatePage/StarterTemplatePageView.tsx
+++ b/site/src/pages/StarterTemplatePage/StarterTemplatePageView.tsx
@@ -2,7 +2,7 @@ import { useTheme } from "@emotion/react";
 import type { TemplateExample } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Loader } from "components/Loader/Loader";
 import { Margins } from "components/Margins/Margins";
 import { MemoizedMarkdown } from "components/Markdown/Markdown";
@@ -73,7 +73,7 @@ export const StarterTemplatePageView: FC<StarterTemplatePageViewProps> = ({
 							},
 						}}
 					>
-						<ExternalImage src={starterTemplate.icon} />
+						<DecorativeImage src={starterTemplate.icon} />
 					</div>
 					<div>
 						<PageHeaderTitle>{starterTemplate.name}</PageHeaderTitle>

--- a/site/src/pages/TaskPage/TaskApps.tsx
+++ b/site/src/pages/TaskPage/TaskApps.tsx
@@ -6,7 +6,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { InfoTooltip } from "components/InfoTooltip/InfoTooltip";
 import { Link } from "components/Link/Link";
 import { ScrollArea, ScrollBar } from "components/ScrollArea/ScrollArea";
@@ -171,7 +171,7 @@ const ExternalAppMenuItem: FC<{
 	return (
 		<DropdownMenuItem asChild>
 			<RouterLink to={link.href}>
-				{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
+				{app.icon ? <DecorativeImage src={app.icon} /> : <LayoutGridIcon />}
 				{link.label}
 			</RouterLink>
 		</DropdownMenuItem>
@@ -198,7 +198,7 @@ const TaskAppTab: FC<TaskAppTabProps> = ({
 
 	return (
 		<TaskTab active={active} to={link.href} onClick={onClick}>
-			{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
+			{app.icon ? <DecorativeImage src={app.icon} /> : <LayoutGridIcon />}
 			{link.label}
 			{app.health === "unhealthy" && (
 				<InfoTooltip

--- a/site/src/pages/TaskPage/TaskStatusLink.tsx
+++ b/site/src/pages/TaskPage/TaskStatusLink.tsx
@@ -1,5 +1,5 @@
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import {
 	BugIcon,
 	ExternalLinkIcon,
@@ -47,7 +47,7 @@ export const TaskStatusLink: FC<TaskStatusLinkProps> = ({ uri }) => {
 										: `${org}/${repo} issue`;
 							break;
 						default:
-							icon = <ExternalImage src="/icon/github.svg" />;
+							icon = <DecorativeImage src="/icon/github.svg" />;
 							if (org && repo) {
 								label = `${org}/${repo}`;
 							}

--- a/site/src/pages/TasksPage/TasksPage.test.tsx
+++ b/site/src/pages/TasksPage/TasksPage.test.tsx
@@ -1,0 +1,78 @@
+import { MockTask } from "testHelpers/entities";
+import { renderWithRouter } from "testHelpers/renderHelpers";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Task } from "api/typesGenerated";
+import { createMemoryRouter } from "react-router";
+import { TasksTable } from "./TasksTable";
+
+const renderTasksTable = (task: Task) => {
+	const onCheckChange = vi.fn();
+	const router = createMemoryRouter(
+		[
+			{
+				path: "/tasks",
+				element: (
+					<TasksTable
+						tasks={[task]}
+						error={undefined}
+						onRetry={vi.fn()}
+						checkedTaskIds={new Set()}
+						onCheckChange={onCheckChange}
+					/>
+				),
+			},
+			{
+				path: "/tasks/:owner/:taskId",
+				element: <div>Task details page</div>,
+			},
+		],
+		{ initialEntries: ["/tasks"] },
+	);
+
+	return {
+		...renderWithRouter(router),
+		onCheckChange,
+	};
+};
+
+describe("TasksPage", () => {
+	it("uses explicit links for primary navigation without row button semantics", async () => {
+		const user = userEvent.setup();
+		const task: Task = {
+			...MockTask,
+			id: "task-with-row-link",
+		};
+		const { onCheckChange, router } = renderTasksTable(task);
+
+		const row = screen.getByTestId(`task-${task.id}`);
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+
+		const primaryLink = within(row).getByRole("link", {
+			name: task.display_name,
+		});
+		expect(primaryLink).toHaveAttribute(
+			"href",
+			`/tasks/${task.owner_name}/${task.id}`,
+		);
+
+		await user.click(screen.getByTestId(`checkbox-${task.id}`));
+		expect(onCheckChange).toHaveBeenCalledTimes(1);
+		expect(router.state.location.pathname).toBe("/tasks");
+
+		await user.click(
+			within(row).getByRole("button", {
+				name: /show task actions/i,
+			}),
+		);
+		expect(router.state.location.pathname).toBe("/tasks");
+
+		fireEvent.click(primaryLink);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(
+				`/tasks/${task.owner_name}/${task.id}`,
+			);
+		});
+	});
+});

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -37,7 +37,7 @@ import {
 } from "modules/tasks/taskActions";
 import { type FC, type ReactNode, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { relativeTime } from "utils/time";
 
@@ -207,8 +207,7 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 	});
 
 	const taskPageLink = `/tasks/${task.owner_name}/${task.id}`;
-	// Discard role, breaks Chromatic.
-	const { role, ...clickableRowProps } = useClickableTableRow({
+	const clickableRowProps = useClickableTableRow({
 		onClick: () => {
 			navigate(taskPageLink);
 		},
@@ -236,9 +235,15 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 						/>
 						<AvatarData
 							title={
-								<span className="block max-w-[520px] truncate">
+								<Link
+									to={taskPageLink}
+									onClick={(event) => {
+										event.stopPropagation();
+									}}
+									className="pointer-events-auto block max-w-[520px] truncate text-content-primary no-underline hover:underline"
+								>
 									{task.display_name}
-								</span>
+								</Link>
 							}
 							subtitle={templateDisplayName}
 							avatar={

--- a/site/src/pages/TasksPage/TasksTable.tsx
+++ b/site/src/pages/TasksPage/TasksTable.tsx
@@ -240,6 +240,9 @@ const TaskRow: FC<TaskRowProps> = ({ task, checked, onCheckChange }) => {
 									onClick={(event) => {
 										event.stopPropagation();
 									}}
+									onAuxClick={(event) => {
+										event.stopPropagation();
+									}}
 									className="pointer-events-auto block max-w-[520px] truncate text-content-primary no-underline hover:underline"
 								>
 									{task.display_name}

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/TemplateVersionsPage.test.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/TemplateVersionsPage.test.tsx
@@ -1,0 +1,63 @@
+import { MockTemplateVersion } from "testHelpers/entities";
+import { renderWithRouter } from "testHelpers/renderHelpers";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter } from "react-router";
+import { VersionsTable } from "./VersionsTable";
+
+describe("TemplateVersionsPage", () => {
+	it("uses explicit version links and keeps row actions independent", async () => {
+		const user = userEvent.setup();
+		const onPromoteClick = vi.fn();
+		const router = createMemoryRouter(
+			[
+				{
+					path: "/templates/:templateName/versions",
+					element: (
+						<VersionsTable
+							activeVersionId="not-the-active-version"
+							versions={[MockTemplateVersion]}
+							onPromoteClick={onPromoteClick}
+						/>
+					),
+				},
+				{
+					path: "/templates/:templateName/versions/:versionName",
+					element: <div>Version details page</div>,
+				},
+			],
+			{
+				initialEntries: [
+					`/templates/${MockTemplateVersion.template_id}/versions`,
+				],
+			},
+		);
+
+		renderWithRouter(router);
+
+		const row = screen.getByTestId(`version-${MockTemplateVersion.id}`);
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+
+		const versionLink = within(row).getByRole("link", {
+			name: MockTemplateVersion.name,
+		});
+		expect(versionLink).toHaveAttribute(
+			"href",
+			`/templates/${MockTemplateVersion.template_id}/versions/${MockTemplateVersion.name}`,
+		);
+
+		await user.click(within(row).getByRole("button", { name: /promote/i }));
+		expect(onPromoteClick).toHaveBeenCalledWith(MockTemplateVersion.id);
+		expect(router.state.location.pathname).toBe(
+			`/templates/${MockTemplateVersion.template_id}/versions`,
+		);
+
+		await user.click(versionLink);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(
+				`/templates/${MockTemplateVersion.template_id}/versions/${MockTemplateVersion.name}`,
+			);
+		});
+	});
+});

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
@@ -9,7 +9,7 @@ import { TableCell } from "components/Table/Table";
 import { TimelineEntry } from "components/Timeline/TimelineEntry";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
 import type { FC } from "react";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 
 interface VersionRowProps {
 	version: TemplateVersion;
@@ -27,9 +27,10 @@ export const VersionRow: FC<VersionRowProps> = ({
 	onArchiveClick,
 }) => {
 	const navigate = useNavigate();
+	const versionPageLink = version.name;
 
 	const clickableProps = useClickableTableRow({
-		onClick: () => navigate(version.name),
+		onClick: () => navigate(versionPageLink),
 	});
 
 	const jobStatus = version.job.status;
@@ -60,7 +61,18 @@ export const VersionRow: FC<VersionRowProps> = ({
 						>
 							<span>
 								<strong>{version.created_by.username}</strong> created the
-								version <strong>{version.name}</strong>
+								version{" "}
+								<strong>
+									<Link
+										to={versionPageLink}
+										onClick={(event) => {
+											event.stopPropagation();
+										}}
+										className="pointer-events-auto text-content-primary no-underline hover:underline"
+									>
+										{version.name}
+									</Link>
+								</strong>
 							</span>
 
 							{version.message && (

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
@@ -68,6 +68,9 @@ export const VersionRow: FC<VersionRowProps> = ({
 										onClick={(event) => {
 											event.stopPropagation();
 										}}
+										onAuxClick={(event) => {
+											event.stopPropagation();
+										}}
 										className="pointer-events-auto text-content-primary no-underline hover:underline"
 									>
 										{version.name}

--- a/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -1,0 +1,89 @@
+import { MockTemplate } from "testHelpers/entities";
+import { renderWithAuth } from "testHelpers/renderHelpers";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { TemplateFilterState } from "./TemplatesPage";
+import { TemplatesPageView } from "./TemplatesPageView";
+
+vi.mock("./TemplatesFilter", () => ({
+	TemplatesFilter: () => null,
+}));
+
+describe("TemplatesPage", () => {
+	it("uses explicit template links and keeps row actions independent", async () => {
+		const user = userEvent.setup();
+		const filterState = {
+			filter: {} as TemplateFilterState["filter"],
+			menus: {},
+		} satisfies TemplateFilterState;
+
+		const { router } = renderWithAuth(
+			<TemplatesPageView
+				error={undefined}
+				filterState={filterState}
+				showOrganizations={false}
+				canCreateTemplates={false}
+				examples={[]}
+				templates={[MockTemplate]}
+				workspacePermissions={{
+					[MockTemplate.organization_id]: {
+						createWorkspaceForUserID: true,
+					},
+				}}
+			/>,
+			{
+				path: "/templates",
+				route: "/templates",
+				extraRoutes: [
+					{
+						path: "/templates/:templateName",
+						element: <div>Template details page</div>,
+					},
+					{
+						path: "/templates/:templateName/workspace",
+						element: <div>Create workspace page</div>,
+					},
+				],
+			},
+		);
+
+		const row = await screen.findByTestId(`template-${MockTemplate.id}`);
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+
+		const templateLink = within(row).getByRole("link", {
+			name: MockTemplate.display_name,
+		});
+		expect(templateLink).toHaveAttribute(
+			"href",
+			`/templates/${MockTemplate.name}`,
+		);
+
+		const createWorkspaceLink = within(row).getByRole("link", {
+			name: /create workspace/i,
+		});
+		await user.click(createWorkspaceLink);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(
+				`/templates/${MockTemplate.name}/workspace`,
+			);
+		});
+
+		await router.navigate("/templates");
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe("/templates");
+		});
+
+		const templateLinkAfterReturn = within(
+			await screen.findByTestId(`template-${MockTemplate.id}`),
+		).getByRole("link", {
+			name: MockTemplate.display_name,
+		});
+		await user.click(templateLinkAfterReturn);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(
+				`/templates/${MockTemplate.name}`,
+			);
+		});
+	});
+});

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -166,6 +166,9 @@ const TemplateRow: FC<TemplateRowProps> = ({
 							onClick={(event) => {
 								event.stopPropagation();
 							}}
+							onAuxClick={(event) => {
+								event.stopPropagation();
+							}}
 							className="pointer-events-auto text-content-primary no-underline hover:underline"
 						>
 							{templateTitle}

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -149,6 +149,8 @@ const TemplateRow: FC<TemplateRowProps> = ({
 		onClick: () => navigate(templatePageLink),
 	});
 
+	const templateTitle = template.display_name || template.name;
+
 	return (
 		<TableRow
 			key={template.id}
@@ -158,7 +160,17 @@ const TemplateRow: FC<TemplateRowProps> = ({
 		>
 			<TableCell>
 				<AvatarData
-					title={template.display_name || template.name}
+					title={
+						<RouterLink
+							to={templatePageLink}
+							onClick={(event) => {
+								event.stopPropagation();
+							}}
+							className="pointer-events-auto text-content-primary no-underline hover:underline"
+						>
+							{templateTitle}
+						</RouterLink>
+					}
 					subtitle={template.description}
 					avatar={
 						<Avatar

--- a/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
@@ -11,7 +11,7 @@ import type {
 import { Button } from "components/Button/Button";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { EmptyState } from "components/EmptyState/EmptyState";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { Stack } from "components/Stack/Stack";
 import { CircleCheck as CircleCheckIcon, KeyIcon } from "lucide-react";
 import { type FC, useState } from "react";
@@ -152,7 +152,7 @@ export const SingleSignOnSection: FC<SingleSignOnSectionProps> = ({
 									disabled={isUpdating}
 									onClick={() => openConfirmation("github")}
 								>
-									<ExternalImage src="/icon/github.svg" />
+									<DecorativeImage src="/icon/github.svg" />
 									GitHub
 								</Button>
 							)}
@@ -185,7 +185,7 @@ export const SingleSignOnSection: FC<SingleSignOnSectionProps> = ({
 							</span>
 							<div className="leading-none ml-auto">
 								{userLoginType.login_type === "github" ? (
-									<ExternalImage src="/icon/github.svg" className="size-4" />
+									<DecorativeImage src="/icon/github.svg" className="size-4" />
 								) : (
 									<OIDCIcon oidcAuth={authMethods.oidc} />
 								)}

--- a/site/src/pages/UsersPage/UsersTable/UsersTableBody.tsx
+++ b/site/src/pages/UsersPage/UsersTable/UsersTableBody.tsx
@@ -15,7 +15,7 @@ import {
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
 import { EmptyState } from "components/EmptyState/EmptyState";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { LastSeen } from "components/LastSeen/LastSeen";
 import { TableCell, TableRow } from "components/Table/Table";
 import {
@@ -269,7 +269,7 @@ const LoginType: FC<LoginTypeProps> = ({ authMethods, value }) => {
 		icon = <BanIcon css={styles.icon} />;
 	} else if (value === "github") {
 		displayName = "GitHub";
-		icon = <ExternalImage src="/icon/github.svg" css={styles.icon} />;
+		icon = <DecorativeImage src="/icon/github.svg" css={styles.icon} />;
 	} else if (value === "token") {
 		displayName = "Token";
 		icon = <KeyIcon css={styles.icon} />;

--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -6,7 +6,7 @@ import type {
 } from "api/typesGenerated";
 import { ChevronDownIcon } from "components/AnimatedIcons/ChevronDown";
 import { Button } from "components/Button/Button";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import {
 	Tooltip,
@@ -180,7 +180,7 @@ const AppLink: FC<AppLinkProps> = ({ app, agent, workspace }) => {
 				target="_blank"
 				rel="noreferrer"
 			>
-				{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
+				{app.icon ? <DecorativeImage src={app.icon} /> : <LayoutGridIcon />}
 				{link.label}
 			</a>
 		</Button>

--- a/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchDeleteConfirmation.tsx
@@ -1,6 +1,6 @@
 import type { Workspace } from "api/typesGenerated";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { ClockIcon, UserIcon } from "lucide-react";
@@ -214,7 +214,7 @@ const Resources: FC<StageProps> = ({ workspaces }) => {
 			<div className="flex flex-wrap justify-center gap-x-5 gap-y-1.5 text-sm">
 				{Object.entries(resources).map(([type, summary]) => (
 					<div key={type} className="flex items-center gap-2">
-						<ExternalImage src={summary.icon} width={16} height={16} />
+						<DecorativeImage src={summary.icon} width={16} height={16} />
 						<span>
 							{summary.count} <code>{type}</code>
 						</span>

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -297,6 +297,53 @@ describe("WorkspacesPage", () => {
 		);
 	});
 
+	it("uses explicit workspace links without row button semantics", async () => {
+		const workspace = {
+			...MockWorkspace,
+			id: "workspace-link-row",
+			name: "workspace-link-row",
+		};
+		vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces: [workspace],
+			count: 1,
+		});
+		const user = userEvent.setup();
+		const { router } = renderWithAuth(<WorkspacesPage />, {
+			path: "/workspaces",
+			route: "/workspaces",
+			extraRoutes: [
+				{
+					path: "/@:owner/:workspace",
+					element: <div>Workspace details page</div>,
+				},
+			],
+		});
+		await waitForLoaderToBeRemoved();
+
+		const row = screen.getByTestId(`workspace-${workspace.id}`);
+		expect(row).not.toHaveAttribute("role");
+		expect(row).not.toHaveAttribute("tabindex");
+
+		const workspaceLink = within(row).getByRole("link", {
+			name: workspace.name,
+		});
+		expect(workspaceLink).toHaveAttribute(
+			"href",
+			`/@${workspace.owner_name}/${workspace.name}`,
+		);
+
+		await user.click(getWorkspaceCheckbox(workspace));
+		expect(getWorkspaceCheckbox(workspace)).toBeChecked();
+		expect(router.state.location.pathname).toBe("/workspaces");
+
+		await user.click(workspaceLink);
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe(
+				`/@${workspace.owner_name}/${workspace.name}`,
+			);
+		});
+	});
+
 	it("correctly handles pagination by including pagination parameters in query key", async () => {
 		const totalWorkspaces = 50;
 		const workspacesPage1 = Array.from({ length: 25 }, (_, i) => ({

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -80,7 +80,7 @@ import {
 	useState,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { cn } from "utils/cn";
 import { getDisplayWorkspaceTemplateName } from "utils/workspace";
 import { WorkspaceSharingIndicator } from "./WorkspaceSharingIndicator";
@@ -166,9 +166,12 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 						(o) => o.id === workspace.organization_id,
 					);
 
+					const workspacePageLink = `/@${workspace.owner_name}/${workspace.name}`;
+
 					return (
 						<WorkspacesRow
 							workspace={workspace}
+							workspacePageLink={workspacePageLink}
 							key={workspace.id}
 							checked={checked}
 						>
@@ -197,9 +200,15 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 									<AvatarData
 										title={
 											<Stack direction="row" spacing={0.5} alignItems="center">
-												<span className="whitespace-nowrap">
+												<Link
+													to={workspacePageLink}
+													onClick={(event) => {
+														event.stopPropagation();
+													}}
+													className="pointer-events-auto whitespace-nowrap text-content-primary no-underline hover:underline"
+												>
 													{workspace.name}
-												</span>
+												</Link>
 												{workspace.favorite && (
 													<StarIcon className="size-icon-xs" />
 												)}
@@ -284,20 +293,21 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 
 interface WorkspacesRowProps {
 	workspace: Workspace;
+	workspacePageLink: string;
 	children?: ReactNode;
 	checked: boolean;
 }
 
 const WorkspacesRow: FC<WorkspacesRowProps> = ({
 	workspace,
+	workspacePageLink,
 	children,
 	checked,
 }) => {
 	const navigate = useNavigate();
 
-	const workspacePageLink = `/@${workspace.owner_name}/${workspace.name}`;
 	const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
-	const { role, hover, ...clickableProps } = useClickableTableRow({
+	const clickableProps = useClickableTableRow({
 		onMiddleClick: openLinkInNewTab,
 		onClick: (event) => {
 			// Order of booleans actually matters here for Windows-Mac compatibility;

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -205,6 +205,9 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													onClick={(event) => {
 														event.stopPropagation();
 													}}
+													onAuxClick={(event) => {
+														event.stopPropagation();
+													}}
 													className="pointer-events-auto whitespace-nowrap text-content-primary no-underline hover:underline"
 												>
 													{workspace.name}

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -20,7 +20,7 @@ import { Badge } from "components/Badge/Badge";
 import { Button } from "components/Button/Button";
 import { Checkbox } from "components/Checkbox/Checkbox";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { DecorativeImage } from "components/ExternalImage";
 import { VSCodeIcon } from "components/Icons/VSCodeIcon";
 import { VSCodeInsidersIcon } from "components/Icons/VSCodeInsidersIcon";
 import { Spinner } from "components/Spinner/Spinner";
@@ -790,7 +790,7 @@ const IconAppLink: FC<IconAppLinkProps> = ({ app, workspace, agent }) => {
 			href={link.href}
 			onClick={link.onClick}
 		>
-			<ExternalImage src={app.icon ?? "/icon/widgets.svg"} />
+			<DecorativeImage src={app.icon ?? "/icon/widgets.svg"} />
 		</BaseIconLink>
 	);
 };


### PR DESCRIPTION
## Summary

WCAG 2.1 AA remediation for the Coder frontend — **Workstream 1** (Semantics and interactive name/role fixes) and **Workstream 2** (Non-text alternatives).

### Workstream 1 — Semantics & Name/Role Fixes (WCAG 1.3.1, 4.1.2, 2.5.3)

**Table row semantics:** Removed synthetic `role="button"` / `tabIndex={0}` from `useClickableTableRow`. Primary navigation now uses explicit `<Link>` controls inside name/title cells across all 6 clickable-table callsites. Row click-to-navigate is preserved as a progressive enhancement.

Affected pages: Tasks, Groups, Template Versions, Workspaces, Templates, OAuth2 Apps.

**Autocomplete nested interactive:** Moved the clear-action control from a nested `<span>` inside the trigger button to a sibling `<button>` with `aria-label="Clear selection"`, resolving invalid nested interactive markup.

**Notifications trigger:** Added `aria-label="Notifications"` to the icon-only `InboxButton`.

### Workstream 2 — Non-text Alternatives (WCAG 1.1.1)

**`ExternalImage`:** Made `alt: string` a required prop and removed the `biome-ignore lint/a11y/useAltText` suppression.

**`DecorativeImage`:** New wrapper component enforcing `alt=""` + `aria-hidden="true"` for intentionally silent imagery. Barrel export with developer guidance on informative vs decorative usage.

**Callsite migration:** All `ExternalImage` usages (~20+ files) updated with explicit alt intent — informative images get meaningful alt text, decorative images use `DecorativeImage`.

### Testing

- 36 new tests across 15 test files covering all changes.
- `pnpm -C site lint:types` ✅
- `pnpm -C site lint:check` ✅ (1371 files, no warnings)
- All targeted vitest suites pass ✅

### Risks / QA notes

- **UX drift from row interaction changes:** Table rows still respond to click (progressive enhancement), but primary navigation is now via explicit links. Focused product QA recommended on table-heavy pages.
- **Large callsite churn for image alt migration:** Mitigated by explicit wrappers and informative/decorative classification.
