### PR TITLE
fix(provisioner): skip duplicate-env-keys in generate.sh

### DIFF
--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -78,6 +78,9 @@ run() {
 	toskip=(
 		# This needs care to update correctly.
 		"kubernetes-metadata"
+		# Multiple resources with duplicate JSON key names (id, agent_id)
+		# cause minimize_diff() to scramble UUIDs. Hand-crafted fixture.
+		"duplicate-env-keys"
 	)
 	for skip in "${toskip[@]}"; do
 		if [[ $name == "$skip" ]]; then


### PR DESCRIPTION
## Problem

When `generate.sh` is run (e.g. to regenerate fixtures after adding a new field like `subagent_id`), the `duplicate-env-keys` fixture gets UUID scrambling.

The `minimize_diff()` function uses a bash associative array keyed by JSON field name (`deleted["id"]`). The `duplicate-env-keys` fixture has multiple `coder_env` resources, each with the same key names (`id`, `agent_id`). Since an associative array can only hold one value per key, UUIDs get cross-contaminated or left as random terraform-generated values.

Discovered while working on #23122.

## Fix

Add `duplicate-env-keys` to the `toskip` array in `generate.sh`, alongside `kubernetes-metadata`. This fixture uses hand-crafted placeholder UUIDs and should not be regenerated.

Relates to #21885.