### PR TITLE
fix: improve push notification message shown on subscribe

### DIFF
--- a/coderd/webpush/webpush.go
+++ b/coderd/webpush/webpush.go
@@ -174,8 +174,8 @@ func (n *Webpusher) webpushSend(ctx context.Context, msg []byte, endpoint string
 
 func (n *Webpusher) Test(ctx context.Context, req codersdk.WebpushSubscription) error {
 	msgJSON, err := json.Marshal(codersdk.WebpushMessage{
-		Title: "Test",
-		Body:  "This is a test Web Push notification",
+		Title: "It's working!",
+		Body:  "You've successfully subscribed to push notifications.",
 	})
 	if err != nil {
 		return xerrors.Errorf("marshal webpush notification: %w", err)

--- a/coderd/webpush/webpush.go
+++ b/coderd/webpush/webpush.go
@@ -175,7 +175,7 @@ func (n *Webpusher) webpushSend(ctx context.Context, msg []byte, endpoint string
 func (n *Webpusher) Test(ctx context.Context, req codersdk.WebpushSubscription) error {
 	msgJSON, err := json.Marshal(codersdk.WebpushMessage{
 		Title: "It's working!",
-		Body:  "You've successfully subscribed to push notifications.",
+		Body:  "You've subscribed to push notifications.",
 	})
 	if err != nil {
 		return xerrors.Errorf("marshal webpush notification: %w", err)


### PR DESCRIPTION
When users enable push notifications on the agents page, the `Test` method in `coderd/webpush/webpush.go` sends a validation notification to confirm the subscription works. The previous message was:

- **Title:** `Test`
- **Body:** `This is a test Web Push notification`

This looked like a placeholder/debug message. Updated to:

- **Title:** `It's working!`
- **Body:** `You've successfully subscribed to push notifications.`

This matches the tone of the explicit test notification endpoint (`postUserPushNotificationTest`) and gives users clear confirmation that they've set things up correctly.

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻