### PR TITLE
ci: fix build job disk exhaustion on Depot runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1198,7 +1198,7 @@ jobs:
           make -j \
             build/coder_linux_{amd64,arm64,armv7} \
             build/coder_"$version"_windows_amd64.zip \
-            build/coder_"$version"_linux_amd64.{tar.gz,deb}
+            build/coder_"$version"_linux_{amd64,arm64,armv7}.{tar.gz,deb}
         env:
           # The Windows and Darwin slim binaries must be signed for Coder
           # Desktop to accept them.
@@ -1216,11 +1216,28 @@ jobs:
           GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
           JSIGN_PATH: /tmp/jsign-6.0.jar
 
+      # Free up disk space before building Docker images. The preceding
+      # Build step produces ~2 GB of binaries and packages, the Go build
+      # cache is ~1.3 GB, and node_modules is ~500 MB. Docker image
+      # builds, pushes, and SBOM generation need headroom that isn't
+      # available without reclaiming some of that space.
+      - name: Clean up build cache
+        run: |
+          set -euxo pipefail
+          # Go caches are no longer needed — binaries are already compiled.
+          go clean -cache -modcache
+          # Remove .apk and .rpm packages that are not uploaded as
+          # artifacts and were only built as make prerequisites.
+          rm -f ./build/*.apk ./build/*.rpm
+
       - name: Build Linux Docker images
         id: build-docker
         env:
           CODER_IMAGE_BASE: ghcr.io/coder/coder-preview
           DOCKER_CLI_EXPERIMENTAL: "enabled"
+          # Skip building .deb/.rpm/.apk/.tar.gz as prerequisites for
+          # the Docker image targets — they were already built above.
+          DOCKER_IMAGE_NO_PREREQUISITES: "true"
         run: |
           set -euxo pipefail
 


### PR DESCRIPTION
## Problem

The `build` job on `main` has been failing intermittently (and now consistently) with `no space left on device` on the `depot-ubuntu-22.04-8` runner. The runner's disk fills up during Docker image builds or SBOM generation, depending on how close to the limit a given run lands.

The build was already at the boundary — the Go build cache alone is ~1.3 GB, build artifacts are ~2 GB, and Docker image builds + SBOM scans need several hundred MB of headroom in `/tmp`. No single commit caused this; cumulative growth in dependencies and the scheduled `coder-base:latest` rebuild on Monday morning nudged it past the limit.

## Fix

Three changes to reclaim ~2 GB of disk before Docker runs:

1. **Build all platform archives and packages in the Build step** — moves arm64/armv7 `.tar.gz` and `.deb` from the Docker step to the Build step so we can clean caches in between.

2. **Clean up Go caches between Build and Docker** — once binaries are compiled, the Go build cache and module cache aren't needed. Also removes `.apk`/`.rpm` packages that are never uploaded.

3. **Set `DOCKER_IMAGE_NO_PREREQUISITES`** — tells make to skip redundantly building `.deb`/`.rpm`/`.apk`/`.tar.gz` as prerequisites of Docker image targets. The Makefile already supports this flag for exactly this purpose.