### PR TITLE
fix(site): add left offset to agents sidebar user dropdown

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -851,7 +851,11 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 								</span>
 							</button>
 						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start" className="min-w-auto w-[260px]">
+						<DropdownMenuContent
+							align="start"
+							alignOffset={4}
+							className="min-w-auto w-[260px]"
+						>
 							<UserDropdownContent
 								user={user}
 								buildInfo={buildInfo}


### PR DESCRIPTION
The user popup dropdown at the bottom of the agents sidebar was flush against the left edge of the viewport. This adds `alignOffset={4}` to the `DropdownMenuContent` so it has a slight gap from the edge.