### PR TITLE
feat: add endpoint and CLI for users to view their own OIDC claims

### DIFF
--- a/cli/testdata/coder_users_--help.golden
+++ b/cli/testdata/coder_users_--help.golden
@@ -8,16 +8,17 @@ USAGE:
   Aliases: user
 
 SUBCOMMANDS:
-    activate      Update a user's status to 'active'. Active users can fully
-                  interact with the platform
-    create        Create a new user.
-    delete        Delete a user by username or user_id.
-    edit-roles    Edit a user's roles by username or id
-    list          Prints the list of users.
-    show          Show a single user. Use 'me' to indicate the currently
-                  authenticated user.
-    suspend       Update a user's status to 'suspended'. A suspended user cannot
-                  log into the platform
+    activate       Update a user's status to 'active'. Active users can fully
+                   interact with the platform
+    create         Create a new user.
+    delete         Delete a user by username or user_id.
+    edit-roles     Edit a user's roles by username or id
+    list           Prints the list of users.
+    oidc-claims    Display the OIDC claims for the authenticated user.
+    show           Show a single user. Use 'me' to indicate the currently
+                   authenticated user.
+    suspend        Update a user's status to 'suspended'. A suspended user
+                   cannot log into the platform
 
 ———
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_users_oidc-claims_--help.golden
+++ b/cli/testdata/coder_users_oidc-claims_--help.golden
@@ -5,11 +5,11 @@ USAGE:
 
   Display the OIDC claims for the authenticated user.
 
-    - Display your OIDC claims::
+    - Display your OIDC claims:
   
        $ coder users oidc-claims
   
-    - Display your OIDC claims as JSON::
+    - Display your OIDC claims as JSON:
   
        $ coder users oidc-claims -o json
 

--- a/cli/testdata/coder_users_oidc-claims_--help.golden
+++ b/cli/testdata/coder_users_oidc-claims_--help.golden
@@ -1,0 +1,24 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder users oidc-claims [flags]
+
+  Display the OIDC claims for the authenticated user.
+
+    - Display your OIDC claims::
+  
+       $ coder users oidc-claims
+  
+    - Display your OIDC claims as JSON::
+  
+       $ coder users oidc-claims -o json
+
+OPTIONS:
+  -c, --column [key|value] (default: key,value)
+          Columns to display in table output.
+
+  -o, --output table|json (default: table)
+          Output format.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/useroidcclaims.go
+++ b/cli/useroidcclaims.go
@@ -37,11 +37,11 @@ func (r *RootCmd) userOIDCClaims() *serpent.Command {
 		Short: "Display the OIDC claims for the authenticated user.",
 		Long: FormatExamples(
 			Example{
-				Description: "Display your OIDC claims:",
+				Description: "Display your OIDC claims",
 				Command:     "coder users oidc-claims",
 			},
 			Example{
-				Description: "Display your OIDC claims as JSON:",
+				Description: "Display your OIDC claims as JSON",
 				Command:     "coder users oidc-claims -o json",
 			},
 		),

--- a/cli/useroidcclaims.go
+++ b/cli/useroidcclaims.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) userOIDCClaims() *serpent.Command {
+	formatter := cliui.NewOutputFormatter(
+		cliui.ChangeFormatterData(
+			cliui.TableFormat([]claimRow{}, []string{"key", "value"}),
+			func(data any) (any, error) {
+				resp, ok := data.(codersdk.OIDCClaimsResponse)
+				if !ok {
+					return nil, xerrors.Errorf("expected type %T, got %T", resp, data)
+				}
+				rows := make([]claimRow, 0, len(resp.Claims))
+				for k, v := range resp.Claims {
+					rows = append(rows, claimRow{
+						Key:   k,
+						Value: fmt.Sprintf("%v", v),
+					})
+				}
+				return rows, nil
+			},
+		),
+		cliui.JSONFormat(),
+	)
+
+	cmd := &serpent.Command{
+		Use:   "oidc-claims",
+		Short: "Display the OIDC claims for the authenticated user.",
+		Long: FormatExamples(
+			Example{
+				Description: "Display your OIDC claims:",
+				Command:     "coder users oidc-claims",
+			},
+			Example{
+				Description: "Display your OIDC claims as JSON:",
+				Command:     "coder users oidc-claims -o json",
+			},
+		),
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(0),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			client, err := r.InitClient(inv)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.UserOIDCClaims(inv.Context())
+			if err != nil {
+				return xerrors.Errorf("get oidc claims: %w", err)
+			}
+
+			out, err := formatter.Format(inv.Context(), resp)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintln(inv.Stdout, out)
+			return err
+		},
+	}
+
+	formatter.AttachOptions(&cmd.Options)
+	return cmd
+}
+
+type claimRow struct {
+	Key   string `json:"-" table:"key,default_sort"`
+	Value string `json:"-" table:"value"`
+}

--- a/cli/useroidcclaims_test.go
+++ b/cli/useroidcclaims_test.go
@@ -130,4 +130,23 @@ func TestUserOIDCClaims(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "bob-isolation@coder.com", bobResp.Claims["email"])
 	})
+
+
+	t.Run("ClaimsNeverNull", func(t *testing.T) {
+		t.Parallel()
+
+		// Use minimal claims — just enough for OIDC login.
+		claims := jwt.MapClaims{
+			"email":          "minimal@coder.com",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+		}
+		userClient, loginResp := fake.Login(t, ownerClient, claims)
+		defer loginResp.Body.Close()
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		resp, err := userClient.UserOIDCClaims(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Claims, "claims should never be nil, expected empty map")
+	})
 }

--- a/cli/useroidcclaims_test.go
+++ b/cli/useroidcclaims_test.go
@@ -131,7 +131,6 @@ func TestUserOIDCClaims(t *testing.T) {
 		assert.Equal(t, "bob-isolation@coder.com", bobResp.Claims["email"])
 	})
 
-
 	t.Run("ClaimsNeverNull", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/useroidcclaims_test.go
+++ b/cli/useroidcclaims_test.go
@@ -1,0 +1,153 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestUserOIDCClaims(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OwnClaims", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithServing(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+		owner := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+
+		claims := jwt.MapClaims{
+			"email":          "alice@coder.com",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+			"groups":         []string{"admin", "eng"},
+		}
+		userClient, loginResp := fake.Login(t, owner, claims)
+		defer loginResp.Body.Close()
+
+		inv, root := clitest.New(t, "users", "oidc-claims", "-o", "json")
+		clitest.SetupConfig(t, userClient, root)
+
+		buf := bytes.NewBuffer(nil)
+		inv.Stdout = buf
+		err := inv.WithContext(testutil.Context(t, testutil.WaitMedium)).Run()
+		require.NoError(t, err)
+
+		var resp codersdk.OIDCClaimsResponse
+		err = json.Unmarshal(buf.Bytes(), &resp)
+		require.NoError(t, err, "unmarshal JSON output")
+		require.NotEmpty(t, resp.Claims, "claims should not be empty")
+		assert.Equal(t, "alice@coder.com", resp.Claims["email"])
+	})
+
+	t.Run("Table", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithServing(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+		owner := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+
+		claims := jwt.MapClaims{
+			"email":          "bob@coder.com",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+		}
+		userClient, loginResp := fake.Login(t, owner, claims)
+		defer loginResp.Body.Close()
+
+		inv, root := clitest.New(t, "users", "oidc-claims")
+		clitest.SetupConfig(t, userClient, root)
+
+		buf := bytes.NewBuffer(nil)
+		inv.Stdout = buf
+		err := inv.WithContext(testutil.Context(t, testutil.WaitMedium)).Run()
+		require.NoError(t, err)
+
+		output := buf.String()
+		require.Contains(t, output, "email")
+		require.Contains(t, output, "bob@coder.com")
+	})
+
+	t.Run("NotOIDCUser", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		inv, root := clitest.New(t, "users", "oidc-claims")
+		clitest.SetupConfig(t, client, root)
+
+		err := inv.WithContext(testutil.Context(t, testutil.WaitMedium)).Run()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not an OIDC user")
+	})
+
+	// Verify that two different OIDC users each only see their own
+	// claims. The endpoint has no user parameter, so there is no way
+	// to request another user's claims by design.
+	t.Run("OnlyOwnClaims", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t,
+			oidctest.WithServing(),
+		)
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+		owner := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+
+		aliceClaims := jwt.MapClaims{
+			"email":          "alice@coder.com",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+		}
+		aliceClient, aliceLoginResp := fake.Login(t, owner, aliceClaims)
+		defer aliceLoginResp.Body.Close()
+
+		bobClaims := jwt.MapClaims{
+			"email":          "bob@coder.com",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+		}
+		bobClient, bobLoginResp := fake.Login(t, owner, bobClaims)
+		defer bobLoginResp.Body.Close()
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		// Alice sees her own claims.
+		aliceResp, err := aliceClient.UserOIDCClaims(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "alice@coder.com", aliceResp.Claims["email"])
+
+		// Bob sees his own claims.
+		bobResp, err := bobClient.UserOIDCClaims(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "bob@coder.com", bobResp.Claims["email"])
+	})
+}

--- a/cli/useroidcclaims_test.go
+++ b/cli/useroidcclaims_test.go
@@ -21,18 +21,18 @@ import (
 func TestUserOIDCClaims(t *testing.T) {
 	t.Parallel()
 
+	fake := oidctest.NewFakeIDP(t,
+		oidctest.WithServing(),
+	)
+	cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+		cfg.AllowSignups = true
+	})
+	ownerClient := coderdtest.New(t, &coderdtest.Options{
+		OIDCConfig: cfg,
+	})
+
 	t.Run("OwnClaims", func(t *testing.T) {
 		t.Parallel()
-
-		fake := oidctest.NewFakeIDP(t,
-			oidctest.WithServing(),
-		)
-		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-			cfg.AllowSignups = true
-		})
-		owner := coderdtest.New(t, &coderdtest.Options{
-			OIDCConfig: cfg,
-		})
 
 		claims := jwt.MapClaims{
 			"email":          "alice@coder.com",
@@ -40,7 +40,7 @@ func TestUserOIDCClaims(t *testing.T) {
 			"sub":            uuid.NewString(),
 			"groups":         []string{"admin", "eng"},
 		}
-		userClient, loginResp := fake.Login(t, owner, claims)
+		userClient, loginResp := fake.Login(t, ownerClient, claims)
 		defer loginResp.Body.Close()
 
 		inv, root := clitest.New(t, "users", "oidc-claims", "-o", "json")
@@ -61,22 +61,12 @@ func TestUserOIDCClaims(t *testing.T) {
 	t.Run("Table", func(t *testing.T) {
 		t.Parallel()
 
-		fake := oidctest.NewFakeIDP(t,
-			oidctest.WithServing(),
-		)
-		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-			cfg.AllowSignups = true
-		})
-		owner := coderdtest.New(t, &coderdtest.Options{
-			OIDCConfig: cfg,
-		})
-
 		claims := jwt.MapClaims{
 			"email":          "bob@coder.com",
 			"email_verified": true,
 			"sub":            uuid.NewString(),
 		}
-		userClient, loginResp := fake.Login(t, owner, claims)
+		userClient, loginResp := fake.Login(t, ownerClient, claims)
 		defer loginResp.Body.Close()
 
 		inv, root := clitest.New(t, "users", "oidc-claims")
@@ -112,30 +102,20 @@ func TestUserOIDCClaims(t *testing.T) {
 	t.Run("OnlyOwnClaims", func(t *testing.T) {
 		t.Parallel()
 
-		fake := oidctest.NewFakeIDP(t,
-			oidctest.WithServing(),
-		)
-		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-			cfg.AllowSignups = true
-		})
-		owner := coderdtest.New(t, &coderdtest.Options{
-			OIDCConfig: cfg,
-		})
-
 		aliceClaims := jwt.MapClaims{
-			"email":          "alice@coder.com",
+			"email":          "alice-isolation@coder.com",
 			"email_verified": true,
 			"sub":            uuid.NewString(),
 		}
-		aliceClient, aliceLoginResp := fake.Login(t, owner, aliceClaims)
+		aliceClient, aliceLoginResp := fake.Login(t, ownerClient, aliceClaims)
 		defer aliceLoginResp.Body.Close()
 
 		bobClaims := jwt.MapClaims{
-			"email":          "bob@coder.com",
+			"email":          "bob-isolation@coder.com",
 			"email_verified": true,
 			"sub":            uuid.NewString(),
 		}
-		bobClient, bobLoginResp := fake.Login(t, owner, bobClaims)
+		bobClient, bobLoginResp := fake.Login(t, ownerClient, bobClaims)
 		defer bobLoginResp.Body.Close()
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
@@ -143,11 +123,11 @@ func TestUserOIDCClaims(t *testing.T) {
 		// Alice sees her own claims.
 		aliceResp, err := aliceClient.UserOIDCClaims(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "alice@coder.com", aliceResp.Claims["email"])
+		assert.Equal(t, "alice-isolation@coder.com", aliceResp.Claims["email"])
 
 		// Bob sees his own claims.
 		bobResp, err := bobClient.UserOIDCClaims(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "bob@coder.com", bobResp.Claims["email"])
+		assert.Equal(t, "bob-isolation@coder.com", bobResp.Claims["email"])
 	})
 }

--- a/cli/users.go
+++ b/cli/users.go
@@ -19,6 +19,7 @@ func (r *RootCmd) users() *serpent.Command {
 			r.userSingle(),
 			r.userDelete(),
 			r.userEditRoles(),
+			r.userOIDCClaims(),
 			r.createUserStatusCommand(codersdk.UserStatusActive),
 			r.createUserStatusCommand(codersdk.UserStatusSuspended),
 		},

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7879,7 +7879,7 @@ const docTemplate = `{
                     "Users"
                 ],
                 "summary": "Get OIDC claims for the authenticated user",
-                "operationId": "get-oidc-claims-for-authenticated-user",
+                "operationId": "get-oidc-claims-for-the-authenticated-user",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16915,7 +16915,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "claims": {
-                    "description": "Claims are the merged claims from the OIDC provider. These\nare the intersection of the ID token claims and the userinfo\nclaims, where userinfo claims take precedence.",
+                    "description": "Claims are the merged claims from the OIDC provider. These\nare the union of the ID token claims and the userinfo claims,\nwhere userinfo claims take precedence on conflict.",
                     "type": "object",
                     "additionalProperties": true
                 }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7819,35 +7819,6 @@ const docTemplate = `{
                         }
                     }
                 },
-            }
-        },
-        "/users/me/oidc-claims": {
-            "get": {
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Get OIDC claims for the authenticated user",
-                "operationId": "get-oidc-claims-for-authenticated-user",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.OIDCClaimsResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/users/oauth2/github/callback": {
-            "get": {
                 "security": [
                     {
                         "CoderSessionToken": []
@@ -7889,6 +7860,31 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/codersdk.ExternalAuthDevice"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/users/oidc-claims": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get OIDC claims for the authenticated user",
+                "operationId": "get-oidc-claims-for-authenticated-user",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.OIDCClaimsResponse"
                         }
                     }
                 },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7819,6 +7819,35 @@ const docTemplate = `{
                         }
                     }
                 },
+            }
+        },
+        "/users/me/oidc-claims": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get OIDC claims for the authenticated user",
+                "operationId": "get-oidc-claims-for-authenticated-user",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.OIDCClaimsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/oauth2/github/callback": {
+            "get": {
                 "security": [
                     {
                         "CoderSessionToken": []
@@ -16883,6 +16912,16 @@ const docTemplate = `{
                 },
                 "signInText": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.OIDCClaimsResponse": {
+            "type": "object",
+            "properties": {
+                "claims": {
+                    "description": "Claims are the merged claims from the OIDC provider. These\nare the intersection of the ID token claims and the userinfo\nclaims, where userinfo claims take precedence.",
+                    "type": "object",
+                    "additionalProperties": true
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15362,7 +15362,7 @@
 			"type": "object",
 			"properties": {
 				"claims": {
-					"description": "Claims are the merged claims from the OIDC provider. These\nare the intersection of the ID token claims and the userinfo\nclaims, where userinfo claims take precedence.",
+					"description": "Claims are the merged claims from the OIDC provider. These\nare the union of the ID token claims and the userinfo claims,\nwhere userinfo claims take precedence on conflict.",
 					"type": "object",
 					"additionalProperties": true
 				}

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6970,7 +6970,7 @@
 				"produces": ["application/json"],
 				"tags": ["Users"],
 				"summary": "Get OIDC claims for the authenticated user",
-				"operationId": "get-oidc-claims-for-authenticated-user",
+				"operationId": "get-oidc-claims-for-the-authenticated-user",
 				"responses": {
 					"200": {
 						"description": "OK",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6920,6 +6920,31 @@
 						}
 					}
 				},
+			}
+		},
+		"/users/me/oidc-claims": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"produces": ["application/json"],
+				"tags": ["Users"],
+				"summary": "Get OIDC claims for the authenticated user",
+				"operationId": "get-oidc-claims-for-authenticated-user",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.OIDCClaimsResponse"
+						}
+					}
+				}
+			}
+		},
+		"/users/oauth2/github/callback": {
+			"get": {
 				"security": [
 					{
 						"CoderSessionToken": []
@@ -15334,6 +15359,16 @@
 				},
 				"signInText": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.OIDCClaimsResponse": {
+			"type": "object",
+			"properties": {
+				"claims": {
+					"description": "Claims are the merged claims from the OIDC provider. These\nare the intersection of the ID token claims and the userinfo\nclaims, where userinfo claims take precedence.",
+					"type": "object",
+					"additionalProperties": true
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6920,31 +6920,6 @@
 						}
 					}
 				},
-			}
-		},
-		"/users/me/oidc-claims": {
-			"get": {
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"produces": ["application/json"],
-				"tags": ["Users"],
-				"summary": "Get OIDC claims for the authenticated user",
-				"operationId": "get-oidc-claims-for-authenticated-user",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.OIDCClaimsResponse"
-						}
-					}
-				}
-			}
-		},
-		"/users/oauth2/github/callback": {
-			"get": {
 				"security": [
 					{
 						"CoderSessionToken": []
@@ -6980,6 +6955,27 @@
 						"description": "OK",
 						"schema": {
 							"$ref": "#/definitions/codersdk.ExternalAuthDevice"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/users/oidc-claims": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Users"],
+				"summary": "Get OIDC claims for the authenticated user",
+				"operationId": "get-oidc-claims-for-authenticated-user",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.OIDCClaimsResponse"
 						}
 					}
 				},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1495,6 +1495,7 @@ func New(options *Options) *API {
 				r.Post("/", api.postUser)
 				r.Get("/", api.users)
 				r.Post("/logout", api.postLogout)
+				r.Get("/oidc-claims", api.userOIDCClaims)
 				// These routes query information about site wide roles.
 				r.Route("/roles", func(r chi.Router) {
 					r.Get("/", api.AssignableSiteRoles)

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -121,8 +121,12 @@ func (api *API) userOIDCClaims(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	claims := link.Claims.MergedClaims
+	if claims == nil {
+		claims = map[string]interface{}{}
+	}
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.OIDCClaimsResponse{
-		Claims: link.Claims.MergedClaims,
+		Claims: claims,
 	})
 }
 

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -75,7 +75,7 @@ func (api *API) userDebugOIDC(rw http.ResponseWriter, r *http.Request) {
 // Returns the merged OIDC claims for the authenticated user.
 //
 // @Summary Get OIDC claims for the authenticated user
-// @ID get-oidc-claims-for-authenticated-user
+// @ID get-oidc-claims-for-the-authenticated-user
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Users

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -80,18 +80,14 @@ func (api *API) userDebugOIDC(rw http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Tags Users
 // @Success 200 {object} codersdk.OIDCClaimsResponse
-// @Router /users/me/oidc-claims [get]
+// @Router /users/oidc-claims [get]
 func (api *API) userOIDCClaims(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
 		apiKey = httpmw.APIKey(r)
 	)
 
-	//nolint:gocritic // The caller can only access their own claims,
-	// so we use system context for the DB lookups.
-	sysCtx := dbauthz.AsSystemRestricted(ctx)
-
-	user, err := api.Database.GetUserByID(sysCtx, apiKey.UserID)
+	user, err := api.Database.GetUserByID(ctx, apiKey.UserID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to get user.",
@@ -107,10 +103,16 @@ func (api *API) userOIDCClaims(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	link, err := api.Database.GetUserLinkByUserIDLoginType(sysCtx, database.GetUserLinkByUserIDLoginTypeParams{
-		UserID:    user.ID,
-		LoginType: database.LoginTypeOIDC,
-	})
+	//nolint:gocritic // GetUserLinkByUserIDLoginType requires reading
+	// rbac.ResourceSystem. The endpoint is scoped to the authenticated
+	// user's own identity via apiKey, so this is safe.
+	link, err := api.Database.GetUserLinkByUserIDLoginType(
+		dbauthz.AsSystemRestricted(ctx),
+		database.GetUserLinkByUserIDLoginTypeParams{
+			UserID:    user.ID,
+			LoginType: database.LoginTypeOIDC,
+		},
+	)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to get user link.",

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -72,6 +72,58 @@ func (api *API) userDebugOIDC(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, link.Claims)
 }
 
+// Returns the merged OIDC claims for the authenticated user.
+//
+// @Summary Get OIDC claims for the authenticated user
+// @ID get-oidc-claims-for-authenticated-user
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Users
+// @Success 200 {object} codersdk.OIDCClaimsResponse
+// @Router /users/me/oidc-claims [get]
+func (api *API) userOIDCClaims(rw http.ResponseWriter, r *http.Request) {
+	var (
+		ctx    = r.Context()
+		apiKey = httpmw.APIKey(r)
+	)
+
+	//nolint:gocritic // The caller can only access their own claims,
+	// so we use system context for the DB lookups.
+	sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+	user, err := api.Database.GetUserByID(sysCtx, apiKey.UserID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get user.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	if user.LoginType != database.LoginTypeOIDC {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "User is not an OIDC user.",
+		})
+		return
+	}
+
+	link, err := api.Database.GetUserLinkByUserIDLoginType(sysCtx, database.GetUserLinkByUserIDLoginTypeParams{
+		UserID:    user.ID,
+		LoginType: database.LoginTypeOIDC,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get user link.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.OIDCClaimsResponse{
+		Claims: link.Claims.MergedClaims,
+	})
+}
+
 // Returns whether the initial user has been created or not.
 //
 // @Summary Check initial user created

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -342,8 +342,8 @@ type OIDCAuthMethod struct {
 // OIDCClaimsResponse represents the merged OIDC claims for a user.
 type OIDCClaimsResponse struct {
 	// Claims are the merged claims from the OIDC provider. These
-	// are the intersection of the ID token claims and the userinfo
-	// claims, where userinfo claims take precedence.
+	// are the union of the ID token claims and the userinfo claims,
+	// where userinfo claims take precedence on conflict.
 	Claims map[string]interface{} `json:"claims"`
 }
 

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -339,6 +339,14 @@ type OIDCAuthMethod struct {
 	IconURL    string `json:"iconUrl"`
 }
 
+// OIDCClaimsResponse represents the merged OIDC claims for a user.
+type OIDCClaimsResponse struct {
+	// Claims are the merged claims from the OIDC provider. These
+	// are the intersection of the ID token claims and the userinfo
+	// claims, where userinfo claims take precedence.
+	Claims map[string]interface{} `json:"claims"`
+}
+
 type UserParameter struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
@@ -721,6 +729,20 @@ func (c *Client) UserRoles(ctx context.Context, user string) (UserRoles, error) 
 	}
 	var roles UserRoles
 	return roles, json.NewDecoder(res.Body).Decode(&roles)
+}
+
+// UserOIDCClaims returns the merged OIDC claims for the authenticated user.
+func (c *Client) UserOIDCClaims(ctx context.Context) (OIDCClaimsResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/users/oidc-claims", nil)
+	if err != nil {
+		return OIDCClaimsResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return OIDCClaimsResponse{}, ReadBodyAsError(res)
+	}
+	var resp OIDCClaimsResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
 // LoginWithPassword creates a session token authenticating with an email and password.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5778,9 +5778,9 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 
 ### Properties
 
-| Name     | Type   | Required | Restrictions | Description                                                                                                                                                            |
-|----------|--------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `claims` | object | false    |              | Claims are the merged claims from the OIDC provider. These are the intersection of the ID token claims and the userinfo claims, where userinfo claims take precedence. |
+| Name     | Type   | Required | Restrictions | Description                                                                                                                                                                 |
+|----------|--------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `claims` | object | false    |              | Claims are the merged claims from the OIDC provider. These are the union of the ID token claims and the userinfo claims, where userinfo claims take precedence on conflict. |
 
 ## codersdk.OIDCConfig
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5768,6 +5768,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `iconUrl`    | string  | false    |              |             |
 | `signInText` | string  | false    |              |             |
 
+## codersdk.OIDCClaimsResponse
+
+```json
+{
+  "claims": {}
+}
+```
+
+### Properties
+
+| Name     | Type   | Required | Restrictions | Description                                                                                                                                                            |
+|----------|--------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `claims` | object | false    |              | Claims are the merged claims from the OIDC provider. These are the intersection of the ID token claims and the userinfo claims, where userinfo claims take precedence. |
+
 ## codersdk.OIDCConfig
 
 ```json

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -321,37 +321,6 @@ curl -X POST http://coder-server:8080/api/v2/users/logout \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Get OIDC claims for the authenticated user
-
-### Code samples
-
-```shell
-# Example request using curl
-curl -X GET http://coder-server:8080/api/v2/users/me/oidc-claims \
-  -H 'Accept: application/json' \
-  -H 'Coder-Session-Token: API_KEY'
-```
-
-`GET /users/me/oidc-claims`
-
-### Example responses
-
-> 200 Response
-
-```json
-{
-  "claims": {}
-}
-```
-
-### Responses
-
-| Status | Meaning                                                 | Description | Schema                                                               |
-|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.OIDCClaimsResponse](schemas.md#codersdkoidcclaimsresponse) |
-
-To perform this operation, you must be authenticated. [Learn more](authentication.md).
-
 ## OAuth 2.0 GitHub Callback
 
 ### Code samples
@@ -404,6 +373,37 @@ curl -X GET http://coder-server:8080/api/v2/users/oauth2/github/device \
 | Status | Meaning                                                 | Description | Schema                                                               |
 |--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ExternalAuthDevice](schemas.md#codersdkexternalauthdevice) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get OIDC claims for the authenticated user
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/users/oidc-claims \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /users/oidc-claims`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "claims": {}
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                               |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.OIDCClaimsResponse](schemas.md#codersdkoidcclaimsresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -321,6 +321,37 @@ curl -X POST http://coder-server:8080/api/v2/users/logout \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get OIDC claims for the authenticated user
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/users/me/oidc-claims \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /users/me/oidc-claims`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "claims": {}
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                               |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.OIDCClaimsResponse](schemas.md#codersdkoidcclaimsresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## OAuth 2.0 GitHub Callback
 
 ### Code samples

--- a/docs/reference/cli/users.md
+++ b/docs/reference/cli/users.md
@@ -15,12 +15,13 @@ coder users [subcommand]
 
 ## Subcommands
 
-| Name                                             | Purpose                                                                               |
-|--------------------------------------------------|---------------------------------------------------------------------------------------|
-| [<code>create</code>](./users_create.md)         | Create a new user.                                                                    |
-| [<code>list</code>](./users_list.md)             | Prints the list of users.                                                             |
-| [<code>show</code>](./users_show.md)             | Show a single user. Use 'me' to indicate the currently authenticated user.            |
-| [<code>delete</code>](./users_delete.md)         | Delete a user by username or user_id.                                                 |
-| [<code>edit-roles</code>](./users_edit-roles.md) | Edit a user's roles by username or id                                                 |
-| [<code>activate</code>](./users_activate.md)     | Update a user's status to 'active'. Active users can fully interact with the platform |
-| [<code>suspend</code>](./users_suspend.md)       | Update a user's status to 'suspended'. A suspended user cannot log into the platform  |
+| Name                                               | Purpose                                                                               |
+|----------------------------------------------------|---------------------------------------------------------------------------------------|
+| [<code>create</code>](./users_create.md)           | Create a new user.                                                                    |
+| [<code>list</code>](./users_list.md)               | Prints the list of users.                                                             |
+| [<code>show</code>](./users_show.md)               | Show a single user. Use 'me' to indicate the currently authenticated user.            |
+| [<code>delete</code>](./users_delete.md)           | Delete a user by username or user_id.                                                 |
+| [<code>edit-roles</code>](./users_edit-roles.md)   | Edit a user's roles by username or id                                                 |
+| [<code>oidc-claims</code>](./users_oidc-claims.md) | Display the OIDC claims for the authenticated user.                                   |
+| [<code>activate</code>](./users_activate.md)       | Update a user's status to 'active'. Active users can fully interact with the platform |
+| [<code>suspend</code>](./users_suspend.md)         | Update a user's status to 'suspended'. A suspended user cannot log into the platform  |

--- a/docs/reference/cli/users_oidc-claims.md
+++ b/docs/reference/cli/users_oidc-claims.md
@@ -12,11 +12,11 @@ coder users oidc-claims [flags]
 ## Description
 
 ```console
-  - Display your OIDC claims::
+  - Display your OIDC claims:
 
      $ coder users oidc-claims
 
-  - Display your OIDC claims as JSON::
+  - Display your OIDC claims as JSON:
 
      $ coder users oidc-claims -o json
 ```

--- a/docs/reference/cli/users_oidc-claims.md
+++ b/docs/reference/cli/users_oidc-claims.md
@@ -1,0 +1,42 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+# users oidc-claims
+
+Display the OIDC claims for the authenticated user.
+
+## Usage
+
+```console
+coder users oidc-claims [flags]
+```
+
+## Description
+
+```console
+  - Display your OIDC claims::
+
+     $ coder users oidc-claims
+
+  - Display your OIDC claims as JSON::
+
+     $ coder users oidc-claims -o json
+```
+
+## Options
+
+### -c, --column
+
+|         |                           |
+|---------|---------------------------|
+| Type    | <code>[key\|value]</code> |
+| Default | <code>key,value</code>    |
+
+Columns to display in table output.
+
+### -o, --output
+
+|         |                          |
+|---------|--------------------------|
+| Type    | <code>table\|json</code> |
+| Default | <code>table</code>       |
+
+Output format.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4337,8 +4337,8 @@ export interface OIDCAuthMethod extends AuthMethod {
 export interface OIDCClaimsResponse {
 	/**
 	 * Claims are the merged claims from the OIDC provider. These
-	 * are the intersection of the ID token claims and the userinfo
-	 * claims, where userinfo claims take precedence.
+	 * are the union of the ID token claims and the userinfo claims,
+	 * where userinfo claims take precedence on conflict.
 	 */
 	// empty interface{} type, falling back to unknown
 	readonly claims: Record<string, unknown>;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4330,6 +4330,20 @@ export interface OIDCAuthMethod extends AuthMethod {
 	readonly iconUrl: string;
 }
 
+// From codersdk/users.go
+/**
+ * OIDCClaimsResponse represents the merged OIDC claims for a user.
+ */
+export interface OIDCClaimsResponse {
+	/**
+	 * Claims are the merged claims from the OIDC provider. These
+	 * are the intersection of the ID token claims and the userinfo
+	 * claims, where userinfo claims take precedence.
+	 */
+	// empty interface{} type, falling back to unknown
+	readonly claims: Record<string, unknown>;
+}
+
 // From codersdk/deployment.go
 export interface OIDCConfig {
 	readonly allow_signups: boolean;


### PR DESCRIPTION
- Adds a new API endpoint `GET /api/v2/users/oidc-claims` that returns only the **merged claims** (not the separate id_token/userinfo breakdown). Scoped exclusively to the authenticated user's own identity — no user parameter, so users cannot view each other's claims.
- Adds a new CLI command:** `coder users oidc-claims` that hits the above endpoint.
- The existing owner-only debug endpoint is preserved unchanged for admins who need the full claim breakdown.


> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻