### PR TITLE
feat(site): add Early Access notice below agents chat input

### DIFF
--- a/site/src/pages/AgentsPage/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/AgentCreateForm.tsx
@@ -393,6 +393,17 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						</Combobox>
 					}
 				/>
+				<p className="mt-1 text-center text-xs text-content-secondary/50">
+					Coder Agents is available via{" "}
+					<a
+						href="https://coder.com/docs/ai-coder/agents/early-access"
+						target="_blank"
+						rel="noreferrer"
+						className="text-content-secondary/50 underline hover:text-content-secondary"
+					>
+						Early Access
+					</a>
+				</p>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Adds a centered "Coder Agents is available via Early Access" line directly beneath the chat input on the `/agents` index page. The "Early Access" text links to https://coder.com/docs/ai-coder/agents/early-access.

<img width="1192" height="683" alt="image" src="https://github.com/user-attachments/assets/1823a5d2-6f02-48c2-ac70-a62b8f52be55" />

---

PR generated with Coder Agents