### PR TITLE
ci: split build artifacts into per-platform uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1438,15 +1438,60 @@ jobs:
             ^v
           prune-untagged: true
 
-      - name: Upload build artifacts
+      - name: Upload build artifact (coder-linux-amd64.tar.gz)
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: coder
-          path: |
-            ./build/*.zip
-            ./build/*.tar.gz
-            ./build/*.deb
+          name: coder-linux-amd64.tar.gz
+          path: ./build/*_linux_amd64.tar.gz
+          retention-days: 7
+
+      - name: Upload build artifact (coder-linux-amd64.deb)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coder-linux-amd64.deb
+          path: ./build/*_linux_amd64.deb
+          retention-days: 7
+
+      - name: Upload build artifact (coder-linux-arm64.tar.gz)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coder-linux-arm64.tar.gz
+          path: ./build/*_linux_arm64.tar.gz
+          retention-days: 7
+
+      - name: Upload build artifact (coder-linux-arm64.deb)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coder-linux-arm64.deb
+          path: ./build/*_linux_arm64.deb
+          retention-days: 7
+
+      - name: Upload build artifact (coder-linux-armv7.tar.gz)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coder-linux-armv7.tar.gz
+          path: ./build/*_linux_armv7.tar.gz
+          retention-days: 7
+
+      - name: Upload build artifact (coder-linux-armv7.deb)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coder-linux-armv7.deb
+          path: ./build/*_linux_armv7.deb
+          retention-days: 7
+
+      - name: Upload build artifact (coder-windows-amd64.zip)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coder-windows-amd64.zip
+          path: ./build/*_windows_amd64.zip
           retention-days: 7
 
   # Deploy is handled in deploy.yaml so we can apply concurrency limits.


### PR DESCRIPTION
Splits the single `coder` artifact (containing all platforms in a 1.3GB zip) into individual artifacts per OS/arch/format.

## Problem

All CI build artifacts are uploaded as a single artifact named `coder`, producing a 1.3GB zip containing every platform's binary. This makes it impossible to download a single platform's binary without pulling the entire bundle.

## Solution

Upload each platform/format combination as a separate artifact:

| Artifact Name | Contents |
|---|---|
| `coder-linux-amd64.tar.gz` | Linux amd64 tarball |
| `coder-linux-amd64.deb` | Linux amd64 deb package |
| `coder-linux-arm64.tar.gz` | Linux arm64 tarball |
| `coder-linux-arm64.deb` | Linux arm64 deb package |
| `coder-linux-armv7.tar.gz` | Linux armv7 tarball |
| `coder-linux-armv7.deb` | Linux armv7 deb package |
| `coder-windows-amd64.zip` | Windows amd64 zip |

## Plan

This is the first step toward letting customers install directly from `main` via:

```bash
curl -L https://coder.com/install.sh | sh -s -- --unsafe-unstable
```

GitHub Actions artifact downloads require authentication even for public repos, so the next steps are to add a small Cloudflare Worker (similar to the one we already have for `install.sh`) that:

1. Lists artifacts via the GitHub API (unauthenticated) to find the latest artifact ID for the requested platform
2. Calls the download endpoint with a GitHub token (CF Worker secret) to get a 302 redirect to a time-limited Azure Blob URL
3. Redirects the caller to that URL (which requires no auth)

This gives us publicly accessible per-platform URLs that the `--unsafe-unstable` flag would point at. The worker doesn't proxy the binary itself — it only proxies the metadata API call (~1KB) and redirects for the actual download.

This PR splits the artifacts so the worker can serve individual platform downloads (~200MB each) instead of forcing a 1.3GB bundle.