### PR TITLE
fix: disable agent notification chime by default

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/useAgentChime.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/useAgentChime.test.ts
@@ -44,8 +44,8 @@ describe("getChimeEnabled / setChimeEnabled", () => {
 		localStorage.clear();
 	});
 
-	it("defaults to true when nothing is stored", () => {
-		expect(getChimeEnabled()).toBe(true);
+	it("defaults to false when nothing is stored", () => {
+		expect(getChimeEnabled()).toBe(false);
 	});
 
 	it("returns true when stored as 'true'", () => {
@@ -80,6 +80,8 @@ describe("maybePlayChime", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		localStorage.clear();
+		// Explicitly enable the chime — the default is now disabled.
+		setChimeEnabled(true);
 
 		mockLocks = new MockLockManager();
 		Object.defineProperty(navigator, "locks", {

--- a/site/src/pages/AgentsPage/AgentDetail/useAgentChime.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/useAgentChime.ts
@@ -3,10 +3,10 @@ const CHIME_PREFERENCE_KEY = "agents.chime-on-completion";
 export function getChimeEnabled(): boolean {
 	try {
 		const stored = localStorage.getItem(CHIME_PREFERENCE_KEY);
-		// Default to enabled when no preference has been saved.
-		return stored === null ? true : stored === "true";
+		// Default to disabled when no preference has been saved.
+		return stored === null ? false : stored === "true";
 	} catch {
-		return true;
+		return false;
 	}
 }
 


### PR DESCRIPTION
The completion chime on `/agents` was enabled by default for new users (or when no localStorage preference existed). This changes the default to disabled, so users must explicitly opt in via the sound toggle button.

## Changes

- `getChimeEnabled()` now returns `false` when no preference is stored (was `true`)
- `catch` fallback also returns `false` (was `true`)
- Updated tests to reflect the new default and explicitly enable the chime in `maybePlayChime` tests