### PR TITLE
chore: remove swagger annotations from experimental chat endpoints

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -481,49 +481,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/chats/{chat}/archive": {
-            "post": {
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Archive a chat",
-                "operationId": "archive-chat",
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                }
-            }
-        },
-        "/chats/{chat}/desktop": {
-            "get": {
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat desktop",
-                "operationId": "watch-chat-desktop",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "101": {
-                        "description": "Switching Protocols"
-                    }
-                }
-            }
-        },
         "/connectionlog": {
             "get": {
                 "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -410,45 +410,6 @@
 				}
 			}
 		},
-		"/chats/{chat}/archive": {
-			"post": {
-				"tags": ["Chats"],
-				"summary": "Archive a chat",
-				"operationId": "archive-chat",
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				}
-			}
-		},
-		"/chats/{chat}/desktop": {
-			"get": {
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				],
-				"tags": ["Chats"],
-				"summary": "Watch chat desktop",
-				"operationId": "watch-chat-desktop",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"101": {
-						"description": "Switching Protocols"
-					}
-				}
-			}
-		},
 		"/connectionlog": {
 			"get": {
 				"security": [

--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -748,14 +748,6 @@ proxyLoop:
 	_ = clientStream.Close(websocket.StatusGoingAway)
 }
 
-// @Summary Watch chat desktop
-// @ID watch-chat-desktop
-// @Security CoderSessionToken
-// @Tags Chats
-// @Param chat path string true "Chat ID" format(uuid)
-// @Success 101
-// @Router /chats/{chat}/desktop [get]
-//
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -871,11 +863,7 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 	logger.Debug(ctx, "desktop Bicopy finished")
 }
 
-// @Summary Archive a chat
-// @ID archive-chat
-// @Tags Chats
-// @Success 204
-// @Router /chats/{chat}/archive [post]
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
 func (api *API) archiveChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	chat := httpmw.ChatParam(r)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1417,10 +1417,6 @@
 							"path": "./reference/api/builds.md"
 						},
 						{
-							"title": "Chats",
-							"path": "./reference/api/chats.md"
-						},
-						{
 							"title": "Debug",
 							"path": "./reference/api/debug.md"
 						},


### PR DESCRIPTION
The `/archive` and `/desktop` chat endpoints had swagger route comments (`@Summary`, `@ID`, `@Router`, etc.) that would cause them to appear in generated API docs. Since these live under `/experimental/chats`, they should not be documented.

This removes the swagger annotations and adds the standard `// EXPERIMENTAL: this endpoint is experimental and is subject to change.` comment to `archiveChat` (the `watchChatDesktop` handler already had it, just needed the swagger block removed).