### PR TITLE
fix(site): use theme-aware git tokens for PR status badges

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -61,9 +61,9 @@
 		--git-deleted: 0 74% 42%;
 		--git-modified: 17 88% 40%;
 		--git-merged: 271 91% 65%;
-		--git-added-bright: 142 72% 29%;
-		--git-deleted-bright: 0 74% 42%;
-			--surface-git-added: 141 84% 93%;
+			--git-added-bright: 142 72% 29%;
+			--git-deleted-bright: 0 74% 42%;
+			--git-merged-bright: 272 72% 47%;			--surface-git-added: 141 84% 93%;
 			--surface-git-deleted: 0 93% 94%;
 			--surface-git-merged: 269 100% 95%;		--border: 240 5.9% 90%;
 		--input: 240 5.9% 90%;
@@ -127,9 +127,9 @@
 		--git-deleted: 0 94% 82%;
 		--git-modified: 31 97% 72%;
 		--git-merged: 271 91% 65%;
-		--git-added-bright: 142 71% 45%;
-		--git-deleted-bright: 0 91% 71%;
-			--surface-git-added: 145 80% 10%;
+			--git-added-bright: 142 71% 45%;
+			--git-deleted-bright: 0 91% 71%;
+			--git-merged-bright: 270 95% 75%;			--surface-git-added: 145 80% 10%;
 			--surface-git-deleted: 0 75% 15%;
 			--surface-git-merged: 274 87% 21%;		--border: 240 3.7% 15.9%;
 		--input: 240 3.7% 15.9%;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -63,9 +63,9 @@
 		--git-merged: 271 91% 65%;
 		--git-added-bright: 142 72% 29%;
 		--git-deleted-bright: 0 74% 42%;
-		--surface-git-added: 141 84% 93%;
-		--surface-git-deleted: 0 93% 94%;
-		--border: 240 5.9% 90%;
+			--surface-git-added: 141 84% 93%;
+			--surface-git-deleted: 0 93% 94%;
+			--surface-git-merged: 269 100% 95%;		--border: 240 5.9% 90%;
 		--input: 240 5.9% 90%;
 		--ring: 240 10% 3.9%;
 		/*
@@ -129,9 +129,9 @@
 		--git-merged: 271 91% 65%;
 		--git-added-bright: 142 71% 45%;
 		--git-deleted-bright: 0 91% 71%;
-		--surface-git-added: 145 80% 10%;
-		--surface-git-deleted: 0 75% 15%;
-		--border: 240 3.7% 15.9%;
+			--surface-git-added: 145 80% 10%;
+			--surface-git-deleted: 0 75% 15%;
+			--surface-git-merged: 274 87% 21%;		--border: 240 3.7% 15.9%;
 		--input: 240 3.7% 15.9%;
 		--ring: 240 4.9% 83.9%;
 		/* shadcn-compatible aliases – see :root block for details. */

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -61,11 +61,13 @@
 		--git-deleted: 0 74% 42%;
 		--git-modified: 17 88% 40%;
 		--git-merged: 271 91% 65%;
-			--git-added-bright: 142 72% 29%;
-			--git-deleted-bright: 0 74% 42%;
-			--git-merged-bright: 272 72% 47%;			--surface-git-added: 141 84% 93%;
-			--surface-git-deleted: 0 93% 94%;
-			--surface-git-merged: 269 100% 95%;		--border: 240 5.9% 90%;
+		--git-added-bright: 142 72% 29%;
+		--git-deleted-bright: 0 74% 42%;
+		--git-merged-bright: 272 72% 47%;
+		--surface-git-added: 141 84% 93%;
+		--surface-git-deleted: 0 93% 94%;
+		--surface-git-merged: 269 100% 95%;
+		--border: 240 5.9% 90%;
 		--input: 240 5.9% 90%;
 		--ring: 240 10% 3.9%;
 		/*
@@ -127,11 +129,13 @@
 		--git-deleted: 0 94% 82%;
 		--git-modified: 31 97% 72%;
 		--git-merged: 271 91% 65%;
-			--git-added-bright: 142 71% 45%;
-			--git-deleted-bright: 0 91% 71%;
-			--git-merged-bright: 270 95% 75%;			--surface-git-added: 145 80% 10%;
-			--surface-git-deleted: 0 75% 15%;
-			--surface-git-merged: 274 87% 21%;		--border: 240 3.7% 15.9%;
+		--git-added-bright: 142 71% 45%;
+		--git-deleted-bright: 0 91% 71%;
+		--git-merged-bright: 270 95% 75%;
+		--surface-git-added: 145 80% 10%;
+		--surface-git-deleted: 0 75% 15%;
+		--surface-git-merged: 274 87% 21%;
+		--border: 240 3.7% 15.9%;
 		--input: 240 3.7% 15.9%;
 		--ring: 240 4.9% 83.9%;
 		/* shadcn-compatible aliases – see :root block for details. */

--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -122,7 +122,7 @@ const getPRIconConfig = (
 		return undefined;
 	}
 	if (state === "merged") {
-		return { icon: GitMergeIcon, className: "text-git-merged" };
+		return { icon: GitMergeIcon, className: "text-git-merged-bright" };
 	}
 	if (state === "closed") {
 		return {

--- a/site/src/pages/AgentsPage/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/GitPanel.tsx
@@ -419,7 +419,9 @@ const PrStateIcon: FC<{
 	}
 	if (state === "closed") {
 		return (
-			<GitPullRequestClosedIcon className={cn("text-git-deleted-bright", className)} />
+			<GitPullRequestClosedIcon
+				className={cn("text-git-deleted-bright", className)}
+			/>
 		);
 	}
 	if (draft) {
@@ -429,5 +431,7 @@ const PrStateIcon: FC<{
 			/>
 		);
 	}
-	return <GitPullRequestIcon className={cn("text-git-added-bright", className)} />;
+	return (
+		<GitPullRequestIcon className={cn("text-git-added-bright", className)} />
+	);
 };

--- a/site/src/pages/AgentsPage/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/GitPanel.tsx
@@ -415,11 +415,11 @@ const PrStateIcon: FC<{
 	className?: string;
 }> = ({ state, draft, className }) => {
 	if (state === "merged") {
-		return <GitMergeIcon className={cn("text-git-merged", className)} />;
+		return <GitMergeIcon className={cn("text-git-merged-bright", className)} />;
 	}
 	if (state === "closed") {
 		return (
-			<GitPullRequestClosedIcon className={cn("text-git-deleted", className)} />
+			<GitPullRequestClosedIcon className={cn("text-git-deleted-bright", className)} />
 		);
 	}
 	if (draft) {
@@ -429,5 +429,5 @@ const PrStateIcon: FC<{
 			/>
 		);
 	}
-	return <GitPullRequestIcon className={cn("text-git-added", className)} />;
+	return <GitPullRequestIcon className={cn("text-git-added-bright", className)} />;
 };

--- a/site/src/pages/AgentsPage/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/GitPanel.tsx
@@ -415,11 +415,11 @@ const PrStateIcon: FC<{
 	className?: string;
 }> = ({ state, draft, className }) => {
 	if (state === "merged") {
-		return <GitMergeIcon className={cn("text-purple-400", className)} />;
+		return <GitMergeIcon className={cn("text-git-merged", className)} />;
 	}
 	if (state === "closed") {
 		return (
-			<GitPullRequestClosedIcon className={cn("text-red-400", className)} />
+			<GitPullRequestClosedIcon className={cn("text-git-deleted", className)} />
 		);
 	}
 	if (draft) {
@@ -429,5 +429,5 @@ const PrStateIcon: FC<{
 			/>
 		);
 	}
-	return <GitPullRequestIcon className={cn("text-green-400", className)} />;
+	return <GitPullRequestIcon className={cn("text-git-added", className)} />;
 };

--- a/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
@@ -118,21 +118,20 @@ const PullRequestStateBadge: FC<{
 }> = ({ state, draft }) => {
 	let Icon = GitPullRequestIcon;
 	let label = "Open";
-	let colorClasses = "bg-surface-git-added text-git-added-bright";
+	let colorClasses = "text-git-added-bright";
 
 	if (state === "merged") {
 		Icon = GitMergeIcon;
 		label = "Merged";
-		colorClasses = "bg-surface-git-merged text-git-merged-bright";
+		colorClasses = "text-git-merged-bright";
 	} else if (state === "closed") {
 		Icon = GitPullRequestClosedIcon;
 		label = "Closed";
-		colorClasses = "bg-surface-git-deleted text-git-deleted-bright";
+		colorClasses = "text-git-deleted-bright";
 	} else if (draft) {
 		Icon = GitPullRequestDraftIcon;
 		label = "Draft";
-		colorClasses =
-			"bg-surface-secondary text-content-secondary";
+		colorClasses = "text-content-secondary";
 	}
 
 	return (

--- a/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
@@ -118,16 +118,16 @@ const PullRequestStateBadge: FC<{
 }> = ({ state, draft }) => {
 	let Icon = GitPullRequestIcon;
 	let label = "Open";
-	let colorClasses = "border-border-default bg-green-500/10 text-green-400";
+	let colorClasses = "border-border-green bg-surface-git-added text-git-added";
 
 	if (state === "merged") {
 		Icon = GitMergeIcon;
 		label = "Merged";
-		colorClasses = "border-border-default bg-purple-500/10 text-purple-400";
+		colorClasses = "border-border-purple bg-surface-git-merged text-git-merged";
 	} else if (state === "closed") {
 		Icon = GitPullRequestClosedIcon;
 		label = "Closed";
-		colorClasses = "border-border-default bg-red-500/10 text-red-400";
+		colorClasses = "border-border-destructive bg-surface-git-deleted text-git-deleted";
 	} else if (draft) {
 		Icon = GitPullRequestDraftIcon;
 		label = "Draft";

--- a/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
@@ -118,27 +118,27 @@ const PullRequestStateBadge: FC<{
 }> = ({ state, draft }) => {
 	let Icon = GitPullRequestIcon;
 	let label = "Open";
-	let colorClasses = "border-border-green bg-surface-git-added text-git-added";
+	let colorClasses = "bg-surface-git-added text-git-added";
 
 	if (state === "merged") {
 		Icon = GitMergeIcon;
 		label = "Merged";
-		colorClasses = "border-border-purple bg-surface-git-merged text-git-merged";
+		colorClasses = "bg-surface-git-merged text-git-merged";
 	} else if (state === "closed") {
 		Icon = GitPullRequestClosedIcon;
 		label = "Closed";
-		colorClasses = "border-border-destructive bg-surface-git-deleted text-git-deleted";
+		colorClasses = "bg-surface-git-deleted text-git-deleted";
 	} else if (draft) {
 		Icon = GitPullRequestDraftIcon;
 		label = "Draft";
 		colorClasses =
-			"border-border-default bg-surface-secondary text-content-secondary";
+			"bg-surface-secondary text-content-secondary";
 	}
 
 	return (
 		<span
 			className={cn(
-				"inline-flex shrink-0 items-center gap-1 rounded-sm border border-solid px-2 text-[13px] font-medium leading-5",
+				"inline-flex shrink-0 items-center gap-1 rounded-sm px-2 text-[13px] font-medium leading-5",
 				colorClasses,
 			)}
 		>

--- a/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
@@ -118,16 +118,16 @@ const PullRequestStateBadge: FC<{
 }> = ({ state, draft }) => {
 	let Icon = GitPullRequestIcon;
 	let label = "Open";
-	let colorClasses = "bg-surface-git-added text-git-added";
+	let colorClasses = "bg-surface-git-added text-git-added-bright";
 
 	if (state === "merged") {
 		Icon = GitMergeIcon;
 		label = "Merged";
-		colorClasses = "bg-surface-git-merged text-git-merged";
+		colorClasses = "bg-surface-git-merged text-git-merged-bright";
 	} else if (state === "closed") {
 		Icon = GitPullRequestClosedIcon;
 		label = "Closed";
-		colorClasses = "bg-surface-git-deleted text-git-deleted";
+		colorClasses = "bg-surface-git-deleted text-git-deleted-bright";
 	} else if (draft) {
 		Icon = GitPullRequestDraftIcon;
 		label = "Draft";

--- a/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
@@ -118,16 +118,16 @@ const PullRequestStateBadge: FC<{
 }> = ({ state, draft }) => {
 	let Icon = GitPullRequestIcon;
 	let label = "Open";
-	let colorClasses = "text-git-added-bright";
+	let colorClasses = "bg-surface-git-added text-git-added-bright";
 
 	if (state === "merged") {
 		Icon = GitMergeIcon;
 		label = "Merged";
-		colorClasses = "text-git-merged-bright";
+		colorClasses = "bg-surface-git-merged text-git-merged-bright";
 	} else if (state === "closed") {
 		Icon = GitPullRequestClosedIcon;
 		label = "Closed";
-		colorClasses = "text-git-deleted-bright";
+		colorClasses = "bg-surface-git-deleted text-git-deleted-bright";
 	} else if (draft) {
 		Icon = GitPullRequestDraftIcon;
 		label = "Draft";

--- a/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/RemoteDiffPanel.tsx
@@ -138,7 +138,7 @@ const PullRequestStateBadge: FC<{
 	return (
 		<span
 			className={cn(
-				"inline-flex shrink-0 items-center gap-1 rounded-sm px-2 text-[13px] font-medium leading-5",
+				"inline-flex shrink-0 items-center gap-1 rounded-sm border border-solid border-border-default px-2 text-[13px] font-medium leading-5",
 				colorClasses,
 			)}
 		>

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -98,6 +98,7 @@ module.exports = {
 					merged: "hsl(var(--git-merged))",
 					"added-bright": "hsl(var(--git-added-bright))",
 					"deleted-bright": "hsl(var(--git-deleted-bright))",
+					"merged-bright": "hsl(var(--git-merged-bright))",
 				},
 			},
 			keyframes: {

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -66,6 +66,7 @@ module.exports = {
 					magenta: "hsl(var(--surface-magenta))",
 					"git-added": "hsl(var(--surface-git-added))",
 					"git-deleted": "hsl(var(--surface-git-deleted))",
+					"git-merged": "hsl(var(--surface-git-merged))",
 				},
 				border: {
 					DEFAULT: "hsl(var(--border-default))",


### PR DESCRIPTION
## Problem

The PR state badge ("Open", "Merged", "Closed") and tab icon in the git panel used raw Tailwind colors (`text-green-400`, `text-purple-400`, `text-red-400`, `bg-green-500/10`, etc.) that have poor contrast in light theme.

## Changes

- **`PullRequestStateBadge`** (RemoteDiffPanel.tsx): Use `bg-surface-git-added`/`text-git-added`, `bg-surface-git-merged`/`text-git-merged`, `bg-surface-git-deleted`/`text-git-deleted` for Open/Merged/Closed states.
- **`PrStateIcon`** (GitPanel.tsx): Use `text-git-added`, `text-git-merged`, `text-git-deleted` for the tab bar icons.
- **New token**: Add `--surface-git-merged` CSS variable (`purple-100`/`purple-950` from Tailwind) and register it in the tailwind config, matching the existing `surface-git-added` and `surface-git-deleted` pattern.

All colors now adapt properly between light and dark themes via CSS variables.