### PR TITLE
feat(chatd): add best-of-N support to spawn_agent

### DIFF
--- a/coderd/chatd/subagent.go
+++ b/coderd/chatd/subagent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -44,6 +45,7 @@ Guidelines:
 type spawnAgentArgs struct {
 	Prompt string `json:"prompt"`
 	Title  string `json:"title,omitempty"`
+	N      *int   `json:"n,omitempty"`
 }
 
 type spawnComputerUseAgentArgs struct {
@@ -104,7 +106,13 @@ func (p *Server) subagentTools(ctx context.Context, currentChat func() database.
 				"parallel subagent tasks are independent. "+
 				"The child agent receives the same workspace tools but "+
 				"cannot spawn its own subagents. After spawning, use "+
-				"wait_agent to collect the result.",
+				"wait_agent to collect the result. "+
+				"When n is set (2-10), spawns N competing subagents with "+
+				"the same prompt (best-of-N). Each runs independently. "+
+				"Call wait_agent on each returned chat_id to collect "+
+				"results, then pick the best. Only use n > 1 for "+
+				"side-effect-free tasks where parallel attempts are safe. "+
+				"Leave n unset for normal delegation.",
 			func(ctx context.Context, args spawnAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
@@ -119,21 +127,51 @@ func (p *Server) subagentTools(ctx context.Context, currentChat func() database.
 				if err != nil {
 					return fantasy.NewTextErrorResponse(err.Error()), nil
 				}
-				childChat, err := p.createChildSubagentChat(
-					ctx,
-					parent,
-					args.Prompt,
-					args.Title,
-				)
-				if err != nil {
-					return fantasy.NewTextErrorResponse(err.Error()), nil
+
+				n := 1
+				if args.N != nil && *args.N > 1 {
+					n = *args.N
+				}
+				if n > 10 {
+					return fantasy.NewTextErrorResponse("n must be between 1 and 10"), nil
 				}
 
-				return toolJSONResponse(map[string]any{
-					"chat_id": childChat.ID.String(),
-					"title":   childChat.Title,
-					"status":  string(childChat.Status),
-				}), nil
+				type candidate struct {
+					ChatID string `json:"chat_id"`
+					Title  string `json:"title"`
+					Status string `json:"status"`
+				}
+				candidates := make([]candidate, 0, n)
+
+				for i := range n {
+					title := args.Title
+					if title == "" {
+						title = subagentFallbackChatTitle(args.Prompt)
+					}
+					if n > 1 {
+						title = fmt.Sprintf("%s (%d/%d)", title, i+1, n)
+					}
+
+					childChat, createErr := p.createChildSubagentChat(ctx, parent, args.Prompt, title)
+					if createErr != nil {
+						break
+					}
+					candidates = append(candidates, candidate{
+						ChatID: childChat.ID.String(),
+						Title:  title,
+						Status: string(childChat.Status),
+					})
+				}
+
+				if len(candidates) == 0 {
+					return fantasy.NewTextErrorResponse("failed to spawn any subagents"), nil
+				}
+
+				data, marshalErr := json.Marshal(candidates)
+				if marshalErr != nil {
+					return fantasy.NewTextResponse("[]"), nil
+				}
+				return fantasy.NewTextResponse(string(data)), nil
 			},
 		),
 		fantasy.NewAgentTool(

--- a/coderd/chatd/subagent_internal_test.go
+++ b/coderd/chatd/subagent_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"charm.land/fantasy"
@@ -297,4 +298,155 @@ func TestSpawnComputerUseAgent_UsesComputerUseModelNotParent(t *testing.T) {
 		"computer use model provider must differ from parent model provider")
 	assert.Equal(t, "anthropic", chattool.ComputerUseModelProvider)
 	assert.NotEmpty(t, chattool.ComputerUseModelName)
+}
+
+func TestSpawnAgent_SingleReturnsArray(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedInternalChatDeps(ctx, t, db)
+
+	parent, err := server.CreateChat(ctx, CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "parent-single",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	// Re-fetch so LastModelConfigID is populated from the DB.
+	parentChat, err := db.GetChatByID(ctx, parent.ID)
+	require.NoError(t, err)
+
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tool := findToolByName(tools, "spawn_agent")
+	require.NotNil(t, tool, "spawn_agent tool must be present")
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "call-single-1",
+		Name:  "spawn_agent",
+		Input: `{"prompt":"fix the bug"}`,
+	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError, "expected success but got: %s", resp.Content)
+
+	// Response must always be a JSON array, even for n=1.
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &results))
+	require.Len(t, results, 1, "single spawn must return exactly one element")
+
+	elem := results[0]
+
+	chatID, ok := elem["chat_id"].(string)
+	require.True(t, ok, "element must contain chat_id")
+	_, err = uuid.Parse(chatID)
+	require.NoError(t, err, "chat_id must be a valid UUID")
+
+	title, ok := elem["title"].(string)
+	require.True(t, ok, "element must contain title")
+	assert.NotEmpty(t, title)
+	// Single spawn (n=1) should NOT have a (1/1) suffix.
+	assert.NotContains(t, title, "(1/1)")
+
+	status, ok := elem["status"].(string)
+	require.True(t, ok, "element must contain status")
+	assert.NotEmpty(t, status)
+}
+
+func TestSpawnAgent_BestOfN(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedInternalChatDeps(ctx, t, db)
+
+	parent, err := server.CreateChat(ctx, CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "parent-best-of-n",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	// Re-fetch so LastModelConfigID is populated from the DB.
+	parentChat, err := db.GetChatByID(ctx, parent.ID)
+	require.NoError(t, err)
+
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tool := findToolByName(tools, "spawn_agent")
+	require.NotNil(t, tool, "spawn_agent tool must be present")
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "call-best-of-3",
+		Name:  "spawn_agent",
+		Input: `{"prompt":"fix the bug","n":3}`,
+	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError, "expected success but got: %s", resp.Content)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &results))
+	require.Len(t, results, 3, "best-of-3 must return exactly three elements")
+
+	seenIDs := make(map[string]struct{}, 3)
+	for i, elem := range results {
+		chatID, ok := elem["chat_id"].(string)
+		require.True(t, ok, "element %d must contain chat_id", i)
+		_, err := uuid.Parse(chatID)
+		require.NoError(t, err, "element %d chat_id must be a valid UUID", i)
+
+		_, duplicate := seenIDs[chatID]
+		assert.False(t, duplicate, "element %d has duplicate chat_id %s", i, chatID)
+		seenIDs[chatID] = struct{}{}
+
+		title, ok := elem["title"].(string)
+		require.True(t, ok, "element %d must contain title", i)
+		expectedSuffix := fmt.Sprintf("(%d/3)", i+1)
+		assert.Contains(t, title, expectedSuffix,
+			"element %d title must contain %s", i, expectedSuffix)
+
+		status, ok := elem["status"].(string)
+		require.True(t, ok, "element %d must contain status", i)
+		assert.NotEmpty(t, status)
+	}
+}
+
+func TestSpawnAgent_NExceedsLimit(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedInternalChatDeps(ctx, t, db)
+
+	parent, err := server.CreateChat(ctx, CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "parent-n-exceeds",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	// Re-fetch so LastModelConfigID is populated from the DB.
+	parentChat, err := db.GetChatByID(ctx, parent.ID)
+	require.NoError(t, err)
+
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tool := findToolByName(tools, "spawn_agent")
+	require.NotNil(t, tool, "spawn_agent tool must be present")
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "call-n-exceeds",
+		Name:  "spawn_agent",
+		Input: `{"prompt":"fix the bug","n":11}`,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.IsError, "expected an error response")
+	assert.Contains(t, resp.Content, "n must be between 1 and 10")
 }

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -170,6 +170,76 @@ export const SubagentRunning: Story = {
 	},
 };
 
+export const SubagentBestOfNRunning: Story = {
+	args: {
+		name: "spawn_agent",
+		status: "running",
+		args: {
+			title: "Refactor auth module",
+			prompt: "Refactor the auth module to use the new token format.",
+			n: 3,
+		},
+		result: [
+			{
+				chat_id: "child-chat-1",
+				title: "Refactor auth module (1/3)",
+				status: "pending",
+			},
+			{
+				chat_id: "child-chat-2",
+				title: "Refactor auth module (2/3)",
+				status: "pending",
+			},
+			{
+				chat_id: "child-chat-3",
+				title: "Refactor auth module (3/3)",
+				status: "pending",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/best of 3/)).toBeInTheDocument();
+		expect(canvas.getByRole("link", { name: "View agent" })).toHaveAttribute(
+			"href",
+			"/agents/child-chat-1",
+		);
+	},
+};
+
+export const SubagentBestOfNCompleted: Story = {
+	args: {
+		name: "spawn_agent",
+		status: "completed",
+		args: {
+			title: "Refactor auth module",
+			prompt: "Refactor the auth module to use the new token format.",
+			n: 3,
+		},
+		result: [
+			{
+				chat_id: "child-chat-1",
+				title: "Refactor auth module (1/3)",
+				status: "completed",
+			},
+			{
+				chat_id: "child-chat-2",
+				title: "Refactor auth module (2/3)",
+				status: "completed",
+			},
+			{
+				chat_id: "child-chat-3",
+				title: "Refactor auth module (3/3)",
+				status: "completed",
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/best of 3/)).toBeInTheDocument();
+	},
+};
+
 export const SubagentAwaitLinkCard: Story = {
 	args: {
 		name: "wait_agent",

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -153,11 +153,13 @@ export const SubagentRunning: Story = {
 			title: "Workspace diagnostics",
 			prompt: "Collect logs and summarize why startup failed.",
 		},
-		result: {
-			chat_id: "child-chat-id",
-			title: "Workspace diagnostics",
-			status: "pending",
-		},
+		result: [
+			{
+				chat_id: "child-chat-id",
+				title: "Workspace diagnostics",
+				status: "pending",
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -202,7 +204,7 @@ export const SubagentCompletedDelegatedPending: Story = {
 	args: {
 		name: "spawn_agent",
 		args: undefined,
-		result: { chat_id: "child-chat-id", status: "pending" },
+		result: [{ chat_id: "child-chat-id", status: "pending" }],
 		status: "completed",
 	},
 	play: async ({ canvasElement }) => {
@@ -222,7 +224,7 @@ export const SubagentStreamOverrideStatus: Story = {
 	args: {
 		name: "spawn_agent",
 		args: undefined,
-		result: { chat_id: "child-chat-id", status: "pending" },
+		result: [{ chat_id: "child-chat-id", status: "pending" }],
 		status: "completed",
 		subagentStatusOverrides: new Map([["child-chat-id", "completed"]]),
 	},
@@ -239,11 +241,13 @@ export const SubagentNoErrorWhenCompleted: Story = {
 	args: {
 		name: "spawn_agent",
 		args: undefined,
-		result: {
-			chat_id: "child-chat-id",
-			status: "completed",
-			error: "provider metadata noise",
-		},
+		result: [
+			{
+				chat_id: "child-chat-id",
+				status: "completed",
+				error: "provider metadata noise",
+			},
+		],
 		status: "error",
 		isError: true,
 	},
@@ -282,12 +286,14 @@ export const SubagentRequestMetadata: Story = {
 	args: {
 		name: "spawn_agent",
 		args: undefined,
-		result: {
-			chat_id: "child-chat-id",
-			status: "completed",
-			request_id: "request-123",
-			duration_ms: 1530,
-		},
+		result: [
+			{
+				chat_id: "child-chat-id",
+				status: "completed",
+				request_id: "request-123",
+				duration_ms: 1530,
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -255,8 +255,11 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	subagentStatusOverrides,
 }) => {
 	const parsedArgs = parseArgs(args);
-	const rawResult = Array.isArray(result) ? result[0] : result;
-	const rec = asRecord(rawResult);
+	// spawn_agent returns an array of candidates (best-of-N or single).
+	// wait_agent / message_agent / close_agent return a single object.
+	const items = Array.isArray(result) ? result : [result];
+	const candidateCount = items.length;
+	const rec = asRecord(items[0]);
 	// wait_agent and message_agent have chat_id in args, so
 	// check both result and args.
 	const chatId =
@@ -274,11 +277,13 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	const report = rec ? asString(rec.report) : "";
 	const prompt = parsedArgs ? asString(parsedArgs.prompt) : "";
 	const subagentMessage = parsedArgs ? asString(parsedArgs.message) : "";
-	const title =
+	const baseTitle =
 		(rec ? asString(rec.title) : "") ||
 		(parsedArgs ? asString(parsedArgs.title) : "") ||
 		(chatId && subagentTitles?.get(chatId)) ||
 		"Sub-agent";
+	const title =
+		candidateCount > 1 ? `${baseTitle} (best of ${candidateCount})` : baseTitle;
 	const subagentCompleted = isSubagentSuccessStatus(subagentStatus);
 	const subagentToolStatus = mapSubagentStatusToToolStatus(
 		subagentStatus,

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -255,7 +255,8 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 	subagentStatusOverrides,
 }) => {
 	const parsedArgs = parseArgs(args);
-	const rec = asRecord(result);
+	const rawResult = Array.isArray(result) ? result[0] : result;
+	const rec = asRecord(rawResult);
 	// wait_agent and message_agent have chat_id in args, so
 	// check both result and args.
 	const chatId =

--- a/site/src/components/ai-elements/tool/ToolLabel.tsx
+++ b/site/src/components/ai-elements/tool/ToolLabel.tsx
@@ -113,8 +113,9 @@ export const ToolLabel: React.FC<{
 			);
 		}
 		case "spawn_agent": {
+			const firstResult = asRecord(Array.isArray(result) ? result[0] : result);
 			const spawnTitle =
-				(parsedResult ? asString(parsedResult.title) : "") ||
+				(firstResult ? asString(firstResult.title) : "") ||
 				(parsed ? asString(parsed.title) : "");
 			return (
 				<span className="truncate text-sm text-content-secondary">

--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -622,11 +622,16 @@ export const WithSubagentCards: Story = {
 								type: "tool-result",
 								tool_call_id: "tool-subagent-1",
 								tool_name: "spawn_agent",
-								result: {
-									chat_id: "child-chat-1",
-									title: "Child agent",
-									status: "pending",
-								},
+								// spawn_agent returns an array, but ChatMessagePart.result
+								// is typed as Record<string, string> due to the type
+								// generator mapping json.RawMessage too narrowly.
+								result: [
+									{
+										chat_id: "child-chat-1",
+										title: "Child agent",
+										status: "pending",
+									},
+								] as unknown as Record<string, string>,
 							},
 						],
 					},

--- a/site/src/pages/AgentsPage/AgentDetail/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/messageParsing.test.ts
@@ -38,11 +38,9 @@ describe("parseToolResultIsError", () => {
 
 	it("returns false for completed subagent even with error field", () => {
 		expect(
-			parseToolResultIsError(
-				"spawn_agent",
-				{ error: "metadata" },
+			parseToolResultIsError("spawn_agent", { error: "metadata" }, [
 				{ status: "completed" },
-			),
+			]),
 		).toBe(false);
 		expect(
 			parseToolResultIsError(

--- a/site/src/pages/AgentsPage/AgentDetail/messageParsing.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/messageParsing.ts
@@ -35,7 +35,8 @@ const isCompletedSubagentResult = (
 	if (!isSubagentToolName(toolName)) {
 		return false;
 	}
-	const typedResult = asRecord(result);
+	const raw = Array.isArray(result) ? result[0] : result;
+	const typedResult = asRecord(raw);
 	if (!typedResult) {
 		return false;
 	}
@@ -376,14 +377,15 @@ export const buildSubagentTitles = (
 			if (tool.name !== "spawn_agent") {
 				continue;
 			}
-			const rec = asRecord(tool.result);
-			if (!rec) {
-				continue;
-			}
-			const chatId = asString(rec.chat_id);
-			const title = asString(rec.title);
-			if (chatId && title) {
-				map.set(chatId, title);
+			const items = Array.isArray(tool.result) ? tool.result : [tool.result];
+			for (const item of items) {
+				const rec = asRecord(item);
+				if (!rec) continue;
+				const chatId = asString(rec.chat_id);
+				const title = asString(rec.title);
+				if (chatId && title) {
+					map.set(chatId, title);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Extends `spawn_agent` with an optional `n` parameter (2-10) that spawns N competing subagents with the same prompt. Inspired by [coder/mux's best-of-N pattern](https://github.com/coder/mux).

## Changes

### Backend (`spawn_agent` tool)
- New optional `n` field in args (integer, 2-10)
- Response is now **always** a JSON array of `[{chat_id, title, status}]`, even for `n=1` (breaking change for frontend rendering)
- When `n > 1`, each candidate's title gets a `(i/n)` suffix for disambiguation
- Partial success: if some candidates fail to spawn, returns what succeeded

### Frontend
- `SubagentRenderer`, `ToolLabel`, `messageParsing` updated to unwrap array results
- Storybook fixtures and test fixtures updated for array shape

### How it works
1. Parent LLM calls `spawn_agent` with `n=3`
2. Gets back 3 `chat_id`s
3. Calls `wait_agent` 3 times (one per `chat_id`) — these execute concurrently via the existing tool executor's `sync.WaitGroup`
4. Receives all 3 reports, picks the best

### What doesn't change
- `wait_agent`, `message_agent`, `close_agent` — untouched
- No database schema migration
- No automated scoring — the parent LLM judges (same as mux)