### PR TITLE
fix(scripts/develop): skip build on Windows via build tag

### DIFF
--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Command develop orchestrates the Coder development environment. It
 // builds the binary, starts the API server and frontend dev server,
 // sets up a first user, and handles graceful shutdown on signals.

--- a/scripts/develop/main_test.go
+++ b/scripts/develop/main_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (


### PR DESCRIPTION
PR #23054 introduced `scripts/develop/main.go` with `syscall.SysProcAttr{Setpgid: true}` and `syscall.Kill`, both undefined on Windows. This broke `GOOS=windows go build ./scripts/develop`.

Add a `//go:build !windows` constraint to the package since it is a dev-only tool that requires Unix utilities (bash, make, etc.) and does not run on Windows.

Refs #23054
Fixes coder/internal#1407

> 🤖 This PR was created with the help of Mux, and has been reviewed by a human. 🏂🏻