### PR TITLE
fix(site): fix chat usage UX inconsistencies in AgentsPage

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -883,14 +883,20 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 						</Tooltip>
 					)}
 					{onOpenSettings && (
-						<button
-							type="button"
-							onClick={onOpenSettings}
-							className="flex shrink-0 items-center justify-center bg-transparent border-0 cursor-pointer p-2 mr-1 rounded-md text-content-secondary hover:text-content-primary hover:bg-surface-tertiary/50 transition-colors"
-							aria-label="Settings"
-						>
-							<SettingsIcon className="h-4 w-4" />
-						</button>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="subtle"
+									size="icon"
+									onClick={onOpenSettings}
+									aria-label="Settings"
+									className="mr-1"
+								>
+									<SettingsIcon className="h-4 w-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Settings</TooltipContent>
+						</Tooltip>
 					)}
 				</div>
 			</div>

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -43,6 +43,7 @@ import type { LucideIcon } from "lucide-react";
 import {
 	BarChart3Icon,
 	BoxesIcon,
+	ChevronLeftIcon,
 	KeyRoundIcon,
 	ShieldIcon,
 	UserIcon,
@@ -192,20 +193,11 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 			}
 			badge={<AdminBadge />}
 			action={
-				selectedUser ? (
-					<Button
-						variant="outline"
-						size="sm"
-						type="button"
-						onClick={() => setSelectedUser(null)}
-					>
-						← Back to all users
-					</Button>
-				) : (
+				!selectedUser ? (
 					<span className="text-xs text-content-secondary">
 						{dateRange.rangeLabel}
 					</span>
-				)
+				) : undefined
 			}
 		/>
 	);
@@ -213,6 +205,14 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 	if (selectedUser) {
 		return (
 			<div className="space-y-6">
+				<button
+					type="button"
+					onClick={() => setSelectedUser(null)}
+					className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+				>
+					<ChevronLeftIcon className="h-4 w-4" />
+					Back
+				</button>
 				{header}
 				<div className="flex flex-wrap items-center gap-3 rounded-lg border border-border-default bg-surface-secondary px-4 py-3">
 					<AvatarData

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -204,7 +204,7 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 
 	if (selectedUser) {
 		return (
-			<div className="space-y-6">
+			<>
 				<button
 					type="button"
 					onClick={() => setSelectedUser(null)}
@@ -214,28 +214,30 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 					Back
 				</button>
 				{header}
-				<div className="flex flex-wrap items-center gap-3 rounded-lg border border-border-default bg-surface-secondary px-4 py-3">
-					<AvatarData
-						title={selectedUser.name || selectedUser.username}
-						subtitle={`@${selectedUser.username}`}
-						src={selectedUser.avatar_url}
-						imgFallbackText={selectedUser.username}
-					/>
-					<div className="min-w-0 text-xs text-content-secondary">
-						<div>User ID: {selectedUser.user_id}</div>
-						<div>{dateRange.rangeLabel}</div>
+				<div className="space-y-6">
+					<div className="flex flex-wrap items-center gap-3 rounded-lg border border-border-default bg-surface-secondary px-4 py-3">
+						<AvatarData
+							title={selectedUser.name || selectedUser.username}
+							subtitle={`@${selectedUser.username}`}
+							src={selectedUser.avatar_url}
+							imgFallbackText={selectedUser.username}
+						/>
+						<div className="min-w-0 text-xs text-content-secondary">
+							<div>User ID: {selectedUser.user_id}</div>
+							<div>{dateRange.rangeLabel}</div>
+						</div>
 					</div>
-				</div>
 
-				<ChatCostSummaryView
-					summary={summaryQuery.data}
-					isLoading={summaryQuery.isLoading}
-					error={summaryQuery.error}
-					onRetry={() => void summaryQuery.refetch()}
-					loadingLabel="Loading usage details"
-					emptyMessage="No usage data for this user in the selected period."
-				/>
-			</div>
+					<ChatCostSummaryView
+						summary={summaryQuery.data}
+						isLoading={summaryQuery.isLoading}
+						error={summaryQuery.error}
+						onRetry={() => void summaryQuery.refetch()}
+						loadingLabel="Loading usage details"
+						emptyMessage="No usage data for this user in the selected period."
+					/>
+				</div>
+			</>
 		);
 	}
 

--- a/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
+++ b/site/src/pages/AgentsPage/ConfigureAgentsDialog.tsx
@@ -296,10 +296,10 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 					</p>
 				) : (
 					<>
-						<div className="overflow-hidden rounded-lg border border-border-default">
+						<div className="overflow-x-auto rounded-lg border border-border-default">
 							<Table>
 								<TableHeader>
-									<TableRow className="text-left text-xs uppercase tracking-wide text-content-secondary">
+									<TableRow className="text-left text-xs font-medium uppercase tracking-wide text-content-secondary">
 										<TableHead className="px-4 py-3">User</TableHead>
 										<TableHead className="px-4 py-3 text-right">
 											Total Cost

--- a/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
+++ b/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
@@ -58,17 +58,17 @@ export const UserAnalyticsDialog: FC<UserAnalyticsDialogProps> = ({
 						Review your personal chat usage for the last 30 days.
 					</DialogDescription>
 				</DialogHeader>
-				<DialogClose asChild>
-					<Button
-						variant="subtle"
-						size="icon-lg"
-						className="absolute left-4 top-4 z-10 shrink-0 border-none bg-transparent shadow-none hover:bg-surface-tertiary/50"
-					>
-						<XIcon className="text-content-secondary" />
-						<span className="sr-only">Close</span>
-					</Button>
-				</DialogClose>
 				<div className="flex max-h-[min(88dvh,720px)] min-h-0 flex-col overflow-y-auto px-6 py-5 [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]">
+					<DialogClose asChild>
+						<Button
+							variant="subtle"
+							size="icon-lg"
+							className="mb-3 shrink-0 border-none bg-transparent shadow-none hover:bg-surface-tertiary/50"
+						>
+							<XIcon className="text-content-secondary" />
+							<span className="sr-only">Close</span>
+						</Button>
+					</DialogClose>
 					<SectionHeader
 						label="Analytics"
 						description="Review your personal chat usage and cost breakdowns."

--- a/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
+++ b/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
@@ -58,29 +58,27 @@ export const UserAnalyticsDialog: FC<UserAnalyticsDialogProps> = ({
 						Review your personal chat usage for the last 30 days.
 					</DialogDescription>
 				</DialogHeader>
+				<DialogClose asChild>
+					<Button
+						variant="subtle"
+						size="icon-lg"
+						className="absolute right-4 top-4 z-10 shrink-0 border-none bg-transparent shadow-none hover:bg-surface-tertiary/50"
+					>
+						<XIcon className="text-content-secondary" />
+						<span className="sr-only">Close</span>
+					</Button>
+				</DialogClose>
 				<div className="flex max-h-[min(88dvh,720px)] min-h-0 flex-col overflow-y-auto px-6 py-5 [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]">
-					<div className="mb-6 flex items-start justify-between gap-4">
-						<SectionHeader
-							label="Analytics"
-							description="Review your personal chat usage and cost breakdowns."
-							action={
-								<div className="flex items-center gap-2 text-xs text-content-secondary">
-									<BarChart3Icon className="h-4 w-4" />
-									<span>{dateRange.rangeLabel}</span>
-								</div>
-							}
-						/>
-						<DialogClose asChild>
-							<Button
-								variant="subtle"
-								size="icon-lg"
-								className="shrink-0 border-none bg-transparent shadow-none hover:bg-surface-tertiary/50"
-							>
-								<XIcon className="text-content-secondary" />
-								<span className="sr-only">Close</span>
-							</Button>
-						</DialogClose>
-					</div>
+					<SectionHeader
+						label="Analytics"
+						description="Review your personal chat usage and cost breakdowns."
+						action={
+							<div className="flex items-center gap-2 text-xs text-content-secondary">
+								<BarChart3Icon className="h-4 w-4" />
+								<span>{dateRange.rangeLabel}</span>
+							</div>
+						}
+					/>
 
 					<ChatCostSummaryView
 						summary={summaryQuery.data}

--- a/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
+++ b/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
@@ -62,7 +62,7 @@ export const UserAnalyticsDialog: FC<UserAnalyticsDialogProps> = ({
 					<Button
 						variant="subtle"
 						size="icon-lg"
-						className="absolute right-4 top-4 z-10 shrink-0 border-none bg-transparent shadow-none hover:bg-surface-tertiary/50"
+						className="absolute left-4 top-4 z-10 shrink-0 border-none bg-transparent shadow-none hover:bg-surface-tertiary/50"
 					>
 						<XIcon className="text-content-secondary" />
 						<span className="sr-only">Close</span>


### PR DESCRIPTION
## Summary

Fix several styling and positioning inconsistencies across the AgentsPage chat usage feature to match established patterns used by other tabs/panels.

## Changes

### AgentsSidebar — Settings button consistency
The Settings button used a raw `<button>` with manual Tailwind classes while the adjacent Analytics button used the `<Button>` component with `variant="subtle" size="icon"` wrapped in a `<Tooltip>`. Converted to match.

### ConfigureAgentsDialog — Usage table styling
- **Table header**: Added missing `font-medium` to the usage table header `<TableRow>`, matching `ChatCostSummaryView` table headers.
- **Table container**: Changed `overflow-hidden` to `overflow-x-auto` so wide tables scroll horizontally instead of clipping content.

### UserAnalyticsDialog — Close button positioning
The close button was placed inside a flex wrapper alongside `SectionHeader`, which renders a React Fragment (`<>`) with two children (a flex row + an `<hr>` divider). This created a broken 3-child flex layout where the `<hr>` floated as a flex item between the header and close button, and the close button scrolled away with content.

Moved the close button to `absolute right-4 top-4` on the `DialogContent` — outside the scrollable area and properly anchored to the top-right corner, consistent with how `ConfigureAgentsDialog` pins its close button outside the content flow.