### PR TITLE
ci: speed up PR checks by gating gen and skipping PG 17 tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
               - "**.sql"
               - "**.go"
               - "**.golden"
+              - "**.proto"
               - "go.mod"
               - "go.sum"
               # Other non-Go files that may affect Go code:
@@ -267,9 +268,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   gen:
+    needs: changes
     timeout-minutes: 20
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
-    if: ${{ !cancelled() }}
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.site == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
@@ -567,7 +569,9 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     needs:
       - changes
-    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    # PG 17 compatibility is validated on main; PRs only test against PG 13
+    # to cut ~25 min of redundant runner time.
+    if: github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
     # `make test` to ensure we receive a trace of running goroutines.
     # Setting this to the timeout +5m should work quite well even if


### PR DESCRIPTION
## Summary

Three targeted optimizations to reduce CI wall time and runner cost on PRs:

### 1. Gate `gen` job behind changes filter
Previously `gen` ran unconditionally (`if: !cancelled()`) on **every** PR — including docs-only changes — costing ~8–20 min of an 8-core runner. It now only runs when Go, site, or CI files change. Still runs unconditionally on `main`.

### 2. Run `test-go-pg-17` only on `main`
PR Go tests already run the full suite against PG 13 (`test-go-pg`). Running the identical suite again on PG 17 adds ~25 min of runner time per Go PR with negligible incremental coverage for PR validation. PG 17 compatibility is still validated on every `main` push.

### 3. Add `**.proto` to the `go` changes filter
Closes a coverage gap: proto-only changes (e.g. `vpn/vpn.proto`) would previously not trigger Go test or `gen` jobs because `vpn/` was not in the directory list and `.proto` was not in the extension list.

## Impact
- **Docs-only PRs**: skip `gen` entirely (~8-20 min saved)
- **Go PRs**: skip redundant PG 17 test run (~25 min saved)
- **Proto PRs**: now correctly trigger Go tests and gen

The `required` job already allows `skipped` results, so gating these jobs does not break branch protection.