### PR TITLE
refactor(chat): simplify chat cost storage from nullable to non-null + boolean

### DIFF
--- a/coderd/chatd/chatcost/chatcost.go
+++ b/coderd/chatd/chatcost/chatcost.go
@@ -9,23 +9,24 @@ import (
 
 // Returns cost in micros -- millionths of a dollar, rounded up to the next
 // whole microdollar.
-// Returns nil when pricing is not configured or when all priced usage fields
-// are nil, allowing callers to distinguish "zero cost" from "unpriced".
+// Returns valid=false when pricing is not configured or when all priced usage
+// fields are nil, allowing callers to distinguish "zero cost" from
+// "unpriced".
 func CalculateTotalCostMicros(
 	usage codersdk.ChatMessageUsage,
 	cost *codersdk.ModelCostConfig,
-) *int64 {
+) (micros int64, valid bool) {
 	if cost == nil {
-		return nil
+		return 0, false
 	}
 
 	// A cost config with no prices set means pricing is effectively
-	// unconfigured — return nil (unpriced) rather than zero.
+	// unconfigured — return valid=false (unpriced) rather than zero.
 	if cost.InputPricePerMillionTokens == nil &&
 		cost.OutputPricePerMillionTokens == nil &&
 		cost.CacheReadPricePerMillionTokens == nil &&
 		cost.CacheWritePricePerMillionTokens == nil {
-		return nil
+		return 0, false
 	}
 
 	if usage.InputTokens == nil &&
@@ -33,7 +34,7 @@ func CalculateTotalCostMicros(
 		usage.ReasoningTokens == nil &&
 		usage.CacheCreationTokens == nil &&
 		usage.CacheReadTokens == nil {
-		return nil
+		return 0, false
 	}
 
 	// OutputTokens already includes reasoning tokens per provider
@@ -41,14 +42,15 @@ func CalculateTotalCostMicros(
 	// reasoning_tokens). Adding ReasoningTokens here would
 	// double-count.
 
-	// Preserve nil when usage exists only in categories without configured
-	// pricing, so callers can distinguish "unpriced" from "priced at zero".
+	// Preserve valid=false when usage exists only in categories without
+	// configured pricing, so callers can distinguish "unpriced" from
+	// "priced at zero".
 	hasMatchingPrice := (usage.InputTokens != nil && cost.InputPricePerMillionTokens != nil) ||
 		(usage.OutputTokens != nil && cost.OutputPricePerMillionTokens != nil) ||
 		(usage.CacheReadTokens != nil && cost.CacheReadPricePerMillionTokens != nil) ||
 		(usage.CacheCreationTokens != nil && cost.CacheWritePricePerMillionTokens != nil)
 	if !hasMatchingPrice {
-		return nil
+		return 0, false
 	}
 
 	inputMicros := calcCost(usage.InputTokens, cost.InputPricePerMillionTokens)
@@ -60,8 +62,8 @@ func CalculateTotalCostMicros(
 		Add(outputMicros).
 		Add(cacheReadMicros).
 		Add(cacheWriteMicros)
-	rounded := total.Ceil().IntPart()
-	return &rounded
+
+	return total.Ceil().IntPart(), true
 }
 
 // calcCost returns the cost in fractional microdollars (millionths of a USD)

--- a/coderd/chatd/chatcost/chatcost_test.go
+++ b/coderd/chatd/chatcost/chatcost_test.go
@@ -15,19 +15,21 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		usage codersdk.ChatMessageUsage
-		cost  *codersdk.ModelCostConfig
-		want  *int64
+		name       string
+		usage      codersdk.ChatMessageUsage
+		cost       *codersdk.ModelCostConfig
+		wantMicros int64
+		wantValid  bool
 	}{
 		{
-			name:  "nil cost returns nil",
-			usage: codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1000)},
-			cost:  nil,
-			want:  nil,
+			name:       "nil cost returns unpriced",
+			usage:      codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1000)},
+			cost:       nil,
+			wantMicros: 0,
+			wantValid:  false,
 		},
 		{
-			name: "all priced usage fields nil returns nil",
+			name: "all priced usage fields nil returns unpriced",
 			usage: codersdk.ChatMessageUsage{
 				TotalTokens:  ptr.Ref[int64](1234),
 				ContextLimit: ptr.Ref[int64](8192),
@@ -35,31 +37,29 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 			cost: &codersdk.ModelCostConfig{
 				InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3")),
 			},
-			want: nil,
+			wantMicros: 0,
+			wantValid:  false,
 		},
 		{
-			name:  "sub-micro total rounds up to 1",
-			usage: codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1)},
-			cost: &codersdk.ModelCostConfig{
-				InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("0.01")),
-			},
-			want: ptr.Ref[int64](1),
+			name:       "sub-micro total rounds up to 1",
+			usage:      codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1)},
+			cost:       &codersdk.ModelCostConfig{InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("0.01"))},
+			wantMicros: 1,
+			wantValid:  true,
 		},
 		{
-			name:  "simple input only",
-			usage: codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1000)},
-			cost: &codersdk.ModelCostConfig{
-				InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3")),
-			},
-			want: ptr.Ref[int64](3000),
+			name:       "simple input only",
+			usage:      codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1000)},
+			cost:       &codersdk.ModelCostConfig{InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3"))},
+			wantMicros: 3000,
+			wantValid:  true,
 		},
 		{
-			name:  "simple output only",
-			usage: codersdk.ChatMessageUsage{OutputTokens: ptr.Ref[int64](500)},
-			cost: &codersdk.ModelCostConfig{
-				OutputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("15")),
-			},
-			want: ptr.Ref[int64](7500),
+			name:       "simple output only",
+			usage:      codersdk.ChatMessageUsage{OutputTokens: ptr.Ref[int64](500)},
+			cost:       &codersdk.ModelCostConfig{OutputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("15"))},
+			wantMicros: 7500,
+			wantValid:  true,
 		},
 		{
 			name: "reasoning tokens included in output total",
@@ -67,26 +67,23 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 				OutputTokens:    ptr.Ref[int64](500),
 				ReasoningTokens: ptr.Ref[int64](200),
 			},
-			cost: &codersdk.ModelCostConfig{
-				OutputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("15")),
-			},
-			want: ptr.Ref[int64](7500),
+			cost:       &codersdk.ModelCostConfig{OutputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("15"))},
+			wantMicros: 7500,
+			wantValid:  true,
 		},
 		{
-			name:  "cache read tokens",
-			usage: codersdk.ChatMessageUsage{CacheReadTokens: ptr.Ref[int64](10000)},
-			cost: &codersdk.ModelCostConfig{
-				CacheReadPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("0.3")),
-			},
-			want: ptr.Ref[int64](3000),
+			name:       "cache read tokens",
+			usage:      codersdk.ChatMessageUsage{CacheReadTokens: ptr.Ref[int64](10000)},
+			cost:       &codersdk.ModelCostConfig{CacheReadPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("0.3"))},
+			wantMicros: 3000,
+			wantValid:  true,
 		},
 		{
-			name:  "cache creation tokens",
-			usage: codersdk.ChatMessageUsage{CacheCreationTokens: ptr.Ref[int64](5000)},
-			cost: &codersdk.ModelCostConfig{
-				CacheWritePricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3.75")),
-			},
-			want: ptr.Ref[int64](18750),
+			name:       "cache creation tokens",
+			usage:      codersdk.ChatMessageUsage{CacheCreationTokens: ptr.Ref[int64](5000)},
+			cost:       &codersdk.ModelCostConfig{CacheWritePricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3.75"))},
+			wantMicros: 18750,
+			wantValid:  true,
 		},
 		{
 			name: "full mixed usage totals all components exactly",
@@ -105,7 +102,8 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 				CacheReadPricePerMillionTokens:  ptr.Ref(decimal.RequireFromString("0.7")),
 				CacheWritePricePerMillionTokens: ptr.Ref(decimal.RequireFromString("7.89")),
 			},
-			want: ptr.Ref[int64](2005),
+			wantMicros: 2005,
+			wantValid:  true,
 		},
 		{
 			name: "partial pricing only input contributes",
@@ -116,32 +114,30 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 				CacheReadTokens:     ptr.Ref[int64](500),
 				CacheCreationTokens: ptr.Ref[int64](250),
 			},
-			cost: &codersdk.ModelCostConfig{
-				InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("2.5")),
-			},
-			want: ptr.Ref[int64](3085),
+			cost:       &codersdk.ModelCostConfig{InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("2.5"))},
+			wantMicros: 3085,
+			wantValid:  true,
 		},
 		{
-			name:  "zero tokens with pricing returns zero pointer",
-			usage: codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](0)},
-			cost: &codersdk.ModelCostConfig{
-				InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3")),
-			},
-			want: ptr.Ref[int64](0),
+			name:       "zero tokens with pricing returns zero cost",
+			usage:      codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](0)},
+			cost:       &codersdk.ModelCostConfig{InputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3"))},
+			wantMicros: 0,
+			wantValid:  true,
 		},
 		{
-			name:  "usage only in unpriced categories returns nil",
-			usage: codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1000)},
-			cost: &codersdk.ModelCostConfig{
-				OutputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("15")),
-			},
-			want: nil,
+			name:       "usage only in unpriced categories returns unpriced",
+			usage:      codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](1000)},
+			cost:       &codersdk.ModelCostConfig{OutputPricePerMillionTokens: ptr.Ref(decimal.RequireFromString("15"))},
+			wantMicros: 0,
+			wantValid:  false,
 		},
 		{
-			name:  "non nil usage with empty cost config returns nil",
-			usage: codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](42)},
-			cost:  &codersdk.ModelCostConfig{},
-			want:  nil,
+			name:       "non nil usage with empty cost config returns unpriced",
+			usage:      codersdk.ChatMessageUsage{InputTokens: ptr.Ref[int64](42)},
+			cost:       &codersdk.ModelCostConfig{},
+			wantMicros: 0,
+			wantValid:  false,
 		},
 	}
 
@@ -150,14 +146,10 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := chatcost.CalculateTotalCostMicros(tt.usage, tt.cost)
+			micros, valid := chatcost.CalculateTotalCostMicros(tt.usage, tt.cost)
 
-			if tt.want == nil {
-				require.Nil(t, got)
-			} else {
-				require.NotNil(t, got)
-				require.Equal(t, *tt.want, *got)
-			}
+			require.Equal(t, tt.wantValid, valid)
+			require.Equal(t, tt.wantMicros, micros)
 		})
 	}
 }

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -2388,6 +2388,7 @@ func (p *Server) runChat(
 				}
 
 				totalCostMicros, costValid := chatcost.CalculateTotalCostMicros(usageForCost, callConfig.Cost)
+				totalCostMicrosValue, costValidValue := persistedMessageCost(totalCostMicros, costValid)
 
 				assistantMessage, insertErr := tx.InsertChatMessage(persistCtx, database.InsertChatMessageParams{
 					ChatID:         chat.ID,
@@ -2412,9 +2413,11 @@ func (p *Server) runChat(
 					ContextLimit:    step.ContextLimit,
 					Compressed:      sql.NullBool{},
 					// cost_valid=true means priced (including zero-cost),
-					// false means unpriced.
-					TotalCostMicros: sql.NullInt64{Int64: totalCostMicros, Valid: true},
-					CostValid:       sql.NullBool{Bool: costValid, Valid: true},
+					// false means unpriced. Keep total_cost_micros NULL for
+					// unpriced writes so older readers still infer pricing
+					// correctly during mixed-version rollout.
+					TotalCostMicros: totalCostMicrosValue,
+					CostValid:       costValidValue,
 				})
 				if insertErr != nil {
 					return xerrors.Errorf("insert assistant message: %w", insertErr)
@@ -3000,6 +3003,16 @@ func usageNullInt64(value int64, valid bool) sql.NullInt64 {
 		Int64: value,
 		Valid: valid,
 	}
+}
+
+//nolint:revive // Boolean controls SQL NULL validity.
+func persistedMessageCost(totalCostMicros int64, costValid bool) (sql.NullInt64, sql.NullBool) {
+	costValidValue := sql.NullBool{Bool: costValid, Valid: true}
+	if !costValid {
+		return sql.NullInt64{}, costValidValue
+	}
+
+	return sql.NullInt64{Int64: totalCostMicros, Valid: true}, costValidValue
 }
 
 func refreshChatWorkspaceSnapshot(

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -297,8 +297,8 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 				CacheReadTokens:     sql.NullInt64{},
 				ContextLimit:        sql.NullInt64{},
 				Compressed:          sql.NullBool{},
-				TotalCostMicros:     0,
-				CostValid:           false,
+				TotalCostMicros:     sql.NullInt64{},
+				CostValid:           sql.NullBool{},
 			})
 			if err != nil {
 				return xerrors.Errorf("insert system message: %w", err)
@@ -327,8 +327,8 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     0,
-			CostValid:           false,
+			TotalCostMicros:     sql.NullInt64{},
+			CostValid:           sql.NullBool{},
 			Compressed:          sql.NullBool{},
 		})
 		if err != nil {
@@ -918,8 +918,8 @@ func insertUserMessageAndSetPending(
 		CacheCreationTokens: sql.NullInt64{},
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
-		TotalCostMicros:     0,
-		CostValid:           false,
+		TotalCostMicros:     sql.NullInt64{},
+		CostValid:           sql.NullBool{},
 		Compressed:          sql.NullBool{},
 	})
 	if err != nil {
@@ -1979,8 +1979,8 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 						CacheCreationTokens: sql.NullInt64{},
 						CacheReadTokens:     sql.NullInt64{},
 						ContextLimit:        sql.NullInt64{},
-						TotalCostMicros:     0,
-						CostValid:           false,
+						TotalCostMicros:     sql.NullInt64{},
+						CostValid:           sql.NullBool{},
 						Compressed:          sql.NullBool{},
 					})
 					if insertErr != nil {
@@ -2413,8 +2413,8 @@ func (p *Server) runChat(
 					Compressed:      sql.NullBool{},
 					// cost_valid=true means priced (including zero-cost),
 					// false means unpriced.
-					TotalCostMicros: totalCostMicros,
-					CostValid:       costValid,
+					TotalCostMicros: sql.NullInt64{Int64: totalCostMicros, Valid: true},
+					CostValid:       sql.NullBool{Bool: costValid, Valid: true},
 				})
 				if insertErr != nil {
 					return xerrors.Errorf("insert assistant message: %w", insertErr)
@@ -2444,8 +2444,8 @@ func (p *Server) runChat(
 					CacheCreationTokens: sql.NullInt64{},
 					CacheReadTokens:     sql.NullInt64{},
 					ContextLimit:        sql.NullInt64{},
-					TotalCostMicros:     0,
-					CostValid:           false,
+					TotalCostMicros:     sql.NullInt64{},
+					CostValid:           sql.NullBool{},
 					Compressed:          sql.NullBool{},
 				})
 				if insertErr != nil {
@@ -2820,8 +2820,8 @@ func (p *Server) persistChatContextSummary(
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     0,
-			CostValid:           false,
+			TotalCostMicros:     sql.NullInt64{},
+			CostValid:           sql.NullBool{},
 		})
 		if txErr != nil {
 			return xerrors.Errorf("insert hidden summary message: %w", txErr)
@@ -2846,8 +2846,8 @@ func (p *Server) persistChatContextSummary(
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     0,
-			CostValid:           false,
+			TotalCostMicros:     sql.NullInt64{},
+			CostValid:           sql.NullBool{},
 		})
 		if txErr != nil {
 			return xerrors.Errorf("insert summary tool call message: %w", txErr)
@@ -2873,8 +2873,8 @@ func (p *Server) persistChatContextSummary(
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     0,
-			CostValid:           false,
+			TotalCostMicros:     sql.NullInt64{},
+			CostValid:           sql.NullBool{},
 		})
 		if txErr != nil {
 			return xerrors.Errorf("insert summary tool result message: %w", txErr)

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -297,7 +297,8 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 				CacheReadTokens:     sql.NullInt64{},
 				ContextLimit:        sql.NullInt64{},
 				Compressed:          sql.NullBool{},
-				TotalCostMicros:     sql.NullInt64{},
+				TotalCostMicros:     0,
+				CostValid:           false,
 			})
 			if err != nil {
 				return xerrors.Errorf("insert system message: %w", err)
@@ -326,7 +327,8 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     sql.NullInt64{},
+			TotalCostMicros:     0,
+			CostValid:           false,
 			Compressed:          sql.NullBool{},
 		})
 		if err != nil {
@@ -916,7 +918,8 @@ func insertUserMessageAndSetPending(
 		CacheCreationTokens: sql.NullInt64{},
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
-		TotalCostMicros:     sql.NullInt64{},
+		TotalCostMicros:     0,
+		CostValid:           false,
 		Compressed:          sql.NullBool{},
 	})
 	if err != nil {
@@ -1976,7 +1979,8 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 						CacheCreationTokens: sql.NullInt64{},
 						CacheReadTokens:     sql.NullInt64{},
 						ContextLimit:        sql.NullInt64{},
-						TotalCostMicros:     sql.NullInt64{},
+						TotalCostMicros:     0,
+						CostValid:           false,
 						Compressed:          sql.NullBool{},
 					})
 					if insertErr != nil {
@@ -2383,7 +2387,7 @@ func (p *Server) runChat(
 					}
 				}
 
-				totalCostMicros := chatcost.CalculateTotalCostMicros(usageForCost, callConfig.Cost)
+				totalCostMicros, costValid := chatcost.CalculateTotalCostMicros(usageForCost, callConfig.Cost)
 
 				assistantMessage, insertErr := tx.InsertChatMessage(persistCtx, database.InsertChatMessageParams{
 					ChatID:         chat.ID,
@@ -2407,11 +2411,10 @@ func (p *Server) runChat(
 					CacheReadTokens: usageNullInt64(step.Usage.CacheReadTokens, hasUsage),
 					ContextLimit:    step.ContextLimit,
 					Compressed:      sql.NullBool{},
-					// TotalCostMicros is nullable: NULL means "unpriced"
-					// (pricing config was missing or no priced token
-					// breakdown available), while 0 means "priced at
-					// zero cost" (e.g., a free model).
-					TotalCostMicros: usageNullInt64Ptr(totalCostMicros),
+					// cost_valid=true means priced (including zero-cost),
+					// false means unpriced.
+					TotalCostMicros: totalCostMicros,
+					CostValid:       costValid,
 				})
 				if insertErr != nil {
 					return xerrors.Errorf("insert assistant message: %w", insertErr)
@@ -2441,7 +2444,8 @@ func (p *Server) runChat(
 					CacheCreationTokens: sql.NullInt64{},
 					CacheReadTokens:     sql.NullInt64{},
 					ContextLimit:        sql.NullInt64{},
-					TotalCostMicros:     sql.NullInt64{},
+					TotalCostMicros:     0,
+					CostValid:           false,
 					Compressed:          sql.NullBool{},
 				})
 				if insertErr != nil {
@@ -2816,7 +2820,8 @@ func (p *Server) persistChatContextSummary(
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     sql.NullInt64{},
+			TotalCostMicros:     0,
+			CostValid:           false,
 		})
 		if txErr != nil {
 			return xerrors.Errorf("insert hidden summary message: %w", txErr)
@@ -2841,7 +2846,8 @@ func (p *Server) persistChatContextSummary(
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     sql.NullInt64{},
+			TotalCostMicros:     0,
+			CostValid:           false,
 		})
 		if txErr != nil {
 			return xerrors.Errorf("insert summary tool call message: %w", txErr)
@@ -2867,7 +2873,8 @@ func (p *Server) persistChatContextSummary(
 			CacheCreationTokens: sql.NullInt64{},
 			CacheReadTokens:     sql.NullInt64{},
 			ContextLimit:        sql.NullInt64{},
-			TotalCostMicros:     sql.NullInt64{},
+			TotalCostMicros:     0,
+			CostValid:           false,
 		})
 		if txErr != nil {
 			return xerrors.Errorf("insert summary tool result message: %w", txErr)
@@ -2993,13 +3000,6 @@ func usageNullInt64(value int64, valid bool) sql.NullInt64 {
 		Int64: value,
 		Valid: valid,
 	}
-}
-
-func usageNullInt64Ptr(v *int64) sql.NullInt64 {
-	if v == nil {
-		return sql.NullInt64{}
-	}
-	return sql.NullInt64{Int64: *v, Valid: true}
 }
 
 func refreshChatWorkspaceSnapshot(

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -1411,6 +1411,82 @@ func setOpenAIProviderBaseURL(
 	require.NoError(t, err)
 }
 
+func TestSuccessfulChatPersistsNullCostForUnpricedAssistantMessages(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	_, err := db.UpdateChatModelConfig(ctx, database.UpdateChatModelConfigParams{
+		Provider:             model.Provider,
+		Model:                model.Model,
+		DisplayName:          model.DisplayName,
+		UpdatedBy:            model.UpdatedBy,
+		Enabled:              model.Enabled,
+		IsDefault:            model.IsDefault,
+		ContextLimit:         model.ContextLimit,
+		CompressionThreshold: model.CompressionThreshold,
+		Options:              json.RawMessage(`{"cost":{"input_price_per_million_tokens":"0.15"}}`),
+		ID:                   model.ID,
+	})
+	require.NoError(t, err)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "unpriced-cost-write-test",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusWaiting && !fromDB.WorkerID.Valid
+	}, testutil.IntervalFast)
+
+	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:  chat.ID,
+		AfterID: 0,
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+
+	assistantMessage := messages[1]
+	require.Equal(t, database.ChatMessageRoleAssistant, assistantMessage.Role)
+	require.False(t, assistantMessage.TotalCostMicros.Valid)
+	require.Equal(t, int64(0), assistantMessage.TotalCostMicros.Int64)
+	require.True(t, assistantMessage.CostValid.Valid)
+	require.False(t, assistantMessage.CostValid.Bool)
+}
+
 func TestInterruptChatDoesNotSendWebPushNotification(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -588,6 +588,8 @@ func TestEditMessageRejectsNonUserMessage(t *testing.T) {
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
 		Compressed:          sql.NullBool{},
+		TotalCostMicros:     0,
+		CostValid:           false,
 	})
 	require.NoError(t, err)
 
@@ -936,6 +938,8 @@ func TestSubscribeAfterMessageID(t *testing.T) {
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
 		Compressed:          sql.NullBool{},
+		TotalCostMicros:     0,
+		CostValid:           false,
 	})
 	require.NoError(t, err)
 
@@ -959,6 +963,8 @@ func TestSubscribeAfterMessageID(t *testing.T) {
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
 		Compressed:          sql.NullBool{},
+		TotalCostMicros:     0,
+		CostValid:           false,
 	})
 	require.NoError(t, err)
 

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -588,8 +588,8 @@ func TestEditMessageRejectsNonUserMessage(t *testing.T) {
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
 		Compressed:          sql.NullBool{},
-		TotalCostMicros:     0,
-		CostValid:           false,
+		TotalCostMicros:     sql.NullInt64{},
+		CostValid:           sql.NullBool{},
 	})
 	require.NoError(t, err)
 
@@ -938,8 +938,8 @@ func TestSubscribeAfterMessageID(t *testing.T) {
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
 		Compressed:          sql.NullBool{},
-		TotalCostMicros:     0,
-		CostValid:           false,
+		TotalCostMicros:     sql.NullInt64{},
+		CostValid:           sql.NullBool{},
 	})
 	require.NoError(t, err)
 
@@ -963,8 +963,8 @@ func TestSubscribeAfterMessageID(t *testing.T) {
 		CacheReadTokens:     sql.NullInt64{},
 		ContextLimit:        sql.NullInt64{},
 		Compressed:          sql.NullBool{},
-		TotalCostMicros:     0,
-		CostValid:           false,
+		TotalCostMicros:     sql.NullInt64{},
+		CostValid:           sql.NullBool{},
 	})
 	require.NoError(t, err)
 

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -3509,8 +3509,8 @@ func seedChatCostFixture(t *testing.T) chatCostTestFixture {
 			Visibility:      database.ChatMessageVisibilityBoth,
 			InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 			OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-			TotalCostMicros: 500,
-			CostValid:       true,
+			TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+			CostValid:       sql.NullBool{Bool: true, Valid: true},
 		})
 		require.NoError(t, err)
 	}
@@ -3602,8 +3602,8 @@ func TestChatCostSummary_AdminDrilldown(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 100, Valid: true},
-		TotalCostMicros: 750,
-		CostValid:       true,
+		TotalCostMicros: sql.NullInt64{Int64: 750, Valid: true},
+		CostValid:       sql.NullBool{Bool: true, Valid: true},
 	})
 	require.NoError(t, err)
 
@@ -3653,8 +3653,8 @@ func TestChatCostUsers(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-		TotalCostMicros: 300,
-		CostValid:       true,
+		TotalCostMicros: sql.NullInt64{Int64: 300, Valid: true},
+		CostValid:       sql.NullBool{Bool: true, Valid: true},
 	})
 	require.NoError(t, err)
 
@@ -3671,8 +3671,8 @@ func TestChatCostUsers(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 100, Valid: true},
-		TotalCostMicros: 800,
-		CostValid:       true,
+		TotalCostMicros: sql.NullInt64{Int64: 800, Valid: true},
+		CostValid:       sql.NullBool{Bool: true, Valid: true},
 	})
 	require.NoError(t, err)
 
@@ -3746,8 +3746,8 @@ func TestChatCostSummary_DateRange(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-		TotalCostMicros: 500,
-		CostValid:       true,
+		TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+		CostValid:       sql.NullBool{Bool: true, Valid: true},
 	})
 	require.NoError(t, err)
 
@@ -3802,8 +3802,8 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-		TotalCostMicros: 500,
-		CostValid:       true,
+		TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+		CostValid:       sql.NullBool{Bool: true, Valid: true},
 	})
 	require.NoError(t, err)
 
@@ -3814,8 +3814,8 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 75, Valid: true},
-		TotalCostMicros: 0,
-		CostValid:       false,
+		TotalCostMicros: sql.NullInt64{},
+		CostValid:       sql.NullBool{},
 	})
 	require.NoError(t, err)
 

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -3509,7 +3509,8 @@ func seedChatCostFixture(t *testing.T) chatCostTestFixture {
 			Visibility:      database.ChatMessageVisibilityBoth,
 			InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 			OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-			TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+			TotalCostMicros: 500,
+			CostValid:       true,
 		})
 		require.NoError(t, err)
 	}
@@ -3601,7 +3602,8 @@ func TestChatCostSummary_AdminDrilldown(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 100, Valid: true},
-		TotalCostMicros: sql.NullInt64{Int64: 750, Valid: true},
+		TotalCostMicros: 750,
+		CostValid:       true,
 	})
 	require.NoError(t, err)
 
@@ -3651,7 +3653,8 @@ func TestChatCostUsers(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-		TotalCostMicros: sql.NullInt64{Int64: 300, Valid: true},
+		TotalCostMicros: 300,
+		CostValid:       true,
 	})
 	require.NoError(t, err)
 
@@ -3668,7 +3671,8 @@ func TestChatCostUsers(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 100, Valid: true},
-		TotalCostMicros: sql.NullInt64{Int64: 800, Valid: true},
+		TotalCostMicros: 800,
+		CostValid:       true,
 	})
 	require.NoError(t, err)
 
@@ -3742,7 +3746,8 @@ func TestChatCostSummary_DateRange(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-		TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+		TotalCostMicros: 500,
+		CostValid:       true,
 	})
 	require.NoError(t, err)
 
@@ -3797,7 +3802,8 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-		TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+		TotalCostMicros: 500,
+		CostValid:       true,
 	})
 	require.NoError(t, err)
 
@@ -3808,7 +3814,8 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 		Visibility:      database.ChatMessageVisibilityBoth,
 		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 75, Valid: true},
-		TotalCostMicros: sql.NullInt64{},
+		TotalCostMicros: 0,
+		CostValid:       false,
 	})
 	require.NoError(t, err)
 

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -3829,6 +3829,69 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 	require.Equal(t, int64(125), summary.TotalOutputTokens)
 }
 
+func TestChatCostSummary_MixedVersionRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	client, db := newChatClientWithDatabase(t)
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	modelConfig := createChatModelConfig(t, client)
+
+	chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+		OwnerID:           firstUser.UserID,
+		LastModelConfigID: modelConfig.ID,
+		Title:             "mixed version test",
+	})
+	require.NoError(t, err)
+
+	_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+		ChatID:          chat.ID,
+		ModelConfigID:   uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+		Role:            "assistant",
+		ContentVersion:  1,
+		Visibility:      database.ChatMessageVisibilityBoth,
+		InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
+		OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
+		TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+		CostValid:       sql.NullBool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+
+	_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+		ChatID:          chat.ID,
+		ModelConfigID:   uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+		Role:            "assistant",
+		ContentVersion:  1,
+		Visibility:      database.ChatMessageVisibilityBoth,
+		InputTokens:     sql.NullInt64{Int64: 200, Valid: true},
+		OutputTokens:    sql.NullInt64{Int64: 100, Valid: true},
+		TotalCostMicros: sql.NullInt64{Int64: 300, Valid: true},
+		CostValid:       sql.NullBool{},
+	})
+	require.NoError(t, err)
+
+	_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+		ChatID:          chat.ID,
+		ModelConfigID:   uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+		Role:            "assistant",
+		ContentVersion:  1,
+		Visibility:      database.ChatMessageVisibilityBoth,
+		InputTokens:     sql.NullInt64{Int64: 150, Valid: true},
+		OutputTokens:    sql.NullInt64{Int64: 75, Valid: true},
+		TotalCostMicros: sql.NullInt64{},
+		CostValid:       sql.NullBool{},
+	})
+	require.NoError(t, err)
+
+	summary, err := client.GetChatCostSummary(ctx, "me", codersdk.ChatCostSummaryOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(800), summary.TotalCostMicros)
+	require.Equal(t, int64(2), summary.PricedMessageCount)
+	require.Equal(t, int64(1), summary.UnpricedMessageCount)
+	require.Equal(t, int64(450), summary.TotalInputTokens)
+	require.Equal(t, int64(225), summary.TotalOutputTokens)
+}
+
 func requireChatModelPricing(
 	t *testing.T,
 	actual *codersdk.ChatModelCallConfig,

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -3879,6 +3879,19 @@ func TestChatCostSummary_MixedVersionRows(t *testing.T) {
 		InputTokens:     sql.NullInt64{Int64: 150, Valid: true},
 		OutputTokens:    sql.NullInt64{Int64: 75, Valid: true},
 		TotalCostMicros: sql.NullInt64{},
+		CostValid:       sql.NullBool{Bool: false, Valid: true},
+	})
+	require.NoError(t, err)
+
+	_, err = db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
+		ChatID:          chat.ID,
+		ModelConfigID:   uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+		Role:            "assistant",
+		ContentVersion:  1,
+		Visibility:      database.ChatMessageVisibilityBoth,
+		InputTokens:     sql.NullInt64{Int64: 25, Valid: true},
+		OutputTokens:    sql.NullInt64{Int64: 10, Valid: true},
+		TotalCostMicros: sql.NullInt64{},
 		CostValid:       sql.NullBool{},
 	})
 	require.NoError(t, err)
@@ -3887,9 +3900,9 @@ func TestChatCostSummary_MixedVersionRows(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(800), summary.TotalCostMicros)
 	require.Equal(t, int64(2), summary.PricedMessageCount)
-	require.Equal(t, int64(1), summary.UnpricedMessageCount)
-	require.Equal(t, int64(450), summary.TotalInputTokens)
-	require.Equal(t, int64(225), summary.TotalOutputTokens)
+	require.Equal(t, int64(2), summary.UnpricedMessageCount)
+	require.Equal(t, int64(475), summary.TotalInputTokens)
+	require.Equal(t, int64(235), summary.TotalOutputTokens)
 }
 
 func requireChatModelPricing(

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1239,8 +1239,8 @@ CREATE TABLE chat_messages (
     compressed boolean DEFAULT false NOT NULL,
     created_by uuid,
     content_version smallint NOT NULL,
-    total_cost_micros bigint DEFAULT 0 NOT NULL,
-    cost_valid boolean DEFAULT false NOT NULL
+    total_cost_micros bigint,
+    cost_valid boolean
 );
 
 CREATE SEQUENCE chat_messages_id_seq

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1239,7 +1239,8 @@ CREATE TABLE chat_messages (
     compressed boolean DEFAULT false NOT NULL,
     created_by uuid,
     content_version smallint NOT NULL,
-    total_cost_micros bigint
+    total_cost_micros bigint DEFAULT 0 NOT NULL,
+    cost_valid boolean DEFAULT false NOT NULL
 );
 
 CREATE SEQUENCE chat_messages_id_seq

--- a/coderd/database/migrations/000439_simplify_chat_cost_nullable.down.sql
+++ b/coderd/database/migrations/000439_simplify_chat_cost_nullable.down.sql
@@ -1,9 +1,9 @@
--- Restore NULL for unpriced rows.
-UPDATE chat_messages SET total_cost_micros = NULL WHERE cost_valid = false;
-
 -- Remove NOT NULL constraint and default.
 ALTER TABLE chat_messages ALTER COLUMN total_cost_micros DROP NOT NULL;
 ALTER TABLE chat_messages ALTER COLUMN total_cost_micros DROP DEFAULT;
+
+-- Restore NULL for unpriced rows.
+UPDATE chat_messages SET total_cost_micros = NULL WHERE cost_valid = false;
 
 -- Drop cost_valid column.
 ALTER TABLE chat_messages DROP COLUMN cost_valid;

--- a/coderd/database/migrations/000439_simplify_chat_cost_nullable.down.sql
+++ b/coderd/database/migrations/000439_simplify_chat_cost_nullable.down.sql
@@ -1,8 +1,4 @@
--- Remove NOT NULL constraint and default.
-ALTER TABLE chat_messages ALTER COLUMN total_cost_micros DROP NOT NULL;
-ALTER TABLE chat_messages ALTER COLUMN total_cost_micros DROP DEFAULT;
-
--- Restore NULL for unpriced rows.
+-- Restore NULL cost for rows that new code marked as unpriced.
 UPDATE chat_messages SET total_cost_micros = NULL WHERE cost_valid = false;
 
 -- Drop cost_valid column.

--- a/coderd/database/migrations/000439_simplify_chat_cost_nullable.down.sql
+++ b/coderd/database/migrations/000439_simplify_chat_cost_nullable.down.sql
@@ -1,0 +1,9 @@
+-- Restore NULL for unpriced rows.
+UPDATE chat_messages SET total_cost_micros = NULL WHERE cost_valid = false;
+
+-- Remove NOT NULL constraint and default.
+ALTER TABLE chat_messages ALTER COLUMN total_cost_micros DROP NOT NULL;
+ALTER TABLE chat_messages ALTER COLUMN total_cost_micros DROP DEFAULT;
+
+-- Drop cost_valid column.
+ALTER TABLE chat_messages DROP COLUMN cost_valid;

--- a/coderd/database/migrations/000439_simplify_chat_cost_nullable.up.sql
+++ b/coderd/database/migrations/000439_simplify_chat_cost_nullable.up.sql
@@ -1,12 +1,9 @@
--- Add cost_valid column. Default false = unpriced.
-ALTER TABLE chat_messages ADD COLUMN cost_valid boolean NOT NULL DEFAULT false;
+-- Add cost_valid as a nullable column with no default for
+-- mixed-version rollout compatibility. Old writers that do not
+-- know about this column will insert NULL, which the summary
+-- query interprets via COALESCE as falling back to the
+-- total_cost_micros IS NOT NULL heuristic.
+ALTER TABLE chat_messages ADD COLUMN cost_valid boolean;
 
--- Backfill: any row with non-NULL total_cost_micros is priced.
-UPDATE chat_messages SET cost_valid = true WHERE total_cost_micros IS NOT NULL;
-
--- Convert NULL costs to 0 so column can become NOT NULL.
-UPDATE chat_messages SET total_cost_micros = 0 WHERE total_cost_micros IS NULL;
-
--- Make total_cost_micros non-nullable with default 0.
-ALTER TABLE chat_messages ALTER COLUMN total_cost_micros SET NOT NULL;
-ALTER TABLE chat_messages ALTER COLUMN total_cost_micros SET DEFAULT 0;
+-- Backfill: mark existing rows based on whether they have a cost.
+UPDATE chat_messages SET cost_valid = (total_cost_micros IS NOT NULL);

--- a/coderd/database/migrations/000439_simplify_chat_cost_nullable.up.sql
+++ b/coderd/database/migrations/000439_simplify_chat_cost_nullable.up.sql
@@ -1,0 +1,12 @@
+-- Add cost_valid column. Default false = unpriced.
+ALTER TABLE chat_messages ADD COLUMN cost_valid boolean NOT NULL DEFAULT false;
+
+-- Backfill: any row with non-NULL total_cost_micros is priced.
+UPDATE chat_messages SET cost_valid = true WHERE total_cost_micros IS NOT NULL;
+
+-- Convert NULL costs to 0 so column can become NOT NULL.
+UPDATE chat_messages SET total_cost_micros = 0 WHERE total_cost_micros IS NULL;
+
+-- Make total_cost_micros non-nullable with default 0.
+ALTER TABLE chat_messages ALTER COLUMN total_cost_micros SET NOT NULL;
+ALTER TABLE chat_messages ALTER COLUMN total_cost_micros SET DEFAULT 0;

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -465,6 +465,180 @@ func TestMigration000362AggregateUsageEvents(t *testing.T) {
 	}
 }
 
+func TestMigration000439ChatCostRolloutSafety(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	const migrationVersion = 439
+
+	sqlDB := testSQLDB(t)
+
+	next, err := migrations.Stepper(sqlDB)
+	require.NoError(t, err)
+	for {
+		version, more, err := next()
+		require.NoError(t, err)
+		if !more {
+			t.Fatalf("migration %d not found", migrationVersion)
+		}
+		if version == migrationVersion-1 {
+			break
+		}
+	}
+
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
+	orgID := uuid.New()
+	userID := uuid.New()
+	chatProviderID := uuid.New()
+	modelConfigID := uuid.New()
+	chatID := uuid.New()
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO organizations (id, name, display_name, description, icon, created_at, updated_at, is_default)
+		VALUES ($1, 'test-org', 'Test Org', '', '', NOW(), NOW(), false)
+	`, orgID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO users (id, email, username, name, hashed_password, created_at, updated_at, status, rbac_roles, login_type)
+		VALUES ($1, 'test@test.com', 'testuser', 'Test User', 'xxx', NOW(), NOW(), 'active', '{}', 'password')
+	`, userID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO organization_members (organization_id, user_id, created_at, updated_at, roles)
+		VALUES ($1, $2, NOW(), NOW(), '{}')
+	`, orgID, userID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO chat_providers (
+			id,
+			provider,
+			display_name,
+			api_key,
+			api_key_key_id,
+			enabled,
+			created_at,
+			updated_at
+		) VALUES (
+			$1,
+			'openai',
+			'OpenAI',
+			'',
+			NULL,
+			true,
+			NOW(),
+			NOW()
+		)
+	`, chatProviderID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO chat_model_configs (
+			id,
+			display_name,
+			provider,
+			model,
+			enabled,
+			context_limit,
+			compression_threshold,
+			created_at,
+			updated_at
+		) VALUES (
+			$1,
+			'test model',
+			'openai',
+			'gpt-4',
+			true,
+			200000,
+			70,
+			NOW(),
+			NOW()
+		)
+	`, modelConfigID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO chats (id, owner_id, last_model_config_id, title, created_at, updated_at)
+		VALUES ($1, $2, $3, 'test chat', NOW(), NOW())
+	`, chatID, userID, modelConfigID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO chat_messages (chat_id, role, content_version, visibility, total_cost_micros, created_at)
+		VALUES ($1, 'assistant', 1, 'both', 500, NOW())
+	`, chatID)
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO chat_messages (chat_id, role, content_version, visibility, total_cost_micros, created_at)
+		VALUES ($1, 'assistant', 1, 'both', NULL, NOW())
+	`, chatID)
+	require.NoError(t, err)
+
+	version, _, err := next()
+	require.NoError(t, err)
+	require.EqualValues(t, migrationVersion, version)
+
+	rows, err := sqlDB.QueryContext(ctx, `
+		SELECT total_cost_micros, cost_valid
+		FROM chat_messages
+		WHERE chat_id = $1
+		ORDER BY id
+	`, chatID)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var messages []struct {
+		totalCost sql.NullInt64
+		costValid sql.NullBool
+	}
+	for rows.Next() {
+		var message struct {
+			totalCost sql.NullInt64
+			costValid sql.NullBool
+		}
+		err = rows.Scan(&message.totalCost, &message.costValid)
+		require.NoError(t, err)
+		messages = append(messages, message)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, messages, 2)
+
+	require.True(t, messages[0].totalCost.Valid)
+	require.Equal(t, int64(500), messages[0].totalCost.Int64)
+	require.True(t, messages[0].costValid.Valid)
+	require.True(t, messages[0].costValid.Bool)
+
+	require.False(t, messages[1].totalCost.Valid)
+	require.True(t, messages[1].costValid.Valid)
+	require.False(t, messages[1].costValid.Bool)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO chat_messages (chat_id, role, content_version, visibility, total_cost_micros, created_at)
+		VALUES ($1, 'assistant', 1, 'both', NULL, NOW())
+	`, chatID)
+	require.NoError(t, err)
+
+	var oldStyleTotalCost sql.NullInt64
+	var oldStyleCostValid sql.NullBool
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT total_cost_micros, cost_valid
+		FROM chat_messages
+		WHERE chat_id = $1
+		ORDER BY id DESC
+		LIMIT 1
+	`, chatID).Scan(&oldStyleTotalCost, &oldStyleCostValid)
+	require.NoError(t, err)
+	require.False(t, oldStyleTotalCost.Valid)
+	require.False(t, oldStyleCostValid.Valid)
+}
+
 func TestMigration000387MigrateTaskWorkspaces(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4084,7 +4084,8 @@ type ChatMessage struct {
 	Compressed          bool                  `db:"compressed" json:"compressed"`
 	CreatedBy           uuid.NullUUID         `db:"created_by" json:"created_by"`
 	ContentVersion      int16                 `db:"content_version" json:"content_version"`
-	TotalCostMicros     sql.NullInt64         `db:"total_cost_micros" json:"total_cost_micros"`
+	TotalCostMicros     int64                 `db:"total_cost_micros" json:"total_cost_micros"`
+	CostValid           bool                  `db:"cost_valid" json:"cost_valid"`
 }
 
 type ChatModelConfig struct {

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4084,8 +4084,8 @@ type ChatMessage struct {
 	Compressed          bool                  `db:"compressed" json:"compressed"`
 	CreatedBy           uuid.NullUUID         `db:"created_by" json:"created_by"`
 	ContentVersion      int16                 `db:"content_version" json:"content_version"`
-	TotalCostMicros     int64                 `db:"total_cost_micros" json:"total_cost_micros"`
-	CostValid           bool                  `db:"cost_valid" json:"cost_valid"`
+	TotalCostMicros     sql.NullInt64         `db:"total_cost_micros" json:"total_cost_micros"`
+	CostValid           sql.NullBool          `db:"cost_valid" json:"cost_valid"`
 }
 
 type ChatModelConfig struct {

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -9057,8 +9057,8 @@ func TestGetChatMessagesForPromptByChatID(t *testing.T) {
 			ContentVersion:  chatprompt.CurrentContentVersion,
 			Visibility:      vis,
 			Compressed:      sql.NullBool{Bool: compressed, Valid: true},
-			TotalCostMicros: 0,
-			CostValid:       false,
+			TotalCostMicros: sql.NullInt64{},
+			CostValid:       sql.NullBool{},
 			Content: pqtype.NullRawMessage{
 				RawMessage: json.RawMessage(`"` + content + `"`),
 				Valid:      true,

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -9052,11 +9052,13 @@ func TestGetChatMessagesForPromptByChatID(t *testing.T) {
 	) database.ChatMessage {
 		t.Helper()
 		msg, err := db.InsertChatMessage(ctx, database.InsertChatMessageParams{
-			ChatID:         chatID,
-			Role:           role,
-			ContentVersion: chatprompt.CurrentContentVersion,
-			Visibility:     vis,
-			Compressed:     sql.NullBool{Bool: compressed, Valid: true},
+			ChatID:          chatID,
+			Role:            role,
+			ContentVersion:  chatprompt.CurrentContentVersion,
+			Visibility:      vis,
+			Compressed:      sql.NullBool{Bool: compressed, Valid: true},
+			TotalCostMicros: 0,
+			CostValid:       false,
 			Content: pqtype.NullRawMessage{
 				RawMessage: json.RawMessage(`"` + content + `"`),
 				Valid:      true,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3563,10 +3563,10 @@ const getChatCostSummary = `-- name: GetChatCostSummary :one
 SELECT
     COALESCE(SUM(cm.total_cost_micros), 0)::bigint AS total_cost_micros,
     COUNT(*) FILTER (
-        WHERE cm.cost_valid
+        WHERE COALESCE(cm.cost_valid, cm.total_cost_micros IS NOT NULL)
     )::bigint AS priced_message_count,
     COUNT(*) FILTER (
-        WHERE NOT cm.cost_valid
+        WHERE NOT COALESCE(cm.cost_valid, cm.total_cost_micros IS NOT NULL)
             AND (
                 cm.input_tokens IS NOT NULL
                 OR cm.output_tokens IS NOT NULL
@@ -4273,8 +4273,8 @@ type InsertChatMessageParams struct {
 	CacheReadTokens     sql.NullInt64         `db:"cache_read_tokens" json:"cache_read_tokens"`
 	ContextLimit        sql.NullInt64         `db:"context_limit" json:"context_limit"`
 	Compressed          sql.NullBool          `db:"compressed" json:"compressed"`
-	TotalCostMicros     int64                 `db:"total_cost_micros" json:"total_cost_micros"`
-	CostValid           bool                  `db:"cost_valid" json:"cost_valid"`
+	TotalCostMicros     sql.NullInt64         `db:"total_cost_micros" json:"total_cost_micros"`
+	CostValid           sql.NullBool          `db:"cost_valid" json:"cost_valid"`
 }
 
 func (q *sqlQuerier) InsertChatMessage(ctx context.Context, arg InsertChatMessageParams) (ChatMessage, error) {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3563,10 +3563,10 @@ const getChatCostSummary = `-- name: GetChatCostSummary :one
 SELECT
     COALESCE(SUM(cm.total_cost_micros), 0)::bigint AS total_cost_micros,
     COUNT(*) FILTER (
-        WHERE cm.total_cost_micros IS NOT NULL
+        WHERE cm.cost_valid
     )::bigint AS priced_message_count,
     COUNT(*) FILTER (
-        WHERE cm.total_cost_micros IS NULL
+        WHERE NOT cm.cost_valid
             AND (
                 cm.input_tokens IS NOT NULL
                 OR cm.output_tokens IS NOT NULL
@@ -3721,7 +3721,7 @@ func (q *sqlQuerier) GetChatDiffStatusesByChatIDs(ctx context.Context, chatIds [
 
 const getChatMessageByID = `-- name: GetChatMessageByID :one
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, cost_valid
 FROM
     chat_messages
 WHERE
@@ -3750,13 +3750,14 @@ func (q *sqlQuerier) GetChatMessageByID(ctx context.Context, id int64) (ChatMess
 		&i.CreatedBy,
 		&i.ContentVersion,
 		&i.TotalCostMicros,
+		&i.CostValid,
 	)
 	return i, err
 }
 
 const getChatMessagesByChatID = `-- name: GetChatMessagesByChatID :many
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, cost_valid
 FROM
     chat_messages
 WHERE
@@ -3800,6 +3801,7 @@ func (q *sqlQuerier) GetChatMessagesByChatID(ctx context.Context, arg GetChatMes
 			&i.CreatedBy,
 			&i.ContentVersion,
 			&i.TotalCostMicros,
+			&i.CostValid,
 		); err != nil {
 			return nil, err
 		}
@@ -3831,7 +3833,7 @@ WITH latest_compressed_summary AS (
         1
 )
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, cost_valid
 FROM
     chat_messages
 WHERE
@@ -3899,6 +3901,7 @@ func (q *sqlQuerier) GetChatMessagesForPromptByChatID(ctx context.Context, chatI
 			&i.CreatedBy,
 			&i.ContentVersion,
 			&i.TotalCostMicros,
+			&i.CostValid,
 		); err != nil {
 			return nil, err
 		}
@@ -4043,7 +4046,7 @@ func (q *sqlQuerier) GetChatsByOwnerID(ctx context.Context, arg GetChatsByOwnerI
 
 const getLastChatMessageByRole = `-- name: GetLastChatMessageByRole :one
 SELECT
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, cost_valid
 FROM
     chat_messages
 WHERE
@@ -4082,6 +4085,7 @@ func (q *sqlQuerier) GetLastChatMessageByRole(ctx context.Context, arg GetLastCh
 		&i.CreatedBy,
 		&i.ContentVersion,
 		&i.TotalCostMicros,
+		&i.CostValid,
 	)
 	return i, err
 }
@@ -4228,7 +4232,8 @@ INSERT INTO chat_messages (
     cache_read_tokens,
     context_limit,
     compressed,
-    total_cost_micros
+    total_cost_micros,
+    cost_valid
 ) VALUES (
     $1::uuid,
     $2::uuid,
@@ -4245,10 +4250,11 @@ INSERT INTO chat_messages (
     $13::bigint,
     $14::bigint,
     COALESCE($15::boolean, FALSE),
-    $16::bigint
+    $16::bigint,
+    $17::boolean
 )
 RETURNING
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, cost_valid
 `
 
 type InsertChatMessageParams struct {
@@ -4267,7 +4273,8 @@ type InsertChatMessageParams struct {
 	CacheReadTokens     sql.NullInt64         `db:"cache_read_tokens" json:"cache_read_tokens"`
 	ContextLimit        sql.NullInt64         `db:"context_limit" json:"context_limit"`
 	Compressed          sql.NullBool          `db:"compressed" json:"compressed"`
-	TotalCostMicros     sql.NullInt64         `db:"total_cost_micros" json:"total_cost_micros"`
+	TotalCostMicros     int64                 `db:"total_cost_micros" json:"total_cost_micros"`
+	CostValid           bool                  `db:"cost_valid" json:"cost_valid"`
 }
 
 func (q *sqlQuerier) InsertChatMessage(ctx context.Context, arg InsertChatMessageParams) (ChatMessage, error) {
@@ -4288,6 +4295,7 @@ func (q *sqlQuerier) InsertChatMessage(ctx context.Context, arg InsertChatMessag
 		arg.ContextLimit,
 		arg.Compressed,
 		arg.TotalCostMicros,
+		arg.CostValid,
 	)
 	var i ChatMessage
 	err := row.Scan(
@@ -4309,6 +4317,7 @@ func (q *sqlQuerier) InsertChatMessage(ctx context.Context, arg InsertChatMessag
 		&i.CreatedBy,
 		&i.ContentVersion,
 		&i.TotalCostMicros,
+		&i.CostValid,
 	)
 	return i, err
 }
@@ -4444,7 +4453,7 @@ SET
 WHERE
     id = $3::bigint
 RETURNING
-    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros
+    id, chat_id, model_config_id, created_at, role, content, visibility, input_tokens, output_tokens, total_tokens, reasoning_tokens, cache_creation_tokens, cache_read_tokens, context_limit, compressed, created_by, content_version, total_cost_micros, cost_valid
 `
 
 type UpdateChatMessageByIDParams struct {
@@ -4475,6 +4484,7 @@ func (q *sqlQuerier) UpdateChatMessageByID(ctx context.Context, arg UpdateChatMe
 		&i.CreatedBy,
 		&i.ContentVersion,
 		&i.TotalCostMicros,
+		&i.CostValid,
 	)
 	return i, err
 }

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -182,7 +182,8 @@ INSERT INTO chat_messages (
     cache_read_tokens,
     context_limit,
     compressed,
-    total_cost_micros
+    total_cost_micros,
+    cost_valid
 ) VALUES (
     @chat_id::uuid,
     sqlc.narg('created_by')::uuid,
@@ -199,7 +200,8 @@ INSERT INTO chat_messages (
     sqlc.narg('cache_read_tokens')::bigint,
     sqlc.narg('context_limit')::bigint,
     COALESCE(sqlc.narg('compressed')::boolean, FALSE),
-    sqlc.narg('total_cost_micros')::bigint
+    @total_cost_micros::bigint,
+    @cost_valid::boolean
 )
 RETURNING
     *;
@@ -516,10 +518,10 @@ WHERE
 SELECT
     COALESCE(SUM(cm.total_cost_micros), 0)::bigint AS total_cost_micros,
     COUNT(*) FILTER (
-        WHERE cm.total_cost_micros IS NOT NULL
+        WHERE cm.cost_valid
     )::bigint AS priced_message_count,
     COUNT(*) FILTER (
-        WHERE cm.total_cost_micros IS NULL
+        WHERE NOT cm.cost_valid
             AND (
                 cm.input_tokens IS NOT NULL
                 OR cm.output_tokens IS NOT NULL

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -200,8 +200,8 @@ INSERT INTO chat_messages (
     sqlc.narg('cache_read_tokens')::bigint,
     sqlc.narg('context_limit')::bigint,
     COALESCE(sqlc.narg('compressed')::boolean, FALSE),
-    @total_cost_micros::bigint,
-    @cost_valid::boolean
+    sqlc.narg('total_cost_micros')::bigint,
+    sqlc.narg('cost_valid')::boolean
 )
 RETURNING
     *;
@@ -518,10 +518,10 @@ WHERE
 SELECT
     COALESCE(SUM(cm.total_cost_micros), 0)::bigint AS total_cost_micros,
     COUNT(*) FILTER (
-        WHERE cm.cost_valid
+        WHERE COALESCE(cm.cost_valid, cm.total_cost_micros IS NOT NULL)
     )::bigint AS priced_message_count,
     COUNT(*) FILTER (
-        WHERE NOT cm.cost_valid
+        WHERE NOT COALESCE(cm.cost_valid, cm.total_cost_micros IS NOT NULL)
             AND (
                 cm.input_tokens IS NOT NULL
                 OR cm.output_tokens IS NOT NULL


### PR DESCRIPTION
## Summary

Makes the chat cost simplification rollout-safe without changing external behavior.

This PR keeps the clearer `(micros int64, valid bool)` calculation API, adds an explicit `cost_valid` bit for new logic, and preserves mixed-version compatibility by continuing to store `NULL total_cost_micros` for unpriced rows until all readers understand `cost_valid`.

## What changed

- Migration `000439` now adds `cost_valid` as a nullable compatibility column and backfills it from the existing `total_cost_micros IS NOT NULL` semantics.
- `GetChatCostSummary` now uses `COALESCE(cost_valid, total_cost_micros IS NOT NULL)` so legacy rows and mixed-version writers are counted correctly.
- New write paths keep explicit `(cost, valid)` semantics, but still persist `NULL total_cost_micros` for unpriced messages so older readers keep working during rollout.
- Added rollout-safety regression tests for:
  - migration/application of `000439`
  - mixed-version summary behavior
  - new unpriced assistant writes staying NULL-backed

## Why

Codex correctly flagged two rollout hazards:
1. immediately making `total_cost_micros NOT NULL` breaks old writers that still insert `NULL`
2. writing `0` for new unpriced rows breaks old readers that still use `total_cost_micros IS NOT NULL`

This PR takes the safe phased approach instead of breaking mixed-version deployments.

## Validation

- `make pre-commit`
- `make test RUN=TestChatCostSummary_UnpricedMessages`
- `make gen`
- `go build ./coderd/...`
- `go test ./coderd/chatd/chatcost/...`
- `make lint`
- `go test ./coderd/chatd -run '^TestSuccessfulChatPersistsNullCostForUnpricedAssistantMessages$' -count=1`
- `go test ./coderd -run '^TestChatCostSummary_(UnpricedMessages|MixedVersionRows)$' -count=1`
