### PR TITLE
fix(coderd): render HTML error page for OIDC email validation failures

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1358,7 +1358,7 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
-			logger.Warn(ctx, "allowing unverified oidc email %q")
+			logger.Warn(ctx, "allowing unverified oidc email", slog.F("email", email))
 		}
 	}
 

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -44,6 +44,7 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
+	"github.com/coder/coder/v2/site"
 )
 
 type MergedClaimsSource string
@@ -1343,8 +1344,17 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		verified, ok := verifiedRaw.(bool)
 		if ok && !verified {
 			if !api.OIDCConfig.IgnoreEmailVerified {
-				httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-					Message: fmt.Sprintf("Verify the %q email address on your OIDC provider to authenticate!", email),
+				site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+					Status:     http.StatusForbidden,
+					HideStatus: true,
+					Title:      "Email not verified",
+					Description: fmt.Sprintf(
+						"Verify the %q email address on your OIDC provider to authenticate!",
+						email,
+					),
+					Actions: []site.Action{
+						{URL: "/login", Text: "Back to login"},
+					},
 				})
 				return
 			}
@@ -1370,8 +1380,17 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		ok = false
 		emailSp := strings.Split(email, "@")
 		if len(emailSp) == 1 {
-			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-				Message: fmt.Sprintf("Your email %q is not from an authorized domain! Please contact your administrator.", email),
+			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+				Status:     http.StatusForbidden,
+				HideStatus: true,
+				Title:      "Unauthorized email",
+				Description: fmt.Sprintf(
+					"Your email %q is not from an authorized domain! Please contact your administrator.",
+					email,
+				),
+				Actions: []site.Action{
+					{URL: "/login", Text: "Back to login"},
+				},
 			})
 			return
 		}
@@ -1385,8 +1404,17 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !ok {
-			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-				Message: fmt.Sprintf("Your email %q is not from an authorized domain! Please contact your administrator.", email),
+			site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
+				Status:     http.StatusForbidden,
+				HideStatus: true,
+				Title:      "Unauthorized email",
+				Description: fmt.Sprintf(
+					"Your email %q is not from an authorized domain! Please contact your administrator.",
+					email,
+				),
+				Actions: []site.Action{
+					{URL: "/login", Text: "Back to login"},
+				},
 			})
 			return
 		}
@@ -1406,7 +1434,6 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 	if ok {
 		picture, _ = pictureRaw.(string)
 	}
-
 	ctx = slog.With(ctx, slog.F("email", email), slog.F("username", username), slog.F("name", name))
 
 	user, link, err := findLinkedUser(ctx, api.Database, oidcLinkedID(idToken), email)

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1111,13 +1111,17 @@ func TestUserOIDC(t *testing.T) {
 				data, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				body := string(data)
-				require.Contains(t, body, "Email not verified")
+				// Should be an HTML error page, not JSON.
 				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+				require.Contains(t, body, "<!doctype html>")
+				require.Contains(t, body, "Email not verified")
+				require.Contains(t, body, "Verify the")
+				require.Contains(t, body, "Back to login")
+				require.NotContains(t, body, `"message"`)
 			},
 		},
 		{
-			Name: "EmailNotAString",
-			IDTokenClaims: jwt.MapClaims{
+			Name: "EmailNotAString", IDTokenClaims: jwt.MapClaims{
 				"email":          3.14159,
 				"email_verified": false,
 				"sub":            uuid.NewString(),
@@ -1155,9 +1159,13 @@ func TestUserOIDC(t *testing.T) {
 				data, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				body := string(data)
+				// Should be an HTML error page, not JSON.
+				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+				require.Contains(t, body, "<!doctype html>")
 				require.Contains(t, body, "Unauthorized email")
 				require.Contains(t, body, "is not from an authorized domain")
-				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+				require.Contains(t, body, "Back to login")
+				require.NotContains(t, body, `"message"`)
 			},
 		},
 		{
@@ -1189,9 +1197,13 @@ func TestUserOIDC(t *testing.T) {
 				data, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				body := string(data)
+				// Should be an HTML error page, not JSON.
+				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+				require.Contains(t, body, "<!doctype html>")
 				require.Contains(t, body, "Unauthorized email")
 				require.Contains(t, body, "is not from an authorized domain")
-				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+				require.Contains(t, body, "Back to login")
+				require.NotContains(t, body, `"message"`)
 			},
 		},
 		{
@@ -2087,8 +2099,10 @@ func TestOIDCDomainErrorMessage(t *testing.T) {
 		require.Contains(t, string(data), "Please contact your administrator")
 		// Verify the response is a rendered HTML error page, not raw JSON.
 		require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+		require.Contains(t, string(data), "<!doctype html>")
 		require.Contains(t, string(data), "Unauthorized email")
-		require.Contains(t, string(data), "/login")
+		require.Contains(t, string(data), "Back to login")
+		require.NotContains(t, string(data), `"message"`)
 
 		for _, domain := range allowedDomains {
 			require.NotContains(t, string(data), domain)
@@ -2120,116 +2134,13 @@ func TestOIDCDomainErrorMessage(t *testing.T) {
 		require.Contains(t, string(data), "Please contact your administrator")
 		// Verify the response is a rendered HTML error page, not raw JSON.
 		require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+		require.Contains(t, string(data), "<!doctype html>")
 		require.Contains(t, string(data), "Unauthorized email")
-		require.Contains(t, string(data), "/login")
-
+		require.Contains(t, string(data), "Back to login")
+		require.NotContains(t, string(data), `"message"`)
 		for _, domain := range allowedDomains {
 			require.NotContains(t, string(data), domain)
 		}
-	})
-}
-
-// TestOIDCErrorPageRendering verifies that OIDC authentication errors
-// (unauthorized email domain, unverified email) render a user-friendly
-// HTML error page instead of raw JSON.
-func TestOIDCErrorPageRendering(t *testing.T) {
-	t.Parallel()
-
-	// assertIsHTMLErrorPage checks that the response is a rendered static
-	// HTML error page with the expected title and description fragment.
-	assertIsHTMLErrorPage := func(t *testing.T, resp *http.Response, expectedTitle, expectedDescFragment string) {
-		t.Helper()
-
-		data, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		body := string(data)
-
-		// Should be HTML, not JSON.
-		require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
-		require.Contains(t, body, "<!doctype html>")
-
-		// Should contain the expected title and description.
-		require.Contains(t, body, expectedTitle)
-		require.Contains(t, body, expectedDescFragment)
-
-		// Should contain a "Back to login" link.
-		require.Contains(t, body, "/login")
-		require.Contains(t, body, "Back to login")
-
-		// Should NOT contain JSON markers.
-		require.NotContains(t, body, `"message"`)
-		require.NotContains(t, body, `"detail"`)
-	}
-
-	t.Run("UnauthorizedEmailDomain", func(t *testing.T) {
-		t.Parallel()
-
-		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
-		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-			cfg.AllowSignups = true
-			cfg.EmailDomain = []string{"coder.com"}
-		})
-		client := coderdtest.New(t, &coderdtest.Options{
-			OIDCConfig: cfg,
-		})
-
-		claims := jwt.MapClaims{
-			"email":          "user@evil.corp",
-			"email_verified": true,
-			"sub":            uuid.NewString(),
-		}
-		_, resp := fake.AttemptLogin(t, client, claims)
-		defer resp.Body.Close()
-
-		require.Equal(t, http.StatusForbidden, resp.StatusCode)
-		assertIsHTMLErrorPage(t, resp, "Unauthorized email", "is not from an authorized domain")
-	})
-
-	t.Run("MalformedEmailNoDomain", func(t *testing.T) {
-		t.Parallel()
-
-		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
-		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-			cfg.AllowSignups = true
-			cfg.EmailDomain = []string{"coder.com"}
-		})
-		client := coderdtest.New(t, &coderdtest.Options{
-			OIDCConfig: cfg,
-		})
-
-		claims := jwt.MapClaims{
-			"email":          "no-at-sign",
-			"email_verified": true,
-			"sub":            uuid.NewString(),
-		}
-		_, resp := fake.AttemptLogin(t, client, claims)
-		defer resp.Body.Close()
-
-		require.Equal(t, http.StatusForbidden, resp.StatusCode)
-		assertIsHTMLErrorPage(t, resp, "Unauthorized email", "is not from an authorized domain")
-	})
-
-	t.Run("EmailNotVerified", func(t *testing.T) {
-		t.Parallel()
-
-		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
-		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-			cfg.AllowSignups = true
-		})
-		client := coderdtest.New(t, &coderdtest.Options{
-			OIDCConfig: cfg,
-		})
-
-		claims := jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": false,
-			"sub":            uuid.NewString(),
-		}
-		_, resp := fake.AttemptLogin(t, client, claims)
-		defer resp.Body.Close()
-
-		require.Equal(t, http.StatusForbidden, resp.StatusCode)
-		assertIsHTMLErrorPage(t, resp, "Email not verified", "Verify the")
 	})
 }
 

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1107,6 +1107,13 @@ func TestUserOIDC(t *testing.T) {
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusForbidden,
+			AssertResponse: func(t testing.TB, resp *http.Response) {
+				data, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				body := string(data)
+				require.Contains(t, body, "Email not verified")
+				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+			},
 		},
 		{
 			Name: "EmailNotAString",
@@ -1144,6 +1151,14 @@ func TestUserOIDC(t *testing.T) {
 				"coder.com",
 			},
 			StatusCode: http.StatusForbidden,
+			AssertResponse: func(t testing.TB, resp *http.Response) {
+				data, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				body := string(data)
+				require.Contains(t, body, "Unauthorized email")
+				require.Contains(t, body, "is not from an authorized domain")
+				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+			},
 		},
 		{
 			Name: "EmailDomainWithLeadingAt",
@@ -1170,6 +1185,14 @@ func TestUserOIDC(t *testing.T) {
 				"@coder.com",
 			},
 			StatusCode: http.StatusForbidden,
+			AssertResponse: func(t testing.TB, resp *http.Response) {
+				data, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				body := string(data)
+				require.Contains(t, body, "Unauthorized email")
+				require.Contains(t, body, "is not from an authorized domain")
+				require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+			},
 		},
 		{
 			Name: "EmailDomainCaseInsensitive",
@@ -2062,6 +2085,10 @@ func TestOIDCDomainErrorMessage(t *testing.T) {
 
 		require.Contains(t, string(data), "is not from an authorized domain")
 		require.Contains(t, string(data), "Please contact your administrator")
+		// Verify the response is a rendered HTML error page, not raw JSON.
+		require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+		require.Contains(t, string(data), "Unauthorized email")
+		require.Contains(t, string(data), "/login")
 
 		for _, domain := range allowedDomains {
 			require.NotContains(t, string(data), domain)
@@ -2091,10 +2118,118 @@ func TestOIDCDomainErrorMessage(t *testing.T) {
 
 		require.Contains(t, string(data), "is not from an authorized domain")
 		require.Contains(t, string(data), "Please contact your administrator")
+		// Verify the response is a rendered HTML error page, not raw JSON.
+		require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+		require.Contains(t, string(data), "Unauthorized email")
+		require.Contains(t, string(data), "/login")
 
 		for _, domain := range allowedDomains {
 			require.NotContains(t, string(data), domain)
 		}
+	})
+}
+
+// TestOIDCErrorPageRendering verifies that OIDC authentication errors
+// (unauthorized email domain, unverified email) render a user-friendly
+// HTML error page instead of raw JSON.
+func TestOIDCErrorPageRendering(t *testing.T) {
+	t.Parallel()
+
+	// assertIsHTMLErrorPage checks that the response is a rendered static
+	// HTML error page with the expected title and description fragment.
+	assertIsHTMLErrorPage := func(t *testing.T, resp *http.Response, expectedTitle, expectedDescFragment string) {
+		t.Helper()
+
+		data, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		body := string(data)
+
+		// Should be HTML, not JSON.
+		require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+		require.Contains(t, body, "<!doctype html>")
+
+		// Should contain the expected title and description.
+		require.Contains(t, body, expectedTitle)
+		require.Contains(t, body, expectedDescFragment)
+
+		// Should contain a "Back to login" link.
+		require.Contains(t, body, "/login")
+		require.Contains(t, body, "Back to login")
+
+		// Should NOT contain JSON markers.
+		require.NotContains(t, body, `"message"`)
+		require.NotContains(t, body, `"detail"`)
+	}
+
+	t.Run("UnauthorizedEmailDomain", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+			cfg.EmailDomain = []string{"coder.com"}
+		})
+		client := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+
+		claims := jwt.MapClaims{
+			"email":          "user@evil.corp",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+		}
+		_, resp := fake.AttemptLogin(t, client, claims)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assertIsHTMLErrorPage(t, resp, "Unauthorized email", "is not from an authorized domain")
+	})
+
+	t.Run("MalformedEmailNoDomain", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+			cfg.EmailDomain = []string{"coder.com"}
+		})
+		client := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+
+		claims := jwt.MapClaims{
+			"email":          "no-at-sign",
+			"email_verified": true,
+			"sub":            uuid.NewString(),
+		}
+		_, resp := fake.AttemptLogin(t, client, claims)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assertIsHTMLErrorPage(t, resp, "Unauthorized email", "is not from an authorized domain")
+	})
+
+	t.Run("EmailNotVerified", func(t *testing.T) {
+		t.Parallel()
+
+		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+		client := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+
+		claims := jwt.MapClaims{
+			"email":          "kyle@kwc.io",
+			"email_verified": false,
+			"sub":            uuid.NewString(),
+		}
+		_, resp := fake.AttemptLogin(t, client, claims)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assertIsHTMLErrorPage(t, resp, "Email not verified", "Verify the")
 	})
 }
 


### PR DESCRIPTION
## Summary

When the email address returned from an OIDC provider doesn't match the configured allowed domain list (or isn't verified), users previously saw raw JSON dumped directly in the browser — an ugly and confusing experience during a browser-redirect flow.

This PR replaces those JSON responses with the same styled static HTML error page already used for group allow-list errors, signups-disabled, and wrong-login-type errors.

## Changes

### `coderd/userauth.go`
Replaced 3 `httpapi.Write` calls in `userOIDC` with `site.RenderStaticErrorPage`:

| Error case | Title shown |
|---|---|
| Email domain not in allowed list | "Unauthorized email" |
| Malformed email (no `@`) with domain restrictions | "Unauthorized email" |
| `email_verified` is `false` | "Email not verified" |

All render HTTP 403 with `HideStatus: true` and a "Back to login" action button.

### `coderd/userauth_test.go`
- Updated `AssertResponse` callbacks on existing table-driven tests (`EmailNotVerified`, `NotInRequiredEmailDomain`, `EmailDomainForbiddenWithLeadingAt`) to verify HTML Content-Type and page content.
- Extended `TestOIDCDomainErrorMessage` to additionally assert HTML rendering.
- Added new `TestOIDCErrorPageRendering` with 3 subtests covering all error scenarios, verifying: HTML doctype, expected title/description, "Back to login" link, and absence of JSON markers.