### PR TITLE
fix(scripts/develop): allow empty access-url for devtunnel

### DIFF
--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -40,6 +40,7 @@ const (
 	defaultAPIPort         = "3000"
 	defaultWebPort         = "8080"
 	defaultProxyPort       = "3010"
+	defaultAccessURL       = "127.0.0.1:%d"
 	defaultPassword        = "SomeSecurePassword!"
 	defaultStarterTemplate = "docker"
 	healthTimeout          = 60 * time.Second
@@ -83,7 +84,8 @@ func main() {
 			{
 				Flag:        "access-url",
 				Env:         "CODER_DEV_ACCESS_URL",
-				Description: "Override access URL.",
+				Default:     defaultAccessURL,
+				Description: "Override access URL. The %d placeholder will be replaced with the API port. Set to empty to enable devtunnel (pit-1.try.coder.app).",
 				Value:       serpent.StringOf(&cfg.accessURL),
 			},
 			{
@@ -190,8 +192,8 @@ func (c *devConfig) validate() error {
 // resolveEnv sets defaults, unsets leaked credentials, resolves
 // filesystem paths, and computes the child process environment.
 func (c *devConfig) resolveEnv() error {
-	if c.accessURL == "" {
-		c.accessURL = fmt.Sprintf("http://127.0.0.1:%d", c.apiPort)
+	if strings.Contains(c.accessURL, "%d") {
+		c.accessURL = fmt.Sprintf(c.accessURL, c.apiPort)
 	}
 
 	// Prevent inherited credentials from leaking into child

--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -40,7 +40,7 @@ const (
 	defaultAPIPort         = "3000"
 	defaultWebPort         = "8080"
 	defaultProxyPort       = "3010"
-	defaultAccessURL       = "127.0.0.1:%d"
+	defaultAccessURL       = "http://127.0.0.1:%d"
 	defaultPassword        = "SomeSecurePassword!"
 	defaultStarterTemplate = "docker"
 	healthTimeout          = 60 * time.Second

--- a/scripts/develop/main_test.go
+++ b/scripts/develop/main_test.go
@@ -287,7 +287,7 @@ func TestDevConfigResolveEnv(t *testing.T) {
 	t.Setenv("CODER_SESSION_TOKEN", "leaked")
 	t.Setenv("CODER_URL", "https://leaked.example.com")
 
-	cfg := &devConfig{apiPort: 3000}
+	cfg := &devConfig{apiPort: 3000, accessURL: defaultAccessURL}
 	require.NoError(t, cfg.resolveEnv())
 
 	wd, _ := os.Getwd()


### PR DESCRIPTION
This feature was lost in the Bash -> Go migration, restored.