### PR TITLE
fix(site): move analytics date range above cards

### DIFF
--- a/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
+++ b/site/src/pages/AgentsPage/UserAnalyticsDialog.tsx
@@ -63,12 +63,6 @@ export const UserAnalyticsDialog: FC<UserAnalyticsDialogProps> = ({
 						<SectionHeader
 							label="Analytics"
 							description="Review your personal chat usage and cost breakdowns."
-							action={
-								<div className="flex items-center gap-2 text-xs text-content-secondary">
-									<BarChart3Icon className="h-4 w-4" />
-									<span>{dateRange.rangeLabel}</span>
-								</div>
-							}
 						/>
 						<DialogClose asChild>
 							<Button
@@ -80,6 +74,11 @@ export const UserAnalyticsDialog: FC<UserAnalyticsDialogProps> = ({
 								<span className="sr-only">Close</span>
 							</Button>
 						</DialogClose>
+					</div>
+
+					<div className="mb-4 flex w-fit items-center gap-2 text-xs text-content-secondary">
+						<BarChart3Icon className="h-4 w-4" />
+						<span>{dateRange.rangeLabel}</span>
 					</div>
 
 					<ChatCostSummaryView


### PR DESCRIPTION
The date range label in the analytics dialog was awkwardly positioned inside the SectionHeader action slot, competing with the close button. This moves it to its own left-aligned row between the header and the stat cards for better visual hierarchy.

Before:
<img width="886" height="120" alt="image" src="https://github.com/user-attachments/assets/a32f5b36-6ab0-41cc-ac3c-85b83d739414" />

After:
<img width="896" height="150" alt="image" src="https://github.com/user-attachments/assets/22a84d0f-41a6-4304-8c76-9b5c80f7d677" />