### PR TITLE
docs(ai-coder): add enablement instructions for agents experiment

### DIFF
--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -89,6 +89,3 @@ Participants will receive reasonable advance notice before:
 Participants are encouraged to share workflow feedback, feature requests,
 performance observations, and operational challenges. Feedback channels are
 coordinated directly with the Coder product team.
-
-You can also file issues on the
-[coder/coder](https://github.com/coder/coder/issues) repository.

--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -60,10 +60,6 @@ comma-separated list:
 CODER_EXPERIMENTS="agents,oauth2,mcp-server-http" coder server
 ```
 
-> [!NOTE]
-> The `agents` experiment is not included in the wildcard (`*`) opt-in.
-> You must enable it explicitly.
-
 Once the server restarts with the experiment enabled:
 
 1. Navigate to the **Agents** page in the Coder dashboard.

--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -5,6 +5,36 @@ to evaluate while the product is under active development.
 Participation comes with important expectations and limitations described
 below.
 
+## Enable Coder Agents
+
+Coder Agents is gated behind the `agents` experiment flag. To enable it,
+pass the flag when starting the Coder server using an environment variable
+or CLI flag:
+
+```sh
+CODER_EXPERIMENTS="agents" coder server
+# or
+coder server --experiments=agents
+```
+
+If you are already using other experiments, add `agents` to the
+comma-separated list:
+
+```sh
+CODER_EXPERIMENTS="agents,oauth2,mcp-server-http" coder server
+```
+
+> [!NOTE]
+> The `agents` experiment is not included in the wildcard (`*`) opt-in.
+> You must enable it explicitly.
+
+Once the server restarts with the experiment enabled:
+
+1. Navigate to the **Agents** page in the Coder dashboard.
+1. Open **Admin** settings and configure at least one LLM provider and model.
+   See [Models](./models.md) for detailed setup instructions.
+1. Developers can then start a new chat from the Agents page.
+
 ## What Early Access includes
 
 Early Access is a collaborative evaluation period between Coder and
@@ -54,3 +84,6 @@ Participants will receive reasonable advance notice before:
 Participants are encouraged to share workflow feedback, feature requests,
 performance observations, and operational challenges. Feedback channels are
 coordinated directly with the Coder product team.
+
+You can also file issues on the
+[coder/coder](https://github.com/coder/coder/issues) repository.

--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -5,35 +5,10 @@ to evaluate while the product is under active development.
 Participation comes with important expectations and limitations described
 below.
 
-## Enable Coder Agents
-
-Coder Agents is gated behind the `agents` experiment flag. To enable it,
-pass the flag when starting the Coder server using an environment variable
-or CLI flag:
-
-```sh
-CODER_EXPERIMENTS="agents" coder server
-# or
-coder server --experiments=agents
-```
-
-If you are already using other experiments, add `agents` to the
-comma-separated list:
-
-```sh
-CODER_EXPERIMENTS="agents,oauth2,mcp-server-http" coder server
-```
-
-> [!NOTE]
-> The `agents` experiment is not included in the wildcard (`*`) opt-in.
-> You must enable it explicitly.
-
-Once the server restarts with the experiment enabled:
-
-1. Navigate to the **Agents** page in the Coder dashboard.
-1. Open **Admin** settings and configure at least one LLM provider and model.
-   See [Models](./models.md) for detailed setup instructions.
-1. Developers can then start a new chat from the Agents page.
+> [!CAUTION]
+> Coder Agents is experimental and must not be deployed to production
+> environments. Use it only in development or staging deployments for
+> evaluation purposes.
 
 ## What Early Access includes
 
@@ -69,6 +44,36 @@ Early Access is not a production-ready offering. It does not include:
 Functionality available during Early Access may be a subset of planned
 capabilities. Some features may be incomplete, experimental, or subject to
 redesign.
+
+## Enable Coder Agents
+
+Coder Agents is gated behind the `agents` experiment flag. To enable it,
+pass the flag when starting the Coder server using an environment variable
+or CLI flag:
+
+```sh
+CODER_EXPERIMENTS="agents" coder server
+# or
+coder server --experiments=agents
+```
+
+If you are already using other experiments, add `agents` to the
+comma-separated list:
+
+```sh
+CODER_EXPERIMENTS="agents,oauth2,mcp-server-http" coder server
+```
+
+> [!NOTE]
+> The `agents` experiment is not included in the wildcard (`*`) opt-in.
+> You must enable it explicitly.
+
+Once the server restarts with the experiment enabled:
+
+1. Navigate to the **Agents** page in the Coder dashboard.
+1. Open **Admin** settings and configure at least one LLM provider and model.
+   See [Models](./models.md) for detailed setup instructions.
+1. Developers can then start a new chat from the Agents page.
 
 ## Licensing and availability
 

--- a/docs/ai-coder/agents/early-access.md
+++ b/docs/ai-coder/agents/early-access.md
@@ -5,11 +5,6 @@ to evaluate while the product is under active development.
 Participation comes with important expectations and limitations described
 below.
 
-> [!CAUTION]
-> Coder Agents is experimental and must not be deployed to production
-> environments. Use it only in development or staging deployments for
-> evaluation purposes.
-
 ## What Early Access includes
 
 Early Access is a collaborative evaluation period between Coder and
@@ -47,7 +42,8 @@ redesign.
 
 ## Enable Coder Agents
 
-Coder Agents is gated behind the `agents` experiment flag. To enable it,
+Coder Agents is experimental and must not be deployed to production
+environments. It is gated behind the `agents` experiment flag. To enable it,
 pass the flag when starting the Coder server using an environment variable
 or CLI flag:
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -247,8 +247,6 @@ Coder Agents is a new approach that differs from
 
 ## Product status
 
-Coder Agents is currently in internal preview. We are actively developing the
-feature and demoing it with customers for feedback.
-
-Our next step is to offer an early access program for interested customers. If
-you would like to participate, [contact us](https://coder.com/contact).
+Coder Agents is in Early Access. The feature is under active development and
+available for evaluation. See [Early Access](./early-access.md) for
+enablement instructions and program details.


### PR DESCRIPTION
Adds a new **Enable Coder Agents** section to the Early Access doc explaining how to activate the `agents` experiment flag via `CODER_EXPERIMENTS` or `--experiments`.

## Changes

### `docs/ai-coder/agents/early-access.md`
- New **Enable Coder Agents** section with env var and CLI flag examples.
- Note that the `agents` flag is excluded from wildcard (`*`) opt-in.
- Quick-start checklist: dashboard → Admin → configure provider/model → start chatting.
- Link to GitHub issues for feedback.

### `docs/ai-coder/agents/index.md`
- Updated **Product status** from "internal preview" to "Early Access" with a link to the early-access page for enablement instructions.