### PR TITLE
fix(cored): fix flaky TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease

### DIFF
--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -867,6 +867,19 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 	require.True(t, queuedResult.Queued)
 	require.NotNil(t, queuedResult.QueuedMessage)
 
+	// Send "later queued" immediately after "queued" while the first
+	// message is still in chat_queued_messages. The existing backlog
+	// (len(existingQueued) > 0) guarantees this is queued regardless
+	// of chat status, avoiding a race where the auto-promoted "queued"
+	// message finishes processing before we can send this.
+	laterQueuedResult, err := server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:  chat.ID,
+		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("later queued")},
+	})
+	require.NoError(t, err)
+	require.True(t, laterQueuedResult.Queued)
+	require.NotNil(t, laterQueuedResult.QueuedMessage)
+
 	require.Eventually(t, func() bool {
 		select {
 		case <-interrupted:
@@ -875,14 +888,6 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 			return false
 		}
 	}, testutil.WaitMedium, testutil.IntervalFast)
-
-	laterQueuedResult, err := server.SendMessage(ctx, chatd.SendMessageOptions{
-		ChatID:  chat.ID,
-		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("later queued")},
-	})
-	require.NoError(t, err)
-	require.True(t, laterQueuedResult.Queued)
-	require.NotNil(t, laterQueuedResult.QueuedMessage)
 
 	spendChat, err := db.InsertChat(ctx, database.InsertChatParams{
 		OwnerID:           user.ID,


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/1406

## Root cause

The second `SendMessage("later queued")` was called after waiting for the `interrupted` channel. By that point, the auto-promoted "queued" message's `processChat` could complete (request #2 returns instantly via `OpenAIStreamingResponse`), leaving the chat in `Waiting` status with an empty queue. `shouldQueueUserMessage(Waiting)` returns `false` and `len(existingQueued) == 0`, so the message was inserted directly instead of queued — `Queued: false`.

## Fix

Move `SendMessage("later queued")` to immediately after `SendMessage("queued")`, before waiting for the interrupt. At that point, "queued" is guaranteed to still be in `chat_queued_messages` (the auto-promotion requires multiple goroutine switches and DB transactions that cannot complete between two consecutive synchronous calls). The `len(existingQueued) > 0` condition reliably triggers queueing regardless of chat status.

Passes 25/25 with `-count=25`.