### PR TITLE
fix(site): balance sidebar header spacing in agents page

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -682,7 +682,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							<CoderIcon className="h-6 w-6 fill-content-primary" />
 						)}
 					</NavLink>
-					<div className="flex items-center gap-0.5">
+					<div className="flex items-center gap-0.5 -mr-1.5">
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
 								<Button


### PR DESCRIPTION
The filter and collapse buttons in the agents sidebar header appeared to have more space on the right than the Coder logo had on the left.

Both sides use `px-3.5` (14px) container padding, but the icon buttons (28px) contain icons rendered at `size-icon-sm` (18px) with `p-0.5` (2px) SVG padding, creating ~7px of visual whitespace between the icon edge and button boundary.

Adds `-mr-1.5` (6px negative right margin) to the buttons container to pull the icons closer to the sidebar edge, visually balancing the perceived gaps (~15px right vs 14px left).