### PR TITLE
fix(site): right-align admin badge in agent settings nav tabs

### DIFF
--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -493,13 +493,13 @@ export const ConfigureAgentsDialog: FC<ConfigureAgentsDialogProps> = ({
 								onClick={() => setUserActiveSection(section.id)}
 							>
 								<SectionIcon className="h-5 w-5 shrink-0" />
-								<span className="flex items-center gap-2 text-sm font-medium">
+								<span className="flex flex-1 items-center gap-2 text-sm font-medium">
 									{section.label}
 									{section.adminOnly && (
 										<TooltipProvider delayDuration={0}>
 											<Tooltip>
 												<TooltipTrigger asChild>
-													<span className="inline-flex">
+													<span className="ml-auto inline-flex">
 														<ShieldIcon className="h-3 w-3 shrink-0 opacity-50" />
 													</span>
 												</TooltipTrigger>


### PR DESCRIPTION
Fixes alignment of the admin shield badge in the agent settings dialog navigation tabs. The badge is now right-aligned within each tab button instead of sitting immediately after the label text.

### Changes
- Added `flex-1` to the label `<span>` so it expands to fill the button width.
- Added `ml-auto` to the badge wrapper so the shield icon is pushed to the right edge.

<img width="1702" height="617" alt="image" src="https://github.com/user-attachments/assets/c942d769-e801-46d1-b2a9-9a82195a366d" />
