### PR TITLE
chore(dogfood): bump mux to 1.4.3

### DIFF
--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -71,7 +71,7 @@ resource "coder_agent" "main" {
 
 module "mux" {
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.4.3"
+  version  = "~> 1.0" # See the module page for the latest version.
   agent_id = coder_agent.main.id
 }
 ```

--- a/docs/ai-coder/ai-bridge/clients/mux.md
+++ b/docs/ai-coder/ai-bridge/clients/mux.md
@@ -71,7 +71,7 @@ resource "coder_agent" "main" {
 
 module "mux" {
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "~> 1.0" # See the module page for the latest version.
+  version  = "1.4.3"
   agent_id = coder_agent.main.id
 }
 ```

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -378,15 +378,17 @@ module "personalize" {
 }
 
 module "mux" {
-  count           = data.coder_workspace.me.start_count
-  source          = "registry.coder.com/coder/mux/coder"
-  version         = "1.4.0"
-  agent_id        = coder_agent.dev.id
-  subdomain       = true
-  display_name    = "Mux"
-  add_project     = local.repo_dir
-  install_version = "next"
-  package_manager = "bun"
+  count                = data.coder_workspace.me.start_count
+  source               = "registry.coder.com/coder/mux/coder"
+  version              = "1.4.3"
+  agent_id             = coder_agent.dev.id
+  subdomain            = true
+  display_name         = "Mux"
+  add_project          = local.repo_dir
+  install_version      = "next"
+  package_manager      = "bun"
+  restart_on_kill      = true
+  max_restart_attempts = 10
 }
 
 module "code-server" {


### PR DESCRIPTION
## Summary
- bump the dogfood Mux module to 1.4.3
- enable the new restart logic and allow up to 10 restart attempts

## Testing
- terraform fmt -check -diff dogfood/coder/main.tf
- git diff --check -- dogfood/coder/main.tf
- terraform -chdir=dogfood/coder validate