### PR TITLE
fix(coderd): return 404 for resource lookup failures in chat handlers

### DIFF
--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -387,7 +387,7 @@ func (api *API) chatCostSummary(rw http.ResponseWriter, r *http.Request) {
 
 	targetUser := httpmw.UserParam(r)
 	if targetUser.ID != apiKey.UserID && !api.Authorize(r, policy.ActionRead, rbac.ResourceChat.WithOwner(targetUser.ID.String())) {
-		httpapi.Forbidden(rw)
+		httpapi.ResourceNotFound(rw)
 		return
 	}
 
@@ -775,14 +775,16 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 
 	workspace, err := api.Database.GetWorkspaceByID(ctx, chat.WorkspaceID.UUID)
 	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Chat workspace not found.",
-		})
+		if httpapi.Is404Error(err) {
+			httpapi.ResourceNotFound(rw)
+			return
+		}
+		httpapi.InternalServerError(rw, err)
 		return
 	}
 	if !api.Authorize(r, policy.ActionApplicationConnect, workspace) &&
 		!api.Authorize(r, policy.ActionSSH, workspace) {
-		httpapi.Forbidden(rw)
+		httpapi.ResourceNotFound(rw)
 		return
 	}
 
@@ -1903,9 +1905,8 @@ func (api *API) validateCreateChatWorkspaceSelection(
 	workspace, err := api.Database.GetWorkspaceByID(ctx, *req.WorkspaceID)
 	if err != nil {
 		if httpapi.Is404Error(err) {
-			return selection, http.StatusBadRequest, &codersdk.Response{
-				Message: "Workspace not found or you do not have access to this resource",
-			}
+			response := httpapi.ResourceNotFoundResponse
+			return selection, http.StatusNotFound, &response
 		}
 		return selection, http.StatusInternalServerError, &codersdk.Response{
 			Message: "Failed to get workspace.",
@@ -1918,9 +1919,8 @@ func (api *API) validateCreateChatWorkspaceSelection(
 	}
 
 	if !api.Authorize(r, policy.ActionSSH, workspace) {
-		return selection, http.StatusBadRequest, &codersdk.Response{
-			Message: "Workspace not found or you do not have access to this resource",
-		}
+		response := httpapi.ResourceNotFoundResponse
+		return selection, http.StatusNotFound, &response
 	}
 
 	return selection, 0, nil

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -158,7 +158,7 @@ func TestPostChats(t *testing.T) {
 		sdkErr := requireSDKError(t, err, http.StatusNotFound)
 		require.Equal(
 			t,
-			"Workspace not found or you do not have access to this resource",
+			"Resource not found or you do not have access to this resource",
 			sdkErr.Message,
 		)
 	})
@@ -193,7 +193,7 @@ func TestPostChats(t *testing.T) {
 		sdkErr := requireSDKError(t, err, http.StatusNotFound)
 		require.Equal(
 			t,
-			"Workspace not found or you do not have access to this resource",
+			"Resource not found or you do not have access to this resource",
 			sdkErr.Message,
 		)
 	})
@@ -218,7 +218,7 @@ func TestPostChats(t *testing.T) {
 		sdkErr := requireSDKError(t, err, http.StatusNotFound)
 		require.Equal(
 			t,
-			"Workspace not found or you do not have access to this resource",
+			"Resource not found or you do not have access to this resource",
 			sdkErr.Message,
 		)
 	})

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -155,7 +155,7 @@ func TestPostChats(t *testing.T) {
 			},
 			WorkspaceID: &workspaceBuild.Workspace.ID,
 		})
-		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		sdkErr := requireSDKError(t, err, http.StatusNotFound)
 		require.Equal(
 			t,
 			"Workspace not found or you do not have access to this resource",
@@ -190,7 +190,7 @@ func TestPostChats(t *testing.T) {
 			},
 			WorkspaceID: &workspaceBuild.Workspace.ID,
 		})
-		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		sdkErr := requireSDKError(t, err, http.StatusNotFound)
 		require.Equal(
 			t,
 			"Workspace not found or you do not have access to this resource",
@@ -215,7 +215,7 @@ func TestPostChats(t *testing.T) {
 			},
 			WorkspaceID: &workspaceID,
 		})
-		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		sdkErr := requireSDKError(t, err, http.StatusNotFound)
 		require.Equal(
 			t,
 			"Workspace not found or you do not have access to this resource",
@@ -3958,6 +3958,81 @@ func TestWatchChatDesktop(t *testing.T) {
 		require.NoError(t, err)
 		defer res.Body.Close()
 		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("WorkspaceNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		createdChat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID: firstUser.UserID,
+			WorkspaceID: uuid.NullUUID{
+				UUID:  uuid.New(),
+				Valid: true,
+			},
+			LastModelConfigID: modelConfig.ID,
+			Title:             "desktop missing workspace test",
+		})
+		require.NoError(t, err)
+
+		res, err := client.Request(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/api/experimental/chats/%s/desktop", createdChat.ID),
+			nil,
+		)
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		err = codersdk.ReadBodyAsError(res)
+		requireSDKError(t, err, http.StatusNotFound)
+	})
+
+	t.Run("WorkspaceNotAccessible", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		orgAdminClient, _ := coderdtest.CreateAnotherUser(
+			t,
+			adminClient,
+			firstUser.OrganizationID,
+			rbac.ScopedRoleOrgAdmin(firstUser.OrganizationID),
+		)
+		modelConfig := createChatModelConfig(t, adminClient)
+
+		workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+			OrganizationID: firstUser.OrganizationID,
+			OwnerID:        firstUser.UserID,
+		}).WithAgent().Do()
+
+		createdChat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID: firstUser.UserID,
+			WorkspaceID: uuid.NullUUID{
+				UUID:  workspaceBuild.Workspace.ID,
+				Valid: true,
+			},
+			LastModelConfigID: modelConfig.ID,
+			Title:             "desktop inaccessible workspace test",
+		})
+		require.NoError(t, err)
+
+		res, err := orgAdminClient.Request(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/api/experimental/chats/%s/desktop", createdChat.ID),
+			nil,
+		)
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		err = codersdk.ReadBodyAsError(res)
+		requireSDKError(t, err, http.StatusNotFound)
 	})
 }
 


### PR DESCRIPTION
## Summary
This switches the resource-scoped chat paths over to `404 Not Found` so they stop leaking whether a specific user or workspace exists via `400`/`403` responses.

Changes in this PR:
- return `404` from `chatCostSummary` when a user tries to drill into another user's summary without access
- return `404` from `watchChatDesktop` when the chat workspace is missing or not accessible
- return `404` from `validateCreateChatWorkspaceSelection` for missing or inaccessible workspaces
- update the existing create-chat tests and add desktop coverage for missing/inaccessible workspaces

Closes #23099

## Testing
- `go test ./coderd -run 'Test(PostChats|TestWatchChatDesktop|TestChatCostSummary)' -count=1`
