### PR TITLE
fix(agent/reaper): skip reaper tests in CI

### DIFF
--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -78,6 +78,9 @@ func withDone(t *testing.T) []reaper.Option {
 // processes and passes their PIDs through the shared channel.
 func TestReap(t *testing.T) {
 	t.Parallel()
+	if testutil.InCI() {
+		t.Skip("Detected CI, skipping reaper tests")
+	}
 	if !runSubprocess(t) {
 		return
 	}
@@ -124,6 +127,9 @@ func TestReap(t *testing.T) {
 //nolint:tparallel // Subtests must be sequential, each starts its own reaper.
 func TestForkReapExitCodes(t *testing.T) {
 	t.Parallel()
+	if testutil.InCI() {
+		t.Skip("Detected CI, skipping reaper tests")
+	}
 	if !runSubprocess(t) {
 		return
 	}
@@ -164,6 +170,9 @@ func TestForkReapExitCodes(t *testing.T) {
 // ensures SIGINT cannot kill the parent test binary.
 func TestReapInterrupt(t *testing.T) {
 	t.Parallel()
+	if testutil.InCI() {
+		t.Skip("Detected CI, skipping reaper tests")
+	}
 	if !runSubprocess(t) {
 		return
 	}


### PR DESCRIPTION
ForkReap's `syscall.ForkExec` and process-directed signals remain flaky in CI despite the subprocess isolation added in #22894. Restore the `testutil.InCI()` skip guard that was removed in that change.

Fixes https://github.com/coder/internal/issues/1402

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻